### PR TITLE
feat(contract): bindable-contract extractor for a ModelView (visual-builder fase 1)

### DIFF
--- a/backend/shared/core/src/main/java/io/mateu/core/application/contract/ModelViewContractExtractor.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/contract/ModelViewContractExtractor.java
@@ -1,0 +1,111 @@
+package io.mateu.core.application.contract;
+
+import io.mateu.dtos.ActionDto;
+import io.mateu.dtos.ClientSideComponentDto;
+import io.mateu.dtos.ComponentDto;
+import io.mateu.dtos.ComponentMetadataDto;
+import io.mateu.dtos.FormFieldDto;
+import io.mateu.dtos.ModelViewContractDto;
+import io.mateu.dtos.ServerSideComponentDto;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+/**
+ * Derives a {@link ModelViewContractDto} — a ModelView's bindable fields and actions — from the
+ * component the reflective mapper actually produced for it. Because it reads the SAME mapped output
+ * the frontend renders, the contract can never drift from what the UI really binds: a field appears
+ * in the contract iff a {@code FormField} for it is emitted, with the very {@code dataType} and
+ * {@code stereotype} the renderer would use; an action appears iff it is advertised on the wire.
+ *
+ * <p>Phase 1 of the visual builder: this is the single source of truth the WYSIWYG plugin / codegen
+ * validate a YAML or visual layout against (does this {@code id} exist? is this {@code actionId}
+ * real? which widget fits this type?). Pure over the DTO tree — the caller supplies the mapped
+ * component (e.g. from a normal sync of the ModelView).
+ */
+public final class ModelViewContractExtractor {
+
+  private ModelViewContractExtractor() {}
+
+  public static ModelViewContractDto extract(ServerSideComponentDto component) {
+    if (component == null) {
+      return new ModelViewContractDto(null, List.of(), List.of());
+    }
+    var formFields = new ArrayList<FormFieldDto>();
+    walk(component, FormFieldDto.class, formFields);
+
+    // De-dup by id, keeping declaration order (a field id is unique on a form).
+    var byId = new LinkedHashMap<String, ModelViewContractDto.Field>();
+    for (var f : formFields) {
+      if (f.fieldId() == null || byId.containsKey(f.fieldId())) {
+        continue;
+      }
+      byId.put(
+          f.fieldId(),
+          new ModelViewContractDto.Field(
+              f.fieldId(), f.dataType(), f.stereotype(), f.label(), f.required(), f.readOnly()));
+    }
+
+    List<ModelViewContractDto.Action> actions =
+        component.actions() == null
+            ? List.of()
+            : component.actions().stream()
+                .map(ActionDto::id)
+                .filter(id -> id != null && !id.isBlank())
+                .distinct()
+                .map(ModelViewContractDto.Action::new)
+                .toList();
+
+    return new ModelViewContractDto(
+        component.serverSideType(), List.copyOf(byId.values()), actions);
+  }
+
+  // Reflective walk of the DTO tree — form fields nest inside component METADATA records, so a
+  // plain
+  // children walk misses them (same shape the wire walkers use elsewhere).
+  private static <T> void walk(Object node, Class<T> type, List<T> found) {
+    if (node == null) {
+      return;
+    }
+    if (node instanceof ClientSideComponentDto client) {
+      if (client.metadata() != null) {
+        if (type.isInstance(client.metadata())) {
+          found.add(type.cast(client.metadata()));
+        }
+        walkMetadata(client.metadata(), type, found);
+      }
+      if (client.children() != null) {
+        client.children().forEach(child -> walk(child, type, found));
+      }
+    } else if (node instanceof ServerSideComponentDto server) {
+      if (server.children() != null) {
+        server.children().forEach(child -> walk(child, type, found));
+      }
+    }
+  }
+
+  private static <T> void walkMetadata(
+      ComponentMetadataDto metadata, Class<T> type, List<T> found) {
+    if (!metadata.getClass().isRecord()) {
+      return;
+    }
+    for (var recordComponent : metadata.getClass().getRecordComponents()) {
+      Object value;
+      try {
+        value = recordComponent.getAccessor().invoke(metadata);
+      } catch (ReflectiveOperationException e) {
+        continue; // a metadata accessor we can't read is not worth failing the whole extraction
+      }
+      if (value instanceof ComponentDto dto) {
+        walk(dto, type, found);
+      } else if (value instanceof List<?> list) {
+        list.forEach(
+            item -> {
+              if (item instanceof ComponentDto dto) {
+                walk(dto, type, found);
+              }
+            });
+      }
+    }
+  }
+}

