### PR TITLE
fix(drawer): collapsible drawers collapse instead of close

### DIFF
--- a/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/mateu-drawer.ts
+++ b/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/mateu-drawer.ts
@@ -140,7 +140,9 @@ export class MateuDrawer extends ComponentElement {
                 ${this.canMaximize(metadata) ? html`
                     <button class="drawer-icon" aria-label="Maximize" title="Maximize" @click="${() => this.maximizeSteps++}">⤢</button>
                 ` : nothing}
-                <button class="drawer-close" aria-label="Close" @click="${this.close}">✕</button>
+                ${metadata.collapsible ? nothing : html`
+                    <button class="drawer-close" aria-label="Close" @click="${this.close}">✕</button>
+                `}
             </header>
             ${this.collapsed ? nothing : html`
             <div class="content ${metadata.noPadding ? 'no-padding' : ''}">


### PR DESCRIPTION
A collapsible `Drawer` (the Redwood **Bottom Drawer** template — `DrawerPosition.bottom` + `collapsible`) is a *docked* panel: its affordance is the ▾ collapse handle, not a ✕ close. The ✕ ran `close()`, which removes the drawer from the DOM — wrong for a panel that should collapse to its header strip and expand again. This suppresses the ✕ when `collapsible`, leaving the collapse toggle as the only dismiss affordance.

### Context — the deferred polish items

This came out of scoping the two remaining "polish" items from the page-templates epic. Both turned out to be **features, not polish**, and are deferred:

- **Gantt page — bottom + side drawer simultaneously.** Docking the bottom panel as a real collapsible drawer needs the drawer to be emitted as an *overlay on load*; the current overlay path only hoists drawers **returned from an action**, not drawers embedded inline in a `component()` tree (verified: an inline `Drawer` child never reaches a fragment). The archetype already docks a bottom detail Card that coexists with the side task drawer — the true-drawer version needs an overlay-on-load emission mechanism.
- **Guided Process Drawer — batch flows / 5-step limit.** Depends on porting `EmbeddedView` (embed a routed view as an independent ServerSideComponent) to .NET/Python, which isn't ported — a substantial feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)