### PR TITLE
feat(perf): caché cliente de la estructura de pantallas declaradas (fase a)

### DIFF
--- a/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/routeStructureCache.test.ts
+++ b/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/routeStructureCache.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ComponentType } from '@mateu/shared/apiClients/dtos/ComponentType.ts'
+import type Component from '@mateu/shared/apiClients/dtos/Component.ts'
+import {
+    clearStructureCache,
+    getCachedStructure,
+    putCachedStructure,
+    setStructureCacheEnabled,
+    structureCacheKey,
+} from './routeStructureCache.ts'
+
+// the vitest environment is plain node: back localStorage with a Map
+const backing = new Map<string, string>()
+vi.stubGlobal('localStorage', {
+    getItem: (key: string) => backing.get(key) ?? null,
+    setItem: (key: string, value: string) => void backing.set(key, value),
+    removeItem: (key: string) => void backing.delete(key),
+    clear: () => backing.clear(),
+})
+
+beforeEach(() => {
+    localStorage.clear()
+    setStructureCacheEnabled(true)
+})
+
+const comp = (id: string): Component => ({
+    type: ComponentType.ServerSide,
+    id,
+    children: undefined,
+    style: '',
+    cssClasses: '',
+    slot: '',
+    initialData: undefined,
+    confirmOnNavigationIfDirty: false,
+})
+
+const key = (route: string, initialState?: Record<string, unknown>) =>
+    structureCacheKey({ baseUrl: '', consumedRoute: '', route, serverSideType: 'App', initialState })
+
+describe('structureCacheKey', () => {
+    it('composes from baseUrl, consumedRoute, route and serverSideType', () => {
+        expect(structureCacheKey({ baseUrl: 'b', consumedRoute: '/c', route: '/r', serverSideType: 'T' }))
+            .toBe('b|/c|/r|T')
+    })
+
+    it('tolerates undefined parts', () => {
+        expect(structureCacheKey({ baseUrl: '', consumedRoute: undefined, route: undefined, serverSideType: undefined }))
+            .toBe('|||')
+    })
+
+    it('folds a non-empty initialState into a distinct suffix', () => {
+        const a = structureCacheKey({ baseUrl: '', consumedRoute: '', route: '/r', serverSideType: 'T', initialState: { stayId: 1 } })
+        const b = structureCacheKey({ baseUrl: '', consumedRoute: '', route: '/r', serverSideType: 'T', initialState: { stayId: 2 } })
+        const none = structureCacheKey({ baseUrl: '', consumedRoute: '', route: '/r', serverSideType: 'T' })
+        expect(a).not.toBe(b)
+        expect(a).not.toBe(none)
+        expect(a).toContain('#')
+    })
+
+    it('treats an empty initialState like no state', () => {
+        expect(structureCacheKey({ baseUrl: '', consumedRoute: '', route: '/r', serverSideType: 'T', initialState: {} }))
+            .toBe(structureCacheKey({ baseUrl: '', consumedRoute: '', route: '/r', serverSideType: 'T' }))
+    })
+})
+
+describe('routeStructureCache', () => {
+    it('round-trips a structure by key', () => {
+        putCachedStructure(key('/a'), comp('a'))
+        putCachedStructure(key('/b'), comp('b'))
+        expect(getCachedStructure(key('/a'))?.id).toBe('a')
+        expect(getCachedStructure(key('/b'))?.id).toBe('b')
+        expect(getCachedStructure(key('/missing'))).toBeUndefined()
+    })
+
+    it('separates entries seeded with different initialState', () => {
+        putCachedStructure(key('/a', { stayId: 1 }), comp('one'))
+        putCachedStructure(key('/a', { stayId: 2 }), comp('two'))
+        expect(getCachedStructure(key('/a', { stayId: 1 }))?.id).toBe('one')
+        expect(getCachedStructure(key('/a', { stayId: 2 }))?.id).toBe('two')
+        expect(getCachedStructure(key('/a'))).toBeUndefined()
+    })
+
+    it('invalidates entries written under a different cache version', () => {
+        // simulate a stale entry from an older CACHE_VERSION
+        localStorage.setItem('mateu-route-structure-cache', JSON.stringify({
+            [key('/a')]: { v: 999, t: Date.now(), component: comp('stale') },
+        }))
+        expect(getCachedStructure(key('/a'))).toBeUndefined()
+    })
+
+    it('evicts the least-recently-written entries past the cap', () => {
+        let now = 1_000
+        const spy = vi.spyOn(Date, 'now').mockImplementation(() => now++)
+        for (let i = 0; i < 60; i++) putCachedStructure(key('/r' + i), comp('r' + i))
+        // the 10 oldest (r0..r9) are gone, the newest survive
+        expect(getCachedStructure(key('/r0'))).toBeUndefined()
+        expect(getCachedStructure(key('/r9'))).toBeUndefined()
+        expect(getCachedStructure(key('/r10'))?.id).toBe('r10')
+        expect(getCachedStructure(key('/r59'))?.id).toBe('r59')
+        spy.mockRestore()
+    })
+
+    it('honors the kill switch for both read and write', () => {
+        putCachedStructure(key('/a'), comp('a'))
+        setStructureCacheEnabled(false)
+        expect(getCachedStructure(key('/a'))).toBeUndefined()   // read disabled
+        putCachedStructure(key('/b'), comp('b'))                 // write disabled
+        setStructureCacheEnabled(true)
+        expect(getCachedStructure(key('/b'))).toBeUndefined()
+    })
+
+    it('survives corrupt storage', () => {
+        localStorage.setItem('mateu-route-structure-cache', 'not json')
+        expect(getCachedStructure(key('/a'))).toBeUndefined()
+        putCachedStructure(key('/a'), comp('a'))
+        expect(getCachedStructure(key('/a'))?.id).toBe('a')
+    })
+
+    it('clears the whole cache', () => {
+        putCachedStructure(key('/a'), comp('a'))
+        clearStructureCache()
+        expect(getCachedStructure(key('/a'))).toBeUndefined()
+    })
+})

