### PR TITLE
feat(visual-builder): precise drop hit-testing on the preview (fase 3.5)

### DIFF
--- a/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/contract/DropTargeting.kt
+++ b/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/contract/DropTargeting.kt
@@ -1,0 +1,60 @@
+package io.mateu.ijp.contract
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiManager
+import org.jetbrains.yaml.psi.YAMLFile
+import org.jetbrains.yaml.psi.YAMLMapping
+import org.jetbrains.yaml.psi.YAMLSequence
+
+/**
+ * Precise drop targeting: maps the rendered widget a component was dropped ON back to a YAML
+ * insertion point, so the new component lands next to where you dropped it (not just at the page
+ * root). The renderer tags every widget with the wire component it rendered ([WIRE_KEY]); from that
+ * we find the component's child-index path in the wire tree and walk the YAML `content` lists by the
+ * same path. When the wire and YAML structures don't line up (e.g. a FormLayout wraps fields in
+ * rows), navigation returns null and the caller falls back to appending at the page root — degrades,
+ * never breaks.
+ */
+object DropTargeting {
+
+  const val WIRE_KEY = "mateu.wireComponent"
+
+  /** Child-index path from [root] to the [target] wire node (by identity), or null if not found. */
+  fun pathOf(root: JsonNode?, target: JsonNode?): List<Int>? {
+    if (root == null || target == null) return null
+    if (root === target) return emptyList()
+    val children = root.path("children")
+    children.forEachIndexed { i, child ->
+      pathOf(child, target)?.let { return listOf(i) + it }
+    }
+    return null
+  }
+
+  /**
+   * The (offset, textToInsert) to add [snippet] as a sibling right after the component at [path] in
+   * the page's YAML, or null to fall back to a root append.
+   */
+  fun insertionAtPath(
+    project: Project,
+    file: VirtualFile,
+    doc: Document,
+    path: List<Int>,
+    snippet: String,
+  ): Pair<Int, String>? {
+    if (path.isEmpty()) return PaletteDnD.appendToRootContent(project, file, doc, snippet)
+    val psi = PsiManager.getInstance(project).findFile(file) as? YAMLFile ?: return null
+    val top = psi.documents.firstOrNull()?.topLevelValue as? YAMLMapping ?: return null
+    val rootLayout = (top.getKeyValueByKey("layout")?.value as? YAMLMapping) ?: top
+    var seq = rootLayout.getKeyValueByKey("content")?.value as? YAMLSequence ?: return null
+    for (idx in path.dropLast(1)) {
+      val item = seq.items.getOrNull(idx)?.value as? YAMLMapping ?: return null
+      seq = item.getKeyValueByKey("content")?.value as? YAMLSequence ?: return null
+    }
+    val anchor = seq.items.getOrNull(path.last()) ?: return null
+    val indent = PaletteSnippets.lineIndent(doc.text, anchor.textRange.startOffset)
+    return anchor.textRange.endOffset to ("\n" + PaletteSnippets.indent(snippet, indent))
+  }
+}

