### PR TITLE
fix(frontend): match exacto de acción sobre el comodín (SSE) + badges y acciones en cards

### DIFF
--- a/.dev/vb/DESIGN-NOTES.md
+++ b/.dev/vb/DESIGN-NOTES.md
@@ -1386,6 +1386,19 @@ pide SOLO las pendientes.
   persiste en localStorage `mateu-app-context`) se oculta por diseño; con Modo sin fijar
   o Staff, aparece. A 1500px el listado cae a modo cards, donde estado y acciones no se
   proyectan (limitación conocida del modo cards del renderer compartido).
+- **SSE + cards en el renderer compartido (2026-07-28)**: dos fixes en libs/mateu.
+  (1) El escaneo (LongTask SSE) abría el modal pero ni progresaba ni cerraba: en
+  mateu-component el lookup de la acción usaba `find(exacta || comodín)` y el comodín
+  `'*'` (sse:false) va ANTES que `escanearPax(sse:true)` en la lista → la acción salía
+  por el sync normal y solo llegaba el primer increment. El match EXACTO ahora gana al
+  comodín (un flag sse/background/confirmation declarado no puede quedar tapado por un
+  catch-all). Verificado: /sse en red, progreso, cierre y rail refrescado a Cardex OK.
+  (2) El modo CARDS recortaba las columnas a las 6 primeras y estado (@Status, 7ª) y
+  acciones (ColumnActionGroup, 8ª) desaparecían — los badges de estado y las acciones
+  de fila SIEMPRE entran en la card (formatListValue y renderCardActionButtons ya
+  sabían pintarlos). Verificado en /automatizaciones a 1400px: badge + Solucionar
+  operativos desde la card. NOTA: la primera columna de Automatizaciones ya NO sale
+  como link — el gate supportsAction("view") lo dejó correcto tras el último restart.
 - Pendiente: "Total extras" del AddOnPicker no se ve en las copias del host (cosmético). Fase 3: cobro (PaymentPicker), ancillaries (AddOnPicker) y firma vía SSE desde la
   360 (el SSE de host en los chains solo existe para islas — hoy esas ops se hacen en el
   wizard).

--- a/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/mateu-component.ts
+++ b/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/mateu-component.ts
@@ -395,8 +395,11 @@ export class MateuComponent extends ComponentElement {
             e.stopPropagation()
 
             const serverSideComponent = this.component as ServerSideComponent
-            const action = serverSideComponent.actions?.find(action => action.id == detail.actionId
-            || (action.id.endsWith('*') && detail.actionId.startsWith(action.id.replace('*', ''))))
+            // the EXACT action wins over a wildcard: an sse/background/confirmation flag on the
+            // declared action must not be shadowed by a catch-all '*' listed before it
+            const action = serverSideComponent.actions?.find(action => action.id == detail.actionId)
+                ?? serverSideComponent.actions?.find(action =>
+                    action.id.endsWith('*') && detail.actionId.startsWith(action.id.replace('*', '')))
 
             if (action) {
 

--- a/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/mateu-table-crud.ts
+++ b/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/mateu-table-crud.ts
@@ -524,12 +524,18 @@ export class MateuTableCrud extends LitElement {
         const renderCards = () => {
             const idField = this.identifierFieldName
             const selectedId = this.state._selectedId ?? this.appState?._splitDetailId
-            const visibleCols = allCols.slice(0, 6)
-            const imageCols = visibleCols.filter(c => c.stereotype === 'image')
-            const titleCol = visibleCols.find(c => c.identifier) ?? visibleCols[0]
             const isNavCol = (c: GridColumn) => !!c.actionId
             const isActionButtonCol = (c: GridColumn) =>
                 c.dataType === 'action' || c.dataType === 'actionGroup' || c.dataType === 'menu' || c.stereotype === 'button'
+            // the card shows the first columns as data rows, but STATUS badges and row
+            // ACTIONS always make the cut — they carry the row's state and its operations
+            // (they used to be silently dropped when declared beyond the sixth column)
+            const visibleCols = [
+                ...allCols.slice(0, 6),
+                ...allCols.slice(6).filter(c => isActionButtonCol(c) || c.dataType === 'status'),
+            ]
+            const imageCols = visibleCols.filter(c => c.stereotype === 'image')
+            const titleCol = visibleCols.find(c => c.identifier) ?? visibleCols[0]
             const selectCol = visibleCols.find(c => c.id === 'select' && c.dataType === 'action')
             const isSelector = !!selectCol
             const dataCols = visibleCols.filter(c => c !== titleCol && !imageCols.includes(c) && !isNavCol(c) && !isActionButtonCol(c))


### PR DESCRIPTION
Dos fixes en el renderer compartido, encontrados probando el front-office en Vaadin:

1. **SSE roto** (el modal de escaneo ni progresaba ni cerraba): en `mateu-component`, el lookup de la acción hacía `find(exacta || comodín)` — y el comodín `'*'` (sse:false) va **antes** que `escanearPax(sse:true)` en la lista de actions, así que el LongTask salía por el sync normal y solo llegaba el primer increment (el Add del diálogo). El match exacto ahora gana al comodín. Verificado: la petición sale por `/mateu/v3/sse/`, la barra progresa, el modal se cierra y el rail refresca a "Cardex OK".
2. **Cards sin estado ni acciones**: el modo cards recortaba a las 6 primeras columnas, tirando el `@Status` (7ª) y el `ColumnActionGroup` (8ª) — que el propio renderer ya sabía pintar. Los badges y las acciones de fila siempre entran en la card. Verificado en `/automatizaciones` a 1400px: badge de estado + "Solucionar" operativos desde la card.

169 tests de la lib en verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)