### PR TITLE
feat(visual-builder): drag components from the palette onto the preview (fase 3.3)

### DIFF
--- a/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/contract/MateuPaletteToolWindowFactory.kt
+++ b/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/contract/MateuPaletteToolWindowFactory.kt
@@ -10,6 +10,9 @@ import com.intellij.ui.components.JBLabel
 import com.intellij.ui.content.ContentFactory
 import com.intellij.util.ui.JBUI
 import java.awt.Component
+import java.awt.datatransfer.StringSelection
+import java.awt.dnd.DnDConstants
+import java.awt.dnd.DragSource
 import javax.swing.Box
 import javax.swing.BoxLayout
 import javax.swing.JButton
@@ -39,13 +42,23 @@ class MateuPaletteToolWindowFactory : ToolWindowFactory, DumbAware {
         JButton(item.label).apply {
           alignmentX = Component.LEFT_ALIGNMENT
           maximumSize = java.awt.Dimension(Int.MAX_VALUE, preferredSize.height)
+          toolTipText = "Click to insert at the caret, or drag onto the preview"
           addActionListener { insert(project, item) }
+          makeDraggable(this, item.type)
         },
       )
       panel.add(Box.createVerticalStrut(4))
     }
     val content = ContentFactory.getInstance().createContent(panel, "", false)
     toolWindow.contentManager.addContent(content)
