### PR TITLE
feat(contract): ModelView contract (__contract__) parity for .NET + Python

### DIFF
--- a/backend/dotnet/src/Mateu.Core/SyncHandler.cs
+++ b/backend/dotnet/src/Mateu.Core/SyncHandler.cs
@@ -19,6 +19,13 @@ public sealed class SyncHandler(MateuRegistry registry, ITranslator? translator 
         ReflectionMapper.SetCurrentAudience(
             rq.AppState.TryGetValue("audience", out var audience) ? StateString(audience) : null);
 
+        // 0b. Visual-builder contract: return the ModelView's bindable fields + actions instead of
+        // rendering — the tooling POSTs a sync request with the ModelView as serverSideType and this
+        // action (mirrors Java's __contract__ reserved action).
+        if (rq.ActionId == "__contract__" && !string.IsNullOrEmpty(rq.ServerSideType)
+            && registry.Resolve(rq.ServerSideType, rq.Route) is { } contractType)
+            return ContractResponse(contractType, rq);
+
         // 1. App shell at the root route.
         if (string.IsNullOrEmpty(rq.ActionId)
             && registry.Resolve(rq.ServerSideType, rq.Route) is { } t0
@@ -1377,6 +1384,59 @@ public sealed class SyncHandler(MateuRegistry registry, ITranslator? translator 
         UIIncrementDto.Of(
             commands: [new UICommandDto(Target(rq), "SetWindowTitle", title)],
             fragments: [new UIFragmentDto(Target(rq), StampOrStripStructure(component, rq), null, data, "Replace", null)]);
+
+    // ── ModelView contract ─────────────────────────────────────────────────────
+    private UIIncrementDto ContractResponse(Type type, RunActionRqDto rq)
+    {
+        var instance = Activator.CreateInstance(type)!;
+        BindState(instance, rq.ComponentState);
+        var component = _mapper.MapView(type, instance, rq.ConsumedRoute ?? "_empty");
+        var fields = new List<ModelViewContractDto.Field>();
+        CollectFields(component, fields);
+        var actions = component.Actions
+            .Select(a => a.Id)
+            .Where(id => !string.IsNullOrEmpty(id))
+            .Distinct()
+            .Select(id => new ModelViewContractDto.Action(id))
+            .ToList();
+        var contract = new ModelViewContractDto(type.FullName ?? "", fields, actions);
+        return new UIIncrementDto([], [], [], [], false, new Dictionary<string, object?> { ["_contract"] = contract }, null);
+    }
+
+    // A form field is the metadata of a ClientSideComponentDto — but the components themselves nest
+    // inside METADATA records (a Page/Form/Card holds its content there), not always in Children, so
+    // descend into metadata reflectively too (mirrors Java's walk + walkMetadata).
+    private static void CollectFields(ComponentDto? component, List<ModelViewContractDto.Field> fields)
+    {
+        switch (component)
+        {
+            case ClientSideComponentDto client:
+                if (client.Metadata is FormFieldMetadataDto f && !string.IsNullOrEmpty(f.FieldId)
+                    && fields.All(x => x.Id != f.FieldId))
+                    fields.Add(new ModelViewContractDto.Field(f.FieldId, f.DataType, f.Stereotype, f.Label, f.Required, f.ReadOnly));
+                if (client.Metadata is { } md) WalkMetadata(md, fields);
+                foreach (var child in client.Children) CollectFields(child, fields);
+                break;
+            case ServerSideComponentDto server:
+                foreach (var child in server.Children) CollectFields(child, fields);
+                break;
+        }
+    }
+
+    private static void WalkMetadata(object metadata, List<ModelViewContractDto.Field> fields)
+    {
+        foreach (var prop in metadata.GetType().GetProperties())
+        {
+            object? value;
+            try { value = prop.GetValue(metadata); }
+            catch { continue; }
+            if (value is ComponentDto dto)
+                CollectFields(dto, fields);
+            else if (value is System.Collections.IEnumerable seq and not string)
+                foreach (var item in seq)
+                    if (item is ComponentDto d) CollectFields(d, fields);
+        }
+    }
 
     // Structure ETag / template-ref (phase b of the client structure cache): stamp a routed
     // component with a stable hash of its structure and, when the client echoed a still-matching

--- a/backend/dotnet/src/Mateu.Dtos/Wire.cs
+++ b/backend/dotnet/src/Mateu.Dtos/Wire.cs
@@ -1029,6 +1029,21 @@ public record ButtonDto(string Label, string ActionId)
     public string? Shortcut { get; init; }
 }
 
+// ── ModelView bindable contract (mirrors io.mateu.dtos.ModelViewContractDto) ────
+// The bindable surface of a ModelView — its fields (a FormField id must name one) and actions (a
+// Button actionId must name one) — delivered over the wire via the reserved "__contract__" sync
+// action, on the response's appData under "_contract". The visual-builder tooling validates a
+// YAML/visual layout against it.
+public record ModelViewContractDto(
+    string ModelView,
+    IReadOnlyList<ModelViewContractDto.Field> Fields,
+    IReadOnlyList<ModelViewContractDto.Action> Actions)
+{
+    public record Field(string Id, string? DataType, string? Stereotype, string? Label, bool Required, bool ReadOnly);
+
+    public record Action(string Id);
+}
+
 // ── Inbound request (mirrors io.mateu.dtos.RunActionRqDto) ──────────────────────
 public record RunActionRqDto
 {

--- a/backend/dotnet/test/Mateu.Tests/SyncHandlerTests.cs
+++ b/backend/dotnet/test/Mateu.Tests/SyncHandlerTests.cs
@@ -831,6 +831,24 @@ public class SyncHandlerTests
     }
 
     [Fact]
+    public void Contract_action_returns_the_bindable_fields_and_actions_on_appdata()
+    {
+        var inc = Handler().Handle(new RunActionRqDto
+        {
+            ActionId = "__contract__",
+            ServerSideType = typeof(SimpleForm).FullName,
+            Route = "",
+            ConsumedRoute = "_empty",
+        });
+        var json = Render(inc);
+        Assert.Contains("\"_contract\"", json);
+        Assert.Contains("\"modelView\":\"Mateu.Tests.SimpleForm\"", json);
+        Assert.Contains("\"id\":\"name\"", json); // a bindable field
+        Assert.Contains("\"dataType\":\"string\"", json);
+        Assert.Contains("\"id\":\"greet\"", json); // a bindable action
+    }
+
+    [Fact]
     public void InitialLoad_emits_window_title_and_form_with_required_name_field_and_greet_button()
     {
         var inc = Handler().Handle(new RunActionRqDto { Route = "", ConsumedRoute = "_empty" });

--- a/backend/python/mateu_core/sync_handler.py
+++ b/backend/python/mateu_core/sync_handler.py
@@ -15,6 +15,7 @@ from mateu_dtos import (
     ButtonMetadata,
     ClientSideComponent,
     CustomEventRecord,
+    FormFieldMetadata,
     DialogMetadata,
     DrawerMetadata,
     HorizontalLayoutMetadata,
@@ -132,6 +133,14 @@ class SyncHandler:
         # 0. Audience projection: the appState value under "audience" (the @app_context selector
         # named audience) filters Audience()-marked members for the whole request.
         set_current_audience(rq.app_state.get("audience"))
+
+        # 0b. Visual-builder contract: the ModelView's bindable fields + actions instead of a render
+        # (the tooling POSTs a sync request with the ModelView as serverSideType and this action;
+        # mirrors Java's __contract__ reserved action).
+        if rq.action_id == "__contract__" and rq.server_side_type:
+            cls = self.registry.resolve(rq.server_side_type, rq.route)
+            if cls is not None:
+                return self._contract_response(cls, rq)
 
         # 1. App shell at the root route.
         if not rq.action_id:
@@ -1397,6 +1406,63 @@ class SyncHandler:
             rq,
             self.lookup_labels(type_, instance, instance),
         )
+
+    # ── ModelView contract ─────────────────────────────────────────────────────
+    def _contract_response(self, cls, rq: RunActionRq) -> UIIncrement:
+        instance = cls()
+        self.bind_state(instance, rq.component_state)
+        component = self.mapper.map_view(cls, instance, rq.consumed_route or "_empty")
+        fields: list[dict] = []
+        seen: set[str] = set()
+        self._collect_fields(component, fields, seen)
+        action_ids: list[str] = []
+        for action in component.actions or []:
+            aid = getattr(action, "id", None)
+            if aid and aid not in action_ids:
+                action_ids.append(aid)
+        contract = {
+            "modelView": component.server_side_type,
+            "fields": fields,
+            "actions": [{"id": aid} for aid in action_ids],
+        }
+        return UIIncrement(app_data={"_contract": contract})
+
+    # A form field is the metadata of a ClientSideComponent — but components nest inside METADATA
+    # records too (a Page/Form/Card holds its content there), so descend into metadata as well.
+    def _collect_fields(self, component, fields: list[dict], seen: set[str]) -> None:
+        if isinstance(component, ClientSideComponent):
+            md = component.metadata
+            if isinstance(md, FormFieldMetadata) and md.field_id and md.field_id not in seen:
+                seen.add(md.field_id)
+                fields.append({
+                    "id": md.field_id,
+                    "dataType": md.data_type,
+                    "stereotype": md.stereotype,
+                    "label": md.label,
+                    "required": md.required,
+                    "readOnly": md.read_only,
+                })
+            self._walk_metadata(md, fields, seen)
+            for child in component.children:
+                self._collect_fields(child, fields, seen)
+        elif isinstance(component, ServerSideComponent):
+            for child in component.children:
+                self._collect_fields(child, fields, seen)
+
+    def _walk_metadata(self, md, fields: list[dict], seen: set[str]) -> None:
+        if md is None:
+            return
+        for name in getattr(type(md), "model_fields", {}):
+            try:
+                value = getattr(md, name)
+            except Exception:
+                continue
+            if isinstance(value, (ClientSideComponent, ServerSideComponent)):
+                self._collect_fields(value, fields, seen)
+            elif isinstance(value, list):
+                for item in value:
+                    if isinstance(item, (ClientSideComponent, ServerSideComponent)):
+                        self._collect_fields(item, fields, seen)
 
     def run_action(self, type_, instance, rq: RunActionRq) -> UIIncrement:
         name = self._resolve_action(type_, rq.action_id)

--- a/backend/python/tests/test_sync_handler.py
+++ b/backend/python/tests/test_sync_handler.py
@@ -823,6 +823,24 @@ def test_a_static_view_is_never_omitted_even_when_the_hash_matches():
     assert _component_of(inc).static_view is True
 
 
+def test_contract_action_returns_bindable_fields_and_actions_on_app_data():
+    inc = handler().handle(
+        RunActionRq(
+            route="",
+            consumed_route="_empty",
+            action_id="__contract__",
+            server_side_type=_name(SimpleForm),
+        )
+    )
+    assert inc.app_data is not None
+    contract = inc.app_data["_contract"]
+    by_id = {f["id"]: f for f in contract["fields"]}
+    assert "name" in by_id
+    assert by_id["name"]["dataType"] == "string"
+    assert by_id["name"]["required"] is True
+    assert "greet" in [a["id"] for a in contract["actions"]]
+
+
 def test_initial_load_form_with_required_field_and_button():
     inc = handler().handle(RunActionRq(route="", consumed_route="_empty"))
     j = render(inc)

--- a/doc/src/content/docs/reference/parity.md
+++ b/doc/src/content/docs/reference/parity.md
@@ -58,6 +58,7 @@ for the surface below (verified by golden-JSON tests in `backend/dotnet/test` an
 | Global entity search (`GlobalSearchSupplier` → `globalSearchEnabled` + `_globalsearch`) | ✅ | ✅ | ✅ |
 | Dialog/Drawer overlays from actions + `closeModal`/`dispatchEvent` | ✅ | ✅ | ✅ |
 | Structure ETag / template-ref (`structureHash` + request `knownStructureHash` → omit the component when unchanged) | ✅ | ✅ | ✅ |
+| ModelView bindable contract (`__contract__` sync action → fields + actions on `appData._contract`, for the visual-builder tooling) | ✅ | ✅ | ✅ |
 | Static-view skip (`@StaticView`/`[StaticView]`/`@static_view` → `staticView` flag; client caches the full response for the session and skips the round-trip on return) | ✅ | ✅ | ✅ |
 | Sticky sections index (`@Toc`) | ✅ | ✅ | ✅ |
 | Client-side rules (`@Hidden(expr)`/`@Disabled`/rule supplier) | ✅ | ✅ | ✅ |


### PR DESCRIPTION
El contrato bindable del visual builder ahora tiene paridad .NET/Python: el plugin puede validar ModelViews de esos backends vía `__contract__` (sin PSI de Java). .NET (ModelViewContractDto + ContractResponse/CollectFields/WalkMetadata, 238 verde) + Python (_contract_response/_collect_fields, 237 verde). Gotcha: form fields anidan en metadata → walker reflexivo. parity.md fila añadida. Pendiente: carga YAML + __preview__. 🤖 Generated with [Claude Code](https://claude.com/claude-code)