### PR TITLE
feat(intellij): consume the ModelView contract for type-aware validation (fase 2.5)

### DIFF
--- a/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/contract/Contract.kt
+++ b/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/contract/Contract.kt
@@ -1,0 +1,26 @@
+package io.mateu.ijp.contract
+
+/** A ModelView's bindable field (mirrors io.mateu.dtos.ModelViewContractDto.Field). */
+data class ContractField(
+  val id: String,
+  val dataType: String?,
+  val stereotype: String?,
+  val required: Boolean,
+  val readOnly: Boolean,
+)
+
+/**
+ * The bindable surface of a ModelView, as the backend reports it (mirrors
+ * io.mateu.dtos.ModelViewContractDto). Unlike raw PSI — which sees every field and method — this
+ * lists only what actually BINDS at runtime (a `@Hidden`/excluded field is absent; a plain method
+ * that is not an `@Action` is absent), and it carries Mateu's own dataType/stereotype for each field.
+ */
+data class ModelViewContract(
+  val modelView: String?,
+  val fields: List<ContractField>,
+  val actions: List<String>,
+) {
+  fun field(id: String): ContractField? = fields.firstOrNull { it.id == id }
+
+  fun hasAction(id: String): Boolean = actions.contains(id)
+}

--- a/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/contract/ContractCache.kt
+++ b/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/contract/ContractCache.kt
@@ -1,0 +1,63 @@
+package io.mateu.ijp.contract
+
+import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.project.Project
+import java.util.Optional
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Per-project cache of ModelView contracts fetched from the backend. The annotator runs on the
+ * read/UI thread and must not block on HTTP, so [get] returns whatever is cached NOW (or null) and,
+ * on a miss, schedules a one-off background fetch; when it completes it restarts the code analyzer
+ * so the annotator runs again — now with the contract in hand. A failed fetch (backend down) caches
+ * an empty result so a broken connection isn't hammered on every keystroke; [invalidate] retries.
+ */
+@Service(Service.Level.PROJECT)
+class ContractCache(private val project: Project) {
+
+  /** Tests disable the network so only seeded contracts are used (no real HTTP). */
+  @Volatile
+  var networkEnabled: Boolean = true
+
+  private val cache = ConcurrentHashMap<String, Optional<ModelViewContract>>()
+  private val inFlight = ConcurrentHashMap.newKeySet<String>()
+
+  /** The cached contract for [fqn], or null on a miss (which schedules a background fetch). */
+  fun get(fqn: String): ModelViewContract? {
+    cache[fqn]?.let { return it.orElse(null) }
+    if (networkEnabled && inFlight.add(fqn)) fetchAsync(fqn)
+    return null
+  }
+
+  /** Inject a contract directly (a manual refresh, or tests). */
+  fun seed(fqn: String, contract: ModelViewContract?) {
+    cache[fqn] = Optional.ofNullable(contract)
+  }
+
+  fun invalidate() {
+    cache.clear()
+    inFlight.clear()
+  }
+
+  private fun fetchAsync(fqn: String) {
+    ApplicationManager.getApplication().executeOnPooledThread {
+      val contract = try {
+        ContractClient.fetch(fqn)
+      } catch (e: Exception) {
+        null
+      }
+      cache[fqn] = Optional.ofNullable(contract)
+      inFlight.remove(fqn)
+      ApplicationManager.getApplication().invokeLater(
+        { if (!project.isDisposed) DaemonCodeAnalyzer.getInstance(project).restart() },
+        { project.isDisposed },
+      )
+    }
+  }
+
+  companion object {
+    fun getInstance(project: Project): ContractCache = project.getService(ContractCache::class.java)
+  }
+}

