### PR TITLE
ci: only publish to Maven Central for framework (v*) release tags

### DIFF
--- a/.github/workflows/buid-and-publish.yml
+++ b/.github/workflows/buid-and-publish.yml
@@ -7,12 +7,17 @@ on:
   release:
     types: [published]
 
+# The release event can't be filtered by tag in `on:`, so guard the jobs: only framework releases
+# (tag `vX.Y…`, e.g. v3.0-alpha.N) publish to Maven Central. Other releases — e.g. the desktop
+# installers (`mateu-desktop-*`) — publish nothing.
 jobs:
   e2e:
+    if: startsWith(github.event.release.tag_name, 'v')
     uses: ./.github/workflows/run_tests.yml
 
   all:
     needs: e2e
+    if: startsWith(github.event.release.tag_name, 'v')
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
`Build and publish` triggered on **every** published release (`release: published`, no tag filter) and ran `mvn deploy` to Maven Central using the tag as the version.

Guard both jobs with `if: startsWith(github.event.release.tag_name, 'v')` so **only framework releases** (`v3.0-alpha.N` …) publish. Other releases — e.g. the desktop installers (`mateu-desktop-*`) — trigger nothing and can be published safely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)