### PR TITLE
design(figma): add ContentLayout to the Figma contract

### DIFF
--- a/design/figma/contract.json
+++ b/design/figma/contract.json
@@ -704,6 +704,48 @@
       ]
     },
     {
+      "name": "Mateu/Layout/ContentLayout",
+      "kind": "contentLayout",
+      "variants": {
+        "asidePosition": [
+          "end",
+          "start"
+        ],
+        "asideSticky": [
+          "true",
+          "false"
+        ]
+      },
+      "java": "ContentLayout (fluent) / @Aside on a field",
+      "csharp": "ContentLayout / [Aside]",
+      "python": "ContentLayout / Aside()",
+      "props": {
+        "asideWidth": "TEXT"
+      },
+      "container": true,
+      "sketch": [
+        {
+          "t": "row",
+          "items": [
+            {
+              "t": "slot",
+              "w": 260,
+              "h": 170
+            },
+            {
+              "t": "slot",
+              "w": 150,
+              "h": 170
+            }
+          ]
+        },
+        {
+          "t": "slot",
+          "h": 44
+        }
+      ]
+    },
+    {
       "name": "Mateu/Display/Text",
       "kind": "text",
       "variants": {


### PR DESCRIPTION
Syncs `design/figma/contract.json` with the new wire kind from the page-templates epic (#287): **`Mateu/Layout/ContentLayout`** (kind `contentLayout`) — the uniform content-page slot grammar.

Modeled like the other `Mateu/Layout/*` components:
- variants `asidePosition` (end/start) + `asideSticky` (true/false)
- prop `asideWidth` (TEXT)
- `java`/`csharp`/`python` → `ContentLayout` (fluent) or the `@Aside` field annotation
- a `sketch` of a main + aside row over a full-width footer slot

The contract stays valid JSON (75 components; Layout category now 8). The Figma plugin builds the library from this file and modux's importer maps instances back through it.

**Not added** (by design): `@Aside` is a field modifier, and Advanced Create & Edit is a composition with no backing class — neither is a distinct component kind, so neither gets its own entry. The two downstream mirrors (modux's `mateu-contract.json` and the `figma-maven-plugin` resources) live in the **modux** repo and are synced there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)