--- a/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/contract/ContractClient.kt
+++ b/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/contract/ContractClient.kt
@@ -1,0 +1,54 @@
+package io.mateu.ijp.contract
+
+import com.fasterxml.jackson.databind.JsonNode
+import io.mateu.ijp.api.MateuApiClient
+import io.mateu.ijp.plugin.loadMateuConfig
+
+/**
+ * Fetches a ModelView's bindable contract from the running Mateu backend, over the same sync
+ * transport the renderer uses: a POST with the ModelView as `serverSideType` and the reserved
+ * `__contract__` action; the contract rides back on `appData._contract`. Blocking — always call it
+ * off the UI thread (see [ContractCache]).
+ */
+object ContractClient {
+
+  private const val CONTRACT_ACTION = "__contract__"
+  private const val CONTRACT_KEY = "_contract"
+
+  fun fetch(fqn: String): ModelViewContract? {
+    val config = loadMateuConfig()
+    val client = MateuApiClient(config.baseUrl, "mateu-plugin-contract")
+    val response =
+      client.runAction(
+        route = "",
+        consumedRoute = "",
+        actionId = CONTRACT_ACTION,
+        serverSideType = fqn,
+        initiatorComponentId = "ux_main",
+        componentState = emptyMap(),
+        appState = emptyMap(),
+        parameters = emptyMap(),
+      )
+    val node = response.path("appData").path(CONTRACT_KEY)
+    if (node.isMissingNode || node.isNull) return null
+    val modelView = node.path("modelView").takeIf { it.isTextual }?.asText() ?: return null
+    if (modelView != fqn) return null // sanity: we got the class we asked for
+    return ModelViewContract(modelView, parseFields(node.path("fields")), parseActions(node.path("actions")))
+  }
+
+  private fun parseFields(fields: JsonNode): List<ContractField> =
+    fields.mapNotNull { f ->
+      val id = f.path("id").takeIf { it.isTextual }?.asText().orEmpty()
+      if (id.isEmpty()) null
+      else ContractField(
+        id = id,
+        dataType = f.path("dataType").takeIf { it.isTextual }?.asText(),
+        stereotype = f.path("stereotype").takeIf { it.isTextual }?.asText(),
+        required = f.path("required").asBoolean(false),
+        readOnly = f.path("readOnly").asBoolean(false),
+      )
+    }
+
+  private fun parseActions(actions: JsonNode): List<String> =
+    actions.mapNotNull { a -> a.path("id").takeIf { it.isTextual }?.asText() }.filter { it.isNotEmpty() }
+}

--- a/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/contract/MateuYamlBindingAnnotator.kt
+++ b/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/contract/MateuYamlBindingAnnotator.kt
@@ -56,6 +56,13 @@ class MateuYamlBindingAnnotator : Annotator {
         val cls = resolveClass(project, fqn) ?: return // the modelView error is reported on its own
         if (!hasAction(cls, id)) {
           error(holder, value, "'$id' is not an action on ${cls.name} — no method named '$id'")
+          return
+        }
+        // The method exists — but is it a Mateu action? The backend contract knows (a plain method
+        // that is not an @Action won't dispatch). Only available once the contract has been fetched.
+        val contract = ContractCache.getInstance(project).get(fqn) ?: return
+        if (!contract.hasAction(id)) {
+          warn(holder, value, "'$id' exists on ${cls.name} but is not a Mateu action (missing @Action?)")
         }
       }
 
@@ -67,6 +74,21 @@ class MateuYamlBindingAnnotator : Annotator {
         val cls = resolveClass(project, fqn) ?: return
         if (!hasProperty(cls, id)) {
           error(holder, value, "'$id' is not a field on ${cls.name}")
+          return
+        }
+        // The property exists — refine against the backend contract (it lists only what actually
+        // binds, and carries the field's real dataType).
+        val contract = ContractCache.getInstance(project).get(fqn) ?: return
+        val field = contract.field(id)
+        if (field == null) {
+          warn(holder, value, "'$id' exists on ${cls.name} but is not a bindable field (hidden or excluded?)")
+          return
+        }
+        // An annotator may only mark the element it is given, so flag the id value itself (the
+        // message names the conflicting dataType declared on the sibling).
+        val declaredType = mapping.getKeyValueByKey("dataType")?.valueText?.trim()
+        if (declaredType != null && field.dataType != null && declaredType != field.dataType) {
+          warn(holder, value, "'$id' maps to dataType '${field.dataType}', not the declared '$declaredType'")
         }
       }
     }
@@ -102,5 +124,9 @@ class MateuYamlBindingAnnotator : Annotator {
 
   private fun error(holder: AnnotationHolder, range: PsiElement, message: String) {
     holder.newAnnotation(HighlightSeverity.ERROR, message).range(range).create()
+  }
+
+  private fun warn(holder: AnnotationHolder, range: PsiElement, message: String) {
+    holder.newAnnotation(HighlightSeverity.WEAK_WARNING, message).range(range).create()
   }
 }

