### PR TITLE
fix: renderer vaadin contra el front-office (mezcla de Lit + listados declarativos navegables)

### DIFF
--- a/.dev/vb/DESIGN-NOTES.md
+++ b/.dev/vb/DESIGN-NOTES.md
@@ -1360,6 +1360,22 @@ pide SOLO las pendientes.
   `action-on-row-<método>` con parameters {id} → Listing.handleActionOnRow invoca el
   método; el refresco llega por el bus (dispatchEvent "automatizacion-arreglada" +
   @Trigger OnCustomEvent → search). Verificado: 6 Solucionar → clic → toast + 5.
+- **Renderer VAADIN contra el front-office (2026-07-28)**: tres fixes al probar :5174.
+  (1) `lit-vaadin-helpers@0.3.1` (dependencia MUERTA de libs/mateu, sin un solo import)
+  anclaba lit 2.8 → su `@lit/reactive-element@1.6.3` quedaba IZADO a la raíz del
+  monorepo y el `dedupe` de vite se lo servía a todo el árbol mezclado con lit 3.3.3 —
+  síntomas: recursión infinita `__isItemSelectable` en vaadin-grid (el accessor de Lit
+  guarda en `__<nombre>` y cae al método privado del mixin), "component loaded twice",
+  y el tab del menú sin marcar. Eliminada la dependencia → árbol convergido en lit 3 +
+  RE 2.1.2 y los tres síntomas fuera. (2) FRAMEWORK: un Listing declarativo que
+  soporta la acción "view" es NAVEGABLE — PageListingBuilder marca la primera columna
+  con actionId="view" (la misma señal que ListRouteResolver.withViewOnFirstColumn en el
+  camino AutoCrud; Selectors excluidos) → la celda-id se pinta como enlace en el
+  renderer compartido. (3) FRAMEWORK: ListingBackend.actions() ANUNCIA "view" cuando
+  supportsAction("view") — sin anunciarla, mateu-component descarta el action-requested
+  del clic (regla conocida del renderer compartido) y el enlace no hacía nada.
+  Verificado: /reservas en :5174 pinta filas + chips + seed, el clic en el id navega a
+  /reserva/st-sophie y el 360 completo rinde en Vaadin; el VB no se resiente.
 - Pendiente: "Total extras" del AddOnPicker no se ve en las copias del host (cosmético). Fase 3: cobro (PaymentPicker), ancillaries (AddOnPicker) y firma vía SSE desde la
   360 (el SSE de host en los chains solo existe para islas — hoy esas ops se hacen en el
   wizard).

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/out/componentmapper/PageListingBuilder.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/out/componentmapper/PageListingBuilder.java
@@ -61,13 +61,15 @@ public class PageListingBuilder {
                     .groupBy())
             .filters(filters)
             .columns(
-                getColumns(
-                    getRowClass(instance),
+                withViewOnFirstColumnIfNavigable(
                     instance,
-                    baseUrl,
-                    route,
-                    initiatorComponentId,
-                    httpRequest))
+                    getColumns(
+                        getRowClass(instance),
+                        instance,
+                        baseUrl,
+                        route,
+                        initiatorComponentId,
+                        httpRequest)))
             .filtersLayout(filtersLayout)
             .gridLayout(getGridLayout(instance))
             .style(getStyle(instance, httpRequest));
@@ -110,6 +112,27 @@ public class PageListingBuilder {
     }
 
     return List.of(builder.build());
