### PR TITLE
feat(crud): let the viewed entity hide the built-in edit/new actions

### DIFF
--- a/backend/shared/core/src/main/java/io/mateu/core/infra/declarative/orchestrators/crud/routeresolvers/ViewToolbarBuilder.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/infra/declarative/orchestrators/crud/routeresolvers/ViewToolbarBuilder.java
@@ -67,13 +67,22 @@ final class ViewToolbarBuilder {
     if (!MetaAnnotations.isPresent(orchestrator.getClass(), SplitCrud.class)) {
       toolbar.add(new Button(orchestrator.backToListLabel(), "cancel-view"));
     }
-    if (!orchestrator.readOnly()) {
+    if (!orchestrator.readOnly() && !hiddenByEntity(finalEntity, "new", httpRequest)) {
       toolbar.add(new Button(orchestrator.addAnotherLabel(), "new"));
     }
-    if (!viewReadOnly(item, orchestrator)) {
+    if (!viewReadOnly(item, orchestrator) && !hiddenByEntity(finalEntity, "edit", httpRequest)) {
       toolbar.add(new Button(orchestrator.editLabel(), "edit"));
     }
     return toolbar;
+  }
+
+  /**
+   * Lets the viewed entity hide a built-in view action ({@code "new"} / {@code "edit"}) per
+   * instance state by implementing {@link VisibilitySupplier} — same mechanism already used for its
+   * {@link Toolbar} buttons.
+   */
+  private static boolean hiddenByEntity(Object entity, String action, HttpRequest httpRequest) {
+    return entity instanceof VisibilitySupplier vs && vs.isHidden(action, httpRequest);
   }
 
   private static boolean viewReadOnly(Object item, Crud orchestrator) {


### PR DESCRIPTION
The CRUD detail toolbar already lets the viewed entity hide its `@Toolbar` buttons via `VisibilitySupplier.isHidden(...)`. This extends the **same** mechanism to the built-in **`edit`** and **`new`** actions.

In `ViewToolbarBuilder.createViewToolbar`, the `new`/`edit` buttons are now skipped when the viewed entity implements `VisibilitySupplier` and returns `isHidden("new")` / `isHidden("edit")`.

Enables per-instance/per-state control of the edit button (e.g. hide *edit* once a record is locked/active) without an all-or-nothing `@ReadOnly`.

Consumed by EventConductor (`feat/workflow-definition-lifecycle-buttons`) to hide *edit* on ACTIVE workflow definitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)