### PR TITLE
feat(contract): deliver the ModelView contract over the wire (__contract__ action)

### DIFF
--- a/backend/shared/core/src/main/java/io/mateu/core/application/runaction/ActionInstanceCreator.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/runaction/ActionInstanceCreator.java
@@ -123,6 +123,11 @@ public class ActionInstanceCreator {
     if (actionId.startsWith(io.mateu.core.domain.act.AppContextSearchActionRunner.ACTION_PREFIX)) {
       return true;
     }
+    // The visual-builder contract request addresses the ModelView instance directly (skip
+    // menu/route resolution), same as the context selectors' remote search.
+    if (RunActionUseCase.CONTRACT_ACTION.equals(actionId)) {
+      return true;
+    }
     // The notification inbox's list/read actions are app-level too (the bell lives on the shell).
     if (actionId.startsWith(io.mateu.core.domain.act.NotificationsActionRunner.ACTION_PREFIX)) {
       return true;

--- a/backend/shared/core/src/main/java/io/mateu/core/application/runaction/RunActionUseCase.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/runaction/RunActionUseCase.java
@@ -1,8 +1,11 @@
 package io.mateu.core.application.runaction;
 
+import io.mateu.core.application.contract.ModelViewContractExtractor;
 import io.mateu.core.domain.act.ActionRunnerProvider;
 import io.mateu.core.domain.out.UiIncrementMapperProvider;
 import io.mateu.core.infra.StructureHashPostProcessor;
+import io.mateu.dtos.ModelViewContractDto;
+import io.mateu.dtos.ServerSideComponentDto;
 import io.mateu.dtos.UIIncrementDto;
 import io.mateu.uidl.data.Message;
 import io.mateu.uidl.data.NotificationVariant;
@@ -81,6 +84,9 @@ public class RunActionUseCase {
 
   public Flux<UIIncrementDto> handle(RunActionCommand command) {
     log.info("run action {}", command.actionId());
+    if (CONTRACT_ACTION.equals(command.actionId())) {
+      return handleContract(command);
+    }
     return (Mono.just(command)
             .flatMap(ignored -> actionInstanceCreator.createInstance(command))
             // a plain routed Listing declaring interaction capabilities is bridged into the CRUD
@@ -114,6 +120,50 @@ public class RunActionUseCase {
         .switchIfEmpty(
             mapToUiIncrement(
                 Text.builder().text("Not found.").style("color: red;").build(), command));
+  }
+
+  // ── Bindable contract ─────────────────────────────────────────────────────
+  // A reserved "action" that returns the ModelView's bindable contract (its fields + actions)
+  // instead of running anything: the visual-builder tooling POSTs a normal sync request with the
+  // ModelView as serverSideType and this actionId, and reads the contract off the response's
+  // appData. Reuses the real mapping (so the contract can't drift) and rides the existing
+  // transport,
+  // so it needs no new endpoint on any adapter. The contract itself is computed by
+  // ModelViewContractExtractor over the mapped component. Key in appData:
+  public static final String CONTRACT_ACTION = "__contract__";
+  public static final String CONTRACT_KEY = "_contract";
+
+  private Flux<UIIncrementDto> handleContract(RunActionCommand command) {
+    return Mono.just(command)
+        .flatMap(ignored -> actionInstanceCreator.createInstance(command))
+        .map(
+            instance ->
+                io.mateu.core.infra.declarative.orchestrators.crud.CapabilityCrud.bridgeIfNeeded(
+                    instance))
+        .flatMap(instance -> routeIfNeeded(command, instance))
+        // Map the instance as a plain load (no action is run) so we get its component, then reduce
+        // the response to just the extracted contract.
+        .flatMap(instance -> mapToUiIncrement(instance, command))
+        .map(RunActionUseCase::toContractResponse)
+        .flux();
+  }
+
+  private static UIIncrementDto toContractResponse(UIIncrementDto increment) {
+    return UIIncrementDto.builder()
+        .appData(java.util.Map.of(CONTRACT_KEY, extractContract(increment)))
+        .build();
+  }
+
+  private static ModelViewContractDto extractContract(UIIncrementDto increment) {
+    if (increment.fragments() == null) {
+      return new ModelViewContractDto(null, List.of(), List.of());
+    }
+    return increment.fragments().stream()
+        .map(fragment -> fragment.component())
+        .filter(component -> component instanceof ServerSideComponentDto)
+        .map(component -> ModelViewContractExtractor.extract((ServerSideComponentDto) component))
+        .findFirst()
+        .orElse(new ModelViewContractDto(null, List.of(), List.of()));
   }
 
   private String extractTitle(Throwable e) {

--- a/backend/shared/core/src/test/java/io/mateu/core/application/ModelViewContractSyncTest.java
+++ b/backend/shared/core/src/test/java/io/mateu/core/application/ModelViewContractSyncTest.java
@@ -4,8 +4,10 @@ import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.mateu.core.application.contract.ModelViewContractExtractor;
+import io.mateu.core.application.runaction.RunActionUseCase;
 import io.mateu.core.testutil.TestMateu;
 import io.mateu.dtos.ModelViewContractDto;
+import io.mateu.dtos.RunActionRqDto;
 import io.mateu.dtos.ServerSideComponentDto;
 import io.mateu.uidl.annotations.Action;
 import io.mateu.uidl.annotations.UI;
@@ -83,6 +85,31 @@ class ModelViewContractSyncTest {
   @Test
   void reportsTheBindableActionIds() {
     assertThat(contractOf("/contract-demo").actions())
+        .extracting(ModelViewContractDto.Action::id)
+        .contains("save", "reset");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void theContractIsDeliveredOverTheWireViaTheReservedContractAction() {
+    // How the tooling actually fetches it: a normal sync request naming the ModelView as
+    // serverSideType and the reserved __contract__ action; the contract rides back on appData.
+    var increment =
+        mateu.run(
+            RunActionRqDto.builder()
+                .serverSideType(CustomerView.class.getName())
+                .route("/contract-demo")
+                .actionId(RunActionUseCase.CONTRACT_ACTION)
+                .build());
+
+    var appData = (Map<String, Object>) increment.appData();
+    assertThat(appData).containsKey(RunActionUseCase.CONTRACT_KEY);
+    var contract = (ModelViewContractDto) appData.get(RunActionUseCase.CONTRACT_KEY);
+    assertThat(contract.modelView()).isEqualTo(CustomerView.class.getName());
+    assertThat(contract.fields())
+        .extracting(ModelViewContractDto.Field::id)
+        .contains("name", "age");
+    assertThat(contract.actions())
         .extracting(ModelViewContractDto.Action::id)
         .contains("save", "reset");
   }


### PR DESCRIPTION
Entrega del contrato bindable (visual builder). El contrato se **deriva del mapeo real** (cero drift), así que la entrega fiel tiene que ejecutar el mapper — un descriptor del annotation processor no serviría (reimplementaría reglas). Se entrega como una **acción de sync reservada `__contract__`**:

- Atendida en `RunActionUseCase.handle` **antes** del run: instancia el ModelView (por `serverSideType`) → lo mapea como load → `ModelViewContractExtractor` → devuelve un `UIIncrementDto` mínimo con el contrato en `appData["_contract"]`.
- **Adapter-agnóstico**: viaja por el transporte sync existente, **cero cambios en los adapters** (el `MateuController` compartido es solo una interfaz `getBaseUrl`; los endpoints reales los genera el AP por adapter, así que un endpoint nuevo serían 5 plantillas).
- `ActionInstanceCreator.isAppLevelAction` → true para `__contract__` (salta resolución de menú/ruta).
- Test `ModelViewContractSyncTest.theContractIsDeliveredOverTheWire...`. **Core 774 verde.**

Siguiente paso: el plugin consumirá `__contract__` para validación type-aware (fetch async + cache, fuera del path del anotador). Paridad .NET/Python: luego.

🤖 Generated with [Claude Code](https://claude.com/claude-code)