+  }
+
+  /**
+   * A declarative listing whose backend answers the {@code view} action is NAVIGABLE: the first
+   * column carries {@code actionId="view"} so every renderer makes the row open the record — the
+   * same signal {@code ListRouteResolver.withViewOnFirstColumn} emits on the AutoCrud path.
+   * Selectors keep their own {@code select} semantics and are excluded.
+   */
+  private static Collection<? extends GridContent> withViewOnFirstColumnIfNavigable(
+      Object instance, Collection<? extends GridContent> rawColumns) {
+    if (!(instance instanceof ListingBackend<?, ?> listingBackend)
+        || instance instanceof Selector<?>
+        || !listingBackend.supportsAction("view")) {
+      return rawColumns;
+    }
+    var list = new java.util.ArrayList<GridContent>(rawColumns);
+    if (list.isEmpty() || !(list.get(0) instanceof io.mateu.uidl.data.GridColumn first)) {
+      return rawColumns;
+    }
+    list.set(0, first.toBuilder().actionId("view").build());
+    return list;
   }
 
   private static GridLayout getGridLayout(Object instance) {

--- a/backend/shared/uidl/src/main/java/io/mateu/uidl/interfaces/ListingBackend.java
+++ b/backend/shared/uidl/src/main/java/io/mateu/uidl/interfaces/ListingBackend.java
@@ -40,6 +40,11 @@ public interface ListingBackend<Filters, Row> extends ActionHandler, ActionSuppl
 
   @Override
   default List<Action> actions(HttpRequest httpRequest) {
+    // a listing whose backend answers "view" is navigable: the action must be ADVERTISED or
+    // the shared renderer drops the row click (unclaimed action-requested events are ignored)
+    if (supportsAction("view")) {
+      return List.of(Action.builder().id("search").build(), Action.builder().id("view").build());
+    }
     return List.of(Action.builder().id("search").build());
   }
 

--- a/frontend/web/monorepo/libs/mateu/package.json
+++ b/frontend/web/monorepo/libs/mateu/package.json
@@ -84,7 +84,6 @@
     "date-fns": "^4.1.0",
     "dompurify": "^3.4.12",
     "js-base64": "^3.9.1",
-    "lit-vaadin-helpers": "^0.3.1",
     "marked": "^18.0.7",
     "minimatch": "^10.2.3",
     "nanoid": "^5.0.7",

--- a/frontend/web/monorepo/package-lock.json
+++ b/frontend/web/monorepo/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "monorepo",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "Apache-2.0",
       "workspaces": [
         "apps/*",
         "libs/*"
@@ -57,7 +57,7 @@
     "apps/vaadin": {
       "name": "mateu-vaadin",
       "version": "0.0.15",
-      "license": "MIT",
+      "license": "Apache-2.0",
       "dependencies": {
         "keycloak-js": "26.2.4",
         "lit": "^3.3.1",
@@ -256,7 +256,6 @@
         "date-fns": "^4.1.0",
         "dompurify": "^3.4.12",
         "js-base64": "^3.9.1",
-        "lit-vaadin-helpers": "^0.3.1",
         "marked": "^18.0.7",
         "minimatch": "^10.2.3",
         "nanoid": "^5.0.7",
@@ -7051,46 +7050,6 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
-      }
-    },
-    "node_modules/lit-vaadin-helpers": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/lit-vaadin-helpers/-/lit-vaadin-helpers-0.3.1.tgz",
-      "integrity": "sha512-AhLBgd4fZnH7i7Kc2DKJXZJvlFDZDDI8dxN4O+rLOl8m72kdhoKWwHjheBDXqWPcNItl5Fn9P/TpI9cor/Dmiw==",
-      "license": "MIT",
-      "dependencies": {
-        "lit": "^2.0.0"
-      }
-    },
-    "node_modules/lit-vaadin-helpers/node_modules/@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
-      }
-    },
-    "node_modules/lit-vaadin-helpers/node_modules/lit": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
-      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit/reactive-element": "^1.6.0",
-        "lit-element": "^3.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/lit-vaadin-helpers/node_modules/lit-element": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
-      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.1.0",
-        "@lit/reactive-element": "^1.3.0",
-        "lit-html": "^2.8.0"
       }
     },
     "node_modules/lit/node_modules/lit-html": {


### PR DESCRIPTION
El listado de reservas no mostraba filas en el renderer Vaadin (:5174) y el clic de fila no navegaba. Tres causas, tres fixes:

1. **Mezcla de versiones de Lit**: `lit-vaadin-helpers@0.3.1` era una dependencia **muerta** de libs/mateu (cero imports) que anclaba lit 2.8 — su `@lit/reactive-element@1.6.3` quedaba izado a la raíz del monorepo y el `dedupe` de vite se lo servía a todo el árbol mezclado con lit 3.3.3. Síntomas: `RangeError: Maximum call stack size exceeded` en `__isItemSelectable` de vaadin-grid (solo en modo tabla), "component loaded twice", y la pestaña del menú sin marcar. Eliminada → árbol convergido en lit 3 + RE 2.1.2.
2. **Framework (core)**: un Listing declarativo que soporta `view` es navegable — `PageListingBuilder` marca la primera columna con `actionId="view"` (la misma señal que `withViewOnFirstColumn` en el camino AutoCrud; Selectors excluidos).
3. **Framework (uidl)**: `ListingBackend.actions()` **anuncia** `view` cuando `supportsAction("view")` — sin anunciarla, el renderer compartido descarta el `action-requested` del clic.

Verificado: `/reservas` en :5174 pinta filas + chips + seed, el clic en el id navega al 360 completo en Vaadin; el renderer VB no se resiente. 745 tests de core en verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)