### PR TITLE
feat(visual-builder): component palette that inserts YAML (fase 3.2)

### DIFF
--- a/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/contract/MateuPaletteToolWindowFactory.kt
+++ b/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/contract/MateuPaletteToolWindowFactory.kt
@@ -1,0 +1,62 @@
+package io.mateu.ijp.contract
+
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.ToolWindow
+import com.intellij.openapi.wm.ToolWindowFactory
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.content.ContentFactory
+import com.intellij.util.ui.JBUI
+import java.awt.Component
+import javax.swing.Box
+import javax.swing.BoxLayout
+import javax.swing.JButton
+import javax.swing.JPanel
+
+/**
+ * The visual-builder component palette (first rung of drag-and-drop): a tool window of components;
+ * clicking one inserts its YAML on a fresh line after the caret, re-indented to the caret's line —
+ * so you build a page by adding components instead of memorising the YAML. Full drag-onto-the-
+ * preview-canvas is a later increment.
+ */
+class MateuPaletteToolWindowFactory : ToolWindowFactory, DumbAware {
+
+  override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
+    val panel = JPanel().apply {
+      layout = BoxLayout(this, BoxLayout.Y_AXIS)
+      border = JBUI.Borders.empty(8)
+    }
+    panel.add(
+      JBLabel("Insert into the active Mateu page at the caret:").apply {
+        alignmentX = Component.LEFT_ALIGNMENT
+      },
+    )
+    panel.add(Box.createVerticalStrut(8))
+    for (item in PaletteSnippets.ITEMS) {
+      panel.add(
+        JButton(item.label).apply {
+          alignmentX = Component.LEFT_ALIGNMENT
+          maximumSize = java.awt.Dimension(Int.MAX_VALUE, preferredSize.height)
+          addActionListener { insert(project, item) }
+        },
+      )
+      panel.add(Box.createVerticalStrut(4))
+    }
+    val content = ContentFactory.getInstance().createContent(panel, "", false)
+    toolWindow.contentManager.addContent(content)
+  }
+
+  private fun insert(project: Project, item: PaletteSnippets.Item) {
+    val editor = FileEditorManager.getInstance(project).selectedTextEditor ?: return
+    val doc = editor.document
+    val caret = editor.caretModel.offset
+    val lineEnd = doc.getLineEndOffset(doc.getLineNumber(caret))
+    val indented = PaletteSnippets.indent(item.snippet, PaletteSnippets.lineIndent(doc.text, caret))
+    WriteCommandAction.runWriteCommandAction(project) {
+      doc.insertString(lineEnd, "\n" + indented)
+    }
+    editor.caretModel.moveToOffset((lineEnd + 1 + indented.length).coerceAtMost(doc.textLength))
+  }
+}

--- a/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/contract/PaletteSnippets.kt
+++ b/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/contract/PaletteSnippets.kt
@@ -1,0 +1,48 @@
+package io.mateu.ijp.contract
+
+/**
+ * The visual-builder component palette: a catalog of components and the YAML snippet each inserts
+ * into a page. Pure (no IDE deps) so the snippet + indentation logic is unit-testable; the tool
+ * window ([MateuPaletteToolWindowFactory]) just places the snippet at the caret. Each snippet is a
+ * YAML list item (the form components take inside a `content:` list), authored at zero indent and
+ * re-indented to the insertion point.
+ */
+object PaletteSnippets {
+
+  data class Item(val label: String, val type: String, val snippet: String)
+
+  val ITEMS: List<Item> = listOf(
+    Item("Text", "Text", "- type: Text\n  text: \"Text\""),
+    Item("Field", "FormField", "- type: FormField\n  id: fieldId\n  label: \"Label\""),
+    Item("Button", "Button", "- type: Button\n  label: \"Button\"\n  actionId: actionId"),
+    Item(
+      "Vertical Layout",
+      "VerticalLayout",
+      "- type: VerticalLayout\n  spacing: true\n  content:\n    - type: Text\n      text: \"…\"",
+    ),
+    Item(
+      "Horizontal Layout",
+      "HorizontalLayout",
+      "- type: HorizontalLayout\n  spacing: true\n  content:\n    - type: Text\n      text: \"…\"",
+    ),
+    Item(
+      "Form Layout",
+      "FormLayout",
+      "- type: FormLayout\n  content:\n    - type: FormField\n      id: fieldId\n      label: \"Label\"",
+    ),
+  )
+
+  fun byType(type: String): Item? = ITEMS.firstOrNull { it.type == type }
+
+  /** The leading whitespace of the line that contains [offset]. */
+  fun lineIndent(text: String, offset: Int): String {
+    val safe = offset.coerceIn(0, text.length)
+    val lineStart = text.lastIndexOf('\n', (safe - 1).coerceAtLeast(0)).let { if (it < 0) 0 else it + 1 }
+    val lineEnd = text.indexOf('\n', lineStart).let { if (it < 0) text.length else it }
+    return text.substring(lineStart, lineEnd).takeWhile { it == ' ' || it == '\t' }
+  }
+
+  /** Prefix every line of [snippet] with [indent]. */
+  fun indent(snippet: String, indent: String): String =
+    snippet.split("\n").joinToString("\n") { if (it.isEmpty()) it else indent + it }
+}

