### PR TITLE
Desktop: optional Developer ID signing + notarization for Mateu.app

### DIFF
--- a/frontend/app/intellij-plugin/README.md
+++ b/frontend/app/intellij-plugin/README.md
@@ -65,9 +65,36 @@ brand-gradient squircle). The `.dmg` is mounted, the `.app` copied out and modif
 installs it into the custom plugins dir + opens the bundled workspace on first run — because a folder
 dropped into `Contents/plugins` is ignored (only manifest-declared bundled plugins load there; a
 third-party plugin must load from `idea.plugins.path`). Config/system/log/plugins live under
-`~/Library/Application Support|Caches|Logs/Mateu`. The bundle is **re-signed ad-hoc** (modifying it
-invalidates the original signature); unsigned → first launch needs **right-click ▸ Open** (or
-`xattr -dr com.apple.quarantine Mateu.app`).
+`~/Library/Application Support|Caches|Logs/Mateu`. By default the bundle is **re-signed ad-hoc**
+(modifying it invalidates the original signature); unsigned → first launch needs **right-click ▸ Open**
+(or `xattr -dr com.apple.quarantine Mateu.app`).
+
+### Signing & notarization (no right-click on first launch)
+
+Pass a **Developer ID Application** identity to sign with the hardened runtime, and a **notarytool
+keychain profile** to notarize + staple — the result launches with a normal double-click:
+
+```bash
+./gradlew buildInstaller -Pinstaller.platform=macos \
+  -Pmacos.sign.identity="Developer ID Application: Your Name (TEAMID)" \
+  -Pmacos.notarize.profile=mateu-notary
+```
+
+Prerequisites (Apple Developer Program membership required):
+1. Install a **Developer ID Application** certificate in your login keychain (Xcode ▸ Settings ▸
+   Accounts ▸ Manage Certificates, or developer.apple.com). Check with
+   `security find-identity -v -p codesigning`.
+2. Store notarization credentials once as a keychain profile:
+   ```bash
+   xcrun notarytool store-credentials mateu-notary \
+     --apple-id you@example.com --team-id TEAMID --password <app-specific-password>
+   # or --key/--key-id/--issuer for an App Store Connect API key
+   ```
+
+`-Pmacos.sign.identity` alone signs (Developer ID, hardened runtime) but doesn't notarize; both flags
+together sign + notarize the `.dmg` and staple the ticket onto the `.dmg` and the `.app`. Note: the
+launcher is a shell script set as `CFBundleExecutable` — if notarization ever rejects that, the
+fallback is a tiny native launcher stub.
 
 Passing `-Pmateu.registryUrl`/`-Pmateu.appId` bakes the app-registry coordinates into the launcher VM
 options (they override the plugin's bundled `application.properties`). The IDE archive downloads once

--- a/frontend/app/intellij-plugin/build.gradle.kts
+++ b/frontend/app/intellij-plugin/build.gradle.kts
@@ -201,32 +201,61 @@ tasks.register("buildInstaller") {
             )
             wrapper.setExecutable(true)
 
-            // Modifying the bundle invalidates the signature — re-sign ad-hoc so macOS will launch it.
-            logger.lifecycle("Re-signing (ad-hoc)…")
-            run("codesign", "--force", "--deep", "--sign", "-", app.absolutePath, dir = work)
+            // Modifying the bundle invalidates the original signature — re-sign. With a Developer ID
+            // (-Pmacos.sign.identity="Developer ID Application: Name (TEAMID)") sign with the hardened
+            // runtime + a secure timestamp (both required for notarization); otherwise ad-hoc, which
+            // at least launches locally (first launch needs right-click ▸ Open).
+            val signId = findProperty("macos.sign.identity") as String?
+            val notaryProfile = findProperty("macos.notarize.profile") as String?
+            if (signId != null) {
+                logger.lifecycle("Signing with Developer ID (hardened runtime)…")
+                run("codesign", "--force", "--deep", "--options", "runtime", "--timestamp", "--sign", signId, app.absolutePath, dir = work)
+            } else {
+                logger.lifecycle("Re-signing (ad-hoc)…")
+                run("codesign", "--force", "--deep", "--sign", "-", app.absolutePath, dir = work)
+            }
 
-            // Ship the .app, a zip of it, and a double-click .dmg.
-            val out = File(installerDir, "Mateu.app")
-            out.deleteRecursively()
-            run("cp", "-R", app.absolutePath, out.absolutePath, dir = work)
-            val zip = File(installerDir, "mateu-desktop-${project.version}-macos.zip")
-            zip.delete()
-            run("ditto", "-c", "-k", "--keepParent", app.absolutePath, zip.absolutePath, dir = work)
-
-            // Double-click .dmg: Mateu.app beside a drag-to-Applications shortcut. Move (not copy) the
-            // work .app into the staging dir — same filesystem, so it's free (out/zip are already made).
+            // Double-click .dmg: Mateu.app beside a drag-to-/Applications shortcut. Move (not copy) the
+            // work .app into the staging dir — same filesystem, so it's free.
             logger.lifecycle("Creating .dmg…")
             val dmgStage = File(work, "dmg").apply { deleteRecursively(); mkdirs() }
-            run("mv", app.absolutePath, File(dmgStage, "Mateu.app").absolutePath, dir = work)
+            val stagedApp = File(dmgStage, "Mateu.app")
+            run("mv", app.absolutePath, stagedApp.absolutePath, dir = work)
             run("ln", "-s", "/Applications", File(dmgStage, "Applications").absolutePath, dir = work)
             val dmgOut = File(installerDir, "mateu-desktop-${project.version}-macos.dmg")
             dmgOut.delete()
             run("hdiutil", "create", "-volname", "Mateu", "-srcfolder", dmgStage.absolutePath, "-ov", "-format", "UDZO", dmgOut.absolutePath, dir = work)
 
+            // Notarize the .dmg and staple the ticket onto both the .dmg and the .app, so Gatekeeper
+            // passes offline (normal double-click, no right-click). Needs a Developer ID signature and
+            // a notarytool keychain profile (-Pmacos.notarize.profile=<profile>, created once via
+            // `xcrun notarytool store-credentials`).
+            val notarized = signId != null && notaryProfile != null
+            when {
+                notarized -> {
+                    logger.lifecycle("Notarizing (submitting to Apple — can take a few minutes)…")
+                    run("xcrun", "notarytool", "submit", dmgOut.absolutePath, "--keychain-profile", notaryProfile, "--wait", dir = work)
+                    logger.lifecycle("Stapling the notarization ticket…")
+                    run("xcrun", "stapler", "staple", dmgOut.absolutePath, dir = work)
+                    run("xcrun", "stapler", "staple", stagedApp.absolutePath, dir = work)
+                }
+                notaryProfile != null ->
+                    logger.lifecycle("Skipping notarization: -Pmacos.sign.identity is required (an ad-hoc signature can't be notarized).")
+            }
+
+            // Ship the .app and a zip of it — from the staged (possibly stapled) copy.
+            val out = File(installerDir, "Mateu.app")
+            out.deleteRecursively()
+            run("cp", "-R", stagedApp.absolutePath, out.absolutePath, dir = work)
+            val zip = File(installerDir, "mateu-desktop-${project.version}-macos.zip")
+            zip.delete()
+            run("ditto", "-c", "-k", "--keepParent", out.absolutePath, zip.absolutePath, dir = work)
+
             logger.lifecycle("Installer ready: $out")
             logger.lifecycle("  $zip (${zip.length() / (1024 * 1024)} MB)")
             logger.lifecycle("  $dmgOut (${dmgOut.length() / (1024 * 1024)} MB)")
-            logger.lifecycle("First launch: right-click ▸ Open (unsigned), or run: xattr -dr com.apple.quarantine \"/Applications/Mateu.app\"")
+            if (notarized) logger.lifecycle("Signed + notarized — launches with a normal double-click.")
+            else logger.lifecycle("Unsigned/ad-hoc — first launch: right-click ▸ Open (or xattr -dr com.apple.quarantine).")
             return@doLast
         }
 


### PR DESCRIPTION
`buildInstaller` can now produce a **signed + notarized** macOS app that launches with a normal double-click (no right-click ▸ Open), gated behind two props so the default stays ad-hoc:

- `-Pmacos.sign.identity="Developer ID Application: Name (TEAMID)"` → sign with the hardened runtime + secure timestamp (required to notarize).
- `-Pmacos.notarize.profile=<notarytool keychain profile>` → notarize the `.dmg` and staple the ticket onto the `.dmg` **and** the `.app`.

The `.app`/`.zip` are produced from the stapled staging copy so all three artifacts carry the ticket. README documents the prerequisites (Developer ID cert + `xcrun notarytool store-credentials`).

**Not runtime-verified** — this machine has no Developer ID cert/notary creds; default (ad-hoc) behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)