### PR TITLE
feat(visual-builder): live preview of YAML pages (fase 3, primer incremento)

### DIFF
--- a/backend/shared/core/src/main/java/io/mateu/core/application/runaction/RunActionUseCase.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/runaction/RunActionUseCase.java
@@ -33,6 +33,7 @@ public class RunActionUseCase {
   private final ActionRunnerProvider actionRunnerProvider;
   private final UiIncrementMapperProvider uiIncrementMapperProvider;
   private final ActionInstanceCreator actionInstanceCreator;
+  private final YamlUidlLoader yamlUidlLoader;
 
   // ── Public static helpers (used by other classes in the framework) ────────
 
@@ -86,6 +87,9 @@ public class RunActionUseCase {
     log.info("run action {}", command.actionId());
     if (CONTRACT_ACTION.equals(command.actionId())) {
       return handleContract(command);
+    }
+    if (PREVIEW_ACTION.equals(command.actionId())) {
+      return handlePreview(command);
     }
     return (Mono.just(command)
             .flatMap(ignored -> actionInstanceCreator.createInstance(command))
@@ -164,6 +168,28 @@ public class RunActionUseCase {
         .map(component -> ModelViewContractExtractor.extract((ServerSideComponentDto) component))
         .findFirst()
         .orElse(new ModelViewContractDto(null, List.of(), List.of()));
+  }
+
+  // ── Live preview ──────────────────────────────────────────────────────────
+  // Renders arbitrary YAML page TEXT (the visual builder sends the editor's current, unsaved
+  // content in parameters._yaml) into the same wire increment a real route would produce, so the
+  // plugin's preview is faithful (real mapper) and updates as you type. The layout only — no
+  // ModelView instance/data is bound (a layout preview).
+  public static final String PREVIEW_ACTION = "__preview__";
+  public static final String PREVIEW_YAML_KEY = "_yaml";
+
+  private Flux<UIIncrementDto> handlePreview(RunActionCommand command) {
+    var rq = command.httpRequest() != null ? command.httpRequest().runActionRq() : null;
+    var parameters = rq != null ? rq.parameters() : null;
+    var yaml =
+        parameters != null ? String.valueOf(parameters.getOrDefault(PREVIEW_YAML_KEY, "")) : "";
+    var component = yamlUidlLoader.parseText(yaml);
+    if (component == null) {
+      return mapToUiIncrement(
+              Text.builder().text("Invalid or empty YAML").style("color: red;").build(), command)
+          .flux();
+    }
+    return mapToUiIncrement(component, command).flux();
   }
 
   private String extractTitle(Throwable e) {

--- a/backend/shared/core/src/main/java/io/mateu/core/application/runaction/YamlUidlLoader.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/runaction/YamlUidlLoader.java
@@ -49,6 +49,24 @@ public class YamlUidlLoader {
     mapper = YamlUidlMapperFactory.create();
   }
 
+  /**
+   * Parse a YAML page from raw TEXT (not the classpath) into its layout component — the
+   * live-preview path for the visual builder, which sends the editor's current, unsaved content.
+   * Envelope-aware: unwraps {@code layout:} when present, else treats the whole doc as the layout.
+   * Null on blank/invalid input.
+   */
+  public Component parseText(String yaml) {
+    if (yaml == null || yaml.isBlank()) {
+      return null;
+    }
+    try {
+      return layoutOf(mapper.readTree(yaml));
+    } catch (Exception e) {
+      log.warn("Failed to parse YAML preview: {}", e.getMessage());
+      return null;
+    }
+  }
+
   /** Load a layout from an explicit spec path (the {@code @UISpec} path); envelope-aware. */
   public Component loadFromSpec(String specPath) {
     var resource = resolve(specPath);

--- a/backend/shared/core/src/test/java/io/mateu/core/application/YamlModelViewSyncTest.java
+++ b/backend/shared/core/src/test/java/io/mateu/core/application/YamlModelViewSyncTest.java
@@ -103,6 +103,25 @@ class YamlModelViewSyncTest {
   }
 
   @Test
+  void previewRendersArbitraryYamlTextForTheLiveEditor() {
+    // The visual builder's preview: the editor's current (unsaved) YAML text is rendered into the
+    // same wire increment a real route would produce.
+    var yaml =
+        "type: VerticalLayout\ncontent:\n  - type: Text\n    text: \"Hello preview\"\n"
+            + "  - type: Button\n    label: \"Go\"\n    actionId: go\n";
+    var increment =
+        mateu.run(
+            RunActionRqDto.builder()
+                .actionId("__preview__")
+                .initiatorComponentId("preview")
+                .parameters(Map.of("_yaml", yaml))
+                .build());
+    assertThat(increment.fragments()).isNotEmpty();
+    assertThat(increment.fragments().get(0).component()).isNotNull();
+    assertThat(increment.fragments().get(0).component().children()).isNotEmpty();
+  }
+
+  @Test
   void aBareLayoutYamlWithoutAModelViewStillRenders() {
     // backward compatibility: the legacy shape (whole file is a component tree, no modelView)
     var increment = mateu.sync("demo/hello");

--- a/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/contract/YamlPagePreview.kt
+++ b/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/contract/YamlPagePreview.kt
@@ -1,0 +1,153 @@
+package io.mateu.ijp.contract
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.editor.event.DocumentEvent
+import com.intellij.openapi.editor.event.DocumentListener
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.fileEditor.FileEditor
+import com.intellij.openapi.fileEditor.FileEditorPolicy
+import com.intellij.openapi.fileEditor.FileEditorProvider
+import com.intellij.openapi.fileEditor.TextEditor
+import com.intellij.openapi.fileEditor.TextEditorWithPreview
+import com.intellij.openapi.fileEditor.impl.text.TextEditorProvider
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.UserDataHolderBase
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.util.Alarm
+import io.mateu.ijp.plugin.loadMateuConfig
+import io.mateu.ijp.state.AppContext
+import io.mateu.ijp.state.AppSession
+import io.mateu.ijp.ui.ComponentRenderer
+import java.awt.BorderLayout
+import java.beans.PropertyChangeListener
+import javax.swing.JComponent
+import javax.swing.JLabel
+import javax.swing.JPanel
+import javax.swing.ScrollPaneConstants
+import javax.swing.SwingConstants
+
+/**
+ * A split editor for a Mateu visual-builder page (a YAML file under `specs/ui/`): the standard YAML
+ * text editor on one side and a LIVE PREVIEW on the other. The preview renders the editor's current,
+ * unsaved content through the backend's `__preview__` action (so it's faithful — the real mapper)
+ * with the plugin's own Swing renderer, and refreshes (debounced) as you type. Needs a running dev
+ * backend (configured via `mateu.baseUrl`); shows a hint otherwise.
+ */
+class YamlPagePreviewProvider : FileEditorProvider, DumbAware {
+
+  override fun accept(project: Project, file: VirtualFile): Boolean {
+    val ext = file.extension?.lowercase()
+    if (ext != "yaml" && ext != "yml") return false
+    // Convention: Mateu pages live under specs/ui/. Keeps this off unrelated YAML.
+    return file.path.replace('\\', '/').contains("/specs/ui/")
+  }
+
+  override fun createEditor(project: Project, file: VirtualFile): FileEditor {
+    val textEditor = TextEditorProvider.getInstance().createEditor(project, file) as TextEditor
+    val preview = YamlPagePreviewEditor(project, file)
+    return TextEditorWithPreview(
+      textEditor,
+      preview,
+      "Mateu Page",
+      TextEditorWithPreview.Layout.SHOW_EDITOR_AND_PREVIEW,
+    )
+  }
+
+  override fun getEditorTypeId(): String = "mateu-yaml-page-preview"
+
+  // Keep the plain YAML editor available too (the split editor is offered alongside it).
+  override fun getPolicy(): FileEditorPolicy = FileEditorPolicy.PLACE_AFTER_DEFAULT_EDITOR
+}
+
+private class YamlPagePreviewEditor(
+  private val project: Project,
+  private val file: VirtualFile,
+) : UserDataHolderBase(), FileEditor {
+
+  private val root = JPanel(BorderLayout())
+  private val session = AppSession(loadMateuConfig().baseUrl)
+  private val alarm = Alarm(Alarm.ThreadToUse.SWING_THREAD, this)
+  private val document = FileDocumentManager.getInstance().getDocument(file)
+
+  private val documentListener = object : DocumentListener {
+    override fun documentChanged(event: DocumentEvent) = scheduleRefresh()
+  }
+
+  init {
+    root.add(hint("Rendering preview…"), BorderLayout.CENTER)
+    document?.addDocumentListener(documentListener, this)
+    scheduleRefresh(delayMs = 0)
+  }
+
+  private fun scheduleRefresh(delayMs: Int = 350) {
+    alarm.cancelAllRequests()
+    alarm.addRequest({ refresh() }, delayMs)
+  }
+
+  /** Read the current text (EDT), fetch the preview off the EDT, render back on the EDT. */
+  private fun refresh() {
+    val yaml = document?.text ?: return
+    ApplicationManager.getApplication().executeOnPooledThread {
+      val rendered: JComponent = try {
+        val increment = session.apiClient.runAction(
+          route = "",
+          consumedRoute = "",
+          actionId = "__preview__",
+          serverSideType = null,
+          initiatorComponentId = "preview",
+          componentState = emptyMap(),
+          appState = session.appState,
+          parameters = mapOf("_yaml" to yaml),
+        )
+        renderIncrement(increment)
+      } catch (e: Exception) {
+        hint("Preview unavailable — is the Mateu backend running at ${session.baseUrl}?")
+      }
+      ApplicationManager.getApplication().invokeLater({
+        if (!project.isDisposed) {
+          root.removeAll()
+          root.add(wrapScroll(rendered), BorderLayout.CENTER)
+          root.revalidate()
+          root.repaint()
+        }
+      }, { project.isDisposed })
+    }
+  }
+
+  private fun renderIncrement(increment: JsonNode): JComponent {
+    val fragment = increment.path("fragments").firstOrNull() ?: return hint("Nothing to preview.")
+    val component = fragment.path("component")
+    if (component.isMissingNode || component.isNull) return hint("Nothing to preview.")
+    val state = fragment.path("state")
+    val data = fragment.path("data")
+    val ctx = AppContext(session)
+    return ComponentRenderer(ctx).render(component, state, data)
+  }
+
+  private fun wrapScroll(content: JComponent): JComponent =
+    JBScrollPane(content).apply {
+      horizontalScrollBarPolicy = ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED
+      verticalScrollBarPolicy = ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED
+      border = null
+    }
+
+  private fun hint(text: String): JComponent =
+    JLabel(text, SwingConstants.CENTER).apply { isEnabled = false }
+
+  override fun getComponent(): JComponent = root
+  override fun getPreferredFocusedComponent(): JComponent = root
+  override fun getName(): String = "Preview"
+  override fun setState(state: com.intellij.openapi.fileEditor.FileEditorState) {}
+  override fun isModified(): Boolean = false
+  override fun isValid(): Boolean = true
+  override fun addPropertyChangeListener(listener: PropertyChangeListener) {}
+  override fun removePropertyChangeListener(listener: PropertyChangeListener) {}
+  override fun getFile(): VirtualFile = file
+
+  // The Alarm and document listener are parented to this editor (Disposable), so the platform
+  // cleans them up on dispose; nothing extra to do.
+  override fun dispose() {}
+}

--- a/frontend/app/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/frontend/app/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -17,6 +17,8 @@
                     factoryClass="io.mateu.ijp.plugin.MateuToolWindowFactory"
                     icon="/icons/mateu.svg"/>
         <fileEditorProvider implementation="io.mateu.ijp.plugin.MateuFileEditorProvider"/>
+        <!-- Visual-builder live preview: a split editor for specs/ui/*.yaml pages. -->
+        <fileEditorProvider implementation="io.mateu.ijp.contract.YamlPagePreviewProvider"/>
         <postStartupActivity implementation="io.mateu.ijp.plugin.MateuFocusedModeActivity"/>
         <frameTitleBuilder implementation="io.mateu.ijp.plugin.MateuFrameTitleBuilder"/>
         <applicationService serviceInterface="com.intellij.openapi.fileEditor.impl.EditorEmptyTextPainter"


### PR DESCRIPTION
Primer incremento de la Fase 3 (WYSIWYG): **preview en vivo** — ves la pantalla renderizada mientras editas el YAML, reutilizando el renderer Swing del plugin.

**Backend (core):** acción reservada `__preview__` que renderiza **texto YAML arbitrario** (el editor manda su contenido actual sin guardar en `parameters._yaml`) al mismo increment de wire que produciría una ruta real → preview **fiel** (mapper real), solo layout (sin instanciar ModelView). `YamlUidlLoader.parseText` (desde texto, entiende el envelope). Test `previewRendersArbitraryYamlText`. **Core 775 verde.**

**Plugin:** `YamlPagePreviewProvider` (FileEditorProvider para `specs/ui/*.yaml`) → `TextEditorWithPreview` (editor YAML estándar + panel de preview). Reutiliza `AppSession`/`AppContext`/`ComponentRenderer`; refresca con debounce al cambiar el documento, hace fetch de `__preview__` fuera del EDT y renderiza en el EDT (guardado por `isDisposed`); si el backend no está, muestra una pista.

**Verificación:** backend testeado in-JVM; el plugin **compila** + `verifyPluginProjectConfiguration` + 6 tests del anotador verde. El editor de render en vivo **no** está verificado headless (necesita `./gradlew runIde` — es una UI viva).

Pendiente Fase 3: edición drag/drop, paleta, panel de propiedades.

🤖 Generated with [Claude Code](https://claude.com/claude-code)