--- a/backend/shared/core/src/test/java/io/mateu/core/application/ModelViewContractSyncTest.java
+++ b/backend/shared/core/src/test/java/io/mateu/core/application/ModelViewContractSyncTest.java
@@ -1,0 +1,89 @@
+package io.mateu.core.application;
+
+import static java.util.stream.Collectors.toMap;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.mateu.core.application.contract.ModelViewContractExtractor;
+import io.mateu.core.testutil.TestMateu;
+import io.mateu.dtos.ModelViewContractDto;
+import io.mateu.dtos.ServerSideComponentDto;
+import io.mateu.uidl.annotations.Action;
+import io.mateu.uidl.annotations.UI;
+import io.mateu.uidl.data.Message;
+import jakarta.validation.constraints.NotEmpty;
+import java.time.LocalDate;
+import java.util.Map;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Phase 1 of the visual builder: the bindable contract of a ModelView (its fields + actions),
+ * derived from the SAME mapped component the UI renders, is the single source of truth a
+ * visual/YAML layout is validated against. Pins that the extractor reports the real field ids, data
+ * types, required flags and action ids.
+ */
+class ModelViewContractSyncTest {
+
+  @UI("/contract-demo")
+  public static class CustomerView {
+    @NotEmpty public String name;
+    public int age;
+    public LocalDate birthDate;
+
+    @Action
+    public Message save() {
+      return new Message("saved");
+    }
+
+    @Action
+    public Message reset() {
+      return new Message("reset");
+    }
+  }
+
+  static TestMateu mateu;
+
+  @BeforeAll
+  static void boot() {
+    mateu = TestMateu.withUis(CustomerView.class);
+  }
+
+  @AfterAll
+  static void shutdown() {
+    mateu.close();
+  }
+
+  private static ModelViewContractDto contractOf(String route) {
+    var increment = mateu.sync(route);
+    assertThat(increment.fragments()).isNotEmpty();
+    var component = (ServerSideComponentDto) increment.fragments().get(0).component();
+    return ModelViewContractExtractor.extract(component);
+  }
+
+  @Test
+  void reportsTheModelViewClassName() {
+    assertThat(contractOf("/contract-demo").modelView()).isEqualTo(CustomerView.class.getName());
+  }
+
+  @Test
+  void reportsEachBindableFieldWithItsDataTypeAndRequiredFlag() {
+    Map<String, ModelViewContractDto.Field> byId =
+        contractOf("/contract-demo").fields().stream()
+            .collect(toMap(ModelViewContractDto.Field::id, f -> f));
+
+    assertThat(byId).containsKeys("name", "age", "birthDate");
+    assertThat(byId.get("name").dataType()).isEqualTo("string");
+    assertThat(byId.get("name").required()).isTrue();
+    assertThat(byId.get("age").dataType()).isEqualTo("integer");
+    assertThat(byId.get("age").required()).isFalse();
+    assertThat(byId.get("birthDate").dataType()).isEqualTo("date");
+  }
+
+  @Test
+  void reportsTheBindableActionIds() {
+    assertThat(contractOf("/contract-demo").actions())
+        .extracting(ModelViewContractDto.Action::id)
+        .contains("save", "reset");
+  }
+}

--- a/backend/shared/dtos/src/main/java/io/mateu/dtos/ModelViewContractDto.java
+++ b/backend/shared/dtos/src/main/java/io/mateu/dtos/ModelViewContractDto.java
@@ -1,0 +1,41 @@
+package io.mateu.dtos;
+
+import java.util.List;
+
+/**
+ * The bindable surface of a ModelView: the fields a layout can bind to (a {@code FormField id} must
+ * name one) and the actions it can trigger (a {@code Button actionId} must name one). Derived from
+ * the same reflective mapping the real UI uses, so it is the single source of truth for validating
+ * a YAML/visual layout against its ModelView (the visual-builder plugin, codegen, etc.).
+ *
+ * @param modelView the ModelView class' fully-qualified name
+ * @param fields the bindable fields, in declaration order, de-duplicated by id
+ * @param actions the bindable action ids
+ */
+public record ModelViewContractDto(String modelView, List<Field> fields, List<Action> actions) {
+
+  /**
+   * A bindable field.
+   *
+   * @param id the field id a {@code FormField} binds to
+   * @param dataType the wire data type (string, integer, number, date, dateTime, time, bool, …)
+   * @param stereotype how it is painted (combobox, select, radio, money, plainText, …)
+   * @param label the default label
+   * @param required whether it is required
+   * @param readOnly whether it is read-only
+   */
+  public record Field(
+      String id,
+      String dataType,
+      String stereotype,
+      String label,
+      boolean required,
+      boolean readOnly) {}
+
+  /**
+   * A bindable action.
+   *
+   * @param id the action id a {@code Button} triggers
+   */
+  public record Action(String id) {}
+}


### PR DESCRIPTION
Fase 1 (core) del visual builder: el **contrato bindable** de un ModelView (campos + acciones) como fuente única de verdad para validar un layout YAML/visual contra su clase.

Se **deriva del mismo `ServerSideComponentDto` que renderiza la UI**, así que no puede haber drift: un campo está en el contrato sii se emite su `FormField` (con el mismo `dataType`/`stereotype` que pintaría el renderer), una acción sii se anuncia en el wire.

- `ModelViewContractDto` (dtos): `{modelView, fields[{id,dataType,stereotype,label,required,readOnly}], actions[{id}]}`.
- `ModelViewContractExtractor` (core `application/contract`): `extract(component)` con walk reflexivo (los `FormField` anidan dentro de records de metadata).
- Test `ModelViewContractSyncTest`: clase → sync → component → extract; verifica `name(string,required)`/`age(integer)`/`birthDate(date)` + acciones `save`+`reset`.

**Core 773 verde.** Aditivo, sin cambios de comportamiento.

**Pendiente (decisión abierta):** la ENTREGA del contrato (endpoint runtime vs descriptor del annotation processor vs PSI en el plugin) — condiciona la Fase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)