--- a/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/routeStructureCache.ts
+++ b/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/routeStructureCache.ts
@@ -1,0 +1,129 @@
+// Client-side cache of screen STRUCTURE (the `component` tree of a route-load fragment) so a
+// declared/static screen can paint its real layout INSTANTLY on a return visit instead of a
+// generic skeleton. Phase (a) of the structure-cache work: this is a PREDICTION, never a
+// replacement — mateu-ux still fires the normal route request and the authoritative response
+// overwrites this seed (stale-while-revalidate). Only the structure is cached; state/data
+// always come fresh from the server, so no stale business data is ever shown, and a structure
+// that has drifted (permissions, a new deploy) self-corrects within one navigation.
+//
+// Mirrors the localStorage shape of recentRoutesStore.ts / columnPrefsStore.ts: one JSON
+// object per origin under a single key, best-effort (any storage failure degrades to no cache).
+
+import type Component from "@mateu/shared/apiClients/dtos/Component";
+
+const KEY = 'mateu-route-structure-cache'
+// Bump to hard-invalidate every cached structure when this module's shape (or the structural
+// wire contract) changes in a way old entries can no longer be trusted through.
+const CACHE_VERSION = 1
+const MAX_ENTRIES = 50
+
+interface Entry {
+    v: number
+    t: number            // last write (epoch ms), for LRU eviction
+    component: Component
+}
+
+type Store = Record<string, Entry>
+
+// Kill switch — defaults on, flip off from devtools (localStorage['mateu-route-structure-cache-off']='1')
+// to measure the difference, or via setStructureCacheEnabled(false) in code.
+let enabled = (() => {
+    try {
+        return localStorage.getItem('mateu-route-structure-cache-off') !== '1'
+    } catch {
+        return true
+    }
+})()
+
+export const setStructureCacheEnabled = (on: boolean): void => { enabled = on }
+export const isStructureCacheEnabled = (): boolean => enabled
+
+const readAll = (): Store => {
+    try {
+        return JSON.parse(localStorage.getItem(KEY) ?? '{}') as Store
+    } catch {
+        return {}
+    }
+}
+
+const writeAll = (store: Store): void => {
+    try {
+        localStorage.setItem(KEY, JSON.stringify(store))
+    } catch {
+        // Quota exceeded / unavailable: drop the older half and try once more, else give up —
+        // the cache is a best-effort accelerator, never load-bearing.
+        try {
+            const trimmed = Object.entries(store)
+                .sort((a, b) => b[1].t - a[1].t)
+                .slice(0, Math.floor(MAX_ENTRIES / 2))
+            localStorage.setItem(KEY, JSON.stringify(Object.fromEntries(trimmed)))
+        } catch {
+            // no cache this time
+        }
+    }
+}
+
+/**
+ * Stable cache key for a route load. `initialState` (an embedded island's host-seeded state,
+ * e.g. a stayId) is folded in so two islands sharing a route but seeded differently — and thus
+ * potentially yielding different structures — cache separately.
+ */
+export const structureCacheKey = (parts: {
+    baseUrl: string
+    consumedRoute: string | undefined
+    route: string | undefined
+    serverSideType: string | undefined
+    initialState?: Record<string, unknown> | undefined
+}): string => {
+    const seed = parts.initialState && Object.keys(parts.initialState).length
+        ? '#' + hash(JSON.stringify(parts.initialState))
+        : ''
+    return [
+        parts.baseUrl,
+        parts.consumedRoute ?? '',
+        parts.route ?? '',
+        parts.serverSideType ?? '',
+    ].join('|') + seed
+}
+
+/** The cached STRUCTURE for a route, or undefined on miss / version mismatch / disabled. */
+export const getCachedStructure = (key: string): Component | undefined => {
+    if (!enabled) return undefined
+    const entry = readAll()[key]
+    if (!entry || entry.v !== CACHE_VERSION) return undefined
+    return entry.component
+}
+
+/** Record the authoritative structure for a route, evicting the least-recently-written entries
+ *  once the cache is full. */
+export const putCachedStructure = (key: string, component: Component): void => {
+    if (!enabled) return
+    const store = readAll()
+    store[key] = { v: CACHE_VERSION, t: Date.now(), component }
+    const keys = Object.keys(store)
+    if (keys.length > MAX_ENTRIES) {
+        const oldest = keys.sort((a, b) => store[a].t - store[b].t).slice(0, keys.length - MAX_ENTRIES)
+        for (const k of oldest) delete store[k]
+    }
+    writeAll(store)
+}
+
+/** Wipe the whole cache (exposed for debugging / a hard reset). */
+export const clearStructureCache = (): void => {
+    try {
+        localStorage.removeItem(KEY)
+    } catch {
+        // ignore
+    }
+}
+
+// Small, fast, stable string hash (FNV-1a) — for the initialState discriminator only, never
+// for anything security-sensitive.
+const hash = (s: string): string => {
+    let h = 0x811c9dc5
+    for (let i = 0; i < s.length; i++) {
+        h ^= s.charCodeAt(i)
+        h = Math.imul(h, 0x01000193)
+    }
+    return (h >>> 0).toString(36)
+}

