### PR TITLE
feat(routing): section index for menu-group routes instead of Not found

### DIFF
--- a/backend/shared/core/src/main/java/io/mateu/core/application/runaction/AppMenuActionableFinder.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/runaction/AppMenuActionableFinder.java
@@ -1,5 +1,7 @@
 package io.mateu.core.application.runaction;
 
+import io.mateu.core.domain.out.componentmapper.HomeRouteResolver;
+import io.mateu.uidl.data.Menu;
 import io.mateu.uidl.fluent.AppShell;
 import io.mateu.uidl.interfaces.Actionable;
 import io.mateu.uidl.interfaces.HttpRequest;
@@ -22,6 +24,19 @@ final class AppMenuActionableFinder {
         cleanRoute,
         ("_empty".equals(consumedRoute) ? app.route() : "") + route,
         httpRequest);
+  }
+
+  /** The menu group a route points at (has children, no page of its own), or {@code null}. */
+  static Menu findGroup(AppShell app, String route, String consumedRoute, HttpRequest httpRequest) {
+    var resolvedRoute =
+        httpRequest.getAttribute("resolvedRoute") != null
+            ? (String) httpRequest.getAttribute("resolvedRoute")
+            : app.route();
+    var cleanRoute = route;
+    if (route.startsWith(consumedRoute)) {
+      cleanRoute = route.substring(consumedRoute.length());
+    }
+    return HomeRouteResolver.getSelectedGroup(cleanRoute, app.menu(), resolvedRoute).orElse(null);
   }
 
   private AppMenuActionableFinder() {}

--- a/backend/shared/core/src/main/java/io/mateu/core/application/runaction/AppMenuResolver.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/runaction/AppMenuResolver.java
@@ -11,6 +11,8 @@ import io.mateu.core.domain.ports.InstanceFactoryProvider;
 import io.mateu.uidl.data.*;
 import io.mateu.uidl.fluent.AppShell;
 import io.mateu.uidl.fluent.AppSupplier;
+import io.mateu.uidl.fluent.Component;
+import io.mateu.uidl.fluent.PageView;
 import io.mateu.uidl.interfaces.Actionable;
 import io.mateu.uidl.interfaces.HttpRequest;
 import io.mateu.uidl.interfaces.RouteResolver;
@@ -139,6 +141,12 @@ public class AppMenuResolver {
     }
 
     if (actionable == null) {
+      // The route may point at a menu group (children but no page of its own, e.g. /workflow):
+      // render a section-index page instead of letting the frontend show "Not found".
+      var group = AppMenuActionableFinder.findGroup(app, route, consumedRoute, httpRequest);
+      if (group != null && group.submenu() != null && !group.submenu().isEmpty()) {
+        return Mono.just(buildSectionIndex(group, route));
+      }
       return Mono.empty();
     }
     return ActionableDispatcher.dispatch(
@@ -198,6 +206,37 @@ public class AppMenuResolver {
   }
 
   // ── Helpers ──────────────────────────────────────────────────────────────
+
+  /**
+   * Builds a section-index page for a menu group route (e.g. {@code /workflow}): the group's label
+   * as the page title and a clickable list of its child options, so an intermediate menu route
+   * lands on a usable page instead of "Not found". Child links are absolutised against the group
+   * route; {@link RemoteMenu} children keep their own route.
+   */
+  private static Object buildSectionIndex(Menu group, String route) {
+    var base = route.endsWith("/") ? route.substring(0, route.length() - 1) : route;
+    var title =
+        group.label() != null && !group.label().isBlank()
+            ? group.label()
+            : io.mateu.uidl.Humanizer.toUpperCaseFirst(base.substring(base.lastIndexOf('/') + 1));
+    List<Component> links =
+        group.submenu().stream()
+            .filter(child -> !(child instanceof MenuSeparator))
+            .map(
+                child -> {
+                  String target =
+                      (child instanceof RemoteMenu remoteMenu)
+                          ? remoteMenu.route()
+                          : base + child.path();
+                  return (Component) new Anchor(child.label(), target);
+                })
+            .toList();
+    return PageView.builder()
+        .title(title)
+        .contentItem(
+            VerticalLayout.builder().content(links).style("gap: .5rem; padding: .5rem 0;").build())
+        .build();
+  }
 
   @SneakyThrows
   AppShell toApp(

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/out/componentmapper/HomeRouteResolver.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/out/componentmapper/HomeRouteResolver.java
@@ -60,6 +60,37 @@ public class HomeRouteResolver {
     return Optional.empty();
   }
 
+  /**
+   * Like {@link #getSelectedOption} but for a route that points at a menu <em>group</em> itself (no
+   * trailing leaf) — e.g. {@code /workflow}, whose children are {@code /workflow/...}. Returns the
+   * {@link Menu} whose accumulated path equals the route, or empty if the route reaches a leaf or
+   * matches nothing. Used to render a section-index page instead of "Not found".
+   */
+  public static Optional<Menu> getSelectedGroup(
+      String route, Collection<? extends Actionable> actionables, String prefix) {
+    if (route.startsWith(prefix)) {
+      route = route.substring(prefix.length());
+    }
+    if (route.startsWith("/")) {
+      route = route.substring(1);
+    }
+    var token = route.split("/")[0];
+    if (!"".equals(token)) {
+      token = "/" + token;
+      for (Actionable actionable : actionables) {
+        if (token.equals(actionable.path()) && actionable instanceof Menu menu) {
+          var remaining = Arrays.stream(route.split("/")).skip(1).collect(Collectors.joining("/"));
+          if (remaining.isBlank()) {
+            return Optional.of(menu);
+          }
+          String cleanPrefix = !"".equals(prefix) && !"/".equals(prefix) ? prefix : "";
+          return getSelectedGroup(remaining, menu.submenu(), cleanPrefix + token);
+        }
+      }
+    }
+    return Optional.empty();
+  }
+
   static String getHomeUriPrefix(Optional<? extends Actionable> selectedOption) {
     if (selectedOption.isPresent() && selectedOption.get() instanceof RemoteMenu remoteMenu) {
       return remoteMenu.path();


### PR DESCRIPTION
## Problem
A URL that points at a **menu group** — children but no page of its own, e.g. `/workflow` (whose children are `/workflow/definitions`, `/workflow/processes`, …) — resolved to nothing, so the frontend rendered **"Not found"**.

## Fix
Such a route now returns a UIDL page assembled from **existing** components (no frontend change): a `PageView` whose **title is the group's label** and whose content is a `VerticalLayout` of `Anchor` links, one per child option, with **absolutised routes** (`RemoteMenu` children keep their own route).

- `HomeRouteResolver#getSelectedGroup` — additive helper mirroring `getSelectedOption`, returns the `Menu` whose accumulated path equals the route.
- `AppMenuActionableFinder#findGroup` — the same lookup as `find()`, for groups.
- `AppMenuResolver#resolveInApp` — at the `actionable == null` branch, build the section index when the route matches a non-empty group; otherwise unchanged.

`getSelectedOption` is left untouched (it's consumed elsewhere for app-shell selection).

## Verified
Live against an EventConductor orchestrator: `/workflow` now renders a **"Workflow"** heading + clickable links (Definitions → `/workflow/definitions`, Processes, Steps, Analytics) instead of "Not found"; leaf routes like `/workflow/definitions` are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)