### PR TITLE
fix(demo): Solucionar acepta ambos contratos de fila (_clickedRow y {id})

### DIFF
--- a/.dev/vb/DESIGN-NOTES.md
+++ b/.dev/vb/DESIGN-NOTES.md
@@ -1376,6 +1376,16 @@ pide SOLO las pendientes.
   del clic (regla conocida del renderer compartido) y el enlace no hacía nada.
   Verificado: /reservas en :5174 pinta filas + chips + seed, el clic en el id navega a
   /reserva/st-sophie y el 360 completo rinde en Vaadin; el VB no se resiente.
+- **Automatizaciones en el renderer VAADIN (2026-07-28)**: el listado rinde de serie —
+  badges de @Status y menú "···" por fila (renderMenuCell del actionGroup; las filas sin
+  acciones no lo muestran). DOS matices: (1) el renderer compartido envía la fila como
+  `parameters._clickedRow` (contrato canónico) mientras el VB envía `{id}` — la acción
+  de fila del demo acepta AMBOS (helper rowId); verificado: Solucionar → credit pasa a
+  Ok y el listado refresca por el bus. (2) El "tab desaparecido" de Automatizaciones NO
+  es un bug: la opción lleva @Audience("Staff") — con el contexto Modo=Cliente (que
+  persiste en localStorage `mateu-app-context`) se oculta por diseño; con Modo sin fijar
+  o Staff, aparece. A 1500px el listado cae a modo cards, donde estado y acciones no se
+  proyectan (limitación conocida del modo cards del renderer compartido).
 - Pendiente: "Total extras" del AddOnPicker no se ve en las copias del host (cosmético). Fase 3: cobro (PaymentPicker), ancillaries (AddOnPicker) y firma vía SSE desde la
   360 (el SSE de host en los chains solo existe para islas — hoy esas ops se hacen en el
   wizard).

--- a/demo/demo-front-office-evolution/src/main/java/io/mateu/mdd/demofrontoffice/ui/automatizaciones/AutomatizacionesListing.java
+++ b/demo/demo-front-office-evolution/src/main/java/io/mateu/mdd/demofrontoffice/ui/automatizaciones/AutomatizacionesListing.java
@@ -130,8 +130,8 @@ public class AutomatizacionesListing
 
   /** La acción de FILA: resuelve los warnings del proceso (dominio real) y refresca por el bus. */
   public Object solucionar(HttpRequest httpRequest) {
-    var id = String.valueOf(httpRequest.runActionRq().parameters().get("id"));
-    var automation = FrontOffice.automations().findById(id).orElse(null);
+    var id = rowId(httpRequest);
+    var automation = id == null ? null : FrontOffice.automations().findById(id).orElse(null);
     if (automation == null) {
       return new Message("Proceso no encontrado");
     }
@@ -139,5 +139,16 @@ public class AutomatizacionesListing
     return List.of(
         new Message("✅ " + resolved.name() + " — incidencias resueltas"),
         UICommand.dispatchEvent("automatizacion-arreglada"));
+  }
+
+  /** El id de la fila en ambos contratos: {@code _clickedRow} (el canónico del renderer
+   *  compartido — la fila entera) o {@code id} directo (el renderer VB). */
+  private static String rowId(HttpRequest httpRequest) {
+    var parameters = httpRequest.runActionRq().parameters();
+    if (parameters.get("_clickedRow") instanceof java.util.Map<?, ?> row && row.get("id") != null) {
+      return String.valueOf(row.get("id"));
+    }
+    var direct = parameters.get("id");
+    return direct == null ? null : String.valueOf(direct);
   }
 }


### PR DESCRIPTION
Al probar el listado de Automatizaciones en el renderer Vaadin:

- El listado ya rendía de serie (badges de `@Status` + menú "···" por fila del `ColumnActionGroup`), pero **Solucionar no hacía nada**: el renderer compartido envía la fila como `parameters._clickedRow` (contrato canónico) y la acción del demo solo leía el `{id}` directo que envía el renderer VB. El helper `rowId` acepta ambos. Verificado: ··· → Solucionar → el proceso pasa a Ok y el listado refresca por el bus.
- El "tab desaparecido" de Automatizaciones **no es un bug**: la opción lleva `@Audience("Staff")` y con el contexto Modo=Cliente (persistido en localStorage) se oculta por diseño.

🤖 Generated with [Claude Code](https://claude.com/claude-code)