--- a/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/mateu-ux.ts
+++ b/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/mateu-ux.ts
@@ -19,6 +19,7 @@ import {ComponentState, ComponentData} from "@infra/ui/renderers/types.ts";
 import type ClientSideComponent from "@mateu/shared/apiClients/dtos/ClientSideComponent.ts";
 import {nanoid} from "nanoid";
 import {hasWelcomeBanner, pageTypeOf, resolvePageWidth} from "@infra/ui/layout/pageWidth.ts";
+import {getCachedStructure, putCachedStructure, structureCacheKey} from "@infra/routeStructureCache.ts";
 
 @customElement('mateu-ux')
 export class MateuUx extends ConnectedElement {
@@ -100,6 +101,26 @@ export class MateuUx extends ConnectedElement {
      */
     private pendingRouteFocus = false
     private hasRenderedContent = false
+
+    /**
+     * Key of the route whose AUTHORITATIVE structure this ux is currently showing (set when a
+     * real fragment lands). Guards the cache seed: we only paint a cached structure when moving
+     * to a DIFFERENT route — never when re-loading the one already on screen (e.g. an `instant`
+     * self-refresh), where blowing the live content away for a data-less skeleton would be a
+     * regression.
+     */
+    private lastAuthoritativeKey: string | undefined
+
+    /** Stable client-cache key for this ux's current route load (see routeStructureCache.ts). */
+    private structureCacheKey(): string {
+        return structureCacheKey({
+            baseUrl: this.baseUrl,
+            consumedRoute: this.consumedRoute,
+            route: this.route,
+            serverSideType: this.serverSideType,
+            initialState: this.initialState,
+        })
+    }
 
     private focusNewContent() {
         requestAnimationFrame(() => {
@@ -341,6 +362,27 @@ export class MateuUx extends ConnectedElement {
             _changedProperties.has('instant')) {
             if (!this.preventNavigation) {
                 this.callbackToken = this.instant || nanoid()
+                // Predict the screen's structure from the client cache so its real layout paints
+                // immediately instead of a generic skeleton. This is a PREDICTION: the server
+                // request below still fires and its authoritative fragment overwrites this seed
+                // in applyFragment (stale-while-revalidate). Structure only — state/data stay
+                // empty and arrive fresh from the server, so no stale business data is shown.
+                // Skipped when re-loading the route already on screen, to preserve its live
+                // content (see lastAuthoritativeKey). See routeStructureCache.ts.
+                const cacheKey = this.structureCacheKey()
+                if (cacheKey !== this.lastAuthoritativeKey) {
+                    const cached = getCachedStructure(cacheKey)
+                    if (cached) {
+                        this.fragment = {
+                            targetComponentId: this.id,
+                            component: cached,
+                            state: {},
+                            data: {},
+                            action: UIFragmentAction.Replace,
+                            containerId: undefined,
+                        }
+                    }
+                }
                 this.manageActionEvent(new CustomEvent('server-side-action-requested', {
                     detail: {
                         route: this.route,
@@ -392,6 +434,15 @@ export class MateuUx extends ConnectedElement {
         }
         this.fragment = fragment
         if (fragment.component) {
+            // Cache the authoritative STRUCTURE so the next visit to this route can paint it
+            // instantly. Overlay pushes (Add) are not route content — skip them. Remember the
+            // key so an in-place re-load of this same route won't reseed a data-less structure
+            // over the live content.
+            if (fragment.action !== UIFragmentAction.Add) {
+                const cacheKey = this.structureCacheKey()
+                putCachedStructure(cacheKey, fragment.component)
+                this.lastAuthoritativeKey = cacheKey
+            }
             if (this.pendingRouteFocus && this.hasRenderedContent) {
                 this.focusNewContent()
             }


### PR DESCRIPTION
## Qué

Fase (a) de la caché de estructura: pinta la **estructura** cacheada de una pantalla al instante en la vuelta a una ruta, en vez del skeleton genérico, **sin perder la inferencia de UI desde el servidor**.

La caché es una **predicción** (stale-while-revalidate): `mateu-ux` sigue disparando el request de ruta normal y el fragment autoritativo del servidor sobrescribe la semilla. Solo se cachea la **estructura** (el árbol `component`); `state`/`data` llegan siempre frescos del servidor, así que:

- Nunca se muestran datos rancios.
- Una estructura que ha cambiado (permisos, deploy nuevo) se autocorrige en una sola navegación.
- El servidor sigue siendo la fuente de verdad.

Todo vive en `libs/mateu` → cubre **vaadin + redwood + todos los shells** de una vez. **Cero backend, reversible.**

## Cambios

- **`routeStructureCache.ts`** (nuevo): store en localStorage (patrón `recentRoutesStore.ts`), key `baseUrl|consumedRoute|route|serverSideType` (+ hash de `initialState` para islas embebidas), LRU de 50, `CACHE_VERSION`, kill-switch (`localStorage['mateu-route-structure-cache-off']='1'`).
- **`mateu-ux.ts`**: siembra la estructura cacheada en `updated()` antes de lanzar el route-load; cachea el fragment autoritativo en `applyFragment`. Guard `lastAuthoritativeKey` para no re-sembrar la ruta ya en pantalla (protege el self-refresh `instant`).

## Verificación

- **11 tests vitest** nuevos (round-trip, discriminador por `initialState`, invalidación por versión, LRU, kill-switch, storage corrupto, clear).
- Suite completa de `libs/mateu`: **233 pasan** (los 2 errores de `jsdom` son preexistentes, entorno sin instalar).
- **`tsc` limpio** en todo el proyecto (0 errores) + build real del renderer Vaadin (Vite) OK.
- **A/B en navegador real** (demo-vaadin-mvc, respuesta del servidor retardada 2.5s): en cold la estructura aparece solo al responder el servidor; en warm se pinta **al instante desde caché con el request aún en vuelo**, y el servidor revalida en ambos casos.

## Pendiente (fase b, siguiente PR)

Hint de "pantalla estática" desde el servidor + build hash (por `appState`) para **saltarse** la revalidación en pantallas puramente estáticas y cachear datos donde sea seguro; y `template-ref` en el wire (`{templateRef, state}`) para encoger **todas** las respuestas, no solo el primer pintado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)