### PR TITLE
fix(ui): una vista que se refresca a sí misma no pierde el estado de su entorno

### DIFF
--- a/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/ComponentElement.ts
+++ b/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/ComponentElement.ts
@@ -117,6 +117,10 @@ export default abstract class ComponentElement extends MetadataDrivenElement {
                     }
                 } else {
                     this.callbackToken = nanoid()
+                    // Whether this fragment re-renders the component that is already here or
+                    // replaces it with a different one. Decided inside the ServerSide branch and
+                    // read again below, where it decides whether state and data survive.
+                    let inPlace = false
                     if (fragment.component?.type == ComponentType.ServerSide) {
                         if (this.component) {
                             const c0 = this.component as ServerSideComponent
@@ -127,7 +131,7 @@ export default abstract class ComponentElement extends MetadataDrivenElement {
                             // toggling an add-on refreshes the host without closing its drawer.
                             // NOTE: component ids are fresh uuids on every render, so the stable
                             // signal is the serverSideType
-                            const inPlace = c0.serverSideType == c1.serverSideType
+                            inPlace = c0.serverSideType == c1.serverSideType
                             const openOverlays = inPlace
                                 ? (c0.children ?? []).filter(child => this.isOverlayChild(child))
                                 : []
@@ -162,7 +166,14 @@ export default abstract class ComponentElement extends MetadataDrivenElement {
                             this.component.children = children
                         }
                     }
-                    if (fragment.action !== UIFragmentAction.ReplaceKeepData) {
+                    // Wiping is for a component being REPLACED by a different one, where the
+                    // outgoing component's state must not leak into the incoming one. A view that
+                    // re-renders itself is not that: its fragment carries its own state, and
+                    // starting from an empty map throws away everything its surroundings had put
+                    // there. A polling detail view lost the CRUD chrome around it — "Back to
+                    // list", the overflow menu and the status badge — on its first refresh, two
+                    // seconds after it opened, and got it back only on a full page load.
+                    if (fragment.action !== UIFragmentAction.ReplaceKeepData && !inPlace) {
                         this.state = { }
                         this.data = { }
                     }

--- a/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/applyFragment.test.ts
+++ b/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/applyFragment.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+import ComponentElement from './ComponentElement'
+import { ComponentType } from '@mateu/shared/apiClients/dtos/ComponentType'
+import { UIFragmentAction } from '@mateu/shared/apiClients/dtos/UIFragmentAction.ts'
+import UIFragment from '@mateu/shared/apiClients/dtos/UIFragment'
+import ServerSideComponent from '@mateu/shared/apiClients/dtos/ServerSideComponent.ts'
+
+// applyFragment lives on a LitElement, and every branch of it is plain data handling: it decides
+// what of the component, the state and the data survives a fragment. Called on a stand-in `this`
+// with the handful of members it touches, so the decisions can be asserted without a DOM.
+const componentElement = (over: Record<string, any> = {}) => ({
+    id: 'target',
+    component: undefined as ServerSideComponent | undefined,
+    state: {} as Record<string, any>,
+    data: {} as Record<string, any>,
+    callbackToken: '',
+    requestUpdate: () => {},
+    registerCustomEventListeners: () => {},
+    isOverlayChild: () => false,
+    triggerOnLoad: () => {},
+    applyFragment: ComponentElement.prototype.applyFragment,
+    ...over,
+})
+
+const serverSide = (serverSideType: string, id = crypto.randomUUID()): ServerSideComponent =>
+    ({ id, type: ComponentType.ServerSide, serverSideType, children: [] }) as unknown as ServerSideComponent
+
+const fragment = (component: ServerSideComponent, state: Record<string, any>): UIFragment =>
+    ({
+        targetComponentId: 'target',
+        action: UIFragmentAction.Replace,
+        component,
+        state,
+    }) as unknown as UIFragment
+
+describe('applyFragment', () => {
+
+    it('keeps the state its surroundings put there when a view re-renders itself', () => {
+        // The case this exists for: a detail view that polls itself every couple of seconds. Its
+        // fragment carries its own state and nothing else, so wiping the map first threw away
+        // what the CRUD around it had stored — its chrome vanished on the first refresh.
+        const el = componentElement({
+            component: serverSide('ProcessDetail'),
+            state: { crudChrome: 'back to list', status: 'Running (33%)' },
+            data: { rows: [1, 2, 3] },
+        })
+
+        el.applyFragment(fragment(serverSide('ProcessDetail'), { status: 'Running (66%)' }))
+
+        expect(el.state.crudChrome).toBe('back to list')
+        expect(el.state.status).toBe('Running (66%)')
+        expect(el.data.rows).toEqual([1, 2, 3])
+    })
+
+    it('wipes the state when a different component replaces this one', () => {
+        // The case it was written for, and still the right thing: nothing of the outgoing
+        // component may leak into the incoming one.
+        const el = componentElement({
+            component: serverSide('ProcessDetail'),
+            state: { crudChrome: 'back to list' },
+            data: { rows: [1, 2, 3] },
+        })
+
+        el.applyFragment(fragment(serverSide('SomethingElse'), { title: 'other' }))
+
+        expect(el.state.crudChrome).toBeUndefined()
+        expect(el.state.title).toBe('other')
+        expect(el.data.rows).toBeUndefined()
+    })
+
+    it('keeps everything on ReplaceKeepData, as before', () => {
+        const el = componentElement({
+            component: serverSide('ProcessDetail'),
+            state: { crudChrome: 'back to list' },
+            data: { rows: [1] },
+        })
+        const f = fragment(serverSide('SomethingElse'), { title: 'other' })
+        ;(f as any).action = UIFragmentAction.ReplaceKeepData
+
+        el.applyFragment(f)
+
+        expect(el.state.crudChrome).toBe('back to list')
+        expect(el.data.rows).toEqual([1])
+    })
+
+    it('ignores a fragment aimed at another component', () => {
+        const el = componentElement({
+            component: serverSide('ProcessDetail'),
+            state: { untouched: true },
+        })
+        const f = fragment(serverSide('ProcessDetail'), { status: 'new' })
+        ;(f as any).targetComponentId = 'somebody-else'
+
+        el.applyFragment(f)
+
+        expect(el.state).toEqual({ untouched: true })
+    })
+})


### PR DESCRIPTION
## El síntoma

Una vista de detalle que se refresca sola cada dos segundos pierde, en el primer refresco, el cromo
que el CRUD pone a su alrededor. Medido en una página real, justo antes y justo después:

```
antes:    Cancel process | Back to list | Running (33%)
después:  Cancel process
```

Se van el *Back to list*, el menú `⋯` y el badge de estado. Sobrevive sólo el botón que pinta la
propia vista. No vuelven hasta una recarga completa de la página.

## La causa

`ComponentElement.applyFragment` vacía `state` y `data` antes de repoblarlos, salvo en
`ReplaceKeepData`:

```ts
if (fragment.action !== UIFragmentAction.ReplaceKeepData) {
    this.state = { }
    this.data = { }
}
if (fragment.state) this.state = { ...this.state, ...fragment.state }
```

Correcto cuando el componente que llega es **otro**: nada del que se va debe filtrarse al que entra.
Pero el mismo camino se recorre cuando un componente **se re-renderiza a sí mismo** — una acción que
devuelve `this`, o un trigger de refresco —, y entonces el fragmento trae sólo el estado de esa
vista. Empezar de un mapa vacío tira lo que su entorno había dejado ahí.

Verificado interceptando la red: el fragmento del refresco llega con `action = Replace` y con el
árbol completo (`ServerSide` → `Page` → `Card`), idéntico en forma a la carga inicial. El servidor
manda todo; se pierde aquí.

## El cambio

`inPlace` ya se calcula unas líneas más arriba — es lo que impide que un re-render en sitio cierre
los overlays abiertos — así que sale del bloque donde estaba declarado y decide también esto:

```ts
if (fragment.action !== UIFragmentAction.ReplaceKeepData && !inPlace) {
```

Un componente sustituido por otro distinto limpia igual que antes.

**El compromiso, para que quede dicho:** conservando el mapa, una clave que la vista deje de emitir
se queda con su último valor en vez de desaparecer. Para un re-render de la misma vista no suele
pasar, y me parece mejor que perder el entorno — pero es tu criterio, y por eso esto va a revisión y
no a merge.

## Tests

Cuatro sobre `applyFragment`, que no tenía ninguno:

- el estado del entorno sobrevive a un re-render en sitio ← **falla sin este cambio**
- se limpia cuando el componente cambia
- `ReplaceKeepData` sigue conservándolo todo
- un fragmento dirigido a otro componente no toca nada

`vitest run` completo en verde: 25 ficheros, 238 tests.

## De paso, sin tocar

En esa misma rama, `c0.id` no se copia de `c1`, y tres líneas después se compara `c0.id != c1.id`
para decidir si relanzar `triggerOnLoad`. Como los ids son uuids nuevos en cada render, esa
comparación es siempre cierta y el `triggerOnLoad` se dispara en cada refresco. No lo he tocado
porque no sé si es intencionado.