+  }
+
+  /** Let a palette button be dragged onto the preview (carries the component type as a string). */
+  private fun makeDraggable(button: JButton, type: String) {
+    DragSource.getDefaultDragSource().createDefaultDragGestureRecognizer(
+      button,
+      DnDConstants.ACTION_COPY,
+    ) { event -> event.startDrag(DragSource.DefaultCopyDrop, StringSelection(PaletteDnD.PREFIX + type)) }
   }
 
   private fun insert(project: Project, item: PaletteSnippets.Item) {

--- a/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/contract/PaletteDnD.kt
+++ b/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/contract/PaletteDnD.kt
@@ -1,0 +1,38 @@
+package io.mateu.ijp.contract
+
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiManager
+import org.jetbrains.yaml.psi.YAMLFile
+import org.jetbrains.yaml.psi.YAMLMapping
+import org.jetbrains.yaml.psi.YAMLSequence
+
+/**
+ * Drag-and-drop glue between the palette and the live preview. Palette items are dragged as a plain
+ * string ([PREFIX] + component type); the preview accepts the drop and adds the component to the
+ * page's ROOT layout content list. (Dropping at a precise position between nested components is a
+ * later increment — it needs the renderer to tag each Swing component with its YAML source offset.)
+ */
+object PaletteDnD {
+
+  const val PREFIX = "mateu-component:"
+
+  fun typeOf(transfer: String?): String? =
+    transfer?.takeIf { it.startsWith(PREFIX) }?.removePrefix(PREFIX)
+
+  /**
+   * Insertion point for a new component: a fresh item after the last one of the page's root layout
+   * `content:` list, indented to match. Returns (offset, textToInsert), or null when the page has no
+   * such list (the caller then appends at the document end).
+   */
+  fun appendToRootContent(project: Project, file: VirtualFile, doc: Document, snippet: String): Pair<Int, String>? {
+    val psi = PsiManager.getInstance(project).findFile(file) as? YAMLFile ?: return null
+    val top = psi.documents.firstOrNull()?.topLevelValue as? YAMLMapping ?: return null
+    val layout = (top.getKeyValueByKey("layout")?.value as? YAMLMapping) ?: top
+    val content = layout.getKeyValueByKey("content")?.value as? YAMLSequence ?: return null
+    val anchor = content.items.lastOrNull() ?: return null
+    val indent = PaletteSnippets.lineIndent(doc.text, anchor.textRange.startOffset)
+    return anchor.textRange.endOffset to ("\n" + PaletteSnippets.indent(snippet, indent))
+  }
+}

--- a/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/contract/YamlPagePreview.kt
+++ b/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/contract/YamlPagePreview.kt
@@ -15,8 +15,16 @@ import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.UserDataHolderBase
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.util.Alarm
+import java.awt.Component as AwtComponent
+import java.awt.Container
+import java.awt.datatransfer.DataFlavor
+import java.awt.dnd.DnDConstants
+import java.awt.dnd.DropTarget
+import java.awt.dnd.DropTargetAdapter
+import java.awt.dnd.DropTargetDropEvent
 import io.mateu.ijp.plugin.loadMateuConfig
 import io.mateu.ijp.state.AppContext
 import io.mateu.ijp.state.AppSession
@@ -76,9 +84,43 @@ private class YamlPagePreviewEditor(
     override fun documentChanged(event: DocumentEvent) = scheduleRefresh()
   }
 
+  /** Accepts a component dragged from the palette and drops it into the page (root content). */
+  private val dropListener = object : DropTargetAdapter() {
+    override fun drop(event: DropTargetDropEvent) {
+      try {
+        event.acceptDrop(DnDConstants.ACTION_COPY)
+        val transfer = event.transferable.getTransferData(DataFlavor.stringFlavor) as? String
+        val type = PaletteDnD.typeOf(transfer)
+        if (type != null) onDrop(type)
+        event.dropComplete(type != null)
+      } catch (e: Exception) {
+        event.dropComplete(false)
+      }
+    }
+  }
+
   init {
-    root.add(hint("Rendering preview…"), BorderLayout.CENTER)
+    root.add(hint("Rendering preview…  (drag components here from the palette)"), BorderLayout.CENTER)
+    DropTarget(root, DnDConstants.ACTION_COPY, dropListener, true)
     document?.addDocumentListener(documentListener, this)
+    scheduleRefresh(delayMs = 0)
+  }
+
+  /** Make the whole preview a drop zone: Swing has no drop bubbling, so install the target on every
+   *  rendered widget, not just the container. */
+  private fun installDropTargets(component: AwtComponent) {
+    DropTarget(component, DnDConstants.ACTION_COPY, dropListener, true)
+    if (component is Container) component.components.forEach { installDropTargets(it) }
+  }
+
+  private fun onDrop(type: String) {
+    val item = PaletteSnippets.byType(type) ?: return
+    val doc = document ?: return
+    val insertion = PaletteDnD.appendToRootContent(project, file, doc, item.snippet)
+      ?: (doc.textLength to ("\n" + item.snippet))
+    WriteCommandAction.runWriteCommandAction(project) {
+      doc.insertString(insertion.first, insertion.second)
+    }
     scheduleRefresh(delayMs = 0)
   }
 
@@ -109,7 +151,9 @@ private class YamlPagePreviewEditor(
       ApplicationManager.getApplication().invokeLater({
         if (!project.isDisposed) {
           root.removeAll()
-          root.add(wrapScroll(rendered), BorderLayout.CENTER)
+          val wrapped = wrapScroll(rendered)
+          root.add(wrapped, BorderLayout.CENTER)
+          installDropTargets(wrapped) // every rendered widget accepts palette drops
           root.revalidate()
           root.repaint()
         }

--- a/frontend/app/intellij-plugin/src/test/kotlin/io/mateu/ijp/contract/PaletteSnippetsTest.kt
+++ b/frontend/app/intellij-plugin/src/test/kotlin/io/mateu/ijp/contract/PaletteSnippetsTest.kt
@@ -31,4 +31,11 @@ class PaletteSnippetsTest {
   fun indentPrefixesEveryLine() {
     assertEquals("  - type: X\n    id: y", PaletteSnippets.indent("- type: X\n  id: y", "  "))
   }
+
+  @Test
+  fun dndTypeOfParsesTheDragPayload() {
+    assertEquals("Button", PaletteDnD.typeOf(PaletteDnD.PREFIX + "Button"))
+    assertNull(PaletteDnD.typeOf("something-else"))
+    assertNull(PaletteDnD.typeOf(null))
+  }
 }


### PR DESCRIPTION
Arrastras un componente de la paleta y lo sueltas en el preview → se añade al content raíz de la página. Botones = drag sources; el preview instala DropTarget recursivo en cada widget (Swing no hace bubbling); al soltar, inserta vía YAML PSI en el content raíz + refresca. Limitación: se añade al content RAÍZ, no en la posición exacta (el hit-testing preciso necesita que el renderer etiquete cada widget con su offset YAML). Tests: 11 verde. UI compile-only (se ve en runIde). 🤖 Generated with [Claude Code](https://claude.com/claude-code)