--- a/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/contract/YamlPagePreview.kt
+++ b/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/contract/YamlPagePreview.kt
@@ -91,7 +91,7 @@ private class YamlPagePreviewEditor(
         event.acceptDrop(DnDConstants.ACTION_COPY)
         val transfer = event.transferable.getTransferData(DataFlavor.stringFlavor) as? String
         val type = PaletteDnD.typeOf(transfer)
-        if (type != null) onDrop(type)
+        if (type != null) onDrop(type, event.dropTargetContext.component)
         event.dropComplete(type != null)
       } catch (e: Exception) {
         event.dropComplete(false)
@@ -113,15 +113,29 @@ private class YamlPagePreviewEditor(
     if (component is Container) component.components.forEach { installDropTargets(it) }
   }
 
-  private fun onDrop(type: String) {
+  private fun onDrop(type: String, droppedOn: AwtComponent?) {
     val item = PaletteSnippets.byType(type) ?: return
     val doc = document ?: return
-    val insertion = PaletteDnD.appendToRootContent(project, file, doc, item.snippet)
+    // Map the widget dropped on → its wire component → its path → the YAML insertion point. Falls
+    // back to a root append when the drop target can't be resolved (see DropTargeting).
+    val path = DropTargeting.pathOf(lastRoot, wireNodeOf(droppedOn)) ?: emptyList()
+    val insertion = DropTargeting.insertionAtPath(project, file, doc, path, item.snippet)
+      ?: PaletteDnD.appendToRootContent(project, file, doc, item.snippet)
       ?: (doc.textLength to ("\n" + item.snippet))
     WriteCommandAction.runWriteCommandAction(project) {
       doc.insertString(insertion.first, insertion.second)
     }
     scheduleRefresh(delayMs = 0)
+  }
+
+  /** The wire component a widget was rendered from (walking up to the nearest tagged ancestor). */
+  private fun wireNodeOf(component: AwtComponent?): JsonNode? {
+    var c = component
+    while (c != null) {
+      if (c is JComponent) (c.getClientProperty(DropTargeting.WIRE_KEY) as? JsonNode)?.let { return it }
+      c = c.parent
+    }
+    return null
   }
 
   private fun scheduleRefresh(delayMs: Int = 350) {
@@ -161,10 +175,15 @@ private class YamlPagePreviewEditor(
     }
   }
 
+  // The wire root of the last rendered preview — the tree drop targeting searches for a widget's path.
+  @Volatile
+  private var lastRoot: JsonNode? = null
+
   private fun renderIncrement(increment: JsonNode): JComponent {
     val fragment = increment.path("fragments").firstOrNull() ?: return hint("Nothing to preview.")
     val component = fragment.path("component")
     if (component.isMissingNode || component.isNull) return hint("Nothing to preview.")
+    lastRoot = component
     val state = fragment.path("state")
     val data = fragment.path("data")
     val ctx = AppContext(session)

--- a/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/ui/ComponentRenderer.kt
+++ b/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/ui/ComponentRenderer.kt
@@ -17,11 +17,15 @@ class ComponentRenderer(val ctx: AppContext) {
 
     fun render(component: JsonNode?, state: JsonNode, data: JsonNode): JComponent {
         if (component == null || component.isNull || component.isMissingNode) return JPanel()
-        return when (component.text("type", "ClientSide")) {
+        val widget = when (component.text("type", "ClientSide")) {
             "ClientSide" -> renderClientSide(component, state, data)
             "ServerSide" -> ctx.loadServerSideComponent(component)
             else -> JBLabel("Unknown component type: ${component.text("type")}")
         }
+        // Tag the widget with the wire component it rendered, so the visual-builder preview can map a
+        // drop back to its YAML source (see DropTargeting). Unused/harmless outside the builder.
+        widget.putClientProperty(io.mateu.ijp.contract.DropTargeting.WIRE_KEY, component)
+        return widget
     }
 
     private fun renderClientSide(component: JsonNode, state: JsonNode, data: JsonNode): JComponent {

--- a/frontend/app/intellij-plugin/src/test/kotlin/io/mateu/ijp/contract/DropTargetingTest.kt
+++ b/frontend/app/intellij-plugin/src/test/kotlin/io/mateu/ijp/contract/DropTargetingTest.kt
@@ -1,0 +1,46 @@
+package io.mateu.ijp.contract
+
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
+
+/** Verifies the precise-drop insertion point: a component lands as a sibling of the wire node at a
+ *  given child-index path, not just at the page root. */
+class DropTargetingTest : LightJavaCodeInsightFixtureTestCase() {
+
+  private val page = """
+    modelView: demo.X
+    layout:
+      type: VerticalLayout
+      content:
+        - type: Text
+          text: "A"
+        - type: Text
+          text: "B"
+  """.trimIndent()
+
+  /** Applies the computed insertion to the current text and returns the result. */
+  private fun applied(path: List<Int>): String {
+    myFixture.configureByText("page.yaml", page)
+    val doc = myFixture.editor.document
+    val insertion =
+      DropTargeting.insertionAtPath(project, myFixture.file.virtualFile, doc, path, "- type: Button")!!
+    return doc.text.substring(0, insertion.first) + insertion.second + doc.text.substring(insertion.first)
+  }
+
+  fun testDroppingOnTheFirstChildInsertsAfterIt() {
+    val text = applied(listOf(0))
+    // the new Button lands between A and B
+    assertTrue(text.indexOf("Button") > text.indexOf("\"A\""))
+    assertTrue(text.indexOf("Button") < text.indexOf("\"B\""))
+  }
+
+  fun testDroppingOnTheSecondChildInsertsAfterIt() {
+    val text = applied(listOf(1))
+    assertTrue(text.indexOf("Button") > text.indexOf("\"B\""))
+  }
+
+  fun testEmptyPathAppendsAtTheRoot() {
+    val text = applied(emptyList())
+    // appended after the last item
+    assertTrue(text.indexOf("Button") > text.indexOf("\"B\""))
+  }
+}

--- a/frontend/app/intellij-plugin/src/test/kotlin/io/mateu/ijp/contract/PaletteSnippetsTest.kt
+++ b/frontend/app/intellij-plugin/src/test/kotlin/io/mateu/ijp/contract/PaletteSnippetsTest.kt
@@ -38,4 +38,14 @@ class PaletteSnippetsTest {
     assertNull(PaletteDnD.typeOf("something-else"))
     assertNull(PaletteDnD.typeOf(null))
   }
+
+  @Test
+  fun dropTargetingPathOfFindsAWireNodeByIdentity() {
+    val mapper = com.fasterxml.jackson.databind.ObjectMapper()
+    val root = mapper.readTree("""{"children":[{"id":"a"},{"children":[{"id":"b"}]}]}""")
+    val b = root.path("children").get(1).path("children").get(0)
+    assertEquals(listOf(1, 0), DropTargeting.pathOf(root, b))
+    assertEquals(emptyList<Int>(), DropTargeting.pathOf(root, root))
+    assertNull(DropTargeting.pathOf(root, mapper.readTree("{}")))
+  }
 }


### PR DESCRIPTION
El drop cae JUNTO a donde sueltas (hermano del componente objetivo), no solo al final del content raíz. El renderer etiqueta cada widget con su componente de wire (1 línea segura); al soltar se resuelve wire->path->offset YAML, con fallback a root-append cuando no alinean. Core verificado headless (pathOf + DropTargetingTest, 18 tests). 🤖 Generated with [Claude Code](https://claude.com/claude-code)