### PR TITLE
feat(visual-builder): property panel (fase 3.4)

### DIFF
--- a/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/contract/MateuPropertiesToolWindowFactory.kt
+++ b/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/contract/MateuPropertiesToolWindowFactory.kt
@@ -1,0 +1,92 @@
+package io.mateu.ijp.contract
+
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.editor.EditorFactory
+import com.intellij.openapi.editor.event.CaretEvent
+import com.intellij.openapi.editor.event.CaretListener
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.ToolWindow
+import com.intellij.openapi.wm.ToolWindowFactory
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBTextField
+import com.intellij.ui.content.ContentFactory
+import com.intellij.util.ui.JBUI
+import java.awt.BorderLayout
+import java.awt.Component
+import java.awt.Dimension
+import java.awt.Font
+import javax.swing.Box
+import javax.swing.BoxLayout
+import javax.swing.JPanel
+
+/**
+ * The visual-builder property panel: shows the component under the caret in a Mateu page and its
+ * editable scalar properties; pressing Enter in a field writes the new value straight back into the
+ * YAML (and the split-editor preview refreshes). Follows the caret across editors.
+ */
+class MateuPropertiesToolWindowFactory : ToolWindowFactory, DumbAware {
+
+  override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
+    val body = JPanel().apply {
+      layout = BoxLayout(this, BoxLayout.Y_AXIS)
+      border = JBUI.Borders.empty(8)
+    }
+    val panel = JPanel(BorderLayout()).apply { add(body, BorderLayout.NORTH) }
+
+    fun refresh() {
+      val editor = FileEditorManager.getInstance(project).selectedTextEditor
+      val model = editor?.let {
+        val psi = PsiDocumentManager.getInstance(project).getPsiFile(it.document)
+        if (psi != null && psi.name.endsWith(".yaml")) PropertyModel.at(psi, it.caretModel.offset) else null
+      }
+      body.removeAll()
+      if (model == null) {
+        body.add(JBLabel("Place the caret on a component in a Mateu page.").apply { isEnabled = false })
+      } else {
+        body.add(
+          JBLabel(model.type).apply {
+            font = font.deriveFont(font.style or Font.BOLD)
+            alignmentX = Component.LEFT_ALIGNMENT
+          },
+        )
+        body.add(Box.createVerticalStrut(8))
+        for (prop in model.props) {
+          val field = JBTextField(prop.value)
+          field.addActionListener {
+            val target = FileEditorManager.getInstance(project).selectedTextEditor ?: return@addActionListener
+            WriteCommandAction.runWriteCommandAction(project) {
+              target.document.replaceString(prop.valueStart, prop.valueEnd, field.text)
+            }
+            refresh() // offsets shifted — re-read
+          }
+          val row = JPanel(BorderLayout(8, 0)).apply {
+            add(
+              JBLabel(prop.key).apply { preferredSize = Dimension(90, preferredSize.height) },
+              BorderLayout.WEST,
+            )
+            add(field, BorderLayout.CENTER)
+            alignmentX = Component.LEFT_ALIGNMENT
+            maximumSize = Dimension(Int.MAX_VALUE, preferredSize.height)
+          }
+          body.add(row)
+          body.add(Box.createVerticalStrut(4))
+        }
+      }
+      body.revalidate()
+      body.repaint()
+    }
+
+    EditorFactory.getInstance().eventMulticaster.addCaretListener(
+      object : CaretListener {
+        override fun caretPositionChanged(event: CaretEvent) = refresh()
+      },
+      toolWindow.disposable,
+    )
+    refresh()
+
+    toolWindow.contentManager.addContent(ContentFactory.getInstance().createContent(panel, "", false))
+  }
+}

