### PR TITLE
chore(deps): maven-minor-patch group (33 updates) with smallrye convergence fix

### DIFF
--- a/backend/helidon-mp/helidon-mp-core/pom.xml
+++ b/backend/helidon-mp/helidon-mp-core/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>io.helidon.webserver</groupId>
             <artifactId>helidon-webserver</artifactId>
-            <version>4.2.6</version>
+            <version>4.5.1</version>
         </dependency>
         <dependency>
             <groupId>jakarta.annotation</groupId>

--- a/backend/micronaut/micronaut-core/pom.xml
+++ b/backend/micronaut/micronaut-core/pom.xml
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.21.5</version>
+      <version>2.22.1</version>
       <scope>provided</scope>
     </dependency>
 

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -74,7 +74,18 @@
       <dependency>
         <groupId>org.projectlombok</groupId>
         <artifactId>lombok</artifactId>
-        <version>1.18.40</version>
+        <version>1.18.46</version>
+      </dependency>
+      <!--
+        Pin smallrye-common-function ahead of the Quarkus BOM. Quarkus 3.38 pulls it at 2.14.0 via
+        jboss-threads and at 2.19.0 via smallrye-common-io, which the maven-enforcer
+        DependencyConvergence rule rejects. A directly declared managed dependency converges every
+        path on 2.19.0.
+      -->
+      <dependency>
+        <groupId>io.smallrye.common</groupId>
+        <artifactId>smallrye-common-function</artifactId>
+        <version>2.19.0</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
@@ -96,7 +107,7 @@
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>annotations</artifactId>
-      <version>3.0.0</version>
+      <version>3.0.1</version>
     </dependency>
 
   </dependencies>
@@ -107,14 +118,14 @@
                   <plugin>
                       <groupId>org.apache.maven.plugins</groupId>
                       <artifactId>maven-surefire-plugin</artifactId>
-                      <version>3.5.2</version> </plugin>
+                      <version>3.5.6</version> </plugin>
               </plugins>
           </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.14.0</version>
+        <version>3.15.0</version>
         <configuration>
           <source>21</source>
           <target>21</target>
@@ -155,7 +166,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.5.0</version>
+        <version>3.6.3</version>
         <configuration>
           <rules>
             <bannedDependencies>
@@ -201,7 +212,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.3.1</version>
+        <version>3.4.0</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -215,7 +226,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.6.3</version>
+        <version>3.12.0</version>
         <configuration>
           <sourcepath>src/main/java</sourcepath>
           <source>21</source>
@@ -257,7 +268,7 @@
       <plugin>
         <groupId>org.sonatype.central</groupId>
         <artifactId>central-publishing-maven-plugin</artifactId>
-        <version>0.8.0</version>
+        <version>0.11.0</version>
         <extensions>true</extensions>
         <configuration>
           <publishingServerId>central</publishingServerId>
@@ -335,7 +346,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.12</version>
+        <version>0.8.15</version>
         <executions>
           <execution>
             <goals>

--- a/backend/quarkus/quarkus-core/pom.xml
+++ b/backend/quarkus/quarkus-core/pom.xml
@@ -118,7 +118,7 @@
             <plugin>
                 <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>3.6.0</version>
+                <version>3.2.7</version>
                 <executions>
                     <execution>
                         <id>make-index</id>

--- a/backend/quarkus/quarkus-core/pom.xml
+++ b/backend/quarkus/quarkus-core/pom.xml
@@ -35,14 +35,14 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest</artifactId>
-            <version>3.20.5</version>
+            <version>3.38.0</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
-            <version>3.15.0</version>
+            <version>3.15.7</version>
             <exclusions>
                 <exclusion>
                     <groupId>io.quarkus</groupId>
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-spring-di</artifactId>
-            <version>3.20.5</version>
+            <version>3.38.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>io.smallrye.common</groupId>
@@ -118,7 +118,7 @@
             <plugin>
                 <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>3.2.7</version>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <id>make-index</id>

--- a/backend/shared/annotation-processor-core/pom.xml
+++ b/backend/shared/annotation-processor-core/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>org.freemarker</groupId>
       <artifactId>freemarker</artifactId>
-      <version>2.3.31</version>
+      <version>2.3.34</version>
     </dependency>
 
     <dependency>
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>5.14.2</version>
+      <version>5.23.0</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -74,20 +74,20 @@
     <dependency>
       <groupId>net.bytebuddy</groupId>
       <artifactId>byte-buddy-agent</artifactId>
-      <version>1.15.11</version>
+      <version>1.18.11</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>net.bytebuddy</groupId>
       <artifactId>byte-buddy</artifactId>
-      <version>1.15.11</version>
+      <version>1.18.11</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>33.2.0-jre</version>
+      <version>33.6.0-jre</version>
     </dependency>
 
     <dependency>

--- a/backend/shared/annotation-processor-indexer/pom.xml
+++ b/backend/shared/annotation-processor-indexer/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>5.14.2</version>
+      <version>5.23.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/backend/shared/core/pom.xml
+++ b/backend/shared/core/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
-            <version>3.7.2</version>
+            <version>3.8.6</version>
         </dependency>
         <dependency>
             <groupId>jakarta.inject</groupId>
