### PR TITLE
fix(intellij): palette tool window icon (stripe button visibility)

### DIFF
--- a/frontend/app/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/frontend/app/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -16,8 +16,9 @@
         <toolWindow id="Mateu" anchor="right" canCloseContents="false"
                     factoryClass="io.mateu.ijp.plugin.MateuToolWindowFactory"
                     icon="/icons/mateu.svg"/>
-        <!-- Visual-builder component palette (insert components into a page YAML). -->
-        <toolWindow id="Mateu Components" anchor="left"
+        <!-- Visual-builder component palette (insert components into a page YAML). The icon is
+             required by the new UI — an iconless tool window shows no stripe button. -->
+        <toolWindow id="Mateu Components" anchor="left" icon="/icons/mateu.svg"
                     factoryClass="io.mateu.ijp.contract.MateuPaletteToolWindowFactory"/>
         <fileEditorProvider implementation="io.mateu.ijp.plugin.MateuFileEditorProvider"/>
         <!-- Visual-builder live preview: a split editor for specs/ui/*.yaml pages. -->


### PR DESCRIPTION
El new UI oculta el botón de barra de una tool window sin icono. Añade el icono de Mateu a 'Mateu Components'.