--- a/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/contract/PropertyModel.kt
+++ b/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/contract/PropertyModel.kt
@@ -1,0 +1,41 @@
+package io.mateu.ijp.contract
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.PsiTreeUtil
+import org.jetbrains.yaml.psi.YAMLFile
+import org.jetbrains.yaml.psi.YAMLMapping
+import org.jetbrains.yaml.psi.YAMLScalar
+
+/**
+ * Reads the component under the caret and its editable scalar properties, for the property panel.
+ * The component is the nearest enclosing YAML mapping that has a `type:` key; each of its other
+ * scalar key-values is an editable property, carrying the source range of its VALUE so the panel
+ * can write an edit straight back into the document.
+ */
+object PropertyModel {
+
+  /** An editable property: its key, its current raw value text, and that value's source range. */
+  data class Prop(val key: String, val value: String, val valueStart: Int, val valueEnd: Int)
+
+  data class ComponentProps(val type: String, val props: List<Prop>)
+
+  fun at(file: PsiFile, offset: Int): ComponentProps? {
+    if (file !is YAMLFile || file.textLength == 0) return null
+    val element: PsiElement? = file.findElementAt(offset.coerceIn(0, file.textLength - 1))
+    var mapping = PsiTreeUtil.getParentOfType(element, YAMLMapping::class.java)
+    // walk up to the nearest mapping that names a component (has a `type:`)
+    while (mapping != null && mapping.getKeyValueByKey("type") == null) {
+      mapping = PsiTreeUtil.getParentOfType(mapping, YAMLMapping::class.java)
+    }
+    if (mapping == null) return null
+    val type = mapping.getKeyValueByKey("type")?.valueText ?: return null
+    val props = mapping.keyValues.mapNotNull { kv ->
+      val value = kv.value
+      // scalar props only (skip `type` and nested content/children lists/maps)
+      if (kv.keyText == "type" || value !is YAMLScalar) null
+      else Prop(kv.keyText, value.text, value.textRange.startOffset, value.textRange.endOffset)
+    }
+    return ComponentProps(type, props)
+  }
+}

--- a/frontend/app/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/frontend/app/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -20,6 +20,9 @@
              required by the new UI — an iconless tool window shows no stripe button. -->
         <toolWindow id="Mateu Components" anchor="left" icon="/icons/mateu.svg"
                     factoryClass="io.mateu.ijp.contract.MateuPaletteToolWindowFactory"/>
+        <!-- Visual-builder property panel (edit the component under the caret). -->
+        <toolWindow id="Mateu Properties" anchor="bottom" icon="/icons/mateu.svg"
+                    factoryClass="io.mateu.ijp.contract.MateuPropertiesToolWindowFactory"/>
         <fileEditorProvider implementation="io.mateu.ijp.plugin.MateuFileEditorProvider"/>
         <!-- Visual-builder live preview: a split editor for specs/ui/*.yaml pages. -->
         <fileEditorProvider implementation="io.mateu.ijp.contract.YamlPagePreviewProvider"/>

--- a/frontend/app/intellij-plugin/src/test/kotlin/io/mateu/ijp/contract/PropertyModelTest.kt
+++ b/frontend/app/intellij-plugin/src/test/kotlin/io/mateu/ijp/contract/PropertyModelTest.kt
@@ -1,0 +1,40 @@
+package io.mateu.ijp.contract
+
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
+
+/** Verifies the property panel's core: the component under the caret and its editable props. */
+class PropertyModelTest : LightJavaCodeInsightFixtureTestCase() {
+
+  private val page = """
+    modelView: demo.X
+    layout:
+      type: VerticalLayout
+      content:
+        - type: FormField
+          id: name
+          label: "Name"
+  """.trimIndent()
+
+  fun testFindsTheEnclosingComponentAndItsScalarProps() {
+    myFixture.configureByText("page.yaml", page)
+    val props = PropertyModel.at(myFixture.file, myFixture.file.text.indexOf("id: name"))!!
+    assertEquals("FormField", props.type)
+    val byKey = props.props.associate { it.key to it.value }
+    assertEquals("name", byKey["id"])
+    assertTrue(byKey["label"]!!.contains("Name"))
+    // the `type` key is not an editable prop, and there is no nested list here
+    assertFalse(byKey.containsKey("type"))
+  }
+
+  fun testWalksUpToTheNearestComponentFromANestedValue() {
+    myFixture.configureByText("page.yaml", page)
+    // caret on the outer VerticalLayout's `spacing`-less mapping (the `content:` line)
+    val props = PropertyModel.at(myFixture.file, myFixture.file.text.indexOf("content:"))!!
+    assertEquals("VerticalLayout", props.type)
+  }
+
+  fun testReturnsNullOutsideAnyComponent() {
+    myFixture.configureByText("page.yaml", "modelView: demo.X\n")
+    assertNull(PropertyModel.at(myFixture.file, 0))
+  }
+}


### PR DESCRIPTION
Panel de propiedades: caret sobre un componente -> editas sus atributos escalares en un formulario que escribe de vuelta al YAML. PropertyModel.at (PSI, 3 tests headless) + tool window 'Mateu Properties'. Plugin 14 tests verde. UI compile-only. 🤖 Generated with [Claude Code](https://claude.com/claude-code)