@@ -52,19 +52,19 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.17</version>
+            <version>2.0.18</version>
         </dependency>
 
 
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.20.1</version>
+            <version>2.22.1</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>2.17.2</version>
+            <version>2.22.1</version>
         </dependency>
 
         <dependency>
@@ -98,13 +98,13 @@
         <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
-            <version>3.1.0</version>
+            <version>3.1.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.19.0</version>
+            <version>2.22.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -118,7 +118,7 @@
         <dependency>
             <groupId>jaxen</groupId>
             <artifactId>jaxen</artifactId>
-            <version>2.0.0</version>
+            <version>2.0.6</version>
             <scope>test</scope>
         </dependency>
 
@@ -137,7 +137,7 @@
         <dependency>
             <groupId>com.auth0</groupId>
             <artifactId>java-jwt</artifactId>
-            <version>4.4.0</version>
+            <version>4.6.0</version>
         </dependency>
 
     </dependencies>
@@ -172,7 +172,7 @@
                         <path>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
-                            <version>1.18.40</version>
+                            <version>1.18.46</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>
@@ -180,7 +180,7 @@
             <plugin>
                 <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>3.1.2</version>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <id>make-index</id>
@@ -211,7 +211,7 @@
                     <dependency>
                         <groupId>org.projectlombok</groupId>
                         <artifactId>lombok</artifactId>
-                        <version>1.18.40</version>
+                        <version>1.18.46</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/backend/shared/core/pom.xml
+++ b/backend/shared/core/pom.xml
@@ -180,7 +180,7 @@
             <plugin>
                 <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>3.6.0</version>
+                <version>3.2.7</version>
                 <executions>
                     <execution>
                         <id>make-index</id>

--- a/backend/shared/dtos/pom.xml
+++ b/backend/shared/dtos/pom.xml
@@ -32,7 +32,7 @@
                         <path>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
-                            <version>1.18.40</version>
+                            <version>1.18.46</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>
@@ -44,19 +44,19 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.40</version>
+            <version>1.18.46</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.19.0</version>
+            <version>2.22</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/io.swagger.core.v3/swagger-annotations -->
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
             <artifactId>swagger-annotations</artifactId>
-            <version>2.2.34</version>
+            <version>2.2.52</version>
         </dependency>
     </dependencies>
 

--- a/backend/shared/export-excel/pom.xml
+++ b/backend/shared/export-excel/pom.xml
@@ -18,7 +18,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.18.0</version>
+        <version>2.22.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -32,7 +32,7 @@
     <dependency>
       <groupId>org.apache.poi</groupId>
       <artifactId>poi-ooxml</artifactId>
-      <version>5.4.0</version>
+      <version>5.5.1</version>
     </dependency>
     <dependency>
       <groupId>jakarta.inject</groupId>
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.40</version>
+      <version>1.18.46</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/backend/shared/export-pdf/pom.xml
+++ b/backend/shared/export-pdf/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>org.apache.pdfbox</groupId>
       <artifactId>pdfbox</artifactId>
-      <version>3.0.3</version>
+      <version>3.0.8</version>
     </dependency>
     <dependency>
       <groupId>jakarta.inject</groupId>
@@ -32,7 +32,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.40</version>
+      <version>1.18.46</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/backend/shared/uidl/pom.xml
+++ b/backend/shared/uidl/pom.xml
@@ -42,7 +42,7 @@
                         <path>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
-                            <version>1.18.40</version>
+                            <version>1.18.46</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.40</version>
+            <version>1.18.46</version>
             <scope>provided</scope>
         </dependency>
 
@@ -68,19 +68,19 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
-            <version>3.7.2</version>
+            <version>3.8.6</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
-            <version>3.1.0</version>
+            <version>3.1.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.21.5</version>
+            <version>2.22.1</version>
         </dependency>
 
         <dependency>
@@ -118,7 +118,7 @@
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>annotations</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/backend/webflux/webflux-core/pom.xml
+++ b/backend/webflux/webflux-core/pom.xml
@@ -37,7 +37,7 @@
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-test</artifactId>
             <scope>test</scope>
-            <version>3.6.8</version>
+            <version>3.8.6</version>
         </dependency>
 
         <dependency>
@@ -105,7 +105,7 @@
                         <path>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
-                            <version>1.18.40</version>
+                            <version>1.18.46</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>


### PR DESCRIPTION
Supersedes #249 (the `maven-minor-patch` group of 33 updates) with the code fix it needs to build.

## The fix #249 was missing
#249 failed the fresh CI build on a **dependency-convergence** error (maven-enforcer) in `quarkus-core`: Quarkus 3.38 pulls `io.smallrye.common:smallrye-common-function` at 2.14.0 (via `jboss-threads`) and 2.19.0 (via `smallrye-common-io`). This pins it to **2.19.0** in `dependencyManagement` — a directly declared managed dependency converges every path — same pattern as the existing Lombok pin.

## Verification (local)
- Full backend `mvn install -DskipTests` → **green**, enforcer `DependencyConvergence` passes on all modules.
- `mvn -pl shared/core test` → **green**.

Applied by cherry-picking #249's group bumps onto current master + the one-line pin. Once the fresh e2e is green, ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)