### PR TITLE
feat(intellij): validate YAML page bindings against the ModelView (visual-builder fase 2)

### DIFF
--- a/frontend/app/intellij-plugin/build.gradle.kts
+++ b/frontend/app/intellij-plugin/build.gradle.kts
@@ -29,7 +29,17 @@ dependencies {
         } else {
             intellijIdeaCommunity(ideVersion)
         }
+        // Java PSI (to resolve a YAML page's ModelView class + its fields/methods) and YAML PSI (to
+        // read the page file) — both bundled in IDEA Community. Powers the visual-builder binding
+        // validation (a FormField id / Button actionId must exist on the ModelView).
+        bundledPlugin("com.intellij.java")
+        bundledPlugin("org.jetbrains.plugins.yaml")
+        // Headless test fixtures for the annotator test: the Java one carries
+        // LightJavaCodeInsightFixtureTestCase (Java PSI in tests).
+        testFramework(org.jetbrains.intellij.platform.gradle.TestFrameworkType.Platform)
+        testFramework(org.jetbrains.intellij.platform.gradle.TestFrameworkType.Plugin.Java)
     }
+    testImplementation("junit:junit:4.13.2")
 }
 
 intellijPlatform {

--- a/frontend/app/intellij-plugin/gradle.properties
+++ b/frontend/app/intellij-plugin/gradle.properties
@@ -1,4 +1,8 @@
 kotlin.code.style=official
+# Use the Kotlin stdlib bundled in the IntelliJ Platform instead of the Gradle Kotlin plugin's own,
+# which otherwise conflicts at runtime (NoSuchMethodError in platform internals under the headless
+# test framework). Recommended by verifyPluginProjectConfiguration. See jb.gg/intellij-platform-kotlin-stdlib
+kotlin.stdlib.default.dependency=false
 org.gradle.jvmargs=-Xmx3g -Dfile.encoding=UTF-8
 org.gradle.caching=true
 org.gradle.configuration-cache=false

--- a/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/contract/MateuYamlBindingAnnotator.kt
+++ b/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/contract/MateuYamlBindingAnnotator.kt
@@ -1,0 +1,106 @@
+package io.mateu.ijp.contract
+
+import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.lang.annotation.Annotator
+import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.project.Project
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
+import com.intellij.psi.search.GlobalSearchScope
+import org.jetbrains.yaml.psi.YAMLFile
+import org.jetbrains.yaml.psi.YAMLKeyValue
+import org.jetbrains.yaml.psi.YAMLMapping
+
+/**
+ * Validates the binding of a Mateu visual-builder page (phase 2): a page YAML that declares a
+ * `modelView:` must only reference fields and actions that actually exist on that class. It flags,
+ * live as you type:
+ *
+ *  - a `modelView:` that does not resolve to a class,
+ *  - a `FormField` `id:` that is not a property of the ModelView,
+ *  - an `actionId:` that is not a method of the ModelView.
+ *
+ * Purely from the IDE's PSI — no running server, no build — so it works offline. This is membership
+ * validation (does it exist?); the richer type/stereotype rules live in the backend's
+ * `ModelViewContractExtractor` and can be layered on later.
+ */
+class MateuYamlBindingAnnotator : Annotator {
+
+  override fun annotate(element: PsiElement, holder: AnnotationHolder) {
+    if (element !is YAMLKeyValue) return
+    val key = element.keyText
+    if (key != "modelView" && key != "actionId" && key != "id") return
+
+    val project = element.project
+    if (DumbService.isDumb(project)) return // class resolution is unavailable while indexing
+
+    val page = pageMapping(element) ?: return
+    val fqn = page.getKeyValueByKey("modelView")?.valueText?.trim().orEmpty()
+    if (fqn.isEmpty()) return
+
+    val value = element.value ?: return
+    val id = element.valueText?.trim().orEmpty()
+
+    when (key) {
+      "modelView" -> {
+        if (element.parent !== page) return // only the page-level declaration
+        if (resolveClass(project, fqn) == null) {
+          error(holder, value, "Cannot resolve ModelView class '$fqn'")
+        }
+      }
+
+      "actionId" -> {
+        if (id.isEmpty()) return
+        val cls = resolveClass(project, fqn) ?: return // the modelView error is reported on its own
+        if (!hasAction(cls, id)) {
+          error(holder, value, "'$id' is not an action on ${cls.name} — no method named '$id'")
+        }
+      }
+
+      "id" -> {
+        if (id.isEmpty()) return
+        val mapping = element.parent as? YAMLMapping ?: return
+        // only a FormField's id binds to a ModelView property
+        if (mapping.getKeyValueByKey("type")?.valueText?.trim() != "FormField") return
+        val cls = resolveClass(project, fqn) ?: return
+        if (!hasProperty(cls, id)) {
+          error(holder, value, "'$id' is not a field on ${cls.name}")
+        }
+      }
+    }
+  }
+
+  /** The page envelope (top-level mapping) iff this file is a Mateu bound page: has modelView + layout. */
+  private fun pageMapping(element: PsiElement): YAMLMapping? {
+    val file = element.containingFile as? YAMLFile ?: return null
+    val top = file.documents.firstOrNull()?.topLevelValue as? YAMLMapping ?: return null
+    if (top.getKeyValueByKey("modelView") == null || top.getKeyValueByKey("layout") == null) {
+      return null
+    }
+    return top
+  }
+
+  private fun resolveClass(project: Project, fqn: String): PsiClass? {
+    val facade = JavaPsiFacade.getInstance(project)
+    val scope = GlobalSearchScope.allScope(project)
+    // nested classes are written Outer$Inner on the wire but Outer.Inner in Java source
+    return facade.findClass(fqn, scope) ?: facade.findClass(fqn.replace('$', '.'), scope)
+  }
+
+  private fun hasAction(cls: PsiClass, name: String): Boolean =
+    cls.findMethodsByName(name, true).isNotEmpty()
+
+  private fun hasProperty(cls: PsiClass, name: String): Boolean {
+    if (cls.findFieldByName(name, true) != null) return true
+    if (cls.recordComponents.any { it.name == name }) return true
+    val cap = name.replaceFirstChar { it.uppercaseChar() }
+    return cls.findMethodsByName("get$cap", true).isNotEmpty() ||
+      cls.findMethodsByName("is$cap", true).isNotEmpty()
+  }
+
+  private fun error(holder: AnnotationHolder, range: PsiElement, message: String) {
+    holder.newAnnotation(HighlightSeverity.ERROR, message).range(range).create()
+  }
+}

--- a/frontend/app/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/frontend/app/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -5,8 +5,14 @@
     <description>Renders Mateu model-driven Java UIs inside IntelliJ — a dockable tool window, IDE menus, and native platform components (date pickers, popups, tabs).</description>
 
     <depends>com.intellij.modules.platform</depends>
+    <depends>com.intellij.modules.java</depends>
+    <depends>org.jetbrains.plugins.yaml</depends>
 
     <extensions defaultExtensionNs="com.intellij">
+        <!-- Visual-builder binding validation: squiggles when a YAML page's FormField id / Button
+             actionId does not exist on the ModelView the page declares. -->
+        <annotator language="yaml"
+                   implementationClass="io.mateu.ijp.contract.MateuYamlBindingAnnotator"/>
         <toolWindow id="Mateu" anchor="right" canCloseContents="false"
                     factoryClass="io.mateu.ijp.plugin.MateuToolWindowFactory"
                     icon="/icons/mateu.svg"/>

--- a/frontend/app/intellij-plugin/src/test/kotlin/io/mateu/ijp/contract/MateuYamlBindingAnnotatorTest.kt
+++ b/frontend/app/intellij-plugin/src/test/kotlin/io/mateu/ijp/contract/MateuYamlBindingAnnotatorTest.kt
@@ -1,0 +1,93 @@
+package io.mateu.ijp.contract
+
+import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
+
+/**
+ * Verifies the visual-builder binding validation (phase 2): a YAML page's FormField ids and Button
+ * actionIds are checked against the declared ModelView class via PSI — unknown ones are flagged,
+ * real ones are not.
+ */
+class MateuYamlBindingAnnotatorTest : LightJavaCodeInsightFixtureTestCase() {
+
+  private fun errorTexts(yaml: String): List<String> {
+    myFixture.addClass(
+      """
+      package demo;
+      public class CustomerView {
+        public String name;
+        public int age;
+        public Object save() { return null; }
+      }
+      """.trimIndent()
+    )
+    myFixture.configureByText("page.yaml", yaml)
+    val text = myFixture.file.text
+    return myFixture.doHighlighting()
+      .filter { it.severity == HighlightSeverity.ERROR }
+      .map { text.substring(it.startOffset, it.endOffset) }
+  }
+
+  fun testKnownFieldsAndActionsAreNotFlagged() {
+    val errors = errorTexts(
+      """
+      modelView: demo.CustomerView
+      layout:
+        type: VerticalLayout
+        content:
+          - type: FormField
+            id: name
+          - type: FormField
+            id: age
+          - type: Button
+            actionId: save
+      """.trimIndent()
+    )
+    assertEmpty(errors)
+  }
+
+  fun testUnknownFieldAndActionAreFlagged() {
+    val errors = errorTexts(
+      """
+      modelView: demo.CustomerView
+      layout:
+        type: VerticalLayout
+        content:
+          - type: FormField
+            id: name
+          - type: FormField
+            id: nope
+          - type: Button
+            actionId: doesNotExist
+      """.trimIndent()
+    )
+    assertContainsElements(errors, "nope", "doesNotExist")
+    assertDoesntContain(errors, "name")
+  }
+
+  fun testUnresolvedModelViewIsFlagged() {
+    val errors = errorTexts(
+      """
+      modelView: demo.NoSuchView
+      layout:
+        type: FormField
+        id: whatever
+      """.trimIndent()
+    )
+    assertContainsElements(errors, "demo.NoSuchView")
+  }
+
+  fun testAPlainYamlWithoutAModelViewIsIgnored() {
+    val errors = errorTexts(
+      """
+      type: VerticalLayout
+      content:
+        - type: FormField
+          id: name
+        - type: Button
+          actionId: whatever
+      """.trimIndent()
+    )
+    assertEmpty(errors)
+  }
+}


### PR DESCRIPTION
Fase 2 del visual builder: el plugin de IntelliJ valida **en vivo, offline, sin servidor** el binding de una página YAML del builder contra su ModelView.

Marca con squiggle rojo:
- un `modelView:` que no resuelve a una clase,
- un `FormField id:` que no es propiedad del ModelView,
- un `actionId:` que no es método del ModelView.

Validación de *membership* (existe o no) vía PSI. Las reglas de tipo/stereotype (del extractor de la Fase 1) se dejan para cuando haga falta una feature type-aware.

- `MateuYamlBindingAnnotator`: `Annotator` para YAML; solo actúa en ficheros con `modelView:`+`layout:` arriba; resuelve la clase con `JavaPsiFacade` (FQN anidados `$`→`.`); comprueba propiedad (campo/record-component/getter) y método por nombre.
- build.gradle: `bundledPlugin` java+yaml; plugin.xml: `<depends>` + `<annotator>`.
- Test `MateuYamlBindingAnnotatorTest` (`LightJavaCodeInsightFixtureTestCase`, **4 verde**): known ok, unknown campo+acción marcados, modelView irresoluble marcado, yaml sin modelView ignorado.

Nota: el framework de test headless petaba con `NoSuchMethodError` en `Entities.kt` (conflicto de Kotlin stdlib con el bundled del platform); fix = `kotlin.stdlib.default.dependency=false` (lo recomienda `verifyPluginProjectConfiguration`; además silencia un warning preexistente).

🤖 Generated with [Claude Code](https://claude.com/claude-code)