### PR TITLE
docs(vb): add DESIGN-NOTES.md — in-repo handoff

### DIFF
--- a/.dev/vb/DESIGN-NOTES.md
+++ b/.dev/vb/DESIGN-NOTES.md
@@ -1,0 +1,89 @@
+# Mateu-sobre-VB — Notas de diseño (handoff para retomar desde otro PC)
+
+> Este doc es la **fuente de verdad para continuar** el proyecto. La memoria de sesión de Claude vive fuera
+> del repo (local a un PC), así que todo lo necesario para retomar está aquí, en el repo.
+
+## Dónde está cada cosa
+
+- **Roadmap por fases (con puertas visuales) + entregable final**: `.dev/vb/RENDERER-ROADMAP.md`
+- **POC ejecutable** (valida la LÓGICA): `.dev/vb/renderer-poc/` — `reduceContexts.mjs` + `fixtures/*.json` +
+  `test.mjs`. Correr: `cd .dev/vb/renderer-poc && node test.mjs` → 10 tests OK.
+- **Diseño completo (PDF)**: `.dev/vb/mateu-vb-renderer-design.pdf`
+- **Apps VB de referencia**: `.dev/vb/dashboard` (JET clásico), `.dev/vb/empty` (dynamic UI), `.dev/vb/frontoffice`
+  (Redwood Starter con el pack `oj-sp`/Spectra — la BASE sobre la que construir).
+
+## Qué es el proyecto (en una frase)
+
+Convertir una **app VB real alojada en Oracle** en un renderer de Mateu, mediante un **kit JS portable** (bridge)
+que consume el `UIIncrementDto` estándar y lo pinta con los componentes `oj-sp`/`oj-c`/`oj-dynamic` auténticos.
+VB = "un renderer más"; el backend de Mateu **no se toca**. Decisión tomada: la traducción vive en un **bridge JS
+dentro de la app VB** (no server-side, no hosting de Mateu en el runtime de chains de VB).
+
+## Arquitectura (el núcleo, ya validado en el POC)
+
+- **Transporte**: `callMateu(baseUrl, route, actionId, state)` → `POST /{base}/mateu/v3/components/_/action` →
+  `UIIncrementDto`. (Service Connection en prod; `fetch` para el bootstrap.)
+- **`reduceContexts(reg, increment)`** — reducer PURO (mismo código que serán métodos de `app-flow.js`):
+  - Registro = `contexts` (mapa `targetComponentId → contexto`, host = `__root__`) + `stack` (drawers abiertos)
+    + `shell` (cuando llega un `App`).
+  - Un **contexto** guarda el `tree` (árbol de componentes, NO campos planos), `state`, `pageType`, `pageWidth`,
+    `kind` (`host`/`drawer`/`island`), `dirty`, y presentación si es drawer.
+  - Fragmentos enrutados por id: `Add` = overlay nuevo apilado; `Replace`/`ReplaceKeepData`/State = actualizan
+    el contexto destino; un `App` configura la `shell` (menú→navigator, título, ancho, appContext, headerActions)
+    y NO crea contexto de contenido.
+  - Comandos → **efectos** (navigate/toast/download/runAction) o mutan el registro (`CloseModal` = cerrar por
+    puro estado; `MarkAsClean/Dirty`).
+- **`applyIncrement`** (action chain VB) = `reduce → asignar contexts/stack → pipeline de efectos` (ifActions).
+- **Render** = dispatcher recursivo por `metadata.type` → fragment auto-referente `mateu-node` (análogo VB de
+  `renderClientSideComponent`). Los formularios son la rama `FormLayout`; la mayoría de arquetipos (item-overview,
+  overviews, welcome, collection-detail) son COMPOSICIÓN de un núcleo de ~20 tipos → salen "gratis". Solo unos
+  pocos tienen tipo de wire dedicado (DashboardLayout, FoldoutLayout, HeroSection, EntityHeader, Scoreboard,
+  MetricCard). `pageType`/`pageWidth` (ya en el wire) eligen plantilla exterior + ancho.
+- **Saliente**: `onAction(actionId, contextId)` → `runActionChain` usa `contexts[contextId].route/state`
+  (`state` es two-way → guardar = "manda el estado que ya tienes").
+
+## Contrato de wire (confirmado en libs/mateu/.../dtos)
+
+- `UIIncrement { messages, commands, fragments, banners, componentState }`
+- `UIFragment { targetComponentId, component, data, state, action: Add|Replace|ReplaceKeepData }`
+- `UICommand { type, data, targetComponentId }` — tipos: `SetWindowTitle`, `SetFavicon`, `DispatchEvent`,
+  `NavigateTo`, `PushStateToHistory`, `RunAction`, `MarkAsDirty`, `MarkAsClean`, `DownloadFile`, `CloseModal`,
+  `AddContentToHead`, `AddContentToBody`.
+- `FormField { fieldId, dataType, stereotype, label, required, readOnly, options, placeholder, min, max,
+  multiline, … }`
+- `ServerSideComponent.pageType` + `.pageWidth` van en el wire (valores pageType: landing/collection/detail/
+  form/process/dashboard; pageWidth: fixed/fullWidth/edgeToEdge).
+- Catálogo de tipos: `ComponentMetadataType` (~110; App, FormLayout, FormField, Card, TabLayout, FormSection,
+  DashboardLayout, Scoreboard, MetricCard, DashboardPanel, FoldoutLayout, HeroSection, EntityHeader, TaskQueue,
+  Crud/Table/Grid, + hojas).
+
+## Builtins de action chain de VB
+
+**Confirmados** (vistos en `.dev/vb/dashboard/**/*.json`):
+- `vb/action/builtin/assignVariablesAction` — `{ "$scope.variables.x": { "source": "{{ … }}" } }`
+- `vb/action/builtin/ifAction` — `{ condition }` + `outcomes.{true,false}`
+- `vb/action/builtin/callModuleFunctionAction` — `{ module: "[[ $application.functions ]]", functionName, params }`;
+  resultado en `$chain.results.<actionId>`
+- `vb/action/builtin/navigateAction` — `{ "@dt": {targetType:"flow"}, parameters: { flow } }`
+- `vb/action/builtin/fireDataProviderEventAction` — `{ target, add: { data } }` (útil para banners/ADP)
+
+**A verificar en el Designer** (nombres/param keys según versión):
+- `callChainAction` — clave del id de chain (`id` vs `chain`) + `params`
+- `fireEventAction` — `{ name, payload }` (el shell del `frontoffice` ya escucha `spShowToast`)
+- construcción exacta de `JsonMetadataProvider` (de `oj-dynamic`) si se usa `oj-dyn-form`
+- paths reales del wire contra un increment CAPTURADO: `component.id`, `initialData`, metadata del `Drawer`
+
+## Entregable final (NO negociable)
+
+Un **kit JS portable** para VB hosteado en Oracle: (1) bridge como módulo **AMD** (`define([...], …)`) o métodos
+de `app-flow.js`; (2) artefactos VB (chains JSON, fragment `mateu-node`, host-page, entradas de `app-flow.json`);
+(3) `baseUrl`. Sin build que VB no reproduzca; el `.mjs` del POC es solo test Node → se envía el envoltorio
+AMD/UMD del MISMO core. Autocontenido, agnóstico de la app, portátil. "Hecho" = app VB vacía en Oracle + importar
+el kit + apuntar a un Mateu → pantalla con look Redwood nativo, cero código propio. Detalle en el roadmap.
+
+## Próximo paso al retomar
+
+1. `capture.mjs` (15 líneas, en el roadmap) contra un backend Mateu vivo (p.ej. un demo) → volcar increments
+   REALES a `renderer-poc/fixtures/` y correr `test.mjs` para fijar el contrato de wire.
+2. **Fase 1** del roadmap: hola mundo dentro del `oj-sp-simple-ui-shell` real → puerta visual del chrome.
+   No avanzar sin que la captura sea indistinguible de una app Redwood nativa.


### PR DESCRIPTION
Mirrors the project continuation brief (previously only in local session memory) into the repo so work can resume from another machine: architecture, confirmed wire contract, VB action-chain builtins, the portable-AMD-kit deliverable, and next steps. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)