### PR TITLE
fix(vaadin): batch final del renderer — page-header toolbar, seed anunciado, cards apiladas, foldout, drawers

### DIFF
--- a/.dev/vb/DESIGN-NOTES.md
+++ b/.dev/vb/DESIGN-NOTES.md
@@ -1402,3 +1402,44 @@ pide SOLO las pendientes.
 - Pendiente: "Total extras" del AddOnPicker no se ve en las copias del host (cosmético). Fase 3: cobro (PaymentPicker), ancillaries (AddOnPicker) y firma vía SSE desde la
   360 (el SSE de host en los chains solo existe para islas — hoy esas ops se hacen en el
   wizard).
+
+## Batch final del renderer Vaadin (2026-07-28)
+
+- **Toolbar de listados al header de PÁGINA**: el usuario pidió título + toolbar en la
+  MISMA línea sin meter el título en el crud (feedback explícito; el intento inverso se
+  revirtió). `PageListingBuilder.getToolbarButtons(instance)` extraído público
+  (@ListToolbarButton + Import/History/Export) y `ReflectionPageMapper` lo concatena al
+  Page toolbar para ListingBackend/ReactiveListingBackend (cast a
+  `io.mateu.uidl.fluent.UserTrigger` — ¡UserTrigger vive en uidl.fluent, no en
+  .interfaces!). El crud SUPRIME su copia cuando un ancestro MATEU-PAGE lleva toolbar
+  (`pageShowsToolbar` en mateu-table-crud cruza shadow roots hacia arriba). VB no se
+  resiente: sigue leyendo listing.toolbar del crud metadata.
+- **Los @ListToolbarButton se ANUNCIAN en `ListingBackend.actions()`** (uidl): el botón
+  del Page header despacha el nombre del método a pelo y mateu-component descarta
+  acciones no anunciadas — el seed "+ 10 reservas demo" no hacía nada en Vaadin (en VB
+  funcionaba porque su renderer no consulta la lista). Ahora actions() recorre
+  getClass().getMethods() y añade cada método anotado (con sus flags confirmation/
+  rowsSelected). Verificado: 19 → 29 items y re-búsqueda vía el trigger
+  "reservas-seeded". OJO: getAnnotation directo — anotaciones compuestas (semantic) no
+  se resuelven aquí (uidl no ve MetaAnnotations de core).
+- **goHome por URL**: el homeRoute del wire es RELATIVO a la petición (iba a /reservas)
+  → `pushState('/') + PopStateEvent` en mateu-app.
+- **Pestañas del menú vivas**: `isActiveOption(option)` con selectedRoute (el flag
+  `selected` del wire es del momento de construcción).
+- **Cards apiladas (mateu-status-list modo stacked)**: título+chip en una línea (chip a
+  la derecha con margin-left:auto), descripción debajo, acciones como icon-buttons
+  (title=label); grid de operaciones con column-gap 2.5rem/row-gap 1rem; huéspedes
+  (stack 1-col) capadas a `max-width: 22rem` = mismo ancho de card que las celdas del
+  grid de operaciones (pedían igualarse). itemHeadingLevel 3/4 (Perfil → h4 en
+  Preferencias/Última estancia).
+- **Foldout Vaadin al 100%** con reparto proporcional: `flex: <peso> 1 <width>` por
+  sección (peso = parseFloat del width declarado); el contenedor necesitaba
+  `expand-fields` en vaadin-form-layout — con `??` no funcionaba porque expandFields
+  llega `false` primitivo → `||`.
+- **Drawers persistentes**: Add con id de overlay existente refresca in situ;
+  Replace in-place por serverSideType preserva overlays (los ids son uuids frescos por
+  render). Ancillaries/cambio de método de pago ya no cierran el drawer.
+- **Alias de iconos Vaadin** (renderIcon): wifi→connect, pen→pencil, automation→cogs.
+- **KPIs sin doble marco** (dashboardRenderer: panel con único MetricCard → el metric
+  solo) y "N de 7" unido al título de sección (mateu-vaadin-foldout: `· subtitle` en el
+  h3).

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/out/componentmapper/PageListingBuilder.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/out/componentmapper/PageListingBuilder.java
@@ -83,33 +83,7 @@ public class PageListingBuilder {
       }
     }
 
-    // @ListToolbarButton methods on a declarative Listing become toolbar buttons (same
-    // annotation the Crud path honors); label from @Label, actionId = the method name.
-    for (var method : getAllMethods(instance.getClass())) {
-      if (MetaAnnotations.isPresent(method, io.mateu.uidl.annotations.ListToolbarButton.class)) {
-        var label = MetaAnnotations.find(method, io.mateu.uidl.annotations.Label.class);
-        builder.toolbarItem(
-            new Button(label != null ? label.value() : method.getName(), method.getName()));
-      }
-    }
-
-    if (instance instanceof io.mateu.uidl.interfaces.UploadEnabled) {
-      builder.toolbarItem(new Button("Import", "import"));
-    }
-    if (instance instanceof io.mateu.uidl.interfaces.Auditable) {
-      builder.toolbarItem(new Button("History", "history"));
-    }
-    if (instance instanceof io.mateu.core.infra.declarative.Listing<?, ?> listing) {
-      if (listing.csvExportable() && ExporterContext.isCsvAvailable()) {
-        builder.toolbarItem(new Button("Export CSV", "export-csv"));
-      }
-      if (listing.excelExportable() && ExporterContext.isExcelAvailable()) {
-        builder.toolbarItem(new Button("Export Excel", "export-excel"));
-      }
-      if (listing.pdfExportable() && ExporterContext.isPdfAvailable()) {
-        builder.toolbarItem(new Button("Export PDF", "export-pdf"));
-      }
-    }
+    getToolbarButtons(instance).forEach(builder::toolbarItem);
 
     return List.of(builder.build());
   }
@@ -133,6 +107,40 @@ public class PageListingBuilder {
     }
     list.set(0, first.toBuilder().actionId("view").build());
     return list;
+  }
+
+  /**
+   * The listing's toolbar buttons: {@code @ListToolbarButton} methods (label from {@code @Label},
+   * actionId = the method name — same annotation the Crud path honors) plus the built-in
+   * import/history/export entries. Shared by the crud metadata AND the routed listing's PAGE
+   * toolbar (the page header shows title + toolbar on one line; the crud suppresses its copy).
+   */
+  public static List<Button> getToolbarButtons(Object instance) {
+    var buttons = new java.util.ArrayList<Button>();
+    for (var method : getAllMethods(instance.getClass())) {
+      if (MetaAnnotations.isPresent(method, io.mateu.uidl.annotations.ListToolbarButton.class)) {
+        var label = MetaAnnotations.find(method, io.mateu.uidl.annotations.Label.class);
+        buttons.add(new Button(label != null ? label.value() : method.getName(), method.getName()));
+      }
+    }
+    if (instance instanceof io.mateu.uidl.interfaces.UploadEnabled) {
+      buttons.add(new Button("Import", "import"));
+    }
+    if (instance instanceof io.mateu.uidl.interfaces.Auditable) {
+      buttons.add(new Button("History", "history"));
+    }
+    if (instance instanceof io.mateu.core.infra.declarative.Listing<?, ?> listing) {
+      if (listing.csvExportable() && ExporterContext.isCsvAvailable()) {
+        buttons.add(new Button("Export CSV", "export-csv"));
+      }
+      if (listing.excelExportable() && ExporterContext.isExcelAvailable()) {
+        buttons.add(new Button("Export Excel", "export-excel"));
+      }
+      if (listing.pdfExportable() && ExporterContext.isPdfAvailable()) {
+        buttons.add(new Button("Export PDF", "export-pdf"));
+      }
+    }
+    return buttons;
   }
 
   private static GridLayout getGridLayout(Object instance) {

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/out/componentmapper/ReflectionPageMapper.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/out/componentmapper/ReflectionPageMapper.java
@@ -55,7 +55,17 @@ public class ReflectionPageMapper {
         .pageWidth(getPageWidth(instance))
         .pageType(PageTypeResolver.resolve(instance))
         .avatar(getAvatar(instance, baseUrl, route, initiatorComponentId, httpRequest))
-        .toolbar(getToolbar(instance, httpRequest))
+        // un LISTADO enrutado muestra su toolbar en el HEADER de la página (título y
+        // acciones en una línea); el crud del renderer compartido suprime su copia
+        .toolbar(
+            instance instanceof io.mateu.uidl.interfaces.ListingBackend<?, ?>
+                    || instance instanceof io.mateu.uidl.interfaces.ReactiveListingBackend<?, ?>
+                ? java.util.stream.Stream.concat(
+                        getToolbar(instance, httpRequest).stream(),
+                        PageListingBuilder.getToolbarButtons(instance).stream())
+                    .map(trigger -> (io.mateu.uidl.fluent.UserTrigger) trigger)
+                    .toList()
+                : getToolbar(instance, httpRequest))
         .buttons(getButtons(instance, httpRequest))
         .fabs(getFabs(instance, httpRequest))
         .kpis(getKpis(instance))

--- a/backend/shared/uidl/src/main/java/io/mateu/uidl/interfaces/ListingBackend.java
+++ b/backend/shared/uidl/src/main/java/io/mateu/uidl/interfaces/ListingBackend.java
@@ -40,12 +40,27 @@ public interface ListingBackend<Filters, Row> extends ActionHandler, ActionSuppl
 
   @Override
   default List<Action> actions(HttpRequest httpRequest) {
+    var actions = new java.util.ArrayList<Action>();
+    actions.add(Action.builder().id("search").build());
     // a listing whose backend answers "view" is navigable: the action must be ADVERTISED or
     // the shared renderer drops the row click (unclaimed action-requested events are ignored)
     if (supportsAction("view")) {
-      return List.of(Action.builder().id("search").build(), Action.builder().id("view").build());
+      actions.add(Action.builder().id("view").build());
     }
-    return List.of(Action.builder().id("search").build());
+    // @ListToolbarButton methods dispatch their bare method name from the page/crud toolbar —
+    // advertise them too, or the shared renderer drops the click the same way
+    for (var method : getClass().getMethods()) {
+      var toolbarButton = method.getAnnotation(io.mateu.uidl.annotations.ListToolbarButton.class);
+      if (toolbarButton != null) {
+        actions.add(
+            Action.builder()
+                .id(method.getName())
+                .confirmationRequired(toolbarButton.confirmationRequired())
+                .rowsSelectedRequired(toolbarButton.rowsSelectedRequired())
+                .build());
+      }
+    }
+    return actions;
   }
 
   @Override

--- a/demo/demo-front-office-evolution/src/main/java/io/mateu/mdd/demofrontoffice/ui/reservas/ReservaOverview.java
+++ b/demo/demo-front-office-evolution/src/main/java/io/mateu/mdd/demofrontoffice/ui/reservas/ReservaOverview.java
@@ -278,12 +278,12 @@ public class ReservaOverview
     var guest = FrontOffice.stayView(stayId).guest();
     var contenido = new ArrayList<Component>();
     contenido.add(Text.builder().text("Preferencias")
-        .container(io.mateu.uidl.data.TextContainer.h3).style("margin: 0;").build());
+        .container(io.mateu.uidl.data.TextContainer.h4).style("margin: 0;").build());
     contenido.add(io.mateu.uidl.data.BulletedList.builder()
         .items(guest.preferences().stream().map(p -> p.text()).toList())
         .build());
     contenido.add(Text.builder().text("Última estancia")
-        .container(io.mateu.uidl.data.TextContainer.h3).style("margin: 1.5rem 0 0;").build());
+        .container(io.mateu.uidl.data.TextContainer.h4).style("margin: 1.5rem 0 0;").build());
     contenido.add(Text.builder().text(guest.lastStaySummary()).noMargins(true).build());
     contenido.add(Text.builder().text(guest.lastStayComplementaryInfo())
         .size(io.mateu.uidl.data.TextSize.xs).noMargins(true).build());

