### PR TITLE
Port route-based YAML pages (modelView binding) to .NET and Python

### DIFF
--- a/backend/dotnet/src/Mateu.Core/MateuRegistry.cs
+++ b/backend/dotnet/src/Mateu.Core/MateuRegistry.cs
@@ -8,12 +8,14 @@ public sealed class MateuRegistry
 {
     private readonly Dictionary<string, Type> _byRoute = new();
     private readonly Dictionary<string, Type> _byName = new();
+    private readonly Assembly[] _assemblies;
 
     public Type? AppType { get; }
 
     public MateuRegistry(params Assembly[] assemblies)
     {
         var asms = assemblies.Length > 0 ? assemblies : [Assembly.GetEntryAssembly()!];
+        _assemblies = asms;
         foreach (var asm in asms)
         foreach (var type in asm.GetTypes())
         {
@@ -37,6 +39,15 @@ public sealed class MateuRegistry
         var norm = Normalize(route);
         if (_byRoute.TryGetValue(norm, out var r)) return r;
         return norm == "" ? AppType : null;
+    }
+
+    /// <summary>Resolves any type by full name across the scanned assemblies — used to instantiate a
+    /// YAML page's declared <c>modelView:</c> logic class, which need not carry [UI]/[App].</summary>
+    public Type? TypeByName(string? fullName)
+    {
+        if (string.IsNullOrEmpty(fullName)) return null;
+        if (_byName.TryGetValue(fullName, out var known)) return known;
+        return _assemblies.Select(a => a.GetType(fullName)).FirstOrDefault(t => t is not null);
     }
 
     /// <summary>Finds the registered view whose route is the longest prefix of <paramref name="route"/>

--- a/backend/dotnet/src/Mateu.Core/ReflectionMapper.cs
+++ b/backend/dotnet/src/Mateu.Core/ReflectionMapper.cs
@@ -229,7 +229,7 @@ public sealed class ReflectionMapper(ITranslator? translator = null, Func<Identi
         return new MenuItemDto(T(label), route, viewType.FullName!) { ConsumedRoute = route };
     }
 
-    public ServerSideComponentDto MapView(Type type, object instance, string route)
+    public ServerSideComponentDto MapView(Type type, object instance, string route, IComponent? layoutOverride = null)
     {
         var crudElement = CrudElementType(type);
         if (crudElement is not null) return MapCrud(type, crudElement, route, instance);
@@ -260,11 +260,15 @@ public sealed class ReflectionMapper(ITranslator? translator = null, Func<Identi
         // is composed as it — the C# analogue of Java's InferredDashboard/InferredWelcome. The
         // welcome hero title is the declared [Title]; subtitle/image have no declarative source,
         // so setting them remains a reason to subclass Welcome.
-        var tree = instance is IComponentTreeSupplier supplier ? supplier.Component()
+        // A YAML page's layout (bound to this instance as its ModelView) is rendered as the page
+        // content exactly like an archetype's fluent tree — its FormField ids bind to the instance's
+        // state, its Button actionIds (collected below) route back to the instance's methods.
+        var tree = layoutOverride
+            ?? (instance is IComponentTreeSupplier supplier ? supplier.Component()
             : PageInference.ComposesDashboard(type) ? ArchetypeComposers.ComposeDashboard(instance, 0)
             : PageInference.ComposesWelcome(type)
                 ? ArchetypeComposers.ComposeWelcome(instance, type.Find<TitleAttribute>()?.Value, null, null)
-                : null;
+                : null);
         if (tree is not null)
         {
             content = [ComponentMapper.Map(tree)];
@@ -307,10 +311,11 @@ public sealed class ReflectionMapper(ITranslator? translator = null, Func<Identi
 
         var (triggers, emits) = EventsOf(type);
         var initialData = new Dictionary<string, object?>();
-        if (instance is IComponentTreeSupplier)
+        if (instance is IComponentTreeSupplier || layoutOverride is not null)
         {
-            // Tree-supplier views (archetypes): scalar properties are the view's state — seed
-            // them into initialData so they round-trip through componentState (search text,
+            // Tree-supplier views (archetypes) and YAML-bound modelViews: scalar properties are the
+            // view's state — seed them into initialData so they round-trip through componentState
+            // (a YAML FormField id="name" reads its value from the seeded "name", search text,
             // selection, switcher value…).
             foreach (var p in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
             {

--- a/backend/dotnet/src/Mateu.Core/SyncHandler.cs
+++ b/backend/dotnet/src/Mateu.Core/SyncHandler.cs
@@ -11,6 +11,7 @@ namespace Mateu.Core;
 public sealed class SyncHandler(MateuRegistry registry, ITranslator? translator = null, Func<Identity?>? identity = null)
 {
     private readonly ReflectionMapper _mapper = new(translator, identity);
+    private readonly YamlSpecLoader _yaml = new();
 
     public UIIncrementDto Handle(RunActionRqDto rq, string? requestBaseUrl = null)
     {
@@ -54,7 +55,23 @@ public sealed class SyncHandler(MateuRegistry registry, ITranslator? translator 
             return HandleCapabilityListing(cap.Profile, cap.BaseRoute, rq);
 
         var type = registry.Resolve(rq.ServerSideType, rq.Route);
+        var yamlSpec = _yaml.LoadSpec(rq.Route);
+        if (type is null && yamlSpec is not null)
+        {
+            // A route with no view class → a YAML page. A bare layout renders as a static, unbound
+            // page; a page that declares modelView: instantiates that logic class (state + actions)
+            // and renders the YAML layout bound to it (mirrors Java's ActionInstanceCreator.loadYaml).
+            if (string.IsNullOrEmpty(yamlSpec.ModelView))
+                return yamlSpec.Layout is { } bare
+                    ? FragmentResponse(rq.Route ?? "", ComponentMapper.Map(bare), rq)
+                    : Error($"Route not found: {rq.Route}");
+            type = registry.TypeByName(yamlSpec.ModelView);
+        }
         if (type is null) return Error($"Route not found: {rq.Route}");
+        // A YAML page bound to this modelView re-applies its layout on every render (first load AND
+        // any in-place re-render) so the layout stays authoritative (mirrors Java's
+        // ReflectionObjectToComponentMapper.layoutForRoute).
+        var layoutOverride = yamlSpec?.ModelView == type.FullName ? yamlSpec!.Layout : null;
 
         // 2b. A declarative Listing — a read-only searchable listing with typed filters.
         if (ReflectionMapper.ListingTypes(type) is { } listing)
@@ -146,7 +163,7 @@ public sealed class SyncHandler(MateuRegistry registry, ITranslator? translator 
                 return Render(type, instance, rq);
             }
         }
-        return string.IsNullOrEmpty(rq.ActionId) ? Render(type, instance, rq) : RunAction(type, instance, rq);
+        return string.IsNullOrEmpty(rq.ActionId) ? Render(type, instance, rq, layoutOverride) : RunAction(type, instance, rq);
     }
 
     private UIIncrementDto HandleWizard(Type type, RunActionRqDto rq)
@@ -1317,10 +1334,10 @@ public sealed class SyncHandler(MateuRegistry registry, ITranslator? translator 
             commands: [new UICommandDto(Target(rq), "SetWindowTitle", title)],
             fragments: [new UIFragmentDto(Target(rq), _mapper.MapApp(appType, requestBaseUrl), null, null, "Replace", null)]);
 
-    private UIIncrementDto Render(Type type, object instance, RunActionRqDto rq)
+    private UIIncrementDto Render(Type type, object instance, RunActionRqDto rq, IComponent? layoutOverride = null)
     {
         var route = string.IsNullOrEmpty(rq.ConsumedRoute) ? "_empty" : rq.ConsumedRoute!;
-        return FragmentResponse(Title(type), _mapper.MapView(type, instance, route), rq,
+        return FragmentResponse(Title(type), _mapper.MapView(type, instance, route, layoutOverride), rq,
             LookupLabels(type, instance, instance));
     }
 

--- a/backend/dotnet/src/Mateu.Core/YamlComponentBuilder.cs
+++ b/backend/dotnet/src/Mateu.Core/YamlComponentBuilder.cs
@@ -26,6 +26,23 @@ public static class YamlComponentBuilder
         return Build(root);
     }
 
+    /// <summary>
+    /// Parse a page spec (a file under specs/ui): the declared ModelView class name (or null for a
+    /// bare, unbound layout) plus the layout component. Envelope-aware — a `layout:` key holds the
+    /// tree and a `modelView:` key names the logic class the tooling binds it to.
+    /// </summary>
+    public static (string? ModelView, IComponent? Layout) ParseSpec(string yaml)
+    {
+        if (string.IsNullOrWhiteSpace(yaml)) return (null, null);
+        object? root;
+        try { root = Yaml.Deserialize<object>(yaml); }
+        catch { return (null, null); }
+        if (root is not IDictionary<object, object> map) return (null, Build(root));
+        var modelView = map.TryGetValue("modelView", out var mv) ? mv?.ToString() : null;
+        var layoutNode = map.TryGetValue("layout", out var layout) ? layout : root;
+        return (modelView, Build(layoutNode));
+    }
+
     private static IComponent? Build(object? node)
     {
         if (node is not IDictionary<object, object> map) return null;

--- a/backend/dotnet/src/Mateu.Core/YamlSpecLoader.cs
+++ b/backend/dotnet/src/Mateu.Core/YamlSpecLoader.cs
@@ -1,0 +1,60 @@
+using System.Collections.Concurrent;
+using Mateu.Uidl;
+
+namespace Mateu.Core;
+
+/// <summary>
+/// Loads a page defined in a YAML file under <c>specs/ui/</c> relative to the working directory —
+/// the .NET analogue of Java's classpath-based YamlUidlLoader. A spec is a component tree, optionally
+/// wrapped in an envelope with a <c>modelView:</c> key naming the logic class that supplies state and
+/// actions (the YAML supplies only the layout). The binding is by convention, as everywhere in Mateu:
+/// a FormField <c>id="name"</c> binds to the ModelView's <c>Name</c> property, a Button
+/// <c>actionId="save"</c> to its <c>Save()</c> method.
+/// </summary>
+/// <remarks>
+/// Specs are static files, so each route is parsed once and cached (a miss is cached too, so an
+/// unmatched route — checked on every request that has no view class — does not stat the disk each
+/// time). Editing a spec during development needs a restart to be picked up. Override the specs
+/// directory with the MATEU_SPECS_DIR environment variable (default: <c>specs/ui</c> under the cwd).
+/// </remarks>
+public sealed class YamlSpecLoader
+{
+    /// <summary>A parsed page spec: the layout, plus the ModelView class name when the YAML declares one.</summary>
+    public sealed record Spec(string? ModelView, IComponent? Layout);
+
+    private static readonly Spec None = new(null, null);
+    private readonly ConcurrentDictionary<string, Spec> _byRoute = new();
+    private readonly string _dir;
+
+    public YamlSpecLoader(string? dir = null)
+        => _dir = dir ?? Environment.GetEnvironmentVariable("MATEU_SPECS_DIR")
+                       ?? Path.Combine("specs", "ui");
+
+    /// <summary>The parsed spec for a route (<c>specs/ui/&lt;route&gt;.yaml</c>), or null when there is none.</summary>
+    public Spec? LoadSpec(string? route)
+    {
+        var spec = _byRoute.GetOrAdd(Normalize(route), Parse);
+        return ReferenceEquals(spec, None) ? null : spec;
+    }
+
+    private Spec Parse(string normalizedRoute)
+    {
+        var path = Path.Combine(_dir, normalizedRoute + ".yaml");
+        if (!File.Exists(path)) return None;
+        try
+        {
+            var (modelView, layout) = YamlComponentBuilder.ParseSpec(File.ReadAllText(path));
+            return layout is null ? None : new Spec(modelView, layout);
+        }
+        catch { return None; }
+    }
+
+    private static string Normalize(string? route)
+    {
+        var r = route ?? "";
+        var q = r.IndexOf('?');
+        if (q >= 0) r = r[..q];
+        r = r.Trim('/');
+        return r is "_empty" or "_no_route" or "_no_home_route" ? "" : r;
+    }
+}

--- a/backend/dotnet/test/Mateu.Tests/SyncHandlerTests.cs
+++ b/backend/dotnet/test/Mateu.Tests/SyncHandlerTests.cs
@@ -25,6 +25,15 @@ public class StaticViewForm
     public string? Heading { get; set; } = "About";
 }
 
+// A plain logic class (no [UI]): a YAML page under specs/ui declares it as its modelView, so the
+// YAML supplies the layout while this supplies the state (Name) and the action (Greet), bound by
+// convention (FormField id="name" → Name, Button actionId="greet" → Greet()).
+public class YamlBoundView
+{
+    public string? Name { get; set; } = "seed";
+    public Message Greet() => new($"Hello {Name}!");
+}
+
 // Per-action transport knobs: two buttons that differ only in how the CLIENT should call them.
 [UI("action-options"), Title("Action options")]
 public class ActionOptionsForm
@@ -893,6 +902,48 @@ public class SyncHandlerTests
             Parameters = new() { ["_yaml"] = JsonSerializer.SerializeToElement(":\n  - broken: [") },
         });
         Assert.NotNull(inc.Fragments[0].Component); // a notice fragment, not an exception
+    }
+
+    [Fact]
+    public void Yaml_page_binds_its_layout_to_the_declared_modelView()
+    {
+        var dir = Path.Combine("specs", "ui");
+        Directory.CreateDirectory(dir);
+        var file = Path.Combine(dir, "yaml-bound-demo.yaml");
+        File.WriteAllText(file, """
+            modelView: Mateu.Tests.YamlBoundView
+            layout:
+              type: VerticalLayout
+              content:
+                - type: FormField
+                  id: name
+                  label: Name
+                - type: Button
+                  label: Greet
+                  actionId: greet
+            """);
+        try
+        {
+            // First load: no view class resolves the route → the YAML page binds to its modelView.
+            var json = Render(Handler().Handle(
+                new RunActionRqDto { Route = "yaml-bound-demo", ConsumedRoute = "yaml-bound-demo" }));
+            Assert.Contains("\"serverSideType\":\"Mateu.Tests.YamlBoundView\"", json);
+            Assert.Contains("\"fieldId\":\"name\"", json);   // the YAML layout's field
+            Assert.Contains("\"actionId\":\"greet\"", json); // the YAML button routes to the modelView method
+            Assert.Contains("\"seed\"", json);               // the modelView's state seeded into initialData
+
+            // Action round-trip: the button dispatches greet on the modelView (resolved by serverSideType,
+            // which carries no [UI] route — resolved by full name against the scanned assemblies).
+            var acted = Handler().Handle(new RunActionRqDto
+            {
+                Route = "yaml-bound-demo",
+                ActionId = "greet",
+                ServerSideType = "Mateu.Tests.YamlBoundView",
+                ComponentState = new() { ["name"] = JsonSerializer.SerializeToElement("Ann") },
+            });
+            Assert.Equal("Hello Ann!", Assert.Single(acted.Messages).Text);
+        }
+        finally { File.Delete(file); }
     }
 
     [Fact]

--- a/backend/python/mateu_core/mapper.py
+++ b/backend/python/mateu_core/mapper.py
@@ -550,7 +550,7 @@ class ReflectionMapper:
         return MenuItem(label=self.T(label), route=route, server_side_type=ssn, consumed_route=route)
 
     # ── Plain view ─────────────────────────────────────────────────────────────
-    def map_view(self, cls, instance, route: str) -> ServerSideComponent:
+    def map_view(self, cls, instance, route: str, layout_override=None) -> ServerSideComponent:
         element = crud_element_type(cls)
         if element is not None:
             return self.map_crud(cls, element, route, instance)
@@ -573,7 +573,11 @@ class ReflectionMapper:
             if on_row is not None and all(a.id != camel_case(on_row.value) for a in actions):
                 actions.append(Action(id=camel_case(on_row.value), validation_required=False))
 
-        tree = self.component_tree(instance)
+        # A YAML page's layout (bound to this instance as its ModelView) renders as the page
+        # content exactly like an archetype's fluent tree — its FormField ids bind to the
+        # instance's state (seeded into initialData below), its Button actionIds (collected below)
+        # route back to the instance's methods.
+        tree = layout_override if layout_override is not None else self.component_tree(instance)
         if tree is not None:
             children = [self.map_component(tree)]
             known = {a.id for a in actions}

--- a/backend/python/mateu_core/registry.py
+++ b/backend/python/mateu_core/registry.py
@@ -45,6 +45,28 @@ class MateuRegistry:
             return self._by_route[norm]
         return self.app_type if norm == "" else None
 
+    def type_by_name(self, full_name: str | None) -> type | None:
+        """Resolve any class by full name (``module.QualName``) — used to instantiate a YAML page's
+        declared ``modelView:`` logic class, which need not be a registered @ui view."""
+        if not full_name:
+            return None
+        if full_name in self._by_name:
+            return self._by_name[full_name]
+        module_name, _, qual = full_name.rpartition(".")
+        if not module_name:
+            return None
+        try:
+            import importlib
+
+            obj = importlib.import_module(module_name)
+        except ImportError:
+            return None
+        for part in qual.split("."):
+            obj = getattr(obj, part, None)
+            if obj is None:
+                return None
+        return obj if isinstance(obj, type) else None
+
     def resolve_by_prefix(self, route: str | None) -> tuple[type, str] | None:
         """The registered view whose route is the longest prefix of ``route`` (for CRUD sub-routes)."""
         norm = normalize(route)

--- a/backend/python/mateu_core/sync_handler.py
+++ b/backend/python/mateu_core/sync_handler.py
@@ -76,7 +76,8 @@ from .mapper import (
 )
 from .naming import camel_case, humanize
 from .reflection import view_fields
-from .registry import MateuRegistry, normalize
+from .registry import MateuRegistry, normalize, type_name
+from .yaml_spec_loader import YamlSpecLoader
 
 
 def _sort_key(value):
@@ -128,6 +129,7 @@ class SyncHandler:
     def __init__(self, registry: MateuRegistry, translator=None, identity_provider=None):
         self.registry = registry
         self.mapper = ReflectionMapper(translator, identity_provider)
+        self.yaml_specs = YamlSpecLoader()
 
     def handle(self, rq: RunActionRq, request_base_url: str | None = None) -> UIIncrement:
         # 0. Audience projection: the appState value under "audience" (the @app_context selector
@@ -167,8 +169,26 @@ class SyncHandler:
             return self.handle_listing(*lst, rq)
 
         type_ = self.registry.resolve(rq.server_side_type, rq.route)
+        yaml_spec = self.yaml_specs.load_spec(rq.route)
+        if type_ is None and yaml_spec is not None:
+            # A route with no view class → a YAML page. A bare layout renders as a static, unbound
+            # page; a page that declares modelView: instantiates that logic class (state + actions)
+            # and renders the YAML layout bound to it (mirrors Java's ActionInstanceCreator.load_yaml).
+            if not yaml_spec.model_view:
+                return self.fragment_response(
+                    rq.route or "", self.mapper.map_component(yaml_spec.layout), rq
+                )
+            type_ = self.registry.type_by_name(yaml_spec.model_view)
         if type_ is None:
             return self.error(f"Route not found: {rq.route}")
+        # A YAML page bound to this modelView re-applies its layout on every render (first load AND
+        # any in-place re-render) so the layout stays authoritative (mirrors Java's
+        # ReflectionObjectToComponentMapper.layout_for_route).
+        layout_override = (
+            yaml_spec.layout
+            if yaml_spec is not None and yaml_spec.model_view == type_name(type_)
+            else None
+        )
 
         # 2b. The notification inbox's app-level actions — dispatched with the app's
         # serverSideType (the same rail as the @app_context pickers' remote search), exempt
@@ -197,7 +217,7 @@ class SyncHandler:
         if rq.action_id and rq.action_id.startswith("codesearch-"):
             return self.field_code_search(type_, rq)
         if not rq.action_id:
-            return self.render(type_, instance, rq)
+            return self.render(type_, instance, rq, layout_override)
         # 4b. Archetype in-place actions (CollectionDetail / GeneralOverview): selection, search
         # filtering and record switching mutate the bound state and re-render the tree — no
         # navigation, no method dispatch.
@@ -1404,11 +1424,11 @@ class SyncHandler:
             ]
         )
 
-    def render(self, type_, instance, rq: RunActionRq) -> UIIncrement:
+    def render(self, type_, instance, rq: RunActionRq, layout_override=None) -> UIIncrement:
         route = rq.consumed_route if rq.consumed_route else "_empty"
         return self.fragment_response(
             self.title(type_),
-            self.mapper.map_view(type_, instance, route),
+            self.mapper.map_view(type_, instance, route, layout_override),
             rq,
             self.lookup_labels(type_, instance, instance),
         )

--- a/backend/python/mateu_core/yaml_preview.py
+++ b/backend/python/mateu_core/yaml_preview.py
@@ -27,6 +27,21 @@ def build_from_yaml(text: str) -> fluent.Component | None:
     return _build(data)
 
 
+def parse_spec(text: str) -> tuple[str | None, fluent.Component | None]:
+    """Parse a page spec (a file under specs/ui): the declared ModelView class name (or ``None``
+    for a bare, unbound layout) plus the layout component. Envelope-aware — a ``layout:`` key holds
+    the tree and a ``modelView:`` key names the logic class the tooling binds it to."""
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError:
+        return None, None
+    if not isinstance(data, dict):
+        return None, _build(data)
+    model_view = data.get("modelView")
+    layout_node = data["layout"] if "layout" in data else data
+    return model_view, _build(layout_node)
+
+
 def _build(node: Any) -> fluent.Component | None:
     if not isinstance(node, dict):
         return None

--- a/backend/python/mateu_core/yaml_spec_loader.py
+++ b/backend/python/mateu_core/yaml_spec_loader.py
@@ -1,0 +1,60 @@
+"""Loads a page defined in a YAML file under ``specs/ui/`` relative to the working directory — the
+Python analogue of Java's classpath-based YamlUidlLoader and .NET's YamlSpecLoader.
+
+A spec is a component tree, optionally wrapped in an envelope with a ``modelView:`` key naming the
+logic class that supplies state and actions (the YAML supplies only the layout). The binding is by
+convention, as everywhere in Mateu: a FormField ``id="name"`` binds to the ModelView's ``name``
+attribute, a Button ``actionId="save"`` to its ``save()`` method.
+
+Specs are static files, so each route is parsed once and cached (a miss too, so an unmatched route —
+checked on every request that has no view class — does not stat the disk each time). Editing a spec
+during development needs a restart to be picked up. Override the directory with the
+``MATEU_SPECS_DIR`` environment variable (default: ``specs/ui`` under the cwd).
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from mateu_core.yaml_preview import parse_spec
+
+
+@dataclass(frozen=True)
+class Spec:
+    """A parsed page spec: the layout, plus the ModelView class name when the YAML declares one."""
+
+    model_view: str | None
+    layout: object | None
+
+
+class YamlSpecLoader:
+    def __init__(self, directory: str | None = None) -> None:
+        self._dir = Path(directory or os.environ.get("MATEU_SPECS_DIR") or Path("specs") / "ui")
+        self._by_route: dict[str, Spec | None] = {}
+
+    def load_spec(self, route: str | None) -> Spec | None:
+        key = _normalize(route)
+        if key not in self._by_route:
+            self._by_route[key] = self._parse(key)
+        return self._by_route[key]
+
+    def _parse(self, normalized_route: str) -> Spec | None:
+        path = self._dir / f"{normalized_route}.yaml"
+        if not path.is_file():
+            return None
+        try:
+            model_view, layout = parse_spec(path.read_text())
+        except OSError:
+            return None
+        return Spec(model_view, layout) if layout is not None else None
+
+
+def _normalize(route: str | None) -> str:
+    r = route or ""
+    q = r.find("?")
+    if q >= 0:
+        r = r[:q]
+    r = r.strip("/")
+    return "" if r in ("_empty", "_no_route", "_no_home_route") else r

--- a/backend/python/tests/test_sync_handler.py
+++ b/backend/python/tests/test_sync_handler.py
@@ -744,6 +744,17 @@ class Featured:
         return Message(f"Saved {self.name}")
 
 
+class YamlBoundView:
+    """A plain logic class (no @ui): a YAML page under specs/ui declares it as its modelView, so
+    the YAML supplies the layout while this supplies the state (name) and the action (greet),
+    bound by convention (FormField id="name" → name, Button actionId="greet" → greet())."""
+
+    name: str | None = "seed"
+
+    def greet(self) -> Message:
+        return Message(f"Hello {self.name}!")
+
+
 MODULE = sys.modules[__name__]
 
 
@@ -883,6 +894,50 @@ def test_preview_action_on_invalid_yaml_renders_a_notice_instead_of_failing():
         )
     )
     assert inc.fragments[0].component is not None
+
+
+def test_yaml_page_binds_its_layout_to_the_declared_modelView():
+    spec_dir = Path("specs") / "ui"
+    spec_dir.mkdir(parents=True, exist_ok=True)
+    spec_file = spec_dir / "yaml-bound-demo.yaml"
+    spec_file.write_text(
+        f"""
+modelView: {_name(YamlBoundView)}
+layout:
+  type: VerticalLayout
+  content:
+    - type: FormField
+      id: name
+      label: Name
+    - type: Button
+      label: Greet
+      actionId: greet
+"""
+    )
+    try:
+        # First load: no view class resolves the route → the YAML page binds to its modelView.
+        inc = handler().handle(
+            RunActionRq(route="yaml-bound-demo", consumed_route="yaml-bound-demo")
+        )
+        j = render(inc)
+        assert _name(YamlBoundView) in j  # serverSideType is the modelView
+        assert '"fieldId": "name"' in j or '"fieldId":"name"' in j  # the YAML layout's field
+        assert '"greet"' in j  # the YAML button routes to the modelView method
+        assert '"seed"' in j  # the modelView's state seeded into initialData
+
+        # Action round-trip: the button dispatches greet on the modelView (resolved by
+        # serverSideType, which carries no @ui route — resolved by full name).
+        acted = handler().handle(
+            RunActionRq(
+                route="yaml-bound-demo",
+                action_id="greet",
+                server_side_type=_name(YamlBoundView),
+                component_state={"name": "Ann"},
+            )
+        )
+        assert acted.messages[0].text == "Hello Ann!"
+    finally:
+        spec_file.unlink()
 
 
 def test_initial_load_form_with_required_field_and_button():

--- a/doc/src/content/docs/reference/parity.md
+++ b/doc/src/content/docs/reference/parity.md
@@ -59,6 +59,8 @@ for the surface below (verified by golden-JSON tests in `backend/dotnet/test` an
 | Dialog/Drawer overlays from actions + `closeModal`/`dispatchEvent` | ✅ | ✅ | ✅ |
 | Structure ETag / template-ref (`structureHash` + request `knownStructureHash` → omit the component when unchanged) | ✅ | ✅ | ✅ |
 | ModelView bindable contract (`__contract__` sync action → fields + actions on `appData._contract`, for the visual-builder tooling) | ✅ | ✅ | ✅ |
+| Visual-builder live preview (`__preview__` sync action → renders arbitrary YAML page text; the plugin's preview pane) | ✅ | ✅ | ✅ |
+| YAML pages bound to a ModelView (`specs/ui/<route>.yaml` with `modelView:` → the file supplies the layout, the class supplies state + actions; on the classpath in Java, under the cwd — `MATEU_SPECS_DIR` — in the ports) | ✅ | ✅ | ✅ |
 | Static-view skip (`@StaticView`/`[StaticView]`/`@static_view` → `staticView` flag; client caches the full response for the session and skips the round-trip on return) | ✅ | ✅ | ✅ |
 | Sticky sections index (`@Toc`) | ✅ | ✅ | ✅ |
 | Client-side rules (`@Hidden(expr)`/`@Disabled`/rule supplier) | ✅ | ✅ | ✅ |


### PR DESCRIPTION
Completes the visual-builder backend port. Increment 1 (`__preview__`, #331) gave live preview; this adds **route-based YAML pages bound to a ModelView**.

## What
A page can be authored as a file `specs/ui/<route>.yaml` that declares a `modelView:` class — the YAML supplies the **layout**, the class supplies **state + actions**, bound by convention (FormField `id="name"` → the modelView's `name`, Button `actionId="save"` → its `save()`). Mirrors Java's `YamlUidlLoader` + `ActionInstanceCreator.loadYaml` + `ReflectionObjectToComponentMapper.layoutForRoute`.

Where Java loads specs from the classpath, the ports load them from `specs/ui/` under the working directory (override with `MATEU_SPECS_DIR`) — the design choice confirmed for this port.

## Mechanics (both ports)
- **YamlSpecLoader** — loads + caches `specs/ui/<route>.yaml` → `(modelView, layout)`.
- **Registry.TypeByName / type_by_name** — resolves the declared modelView class by full name across the scanned assemblies (Python: `importlib`); it need not be a registered `[UI]`/`@ui` view.
- **SyncHandler fallback** — when no view class resolves the route, fall back to the spec. A bare layout renders as a static, unbound page; a modelView spec instantiates the class, binds state, and renders the YAML layout as the page content — advertising the layout's Button actionIds (so they route back) and seeding the instance's scalar state into `initialData` (so the YAML FormFields show their values). Re-applied on every render for the route (first load AND action round-trips) so it stays authoritative.
- **MapView / map_view** — a `layoutOverride` plugs into the same path as an archetype's fluent tree.

Also adds `YamlComponentBuilder.ParseSpec` / `yaml_preview.parse_spec`.

## Tests
- .NET: 241/241 (+1 YAML page: first load binds layout+state+actions, action round-trip dispatches on the modelView resolved by full name)
- Python: 240 (+1, same)
- Parity row added to `reference/parity.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)