### PR TITLE
CI: verify e2e tests pass for all 4 backends

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -25,7 +25,7 @@ jobs:
         run: mvn -B install -DskipTests --file backend/pom.xml
 
       - name: Build SUT apps
-        run: mvn -B package -DskipTests --file e2e/sut/pom.xml
+        run: mvn -B install -Dmaven.test.skip=true --file e2e/sut/pom.xml
 
       - name: Start SUT apps
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -62,3 +62,4 @@ jobs:
           name: playwright-report
           path: e2e/playwright-report/
           retention-days: 7
+


### PR DESCRIPTION
Triggers the updated E2E Tests workflow to verify all 280 Playwright tests pass across mvc-app1, webflux-app1, quarkus-app1, and micronaut-app1.