--- a/frontend/web/monorepo/apps/vaadin/src/renderers/mateu-vaadin-foldout.ts
+++ b/frontend/web/monorepo/apps/vaadin/src/renderers/mateu-vaadin-foldout.ts
@@ -249,7 +249,10 @@ export class MateuVaadinFoldout extends LitElement {
         }
         .section {
             position: relative;
-            flex: 0 0 var(--mateu-foldout-section-width, 22rem);
+            /* the declared width is the BASIS; sections grow to fill the row when there is
+               free space (100%-wide foldout) and behave exactly as before when overflowing
+               (flex-grow only distributes free space, so the carousel/snapping is untouched) */
+            flex: 22 1 var(--mateu-foldout-section-width, 22rem);
             min-width: 0;
             background: var(--mateu-foldout-panel-bg, transparent);
             border: none;
@@ -456,11 +459,11 @@ export class MateuVaadinFoldout extends LitElement {
                 </section>
                 ${this.panels.map((panel, index) => html`
                     <section class="section" part="section panel"
-                             style="${panel.width ? `flex-basis: ${panel.width};` : nothing}">
+                             style="${panel.width ? `flex: ${parseFloat(panel.width) || 1} 1 ${panel.width};` : nothing}">
                         ${panel.title || panel.subtitle ? html`
                             <div class="panel-header">
-                                ${panel.title ? html`<h3>${panel.title}</h3>` : nothing}
-                                ${panel.subtitle ? html`<div class="subtitle">${panel.subtitle}</div>` : nothing}
+                                ${panel.title ? html`<h3>${panel.title}${panel.subtitle ? html` <span class="subtitle" style="font-weight: 400;">· ${panel.subtitle}</span>` : nothing}</h3>` : nothing}
+                                ${!panel.title && panel.subtitle ? html`<div class="subtitle">${panel.subtitle}</div>` : nothing}
                             </div>
                         ` : nothing}
                         <div class="panel-body">

--- a/frontend/web/monorepo/apps/vaadin/src/renderers/renderIcon.ts
+++ b/frontend/web/monorepo/apps/vaadin/src/renderers/renderIcon.ts
@@ -4,6 +4,15 @@ import { html, nothing } from "lit";
  * Vaadin adapter icon → <vaadin-icon>. Lives in apps/vaadin so the core stays @vaadin-free; registered by
  * VaadinComponentRenderer's renderIcon hook (the core `icon()` port delegates here). The wire icon names are
  * Vaadin/Lumo iconset names ('vaadin:plus', 'lumo:menu'), which vaadin-icon consumes directly.
+ *
+ * Some wire names have NO glyph in the Vaadin collection (they exist in other design systems'
+ * sets) — those map to the closest Vaadin equivalent so the button never renders empty.
  */
+const VAADIN_ICON_ALIASES: Record<string, string> = {
+    'vaadin:wifi': 'vaadin:connect',       // tarjeta wifi (no wifi glyph in the vaadin set)
+    'vaadin:pen': 'vaadin:pencil',         // firma (pen → pencil)
+    'vaadin:automation': 'vaadin:cogs',    // procesos automatizados
+}
+
 export const renderVaadinIcon = (icon: string, style?: string, cssClasses?: string) =>
-    html`<vaadin-icon icon="${icon}" style="${style ?? nothing}" class="${cssClasses ?? nothing}"></vaadin-icon>`
+    html`<vaadin-icon icon="${VAADIN_ICON_ALIASES[icon] ?? icon}" style="${style ?? nothing}" class="${cssClasses ?? nothing}"></vaadin-icon>`

--- a/frontend/web/monorepo/apps/vaadin/src/renderers/renderLayouts.ts
+++ b/frontend/web/monorepo/apps/vaadin/src/renderers/renderLayouts.ts
@@ -66,7 +66,7 @@ export const renderFormLayout = (container: LitElement, component: ClientSideCom
                        auto-responsive="${metadata.autoResponsive || nothing}"
                        column-width="${metadata.columnWidth || nothing}"
                        expand-columns="${metadata.expandColumns || nothing}"
-                       expand-fields="${(metadata.expandFields ?? !metadata.labelsAside) || nothing}"
+                       expand-fields="${(metadata.expandFields || !metadata.labelsAside) || nothing}"
                        labels-aside="${metadata.labelsAside || nothing}"
                        slot="${component.slot || nothing}"
                >

--- a/frontend/web/monorepo/apps/vaadin/vite.config.ts
+++ b/frontend/web/monorepo/apps/vaadin/vite.config.ts
@@ -81,7 +81,7 @@ export default defineConfig({
             '/users/mateu',
             '/chat/mateu',
             '/ai',
-        ].map(path => [path, { target: 'http://localhost:8594', bypass: bypassHtml }])),
+        ].map(path => [path, { target: 'http://localhost:8595', bypass: bypassHtml }])),
     },
     optimizeDeps: {
         // Excluimos el componente problemático para evitar que analice sus propios node_modules internos

--- a/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/ComponentElement.ts
+++ b/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/ComponentElement.ts
@@ -9,6 +9,8 @@ import {TriggerType} from "@mateu/shared/apiClients/dtos/componentmetadata/Trigg
 import {componentRenderer} from "@infra/ui/renderers/ComponentRenderer.ts";
 import OnLoadTrigger from "@mateu/shared/apiClients/dtos/componentmetadata/OnLoadTrigger.ts";
 import {nanoid} from "nanoid";
+import {ComponentMetadataType} from "@mateu/shared/apiClients/dtos/ComponentMetadataType.ts";
+import ClientSideComponent from "@mateu/shared/apiClients/dtos/ClientSideComponent.ts";
 import {evaluateExpression, evaluateTemplate, InterpolationContext} from "@infra/ui/interpolation.ts";
 
 export default abstract class ComponentElement extends MetadataDrivenElement {
@@ -45,13 +47,32 @@ export default abstract class ComponentElement extends MetadataDrivenElement {
     appState: Record<string, any> = {}
 
 
+    /** overlays (Drawer/Dialog) live as children pushed by Add fragments — they only close
+     *  EXPLICITLY (closeModal / ✕ / Esc), never as a side effect of a host re-render */
+    private isOverlayChild(component: unknown): boolean {
+        const type = (component as ClientSideComponent)?.metadata?.type
+        return type == ComponentMetadataType.Drawer || type == ComponentMetadataType.Dialog
+    }
+
     // write state to reactive properties
     applyFragment(fragment: UIFragment) {
         if (this.id == fragment.targetComponentId) {
             if (fragment.component) {
                 if (UIFragmentAction.Add == fragment.action) {
                     if (this.component) {
-                        this.component.children?.push(fragment.component)
+                        const children = this.component.children ?? (this.component.children = [])
+                        // an Add with the id of an OPEN overlay refreshes it in place (the
+                        // "same Drawer.id" contract: e.g. the payment picker re-sent with
+                        // another method selected) instead of stacking a duplicate
+                        const idx = fragment.component.id
+                            ? children.findIndex(child => child.id == fragment.component!.id && this.isOverlayChild(child))
+                            : -1
+                        if (idx >= 0) {
+                            children[idx] = fragment.component
+                            this.component = { ...this.component }
+                        } else {
+                            children.push(fragment.component)
+                        }
                     }
                 } else {
                     this.callbackToken = nanoid()
@@ -59,6 +80,16 @@ export default abstract class ComponentElement extends MetadataDrivenElement {
                         if (this.component) {
                             const c0 = this.component as ServerSideComponent
                             const c1 = fragment.component as ServerSideComponent
+
+                            // an IN-PLACE re-render (same component, e.g. an action returning
+                            // `this` while a drawer is open) must not kill the open overlays —
+                            // toggling an add-on refreshes the host without closing its drawer.
+                            // NOTE: component ids are fresh uuids on every render, so the stable
+                            // signal is the serverSideType
+                            const inPlace = c0.serverSideType == c1.serverSideType
+                            const openOverlays = inPlace
+                                ? (c0.children ?? []).filter(child => this.isOverlayChild(child))
+                                : []
 
                             c0.actions = c1.actions
                             c0.type = c1.type
@@ -71,7 +102,9 @@ export default abstract class ComponentElement extends MetadataDrivenElement {
                             c0.cssClasses = c1.cssClasses
                             c0.slot = c1.slot
                             c0.style = c1.style
-                            c0.children = c1.children
+                            c0.children = openOverlays.length
+                                ? [...(c1.children ?? []), ...openOverlays]
+                                : c1.children
 
                             if (c0.serverSideType != c1.serverSideType
                                 || c0.id != c1.id) {

--- a/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/mateu-app.ts
+++ b/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/mateu-app.ts
@@ -220,7 +220,9 @@ export class MateuApp extends ComponentElement {
         if (options) {
             for (let i = 0; i < options.length; i++) {
                 const option = options[i]
-                if (option.selected) {
+                // tras una navegación en cliente manda la ruta seleccionada; el flag del
+                // wire refleja solo el momento en que se construyó el App
+                if (this.selectedRoute ? this.isActiveOption(option) : option.selected) {
                     return option
                 }
                 const foundInChildren = this.getSelectedOption(option.submenus)
@@ -454,8 +456,15 @@ export class MateuApp extends ComponentElement {
     }
 
     goHome = () => {
-        const metadata = (this.component as ClientSideComponent).metadata as App;
-        this.selectRoute(metadata.route, '_page', '', undefined, undefined, undefined)
+        // la HOME real del app la resuelve el SERVIDOR para la ruta raíz (@HomeRoute) — el
+        // homeRoute del wire es relativo a la petición con que se construyó el App (en
+        // /reservas vale /reservas), así que la vuelta a casa es una navegación de URL a la
+        // raíz, idéntica a cargar '/' (y con el dirty guard del router)
+        if (!dirtyGuard.confirmLeave()) {
+            return
+        }
+        window.history.pushState(null, '', '/')
+        window.dispatchEvent(new PopStateEvent('popstate', { state: null }))
     }
 
     selectRoute = (consumedRoute: string | undefined, route: string | undefined, _actionId: string | undefined, _baseUrl: string | undefined, serverSideType: string | undefined, uriPrefix: string | undefined ) => {
@@ -529,6 +538,16 @@ export class MateuApp extends ComponentElement {
         }
     }
 
+    // el flag selected del wire refleja la ruta en el MOMENTO de construir el App; tras una
+    // navegación en cliente manda la ruta seleccionada actual
+    private isActiveOption = (option: MenuOption): boolean => {
+        if (!this.selectedRoute) {
+            return !!option.selected
+        }
+        return !!option.route
+            && (this.selectedRoute == option.route || this.selectedRoute.startsWith(option.route + '/'))
+    }
+
     mapItems = (options: MenuOption[], filter: string): MenuBarItem[] => {
         return (options.map(option => {
             if (option.submenus && option.submenus.length > 0) {
@@ -545,7 +564,7 @@ export class MateuApp extends ComponentElement {
                         serverSideType: option.serverSideType,
                         uriPrefix: option.uriPrefix,
                         actionId: option.actionId,
-                        selected: filter || option.selected,
+                        selected: filter || this.isActiveOption(option),
                         children
                     }
                 }
@@ -565,7 +584,7 @@ export class MateuApp extends ComponentElement {
                     serverSideType: option.serverSideType,
                     uriPrefix: option.uriPrefix,
                     actionId: option.actionId,
-                    selected: filter || option.selected,
+                    selected: filter || this.isActiveOption(option),
                 }
             } else return undefined
         }) as Array<MenuBarItem | undefined>).filter((option): option is MenuBarItem => option != null)

--- a/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/mateu-status-list.ts
+++ b/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/mateu-status-list.ts
@@ -2,6 +2,7 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from 'lit/decorators.js';
 import StatusItem from "@mateu/shared/apiClients/dtos/componentmetadata/StatusItem";
 import { chipStyles } from "@infra/ui/uxShared.ts";
+import { icon } from "@infra/ui/renderers/neutralIcon.ts";
 
 /**
  * Bordered list of rows with an icon (or a circular initials avatar), a title + muted description,
@@ -20,6 +21,8 @@ export class MateuStatusList extends LitElement {
     @property() rowActionId: string | undefined
     /** N-column responsive grid instead of a single stack; 0 = classic one-column list */
     @property({ type: Number }) columns = 0
+    /** heading level of item titles in stacked mode (3 → h3, 4 → h4 under an h3 group) */
+    @property({ type: Number }) itemHeadingLevel = 3
 
     static styles = [chipStyles, css`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
@@ -79,9 +82,48 @@ export class MateuStatusList extends LitElement {
         .list.grid {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(min(18rem, 100%), 1fr));
-            column-gap: 1.5rem;
+            column-gap: 2.5rem;
+            row-gap: 1rem;
         }
+        .list.grid .cell { padding: .6rem 0; }
         .list.grid .row + .row { border-top: none; }
+        /* STACKED cells (items with actions or a timeline): borderless card — title + status
+           chip on the same line, description below, icon actions below. Mirrors the VB/Redwood
+           check-in anatomy (pax fichas / operations checklist). */
+        .list.stacked { border: none; border-radius: 0; overflow: visible; }
+        .cell { display: flex; flex-direction: column; gap: .2rem; padding: .5rem 0; }
+        .cell + .cell { border-top: none; }
+        .list.stacked:not(.grid) .cell + .cell { margin-top: .6rem; }
+        /* a single-column stack (e.g. the guests rail) keeps card-sized cells — same width
+           as the operations grid cells, however wide the hosting fold grows */
+        .list.stacked:not(.grid) .cell { max-width: 22rem; }
+        .cell-title-row { display: flex; align-items: center; gap: .5rem; min-width: 0; }
+        .cell-title {
+            margin: 0; font-weight: 600; color: var(--lumo-body-text-color, #222);
+            overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+        }
+        h3.cell-title { font-size: var(--lumo-font-size-m, 1rem); }
+        h4.cell-title { font-size: var(--lumo-font-size-s, .875rem); }
+        /* the status chip aligns to the RIGHT edge of the card */
+        .cell-title-row .chip { margin-left: auto; }
+        .cell-description {
+            font-size: var(--lumo-font-size-xs, .75rem);
+            color: var(--lumo-secondary-text-color, #888);
+        }
+        .cell-line {
+            font-size: var(--lumo-font-size-xs, .75rem);
+            color: var(--lumo-secondary-text-color, #888);
+        }
+        .cell-actions { display: flex; gap: .35rem; padding-top: .25rem; }
+        .icon-action {
+            display: inline-flex; align-items: center; justify-content: center;
+            width: 2rem; height: 2rem;
+            border: none; border-radius: var(--lumo-border-radius-m, 6px);
+            background: transparent;
+            color: var(--lumo-primary-text-color, #1a73e8);
+            cursor: pointer; font-size: 1rem;
+        }
+        .icon-action:hover { background: var(--lumo-contrast-5pct, rgba(0,0,0,.04)); }
     `]
 
     private runAction(item: StatusItem, actionId?: string) {
@@ -102,10 +144,57 @@ export class MateuStatusList extends LitElement {
         }))
     }
 
-    render() {
+    /** one of the item's up-to-three actions, as an ICON button (label = tooltip) when it
+     *  carries an icon, or the classic small text button otherwise */
+    private renderItemAction(item: StatusItem, label?: string, actionId?: string, iconName?: string) {
+        if (!label || !actionId) return nothing
+        if (iconName) {
+            return html`
+                <button class="icon-action" title="${label}" aria-label="${label}"
+                    @click="${(e: Event) => { e.stopPropagation(); this.runAction(item, actionId) }}">
+                    ${icon(iconName)}
+                </button>`
+        }
         return html`
-            <div class="list ${this.compact ? 'compact' : ''} ${this.frameless ? 'frameless' : ''} ${this.columns > 1 ? 'grid' : ''}"
-                 style="${this.columns > 1 ? `grid-template-columns: repeat(auto-fit, minmax(min(18rem, calc(100% / ${this.columns} - 1.5rem)), 1fr));` : ''}">
+            <button class="row-action" title="${label}"
+                @click="${(e: Event) => { e.stopPropagation(); this.runAction(item, actionId) }}">${label}</button>`
+    }
+
+    render() {
+        // STACKED mode (the VB/Redwood check-in anatomy): items carrying their own actions or a
+        // timeline render as borderless cards — title + chip on one line, description below,
+        // icon actions below. Plain status rows (and rowActionId listings) keep the classic row.
+        const stacked = this.columns > 1
+            || this.items.some(item => item.actionId || item.actionId2 || item.actionId3 || (item.lines?.length ?? 0) > 0)
+        const heading = this.itemHeadingLevel === 4 ? 'h4' : 'h3'
+        if (stacked) {
+            return html`
+                <div class="list stacked ${this.compact ? 'compact' : ''} ${this.columns > 1 ? 'grid' : ''}"
+                     style="${this.columns > 1 ? `grid-template-columns: repeat(auto-fit, minmax(min(18rem, calc(100% / ${this.columns} - 1.5rem)), 1fr));` : ''}">
+                    ${this.items.map(item => html`
+                        <div class="cell ${(item.lines?.length ?? 0) > 0 ? 'with-lines' : ''} ${this.rowActionId ? 'clickable' : ''}"
+                             @click="${() => this.rowClicked(item)}">
+                            <div class="cell-title-row">
+                                ${heading === 'h4'
+                                    ? html`<h4 class="cell-title">${item.title}</h4>`
+                                    : html`<h3 class="cell-title">${item.title}</h3>`}
+                                ${item.status ? html`<span class="chip ${item.statusColor ?? ''}">${item.status}</span>` : nothing}
+                            </div>
+                            ${item.description ? html`<span class="cell-description">${item.description}</span>` : nothing}
+                            ${(item.lines ?? []).map(line => html`<span class="cell-line">${line}</span>`)}
+                            ${(item.actionId || item.actionId2 || item.actionId3) ? html`
+                                <div class="cell-actions">
+                                    ${this.renderItemAction(item, item.actionLabel, item.actionId, item.actionIcon)}
+                                    ${this.renderItemAction(item, item.actionLabel2, item.actionId2, item.actionIcon2)}
+                                    ${this.renderItemAction(item, item.actionLabel3, item.actionId3, item.actionIcon3)}
+                                </div>` : nothing}
+                        </div>
+                    `)}
+                </div>
+            `
+        }
+        return html`
+            <div class="list ${this.compact ? 'compact' : ''} ${this.frameless ? 'frameless' : ''}">
                 ${this.items.map(item => html`
                     <div class="row ${this.rowActionId ? 'clickable' : ''}"
                          @click="${() => this.rowClicked(item)}">
@@ -117,15 +206,6 @@ export class MateuStatusList extends LitElement {
                             ${item.description ? html`<span class="description">${item.description}</span>` : nothing}
                         </div>
                         ${item.status ? html`<span class="chip ${item.statusColor ?? ''}">${item.status}</span>` : nothing}
-                        ${item.actionLabel && item.actionId
-                            ? html`<button class="row-action" @click="${() => this.runAction(item, item.actionId)}">${item.actionLabel}</button>`
-                            : nothing}
-                        ${item.actionLabel2 && item.actionId2
-                            ? html`<button class="row-action" @click="${() => this.runAction(item, item.actionId2)}">${item.actionLabel2}</button>`
-                            : nothing}
-                        ${item.actionLabel3 && item.actionId3
-                            ? html`<button class="row-action" @click="${() => this.runAction(item, item.actionId3)}">${item.actionLabel3}</button>`
-                            : nothing}
                     </div>
                 `)}
             </div>

--- a/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/mateu-table-crud.ts
+++ b/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/mateu-table-crud.ts
@@ -406,7 +406,21 @@ export class MateuTableCrud extends LitElement {
         const metadata = component.metadata as Crud
         metadata.serverSideOrdering = true
 
-        const toolbar = metadata?.toolbar ?? []
+        // a ROUTED listing shows its toolbar in the PAGE header (title + actions on one
+        // line) — when a mateu-page ancestor carries a toolbar, the crud's copy stands down;
+        // a standalone crud mediator (AutoCrud, no page wrapper) keeps rendering its own
+        const pageShowsToolbar = (() => {
+            let node: Node | null = this
+            while (node) {
+                const el = node as any
+                if (el.tagName === 'MATEU-PAGE') {
+                    return ((el.component?.metadata?.toolbar?.length ?? 0) > 0)
+                }
+                node = el.parentElement ?? ((el.getRootNode?.() instanceof ShadowRoot) ? (el.getRootNode() as ShadowRoot).host : null)
+            }
+            return false
+        })()
+        const toolbar = pageShowsToolbar ? [] : (metadata?.toolbar ?? [])
         const navButtons = toolbar.filter(b => isNavButton(b.actionId))
         const actionButtons = toolbar.filter(b => !isNavButton(b.actionId))
         const hasDivider = navButtons.length > 0 && actionButtons.length > 0

--- a/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/renderers/appRenderer.ts
+++ b/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/renderers/appRenderer.ts
@@ -301,7 +301,7 @@ export const renderApp = (container: MateuApp, metadata: App, _baseUrl: string |
                         <a href="javascript: void(0);" @click="${() => container.goHome()}" style="text-decoration: none; color: inherit; flex-shrink: 0;">
                         <div class="m-hl" style="align-items: center;">
                             ${metadata.logo?html`<img src="${metadata.logo}" alt="logo" height="28px" style="margin-left: 10px;">`:nothing}
-                            ${metadata.title?html`<h2 style="margin: 0; margin-left: 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;">${metadata.title}</h2>`:nothing}
+                            ${metadata.title?html`<h2 style="margin: 0 var(--lumo-space-l, 1.5rem) 0 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;">${metadata.title}</h2>`:nothing}
                         </div>
                         </a>
                         ${(() => {
@@ -351,7 +351,7 @@ export const renderApp = (container: MateuApp, metadata: App, _baseUrl: string |
                         <a href="javascript: void(0);" @click="${() => { container.goHome(); container.tilesMenuOption = null; }}" style="text-decoration: none; color: inherit; flex-shrink: 0;">
                         <div class="m-hl" style="align-items: center;">
                             ${metadata.logo?html`<img src="${metadata.logo}" alt="logo" height="28px" style="margin-left: 10px;">`:nothing}
-                            ${metadata.title?html`<h2 style="margin: 0; margin-left: 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;">${metadata.title}</h2>`:nothing}
+                            ${metadata.title?html`<h2 style="margin: 0 var(--lumo-space-l, 1.5rem) 0 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;">${metadata.title}</h2>`:nothing}
                         </div>
                         </a>
                         ${renderNeutralNav(container.mapItemsForTiles(metadata.menu), fireSelect(container, container.itemSelectedTiles), 'menu-on-top')}
@@ -469,7 +469,7 @@ export const renderApp = (container: MateuApp, metadata: App, _baseUrl: string |
                             <a href="javascript: void(0);" @click="${() => container.goHome()}" style="text-decoration: none; color: inherit; flex-shrink: 0;">
                             <div class="m-hl" style="align-items: center;">
                                 ${metadata.logo?html`<img src="${metadata.logo}" alt="logo" height="28px" style="margin-left: 10px;">`:nothing}
-                                ${metadata.title?html`<h2 style="margin: 0; margin-left: 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;">${metadata.title}</h2>`:nothing}
+                                ${metadata.title?html`<h2 style="margin: 0 var(--lumo-space-l, 1.5rem) 0 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;">${metadata.title}</h2>`:nothing}
                             </div>
                             </a>
                             <nav class="mateu-tabs ${container.component?.cssClasses ?? ''}" style="flex-grow: 1; min-width: 0;">

--- a/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/renderers/dashboardRenderer.ts
+++ b/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/renderers/dashboardRenderer.ts
@@ -83,6 +83,16 @@ export const renderDashboardPanel = (container: LitElement, component: ClientSid
     const metadata = component.metadata as DashboardPanel
     const colSpan = metadata.colSpan && metadata.colSpan > 1 ? `grid-column: span ${metadata.colSpan};` : ''
     const rowSpan = metadata.rowSpan && metadata.rowSpan > 1 ? `grid-row: span ${metadata.rowSpan};` : ''
+    // a panel whose ONLY content is a MetricCard renders the metric ALONE: the metric brings its
+    // own card and title, so the panel chrome would be a double frame with a redundant heading
+    const children = component.children ?? []
+    if (children.length === 1
+        && (children[0] as ClientSideComponent).metadata?.type === 'MetricCard') {
+        return html`
+            <div style="min-width: 0; ${colSpan} ${rowSpan} ${component.style??''}" slot="${component.slot??nothing}">
+                ${renderComponent(container, children[0], baseUrl, state, data, appState, appData)}
+            </div>`
+    }
     return html`
         <div class="mateu-dashboard-panel ${component.cssClasses??''}"
              style="${cardSurface} display: flex; flex-direction: column; gap: .5rem; min-width: 0; ${colSpan} ${rowSpan} ${component.style??''}"

--- a/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/renderers/statusListRenderer.ts
+++ b/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/renderers/statusListRenderer.ts
@@ -12,6 +12,7 @@ export const renderStatusList = (component: ClientSideComponent) => {
                 ?compact="${metadata.compact ?? false}"
                 ?frameless="${metadata.frameless ?? false}"
                 columns="${metadata.columns ?? 0}"
+                itemHeadingLevel="${metadata.itemHeadingLevel ?? 3}"
                 rowActionId="${ifDefined(metadata.rowActionId ?? undefined)}"
                 style="${component.style??nothing}"
                 class="${component.cssClasses??nothing}"

--- a/frontend/web/monorepo/yarn.lock
+++ b/frontend/web/monorepo/yarn.lock
@@ -89,161 +89,14 @@
     htm "^3.1.1"
     preact "^10.29.2"
 
-"@emnapi/core@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.11.1.tgz#b9e1064f3a6b1631e241e638eb48d736bfd372a6"
-  integrity sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==
-  dependencies:
-    "@emnapi/wasi-threads" "1.2.2"
-    tslib "^2.4.0"
-
-"@emnapi/runtime@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.11.1.tgz#58f1f3d5d81a9b12f793ab688c96371901027c24"
-  integrity sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==
-  dependencies:
-    tslib "^2.4.0"
-
-"@emnapi/wasi-threads@1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz#4c93becf5bfa3b13d1bbdcc06aee38321ad8139a"
-  integrity sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==
-  dependencies:
-    tslib "^2.4.0"
-
-"@esbuild/aix-ppc64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz#7a01a8d2ec2fbb2dac78adad09b0fa781e4082be"
-  integrity sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==
-
-"@esbuild/android-arm64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz#b540a27d14e4afd058496a4dbec4d3f414db110a"
-  integrity sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==
-
-"@esbuild/android-arm@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.28.1.tgz#704bd297de6d762de54eabbeafbf55f6756abe2f"
-  integrity sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==
-
-"@esbuild/android-x64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.28.1.tgz#d1cb166d34b0fbf0fe8ab460a5594f24a378701e"
-  integrity sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==
-
 "@esbuild/darwin-arm64@0.28.1":
   version "0.28.1"
   resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz"
   integrity sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==
 
-"@esbuild/darwin-x64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz#65556a432a1e4d72032d8218c1932fcca1a49772"
-  integrity sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==
-
-"@esbuild/freebsd-arm64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz#2e61e0592f9030d7e3dae18ee25ebc535918aef6"
-  integrity sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==
-
-"@esbuild/freebsd-x64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz#c95ec289959ef8079c4dca817a1e2c4be66b9bd3"
-  integrity sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==
-
-"@esbuild/linux-arm64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz#40b22175dda06182f3ee8141186c5ff304c4a717"
-  integrity sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==
-
-"@esbuild/linux-arm@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz#c09a0f67917592ac0de892a9be4d3814debd2a6c"
-  integrity sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==
-
-"@esbuild/linux-ia32@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz#a580f9c676797833891e519fc7a1337c8afd8db3"
-  integrity sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==
-
-"@esbuild/linux-loong64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz#46452cf321dc7f9e91c2fa780a56bb56e79cd68b"
-  integrity sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==
-
-"@esbuild/linux-mips64el@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz#4211b3184dd6608f53dcb22e39f5d34ee08852c8"
-  integrity sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==
-
-"@esbuild/linux-ppc64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz#697857c2a61cb9b0b6bb6652e40c1dc5e1ca8e5d"
-  integrity sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==
-
-"@esbuild/linux-riscv64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz#d192943eb146a40ac4c6497d0cf7be35b986bf08"
-  integrity sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==
-
-"@esbuild/linux-s390x@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz#acea0356da0e0ebc08f97cf7b9c2e401e1e648dc"
-  integrity sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==
-
-"@esbuild/linux-x64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz#6f0c3ce0cb64c534b70c4c45ecb2c16d34e35dfd"
-  integrity sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==
-
-"@esbuild/netbsd-arm64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz#8bcd77077a0dce3378b574fedb26d2a253b73d36"
-  integrity sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==
-
-"@esbuild/netbsd-x64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz#e7fb2a01e99c830c94e6623cd9fefb4c8fb58347"
-  integrity sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==
-
-"@esbuild/openbsd-arm64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz#c52909372db8b86e2c55e05a8940033b5660a3b2"
-  integrity sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==
-
-"@esbuild/openbsd-x64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz#c427b9be5a64c262ff9a7eb70b5fbbaadf446c6c"
-  integrity sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==
-
-"@esbuild/openharmony-arm64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz#dc9b147baca2e6c4b3c85571741ef4860a489097"
-  integrity sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==
-
-"@esbuild/sunos-x64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz#ce866d12df13c15e4c99f073a3d466f6e0649b3a"
-  integrity sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==
-
-"@esbuild/win32-arm64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz#7468e3692d01d629d5941e5d83817bb80f9e39b4"
-  integrity sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==
-
-"@esbuild/win32-ia32@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz#a5bc0063fb2bcab6d0ed63f2a1537958bc269ec6"
-  integrity sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==
-
-"@esbuild/win32-x64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz#10064ee44f4347b90c9a02b446bbf80a91632b12"
-  integrity sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==
-
 "@fabricelements/skeleton-carousel@3.0.2":
   version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@fabricelements/skeleton-carousel/-/skeleton-carousel-3.0.2.tgz#644181294ebbb00c19c28b3e38d149a261fe0d2d"
+  resolved "https://registry.npmjs.org/@fabricelements/skeleton-carousel/-/skeleton-carousel-3.0.2.tgz"
   integrity sha512-lPdaSnFjyX1eTpJsmrU/kB1NY4Q747mtZ9wDm+oRoCGmMcmPfWoqeW/XDTWPbJXKqfS7m6aB7M9TE8kQBxaftg==
   dependencies:
     "@polymer/gen-typescript-declarations" "^1.2.2"
@@ -285,17 +138,10 @@
   resolved "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz"
   integrity sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==
 
-"@lit-labs/ssr-dom-shim@^1.0.0", "@lit-labs/ssr-dom-shim@^1.1.0", "@lit-labs/ssr-dom-shim@^1.1.2", "@lit-labs/ssr-dom-shim@^1.5.0":
+"@lit-labs/ssr-dom-shim@^1.1.2", "@lit-labs/ssr-dom-shim@^1.5.0":
   version "1.6.0"
   resolved "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz"
   integrity sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==
-
-"@lit/reactive-element@^1.3.0", "@lit/reactive-element@^1.6.0":
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/@lit/reactive-element/-/reactive-element-1.6.3.tgz#25b4eece2592132845d303e091bad9b04cdcfe03"
-  integrity sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==
-  dependencies:
-    "@lit-labs/ssr-dom-shim" "^1.0.0"
 
 "@lit/reactive-element@^2.1.0":
   version "2.1.2"
@@ -333,27 +179,27 @@
   resolved "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz"
   integrity sha512-HPnRdYO0WjFjRTSwO3frz1wKaU649OBFPX3Zo/2WZvuRi6zMiRGui8SnPQiQABgqCf8YikDe5t3HViTVw1WUzA==
 
-"@microsoft/api-extractor-model@7.33.8":
-  version "7.33.8"
-  resolved "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.33.8.tgz"
-  integrity sha512-aIcoQggPyer3B6Ze3usz0YWC/oBwUHfRH5ETUsr+oT2BRA6SfTJl7IKPcPZkX4UR+PohowzW4uMxsvjrn8vm+w==
+"@microsoft/api-extractor-model@7.33.10":
+  version "7.33.10"
+  resolved "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.33.10.tgz"
+  integrity sha512-uPUK17xGxeQ3av6TN7awp+dTTSTvx8fZC0XFL1gyt7hFapYuxND3XLXH8vkmI7UjfW92oogzFAFqHSifmJROaw==
   dependencies:
     "@microsoft/tsdoc" "~0.16.0"
     "@microsoft/tsdoc-config" "~0.18.1"
-    "@rushstack/node-core-library" "5.23.1"
+    "@rushstack/node-core-library" "5.23.3"
 
 "@microsoft/api-extractor@^7.50.1":
-  version "7.58.9"
-  resolved "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.58.9.tgz"
-  integrity sha512-S2UF4yza5GoxCmf7hJQNxJNZN9ltOVuOQv8Dy+Z21aol5ERoBNMdWcQHm4MJMPPItW4H/4rZD906iaf4mUojJA==
+  version "7.58.12"
+  resolved "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.58.12.tgz"
+  integrity sha512-VNpgC/1LaroLbn+UKmwDYspq+9r3EHyj4vJ3qUy/g8vB0rKt+1Wgs7WFj/JGpgxhG8SNyXs1XwYwe7nqkk8IDg==
   dependencies:
-    "@microsoft/api-extractor-model" "7.33.8"
+    "@microsoft/api-extractor-model" "7.33.10"
     "@microsoft/tsdoc" "~0.16.0"
     "@microsoft/tsdoc-config" "~0.18.1"
-    "@rushstack/node-core-library" "5.23.1"
+    "@rushstack/node-core-library" "5.23.3"
     "@rushstack/rig-package" "0.7.3"
-    "@rushstack/terminal" "0.24.0"
-    "@rushstack/ts-command-line" "5.3.10"
+    "@rushstack/terminal" "0.24.2"
+    "@rushstack/ts-command-line" "5.3.12"
     diff "~8.0.2"
     minimatch "10.2.3"
     resolve "~1.22.1"
@@ -371,17 +217,10 @@
     jju "~1.4.0"
     resolve "~1.22.2"
 
-"@microsoft/tsdoc@0.16.0", "@microsoft/tsdoc@~0.16.0":
+"@microsoft/tsdoc@~0.16.0", "@microsoft/tsdoc@0.16.0":
   version "0.16.0"
   resolved "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz"
   integrity sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==
-
-"@napi-rs/wasm-runtime@^1.1.6":
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz#ed33806d0f9be98dc76d0c3d4fd872fda701b5d5"
-  integrity sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==
-  dependencies:
-    "@tybys/wasm-util" "^0.10.3"
 
 "@ngyewch/chartjs-v4-webcomponent@^0.4.0":
   version "0.4.0"
@@ -395,7 +234,7 @@
 
 "@oracle/oraclejet-preact@19.0.9":
   version "19.0.9"
-  resolved "https://registry.yarnpkg.com/@oracle/oraclejet-preact/-/oraclejet-preact-19.0.9.tgz#1f7536f0d501c14498e47b0d17c2774a40ffd106"
+  resolved "https://registry.npmjs.org/@oracle/oraclejet-preact/-/oraclejet-preact-19.0.9.tgz"
   integrity sha512-CsrU7jHvpdTtirhUBvZL5wKu7Uq+DhFzSR+RMQlY5OWs704F4QTAU/E6MLRuE2j2xmHfaS8+1LpqTOKM9hSOQg==
   dependencies:
     "@oracle/oraclejet-testing" "19.0.9"
@@ -403,12 +242,12 @@
 
 "@oracle/oraclejet-testing@19.0.9":
   version "19.0.9"
-  resolved "https://registry.yarnpkg.com/@oracle/oraclejet-testing/-/oraclejet-testing-19.0.9.tgz#20dace152d6e96a0ce84253d701d2dcc433e08ed"
+  resolved "https://registry.npmjs.org/@oracle/oraclejet-testing/-/oraclejet-testing-19.0.9.tgz"
   integrity sha512-lp92aAdbvM1j5mAtPy+VXcUaix53zq7uzqS/8YomnOh8o8uebTmBt78mN87sb9pE2LAzENXCTeeN65NRNCP9Pw==
 
 "@oxc-project/types@=0.139.0":
   version "0.139.0"
-  resolved "https://registry.yarnpkg.com/@oxc-project/types/-/types-0.139.0.tgz#38d76b9dbf934c2a02be174fb32ceebf182fe742"
+  resolved "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz"
   integrity sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==
 
 "@petamoriken/float16@^3.4.7":
@@ -607,93 +446,19 @@
   dependencies:
     "@webcomponents/shadycss" "^1.9.1"
 
-"@rolldown/binding-android-arm64@1.1.5":
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz#f58cb9a0a8128ed0582282720528547fc5c035f3"
-  integrity sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==
-
 "@rolldown/binding-darwin-arm64@1.1.5":
   version "1.1.5"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz#441144c05a4a831aa75269abc3a4a324374ea707"
+  resolved "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz"
   integrity sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==
-
-"@rolldown/binding-darwin-x64@1.1.5":
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz#c82e30652cef52c4af925d5c66c8955a40319816"
-  integrity sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==
-
-"@rolldown/binding-freebsd-x64@1.1.5":
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz#c32e9ce7fa1c0fb2b80913a2a3a05c3e907d06b0"
-  integrity sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==
-
-"@rolldown/binding-linux-arm-gnueabihf@1.1.5":
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz#ce90b5e22316adeb502ea010582f498cd0604f27"
-  integrity sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==
-
-"@rolldown/binding-linux-arm64-gnu@1.1.5":
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz#91947110c4ddaa4eefb004e52688070977085201"
-  integrity sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==
-
-"@rolldown/binding-linux-arm64-musl@1.1.5":
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz#eb32b2d4108c1c702b91e8cde8a043eae5caa94d"
-  integrity sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==
-
-"@rolldown/binding-linux-ppc64-gnu@1.1.5":
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz#ccb943c11e5a72655cbb02fc1163541ceb640782"
-  integrity sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==
-
-"@rolldown/binding-linux-s390x-gnu@1.1.5":
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz#a33731ee567e90b75fac6e5e55307e8a2b3038f0"
-  integrity sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==
-
-"@rolldown/binding-linux-x64-gnu@1.1.5":
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz#a74c01aaacedfc11c39b6feba33a5fa0c654949f"
-  integrity sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==
-
-"@rolldown/binding-linux-x64-musl@1.1.5":
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz#28cd178494fa1e65dba412229b5ce55c4dd5cbd1"
-  integrity sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==
-
-"@rolldown/binding-openharmony-arm64@1.1.5":
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz#f7c75fa913fc20884d26a7d488d4f5c597cd71c0"
-  integrity sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==
-
-"@rolldown/binding-wasm32-wasi@1.1.5":
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz#c379581947787081df363ea106140fcd5fec252d"
-  integrity sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==
-  dependencies:
-    "@emnapi/core" "1.11.1"
-    "@emnapi/runtime" "1.11.1"
-    "@napi-rs/wasm-runtime" "^1.1.6"
-
-"@rolldown/binding-win32-arm64-msvc@1.1.5":
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz#f23c88694f7a729a12f395024aee38df80a16ba3"
-  integrity sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==
-
-"@rolldown/binding-win32-x64-msvc@1.1.5":
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz#3377c8de0e56a8857f11217561147090e874cb46"
-  integrity sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==
 
 "@rolldown/pluginutils@^1.0.0":
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz#e3fcee093fbb5ce765e1ad088ff4de2889f6f9be"
+  resolved "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz"
   integrity sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==
 
 "@rollup/plugin-node-resolve@^15.0.1":
   version "15.3.1"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.3.1.tgz#66008953c2524be786aa319d49e32f2128296a78"
+  resolved "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.3.1.tgz"
   integrity sha512-tgg6b91pAybXHJQMAAwW9VuWBO6Thi+q7BCNARLwSqlmsHz0XYURtGvh/AuwSADXSI4h/2uHbs7s4FzlZDGSGA==
   dependencies:
     "@rollup/pluginutils" "^5.0.1"
@@ -711,262 +476,17 @@
     estree-walker "^2.0.2"
     picomatch "^4.0.2"
 
-"@rollup/rollup-android-arm-eabi@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz#5e9849b661c2229cf967a08dbe2dbbe9e8c991e5"
-  integrity sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==
-
-"@rollup/rollup-android-arm-eabi@4.62.3":
-  version "4.62.3"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.3.tgz#b0ab422fb60f3583c8c789e856d64a32507f299e"
-  integrity sha512-c0wdcekXtQvvn5Tsrk/+op/gUArrbWaFduBnTLP2l1cKLSQs4diMWjJw3m6A0DdzT8dAAX95KpkJ3qynCePbmw==
-
-"@rollup/rollup-android-arm64@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz#5b0699ee5dd484b222c9ed74aff43c91ea8b17f8"
-  integrity sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==
-
-"@rollup/rollup-android-arm64@4.62.3":
-  version "4.62.3"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.3.tgz#047e967eeb440a299f1abc773579b5c2516fa48d"
-  integrity sha512-3YjElDdWN+qXAFbJ/CzPV+0wspLqh54k/I6GfdYtEJRqg7buSgc1yPM3B+93j1M4neobtkATHZTmxK2AMVGfnA==
-
 "@rollup/rollup-darwin-arm64@4.62.2":
   version "4.62.2"
   resolved "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz"
   integrity sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==
 
-"@rollup/rollup-darwin-arm64@4.62.3":
-  version "4.62.3"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.3.tgz#18369e67d0d3ffcb01a95561217447b791727697"
-  integrity sha512-Pch2pFNOxxz1hTjypIdPyRTR6riiwRl84+VcN9djS680fw+Co1nAJINrdpqp7KV0NvyuU8ilZXZCjd7ykJl1GQ==
-
-"@rollup/rollup-darwin-x64@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz#ba2ef3e8fb310f0af35588f270cfa5aa96e48764"
-  integrity sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==
-
-"@rollup/rollup-darwin-x64@4.62.3":
-  version "4.62.3"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.3.tgz#bf23ae4c5c0f841b123bc79e3b246176c6d08fd7"
-  integrity sha512-LEuncFUHFiF8t4yZVZvvZA1wk0pjAscRnsrn1EfTEmN4HXotBi2YtcnLRyaK6UbuczW7xZS5ES+81Rdz8Z0T6g==
-
-"@rollup/rollup-freebsd-arm64@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz#93b10bdbfe8ada226b8bc0c02ef6b7f544474d96"
-  integrity sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==
-
-"@rollup/rollup-freebsd-arm64@4.62.3":
-  version "4.62.3"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.3.tgz#c92a1b07d0243181f26d9deb278c3ef09e01f065"
-  integrity sha512-zvBUvsQUpOWALdDsk6qbS8bXf2VxmPisuudNDrY7x0p0jBdsoZl8HsHczIOgkQiZldmcacMKtBzpoGVNeIe2bQ==
-
-"@rollup/rollup-freebsd-x64@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz#3e8aa38ef3c9c300946871e3fdbb0c30e0a20f86"
-  integrity sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==
-
-"@rollup/rollup-freebsd-x64@4.62.3":
-  version "4.62.3"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.3.tgz#b69da0407ea06497d395be0e799cc601004b372e"
-  integrity sha512-C2KmNrcSem/AMg984H/dev+si0lieQGdXdR/lYGJnuumXnFb9Y7QdiI62obFdLlxRYLBv4P0eUVIDbD4c1vVvw==
-
-"@rollup/rollup-linux-arm-gnueabihf@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz#1d7994384bb0ad1bc41921b506e1642d4f9d7fc3"
-  integrity sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==
-
-"@rollup/rollup-linux-arm-gnueabihf@4.62.3":
-  version "4.62.3"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.3.tgz#1b4b63c57fc20e6ea4748a8ea864d86513328ec4"
-  integrity sha512-ggXnsTAEzNQx74XpunRsiZ9aBZDsI7XIa0hm2nzR9f4WzH5/f/d73ZSDaC5ejJ8YLY4NW+V3wr0tjOaeCq8hqA==
-
-"@rollup/rollup-linux-arm-musleabihf@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz#a6540f47cf844a56b80ca9ff95d2acdfb2cef97b"
-  integrity sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==
-
-"@rollup/rollup-linux-arm-musleabihf@4.62.3":
-  version "4.62.3"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.3.tgz#64334f5a5178cabb15e7d2a91fb592db1f8621d3"
-  integrity sha512-2vng+FlzNUhKZxtej3IUqJgbZoQk2M/dwQM20+ULV0R/E/8tr9/P6uEf2iiGIk4HL0zMKh5Jry7mUHdUOvyGgA==
-
-"@rollup/rollup-linux-arm64-gnu@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz#404f2045651840cbf48da91ba6d0f490f0bc2cbf"
-  integrity sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==
-
-"@rollup/rollup-linux-arm64-gnu@4.62.3":
-  version "4.62.3"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.3.tgz#1ff299f7825f0f52a8e107dac7f15ce73009848b"
-  integrity sha512-LLLFZKt4/Nraf9rxDkhiU8QVgLF4WmCkfr0L4fj0fPfIZFBib0DeiFk1hhaYKd03LFAFJcxHslhDFlNJLylf5Q==
-
-"@rollup/rollup-linux-arm64-musl@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz#a3404ffddf7b474b48c99b9c893b6247bb765ba5"
-  integrity sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==
-
-"@rollup/rollup-linux-arm64-musl@4.62.3":
-  version "4.62.3"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.3.tgz#99052380e7a94fa440b9166c67a909aa3572f089"
-  integrity sha512-WJkdQCvS9sWNOUBJZfQRKpZGFBztRzcowI+nndmflKgU4XY+3a420FgTOSKTsVqJbnzSxeT4vaJalpOaPo2YCQ==
-
-"@rollup/rollup-linux-loong64-gnu@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz#e8aac6d549b377945e349882f199b7c8eb75ca38"
-  integrity sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==
-
-"@rollup/rollup-linux-loong64-gnu@4.62.3":
-  version "4.62.3"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.3.tgz#5f58b576b3668edf62acf0c5265826267b7d858f"
-  integrity sha512-PwHXCCS2n64/1Ot6rP1YEYA02MGYBcQlr8CSZZyrUG2O7NH6NklYmvr9v3Jy+5e/eDeNchc/ukmKJi9LuflMIQ==
-
-"@rollup/rollup-linux-loong64-musl@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz#6e2e44ea50310b3a582078a915e5feb879c820d4"
-  integrity sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==
-
-"@rollup/rollup-linux-loong64-musl@4.62.3":
-  version "4.62.3"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.3.tgz#a8cd0337e3ff3a0c95ead67715c51af77c5aff36"
-  integrity sha512-vUjxINQu3RC8NZS3ykk1gN65gIz8pAopOq2HXuZhiIxHdx7TFvDG+jgrdSgInu1Eza4/Rfi2VzZgyIgEH4WOaw==
-
-"@rollup/rollup-linux-ppc64-gnu@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz#6898302da6d77a0537cde64b2b4c6b60659bd110"
-  integrity sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==
-
-"@rollup/rollup-linux-ppc64-gnu@4.62.3":
-  version "4.62.3"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.3.tgz#6335cec15b55a6b063e34cb7e968515fa500ffd4"
-  integrity sha512-wzko4aJ13+0G3kGnviCg5gnXFKd40izKsrf2uOw12US4XqprkDrmwOpeW14aSNa37V8bfPcz5Fkob6LZ3BAPmA==
-
-"@rollup/rollup-linux-ppc64-musl@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz#333717c95dd5a66bef8f63e7ef8a9fd845fd18d0"
-  integrity sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==
-
-"@rollup/rollup-linux-ppc64-musl@4.62.3":
-  version "4.62.3"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.3.tgz#cf2b6fd238f0928c5657bb8a5ca7751dfc2e6ce4"
-  integrity sha512-8120ue0JUMSwy11stlwnfdX3pPd+WZYGCDBwEHWtIHi6pOpZmsEF5QKB7a/UN+XFdqvobxz98kv8RTqikyCEBw==
-
-"@rollup/rollup-linux-riscv64-gnu@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz#81bc06ba380352004d01f4826eb7cdccefa05bad"
-  integrity sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==
-
-"@rollup/rollup-linux-riscv64-gnu@4.62.3":
-  version "4.62.3"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.3.tgz#df9508c8721437f7e51990caaa61d2f38db73cbf"
-  integrity sha512-XLFHnR3tXMjbOCh2vtVJHmxt+995uJsTERQyseFDRA0xxMxyTZPLa3OIUlyFaO4mF/Lu0FjmWHCuPXJT1n/IOg==
-
-"@rollup/rollup-linux-riscv64-musl@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz#95a7cd39de21389ad6788a5284eaaa738e29ca4c"
-  integrity sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==
-
-"@rollup/rollup-linux-riscv64-musl@4.62.3":
-  version "4.62.3"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.3.tgz#0cfe93072f4c398bb9d666e5953371a22aba7f4a"
-  integrity sha512-se6yXvNGMIl0f+RQzyh7XAmia8/9kplQx424wnG2w0C1oi6XgO6Y8otKhdXFHbHs88Ihavzmvh1NWjuovE76BQ==
-
-"@rollup/rollup-linux-s390x-gnu@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz#06e6db2ec1bc48b5374c7923ef83c2eb024b2452"
-  integrity sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==
-
-"@rollup/rollup-linux-s390x-gnu@4.62.3":
-  version "4.62.3"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.3.tgz#f8e7bdf3d419866b688b09d9348253925232d1cb"
-  integrity sha512-gNoxRefktVIiGflpONuxWWXZAzIQG++z9qHO3xKwk4WdDMuQja3JHGfE1u0i3PfPDyvhypdk+WrgIJqLhGG7sg==
-
-"@rollup/rollup-linux-x64-gnu@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz#5dc818988285e09e88790c6462def72413df2da3"
-  integrity sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==
-
-"@rollup/rollup-linux-x64-gnu@4.62.3":
-  version "4.62.3"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.3.tgz#57ef7f039c4f7de0e913f1f2680385467b86bb15"
-  integrity sha512-V4KtWtQfAFMU7+9/A/VDps/VI8CHd3cYz0L8sgJzz8qK7eY7wI4ruFD82UYIYvW9Z4DtlTfhQcsl4XyPHW5uSg==
-
-"@rollup/rollup-linux-x64-musl@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz#2080f4a93349e9afd34be6fc1a37e01fc8bfc80f"
-  integrity sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==
-
-"@rollup/rollup-linux-x64-musl@4.62.3":
-  version "4.62.3"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.3.tgz#6f5b5693d4beb152bf518c487d259362dbece449"
-  integrity sha512-LBx9LYXvj2CBkMkjLdNAWLwH0MLMin7do2VcVo9kVPibGLkY0BQQut2fv7NVqkXqZ/CrAu9LqDHVV1xHCMpCPw==
-
-"@rollup/rollup-openbsd-x64@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz#21d64a8acb66221724b923e51af5333df1af044b"
-  integrity sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==
-
-"@rollup/rollup-openbsd-x64@4.62.3":
-  version "4.62.3"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.3.tgz#9909010093ed7fb2480c73bc193a8f4d44ffb9e3"
-  integrity sha512-ABVf3Q0RCu7NcyCCOZQI0pJ3GuSdfSl8EXcy88QtdceIMIoCUdfhsJChZ64L9zVM2aJHjde1Bhn5uqSRcX9ySA==
-
-"@rollup/rollup-openharmony-arm64@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz#8e0fcd9d02141e337b4c5b5cff576cb9a76b1ba0"
-  integrity sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==
-
-"@rollup/rollup-openharmony-arm64@4.62.3":
-  version "4.62.3"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.3.tgz#aba90b57725fcf4c4072c95a6dbfbcf7500a770d"
-  integrity sha512-+2Cy/ldweGBLlPIKsQLF8U5N44a0KDdbrk1rAjHOM9M2K+kGdIVjHLmmrZIcx+9Ny3ke/1JomCsDI1ocb11+sg==
-
-"@rollup/rollup-win32-arm64-msvc@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz#bdb4cc4efd58efe808203347f0f5463f0ea16e52"
-  integrity sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==
-
-"@rollup/rollup-win32-arm64-msvc@4.62.3":
-  version "4.62.3"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.3.tgz#12cee2b2e6d37dbb83602686812e4bba290c9aa3"
-  integrity sha512-dtZvzc8BedpSaFNy75x6uiWwAGTH+aZHDtdrqP6qk+WcLJrfti6sGje1ZJ9UxyzDLF23d/mV+PaMwuC0hL7UVA==
-
-"@rollup/rollup-win32-ia32-msvc@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz#dbaebde5afd24eae0eefe915d901632e7cb59860"
-  integrity sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==
-
-"@rollup/rollup-win32-ia32-msvc@4.62.3":
-  version "4.62.3"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.3.tgz#391a0d6f8458a675ad720cccae9bcb9a48109016"
-  integrity sha512-Rj8Ra4noo+aYy7sKBggCx0407mws34kAb1ySyWuq5DAtFBQdkSwnsjCgPrhPe9cvgBKZIukpE+CVHvORCS93kQ==
-
-"@rollup/rollup-win32-x64-gnu@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz#84109e85fea5f8f1353499f96578fdc2a0e8b138"
-  integrity sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==
-
-"@rollup/rollup-win32-x64-gnu@4.62.3":
-  version "4.62.3"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.3.tgz#3f38bb180fcf1cfa91975c4b344941e985a6ed13"
-  integrity sha512-vp7N084ew/odXn2gi/mzm9mUkQu9l6AiN6dt4IeUM2Uvm9o+cVmP+YkqbMOteLbiGgqBBlJZjIMYVCfOOIVbVQ==
-
-"@rollup/rollup-win32-x64-msvc@4.62.2":
-  version "4.62.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz#3671ce3f9b928d5c01f879792d5c0b60ae14d4ad"
-  integrity sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==
-
-"@rollup/rollup-win32-x64-msvc@4.62.3":
-  version "4.62.3"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.3.tgz#0ccafd44a8cbcb33f7feaa9e3e85033e7a52295c"
-  integrity sha512-MOG/3gTOn4Fwf574RVOaY61I5o6P90legkFADiTyn1hyjNydT+cerU2rLUwPdZkKKyJ+iT+K9p7WXK4LM1Ka6g==
-
-"@rushstack/node-core-library@5.23.1":
-  version "5.23.1"
-  resolved "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.23.1.tgz"
-  integrity sha512-wlKmIKIYCKuCASbITvOxLZXepPbwXvrv7S6ig6XNWFchSyhL/E2txmVXspHY49Wu2dzf7nI27a2k/yV5BA3EiA==
+"@rushstack/node-core-library@5.23.3":
+  version "5.23.3"
+  resolved "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.23.3.tgz"
+  integrity sha512-f6uuza7Um65bwsIJgf0MRs7IPA5IG+A+zs1AYGQvpZmLjtTGdfHowhQw4kwF0pPhJCrU4UHNhK8Qa6tLygYZCA==
   dependencies:
-    ajv "~8.18.0"
+    ajv "~8.20.0"
     ajv-draft-04 "~1.0.0"
     ajv-formats "~3.0.1"
     fs-extra "~11.3.0"
@@ -988,21 +508,21 @@
     jju "~1.4.0"
     resolve "~1.22.1"
 
-"@rushstack/terminal@0.24.0":
-  version "0.24.0"
-  resolved "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.24.0.tgz"
-  integrity sha512-8ZQS4MMaGsv27EXCBiH7WMPkRZrffeDoIevs6z9TM5dzqiY6+Hn4evfK/G+gvgBTjfvfkHIZPQQmalmI2sM4TQ==
+"@rushstack/terminal@0.24.2":
+  version "0.24.2"
+  resolved "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.24.2.tgz"
+  integrity sha512-KB7PpvzDyKMw/RGU3TxOwxTs3OwZ4gq6+WHlTJN/JfQH4ezliNtWIqver78jTaAJyz/ZAAlJGH7a/M1WyFLFSw==
   dependencies:
-    "@rushstack/node-core-library" "5.23.1"
+    "@rushstack/node-core-library" "5.23.3"
     "@rushstack/problem-matcher" "0.2.1"
     supports-color "~8.1.1"
 
-"@rushstack/ts-command-line@5.3.10":
-  version "5.3.10"
-  resolved "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.3.10.tgz"
-  integrity sha512-fwI076HYknC0IrMXdY6UmjDv+PH7NHhNJX3/pY2UblSE5XrXgndXZPiOe/6ZtuFpn6DvVDVNhtkIzQ+Qu/MhVQ==
+"@rushstack/ts-command-line@5.3.12":
+  version "5.3.12"
+  resolved "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.3.12.tgz"
+  integrity sha512-Vg2n24arSf7JvUNga2DMHYTbxnVq9L5OtVCp4Gfr8YC/kmL/bmdR8FQhGcpMzMYNY9Vdw3+TaimG11Sf+z1Tpw==
   dependencies:
-    "@rushstack/terminal" "0.24.0"
+    "@rushstack/terminal" "0.24.2"
     "@types/argparse" "1.0.38"
     argparse "~1.0.9"
     string-argv "~0.3.1"
@@ -1012,16 +532,9 @@
   resolved "https://registry.npmjs.org/@sap-theming/theming-base-content/-/theming-base-content-11.36.4.tgz"
   integrity sha512-LAcw9hDBTR4QUl2gxVWvErTmp1SHEV1kNhpWQXxv7hHfawY0VbXDv9AXhdy0XTua+PLSe/J1ZQX/eG76Dxd9rw==
 
-"@tybys/wasm-util@^0.10.3":
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.3.tgz#015cba9e9dd47ce14d03d2a8c5d547bfb169665d"
-  integrity sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==
-  dependencies:
-    tslib "^2.4.0"
-
 "@types/accepts@*":
   version "1.3.7"
-  resolved "https://registry.yarnpkg.com/@types/accepts/-/accepts-1.3.7.tgz#3b98b1889d2b2386604c2bbbe62e4fb51e95b265"
+  resolved "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.7.tgz"
   integrity sha512-Pay9fq2lM2wXPWbteBsRAGiWH2hig4ZE2asK+mm7kUzlxRTfL961rj89I6zV/E3PcIkDqyuBEcMxFT7rccugeQ==
   dependencies:
     "@types/node" "*"
@@ -1045,12 +558,7 @@
   dependencies:
     "@types/babel-types" "*"
 
-"@types/babel-types@*":
-  version "7.0.16"
-  resolved "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.16.tgz"
-  integrity sha512-5QXs9GBFTNTmilLlWBhnsprqpjfrotyrnzUdwDrywEL/DA4LuCWQT300BTOXA3Y9ngT9F2uvmCoIxI6z8DlJEA==
-
-"@types/babel-types@^6.25.1":
+"@types/babel-types@*", "@types/babel-types@^6.25.1":
   version "6.25.2"
   resolved "https://registry.npmjs.org/@types/babel-types/-/babel-types-6.25.2.tgz"
   integrity sha512-+3bMuktcY4a70a0KZc8aPJlEOArPuAKQYHU5ErjkOqGJdx8xuEEVK6nWogqigBOJ8nKPxRpyCUDTCPmZ3bUxGA==
@@ -1064,7 +572,7 @@
 
 "@types/body-parser@*":
   version "1.19.6"
-  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.6.tgz#1859bebb8fd7dac9918a45d54c1971ab8b5af474"
+  resolved "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz"
   integrity sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==
   dependencies:
     "@types/connect" "*"
@@ -1082,6 +590,13 @@
   dependencies:
     "@types/deep-eql" "*"
     assertion-error "^2.0.1"
+
+"@types/chai@<5.2.0":
+  version "5.0.1"
+  resolved "https://registry.npmjs.org/@types/chai/-/chai-5.0.1.tgz"
+  integrity sha512-5T8ajsg3M/FOncpLYW7sdOcD6yf4+722sze/tc4KQV0P8Z2rAr3SAuHCIkYmYpt8VbcQlnz8SxlOlPQYefe4cA==
+  dependencies:
+    "@types/deep-eql" "*"
 
 "@types/chalk@^0.4.30":
   version "0.4.31"
@@ -1105,19 +620,19 @@
 
 "@types/connect@*":
   version "3.4.38"
-  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.38.tgz#5ba7f3bc4fbbdeaff8dded952e5ff2cc53f8d858"
+  resolved "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz"
   integrity sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==
   dependencies:
     "@types/node" "*"
 
 "@types/content-disposition@*":
   version "0.5.9"
-  resolved "https://registry.yarnpkg.com/@types/content-disposition/-/content-disposition-0.5.9.tgz#00ca14939432869de829a4ccf6fd380fa9181750"
+  resolved "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.9.tgz"
   integrity sha512-8uYXI3Gw35MhiVYhG3s295oihrxRyytcRHjSjqnqZVDDy/xcGBRny7+Xj1Wgfhv5QzRtN2hB2dVRBUX9XW3UcQ==
 
 "@types/cookies@*":
   version "0.9.2"
-  resolved "https://registry.yarnpkg.com/@types/cookies/-/cookies-0.9.2.tgz#ccdf86d782f2dea34531dd32733a25be48177cd4"
+  resolved "https://registry.npmjs.org/@types/cookies/-/cookies-0.9.2.tgz"
   integrity sha512-1AvkDdZM2dbyFybL4fxpuNCaWyv//0AwsuUk2DWeXyM1/5ZKm6W3z6mQi24RZ4l2ucY+bkSHzbDVpySqPGuV8A==
   dependencies:
     "@types/connect" "*"
@@ -1135,24 +650,24 @@
   resolved "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz"
   integrity sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==
 
-"@types/doctrine@0.0.3":
-  version "0.0.3"
-  resolved "https://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.3.tgz"
-  integrity sha512-w5jZ0ee+HaPOaX25X2/2oGR/7rgAQSYII7X7pp0m9KgBfMP7uKfMfTvcpl5Dj+eDBbpxKGiqE+flqDr6XTd2RA==
-
 "@types/doctrine@^0.0.1":
   version "0.0.1"
   resolved "https://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.1.tgz"
   integrity sha512-iN9ewNbXmuWLOAB3wk/YpCqIBWK3wBNE1D/4u+jA/GyrqsE4r3ozbpS5F0fr0tIYmmnqhbVvT9OOXzt+vw+LDg==
 
-"@types/estree@1.0.9", "@types/estree@^1.0.0":
+"@types/doctrine@0.0.3":
+  version "0.0.3"
+  resolved "https://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.3.tgz"
+  integrity sha512-w5jZ0ee+HaPOaX25X2/2oGR/7rgAQSYII7X7pp0m9KgBfMP7uKfMfTvcpl5Dj+eDBbpxKGiqE+flqDr6XTd2RA==
+
+"@types/estree@^1.0.0", "@types/estree@1.0.9":
   version "1.0.9"
   resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz"
   integrity sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==
 
 "@types/express-serve-static-core@^5.0.0":
   version "5.1.2"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-5.1.2.tgz#19afe821c79f18d05946892bbd5b924b96c8a4f6"
+  resolved "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.2.tgz"
   integrity sha512-d3KvEXBSo/lOAMc2u6fkyDHBvetBHeqD7wm/AcXfLpSOQwlmG9D/aQ0SFswVjv05p7ullQS7Mjohj6/VdbZuTg==
   dependencies:
     "@types/node" "*"
@@ -1162,7 +677,7 @@
 
 "@types/express@*":
   version "5.0.6"
-  resolved "https://registry.yarnpkg.com/@types/express/-/express-5.0.6.tgz#2d724b2c990dcb8c8444063f3580a903f6d500cc"
+  resolved "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz"
   integrity sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==
   dependencies:
     "@types/body-parser" "*"
@@ -1186,12 +701,12 @@
 
 "@types/http-assert@*":
   version "1.5.6"
-  resolved "https://registry.yarnpkg.com/@types/http-assert/-/http-assert-1.5.6.tgz#b6b657c38a2350d21ce213139f33b03b2b5fa431"
+  resolved "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.6.tgz"
   integrity sha512-TTEwmtjgVbYAzZYWyeHPrrtWnfVkm8tQkP8P21uQifPgMRgjrow3XDEYqucuC8SKZJT7pUnhU/JymvjggxO9vw==
 
-"@types/http-errors@*", "@types/http-errors@^2":
+"@types/http-errors@*":
   version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@types/http-errors/-/http-errors-2.0.5.tgz#5b749ab2b16ba113423feb1a64a95dcd30398472"
+  resolved "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz"
   integrity sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==
 
 "@types/is-windows@^0.2.0":
@@ -1208,33 +723,19 @@
 
 "@types/keygrip@*":
   version "1.0.6"
-  resolved "https://registry.yarnpkg.com/@types/keygrip/-/keygrip-1.0.6.tgz#1749535181a2a9b02ac04a797550a8787345b740"
+  resolved "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.6.tgz"
   integrity sha512-lZuNAY9xeJt7Bx4t4dx0rYCDqGPW8RXhQZK1td7d4H6E9zYbLoOtjBvfwdTKpsyxQI/2jv+armjX/RW+ZNpXOQ==
 
 "@types/koa-compose@*":
   version "3.2.9"
-  resolved "https://registry.yarnpkg.com/@types/koa-compose/-/koa-compose-3.2.9.tgz#6efb945ee5573be0f4eddb728a2f6826f7a3f395"
+  resolved "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.9.tgz"
   integrity sha512-BroAZ9FTvPiCy0Pi8tjD1OfJ7bgU1gQf0eR6e1Vm+JJATy9eKOG3hQMFtMciMawiSOVnLMdmUOC46s7HBhSTsA==
   dependencies:
     "@types/koa" "*"
 
-"@types/koa@*":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@types/koa/-/koa-3.0.3.tgz#aa41a80d0d9fed1e3b87d33d1a7057c8badeb668"
-  integrity sha512-TdtNEJ7sYSrFQcVuS2ySsVqnq5EyE3oJbnfFJvkC9UtGP4Kpem5KE7r+ivHIbIAQAofSqnlB5D3vkfYO69TQpg==
-  dependencies:
-    "@types/accepts" "*"
-    "@types/content-disposition" "*"
-    "@types/cookies" "*"
-    "@types/http-assert" "*"
-    "@types/http-errors" "^2"
-    "@types/keygrip" "*"
-    "@types/koa-compose" "*"
-    "@types/node" "*"
-
-"@types/koa@^2.11.6":
+"@types/koa@*", "@types/koa@^2.11.6":
   version "2.15.2"
-  resolved "https://registry.yarnpkg.com/@types/koa/-/koa-2.15.2.tgz#cc570a70170713b1ab6b93384cabf4943a25678b"
+  resolved "https://registry.npmjs.org/@types/koa/-/koa-2.15.2.tgz"
   integrity sha512-CB+iyjjh1uS5N6/CKwXvw0qA7USMS2WVc4Tjf660yCjhdvqzNr8gdFcIawB41zGGptOQ+d1fnpaQWIIUXYxR3w==
   dependencies:
     "@types/accepts" "*"
@@ -1247,18 +748,16 @@
     "@types/node" "*"
 
 "@types/minimatch@*":
-  version "6.0.0"
-  resolved "https://registry.npmjs.org/@types/minimatch/-/minimatch-6.0.0.tgz"
-  integrity sha512-zmPitbQ8+6zNutpwgcQuLcsEpn/Cj54Kbn7L5pX0Os5kdWplB7xPgEh/g+SWOB/qmows2gpuCaPyduq8ZZRnxA==
-  dependencies:
-    minimatch "*"
+  version "5.1.2"
+  resolved "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz"
+  integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
 
 "@types/minimatch@^3.0.1":
   version "3.0.5"
   resolved "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz"
   integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
 
-"@types/node@*":
+"@types/node@*", "@types/node@^18.0.0 || ^20.0.0 || >=22.0.0", "@types/node@^20.19.0 || >=22.12.0":
   version "26.1.1"
   resolved "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz"
   integrity sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==
@@ -1287,7 +786,7 @@
 
 "@types/parse5@^6.0.1":
   version "6.0.3"
-  resolved "https://registry.yarnpkg.com/@types/parse5/-/parse5-6.0.3.tgz#705bb349e789efa06f43f128cef51240753424cb"
+  resolved "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz"
   integrity sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==
 
 "@types/path-is-inside@^1.0.0":
@@ -1297,7 +796,7 @@
 
 "@types/qs@*":
   version "6.15.1"
-  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.15.1.tgz#8606884272c63f0db96986bd3548650d8a9388bf"
+  resolved "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz"
   integrity sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==
 
 "@types/qunit@^2.5.4":
@@ -1307,12 +806,12 @@
 
 "@types/range-parser@*":
   version "1.2.7"
-  resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.7.tgz#50ae4353eaaddc04044279812f52c8c65857dbcb"
+  resolved "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz"
   integrity sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==
 
 "@types/rbush@4.0.0":
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@types/rbush/-/rbush-4.0.0.tgz#b327bf54952e9c924ea6702c36904c2ce1d47f35"
+  resolved "https://registry.npmjs.org/@types/rbush/-/rbush-4.0.0.tgz"
   integrity sha512-+N+2H39P8X+Hy1I5mC6awlTX54k3FhiUmvt7HWzGJZvF+syUAAxP/stwppS8JE84YHqFgRMv6fCy31202CMFxQ==
 
 "@types/resolve@0.0.6":
@@ -1324,19 +823,19 @@
 
 "@types/resolve@1.20.2":
   version "1.20.2"
-  resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.20.2.tgz#97d26e00cd4a0423b4af620abecf3e6f442b7975"
+  resolved "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz"
   integrity sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==
 
 "@types/send@*":
   version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@types/send/-/send-1.2.1.tgz#6a784e45543c18c774c049bff6d3dbaf045c9c74"
+  resolved "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz"
   integrity sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==
   dependencies:
     "@types/node" "*"
 
 "@types/serve-static@^2":
   version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-2.2.0.tgz#d4a447503ead0d1671132d1ab6bd58b805d8de6a"
+  resolved "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz"
   integrity sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==
   dependencies:
     "@types/http-errors" "*"
@@ -1366,114 +865,19 @@
 
 "@types/ws@^7.4.0":
   version "7.4.7"
-  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-7.4.7.tgz#f7c390a36f7a0679aa69de2d501319f4f8d9b702"
+  resolved "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz"
   integrity sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==
   dependencies:
     "@types/node" "*"
 
-"@typescript/typescript-aix-ppc64@7.0.2":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz#cdc7ce81d60f1e09034960ddfb1fb880d7a776b6"
-  integrity sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==
-
 "@typescript/typescript-darwin-arm64@7.0.2":
   version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz#a55fdfcfa58df58d27db2237cde6a5c1e35a7235"
+  resolved "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz"
   integrity sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==
-
-"@typescript/typescript-darwin-x64@7.0.2":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz#38d1c9172800a91d707bec64d2a370a016634db4"
-  integrity sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==
-
-"@typescript/typescript-freebsd-arm64@7.0.2":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz#f1ff8810030b35d2b5be0db6a2dc650460ea94fa"
-  integrity sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==
-
-"@typescript/typescript-freebsd-x64@7.0.2":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz#3d86b03f353c5b1ba95162eb6ce35533bfc294bd"
-  integrity sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==
-
-"@typescript/typescript-linux-arm64@7.0.2":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz#d9334d96d6dac6ff85da9c865588948de939e91f"
-  integrity sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==
-
-"@typescript/typescript-linux-arm@7.0.2":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz#ad94b41e1aee2a4dcc6a298c7b67c43345fde32e"
-  integrity sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==
-
-"@typescript/typescript-linux-loong64@7.0.2":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz#2965aee4fc873360139d893daafe6397a29138ad"
-  integrity sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==
-
-"@typescript/typescript-linux-mips64el@7.0.2":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz#1a887a311bed3a833f80bfd4a9ed37c271936cf0"
-  integrity sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==
-
-"@typescript/typescript-linux-ppc64@7.0.2":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz#8b63c9b2f445b393eb4e43ec21da225dade3577d"
-  integrity sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==
-
-"@typescript/typescript-linux-riscv64@7.0.2":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz#b6e8a35c289b3ea97a92a41d461aaeed0d3b36e1"
-  integrity sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==
-
-"@typescript/typescript-linux-s390x@7.0.2":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz#2ef96693be4861f6d17965427e5b009cbbed1a3e"
-  integrity sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==
-
-"@typescript/typescript-linux-x64@7.0.2":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz#73269cb0baba50aea0ca060445a6b88e583f1ce2"
-  integrity sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==
-
-"@typescript/typescript-netbsd-arm64@7.0.2":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz#3a3649f97fafa210b4e6e3798c15e06605c8a901"
-  integrity sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==
-
-"@typescript/typescript-netbsd-x64@7.0.2":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz#47ec59491a40c470d2807dc4d2b825528fd979ab"
-  integrity sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==
-
-"@typescript/typescript-openbsd-arm64@7.0.2":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz#796be8da0bd989d8a3fb96f2801e38a8365b4baf"
-  integrity sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==
-
-"@typescript/typescript-openbsd-x64@7.0.2":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz#d37fe2a729eb942c076c454ee7f1815faf7d560f"
-  integrity sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==
-
-"@typescript/typescript-sunos-x64@7.0.2":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz#aba8d3464c3565a7044789baba96916bd4ab2c88"
-  integrity sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==
-
-"@typescript/typescript-win32-arm64@7.0.2":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz#b9de50a17196383f62620b5f9d0a2f34ad3b60d7"
-  integrity sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==
-
-"@typescript/typescript-win32-x64@7.0.2":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz#cf3b7b0d6ce5635daca4c8e01c189cdcde47ec3c"
-  integrity sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==
 
 "@ui5/webcomponents-ai@^2.24.2":
   version "2.24.2"
-  resolved "https://registry.yarnpkg.com/@ui5/webcomponents-ai/-/webcomponents-ai-2.24.2.tgz#9d8b4b88b1fbca4f0e57d9bd74128608be752bc6"
+  resolved "https://registry.npmjs.org/@ui5/webcomponents-ai/-/webcomponents-ai-2.24.2.tgz"
   integrity sha512-h0tr+r6UBoMk/fzdDBIt5iRUx3P6i7RTWunWBfUVwcMW1o9hmcxDFACKITj+J0Yc+0rJ3f2NKFbGofSTfKLY1w==
   dependencies:
     "@ui5/webcomponents" "2.24.2"
@@ -1483,7 +887,7 @@
 
 "@ui5/webcomponents-base@2.24.2":
   version "2.24.2"
-  resolved "https://registry.yarnpkg.com/@ui5/webcomponents-base/-/webcomponents-base-2.24.2.tgz#048eca581cdad2152363b6c6d8d054d3a25c32b0"
+  resolved "https://registry.npmjs.org/@ui5/webcomponents-base/-/webcomponents-base-2.24.2.tgz"
   integrity sha512-7sevDFu+ITzHyo2rDT6v33G3U3d6mVa6+eDIHF2dXx0/rlIPgBzhE6pceC/07JdC6ls5J8Hatet5cFvWBGO7Og==
   dependencies:
     "@lit-labs/ssr-dom-shim" "^1.1.2"
@@ -1491,7 +895,7 @@
 
 "@ui5/webcomponents-fiori@^2.24.2":
   version "2.24.2"
-  resolved "https://registry.yarnpkg.com/@ui5/webcomponents-fiori/-/webcomponents-fiori-2.24.2.tgz#9d95877be82564fafc3b57849005f5df81c053e3"
+  resolved "https://registry.npmjs.org/@ui5/webcomponents-fiori/-/webcomponents-fiori-2.24.2.tgz"
   integrity sha512-93JOvdx5zooO6dEUbju+WbEdMG981wao+owVWc+3OFEODtjBbC2jn1cYWgg1Jzcmbf9u+WYUYsyukdYDIG1wIA==
   dependencies:
     "@ui5/webcomponents" "2.24.2"
@@ -1502,28 +906,28 @@
 
 "@ui5/webcomponents-icons-business-suite@2.24.2":
   version "2.24.2"
-  resolved "https://registry.yarnpkg.com/@ui5/webcomponents-icons-business-suite/-/webcomponents-icons-business-suite-2.24.2.tgz#6a5583ae2c175a4bf3db7020103fc9b5dd416b1f"
+  resolved "https://registry.npmjs.org/@ui5/webcomponents-icons-business-suite/-/webcomponents-icons-business-suite-2.24.2.tgz"
   integrity sha512-IX0E8Zmm2+OKacwfJw0EoypbwRRG0ivx7vxmsH7upGo9Tq3OX3BJFV6gL4RvltO+3zN4NMWRQNMC4YRDvAyh3A==
   dependencies:
     "@ui5/webcomponents-base" "2.24.2"
 
 "@ui5/webcomponents-icons-tnt@2.24.2":
   version "2.24.2"
-  resolved "https://registry.yarnpkg.com/@ui5/webcomponents-icons-tnt/-/webcomponents-icons-tnt-2.24.2.tgz#04abf5920d111f8a71cd409cc59322a180115caf"
+  resolved "https://registry.npmjs.org/@ui5/webcomponents-icons-tnt/-/webcomponents-icons-tnt-2.24.2.tgz"
   integrity sha512-Uv2LyfgC5PBk96u9ZTOqFqA6B+TqWeFecmCjqZVXSZsur0BHMcFgDsZkoxWWE+NPt9qCsGeXKJpGRxGEn3a7ww==
   dependencies:
     "@ui5/webcomponents-base" "2.24.2"
 
 "@ui5/webcomponents-icons@2.24.2":
   version "2.24.2"
-  resolved "https://registry.yarnpkg.com/@ui5/webcomponents-icons/-/webcomponents-icons-2.24.2.tgz#2a4c3549c3fbb421602636cb1739604d495b7e66"
+  resolved "https://registry.npmjs.org/@ui5/webcomponents-icons/-/webcomponents-icons-2.24.2.tgz"
   integrity sha512-76YweZ6/YJdZ0e0t2j6XyomQ8HUgM0Xw4QOGlZq+czO/dfPeilDDr+9EIIQ7iDAaRecFf/py11C0ZzDqA6BEVg==
   dependencies:
     "@ui5/webcomponents-base" "2.24.2"
 
 "@ui5/webcomponents-localization@2.24.2":
   version "2.24.2"
-  resolved "https://registry.yarnpkg.com/@ui5/webcomponents-localization/-/webcomponents-localization-2.24.2.tgz#58946b77cccaadf58bd293e2ad86682bf8fe152f"
+  resolved "https://registry.npmjs.org/@ui5/webcomponents-localization/-/webcomponents-localization-2.24.2.tgz"
   integrity sha512-jW0CwxHMLwsJvYtKSF8dQUngdyyr+XLnKjgh4HlKeB0k2zF7yfCq1P+taMcU7Ng3JrgP8Vi141dSncr7m/Qn0A==
   dependencies:
     "@types/openui5" "^1.146.0"
@@ -1531,15 +935,15 @@
 
 "@ui5/webcomponents-theming@2.24.2":
   version "2.24.2"
-  resolved "https://registry.yarnpkg.com/@ui5/webcomponents-theming/-/webcomponents-theming-2.24.2.tgz#b420f68ef5193b8972b436f03ca215b0260ef432"
+  resolved "https://registry.npmjs.org/@ui5/webcomponents-theming/-/webcomponents-theming-2.24.2.tgz"
   integrity sha512-91HrRDrBajEQlB7bt43SmYBILvAgDoVv7P0gpFOXWA3nrub1ZsEV2G6m85kY4hXT9hBg6aojlurAmv/mj7/uzw==
   dependencies:
     "@sap-theming/theming-base-content" "11.36.4"
     "@ui5/webcomponents-base" "2.24.2"
 
-"@ui5/webcomponents@2.24.2", "@ui5/webcomponents@^2.24.2":
+"@ui5/webcomponents@^2.24.2", "@ui5/webcomponents@2.24.2":
   version "2.24.2"
-  resolved "https://registry.yarnpkg.com/@ui5/webcomponents/-/webcomponents-2.24.2.tgz#58c7f7e6f051977901dcbc26ee736f1aa18e20ae"
+  resolved "https://registry.npmjs.org/@ui5/webcomponents/-/webcomponents-2.24.2.tgz"
   integrity sha512-8dWIdHhwIpWh6HH4jAJj16B/HRQQhojb7LD4W71P7JlljvGu9v7+84zetEXs0R5kjxLz7eCX0nMHgzttz2vmyQ==
   dependencies:
     "@ui5/webcomponents-base" "2.24.2"
@@ -1551,7 +955,7 @@
 
 "@vaadin-component-factory/vcf-date-range-picker@^6.0.0":
   version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@vaadin-component-factory/vcf-date-range-picker/-/vcf-date-range-picker-6.0.0.tgz#60997a3fe9f80ef6149b92d9ba84df9f8904eb71"
+  resolved "https://registry.npmjs.org/@vaadin-component-factory/vcf-date-range-picker/-/vcf-date-range-picker-6.0.0.tgz"
   integrity sha512-KfJ866yEl8EeNoYpa6ynEyVb6Rg08C5TsVUgIA6rGydGjL93j/rV8FKPADkIRf1kQ3KMMVcOjVqopxIXkqW78w==
   dependencies:
     "@polymer/iron-a11y-announcer" "^3.0.0"
@@ -1571,7 +975,7 @@
 
 "@vaadin/a11y-base@~25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/a11y-base/-/a11y-base-25.2.6.tgz#b484e12dff84a8a981619426dd7302841ebf6d73"
+  resolved "https://registry.npmjs.org/@vaadin/a11y-base/-/a11y-base-25.2.6.tgz"
   integrity sha512-VgLVbQYyjZ81HWvoNQH7gYODpAQ3NiQvnByHYayVRedO4mae/nQ8uDOvontWFP35MAq7PZxAelxJgOP6W+klMA==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -1580,7 +984,7 @@
 
 "@vaadin/accordion@^25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/accordion/-/accordion-25.2.6.tgz#83a3579f6fd528bdfcb79414080bdf931d09a0e9"
+  resolved "https://registry.npmjs.org/@vaadin/accordion/-/accordion-25.2.6.tgz"
   integrity sha512-eKkb7DNCvBY3/vr73u37mve8mPnRZQsIoJ1dQnHK2zkDz++2SkfaFFEKxX1rxCumUjbJKp2KmpgMcGCJKWGY+A==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -1592,7 +996,7 @@
 
 "@vaadin/app-layout@^25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/app-layout/-/app-layout-25.2.6.tgz#ad4024cfc653ce35008d2d6f13dc309d1b571453"
+  resolved "https://registry.npmjs.org/@vaadin/app-layout/-/app-layout-25.2.6.tgz"
   integrity sha512-4cjuDeQYiJQy/jbNIZnelvjEVwoL/CZ+SlJaXIWNCUmdEdCRNb/t1LbU6iqrBV84t7oqhe/plyR03CYBgcdetQ==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -1604,7 +1008,7 @@
 
 "@vaadin/avatar-group@^25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/avatar-group/-/avatar-group-25.2.6.tgz#321e1df640d3b45a34871919a09da351cf895e22"
+  resolved "https://registry.npmjs.org/@vaadin/avatar-group/-/avatar-group-25.2.6.tgz"
   integrity sha512-P97RmIbtWHMjMcOU+mzYMAVZTIDDmedf8qLEy7stqSx1ysGT/TNyFaKKuQDsHJja2lgOWqD0EeYxxpoBN5KU/Q==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -1619,7 +1023,7 @@
 
 "@vaadin/avatar@^25.2.6", "@vaadin/avatar@~25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/avatar/-/avatar-25.2.6.tgz#513d372060a2c701a085c9d64905cf9447e0deef"
+  resolved "https://registry.npmjs.org/@vaadin/avatar/-/avatar-25.2.6.tgz"
   integrity sha512-6vfT41PKE0791x7vabvPSHOHOy9u0Nbt55gKvtRyyFsZORIVQAAnVopaL1RivkxP8JMqw8gJhrclm9tdrkjW7A==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -1631,7 +1035,7 @@
 
 "@vaadin/board@^25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/board/-/board-25.2.6.tgz#284fd2e893c4e0fdee7f717fbc0e2dd062306b9a"
+  resolved "https://registry.npmjs.org/@vaadin/board/-/board-25.2.6.tgz"
   integrity sha512-6nQTjCa2EjINmf4Wx/qOqUP/R27Y9CFIi8q8MuMzfyT+oCP8MsJEno8uQVBcPlQwgFSQvu5RXuaDKFKqrOp35Q==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -1641,7 +1045,7 @@
 
 "@vaadin/button@^25.0.0", "@vaadin/button@^25.2.6", "@vaadin/button@~25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/button/-/button-25.2.6.tgz#1d6cffcbc562b5944c517597bbd8e524d2e1295c"
+  resolved "https://registry.npmjs.org/@vaadin/button/-/button-25.2.6.tgz"
   integrity sha512-8t0IxzHKYfNLDu7zOGJiVn5ub8KVEm4IVKv50vQ2M+lqSuuL0Ma5G5Mr3tPFmy8nA3wY1D82QKVTnh3yoyhGyw==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -1652,7 +1056,7 @@
 
 "@vaadin/card@^25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/card/-/card-25.2.6.tgz#8375977690f8f9a31ab1cb9a7edd0769e31702b6"
+  resolved "https://registry.npmjs.org/@vaadin/card/-/card-25.2.6.tgz"
   integrity sha512-YtT+Y7pLEUKL+I+7qWxkf5VhWEImv1RlZtQgeJfwPLuNo5Z0oboHRoJEe1nP3rLLEHjfoYqoopqSLj+3nONwyw==
   dependencies:
     "@vaadin/component-base" "~25.2.6"
@@ -1661,7 +1065,7 @@
 
 "@vaadin/charts@^25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/charts/-/charts-25.2.6.tgz#db6b63e1eed17e30e4be05db13e8b56c4ae2b71e"
+  resolved "https://registry.npmjs.org/@vaadin/charts/-/charts-25.2.6.tgz"
   integrity sha512-01p/1cpltX+rDZm8Ze6YQm9SY1sL27EdlX9CD0xQMM+MhfQB1scHR9aMCbZl5e2E834uYDyACWLTrKg4qwhVvA==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -1672,7 +1076,7 @@
 
 "@vaadin/checkbox-group@^25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/checkbox-group/-/checkbox-group-25.2.6.tgz#ad8cea3f04b568e629ce5f255c2355a55a5de1f8"
+  resolved "https://registry.npmjs.org/@vaadin/checkbox-group/-/checkbox-group-25.2.6.tgz"
   integrity sha512-YI8LW55yXCzuxAgZPijiJx0MwLGMIw+gvwrS+RcngZJc+cjM+DnimEdnUYu0q+Bl5TNQTYDSc+d2s1k+zmam7g==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -1685,7 +1089,7 @@
 
 "@vaadin/checkbox@^25.2.6", "@vaadin/checkbox@~25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/checkbox/-/checkbox-25.2.6.tgz#569e5fcd5a03d35fafab6dd7fba86b424da1389a"
+  resolved "https://registry.npmjs.org/@vaadin/checkbox/-/checkbox-25.2.6.tgz"
   integrity sha512-Q+Zwjo7yAMAx5IL6lf4j65aKp9Ba0jBlxaqZqDCOZ79zk7qb8XqMgz5rKKqXGljjBojqDFj/Rb0ncDhMTYyVhg==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -1697,7 +1101,7 @@
 
 "@vaadin/combo-box@^25.2.6", "@vaadin/combo-box@~25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/combo-box/-/combo-box-25.2.6.tgz#aa619468a22ba4d393a1a3e53a5cc972ee54414c"
+  resolved "https://registry.npmjs.org/@vaadin/combo-box/-/combo-box-25.2.6.tgz"
   integrity sha512-Rn/IpfbgRxdlLHAbkUCAHaS/MRu+tcKdBjvM+QeBrbRLOVYLB7eaMeF34JDZysLnmQjIwBjCkl+oAowafRm6gQ==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -1713,7 +1117,7 @@
 
 "@vaadin/component-base@^25.0.0", "@vaadin/component-base@^25.2.6", "@vaadin/component-base@~25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/component-base/-/component-base-25.2.6.tgz#5d53fe627758930208a48a19cf225fa99ff10f23"
+  resolved "https://registry.npmjs.org/@vaadin/component-base/-/component-base-25.2.6.tgz"
   integrity sha512-g/sfKdkd86lDCRC9SmMcEZfRXK9ffO+tyY7+LQFfckZTUyTLUN/VP8iVCk0Key/Ll3L5jQg/t8BbeLs+VUlw3w==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -1723,7 +1127,7 @@
 
 "@vaadin/confirm-dialog@~25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/confirm-dialog/-/confirm-dialog-25.2.6.tgz#89c502684041f07215260b8baaa98a2f8edc94eb"
+  resolved "https://registry.npmjs.org/@vaadin/confirm-dialog/-/confirm-dialog-25.2.6.tgz"
   integrity sha512-ZydzAfnxoMb814XJWkgCMgeaJPKLtEYZU4pnBvYi5IXmJxoyf/Az2NAfEbKr7SIRU2NIBOdI0f/CMGDXhABDBQ==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -1736,7 +1140,7 @@
 
 "@vaadin/context-menu@^25.2.6", "@vaadin/context-menu@~25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/context-menu/-/context-menu-25.2.6.tgz#ee751d73cecf46376eee6a65240782340fa8d30c"
+  resolved "https://registry.npmjs.org/@vaadin/context-menu/-/context-menu-25.2.6.tgz"
   integrity sha512-fzqJv71do9JWR+9XXVuOMPT83Mx3FUj10VP19aftwnFlsAVs0rTLyGSlBXt4Xzk6zoXPG427fcPEl+yyEMhYhw==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -1751,7 +1155,7 @@
 
 "@vaadin/custom-field@^25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/custom-field/-/custom-field-25.2.6.tgz#bf7e9c02d0365f3293019ab2cba9013b405564c5"
+  resolved "https://registry.npmjs.org/@vaadin/custom-field/-/custom-field-25.2.6.tgz"
   integrity sha512-sHR2o8RBOlpf9Qf1TXii4wB4wBMUfB2Enk2nhzHyXjTUqVINup0xfwXZlFo3Nk7Phyw4U9vChieosv7rq02mHg==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -1763,7 +1167,7 @@
 
 "@vaadin/date-picker@^25.2.6", "@vaadin/date-picker@~25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/date-picker/-/date-picker-25.2.6.tgz#2c29d860169e7bac7c59ed939b72f48e959e2ddb"
+  resolved "https://registry.npmjs.org/@vaadin/date-picker/-/date-picker-25.2.6.tgz"
   integrity sha512-pTyBAhFsKxq/GqhpFHWDkYPZXv2arqVz88b8IA/pKYjyXGSxy9mx3oAXfnaIs8da6N07TwMNpM89YWlQuuPd3A==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -1778,7 +1182,7 @@
 
 "@vaadin/date-time-picker@^25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/date-time-picker/-/date-time-picker-25.2.6.tgz#797e41ea6f89f49ab705eda6c8c018a270a57ed5"
+  resolved "https://registry.npmjs.org/@vaadin/date-time-picker/-/date-time-picker-25.2.6.tgz"
   integrity sha512-rt0iIacmM6VPKiPpHlKj6Kq0caATtIwFtGGftmYPcnuwbhue+rJKZN2JKFqbpgb2UdeoGzroBhv6XSqXrMkHiw==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -1792,7 +1196,7 @@
 
 "@vaadin/details@^25.2.6", "@vaadin/details@~25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/details/-/details-25.2.6.tgz#9d2021a20d071e6aa259c63e922f9d39635f4a31"
+  resolved "https://registry.npmjs.org/@vaadin/details/-/details-25.2.6.tgz"
   integrity sha512-niiu+PaV6gWH817j/tjXXktpGHgL6HF09sn4l2TknQniB2FqQeTTViGX2vjbwisSHcf3JQIx/RP0C0oNlExXyg==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -1804,7 +1208,7 @@
 
 "@vaadin/dialog@^25.2.6", "@vaadin/dialog@~25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/dialog/-/dialog-25.2.6.tgz#f8ac8699cc00b6eaeb62f040debdd71b4953d226"
+  resolved "https://registry.npmjs.org/@vaadin/dialog/-/dialog-25.2.6.tgz"
   integrity sha512-/GSeX5+F7XkcYhtsTY01PuqS+A2sR3+T6VM5SnZZirekJztyNeEh5ciw5U4PrMglRFzJK2piF8hoHvg9vZyqbQ==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -1816,7 +1220,7 @@
 
 "@vaadin/email-field@^25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/email-field/-/email-field-25.2.6.tgz#2ac1c47581df5acb1f82a0af4dbf9a317515382f"
+  resolved "https://registry.npmjs.org/@vaadin/email-field/-/email-field-25.2.6.tgz"
   integrity sha512-XJrSoJ7/NcwzoS/rNl+QA77CyVHiIOdyWFNFZhEpp44g/Zg1Y/wlbrPYSz+ze7vW/2foIIjggxIQBLpKsE9zLg==
   dependencies:
     "@vaadin/component-base" "~25.2.6"
@@ -1826,7 +1230,7 @@
 
 "@vaadin/field-base@~25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/field-base/-/field-base-25.2.6.tgz#81c6c29a66234b96e226aa7c6e29f12d5d0ec569"
+  resolved "https://registry.npmjs.org/@vaadin/field-base/-/field-base-25.2.6.tgz"
   integrity sha512-h3tfUY1Y1rZpWI3/as9gzis5M4lGdTKPpgTarkpXCfl2gAG68P7P0uE3LAQ+vUlwktvuYoAQyNfw6KVxR7vUtw==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -1836,7 +1240,7 @@
 
 "@vaadin/form-layout@^25.0.0", "@vaadin/form-layout@^25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/form-layout/-/form-layout-25.2.6.tgz#202f1f3e7da31d5efa158093b4bbb6e5c5ffe3db"
+  resolved "https://registry.npmjs.org/@vaadin/form-layout/-/form-layout-25.2.6.tgz"
   integrity sha512-0A51uN0WbH+pYyXHXEaK5n9+CPODZVCLoCQEYOSv2hlqAF785mgpt5ZbR+rpg+p5/V7ozshjXKtRFYtW1Jsy9A==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -1847,7 +1251,7 @@
 
 "@vaadin/grid@^25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/grid/-/grid-25.2.6.tgz#ee81c821e9306c8eacd3c417e676a1dac2f96d06"
+  resolved "https://registry.npmjs.org/@vaadin/grid/-/grid-25.2.6.tgz"
   integrity sha512-TlOrJ0XEXxtDWNMFEaHmwE4Ygr39S0dqK3X27O8BgJfwOx1vT92Ub01buIgmz+KQWSbnMiL12ldkZDjwSDbDHw==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -1861,7 +1265,7 @@
 
 "@vaadin/horizontal-layout@^25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/horizontal-layout/-/horizontal-layout-25.2.6.tgz#e7812c016f7660aa07843c2d3b344fc5be56c0d2"
+  resolved "https://registry.npmjs.org/@vaadin/horizontal-layout/-/horizontal-layout-25.2.6.tgz"
   integrity sha512-b8EkvK2O4OasN3vHqeFm2+pQqmQvfj8mRg2L5UAHmPzdz9NFuXb/Bi0R1NsYxLqMAsfJ2X34jQq+BvkIe9EZDA==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -1871,7 +1275,7 @@
 
 "@vaadin/icon@~25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/icon/-/icon-25.2.6.tgz#45e5a54baacca19e4d3cb4058e08b82e605a8040"
+  resolved "https://registry.npmjs.org/@vaadin/icon/-/icon-25.2.6.tgz"
   integrity sha512-RfztIzSgdYRQIgCLTFlf7RJwgnGpyugG4hHYDa0yIHenKUXcVcvzZyv8aa4tQJYmQk0jQ2sslxpDL1XAXBFBVg==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -1881,14 +1285,14 @@
 
 "@vaadin/icons@^25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/icons/-/icons-25.2.6.tgz#f3632eb1ad8822a16e48e8f458905b9d4765b195"
+  resolved "https://registry.npmjs.org/@vaadin/icons/-/icons-25.2.6.tgz"
   integrity sha512-JImQj5x6EReLFFUE+KA0lJ+2IipRcxPaxoU4VSQxbjVl96sAqIH4akAAhZOBmVbol412E11f4ZJb34YtbNwA5A==
   dependencies:
     "@vaadin/icon" "~25.2.6"
 
 "@vaadin/input-container@~25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/input-container/-/input-container-25.2.6.tgz#682f39e5fb36b7eddc4bc66e5ea7aead84ed3397"
+  resolved "https://registry.npmjs.org/@vaadin/input-container/-/input-container-25.2.6.tgz"
   integrity sha512-n2vIpJXij1mclETi9Zxw/W0wFO1DhHb4YsGdWl5FKhmrmE/sm5jSIxIrAiyMuR9KniXIt64sIGxayoyDMCQtWg==
   dependencies:
     "@vaadin/component-base" "~25.2.6"
@@ -1897,7 +1301,7 @@
 
 "@vaadin/integer-field@^25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/integer-field/-/integer-field-25.2.6.tgz#fb06339b7c59e8d23c352ed71ebc0a676e956b49"
+  resolved "https://registry.npmjs.org/@vaadin/integer-field/-/integer-field-25.2.6.tgz"
   integrity sha512-D81b7XJCsfFsoz3W2GULwGhh2QkELH+VpZxJLz5T/IQ+Ze8SOWrAwQg/9Bw4z3RGPTD38N2ekd3U9mUJvP1kAA==
   dependencies:
     "@vaadin/component-base" "~25.2.6"
@@ -1905,7 +1309,7 @@
 
 "@vaadin/item@^25.2.6", "@vaadin/item@~25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/item/-/item-25.2.6.tgz#1a71785b29247127880373552aef16999ee7dd23"
+  resolved "https://registry.npmjs.org/@vaadin/item/-/item-25.2.6.tgz"
   integrity sha512-l9bmR5qn1hAwZA90hQe2SkF+9FhBSJbon68VyVaq9L/hrSKAoBcfaJX1f46uO1oy4mtX13pVMxn9B+axk0feZw==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -1916,7 +1320,7 @@
 
 "@vaadin/list-box@^25.2.6", "@vaadin/list-box@~25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/list-box/-/list-box-25.2.6.tgz#7d71484e2d1504a2f716f922c150eef053a4f177"
+  resolved "https://registry.npmjs.org/@vaadin/list-box/-/list-box-25.2.6.tgz"
   integrity sha512-clm3Vlxegh2R8YxbHZ+y+vLtE3mO9zZpIzE2+s9zujdbYzGlWT5Q5jNv50xoGxdVFm+bSjCrLL35pa1i14uKLQ==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -1928,14 +1332,14 @@
 
 "@vaadin/lit-renderer@~25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/lit-renderer/-/lit-renderer-25.2.6.tgz#06dfff943dbe77d338c6cc0e561ec5af5edc3589"
+  resolved "https://registry.npmjs.org/@vaadin/lit-renderer/-/lit-renderer-25.2.6.tgz"
   integrity sha512-XE5rp9TX40apUhePK5FgM66Kd2JkK7+/dukmiHlq+JRTL9v8hzxbKrhVNdL7jySMj+4ced5AIE1CjPHOhYz6ww==
   dependencies:
     lit "^3.0.0"
 
 "@vaadin/map@^25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/map/-/map-25.2.6.tgz#1d9f9bfc032e41258b7084b11f9a29ca9d9046b0"
+  resolved "https://registry.npmjs.org/@vaadin/map/-/map-25.2.6.tgz"
   integrity sha512-ybBEvDzD4lcZMIK+OI5iq77OWcmh59B4k1flBg+HanHxCgAtt5oO5/sEkmlMVIN1tuZSEqiyKpOv85GMUoieyg==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -1947,7 +1351,7 @@
 
 "@vaadin/markdown@^25.2.6", "@vaadin/markdown@~25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/markdown/-/markdown-25.2.6.tgz#371f45062f54167d44530fe306ac88b6899cea97"
+  resolved "https://registry.npmjs.org/@vaadin/markdown/-/markdown-25.2.6.tgz"
   integrity sha512-0T1iwbqXpuQO++fwAiJA+XOg4L2QlnH3875tLttEbM02Z0+ZpfaLwjjNeA3CmyLB3AT0+3Z9hOk17GyJKxbFQQ==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -1959,7 +1363,7 @@
 
 "@vaadin/master-detail-layout@^25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/master-detail-layout/-/master-detail-layout-25.2.6.tgz#887ebdb302860818421bf73cfd3b8a580f69967e"
+  resolved "https://registry.npmjs.org/@vaadin/master-detail-layout/-/master-detail-layout-25.2.6.tgz"
   integrity sha512-bUgrthcA3hqxnLdKq/r9x94Lr2ImT+bmFo48M6OGSHVmsPxisCR8vIiUfqLsW/L+uB2qj/tQhYUZ0L1V0YBIsQ==
   dependencies:
     "@vaadin/a11y-base" "~25.2.6"
@@ -1969,7 +1373,7 @@
 
 "@vaadin/menu-bar@^25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/menu-bar/-/menu-bar-25.2.6.tgz#bb30931a9bcb3d5fc466c60dcb9c46b926359b09"
+  resolved "https://registry.npmjs.org/@vaadin/menu-bar/-/menu-bar-25.2.6.tgz"
   integrity sha512-EqX8SQZCRxcLDpt6GtHhSuK1GBO5K5LliRK1MqkxaLRVVMBLYNaK9FXddX/aomvwb9t2g6FdJreOW76vgiwmng==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -1985,7 +1389,7 @@
 
 "@vaadin/message-input@^25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/message-input/-/message-input-25.2.6.tgz#52297a40c2626c66bc0aac0fd7adeac3f93d99b6"
+  resolved "https://registry.npmjs.org/@vaadin/message-input/-/message-input-25.2.6.tgz"
   integrity sha512-BwWKJHsKUzT1/xQiIoCI00GHAwFEVzXlUHCyHNWHrLOD4qAJtsnMhFc0exU1KGz82qwMrHvPU+DMQn4IIulOUg==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -1997,7 +1401,7 @@
 
 "@vaadin/message-list@^25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/message-list/-/message-list-25.2.6.tgz#d7d2735ae4d70338f06f177ae82c5a7152d68ec8"
+  resolved "https://registry.npmjs.org/@vaadin/message-list/-/message-list-25.2.6.tgz"
   integrity sha512-AQDSBO9qpIJnmUss9/3/NWJ0EeQH7qnV4DjjRzArnXkHTLi3gb2bas42hGBYb3RwgMptgB8gQs3jfD0D21DZXQ==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -2010,7 +1414,7 @@
 
 "@vaadin/multi-select-combo-box@^25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/multi-select-combo-box/-/multi-select-combo-box-25.2.6.tgz#55604d2c029892532e12d5b589985a17a424241c"
+  resolved "https://registry.npmjs.org/@vaadin/multi-select-combo-box/-/multi-select-combo-box-25.2.6.tgz"
   integrity sha512-BaTvEaCFoSPDOX6g8uxi3Zz/4k7zHnnTtKuKgcgb9o76k7pOHtzixnAB/cza8Vrwc0mR0oF/Q1artdkg7auBcg==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -2027,7 +1431,7 @@
 
 "@vaadin/notification@^25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/notification/-/notification-25.2.6.tgz#388f3ec1455e6f482bdaada4ff44042e53ae0cfe"
+  resolved "https://registry.npmjs.org/@vaadin/notification/-/notification-25.2.6.tgz"
   integrity sha512-vvXcgid5bX975+a/fj3ByKWWLYr2QqJxu5kKmMnsAd0BJWWK5qNYDhJuGvT/RF2MO3FkECR8HLDIJ1ssmKfYYA==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -2038,7 +1442,7 @@
 
 "@vaadin/number-field@^25.2.6", "@vaadin/number-field@~25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/number-field/-/number-field-25.2.6.tgz#6d8fdec57b48b9194d0cf2932265c89edcbc46c0"
+  resolved "https://registry.npmjs.org/@vaadin/number-field/-/number-field-25.2.6.tgz"
   integrity sha512-9tZhXLXkBmqVDORkegAVeIpk/stCU3sUvgR6gBtXqQJs7/7W4TOqC+KLiezUX8f0BUZIypnDzseZXv7uFMb8lQ==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -2051,7 +1455,7 @@
 
 "@vaadin/overlay@^25.0.0", "@vaadin/overlay@~25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/overlay/-/overlay-25.2.6.tgz#2b1454f7e5ff2d5349015ccc876a13089735beec"
+  resolved "https://registry.npmjs.org/@vaadin/overlay/-/overlay-25.2.6.tgz"
   integrity sha512-dkvUa326otVnL8Cf+dxSs46uzEvrovdEqTkLxmNSQrk7/ajIrYYL+LlCRYASd7w1HuSk4rpDsGLEpDJMpd2+4Q==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -2062,7 +1466,7 @@
 
 "@vaadin/password-field@^25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/password-field/-/password-field-25.2.6.tgz#a118e1023588be3b6b2240edaf46f26ab244ec7d"
+  resolved "https://registry.npmjs.org/@vaadin/password-field/-/password-field-25.2.6.tgz"
   integrity sha512-Kej5DyradYGemv862Ixu5p0oJGtRs70tP/X1/+ZfQO/+CUK0wo4N2sIDH7Z0afAQFouba2TN1Vn3YGrVGk9amg==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -2076,7 +1480,7 @@
 
 "@vaadin/popover@^25.2.6", "@vaadin/popover@~25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/popover/-/popover-25.2.6.tgz#f57ba77f78a792ab102ef70c368624bc70d60eeb"
+  resolved "https://registry.npmjs.org/@vaadin/popover/-/popover-25.2.6.tgz"
   integrity sha512-5fsvbCUeHIZCUdMXFbR7egAomvw31+5bQYHyQOoiimKrgSCSp1YrHQPvDALx2oXPSFqOWLgXt3DJRCWQ7aGjPQ==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -2089,7 +1493,7 @@
 
 "@vaadin/progress-bar@~25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/progress-bar/-/progress-bar-25.2.6.tgz#f14ba97be9b35195802a980f0908a9a88027522e"
+  resolved "https://registry.npmjs.org/@vaadin/progress-bar/-/progress-bar-25.2.6.tgz"
   integrity sha512-qLHUbn/oMmANdY1Q/qI88tod7695ib4hg/hmvnym9NE6rtjyYj95SAV0S9ei/jgZxdwte0kWzQen8B4DGXqY2Q==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -2099,7 +1503,7 @@
 
 "@vaadin/radio-group@^25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/radio-group/-/radio-group-25.2.6.tgz#db2411057f8e7de329ae5927040e4306c714e99b"
+  resolved "https://registry.npmjs.org/@vaadin/radio-group/-/radio-group-25.2.6.tgz"
   integrity sha512-ntlJcV7V+7CKFCBv3ZQHgtyf9Cnexomi9VgNyUYcaI52OkT3apwG/2xtYTnf5lkDWqAmQzoCsGgnM4QpXmPDHw==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -2111,7 +1515,7 @@
 
 "@vaadin/rich-text-editor@^25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/rich-text-editor/-/rich-text-editor-25.2.6.tgz#f3a182e82dd362286378ed180214479bb37639b7"
+  resolved "https://registry.npmjs.org/@vaadin/rich-text-editor/-/rich-text-editor-25.2.6.tgz"
   integrity sha512-D0HouWbBQHYkS89wWh5rOMSduSUbKxZ8D5JozFT+Yw0QAg/MQEXdZ7WHa0NgknuP8rtUW+ACsfDdtBmmutwBzw==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -2136,7 +1540,7 @@
 
 "@vaadin/scroller@~25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/scroller/-/scroller-25.2.6.tgz#ae79b99a831fb4f377cec11b678c8d70624356f0"
+  resolved "https://registry.npmjs.org/@vaadin/scroller/-/scroller-25.2.6.tgz"
   integrity sha512-LXP5MOrsFhlpVEMTtZo3+h8oBYCapaJDRa18a1JYhXTtAoonhoCfNpIFguQ78LuJP/xhQ2dxkrcEtzEmsBu6IA==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -2147,7 +1551,7 @@
 
 "@vaadin/select@^25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/select/-/select-25.2.6.tgz#4a5b7a97a4aeae0fef2b1d8703480953da3b0b10"
+  resolved "https://registry.npmjs.org/@vaadin/select/-/select-25.2.6.tgz"
   integrity sha512-CXnGh5uXsIeTN71Yeoh3o9XhoBpx06MWSrw6RZJ0U4/pjAh3YaaJfpuCAYk7Vx1oFBtSJMqOP05Yu4txhy4s5Q==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -2165,7 +1569,7 @@
 
 "@vaadin/side-nav@^25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/side-nav/-/side-nav-25.2.6.tgz#5e73360772873d067462d91ac1b377d44f036f0b"
+  resolved "https://registry.npmjs.org/@vaadin/side-nav/-/side-nav-25.2.6.tgz"
   integrity sha512-Dc7Y7Uic2+VEYcbYfQYXPXFoaYC+k4z12KHeAaGdg7SWbWcYb0upgvKrWdaLyQ/6DCuHrxPPgp5vhwjyC4hRDg==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -2176,7 +1580,7 @@
 
 "@vaadin/split-layout@^25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/split-layout/-/split-layout-25.2.6.tgz#1ca386789d9cda3c2d3d480134549789c6f1d7d2"
+  resolved "https://registry.npmjs.org/@vaadin/split-layout/-/split-layout-25.2.6.tgz"
   integrity sha512-INbOCVl4ksoXuZar7kUY5GSjlKkHnEIM4FtpEtKBd1kvCRXeBEfDYOq1lUcroKwTTN3Uhk4eg75bnOm98mRpog==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -2186,7 +1590,7 @@
 
 "@vaadin/tabs@^25.2.6", "@vaadin/tabs@~25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/tabs/-/tabs-25.2.6.tgz#17b262c9a48551d0a203bb031910c35a63952fa8"
+  resolved "https://registry.npmjs.org/@vaadin/tabs/-/tabs-25.2.6.tgz"
   integrity sha512-m9jOIExsco6lkaEadoWaVWtk3v+t24s3LhXgakfhgAqegHCn0gnPIlRngJkP0jkGFiKI28Vtrd0HGM0x2qfTUQ==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -2198,7 +1602,7 @@
 
 "@vaadin/tabsheet@^25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/tabsheet/-/tabsheet-25.2.6.tgz#00546ecc4c7515f06795b1660bf2942653eec45f"
+  resolved "https://registry.npmjs.org/@vaadin/tabsheet/-/tabsheet-25.2.6.tgz"
   integrity sha512-Gau/CO7pmYYwXQ2pSHSsdUQ/A73DXNii3oDQJRfc3RqEGbmYm6DF9+9cjlTyjI1gisSopW+REPn9wp+DAa/gFQ==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -2210,7 +1614,7 @@
 
 "@vaadin/text-area@^25.2.6", "@vaadin/text-area@~25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/text-area/-/text-area-25.2.6.tgz#cfdc23444e85293a2a690b0c2d6b0ab7a89f658d"
+  resolved "https://registry.npmjs.org/@vaadin/text-area/-/text-area-25.2.6.tgz"
   integrity sha512-7nFNDWmict9BxBx3IB8tZ/NbYYTSkTrzI9dqfS9GOlzpQk6ke5npFMD9QveTFBlTIB3X1XlV8RvSoi+jXjCvSw==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -2223,7 +1627,7 @@
 
 "@vaadin/text-field@^25.0.0", "@vaadin/text-field@^25.2.6", "@vaadin/text-field@~25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/text-field/-/text-field-25.2.6.tgz#f5be6404cdaa1a0893987c2309a960e706d1574a"
+  resolved "https://registry.npmjs.org/@vaadin/text-field/-/text-field-25.2.6.tgz"
   integrity sha512-cNMWYDHDEAp+Ai9KoW2OR8eLGrCMerg4OzGSN/PNOjNDdyAlMkk1gUrb8WJfwlD7rpxGUQaVQvovOFVllg5Mrw==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -2236,7 +1640,7 @@
 
 "@vaadin/time-picker@^25.2.6", "@vaadin/time-picker@~25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/time-picker/-/time-picker-25.2.6.tgz#4a58ebf90874dd61fc4cbc352df5ad824f94343a"
+  resolved "https://registry.npmjs.org/@vaadin/time-picker/-/time-picker-25.2.6.tgz"
   integrity sha512-obEW8MG3eME0O5+xYvGUFCwcaXF2sHnADiclR2R9JNIa0wh5pnHzyybmv/TkPJDFYfPzgDC/p7viOGMfyZ+/eg==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -2252,7 +1656,7 @@
 
 "@vaadin/tooltip@~25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/tooltip/-/tooltip-25.2.6.tgz#c8afbcc5450967864d0d0586ca9eab473be1e9a8"
+  resolved "https://registry.npmjs.org/@vaadin/tooltip/-/tooltip-25.2.6.tgz"
   integrity sha512-i4Yh1M7XyJ+iKJfxU0GRmGGaNYHu05YMYMwLE2ywx9mkpnOVKc6Rh94DFKiftshV54tRCMPT7XEZ5spe5qALTA==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -2266,7 +1670,7 @@
 
 "@vaadin/upload@^25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/upload/-/upload-25.2.6.tgz#ac692d9f5ed4e7761e993edd076172db0dda559b"
+  resolved "https://registry.npmjs.org/@vaadin/upload/-/upload-25.2.6.tgz"
   integrity sha512-Sg7bDS2PVEUcxc/PjAU1OmPMURJZdPjZUdbzvV4RVGqjpvL0CgFFuwUxvcH4gfGHpoFU10dZIQYF7b1prjyDcw==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -2291,7 +1695,7 @@
 
 "@vaadin/vaadin-lumo-styles@^25.0.0", "@vaadin/vaadin-lumo-styles@^25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-25.2.6.tgz#1ce4aba59d2364715cfa0990a8db6f8d824a0813"
+  resolved "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-25.2.6.tgz"
   integrity sha512-JRAIqca4wpOIZOC5nYW30b3CKpnMja0gP4lrzg84bmU46+Q1MRnWiWFUDJzDB+NVbtWOm8DqOuhCCLGkXp++Kg==
   dependencies:
     "@vaadin/component-base" "~25.2.6"
@@ -2300,7 +1704,7 @@
 
 "@vaadin/vaadin-themable-mixin@^25.0.0", "@vaadin/vaadin-themable-mixin@~25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-25.2.6.tgz#999fc076f3c3f65f1002a042a05f906fab05576a"
+  resolved "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-25.2.6.tgz"
   integrity sha512-Kmmj7A1Wj87ODySV0dEb2rQcWuGJKWJiN2agdl1iQNkUSgcjEwJJhkBn1tfVkcxpZz3o0uzgW2ufCHlJCRbMbQ==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -2316,7 +1720,7 @@
 
 "@vaadin/vertical-layout@^25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/vertical-layout/-/vertical-layout-25.2.6.tgz#ba53185ebc8137f7e2f9bf6577905f4afbc94c3b"
+  resolved "https://registry.npmjs.org/@vaadin/vertical-layout/-/vertical-layout-25.2.6.tgz"
   integrity sha512-CnoTv/Wp6OCdRGQuYLWVeeaRixnrU8NHzyi2Wlyt8Ti1DkSjAnb1UbIWKdDBbmphZR/kUQhZiM/ldNk3AFumcA==
   dependencies:
     "@vaadin/component-base" "~25.2.6"
@@ -2325,7 +1729,7 @@
 
 "@vaadin/virtual-list@^25.2.6":
   version "25.2.6"
-  resolved "https://registry.yarnpkg.com/@vaadin/virtual-list/-/virtual-list-25.2.6.tgz#2fe674f7ea901c5b7f5182cfb2c56a44bc2ed529"
+  resolved "https://registry.npmjs.org/@vaadin/virtual-list/-/virtual-list-25.2.6.tgz"
   integrity sha512-yuOyW7v4axU/ad6FlLdTWqDeJC/r8rPadMz0r6AzcFdnN8THVJUJBtsxNTpb3IAoL0D6bfu8VvomPHeNp99/aQ==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
@@ -2354,7 +1758,7 @@
     estree-walker "^3.0.3"
     magic-string "^0.30.17"
 
-"@vitest/pretty-format@3.2.7", "@vitest/pretty-format@^3.2.7":
+"@vitest/pretty-format@^3.2.7", "@vitest/pretty-format@3.2.7":
   version "3.2.7"
   resolved "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz"
   integrity sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==
@@ -2395,7 +1799,7 @@
     loupe "^3.1.4"
     tinyrainbow "^2.0.0"
 
-"@volar/language-core@2.4.28", "@volar/language-core@~2.4.11":
+"@volar/language-core@~2.4.11", "@volar/language-core@2.4.28":
   version "2.4.28"
   resolved "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz"
   integrity sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==
@@ -2416,24 +1820,24 @@
     path-browserify "^1.0.1"
     vscode-uri "^3.0.8"
 
-"@vue/compiler-core@3.5.39":
-  version "3.5.39"
-  resolved "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.39.tgz"
-  integrity sha512-16KBTEXAJCpDr0mwlw+AZyhu8iyC7R3S2vBwsI7QnWJU6X3WKc9VKeNEZpiMdZ569qWhz9574L3vV55qRL0Vtw==
+"@vue/compiler-core@3.5.40":
+  version "3.5.40"
+  resolved "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.40.tgz"
+  integrity sha512-39E8IgOhTbVDnoJFMKc2DvYnypcZwUqgUhQkccva/0m6FUwtIKSGV7n1hpVmYcFaoRAwf9pBcwnKlCEsN63ZEQ==
   dependencies:
     "@babel/parser" "^7.29.7"
-    "@vue/shared" "3.5.39"
+    "@vue/shared" "3.5.40"
     entities "^7.0.1"
     estree-walker "^2.0.2"
     source-map-js "^1.2.1"
 
 "@vue/compiler-dom@^3.5.0":
-  version "3.5.39"
-  resolved "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.39.tgz"
-  integrity sha512-oQPigALqYbNxTNPvNgSOe+czwVExfbVF02lz8jP0S3AXJiu3jxYDygNUiqSep4ezzW8XgnubqH63My2A7JR/vg==
+  version "3.5.40"
+  resolved "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.40.tgz"
+  integrity sha512-pwkx4vqlqOspFstrcmzwkKLePVMD3PT65imRzLhanU2V1Fj4K13g6OXjanOyzw3aTAuRk84BOmY8f3rEHqPaVA==
   dependencies:
-    "@vue/compiler-core" "3.5.39"
-    "@vue/shared" "3.5.39"
+    "@vue/compiler-core" "3.5.40"
+    "@vue/shared" "3.5.40"
 
 "@vue/compiler-vue2@^2.7.16":
   version "2.7.16"
@@ -2457,12 +1861,12 @@
     muggle-string "^0.4.1"
     path-browserify "^1.0.1"
 
-"@vue/shared@3.5.39", "@vue/shared@^3.5.0":
-  version "3.5.39"
-  resolved "https://registry.npmjs.org/@vue/shared/-/shared-3.5.39.tgz"
-  integrity sha512-l1rrBtBfTnmxvtsvdQDXltUUy8S1Y+ZaqdfUzmAnJkTd8Z8rv5v/ytW+TKiqEOWyHPoqtPlNFSs0lhRmYVSHVA==
+"@vue/shared@^3.5.0", "@vue/shared@3.5.40":
+  version "3.5.40"
+  resolved "https://registry.npmjs.org/@vue/shared/-/shared-3.5.40.tgz"
+  integrity sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg==
 
-"@web-comp/core@^1.0.2":
+"@web-comp/core@^1.0.2", "@web-comp/core@latest":
   version "1.0.2"
   resolved "https://registry.npmjs.org/@web-comp/core/-/core-1.0.2.tgz"
   integrity sha512-w9Yrt90XmhmcyOa3d9o8a41i4ulHs/Ct94c1GJBTAQaD4Y4emuqmuZ1u83U6H2mASHD0c9Jo3KntaFBlMHnQ1w==
@@ -2474,12 +1878,12 @@
 
 "@web/config-loader@^0.3.0":
   version "0.3.3"
-  resolved "https://registry.yarnpkg.com/@web/config-loader/-/config-loader-0.3.3.tgz#13d4852c479d1f3adbc1f24d79c7e6eeedeb6e5d"
+  resolved "https://registry.npmjs.org/@web/config-loader/-/config-loader-0.3.3.tgz"
   integrity sha512-ilzeQzrPpPLWZhzFCV+4doxKDGm7oKVfdKpW9wiUNVgive34NSzCw+WzXTvjE4Jgr5CkyTDIObEmMrqQEjhT0g==
 
 "@web/dev-server-core@^0.7.2":
   version "0.7.5"
-  resolved "https://registry.yarnpkg.com/@web/dev-server-core/-/dev-server-core-0.7.5.tgz#b283d46eb2c0384e848311ec9da25d06bbbc47df"
+  resolved "https://registry.npmjs.org/@web/dev-server-core/-/dev-server-core-0.7.5.tgz"
   integrity sha512-Da65zsiN6iZPMRuj4Oa6YPwvsmZmo5gtPWhW2lx3GTUf5CAEapjVpZVlUXnKPL7M7zRuk72jSsIl8lo+XpTCtw==
   dependencies:
     "@types/koa" "^2.11.6"
@@ -2503,7 +1907,7 @@
 
 "@web/dev-server-rollup@^0.6.1":
   version "0.6.4"
-  resolved "https://registry.yarnpkg.com/@web/dev-server-rollup/-/dev-server-rollup-0.6.4.tgz#d0a4f69e4a659d2b79f172e86236cea6c872e81c"
+  resolved "https://registry.npmjs.org/@web/dev-server-rollup/-/dev-server-rollup-0.6.4.tgz"
   integrity sha512-sJZfTGCCrdku5xYnQQG51odGI092hKY9YFM0X3Z0tRY3iXKXcYRaLZrErw5KfCxr6g0JRuhe4BBhqXTA5Q2I3Q==
   dependencies:
     "@rollup/plugin-node-resolve" "^15.0.1"
@@ -2515,7 +1919,7 @@
 
 "@web/dev-server@^0.4.6":
   version "0.4.6"
-  resolved "https://registry.yarnpkg.com/@web/dev-server/-/dev-server-0.4.6.tgz#18a4421d474a9bd1bfc90419a7a798ed0b5538c5"
+  resolved "https://registry.npmjs.org/@web/dev-server/-/dev-server-0.4.6.tgz"
   integrity sha512-jj/1bcElAy5EZet8m2CcUdzxT+CRvUjIXGh8Lt7vxtthkN9PzY9wlhWx/9WOs5iwlnG1oj0VGo6f/zvbPO0s9w==
   dependencies:
     "@babel/code-frame" "^7.12.11"
@@ -2535,7 +1939,7 @@
 
 "@web/parse5-utils@^2.1.0":
   version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@web/parse5-utils/-/parse5-utils-2.1.1.tgz#a14114ece60f7f55772410b0813585e046478fdd"
+  resolved "https://registry.npmjs.org/@web/parse5-utils/-/parse5-utils-2.1.1.tgz"
   integrity sha512-7rBVZEMGfrq2iPcAEwJ0KSNSvmA2a6jT2CK8/gyIOHgn4reg7bSSRbzyWIEYWyIkeRoYEukX/aW+nAeCgSSqhQ==
   dependencies:
     "@types/parse5" "^6.0.1"
@@ -2562,7 +1966,7 @@
 
 accepts@^1.3.5:
   version "1.3.8"
-  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
+  resolved "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz"
   integrity sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==
   dependencies:
     mime-types "~2.1.34"
@@ -2592,10 +1996,20 @@ ajv-formats@~3.0.1:
   dependencies:
     ajv "^8.0.0"
 
-ajv@^8.0.0, ajv@~8.18.0:
+ajv@^8.0.0, ajv@^8.5.0, ajv@~8.18.0:
   version "8.18.0"
   resolved "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz"
   integrity sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    fast-uri "^3.0.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+
+ajv@~8.20.0:
+  version "8.20.0"
+  resolved "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz"
+  integrity sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==
   dependencies:
     fast-deep-equal "^3.1.3"
     fast-uri "^3.0.1"
@@ -2626,7 +2040,7 @@ ansi-styles@^3.2.1:
 
 ansi-styles@^4.1.0:
   version "4.3.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz"
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
@@ -2652,7 +2066,7 @@ array-back@^3.0.1, array-back@^3.1.0:
 
 array-back@^6.2.2:
   version "6.2.3"
-  resolved "https://registry.yarnpkg.com/array-back/-/array-back-6.2.3.tgz#d41e67598805e614f23b319b9e5960dfbcd72ae2"
+  resolved "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz"
   integrity sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==
 
 assertion-error@^2.0.1:
@@ -2662,7 +2076,7 @@ assertion-error@^2.0.1:
 
 async@^3.2.6:
   version "3.2.6"
-  resolved "https://registry.yarnpkg.com/async/-/async-3.2.6.tgz#1b0728e14929d51b85b449b7f06e27c1145e38ce"
+  resolved "https://registry.npmjs.org/async/-/async-3.2.6.tgz"
   integrity sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==
 
 asynckit@^0.4.0:
@@ -2697,7 +2111,7 @@ balanced-match@^4.0.2:
 
 bpmn-js@^18.22.0:
   version "18.22.0"
-  resolved "https://registry.yarnpkg.com/bpmn-js/-/bpmn-js-18.22.0.tgz#26d771f0c4960f478aced24434c92261ab570554"
+  resolved "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.22.0.tgz"
   integrity sha512-hM5aOiyLVdVGA80nveJLXFVQMpsaST7RilErjeKfXMhpZQJTnzU+yLDaenIJsq2f90+9inyktVPqsS1Ersik2A==
   dependencies:
     bpmn-moddle "^10.0.0"
@@ -2734,9 +2148,9 @@ brace-expansion@^2.0.2:
     balanced-match "^1.0.0"
 
 brace-expansion@^5.0.2, brace-expansion@^5.0.5:
-  version "5.0.7"
-  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz"
-  integrity sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==
+  version "5.0.8"
+  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz"
+  integrity sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==
   dependencies:
     balanced-match "^4.0.2"
 
@@ -2752,7 +2166,7 @@ cac@^6.7.14:
 
 cache-content-type@^1.0.0:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/cache-content-type/-/cache-content-type-1.0.1.tgz#035cde2b08ee2129f4a8315ea8f00a00dba1453c"
+  resolved "https://registry.npmjs.org/cache-content-type/-/cache-content-type-1.0.1.tgz"
   integrity sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==
   dependencies:
     mime-types "^2.1.18"
@@ -2768,7 +2182,7 @@ call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
 
 call-bound@^1.0.2, call-bound@^1.0.4:
   version "1.0.4"
-  resolved "https://registry.yarnpkg.com/call-bound/-/call-bound-1.0.4.tgz#238de935d2a2a692928c538c7ccfa91067fd062a"
+  resolved "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz"
   integrity sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==
   dependencies:
     call-bind-apply-helpers "^1.0.2"
@@ -2776,7 +2190,7 @@ call-bound@^1.0.2, call-bound@^1.0.4:
 
 camelcase@^6.2.0:
   version "6.3.0"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
+  resolved "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 cancel-token@^0.1.1:
@@ -2799,7 +2213,7 @@ chai@^5.2.0:
 
 chalk-template@^0.4.0:
   version "0.4.0"
-  resolved "https://registry.yarnpkg.com/chalk-template/-/chalk-template-0.4.0.tgz#692c034d0ed62436b9062c1707fadcd0f753204b"
+  resolved "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz"
   integrity sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==
   dependencies:
     chalk "^4.1.2"
@@ -2826,13 +2240,13 @@ chalk@^2.4.1:
 
 chalk@^4.1.2:
   version "4.1.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chart.js@^4.5.0:
+chart.js@^4.5.0, chart.js@>=2.8.0:
   version "4.5.1"
   resolved "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz"
   integrity sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==
@@ -2851,7 +2265,7 @@ check-error@^2.1.1:
 
 chokidar@^4.0.1:
   version "4.0.3"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-4.0.3.tgz#7be37a4c03c9aee1ecfe862a4a23b2c70c205d30"
+  resolved "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz"
   integrity sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==
   dependencies:
     readdirp "^4.0.1"
@@ -2868,7 +2282,7 @@ clsx@^2.1.1:
 
 co@^4.6.0:
   version "4.6.0"
-  resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
+  resolved "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
   integrity sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==
 
 color-convert@^1.9.0:
@@ -2880,20 +2294,20 @@ color-convert@^1.9.0:
 
 color-convert@^2.0.1:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  resolved "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz"
   integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
   dependencies:
     color-name "~1.1.4"
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
   integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
-
-color-name@~1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
-  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 combined-stream@^1.0.8:
   version "1.0.8"
@@ -2924,7 +2338,7 @@ command-line-usage@^5.0.2:
 
 command-line-usage@^7.0.1:
   version "7.0.4"
-  resolved "https://registry.yarnpkg.com/command-line-usage/-/command-line-usage-7.0.4.tgz#759449bac39c5410e23513f1f78551b669df1514"
+  resolved "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.4.tgz"
   integrity sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==
   dependencies:
     array-back "^6.2.2"
@@ -2954,14 +2368,14 @@ confbox@^0.2.4:
 
 content-disposition@~0.5.2:
   version "0.5.4"
-  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.4.tgz#8b82b4efac82512a02bb0b1dcec9d2c5e8eb5bfe"
+  resolved "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz"
   integrity sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==
   dependencies:
     safe-buffer "5.2.1"
 
 content-type@^1.0.4:
   version "1.0.5"
-  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.5.tgz#8b773162656d1d1086784c8f23a54ce6d73d7918"
+  resolved "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz"
   integrity sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==
 
 cookieconsent@^3.1.1:
@@ -2971,7 +2385,7 @@ cookieconsent@^3.1.1:
 
 cookies@~0.9.0:
   version "0.9.1"
-  resolved "https://registry.yarnpkg.com/cookies/-/cookies-0.9.1.tgz#3ffed6f60bb4fb5f146feeedba50acc418af67e3"
+  resolved "https://registry.npmjs.org/cookies/-/cookies-0.9.1.tgz"
   integrity sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==
   dependencies:
     depd "~2.0.0"
@@ -2979,7 +2393,7 @@ cookies@~0.9.0:
 
 cross-spawn@^7.0.3:
   version "7.0.6"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
+  resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz"
   integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
   dependencies:
     path-key "^3.1.0"
@@ -2998,10 +2412,10 @@ csscolorparser@~1.0.2:
 
 csstype@3.1.1:
   version "3.1.1"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.1.tgz#841b532c45c758ee546a11d5bd7b7b473c8c30b9"
+  resolved "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz"
   integrity sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==
 
-date-fns@^4.1.0:
+date-fns@^4.1.0, date-fns@>=2.0.0:
   version "4.4.0"
   resolved "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz"
   integrity sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==
@@ -3013,22 +2427,22 @@ de-indent@^1.0.2:
 
 debounce@^1.2.0:
   version "1.2.1"
-  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
+  resolved "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz"
   integrity sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==
 
-debug@4, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.6, debug@^4.4.0, debug@^4.4.1:
+debug@^3.1.0:
+  version "3.2.7"
+  resolved "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz"
+  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
+  dependencies:
+    ms "^2.1.1"
+
+debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.6, debug@^4.4.0, debug@^4.4.1, debug@4:
   version "4.4.3"
   resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
   dependencies:
     ms "^2.1.3"
-
-debug@^3.1.0:
-  version "3.2.7"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
-  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
-  dependencies:
-    ms "^2.1.1"
 
 deep-eql@^5.0.1:
   version "5.0.2"
@@ -3037,7 +2451,7 @@ deep-eql@^5.0.1:
 
 deep-equal@~1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
+  resolved "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
   integrity sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==
 
 deep-extend@~0.6.0:
@@ -3052,19 +2466,19 @@ deep-is@~0.1.3:
 
 deepmerge@^4.2.2:
   version "4.3.1"
-  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
+  resolved "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz"
   integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
 
 default-gateway@^6.0.0:
   version "6.0.3"
-  resolved "https://registry.yarnpkg.com/default-gateway/-/default-gateway-6.0.3.tgz#819494c888053bdb743edbf343d6cdf7f2943a71"
+  resolved "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.3.tgz"
   integrity sha512-fwSOJsbbNzZ/CUFpqFBqYfYNLj1NbMPm8MMCIzHjC83iSJRBEGmDUxU+WP661BaBQImeC2yHwXtz+P/O9o+XEg==
   dependencies:
     execa "^5.0.0"
 
 define-lazy-prop@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz#3f7ae421129bcaaac9bc74905c98a0009ec9ee7f"
+  resolved "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz"
   integrity sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==
 
 delayed-stream@~1.0.0:
@@ -3074,40 +2488,40 @@ delayed-stream@~1.0.0:
 
 delegates@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
+  resolved "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
   integrity sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==
 
 depd@^2.0.0, depd@~2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
+  resolved "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
 depd@~1.1.2:
   version "1.1.2"
-  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
+  resolved "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz"
   integrity sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==
 
 destroy@^1.0.4:
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015"
+  resolved "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz"
   integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
 
 detect-libc@^2.0.3:
   version "2.1.2"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.1.2.tgz#689c5dcdc1900ef5583a4cb9f6d7b473742074ad"
+  resolved "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz"
   integrity sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==
 
 diagram-js-direct-editing@^3.5.1:
   version "3.5.1"
-  resolved "https://registry.yarnpkg.com/diagram-js-direct-editing/-/diagram-js-direct-editing-3.5.1.tgz#535323c3007f933f5a08f59c6821a0d6f00821dc"
+  resolved "https://registry.npmjs.org/diagram-js-direct-editing/-/diagram-js-direct-editing-3.5.1.tgz"
   integrity sha512-fEQCQ/x5oKVV0m7Nmgv7i85Vhw+kJkKNXF8zcV5Vm0KwF8x/8e3Ax0aJgdXt8/fDPymEkY8HmZweXIipCeeh+g==
   dependencies:
     min-dash "^5.0.0"
     min-dom "^5.3.0"
 
-diagram-js@^15.23.0:
+diagram-js@*, diagram-js@^15.23.0:
   version "15.23.0"
-  resolved "https://registry.yarnpkg.com/diagram-js/-/diagram-js-15.23.0.tgz#5a830db734bf1049890a80ad442d0498ab977734"
+  resolved "https://registry.npmjs.org/diagram-js/-/diagram-js-15.23.0.tgz"
   integrity sha512-cCgL+4Ep0xrLe6TtdvRVgo6bWYjUbrQg+ES/9rpltqmTD2YaPoC+NYcRsKYw/fDO+1RN0q16NzErP1svVZhNQg==
   dependencies:
     "@bpmn-io/diagram-js-ui" "^0.2.4"
@@ -3153,7 +2567,7 @@ domify@^3.0.0:
 
 dompurify@^3.4.10, dompurify@^3.4.12:
   version "3.4.12"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.12.tgz#6fa2265e9bbdce882c4ace4107626051b448ffa8"
+  resolved "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz"
   integrity sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
@@ -3169,17 +2583,17 @@ dunder-proto@^1.0.1:
 
 earcut@^3.0.0:
   version "3.2.3"
-  resolved "https://registry.yarnpkg.com/earcut/-/earcut-3.2.3.tgz#74aec19555a7e28773429826729d2e4bfeb19022"
+  resolved "https://registry.npmjs.org/earcut/-/earcut-3.2.3.tgz"
   integrity sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==
 
 ee-first@1.1.1:
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
+  resolved "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
 encodeurl@^1.0.2:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
+  resolved "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz"
   integrity sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==
 
 entities@^7.0.1:
@@ -3221,7 +2635,7 @@ es-set-tostringtag@^2.1.0:
 
 "esbuild@^0.27.0 || ^0.28.0", esbuild@^0.28.1:
   version "0.28.1"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.28.1.tgz#ef45b4634c9c9d97a296aea4114a5f9840f95578"
+  resolved "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz"
   integrity sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==
   optionalDependencies:
     "@esbuild/aix-ppc64" "0.28.1"
@@ -3253,7 +2667,7 @@ es-set-tostringtag@^2.1.0:
 
 escape-html@^1.0.3:
   version "1.0.3"
-  resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
+  resolved "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
   integrity sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
 
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
@@ -3302,12 +2716,12 @@ esutils@^2.0.2:
 
 etag@^1.8.1:
   version "1.8.1"
-  resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
+  resolved "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
 
 execa@^5.0.0:
   version "5.1.1"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
+  resolved "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz"
   integrity sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==
   dependencies:
     cross-spawn "^7.0.3"
@@ -3342,7 +2756,7 @@ fast-levenshtein@~2.0.6:
 
 fast-uri@^3.0.1:
   version "3.1.4"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.4.tgz#3b3daf9ce68f41f956df0b505132c0cfce9ec7af"
+  resolved "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz"
   integrity sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==
 
 fdir@^6.5.0:
@@ -3375,7 +2789,7 @@ form-data@^4.0.5:
 
 fresh@~0.5.2:
   version "0.5.2"
-  resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
+  resolved "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz"
   integrity sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==
 
 fs-extra@^6.0.1:
@@ -3413,7 +2827,7 @@ function-bind@^1.1.2:
 
 generator-function@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/generator-function/-/generator-function-2.0.1.tgz#0e75dd410d1243687a0ba2e951b94eedb8f737a2"
+  resolved "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz"
   integrity sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==
 
 geotiff@^2.0.2, geotiff@^2.1.3:
@@ -3456,7 +2870,7 @@ get-proto@^1.0.1:
 
 get-stream@^6.0.0:
   version "6.0.1"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
+  resolved "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
 
 glob@^7.1.2:
@@ -3524,7 +2938,7 @@ he@^1.2.0:
 
 highcharts@12.2.0:
   version "12.2.0"
-  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-12.2.0.tgz#264633af7e815f0f6291c0d570b1da12e323e9de"
+  resolved "https://registry.npmjs.org/highcharts/-/highcharts-12.2.0.tgz"
   integrity sha512-UUN+osTP3aeGc4KmoMuWAjzpKif8GYHFozzYI4O8h1ILGof25M/ZGBpXLvgqf1z0LVh7N9eG7i0HnzMfjcR4nA==
 
 htm@^3.1.1:
@@ -3534,7 +2948,7 @@ htm@^3.1.1:
 
 http-assert@^1.3.0:
   version "1.5.0"
-  resolved "https://registry.yarnpkg.com/http-assert/-/http-assert-1.5.0.tgz#c389ccd87ac16ed2dfa6246fd73b926aa00e6b8f"
+  resolved "https://registry.npmjs.org/http-assert/-/http-assert-1.5.0.tgz"
   integrity sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==
   dependencies:
     deep-equal "~1.0.1"
@@ -3542,7 +2956,7 @@ http-assert@^1.3.0:
 
 http-errors@^1.6.3, http-errors@^1.7.3, http-errors@~1.8.0:
   version "1.8.1"
-  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.8.1.tgz#7c3f28577cbc8a207388455dbd62295ed07bd68c"
+  resolved "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz"
   integrity sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==
   dependencies:
     depd "~1.1.2"
@@ -3553,7 +2967,7 @@ http-errors@^1.6.3, http-errors@^1.7.3, http-errors@~1.8.0:
 
 http-errors@~1.6.2:
   version "1.6.3"
-  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.3.tgz#8b55680bb4be283a0b5bf4ea2e38580be1d9320d"
+  resolved "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz"
   integrity sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==
   dependencies:
     depd "~1.1.2"
@@ -3571,7 +2985,7 @@ https-proxy-agent@^5.0.1:
 
 human-signals@^2.1.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
+  resolved "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
 ids@^3.0.2:
@@ -3614,12 +3028,12 @@ inherits@2, inherits@2.0.4:
 
 inherits@2.0.3:
   version "2.0.3"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+  resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
   integrity sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==
 
 internal-ip@^6.2.0:
   version "6.2.0"
-  resolved "https://registry.yarnpkg.com/internal-ip/-/internal-ip-6.2.0.tgz#d5541e79716e406b74ac6b07b856ef18dc1621c1"
+  resolved "https://registry.npmjs.org/internal-ip/-/internal-ip-6.2.0.tgz"
   integrity sha512-D8WGsR6yDt8uq7vDMu7mjcR+yRMm3dW8yufyChmszWRjcSHuxLBkR3GdS2HZAjodsaGuCvXeEJpueisXJULghg==
   dependencies:
     default-gateway "^6.0.0"
@@ -3629,12 +3043,12 @@ internal-ip@^6.2.0:
 
 ip-regex@^4.0.0:
   version "4.3.0"
-  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-4.3.0.tgz#687275ab0f57fa76978ff8f4dddc8a23d5990db5"
+  resolved "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz"
   integrity sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==
 
 ipaddr.js@^1.9.1:
   version "1.9.1"
-  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
+  resolved "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz"
   integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
 
 is-core-module@^2.16.1:
@@ -3646,12 +3060,12 @@ is-core-module@^2.16.1:
 
 is-docker@^2.0.0, is-docker@^2.1.1:
   version "2.2.1"
-  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
+  resolved "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz"
   integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
 
 is-generator-function@^1.0.7:
   version "1.1.2"
-  resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.1.2.tgz#ae3b61e3d5ea4e4839b90bad22b02335051a17d5"
+  resolved "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz"
   integrity sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==
   dependencies:
     call-bound "^1.0.4"
@@ -3662,19 +3076,19 @@ is-generator-function@^1.0.7:
 
 is-ip@^3.1.0:
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/is-ip/-/is-ip-3.1.0.tgz#2ae5ddfafaf05cb8008a62093cf29734f657c5d8"
+  resolved "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz"
   integrity sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==
   dependencies:
     ip-regex "^4.0.0"
 
 is-module@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
+  resolved "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz"
   integrity sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==
 
 is-regex@^1.2.1:
   version "1.2.1"
-  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.2.1.tgz#76d70a3ed10ef9be48eb577887d74205bf0cad22"
+  resolved "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz"
   integrity sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==
   dependencies:
     call-bound "^1.0.2"
@@ -3684,7 +3098,7 @@ is-regex@^1.2.1:
 
 is-stream@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
+  resolved "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz"
   integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
 
 is-windows@^1.0.2:
@@ -3694,19 +3108,19 @@ is-windows@^1.0.2:
 
 is-wsl@^2.2.0:
   version "2.2.0"
-  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
+  resolved "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz"
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
   dependencies:
     is-docker "^2.0.0"
 
 isbinaryfile@^5.0.0:
   version "5.0.7"
-  resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-5.0.7.tgz#19a73f2281b7368dca9d3b3ac8a0434074670979"
+  resolved "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.7.tgz"
   integrity sha512-gnWD14Jh3FzS3CPhF0AxNOJ8CxqeblPTADzI38r0wt8ZyQl5edpy75myt08EG2oKvpyiqSqsx+Wkz9vtkbTqYQ==
 
 isexe@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+  resolved "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
 jju@~1.4.0:
@@ -3716,7 +3130,7 @@ jju@~1.4.0:
 
 js-base64@^3.9.1:
   version "3.9.1"
-  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.9.1.tgz#02335c16c6a311c9135dfa71b4b3b7f1af33dd48"
+  resolved "https://registry.npmjs.org/js-base64/-/js-base64-3.9.1.tgz"
   integrity sha512-U73qptcvf/HIOauFOmqT3a0mDUp0MYlfd15oqoe9kqZt5XhiXVb+HG09sLvI9PQ9tZIBFS4nlErai8zbWazP0g==
 
 js-tokens@^4.0.0:
@@ -3767,24 +3181,24 @@ jsonschema@^1.1.0:
 
 keycloak-js@26.2.4:
   version "26.2.4"
-  resolved "https://registry.yarnpkg.com/keycloak-js/-/keycloak-js-26.2.4.tgz#b96ff33ed08ff6fd8d1e09d9e5055c7b3f2fa918"
+  resolved "https://registry.npmjs.org/keycloak-js/-/keycloak-js-26.2.4.tgz"
   integrity sha512-PnXpR3ubETGOt0B/Qt2lxmPbkZr5bc3vlQsOqDoTPPQsZRp7JjhTKxlJ187uWh8qJhvBab6Gsjb06a8ayOPfuw==
 
 keygrip@~1.1.0:
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/keygrip/-/keygrip-1.1.0.tgz#871b1681d5e159c62a445b0c74b615e0917e7226"
+  resolved "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz"
   integrity sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==
   dependencies:
     tsscmp "1.0.6"
 
 koa-compose@^4.1.0:
   version "4.1.0"
-  resolved "https://registry.yarnpkg.com/koa-compose/-/koa-compose-4.1.0.tgz#507306b9371901db41121c812e923d0d67d3e877"
+  resolved "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz"
   integrity sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==
 
 koa-convert@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/koa-convert/-/koa-convert-2.0.0.tgz#86a0c44d81d40551bae22fee6709904573eea4f5"
+  resolved "https://registry.npmjs.org/koa-convert/-/koa-convert-2.0.0.tgz"
   integrity sha512-asOvN6bFlSnxewce2e/DK3p4tltyfC4VM7ZwuTuepI7dEQVcvpyFuBcEARu1+Hxg8DIwytce2n7jrZtRlPrARA==
   dependencies:
     co "^4.6.0"
@@ -3792,14 +3206,14 @@ koa-convert@^2.0.0:
 
 koa-etag@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/koa-etag/-/koa-etag-4.0.0.tgz#2c2bb7ae69ca1ac6ced09ba28dcb78523c810414"
+  resolved "https://registry.npmjs.org/koa-etag/-/koa-etag-4.0.0.tgz"
   integrity sha512-1cSdezCkBWlyuB9l6c/IFoe1ANCDdPBxkDkRiaIup40xpUub6U/wwRXoKBZw/O5BifX9OlqAjYnDyzM6+l+TAg==
   dependencies:
     etag "^1.8.1"
 
 koa-send@^5.0.0, koa-send@^5.0.1:
   version "5.0.1"
-  resolved "https://registry.yarnpkg.com/koa-send/-/koa-send-5.0.1.tgz#39dceebfafb395d0d60beaffba3a70b4f543fe79"
+  resolved "https://registry.npmjs.org/koa-send/-/koa-send-5.0.1.tgz"
   integrity sha512-tmcyQ/wXXuxpDxyNXv5yNNkdAMdFRqwtegBXUaowiQzUKqJehttS0x2j0eOZDQAyloAth5w6wwBImnFzkUz3pQ==
   dependencies:
     debug "^4.1.1"
@@ -3808,7 +3222,7 @@ koa-send@^5.0.0, koa-send@^5.0.1:
 
 koa-static@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/koa-static/-/koa-static-5.0.0.tgz#5e92fc96b537ad5219f425319c95b64772776943"
+  resolved "https://registry.npmjs.org/koa-static/-/koa-static-5.0.0.tgz"
   integrity sha512-UqyYyH5YEXaJrf9S8E23GoJFQZXkBVJ9zYYMPGz919MSX1KuvAcycIuS0ci150HCoPf4XQVhQ84Qf8xRPWxFaQ==
   dependencies:
     debug "^3.1.0"
@@ -3816,7 +3230,7 @@ koa-static@^5.0.0:
 
 koa@^2.13.0:
   version "2.16.4"
-  resolved "https://registry.yarnpkg.com/koa/-/koa-2.16.4.tgz#303b996f5c3f2a3bb771c7db5e4303ee05f2265f"
+  resolved "https://registry.npmjs.org/koa/-/koa-2.16.4.tgz"
   integrity sha512-3An0GCLDSR34tsCO4H8Tef8Pp2ngtaZDAZnsWJYelqXUK5wyiHvGItgK/xcSkmHLSTn1Jcho1mRQs2ehRzvKKw==
   dependencies:
     accepts "^1.3.5"
@@ -3861,64 +3275,14 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-lightningcss-android-arm64@1.33.0:
-  version "1.33.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz#9a6841f88ae50fc83502903892b41af41bc2b907"
-  integrity sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==
-
 lightningcss-darwin-arm64@1.33.0:
   version "1.33.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz#c0f2c31c0bfd19fa4dd3f18e957a1f1a152097d6"
+  resolved "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz"
   integrity sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==
 
-lightningcss-darwin-x64@1.33.0:
+lightningcss@^1.21.0, lightningcss@^1.32.0:
   version "1.33.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz#cb0705965acb538c6683949ce6925fb3cdf7c361"
-  integrity sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==
-
-lightningcss-freebsd-x64@1.33.0:
-  version "1.33.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz#763538828b26bab2680dadafcc84ee78b0eb502b"
-  integrity sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==
-
-lightningcss-linux-arm-gnueabihf@1.33.0:
-  version "1.33.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz#6862e3176a331aedbdec1ed352b4d7d0dd0784de"
-  integrity sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==
-
-lightningcss-linux-arm64-gnu@1.33.0:
-  version "1.33.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz#c6a3a2ed15141daf6bdc2628930f8e39bdf473aa"
-  integrity sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==
-
-lightningcss-linux-arm64-musl@1.33.0:
-  version "1.33.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz#7fa1334971fc82845f9827df6ef8a0b20914bac6"
-  integrity sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==
-
-lightningcss-linux-x64-gnu@1.33.0:
-  version "1.33.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz#8b927862ea8c2bbc6831a46509244b50d9936e55"
-  integrity sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==
-
-lightningcss-linux-x64-musl@1.33.0:
-  version "1.33.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz#0c525bb077dfd94404c059cfe42dad797e96aeaf"
-  integrity sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==
-
-lightningcss-win32-arm64-msvc@1.33.0:
-  version "1.33.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz#850ee1103dac989cfab50e3ac22d1a69e394e63d"
-  integrity sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==
-
-lightningcss-win32-x64-msvc@1.33.0:
-  version "1.33.0"
-  resolved "https://registry.yarnpkg.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz#e343ae152eed3609dc6e11949d1a3bf39a1c946f"
-  integrity sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==
-
-lightningcss@^1.32.0:
-  version "1.33.0"
-  resolved "https://registry.yarnpkg.com/lightningcss/-/lightningcss-1.33.0.tgz#c08867d71a79385c6e190214fd72fef3e5f95f0b"
+  resolved "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz"
   integrity sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==
   dependencies:
     detect-libc "^2.0.3"
@@ -3935,15 +3299,6 @@ lightningcss@^1.32.0:
     lightningcss-win32-arm64-msvc "1.33.0"
     lightningcss-win32-x64-msvc "1.33.0"
 
-lit-element@^3.3.0:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-3.3.3.tgz#10bc19702b96ef5416cf7a70177255bfb17b3209"
-  integrity sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==
-  dependencies:
-    "@lit-labs/ssr-dom-shim" "^1.1.0"
-    "@lit/reactive-element" "^1.3.0"
-    lit-html "^2.8.0"
-
 lit-element@^4.2.0:
   version "4.2.2"
   resolved "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz"
@@ -3953,7 +3308,7 @@ lit-element@^4.2.0:
     "@lit/reactive-element" "^2.1.0"
     lit-html "^3.3.0"
 
-lit-html@^2.0.1, lit-html@^2.8.0:
+lit-html@^2.0.1:
   version "2.8.0"
   resolved "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz"
   integrity sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==
@@ -3966,22 +3321,6 @@ lit-html@^3.3.0:
   integrity sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==
   dependencies:
     "@types/trusted-types" "^2.0.2"
-
-lit-vaadin-helpers@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.npmjs.org/lit-vaadin-helpers/-/lit-vaadin-helpers-0.3.1.tgz"
-  integrity sha512-AhLBgd4fZnH7i7Kc2DKJXZJvlFDZDDI8dxN4O+rLOl8m72kdhoKWwHjheBDXqWPcNItl5Fn9P/TpI9cor/Dmiw==
-  dependencies:
-    lit "^2.0.0"
-
-lit@^2.0.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/lit/-/lit-2.8.0.tgz#4d838ae03059bf9cafa06e5c61d8acc0081e974e"
-  integrity sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==
-  dependencies:
-    "@lit/reactive-element" "^1.6.0"
-    lit-element "^3.3.0"
-    lit-html "^2.8.0"
 
 lit@^3.0.0, lit@^3.2.0, lit@^3.3.1:
   version "3.3.3"
@@ -4023,7 +3362,7 @@ loupe@^3.1.0, loupe@^3.1.4:
 
 lru-cache@^8.0.4:
   version "8.0.5"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-8.0.5.tgz#983fe337f3e176667f8e567cfcce7cb064ea214e"
+  resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-8.0.5.tgz"
   integrity sha512-MhWWlVnuab1RG5/zMRRcVGXZLCXrZTgfwMikgzCegsPnG62yDQo5JnqKkrK4jO5iKqDAZGItAqN5CtKBCBWRUA==
 
 magic-string@^0.30.17:
@@ -4045,13 +3384,106 @@ marked@^15.0.11:
 
 marked@^16.0.0:
   version "16.4.2"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-16.4.2.tgz#4959a64be6c486f0db7467ead7ce288de54290a3"
+  resolved "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz"
   integrity sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==
 
 marked@^18.0.7:
   version "18.0.7"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-18.0.7.tgz#6d8d4dd777730263e7e25bedad56a26bb2809232"
+  resolved "https://registry.npmjs.org/marked/-/marked-18.0.7.tgz"
   integrity sha512-iDVQ5ldaiKXn6b2JroX5kgRfmwgqolW7NpaEzTl1k/2Zh1njIEN9yniyLV/mOvWwtsE8OGgkjsCYvijuPk1dtA==
+
+"mateu-vaadin@file:/Users/mguel/IdeaProjects/mateu-fable/frontend/web/monorepo/apps/vaadin":
+  version "0.0.15"
+  resolved "file:apps/vaadin"
+  dependencies:
+    keycloak-js "26.2.4"
+    lit "^3.3.1"
+    mateu "*"
+    minimatch "^10.2.3"
+
+mateu@*, "mateu@file:/Users/mguel/IdeaProjects/mateu-fable/frontend/web/monorepo/libs/mateu":
+  version "0.0.0"
+  resolved "file:libs/mateu"
+  dependencies:
+    "@alenaksu/json-viewer" "^2.1.1"
+    "@fabricelements/skeleton-carousel" "3.0.2"
+    "@ngyewch/chartjs-v4-webcomponent" "^0.4.0"
+    "@polymer/paper-toggle-button" "^3.0.1"
+    "@types/sortablejs" "^1.15.9"
+    "@ui5/webcomponents" "^2.24.2"
+    "@ui5/webcomponents-ai" "^2.24.2"
+    "@ui5/webcomponents-fiori" "^2.24.2"
+    "@vaadin-component-factory/vcf-date-range-picker" "^6.0.0"
+    "@vaadin/accordion" "^25.2.6"
+    "@vaadin/app-layout" "^25.2.6"
+    "@vaadin/avatar" "^25.2.6"
+    "@vaadin/avatar-group" "^25.2.6"
+    "@vaadin/board" "^25.2.6"
+    "@vaadin/button" "^25.2.6"
+    "@vaadin/card" "^25.2.6"
+    "@vaadin/charts" "^25.2.6"
+    "@vaadin/checkbox" "^25.2.6"
+    "@vaadin/checkbox-group" "^25.2.6"
+    "@vaadin/combo-box" "^25.2.6"
+    "@vaadin/component-base" "^25.2.6"
+    "@vaadin/context-menu" "^25.2.6"
+    "@vaadin/custom-field" "^25.2.6"
+    "@vaadin/date-picker" "^25.2.6"
+    "@vaadin/date-time-picker" "^25.2.6"
+    "@vaadin/details" "^25.2.6"
+    "@vaadin/dialog" "^25.2.6"
+    "@vaadin/email-field" "^25.2.6"
+    "@vaadin/form-layout" "^25.2.6"
+    "@vaadin/grid" "^25.2.6"
+    "@vaadin/horizontal-layout" "^25.2.6"
+    "@vaadin/icons" "^25.2.6"
+    "@vaadin/integer-field" "^25.2.6"
+    "@vaadin/item" "^25.2.6"
+    "@vaadin/list-box" "^25.2.6"
+    "@vaadin/map" "^25.2.6"
+    "@vaadin/markdown" "^25.2.6"
+    "@vaadin/master-detail-layout" "^25.2.6"
+    "@vaadin/menu-bar" "^25.2.6"
+    "@vaadin/message-input" "^25.2.6"
+    "@vaadin/message-list" "^25.2.6"
+    "@vaadin/multi-select-combo-box" "^25.2.6"
+    "@vaadin/notification" "^25.2.6"
+    "@vaadin/number-field" "^25.2.6"
+    "@vaadin/password-field" "^25.2.6"
+    "@vaadin/popover" "^25.2.6"
+    "@vaadin/radio-group" "^25.2.6"
+    "@vaadin/rich-text-editor" "^25.2.6"
+    "@vaadin/router" "^2.0.0"
+    "@vaadin/select" "^25.2.6"
+    "@vaadin/side-nav" "^25.2.6"
+    "@vaadin/split-layout" "^25.2.6"
+    "@vaadin/tabs" "^25.2.6"
+    "@vaadin/tabsheet" "^25.2.6"
+    "@vaadin/text-area" "^25.2.6"
+    "@vaadin/text-field" "^25.2.6"
+    "@vaadin/time-picker" "^25.2.6"
+    "@vaadin/upload" "^25.2.6"
+    "@vaadin/vaadin-lumo-styles" "^25.2.6"
+    "@vaadin/vertical-layout" "^25.2.6"
+    "@vaadin/virtual-list" "^25.2.6"
+    "@web-comp/core" "^1.0.2"
+    "@web-comp/json-viewer" "^1.0.2"
+    axios "^1.16.0"
+    bpmn-js "^18.22.0"
+    chart.js "^4.5.0"
+    chartjs-adapter-date-fns "^3.0.0"
+    cookieconsent "^3.1.1"
+    date-fns "^4.1.0"
+    dompurify "^3.4.12"
+    js-base64 "^3.9.1"
+    lit-vaadin-helpers "^0.3.1"
+    marked "^18.0.7"
+    minimatch "^10.2.3"
+    nanoid "^5.0.7"
+    ol "6.13.0"
+    rxjs "^7.8.1"
+    sortablejs "^1.15.7"
+    vite-plugin-dts "^4.5.4"
 
 math-intrinsics@^1.1.0:
   version "1.1.0"
@@ -4060,12 +3492,12 @@ math-intrinsics@^1.1.0:
 
 media-typer@0.3.0:
   version "0.3.0"
-  resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
+  resolved "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
   integrity sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==
 
 merge-stream@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
+  resolved "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
 mime-db@1.52.0:
@@ -4082,12 +3514,12 @@ mime-types@^2.1.18, mime-types@^2.1.27, mime-types@^2.1.35, mime-types@~2.1.24, 
 
 mimic-fn@^2.1.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
+  resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
 min-dash@^5.0.0, min-dash@^5.1.0:
   version "5.1.0"
-  resolved "https://registry.yarnpkg.com/min-dash/-/min-dash-5.1.0.tgz#ab0d892afa7e2b6b257dfe60fa3e805e0ac73799"
+  resolved "https://registry.npmjs.org/min-dash/-/min-dash-5.1.0.tgz"
   integrity sha512-HAvN6XzmCQj+js43G9sJRRw8kj/7DvoxN7qhoIN9Xo5ZN1NMljtpyKs/NunXmw0QSWwlgZzNv6tLeEa4xaZ0tg==
 
 min-dom@^5.3.0:
@@ -4098,21 +3530,21 @@ min-dom@^5.3.0:
     domify "^3.0.0"
     min-dash "^5.0.0"
 
-minimatch@*, minimatch@^10.2.3:
+minimatch@^10.2.3:
   version "10.2.5"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz"
   integrity sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==
   dependencies:
     brace-expansion "^5.0.5"
 
-minimatch@10.2.3:
-  version "10.2.3"
-  resolved "https://registry.npmjs.org/minimatch/-/minimatch-10.2.3.tgz"
-  integrity sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==
+minimatch@^3.0.4:
+  version "3.1.5"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz"
+  integrity sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==
   dependencies:
-    brace-expansion "^5.0.2"
+    brace-expansion "^1.1.7"
 
-minimatch@^3.0.4, minimatch@^3.1.1:
+minimatch@^3.1.1:
   version "3.1.5"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz"
   integrity sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==
@@ -4125,6 +3557,13 @@ minimatch@^9.0.3:
   integrity sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==
   dependencies:
     brace-expansion "^2.0.2"
+
+minimatch@10.2.3:
+  version "10.2.3"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-10.2.3.tgz"
+  integrity sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==
+  dependencies:
+    brace-expansion "^5.0.2"
 
 minimist@^1.2.6:
   version "1.2.8"
@@ -4142,19 +3581,19 @@ mlly@^1.7.4:
     ufo "^1.6.3"
 
 moddle-xml@^12.0.0:
-  version "12.0.0"
-  resolved "https://registry.npmjs.org/moddle-xml/-/moddle-xml-12.0.0.tgz"
-  integrity sha512-NJc2+sCe4tvuGlaUBcoZcYf6j9f+z+qxHOyGm/LB3ZrlJXVPPHoBTg/KXgDRCufdBJhJ3AheFs3QU/abABNzRg==
+  version "12.1.0"
+  resolved "https://registry.npmjs.org/moddle-xml/-/moddle-xml-12.1.0.tgz"
+  integrity sha512-+m50j9/MFGhvWbLJoKSSjQj3uv7SYm2w5i2lfv6goWarlWW1Nd0A31NYUXmKuWnEZ8Mm/bH1RZYtuf4x8ptY7g==
   dependencies:
-    min-dash "^5.0.0"
-    saxen "^11.0.2"
+    min-dash "^5.1.0"
+    saxen "^11.1.0"
 
-moddle@^8.0.0:
-  version "8.1.0"
-  resolved "https://registry.npmjs.org/moddle/-/moddle-8.1.0.tgz"
-  integrity sha512-dBddc1CNuZHgro8nQWwfPZ2BkyLWdnxoNpPu9d+XKPN96DAiiBOeBw527ft++ebDuFez5PMdaR3pgUgoOaUGrA==
+moddle@^8.0.0, "moddle@>= 6.2.0":
+  version "8.2.0"
+  resolved "https://registry.npmjs.org/moddle/-/moddle-8.2.0.tgz"
+  integrity sha512-okP9kfyOJrUxCVkwy9xpTQ54UmrEkMkjNWsyZNU9+uhdjYO43BLftUrgmaOBBBGZ7hUbJSevJFfRamxiCzaQlw==
   dependencies:
-    min-dash "^5.0.0"
+    min-dash "^5.1.0"
 
 ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
@@ -4168,12 +3607,12 @@ muggle-string@^0.4.1:
 
 nanocolors@^0.2.1:
   version "0.2.13"
-  resolved "https://registry.yarnpkg.com/nanocolors/-/nanocolors-0.2.13.tgz#dfd1ed0bfab05e9fe540eb6874525f0a1684099b"
+  resolved "https://registry.npmjs.org/nanocolors/-/nanocolors-0.2.13.tgz"
   integrity sha512-0n3mSAQLPpGLV9ORXT5+C/D4mwew7Ebws69Hx4E2sgz2ZA5+32Q80B9tL8PbL7XHnRDiAxH/pnrUJ9a4fkTNTA==
 
 nanoid@^3.3.16:
   version "3.3.16"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.16.tgz#a04d8ec4b1f10009d2d533947aefe4293737816c"
+  resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz"
   integrity sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==
 
 nanoid@^5.0.7:
@@ -4183,12 +3622,12 @@ nanoid@^5.0.7:
 
 negotiator@0.6.3:
   version "0.6.3"
-  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
+  resolved "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
 npm-run-path@^4.0.1:
   version "4.0.1"
-  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-4.0.1.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
+  resolved "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz"
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
   dependencies:
     path-key "^3.0.0"
@@ -4209,7 +3648,7 @@ ol-mapbox-style@^7.0.0:
 
 ol@10.6.1:
   version "10.6.1"
-  resolved "https://registry.yarnpkg.com/ol/-/ol-10.6.1.tgz#950f3914b4eec978f087b36aa74ce1e18c41ab09"
+  resolved "https://registry.npmjs.org/ol/-/ol-10.6.1.tgz"
   integrity sha512-xp174YOwPeLj7c7/8TCIEHQ4d41tgTDDhdv6SqNdySsql5/MaFJEJkjlsYcvOPt7xA6vrum/QG4UdJ0iCGT1cg==
   dependencies:
     "@types/rbush" "4.0.0"
@@ -4230,7 +3669,7 @@ ol@6.13.0:
 
 on-finished@^2.3.0:
   version "2.4.1"
-  resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.4.1.tgz#58c8c44116e54845ad57f14ab10b03533184ac3f"
+  resolved "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz"
   integrity sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==
   dependencies:
     ee-first "1.1.1"
@@ -4244,19 +3683,19 @@ once@^1.3.0:
 
 onetime@^5.1.2:
   version "5.1.2"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
+  resolved "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz"
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
 
 only@~0.0.2:
   version "0.0.2"
-  resolved "https://registry.yarnpkg.com/only/-/only-0.0.2.tgz#2afde84d03e50b9a8edc444e30610a70295edfb4"
+  resolved "https://registry.npmjs.org/only/-/only-0.0.2.tgz"
   integrity sha512-Fvw+Jemq5fjjyWz6CpKx6w9s7xxqo3+JCyM0WXWeCSOboZ8ABkyvP8ID4CZuChA/wxSx+XSJmdOm8rGVyJ1hdQ==
 
 open@^8.0.2:
   version "8.4.2"
-  resolved "https://registry.yarnpkg.com/open/-/open-8.4.2.tgz#5b5ffe2a8f793dcd2aad73e550cb87b59cb084f9"
+  resolved "https://registry.npmjs.org/open/-/open-8.4.2.tgz"
   integrity sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==
   dependencies:
     define-lazy-prop "^2.0.0"
@@ -4277,19 +3716,19 @@ optionator@^0.8.1:
 
 p-event@^4.2.0:
   version "4.2.0"
-  resolved "https://registry.yarnpkg.com/p-event/-/p-event-4.2.0.tgz#af4b049c8acd91ae81083ebd1e6f5cae2044c1b5"
+  resolved "https://registry.npmjs.org/p-event/-/p-event-4.2.0.tgz"
   integrity sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==
   dependencies:
     p-timeout "^3.1.0"
 
 p-finally@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
+  resolved "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz"
   integrity sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==
 
 p-timeout@^3.1.0:
   version "3.2.0"
-  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-3.2.0.tgz#c7e17abc971d2a7962ef83626b35d635acf23dfe"
+  resolved "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz"
   integrity sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==
   dependencies:
     p-finally "^1.0.0"
@@ -4311,12 +3750,12 @@ parse5@^4.0.0:
 
 parse5@^6.0.1:
   version "6.0.1"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
+  resolved "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz"
   integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
 
 parseurl@^1.3.2:
   version "1.3.3"
-  resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
+  resolved "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
 
 path-browserify@^1.0.1:
@@ -4329,7 +3768,7 @@ path-intersection@^4.1.0:
   resolved "https://registry.npmjs.org/path-intersection/-/path-intersection-4.1.0.tgz"
   integrity sha512-urUP6WvhnxbHPdHYl6L7Yrc6+1ny6uOFKPCzPxTSUSYGHG0o94RmI7SvMMaScNAM5RtTf08bg4skc6/kjfne3A==
 
-path-is-absolute@1.0.1, path-is-absolute@^1.0.0:
+path-is-absolute@^1.0.0, path-is-absolute@1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
   integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
@@ -4341,7 +3780,7 @@ path-is-inside@^1.0.2:
 
 path-key@^3.0.0, path-key@^3.1.0:
   version "3.1.1"
-  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
+  resolved "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
 path-parse@^1.0.7:
@@ -4374,7 +3813,7 @@ pbf@3.2.1:
 
 pbf@4.0.1:
   version "4.0.1"
-  resolved "https://registry.yarnpkg.com/pbf/-/pbf-4.0.1.tgz#ad9015e022b235dcdbe05fc468a9acadf483f0d4"
+  resolved "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz"
   integrity sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==
   dependencies:
     resolve-protobuf-schema "^2.1.0"
@@ -4386,10 +3825,10 @@ picocolors@^1.1.1:
 
 picomatch@^2.2.2:
   version "2.3.2"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
+  resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz"
   integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
-picomatch@^4.0.2, picomatch@^4.0.3, picomatch@^4.0.4, picomatch@^4.0.5:
+"picomatch@^3 || ^4", picomatch@^4.0.2, picomatch@^4.0.3, picomatch@^4.0.4, picomatch@^4.0.5:
   version "4.0.5"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz"
   integrity sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==
@@ -4457,7 +3896,7 @@ polymer-analyzer@^3.0.2:
 
 portfinder@^1.0.32:
   version "1.0.38"
-  resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.38.tgz#e4fb3a2d888b20d2977da050e48ab5e1f57a185e"
+  resolved "https://registry.npmjs.org/portfinder/-/portfinder-1.0.38.tgz"
   integrity sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg==
   dependencies:
     async "^3.2.6"
@@ -4465,7 +3904,7 @@ portfinder@^1.0.32:
 
 postcss@^8.5.17, postcss@^8.5.6:
   version "8.5.23"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.23.tgz#3493550116f478487298301d2c2e8dc5a56e6594"
+  resolved "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz"
   integrity sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==
   dependencies:
     nanoid "^3.3.16"
@@ -4476,6 +3915,11 @@ preact@^10.29.2:
   version "10.29.7"
   resolved "https://registry.npmjs.org/preact/-/preact-10.29.7.tgz"
   integrity sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==
+
+preact@10.26.10:
+  version "10.26.10"
+  resolved "https://registry.npmjs.org/preact/-/preact-10.26.10.tgz"
+  integrity sha512-sqdfdSa8AZeJ+wfMYjFImIRTnhfyPSLCH+LEb1+BoRUDKLnE6AnvZeClx3Bkj2Q9nn44GFAefOKIx5oc54q93A==
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -4514,7 +3958,7 @@ quickselect@^2.0.0:
 
 quickselect@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/quickselect/-/quickselect-3.0.0.tgz#a37fc953867d56f095a20ac71c6d27063d2de603"
+  resolved "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz"
   integrity sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==
 
 rbush@^3.0.1:
@@ -4526,20 +3970,38 @@ rbush@^3.0.1:
 
 rbush@^4.0.0:
   version "4.0.1"
-  resolved "https://registry.yarnpkg.com/rbush/-/rbush-4.0.1.tgz#1f55afa64a978f71bf9e9a99bc14ff84f3cb0d6d"
+  resolved "https://registry.npmjs.org/rbush/-/rbush-4.0.1.tgz"
   integrity sha512-IP0UpfeWQujYC8Jg162rMNc01Rf0gWMMAb2Uxus/Q0qOFw4lCcq6ZnQEZwUoJqWyUGJ9th7JjwI4yIWo+uvoAQ==
   dependencies:
     quickselect "^3.0.0"
 
 readdirp@^4.0.1:
   version "4.1.2"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-4.1.2.tgz#eb85801435fbf2a7ee58f19e0921b068fc69948d"
+  resolved "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz"
   integrity sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==
 
 reduce-flatten@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz"
   integrity sha512-j5WfFJfc9CoXv/WbwVLHq74i/hdTUpy+iNC534LxczMRP67vJeK3V9JOdnL0N1cIRbn9mYhE2yVjvvKXDxvNXQ==
+
+"redwood-spectra@file:/Users/mguel/IdeaProjects/mateu-fable/frontend/web/monorepo/apps/redwood-spectra":
+  version "0.0.0"
+  resolved "file:apps/redwood-spectra"
+  dependencies:
+    "@oracle/oraclejet-preact" "19.0.9"
+    lit "^3.3.1"
+    marked "^15.0.11"
+    mateu "*"
+    minimatch "^10.2.3"
+
+"redwood@file:/Users/mguel/IdeaProjects/mateu-fable/frontend/web/monorepo/apps/redwood":
+  version "0.0.0"
+  resolved "file:apps/redwood"
+  dependencies:
+    "@oracle/oraclejet-preact" "19.0.9"
+    lit "^3.3.1"
+    mateu "*"
 
 require-from-string@^2.0.2:
   version "2.0.2"
@@ -4548,7 +4010,7 @@ require-from-string@^2.0.2:
 
 resolve-path@^1.4.0:
   version "1.4.0"
-  resolved "https://registry.yarnpkg.com/resolve-path/-/resolve-path-1.4.0.tgz#c4bda9f5efb2fce65247873ab36bb4d834fe16f7"
+  resolved "https://registry.npmjs.org/resolve-path/-/resolve-path-1.4.0.tgz"
   integrity sha512-i1xevIst/Qa+nA9olDxLWnLk8YZbi8R/7JPbCMcgyWaFR6bKWaexgJgEB5oc2PKMjYdrHynyz0NY+if+H98t1w==
   dependencies:
     http-errors "~1.6.2"
@@ -4573,7 +4035,7 @@ resolve@^1.22.1, resolve@^1.5.0, resolve@~1.22.1, resolve@~1.22.2:
 
 rolldown@~1.1.5:
   version "1.1.5"
-  resolved "https://registry.yarnpkg.com/rolldown/-/rolldown-1.1.5.tgz#339aae250844351fc55b74e2652d3ebd6fba389d"
+  resolved "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz"
   integrity sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==
   dependencies:
     "@oxc-project/types" "=0.139.0"
@@ -4595,41 +4057,7 @@ rolldown@~1.1.5:
     "@rolldown/binding-win32-arm64-msvc" "1.1.5"
     "@rolldown/binding-win32-x64-msvc" "1.1.5"
 
-rollup@^4.4.0:
-  version "4.62.3"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.62.3.tgz#03ee99e2b5b0744dd99be6d4238b2fcd4087b4f6"
-  integrity sha512-Gu0c0iH9FzgX1L1t7ByIbbS3Vmdz+6KHm/EsqmmC71gUQ82yvZRkTK6XzrFObSka91WUVdynqp6nsfilzr5k6Q==
-  dependencies:
-    "@types/estree" "1.0.9"
-  optionalDependencies:
-    "@rollup/rollup-android-arm-eabi" "4.62.3"
-    "@rollup/rollup-android-arm64" "4.62.3"
-    "@rollup/rollup-darwin-arm64" "4.62.3"
-    "@rollup/rollup-darwin-x64" "4.62.3"
-    "@rollup/rollup-freebsd-arm64" "4.62.3"
-    "@rollup/rollup-freebsd-x64" "4.62.3"
-    "@rollup/rollup-linux-arm-gnueabihf" "4.62.3"
-    "@rollup/rollup-linux-arm-musleabihf" "4.62.3"
-    "@rollup/rollup-linux-arm64-gnu" "4.62.3"
-    "@rollup/rollup-linux-arm64-musl" "4.62.3"
-    "@rollup/rollup-linux-loong64-gnu" "4.62.3"
-    "@rollup/rollup-linux-loong64-musl" "4.62.3"
-    "@rollup/rollup-linux-ppc64-gnu" "4.62.3"
-    "@rollup/rollup-linux-ppc64-musl" "4.62.3"
-    "@rollup/rollup-linux-riscv64-gnu" "4.62.3"
-    "@rollup/rollup-linux-riscv64-musl" "4.62.3"
-    "@rollup/rollup-linux-s390x-gnu" "4.62.3"
-    "@rollup/rollup-linux-x64-gnu" "4.62.3"
-    "@rollup/rollup-linux-x64-musl" "4.62.3"
-    "@rollup/rollup-openbsd-x64" "4.62.3"
-    "@rollup/rollup-openharmony-arm64" "4.62.3"
-    "@rollup/rollup-win32-arm64-msvc" "4.62.3"
-    "@rollup/rollup-win32-ia32-msvc" "4.62.3"
-    "@rollup/rollup-win32-x64-gnu" "4.62.3"
-    "@rollup/rollup-win32-x64-msvc" "4.62.3"
-    fsevents "~2.3.2"
-
-rollup@^4.43.0:
+rollup@^1.20.0||^2.0.0||^3.0.0||^4.0.0, rollup@^2.78.0||^3.0.0||^4.0.0, rollup@^4.4.0, rollup@^4.43.0:
   version "4.62.2"
   resolved "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz"
   integrity sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==
@@ -4677,22 +4105,33 @@ rxjs@^7.8.1:
 
 safe-buffer@5.2.1:
   version "5.2.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 safe-regex-test@^1.1.0:
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/safe-regex-test/-/safe-regex-test-1.1.0.tgz#7f87dfb67a3150782eaaf18583ff5d1711ac10c1"
+  resolved "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz"
   integrity sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==
   dependencies:
     call-bound "^1.0.2"
     es-errors "^1.3.0"
     is-regex "^1.2.1"
 
-saxen@^11.0.2:
-  version "11.0.2"
-  resolved "https://registry.npmjs.org/saxen/-/saxen-11.0.2.tgz"
-  integrity sha512-WDb4gqac8uiJzOdOdVpr9NWh9NrJMm7Brn5GX2Poj+mjE/QTXqYQENr8T/mom54dDDgbd3QjwTg23TRHYiWXRA==
+"sapui5@file:/Users/mguel/IdeaProjects/mateu-fable/frontend/web/monorepo/apps/sapui5":
+  version "0.0.0"
+  resolved "file:apps/sapui5"
+  dependencies:
+    "@ui5/webcomponents" "^2.24.2"
+    "@ui5/webcomponents-ai" "^2.24.2"
+    "@ui5/webcomponents-fiori" "^2.24.2"
+    lit "^3.3.1"
+    mateu "*"
+    minimatch "^10.2.3"
+
+saxen@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.npmjs.org/saxen/-/saxen-11.1.0.tgz"
+  integrity sha512-GOxBOAmiWVAytOHBuMlgFMZ4MAk+2Ny5QJpzM9I4IozfPLXq3FsDdIHNviTQGZGIx7G2mBkA+uySiJlYmSU1Gg==
 
 semver@~7.7.4:
   version "7.7.4"
@@ -4701,12 +4140,12 @@ semver@~7.7.4:
 
 setprototypeof@1.1.0:
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
+  resolved "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz"
   integrity sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==
 
 setprototypeof@1.2.0:
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
+  resolved "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
 shady-css-parser@^0.1.0:
@@ -4716,14 +4155,14 @@ shady-css-parser@^0.1.0:
 
 shebang-command@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
+  resolved "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz"
   integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
   dependencies:
     shebang-regex "^3.0.0"
 
 shebang-regex@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
+  resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 siginfo@^2.0.0:
@@ -4733,7 +4172,7 @@ siginfo@^2.0.0:
 
 signal-exit@^3.0.3:
   version "3.0.7"
-  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
+  resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
 sort-asc@^0.1.0:
@@ -4792,9 +4231,9 @@ stackback@0.0.2:
   resolved "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz"
   integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
 
-"statuses@>= 1.4.0 < 2", "statuses@>= 1.5.0 < 2", statuses@^1.5.0:
+statuses@^1.5.0, "statuses@>= 1.4.0 < 2", "statuses@>= 1.5.0 < 2":
   version "1.5.0"
-  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
+  resolved "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
 
 std-env@^3.9.0:
@@ -4816,7 +4255,7 @@ strip-ansi@^3.0.0:
 
 strip-final-newline@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
+  resolved "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
 strip-indent@^2.0.0:
@@ -4845,7 +4284,7 @@ supports-color@^5.3.0:
 
 supports-color@^7.1.0:
   version "7.2.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   dependencies:
     has-flag "^4.0.0"
@@ -4875,7 +4314,7 @@ table-layout@^0.4.3:
 
 table-layout@^4.1.1:
   version "4.1.1"
-  resolved "https://registry.yarnpkg.com/table-layout/-/table-layout-4.1.1.tgz#0f72965de1a5c0c1419c9ba21cae4e73a2f73a42"
+  resolved "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz"
   integrity sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==
   dependencies:
     array-back "^6.2.2"
@@ -4926,7 +4365,7 @@ tinyspy@^4.0.3:
 
 toidentifier@1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
+  resolved "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
 tr46@^1.0.1:
@@ -4938,7 +4377,7 @@ tr46@^1.0.1:
 
 tr46@^5.1.0:
   version "5.1.1"
-  resolved "https://registry.yarnpkg.com/tr46/-/tr46-5.1.1.tgz#96ae867cddb8fdb64a49cc3059a8d428bcf238ca"
+  resolved "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz"
   integrity sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==
   dependencies:
     punycode "^2.3.1"
@@ -4948,14 +4387,14 @@ ts-custom-error@^3.2.1:
   resolved "https://registry.npmjs.org/ts-custom-error/-/ts-custom-error-3.3.1.tgz"
   integrity sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A==
 
-tslib@^2.1.0, tslib@^2.4.0:
+tslib@^2.1.0:
   version "2.8.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tsscmp@1.0.6:
   version "1.0.6"
-  resolved "https://registry.yarnpkg.com/tsscmp/-/tsscmp-1.0.6.tgz#85b99583ac3589ec4bfef825b5000aa911d605eb"
+  resolved "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz"
   integrity sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==
 
 type-check@~0.3.2:
@@ -4974,30 +4413,25 @@ type-fest@^5.2.0:
 
 type-is@^1.6.16:
   version "1.6.18"
-  resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
+  resolved "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz"
   integrity sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typescript@5.9.3:
-  version "5.9.3"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz"
-  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+typescript@*, typescript@~5.8.3:
+  version "5.8.3"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz"
+  integrity sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==
 
 typescript@^3.0.1:
   version "3.9.10"
   resolved "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz"
   integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
 
-typescript@~5.8.3:
-  version "5.8.3"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz"
-  integrity sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==
-
 typescript@~7.0.2:
   version "7.0.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-7.0.2.tgz#9ec773d7954a8c182c17cc5bbd575aa28bc51582"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz"
   integrity sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==
   optionalDependencies:
     "@typescript/typescript-aix-ppc64" "7.0.2"
@@ -5021,6 +4455,11 @@ typescript@~7.0.2:
     "@typescript/typescript-win32-arm64" "7.0.2"
     "@typescript/typescript-win32-x64" "7.0.2"
 
+typescript@5.9.3:
+  version "5.9.3"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz"
+  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+
 typical@^2.6.1:
   version "2.6.1"
   resolved "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz"
@@ -5033,7 +4472,7 @@ typical@^4.0.0:
 
 typical@^7.3.0:
   version "7.3.0"
-  resolved "https://registry.yarnpkg.com/typical/-/typical-7.3.0.tgz#930376be344228709f134613911fa22aa09617a4"
+  resolved "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz"
   integrity sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==
 
 ufo@^1.6.3:
@@ -5058,7 +4497,7 @@ universalify@^2.0.0:
 
 vary@^1.1.2:
   version "1.1.2"
-  resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
+  resolved "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
 vite-node@3.2.4:
@@ -5087,7 +4526,7 @@ vite-plugin-dts@^4.5.4:
     local-pkg "^1.0.0"
     magic-string "^0.30.17"
 
-"vite@^5.0.0 || ^6.0.0 || ^7.0.0-0", vite@^7.1.2:
+vite@*, "vite@^5.0.0 || ^6.0.0 || ^7.0.0-0", vite@^7.1.2:
   version "7.3.6"
   resolved "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz"
   integrity sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==
@@ -5103,7 +4542,7 @@ vite-plugin-dts@^4.5.4:
 
 vite@^8.1.5:
   version "8.1.5"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-8.1.5.tgz#ccffce3ee487b1886223b24ebb27b91674827d30"
+  resolved "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz"
   integrity sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==
   dependencies:
     lightningcss "^1.32.0"
@@ -5143,15 +4582,15 @@ vitest@^3.2.4:
     vite-node "3.2.4"
     why-is-node-running "^2.3.0"
 
-vscode-uri@=1.0.6:
-  version "1.0.6"
-  resolved "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.6.tgz"
-  integrity sha512-sLI2L0uGov3wKVb9EB+vIQBl9tVP90nqRvxSoJ35vI3NjxE8jfsE5DSOhWgSunHSZmKS4OCi2jrtfxK7uyp2ww==
-
 vscode-uri@^3.0.8:
   version "3.1.0"
   resolved "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz"
   integrity sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==
+
+vscode-uri@=1.0.6:
+  version "1.0.6"
+  resolved "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.6.tgz"
+  integrity sha512-sLI2L0uGov3wKVb9EB+vIQBl9tVP90nqRvxSoJ35vI3NjxE8jfsE5DSOhWgSunHSZmKS4OCi2jrtfxK7uyp2ww==
 
 web-worker@^1.2.0:
   version "1.5.0"
@@ -5170,12 +4609,12 @@ webidl-conversions@^4.0.2:
 
 webidl-conversions@^7.0.0:
   version "7.0.0"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
+  resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz"
   integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
 
 whatwg-url@^14.0.0:
   version "14.2.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-14.2.0.tgz#4ee02d5d725155dae004f6ae95c73e7ef5d95663"
+  resolved "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz"
   integrity sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==
   dependencies:
     tr46 "^5.1.0"
@@ -5192,7 +4631,7 @@ whatwg-url@^6.4.0:
 
 which@^2.0.1:
   version "2.0.2"
-  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  resolved "https://registry.npmjs.org/which/-/which-2.0.2.tgz"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
@@ -5220,7 +4659,7 @@ wordwrapjs@^3.0.0:
 
 wordwrapjs@^5.1.0:
   version "5.1.1"
-  resolved "https://registry.yarnpkg.com/wordwrapjs/-/wordwrapjs-5.1.1.tgz#bfd1eb426f0f7eec73b7df32cf7df1f618bfb3a9"
+  resolved "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz"
   integrity sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==
 
 wrappy@1:
@@ -5230,7 +4669,7 @@ wrappy@1:
 
 ws@^7.5.10:
   version "7.5.13"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.13.tgz#12aa507eaca76c295c278b1aebf4698ab2c1845f"
+  resolved "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz"
   integrity sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==
 
 xml-utils@^1.0.2:
@@ -5240,7 +4679,7 @@ xml-utils@^1.0.2:
 
 ylru@^1.2.0:
   version "1.4.0"
-  resolved "https://registry.yarnpkg.com/ylru/-/ylru-1.4.0.tgz#0cf0aa57e9c24f8a2cbde0cc1ca2c9592ac4e0f6"
+  resolved "https://registry.npmjs.org/ylru/-/ylru-1.4.0.tgz"
   integrity sha512-2OQsPNEmBCvXuFlIni/a+Rn+R2pHW9INm0BxXJ4hVDA8TirqMj+J/Rp9ItLatT/5pZqWwefVrTQcHpixsxnVlA==
 
 zstddec@^0.1.0:


### PR DESCRIPTION
Cierra el batch de fixes del renderer Vaadin contra demo-front-office-evolution:

- **Toolbar de listados en el page header** (título + acciones en una línea): `PageListingBuilder.getToolbarButtons` público, `ReflectionPageMapper` lo suma al Page toolbar; el crud suprime su copia si un `mateu-page` ancestro ya la muestra.
- **`ListingBackend.actions()` anuncia los `@ListToolbarButton`** — el renderer compartido descarta acciones no anunciadas; el botón de seed no hacía nada (verificado: 19→29 items + re-búsqueda por trigger).
- **Cards apiladas** en `mateu-status-list` (anatomía check-in): badge a la derecha, acciones como iconos, aire en el grid, huéspedes capados a 22rem.
- **Foldout Vaadin al 100%** con reparto proporcional + `expand-fields` (`||` sobre `false` primitivo).
- **Drawers persistentes** ante Add/Replace (refresh in situ por id, in-place por serverSideType).
- **SSE**: match exacto de acción gana al comodín.
- **goHome/pestañas**: navegación por URL + `isActiveOption` con `selectedRoute`.
- KPIs sin doble marco, alias de iconos, N de M en el título, Perfil con h4.

Tests: libs/mateu 169 ✅ · core 745 ✅. Verificación visual en :5174 (listado, seed, check-in, welcome).

🤖 Generated with [Claude Code](https://claude.com/claude-code)