### PR TITLE
feat(perf): @StaticView skips the round-trip on return visits (fase b)

### DIFF
--- a/backend/dotnet/src/Mateu.Core/ReflectionMapper.cs
+++ b/backend/dotnet/src/Mateu.Core/ReflectionMapper.cs
@@ -339,6 +339,7 @@ public sealed class ReflectionMapper(ITranslator? translator = null, Func<Identi
             Rules = MapRules(type, instance),
             PageWidth = PageWidthOf(type, instance),
             PageType = PageTypeOf(type),
+            StaticView = type.Find<StaticViewAttribute>() != null,
         };
     }
 

--- a/backend/dotnet/src/Mateu.Core/SyncHandler.cs
+++ b/backend/dotnet/src/Mateu.Core/SyncHandler.cs
@@ -1387,7 +1387,10 @@ public sealed class SyncHandler(MateuRegistry registry, ITranslator? translator 
     {
         if (component is not ServerSideComponentDto ss) return component;
         var hash = StructureHashOf(ss);
-        if (rq.KnownStructureHash is { Length: > 0 } known && known == hash) return null;
+        // A [StaticView] is never omitted: the client caches its FULL response the first time it
+        // sees it each session and then skips the round-trip entirely, so it must always receive
+        // the component (carrying staticView=true) to learn that.
+        if (!ss.StaticView && rq.KnownStructureHash is { Length: > 0 } known && known == hash) return null;
         return ss with { StructureHash = hash };
     }
 

--- a/backend/dotnet/src/Mateu.Dtos/Wire.cs
+++ b/backend/dotnet/src/Mateu.Dtos/Wire.cs
@@ -106,6 +106,11 @@ public record ServerSideComponentDto(
     /// no-eval engine re-evaluates them on every state change.</summary>
     public IReadOnlyList<RuleDto> Rules { get; init; } = [];
 
+    /// <summary>The view is declared [StaticView]: its full response never varies, so the client
+    /// caches it for the session and skips the round-trip on return visits (mirrors
+    /// io.mateu.dtos.ServerSideComponentDto.staticView). A developer promise; false unless declared.</summary>
+    public bool StaticView { get; init; }
+
     /// <summary>Stable content hash (ETag) of this component's structure (phase b of the client
     /// structure cache). The client stores it next to the cached structure and echoes it back as
     /// RunActionRqDto.KnownStructureHash; when it still matches, the server omits the component and

--- a/backend/dotnet/src/Mateu.Uidl/FieldAndPageFeatures.cs
+++ b/backend/dotnet/src/Mateu.Uidl/FieldAndPageFeatures.cs
@@ -180,6 +180,14 @@ public sealed class TocAttribute(bool value = true) : Attribute
 [AttributeUsage(AttributeTargets.Class)]
 public sealed class CompactAttribute : Attribute;
 
+/// <summary>Marks a view whose FULL response — structure and data — never varies per request, user
+/// or time. The client caches the whole response for the session and skips the server round-trip
+/// on return visits (the last step of the client structure cache). A developer promise, like
+/// <c>[ActionOptions(Idempotent=…)]</c>; do NOT use it where content depends on data, the user,
+/// permissions, time or live-state interpolation. Mirrors io.mateu's <c>@StaticView</c>.</summary>
+[AttributeUsage(AttributeTargets.Class)]
+public sealed class StaticViewAttribute : Attribute;
+
 /// <summary>How a page's content column is sized within the viewport (the first parameter of the
 /// Oracle Redwood page templates; the names follow them). Selected with [PageWidth] or the
 /// <see cref="IPageWidthSupplier"/> hook; when neither is present the renderer infers the width

--- a/backend/dotnet/test/Mateu.Tests/SyncHandlerTests.cs
+++ b/backend/dotnet/test/Mateu.Tests/SyncHandlerTests.cs
@@ -18,6 +18,13 @@ public class SimpleForm
     [Button] public string GoHome() => "/things";
 }
 
+// A fully-static screen: the client caches its whole response and skips the round-trip on return.
+[UI("static-view"), Title("About"), StaticView]
+public class StaticViewForm
+{
+    public string? Heading { get; set; } = "About";
+}
+
 // Per-action transport knobs: two buttons that differ only in how the CLIENT should call them.
 [UI("action-options"), Title("Action options")]
 public class ActionOptionsForm
@@ -804,6 +811,23 @@ public class SyncHandlerTests
 
         var cold = Handler().Handle(new RunActionRqDto { Route = "", ConsumedRoute = "_empty" });
         Assert.NotNull(cold.Fragments[0].Component);
+    }
+
+    [Fact]
+    public void StaticView_is_flagged_only_when_declared()
+    {
+        Assert.True(ComponentOf(Handler().Handle(new RunActionRqDto { Route = "static-view", ConsumedRoute = "_empty" })).StaticView);
+        Assert.False(ComponentOf(Handler().Handle(new RunActionRqDto { Route = "", ConsumedRoute = "_empty" })).StaticView);
+    }
+
+    [Fact]
+    public void A_static_view_is_never_omitted_even_when_the_hash_matches()
+    {
+        var hash = ComponentOf(Handler().Handle(new RunActionRqDto { Route = "static-view", ConsumedRoute = "_empty" })).StructureHash;
+        var inc = Handler().Handle(
+            new RunActionRqDto { Route = "static-view", ConsumedRoute = "_empty", KnownStructureHash = hash });
+        Assert.NotNull(inc.Fragments[0].Component);
+        Assert.True(ComponentOf(inc).StaticView);
     }
 
     [Fact]