--- a/frontend/app/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/frontend/app/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -16,6 +16,9 @@
         <toolWindow id="Mateu" anchor="right" canCloseContents="false"
                     factoryClass="io.mateu.ijp.plugin.MateuToolWindowFactory"
                     icon="/icons/mateu.svg"/>
+        <!-- Visual-builder component palette (insert components into a page YAML). -->
+        <toolWindow id="Mateu Components" anchor="left"
+                    factoryClass="io.mateu.ijp.contract.MateuPaletteToolWindowFactory"/>
         <fileEditorProvider implementation="io.mateu.ijp.plugin.MateuFileEditorProvider"/>
         <!-- Visual-builder live preview: a split editor for specs/ui/*.yaml pages. -->
         <fileEditorProvider implementation="io.mateu.ijp.contract.YamlPagePreviewProvider"/>

--- a/frontend/app/intellij-plugin/src/test/kotlin/io/mateu/ijp/contract/PaletteSnippetsTest.kt
+++ b/frontend/app/intellij-plugin/src/test/kotlin/io/mateu/ijp/contract/PaletteSnippetsTest.kt
@@ -1,0 +1,34 @@
+package io.mateu.ijp.contract
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Pure unit tests of the palette snippet + indentation logic (no IDE platform needed). */
+class PaletteSnippetsTest {
+
+  @Test
+  fun everyItemIsAYamlListItem() {
+    assertTrue(PaletteSnippets.ITEMS.isNotEmpty())
+    PaletteSnippets.ITEMS.forEach { assertTrue(it.snippet.startsWith("- type:")) }
+  }
+
+  @Test
+  fun byTypeFindsItemsAndMissesUnknowns() {
+    assertEquals("Field", PaletteSnippets.byType("FormField")?.label)
+    assertNull(PaletteSnippets.byType("Nope"))
+  }
+
+  @Test
+  fun lineIndentReadsTheLeadingWhitespaceOfTheCaretLine() {
+    val text = "a:\n    b: c\n"
+    assertEquals("    ", PaletteSnippets.lineIndent(text, text.indexOf("b:")))
+    assertEquals("", PaletteSnippets.lineIndent(text, 0))
+  }
+
+  @Test
+  fun indentPrefixesEveryLine() {
+    assertEquals("  - type: X\n    id: y", PaletteSnippets.indent("- type: X\n  id: y", "  "))
+  }
+}


### PR DESCRIPTION
Primer peldaño del drag-and-drop: una **paleta de componentes**. En vez del drag sobre el canvas (la pieza pesada de UX, para después), un tool window **"Mateu Components"** con un botón por componente; al pulsarlo inserta el YAML del componente en una línea nueva tras el caret, re-indentado al nivel de la línea. Construyes una página añadiendo componentes sin memorizar el YAML.

- `PaletteSnippets` (puro, sin deps de IDE → unit-testeable): catálogo (Text/Field/Button/Vertical+Horizontal+Form Layout) + `lineIndent` + `indent`.
- `MateuPaletteToolWindowFactory`: inserta vía `WriteCommandAction` sobre el `selectedTextEditor`.
- Test `PaletteSnippetsTest` (JUnit4 puro, sin arrancar el platform): **4 verde**. Tests del plugin ahora **10**.

Pendiente Fase 3: drag sobre el preview + panel de propiedades (UX-heavy, a iterar en runIde).

🤖 Generated with [Claude Code](https://claude.com/claude-code)