### PR TITLE
feat(yaml): a YAML page can declare its ModelView (visual-builder fase 0)

### DIFF
--- a/backend/shared/core/src/main/java/io/mateu/core/application/runaction/ActionInstanceCreator.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/runaction/ActionInstanceCreator.java
@@ -63,7 +63,24 @@ public class ActionInstanceCreator {
     RunActionCommand finalCommand = command;
     return routeInstanceCreator
         .findRouteResolver(command)
-        .switchIfEmpty((Mono) Mono.defer(() -> yamlUidlLoader.load(finalCommand)));
+        .switchIfEmpty((Mono) Mono.defer(() -> loadYaml(finalCommand)));
+  }
+
+  /**
+   * Route with no Java class: fall back to a YAML page. A bare layout renders as-is (static); a
+   * page that declares a {@code modelView:} instantiates that class as the ModelView (state +
+   * actions), and the reflective mapper re-applies the YAML layout to it (by route). Empty when
+   * there is no spec.
+   */
+  private Mono<?> loadYaml(RunActionCommand command) {
+    var spec = yamlUidlLoader.loadSpec(command.route());
+    if (spec == null) {
+      return Mono.empty();
+    }
+    if (spec.modelView() == null || spec.modelView().isBlank()) {
+      return Mono.justOrEmpty(spec.layout());
+    }
+    return createInstanceAndPostHydrate(spec.modelView(), command);
   }
 
   private Mono<?> instantiateWithKnownType(RunActionCommand command) {

--- a/backend/shared/core/src/main/java/io/mateu/core/application/runaction/YamlUidlLoader.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/runaction/YamlUidlLoader.java
@@ -1,72 +1,144 @@
 package io.mateu.core.application.runaction;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.mateu.uidl.fluent.Component;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
+import java.io.InputStream;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.extern.slf4j.Slf4j;
-import reactor.core.publisher.Mono;
 
+/**
+ * Loads a page defined in a YAML file under {@code specs/ui/} on the classpath.
+ *
+ * <p>Two shapes are supported:
+ *
+ * <ul>
+ *   <li><b>Bare layout</b> (legacy): the whole file is a component tree ({@code type: ...}). It
+ *       renders as a static, unbound page — good for help/landing screens with no behaviour.
+ *   <li><b>Page envelope</b>: a {@code layout:} key holds the component tree and an optional {@code
+ *       modelView:} key names a Java class. When present, that class is instantiated as the page's
+ *       ModelView — it supplies the state, actions, validations and rules — while the YAML supplies
+ *       the layout. This is the inverse of {@code @UISpec} (there the class points at the YAML;
+ *       here the YAML points at the class), so a page can be authored as a file that references a
+ *       plain, unannotated logic class.
+ * </ul>
+ *
+ * The binding between the YAML layout and the ModelView is by convention, exactly as everywhere
+ * else in Mateu: a {@code FormField id="name"} binds to the ModelView's {@code name} property and a
+ * {@code Button actionId="save"} to its {@code save()} method.
+ */
 @Slf4j
 @Named
 @Singleton
 public class YamlUidlLoader {
 
+  /** A parsed page spec: the layout, plus the ModelView class name when the YAML declares one. */
+  public record YamlPageSpec(String modelView, Component layout) {}
+
+  // Specs are static files, so parse once and cache by (normalized) route. A miss is cached as
+  // NONE so an unmatched route — checked on every request that has no Java class — doesn't hit the
+  // classpath each time. (Editing a YAML during development needs a restart to be picked up.)
+  private static final YamlPageSpec NONE = new YamlPageSpec(null, null);
+
   private final ObjectMapper mapper;
+  private final ConcurrentHashMap<String, YamlPageSpec> byRoute = new ConcurrentHashMap<>();
 
   public YamlUidlLoader() {
     mapper = YamlUidlMapperFactory.create();
   }
 
+  /** Load a layout from an explicit spec path (the {@code @UISpec} path); envelope-aware. */
   public Component loadFromSpec(String specPath) {
-    var cl = Thread.currentThread().getContextClassLoader();
-    var resource = cl.getResourceAsStream(specPath);
-    if (resource == null) {
-      resource = YamlUidlLoader.class.getClassLoader().getResourceAsStream(specPath);
-    }
+    var resource = resolve(specPath);
     if (resource == null) {
       log.warn("No YAML spec found at classpath:{}", specPath);
       return null;
     }
     try (var is = resource) {
-      return mapper.readValue(is, Component.class);
+      return layoutOf(mapper.readTree(is));
     } catch (Exception e) {
       log.warn("Failed to parse YAML spec {}: {}", specPath, e.getMessage());
       return null;
     }
   }
 
-  public Mono<Component> load(RunActionCommand command) {
-    var route = stripQueryParams(command.route());
-    if (route.startsWith("/")) {
-      route = route.substring(1);
-    }
-    var yamlPath = "specs/ui/" + route + ".yaml";
-    log.info("Looking for YAML spec at classpath:{}", yamlPath);
+  /**
+   * The parsed spec for a route ({@code specs/ui/<route>.yaml}), or {@code null} when there is
+   * none.
+   */
+  public YamlPageSpec loadSpec(String route) {
+    var spec = byRoute.computeIfAbsent(normalize(route), this::parseSpec);
+    return spec == NONE ? null : spec;
+  }
 
-    var cl = Thread.currentThread().getContextClassLoader();
-    var resource = cl.getResourceAsStream(yamlPath);
-    if (resource == null) {
-      resource = YamlUidlLoader.class.getClassLoader().getResourceAsStream(yamlPath);
+  /**
+   * The YAML layout for {@code route}, but only when the route's spec declares {@code modelView}
+   * and it matches {@code modelViewClass} — i.e. this instance IS the page's declared ModelView.
+   * This is what re-applies the YAML layout on an action round-trip (which routes by
+   * serverSideType), not just on the first load. Returns {@code null} otherwise.
+   */
+  public Component layoutForRoute(String route, Class<?> modelViewClass) {
+    var spec = loadSpec(route);
+    if (spec == null || spec.modelView() == null || modelViewClass == null) {
+      return null;
     }
+    return spec.modelView().equals(modelViewClass.getName()) ? spec.layout() : null;
+  }
+
+  private YamlPageSpec parseSpec(String normalizedRoute) {
+    var yamlPath = "specs/ui/" + normalizedRoute + ".yaml";
+    var resource = resolve(yamlPath);
     if (resource == null) {
       log.info("No YAML spec found at {}", yamlPath);
-      return Mono.empty();
+      return NONE;
     }
-
     try (var is = resource) {
-      var component = mapper.readValue(is, Component.class);
-      log.info("Loaded component from YAML spec: {}", yamlPath);
-      return Mono.just(component);
+      var root = mapper.readTree(is);
+      if (root == null) {
+        return NONE;
+      }
+      var modelView = root.hasNonNull("modelView") ? root.get("modelView").asText() : null;
+      var layout = layoutOf(root);
+      log.info("Loaded YAML spec {} (modelView={})", yamlPath, modelView);
+      return new YamlPageSpec(modelView, layout);
     } catch (Exception e) {
       log.warn("Failed to parse YAML spec {}: {}", yamlPath, e.getMessage());
-      return Mono.empty();
+      return NONE;
     }
   }
 
-  private String stripQueryParams(String route) {
-    if (route == null) return "";
-    int idx = route.indexOf('?');
-    return idx >= 0 ? route.substring(0, idx) : route;
+  /**
+   * The component tree of a parsed doc: the {@code layout:} node in an envelope, else the whole
+   * doc.
+   */
+  private Component layoutOf(JsonNode root) throws Exception {
+    if (root == null) {
+      return null;
+    }
+    var node = root.has("layout") ? root.get("layout") : root;
+    return mapper.treeToValue(node, Component.class);
+  }
+
+  private InputStream resolve(String path) {
+    var cl = Thread.currentThread().getContextClassLoader();
+    var resource = cl != null ? cl.getResourceAsStream(path) : null;
+    if (resource == null) {
+      resource = YamlUidlLoader.class.getClassLoader().getResourceAsStream(path);
+    }
+    return resource;
+  }
+
+  private String normalize(String route) {
+    var r = route == null ? "" : route;
+    int idx = r.indexOf('?');
+    if (idx >= 0) {
+      r = r.substring(0, idx);
+    }
+    while (r.startsWith("/")) {
+      r = r.substring(1);
+    }
+    return r;
   }
 }

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/out/componentmapper/ReflectionObjectToComponentMapper.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/out/componentmapper/ReflectionObjectToComponentMapper.java
@@ -53,10 +53,18 @@ public class ReflectionObjectToComponentMapper {
           UIFragmentActionDto.Replace,
           serverSideComponentDto.containerId());
     }
-    if (!(instance instanceof ComponentTreeSupplier)
-        && MetaAnnotations.isPresent(instance.getClass(), UISpec.class)) {
+    if (!(instance instanceof ComponentTreeSupplier)) {
+      // Layout from a YAML file bound to this instance as its ModelView: either the class points at
+      // the YAML (@UISpec) or the route's YAML points at this class (modelView:). Applied on every
+      // request for the route — first load AND action round-trips — so the layout stays
+      // authoritative.
+      Component component = null;
       var uiSpec = MetaAnnotations.find(instance.getClass(), UISpec.class);
-      var component = yamlUidlLoader.loadFromSpec(uiSpec.value());
+      if (uiSpec != null) {
+        component = yamlUidlLoader.loadFromSpec(uiSpec.value());
+      } else {
+        component = yamlUidlLoader.layoutForRoute(route, instance.getClass());
+      }
       if (component != null) {
         return buildPageUIFragment(
             instance, component, baseUrl, route, consumedRoute, initiatorComponentId, httpRequest);

--- a/backend/shared/core/src/test/java/io/mateu/core/application/YamlModelViewSyncTest.java
+++ b/backend/shared/core/src/test/java/io/mateu/core/application/YamlModelViewSyncTest.java
@@ -1,0 +1,112 @@
+package io.mateu.core.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.mateu.core.testutil.TestMateu;
+import io.mateu.dtos.MessageDto;
+import io.mateu.dtos.RunActionRqDto;
+import io.mateu.dtos.ServerSideComponentDto;
+import io.mateu.dtos.UIIncrementDto;
+import io.mateu.uidl.annotations.Action;
+import io.mateu.uidl.data.Message;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Phase 0 of the visual-builder work: a page defined in YAML can declare its ModelView (inverse of
+ * {@code @UISpec}). The YAML supplies the layout, the referenced Java class supplies state and
+ * actions, and Mateu's convention binding wires them together — on the first load AND on action
+ * round-trips (which route by serverSideType, so the layout is re-applied by route).
+ *
+ * <p>The bound page is {@code specs/ui/yaml-bound.yaml} → {@link GreeterView}.
+ */
+class YamlModelViewSyncTest {
+
+  /** The ModelView the YAML page points at — a plain class, no routing/layout annotations. */
+  public static class GreeterView {
+    public String name = "World";
+
+    @Action
+    public Message greet() {
+      return new Message("Hello " + name + "!");
+    }
+
+    @Action
+    public Object stay() {
+      return this;
+    }
+  }
+
+  static final String GREETER = GreeterView.class.getName();
+
+  static TestMateu mateu;
+
+  @BeforeAll
+  static void boot() {
+    // GreeterView carries no route, so /yaml-bound has no Java route → the YAML fallback fires.
+    mateu = TestMateu.withUis(GreeterView.class);
+  }
+
+  @AfterAll
+  static void shutdown() {
+    mateu.close();
+  }
+
+  private static ServerSideComponentDto componentOf(UIIncrementDto increment) {
+    assertThat(increment.fragments()).isNotEmpty();
+    return (ServerSideComponentDto) increment.fragments().get(0).component();
+  }
+
+  @Test
+  void yamlPagePointsAtItsModelViewAndRendersTheYamlLayoutBoundToIt() {
+    var component = componentOf(mateu.sync("yaml-bound"));
+    // the ModelView class is the server-side type (so state and actions route back to it) …
+    assertThat(component.serverSideType()).isEqualTo(GREETER);
+    // … and the layout came from the YAML file (a non-empty component subtree)
+    assertThat(component.children()).isNotEmpty();
+  }
+
+  @Test
+  void stateAndActionsBindByConventionToTheModelView() {
+    // Button actionId "greet" → the ModelView's greet() method; FormField "name" → its name field.
+    var increment =
+        mateu.run(
+            RunActionRqDto.builder()
+                .route("yaml-bound")
+                .serverSideType(GREETER)
+                .actionId("greet")
+                .componentState(Map.of("name", "Ada"))
+                .build());
+    List<MessageDto> messages = increment.messages();
+    assertThat(messages).isNotEmpty();
+    assertThat(messages.get(0).text()).isEqualTo("Hello Ada!");
+  }
+
+  @Test
+  void anActionRoundTripReAppliesTheYamlLayout() {
+    // stay() returns the ModelView → it is re-mapped; the layout must be re-applied by route even
+    // though the action routed by serverSideType (the class is not @UISpec-annotated).
+    var increment =
+        mateu.run(
+            RunActionRqDto.builder()
+                .route("yaml-bound")
+                .serverSideType(GREETER)
+                .actionId("stay")
+                .componentState(Map.of("name", "Bob"))
+                .build());
+    var component = componentOf(increment);
+    assertThat(component.serverSideType()).isEqualTo(GREETER);
+    assertThat(component.children()).isNotEmpty();
+  }
+
+  @Test
+  void aBareLayoutYamlWithoutAModelViewStillRenders() {
+    // backward compatibility: the legacy shape (whole file is a component tree, no modelView)
+    var increment = mateu.sync("demo/hello");
+    assertThat(increment.fragments()).isNotEmpty();
+    assertThat(increment.fragments().get(0).component()).isNotNull();
+  }
+}

--- a/backend/shared/core/src/test/java/io/mateu/core/application/runaction/YamlUidlLoaderTest.java
+++ b/backend/shared/core/src/test/java/io/mateu/core/application/runaction/YamlUidlLoaderTest.java
@@ -18,9 +18,7 @@ class YamlUidlLoaderTest {
 
   @Test
   void loadsVerticalLayoutFromYaml() {
-    var command = command("demo/hello");
-
-    Component component = loader.load(command).block();
+    Component component = layoutFor("demo/hello");
 
     assertThat(component).isInstanceOf(VerticalLayout.class);
     VerticalLayout layout = (VerticalLayout) component;
@@ -31,9 +29,7 @@ class YamlUidlLoaderTest {
 
   @Test
   void parsesNestedComponentsCorrectly() {
-    var command = command("demo/hello");
-
-    VerticalLayout layout = (VerticalLayout) loader.load(command).block();
+    VerticalLayout layout = (VerticalLayout) layoutFor("demo/hello");
 
     assertThat(layout.content().get(0)).isInstanceOf(Text.class);
     Text title = (Text) layout.content().get(0);
@@ -51,9 +47,7 @@ class YamlUidlLoaderTest {
 
   @Test
   void parsesFormFieldsCorrectly() {
-    var command = command("demo/hello");
-
-    VerticalLayout layout = (VerticalLayout) loader.load(command).block();
+    VerticalLayout layout = (VerticalLayout) layoutFor("demo/hello");
 
     FormLayout form = (FormLayout) layout.content().get(3);
     assertThat(form.content()).hasSize(3);
@@ -72,30 +66,18 @@ class YamlUidlLoaderTest {
   }
 
   @Test
-  void returnsEmptyWhenFileNotFound() {
-    var command = command("nonexistent/page");
-
-    Component component = loader.load(command).block();
-
-    assertThat(component).isNull();
+  void returnsNullWhenFileNotFound() {
+    assertThat(loader.loadSpec("nonexistent/page")).isNull();
   }
 
   @Test
   void stripsLeadingSlashFromRoute() {
-    var command = command("/demo/hello");
-
-    Component component = loader.load(command).block();
-
-    assertThat(component).isInstanceOf(VerticalLayout.class);
+    assertThat(layoutFor("/demo/hello")).isInstanceOf(VerticalLayout.class);
   }
 
   @Test
   void stripsQueryParamsFromRoute() {
-    var command = command("demo/hello?foo=bar");
-
-    Component component = loader.load(command).block();
-
-    assertThat(component).isInstanceOf(VerticalLayout.class);
+    assertThat(layoutFor("demo/hello?foo=bar")).isInstanceOf(VerticalLayout.class);
   }
 
   @Test
@@ -112,7 +94,8 @@ class YamlUidlLoaderTest {
     assertThat(component).isNull();
   }
 
-  private RunActionCommand command(String route) {
-    return new RunActionCommand(null, null, route, null, null, null, null, null, null, null, null);
+  private Component layoutFor(String route) {
+    var spec = loader.loadSpec(route);
+    return spec == null ? null : spec.layout();
   }
 }

--- a/backend/shared/core/src/test/resources/specs/ui/yaml-bound.yaml
+++ b/backend/shared/core/src/test/resources/specs/ui/yaml-bound.yaml
@@ -1,0 +1,18 @@
+# A page defined in YAML that declares its ModelView (the inverse of @UISpec): the layout lives
+# here, the behaviour/state in the referenced Java class. Used by YamlModelViewSyncTest.
+modelView: io.mateu.core.application.YamlModelViewSyncTest$GreeterView
+layout:
+  type: VerticalLayout
+  spacing: true
+  padding: true
+  content:
+    - type: FormLayout
+      content:
+        - type: FormField
+          id: name
+          label: "Name"
+          dataType: string
+    - type: Button
+      label: "Greet"
+      actionId: greet
+      buttonStyle: primary


### PR DESCRIPTION
Fase 0 del visual builder: una página YAML puede **declarar su ModelView** (el inverso de `@UISpec`).

```yaml
modelView: com.example.CustomerView
layout: { type: VerticalLayout, content: [ ... ] }
```

El layout vive en el fichero; el estado/acciones/validaciones/reglas en la clase referenciada. Binding por convención (FormField id↔propiedad, Button actionId↔método `@Action`).

- `YamlUidlLoader`: `loadSpec(route)`→`YamlPageSpec` cacheado por ruta; `layoutForRoute(route, class)` re-aplica el layout en los **round-trips de acción** (que enrutan por serverSideType), no solo en la primera carga; `loadFromSpec` entiende el envelope.
- `ActionInstanceCreator`: ruta sin clase Java → instancia el `modelView` como el instance enrutado; si no, layout suelto (legacy intacto).
- `ReflectionObjectToComponentMapper`: reutiliza `buildPageUIFragment` → salida = `ServerSideComponentDto` normal → **renderers sin cambios**.

Tests: `YamlModelViewSyncTest` (render bound, binding estado+acción, round-trip de acción re-aplica layout, compat con layout suelto) + `YamlUidlLoaderTest` migrado. **Core 770 verde.**

Pendiente: paridad .NET/Python, demo, y fases 1-3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)