--- a/frontend/app/intellij-plugin/src/test/kotlin/io/mateu/ijp/contract/MateuYamlBindingAnnotatorTest.kt
+++ b/frontend/app/intellij-plugin/src/test/kotlin/io/mateu/ijp/contract/MateuYamlBindingAnnotatorTest.kt
@@ -1,35 +1,55 @@
 package io.mateu.ijp.contract
 
+import com.intellij.codeInsight.daemon.impl.HighlightInfo
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
 
 /**
- * Verifies the visual-builder binding validation (phase 2): a YAML page's FormField ids and Button
- * actionIds are checked against the declared ModelView class via PSI — unknown ones are flagged,
- * real ones are not.
+ * Verifies the visual-builder binding validation: PSI catches ids/actionIds that do not exist at
+ * all (errors), and the backend contract — when present — refines that to what actually BINDS
+ * (weak warnings for a field/method that exists but is hidden/excluded/not an @Action, or a
+ * declared dataType that conflicts).
  */
 class MateuYamlBindingAnnotatorTest : LightJavaCodeInsightFixtureTestCase() {
 
-  private fun errorTexts(yaml: String): List<String> {
-    myFixture.addClass(
-      """
-      package demo;
-      public class CustomerView {
-        public String name;
-        public int age;
-        public Object save() { return null; }
-      }
-      """.trimIndent()
-    )
+  override fun setUp() {
+    super.setUp()
+    ContractCache.getInstance(project).networkEnabled = false // no real HTTP in tests
+  }
+
+  private val customerView = """
+    package demo;
+    public class CustomerView {
+      public String name;
+      public int age;
+      public String secret;
+      public Object save() { return null; }
+      public Object internalHelper() { return null; }
+    }
+  """.trimIndent()
+
+  private fun highlight(yaml: String): List<HighlightInfo> {
+    myFixture.addClass(customerView)
     myFixture.configureByText("page.yaml", yaml)
-    val text = myFixture.file.text
     return myFixture.doHighlighting()
-      .filter { it.severity == HighlightSeverity.ERROR }
+  }
+
+  private fun List<HighlightInfo>.errors(): List<String> = at(HighlightSeverity.ERROR) { true }
+
+  /** Our binding weak-warnings only (ignore any unrelated YAML inspections). */
+  private fun List<HighlightInfo>.bindingWarnings(): List<String> =
+    at(HighlightSeverity.WEAK_WARNING) {
+      it.contains("bindable field") || it.contains("Mateu action") || it.contains("not the declared")
+    }
+
+  private fun List<HighlightInfo>.at(severity: HighlightSeverity, keep: (String) -> Boolean): List<String> {
+    val text = myFixture.file.text
+    return filter { it.severity == severity && keep(it.description ?: "") }
       .map { text.substring(it.startOffset, it.endOffset) }
   }
 
   fun testKnownFieldsAndActionsAreNotFlagged() {
-    val errors = errorTexts(
+    val errors = highlight(
       """
       modelView: demo.CustomerView
       layout:
@@ -42,12 +62,66 @@ class MateuYamlBindingAnnotatorTest : LightJavaCodeInsightFixtureTestCase() {
           - type: Button
             actionId: save
       """.trimIndent()
-    )
+    ).errors()
     assertEmpty(errors)
   }
 
-  fun testUnknownFieldAndActionAreFlagged() {
-    val errors = errorTexts(
+  fun testUnknownFieldAndActionAreErrors() {
+    val errors = highlight(
+      """
+      modelView: demo.CustomerView
+      layout:
+        type: VerticalLayout
+        content:
+          - type: FormField
+            id: nope
+          - type: Button
+            actionId: doesNotExist
+      """.trimIndent()
+    ).errors()
+    assertContainsElements(errors, "nope", "doesNotExist")
+  }
+
+  fun testUnresolvedModelViewIsFlagged() {
+    val errors = highlight(
+      """
+      modelView: demo.NoSuchView
+      layout:
+        type: FormField
+        id: whatever
+      """.trimIndent()
+    ).errors()
+    assertContainsElements(errors, "demo.NoSuchView")
+  }
+
+  fun testPlainYamlWithoutModelViewIsIgnored() {
+    assertEmpty(
+      highlight(
+        """
+        type: VerticalLayout
+        content:
+          - type: FormField
+            id: name
+          - type: Button
+            actionId: whatever
+        """.trimIndent()
+      ).errors()
+    )
+  }
+
+  fun testContractFlagsExistingButNonBindableFieldAndAction() {
+    ContractCache.getInstance(project).seed(
+      "demo.CustomerView",
+      ModelViewContract(
+        "demo.CustomerView",
+        listOf(
+          ContractField("name", "string", "regular", required = true, readOnly = false),
+          ContractField("age", "integer", "regular", required = false, readOnly = false),
+        ),
+        listOf("save"),
+      ),
+    )
+    val infos = highlight(
       """
       modelView: demo.CustomerView
       layout:
@@ -56,38 +130,40 @@ class MateuYamlBindingAnnotatorTest : LightJavaCodeInsightFixtureTestCase() {
           - type: FormField
             id: name
           - type: FormField
-            id: nope
+            id: secret
           - type: Button
-            actionId: doesNotExist
+            actionId: save
+          - type: Button
+            actionId: internalHelper
       """.trimIndent()
     )
-    assertContainsElements(errors, "nope", "doesNotExist")
-    assertDoesntContain(errors, "name")
+    // everything exists via PSI → no errors …
+    assertEmpty(infos.errors())
+    // … but the contract flags what exists yet does not bind
+    val warnings = infos.bindingWarnings()
+    assertContainsElements(warnings, "secret", "internalHelper")
+    assertDoesntContain(warnings, "name", "save")
   }
 
-  fun testUnresolvedModelViewIsFlagged() {
-    val errors = errorTexts(
+  fun testContractFlagsDataTypeMismatch() {
+    ContractCache.getInstance(project).seed(
+      "demo.CustomerView",
+      ModelViewContract(
+        "demo.CustomerView",
+        listOf(ContractField("name", "string", "regular", required = true, readOnly = false)),
+        listOf("save"),
+      ),
+    )
+    val warnings = highlight(
       """
-      modelView: demo.NoSuchView
+      modelView: demo.CustomerView
       layout:
         type: FormField
-        id: whatever
+        id: name
+        dataType: number
       """.trimIndent()
-    )
-    assertContainsElements(errors, "demo.NoSuchView")
-  }
-
-  fun testAPlainYamlWithoutAModelViewIsIgnored() {
-    val errors = errorTexts(
-      """
-      type: VerticalLayout
-      content:
-        - type: FormField
-          id: name
-        - type: Button
-          actionId: whatever
-      """.trimIndent()
-    )
-    assertEmpty(errors)
+    ).bindingWarnings()
+    // the mismatch is flagged on the field id (an annotator may only mark its own element)
+    assertContainsElements(warnings, "name")
   }
 }


### PR DESCRIPTION
El plugin de IntelliJ ahora **consume el contrato** del backend para afinar la validación de binding del visual builder: PSI marca **ERROR** lo que no existe; el contrato marca **WEAK_WARNING** lo que existe pero **no bindea** (campo `@Hidden`/excluido, método que no es `@Action`, `dataType` declarado que no coincide con el del ModelView).

- `ContractCache` (`@Service` PROJECT): `get(fqn)` devuelve lo cacheado o null y, en miss, lanza **un** fetch en background (`executeOnPooledThread`) y luego `DaemonCodeAnalyzer.restart()` en `invokeLater` (guardado por `isDisposed`) para re-ejecutar el anotador con el contrato ya disponible → **nunca bloquea el path síncrono del anotador**. `seed()`/`networkEnabled=false` para tests; un fetch fallido se cachea (no machacar un backend caído).
- `ContractClient`: fetch vía el `MateuApiClient` existente (`actionId=__contract__`, `serverSideType=fqn`) + `loadMateuConfig().baseUrl`; lee `appData._contract`.
- Test `MateuYamlBindingAnnotatorTest`: **6 verde** (siembra la cache, red off).

Nota (gotcha): un `Annotator` solo puede marcar el elemento que recibe; marcar un hermano (el valor de `dataType` mientras se procesa el `id`) lanza `PluginException` → se marca el propio valor del `id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)