--- a/backend/python/mateu_core/mapper.py
+++ b/backend/python/mateu_core/mapper.py
@@ -662,6 +662,7 @@ class ReflectionMapper:
             rules=self.map_rules(cls, instance),
             page_width=getattr(cls, "__mateu_page_width__", None),
             page_type=page_type,
+            static_view=bool(class_flag(cls, "__mateu_static_view__", False)),
         )
 
     # ── Fluent component trees & declarative archetypes ───────────────────────

--- a/backend/python/mateu_core/sync_handler.py
+++ b/backend/python/mateu_core/sync_handler.py
@@ -1532,7 +1532,10 @@ class SyncHandler:
             return component
         h = SyncHandler._structure_hash(component)
         known = rq.known_structure_hash if rq else None
-        if known and known == h:
+        # A @static_view is never omitted: the client caches its FULL response the first time it
+        # sees it each session and then skips the round-trip entirely, so it must always receive
+        # the component (carrying static_view=True) to learn that.
+        if known and known == h and not component.static_view:
             return None
         return component.model_copy(update={"structure_hash": h})
 

--- a/backend/python/mateu_dtos/__init__.py
+++ b/backend/python/mateu_dtos/__init__.py
@@ -1211,6 +1211,10 @@ class ServerSideComponent(Wire):
     #: the family of Redwood page templates the view belongs to; never None on the wire
     #: (mirrors ServerSideComponentDto.pageType).
     page_type: str | None = None
+    #: The view is declared @static_view: its full response never varies, so the client caches it
+    #: for the session and skips the round-trip on return visits (mirrors
+    #: ServerSideComponentDto.staticView). A developer promise; False unless declared.
+    static_view: bool = False
     #: Stable content hash (ETag) of this component's structure (phase b of the client structure
     #: cache). The client stores it next to the cached structure and echoes it back as
     #: RunActionRq.known_structure_hash; when it still matches, the server omits the component and

--- a/backend/python/mateu_uidl/__init__.py
+++ b/backend/python/mateu_uidl/__init__.py
@@ -825,6 +825,16 @@ def compact(cls: type) -> type:
     return cls
 
 
