### PR TITLE
Port __preview__ to .NET and Python (visual-builder live preview)

### DIFF
--- a/backend/dotnet/src/Mateu.Core/Mateu.Core.csproj
+++ b/backend/dotnet/src/Mateu.Core/Mateu.Core.csproj
@@ -9,4 +9,7 @@
     <ProjectReference Include="../Mateu.Uidl/Mateu.Uidl.csproj" />
     <ProjectReference Include="../Mateu.Dtos/Mateu.Dtos.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="YamlDotNet" Version="18.1.0" />
+  </ItemGroup>
 </Project>

--- a/backend/dotnet/src/Mateu.Core/SyncHandler.cs
+++ b/backend/dotnet/src/Mateu.Core/SyncHandler.cs
@@ -26,6 +26,16 @@ public sealed class SyncHandler(MateuRegistry registry, ITranslator? translator 
             && registry.Resolve(rq.ServerSideType, rq.Route) is { } contractType)
             return ContractResponse(contractType, rq);
 
+        // 0c. Visual-builder live preview: render arbitrary YAML page text (the plugin's preview pane
+        // POSTs the editor buffer under _yaml). No ModelView binding — layout only (mirrors Java's
+        // __preview__ reserved action / YamlUidlLoader.parseText).
+        if (rq.ActionId == "__preview__" && rq.Parameters.TryGetValue("_yaml", out var yamlParam))
+        {
+            var previewTree = YamlComponentBuilder.Parse(StateString(yamlParam) ?? "")
+                              ?? new Text("Invalid YAML");
+            return FragmentResponse("Preview", ComponentMapper.Map(previewTree), rq);
+        }
+
         // 1. App shell at the root route.
         if (string.IsNullOrEmpty(rq.ActionId)
             && registry.Resolve(rq.ServerSideType, rq.Route) is { } t0

--- a/backend/dotnet/src/Mateu.Core/YamlComponentBuilder.cs
+++ b/backend/dotnet/src/Mateu.Core/YamlComponentBuilder.cs
@@ -1,0 +1,70 @@
+using Mateu.Uidl;
+using YamlDotNet.Serialization;
+
+namespace Mateu.Core;
+
+/// <summary>
+/// Builds a fluent component tree from YAML page text — the visual-builder live preview (mirrors
+/// Java's YamlUidlLoader.parseText). The YAML uses a `type` discriminator; this dispatches on it and
+/// reads the YAML keys into the fluent components (handling the name differences: a FormField's
+/// `id` → FieldId, a Text's `text` → Content). Envelope-aware: unwraps a `layout:` key. The tree is
+/// then mapped to the wire by the normal <see cref="ComponentMapper"/>.
+/// </summary>
+public static class YamlComponentBuilder
+{
+    private static readonly IDeserializer Yaml = new DeserializerBuilder().Build();
+
+    public static IComponent? Parse(string yaml)
+    {
+        if (string.IsNullOrWhiteSpace(yaml)) return null;
+        object? root;
+        try { root = Yaml.Deserialize<object>(yaml); }
+        catch { return null; }
+        // Page envelope: render the layout; a bare component tree renders as-is.
+        if (root is IDictionary<object, object> map && map.TryGetValue("layout", out var layout))
+            return Build(layout);
+        return Build(root);
+    }
+
+    private static IComponent? Build(object? node)
+    {
+        if (node is not IDictionary<object, object> map) return null;
+        return Str(map, "type") switch
+        {
+            "VerticalLayout" => new VerticalLayout { Spacing = Bool(map, "spacing"), Content = Children(map) },
+            "HorizontalLayout" => new HorizontalLayout { Spacing = Bool(map, "spacing", true), Content = Children(map) },
+            // .NET has no standalone FormLayout fluent — a stacked VerticalLayout is a faithful preview.
+            "FormLayout" => new VerticalLayout { Content = Children(map) },
+            "FormField" => new FormField
+            {
+                FieldId = Str(map, "id") ?? "",
+                DataType = Str(map, "dataType") ?? "string",
+                Label = Str(map, "label"),
+                Stereotype = Str(map, "stereotype") ?? "regular",
+                Required = Bool(map, "required"),
+            },
+            "Button" => new Button(Str(map, "label") ?? "", Str(map, "actionId") ?? "")
+            {
+                Primary = Str(map, "buttonStyle") == "primary",
+            },
+            "Text" => new Text(Str(map, "text") ?? ""),
+            var other => new Text($"Unsupported component: {other}"),
+        };
+    }
+
+    private static IReadOnlyList<IComponent> Children(IDictionary<object, object> map)
+    {
+        if (!map.TryGetValue("content", out var content) || content is not IEnumerable<object> seq)
+            return [];
+        return seq.Select(Build).Where(c => c is not null).Cast<IComponent>().ToList();
+    }
+
+    private static string? Str(IDictionary<object, object> map, string key)
+        => map.TryGetValue(key, out var v) ? v?.ToString() : null;
+
+    private static bool Bool(IDictionary<object, object> map, string key, bool def = false)
+    {
+        var s = Str(map, key);
+        return s is null ? def : s.Equals("true", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/backend/dotnet/test/Mateu.Tests/SyncHandlerTests.cs
+++ b/backend/dotnet/test/Mateu.Tests/SyncHandlerTests.cs
@@ -849,6 +849,53 @@ public class SyncHandlerTests
     }
 
     [Fact]
+    public void Preview_action_renders_arbitrary_yaml_page_text()
+    {
+        const string yaml = """
+            type: VerticalLayout
+            spacing: true
+            content:
+              - type: Text
+                text: "Hi"
+              - type: FormField
+                id: email
+                dataType: string
+                label: "Email"
+                required: true
+              - type: Button
+                label: "Save"
+                actionId: "save"
+                buttonStyle: primary
+            """;
+        var inc = Handler().Handle(new RunActionRqDto
+        {
+            ActionId = "__preview__",
+            Route = "",
+            ConsumedRoute = "_empty",
+            Parameters = new() { ["_yaml"] = JsonSerializer.SerializeToElement(yaml) },
+        });
+        var json = Render(inc);
+        Assert.Contains("\"type\":\"VerticalLayout\"", json);
+        Assert.Contains("\"type\":\"Text\"", json);
+        Assert.Contains("\"fieldId\":\"email\"", json); // YAML id → wire fieldId
+        Assert.Contains("\"required\":true", json);
+        Assert.Contains("\"actionId\":\"save\"", json);
+    }
+
+    [Fact]
+    public void Preview_action_on_invalid_yaml_renders_a_notice_instead_of_failing()
+    {
+        var inc = Handler().Handle(new RunActionRqDto
+        {
+            ActionId = "__preview__",
+            Route = "",
+            ConsumedRoute = "_empty",
+            Parameters = new() { ["_yaml"] = JsonSerializer.SerializeToElement(":\n  - broken: [") },
+        });
+        Assert.NotNull(inc.Fragments[0].Component); // a notice fragment, not an exception
+    }
+
+    [Fact]
     public void InitialLoad_emits_window_title_and_form_with_required_name_field_and_greet_button()
     {
         var inc = Handler().Handle(new RunActionRqDto { Route = "", ConsumedRoute = "_empty" });

--- a/backend/python/mateu_core/sync_handler.py
+++ b/backend/python/mateu_core/sync_handler.py
@@ -142,6 +142,12 @@ class SyncHandler:
             if cls is not None:
                 return self._contract_response(cls, rq)
 
+        # 0c. Visual-builder live preview: render arbitrary YAML page text (the plugin's preview
+        # pane POSTs the editor buffer under _yaml). No ModelView binding — layout only (mirrors
+        # Java's __preview__ reserved action / YamlUidlLoader.parseText).
+        if rq.action_id == "__preview__" and rq.parameters.get("_yaml"):
+            return self._preview_response(rq.parameters["_yaml"], rq)
+
         # 1. App shell at the root route.
         if not rq.action_id:
             t0 = self.registry.resolve(rq.server_side_type, rq.route)
@@ -1406,6 +1412,14 @@ class SyncHandler:
             rq,
             self.lookup_labels(type_, instance, instance),
         )
+
+    # ── Visual-builder live preview ────────────────────────────────────────────
+    def _preview_response(self, yaml_text: str, rq: RunActionRq) -> UIIncrement:
+        from mateu_core.yaml_preview import build_from_yaml
+        from mateu_uidl import components as fluent
+
+        tree = build_from_yaml(yaml_text) or fluent.Text(text="Invalid YAML")
+        return self.fragment_response("Preview", self.mapper.map_component(tree), rq)
 
     # ── ModelView contract ─────────────────────────────────────────────────────
     def _contract_response(self, cls, rq: RunActionRq) -> UIIncrement:

--- a/backend/python/mateu_core/yaml_preview.py
+++ b/backend/python/mateu_core/yaml_preview.py
@@ -1,0 +1,65 @@
+"""Builds a fluent component tree from YAML page text — the visual-builder live preview
+(mirrors Java's YamlUidlLoader.parseText and the .NET YamlComponentBuilder).
+
+The YAML uses a ``type`` discriminator; :func:`build_from_yaml` dispatches on it and reads the
+YAML keys into the fluent dataclasses, handling the name differences: a FormField's ``id`` →
+``field_id``. Envelope-aware — a page with a ``layout:`` key renders that layout. The tree is
+then mapped to the wire by the normal ``ReflectionMapper.map_component``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import yaml
+
+from mateu_uidl import components as fluent
+
+
+def build_from_yaml(text: str) -> fluent.Component | None:
+    """Parse YAML page text and build a fluent component tree (or ``None`` on failure)."""
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError:
+        return None
+    if isinstance(data, dict) and "layout" in data:
+        data = data["layout"]  # page envelope → render the layout
+    return _build(data)
+
+
+def _build(node: Any) -> fluent.Component | None:
+    if not isinstance(node, dict):
+        return None
+    kind = node.get("type")
+    if kind == "VerticalLayout":
+        return fluent.VerticalLayout(content=_children(node), spacing=bool(node.get("spacing", False)))
+    if kind == "HorizontalLayout":
+        return fluent.HorizontalLayout(content=_children(node), spacing=bool(node.get("spacing", True)))
+    if kind == "FormLayout":
+        # Python has no standalone FormLayout fluent — a stacked VerticalLayout is a faithful preview.
+        return fluent.VerticalLayout(content=_children(node))
+    if kind == "FormField":
+        return fluent.FormField(
+            field_id=node.get("id", ""),  # YAML id → wire binding key field_id
+            data_type=node.get("dataType", "string"),
+            label=node.get("label"),
+            stereotype=node.get("stereotype", "regular"),
+            required=bool(node.get("required", False)),
+            read_only=bool(node.get("readOnly", False)),
+        )
+    if kind == "Button":
+        return fluent.Button(
+            label=node.get("label", ""),
+            action_id=node.get("actionId", ""),
+            button_style="primary" if node.get("buttonStyle") == "primary" else None,
+        )
+    if kind == "Text":
+        return fluent.Text(text=node.get("text", ""))
+    return fluent.Text(text=f"Unsupported component: {kind}")
+
+
+def _children(node: dict) -> tuple:
+    content = node.get("content")
+    if not isinstance(content, list):
+        return ()
+    return tuple(c for c in (_build(item) for item in content) if c is not None)

--- a/backend/python/pyproject.toml
+++ b/backend/python/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Mateu server-side for Python — annotate Python classes; any Mateu renderer renders them."
 requires-python = ">=3.11"
 license = { text = "Apache-2.0" }
-dependencies = ["fastapi>=0.110", "uvicorn>=0.27", "pydantic>=2.6"]
+dependencies = ["fastapi>=0.110", "uvicorn>=0.27", "pydantic>=2.6", "pyyaml>=6"]
 
 [project.optional-dependencies]
 dev = ["pytest>=8", "httpx>=0.27"]

--- a/backend/python/tests/test_sync_handler.py
+++ b/backend/python/tests/test_sync_handler.py
@@ -841,6 +841,50 @@ def test_contract_action_returns_bindable_fields_and_actions_on_app_data():
     assert "greet" in [a["id"] for a in contract["actions"]]
 
 
+def test_preview_action_renders_arbitrary_yaml_page_text():
+    yaml_text = """
+type: VerticalLayout
+spacing: true
+content:
+  - type: Text
+    text: "Hi"
+  - type: FormField
+    id: email
+    dataType: string
+    label: "Email"
+    required: true
+  - type: Button
+    label: "Save"
+    actionId: "save"
+    buttonStyle: primary
+"""
+    inc = handler().handle(
+        RunActionRq(
+            route="",
+            consumed_route="_empty",
+            action_id="__preview__",
+            parameters={"_yaml": yaml_text},
+        )
+    )
+    j = render(inc)
+    assert '"VerticalLayout"' in j
+    assert '"email"' in j  # YAML id → wire fieldId
+    assert '"save"' in j
+    assert '"required": true' in j or '"required":true' in j
+
+
+def test_preview_action_on_invalid_yaml_renders_a_notice_instead_of_failing():
+    inc = handler().handle(
+        RunActionRq(
+            route="",
+            consumed_route="_empty",
+            action_id="__preview__",
+            parameters={"_yaml": ":\n  - broken: ["},
+        )
+    )
+    assert inc.fragments[0].component is not None
+
+
 def test_initial_load_form_with_required_field_and_button():
     inc = handler().handle(RunActionRq(route="", consumed_route="_empty"))
     j = render(inc)


### PR DESCRIPTION
Ports the visual-builder **live preview** backend piece to Mateu.NET and the Python backend so the IntelliJ plugin's preview pane works against non-Java backends.

## What
The plugin POSTs the YAML editor buffer under `_yaml` with the reserved `__preview__` action; the handler parses the YAML page text and renders it (layout only, no ModelView binding), mirroring Java's `YamlUidlLoader.parseText`.

- **.NET** — `YamlComponentBuilder` parses YAML (YamlDotNet) into a fluent component tree, dispatching on the `type` discriminator and mapping YAML keys to fluent properties (FormField `id` → `FieldId`, Text `text` → `Content`, `FormLayout` → `VerticalLayout` — .NET has no standalone FormLayout fluent). Reuses `ComponentMapper.Map`. Hooked next to `__contract__` in `SyncHandler`.
- **Python** — `mateu_core/yaml_preview.build_from_yaml` (PyYAML) builds the frozen-dataclass fluent tree (`id` → `field_id`, `content` → tuple), reuses `ReflectionMapper.map_component`. Hooked in `sync_handler.handle`.

Both are envelope-aware (unwrap a `layout:` key) and degrade an unparseable buffer to an "Invalid YAML" notice instead of failing.

## Tests
- .NET: 240/240 (+2 preview)
- Python: 239 (+2 preview)

🤖 Generated with [Claude Code](https://claude.com/claude-code)