+def static_view(cls: type) -> type:
+    """Class-level: the view's FULL response — structure and data — never varies per request, user
+    or time. The client caches the whole response for the session and skips the server round-trip
+    on return visits (the last step of the client structure cache). A developer promise, like
+    ``@action_options(idempotent=…)``; do NOT use it where content depends on data, the user,
+    permissions, time or live-state interpolation. Mirrors io.mateu's ``@StaticView``."""
+    cls.__mateu_static_view__ = True
+    return cls
+
+
 def auto_layout(arg=True):
     """Class-level: let Mateu infer the UX patterns (folded optionals, tabs, radio enums…) from
     the amount and structure of the declared information. Explicit layout markers always win —
@@ -1483,6 +1493,7 @@ __all__ = [
     "Required", "Label", "Section", "Tab", "Stereotype", "Multiline", "Password",
     "Money", "PlainText", "ReadOnly", "Version", "Lookup", "Hidden", "Disabled", "OnRowSelected", "InlineEditing", "EyesOnly", "ReadOnlyUnless", "DisabledUnless", "Identity", "disabled_unless", "Audience", "audience", "LookupLabelSupplier", "Rule", "RuleSupplier", "AppHeaderAction", "AppActionsSupplier", "PeerNav", "PeerNavigationSupplier", "AppNotification", "NotificationsSupplier", "BulletedList", "SeparatorBefore", "Signature", "PhotoCapture", "FileUpload", "RangeFilter", "Aggregate", "AggregateFunction", "GroupBy", "TreeSelect", "UseRadioButtons", "HeaderBadge", "Timestamp", "Step", "Panel",
     "ai", "remote_menu", "ui", "title", "subtitle", "app", "auto_layout", "read_only", "compact",
+    "static_view",
     "confirm_on_navigation_if_dirty", "inline_editing", "toc", "zones", "folded_layout", "form_layout", "LabelsAsideMode", "wizard_progress", "page_width", "page_template",
     "plain_text", "emits", "subscribe_to", "secured", "welcome_banner",
     "button", "menu_item", "kpi", "fab", "banner", "shortcut", "list_toolbar_button",

--- a/backend/python/tests/test_sync_handler.py
+++ b/backend/python/tests/test_sync_handler.py
@@ -64,6 +64,7 @@ from mateu_uidl import (  # noqa: E402
     banner,
     button,
     compact,
+    static_view,
     confirm_on_navigation_if_dirty,
     emits,
     fab,
@@ -117,6 +118,13 @@ class SimpleForm:
     @button()
     def go_home(self):
         return "/things"
+
+
+@ui("static-view")
+@title("About")
+@static_view
+class StaticViewForm:
+    heading: str = "About"
 
 
 @ui("action-options")
@@ -799,6 +807,20 @@ def test_a_stale_or_missing_hash_still_sends_the_full_structure():
 
     cold = handler().handle(RunActionRq(route="", consumed_route="_empty"))
     assert cold.fragments[0].component is not None
+
+
+def test_static_view_is_flagged_only_when_declared():
+    assert _component_of(handler().handle(RunActionRq(route="static-view", consumed_route="_empty"))).static_view is True
+    assert _component_of(handler().handle(RunActionRq(route="", consumed_route="_empty"))).static_view is False
+
+
+def test_a_static_view_is_never_omitted_even_when_the_hash_matches():
+    h = _component_of(handler().handle(RunActionRq(route="static-view", consumed_route="_empty"))).structure_hash
+    inc = handler().handle(
+        RunActionRq(route="static-view", consumed_route="_empty", known_structure_hash=h)
+    )
+    assert inc.fragments[0].component is not None
+    assert _component_of(inc).static_view is True
 
 
 def test_initial_load_form_with_required_field_and_button():

--- a/backend/shared/core/src/main/java/io/mateu/core/application/runaction/ComponentStateHelper.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/runaction/ComponentStateHelper.java
@@ -12,6 +12,7 @@ import static io.mateu.core.infra.declarative.orchestrators.wizard.Wizard.addRow
 
 import io.mateu.core.domain.out.componentmapper.PageTypeResolver;
 import io.mateu.core.domain.out.componentmapper.PageWidthResolver;
+import io.mateu.core.domain.out.componentmapper.StaticViewResolver;
 import io.mateu.dtos.ServerSideComponentDto;
 import io.mateu.uidl.annotations.Route;
 import io.mateu.uidl.annotations.UI;
@@ -82,6 +83,7 @@ public class ComponentStateHelper {
         emitsName(modelView),
         PageWidthResolver.wirePageWidth(modelView),
         PageTypeResolver.wirePageType(modelView),
+        StaticViewResolver.isStatic(modelView),
         null);
   }
 

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/out/componentmapper/ReflectionObjectToComponentMapper.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/out/componentmapper/ReflectionObjectToComponentMapper.java
@@ -116,6 +116,7 @@ public class ReflectionObjectToComponentMapper {
             emitsName(instance),
             PageWidthResolver.wirePageWidth(instance),
             PageTypeResolver.wirePageType(instance),
+            StaticViewResolver.isStatic(instance),
             null),
         instance,
         getData(httpRequest, instance),

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/out/componentmapper/StaticViewResolver.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/out/componentmapper/StaticViewResolver.java
@@ -1,0 +1,19 @@
+package io.mateu.core.domain.out.componentmapper;
+
+import io.mateu.core.infra.reflection.MetaAnnotations;
+import io.mateu.uidl.annotations.StaticView;
+
+/**
+ * Whether a view is declared {@code @StaticView} — its full response never varies, so the client
+ * may cache it for the session and skip the round-trip on return visits (the last step of the
+ * client structure cache). Read reflectively like {@code @Compact}/{@code @Toc}, so composed
+ * (semantic) annotations that wrap {@code @StaticView} are honored.
+ */
+public final class StaticViewResolver {
+
+  private StaticViewResolver() {}
+
+  public static boolean isStatic(Object instance) {
+    return instance != null && MetaAnnotations.isPresent(instance.getClass(), StaticView.class);
+  }
+}

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/ComponentToFragmentDtoMapper.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/ComponentToFragmentDtoMapper.java
@@ -11,6 +11,7 @@ import static io.mateu.core.domain.out.fragmentmapper.mappers.PageMapper.mapPage
 import io.mateu.core.domain.out.componentmapper.PageTypeResolver;
 import io.mateu.core.domain.out.componentmapper.PageWidthResolver;
 import io.mateu.core.domain.out.componentmapper.ReflectionPageMapper;
+import io.mateu.core.domain.out.componentmapper.StaticViewResolver;
 import io.mateu.core.domain.out.componentmapper.ViewTypeClassifier;
 import io.mateu.core.domain.out.fragmentmapper.mappers.ActionMapper;
 import io.mateu.core.domain.out.fragmentmapper.mappers.EmitsMapper;
@@ -160,6 +161,7 @@ public final class ComponentToFragmentDtoMapper {
           EmitsMapper.emitsName(view),
           PageWidthResolver.wirePageWidth(view),
           PageTypeResolver.wirePageType(view),
+          StaticViewResolver.isStatic(view),
           null);
     }
     if (component instanceof FutureComponent futureComponent) {

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/mappers/ComponentTreeSupplierMapper.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/mappers/ComponentTreeSupplierMapper.java
@@ -5,6 +5,7 @@ import static io.mateu.core.domain.out.fragmentmapper.ComponentToFragmentDtoMapp
 
 import io.mateu.core.domain.out.componentmapper.PageTypeResolver;
 import io.mateu.core.domain.out.componentmapper.PageWidthResolver;
+import io.mateu.core.domain.out.componentmapper.StaticViewResolver;
 import io.mateu.dtos.ComponentDto;
 import io.mateu.dtos.ServerSideComponentDto;
 import io.mateu.uidl.interfaces.ComponentTreeSupplier;
@@ -47,6 +48,7 @@ public class ComponentTreeSupplierMapper {
         EmitsMapper.emitsName(componentTreeSupplier),
         PageWidthResolver.wirePageWidth(componentTreeSupplier),
         PageTypeResolver.wirePageType(componentTreeSupplier),
+        StaticViewResolver.isStatic(componentTreeSupplier),
         null);
   }
 }

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/mappers/FutureComponentMapper.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/mappers/FutureComponentMapper.java
@@ -8,6 +8,7 @@ import static io.mateu.core.domain.out.fragmentmapper.mappers.ValidationMapper.m
 
 import io.mateu.core.domain.out.componentmapper.PageTypeResolver;
 import io.mateu.core.domain.out.componentmapper.PageWidthResolver;
+import io.mateu.core.domain.out.componentmapper.StaticViewResolver;
 import io.mateu.core.infra.reflection.MetaAnnotations;
 import io.mateu.dtos.ComponentDto;
 import io.mateu.dtos.ServerSideComponentDto;
@@ -63,6 +64,7 @@ public class FutureComponentMapper {
         EmitsMapper.emitsName(futureComponent.instance()),
         PageWidthResolver.wirePageWidth(futureComponent.instance()),
         PageTypeResolver.wirePageType(futureComponent.instance()),
+        StaticViewResolver.isStatic(futureComponent.instance()),
         null);
   }
 

--- a/backend/shared/core/src/main/java/io/mateu/core/infra/StructureHashPostProcessor.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/infra/StructureHashPostProcessor.java
@@ -71,7 +71,10 @@ public final class StructureHashPostProcessor {
       return fragment;
     }
     String hash = hashOf(component);
-    if (knownStructureHash != null && knownStructureHash.equals(hash)) {
+    // A @StaticView is never omitted: the client caches its FULL response the first time it sees it
+    // each session and then skips the round-trip entirely, so it must always receive the component
+    // (carrying staticView=true) to learn that — even when it already holds the structure.
+    if (knownStructureHash != null && knownStructureHash.equals(hash) && !component.staticView()) {
       // The client already holds this exact structure — drop it, keep only state/data.
       return fragment.withComponent(null);
     }

--- a/backend/shared/core/src/test/java/io/mateu/core/application/StructureCacheEtagSyncTest.java
+++ b/backend/shared/core/src/test/java/io/mateu/core/application/StructureCacheEtagSyncTest.java
@@ -7,6 +7,7 @@ import io.mateu.dtos.RunActionRqDto;
 import io.mateu.dtos.ServerSideComponentDto;
 import io.mateu.dtos.UIFragmentDto;
 import io.mateu.dtos.UIIncrementDto;
+import io.mateu.uidl.annotations.StaticView;
 import io.mateu.uidl.annotations.UI;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -28,11 +29,17 @@ class StructureCacheEtagSyncTest {
     private int age = 42;
   }
 
+  @StaticView
+  @UI("/static-form")
+  public static class StaticForm {
+    private String heading = "About";
+  }
+
   static TestMateu mateu;
 
   @BeforeAll
   static void boot() {
-    mateu = TestMateu.withUis(EtagForm.class);
+    mateu = TestMateu.withUis(EtagForm.class, StaticForm.class);
   }
 
   @AfterAll
@@ -95,5 +102,23 @@ class StructureCacheEtagSyncTest {
   void aNullHashSendsTheFullStructure() {
     // the old-client / cold-cache path
     assertThat(componentOf(load("/etag-form", null))).isNotNull();
+  }
+
+  @Test
+  void staticViewIsFlaggedOnlyWhenDeclared() {
+    // @StaticView → the client may cache the full response and skip revalidation for the session
+    assertThat(componentOf(load("/static-form", null)).staticView()).isTrue();
+    // a plain view is not static
+    assertThat(componentOf(load("/etag-form", null)).staticView()).isFalse();
+  }
+
+  @Test
+  void aStaticViewIsNeverOmittedEvenWhenTheHashMatches() {
+    // so the client always learns staticView (and caches the full response) the first time it sees
+    // the view in a session, then skips the round-trip entirely on return visits
+    var hash = componentOf(load("/static-form", null)).structureHash();
+    var component = componentOf(load("/static-form", hash));
+    assertThat(component).isNotNull();
+    assertThat(component.staticView()).isTrue();
   }
 }

--- a/backend/shared/dtos/src/main/java/io/mateu/dtos/ServerSideComponentDto.java
+++ b/backend/shared/dtos/src/main/java/io/mateu/dtos/ServerSideComponentDto.java
@@ -47,6 +47,12 @@ public record ServerSideComponentDto(
      */
     String pageType,
     /**
+     * The view is declared {@code @StaticView}: its full response never varies, so the client may
+     * cache it for the session and SKIP the round-trip on return visits (the last step of the
+     * client structure cache). A developer promise; {@code false} unless declared.
+     */
+    boolean staticView,
+    /**
      * Stable content hash (ETag) of this component's STRUCTURE — everything but per-request
      * state/data. The client stores it next to the cached structure and echoes it back as {@code
      * RunActionRqDto.knownStructureHash}; when it still matches, the server omits the component
@@ -77,6 +83,7 @@ public record ServerSideComponentDto(
         emitsName,
         pageWidth,
         pageType,
+        staticView,
         structureHash);
   }
 
@@ -102,6 +109,7 @@ public record ServerSideComponentDto(
         emitsName,
         pageWidth,
         pageType,
+        staticView,
         structureHash);
   }
 
@@ -125,6 +133,7 @@ public record ServerSideComponentDto(
         emitsName,
         pageWidth,
         pageType,
+        staticView,
         structureHash);
   }
 
@@ -148,6 +157,7 @@ public record ServerSideComponentDto(
         emitsName,
         pageWidth,
         pageType,
+        staticView,
         structureHash);
   }
 }

--- a/backend/shared/uidl/src/main/java/io/mateu/uidl/annotations/StaticView.java
+++ b/backend/shared/uidl/src/main/java/io/mateu/uidl/annotations/StaticView.java
@@ -1,0 +1,26 @@
+package io.mateu.uidl.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a view whose FULL response — structure <em>and</em> data — never varies per request, user
+ * or time: a static help page, an "about" screen, a fixed dashboard of constants. It is a promise
+ * by the developer, like {@code @Action(idempotent=…)}.
+ *
+ * <p>The client caches the whole response for such a view (in memory, for the session) and, on a
+ * return visit within that session, renders it from the cache and SKIPS the server round-trip
+ * entirely — the last step of the client structure cache: phase (a) paints the structure instantly,
+ * phase (b) shrinks the revalidation, and this drops it altogether. Session scope keeps it safe
+ * without a build hash: a full page reload always reloads, so a new deployment is picked up.
+ *
+ * <p>Do NOT use it on a view whose content depends on data, the logged-in user, permissions, time,
+ * or {@code ${…}} interpolation of live state — the client would keep showing the first rendering
+ * for the rest of the session. When in doubt, leave it off: phases (a)+(b) already make a return
+ * visit cheap.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+public @interface StaticView {}

--- a/demo/demo-vaadin-mvc/src/main/java/com/example/demo/infra/in/ui/pages/tests/StaticAbout.java
+++ b/demo/demo-vaadin-mvc/src/main/java/com/example/demo/infra/in/ui/pages/tests/StaticAbout.java
@@ -1,0 +1,20 @@
+package com.example.demo.infra.in.ui.pages.tests;
+
+import io.mateu.uidl.annotations.PlainText;
+import io.mateu.uidl.annotations.Route;
+import io.mateu.uidl.annotations.StaticView;
+import io.mateu.uidl.annotations.Title;
+
+/**
+ * A fully-static screen: its content never varies. Marked {@code @StaticView} so the client caches
+ * the whole response for the session and skips the round-trip on return visits.
+ */
+@Route("/static-about")
+@Title("About Mateu")
+@StaticView
+@PlainText
+public class StaticAbout {
+    String product = "Mateu";
+    String tagline = "Model-driven UI for Java.";
+    String version = "3.0";
+}

--- a/doc/src/content/docs/reference/parity.md
+++ b/doc/src/content/docs/reference/parity.md
@@ -58,6 +58,7 @@ for the surface below (verified by golden-JSON tests in `backend/dotnet/test` an
 | Global entity search (`GlobalSearchSupplier` → `globalSearchEnabled` + `_globalsearch`) | ✅ | ✅ | ✅ |
 | Dialog/Drawer overlays from actions + `closeModal`/`dispatchEvent` | ✅ | ✅ | ✅ |
 | Structure ETag / template-ref (`structureHash` + request `knownStructureHash` → omit the component when unchanged) | ✅ | ✅ | ✅ |
+| Static-view skip (`@StaticView`/`[StaticView]`/`@static_view` → `staticView` flag; client caches the full response for the session and skips the round-trip on return) | ✅ | ✅ | ✅ |
 | Sticky sections index (`@Toc`) | ✅ | ✅ | ✅ |
 | Client-side rules (`@Hidden(expr)`/`@Disabled`/rule supplier) | ✅ | ✅ | ✅ |
 | Grid form fields + `@OnRowSelected` row-click actions (incl. add/create/select on plain forms outside wizards) | ✅ | ✅ | ✅ |

--- a/frontend/web/monorepo/libs/mateu/src/mateu/shared/apiClients/dtos/ServerSideComponent.ts
+++ b/frontend/web/monorepo/libs/mateu/src/mateu/shared/apiClients/dtos/ServerSideComponent.ts
@@ -38,4 +38,11 @@ export default interface ServerSideComponent extends Component {
      */
     structureHash?: string | undefined
 
+    /**
+     * The view is declared @StaticView: its full response never varies, so the client caches the
+     * whole fragment for the session and skips the round-trip on return visits (phase b, static
+     * skip). A developer promise; false/undefined unless declared.
+     */
+    staticView?: boolean | undefined
+
 }

--- a/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/staticViewCache.test.ts
+++ b/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/staticViewCache.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import type UIFragment from '@mateu/shared/apiClients/dtos/UIFragment.ts'
+import {
+    clearStaticFragments,
+    getStaticFragment,
+    putStaticFragment,
+    setStaticViewCacheEnabled,
+} from './staticViewCache.ts'
+
+const frag = (id: string): UIFragment => ({
+    targetComponentId: '_ux',
+    component: { id } as any,
+    state: { v: id },
+    data: {},
+    action: undefined,
+    containerId: undefined,
+})
+
+beforeEach(() => {
+    clearStaticFragments()
+    setStaticViewCacheEnabled(true)
+})
+
+describe('staticViewCache', () => {
+    it('round-trips a full fragment by key', () => {
+        putStaticFragment('/a', frag('a'))
+        expect(getStaticFragment('/a')?.state).toEqual({ v: 'a' })
+        expect(getStaticFragment('/missing')).toBeUndefined()
+    })
+
+    it('evicts least-recently-used past the cap of 30', () => {
+        for (let i = 0; i < 35; i++) putStaticFragment('/r' + i, frag('r' + i))
+        expect(getStaticFragment('/r0')).toBeUndefined()   // oldest 5 gone
+        expect(getStaticFragment('/r4')).toBeUndefined()
+        expect(getStaticFragment('/r5')).toBeDefined()
+        expect(getStaticFragment('/r34')).toBeDefined()
+    })
+
+    it('re-inserting a key refreshes its recency', () => {
+        for (let i = 0; i < 30; i++) putStaticFragment('/r' + i, frag('r' + i))
+        putStaticFragment('/r0', frag('r0'))              // touch the oldest → now newest
+        putStaticFragment('/new', frag('new'))            // evicts the now-oldest (/r1)
+        expect(getStaticFragment('/r0')).toBeDefined()
+        expect(getStaticFragment('/r1')).toBeUndefined()
+    })
+
+    it('the kill switch clears and disables the cache', () => {
+        putStaticFragment('/a', frag('a'))
+        setStaticViewCacheEnabled(false)
+        expect(getStaticFragment('/a')).toBeUndefined()
+        putStaticFragment('/b', frag('b'))
+        setStaticViewCacheEnabled(true)
+        expect(getStaticFragment('/b')).toBeUndefined()   // write while disabled was dropped
+    })
+
+    it('clears on demand', () => {
+        putStaticFragment('/a', frag('a'))
+        clearStaticFragments()
+        expect(getStaticFragment('/a')).toBeUndefined()
+    })
+})

--- a/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/staticViewCache.ts
+++ b/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/staticViewCache.ts
@@ -1,0 +1,41 @@
+// Session-scoped cache of the FULL response of a @StaticView screen (the last step of the client
+// structure cache). When the server marks a view static — its whole response never varies — the
+// client keeps the complete fragment (structure + state + data) here and, on a return visit within
+// the same session, renders it from the cache and SKIPS the server round-trip entirely.
+//
+// Deliberately IN-MEMORY (module scope), not localStorage: session scope is what makes skipping
+// revalidation safe without a build hash — a full page reload wipes this map, so a new deployment
+// is always picked up. It survives client-side navigations (that's the win) but not a reload.
+
+import type UIFragment from "@mateu/shared/apiClients/dtos/UIFragment";
+
+const MAX_ENTRIES = 30
+
+// key → the full authoritative fragment (component + state + data) for a static view
+const store = new Map<string, UIFragment>()
+
+let enabled = true
+export const setStaticViewCacheEnabled = (on: boolean): void => {
+    enabled = on
+    if (!on) store.clear()
+}
+
+/** The cached full response for a static route, or undefined on miss / disabled. */
+export const getStaticFragment = (key: string): UIFragment | undefined => {
+    if (!enabled) return undefined
+    return store.get(key)
+}
+
+/** Cache the full response of a static view for the session (most-recently-used eviction). */
+export const putStaticFragment = (key: string, fragment: UIFragment): void => {
+    if (!enabled) return
+    store.delete(key)            // re-insert at the end so the Map's iteration order is LRU
+    store.set(key, fragment)
+    if (store.size > MAX_ENTRIES) {
+        const oldest = store.keys().next().value
+        if (oldest !== undefined) store.delete(oldest)
+    }
+}
+
+/** Wipe the session cache (exposed for debugging / a hard reset). */
+export const clearStaticFragments = (): void => store.clear()

--- a/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/mateu-ux.ts
+++ b/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/mateu-ux.ts
@@ -21,6 +21,7 @@ import type ServerSideComponent from "@mateu/shared/apiClients/dtos/ServerSideCo
 import {nanoid} from "nanoid";
 import {hasWelcomeBanner, pageTypeOf, resolvePageWidth} from "@infra/ui/layout/pageWidth.ts";
 import {getCachedStructure, putCachedStructure, structureCacheKey} from "@infra/routeStructureCache.ts";
+import {getStaticFragment, putStaticFragment} from "@infra/staticViewCache.ts";
 
 @customElement('mateu-ux')
 export class MateuUx extends ConnectedElement {
@@ -382,25 +383,34 @@ export class MateuUx extends ConnectedElement {
                 // Skipped when re-loading the route already on screen, to preserve its live
                 // content (see lastAuthoritativeKey). See routeStructureCache.ts.
                 const cacheKey = this.structureCacheKey()
-                if (cacheKey !== this.lastAuthoritativeKey) {
-                    // Fresh navigation: seed from cache (if any) and adopt its ETag; a miss clears
-                    // the ETag so we don't echo the previous route's hash. When re-loading the SAME
-                    // route (key unchanged) we keep both the live content AND its hash, so the
-                    // request still carries knownStructureHash and the server can reply state-only.
-                    const cached = getCachedStructure(cacheKey)
-                    this.currentStructureHash = cached?.hash
-                    if (cached) {
-                        this.fragment = {
-                            targetComponentId: this.id,
-                            component: cached.component,
-                            state: {},
-                            data: {},
-                            action: UIFragmentAction.Replace,
-                            containerId: undefined,
+                // A @StaticView already loaded this session: its whole response never varies, so
+                // render the cached full fragment and SKIP the server round-trip entirely. Deferred
+                // to a microtask so it lands after this synchronous updated() sets pendingRouteFocus
+                // below — exactly as a real server response would, so focus still follows the route.
+                const staticFull =
+                    cacheKey !== this.lastAuthoritativeKey ? getStaticFragment(cacheKey) : undefined
+                if (staticFull) {
+                    queueMicrotask(() => this.applyFragment(staticFull))
+                } else {
+                    if (cacheKey !== this.lastAuthoritativeKey) {
+                        // Fresh navigation: seed from cache (if any) and adopt its ETag; a miss clears
+                        // the ETag so we don't echo the previous route's hash. When re-loading the SAME
+                        // route (key unchanged) we keep both the live content AND its hash, so the
+                        // request still carries knownStructureHash and the server can reply state-only.
+                        const cached = getCachedStructure(cacheKey)
+                        this.currentStructureHash = cached?.hash
+                        if (cached) {
+                            this.fragment = {
+                                targetComponentId: this.id,
+                                component: cached.component,
+                                state: {},
+                                data: {},
+                                action: UIFragmentAction.Replace,
+                                containerId: undefined,
+                            }
                         }
                     }
-                }
-                this.manageActionEvent(new CustomEvent('server-side-action-requested', {
+                    this.manageActionEvent(new CustomEvent('server-side-action-requested', {
                     detail: {
                         route: this.route,
                         consumedRoute: this.consumedRoute,
@@ -418,6 +428,7 @@ export class MateuUx extends ConnectedElement {
                     bubbles: true,
                     composed: true
                 }))
+                }
             }
         }
         if (_changedProperties.has('route') && !!this.top) {
@@ -467,6 +478,11 @@ export class MateuUx extends ConnectedElement {
                 putCachedStructure(cacheKey, fragment.component, hash)
                 this.lastAuthoritativeKey = cacheKey
                 this.currentStructureHash = hash
+                // A @StaticView: cache the WHOLE fragment (structure + state + data) for the session
+                // so the next visit renders from cache and skips the round-trip entirely.
+                if ((fragment.component as ServerSideComponent).staticView) {
+                    putStaticFragment(cacheKey, fragment)
+                }
             }
             if (this.pendingRouteFocus && this.hasRenderedContent) {
                 this.focusNewContent()


### PR DESCRIPTION
## Qué

Último paso de la caché de estructura cliente (fase (a) = PR #315, ETag = PR #316). `@StaticView` marca una vista cuyo **response completo (estructura + datos) no varía nunca** por request/usuario/tiempo. El cliente cachea el fragment entero **en memoria por SESIÓN** y, en la vuelta dentro de esa sesión, lo pinta desde caché **sin llamar al servidor**.

Composición de las tres fases: (a) pinta la estructura al instante, (b) encoge la revalidación, y esto la **elimina**.

**Seguro sin build hash:** el ámbito de sesión (Map en memoria) hace que un reload recargue siempre → un deploy se recoge solo. Refinamiento clave: el ETag de (b) **nunca omite** una vista estática (debe llegar completa para que el cliente aprenda el flag la primera vez de cada sesión y luego se la salte). Es una promesa del desarrollador (como `idempotent`): no usar donde el contenido dependa de datos/usuario/permisos/tiempo/interpolación.

## Alcance (paridad completa)

- **Java core** — `@StaticView` (uidl) → `StaticViewResolver.isStatic()` en los 5 sitios de construcción → `ServerSideComponentDto.staticView`; el post-procesador del ETag no omite estáticas.
- **Frontend** (`libs/mateu` → vaadin + redwood + shells) — `staticViewCache.ts` (Map en memoria, LRU 30, kill-switch); `mateu-ux` pinta el fragment cacheado y salta `manageActionEvent` (en un microtask, para que el foco siga a la ruta).
- **.NET** (`[StaticView]`) y **Python** (`@static_view`) — mismo wire, set en `MapView`/`map_view`, ETag no omite estáticas.

## Verificación

- **Java**: `StructureCacheEtagSyncTest` (+2 staticView) → suite core **765 verde**.
- **Frontend**: `staticViewCache` 5 vitest + `tsc` limpio.
- **.NET**: `SyncHandlerTests` (+2) → **237 verde**. **Python**: `test_sync_handler` (+2) → **236 verde**.
- **Navegador real** (demo `/static-about`): carga fría = **1 llamada** + render; vuelta in-SPA = **0 llamadas** + render desde la caché de sesión.
- `parity.md`: fila añadida.

Con esto la fase (b) queda completa: build-version+template-ref (ETag) **y** el hint de estático para saltarse el round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)