### PR TITLE
@RestOptions — select options from an arbitrary REST endpoint (client-side)

### DIFF
--- a/backend/shared/core/src/main/java/io/mateu/core/domain/out/componentmapper/FieldMetadataExtractor.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/out/componentmapper/FieldMetadataExtractor.java
@@ -189,6 +189,34 @@ public class FieldMetadataExtractor {
     return null;
   }
 
+  /**
+   * A client-side external options source when the field carries {@code @RestOptions} — the
+   * renderer fetches the endpoint directly and maps the JSON into the select's options. Null
+   * otherwise.
+   */
+  static io.mateu.uidl.data.RestDataSource getOptionsSource(Field field) {
+    if (!MetaAnnotations.isPresent(field, RestOptions.class)) {
+      return null;
+    }
+    RestOptions a = MetaAnnotations.find(field, RestOptions.class);
+    Map<String, String> headers = new java.util.LinkedHashMap<>();
+    for (String h : a.headers()) {
+      int i = h.indexOf(':');
+      if (i > 0) {
+        headers.put(h.substring(0, i).trim(), h.substring(i + 1).trim());
+      }
+    }
+    return io.mateu.uidl.data.RestDataSource.builder()
+        .url(a.url())
+        .method(a.method())
+        .headers(headers)
+        .body(a.body())
+        .itemsPath(a.itemsPath())
+        .valuePath(a.valuePath())
+        .labelPath(a.labelPath())
+        .build();
+  }
+
   static List<Option> getOptions(Field field, Object instance, HttpRequest httpRequest) {
     if (instance instanceof OptionsSupplier optionsSupplier) {
       return optionsSupplier.options(field.getName(), httpRequest);

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/out/componentmapper/FieldTypeMapper.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/out/componentmapper/FieldTypeMapper.java
@@ -170,6 +170,10 @@ public class FieldTypeMapper {
       }
       return FieldStereotype.select;
     }
+    if (MetaAnnotations.isPresent(field, io.mateu.uidl.annotations.RestOptions.class)) {
+      // options fetched client-side from an arbitrary REST endpoint → a select
+      return FieldStereotype.select;
+    }
     if (MetaAnnotations.isPresent(field, Lookup.class)) {
       return FieldStereotype.combobox;
     }

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/out/componentmapper/StandardFormFieldBuilder.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/out/componentmapper/StandardFormFieldBuilder.java
@@ -30,6 +30,7 @@ final class StandardFormFieldBuilder {
         .max(getMax(field))
         .stepButtonsVisible(getStepButtonsVisible(field))
         .remoteCoordinates(getRemoteCoordinates(prefix, field))
+        .optionsSource(getOptionsSource(field))
         .readOnly(
             readOnly || PageFormBuilder.isReadOnly(field, instance, forCreationForm, httpRequest))
         .options(getOptions(field, instance, httpRequest))

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/mappers/FieldMapper.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/mappers/FieldMapper.java
@@ -31,6 +31,7 @@ public class FieldMapper {
             .options(formField.options().stream().map(FieldMapper::mapOption).toList())
             .treeLeavesOnly(formField.treeLeavesOnly())
             .remoteCoordinates(mapRemoteCoordinates(formField.remoteCoordinates()))
+            .optionsSource(mapRestDataSource(formField.optionsSource()))
             .initialValue(formField.initialValue())
             .readOnly(formField.readOnly())
             .required(formField.required())
@@ -94,6 +95,20 @@ public class FieldMapper {
       return null;
     }
     return new NavLinkDto(link.href(), link.icon(), link.title(), link.target());
+  }
+
+  private static RestDataSourceDto mapRestDataSource(io.mateu.uidl.data.RestDataSource source) {
+    if (source == null) {
+      return null;
+    }
+    return new RestDataSourceDto(
+        source.url(),
+        source.method(),
+        source.headers(),
+        source.body(),
+        source.itemsPath(),
+        source.valuePath(),
+        source.labelPath());
   }
 
   private static RemoteCoordinatesDto mapRemoteCoordinates(RemoteCoordinates remoteCoordinates) {

--- a/backend/shared/core/src/test/java/io/mateu/core/application/RestOptionsSyncTest.java
+++ b/backend/shared/core/src/test/java/io/mateu/core/application/RestOptionsSyncTest.java
@@ -1,0 +1,67 @@
+package io.mateu.core.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.mateu.core.testutil.TestMateu;
+import io.mateu.uidl.annotations.RestOptions;
+import io.mateu.uidl.annotations.Title;
+import io.mateu.uidl.annotations.UI;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * External REST options: a @RestOptions field renders as a select whose options the renderer
+ * fetches CLIENT-SIDE — the descriptor (url/method/headers/paths) travels on FormFieldDto.
+ * optionsSource so the frontend can call the endpoint directly (the first surface of consuming
+ * non-Mateu endpoints).
+ */
+class RestOptionsSyncTest {
+
+  @SuppressWarnings("unused")
+  @UI("/restopts")
+  @Title("Rest options")
+  public static class RestOptsForm {
+
+    @RestOptions(
+        url = "https://api.example.com/countries?token=${state.token}",
+        method = "GET",
+        headers = {"Authorization: Bearer ${state.token}"},
+        itemsPath = "data.countries",
+        valuePath = "code",
+        labelPath = "name.common")
+    String country;
+  }
+
+  static TestMateu mateu;
+
+  @BeforeAll
+  static void boot() {
+    mateu = TestMateu.withUis(RestOptsForm.class);
+  }
+
+  @AfterAll
+  static void shutdown() {
+    mateu.close();
+  }
+
+  @Test
+  void restOptionsFieldIsASelectCarryingTheEndpointDescriptor() {
+    var increment = mateu.sync("/restopts");
+    var fields = new java.util.ArrayList<io.mateu.dtos.FormFieldDto>();
+    FieldKindsSyncTest.walk(
+        increment.fragments().get(0).component(), io.mateu.dtos.FormFieldDto.class, fields);
+
+    var country =
+        fields.stream().filter(f -> "country".equals(f.fieldId())).findFirst().orElseThrow();
+    assertThat(country.stereotype()).isEqualTo("select");
+    var source = country.optionsSource();
+    assertThat(source).isNotNull();
+    assertThat(source.url()).isEqualTo("https://api.example.com/countries?token=${state.token}");
+    assertThat(source.method()).isEqualTo("GET");
+    assertThat(source.headers()).containsEntry("Authorization", "Bearer ${state.token}");
+    assertThat(source.itemsPath()).isEqualTo("data.countries");
+    assertThat(source.valuePath()).isEqualTo("code");
+    assertThat(source.labelPath()).isEqualTo("name.common");
+  }
+}

--- a/backend/shared/dtos/src/main/java/io/mateu/dtos/FormFieldDto.java
+++ b/backend/shared/dtos/src/main/java/io/mateu/dtos/FormFieldDto.java
@@ -39,6 +39,7 @@ public record FormFieldDto(
     boolean bold,
     List<OptionDto> options,
     RemoteCoordinatesDto remoteCoordinates,
+    RestDataSourceDto optionsSource,
     Object initialValue,
     boolean readOnly,
     boolean required,

--- a/backend/shared/dtos/src/main/java/io/mateu/dtos/RestDataSourceDto.java
+++ b/backend/shared/dtos/src/main/java/io/mateu/dtos/RestDataSourceDto.java
@@ -1,0 +1,30 @@
+package io.mateu.dtos;
+
+import java.util.Map;
+
+/**
+ * A declarative descriptor for consuming an arbitrary (non-Mateu) REST endpoint CLIENT-SIDE: the
+ * renderer fetches the URL directly (no Mateu server mediating) and shapes the JSON response into
+ * whatever the surface expects — a select's options, a listing's rows, a form's state.
+ *
+ * <p>This is the shared artifact of the "decouple the UI from the Mateu backend" line: the same
+ * descriptor serves every surface, only the mapping paths differ. For a select the mapping is
+ * {@code itemsPath} → the array, then {@code valuePath}/{@code labelPath} per item.
+ *
+ * @param url the endpoint URL; supports {@code ${state.x}}/{@code ${data.y}} interpolation
+ * @param method the HTTP method (GET, POST, …); defaults to GET when blank
+ * @param headers request headers (values interpolated) — e.g. an Authorization bearer token
+ * @param body a request body template (interpolated) for non-GET methods; null/blank sends none
+ * @param itemsPath a dot path to the array inside the JSON response (e.g. {@code data.items});
+ *     blank means the response root IS the array
+ * @param valuePath a dot path within each item to the option value / row id
+ * @param labelPath a dot path within each item to the option label
+ */
+public record RestDataSourceDto(
+    String url,
+    String method,
+    Map<String, String> headers,
+    String body,
+    String itemsPath,
+    String valuePath,
+    String labelPath) {}

--- a/backend/shared/frontend/vaadin-lit/src/main/resources/META-INF/resources/assets/mateu-vaadin.js
+++ b/backend/shared/frontend/vaadin-lit/src/main/resources/META-INF/resources/assets/mateu-vaadin.js
@@ -1,19 +1,19 @@
 const __vite__mapDeps=(i,m=__vite__mapDeps,d=(m.f||(m.f=["assets/vendor-ol.js","assets/rolldown-runtime.js","assets/vendor.js","assets/vendor-chartjs.js","assets/vendor-diagrams.js","assets/vendor-ui5.js"])))=>i.map(i=>d[i]);
-import{_ as e,a as t,c as n,d as r,f as i,g as a,h as o,i as s,l as c,m as l,n as u,o as d,p as f,r as p,s as m,t as ee,u as te,v as ne}from"./vendor-vaadin.js";import{S as h,a as g,c as _,g as re,h as v,i as y,m as b,n as x,o as S,r as C,v as w,w as ie,y as T}from"./vendor-lit.js";import{c as ae,l as oe,o as se,s as E}from"./vendor.js";import{r as D}from"./vendor-ui5.js";(function(){let e=document.createElement(`link`).relList;if(e&&e.supports&&e.supports(`modulepreload`))return;for(let e of document.querySelectorAll(`link[rel="modulepreload"]`))n(e);new MutationObserver(e=>{for(let t of e)if(t.type===`childList`)for(let e of t.addedNodes)e.tagName===`LINK`&&e.rel===`modulepreload`&&n(e)}).observe(document,{childList:!0,subtree:!0});function t(e){let t={};return e.integrity&&(t.integrity=e.integrity),e.referrerPolicy&&(t.referrerPolicy=e.referrerPolicy),e.crossOrigin===`use-credentials`?t.credentials=`include`:e.crossOrigin===`anonymous`?t.credentials=`omit`:t.credentials=`same-origin`,t}function n(e){if(e.ep)return;e.ep=!0;let n=t(e);fetch(e.href,n)}})(),ne(`vaadin-card`,h`
+import{_ as e,a as t,c as n,d as r,f as i,g as a,h as o,i as s,l as c,m as l,n as u,o as d,p as f,r as p,s as ee,t as te,u as ne,v as re}from"./vendor-vaadin.js";import{S as m,a as h,c as g,g as ie,h as _,i as v,m as y,n as b,o as x,r as S,v as C,w as ae,y as w}from"./vendor-lit.js";import{c as oe,l as se,o as ce,s as T}from"./vendor.js";import{r as E}from"./vendor-ui5.js";(function(){let e=document.createElement(`link`).relList;if(e&&e.supports&&e.supports(`modulepreload`))return;for(let e of document.querySelectorAll(`link[rel="modulepreload"]`))n(e);new MutationObserver(e=>{for(let t of e)if(t.type===`childList`)for(let e of t.addedNodes)e.tagName===`LINK`&&e.rel===`modulepreload`&&n(e)}).observe(document,{childList:!0,subtree:!0});function t(e){let t={};return e.integrity&&(t.integrity=e.integrity),e.referrerPolicy&&(t.referrerPolicy=e.referrerPolicy),e.crossOrigin===`use-credentials`?t.credentials=`include`:e.crossOrigin===`anonymous`?t.credentials=`omit`:t.credentials=`same-origin`,t}function n(e){if(e.ep)return;e.ep=!0;let n=t(e);fetch(e.href,n)}})(),re(`vaadin-card`,m`
       :host(.mateu-section) {
         --vaadin-card-border-width: 0 !important;
         --vaadin-card-background: transparent !important;
         --vaadin-card-shadow: none !important;
         --vaadin-card-padding: 0 !important;
       }
-    `);var ce=document.createElement(`style`);ce.innerHTML=`
+    `);var le=document.createElement(`style`);le.innerHTML=`
 ${e.cssText}
 ${o.cssText}
 ${a.cssText}
 ${l.cssText}
 ${f}
 ${i}
-`,document.body.appendChild(ce);{let e=window.Vaadin;e&&((e.featureFlags??={}).masterDetailLayoutComponent=!0)}new class{constructor(){this.ui=void 0,this.loading=!1,this.config={},this.sharedData={},this.userData={},this.appData={},this.runtimeData={}}};var le=new oe,O={value:{}},ue={value:{}},de=h`
+`,document.body.appendChild(le);{let e=window.Vaadin;e&&((e.featureFlags??={}).masterDetailLayoutComponent=!0)}new class{constructor(){this.ui=void 0,this.loading=!1,this.config={},this.sharedData={},this.userData={},this.appData={},this.runtimeData={}}};var ue=new se,D={value:{}},de={value:{}},fe=m`
   [theme~='badge'] {
     display: inline-flex;
     align-items: center;
@@ -129,7 +129,7 @@ ${i}
   [theme~='badge'][theme~='pill'] {
     --lumo-border-radius-s: 1em;
   }
-`,fe={lon:0,lat:0},pe=e=>{if(!e)return;let t=e.split(`,`).map(e=>e.trim());if(t.length!==2)return;let n=Number(t[0]),r=Number(t[1]);if(!(t[0]===``||t[1]===``||!Number.isFinite(n)||!Number.isFinite(r)))return{lon:r,lat:n}},me=e=>{if(e==null||e.trim()===``)return 3;let t=Number(e);return Number.isFinite(t)?t:3};function k(e,t,n,r){var i=arguments.length,a=i<3?t:r===null?r=Object.getOwnPropertyDescriptor(t,n):r,o;if(typeof Reflect==`object`&&typeof Reflect.decorate==`function`)a=Reflect.decorate(e,t,n,r);else for(var s=e.length-1;s>=0;s--)(o=e[s])&&(a=(i<3?o(a):i>3?o(t,n,a):o(t,n))||a);return i>3&&a&&Object.defineProperty(t,n,a),a}var he=class extends b{constructor(...e){super(...e),this.renderSeq=0}updated(e){super.updated(e),this.createMap()}disconnectedCallback(){super.disconnectedCallback(),this.map?.setTarget(void 0),this.map=void 0}async createMap(){let e=++this.renderSeq,[{default:t},{default:n},{default:r},{default:i},{fromLonLat:a},{default:o}]=await Promise.all([D(()=>import(`./vendor-ol.js`).then(e=>e.i),__vite__mapDeps([0,1])),D(()=>import(`./vendor-ol.js`).then(e=>e.a),__vite__mapDeps([0,1])),D(()=>import(`./vendor-ol.js`).then(e=>e.r),__vite__mapDeps([0,1])),D(()=>import(`./vendor-ol.js`).then(e=>e.t),__vite__mapDeps([0,1])),D(()=>import(`./vendor-ol.js`).then(e=>e.o),__vite__mapDeps([0,1])),D(()=>import(`./vendor-ol.js`).then(e=>e.n),__vite__mapDeps([0,1]))]);if(e!==this.renderSeq||!this.isConnected)return;if(!this.shadowRoot.querySelector(`style[data-ol]`)){let e=document.createElement(`style`);e.setAttribute(`data-ol`,``),e.textContent=o,this.shadowRoot.appendChild(e)}this.map&&=(this.map.setTarget(void 0),void 0);let s=pe(this.position)??fe;this.map=new t({target:this.mapElement,layers:[new r({source:new i})],view:new n({center:a([s.lon,s.lat]),zoom:me(this.zoom)})})}render(){return T`<div id="map"></div>`}static{this.styles=h`
+`,pe={lon:0,lat:0},me=e=>{if(!e)return;let t=e.split(`,`).map(e=>e.trim());if(t.length!==2)return;let n=Number(t[0]),r=Number(t[1]);if(!(t[0]===``||t[1]===``||!Number.isFinite(n)||!Number.isFinite(r)))return{lon:r,lat:n}},he=e=>{if(e==null||e.trim()===``)return 3;let t=Number(e);return Number.isFinite(t)?t:3};function O(e,t,n,r){var i=arguments.length,a=i<3?t:r===null?r=Object.getOwnPropertyDescriptor(t,n):r,o;if(typeof Reflect==`object`&&typeof Reflect.decorate==`function`)a=Reflect.decorate(e,t,n,r);else for(var s=e.length-1;s>=0;s--)(o=e[s])&&(a=(i<3?o(a):i>3?o(t,n,a):o(t,n))||a);return i>3&&a&&Object.defineProperty(t,n,a),a}var ge=class extends y{constructor(...e){super(...e),this.renderSeq=0}updated(e){super.updated(e),this.createMap()}disconnectedCallback(){super.disconnectedCallback(),this.map?.setTarget(void 0),this.map=void 0}async createMap(){let e=++this.renderSeq,[{default:t},{default:n},{default:r},{default:i},{fromLonLat:a},{default:o}]=await Promise.all([E(()=>import(`./vendor-ol.js`).then(e=>e.i),__vite__mapDeps([0,1])),E(()=>import(`./vendor-ol.js`).then(e=>e.a),__vite__mapDeps([0,1])),E(()=>import(`./vendor-ol.js`).then(e=>e.r),__vite__mapDeps([0,1])),E(()=>import(`./vendor-ol.js`).then(e=>e.t),__vite__mapDeps([0,1])),E(()=>import(`./vendor-ol.js`).then(e=>e.o),__vite__mapDeps([0,1])),E(()=>import(`./vendor-ol.js`).then(e=>e.n),__vite__mapDeps([0,1]))]);if(e!==this.renderSeq||!this.isConnected)return;if(!this.shadowRoot.querySelector(`style[data-ol]`)){let e=document.createElement(`style`);e.setAttribute(`data-ol`,``),e.textContent=o,this.shadowRoot.appendChild(e)}this.map&&=(this.map.setTarget(void 0),void 0);let s=me(this.position)??pe;this.map=new t({target:this.mapElement,layers:[new r({source:new i})],view:new n({center:a([s.lon,s.lat]),zoom:he(this.zoom)})})}render(){return w`<div id="map"></div>`}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -139,23 +139,23 @@ ${i}
             width: 100%;
             height: 100%;
         }
-    `}};k([y()],he.prototype,`position`,void 0),k([y()],he.prototype,`zoom`,void 0),k([x(`#map`)],he.prototype,`mapElement`,void 0),he=k([g(`mateu-map`)],he);var ge=typeof HTMLElement<`u`?HTMLElement:class{},_e=class extends ge{static get observedAttributes(){return[`content`]}#e;#t=0;get content(){return this.#e}set content(e){this.#e=e,this.#n()}attributeChangedCallback(e,t,n){this.content=n??void 0}connectedCallback(){this.style.display=`block`,this.#n()}async#n(){if(!this.isConnected)return;let e=this.#e??``,t=++this.#t,[{marked:n},{default:r}]=await Promise.all([D(()=>import(`./vendor.js`).then(e=>e.n),__vite__mapDeps([2,1])),D(()=>import(`./vendor.js`).then(e=>e.a),__vite__mapDeps([2,1]))]);t===this.#t&&(this.innerHTML=r.sanitize(await n.parse(e),{USE_PROFILES:{html:!0,svg:!0,svgFilters:!0},CUSTOM_ELEMENT_HANDLING:{tagNameCheck:e=>!0}}))}};typeof customElements<`u`&&!customElements.get(`mateu-markdown`)&&customElements.define(`mateu-markdown`,_e);var A=function(e){return e.ServerSide=`ServerSide`,e.ClientSide=`ClientSide`,e}({}),j=function(e){return e.Page=`Page`,e.Div=`Div`,e.Element=`Element`,e.MicroFrontend=`MicroFrontend`,e.Form=`Form`,e.Crud=`Crud`,e.Result=`Result`,e.Card=`Card`,e.Directory=`Directory`,e.Stepper=`Stepper`,e.HorizontalLayout=`HorizontalLayout`,e.VerticalLayout=`VerticalLayout`,e.SplitLayout=`SplitLayout`,e.MasterDetailLayout=`MasterDetailLayout`,e.TabLayout=`TabLayout`,e.AccordionLayout=`AccordionLayout`,e.FormLayout=`FormLayout`,e.FormRow=`FormRow`,e.FormItem=`FormItem`,e.BoardLayout=`BoardLayout`,e.BoardLayoutRow=`BoardLayoutRow`,e.BoardLayoutItem=`BoardLayoutItem`,e.Scroller=`Scroller`,e.FullWidth=`FullWidth`,e.Container=`Container`,e.FormField=`FormField`,e.Table=`Table`,e.App=`App`,e.Text=`Text`,e.Avatar=`Avatar`,e.Chat=`Chat`,e.AvatarGroup=`AvatarGroup`,e.Badge=`Badge`,e.Breadcrumbs=`Breadcrumbs`,e.Anchor=`Anchor`,e.Button=`Button`,e.Chart=`Chart`,e.Icon=`Icon`,e.ConfirmDialog=`ConfirmDialog`,e.ContextMenu=`ContextMenu`,e.CookieConsent=`CookieConsent`,e.Details=`Details`,e.Dialog=`Dialog`,e.Drawer=`Drawer`,e.Image=`Image`,e.Map=`Map`,e.Markdown=`Markdown`,e.Notification=`Notification`,e.ProgressBar=`ProgressBar`,e.Popover=`Popover`,e.CarouselLayout=`CarouselLayout`,e.Tooltip=`Tooltip`,e.MessageInput=`MessageInput`,e.MessageList=`MessageList`,e.CustomField=`CustomField`,e.MenuBar=`MenuBar`,e.Grid=`Grid`,e.GridColumn=`GridColumn`,e.GridGroupColumn=`GridGroupColumn`,e.VirtualList=`VirtualList`,e.FormSection=`FormSection`,e.FormSubSection=`FormSubSection`,e.Bpmn=`Bpmn`,e.Workflow=`Workflow`,e.FormEditor=`FormEditor`,e.MetricCard=`MetricCard`,e.Scoreboard=`Scoreboard`,e.DashboardPanel=`DashboardPanel`,e.DashboardLayout=`DashboardLayout`,e.FoldoutLayout=`FoldoutLayout`,e.ContentLayout=`ContentLayout`,e.HeroSection=`HeroSection`,e.EmptyState=`EmptyState`,e.Skeleton=`Skeleton`,e.Gantt=`Gantt`,e.PlanningBoard=`PlanningBoard`,e.Kanban=`Kanban`,e.Timeline=`Timeline`,e.ProgressSteps=`ProgressSteps`,e.Stat=`Stat`,e.Calendar=`Calendar`,e.PricingTable=`PricingTable`,e.OrgChart=`OrgChart`,e.Heatmap=`Heatmap`,e.Funnel=`Funnel`,e.TrendChart=`TrendChart`,e.FeatureGrid=`FeatureGrid`,e.Testimonials=`Testimonials`,e.Faq=`Faq`,e.CalloutCard=`CalloutCard`,e.CommentThread=`CommentThread`,e.FileList=`FileList`,e.Checklist=`Checklist`,e.ComparisonCard=`ComparisonCard`,e.EntityHeader=`EntityHeader`,e.Meter=`Meter`,e.TaskProgress=`TaskProgress`,e.StatusList=`StatusList`,e.BulletedList=`BulletedList`,e.Separator=`Separator`,e.Notice=`Notice`,e.TaskQueue=`TaskQueue`,e.ResourceGrid=`ResourceGrid`,e.OfferCard=`OfferCard`,e.AddOnPicker=`AddOnPicker`,e.Ledger=`Ledger`,e.PaymentPicker=`PaymentPicker`,e.ProcessMonitor=`ProcessMonitor`,e}({}),ve=`mateu-app-context`,ye=`mateu-app-context-labels`,be=e=>{try{return JSON.parse(localStorage.getItem(e)??`{}`)}catch{return{}}},xe=(e,t)=>{try{localStorage.setItem(e,JSON.stringify(t))}catch{}},Se=()=>be(ve),Ce=()=>be(ye),we=(e,t,n)=>{let r=Se(),i=Ce();t==null||t===``?(delete r[e],delete i[e]):(r[e]=t,n!==void 0&&(i[e]=n)),xe(ve,r),xe(ye,i)},Te=!1,Ee=()=>{Te||(Te=!0,window.addEventListener(`storage`,e=>{e.key===ve&&e.newValue!==e.oldValue&&window.location.reload()}))},De,Oe=(e,t)=>new Promise((n,r)=>{let i=!1,a={retry:()=>{i||(i=!0,t().then(n,r))},giveUp:()=>{i||(i=!0,r(e))}};if(De){De(a);return}let o=new CustomEvent(`mateu-session-expired`,{detail:a,cancelable:!0,bubbles:!1});typeof document<`u`&&!document.dispatchEvent(o)||a.giveUp()}),ke=(e,t)=>e.includes(`json`)?!0:typeof t==`object`&&!!t,Ae=(e,t)=>{let n=e.finalUrl;if(!n)return;let r=t??(typeof window<`u`?window.location.href:void 0),i;try{i=new URL(e.requestedUrl,r).href}catch{return}if(i!==n&&!ke(e.contentType??``,e.data))return n},je=new class{constructor(){this.windowMs=4e3,this.threshold=12,this.events=[],this.reported=new Set}check(e,t=Date.now()){this.events.push({sig:e,t});let n=t-this.windowMs;this.events=this.events.filter(e=>e.t>=n);let r=0;for(let t of this.events)t.sig===e&&r++;if(r>=this.threshold){let t=!this.reported.has(e);return this.reported.add(e),{blocked:!0,firstTrip:t}}return this.reported.delete(e),{blocked:!1,firstTrip:!1}}reset(){this.events=[],this.reported.clear()}configure(e){e.windowMs!==void 0&&(this.windowMs=e.windowMs),e.threshold!==void 0&&(this.threshold=e.threshold)}},Me={offline:()=>`No connection. Your changes have not been sent — check your network and try again.`,timeout:()=>`The server is taking too long to answer. Your changes may not have been saved.`,server:e=>`The server could not complete the request${e?` (error ${e})`:``}. Please try again.`,unauthorized:()=>`Your session is no longer valid. Please sign in again.`,notFound:()=>`This is no longer available. It may have been moved or deleted.`,client:e=>`The request was rejected${e?` (error ${e})`:``}.`,cancelled:()=>``,unknown:()=>`Something went wrong. Please try again.`},Ne=new Set([`offline`,`timeout`,`server`]),Pe=(e,t={})=>{let n=e??{},r=n.response?.status,i=n.code,a=t.online??(typeof navigator<`u`&&typeof navigator.onLine==`boolean`?navigator.onLine:!0),o=e=>({kind:e,message:Me[e](r),retryable:Ne.has(e),status:r});return i===`ERR_CANCELED`?o(`cancelled`):i===`ECONNABORTED`||i===`ETIMEDOUT`||/timeout/i.test(n.message??``)?o(`timeout`):r===void 0?!a||i===`ERR_NETWORK`||/network error/i.test(n.message??``)?o(`offline`):o(`unknown`):o(r===401||r===403?`unauthorized`:r===404||r===410?`notFound`:r===408||r===429?`timeout`:r>=500?`server`:r>=400?`client`:`unknown`)},Fe=new Set([``,`__load__`,`search`,`_globalsearch`,`_notifications-list`]),Ie=[`_appcontext-search-`,`search-`],Le=(e,t)=>t===!0?!0:e==null?!1:Fe.has(e)?!0:Ie.some(t=>e.startsWith(t)),Re=(e,t=Math.random)=>{let n=300*3**Math.max(0,e-1);return Math.round(n*(.75+t()*.5))},ze=(e,t,n)=>!n.idempotent||t>2||!e.retryable?!1:e.kind===`timeout`||e.kind===`server`,Be=new class{constructor(){this.linkUp=!0,this.listeners=new Set,this.waiters=new Set,this.started=!1}start(){this.started||typeof window>`u`||(this.started=!0,this.linkUp=typeof navigator<`u`&&typeof navigator.onLine==`boolean`?navigator.onLine:!0,window.addEventListener(`online`,()=>{this.linkUp=!0,this.reachable=void 0,this.changed(),this.releaseWaiters()}),window.addEventListener(`offline`,()=>{this.linkUp=!1,this.changed()}))}isOnline(){return this.linkUp?this.reachable!==!1:!1}noteReachable(){let e=this.isOnline();this.reachable=!0,e||(this.changed(),this.releaseWaiters())}noteUnreachable(){let e=this.isOnline();this.reachable=!1,e&&this.changed()}subscribe(e){return this.listeners.add(e),()=>this.listeners.delete(e)}whenBack(e){return this.isOnline()?(e(),()=>{}):(this.waiters.add(e),()=>this.waiters.delete(e))}reset(){this.linkUp=!0,this.reachable=void 0,this.waiters.clear()}changed(){let e=this.isOnline();this.listeners.forEach(t=>t(e))}releaseWaiters(){let e=Array.from(this.waiters);this.waiters.clear(),e.forEach(e=>e())}};Be.start();var Ve=[],He=6e4,Ue=e=>new Promise(t=>setTimeout(t,e)),We=new class{constructor(){this.axiosInstance=ae.create({timeout:He}),this.axiosInstance.interceptors.request.use(e=>(this.addAuthToken(e),this.addSessionId(e),e)),this.axiosInstance.interceptors.response.use(e=>{let t=Ae({requestedUrl:this.axiosInstance.getUri(e.config),finalUrl:e.request?.responseURL,contentType:String(e.headers?.[`content-type`]??``),data:e.data});if(t)throw window.location.assign(t),Object.assign(Error(`session lost — redirecting to `+t),{code:`ERR_CANCELED`});return e},e=>{let t=e;if(t?.response?.status===401&&t.config&&!t.config.__mateuRetried){let n=t.config;return n.__mateuRetried=!0,Oe(e,()=>this.axiosInstance.request(n))}throw e})}addSessionId(e){let t=sessionStorage.getItem(`__mateu_sesion_id`);t||(t=E(),sessionStorage.setItem(`__mateu_sesion_id`,t)),e.headers[`X-Session-Id`]=t}addAuthToken(e){let t=localStorage.getItem(`__mateu_auth_token`);t&&(e.headers.Authorization=`Bearer `+t)}async wrap(e,t,n,r,i){return n||t.dispatchEvent(new CustomEvent(`backend-called-event`,{bubbles:!0,composed:!0,detail:{}})),e().then(e=>(t.dispatchEvent(new CustomEvent(`backend-succeeded-event`,{bubbles:!0,composed:!0,detail:{actionId:r}})),e)).catch(e=>{let n=Pe(e,{online:Be.isOnline()});throw n.kind==`cancelled`?t.dispatchEvent(new CustomEvent(`backend-cancelled-event`,{bubbles:!0,composed:!0,detail:{actionId:r}})):(e&&typeof e==`object`&&(e.__mateuReported=!0),t.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:r,reason:this.serialize(e),failure:n,retry:i}}))),e})}async sendWithRetry(e,t){let n=0;for(;;)try{let t=await e();return Be.noteReachable(),t}catch(e){let r=Pe(e,{online:Be.isOnline()});if(r.kind==`offline`&&Be.noteUnreachable(),n++,!ze(r,n,{idempotent:t}))throw e;await Ue(Re(n))}}serialize(e){return e?.message?e:JSON.stringify(e)}release(e){Ve=Ve.filter(t=>t!==e)}async get(e){let t=new AbortController;return Ve=[...Ve,t],this.axiosInstance.get(e,{signal:t.signal}).finally(()=>this.release(t))}async post(e,t,n){let r=new AbortController;return Ve=[...Ve,r],this.axiosInstance.post(e,t,{signal:r.signal,...n&&n>0?{timeout:n}:{}}).finally(()=>this.release(r))}async abortAll(){Ve.forEach(e=>e.abort()),Ve=[]}async runAction(e,t,n,r,i,a,o,s,c,l,u,d={}){t&&t.startsWith(`/`)&&(t=t.substring(1));let f=[e,t,n,o??``,r,i].join(``),p=je.check(f);if(p.blocked)return await this.abortAll(),p.firstTrip&&console.error(`[mateu] request loop detected — aborting repeated request`,f),{messages:p.firstTrip?[{title:``,text:`A repeating request was detected and stopped to protect the server. Reload the page or navigate elsewhere.`,position:`bottom-end`,variant:`error`,duration:6e3}]:[],commands:[],fragments:[],banners:[],appendBanners:!1,appData:void 0,appState:void 0};a={...Se(),...a};let m=e+`/mateu/v3/sync/`+(t&&t!=``?t:`_no_route`),ee={serverSideType:o,appState:a,componentState:s,parameters:c,initiatorComponentId:i,consumedRoute:n,route:t&&t!=``?`/`+t:``,actionId:r},te=Le(r,d.idempotent),ne=()=>this.post(m,ee,d.timeoutMillis).then(e=>e.data);return await this.wrap(()=>this.sendWithRetry(ne,te),l,u,r,d.retry)}},Ge=function(e){return e.Add=`Add`,e.Replace=`Replace`,e.ReplaceKeepData=`ReplaceKeepData`,e}({}),Ke=function(e){return e.HAMBURGUER_MENU=`HAMBURGUER_MENU`,e.MENU_ON_LEFT=`MENU_ON_LEFT`,e.MENU_ON_TOP=`MENU_ON_TOP`,e.TABS=`TABS`,e.TILES=`TILES`,e.RAIL=`RAIL`,e.AUTO=`AUTO`,e.MEDIATOR=`MEDIATOR`,e}({}),qe=new Map,Je=[`position:absolute`,`width:1px`,`height:1px`,`margin:-1px`,`padding:0`,`overflow:hidden`,`clip:rect(0 0 0 0)`,`clip-path:inset(50%)`,`white-space:nowrap`,`border:0`].join(`;`),Ye=e=>{if(typeof document>`u`||!document.body)return;let t=qe.get(e);return t?.isConnected?t:(t=document.createElement(`div`),t.setAttribute(`aria-live`,e),t.setAttribute(`aria-atomic`,`true`),t.setAttribute(`role`,e===`assertive`?`alert`:`status`),t.setAttribute(`data-mateu-live-region`,e),t.style.cssText=Je,document.body.appendChild(t),qe.set(e,t),t)},Xe=()=>{if(!(typeof document>`u`)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>Xe(),{once:!0});return}Ye(`polite`),Ye(`assertive`)}},Ze=(e,t={})=>{let n=(e??``).trim();if(!n)return;let r=Ye(t.politeness??`polite`);if(r){if(r.textContent===n){r.textContent=``,setTimeout(()=>{r.textContent=n},60);return}r.textContent=n}},Qe=class extends b{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.callbackToken=``,this.createElement=e=>{let t=e.data,n=document.createElement(t.name);for(let e in t.attributes)n.setAttribute(e,t.attributes[e]);for(let e in t.on)n.addEventListener(e,n=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.on[e],parameters:{event:n}},bubbles:!0,composed:!0}))});return n},this.closeModal=()=>{let e=(this.shadowRoot??this).querySelectorAll(`mateu-dialog, mateu-drawer`);if(e&&e.length>0){e[e.length-1].close();return}this.dispatchEvent(new CustomEvent(`close-modal-requested`,{bubbles:!0,composed:!0}))},this.changeFavicon=e=>{let t=document.querySelector(`link[rel="icon"]`);t===null?(t=document.createElement(`link`),t.setAttribute(`rel`,`icon`),t.setAttribute(`href`,e),document.head.appendChild(t)):t.setAttribute(`href`,e)}}connectedCallback(){super.connectedCallback(),this.upstreamSubscription=le.subscribe(e=>{if(e.command){let t=e.command;this.id==t.targetComponentId&&this.applyCommand(t)}if((!e.callbackToken||!this.callbackToken||e.callbackToken===this.callbackToken)&&e.fragment){let t=e.fragment;this.id==t.targetComponentId&&(this.applyFragment(t),this.completeMenu(t))}})}completeMenu(e){if(e.component&&e.component.type==A.ClientSide){let t=e.component,n=t.metadata;if(n?.type==j.App){let e=n,r=this.getRemoteMenus(e.menu);if(r.length>0){let n=r.map(e=>We.runAction(e.baseUrl,e.route,`_empty`,``,e.baseUrl+`#`+e.route,void 0,void 0,void 0,e.params,this,!0));Promise.all(n).then(n=>{e.menu=this.updateMenu(e.menu,n.map(e=>e.fragments).filter(e=>e).map(e=>e).flat()),e.variant=Ke.MENU_ON_TOP,le.next({fragment:{component:t,data:void 0,state:void 0,action:Ge.Replace,targetComponentId:this.id,containerId:void 0},callbackToken:this.callbackToken})})}}}}updateMenu(e,t){let n=[];return e.forEach(e=>{if(e.remote){let r=t.find(t=>t.targetComponentId==e.baseUrl+`#`+e.route);if(r&&r.component?.type==A.ClientSide){let t=r.component;if(t.metadata?.type==j.App){let r=t.metadata,i=e.serverSideType&&e.serverSideType!=``?e.serverSideType:r.serverSideType;this.changeBaseUrl(r.menu,e.baseUrl,i,e.route,r.route),n.push(...r.menu)}}}else n.push(e)}),n}changeBaseUrl(e,t,n,r,i){e.forEach(e=>{e.baseUrl||(e.submenus&&e.submenus.length>0?this.changeBaseUrl(e.submenus,t,n,r,i):(e.consumedRoute=i??``,e.baseUrl=t,e.serverSideType=n,e.uriPrefix=r))})}getRemoteMenus(e){let t=[];return e.forEach(e=>{e.remote&&t.push(e)}),t}disconnectedCallback(){super.disconnectedCallback(),this.upstreamSubscription?.unsubscribe()}applyCommand(e){if(e.type==`SetWindowTitle`&&(document.title=e.data,Ze(document.title)),e.type==`SetFavicon`&&this.changeFavicon(e.data),e.type==`DispatchEvent`&&this.dispatchNamedEvent(e.data),e.type==`NavigateTo`){let t=e.data;t&&(t.startsWith(`http:`)||t.startsWith(`https:`)?window.open(e.data,`_blank`):window.location.href=e.data)}if(e.type==`PushStateToHistory`){let t=e.data;t!==void 0&&this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0}))}if(e.type==`RunAction`){let t=e.data;if(t&&t.actionId)if(t.targetComponentId){let e={command:{type:`RunAction`,data:{actionId:t.actionId},targetComponentId:t.targetComponentId},fragment:void 0,ui:void 0,error:void 0,callbackToken:``};setTimeout(()=>le.next(e))}else this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:{}},bubbles:!0,composed:!0}))}if(e.type==`MarkAsDirty`&&this.dispatchEvent(new CustomEvent(`dirty`,{detail:{},bubbles:!0,composed:!0})),e.type==`MarkAsClean`&&this.dispatchEvent(new CustomEvent(`clean`,{detail:{},bubbles:!0,composed:!0})),e.type==`DownloadFile`){let t=e.data;if(t&&t.base64Content){let e=atob(t.base64Content),n=new Uint8Array(e.length);for(let t=0;t<e.length;t++)n[t]=e.charCodeAt(t);let r=new Blob([n],{type:t.mimeType}),i=URL.createObjectURL(r),a=document.createElement(`a`);a.href=i,a.download=t.filename??`export`,a.click(),URL.revokeObjectURL(i)}}if(e.type==`CloseModal`&&(this.closeModal(),this.dispatchNamedEvent(e.data)),e.type==`AddContentToHead`){let t=e.data;if(t&&t.name){if(t.attributes&&t.attributes.id&&document.getElementById(t.attributes.id))return;document.head.appendChild(this.createElement(e))}}if(e.type==`AddContentToBody`){let t=e.data;if(t&&t.name){if(t.attributes&&t.attributes.id&&document.getElementById(t.attributes.id))return;document.body.appendChild(this.createElement(e))}}}dispatchNamedEvent(e){if(e&&e.eventName){let t=this.component,n=t?.emitsName??t?.serverSideType,r=e.payload??e.detail;n&&r&&typeof r==`object`&&(r={...r,__source:n}),this.dispatchEvent(new CustomEvent(e.eventName,{detail:r,bubbles:!0,composed:!0}))}}};k([y()],Qe.prototype,`id`,void 0),k([y()],Qe.prototype,`baseUrl`,void 0);var $e=class extends Qe{applyFragment(e){}manageActionRequestedEvent(e){}};k([y()],$e.prototype,`component`,void 0);var et=(e,t)=>Function(...Object.keys(t),"return `"+e+"`")(...Object.values(t)),tt=(e,t,n)=>({state:e??{},data:t??{},...n});function M(e,t,n,r){if(!e?.includes("${"))return e;try{return et(e,tt(t,n,r))}catch(t){return console.warn(`Mateu: could not interpolate "${e}":`,t),e}}var nt=(e,t,n)=>{if(e&&e.indexOf("${")>=0)try{return et(e,tt(t,n))}catch(e){return e.message}return e},rt=(e,t,n,r,i)=>{if(!e)return e;let a=tt(t,n,{appState:r??{},appData:i??{}}),o=e;try{if(o=et(e,a),o.includes("${"))try{o=et(o,a)}catch(a){o=`when evaluating nested `+e+` :`+a+`, where data is `+n+` and state is `+t+` and app state is `+r+` and app data is `+i,console.error(a,o,t,n,r,i)}}catch(a){o=`when evaluating `+e+` :`+a+`, where data is `+n+` and state is `+t+` and app state is `+r+` and app data is `+i,console.error(a,o,t,n,r,i)}return o},it=(e,t,n,r,i,a)=>{let o=tt(t,n,{appState:r??{},appData:i??{},...a}),s=et(e,o);return Function(...Object.keys(o),`return (${s})`)(...Object.values(o))},at=(e,t,n,r)=>{let i=tt(t,n,r);return Function(...Object.keys(i),`return (${e})`)(...Object.values(i))},ot=(e,t,n,r)=>et(e,tt(t,n,r)),st=`display:inline-flex; align-items:center; justify-content:center; width:2rem; height:2rem; border-radius:50%; background:var(--lumo-contrast-10pct,#e0e0e0); color:var(--lumo-secondary-text-color,#555); font-size:.8rem; font-weight:600; overflow:hidden; flex:none;`,ct=(e,t)=>t||(typeof e==`string`&&e?e.trim().split(/\s+/).map(e=>e[0]).slice(0,2).join(``).toUpperCase():``),lt=(e,t,n)=>{let r=e.metadata,i=N(r.name,t,n);return T`<span style="${st}${e.style}" class="${e.cssClasses}"
-                      title="${i||v}" slot="${e.slot??v}">
-        ${r.image?T`<img src="${r.image}" alt="${i}" style="width:100%;height:100%;object-fit:cover;">`:ct(i,r.abbreviation)}
-    </span>`},N=(e,t,n)=>typeof e==`string`&&e.includes("${")?M(e,t,n):e,ut=e=>{let t=e.metadata,n=t.avatars??[],r=t.maxItemsVisible&&t.maxItemsVisible>0?t.maxItemsVisible:n.length,i=n.slice(0,r),a=n.length-i.length,o=`margin-left:-0.4rem; border:2px solid var(--lumo-base-color,#fff);`;return T`<span style="display:inline-flex; ${e.style}" class="${e.cssClasses}" slot="${e.slot??v}">
-        ${i.map(e=>T`<span style="${st}${o}" title="${e.name||v}">
-            ${e.img?T`<img src="${e.img}" style="width:100%;height:100%;object-fit:cover;">`:ct(e.name??``,e.abbr)}
+    `}};O([v()],ge.prototype,`position`,void 0),O([v()],ge.prototype,`zoom`,void 0),O([b(`#map`)],ge.prototype,`mapElement`,void 0),ge=O([h(`mateu-map`)],ge);var _e=typeof HTMLElement<`u`?HTMLElement:class{},ve=class extends _e{static get observedAttributes(){return[`content`]}#e;#t=0;get content(){return this.#e}set content(e){this.#e=e,this.#n()}attributeChangedCallback(e,t,n){this.content=n??void 0}connectedCallback(){this.style.display=`block`,this.#n()}async#n(){if(!this.isConnected)return;let e=this.#e??``,t=++this.#t,[{marked:n},{default:r}]=await Promise.all([E(()=>import(`./vendor.js`).then(e=>e.n),__vite__mapDeps([2,1])),E(()=>import(`./vendor.js`).then(e=>e.a),__vite__mapDeps([2,1]))]);t===this.#t&&(this.innerHTML=r.sanitize(await n.parse(e),{USE_PROFILES:{html:!0,svg:!0,svgFilters:!0},CUSTOM_ELEMENT_HANDLING:{tagNameCheck:e=>!0}}))}};typeof customElements<`u`&&!customElements.get(`mateu-markdown`)&&customElements.define(`mateu-markdown`,ve);var k=function(e){return e.ServerSide=`ServerSide`,e.ClientSide=`ClientSide`,e}({}),A=function(e){return e.Page=`Page`,e.Div=`Div`,e.Element=`Element`,e.MicroFrontend=`MicroFrontend`,e.Form=`Form`,e.Crud=`Crud`,e.Result=`Result`,e.Card=`Card`,e.Directory=`Directory`,e.Stepper=`Stepper`,e.HorizontalLayout=`HorizontalLayout`,e.VerticalLayout=`VerticalLayout`,e.SplitLayout=`SplitLayout`,e.MasterDetailLayout=`MasterDetailLayout`,e.TabLayout=`TabLayout`,e.AccordionLayout=`AccordionLayout`,e.FormLayout=`FormLayout`,e.FormRow=`FormRow`,e.FormItem=`FormItem`,e.BoardLayout=`BoardLayout`,e.BoardLayoutRow=`BoardLayoutRow`,e.BoardLayoutItem=`BoardLayoutItem`,e.Scroller=`Scroller`,e.FullWidth=`FullWidth`,e.Container=`Container`,e.FormField=`FormField`,e.Table=`Table`,e.App=`App`,e.Text=`Text`,e.Avatar=`Avatar`,e.Chat=`Chat`,e.AvatarGroup=`AvatarGroup`,e.Badge=`Badge`,e.Breadcrumbs=`Breadcrumbs`,e.Anchor=`Anchor`,e.Button=`Button`,e.Chart=`Chart`,e.Icon=`Icon`,e.ConfirmDialog=`ConfirmDialog`,e.ContextMenu=`ContextMenu`,e.CookieConsent=`CookieConsent`,e.Details=`Details`,e.Dialog=`Dialog`,e.Drawer=`Drawer`,e.Image=`Image`,e.Map=`Map`,e.Markdown=`Markdown`,e.Notification=`Notification`,e.ProgressBar=`ProgressBar`,e.Popover=`Popover`,e.CarouselLayout=`CarouselLayout`,e.Tooltip=`Tooltip`,e.MessageInput=`MessageInput`,e.MessageList=`MessageList`,e.CustomField=`CustomField`,e.MenuBar=`MenuBar`,e.Grid=`Grid`,e.GridColumn=`GridColumn`,e.GridGroupColumn=`GridGroupColumn`,e.VirtualList=`VirtualList`,e.FormSection=`FormSection`,e.FormSubSection=`FormSubSection`,e.Bpmn=`Bpmn`,e.Workflow=`Workflow`,e.FormEditor=`FormEditor`,e.MetricCard=`MetricCard`,e.Scoreboard=`Scoreboard`,e.DashboardPanel=`DashboardPanel`,e.DashboardLayout=`DashboardLayout`,e.FoldoutLayout=`FoldoutLayout`,e.ContentLayout=`ContentLayout`,e.HeroSection=`HeroSection`,e.EmptyState=`EmptyState`,e.Skeleton=`Skeleton`,e.Gantt=`Gantt`,e.PlanningBoard=`PlanningBoard`,e.Kanban=`Kanban`,e.Timeline=`Timeline`,e.ProgressSteps=`ProgressSteps`,e.Stat=`Stat`,e.Calendar=`Calendar`,e.PricingTable=`PricingTable`,e.OrgChart=`OrgChart`,e.Heatmap=`Heatmap`,e.Funnel=`Funnel`,e.TrendChart=`TrendChart`,e.FeatureGrid=`FeatureGrid`,e.Testimonials=`Testimonials`,e.Faq=`Faq`,e.CalloutCard=`CalloutCard`,e.CommentThread=`CommentThread`,e.FileList=`FileList`,e.Checklist=`Checklist`,e.ComparisonCard=`ComparisonCard`,e.EntityHeader=`EntityHeader`,e.Meter=`Meter`,e.TaskProgress=`TaskProgress`,e.StatusList=`StatusList`,e.BulletedList=`BulletedList`,e.Separator=`Separator`,e.Notice=`Notice`,e.TaskQueue=`TaskQueue`,e.ResourceGrid=`ResourceGrid`,e.OfferCard=`OfferCard`,e.AddOnPicker=`AddOnPicker`,e.Ledger=`Ledger`,e.PaymentPicker=`PaymentPicker`,e.ProcessMonitor=`ProcessMonitor`,e}({}),ye=`mateu-app-context`,be=`mateu-app-context-labels`,xe=e=>{try{return JSON.parse(localStorage.getItem(e)??`{}`)}catch{return{}}},Se=(e,t)=>{try{localStorage.setItem(e,JSON.stringify(t))}catch{}},Ce=()=>xe(ye),we=()=>xe(be),Te=(e,t,n)=>{let r=Ce(),i=we();t==null||t===``?(delete r[e],delete i[e]):(r[e]=t,n!==void 0&&(i[e]=n)),Se(ye,r),Se(be,i)},Ee=!1,De=()=>{Ee||(Ee=!0,window.addEventListener(`storage`,e=>{e.key===ye&&e.newValue!==e.oldValue&&window.location.reload()}))},Oe,ke=(e,t)=>new Promise((n,r)=>{let i=!1,a={retry:()=>{i||(i=!0,t().then(n,r))},giveUp:()=>{i||(i=!0,r(e))}};if(Oe){Oe(a);return}let o=new CustomEvent(`mateu-session-expired`,{detail:a,cancelable:!0,bubbles:!1});typeof document<`u`&&!document.dispatchEvent(o)||a.giveUp()}),Ae=(e,t)=>e.includes(`json`)?!0:typeof t==`object`&&!!t,je=(e,t)=>{let n=e.finalUrl;if(!n)return;let r=t??(typeof window<`u`?window.location.href:void 0),i;try{i=new URL(e.requestedUrl,r).href}catch{return}if(i!==n&&!Ae(e.contentType??``,e.data))return n},Me=new class{constructor(){this.windowMs=4e3,this.threshold=12,this.events=[],this.reported=new Set}check(e,t=Date.now()){this.events.push({sig:e,t});let n=t-this.windowMs;this.events=this.events.filter(e=>e.t>=n);let r=0;for(let t of this.events)t.sig===e&&r++;if(r>=this.threshold){let t=!this.reported.has(e);return this.reported.add(e),{blocked:!0,firstTrip:t}}return this.reported.delete(e),{blocked:!1,firstTrip:!1}}reset(){this.events=[],this.reported.clear()}configure(e){e.windowMs!==void 0&&(this.windowMs=e.windowMs),e.threshold!==void 0&&(this.threshold=e.threshold)}},Ne={offline:()=>`No connection. Your changes have not been sent — check your network and try again.`,timeout:()=>`The server is taking too long to answer. Your changes may not have been saved.`,server:e=>`The server could not complete the request${e?` (error ${e})`:``}. Please try again.`,unauthorized:()=>`Your session is no longer valid. Please sign in again.`,notFound:()=>`This is no longer available. It may have been moved or deleted.`,client:e=>`The request was rejected${e?` (error ${e})`:``}.`,cancelled:()=>``,unknown:()=>`Something went wrong. Please try again.`},Pe=new Set([`offline`,`timeout`,`server`]),Fe=(e,t={})=>{let n=e??{},r=n.response?.status,i=n.code,a=t.online??(typeof navigator<`u`&&typeof navigator.onLine==`boolean`?navigator.onLine:!0),o=e=>({kind:e,message:Ne[e](r),retryable:Pe.has(e),status:r});return i===`ERR_CANCELED`?o(`cancelled`):i===`ECONNABORTED`||i===`ETIMEDOUT`||/timeout/i.test(n.message??``)?o(`timeout`):r===void 0?!a||i===`ERR_NETWORK`||/network error/i.test(n.message??``)?o(`offline`):o(`unknown`):o(r===401||r===403?`unauthorized`:r===404||r===410?`notFound`:r===408||r===429?`timeout`:r>=500?`server`:r>=400?`client`:`unknown`)},Ie=new Set([``,`__load__`,`search`,`_globalsearch`,`_notifications-list`]),Le=[`_appcontext-search-`,`search-`],Re=(e,t)=>t===!0?!0:e==null?!1:Ie.has(e)?!0:Le.some(t=>e.startsWith(t)),ze=(e,t=Math.random)=>{let n=300*3**Math.max(0,e-1);return Math.round(n*(.75+t()*.5))},Be=(e,t,n)=>!n.idempotent||t>2||!e.retryable?!1:e.kind===`timeout`||e.kind===`server`,Ve=new class{constructor(){this.linkUp=!0,this.listeners=new Set,this.waiters=new Set,this.started=!1}start(){this.started||typeof window>`u`||(this.started=!0,this.linkUp=typeof navigator<`u`&&typeof navigator.onLine==`boolean`?navigator.onLine:!0,window.addEventListener(`online`,()=>{this.linkUp=!0,this.reachable=void 0,this.changed(),this.releaseWaiters()}),window.addEventListener(`offline`,()=>{this.linkUp=!1,this.changed()}))}isOnline(){return this.linkUp?this.reachable!==!1:!1}noteReachable(){let e=this.isOnline();this.reachable=!0,e||(this.changed(),this.releaseWaiters())}noteUnreachable(){let e=this.isOnline();this.reachable=!1,e&&this.changed()}subscribe(e){return this.listeners.add(e),()=>this.listeners.delete(e)}whenBack(e){return this.isOnline()?(e(),()=>{}):(this.waiters.add(e),()=>this.waiters.delete(e))}reset(){this.linkUp=!0,this.reachable=void 0,this.waiters.clear()}changed(){let e=this.isOnline();this.listeners.forEach(t=>t(e))}releaseWaiters(){let e=Array.from(this.waiters);this.waiters.clear(),e.forEach(e=>e())}};Ve.start();var He=[],Ue=6e4,We=e=>new Promise(t=>setTimeout(t,e)),Ge=new class{constructor(){this.axiosInstance=oe.create({timeout:Ue}),this.axiosInstance.interceptors.request.use(e=>(this.addAuthToken(e),this.addSessionId(e),e)),this.axiosInstance.interceptors.response.use(e=>{let t=je({requestedUrl:this.axiosInstance.getUri(e.config),finalUrl:e.request?.responseURL,contentType:String(e.headers?.[`content-type`]??``),data:e.data});if(t)throw window.location.assign(t),Object.assign(Error(`session lost — redirecting to `+t),{code:`ERR_CANCELED`});return e},e=>{let t=e;if(t?.response?.status===401&&t.config&&!t.config.__mateuRetried){let n=t.config;return n.__mateuRetried=!0,ke(e,()=>this.axiosInstance.request(n))}throw e})}addSessionId(e){let t=sessionStorage.getItem(`__mateu_sesion_id`);t||(t=T(),sessionStorage.setItem(`__mateu_sesion_id`,t)),e.headers[`X-Session-Id`]=t}addAuthToken(e){let t=localStorage.getItem(`__mateu_auth_token`);t&&(e.headers.Authorization=`Bearer `+t)}async wrap(e,t,n,r,i){return n||t.dispatchEvent(new CustomEvent(`backend-called-event`,{bubbles:!0,composed:!0,detail:{}})),e().then(e=>(t.dispatchEvent(new CustomEvent(`backend-succeeded-event`,{bubbles:!0,composed:!0,detail:{actionId:r}})),e)).catch(e=>{let n=Fe(e,{online:Ve.isOnline()});throw n.kind==`cancelled`?t.dispatchEvent(new CustomEvent(`backend-cancelled-event`,{bubbles:!0,composed:!0,detail:{actionId:r}})):(e&&typeof e==`object`&&(e.__mateuReported=!0),t.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:r,reason:this.serialize(e),failure:n,retry:i}}))),e})}async sendWithRetry(e,t){let n=0;for(;;)try{let t=await e();return Ve.noteReachable(),t}catch(e){let r=Fe(e,{online:Ve.isOnline()});if(r.kind==`offline`&&Ve.noteUnreachable(),n++,!Be(r,n,{idempotent:t}))throw e;await We(ze(n))}}serialize(e){return e?.message?e:JSON.stringify(e)}release(e){He=He.filter(t=>t!==e)}async get(e){let t=new AbortController;return He=[...He,t],this.axiosInstance.get(e,{signal:t.signal}).finally(()=>this.release(t))}async post(e,t,n){let r=new AbortController;return He=[...He,r],this.axiosInstance.post(e,t,{signal:r.signal,...n&&n>0?{timeout:n}:{}}).finally(()=>this.release(r))}async abortAll(){He.forEach(e=>e.abort()),He=[]}async runAction(e,t,n,r,i,a,o,s,c,l,u,d={}){t&&t.startsWith(`/`)&&(t=t.substring(1));let f=[e,t,n,o??``,r,i].join(``),p=Me.check(f);if(p.blocked)return await this.abortAll(),p.firstTrip&&console.error(`[mateu] request loop detected — aborting repeated request`,f),{messages:p.firstTrip?[{title:``,text:`A repeating request was detected and stopped to protect the server. Reload the page or navigate elsewhere.`,position:`bottom-end`,variant:`error`,duration:6e3}]:[],commands:[],fragments:[],banners:[],appendBanners:!1,appData:void 0,appState:void 0};a={...Ce(),...a};let ee=e+`/mateu/v3/sync/`+(t&&t!=``?t:`_no_route`),te={serverSideType:o,appState:a,componentState:s,parameters:c,initiatorComponentId:i,consumedRoute:n,route:t&&t!=``?`/`+t:``,actionId:r,knownStructureHash:d.knownStructureHash},ne=Re(r,d.idempotent),re=()=>this.post(ee,te,d.timeoutMillis).then(e=>e.data);return await this.wrap(()=>this.sendWithRetry(re,ne),l,u,r,d.retry)}},Ke=function(e){return e.Add=`Add`,e.Replace=`Replace`,e.ReplaceKeepData=`ReplaceKeepData`,e}({}),qe=function(e){return e.HAMBURGUER_MENU=`HAMBURGUER_MENU`,e.MENU_ON_LEFT=`MENU_ON_LEFT`,e.MENU_ON_TOP=`MENU_ON_TOP`,e.TABS=`TABS`,e.TILES=`TILES`,e.RAIL=`RAIL`,e.AUTO=`AUTO`,e.MEDIATOR=`MEDIATOR`,e}({}),Je=new Map,Ye=[`position:absolute`,`width:1px`,`height:1px`,`margin:-1px`,`padding:0`,`overflow:hidden`,`clip:rect(0 0 0 0)`,`clip-path:inset(50%)`,`white-space:nowrap`,`border:0`].join(`;`),Xe=e=>{if(typeof document>`u`||!document.body)return;let t=Je.get(e);return t?.isConnected?t:(t=document.createElement(`div`),t.setAttribute(`aria-live`,e),t.setAttribute(`aria-atomic`,`true`),t.setAttribute(`role`,e===`assertive`?`alert`:`status`),t.setAttribute(`data-mateu-live-region`,e),t.style.cssText=Ye,document.body.appendChild(t),Je.set(e,t),t)},Ze=()=>{if(!(typeof document>`u`)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>Ze(),{once:!0});return}Xe(`polite`),Xe(`assertive`)}},Qe=(e,t={})=>{let n=(e??``).trim();if(!n)return;let r=Xe(t.politeness??`polite`);if(r){if(r.textContent===n){r.textContent=``,setTimeout(()=>{r.textContent=n},60);return}r.textContent=n}},$e=class extends y{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.callbackToken=``,this.createElement=e=>{let t=e.data,n=document.createElement(t.name);for(let e in t.attributes)n.setAttribute(e,t.attributes[e]);for(let e in t.on)n.addEventListener(e,n=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.on[e],parameters:{event:n}},bubbles:!0,composed:!0}))});return n},this.closeModal=()=>{let e=(this.shadowRoot??this).querySelectorAll(`mateu-dialog, mateu-drawer`);if(e&&e.length>0){e[e.length-1].close();return}this.dispatchEvent(new CustomEvent(`close-modal-requested`,{bubbles:!0,composed:!0}))},this.changeFavicon=e=>{let t=document.querySelector(`link[rel="icon"]`);t===null?(t=document.createElement(`link`),t.setAttribute(`rel`,`icon`),t.setAttribute(`href`,e),document.head.appendChild(t)):t.setAttribute(`href`,e)}}connectedCallback(){super.connectedCallback(),this.upstreamSubscription=ue.subscribe(e=>{if(e.command){let t=e.command;this.id==t.targetComponentId&&this.applyCommand(t)}if((!e.callbackToken||!this.callbackToken||e.callbackToken===this.callbackToken)&&e.fragment){let t=e.fragment;this.id==t.targetComponentId&&(this.applyFragment(t),this.completeMenu(t))}})}completeMenu(e){if(e.component&&e.component.type==k.ClientSide){let t=e.component,n=t.metadata;if(n?.type==A.App){let e=n,r=this.getRemoteMenus(e.menu);if(r.length>0){let n=r.map(e=>Ge.runAction(e.baseUrl,e.route,`_empty`,``,e.baseUrl+`#`+e.route,void 0,void 0,void 0,e.params,this,!0));Promise.all(n).then(n=>{e.menu=this.updateMenu(e.menu,n.map(e=>e.fragments).filter(e=>e).map(e=>e).flat()),e.variant=qe.MENU_ON_TOP,ue.next({fragment:{component:t,data:void 0,state:void 0,action:Ke.Replace,targetComponentId:this.id,containerId:void 0},callbackToken:this.callbackToken})})}}}}updateMenu(e,t){let n=[];return e.forEach(e=>{if(e.remote){let r=t.find(t=>t.targetComponentId==e.baseUrl+`#`+e.route);if(r&&r.component?.type==k.ClientSide){let t=r.component;if(t.metadata?.type==A.App){let r=t.metadata,i=e.serverSideType&&e.serverSideType!=``?e.serverSideType:r.serverSideType;this.changeBaseUrl(r.menu,e.baseUrl,i,e.route,r.route),n.push(...r.menu)}}}else n.push(e)}),n}changeBaseUrl(e,t,n,r,i){e.forEach(e=>{e.baseUrl||(e.submenus&&e.submenus.length>0?this.changeBaseUrl(e.submenus,t,n,r,i):(e.consumedRoute=i??``,e.baseUrl=t,e.serverSideType=n,e.uriPrefix=r))})}getRemoteMenus(e){let t=[];return e.forEach(e=>{e.remote&&t.push(e)}),t}disconnectedCallback(){super.disconnectedCallback(),this.upstreamSubscription?.unsubscribe()}applyCommand(e){if(e.type==`SetWindowTitle`&&(document.title=e.data,Qe(document.title)),e.type==`SetFavicon`&&this.changeFavicon(e.data),e.type==`DispatchEvent`&&this.dispatchNamedEvent(e.data),e.type==`NavigateTo`){let t=e.data;t&&(t.startsWith(`http:`)||t.startsWith(`https:`)?window.open(e.data,`_blank`):window.location.href=e.data)}if(e.type==`PushStateToHistory`){let t=e.data;t!==void 0&&this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0}))}if(e.type==`RunAction`){let t=e.data;if(t&&t.actionId)if(t.targetComponentId){let e={command:{type:`RunAction`,data:{actionId:t.actionId},targetComponentId:t.targetComponentId},fragment:void 0,ui:void 0,error:void 0,callbackToken:``};setTimeout(()=>ue.next(e))}else this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:{}},bubbles:!0,composed:!0}))}if(e.type==`MarkAsDirty`&&this.dispatchEvent(new CustomEvent(`dirty`,{detail:{},bubbles:!0,composed:!0})),e.type==`MarkAsClean`&&this.dispatchEvent(new CustomEvent(`clean`,{detail:{},bubbles:!0,composed:!0})),e.type==`DownloadFile`){let t=e.data;if(t&&t.base64Content){let e=atob(t.base64Content),n=new Uint8Array(e.length);for(let t=0;t<e.length;t++)n[t]=e.charCodeAt(t);let r=new Blob([n],{type:t.mimeType}),i=URL.createObjectURL(r),a=document.createElement(`a`);a.href=i,a.download=t.filename??`export`,a.click(),URL.revokeObjectURL(i)}}if(e.type==`CloseModal`&&(this.closeModal(),this.dispatchNamedEvent(e.data)),e.type==`AddContentToHead`){let t=e.data;if(t&&t.name){if(t.attributes&&t.attributes.id&&document.getElementById(t.attributes.id))return;document.head.appendChild(this.createElement(e))}}if(e.type==`AddContentToBody`){let t=e.data;if(t&&t.name){if(t.attributes&&t.attributes.id&&document.getElementById(t.attributes.id))return;document.body.appendChild(this.createElement(e))}}}dispatchNamedEvent(e){if(e&&e.eventName){let t=this.component,n=t?.emitsName??t?.serverSideType,r=e.payload??e.detail;n&&r&&typeof r==`object`&&(r={...r,__source:n}),this.dispatchEvent(new CustomEvent(e.eventName,{detail:r,bubbles:!0,composed:!0}))}}};O([v()],$e.prototype,`id`,void 0),O([v()],$e.prototype,`baseUrl`,void 0);var et=class extends $e{applyFragment(e){}manageActionRequestedEvent(e){}};O([v()],et.prototype,`component`,void 0);var tt=(e,t)=>Function(...Object.keys(t),"return `"+e+"`")(...Object.values(t)),nt=(e,t,n)=>({state:e??{},data:t??{},...n});function j(e,t,n,r){if(!e?.includes("${"))return e;try{return tt(e,nt(t,n,r))}catch(t){return console.warn(`Mateu: could not interpolate "${e}":`,t),e}}var rt=(e,t,n)=>{if(e&&e.indexOf("${")>=0)try{return tt(e,nt(t,n))}catch(e){return e.message}return e},it=(e,t,n,r,i)=>{if(!e)return e;let a=nt(t,n,{appState:r??{},appData:i??{}}),o=e;try{if(o=tt(e,a),o.includes("${"))try{o=tt(o,a)}catch(a){o=`when evaluating nested `+e+` :`+a+`, where data is `+n+` and state is `+t+` and app state is `+r+` and app data is `+i,console.error(a,o,t,n,r,i)}}catch(a){o=`when evaluating `+e+` :`+a+`, where data is `+n+` and state is `+t+` and app state is `+r+` and app data is `+i,console.error(a,o,t,n,r,i)}return o},at=(e,t,n,r,i,a)=>{let o=nt(t,n,{appState:r??{},appData:i??{},...a}),s=tt(e,o);return Function(...Object.keys(o),`return (${s})`)(...Object.values(o))},ot=(e,t,n,r)=>{let i=nt(t,n,r);return Function(...Object.keys(i),`return (${e})`)(...Object.values(i))},st=(e,t,n,r)=>tt(e,nt(t,n,r)),ct=`display:inline-flex; align-items:center; justify-content:center; width:2rem; height:2rem; border-radius:50%; background:var(--lumo-contrast-10pct,#e0e0e0); color:var(--lumo-secondary-text-color,#555); font-size:.8rem; font-weight:600; overflow:hidden; flex:none;`,lt=(e,t)=>t||(typeof e==`string`&&e?e.trim().split(/\s+/).map(e=>e[0]).slice(0,2).join(``).toUpperCase():``),ut=(e,t,n)=>{let r=e.metadata,i=M(r.name,t,n);return w`<span style="${ct}${e.style}" class="${e.cssClasses}"
+                      title="${i||_}" slot="${e.slot??_}">
+        ${r.image?w`<img src="${r.image}" alt="${i}" style="width:100%;height:100%;object-fit:cover;">`:lt(i,r.abbreviation)}
+    </span>`},M=(e,t,n)=>typeof e==`string`&&e.includes("${")?j(e,t,n):e,dt=e=>{let t=e.metadata,n=t.avatars??[],r=t.maxItemsVisible&&t.maxItemsVisible>0?t.maxItemsVisible:n.length,i=n.slice(0,r),a=n.length-i.length,o=`margin-left:-0.4rem; border:2px solid var(--lumo-base-color,#fff);`;return w`<span style="display:inline-flex; ${e.style}" class="${e.cssClasses}" slot="${e.slot??_}">
+        ${i.map(e=>w`<span style="${ct}${o}" title="${e.name||_}">
+            ${e.img?w`<img src="${e.img}" style="width:100%;height:100%;object-fit:cover;">`:lt(e.name??``,e.abbr)}
         </span>`)}
-        ${a>0?T`<span style="${st}${o}">+${a}</span>`:v}
-    </span>`},dt=(e,t,n)=>{let r=e.metadata;return T`<span theme="badge ${r.color} ${r.pill?`pill`:``} ${r.small?`small`:``} ${r.primary?`primary`:``}"
+        ${a>0?w`<span style="${ct}${o}">+${a}</span>`:_}
+    </span>`},ft=(e,t,n)=>{let r=e.metadata;return w`<span theme="badge ${r.color} ${r.pill?`pill`:``} ${r.small?`small`:``} ${r.primary?`primary`:``}"
                       style="${e.style}" class="${e.cssClasses}"
-                      slot="${e.slot??v}">${N(r.text,t,n)}</span>`},ft=(e,t,n)=>{let r=N(e.text,t,n);if(!r)return v;let i=N(e.color,t,n);return i==`SUCCESS`&&(i=`success`),i==`ERROR`&&(i=`error`),i==`DANGER`&&(i=`error`),i==`WARNING`&&(i=`warning`),i==`INFO`&&(i=`info`),i==`PRIMARY`&&(i=`primary`),i==`SECONDARY`&&(i=`secondary`),i==`TERTIARY`&&(i=`tertiary`),i==`QUATERNARY`&&(i=`quaternary`),i==`LIGHT`&&(i=`light`),i==`DARK`&&(i=`dark`),T`<span theme="badge ${i} ${e.pill?`pill`:``} ${e.small?`small`:``} ${e.primary?`primary`:``}">${r}</span>`},P=new class{constructor(){this.afterRenderHook=void 0,this.useShadowRoot=!0,this.componentRenderer=void 0}set(e){if(this.componentRenderer=e,typeof window<`u`){let t=e.supportedClientSideTypes?.();window.__mateuRendererInfo={name:e.rendererName?.()??e.constructor?.name??`unknown`,supportedTypes:t?[...t].sort():null}}}get(){return this.componentRenderer}setUseShadowRoot(e){this.useShadowRoot=e}mustUseShadowRoot(){return this.useShadowRoot}setAfterRenderHook(e){this.afterRenderHook=e}getAfterRenderHook(){return this.afterRenderHook}},pt=(e,t,n,r,i,a,o,s,c)=>(t.slot=s,F(e,t,n,r,i,a,o,c)),F=(e,t,n,r,i,a,o,s)=>{if(!t)return T``;if(t.type==A.ClientSide)return P.get().renderClientSideComponent(e,t,n,r,i,a,o,s);let c=e.route,l=e.consumedRoute;return T`
+                      slot="${e.slot??_}">${M(r.text,t,n)}</span>`},pt=(e,t,n)=>{let r=M(e.text,t,n);if(!r)return _;let i=M(e.color,t,n);return i==`SUCCESS`&&(i=`success`),i==`ERROR`&&(i=`error`),i==`DANGER`&&(i=`error`),i==`WARNING`&&(i=`warning`),i==`INFO`&&(i=`info`),i==`PRIMARY`&&(i=`primary`),i==`SECONDARY`&&(i=`secondary`),i==`TERTIARY`&&(i=`tertiary`),i==`QUATERNARY`&&(i=`quaternary`),i==`LIGHT`&&(i=`light`),i==`DARK`&&(i=`dark`),w`<span theme="badge ${i} ${e.pill?`pill`:``} ${e.small?`small`:``} ${e.primary?`primary`:``}">${r}</span>`},N=new class{constructor(){this.afterRenderHook=void 0,this.useShadowRoot=!0,this.componentRenderer=void 0}set(e){if(this.componentRenderer=e,typeof window<`u`){let t=e.supportedClientSideTypes?.();window.__mateuRendererInfo={name:e.rendererName?.()??e.constructor?.name??`unknown`,supportedTypes:t?[...t].sort():null}}}get(){return this.componentRenderer}setUseShadowRoot(e){this.useShadowRoot=e}mustUseShadowRoot(){return this.useShadowRoot}setAfterRenderHook(e){this.afterRenderHook=e}getAfterRenderHook(){return this.afterRenderHook}},mt=(e,t,n,r,i,a,o,s,c)=>(t.slot=s,P(e,t,n,r,i,a,o,c)),P=(e,t,n,r,i,a,o,s)=>{if(!t)return w``;if(t.type==k.ClientSide)return N.get().renderClientSideComponent(e,t,n,r,i,a,o,s);let c=e.route,l=e.consumedRoute;return w`
         <mateu-component id="${t.id}"
                          .component="${t}"
                         route="${c}"
                          consumedRoute="${l}"
                          baseUrl="${n}"
-                         slot="${t.slot??v}"
+                         slot="${t.slot??_}"
                          style="${t.style}"
                          class="${t.cssClasses}"
                          .state="${{...t.initialData??{},...r}}"
@@ -163,29 +163,29 @@ ${i}
                          .appState="${a}"
                          .appData="${o}"
         >
-       </mateu-component>`},mt=e=>{let t=[];return e.color&&e.color!==`normal`&&e.color!==`none`&&t.push(e.color),e.buttonStyle&&t.push(e.buttonStyle===`tertiaryInline`?`tertiary-inline`:e.buttonStyle),e.size&&e.size!==`none`&&e.size!==`normal`&&t.push(e.size),t.length?t.join(` `):void 0},ht=e=>{let t=mt(e)??``,n=[];return t.includes(`primary`)&&n.push(`primary`),t.includes(`tertiary`)&&n.push(`tertiary`),(t.includes(`error`)||e.color===`error`)&&n.push(`danger`),n.join(` `)},gt=e=>e===`back`||e===`backToList`||!!e&&e.startsWith(`cancel`),_t=class extends b{constructor(...e){super(...e),this.appState={},this.appData={},this._overflowOpen=!1,this._onDocClick=e=>{e.composedPath().includes(this)||(this._overflowOpen=!1)},this.handleButtonClick=e=>{this._overflowOpen=!1,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.evalLabel=e=>M(e,this.state,this.data),this.renderBtn=e=>{if((this.data??{})[e.actionId+`.hidden`])return v;let t=this.evalLabel(e.label);return P.get()?.renderToolbarButton?.(e,t,()=>this.handleButtonClick(e.actionId))||T`
-        <button class="mtb ${ht(e)}"
+       </mateu-component>`},ht=e=>{let t=[];return e.color&&e.color!==`normal`&&e.color!==`none`&&t.push(e.color),e.buttonStyle&&t.push(e.buttonStyle===`tertiaryInline`?`tertiary-inline`:e.buttonStyle),e.size&&e.size!==`none`&&e.size!==`normal`&&t.push(e.size),t.length?t.join(` `):void 0},gt=e=>{let t=ht(e)??``,n=[];return t.includes(`primary`)&&n.push(`primary`),t.includes(`tertiary`)&&n.push(`tertiary`),(t.includes(`error`)||e.color===`error`)&&n.push(`danger`),n.join(` `)},_t=e=>e===`back`||e===`backToList`||!!e&&e.startsWith(`cancel`),vt=class extends y{constructor(...e){super(...e),this.appState={},this.appData={},this._overflowOpen=!1,this._onDocClick=e=>{e.composedPath().includes(this)||(this._overflowOpen=!1)},this.handleButtonClick=e=>{this._overflowOpen=!1,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.evalLabel=e=>j(e,this.state,this.data),this.renderBtn=e=>{if((this.data??{})[e.actionId+`.hidden`])return _;let t=this.evalLabel(e.label);return N.get()?.renderToolbarButton?.(e,t,()=>this.handleButtonClick(e.actionId))||w`
+        <button class="mtb ${gt(e)}"
                 data-action-id="${e.id}"
                 @click="${()=>this.handleButtonClick(e.actionId)}"
                 ?disabled="${e.disabled}"
         >${t}</button>
-    `},this.renderActions=e=>{let t=e.filter(e=>!(this.data??{})[e.actionId+`.hidden`]),n=t.filter(e=>e.buttonStyle===`primary`),r=t.filter(e=>e.buttonStyle!==`primary`);return r.length<2?T`${t.map(this.renderBtn)}`:T`
+    `},this.renderActions=e=>{let t=e.filter(e=>!(this.data??{})[e.actionId+`.hidden`]),n=t.filter(e=>e.buttonStyle===`primary`),r=t.filter(e=>e.buttonStyle!==`primary`);return r.length<2?w`${t.map(this.renderBtn)}`:w`
             ${n.map(this.renderBtn)}
             <div class="overflow-wrap">
                 <button class="mtb overflow-btn" title="Más acciones" aria-haspopup="true"
                         aria-expanded="${this._overflowOpen}"
                         @click="${e=>{e.stopPropagation(),this._overflowOpen=!this._overflowOpen}}">⋯</button>
-                ${this._overflowOpen?T`
+                ${this._overflowOpen?w`
                     <div class="overflow-menu">
-                        ${r.map(e=>T`
+                        ${r.map(e=>w`
                             <button class="overflow-item" ?disabled="${e.disabled}"
                                     data-action-id="${e.actionId}"
                                     @click="${()=>this.handleButtonClick(e.actionId)}">${this.evalLabel(e.label)}</button>
                         `)}
                     </div>
-                `:v}
+                `:_}
             </div>
-        `},this.renderPeerNav=e=>P.get()?.renderPeerNav?.(e)||T`
+        `},this.renderPeerNav=e=>N.get()?.renderPeerNav?.(e)||w`
             <div style="display: flex; gap: var(--lumo-space-xs, .25rem); align-items: center;" class="peer-nav">
                 <button class="mtb tertiary peer-nav-prev"
                         title="${e.prevLabel??`Previous`}"
@@ -196,71 +196,71 @@ ${i}
                         ?disabled="${!e.nextRoute}"
                         @click="${()=>{e.nextRoute&&(window.location.href=e.nextRoute)}}">›</button>
             </div>
-        `}connectedCallback(){super.connectedCallback(),document.addEventListener(`click`,this._onDocClick)}disconnectedCallback(){document.removeEventListener(`click`,this._onDocClick),super.disconnectedCallback()}render(){let e=this.metadata;if(!e)return T``;let t=e.peerNav&&(e.peerNav.prevRoute||e.peerNav.nextRoute)?e.peerNav:void 0,n=e.toolbar??[],r=n.filter(e=>gt(e.actionId)),i=n.filter(e=>!gt(e.actionId)),a=r.length>0&&i.length>0?T`<span class="toolbar-divider"></span>`:v,o=e.avatar||e.title||e.subtitle||e.kpis?.length>0||e.header?.length>0||n.length>0||!!t,s=e.level??0;return s>0?this.setAttribute(`data-nested`,``):this.removeAttribute(`data-nested`),T`
-            ${e.breadcrumbs&&e.breadcrumbs.length>0?T`
+        `}connectedCallback(){super.connectedCallback(),document.addEventListener(`click`,this._onDocClick)}disconnectedCallback(){document.removeEventListener(`click`,this._onDocClick),super.disconnectedCallback()}render(){let e=this.metadata;if(!e)return w``;let t=e.peerNav&&(e.peerNav.prevRoute||e.peerNav.nextRoute)?e.peerNav:void 0,n=e.toolbar??[],r=n.filter(e=>_t(e.actionId)),i=n.filter(e=>!_t(e.actionId)),a=r.length>0&&i.length>0?w`<span class="toolbar-divider"></span>`:_,o=e.avatar||e.title||e.subtitle||e.kpis?.length>0||e.header?.length>0||n.length>0||!!t,s=e.level??0;return s>0?this.setAttribute(`data-nested`,``):this.removeAttribute(`data-nested`),w`
+            ${e.breadcrumbs&&e.breadcrumbs.length>0?w`
                 <div style="display: flex; gap: var(--lumo-space-m, 1rem); width: 100%; align-items: center;" class="breadcrumbs-bar">
-                    ${e.breadcrumbs.map((e,t)=>T`
-                        ${t>0?T`<span>/</span>`:v}
-                        ${e.link?T`<button class="breadcrumb-link" @click="${()=>window.location.href=`${e.link}`}">${e.text}</button>`:T`<span>${e.text}</span>`}
+                    ${e.breadcrumbs.map((e,t)=>w`
+                        ${t>0?w`<span>/</span>`:_}
+                        ${e.link?w`<button class="breadcrumb-link" @click="${()=>window.location.href=`${e.link}`}">${e.text}</button>`:w`<span>${e.text}</span>`}
                     `)}
                 </div>
-            `:v}
-            ${e.noHeader?T`
+            `:_}
+            ${e.noHeader?w`
                 <div style="display: flex; gap: var(--lumo-space-m, 1rem); align-items: center;">
-                    ${e?.header?.map(e=>F(this,e,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData))}
-                    ${t?this.renderPeerNav(t):v}
+                    ${e?.header?.map(e=>P(this,e,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData))}
+                    ${t?this.renderPeerNav(t):_}
                     ${r.map(this.renderBtn)}
                     ${a}
                     ${this.renderActions(i)}
                 </div>
-            `:o?T`
+            `:o?w`
                 <div style="display: flex; gap: var(--lumo-space-m, 1rem); width: 100%; align-items: center; flex-wrap: wrap;" class="form-header">
-                    ${e.avatar?F(this,e.avatar,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData):v}
+                    ${e.avatar?P(this,e.avatar,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData):_}
                     <div style="flex: 1; min-width: min(22rem, 100%); overflow: hidden;">
-                        ${e?.title&&s==0?T`
+                        ${e?.title&&s==0?w`
                             <div style="display: flex; align-items: center; gap: var(--lumo-space-s, .5rem); min-width: 0;">
-                                <h2 style="margin: 0; margin-block-end: 0px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">${_(nt(e?.title,this.state??{},this.data??{}))}</h2>
-                                ${e.kpisBelow&&e.badges?.length?e.badges.map(e=>ft(e,this.state??{},this.data??{})):v}
-                            </div>`:v}
-                        ${e?.title&&s==1?T`<h3 style="margin: 0; margin-block-end: 0px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; width: 100%;">${_(nt(e?.title,this.state??{},this.data??{}))}</h3>`:v}
-                        ${e?.title&&s==2?T`<h4 style="margin: 0; margin-block-end: 0px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; width: 100%;">${_(nt(e?.title,this.state??{},this.data??{}))}</h4>`:v}
-                        ${e?.title&&s==3?T`<h5 style="margin: 0; margin-block-end: 0px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; width: 100%;">${_(nt(e?.title,this.state??{},this.data??{}))}</h5>`:v}
-                        ${e?.title&&s>3?T`<h6 style="margin: 0; margin-block-end: 0px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; width: 100%;">${_(nt(e?.title,this.state??{},this.data??{}))}</h6>`:v}
+                                <h2 style="margin: 0; margin-block-end: 0px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">${g(rt(e?.title,this.state??{},this.data??{}))}</h2>
+                                ${e.kpisBelow&&e.badges?.length?e.badges.map(e=>pt(e,this.state??{},this.data??{})):_}
+                            </div>`:_}
+                        ${e?.title&&s==1?w`<h3 style="margin: 0; margin-block-end: 0px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; width: 100%;">${g(rt(e?.title,this.state??{},this.data??{}))}</h3>`:_}
+                        ${e?.title&&s==2?w`<h4 style="margin: 0; margin-block-end: 0px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; width: 100%;">${g(rt(e?.title,this.state??{},this.data??{}))}</h4>`:_}
+                        ${e?.title&&s==3?w`<h5 style="margin: 0; margin-block-end: 0px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; width: 100%;">${g(rt(e?.title,this.state??{},this.data??{}))}</h5>`:_}
+                        ${e?.title&&s>3?w`<h6 style="margin: 0; margin-block-end: 0px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; width: 100%;">${g(rt(e?.title,this.state??{},this.data??{}))}</h6>`:_}
 
-                        ${e?.subtitle?T`<span style="display: inline-block; margin-block-end: 0.83em;">${_(nt(e?.subtitle,this.state??{},this.data??{}))}</span>`:v}
-                        ${e?.timestamp?T`<span class="page-timestamp" style="display: block; color: var(--lumo-secondary-text-color, #6b7280); font-size: var(--lumo-font-size-s, .875rem);">${_(nt(e.timestamp,this.state??{},this.data??{}))}</span>`:v}
+                        ${e?.subtitle?w`<span style="display: inline-block; margin-block-end: 0.83em;">${g(rt(e?.subtitle,this.state??{},this.data??{}))}</span>`:_}
+                        ${e?.timestamp?w`<span class="page-timestamp" style="display: block; color: var(--lumo-secondary-text-color, #6b7280); font-size: var(--lumo-font-size-s, .875rem);">${g(rt(e.timestamp,this.state??{},this.data??{}))}</span>`:_}
                     </div>
                     <div style="display: flex; gap: var(--lumo-space-m, 1rem); align-items: center;">
-                        ${e.kpisBelow?v:e?.kpis?.map(e=>T`
+                        ${e.kpisBelow?_:e?.kpis?.map(e=>w`
                             <div style="display: flex; flex-direction: column; align-items: center;">
                                 <div>${this.evalLabel(e.title)}</div>
-                                <div>${_(nt(e.text,this.state??{},this.data??{}))}</div>
+                                <div>${g(rt(e.text,this.state??{},this.data??{}))}</div>
                             </div>
                         `)}
-                        ${e?.header?.map(e=>F(this,e,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData))}
-                        ${t?this.renderPeerNav(t):v}
+                        ${e?.header?.map(e=>P(this,e,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData))}
+                        ${t?this.renderPeerNav(t):_}
                         ${r.map(this.renderBtn)}
                         ${a}
                         ${this.renderActions(i)}
                     </div>
                 </div>
-            `:v}
-            ${e.kpisBelow&&e?.kpis?.length?T`
+            `:_}
+            ${e.kpisBelow&&e?.kpis?.length?w`
                 <div class="kpi-row">
-                    ${e.kpis.map(e=>T`
+                    ${e.kpis.map(e=>w`
                         <div class="kpi-pair">
                             <span class="kpi-label">${this.evalLabel(e.title)}</span>
-                            <span class="kpi-value">${_(nt(e.text,this.state??{},this.data??{}))}</span>
+                            <span class="kpi-value">${g(rt(e.text,this.state??{},this.data??{}))}</span>
                         </div>
                     `)}
                 </div>
-            `:v}
-            ${e.badges&&e.badges.length>0&&!e.kpisBelow?T`
+            `:_}
+            ${e.badges&&e.badges.length>0&&!e.kpisBelow?w`
                 <div style="display: flex; gap: var(--lumo-space-s, .5rem); padding-bottom: var(--lumo-space-s, .5rem);">
-                    ${e.badges.map(e=>ft(e,this.state??{},this.data??{}))}
+                    ${e.badges.map(e=>pt(e,this.state??{},this.data??{}))}
                 </div>
-            `:v}
-        `}static{this.styles=h`
+            `:_}
+        `}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -372,8 +372,8 @@ ${i}
         .mtb.danger { color: var(--lumo-error-text-color, #c0392b); border-color: var(--lumo-error-color-50pct, rgba(192,57,43,.5)); }
         .mtb.danger.primary { background: var(--lumo-error-color, #c0392b); color: #fff; border-color: transparent; }
 
-        ${de}
-    `}};k([y()],_t.prototype,`metadata`,void 0),k([y()],_t.prototype,`baseUrl`,void 0),k([y()],_t.prototype,`state`,void 0),k([y()],_t.prototype,`data`,void 0),k([y()],_t.prototype,`appState`,void 0),k([y()],_t.prototype,`appData`,void 0),k([C()],_t.prototype,`_overflowOpen`,void 0),_t=k([g(`mateu-content-header`)],_t);var vt=class extends $e{constructor(...e){super(...e),this.state={},this.data={},this.appState={},this.appData={}}render(){let e=this.component?.metadata;return T`
+        ${fe}
+    `}};O([v()],vt.prototype,`metadata`,void 0),O([v()],vt.prototype,`baseUrl`,void 0),O([v()],vt.prototype,`state`,void 0),O([v()],vt.prototype,`data`,void 0),O([v()],vt.prototype,`appState`,void 0),O([v()],vt.prototype,`appData`,void 0),O([S()],vt.prototype,`_overflowOpen`,void 0),vt=O([h(`mateu-content-header`)],vt);var yt=class extends et{constructor(...e){super(...e),this.state={},this.data={},this.appState={},this.appData={}}render(){let e=this.component?.metadata;return w`
             <div class="mateu-vlayout ${this.component?.cssClasses??``}">
                 <mateu-content-header
                     .metadata="${e}"
@@ -390,7 +390,7 @@ ${i}
                     </div>
                 </div>
             </div>
-       `}static{this.styles=h`
+       `}static{this.styles=m`
         :host {
         }
 
@@ -419,7 +419,7 @@ ${i}
         .form-content {
             padding-bottom: 3rem;
         }
-    `}};k([y()],vt.prototype,`state`,void 0),k([y()],vt.prototype,`data`,void 0),k([y()],vt.prototype,`appState`,void 0),k([y()],vt.prototype,`appData`,void 0),vt=k([g(`mateu-form`)],vt);var yt=class extends b{constructor(...e){super(...e),this.variant=`text`,this.count=3}static{this.styles=h`
+    `}};O([v()],yt.prototype,`state`,void 0),O([v()],yt.prototype,`data`,void 0),O([v()],yt.prototype,`appState`,void 0),O([v()],yt.prototype,`appData`,void 0),yt=O([h(`mateu-form`)],yt);var bt=class extends y{constructor(...e){super(...e),this.variant=`text`,this.count=3}static{this.styles=m`
         :host {
             display: block;
             flex: 1 1 0;
@@ -448,37 +448,37 @@ ${i}
         .form-pair { display: flex; flex-direction: column; gap: .35em; margin: .9em 0; }
         .label { height: .8em; width: 30%; }
         .field { height: 2.25em; width: 100%; }
-    `}render(){let e=Array.from({length:Math.max(1,this.count)});return this.variant==`card`?T`${e.map(()=>T`<div class="bone card" style="margin: .5em 0;"></div>`)}`:this.variant==`grid`?T`${e.map(()=>T`<div class="bone row"></div>`)}`:this.variant==`form`?T`${e.map(()=>T`
+    `}render(){let e=Array.from({length:Math.max(1,this.count)});return this.variant==`card`?w`${e.map(()=>w`<div class="bone card" style="margin: .5em 0;"></div>`)}`:this.variant==`grid`?w`${e.map(()=>w`<div class="bone row"></div>`)}`:this.variant==`form`?w`${e.map(()=>w`
                 <div class="form-pair">
                     <div class="bone label"></div>
                     <div class="bone field"></div>
                 </div>
-            `)}`:T`${e.map(()=>T`<div class="bone line"></div>`)}`}};k([y()],yt.prototype,`variant`,void 0),k([y({type:Number})],yt.prototype,`count`,void 0),yt=k([g(`mateu-skeleton`)],yt);var bt=(e,t)=>{t&&e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},xt=(e,t,n,r,i,a)=>T`
+            `)}`:w`${e.map(()=>w`<div class="bone line"></div>`)}`}};O([v()],bt.prototype,`variant`,void 0),O([v({type:Number})],bt.prototype,`count`,void 0),bt=O([h(`mateu-skeleton`)],bt);var xt=(e,t)=>{t&&e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},St=(e,t,n,r,i,a)=>w`
         <div class="mateu-empty-state"
              style="display: flex; flex-direction: column; align-items: center; justify-content: center; gap: .35rem; padding: var(--lumo-space-l, 1.5rem); text-align: center; color: var(--lumo-secondary-text-color, #666);">
             <span style="font-size: 1.8rem; line-height: 1; opacity: .6;">${t??`🗂`}</span>
-            ${n?T`<span style="font-weight: 600; color: var(--lumo-body-text-color, #333);">${n}</span>`:v}
+            ${n?w`<span style="font-weight: 600; color: var(--lumo-body-text-color, #333);">${n}</span>`:_}
             <span style="font-size: var(--lumo-font-size-s, .875rem);">${r??e??`Nothing here yet.`}</span>
-            ${i&&a?T`
+            ${i&&a?w`
                 <button style="margin-top: .25rem; font: inherit; font-weight: 500; cursor: pointer; padding: .4rem .9rem; border: none; border-radius: var(--lumo-border-radius-m, 6px); background: transparent; color: var(--lumo-primary-text-color, #3b5bdb);"
-                        @click="${e=>bt(e,i)}">${a}</button>
-            `:v}
+                        @click="${e=>xt(e,i)}">${a}</button>
+            `:_}
         </div>
-    `,St=e=>{let t=e.metadata;return T`
-        <div style="${e.style??v}" class="${e.cssClasses??v}" slot="${e.slot??v}">
-            ${xt(void 0,t.icon,t.title,t.description,t.actionId,t.actionLabel)}
+    `,Ct=e=>{let t=e.metadata;return w`
+        <div style="${e.style??_}" class="${e.cssClasses??_}" slot="${e.slot??_}">
+            ${St(void 0,t.icon,t.title,t.description,t.actionId,t.actionLabel)}
         </div>
-    `},Ct=e=>{let t=e.metadata;return T`
+    `},wt=e=>{let t=e.metadata;return w`
         <mateu-skeleton
                 variant="${t.variant??`text`}"
                 count="${t.count&&t.count>0?t.count:3}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-skeleton>
-    `},I=(e,t,n,r)=>{if(!e)return T``;let i=P.get()?.renderIcon;if(i){let a=i.call(P.get(),e,t,n);return r?T`<span slot="${r}">${a}</span>`:a}return T`<span class="mateu-icon ${n??``}" data-icon="${e}" aria-hidden="true"
-                      style="display:inline-block; width:1em; height:1em; ${t??``}" slot="${r??v}"></span>`},wt=`mateu-saved-views`,Tt=()=>{try{return JSON.parse(localStorage.getItem(wt)??`{}`)}catch{return{}}},Et=e=>{try{localStorage.setItem(wt,JSON.stringify(e))}catch{}},Dt=e=>Tt()[e]??[],Ot=(e,t)=>{let n=t.name?.trim();if(!n||Object.keys(t.values??{}).length===0)return;let r=Tt(),i=(r[e]??[]).filter(e=>e.name!==n);i.push({...t,name:n}),r[e]=i,Et(r)},kt=(e,t)=>{let n=Tt(),r=(n[e]??[]).filter(e=>e.name!==t);r.length===0?delete n[e]:n[e]=r,Et(n)},At=(e,t)=>{let n=Tt();n[e]=(n[e]??[]).map(e=>({...e,isDefault:e.name===t&&!e.isDefault})),Et(n)},jt=e=>Dt(e).find(e=>e.isDefault),L=class extends b{constructor(...e){super(...e),this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.searchOnly=!1,this.panelOpened=!1,this.viewsOpened=!1,this.draftText=``,this.openPanel=()=>{this.panelOpened||this.filters.length===0||(this.panelOpened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick))},this.closePanel=()=>{this.detachOutsideClick(),this.panelOpened=!1,this.activeFilter=void 0},this.clearAllFilters=()=>{let e=this.filters.flatMap(e=>this.isRangeFilter(e)?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId]),t={searchText:void 0};e.forEach(e=>{t[e]=void 0}),this.state={...this.state,...t},this.dispatchEvent(new CustomEvent(`filter-reset-requested`,{detail:{fieldIds:e},bubbles:!0,composed:!0})),this.requestSearch()},this.keepFocus=e=>e.preventDefault()}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}get filters(){return this.metadata?.filters??[]}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}requestSearch(){this.closePanel(),this.dispatchEvent(new CustomEvent(`search-requested`,{detail:{},bubbles:!0,composed:!0}))}emitValueChanged(e,t){this.state={...this.state,[e]:t},this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:e},bubbles:!0,composed:!0}))}applyFilter(e,t){this.emitValueChanged(e,t),this.requestSearch()}removeChip(e){let t=this.filters.find(t=>t.fieldId===e);t&&this.isRangeFilter(t)?(this.emitValueChanged(`${e}_from`,void 0),this.emitValueChanged(`${e}_to`,void 0)):this.emitValueChanged(e,e===`searchText`?``:void 0),this.requestSearch()}commitText(e){this.emitValueChanged(`searchText`,e.value),this.draftText=``,e.value=``,this.requestSearch()}get viewsScope(){return window.location.pathname}allFilterKeys(){return[`searchText`,...this.filters.flatMap(e=>this.isRangeFilter(e)?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId])]}snapshotValues(){let e={};return this.state.searchText&&(e.searchText=this.state.searchText),this.filters.forEach(t=>{if(this.isSet(t))if(this.isRangeFilter(t)){let n=this.rangeBound(t,`from`),r=this.rangeBound(t,`to`);n&&(e[`${t.fieldId}_from`]=n),r&&(e[`${t.fieldId}_to`]=r)}else this.isMultiFilter(t)?e[t.fieldId]=this.multiValues(t):e[t.fieldId]=this.state[t.fieldId]}),e}applyView(e){let t=this.allFilterKeys(),n={};t.forEach(e=>{n[e]=void 0}),this.state={...this.state,...n},this.dispatchEvent(new CustomEvent(`filter-reset-requested`,{detail:{fieldIds:t},bubbles:!0,composed:!0})),Object.entries(e.values).forEach(([e,t])=>this.emitValueChanged(e,t)),this.viewsOpened=!1,this.detachOutsideClick(),this.requestSearch()}saveCurrentView(e){let t=e.value.trim();t&&(Ot(this.viewsScope,{name:t,values:this.snapshotValues()}),e.value=``,this.requestUpdate())}firstUpdated(){if(window.location.search)return;let e=jt(this.viewsScope);e&&setTimeout(()=>{this.state.searchText||this.filters.some(e=>this.isSet(e))||this.applyView(e)},0)}isBooleanFilter(e){return e.dataType===`boolean`||e.dataType===`bool`||e.stereotype===`checkbox`||e.stereotype===`toggle`}isNumericFilter(e){return[`integer`,`decimal`,`number`,`money`].includes(e.dataType??``)}isRangeFilter(e){return e.stereotype===`dateRange`||e.stereotype===`numberRange`}isMultiFilter(e){return e.stereotype===`multiSelect`}hasOptions(e){return(e.options?.length??0)>0}multiValues(e){let t=this.state[e.fieldId];return Array.isArray(t)?t.map(String):typeof t==`string`&&t!==``?t.split(`,`).map(e=>e.trim()).filter(e=>e):[]}rangeBound(e,t){let n=this.state[`${e.fieldId}_${t}`];return n==null?``:String(n)}isSet(e){if(this.isRangeFilter(e))return this.rangeBound(e,`from`)!==``||this.rangeBound(e,`to`)!==``;if(this.isMultiFilter(e))return this.multiValues(e).length>0;let t=this.state[e.fieldId];return t!=null&&t!==``&&!Number.isNaN(t)}getFilterDisplayValue(e,t){if(e.options?.length){let n=e.options.find(e=>e.value===String(t));if(n)return n.label??n.value}return typeof t==`boolean`?t?`Yes`:`No`:String(t)}conditionDisplay(e){if(this.isRangeFilter(e)){let t=this.rangeBound(e,`from`),n=this.rangeBound(e,`to`);return t&&n?`${t} – ${n}`:t?`≥ ${t}`:`≤ ${n}`}return this.isMultiFilter(e)?this.multiValues(e).map(t=>this.getFilterDisplayValue(e,t)).join(`, `):this.getFilterDisplayValue(e,this.state[e.fieldId])}labelOf(e){return M(e.label,this.state,this.data)||e.fieldId}panelRow(e,t,n=`panel-row`){return T`
-            <div class="${n}" @mousedown="${this.keepFocus}" @click="${t}">${e}</div>`}renderRangeWidget(e){let t=e.stereotype===`numberRange`?`number`:e.dataType===`dateTime`?`datetime-local`:e.dataType===`time`?`time`:`date`,n=t=>{let n=t.closest(`.panel-input-row`),r=n.querySelector(`input.range-from`).value,i=n.querySelector(`input.range-to`).value;this.emitValueChanged(`${e.fieldId}_from`,r===``?void 0:r),this.emitValueChanged(`${e.fieldId}_to`,i===``?void 0:i),this.requestSearch()},r=e=>{e.key===`Enter`&&n(e.target),e.key===`Escape`&&this.closePanel()};return T`
+    `},F=(e,t,n,r)=>{if(!e)return w``;let i=N.get()?.renderIcon;if(i){let a=i.call(N.get(),e,t,n);return r?w`<span slot="${r}">${a}</span>`:a}return w`<span class="mateu-icon ${n??``}" data-icon="${e}" aria-hidden="true"
+                      style="display:inline-block; width:1em; height:1em; ${t??``}" slot="${r??_}"></span>`},Tt=`mateu-saved-views`,Et=()=>{try{return JSON.parse(localStorage.getItem(Tt)??`{}`)}catch{return{}}},Dt=e=>{try{localStorage.setItem(Tt,JSON.stringify(e))}catch{}},Ot=e=>Et()[e]??[],kt=(e,t)=>{let n=t.name?.trim();if(!n||Object.keys(t.values??{}).length===0)return;let r=Et(),i=(r[e]??[]).filter(e=>e.name!==n);i.push({...t,name:n}),r[e]=i,Dt(r)},At=(e,t)=>{let n=Et(),r=(n[e]??[]).filter(e=>e.name!==t);r.length===0?delete n[e]:n[e]=r,Dt(n)},jt=(e,t)=>{let n=Et();n[e]=(n[e]??[]).map(e=>({...e,isDefault:e.name===t&&!e.isDefault})),Dt(n)},Mt=e=>Ot(e).find(e=>e.isDefault),I=class extends y{constructor(...e){super(...e),this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.searchOnly=!1,this.panelOpened=!1,this.viewsOpened=!1,this.draftText=``,this.openPanel=()=>{this.panelOpened||this.filters.length===0||(this.panelOpened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick))},this.closePanel=()=>{this.detachOutsideClick(),this.panelOpened=!1,this.activeFilter=void 0},this.clearAllFilters=()=>{let e=this.filters.flatMap(e=>this.isRangeFilter(e)?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId]),t={searchText:void 0};e.forEach(e=>{t[e]=void 0}),this.state={...this.state,...t},this.dispatchEvent(new CustomEvent(`filter-reset-requested`,{detail:{fieldIds:e},bubbles:!0,composed:!0})),this.requestSearch()},this.keepFocus=e=>e.preventDefault()}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}get filters(){return this.metadata?.filters??[]}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}requestSearch(){this.closePanel(),this.dispatchEvent(new CustomEvent(`search-requested`,{detail:{},bubbles:!0,composed:!0}))}emitValueChanged(e,t){this.state={...this.state,[e]:t},this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:e},bubbles:!0,composed:!0}))}applyFilter(e,t){this.emitValueChanged(e,t),this.requestSearch()}removeChip(e){let t=this.filters.find(t=>t.fieldId===e);t&&this.isRangeFilter(t)?(this.emitValueChanged(`${e}_from`,void 0),this.emitValueChanged(`${e}_to`,void 0)):this.emitValueChanged(e,e===`searchText`?``:void 0),this.requestSearch()}commitText(e){this.emitValueChanged(`searchText`,e.value),this.draftText=``,e.value=``,this.requestSearch()}get viewsScope(){return window.location.pathname}allFilterKeys(){return[`searchText`,...this.filters.flatMap(e=>this.isRangeFilter(e)?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId])]}snapshotValues(){let e={};return this.state.searchText&&(e.searchText=this.state.searchText),this.filters.forEach(t=>{if(this.isSet(t))if(this.isRangeFilter(t)){let n=this.rangeBound(t,`from`),r=this.rangeBound(t,`to`);n&&(e[`${t.fieldId}_from`]=n),r&&(e[`${t.fieldId}_to`]=r)}else this.isMultiFilter(t)?e[t.fieldId]=this.multiValues(t):e[t.fieldId]=this.state[t.fieldId]}),e}applyView(e){let t=this.allFilterKeys(),n={};t.forEach(e=>{n[e]=void 0}),this.state={...this.state,...n},this.dispatchEvent(new CustomEvent(`filter-reset-requested`,{detail:{fieldIds:t},bubbles:!0,composed:!0})),Object.entries(e.values).forEach(([e,t])=>this.emitValueChanged(e,t)),this.viewsOpened=!1,this.detachOutsideClick(),this.requestSearch()}saveCurrentView(e){let t=e.value.trim();t&&(kt(this.viewsScope,{name:t,values:this.snapshotValues()}),e.value=``,this.requestUpdate())}firstUpdated(){if(window.location.search)return;let e=Mt(this.viewsScope);e&&setTimeout(()=>{this.state.searchText||this.filters.some(e=>this.isSet(e))||this.applyView(e)},0)}isBooleanFilter(e){return e.dataType===`boolean`||e.dataType===`bool`||e.stereotype===`checkbox`||e.stereotype===`toggle`}isNumericFilter(e){return[`integer`,`decimal`,`number`,`money`].includes(e.dataType??``)}isRangeFilter(e){return e.stereotype===`dateRange`||e.stereotype===`numberRange`}isMultiFilter(e){return e.stereotype===`multiSelect`}hasOptions(e){return(e.options?.length??0)>0}multiValues(e){let t=this.state[e.fieldId];return Array.isArray(t)?t.map(String):typeof t==`string`&&t!==``?t.split(`,`).map(e=>e.trim()).filter(e=>e):[]}rangeBound(e,t){let n=this.state[`${e.fieldId}_${t}`];return n==null?``:String(n)}isSet(e){if(this.isRangeFilter(e))return this.rangeBound(e,`from`)!==``||this.rangeBound(e,`to`)!==``;if(this.isMultiFilter(e))return this.multiValues(e).length>0;let t=this.state[e.fieldId];return t!=null&&t!==``&&!Number.isNaN(t)}getFilterDisplayValue(e,t){if(e.options?.length){let n=e.options.find(e=>e.value===String(t));if(n)return n.label??n.value}return typeof t==`boolean`?t?`Yes`:`No`:String(t)}conditionDisplay(e){if(this.isRangeFilter(e)){let t=this.rangeBound(e,`from`),n=this.rangeBound(e,`to`);return t&&n?`${t} – ${n}`:t?`≥ ${t}`:`≤ ${n}`}return this.isMultiFilter(e)?this.multiValues(e).map(t=>this.getFilterDisplayValue(e,t)).join(`, `):this.getFilterDisplayValue(e,this.state[e.fieldId])}labelOf(e){return j(e.label,this.state,this.data)||e.fieldId}panelRow(e,t,n=`panel-row`){return w`
+            <div class="${n}" @mousedown="${this.keepFocus}" @click="${t}">${e}</div>`}renderRangeWidget(e){let t=e.stereotype===`numberRange`?`number`:e.dataType===`dateTime`?`datetime-local`:e.dataType===`time`?`time`:`date`,n=t=>{let n=t.closest(`.panel-input-row`),r=n.querySelector(`input.range-from`).value,i=n.querySelector(`input.range-to`).value;this.emitValueChanged(`${e.fieldId}_from`,r===``?void 0:r),this.emitValueChanged(`${e.fieldId}_to`,i===``?void 0:i),this.requestSearch()},r=e=>{e.key===`Enter`&&n(e.target),e.key===`Escape`&&this.closePanel()};return w`
             <div class="panel-input-row">
                 <input class="range-from" type="${t}" placeholder="From"
                        .value="${this.rangeBound(e,`from`)}"
@@ -492,13 +492,13 @@ ${i}
                 <button class="apply-button"
                         @mousedown="${this.keepFocus}"
                         @click="${e=>n(e.target)}">Apply</button>
-            </div>`}renderMultiWidget(e){let t=this.multiValues(e),n=n=>{let r=t.includes(n)?t.filter(e=>e!==n):[...t,n];this.emitValueChanged(e.fieldId,r.length>0?r:void 0),this.dispatchEvent(new CustomEvent(`search-requested`,{detail:{},bubbles:!0,composed:!0}))};return T`${(e.options??[]).map(e=>this.panelRow(T`
+            </div>`}renderMultiWidget(e){let t=this.multiValues(e),n=n=>{let r=t.includes(n)?t.filter(e=>e!==n):[...t,n];this.emitValueChanged(e.fieldId,r.length>0?r:void 0),this.dispatchEvent(new CustomEvent(`search-requested`,{detail:{},bubbles:!0,composed:!0}))};return w`${(e.options??[]).map(e=>this.panelRow(w`
             <span class="multi-check ${t.includes(e.value)?`multi-check--on`:``}"
                   aria-hidden="true">${t.includes(e.value)?`✓`:``}</span>
             ${e.label??e.value}
-        `,()=>n(e.value)))}`}renderActiveFilterWidget(e){if(this.isRangeFilter(e))return this.renderRangeWidget(e);if(this.isMultiFilter(e))return this.renderMultiWidget(e);if(this.hasOptions(e))return T`${e.options.map(t=>this.panelRow(t.label??t.value,()=>this.applyFilter(e.fieldId,t.value)))}`;if(this.isBooleanFilter(e))return T`
+        `,()=>n(e.value)))}`}renderActiveFilterWidget(e){if(this.isRangeFilter(e))return this.renderRangeWidget(e);if(this.isMultiFilter(e))return this.renderMultiWidget(e);if(this.hasOptions(e))return w`${e.options.map(t=>this.panelRow(t.label??t.value,()=>this.applyFilter(e.fieldId,t.value)))}`;if(this.isBooleanFilter(e))return w`
                 ${this.panelRow(`Yes`,()=>this.applyFilter(e.fieldId,!0))}
-                ${this.panelRow(`No`,()=>this.applyFilter(e.fieldId,!1))}`;let t=this.isNumericFilter(e),n=n=>{n.value!==``&&this.applyFilter(e.fieldId,t?Number(n.value):n.value)};return T`
+                ${this.panelRow(`No`,()=>this.applyFilter(e.fieldId,!1))}`;let t=this.isNumericFilter(e),n=n=>{n.value!==``&&this.applyFilter(e.fieldId,t?Number(n.value):n.value)};return w`
             <div class="panel-input-row">
                 <input type="${t?`number`:`text`}"
                        placeholder="${e.placeholder||this.labelOf(e)}"
@@ -507,29 +507,29 @@ ${i}
                 <button class="apply-button"
                         @mousedown="${this.keepFocus}"
                         @click="${e=>n(e.target.previousElementSibling)}">Apply</button>
-            </div>`}renderViewsPanel(){if(!this.viewsOpened)return v;let e=Dt(this.viewsScope),t=!!this.state.searchText||this.filters.some(e=>this.isSet(e));return T`
+            </div>`}renderViewsPanel(){if(!this.viewsOpened)return _;let e=Ot(this.viewsScope),t=!!this.state.searchText||this.filters.some(e=>this.isSet(e));return w`
             <div class="panel views-panel">
                 <div class="panel-caption">Saved views</div>
-                ${e.length===0?T`
-                    <div class="panel-row views-empty">No saved views yet</div>`:v}
-                ${e.map(e=>T`
+                ${e.length===0?w`
+                    <div class="panel-row views-empty">No saved views yet</div>`:_}
+                ${e.map(e=>w`
                     <div class="panel-row view-row" @mousedown="${this.keepFocus}">
                         <span class="view-name" @click="${()=>this.applyView(e)}">${e.name}</span>
                         <button class="view-star ${e.isDefault?`view-star--on`:``}"
                                 title="${e.isDefault?`Unset as default`:`Open this listing with this view`}"
-                                @click="${()=>{At(this.viewsScope,e.name),this.requestUpdate()}}">★</button>
+                                @click="${()=>{jt(this.viewsScope,e.name),this.requestUpdate()}}">★</button>
                         <button class="chip-remove" aria-label="Delete view ${e.name}"
-                                @click="${()=>{kt(this.viewsScope,e.name),this.requestUpdate()}}">✕</button>
+                                @click="${()=>{At(this.viewsScope,e.name),this.requestUpdate()}}">✕</button>
                     </div>`)}
-                ${t?T`
+                ${t?w`
                     <div class="panel-input-row" @mousedown="${e=>e.stopPropagation()}">
                         <input class="view-name-input" type="text" placeholder="Save current view as…"
                                @keydown="${e=>{e.key===`Enter`&&this.saveCurrentView(e.target),e.key===`Escape`&&(this.viewsOpened=!1)}}"/>
                         <button class="apply-button"
                                 @click="${e=>this.saveCurrentView(e.target.previousElementSibling)}">Save</button>
-                    </div>`:T`
+                    </div>`:w`
                     <div class="panel-row views-empty">Apply some filters to save a view</div>`}
-            </div>`}renderPanel(){if(!this.panelOpened||this.filters.length===0)return v;if(this.activeFilter){let e=this.activeFilter;return T`
+            </div>`}renderPanel(){if(!this.panelOpened||this.filters.length===0)return _;if(this.activeFilter){let e=this.activeFilter;return w`
                 <div class="panel">
                     <div class="panel-row panel-header"
                          @mousedown="${this.keepFocus}"
@@ -537,32 +537,32 @@ ${i}
                         <span aria-hidden="true">←</span> ${this.labelOf(e)}
                     </div>
                     ${this.renderActiveFilterWidget(e)}
-                </div>`}let e=!!this.state.searchText||this.filters.some(e=>this.isSet(e));return T`
+                </div>`}let e=!!this.state.searchText||this.filters.some(e=>this.isSet(e));return w`
             <div class="panel">
                 <div class="panel-caption">Filter by</div>
-                ${this.filters.map(e=>this.panelRow(T`
+                ${this.filters.map(e=>this.panelRow(w`
                     ${this.labelOf(e)}
-                    ${this.isSet(e)?T`<span class="current-value">${this.conditionDisplay(e)}</span>`:v}
+                    ${this.isSet(e)?w`<span class="current-value">${this.conditionDisplay(e)}</span>`:_}
                 `,()=>{this.activeFilter=e}))}
-                ${e?this.panelRow(`Clear filters`,this.clearAllFilters,`panel-row panel-footer`):v}
-            </div>`}render(){let e=[];return this.state.searchText&&e.push({fieldId:`searchText`,label:`Text`,display:String(this.state.searchText)}),this.filters.forEach(t=>{this.isSet(t)&&e.push({fieldId:t.fieldId,label:this.labelOf(t),display:this.conditionDisplay(t)})}),T`
+                ${e?this.panelRow(`Clear filters`,this.clearAllFilters,`panel-row panel-footer`):_}
+            </div>`}render(){let e=[];return this.state.searchText&&e.push({fieldId:`searchText`,label:`Text`,display:String(this.state.searchText)}),this.filters.forEach(t=>{this.isSet(t)&&e.push({fieldId:t.fieldId,label:this.labelOf(t),display:this.conditionDisplay(t)})}),w`
             <div class="smart-search">
                 <div class="bar"
                      @click="${e=>{e.currentTarget.querySelector(`input.free-text`)?.focus(),this.openPanel()}}">
                     <svg aria-hidden="true" class="magnifier" width="16" height="16" viewBox="0 0 24 24">
                         <path fill="currentColor" d="M15.5 14h-.79l-.28-.27a6.5 6.5 0 1 0-.7.7l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0A4.5 4.5 0 1 1 14 9.5 4.5 4.5 0 0 1 9.5 14z"/>
                     </svg>
-                    ${e.map(e=>T`
+                    ${e.map(e=>w`
                         <span theme="badge contrast pill" class="chip">
                             <span class="chip-label">${e.label}:</span> ${e.display}
                             <button class="chip-remove" aria-label="Remove filter ${e.label}"
                                     @mousedown="${this.keepFocus}"
                                     @click="${t=>{t.stopPropagation(),this.removeChip(e.fieldId)}}">✕</button>
                         </span>`)}
-                    ${this.metadata?.searchable===!1?v:T`
+                    ${this.metadata?.searchable===!1?_:w`
                         <input class="free-text" type="text" id="searchText"
                                placeholder="${e.length===0?`Search`:``}"
-                               autofocus="${this.metadata?.autoFocusOnSearchText?!0:v}"
+                               autofocus="${this.metadata?.autoFocusOnSearchText?!0:_}"
                                .value="${this.draftText??``}"
                                @input="${e=>{this.draftText=e.target.value,this.openPanel()}}"
                                @keydown="${e=>{e.key===`Enter`&&this.commitText(e.target),e.key===`Escape`&&this.closePanel()}}"/>
@@ -579,8 +579,8 @@ ${i}
                 ${this.renderViewsPanel()}
             </div>
             <slot></slot>
-        `}static{this.styles=h`
-        ${de}
+        `}static{this.styles=m`
+        ${fe}
         :host {
             width: 100%;
         }
@@ -776,7 +776,7 @@ ${i}
             padding: 0.35rem 0.75rem;
             cursor: pointer;
         }
-    `}};k([y()],L.prototype,`metadata`,void 0),k([y()],L.prototype,`baseUrl`,void 0),k([C()],L.prototype,`state`,void 0),k([C()],L.prototype,`data`,void 0),k([y()],L.prototype,`appState`,void 0),k([y()],L.prototype,`appData`,void 0),k([y({type:Boolean})],L.prototype,`searchOnly`,void 0),k([C()],L.prototype,`panelOpened`,void 0),k([C()],L.prototype,`viewsOpened`,void 0),k([C()],L.prototype,`activeFilter`,void 0),k([C()],L.prototype,`draftText`,void 0),L=k([g(`mateu-filter-bar`)],L);var Mt=`mateu-column-prefs`,Nt=()=>{try{let e=JSON.parse(localStorage.getItem(Mt)??`{}`);return e&&typeof e==`object`&&!Array.isArray(e)?e:{}}catch{return{}}},Pt=e=>{try{localStorage.setItem(Mt,JSON.stringify(e))}catch{}},Ft=e=>{if(!e||typeof e!=`object`)return;let t=e=>Array.isArray(e)?e.filter(e=>typeof e==`string`):[];return{hidden:t(e.hidden),order:t(e.order)}},It=e=>Ft(Nt()[e]),Lt=(e,t)=>{let n=Nt(),r=Ft(t);r.hidden.length===0&&r.order.length===0?delete n[e]:n[e]=r,Pt(n)},Rt=e=>{let t=Nt();delete t[e],Pt(t)},zt=e=>e?!!e.identifier||e.dataType===`action`||e.dataType===`actionGroup`||e.dataType===`menu`||e.id===`select`||e.id===`menu`:!1,Bt=(e,t,n=e=>e)=>{let r=Ft(t);if(!r||r.hidden.length===0&&r.order.length===0)return e;let i=e=>n(e)?.id??e.id,a=new Set(r.hidden),o=e.filter(e=>{let t=i(e);return!t||!a.has(t)||zt(n(e))});if(r.order.length===0)return o.length===e.length?e:o;let s=new Map;o.forEach(e=>{let t=i(e);t&&!s.has(t)&&s.set(t,e)});let c=[],l=new Set;return r.order.forEach(e=>{let t=s.get(e);t&&!l.has(t)&&(c.push(t),l.add(t))}),o.forEach(e=>{l.has(e)||(c.push(e),l.add(e))}),c.length===e.length&&c.every((t,n)=>t===e[n])?e:c},Vt=class extends b{constructor(...e){super(...e),this.columns=[],this.scope=``,this.panelOpened=!1,this.revision=0,this.togglePanel=()=>{if(this.panelOpened){this.closePanel();return}this.panelOpened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick)},this.closePanel=()=>{this.detachOutsideClick(),this.panelOpened=!1},this.reset=()=>{Rt(this.scope),this.revision++,this.dispatchEvent(new CustomEvent(`column-prefs-changed`,{bubbles:!0,composed:!0}))}}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}get prefs(){return It(this.scope)??{hidden:[],order:[]}}effectiveEntries(e){return Bt(this.columns,{hidden:[],order:e.order})}commit(e){Lt(this.scope,e),this.revision++,this.dispatchEvent(new CustomEvent(`column-prefs-changed`,{bubbles:!0,composed:!0}))}toggleVisibility(e){let t=this.prefs,n=t.hidden.includes(e)?t.hidden.filter(t=>t!==e):[...t.hidden,e];this.commit({...t,hidden:n})}move(e,t){let n=this.prefs,r=[...this.effectiveEntries(n)],i=r.findIndex(t=>t.id===e);if(i<0)return;let a=i+t;for(;a>=0&&a<r.length&&r[a].protected;)a+=t;if(a<0||a>=r.length)return;let o=r[i];r[i]=r[a],r[a]=o,this.commit({...n,order:r.map(e=>e.id)})}render(){this.revision;let e=this.prefs,t=this.effectiveEntries(e).filter(e=>!e.protected);if(t.length===0)return T``;let n=e.hidden.length>0||e.order.length>0;return T`
+    `}};O([v()],I.prototype,`metadata`,void 0),O([v()],I.prototype,`baseUrl`,void 0),O([S()],I.prototype,`state`,void 0),O([S()],I.prototype,`data`,void 0),O([v()],I.prototype,`appState`,void 0),O([v()],I.prototype,`appData`,void 0),O([v({type:Boolean})],I.prototype,`searchOnly`,void 0),O([S()],I.prototype,`panelOpened`,void 0),O([S()],I.prototype,`viewsOpened`,void 0),O([S()],I.prototype,`activeFilter`,void 0),O([S()],I.prototype,`draftText`,void 0),I=O([h(`mateu-filter-bar`)],I);var Nt=`mateu-column-prefs`,Pt=()=>{try{let e=JSON.parse(localStorage.getItem(Nt)??`{}`);return e&&typeof e==`object`&&!Array.isArray(e)?e:{}}catch{return{}}},Ft=e=>{try{localStorage.setItem(Nt,JSON.stringify(e))}catch{}},It=e=>{if(!e||typeof e!=`object`)return;let t=e=>Array.isArray(e)?e.filter(e=>typeof e==`string`):[];return{hidden:t(e.hidden),order:t(e.order)}},Lt=e=>It(Pt()[e]),Rt=(e,t)=>{let n=Pt(),r=It(t);r.hidden.length===0&&r.order.length===0?delete n[e]:n[e]=r,Ft(n)},zt=e=>{let t=Pt();delete t[e],Ft(t)},Bt=e=>e?!!e.identifier||e.dataType===`action`||e.dataType===`actionGroup`||e.dataType===`menu`||e.id===`select`||e.id===`menu`:!1,Vt=(e,t,n=e=>e)=>{let r=It(t);if(!r||r.hidden.length===0&&r.order.length===0)return e;let i=e=>n(e)?.id??e.id,a=new Set(r.hidden),o=e.filter(e=>{let t=i(e);return!t||!a.has(t)||Bt(n(e))});if(r.order.length===0)return o.length===e.length?e:o;let s=new Map;o.forEach(e=>{let t=i(e);t&&!s.has(t)&&s.set(t,e)});let c=[],l=new Set;return r.order.forEach(e=>{let t=s.get(e);t&&!l.has(t)&&(c.push(t),l.add(t))}),o.forEach(e=>{l.has(e)||(c.push(e),l.add(e))}),c.length===e.length&&c.every((t,n)=>t===e[n])?e:c},Ht=class extends y{constructor(...e){super(...e),this.columns=[],this.scope=``,this.panelOpened=!1,this.revision=0,this.togglePanel=()=>{if(this.panelOpened){this.closePanel();return}this.panelOpened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick)},this.closePanel=()=>{this.detachOutsideClick(),this.panelOpened=!1},this.reset=()=>{zt(this.scope),this.revision++,this.dispatchEvent(new CustomEvent(`column-prefs-changed`,{bubbles:!0,composed:!0}))}}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}get prefs(){return Lt(this.scope)??{hidden:[],order:[]}}effectiveEntries(e){return Vt(this.columns,{hidden:[],order:e.order})}commit(e){Rt(this.scope,e),this.revision++,this.dispatchEvent(new CustomEvent(`column-prefs-changed`,{bubbles:!0,composed:!0}))}toggleVisibility(e){let t=this.prefs,n=t.hidden.includes(e)?t.hidden.filter(t=>t!==e):[...t.hidden,e];this.commit({...t,hidden:n})}move(e,t){let n=this.prefs,r=[...this.effectiveEntries(n)],i=r.findIndex(t=>t.id===e);if(i<0)return;let a=i+t;for(;a>=0&&a<r.length&&r[a].protected;)a+=t;if(a<0||a>=r.length)return;let o=r[i];r[i]=r[a],r[a]=o,this.commit({...n,order:r.map(e=>e.id)})}render(){this.revision;let e=this.prefs,t=this.effectiveEntries(e).filter(e=>!e.protected);if(t.length===0)return w``;let n=e.hidden.length>0||e.order.length>0;return w`
             <div class="chooser">
                 <button
                     class="trigger ${n?`active`:``}"
@@ -793,10 +793,10 @@ ${i}
                         <rect x="11" y="2" width="4" height="12" rx="1" fill="currentColor" opacity="0.35"/>
                     </svg>
                 </button>
-                ${this.panelOpened?T`
+                ${this.panelOpened?w`
                     <div class="panel" role="menu">
                         <div class="panel-title">Columns</div>
-                        ${t.map((n,r)=>{let i=e.hidden.includes(n.id);return T`
+                        ${t.map((n,r)=>{let i=e.hidden.includes(n.id);return w`
                                 <div class="row" data-column-id="${n.id}">
                                     <label class="row-label">
                                         <input
@@ -818,9 +818,9 @@ ${i}
                             <button class="reset" type="button" ?disabled="${!n}" @click="${this.reset}">Reset</button>
                         </div>
                     </div>
-                `:v}
+                `:_}
             </div>
-        `}static{this.styles=h`
+        `}static{this.styles=m`
         :host {
             display: block;
             flex: none;
@@ -933,9 +933,9 @@ ${i}
             opacity: 0.4;
             cursor: default;
         }
-    `}};k([y()],Vt.prototype,`columns`,void 0),k([y()],Vt.prototype,`scope`,void 0),k([C()],Vt.prototype,`panelOpened`,void 0),k([C()],Vt.prototype,`revision`,void 0),Vt=k([g(`mateu-column-chooser`)],Vt);var Ht=class extends b{constructor(...e){super(...e),this.totalElements=0,this.pageSize=100,this.pageNumber=0,this.totalPages=0}updated(e){super.updated(e),(e.has(`totalElements`)||e.has(`pageSize`))&&(this.totalPages=Math.ceil(this.totalElements/this.pageSize))}dispatch(e){this.dispatchEvent(new CustomEvent(`page-changed`,{bubbles:!0,composed:!0,detail:{page:e}}))}render(){if(!this.totalElements)return v;let e=this.totalPages>1,t=this.pageNumber,n=t===0,r=t>=this.totalPages-1;return T`
+    `}};O([v()],Ht.prototype,`columns`,void 0),O([v()],Ht.prototype,`scope`,void 0),O([S()],Ht.prototype,`panelOpened`,void 0),O([S()],Ht.prototype,`revision`,void 0),Ht=O([h(`mateu-column-chooser`)],Ht);var Ut=class extends y{constructor(...e){super(...e),this.totalElements=0,this.pageSize=100,this.pageNumber=0,this.totalPages=0}updated(e){super.updated(e),(e.has(`totalElements`)||e.has(`pageSize`))&&(this.totalPages=Math.ceil(this.totalElements/this.pageSize))}dispatch(e){this.dispatchEvent(new CustomEvent(`page-changed`,{bubbles:!0,composed:!0,detail:{page:e}}))}render(){if(!this.totalElements)return _;let e=this.totalPages>1,t=this.pageNumber,n=t===0,r=t>=this.totalPages-1;return w`
             <div class="bar">
-                ${e?T`
+                ${e?w`
                     <button class="nav" title="First page" ?disabled="${n}"
                         @click="${()=>this.dispatch(0)}" data-testid="page-first">«</button>
                     <button class="nav" title="Previous page" ?disabled="${n}"
@@ -946,11 +946,11 @@ ${i}
                     <button class="nav" title="Last page" ?disabled="${r}"
                         @click="${()=>this.dispatch(this.totalPages-1)}" data-testid="page-last">»</button>
                     <span class="separator"></span>
-                `:v}
+                `:_}
                 <span class="total-count">${this.totalElements} item${this.totalElements===1?``:`s`}</span>
                 <slot></slot>
             </div>
-        `}static{this.styles=h`
+        `}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -997,301 +997,301 @@ ${i}
             align-self: center;
             margin: 0 4px;
         }
-    `}};k([y()],Ht.prototype,`totalElements`,void 0),k([y()],Ht.prototype,`pageSize`,void 0),k([y()],Ht.prototype,`pageNumber`,void 0),k([C()],Ht.prototype,`totalPages`,void 0),Ht=k([g(`mateu-pagination`)],Ht);var Ut=`var(--lumo-space-m, 1rem)`,Wt=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.columnWidth||`13rem`,l=`display: grid; grid-template-columns: ${s.maxColumns&&s.maxColumns>0?`repeat(${s.maxColumns}, minmax(0, 1fr))`:`repeat(auto-fill, minmax(min(100%, ${c}), 1fr))`}; gap: ${Ut} var(--lumo-space-l, 1.5rem); align-items: start;`;return s.labelsAside&&(l+=` --mateu-label-width: 10rem;`),s.fullWidth&&(l+=` width: 100%;`),l+=t.style??``,T`
-        <div style="${l}" class="${t.cssClasses}" slot="${t.slot||v}">
-            ${t.children?.map(t=>Gt(s,e,t,n,r,i,a,o))}
+    `}};O([v()],Ut.prototype,`totalElements`,void 0),O([v()],Ut.prototype,`pageSize`,void 0),O([v()],Ut.prototype,`pageNumber`,void 0),O([S()],Ut.prototype,`totalPages`,void 0),Ut=O([h(`mateu-pagination`)],Ut);var Wt=`var(--lumo-space-m, 1rem)`,Gt=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.columnWidth||`13rem`,l=`display: grid; grid-template-columns: ${s.maxColumns&&s.maxColumns>0?`repeat(${s.maxColumns}, minmax(0, 1fr))`:`repeat(auto-fill, minmax(min(100%, ${c}), 1fr))`}; gap: ${Wt} var(--lumo-space-l, 1.5rem); align-items: start;`;return s.labelsAside&&(l+=` --mateu-label-width: 10rem;`),s.fullWidth&&(l+=` width: 100%;`),l+=t.style??``,w`
+        <div style="${l}" class="${t.cssClasses}" slot="${t.slot||_}">
+            ${t.children?.map(t=>Kt(s,e,t,n,r,i,a,o))}
         </div>
-    `},Gt=(e,t,n,r,i,a,o,s)=>n.type==A.ClientSide&&n.metadata?.type==j.FormRow?Jt(e,t,n,r,i,a,o,s):T`<div style="grid-column: span ${Kt(n)}; min-width: 0;">${e.labelsAside?qt(t,n,r,i,a,o,s):F(t,n,r,i,a,o,s)}</div>`,Kt=e=>{if(e.type==A.ClientSide){let t=e.metadata;if(t?.type==j.FormField)return t.colspan||1}return 1},qt=(e,t,n,r,i,a,o)=>{if(t.type==A.ClientSide&&t.metadata?.type==j.FormField&&t.metadata.label){let s=t.metadata;return T`
-            <div style="display: flex; gap: ${Ut}; align-items: baseline;">
+    `},Kt=(e,t,n,r,i,a,o,s)=>n.type==k.ClientSide&&n.metadata?.type==A.FormRow?Yt(e,t,n,r,i,a,o,s):w`<div style="grid-column: span ${qt(n)}; min-width: 0;">${e.labelsAside?Jt(t,n,r,i,a,o,s):P(t,n,r,i,a,o,s)}</div>`,qt=e=>{if(e.type==k.ClientSide){let t=e.metadata;if(t?.type==A.FormField)return t.colspan||1}return 1},Jt=(e,t,n,r,i,a,o)=>{if(t.type==k.ClientSide&&t.metadata?.type==A.FormField&&t.metadata.label){let s=t.metadata;return w`
+            <div style="display: flex; gap: ${Wt}; align-items: baseline;">
                 <label style="flex: 0 0 var(--mateu-label-width, 10rem); color: var(--lumo-secondary-text-color, #667);">${s.label?.includes("${")?e._evalTemplate(s.label):s.label}</label>
-                <div style="flex: 1; min-width: 0;">${F(e,t,n,r,i,a,o,!0)}</div>
+                <div style="flex: 1; min-width: 0;">${P(e,t,n,r,i,a,o,!0)}</div>
             </div>
-        `}return F(e,t,n,r,i,a,o)},Jt=(e,t,n,r,i,a,o,s)=>T`
-        <div style="grid-column: 1 / -1; display: flex; gap: ${Ut}; flex-wrap: wrap;">
-            ${n.children?.map(c=>T`<div style="flex: 1 1 ${100/Math.max(1,n.children.length)}%; min-width: min(100%, 13rem);">${Gt(e,t,c,r,i,a,o,s)}</div>`)}
+        `}return P(e,t,n,r,i,a,o)},Yt=(e,t,n,r,i,a,o,s)=>w`
+        <div style="grid-column: 1 / -1; display: flex; gap: ${Wt}; flex-wrap: wrap;">
+            ${n.children?.map(c=>w`<div style="flex: 1 1 ${100/Math.max(1,n.children.length)}%; min-width: min(100%, 13rem);">${Kt(e,t,c,r,i,a,o,s)}</div>`)}
         </div>
-    `,Yt=(e,t,n,r,i,a,o,s)=>{let c=n.metadata,l=`display: flex; flex-direction: ${e};`;c.spacing&&(l+=` gap: ${Ut};`),c.padding&&(l+=` padding: var(--lumo-space-m, 1rem);`),c.wrap&&(l+=` flex-wrap: wrap;`),c.fullWidth&&(l+=` width: 100%;`),c.justification&&(l+=` justify-content: ${c.justification};`);let u=e===`row`?c.verticalAlignment:c.horizontalAlignment;return u&&(l+=` align-items: ${u};`),l+=n.style??``,T`
-        <div style="${l}" class="${n.cssClasses}" slot="${n.slot??v}">
-            ${n.children?.map(e=>F(t,e,r,i,a,o,s))}
+    `,Xt=(e,t,n,r,i,a,o,s)=>{let c=n.metadata,l=`display: flex; flex-direction: ${e};`;c.spacing&&(l+=` gap: ${Wt};`),c.padding&&(l+=` padding: var(--lumo-space-m, 1rem);`),c.wrap&&(l+=` flex-wrap: wrap;`),c.fullWidth&&(l+=` width: 100%;`),c.justification&&(l+=` justify-content: ${c.justification};`);let u=e===`row`?c.verticalAlignment:c.horizontalAlignment;return u&&(l+=` align-items: ${u};`),l+=n.style??``,w`
+        <div style="${l}" class="${n.cssClasses}" slot="${n.slot??_}">
+            ${n.children?.map(e=>P(t,e,r,i,a,o,s))}
         </div>
-    `},Xt=(e,t,n,r,i,a,o)=>Yt(`row`,e,t,n,r,i,a,o),Zt=(e,t,n,r,i,a,o)=>Yt(`column`,e,t,n,r,i,a,o),Qt=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=`display: flex; flex-direction: ${s.orientation===`vertical`?`column`:`row`}; gap: var(--lumo-space-s, 0.5rem);`;return s.fullWidth&&(c+=` width: 100%;`),c+=t.style??``,T`
-        <div style="${c}" class="${t.cssClasses}" slot="${t.slot??v}">
-            <div style="flex: 1; min-width: 0; min-height: 0;">${F(e,t.children[0],n,r,i,a,o)}</div>
-            <div style="flex: 1; min-width: 0; min-height: 0;">${F(e,t.children[1],n,r,i,a,o)}</div>
+    `},Zt=(e,t,n,r,i,a,o)=>Xt(`row`,e,t,n,r,i,a,o),Qt=(e,t,n,r,i,a,o)=>Xt(`column`,e,t,n,r,i,a,o),$t=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=`display: flex; flex-direction: ${s.orientation===`vertical`?`column`:`row`}; gap: var(--lumo-space-s, 0.5rem);`;return s.fullWidth&&(c+=` width: 100%;`),c+=t.style??``,w`
+        <div style="${c}" class="${t.cssClasses}" slot="${t.slot??_}">
+            <div style="flex: 1; min-width: 0; min-height: 0;">${P(e,t.children[0],n,r,i,a,o)}</div>
+            <div style="flex: 1; min-width: 0; min-height: 0;">${P(e,t.children[1],n,r,i,a,o)}</div>
         </div>
-    `},$t=(e,t,n,r,i,a,o)=>{let s=t.children&&t.children.length>1?t.children[1]:null,c=i?.detailComponent??null,l=!!i?.hasDetail||!!s,u=c??s;return T`
-        <div style="display: flex; gap: var(--lumo-space-m, 1rem); ${t.style??``}" class="${t.cssClasses}" slot="${t.slot??v}">
-            <div style="flex: 1; min-width: 0;">${F(e,t.children[0],n,r,i,a,o)}</div>
-            ${l&&u?T`<div style="flex: 1; min-width: 0;">${F(e,u,n,r,i,a,o)}</div>`:T`<div style="flex: 1; display: flex; align-items: center; justify-content: center; color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-s, .875rem);">Select an item to view details</div>`}
+    `},en=(e,t,n,r,i,a,o)=>{let s=t.children&&t.children.length>1?t.children[1]:null,c=i?.detailComponent??null,l=!!i?.hasDetail||!!s,u=c??s;return w`
+        <div style="display: flex; gap: var(--lumo-space-m, 1rem); ${t.style??``}" class="${t.cssClasses}" slot="${t.slot??_}">
+            <div style="flex: 1; min-width: 0;">${P(e,t.children[0],n,r,i,a,o)}</div>
+            ${l&&u?w`<div style="flex: 1; min-width: 0;">${P(e,u,n,r,i,a,o)}</div>`:w`<div style="flex: 1; display: flex; align-items: center; justify-content: center; color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-s, .875rem);">Select an item to view details</div>`}
         </div>
-    `},en=(e,t,n,r,i,a,o)=>{let s=t.style??``;t.metadata.fullWidth&&(s+=` width: 100%;`);let c=Math.max(0,(t.children??[]).findIndex(e=>e.metadata.active));return T`
-        <div style="${s}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${t.children?.map((t,s)=>{let l=t,u=l.metadata.label,d=u?.includes("${")?e._evalTemplate(u):u;return T`
+    `},tn=(e,t,n,r,i,a,o)=>{let s=t.style??``;t.metadata.fullWidth&&(s+=` width: 100%;`);let c=Math.max(0,(t.children??[]).findIndex(e=>e.metadata.active));return w`
+        <div style="${s}" class="${t.cssClasses}" slot="${t.slot??_}">
+            ${t.children?.map((t,s)=>{let l=t,u=l.metadata.label,d=u?.includes("${")?e._evalTemplate(u):u;return w`
                     <details ?open="${s===c}" style="border-bottom: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));">
                         <summary style="cursor: pointer; padding: var(--lumo-space-s, .5rem) 0; font-weight: 600;">${d}</summary>
                         <div style="padding: var(--lumo-space-m, 1rem) 0;">
-                            ${l.children?.map(t=>F(e,t,n,r,i,a,o))}
+                            ${l.children?.map(t=>P(e,t,n,r,i,a,o))}
                         </div>
                     </details>
                 `})}
         </div>
-    `},tn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style??``;return s.fullWidth&&(c+=` width: 100%;`),T`
-        <div style="${c}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${t.children?.map(t=>nn(e,t,n,r,i,a,o,s.variant))}
+    `},nn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style??``;return s.fullWidth&&(c+=` width: 100%;`),w`
+        <div style="${c}" class="${t.cssClasses}" slot="${t.slot??_}">
+            ${t.children?.map(t=>rn(e,t,n,r,i,a,o,s.variant))}
         </div>
-    `},nn=(e,t,n,r,i,a,o,s)=>{let c=t.metadata,l=c.label?.includes("${")?e._evalTemplate(c.label):c.label;return T`
+    `},rn=(e,t,n,r,i,a,o,s)=>{let c=t.metadata,l=c.label?.includes("${")?e._evalTemplate(c.label):c.label;return w`
         <details ?open="${c.active}" style="border-bottom: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1)); ${t.style??``}" class="${t.cssClasses}">
             <summary style="cursor: pointer; padding: var(--lumo-space-s, .5rem) 0; font-weight: 600; ${c.disabled?`pointer-events: none; opacity: .5;`:``}">${l}</summary>
             <div style="padding: var(--lumo-space-s, .5rem) 0;">
-                ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+                ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
             </div>
         </details>
-    `},rn=(e,t,n,r,i,a,o)=>T`
-        <div style="overflow: auto; ${t.style??``}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+    `},an=(e,t,n,r,i,a,o)=>w`
+        <div style="overflow: auto; ${t.style??``}" class="${t.cssClasses}" slot="${t.slot??_}">
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `,an=(e,t,n,r,i,a,o)=>T`
-        <div style="width: 100%; ${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+    `,on=(e,t,n,r,i,a,o)=>w`
+        <div style="width: 100%; ${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `,on=(e,t,n,r,i,a,o)=>T`
-        <div style="max-width: min(100%, 1200px); margin: auto; ${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+    `,sn=(e,t,n,r,i,a,o)=>w`
+        <div style="max-width: min(100%, 1200px); margin: auto; ${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `,sn=(e,t,n,r,i,a,o)=>T`
-        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr)); gap: ${Ut}; ${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+    `,cn=(e,t,n,r,i,a,o)=>w`
+        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr)); gap: ${Wt}; ${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `,cn=(e,t,n,r,i,a,o)=>T`
-        <div style="display: flex; gap: ${Ut}; flex-wrap: wrap; ${t.style}" class="${t.cssClasses}">
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+    `,ln=(e,t,n,r,i,a,o)=>w`
+        <div style="display: flex; gap: ${Wt}; flex-wrap: wrap; ${t.style}" class="${t.cssClasses}">
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `,ln=(e,t,n,r,i,a,o)=>T`
+    `,un=(e,t,n,r,i,a,o)=>w`
         <div style="flex: ${t.metadata.boardCols??1} 1 0; min-width: min(100%, 12rem); ${t.style}" class="${t.cssClasses}">
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `,un=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+    `,dn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <div
                 style="display: flex; flex-direction: column; overflow: auto; ${t.style}"
                 class="${t.cssClasses}"
-                slot="${t.slot??v}"
+                slot="${t.slot??_}"
         >
-            ${s.page.content.map(t=>F(e,t,n,r,i,a,o))}
+            ${s.page.content.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `},dn=e=>{let t=e.metadata;return(t?.content??t?.columns??[]).filter(e=>e&&e.metadata).map(e=>{let t=e.metadata;return{id:e.id??``,label:t?.label??e.id??``,autoWidth:t?.autoWidth,width:t?.width}})},fn=(e,t)=>{let n=e?.[t];return n==null?``:typeof n==`object`?n.text??n.label??n.value??``:String(n)},pn=(e,t,n)=>{let r=dn(e);return T`
-        <div style="overflow:auto; width:100%; ${e.style}" class="${e.cssClasses}" slot="${e.slot??v}">
+    `},fn=e=>{let t=e.metadata;return(t?.content??t?.columns??[]).filter(e=>e&&e.metadata).map(e=>{let t=e.metadata;return{id:e.id??``,label:t?.label??e.id??``,autoWidth:t?.autoWidth,width:t?.width}})},pn=(e,t)=>{let n=e?.[t];return n==null?``:typeof n==`object`?n.text??n.label??n.value??``:String(n)},mn=(e,t,n)=>{let r=fn(e);return w`
+        <div style="overflow:auto; width:100%; ${e.style}" class="${e.cssClasses}" slot="${e.slot??_}">
             <table style="border-collapse:collapse; width:100%; font-size: var(--lumo-font-size-s,.875rem);">
-                <thead><tr>${r.map(e=>T`<th style="${`text-align:left; padding:.45rem .6rem; border-bottom:2px solid var(--lumo-contrast-20pct,rgba(0,0,0,.2)); font-weight:600; white-space:nowrap; color: var(--lumo-secondary-text-color,#556);`}">${e.label}</th>`)}</tr></thead>
+                <thead><tr>${r.map(e=>w`<th style="${`text-align:left; padding:.45rem .6rem; border-bottom:2px solid var(--lumo-contrast-20pct,rgba(0,0,0,.2)); font-weight:600; white-space:nowrap; color: var(--lumo-secondary-text-color,#556);`}">${e.label}</th>`)}</tr></thead>
                 <tbody>
-                    ${(t??[]).length===0?T`<tr><td colspan="${Math.max(1,r.length)}" style="padding:1.5rem; text-align:center; color: var(--lumo-secondary-text-color,#888);">${n??`No data.`}</td></tr>`:t.map(e=>T`<tr>${r.map(t=>T`<td style="${`padding:.4rem .6rem; border-bottom:1px solid var(--lumo-contrast-10pct,rgba(0,0,0,.08)); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:24rem;`}" title="${fn(e,t.id)}">${fn(e,t.id)}</td>`)}</tr>`)}
+                    ${(t??[]).length===0?w`<tr><td colspan="${Math.max(1,r.length)}" style="padding:1.5rem; text-align:center; color: var(--lumo-secondary-text-color,#888);">${n??`No data.`}</td></tr>`:t.map(e=>w`<tr>${r.map(t=>w`<td style="${`padding:.4rem .6rem; border-bottom:1px solid var(--lumo-contrast-10pct,rgba(0,0,0,.08)); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:24rem;`}" title="${pn(e,t.id)}">${pn(e,t.id)}</td>`)}</tr>`)}
                 </tbody>
             </table>
         </div>
-    `},mn=(e,t)=>{let n=e.metadata;return e.id&&t&&t[e.id]?t[e.id]:n?.page?.content??[]},hn=e=>{let t=e.metadata.items??[];return T`
+    `},hn=(e,t)=>{let n=e.metadata;return e.id&&t&&t[e.id]?t[e.id]:n?.page?.content??[]},gn=e=>{let t=e.metadata.items??[];return w`
         <div class="mateu-message-list ${e.cssClasses??``}"
              style="display:flex; flex-direction:column; gap:.75rem; ${e.style??``}"
-             slot="${e.slot??v}">
-            ${t.map(e=>T`
+             slot="${e.slot??_}">
+            ${t.map(e=>w`
                 <div style="display:flex; gap:.6rem; align-items:flex-start;">
                     <span style="flex:0 0 auto; width:2rem; height:2rem; border-radius:50%; overflow:hidden; display:flex; align-items:center; justify-content:center; font-size:.8rem; background:var(--lumo-primary-color,#3b5bdb); color:var(--lumo-primary-contrast-color,#fff);">
-                        ${e.userImg?T`<img src="${e.userImg}" alt="" style="width:100%; height:100%; object-fit:cover;">`:e.userAbbr??(e.userName?e.userName.charAt(0):`?`)}
+                        ${e.userImg?w`<img src="${e.userImg}" alt="" style="width:100%; height:100%; object-fit:cover;">`:e.userAbbr??(e.userName?e.userName.charAt(0):`?`)}
                     </span>
                     <div style="min-width:0;">
                         <div style="display:flex; gap:.5rem; align-items:baseline;">
-                            ${e.userName?T`<span style="font-weight:600;">${e.userName}</span>`:v}
-                            ${e.time?T`<span style="font-size:var(--lumo-font-size-xs,.75rem); color:var(--lumo-secondary-text-color,#666);">${e.time}</span>`:v}
+                            ${e.userName?w`<span style="font-weight:600;">${e.userName}</span>`:_}
+                            ${e.time?w`<span style="font-size:var(--lumo-font-size-xs,.75rem); color:var(--lumo-secondary-text-color,#666);">${e.time}</span>`:_}
                         </div>
                         <div style="white-space:pre-wrap; overflow-wrap:anywhere;">${e.text}</div>
                     </div>
                 </div>
             `)}
         </div>
-    `},gn=(e,t,n,r,i,a,o)=>t.separator?T`<span style="align-self: stretch; width: 1px; background: var(--lumo-contrast-20pct, rgba(0,0,0,.2));"></span>`:t.submenus?T`
+    `},_n=(e,t,n,r,i,a,o)=>t.separator?w`<span style="align-self: stretch; width: 1px; background: var(--lumo-contrast-20pct, rgba(0,0,0,.2));"></span>`:t.submenus?w`
             <details style="position: relative;">
                 <summary style="cursor: pointer; list-style: none; padding: .35rem .7rem; border-radius: var(--lumo-border-radius-m, 6px);">
-                    ${t.component?F(e,t.component,n,r,i,a,o):t.label} ▾
+                    ${t.component?P(e,t.component,n,r,i,a,o):t.label} ▾
                 </summary>
                 <div style="display: flex; flex-direction: column; gap: .1rem; padding: .3rem; min-width: 10rem;
                             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1)); border-radius: var(--lumo-border-radius-m, 6px);
                             background: var(--lumo-base-color, #fff); box-shadow: var(--lumo-box-shadow-s, 0 2px 8px rgba(0,0,0,.15));">
-                    ${t.submenus.map(t=>gn(e,t,n,r,i,a,o))}
+                    ${t.submenus.map(t=>_n(e,t,n,r,i,a,o))}
                 </div>
             </details>
-        `:T`
+        `:w`
         <span class="${t.className??``}"
               style="cursor: ${t.disabled?`default`:`pointer`}; opacity: ${t.disabled?.5:1};
                      padding: .35rem .7rem; border-radius: var(--lumo-border-radius-m, 6px);
                      ${t.selected?`background: var(--lumo-primary-color-10pct, rgba(26,115,232,.12));`:``}">
-            ${t.component?F(e,t.component,n,r,i,a,o):t.label}
+            ${t.component?P(e,t.component,n,r,i,a,o):t.label}
         </span>
-    `,_n=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+    `,vn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <div style="display: flex; flex-wrap: wrap; gap: .25rem; align-items: center; ${t.style}"
-             class="${t.cssClasses}" slot="${t.slot??v}">
-            ${s.options?.map(t=>gn(e,t,n,r,i,a??{},o??{}))}
+             class="${t.cssClasses}" slot="${t.slot??_}">
+            ${s.options?.map(t=>_n(e,t,n,r,i,a??{},o??{}))}
         </div>
-    `},vn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
-        <div style="${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${F(e,s.wrapped,n,r,i,a,o)}
+    `},yn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+        <div style="${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
+            ${P(e,s.wrapped,n,r,i,a,o)}
         </div>
-    `},yn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.content?.metadata,l=c?.type==j.Notice&&c.fullWidth===!0;return T`
+    `},bn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.content?.metadata,l=c?.type==A.Notice&&c.fullWidth===!0;return w`
         <div style="display:flex; flex-direction:column; ${l?`width: 100%; `:``}${t.style}"
              class="${t.cssClasses}"
-             slot="${t.slot??v}"
-             data-colspan="${s.colspan||(l?99:v)}"
+             slot="${t.slot??_}"
+             data-colspan="${s.colspan||(l?99:_)}"
         >
-            ${s.label?T`<label style="font-size: var(--lumo-font-size-s,.875rem); color: var(--lumo-secondary-text-color,#667); margin-bottom:.15rem;">${s.label}</label>`:v}
-            ${F(e,s.content,n,r,i,a,o)}
+            ${s.label?w`<label style="font-size: var(--lumo-font-size-s,.875rem); color: var(--lumo-secondary-text-color,#667); margin-bottom:.15rem;">${s.label}</label>`:_}
+            ${P(e,s.content,n,r,i,a,o)}
         </div>
-            `},bn=e=>{let t=e.metadata,n=e=>{let n=e.closest(`.mateu-message-input`)?.querySelector(`input`),r=n?.value??``;!t.actionId||!r.trim()||(e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:{message:r}},bubbles:!0,composed:!0})),n&&(n.value=``))};return T`
+            `},xn=e=>{let t=e.metadata,n=e=>{let n=e.closest(`.mateu-message-input`)?.querySelector(`input`),r=n?.value??``;!t.actionId||!r.trim()||(e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:{message:r}},bubbles:!0,composed:!0})),n&&(n.value=``))};return w`
         <div class="mateu-message-input ${e.cssClasses??``}"
              style="display:flex; gap:.5rem; align-items:center; ${e.style??``}"
-             slot="${e.slot??v}">
+             slot="${e.slot??_}">
             <input type="text"
                    style="flex:1; min-width:0; font:inherit; padding:.5rem .75rem; border:1px solid var(--lumo-contrast-20pct,rgba(0,0,0,.16)); border-radius:var(--lumo-border-radius-m,6px); background:var(--lumo-base-color,#fff); color:var(--lumo-body-text-color,#161513);"
                    @keydown="${e=>{e.key===`Enter`&&!e.shiftKey&&(e.preventDefault(),n(e.currentTarget))}}">
             <button style="font:inherit; font-weight:500; cursor:pointer; padding:.5rem 1rem; border:none; border-radius:var(--lumo-border-radius-m,6px); background:var(--lumo-primary-color,#3b5bdb); color:var(--lumo-primary-contrast-color,#fff);"
                     @click="${e=>n(e.currentTarget)}">Send</button>
         </div>
-    `},xn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`<span title="${s.text}" style="${t.style}" class="${t.cssClasses}" slot="${t.slot??v}"
-        >${F(e,s.wrapped,n,r,i,a,o)}</span>`},Sn=e=>{if(e instanceof CustomEvent)return e.detail;let t={};for(let n in e){let r=e[n];[`number`,`string`,`boolean`].indexOf(typeof r)>=0&&(t[n]=e[n])}return t},Cn=(e,t,n)=>{for(let n in t.attributes)e.setAttribute(n,t.attributes[n]);n.style&&e.setAttribute(`style`,n.style),n.cssClasses&&e.setAttribute(`class`,n.cssClasses),n.slot&&e.setAttribute(`slot`,n.slot),t.content&&(t.html?e.innerHTML=t.content:e.append(t.content))},wn=e=>{let t=e.name,n=e.attributes?e.attributes.import:void 0;n&&t.includes(`-`)&&!customElements.get(t)&&D(()=>import(n),[])},Tn=(e,t,n)=>{wn(t);let r=t.name;return t.attributes&&t.attributes.id&&(r=`#`+t.attributes.id),setTimeout(()=>{let i=e.shadowRoot?.querySelector(`.element-container`)?.querySelector(r);if(i){for(;i.firstChild;)i.removeChild(i.lastChild);Cn(i,t,n)}else{let r=document.createElement(t.name);Cn(r,t,n);for(let n in t.on)r.addEventListener(n,r=>{let i=Sn(r);e.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.on[n],parameters:{event:i}},bubbles:!0,composed:!0}))});e.shadowRoot?.querySelector(`.element-container`)?.appendChild(r)}}),T`<div class="element-container"></div>`},En=function(e){return e.div=`div`,e.p=`p`,e.h1=`h1`,e.h2=`h2`,e.h3=`h3`,e.h4=`h4`,e.h5=`h5`,e.h6=`h6`,e.span=`span`,e}({}),Dn=(e,t,n,r,i)=>{let a=e.metadata,o=a.attributes?.[`data-colspan`],s=rt(a.text,t,n,r,i),c={xl:`var(--lumo-font-size-xl, 1.375rem)`,l:`var(--lumo-font-size-l, 1.125rem)`,s:`var(--lumo-font-size-s, .875rem)`,xs:`var(--lumo-font-size-xs, .8125rem)`},l=(a.size&&c[a.size]?`font-size: ${c[a.size]}; `:``)+(a.noMargins?`margin-block-start: 0; margin-block-end: 0; `:``);return En.h1==a.container?T`
+    `},Sn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`<span title="${s.text}" style="${t.style}" class="${t.cssClasses}" slot="${t.slot??_}"
+        >${P(e,s.wrapped,n,r,i,a,o)}</span>`},Cn=e=>{if(e instanceof CustomEvent)return e.detail;let t={};for(let n in e){let r=e[n];[`number`,`string`,`boolean`].indexOf(typeof r)>=0&&(t[n]=e[n])}return t},wn=(e,t,n)=>{for(let n in t.attributes)e.setAttribute(n,t.attributes[n]);n.style&&e.setAttribute(`style`,n.style),n.cssClasses&&e.setAttribute(`class`,n.cssClasses),n.slot&&e.setAttribute(`slot`,n.slot),t.content&&(t.html?e.innerHTML=t.content:e.append(t.content))},Tn=e=>{let t=e.name,n=e.attributes?e.attributes.import:void 0;n&&t.includes(`-`)&&!customElements.get(t)&&E(()=>import(n),[])},En=(e,t,n)=>{Tn(t);let r=t.name;return t.attributes&&t.attributes.id&&(r=`#`+t.attributes.id),setTimeout(()=>{let i=e.shadowRoot?.querySelector(`.element-container`)?.querySelector(r);if(i){for(;i.firstChild;)i.removeChild(i.lastChild);wn(i,t,n)}else{let r=document.createElement(t.name);wn(r,t,n);for(let n in t.on)r.addEventListener(n,r=>{let i=Cn(r);e.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.on[n],parameters:{event:i}},bubbles:!0,composed:!0}))});e.shadowRoot?.querySelector(`.element-container`)?.appendChild(r)}}),w`<div class="element-container"></div>`},Dn=function(e){return e.div=`div`,e.p=`p`,e.h1=`h1`,e.h2=`h2`,e.h3=`h3`,e.h4=`h4`,e.h5=`h5`,e.h6=`h6`,e.span=`span`,e}({}),On=(e,t,n,r,i)=>{let a=e.metadata,o=a.attributes?.[`data-colspan`],s=it(a.text,t,n,r,i),c={xl:`var(--lumo-font-size-xl, 1.375rem)`,l:`var(--lumo-font-size-l, 1.125rem)`,s:`var(--lumo-font-size-s, .875rem)`,xs:`var(--lumo-font-size-xs, .8125rem)`},l=(a.size&&c[a.size]?`font-size: ${c[a.size]}; `:``)+(a.noMargins?`margin-block-start: 0; margin-block-end: 0; `:``);return Dn.h1==a.container?w`
             <h1 style="${l}${e.style}" class="${e.cssClasses}"
-                id="${S(e.id)}"
-                data-colspan="${S(o)}"
-                slot="${e.slot??v}">
-                ${s??v}
+                id="${x(e.id)}"
+                data-colspan="${x(o)}"
+                slot="${e.slot??_}">
+                ${s??_}
             </h1>
-        `:En.h2==a.container?T`
+        `:Dn.h2==a.container?w`
             <h2 style="${l}${e.style}" class="${e.cssClasses}"
-                id="${S(e.id)}"
-                data-colspan="${S(o)}"
-                slot="${e.slot??v}">
-                ${s??v}
+                id="${x(e.id)}"
+                data-colspan="${x(o)}"
+                slot="${e.slot??_}">
+                ${s??_}
             </h2>
-        `:En.h3==a.container?T`
+        `:Dn.h3==a.container?w`
             <h3 style="${l}${e.style}" class="${e.cssClasses}"
-                id="${S(e.id)}"
-                data-colspan="${S(o)}"
-                slot="${e.slot??v}">
-                ${s??v}
+                id="${x(e.id)}"
+                data-colspan="${x(o)}"
+                slot="${e.slot??_}">
+                ${s??_}
             </h3>
-        `:En.h4==a.container?T`
+        `:Dn.h4==a.container?w`
             <h4 style="${l}${e.style}" class="${e.cssClasses}"
-                id="${S(e.id)}"
-                data-colspan="${S(o)}"
-                slot="${e.slot??v}">
-                ${s??v}
+                id="${x(e.id)}"
+                data-colspan="${x(o)}"
+                slot="${e.slot??_}">
+                ${s??_}
             </h4>
-        `:En.h5==a.container?T`
+        `:Dn.h5==a.container?w`
             <h5 style="${l}${e.style}" class="${e.cssClasses}"
-                id="${S(e.id)}"
-                data-colspan="${S(o)}"
-                slot="${e.slot??v}">
-                ${s??v}
+                id="${x(e.id)}"
+                data-colspan="${x(o)}"
+                slot="${e.slot??_}">
+                ${s??_}
             </h5>
-        `:En.h6==a.container?T`
+        `:Dn.h6==a.container?w`
             <h6 style="${l}${e.style}" class="${e.cssClasses}"
-                id="${S(e.id)}"
-                data-colspan="${S(o)}"
-                slot="${e.slot??v}">
-                ${s??v}
+                id="${x(e.id)}"
+                data-colspan="${x(o)}"
+                slot="${e.slot??_}">
+                ${s??_}
             </h6>
-        `:En.p==a.container?T`
+        `:Dn.p==a.container?w`
                <p style="${l}${e.style}" class="${e.cssClasses}"
-                  id="${S(e.id)}"
-                  data-colspan="${S(o)}"
-                  slot="${e.slot??v}">
-                   ${s??v}
+                  id="${x(e.id)}"
+                  data-colspan="${x(o)}"
+                  slot="${e.slot??_}">
+                   ${s??_}
                </p>
-            `:En.div==a.container?T`
+            `:Dn.div==a.container?w`
                <div style="${l}${e.style}" class="${e.cssClasses}"
-                    id="${S(e.id)}"
-                    data-colspan="${S(o)}"
-                    slot="${e.slot??v}">${s?_(s):v}</div>
-            `:En.span==a.container?T`
+                    id="${x(e.id)}"
+                    data-colspan="${x(o)}"
+                    slot="${e.slot??_}">${s?g(s):_}</div>
+            `:Dn.span==a.container?w`
                <span style="${l}${e.style}" class="${e.cssClasses}"
-                     id="${S(e.id)}"
-                     data-colspan="${S(o)}"
-                    slot="${e.slot??v}">${s??v}</span>
-            `:T`
+                     id="${x(e.id)}"
+                     data-colspan="${x(o)}"
+                    slot="${e.slot??_}">${s??_}</span>
+            `:w`
                <p
-                       id="${S(e.id)}"
-                       data-colspan="${S(o)}"
-                       slot="${e.slot??v}">
+                       id="${x(e.id)}"
+                       data-colspan="${x(o)}"
+                       slot="${e.slot??_}">
                    Unknown text container: ${a.container} 
                </p>
-            `},On=e=>{let t=e.metadata;return T`<a href="${t.url}" target="${t.target??v}"
-                   rel="${t.target===`_blank`?`noopener`:v}"
+            `},kn=e=>{let t=e.metadata;return w`<a href="${t.url}" target="${t.target??_}"
+                   rel="${t.target===`_blank`?`noopener`:_}"
                    style="${e.style}" class="${e.cssClasses}"
-                   slot="${e.slot??v}">${t.text}</a>`},kn=(e,t)=>{let n=e.toLowerCase().split(`+`);return t.ctrlKey===n.includes(`ctrl`)&&t.altKey===n.includes(`alt`)&&t.shiftKey===n.includes(`shift`)&&t.metaKey===n.includes(`meta`)},An=(e,t)=>{if(!kn(e,t))return!1;let n=e.toLowerCase().split(`+`),r=n[n.length-1];return!!(t.key.toLowerCase()===r||/^[a-z]$/.test(r)&&t.code===`Key`+r.toUpperCase()||/^[0-9]$/.test(r)&&(t.code===`Digit`+r||t.code===`Numpad`+r))},jn=e=>e?e.split(`+`).map(e=>e.length<=1?e.toUpperCase():e.charAt(0).toUpperCase()+e.slice(1)).join(`+`):void 0,Mn=(e,t)=>{let n=e.currentTarget.dataset.actionId;e.currentTarget?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:n,parameters:t.parameters},bubbles:!0,composed:!0}))},Nn=`display:inline-flex; align-items:center; justify-content:center; gap:.4em; box-sizing:border-box; font:inherit; font-weight:500; cursor:pointer; border-radius:var(--lumo-border-radius-m,6px); border:1px solid transparent; line-height:1; white-space:nowrap;`,Pn=e=>{let t=e.buttonStyle??``,n=e.color&&e.color!==`none`&&e.color!==`normal`?e.color:``,r=e.size,i=n===`success`?`var(--lumo-success-color,#1a7f37)`:n===`error`?`var(--lumo-error-color,#c5221f)`:n===`contrast`?`var(--lumo-contrast,#161513)`:`var(--lumo-primary-color,#3b5bdb)`,a=n===`success`?`var(--lumo-success-contrast-color,#fff)`:n===`error`?`var(--lumo-error-contrast-color,#fff)`:n===`contrast`?`var(--lumo-base-color,#fff)`:`var(--lumo-primary-contrast-color,#fff)`,o=n===`success`?`var(--lumo-success-text-color,#1a7f37)`:n===`error`?`var(--lumo-error-text-color,#c5221f)`:n===`contrast`?`var(--lumo-body-text-color,#161513)`:`var(--lumo-primary-text-color,#3b5bdb)`,s;return s=t===`primary`?`background:${i}; color:${a};`:t===`tertiary`||t===`tertiaryInline`?`background:transparent; color:${o};`:`background:var(--lumo-contrast-5pct,rgba(0,0,0,.04)); color:${o}; border-color:var(--lumo-contrast-20pct,rgba(0,0,0,.16));`,`${Nn}${s}${r===`small`?`padding:.25rem .6rem; font-size:var(--lumo-font-size-s,.875rem);`:r===`large`?`padding:.65rem 1.4rem; font-size:var(--lumo-font-size-l,1.125rem);`:`padding:.45rem 1rem; font-size:var(--lumo-font-size-m,1rem);`}`},Fn=(e,t,n)=>{let r=e.metadata,i=M(r.label,t,n);return T`<button
+                   slot="${e.slot??_}">${t.text}</a>`},An=(e,t)=>{let n=e.toLowerCase().split(`+`);return t.ctrlKey===n.includes(`ctrl`)&&t.altKey===n.includes(`alt`)&&t.shiftKey===n.includes(`shift`)&&t.metaKey===n.includes(`meta`)},jn=(e,t)=>{if(!An(e,t))return!1;let n=e.toLowerCase().split(`+`),r=n[n.length-1];return!!(t.key.toLowerCase()===r||/^[a-z]$/.test(r)&&t.code===`Key`+r.toUpperCase()||/^[0-9]$/.test(r)&&(t.code===`Digit`+r||t.code===`Numpad`+r))},Mn=e=>e?e.split(`+`).map(e=>e.length<=1?e.toUpperCase():e.charAt(0).toUpperCase()+e.slice(1)).join(`+`):void 0,Nn=(e,t)=>{let n=e.currentTarget.dataset.actionId;e.currentTarget?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:n,parameters:t.parameters},bubbles:!0,composed:!0}))},Pn=`display:inline-flex; align-items:center; justify-content:center; gap:.4em; box-sizing:border-box; font:inherit; font-weight:500; cursor:pointer; border-radius:var(--lumo-border-radius-m,6px); border:1px solid transparent; line-height:1; white-space:nowrap;`,Fn=e=>{let t=e.buttonStyle??``,n=e.color&&e.color!==`none`&&e.color!==`normal`?e.color:``,r=e.size,i=n===`success`?`var(--lumo-success-color,#1a7f37)`:n===`error`?`var(--lumo-error-color,#c5221f)`:n===`contrast`?`var(--lumo-contrast,#161513)`:`var(--lumo-primary-color,#3b5bdb)`,a=n===`success`?`var(--lumo-success-contrast-color,#fff)`:n===`error`?`var(--lumo-error-contrast-color,#fff)`:n===`contrast`?`var(--lumo-base-color,#fff)`:`var(--lumo-primary-contrast-color,#fff)`,o=n===`success`?`var(--lumo-success-text-color,#1a7f37)`:n===`error`?`var(--lumo-error-text-color,#c5221f)`:n===`contrast`?`var(--lumo-body-text-color,#161513)`:`var(--lumo-primary-text-color,#3b5bdb)`,s;return s=t===`primary`?`background:${i}; color:${a};`:t===`tertiary`||t===`tertiaryInline`?`background:transparent; color:${o};`:`background:var(--lumo-contrast-5pct,rgba(0,0,0,.04)); color:${o}; border-color:var(--lumo-contrast-20pct,rgba(0,0,0,.16));`,`${Pn}${s}${r===`small`?`padding:.25rem .6rem; font-size:var(--lumo-font-size-s,.875rem);`:r===`large`?`padding:.65rem 1.4rem; font-size:var(--lumo-font-size-l,1.125rem);`:`padding:.45rem 1rem; font-size:var(--lumo-font-size-m,1rem);`}`},In=(e,t,n)=>{let r=e.metadata,i=j(r.label,t,n);return w`<button
             id="${e.id}"
             data-action-id="${r.actionId}"
-            @click="${e=>Mn(e,r)}"
-            style="${Pn(r)}${e.style}"
+            @click="${e=>Nn(e,r)}"
+            style="${Fn(r)}${e.style}"
             class="${e.cssClasses}"
             ?disabled="${r.disabled}"
-            title="${r.shortcut?`${i} (${jn(r.shortcut)})`:v}"
-            slot="${e.slot??v}"
-    >${r.iconOnLeft?I(r.iconOnLeft):v}${i}${r.iconOnRight?I(r.iconOnRight):v}</button>`},In=`display:block; box-sizing:border-box; background:var(--lumo-base-color,#fff); border:1px solid var(--lumo-contrast-10pct,rgba(0,0,0,.1)); border-radius:var(--lumo-border-radius-l,12px); box-shadow:var(--lumo-box-shadow-xs,0 1px 3px rgba(0,0,0,.08)); overflow:hidden;`,Ln=(e,t,n,r,i,a,o)=>{let s=t.metadata;if(!s)return T``;let c=t=>t?F(e,t,n,r,i,a,o,!1):v,l=s.header||s.headerPrefix||s.headerSuffix||s.title||s.subtitle;return T`
-        <div style="${In}${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${s.media?c(s.media):v}
-            ${l?T`<div style="display:flex; align-items:flex-start; gap:.75rem; padding:1rem 1.25rem ${s.content||s.footer?`0`:`1rem`};">
-                ${s.headerPrefix?c(s.headerPrefix):v}
+            title="${r.shortcut?`${i} (${Mn(r.shortcut)})`:_}"
+            slot="${e.slot??_}"
+    >${r.iconOnLeft?F(r.iconOnLeft):_}${i}${r.iconOnRight?F(r.iconOnRight):_}</button>`},Ln=`display:block; box-sizing:border-box; background:var(--lumo-base-color,#fff); border:1px solid var(--lumo-contrast-10pct,rgba(0,0,0,.1)); border-radius:var(--lumo-border-radius-l,12px); box-shadow:var(--lumo-box-shadow-xs,0 1px 3px rgba(0,0,0,.08)); overflow:hidden;`,Rn=(e,t,n,r,i,a,o)=>{let s=t.metadata;if(!s)return w``;let c=t=>t?P(e,t,n,r,i,a,o,!1):_,l=s.header||s.headerPrefix||s.headerSuffix||s.title||s.subtitle;return w`
+        <div style="${Ln}${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
+            ${s.media?c(s.media):_}
+            ${l?w`<div style="display:flex; align-items:flex-start; gap:.75rem; padding:1rem 1.25rem ${s.content||s.footer?`0`:`1rem`};">
+                ${s.headerPrefix?c(s.headerPrefix):_}
                 <div style="flex:1; min-width:0;">
-                    ${s.header?c(s.header):v}
-                    ${s.title?T`<div style="font-weight:600; font-size:1.05rem; color:var(--lumo-body-text-color,#161513);">${c(s.title)}</div>`:v}
-                    ${s.subtitle?T`<div style="color:var(--lumo-secondary-text-color,#667);">${c(s.subtitle)}</div>`:v}
+                    ${s.header?c(s.header):_}
+                    ${s.title?w`<div style="font-weight:600; font-size:1.05rem; color:var(--lumo-body-text-color,#161513);">${c(s.title)}</div>`:_}
+                    ${s.subtitle?w`<div style="color:var(--lumo-secondary-text-color,#667);">${c(s.subtitle)}</div>`:_}
                 </div>
-                ${s.headerSuffix?c(s.headerSuffix):v}
-            </div>`:v}
-            ${s.content?T`<div style="padding:1rem 1.25rem;">${c(s.content)}</div>`:v}
-            ${s.footer?T`<div style="padding:0 1.25rem 1rem;">${c(s.footer)}</div>`:v}
+                ${s.headerSuffix?c(s.headerSuffix):_}
+            </div>`:_}
+            ${s.content?w`<div style="padding:1rem 1.25rem;">${c(s.content)}</div>`:_}
+            ${s.footer?w`<div style="padding:0 1.25rem 1rem;">${c(s.footer)}</div>`:_}
         </div>
-    `},Rn=e=>{let t=e.metadata;return T`
+    `},zn=e=>{let t=e.metadata;return w`
         <mateu-chart 
                 style="${e.style}" 
                 class="${e.cssClasses}"
-                slot="${e.slot??v}" 
+                slot="${e.slot??_}" 
                 type="${t.chartType}" 
                 .data="${t.chartData}" 
                 .options="${t.chartOptions}"
         >
         </mateu-chart>
-    `},zn=e=>{let t=e.metadata;return I(t.icon,e.style,e.cssClasses,e.slot)},Bn=(e,t)=>{e&&e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},Vn=`font:inherit; font-weight:500; cursor:pointer; padding:.45rem 1rem; border-radius:var(--lumo-border-radius-m,6px);`,Hn=`${Vn} background:var(--lumo-contrast-5pct,rgba(0,0,0,.04)); color:var(--lumo-body-text-color,#161513); border:1px solid var(--lumo-contrast-20pct,rgba(0,0,0,.16));`,Un=`${Vn} background:var(--lumo-primary-color,#3b5bdb); color:var(--lumo-primary-contrast-color,#fff); border:1px solid transparent;`,Wn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!1;if(s.openedCondition)try{c=it(s.openedCondition,r,i,a,o)}catch(e){console.error(`when evaluating `+s.openedCondition+` :`+e+`, where data is `+i+` and state is `+r)}return c?T`
+    `},Bn=e=>{let t=e.metadata;return F(t.icon,e.style,e.cssClasses,e.slot)},Vn=(e,t)=>{e&&e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},Hn=`font:inherit; font-weight:500; cursor:pointer; padding:.45rem 1rem; border-radius:var(--lumo-border-radius-m,6px);`,Un=`${Hn} background:var(--lumo-contrast-5pct,rgba(0,0,0,.04)); color:var(--lumo-body-text-color,#161513); border:1px solid var(--lumo-contrast-20pct,rgba(0,0,0,.16));`,Wn=`${Hn} background:var(--lumo-primary-color,#3b5bdb); color:var(--lumo-primary-contrast-color,#fff); border:1px solid transparent;`,Gn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!1;if(s.openedCondition)try{c=at(s.openedCondition,r,i,a,o)}catch(e){console.error(`when evaluating `+s.openedCondition+` :`+e+`, where data is `+i+` and state is `+r)}return c?w`
         <div class="mateu-confirm-dialog ${t.cssClasses??``}"
              style="position:fixed; inset:0; z-index:1000; display:flex; align-items:center; justify-content:center; background:rgba(0,0,0,.4); ${t.style??``}"
-             slot="${t.slot??v}">
+             slot="${t.slot??_}">
             <div style="background:var(--lumo-base-color,#fff); color:var(--lumo-body-text-color,#161513); border-radius:var(--lumo-border-radius-l,12px); box-shadow:var(--lumo-box-shadow-l,0 8px 24px rgba(0,0,0,.2)); width:100%; max-width:min(90vw,32rem); padding:1.5rem; box-sizing:border-box;">
-                ${s.header?T`<h3 style="margin:0 0 .75rem; font-size:1.15rem;">${s.header}</h3>`:v}
-                <div>${t.children?.map(t=>F(e,t,n,r,i,a,o))}</div>
+                ${s.header?w`<h3 style="margin:0 0 .75rem; font-size:1.15rem;">${s.header}</h3>`:_}
+                <div>${t.children?.map(t=>P(e,t,n,r,i,a,o))}</div>
                 <div style="display:flex; gap:.5rem; justify-content:flex-end; margin-top:1.25rem;">
-                    ${s.canCancel?T`<button style="${Hn}" @click="${e=>Bn(e.currentTarget,s.cancelActionId)}">${s.rejectText&&!s.canReject?s.rejectText:`Cancel`}</button>`:v}
-                    ${s.canReject?T`<button style="${Hn}" @click="${e=>Bn(e.currentTarget,s.rejectActionId)}">${s.rejectText||`No`}</button>`:v}
-                    <button style="${Un}" @click="${e=>Bn(e.currentTarget,s.confirmActionId)}">${s.confirmText||`OK`}</button>
+                    ${s.canCancel?w`<button style="${Un}" @click="${e=>Vn(e.currentTarget,s.cancelActionId)}">${s.rejectText&&!s.canReject?s.rejectText:`Cancel`}</button>`:_}
+                    ${s.canReject?w`<button style="${Un}" @click="${e=>Vn(e.currentTarget,s.rejectActionId)}">${s.rejectText||`No`}</button>`:_}
+                    <button style="${Wn}" @click="${e=>Vn(e.currentTarget,s.confirmActionId)}">${s.confirmText||`OK`}</button>
                 </div>
             </div>
         </div>
-    `:T``},Gn=e=>{let t=e.metadata,n;return t.position&&(n={Top:`top`,Bottom:`bottom`,TopLeft:`top-left`,TopRight:`top-right`,BottomLeft:`bottom-left`,BottomRight:`bottom-right`}[t.position]),T`
+    `:w``},Kn=e=>{let t=e.metadata,n;return t.position&&(n={Top:`top`,Bottom:`bottom`,TopLeft:`top-left`,TopRight:`top-right`,BottomLeft:`bottom-left`,BottomRight:`bottom-right`}[t.position]),w`
         <mateu-cookie-consent style="${e.style}" class="${e.cssClasses}"
-                               slot="${e.slot??v}"
-                               position="${n??v}"
-                               cookie-name="${t.cookieName??v}"
-                               .message="${t.message??v}"
-                               theme="${t.theme??v}"
-                               .learnMore="${t.learnMore??v}"
-                               .learnMoreLink="${t.learnMoreLink??v}"
-                               .dismiss="${t.dismiss??v}"
+                               slot="${e.slot??_}"
+                               position="${n??_}"
+                               cookie-name="${t.cookieName??_}"
+                               .message="${t.message??_}"
+                               theme="${t.theme??_}"
+                               .learnMore="${t.learnMore??_}"
+                               .learnMoreLink="${t.learnMoreLink??_}"
+                               .dismiss="${t.dismiss??_}"
         ></mateu-cookie-consent>
-    `},Kn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+    `},qn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <details
                 ?open="${s.opened}"
                 style="${t.style}"
                 class="${t.cssClasses}"
-                slot="${t.slot??v}"
+                slot="${t.slot??_}"
         >
-            <summary>${F(e,s.summary,n,r,i,a,o)}</summary>
-            ${F(e,s.content,n,r,i,a,o)}
+            <summary>${P(e,s.summary,n,r,i,a,o)}</summary>
+            ${P(e,s.content,n,r,i,a,o)}
         </details>
-            `},qn=(e,t,n,r,i,a)=>T`
+            `},Jn=(e,t,n,r,i,a)=>w`
         <mateu-dialog
                 id="${e.metadata.id}"
             .component="${e}"
@@ -1301,7 +1301,7 @@ ${i}
             .appState="${i}"
             .appdata="${a}"
         ></mateu-dialog>
-            `,Jn=(e,t,n,r,i,a)=>T`
+            `,Yn=(e,t,n,r,i,a)=>w`
         <mateu-drawer
                 id="${e.metadata.id}"
             .component="${e}"
@@ -1311,69 +1311,69 @@ ${i}
             .appState="${i}"
             .appdata="${a}"
         ></mateu-drawer>
-            `,Yn=e=>{let t=e.metadata;return T`
+            `,Xn=e=>{let t=e.metadata;return w`
         <mateu-api-caller>
         <mateu-ux baseUrl="${t.baseUrl}"  
                   route="${t.route}" 
                   consumedRoute="${t.consumedRoute}" 
-                  id="${E()}"
+                  id="${T()}"
                   serverSideType="${t.serverSideType}"
                   .appState="${t.appState}"
                   style="${e.style}" class="${e.cssClasses}"
-                  slot="${e.slot??v}"
+                  slot="${e.slot??_}"
         ></mateu-ux>
         </mateu-api-caller>
-            `},Xn=e=>T`
+            `},Zn=e=>w`
         <mateu-markdown .content=${e.metadata.markdown}
                         style="${e.style}" class="${e.cssClasses}"
-                        slot="${e.slot??v}"></mateu-markdown>
-            `,Zn=e=>{let t=e.metadata;return T`
+                        slot="${e.slot??_}"></mateu-markdown>
+            `,Qn=e=>{let t=e.metadata;return w`
         <div
             role="status"
-            slot="${e.slot??v}"
+            slot="${e.slot??_}"
             class="${e.cssClasses}"
             style="display: flex; align-items: center; gap: 0.6rem; padding: 0.6rem 0.9rem;
                    border-radius: var(--lumo-border-radius-m, 8px);
                    background: var(--lumo-contrast-5pct, rgba(0,0,0,0.05));
                    color: var(--lumo-body-text-color, #1a1a1a); ${e.style}"
         >
-            ${t.title?T`<strong>${t.title}</strong>`:v}
-            ${t.text?T`<span>${t.text}</span>`:v}
+            ${t.title?w`<strong>${t.title}</strong>`:_}
+            ${t.text?w`<span>${t.text}</span>`:_}
         </div>
-    `},Qn=(e,t={})=>{let n=e.metadata,r=n.valueKey?t[n.valueKey]:n.value,i=n.max&&n.max!=0?n.max:1,a=!n.indeterminate&&r!=null;return T`
-        <div style="${e.style}" class="${e.cssClasses}" slot="${e.slot??v}">
+    `},$n=(e,t={})=>{let n=e.metadata,r=n.valueKey?t[n.valueKey]:n.value,i=n.max&&n.max!=0?n.max:1,a=!n.indeterminate&&r!=null;return w`
+        <div style="${e.style}" class="${e.cssClasses}" slot="${e.slot??_}">
             <progress
                     style="width:100%;"
                     max="${i}"
-                    .value="${a?r:v}"
+                    .value="${a?r:_}"
             ></progress>
-            ${n.text?T`<span class="text-secondary text-xs" id="sublbl">
+            ${n.text?w`<span class="text-secondary text-xs" id="sublbl">
     ${n.text}
-  </span>`:v}
+  </span>`:_}
         </div>
-    `},$n=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
-        <details style="position: relative; ${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
-            <summary style="list-style: none; cursor: pointer;">${F(e,s.wrapped,n,r,i,a,o)}</summary>
+    `},er=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+        <details style="position: relative; ${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
+            <summary style="list-style: none; cursor: pointer;">${P(e,s.wrapped,n,r,i,a,o)}</summary>
             <div style="position: absolute; z-index: 100; min-width: 300px; margin-top: .25rem; padding: .6rem .8rem;
                         border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1)); border-radius: var(--lumo-border-radius-m, 8px);
                         background: var(--lumo-base-color, #fff); box-shadow: var(--lumo-box-shadow-m, 0 4px 16px rgba(0,0,0,.2));">
-                ${F(e,s.content,n,r,i,a,o)}
+                ${P(e,s.content,n,r,i,a,o)}
             </div>
         </details>
-    `},er=e=>{let t=e.metadata;return T`
+    `},tr=e=>{let t=e.metadata;return w`
         <mateu-map position="${t.position}" zoom="${t.zoom}"
                    style="${e.style}" class="${e.cssClasses}"
-                   slot="${e.slot??v}"></mateu-map>
-            `},tr=e=>T`
+                   slot="${e.slot??_}"></mateu-map>
+            `},nr=e=>w`
         <img src="${e.metadata.src}" style="${e.style}" class="${e.cssClasses}"
-             slot="${e.slot??v}">
-            `,nr=e=>{let t=e.metadata;return T`<div style="display:flex; align-items:center; gap:0.5rem;" slot="${e.slot??v}">
-        ${t.breadcrumbs.map(e=>T`
+             slot="${e.slot??_}">
+            `,rr=e=>{let t=e.metadata;return w`<div style="display:flex; align-items:center; gap:0.5rem;" slot="${e.slot??_}">
+        ${t.breadcrumbs.map(e=>w`
             <a href="${e.link}">${e.text}</a>
             <span>/</span>
         `)}
         <span style="${e.style}" class="${e.cssClasses}">${t.currentItemText}</span>
-    </div>`},rr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+    </div>`},ir=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <skeleton-carousel 
                 id="${t.id}"
                 ?dots = "${s.dots}" 
@@ -1382,77 +1382,77 @@ ${i}
                 style="${t.style}"
                 css="${t.cssClasses}"
         >
-            ${t.children?.map(t=>T`<div>${F(e,t,n,r,i,a,o)}</div>`)}
+            ${t.children?.map(t=>w`<div>${P(e,t,n,r,i,a,o)}</div>`)}
         </skeleton-carousel>
-    `},ir=(e,t,n,r)=>{let i=e.metadata;return T`
-        <div style="display: flex; gap: 3rem; ${e.style}" class="${e.cssClasses}" slot="${e.slot??v}">
-            ${i.menu.map(e=>ar(e))}
+    `},ar=(e,t,n,r)=>{let i=e.metadata;return w`
+        <div style="display: flex; gap: 3rem; ${e.style}" class="${e.cssClasses}" slot="${e.slot??_}">
+            ${i.menu.map(e=>or(e))}
         </div>
-            `},ar=e=>T`
-        ${e.submenus?T`
+            `},or=e=>w`
+        ${e.submenus?w`
                 <details open>
                     <summary>${e.label}</summary>
                     <div style="display:flex; flex-direction:column; gap:0.25rem; padding-left:0.5rem;">
-                        ${e.submenus.map(e=>ar(e))}
+                        ${e.submenus.map(e=>or(e))}
                     </div>
                 </details>
-            `:T`
+            `:w`
                 <a href="${e.path}">${e.label}</a>
         `}
-        `,or=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`<div
-                slot="${t.slot??v}"
+        `,sr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`<div
+                slot="${t.slot??_}"
                 style="${t.style}" class="${t.cssClasses}"
-        >${s.content?_(s.content):v}${t.children?.map(t=>F(e,t,n,r,i,a,o))}</div>
-    `},sr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.title?.includes("${")?e._evalTemplate(s.title):s.title;return T`<div
-                slot="${t.slot??v}"
+        >${s.content?g(s.content):_}${t.children?.map(t=>P(e,t,n,r,i,a,o))}</div>
+    `},cr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.title?.includes("${")?e._evalTemplate(s.title):s.title;return w`<div
+                slot="${t.slot??_}"
                 style="width: 100%; margin-bottom: var(--lumo-space-m); ${t.style}"
                 class="${t.cssClasses}"
         >
-        ${c?T`<div style="font-size: var(--lumo-font-size-l); font-weight: 600; color: var(--lumo-header-text-color); margin-bottom: var(--lumo-space-s);">${c}</div>`:v}
-        ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+        ${c?w`<div style="font-size: var(--lumo-font-size-l); font-weight: 600; color: var(--lumo-header-text-color); margin-bottom: var(--lumo-space-s);">${c}</div>`:_}
+        ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
     </div>
-    `},cr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.title?.includes("${")?e._evalTemplate(s.title):s.title;return T`
+    `},lr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.title?.includes("${")?e._evalTemplate(s.title):s.title;return w`
         <div
-                slot="${t.slot??v}"
+                slot="${t.slot??_}"
                 style="${t.style}" class="${t.cssClasses}"
         >
         <h4>${c}</h4>
-        ${t.children?.map(t=>F(e,t,n,r,i,a,o))}</div>
-    `},lr=(e,t,n)=>{n.dispatchEvent(new CustomEvent(`value-changed`,{detail:{fieldId:e,value:t},bubbles:!0,composed:!0}))},ur=e=>t=>{let n=t.target,r=n.type===`checkbox`?n.checked:n.value;lr(e.fieldId,r,n)},dr=(e,t)=>{let n=e.metadata,r=t?.[n.fieldId]??``,i=n,a=i.dataType,o=i.stereotype,s=!!i.readOnly,c=!!i.disabled,l=i.options,u=n.label?T`<label style="display:block; font-size: var(--lumo-font-size-s,.875rem); color: var(--lumo-secondary-text-color,#667); margin-bottom:.15rem;">${n.label}</label>`:v,d=`width:100%; box-sizing:border-box; padding:.4rem .6rem; border:1px solid var(--lumo-contrast-30pct,rgba(0,0,0,.3)); border-radius: var(--lumo-border-radius-m,6px); font:inherit; background: var(--lumo-base-color,#fff); color: var(--lumo-body-text-color,#1a1a1a);`,f;return f=s||o===`plainText`?T`<div style="padding:.4rem 0;">${String(r??``)}</div>`:a===`boolean`||o===`checkbox`||o===`badge`?T`<input type="checkbox" ?checked="${!!r}" ?disabled="${c}" @change="${ur(n)}">`:l&&l.length?T`
-            <select style="${d}" ?disabled="${c}" @change="${ur(n)}">
+        ${t.children?.map(t=>P(e,t,n,r,i,a,o))}</div>
+    `},ur=(e,t,n)=>{n.dispatchEvent(new CustomEvent(`value-changed`,{detail:{fieldId:e,value:t},bubbles:!0,composed:!0}))},dr=e=>t=>{let n=t.target,r=n.type===`checkbox`?n.checked:n.value;ur(e.fieldId,r,n)},fr=(e,t)=>{let n=e.metadata,r=t?.[n.fieldId]??``,i=n,a=i.dataType,o=i.stereotype,s=!!i.readOnly,c=!!i.disabled,l=i.options,u=n.label?w`<label style="display:block; font-size: var(--lumo-font-size-s,.875rem); color: var(--lumo-secondary-text-color,#667); margin-bottom:.15rem;">${n.label}</label>`:_,d=`width:100%; box-sizing:border-box; padding:.4rem .6rem; border:1px solid var(--lumo-contrast-30pct,rgba(0,0,0,.3)); border-radius: var(--lumo-border-radius-m,6px); font:inherit; background: var(--lumo-base-color,#fff); color: var(--lumo-body-text-color,#1a1a1a);`,f;return f=s||o===`plainText`?w`<div style="padding:.4rem 0;">${String(r??``)}</div>`:a===`boolean`||o===`checkbox`||o===`badge`?w`<input type="checkbox" ?checked="${!!r}" ?disabled="${c}" @change="${dr(n)}">`:l&&l.length?w`
+            <select style="${d}" ?disabled="${c}" @change="${dr(n)}">
                 <option value="">—</option>
-                ${l.map(e=>T`<option value="${e.value}" ?selected="${e.value===r}">${e.label}</option>`)}
-            </select>`:o===`textarea`||o===`richText`||o===`html`?T`<textarea style="${d}" rows="3" ?disabled="${c}" @input="${ur(n)}">${String(r??``)}</textarea>`:T`<input type="${a===`integer`||a===`number`||a===`double`||a===`money`?`number`:a===`date`?`date`:a===`datetime`?`datetime-local`:a===`time`?`time`:o===`password`?`password`:a===`email`?`email`:`text`}" style="${d}" .value="${String(r??``)}"
-                              placeholder="${i.placeholder??v}" ?disabled="${c}" @input="${ur(n)}">`,T`
-        <div style="${e.style}" class="${e.cssClasses}" slot="${e.slot??v}">
+                ${l.map(e=>w`<option value="${e.value}" ?selected="${e.value===r}">${e.label}</option>`)}
+            </select>`:o===`textarea`||o===`richText`||o===`html`?w`<textarea style="${d}" rows="3" ?disabled="${c}" @input="${dr(n)}">${String(r??``)}</textarea>`:w`<input type="${a===`integer`||a===`number`||a===`double`||a===`money`?`number`:a===`date`?`date`:a===`datetime`?`datetime-local`:a===`time`?`time`:o===`password`?`password`:a===`email`?`email`:`text`}" style="${d}" .value="${String(r??``)}"
+                              placeholder="${i.placeholder??_}" ?disabled="${c}" @input="${dr(n)}">`,w`
+        <div style="${e.style}" class="${e.cssClasses}" slot="${e.slot??_}">
             ${u}
             ${f}
         </div>
-    `},fr=e=>{let t=e.metadata;if((t?.level??0)>0)return e;let n=e=>{if(e?.metadata?.type===j.EntityHeader)return e;let t=e?.metadata?.content,r=[...e?.children??[],...Array.isArray(t)?t:t?[t]:[]];for(let e of r){let t=n(e);if(t)return t}},r;for(let t of e.children??[])if(r=n(t),r)break;if(!r)return e;let i=r.metadata;r.__hoistedToPageHeader=!0;let a=[...(i.facts??[]).filter(e=>e.label||e.value).map(e=>({title:e.label??``,text:e.value??``})),...i.metricLabel?[{title:i.metricLabel,text:i.metricValue??``}]:[]],o=(i.badges??[]).filter(e=>e.label).map(e=>({text:e.label,color:e.color})),s={...t,title:i.title||t.title,subtitle:i.subtitle??t.subtitle,kpis:[...t.kpis??[],...a],kpisBelow:!0,badges:[...t.badges??[],...o]};return{...e,metadata:s}},pr=(e,t,n,r,i,a,o,s)=>{let c=fr(t),l=c.metadata,u=l?.fabs??[];return T`<mateu-page
+    `},pr=e=>{let t=e.metadata;if((t?.level??0)>0)return e;let n=e=>{if(e?.metadata?.type===A.EntityHeader)return e;let t=e?.metadata?.content,r=[...e?.children??[],...Array.isArray(t)?t:t?[t]:[]];for(let e of r){let t=n(e);if(t)return t}},r;for(let t of e.children??[])if(r=n(t),r)break;if(!r)return e;let i=r.metadata;r.__hoistedToPageHeader=!0;let a=[...(i.facts??[]).filter(e=>e.label||e.value).map(e=>({title:e.label??``,text:e.value??``})),...i.metricLabel?[{title:i.metricLabel,text:i.metricValue??``}]:[]],o=(i.badges??[]).filter(e=>e.label).map(e=>({text:e.label,color:e.color})),s={...t,title:i.title||t.title,subtitle:i.subtitle??t.subtitle,kpis:[...t.kpis??[],...a],kpisBelow:!0,badges:[...t.badges??[],...o]};return{...e,metadata:s}},mr=(e,t,n,r,i,a,o,s)=>{let c=pr(t),l=c.metadata,u=l?.fabs??[];return w`<mateu-page
             .component="${c}"
             baseUrl="${n}"
             .state="${r}"
             .data="${i}"
             .appState="${a}"
             .appdata="${o}"
-            slot="${c.slot??v}"
+            slot="${c.slot??_}"
             style="${c.style}"
             class="${c.cssClasses}"
             ?standalone="${s??!1}"
     >
-        ${c.children?.map(t=>F(e,t,n,r,i,a,o))}
-        ${l?.buttons?.map(t=>T`
-                   ${F(e,{id:t.actionId,metadata:t,type:A.ClientSide,slot:`buttons`},void 0,r,i,a,o)}
+        ${c.children?.map(t=>P(e,t,n,r,i,a,o))}
+        ${l?.buttons?.map(t=>w`
+                   ${P(e,{id:t.actionId,metadata:t,type:k.ClientSide,slot:`buttons`},void 0,r,i,a,o)}
 `)}
-        ${u.map((t,n)=>T`
+        ${u.map((t,n)=>w`
             <button class="page-fab" style="position: fixed; bottom: ${1.5+n*4}rem; right: 5.5rem;"
                 @click="${()=>e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))}"
                 title="${t.label}">
-                ${I(t.icon)}
+                ${F(t.icon)}
             </button>
         `)}
 </mateu-page>
-    `},mr=(e,t,n,r,i,a,o,s)=>T`<mateu-table-crud
+    `},hr=(e,t,n,r,i,a,o,s)=>w`<mateu-table-crud
             id="${t.id}"
             baseUrl="${n}"
             .component="${t}"
@@ -1463,96 +1463,96 @@ ${i}
             .appdata="${o}"
             style="${t.style}"
             class="${t.cssClasses}"
-            slot="${t.slot??v}"
+            slot="${t.slot??_}"
             ?standalone="${s??!1}"
     >
-        ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
-    </mateu-table-crud>`,hr=e=>{let t=e.metadata;return T`
+        ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
+    </mateu-table-crud>`,gr=e=>{let t=e.metadata;return w`
         <mateu-bpmn
                 style="${e.style}"
                 class="${e.cssClasses}"
-                slot="${e.slot??v}"
+                slot="${e.slot??_}"
                 xml="${t.xml}"
         >
         </mateu-bpmn>
-    `},gr=(e,t,n)=>T`<mateu-chat sseUrl="${e.metadata.sseUrl}"
+    `},_r=(e,t,n)=>w`<mateu-chat sseUrl="${e.metadata.sseUrl}"
                             style="${e.style}" 
                             class="${e.cssClasses}" 
-                            slot="${e.slot??v}"></mateu-chat>`,_r=e=>{let t=e.metadata;return T`
+                            slot="${e.slot??_}"></mateu-chat>`,vr=e=>{let t=e.metadata;return w`
         <mateu-workflow
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
                 value="${t.value??`{"name":"New Workflow","steps":[]}`}"
         ></mateu-workflow>
-    `},vr=e=>{let t=e.metadata;return T`
+    `},yr=e=>{let t=e.metadata;return w`
         <mateu-form-editor
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
                 value="${t.value??`{"name":"New Form","fields":[]}`}"
         ></mateu-form-editor>
-    `},yr=`
+    `},br=`
     background: var(--lumo-base-color, #fff);
     border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.08));
     border-radius: var(--lumo-border-radius-l, 12px);
     padding: var(--lumo-space-m, 1rem);
     box-sizing: border-box;
-`,br=e=>e==`up`?`var(--lumo-success-text-color, #1a7f37)`:e==`down`?`var(--lumo-error-text-color, #c5221f)`:`var(--lumo-secondary-text-color, #666)`,xr=e=>e==`up`?`▲`:e==`down`?`▼`:``,Sr=(e,t)=>{t.actionId&&e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))},Cr=e=>{let t=e.metadata,n=!!t.actionId;return T`
+`,xr=e=>e==`up`?`var(--lumo-success-text-color, #1a7f37)`:e==`down`?`var(--lumo-error-text-color, #c5221f)`:`var(--lumo-secondary-text-color, #666)`,Sr=e=>e==`up`?`▲`:e==`down`?`▼`:``,Cr=(e,t)=>{t.actionId&&e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))},wr=e=>{let t=e.metadata,n=!!t.actionId;return w`
         <div class="mateu-metric-card ${e.cssClasses??``}"
-             style="${yr} display: flex; flex-direction: column; gap: .25rem; min-width: 11rem; flex: 1; ${n?`cursor: pointer;`:``} ${e.style??``}"
-             slot="${e.slot??v}"
-             role="${n?`button`:v}"
-             @click="${e=>Sr(e,t)}"
+             style="${br} display: flex; flex-direction: column; gap: .25rem; min-width: 11rem; flex: 1; ${n?`cursor: pointer;`:``} ${e.style??``}"
+             slot="${e.slot??_}"
+             role="${n?`button`:_}"
+             @click="${e=>Cr(e,t)}"
         >
             <div style="display: flex; align-items: center; justify-content: space-between; gap: .5rem;">
                 <span style="font-size: var(--lumo-font-size-s, .875rem); color: var(--lumo-secondary-text-color, #666);">${t.title}</span>
-                ${t.icon?I(t.icon,`color: var(--lumo-tertiary-text-color, #999); width: 1.1em; height: 1.1em;`):v}
+                ${t.icon?F(t.icon,`color: var(--lumo-tertiary-text-color, #999); width: 1.1em; height: 1.1em;`):_}
             </div>
             <div style="display: flex; align-items: baseline; gap: .35rem;">
                 <span style="font-size: var(--lumo-font-size-xxxl, 2rem); font-weight: 600; line-height: 1.1;">${t.value}</span>
-                ${t.unit?T`<span style="font-size: var(--lumo-font-size-m, 1rem); color: var(--lumo-secondary-text-color, #666);">${t.unit}</span>`:v}
+                ${t.unit?w`<span style="font-size: var(--lumo-font-size-m, 1rem); color: var(--lumo-secondary-text-color, #666);">${t.unit}</span>`:_}
             </div>
-            ${t.trend||t.trendLabel?T`
-                <span style="font-size: var(--lumo-font-size-s, .875rem); color: ${br(t.trend)};">
-                    ${xr(t.trend)} ${t.trendLabel??v}
+            ${t.trend||t.trendLabel?w`
+                <span style="font-size: var(--lumo-font-size-s, .875rem); color: ${xr(t.trend)};">
+                    ${Sr(t.trend)} ${t.trendLabel??_}
                 </span>
-            `:v}
-            ${t.description?T`<span style="font-size: var(--lumo-font-size-xs, .8rem); color: var(--lumo-tertiary-text-color, #999);">${t.description}</span>`:v}
+            `:_}
+            ${t.description?w`<span style="font-size: var(--lumo-font-size-xs, .8rem); color: var(--lumo-tertiary-text-color, #999);">${t.description}</span>`:_}
         </div>
-    `},wr=(e,t,n,r,i,a,o)=>T`
+    `},Tr=(e,t,n,r,i,a,o)=>w`
         <div class="mateu-scoreboard ${t.cssClasses??``}"
              style="display: flex; flex-wrap: wrap; gap: var(--lumo-space-m, 1rem); grid-column: 1 / -1; ${t.style??``}"
-             slot="${t.slot??v}"
+             slot="${t.slot??_}"
         >
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `,Tr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.colSpan&&s.colSpan>1?`grid-column: span ${s.colSpan};`:``,l=s.rowSpan&&s.rowSpan>1?`grid-row: span ${s.rowSpan};`:``,u=t.children??[];return u.length===1&&u[0].metadata?.type===`MetricCard`?T`
-            <div style="min-width: 0; ${c} ${l} ${t.style??``}" slot="${t.slot??v}">
-                ${F(e,u[0],n,r,i,a,o)}
-            </div>`:T`
+    `,Er=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.colSpan&&s.colSpan>1?`grid-column: span ${s.colSpan};`:``,l=s.rowSpan&&s.rowSpan>1?`grid-row: span ${s.rowSpan};`:``,u=t.children??[];return u.length===1&&u[0].metadata?.type===`MetricCard`?w`
+            <div style="min-width: 0; ${c} ${l} ${t.style??``}" slot="${t.slot??_}">
+                ${P(e,u[0],n,r,i,a,o)}
+            </div>`:w`
         <div class="mateu-dashboard-panel ${t.cssClasses??``}"
-             style="${yr} display: flex; flex-direction: column; gap: .5rem; min-width: 0; ${c} ${l} ${t.style??``}"
-             slot="${t.slot??v}"
+             style="${br} display: flex; flex-direction: column; gap: .5rem; min-width: 0; ${c} ${l} ${t.style??``}"
+             slot="${t.slot??_}"
         >
-            ${s.title?T`
+            ${s.title?w`
                 <div>
                     <h3 style="margin: 0; font-size: var(--lumo-font-size-l, 1.125rem);">${s.title}</h3>
-                    ${s.subtitle?T`<span style="font-size: var(--lumo-font-size-s, .875rem); color: var(--lumo-secondary-text-color, #666);">${s.subtitle}</span>`:v}
+                    ${s.subtitle?w`<span style="font-size: var(--lumo-font-size-s, .875rem); color: var(--lumo-secondary-text-color, #666);">${s.subtitle}</span>`:_}
                 </div>
-            `:v}
+            `:_}
             <div style="flex: 1; min-height: 0;">
-                ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+                ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
             </div>
         </div>
-    `},Er=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.columns&&s.columns>0?`repeat(${s.columns}, minmax(0, 1fr))`:`repeat(auto-fit, minmax(20rem, 1fr))`;return T`
+    `},Dr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.columns&&s.columns>0?`repeat(${s.columns}, minmax(0, 1fr))`:`repeat(auto-fit, minmax(20rem, 1fr))`;return w`
         <div class="mateu-dashboard ${t.cssClasses??``}"
              style="display: grid; grid-template-columns: ${c}; gap: var(--lumo-space-m, 1rem); align-items: stretch; ${t.style??``}"
-             slot="${t.slot??v}"
+             slot="${t.slot??_}"
         >
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `},Dr=class extends b{constructor(...e){super(...e),this.panels=[],this.headerTitle=``,this.badges=[],this.orientation=`vertical`,this.navigation=null,this.overviewEditActionId=``,this.openPanels=new Set,this.expandedPanel=null,this._onPopState=()=>{let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(e.startsWith(`expand=`)){let t=e.slice(7),n=this.panels.findIndex((e,n)=>this.panelAnchor(e,n)===t);this.expandedPanel=n>=0?n:null}else this.expandedPanel=null},this.initialized=!1}navAction(e){e&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{}},bubbles:!0,composed:!0}))}connectedCallback(){super.connectedCallback(),window.addEventListener(`popstate`,this._onPopState)}disconnectedCallback(){window.removeEventListener(`popstate`,this._onPopState),super.disconnectedCallback()}willUpdate(){if(!this.initialized&&this.panels.length){this.openPanels=new Set(this.panels.map((e,t)=>e.open?t:-1).filter(e=>e>=0));let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(e.startsWith(`expand=`)){let t=e.slice(7),n=this.panels.findIndex((e,n)=>this.panelAnchor(e,n)===t);n>=0&&(this.expandedPanel=n)}else if(e){let t=this.panels.findIndex((t,n)=>this.panelAnchor(t,n)===e);t>=0&&this.openPanels.add(t)}this.initialized=!0}}firstUpdated(){let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(!e)return;let t=this.renderRoot.querySelector(`[data-anchor="${CSS.escape(e)}"]`);t&&t.scrollIntoView({block:`nearest`})}panelAnchor(e,t){return(e.title??``).toLowerCase().replace(/[^a-z0-9]+/g,`-`).replace(/^-|-$/g,``)||`panel-${t}`}bookmarkPanel(e){let t=this.panelAnchor(this.panels[e],e);try{history.replaceState(history.state,``,`#`+t)}catch{}}clearBookmark(e){let t=this.panelAnchor(this.panels[e],e);if(decodeURIComponent((location.hash||``).replace(/^#/,``))===t)try{history.replaceState(history.state,``,location.pathname+location.search)}catch{}}expandPanel(e,t){t?.stopPropagation(),this.expandedPanel=e;let n=this.panelAnchor(this.panels[e],e);try{history.pushState(history.state,``,`#expand=`+n)}catch{}}collapsePanel(){try{history.back()}catch{this.expandedPanel=null}}toggle(e){let t=new Set(this.openPanels);t.has(e)?(t.delete(e),this.clearBookmark(e)):(t.add(e),this.bookmarkPanel(e)),this.openPanels=t}static{this.styles=h`
+    `},Or=class extends y{constructor(...e){super(...e),this.panels=[],this.headerTitle=``,this.badges=[],this.orientation=`vertical`,this.navigation=null,this.overviewEditActionId=``,this.openPanels=new Set,this.expandedPanel=null,this._onPopState=()=>{let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(e.startsWith(`expand=`)){let t=e.slice(7),n=this.panels.findIndex((e,n)=>this.panelAnchor(e,n)===t);this.expandedPanel=n>=0?n:null}else this.expandedPanel=null},this.initialized=!1}navAction(e){e&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{}},bubbles:!0,composed:!0}))}connectedCallback(){super.connectedCallback(),window.addEventListener(`popstate`,this._onPopState)}disconnectedCallback(){window.removeEventListener(`popstate`,this._onPopState),super.disconnectedCallback()}willUpdate(){if(!this.initialized&&this.panels.length){this.openPanels=new Set(this.panels.map((e,t)=>e.open?t:-1).filter(e=>e>=0));let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(e.startsWith(`expand=`)){let t=e.slice(7),n=this.panels.findIndex((e,n)=>this.panelAnchor(e,n)===t);n>=0&&(this.expandedPanel=n)}else if(e){let t=this.panels.findIndex((t,n)=>this.panelAnchor(t,n)===e);t>=0&&this.openPanels.add(t)}this.initialized=!0}}firstUpdated(){let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(!e)return;let t=this.renderRoot.querySelector(`[data-anchor="${CSS.escape(e)}"]`);t&&t.scrollIntoView({block:`nearest`})}panelAnchor(e,t){return(e.title??``).toLowerCase().replace(/[^a-z0-9]+/g,`-`).replace(/^-|-$/g,``)||`panel-${t}`}bookmarkPanel(e){let t=this.panelAnchor(this.panels[e],e);try{history.replaceState(history.state,``,`#`+t)}catch{}}clearBookmark(e){let t=this.panelAnchor(this.panels[e],e);if(decodeURIComponent((location.hash||``).replace(/^#/,``))===t)try{history.replaceState(history.state,``,location.pathname+location.search)}catch{}}expandPanel(e,t){t?.stopPropagation(),this.expandedPanel=e;let n=this.panelAnchor(this.panels[e],e);try{history.pushState(history.state,``,`#expand=`+n)}catch{}}collapsePanel(){try{history.back()}catch{this.expandedPanel=null}}toggle(e){let t=new Set(this.openPanels);t.has(e)?(t.delete(e),this.clearBookmark(e)):(t.add(e),this.bookmarkPanel(e)),this.openPanels=t}static{this.styles=m`
         :host {
             display: flex;
             flex-direction: column;
@@ -1851,7 +1851,7 @@ ${i}
             overflow: auto;
             padding: var(--mateu-foldout-panel-padding, var(--lumo-space-m, 1rem));
         }
-    `}render(){if(this.expandedPanel!=null&&this.panels[this.expandedPanel]){let e=this.panels[this.expandedPanel];return T`
+    `}render(){if(this.expandedPanel!=null&&this.panels[this.expandedPanel]){let e=this.panels[this.expandedPanel];return w`
                 <div class="expanded-view" part="expanded-view">
                     <div class="expanded-header">
                         <button class="nav-parent" title="Back"
@@ -1859,40 +1859,40 @@ ${i}
                             <span>‹</span><span>Back</span>
                         </button>
                         <span class="nav-title">${e.title}</span>
-                        ${e.subtitle?T`<span class="subtitle">${e.subtitle}</span>`:v}
+                        ${e.subtitle?w`<span class="subtitle">${e.subtitle}</span>`:_}
                     </div>
                     <div class="expanded-body">
                         <slot name="panel-${this.expandedPanel}"></slot>
                     </div>
                 </div>
-            `}let e=this.navigation;return T`
-            ${e?T`
+            `}let e=this.navigation;return w`
+            ${e?w`
                 <div class="nav-header" part="nav-header">
-                    ${e.parentActionId?T`
+                    ${e.parentActionId?w`
                         <button class="nav-parent" title="${e.parentLabel??`Back`}"
                                 @click="${()=>this.navAction(e.parentActionId)}">
                             <span>‹</span><span>${e.parentLabel??`Back`}</span>
                         </button>
-                    `:v}
-                    ${e.title?T`<span class="nav-title">${e.title}</span>`:v}
+                    `:_}
+                    ${e.title?w`<span class="nav-title">${e.title}</span>`:_}
                     <span class="nav-spacer"></span>
-                    ${e.previousActionId?T`
+                    ${e.previousActionId?w`
                         <button class="nav-move" title="Previous"
                                 @click="${()=>this.navAction(e.previousActionId)}">‹</button>
-                    `:v}
-                    ${e.nextActionId?T`
+                    `:_}
+                    ${e.nextActionId?w`
                         <button class="nav-move" title="Next"
                                 @click="${()=>this.navAction(e.nextActionId)}">›</button>
-                    `:v}
+                    `:_}
                 </div>
-            `:v}
-            ${this.headerTitle?T`
+            `:_}
+            ${this.headerTitle?w`
                 <div class="header-band" part="header-band">
                     <div class="header-content">
                         <h2 class="header-title">${this.headerTitle}</h2>
-                        ${this.badges.length?T`
+                        ${this.badges.length?w`
                             <div class="header-badges">
-                                ${this.badges.map(e=>T`<span class="header-badge">${e}</span>`)}
+                                ${this.badges.map(e=>w`<span class="header-badge">${e}</span>`)}
                             </div>
                         `:``}
                     </div>
@@ -1901,23 +1901,23 @@ ${i}
             `:``}
             <div class="columns" part="columns">
                 <div class="overview" part="overview">
-                    ${this.overviewEditActionId?T`
+                    ${this.overviewEditActionId?w`
                         <button class="overview-edit" title="Edit"
                                 @click="${()=>this.navAction(this.overviewEditActionId)}">
                             <span>✎</span><span>Edit</span>
                         </button>
-                    `:v}
+                    `:_}
                     <slot name="overview"></slot>
                 </div>
                 <div class="rail" part="rail">
-                    ${this.panels.map((e,t)=>this.openPanels.has(t)?T`
+                    ${this.panels.map((e,t)=>this.openPanels.has(t)?w`
                         <div class="panel" part="panel" data-anchor="${this.panelAnchor(e,t)}"
-                             style="${e.width?`flex-basis: ${e.width}; min-width: min(${e.width}, 100%);`:v}"
+                             style="${e.width?`flex-basis: ${e.width}; min-width: min(${e.width}, 100%);`:_}"
                              @click="${()=>this.bookmarkPanel(t)}">
                             <div class="panel-header">
                                 <div>
                                     <h3>${e.title}</h3>
-                                    ${e.subtitle?T`<div class="subtitle">${e.subtitle}</div>`:``}
+                                    ${e.subtitle?w`<div class="subtitle">${e.subtitle}</div>`:``}
                                 </div>
                                 <span class="panel-actions">
                                     <button class="panel-expand" title="Show all"
@@ -1929,7 +1929,7 @@ ${i}
                                 <slot name="panel-${t}"></slot>
                             </div>
                         </div>
-                    `:T`
+                    `:w`
                         <div class="strip" role="button" title="${e.title}"
                              data-anchor="${this.panelAnchor(e,t)}" @click="${()=>this.toggle(t)}">
                             <button class="fold" tabindex="-1">⟩</button>
@@ -1938,7 +1938,7 @@ ${i}
                     `)}
                 </div>
             </div>
-        `}};k([y({type:Array})],Dr.prototype,`panels`,void 0),k([y({type:String})],Dr.prototype,`headerTitle`,void 0),k([y({type:Array})],Dr.prototype,`badges`,void 0),k([y({type:String,reflect:!0})],Dr.prototype,`orientation`,void 0),k([y({attribute:!1})],Dr.prototype,`navigation`,void 0),k([y({type:String})],Dr.prototype,`overviewEditActionId`,void 0),k([C()],Dr.prototype,`openPanels`,void 0),k([C()],Dr.prototype,`expandedPanel`,void 0),Dr=k([g(`mateu-foldout`)],Dr);var Or=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+        `}};O([v({type:Array})],Or.prototype,`panels`,void 0),O([v({type:String})],Or.prototype,`headerTitle`,void 0),O([v({type:Array})],Or.prototype,`badges`,void 0),O([v({type:String,reflect:!0})],Or.prototype,`orientation`,void 0),O([v({attribute:!1})],Or.prototype,`navigation`,void 0),O([v({type:String})],Or.prototype,`overviewEditActionId`,void 0),O([S()],Or.prototype,`openPanels`,void 0),O([S()],Or.prototype,`expandedPanel`,void 0),Or=O([h(`mateu-foldout`)],Or);var kr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <mateu-foldout
                 .panels="${s.panels??[]}"
                 .headerTitle="${s.headerTitle??``}"
@@ -1948,45 +1948,45 @@ ${i}
                 orientation="${s.orientation??`vertical`}"
                 style="${t.style}"
                 class="${t.cssClasses}"
-                slot="${t.slot??v}"
+                slot="${t.slot??_}"
         >
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </mateu-foldout>
-    `},kr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.children??[],l=e=>c.filter(t=>(t.slot??``).startsWith(e)),u=l(`main-`),d=l(`aside-`),f=l(`footer-`),p=s.asideWidth&&s.asideWidth.trim()?s.asideWidth:`32%`,m=s.asidePosition===`start`,ee=s.asideSticky!==!1,te=t=>t.map(t=>F(e,t,n,r,i,a,o)),ne=T`
+    `},Ar=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.children??[],l=e=>c.filter(t=>(t.slot??``).startsWith(e)),u=l(`main-`),d=l(`aside-`),f=l(`footer-`),p=s.asideWidth&&s.asideWidth.trim()?s.asideWidth:`32%`,ee=s.asidePosition===`start`,te=s.asideSticky!==!1,ne=t=>t.map(t=>P(e,t,n,r,i,a,o)),re=w`
         <div class="mateu-content-main"
              style="flex: 1 1 0; min-width: min(20rem, 100%); box-sizing: border-box;">
-            ${te(u)}
-        </div>`,h=d.length?T`
+            ${ne(u)}
+        </div>`,m=d.length?w`
         <div class="mateu-content-aside"
-             style="flex: 0 1 calc(${p} - var(--lumo-space-m, 1rem)); min-width: min(18rem, 100%); box-sizing: border-box; ${ee?`position: sticky; top: 1rem; align-self: flex-start;`:``}">
-            ${te(d)}
-        </div>`:v;return T`
+             style="flex: 0 1 calc(${p} - var(--lumo-space-m, 1rem)); min-width: min(18rem, 100%); box-sizing: border-box; ${te?`position: sticky; top: 1rem; align-self: flex-start;`:``}">
+            ${ne(d)}
+        </div>`:_;return w`
         <div class="mateu-content-layout ${t.cssClasses??``}"
              style="${t.style??``}"
-             slot="${t.slot??v}">
+             slot="${t.slot??_}">
             <div style="display: flex; flex-wrap: wrap; gap: var(--lumo-space-m, 1rem); align-items: flex-start;">
-                ${m?[h,ne]:[ne,h]}
+                ${ee?[m,re]:[re,m]}
             </div>
-            ${f.length?T`
+            ${f.length?w`
                 <div class="mateu-content-footer"
                      style="flex-basis: 100%; margin-top: var(--lumo-space-m, 1rem);">
-                    ${te(f)}
-                </div>`:v}
+                    ${ne(f)}
+                </div>`:_}
         </div>
-    `},Ar=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!!s.image,l=c?`background-image: linear-gradient(rgba(0,0,0,.35), rgba(0,0,0,.35)), url('${s.image}'); background-size: cover; background-position: center; color: #fff;`:``,u=s.centered===!1?`flex-start`:`center`,d=s.centered===!1?`left`:`center`;return T`
+    `},jr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!!s.image,l=c?`background-image: linear-gradient(rgba(0,0,0,.35), rgba(0,0,0,.35)), url('${s.image}'); background-size: cover; background-position: center; color: #fff;`:``,u=s.centered===!1?`flex-start`:`center`,d=s.centered===!1?`left`:`center`;return w`
         <div class="mateu-hero ${t.cssClasses??``}"
              style="display: flex; flex-direction: column; align-items: ${u}; justify-content: center; gap: var(--lumo-space-m, 1rem); text-align: ${d}; padding: var(--lumo-space-xl, 2.5rem) var(--lumo-space-l, 1.5rem); border-radius: var(--lumo-border-radius-l, 12px); min-height: ${s.height??`12rem`}; box-sizing: border-box; ${l} ${t.style??``}"
-             slot="${t.slot??v}"
+             slot="${t.slot??_}"
         >
-            ${s.title?T`<h1 style="margin: 0; font-size: var(--lumo-font-size-xxxl, 2.5rem); line-height: 1.15;">${s.title}</h1>`:v}
-            ${s.subtitle?T`<p style="margin: 0; font-size: var(--lumo-font-size-l, 1.125rem); ${c?``:`color: var(--lumo-secondary-text-color, #666);`} max-width: 40rem;">${s.subtitle}</p>`:v}
-            ${t.children?.length?T`
+            ${s.title?w`<h1 style="margin: 0; font-size: var(--lumo-font-size-xxxl, 2.5rem); line-height: 1.15;">${s.title}</h1>`:_}
+            ${s.subtitle?w`<p style="margin: 0; font-size: var(--lumo-font-size-l, 1.125rem); ${c?``:`color: var(--lumo-secondary-text-color, #666);`} max-width: 40rem;">${s.subtitle}</p>`:_}
+            ${t.children?.length?w`
                 <div style="display: flex; gap: var(--lumo-space-s, .5rem); flex-wrap: wrap; justify-content: ${u}; width: 100%; max-width: 40rem;">
-                    ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+                    ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
                 </div>
-            `:v}
+            `:_}
         </div>
-    `},R=e=>t=>{if(t.key===`Enter`){e(t);return}(t.key===` `||t.key===`Spacebar`)&&(t.preventDefault(),e(t))},z=h`
+    `},L=e=>t=>{if(t.key===`Enter`){e(t);return}(t.key===` `||t.key===`Spacebar`)&&(t.preventDefault(),e(t))},R=m`
     [role="button"]:focus-visible,
     [role="option"]:focus-visible,
     [role="treeitem"]:focus-visible,
@@ -1997,7 +1997,7 @@ ${i}
         outline-offset: 2px;
         border-radius: var(--lumo-border-radius-s, 4px);
     }
-`,jr=1440*60*1e3,Mr=class extends b{constructor(...e){super(...e),this.tasks=[],this.onTaskSelectionActionId=``}selectTask(e){this.onTaskSelectionActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.onTaskSelectionActionId,parameters:{_clickedTaskId:e.id}},bubbles:!0,composed:!0}))}static{this.styles=h`
+`,Mr=1440*60*1e3,Nr=class extends y{constructor(...e){super(...e),this.tasks=[],this.onTaskSelectionActionId=``}selectTask(e){this.onTaskSelectionActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.onTaskSelectionActionId,parameters:{_clickedTaskId:e.id}},bubbles:!0,composed:!0}))}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2072,39 +2072,39 @@ ${i}
             opacity: .55;
         }
     
-        ${z}
-    `}range(){let e=this.tasks.flatMap(e=>[e.start,e.end]).filter(e=>!!e).map(e=>new Date(e+`T00:00:00`).getTime());return e.length?{min:Math.min(...e)-jr,max:Math.max(...e)+2*jr}:null}months(e,t){let n=[],r=new Date(e);for(r.setDate(1);r.getTime()<=t;){let i=Math.max(r.getTime(),e),a=new Date(r.getFullYear(),r.getMonth()+1,1),o=Math.min(a.getTime(),t);n.push({label:r.toLocaleDateString(void 0,{month:`short`,year:`2-digit`}),from:i,to:o}),r.setMonth(r.getMonth()+1)}return n}render(){let e=this.range();if(!e)return T``;let t=e.max-e.min,n=n=>(n-e.min)/t*100,r=Date.now();return T`
+        ${R}
+    `}range(){let e=this.tasks.flatMap(e=>[e.start,e.end]).filter(e=>!!e).map(e=>new Date(e+`T00:00:00`).getTime());return e.length?{min:Math.min(...e)-Mr,max:Math.max(...e)+2*Mr}:null}months(e,t){let n=[],r=new Date(e);for(r.setDate(1);r.getTime()<=t;){let i=Math.max(r.getTime(),e),a=new Date(r.getFullYear(),r.getMonth()+1,1),o=Math.min(a.getTime(),t);n.push({label:r.toLocaleDateString(void 0,{month:`short`,year:`2-digit`}),from:i,to:o}),r.setMonth(r.getMonth()+1)}return n}render(){let e=this.range();if(!e)return w``;let t=e.max-e.min,n=n=>(n-e.min)/t*100,r=Date.now();return w`
             <div class="frame">
                 <div class="head">Task</div>
                 <div class="head months">
-                    ${this.months(e.min,e.max).map(e=>T`
+                    ${this.months(e.min,e.max).map(e=>w`
                         <div class="month" style="width: ${(e.to-e.from)/t*100}%;">${e.label}</div>
                     `)}
                 </div>
-                ${this.tasks.map(i=>{let a=new Date(i.start+`T00:00:00`).getTime(),o=new Date(i.end+`T00:00:00`).getTime()+jr;return T`
+                ${this.tasks.map(i=>{let a=new Date(i.start+`T00:00:00`).getTime(),o=new Date(i.end+`T00:00:00`).getTime()+Mr;return w`
                         <div class="label" title="${i.title}">${i.title}</div>
                         <div class="lane">
-                            ${r>=e.min&&r<=e.max?T`<div class="today" style="left: ${n(r)}%;"></div>`:v}
+                            ${r>=e.min&&r<=e.max?w`<div class="today" style="left: ${n(r)}%;"></div>`:_}
                             <div role="button" tabindex="0"
                                  aria-label="${i.title}, ${i.start} to ${i.end}${i.progress?`, ${i.progress}% complete`:``}"
                                  class="bar ${this.onTaskSelectionActionId?`clickable`:``}"
                                  title="${i.title} · ${i.start} → ${i.end}${i.progress?` · ${i.progress}%`:``}"
-                                 @click="${()=>this.selectTask(i)}" @keydown="${R(()=>this.selectTask(i))}"
+                                 @click="${()=>this.selectTask(i)}" @keydown="${L(()=>this.selectTask(i))}"
                                  style="left: ${n(a)}%; width: ${(o-a)/t*100}%; ${i.color?`--mateu-gantt-fill: ${i.color};`:``}">
                                 <div class="fill" style="width: ${i.progress??0}%;"></div>
                             </div>
                         </div>
                     `})}
             </div>
-        `}};k([y({type:Array})],Mr.prototype,`tasks`,void 0),k([y()],Mr.prototype,`onTaskSelectionActionId`,void 0),Mr=k([g(`mateu-gantt`)],Mr);var Nr=e=>{let t=e.metadata;return T`
+        `}};O([v({type:Array})],Nr.prototype,`tasks`,void 0),O([v()],Nr.prototype,`onTaskSelectionActionId`,void 0),Nr=O([h(`mateu-gantt`)],Nr);var Pr=e=>{let t=e.metadata;return w`
         <mateu-gantt
                 .tasks="${t.tasks??[]}"
                 .onTaskSelectionActionId="${t.onTaskSelectionActionId??``}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-gantt>
-    `},B,Pr=class extends b{static{B=this}constructor(...e){super(...e),this.resources=[],this.blocks=[],this.drag=null,this.dragStartX=0,this.dragStartY=0,this.laneRects=[],this.onDragKeydown=e=>{e.key===`Escape`&&this.drag&&(e.stopPropagation(),this.endDrag())}}static{this.styles=h`
+    `},z,Fr=class extends y{static{z=this}constructor(...e){super(...e),this.resources=[],this.blocks=[],this.drag=null,this.dragStartX=0,this.dragStartY=0,this.laneRects=[],this.onDragKeydown=e=>{e.key===`Escape`&&this.drag&&(e.stopPropagation(),this.endDrag())}}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2246,10 +2246,10 @@ ${i}
             pointer-events: none;
             z-index: 2;
         }
-    `}static parse(e){return new Date(e+`T00:00:00`)}static iso(e){let t=e=>String(e).padStart(2,`0`);return`${e.getFullYear()}-${t(e.getMonth()+1)}-${t(e.getDate())}`}static addDays(e,t){return new Date(e.getFullYear(),e.getMonth(),e.getDate()+t)}static daysBetween(e,t){return Math.round((t.getTime()-e.getTime())/864e5)}window(){if(this.from&&this.to){let e=B.parse(this.from),t=B.daysBetween(e,B.parse(this.to))+1;return t>0?{from:e,days:t}:null}let e=this.blocks.flatMap(e=>[e.start,e.end]).filter(e=>!!e).map(e=>B.parse(e));if(!e.length)return null;let t=new Date(Math.min(...e.map(e=>e.getTime()))),n=new Date(Math.max(...e.map(e=>e.getTime())));return{from:t,days:B.daysBetween(t,n)+1}}onBlockPointerDown(e,t,n){if(!this.moveActionId&&!this.selectActionId||(e.preventDefault(),e.currentTarget.setPointerCapture(e.pointerId),this.dragStartX=e.clientX,this.dragStartY=e.clientY,!this.window()))return;let r=B.parse(t.start),i=B.parse(t.end),a=Math.max(1,B.daysBetween(r,i)+1);this.laneRects=[...this.renderRoot.querySelectorAll(`.lane[data-resource-id]`)].map(e=>({resourceId:e.dataset.resourceId,rect:e.getBoundingClientRect()}));let o=this.dayAt(t.resourceId,e.clientX)??n;this.drag={blockId:t.id,duration:a,grabOffsetDays:o-n,originResourceId:t.resourceId,originStartIdx:n,targetResourceId:t.resourceId,targetStartIdx:n,moved:!1},window.addEventListener(`keydown`,this.onDragKeydown)}dayAt(e,t){let n=this.laneRects.find(t=>t.resourceId===e),r=this.window();if(!n||!r||n.rect.width===0)return null;let i=Math.floor((t-n.rect.left)/n.rect.width*r.days);return Math.max(0,Math.min(r.days-1,i))}onBlockPointerMove(e){if(!this.drag||!this.drag.moved&&Math.abs(e.clientX-this.dragStartX)<4&&Math.abs(e.clientY-this.dragStartY)<4||!this.moveActionId)return;let t=this.window();if(!t)return;let n=this.laneRects.find(t=>e.clientY>=t.rect.top&&e.clientY<=t.rect.bottom)??this.laneRects.find(e=>e.resourceId===this.drag.targetResourceId);if(!n)return;let r=this.dayAt(n.resourceId,e.clientX);if(r==null)return;let i=Math.max(0,Math.min(t.days-this.drag.duration,r-this.drag.grabOffsetDays));this.drag={...this.drag,moved:!0,targetResourceId:n.resourceId,targetStartIdx:i}}onBlockPointerUp(e){let t=this.drag;if(this.endDrag(),!t)return;if(!t.moved){this.selectActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.selectActionId,parameters:{_blockId:e.id}},bubbles:!0,composed:!0}));return}if(!this.moveActionId||t.targetResourceId===t.originResourceId&&t.targetStartIdx===t.originStartIdx)return;let n=this.window();if(!n)return;let r=B.addDays(n.from,t.targetStartIdx),i=B.addDays(r,t.duration-1);this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.moveActionId,parameters:{_blockId:t.blockId,_resourceId:t.targetResourceId,_start:B.iso(r),_end:B.iso(i)}},bubbles:!0,composed:!0}))}endDrag(){this.drag=null,window.removeEventListener(`keydown`,this.onDragKeydown)}disconnectedCallback(){super.disconnectedCallback(),window.removeEventListener(`keydown`,this.onDragKeydown)}render(){let e=this.window();if(!e||!this.resources.length)return T``;let t=[...Array(e.days).keys()].map(t=>B.addDays(e.from,t)),n=new Date,r=B.daysBetween(e.from,new Date(n.getFullYear(),n.getMonth(),n.getDate())),i=r>=0&&r<e.days,a=[],o;return this.resources.forEach(n=>{n.group&&n.group!==o&&a.push(T`<div class="group">${n.group}</div>`),o=n.group,a.push(this.renderRow(n,e,t,i?r:null))}),T`
+    `}static parse(e){return new Date(e+`T00:00:00`)}static iso(e){let t=e=>String(e).padStart(2,`0`);return`${e.getFullYear()}-${t(e.getMonth()+1)}-${t(e.getDate())}`}static addDays(e,t){return new Date(e.getFullYear(),e.getMonth(),e.getDate()+t)}static daysBetween(e,t){return Math.round((t.getTime()-e.getTime())/864e5)}window(){if(this.from&&this.to){let e=z.parse(this.from),t=z.daysBetween(e,z.parse(this.to))+1;return t>0?{from:e,days:t}:null}let e=this.blocks.flatMap(e=>[e.start,e.end]).filter(e=>!!e).map(e=>z.parse(e));if(!e.length)return null;let t=new Date(Math.min(...e.map(e=>e.getTime()))),n=new Date(Math.max(...e.map(e=>e.getTime())));return{from:t,days:z.daysBetween(t,n)+1}}onBlockPointerDown(e,t,n){if(!this.moveActionId&&!this.selectActionId||(e.preventDefault(),e.currentTarget.setPointerCapture(e.pointerId),this.dragStartX=e.clientX,this.dragStartY=e.clientY,!this.window()))return;let r=z.parse(t.start),i=z.parse(t.end),a=Math.max(1,z.daysBetween(r,i)+1);this.laneRects=[...this.renderRoot.querySelectorAll(`.lane[data-resource-id]`)].map(e=>({resourceId:e.dataset.resourceId,rect:e.getBoundingClientRect()}));let o=this.dayAt(t.resourceId,e.clientX)??n;this.drag={blockId:t.id,duration:a,grabOffsetDays:o-n,originResourceId:t.resourceId,originStartIdx:n,targetResourceId:t.resourceId,targetStartIdx:n,moved:!1},window.addEventListener(`keydown`,this.onDragKeydown)}dayAt(e,t){let n=this.laneRects.find(t=>t.resourceId===e),r=this.window();if(!n||!r||n.rect.width===0)return null;let i=Math.floor((t-n.rect.left)/n.rect.width*r.days);return Math.max(0,Math.min(r.days-1,i))}onBlockPointerMove(e){if(!this.drag||!this.drag.moved&&Math.abs(e.clientX-this.dragStartX)<4&&Math.abs(e.clientY-this.dragStartY)<4||!this.moveActionId)return;let t=this.window();if(!t)return;let n=this.laneRects.find(t=>e.clientY>=t.rect.top&&e.clientY<=t.rect.bottom)??this.laneRects.find(e=>e.resourceId===this.drag.targetResourceId);if(!n)return;let r=this.dayAt(n.resourceId,e.clientX);if(r==null)return;let i=Math.max(0,Math.min(t.days-this.drag.duration,r-this.drag.grabOffsetDays));this.drag={...this.drag,moved:!0,targetResourceId:n.resourceId,targetStartIdx:i}}onBlockPointerUp(e){let t=this.drag;if(this.endDrag(),!t)return;if(!t.moved){this.selectActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.selectActionId,parameters:{_blockId:e.id}},bubbles:!0,composed:!0}));return}if(!this.moveActionId||t.targetResourceId===t.originResourceId&&t.targetStartIdx===t.originStartIdx)return;let n=this.window();if(!n)return;let r=z.addDays(n.from,t.targetStartIdx),i=z.addDays(r,t.duration-1);this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.moveActionId,parameters:{_blockId:t.blockId,_resourceId:t.targetResourceId,_start:z.iso(r),_end:z.iso(i)}},bubbles:!0,composed:!0}))}endDrag(){this.drag=null,window.removeEventListener(`keydown`,this.onDragKeydown)}disconnectedCallback(){super.disconnectedCallback(),window.removeEventListener(`keydown`,this.onDragKeydown)}render(){let e=this.window();if(!e||!this.resources.length)return w``;let t=[...Array(e.days).keys()].map(t=>z.addDays(e.from,t)),n=new Date,r=z.daysBetween(e.from,new Date(n.getFullYear(),n.getMonth(),n.getDate())),i=r>=0&&r<e.days,a=[],o;return this.resources.forEach(n=>{n.group&&n.group!==o&&a.push(w`<div class="group">${n.group}</div>`),o=n.group,a.push(this.renderRow(n,e,t,i?r:null))}),w`
             <div class="frame" style="grid-template-columns: minmax(8rem, 12rem) repeat(${e.days}, minmax(2.2rem, 1fr));">
                 <div class="corner">Resource</div>
-                ${t.map((e,t)=>T`
+                ${t.map((e,t)=>w`
                     <div class="day-head ${this.isWeekend(e)?`weekend`:``} ${t===r?`today`:``}">
                         <span class="dow">${e.toLocaleDateString(void 0,{weekday:`short`})}</span>
                         <span class="num">${e.getDate()}</span>
@@ -2257,14 +2257,14 @@ ${i}
                 `)}
                 ${a}
             </div>
-        `}isWeekend(e){return e.getDay()===0||e.getDay()===6}renderRow(e,t,n,r){let i=100/t.days,a=this.blocks.filter(t=>t.resourceId===e.id&&t.start&&t.end),o=this.drag?.moved&&this.drag.targetResourceId===e.id?this.drag:null;return T`
+        `}isWeekend(e){return e.getDay()===0||e.getDay()===6}renderRow(e,t,n,r){let i=100/t.days,a=this.blocks.filter(t=>t.resourceId===e.id&&t.start&&t.end),o=this.drag?.moved&&this.drag.targetResourceId===e.id?this.drag:null;return w`
             <div class="label" title="${e.label??``}">${e.label}</div>
             <div class="lane" data-resource-id="${e.id}">
                 <div class="cells">
-                    ${n.map(e=>T`<div class="cell ${this.isWeekend(e)?`weekend`:``}"></div>`)}
+                    ${n.map(e=>w`<div class="cell ${this.isWeekend(e)?`weekend`:``}"></div>`)}
                 </div>
-                ${r==null?v:T`<div class="today-line" style="left: ${(r+.5)*i}%;"></div>`}
-                ${a.map(e=>{let n=B.daysBetween(t.from,B.parse(e.start)),r=B.daysBetween(t.from,B.parse(e.end));if(r<0||n>=t.days)return v;let a=Math.max(0,n),o=Math.min(t.days-1,r),s=this.drag?.moved&&this.drag.blockId===e.id;return T`
+                ${r==null?_:w`<div class="today-line" style="left: ${(r+.5)*i}%;"></div>`}
+                ${a.map(e=>{let n=z.daysBetween(t.from,z.parse(e.start)),r=z.daysBetween(t.from,z.parse(e.end));if(r<0||n>=t.days)return _;let a=Math.max(0,n),o=Math.min(t.days-1,r),s=this.drag?.moved&&this.drag.blockId===e.id;return w`
                         <div class="block ${this.selectActionId?`clickable`:``} ${this.moveActionId?`draggable`:``} ${s?`dragging`:``}"
                              title="${e.label??``} · ${e.start} → ${e.end}${e.status?` · ${e.status}`:``}"
                              style="left: ${a*i}%; width: ${(o-a+1)*i}%; ${e.color?`--mateu-planning-block: ${e.color};`:``}"
@@ -2274,12 +2274,12 @@ ${i}
                              @pointercancel="${()=>this.endDrag()}"
                         >${e.label}</div>
                     `})}
-                ${o?T`
+                ${o?w`
                     <div class="ghost"
                          style="left: ${o.targetStartIdx*i}%; width: ${Math.min(o.duration,t.days-o.targetStartIdx)*i}%;"></div>
-                `:v}
+                `:_}
             </div>
-        `}};k([y({type:Array})],Pr.prototype,`resources`,void 0),k([y({type:Array})],Pr.prototype,`blocks`,void 0),k([y()],Pr.prototype,`from`,void 0),k([y()],Pr.prototype,`to`,void 0),k([y()],Pr.prototype,`moveActionId`,void 0),k([y()],Pr.prototype,`selectActionId`,void 0),k([C()],Pr.prototype,`drag`,void 0),Pr=B=k([g(`mateu-planning-board`)],Pr);var Fr=e=>{let t=e.metadata;return T`
+        `}};O([v({type:Array})],Fr.prototype,`resources`,void 0),O([v({type:Array})],Fr.prototype,`blocks`,void 0),O([v()],Fr.prototype,`from`,void 0),O([v()],Fr.prototype,`to`,void 0),O([v()],Fr.prototype,`moveActionId`,void 0),O([v()],Fr.prototype,`selectActionId`,void 0),O([S()],Fr.prototype,`drag`,void 0),Fr=z=O([h(`mateu-planning-board`)],Fr);var Ir=e=>{let t=e.metadata;return w`
         <mateu-planning-board
                 .resources="${t.resources??[]}"
                 .blocks="${t.blocks??[]}"
@@ -2287,11 +2287,11 @@ ${i}
                 .to="${t.to}"
                 .moveActionId="${t.moveActionId}"
                 .selectActionId="${t.selectActionId}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-planning-board>
-    `},Ir=class extends b{constructor(...e){super(...e),this.columns=[]}static{this.styles=h`
+    `},Lr=class extends y{constructor(...e){super(...e),this.columns=[]}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2374,35 +2374,35 @@ ${i}
             .card { background: var(--lumo-contrast-5pct, #2a2a2a); }
         }
     
-        ${z}
-    `}clickCard(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_clickedCard:e}},bubbles:!0,composed:!0}))}render(){return T`
+        ${R}
+    `}clickCard(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_clickedCard:e}},bubbles:!0,composed:!0}))}render(){return w`
             <div class="board">
-                ${this.columns.map(e=>T`
+                ${this.columns.map(e=>w`
                     <div class="column" style="${e.color?`--mateu-kanban-accent: ${e.color};`:``}">
                         <div class="column-head">
                             <span class="column-title" title="${e.title??``}">${e.title}</span>
                             <span class="count">${e.cards?.length??0}</span>
                         </div>
-                        ${(e.cards??[]).map(e=>T`
+                        ${(e.cards??[]).map(e=>w`
                             <div role="button" tabindex="0" class="card ${e.actionId?`clickable`:``}"
                                  style="${e.color?`--mateu-kanban-card-accent: ${e.color};`:``}"
-                                 @click="${()=>this.clickCard(e)}" @keydown="${R(()=>this.clickCard(e))}">
+                                 @click="${()=>this.clickCard(e)}" @keydown="${L(()=>this.clickCard(e))}">
                                 <span class="card-title">${e.title}</span>
-                                ${e.description?T`<span class="card-desc">${e.description}</span>`:v}
-                                ${e.badge?T`<span class="badge">${e.badge}</span>`:v}
+                                ${e.description?w`<span class="card-desc">${e.description}</span>`:_}
+                                ${e.badge?w`<span class="badge">${e.badge}</span>`:_}
                             </div>
                         `)}
                     </div>
                 `)}
             </div>
-        `}};k([y({type:Array})],Ir.prototype,`columns`,void 0),Ir=k([g(`mateu-kanban`)],Ir);var Lr=e=>T`
+        `}};O([v({type:Array})],Lr.prototype,`columns`,void 0),Lr=O([h(`mateu-kanban`)],Lr);var Rr=e=>w`
         <mateu-kanban
                 .columns="${e.metadata.columns??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-kanban>
-    `,Rr=class extends b{constructor(...e){super(...e),this.items=[]}static{this.styles=h`
+    `,zr=class extends y{constructor(...e){super(...e),this.items=[]}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2474,33 +2474,33 @@ ${i}
             margin-top: .15rem;
         }
     
-        ${z}
-    `}clickItem(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_clickedItem:e}},bubbles:!0,composed:!0}))}render(){return T`
+        ${R}
+    `}clickItem(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_clickedItem:e}},bubbles:!0,composed:!0}))}render(){return w`
             <div class="feed">
-                ${this.items.map(e=>T`
+                ${this.items.map(e=>w`
                     <div class="item ${e.actionId?`clickable`:``}">
                         <div class="rail">
                             <div class="dot" style="${e.color?`--mateu-timeline-dot: ${e.color};`:``}">${e.icon??``}</div>
                             <div class="line"></div>
                         </div>
-                        <div role="button" tabindex="0" class="body" @click="${()=>this.clickItem(e)}" @keydown="${R(()=>this.clickItem(e))}">
+                        <div role="button" tabindex="0" class="body" @click="${()=>this.clickItem(e)}" @keydown="${L(()=>this.clickItem(e))}">
                             <div class="head">
                                 <span class="title">${e.title}</span>
-                                ${e.timestamp?T`<span class="time">${e.timestamp}</span>`:v}
+                                ${e.timestamp?w`<span class="time">${e.timestamp}</span>`:_}
                             </div>
-                            ${e.description?T`<div class="desc">${e.description}</div>`:v}
+                            ${e.description?w`<div class="desc">${e.description}</div>`:_}
                         </div>
                     </div>
                 `)}
             </div>
-        `}};k([y({type:Array})],Rr.prototype,`items`,void 0),Rr=k([g(`mateu-timeline`)],Rr);var zr=e=>T`
+        `}};O([v({type:Array})],zr.prototype,`items`,void 0),zr=O([h(`mateu-timeline`)],zr);var Br=e=>w`
         <mateu-timeline
                 .items="${e.metadata.items??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-timeline>
-    `,Br=class extends b{constructor(...e){super(...e),this.steps=[],this.vertical=!1}static{this.styles=h`
+    `,Vr=class extends y{constructor(...e){super(...e),this.steps=[],this.vertical=!1}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2603,26 +2603,26 @@ ${i}
             margin-top: 0;
             padding: 0;
         }
-    `}updated(){let e=this.steps.length;if(e===0)return;let t=this.steps.findIndex(e=>e.status===`current`),n=this.steps.every(e=>e.status===`done`),r=t>=0?t+1:n?e:0;this.dispatchEvent(new CustomEvent(`mateu-guided-progress`,{detail:{current:r,total:e,steps:this.steps.map(e=>({id:e.id,title:e.title,status:e.status??`upcoming`}))},bubbles:!0,composed:!0}))}render(){return T`
+    `}updated(){let e=this.steps.length;if(e===0)return;let t=this.steps.findIndex(e=>e.status===`current`),n=this.steps.every(e=>e.status===`done`),r=t>=0?t+1:n?e:0;this.dispatchEvent(new CustomEvent(`mateu-guided-progress`,{detail:{current:r,total:e,steps:this.steps.map(e=>({id:e.id,title:e.title,status:e.status??`upcoming`}))},bubbles:!0,composed:!0}))}render(){return w`
             <div class="steps">
-                ${this.steps.map((e,t)=>{let n=e.status??`upcoming`;return T`
+                ${this.steps.map((e,t)=>{let n=e.status??`upcoming`;return w`
                         <div class="step ${n}">
                             <div class="connector"></div>
                             <div class="dot">${n===`done`?`✓`:t+1}</div>
                             <div class="label">${e.title}</div>
-                            ${e.description?T`<div class="desc">${e.description}</div>`:v}
+                            ${e.description?w`<div class="desc">${e.description}</div>`:_}
                         </div>
                     `})}
             </div>
-        `}};k([y({type:Array})],Br.prototype,`steps`,void 0),k([y({type:Boolean,reflect:!0})],Br.prototype,`vertical`,void 0),Br=k([g(`mateu-progress-steps`)],Br);var Vr=e=>{let t=e.metadata;return T`
+        `}};O([v({type:Array})],Vr.prototype,`steps`,void 0),O([v({type:Boolean,reflect:!0})],Vr.prototype,`vertical`,void 0),Vr=O([h(`mateu-progress-steps`)],Vr);var Hr=e=>{let t=e.metadata;return w`
         <mateu-progress-steps
                 .steps="${t.steps??[]}"
                 ?vertical="${t.vertical??!1}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-progress-steps>
-    `},Hr=class extends b{constructor(...e){super(...e),this.spark=[]}static{this.styles=h`
+    `},Ur=class extends y{constructor(...e){super(...e),this.spark=[]}static{this.styles=m`
         :host {
             display: block;
         }
@@ -2677,36 +2677,36 @@ ${i}
             .tile { background: var(--lumo-contrast-5pct, #2a2a2a); }
         }
     
-        ${z}
-    `}sparkline(){let e=this.spark;if(!e||e.length<2)return v;let t=Math.min(...e),n=Math.max(...e)-t||1,r=80/(e.length-1),i=e.map((e,i)=>[2+i*r,2+26*(1-(e-t)/n)]),a=i.map(([e,t],n)=>`${n===0?`M`:`L`}${e.toFixed(1)} ${t.toFixed(1)}`).join(` `),o=`${a} L${i[i.length-1][0].toFixed(1)} 30 L${i[0][0].toFixed(1)} 30 Z`,s=this.trend===`down`?`var(--lumo-error-color, #e11d48)`:this.trend===`flat`?`var(--lumo-secondary-text-color, #888)`:`var(--lumo-success-color, #12b76a)`;return w`
+        ${R}
+    `}sparkline(){let e=this.spark;if(!e||e.length<2)return _;let t=Math.min(...e),n=Math.max(...e)-t||1,r=80/(e.length-1),i=e.map((e,i)=>[2+i*r,2+26*(1-(e-t)/n)]),a=i.map(([e,t],n)=>`${n===0?`M`:`L`}${e.toFixed(1)} ${t.toFixed(1)}`).join(` `),o=`${a} L${i[i.length-1][0].toFixed(1)} 30 L${i[0][0].toFixed(1)} 30 Z`,s=this.trend===`down`?`var(--lumo-error-color, #e11d48)`:this.trend===`flat`?`var(--lumo-secondary-text-color, #888)`:`var(--lumo-success-color, #12b76a)`;return C`
             <svg width="${84}" height="${30}" viewBox="0 0 ${84} ${30}">
                 <path d="${o}" fill="${s}" opacity="0.12"></path>
                 <path d="${a}" fill="none" stroke="${s}" stroke-width="1.6"
                       stroke-linejoin="round" stroke-linecap="round"></path>
             </svg>
-        `}dispatchAction(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId},bubbles:!0,composed:!0}))}render(){let e=this.trend??`up`;return T`
-            <div role="button" tabindex="0" class="tile ${this.actionId?`clickable`:``}" @click="${()=>this.dispatchAction()}" @keydown="${R(()=>this.dispatchAction())}">
-                ${this.label?T`<span class="label">${this.label}</span>`:v}
-                <span class="value">${this.value}${this.unit?T`<span class="unit">${this.unit}</span>`:v}</span>
+        `}dispatchAction(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId},bubbles:!0,composed:!0}))}render(){let e=this.trend??`up`;return w`
+            <div role="button" tabindex="0" class="tile ${this.actionId?`clickable`:``}" @click="${()=>this.dispatchAction()}" @keydown="${L(()=>this.dispatchAction())}">
+                ${this.label?w`<span class="label">${this.label}</span>`:_}
+                <span class="value">${this.value}${this.unit?w`<span class="unit">${this.unit}</span>`:_}</span>
                 <div class="foot">
-                    ${this.delta?T`<span class="delta ${e}">${e===`up`?`▲`:e===`down`?`▼`:`→`} ${this.delta}</span>`:T`<span></span>`}
+                    ${this.delta?w`<span class="delta ${e}">${e===`up`?`▲`:e===`down`?`▼`:`→`} ${this.delta}</span>`:w`<span></span>`}
                     ${this.sparkline()}
                 </div>
             </div>
-        `}};k([y()],Hr.prototype,`label`,void 0),k([y()],Hr.prototype,`value`,void 0),k([y()],Hr.prototype,`unit`,void 0),k([y()],Hr.prototype,`delta`,void 0),k([y()],Hr.prototype,`trend`,void 0),k([y({type:Array})],Hr.prototype,`spark`,void 0),k([y()],Hr.prototype,`actionId`,void 0),Hr=k([g(`mateu-stat`)],Hr);var Ur=e=>{let t=e.metadata;return T`
+        `}};O([v()],Ur.prototype,`label`,void 0),O([v()],Ur.prototype,`value`,void 0),O([v()],Ur.prototype,`unit`,void 0),O([v()],Ur.prototype,`delta`,void 0),O([v()],Ur.prototype,`trend`,void 0),O([v({type:Array})],Ur.prototype,`spark`,void 0),O([v()],Ur.prototype,`actionId`,void 0),Ur=O([h(`mateu-stat`)],Ur);var Wr=e=>{let t=e.metadata;return w`
         <mateu-stat
-                label="${t.label??v}"
-                value="${t.value??v}"
-                unit="${t.unit??v}"
-                delta="${t.delta??v}"
-                trend="${t.trend??v}"
-                actionId="${t.actionId??v}"
+                label="${t.label??_}"
+                value="${t.value??_}"
+                unit="${t.unit??_}"
+                delta="${t.delta??_}"
+                trend="${t.trend??_}"
+                actionId="${t.actionId??_}"
                 .spark="${t.spark??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-stat>
-    `},Wr=class extends b{constructor(...e){super(...e),this.events=[]}static{this.styles=h`
+    `},Gr=class extends y{constructor(...e){super(...e),this.events=[]}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2780,32 +2780,32 @@ ${i}
             .dow { background: var(--lumo-contrast-10pct, #333); }
         }
     
-        ${z}
-    `}clickEvent(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_clickedEvent:e}},bubbles:!0,composed:!0}))}render(){let e=this.month?new Date(this.month+`T00:00:00`):new Date,t=e.getFullYear(),n=e.getMonth(),r=new Date(t,n,1),i=(r.getDay()+6)%7,a=new Date(t,n+1,0).getDate(),o=new Date,s=e=>o.getFullYear()===t&&o.getMonth()===n&&o.getDate()===e,c={};for(let e of this.events){if(!e.date)continue;let r=new Date(e.date+`T00:00:00`);r.getFullYear()===t&&r.getMonth()===n&&(c[r.getDate()]??=[]).push(e)}let l=[`Mon`,`Tue`,`Wed`,`Thu`,`Fri`,`Sat`,`Sun`],u=[];for(let e=0;e<i;e++)u.push(T`<div class="cell blank"></div>`);for(let e=1;e<=a;e++)u.push(T`
+        ${R}
+    `}clickEvent(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_clickedEvent:e}},bubbles:!0,composed:!0}))}render(){let e=this.month?new Date(this.month+`T00:00:00`):new Date,t=e.getFullYear(),n=e.getMonth(),r=new Date(t,n,1),i=(r.getDay()+6)%7,a=new Date(t,n+1,0).getDate(),o=new Date,s=e=>o.getFullYear()===t&&o.getMonth()===n&&o.getDate()===e,c={};for(let e of this.events){if(!e.date)continue;let r=new Date(e.date+`T00:00:00`);r.getFullYear()===t&&r.getMonth()===n&&(c[r.getDate()]??=[]).push(e)}let l=[`Mon`,`Tue`,`Wed`,`Thu`,`Fri`,`Sat`,`Sun`],u=[];for(let e=0;e<i;e++)u.push(w`<div class="cell blank"></div>`);for(let e=1;e<=a;e++)u.push(w`
                 <div class="cell ${s(e)?`today`:``}">
                     <span class="num">${e}</span>
-                    ${(c[e]??[]).map(e=>T`
+                    ${(c[e]??[]).map(e=>w`
                         <span role="button" tabindex="0" class="chip ${e.actionId?`clickable`:``}"
                               style="${e.color?`--mateu-cal-accent: ${e.color};`:``}"
                               title="${e.title??``}"
-                              @click="${()=>this.clickEvent(e)}" @keydown="${R(()=>this.clickEvent(e))}">${e.title}</span>
+                              @click="${()=>this.clickEvent(e)}" @keydown="${L(()=>this.clickEvent(e))}">${e.title}</span>
                     `)}
                 </div>
-            `);return T`
+            `);return w`
             <div class="title">${r.toLocaleDateString(void 0,{month:`long`,year:`numeric`})}</div>
             <div class="grid">
-                ${l.map(e=>T`<div class="dow">${e}</div>`)}
+                ${l.map(e=>w`<div class="dow">${e}</div>`)}
                 ${u}
             </div>
-        `}};k([y()],Wr.prototype,`month`,void 0),k([y({type:Array})],Wr.prototype,`events`,void 0),Wr=k([g(`mateu-calendar`)],Wr);var Gr=e=>{let t=e.metadata;return T`
+        `}};O([v()],Gr.prototype,`month`,void 0),O([v({type:Array})],Gr.prototype,`events`,void 0),Gr=O([h(`mateu-calendar`)],Gr);var Kr=e=>{let t=e.metadata;return w`
         <mateu-calendar
-                month="${t.month??v}"
+                month="${t.month??_}"
                 .events="${t.events??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-calendar>
-    `},Kr=class extends b{constructor(...e){super(...e),this.plans=[]}static{this.styles=h`
+    `},qr=class extends y{constructor(...e){super(...e),this.plans=[]}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2898,33 +2898,33 @@ ${i}
         @media (prefers-color-scheme: dark) {
             .plan { background: var(--lumo-contrast-5pct, #2a2a2a); }
         }
-    `}cta(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))}render(){return T`
+    `}cta(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))}render(){return w`
             <div class="plans">
-                ${this.plans.map(e=>T`
+                ${this.plans.map(e=>w`
                     <div class="plan ${e.featured?`featured`:``}">
-                        ${e.featured?T`<span class="badge">Recommended</span>`:v}
+                        ${e.featured?w`<span class="badge">Recommended</span>`:_}
                         <span class="name">${e.name}</span>
                         <div>
                             <span class="price">${e.price}</span>
-                            ${e.period?T`<span class="period">${e.period}</span>`:v}
+                            ${e.period?w`<span class="period">${e.period}</span>`:_}
                         </div>
                         <ul>
-                            ${(e.features??[]).map(e=>T`<li>${e}</li>`)}
+                            ${(e.features??[]).map(e=>w`<li>${e}</li>`)}
                         </ul>
-                        ${e.ctaLabel?T`
+                        ${e.ctaLabel?w`
                             <button class="cta" @click="${()=>this.cta(e)}">${e.ctaLabel}</button>
-                        `:v}
+                        `:_}
                     </div>
                 `)}
             </div>
-        `}};k([y({type:Array})],Kr.prototype,`plans`,void 0),Kr=k([g(`mateu-pricing-table`)],Kr);var qr=e=>T`
+        `}};O([v({type:Array})],qr.prototype,`plans`,void 0),qr=O([h(`mateu-pricing-table`)],qr);var Jr=e=>w`
         <mateu-pricing-table
                 .plans="${e.metadata.plans??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-pricing-table>
-    `,Jr=class extends b{static{this.styles=h`
+    `,Yr=class extends y{static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -3020,26 +3020,26 @@ ${i}
             .node { background: var(--lumo-contrast-5pct, #2a2a2a); }
         }
     
-        ${z}
-    `}clickNode(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_clickedNode:e}},bubbles:!0,composed:!0}))}renderNode(e){let t=e.avatar,n=t&&(t.startsWith(`http`)||t.startsWith(`data:`));return T`
+        ${R}
+    `}clickNode(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_clickedNode:e}},bubbles:!0,composed:!0}))}renderNode(e){let t=e.avatar,n=t&&(t.startsWith(`http`)||t.startsWith(`data:`));return w`
             <li>
                 <div role="button" tabindex="0" class="node ${e.actionId?`clickable`:``}"
                      style="${e.color?`--mateu-org-accent: ${e.color};`:``}"
-                     @click="${()=>this.clickNode(e)}" @keydown="${R(()=>this.clickNode(e))}">
-                    ${t?T`<span class="avatar">${n?T`<img src="${t}" alt="">`:t}</span>`:v}
+                     @click="${()=>this.clickNode(e)}" @keydown="${L(()=>this.clickNode(e))}">
+                    ${t?w`<span class="avatar">${n?w`<img src="${t}" alt="">`:t}</span>`:_}
                     <span class="title">${e.title}</span>
-                    ${e.subtitle?T`<span class="subtitle">${e.subtitle}</span>`:v}
+                    ${e.subtitle?w`<span class="subtitle">${e.subtitle}</span>`:_}
                 </div>
-                ${e.children&&e.children.length?T`<ul>${e.children.map(e=>this.renderNode(e))}</ul>`:v}
+                ${e.children&&e.children.length?w`<ul>${e.children.map(e=>this.renderNode(e))}</ul>`:_}
             </li>
-        `}render(){return this.root?T`<div class="tree"><ul>${this.renderNode(this.root)}</ul></div>`:T``}};k([y({attribute:!1})],Jr.prototype,`root`,void 0),Jr=k([g(`mateu-org-chart`)],Jr);var Yr=e=>T`
+        `}render(){return this.root?w`<div class="tree"><ul>${this.renderNode(this.root)}</ul></div>`:w``}};O([v({attribute:!1})],Yr.prototype,`root`,void 0),Yr=O([h(`mateu-org-chart`)],Yr);var Xr=e=>w`
         <mateu-org-chart
                 .root="${e.metadata.root}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-org-chart>
-    `,Xr=1440*60*1e3,Zr=class extends b{constructor(...e){super(...e),this.cells=[]}static{this.styles=h`
+    `,Zr=1440*60*1e3,Qr=class extends y{constructor(...e){super(...e),this.cells=[]}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -3063,9 +3063,9 @@ ${i}
             margin-top: .15rem;
         }
         .legend .cell { width: 10px; height: 10px; }
-    `}color(e,t){if(e<=0||t<=0)return`var(--lumo-contrast-10pct, #ebedf0)`;let n=e/t;return`color-mix(in srgb, var(--lumo-primary-color, #1a73e8) ${Math.round((n>.75?1:n>.5?.75:n>.25?.5:.3)*100)}%, transparent)`}render(){let e=this.cells.filter(e=>!!e.date);if(!e.length)return T``;let t=e.map(e=>new Date(e.date+`T00:00:00`).getTime()),n=Math.min(...t),r=Math.max(...t),i=new Date(n);i.setDate(i.getDate()-(i.getDay()+6)%7);let a={};for(let t of e)a[t.date]=t;let o=Math.max(...e.map(e=>e.value??0),1),s=[];for(let e=i.getTime();e<=r;e+=Xr){let t=new Date(e),n=t.toISOString().slice(0,10),r=a[n],i=r?.value??0,c=(t.getDay()+6)%7+1,l=r?.label??`${n}: ${i}`;s.push(T`
+    `}color(e,t){if(e<=0||t<=0)return`var(--lumo-contrast-10pct, #ebedf0)`;let n=e/t;return`color-mix(in srgb, var(--lumo-primary-color, #1a73e8) ${Math.round((n>.75?1:n>.5?.75:n>.25?.5:.3)*100)}%, transparent)`}render(){let e=this.cells.filter(e=>!!e.date);if(!e.length)return w``;let t=e.map(e=>new Date(e.date+`T00:00:00`).getTime()),n=Math.min(...t),r=Math.max(...t),i=new Date(n);i.setDate(i.getDate()-(i.getDay()+6)%7);let a={};for(let t of e)a[t.date]=t;let o=Math.max(...e.map(e=>e.value??0),1),s=[];for(let e=i.getTime();e<=r;e+=Zr){let t=new Date(e),n=t.toISOString().slice(0,10),r=a[n],i=r?.value??0,c=(t.getDay()+6)%7+1,l=r?.label??`${n}: ${i}`;s.push(w`
                 <div class="cell" style="grid-row: ${c}; --cell: ${this.color(i,o)};" title="${l}"></div>
-            `)}return T`
+            `)}return w`
             <div class="wrap">
                 <div class="grid">${s}</div>
                 <div class="legend">
@@ -3078,14 +3078,14 @@ ${i}
                     <span>More</span>
                 </div>
             </div>
-        `}};k([y({type:Array})],Zr.prototype,`cells`,void 0),Zr=k([g(`mateu-heatmap`)],Zr);var Qr=e=>T`
+        `}};O([v({type:Array})],Qr.prototype,`cells`,void 0),Qr=O([h(`mateu-heatmap`)],Qr);var $r=e=>w`
         <mateu-heatmap
                 .cells="${e.metadata.cells??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-heatmap>
-    `,$r=class extends b{constructor(...e){super(...e),this.stages=[]}static{this.styles=h`
+    `,ei=class extends y{constructor(...e){super(...e),this.stages=[]}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .funnel { display: flex; flex-direction: column; gap: .35rem; }
         .stage { display: flex; flex-direction: column; align-items: center; gap: .1rem; }
@@ -3104,13 +3104,13 @@ ${i}
         .meta { display: flex; gap: .5rem; align-items: baseline; }
         .label { font-weight: 600; color: var(--lumo-body-text-color, #222); }
         .conv { color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-xs, .75rem); }
-    `}render(){let e=this.stages;if(!e.length)return T``;let t=e[0].value??0,n=Math.max(...e.map(e=>e.value??0),1);return T`
+    `}render(){let e=this.stages;if(!e.length)return w``;let t=e[0].value??0,n=Math.max(...e.map(e=>e.value??0),1);return w`
             <div class="funnel">
-                ${e.map((r,i)=>{let a=r.value??0,o=n>0?Math.max(6,a/n*100):6,s=i>0?e[i-1].value??0:t,c=i===0?t>0?`100%`:``:s>0?`${Math.round(a/s*100)}%`:`0%`;return T`
+                ${e.map((r,i)=>{let a=r.value??0,o=n>0?Math.max(6,a/n*100):6,s=i>0?e[i-1].value??0:t,c=i===0?t>0?`100%`:``:s>0?`${Math.round(a/s*100)}%`:`0%`;return w`
                         <div class="stage">
                             <div class="meta">
                                 <span class="label">${r.label}</span>
-                                ${i>0?T`<span class="conv">${c} of previous</span>`:v}
+                                ${i>0?w`<span class="conv">${c} of previous</span>`:_}
                             </div>
                             <div class="bar" style="width: ${o}%; ${r.color?`--bar: ${r.color};`:``}">
                                 ${a.toLocaleString()}
@@ -3118,38 +3118,38 @@ ${i}
                         </div>
                     `})}
             </div>
-        `}};k([y({type:Array})],$r.prototype,`stages`,void 0),$r=k([g(`mateu-funnel`)],$r);var ei=e=>T`
+        `}};O([v({type:Array})],ei.prototype,`stages`,void 0),ei=O([h(`mateu-funnel`)],ei);var ti=e=>w`
         <mateu-funnel
                 .stages="${e.metadata.stages??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-funnel>
-    `,ti=class extends b{constructor(...e){super(...e),this.values=[],this.labels=[],this.area=!1}static{this.styles=h`
+    `,ni=class extends y{constructor(...e){super(...e),this.values=[],this.labels=[],this.area=!1}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .title { font-weight: 600; margin-bottom: .35rem; color: var(--lumo-body-text-color, #222); }
         svg { display: block; width: 100%; height: auto; overflow: visible; }
         .labels { display: flex; justify-content: space-between; color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-xs, .72rem); margin-top: .2rem; }
-    `}render(){let e=this.values;if(!e||e.length<2)return T``;let t=Math.min(...e),n=Math.max(...e),r=n-t||1,i=584/(e.length-1),a=e.map((e,n)=>[8+n*i,8+144*(1-(e-t)/r)]),o=a.map(([e,t],n)=>`${n===0?`M`:`L`}${e.toFixed(1)} ${t.toFixed(1)}`).join(` `),s=`${o} L${a[a.length-1][0].toFixed(1)} 152 L${a[0][0].toFixed(1)} 152 Z`,c=this.color||`var(--lumo-primary-color, #1a73e8)`,l=e.indexOf(n),u=e.indexOf(t);return T`
-            ${this.heading?T`<div class="title">${this.heading}</div>`:v}
+    `}render(){let e=this.values;if(!e||e.length<2)return w``;let t=Math.min(...e),n=Math.max(...e),r=n-t||1,i=584/(e.length-1),a=e.map((e,n)=>[8+n*i,8+144*(1-(e-t)/r)]),o=a.map(([e,t],n)=>`${n===0?`M`:`L`}${e.toFixed(1)} ${t.toFixed(1)}`).join(` `),s=`${o} L${a[a.length-1][0].toFixed(1)} 152 L${a[0][0].toFixed(1)} 152 Z`,c=this.color||`var(--lumo-primary-color, #1a73e8)`,l=e.indexOf(n),u=e.indexOf(t);return w`
+            ${this.heading?w`<div class="title">${this.heading}</div>`:_}
             <svg viewBox="0 0 ${600} ${160}" preserveAspectRatio="none">
-                ${this.area?w`<path d="${s}" fill="${c}" opacity="0.12"></path>`:v}
+                ${this.area?C`<path d="${s}" fill="${c}" opacity="0.12"></path>`:_}
                 <path d="${o}" fill="none" stroke="${c}" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"></path>
-                ${a.map((t,n)=>n===l||n===u?w`<circle cx="${t[0]}" cy="${t[1]}" r="3.2" fill="${c}"><title>${this.labels[n]??``}: ${e[n]}</title></circle>`:w`<circle cx="${t[0]}" cy="${t[1]}" r="6" fill="transparent"><title>${this.labels[n]??``}: ${e[n]}</title></circle>`)}
+                ${a.map((t,n)=>n===l||n===u?C`<circle cx="${t[0]}" cy="${t[1]}" r="3.2" fill="${c}"><title>${this.labels[n]??``}: ${e[n]}</title></circle>`:C`<circle cx="${t[0]}" cy="${t[1]}" r="6" fill="transparent"><title>${this.labels[n]??``}: ${e[n]}</title></circle>`)}
             </svg>
-            ${this.labels&&this.labels.length?T`<div class="labels"><span>${this.labels[0]}</span><span>${this.labels[this.labels.length-1]}</span></div>`:v}
-        `}};k([y()],ti.prototype,`heading`,void 0),k([y({type:Array})],ti.prototype,`values`,void 0),k([y({type:Array})],ti.prototype,`labels`,void 0),k([y()],ti.prototype,`color`,void 0),k([y({type:Boolean})],ti.prototype,`area`,void 0),ti=k([g(`mateu-trend-chart`)],ti);var ni=e=>{let t=e.metadata;return T`
+            ${this.labels&&this.labels.length?w`<div class="labels"><span>${this.labels[0]}</span><span>${this.labels[this.labels.length-1]}</span></div>`:_}
+        `}};O([v()],ni.prototype,`heading`,void 0),O([v({type:Array})],ni.prototype,`values`,void 0),O([v({type:Array})],ni.prototype,`labels`,void 0),O([v()],ni.prototype,`color`,void 0),O([v({type:Boolean})],ni.prototype,`area`,void 0),ni=O([h(`mateu-trend-chart`)],ni);var ri=e=>{let t=e.metadata;return w`
         <mateu-trend-chart
-                heading="${t.title??v}"
-                color="${t.color??v}"
+                heading="${t.title??_}"
+                color="${t.color??_}"
                 ?area="${t.area??!1}"
                 .values="${t.values??[]}"
                 .labels="${t.labels??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-trend-chart>
-    `},ri=class extends b{constructor(...e){super(...e),this.features=[],this.columns=0}static{this.styles=h`
+    `},ii=class extends y{constructor(...e){super(...e),this.features=[],this.columns=0}static{this.styles=m`
         :host { display: block; width: 100%; }
         .grid {
             display: grid;
@@ -3179,26 +3179,26 @@ ${i}
             .card { background: var(--lumo-contrast-5pct, #2a2a2a); }
         }
     
-        ${z}
-    `}clickFeature(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))}render(){return T`
+        ${R}
+    `}clickFeature(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))}render(){return w`
             <div class="grid" style="grid-template-columns: ${this.columns&&this.columns>0?`repeat(${this.columns}, minmax(0, 1fr))`:`repeat(auto-fit, minmax(15rem, 1fr))`};">
-                ${this.features.map(e=>T`
-                    <div role="button" tabindex="0" class="card ${e.actionId?`clickable`:``}" @click="${()=>this.clickFeature(e)}" @keydown="${R(()=>this.clickFeature(e))}">
-                        ${e.icon?T`<span class="icon">${e.icon}</span>`:v}
+                ${this.features.map(e=>w`
+                    <div role="button" tabindex="0" class="card ${e.actionId?`clickable`:``}" @click="${()=>this.clickFeature(e)}" @keydown="${L(()=>this.clickFeature(e))}">
+                        ${e.icon?w`<span class="icon">${e.icon}</span>`:_}
                         <span class="title">${e.title}</span>
-                        ${e.description?T`<span class="desc">${e.description}</span>`:v}
+                        ${e.description?w`<span class="desc">${e.description}</span>`:_}
                     </div>
                 `)}
             </div>
-        `}};k([y({type:Array})],ri.prototype,`features`,void 0),k([y({type:Number})],ri.prototype,`columns`,void 0),ri=k([g(`mateu-feature-grid`)],ri);var ii=e=>{let t=e.metadata;return T`
+        `}};O([v({type:Array})],ii.prototype,`features`,void 0),O([v({type:Number})],ii.prototype,`columns`,void 0),ii=O([h(`mateu-feature-grid`)],ii);var ai=e=>{let t=e.metadata;return w`
         <mateu-feature-grid
                 .features="${t.features??[]}"
                 .columns="${t.columns??0}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-feature-grid>
-    `},ai=class extends b{constructor(...e){super(...e),this.items=[]}static{this.styles=h`
+    `},oi=class extends y{constructor(...e){super(...e),this.items=[]}static{this.styles=m`
         :host { display: block; width: 100%; }
         .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr)); gap: var(--lumo-space-m, 1rem); }
         .card {
@@ -3222,30 +3222,30 @@ ${i}
         .name { font-weight: 600; color: var(--lumo-body-text-color, #222); }
         .role { color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-xs, .75rem); }
         @media (prefers-color-scheme: dark) { .card { background: var(--lumo-contrast-5pct, #2a2a2a); } }
-    `}stars(e){let t=Math.max(0,Math.min(5,e||0));return`★`.repeat(t)+`☆`.repeat(5-t)}render(){return T`
+    `}stars(e){let t=Math.max(0,Math.min(5,e||0));return`★`.repeat(t)+`☆`.repeat(5-t)}render(){return w`
             <div class="grid">
-                ${this.items.map(e=>{let t=e.avatar&&(e.avatar.startsWith(`http`)||e.avatar.startsWith(`data:`));return T`
+                ${this.items.map(e=>{let t=e.avatar&&(e.avatar.startsWith(`http`)||e.avatar.startsWith(`data:`));return w`
                         <div class="card">
-                            ${e.rating?T`<div class="stars">${this.stars(e.rating)}</div>`:v}
+                            ${e.rating?w`<div class="stars">${this.stars(e.rating)}</div>`:_}
                             <div class="quote">${e.quote}</div>
                             <div class="author">
-                                ${e.avatar?T`<span class="avatar">${t?T`<img src="${e.avatar}" alt="">`:e.avatar}</span>`:v}
+                                ${e.avatar?w`<span class="avatar">${t?w`<img src="${e.avatar}" alt="">`:e.avatar}</span>`:_}
                                 <div>
                                     <div class="name">${e.author}</div>
-                                    ${e.role?T`<div class="role">${e.role}</div>`:v}
+                                    ${e.role?w`<div class="role">${e.role}</div>`:_}
                                 </div>
                             </div>
                         </div>
                     `})}
             </div>
-        `}};k([y({type:Array})],ai.prototype,`items`,void 0),ai=k([g(`mateu-testimonials`)],ai);var oi=e=>T`
+        `}};O([v({type:Array})],oi.prototype,`items`,void 0),oi=O([h(`mateu-testimonials`)],oi);var si=e=>w`
         <mateu-testimonials
                 .items="${e.metadata.items??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-testimonials>
-    `,si=class extends b{constructor(...e){super(...e),this.items=[],this.openSet=new Set,this.seeded=!1}static{this.styles=h`
+    `,ci=class extends y{constructor(...e){super(...e),this.items=[],this.openSet=new Set,this.seeded=!1}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-m, 1rem); }
         .list {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -3269,27 +3269,27 @@ ${i}
         }
         @media (prefers-color-scheme: dark) { .q { background: var(--lumo-contrast-5pct, #2a2a2a); } }
     
-        ${z}
-    `}seed(){this.seeded||(this.seeded=!0,this.items.forEach((e,t)=>{e.open&&this.openSet.add(t)}))}toggle(e){this.openSet.has(e)?this.openSet.delete(e):this.openSet.add(e),this.requestUpdate()}render(){return this.seed(),T`
+        ${R}
+    `}seed(){this.seeded||(this.seeded=!0,this.items.forEach((e,t)=>{e.open&&this.openSet.add(t)}))}toggle(e){this.openSet.has(e)?this.openSet.delete(e):this.openSet.add(e),this.requestUpdate()}render(){return this.seed(),w`
             <div class="list">
-                ${this.items.map((e,t)=>{let n=this.openSet.has(t);return T`
+                ${this.items.map((e,t)=>{let n=this.openSet.has(t);return w`
                         <div class="item ${n?`open`:``}">
-                            <div role="button" tabindex="0" aria-expanded="${n}" class="q" @click="${()=>this.toggle(t)}" @keydown="${R(()=>this.toggle(t))}">
+                            <div role="button" tabindex="0" aria-expanded="${n}" class="q" @click="${()=>this.toggle(t)}" @keydown="${L(()=>this.toggle(t))}">
                                 <span>${e.question}</span>
                                 <span class="chevron">›</span>
                             </div>
-                            ${n?T`<div class="a">${e.answer}</div>`:``}
+                            ${n?w`<div class="a">${e.answer}</div>`:``}
                         </div>
                     `})}
             </div>
-        `}};k([y({type:Array})],si.prototype,`items`,void 0),k([C()],si.prototype,`openSet`,void 0),si=k([g(`mateu-faq`)],si);var ci=e=>T`
+        `}};O([v({type:Array})],ci.prototype,`items`,void 0),O([S()],ci.prototype,`openSet`,void 0),ci=O([h(`mateu-faq`)],ci);var li=e=>w`
         <mateu-faq
                 .items="${e.metadata.items??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-faq>
-    `,li=class extends b{static{this.styles=h`
+    `,ui=class extends y{static{this.styles=m`
         :host { display: block; width: 100%; }
         .callout {
             display: flex; gap: 1rem; align-items: flex-start;
@@ -3309,28 +3309,28 @@ ${i}
             background: var(--accent, var(--lumo-primary-color, #1a73e8)); color: #fff;
         }
         .cta:hover { filter: brightness(.95); }
-    `}themeVars(){switch(this.theme){case`success`:return`--accent: var(--lumo-success-color, #12b76a); --bg: var(--lumo-success-color-10pct, rgba(18,183,106,.1));`;case`warning`:return`--accent: #f59e0b; --bg: rgba(245,158,11,.12);`;case`danger`:return`--accent: var(--lumo-error-color, #e11d48); --bg: var(--lumo-error-color-10pct, rgba(225,29,72,.1));`;default:return`--accent: var(--lumo-primary-color, #1a73e8); --bg: var(--lumo-primary-color-10pct, rgba(26,115,232,.1));`}}cta(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId},bubbles:!0,composed:!0}))}render(){return T`
+    `}themeVars(){switch(this.theme){case`success`:return`--accent: var(--lumo-success-color, #12b76a); --bg: var(--lumo-success-color-10pct, rgba(18,183,106,.1));`;case`warning`:return`--accent: #f59e0b; --bg: rgba(245,158,11,.12);`;case`danger`:return`--accent: var(--lumo-error-color, #e11d48); --bg: var(--lumo-error-color-10pct, rgba(225,29,72,.1));`;default:return`--accent: var(--lumo-primary-color, #1a73e8); --bg: var(--lumo-primary-color-10pct, rgba(26,115,232,.1));`}}cta(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId},bubbles:!0,composed:!0}))}render(){return w`
             <div class="callout" style="${this.themeVars()}">
-                ${this.icon?T`<span class="icon">${this.icon}</span>`:v}
+                ${this.icon?w`<span class="icon">${this.icon}</span>`:_}
                 <div class="body">
-                    ${this.heading?T`<span class="heading">${this.heading}</span>`:v}
-                    ${this.description?T`<span class="desc">${this.description}</span>`:v}
-                    ${this.ctaLabel?T`<button class="cta" @click="${()=>this.cta()}">${this.ctaLabel}</button>`:v}
+                    ${this.heading?w`<span class="heading">${this.heading}</span>`:_}
+                    ${this.description?w`<span class="desc">${this.description}</span>`:_}
+                    ${this.ctaLabel?w`<button class="cta" @click="${()=>this.cta()}">${this.ctaLabel}</button>`:_}
                 </div>
             </div>
-        `}};k([y()],li.prototype,`heading`,void 0),k([y()],li.prototype,`description`,void 0),k([y()],li.prototype,`icon`,void 0),k([y()],li.prototype,`ctaLabel`,void 0),k([y()],li.prototype,`actionId`,void 0),k([y()],li.prototype,`theme`,void 0),li=k([g(`mateu-callout-card`)],li);var ui=e=>{let t=e.metadata;return T`
+        `}};O([v()],ui.prototype,`heading`,void 0),O([v()],ui.prototype,`description`,void 0),O([v()],ui.prototype,`icon`,void 0),O([v()],ui.prototype,`ctaLabel`,void 0),O([v()],ui.prototype,`actionId`,void 0),O([v()],ui.prototype,`theme`,void 0),ui=O([h(`mateu-callout-card`)],ui);var di=e=>{let t=e.metadata;return w`
         <mateu-callout-card
-                heading="${t.title??v}"
-                description="${t.description??v}"
-                icon="${t.icon??v}"
-                ctaLabel="${t.ctaLabel??v}"
-                actionId="${t.actionId??v}"
-                theme="${t.theme??v}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                heading="${t.title??_}"
+                description="${t.description??_}"
+                icon="${t.icon??_}"
+                ctaLabel="${t.ctaLabel??_}"
+                actionId="${t.actionId??_}"
+                theme="${t.theme??_}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-callout-card>
-    `},di=class extends b{constructor(...e){super(...e),this.comments=[]}static{this.styles=h`
+    `},fi=class extends y{constructor(...e){super(...e),this.comments=[]}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .thread { display: flex; flex-direction: column; gap: 1rem; }
         .replies {
@@ -3350,26 +3350,26 @@ ${i}
         .author { font-weight: 600; color: var(--lumo-body-text-color, #222); }
         .time { color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-xs, .72rem); }
         .text { color: var(--lumo-body-text-color, #333); margin-top: .15rem; line-height: 1.5; }
-    `}renderComment(e){let t=e.avatar&&(e.avatar.startsWith(`http`)||e.avatar.startsWith(`data:`));return T`
+    `}renderComment(e){let t=e.avatar&&(e.avatar.startsWith(`http`)||e.avatar.startsWith(`data:`));return w`
             <div class="comment">
-                <span class="avatar">${e.avatar?t?T`<img src="${e.avatar}" alt="">`:e.avatar:e.author?.[0]??`?`}</span>
+                <span class="avatar">${e.avatar?t?w`<img src="${e.avatar}" alt="">`:e.avatar:e.author?.[0]??`?`}</span>
                 <div class="body">
                     <div class="head">
                         <span class="author">${e.author}</span>
-                        ${e.timestamp?T`<span class="time">${e.timestamp}</span>`:v}
+                        ${e.timestamp?w`<span class="time">${e.timestamp}</span>`:_}
                     </div>
                     <div class="text">${e.text}</div>
-                    ${e.replies&&e.replies.length?T`<div class="replies">${e.replies.map(e=>this.renderComment(e))}</div>`:v}
+                    ${e.replies&&e.replies.length?w`<div class="replies">${e.replies.map(e=>this.renderComment(e))}</div>`:_}
                 </div>
             </div>
-        `}render(){return T`<div class="thread">${this.comments.map(e=>this.renderComment(e))}</div>`}};k([y({type:Array})],di.prototype,`comments`,void 0),di=k([g(`mateu-comment-thread`)],di);var fi=e=>T`
+        `}render(){return w`<div class="thread">${this.comments.map(e=>this.renderComment(e))}</div>`}};O([v({type:Array})],fi.prototype,`comments`,void 0),fi=O([h(`mateu-comment-thread`)],fi);var pi=e=>w`
         <mateu-comment-thread
                 .comments="${e.metadata.comments??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-comment-thread>
-    `,pi={pdf:`📕`,image:`🖼️`,img:`🖼️`,doc:`📘`,docx:`📘`,word:`📘`,xls:`📗`,xlsx:`📗`,excel:`📗`,sheet:`📗`,zip:`🗜️`,archive:`🗜️`,video:`🎬`,audio:`🎵`,code:`💻`,csv:`📄`,txt:`📄`},mi=class extends b{constructor(...e){super(...e),this.files=[]}static{this.styles=h`
+    `,mi={pdf:`📕`,image:`🖼️`,img:`🖼️`,doc:`📘`,docx:`📘`,word:`📘`,xls:`📗`,xlsx:`📗`,excel:`📗`,sheet:`📗`,zip:`🗜️`,archive:`🗜️`,video:`🎬`,audio:`🎵`,code:`💻`,csv:`📄`,txt:`📄`},hi=class extends y{constructor(...e){super(...e),this.files=[]}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .list {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -3385,24 +3385,24 @@ ${i}
         .size { color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-xs, .75rem); flex: 0 0 auto; }
         .dl { color: var(--lumo-primary-color, #1a73e8); flex: 0 0 auto; }
     
-        ${z}
-    `}icon(e){return e&&pi[e.toLowerCase()]||`📄`}clickFile(e,t){e.url||e.actionId&&(t.preventDefault(),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_file:e}},bubbles:!0,composed:!0})))}render(){return T`
+        ${R}
+    `}icon(e){return e&&mi[e.toLowerCase()]||`📄`}clickFile(e,t){e.url||e.actionId&&(t.preventDefault(),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_file:e}},bubbles:!0,composed:!0})))}render(){return w`
             <div class="list">
-                ${this.files.map(e=>{let t=!!e.url||!!e.actionId,n=T`
+                ${this.files.map(e=>{let t=!!e.url||!!e.actionId,n=w`
                         <span class="icon">${this.icon(e.type)}</span>
                         <span class="name">${e.name}</span>
-                        ${e.size?T`<span class="size">${e.size}</span>`:v}
-                        ${e.url?T`<span class="dl">⬇</span>`:v}
-                    `;return e.url?T`<a class="file clickable" href="${e.url}" download target="_blank" rel="noopener">${n}</a>`:T`<div role="button" tabindex="0" class="file ${t?`clickable`:``}" @click="${t=>this.clickFile(e,t)}" @keydown="${R(t=>this.clickFile(e,t))}">${n}</div>`})}
+                        ${e.size?w`<span class="size">${e.size}</span>`:_}
+                        ${e.url?w`<span class="dl">⬇</span>`:_}
+                    `;return e.url?w`<a class="file clickable" href="${e.url}" download target="_blank" rel="noopener">${n}</a>`:w`<div role="button" tabindex="0" class="file ${t?`clickable`:``}" @click="${t=>this.clickFile(e,t)}" @keydown="${L(t=>this.clickFile(e,t))}">${n}</div>`})}
             </div>
-        `}};k([y({type:Array})],mi.prototype,`files`,void 0),mi=k([g(`mateu-file-list`)],mi);var hi=e=>T`
+        `}};O([v({type:Array})],hi.prototype,`files`,void 0),hi=O([h(`mateu-file-list`)],hi);var gi=e=>w`
         <mateu-file-list
                 .files="${e.metadata.files??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-file-list>
-    `,gi=class extends b{constructor(...e){super(...e),this.items=[],this.localDone=new Map}static{this.styles=h`
+    `,_i=class extends y{constructor(...e){super(...e),this.items=[],this.localDone=new Map}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .head { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: .5rem; }
         .title { font-weight: 700; color: var(--lumo-body-text-color, #222); }
@@ -3419,28 +3419,28 @@ ${i}
         .label { color: var(--lumo-body-text-color, #333); }
         .item.done .label { color: var(--lumo-secondary-text-color, #999); text-decoration: line-through; }
     
-        ${z}
-    `}isDone(e,t){return this.localDone.has(t)?!!this.localDone.get(t):!!e.done}toggle(e,t){let n=!this.isDone(e,t);this.localDone.set(t,n),this.requestUpdate(),e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_item:e,_done:n}},bubbles:!0,composed:!0}))}render(){let e=this.items.length,t=this.items.filter((e,t)=>this.isDone(e,t)).length,n=e>0?Math.round(t/e*100):0;return T`
+        ${R}
+    `}isDone(e,t){return this.localDone.has(t)?!!this.localDone.get(t):!!e.done}toggle(e,t){let n=!this.isDone(e,t);this.localDone.set(t,n),this.requestUpdate(),e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_item:e,_done:n}},bubbles:!0,composed:!0}))}render(){let e=this.items.length,t=this.items.filter((e,t)=>this.isDone(e,t)).length,n=e>0?Math.round(t/e*100):0;return w`
             <div class="head">
-                ${this.heading?T`<span class="title">${this.heading}</span>`:T`<span></span>`}
+                ${this.heading?w`<span class="title">${this.heading}</span>`:w`<span></span>`}
                 <span class="count">${t} / ${e}</span>
             </div>
             <div class="bar"><div class="fill" style="width: ${n}%;"></div></div>
-            ${this.items.map((e,t)=>{let n=this.isDone(e,t);return T`
-                    <div role="button" tabindex="0" class="item ${n?`done`:``}" @click="${()=>this.toggle(e,t)}" @keydown="${R(()=>this.toggle(e,t))}">
-                        <span class="box">${n?`✓`:v}</span>
+            ${this.items.map((e,t)=>{let n=this.isDone(e,t);return w`
+                    <div role="button" tabindex="0" class="item ${n?`done`:``}" @click="${()=>this.toggle(e,t)}" @keydown="${L(()=>this.toggle(e,t))}">
+                        <span class="box">${n?`✓`:_}</span>
                         <span class="label">${e.label}</span>
                     </div>
                 `})}
-        `}};k([y()],gi.prototype,`heading`,void 0),k([y({type:Array})],gi.prototype,`items`,void 0),k([C()],gi.prototype,`localDone`,void 0),gi=k([g(`mateu-checklist`)],gi);var _i=e=>{let t=e.metadata;return T`
+        `}};O([v()],_i.prototype,`heading`,void 0),O([v({type:Array})],_i.prototype,`items`,void 0),O([S()],_i.prototype,`localDone`,void 0),_i=O([h(`mateu-checklist`)],_i);var vi=e=>{let t=e.metadata;return w`
         <mateu-checklist
-                heading="${t.title??v}"
+                heading="${t.title??_}"
                 .items="${t.items??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-checklist>
-    `},vi=class extends b{static{this.styles=h`
+    `},yi=class extends y{static{this.styles=m`
         :host { display: block; width: 100%; }
         .card {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -3462,38 +3462,38 @@ ${i}
         .delta.down { color: var(--lumo-error-color, #e11d48); background: var(--lumo-error-color-10pct, rgba(225,29,72,.12)); }
         .delta.flat { color: var(--lumo-secondary-text-color, #888); background: var(--lumo-contrast-10pct, rgba(0,0,0,.06)); }
         @media (prefers-color-scheme: dark) { .card { background: var(--lumo-contrast-5pct, #2a2a2a); } }
-    `}render(){let e=this.trend??`flat`;return T`
+    `}render(){let e=this.trend??`flat`;return w`
             <div class="card">
-                ${this.heading?T`<div class="title">${this.heading}</div>`:v}
+                ${this.heading?w`<div class="title">${this.heading}</div>`:_}
                 <div class="row">
                     <div class="side">
-                        ${this.leftLabel?T`<div class="label">${this.leftLabel}</div>`:v}
+                        ${this.leftLabel?w`<div class="label">${this.leftLabel}</div>`:_}
                         <div class="value">${this.leftValue}</div>
                     </div>
                     <div class="mid">
                         <span class="arrow">${`→`}</span>
-                        ${this.delta?T`<span class="delta ${e}">${e===`up`?`▲`:e===`down`?`▼`:``} ${this.delta}</span>`:v}
+                        ${this.delta?w`<span class="delta ${e}">${e===`up`?`▲`:e===`down`?`▼`:``} ${this.delta}</span>`:_}
                     </div>
                     <div class="side">
-                        ${this.rightLabel?T`<div class="label">${this.rightLabel}</div>`:v}
+                        ${this.rightLabel?w`<div class="label">${this.rightLabel}</div>`:_}
                         <div class="value">${this.rightValue}</div>
                     </div>
                 </div>
             </div>
-        `}};k([y()],vi.prototype,`heading`,void 0),k([y()],vi.prototype,`leftLabel`,void 0),k([y()],vi.prototype,`leftValue`,void 0),k([y()],vi.prototype,`rightLabel`,void 0),k([y()],vi.prototype,`rightValue`,void 0),k([y()],vi.prototype,`delta`,void 0),k([y()],vi.prototype,`trend`,void 0),vi=k([g(`mateu-comparison-card`)],vi);var yi=e=>{let t=e.metadata;return T`
+        `}};O([v()],yi.prototype,`heading`,void 0),O([v()],yi.prototype,`leftLabel`,void 0),O([v()],yi.prototype,`leftValue`,void 0),O([v()],yi.prototype,`rightLabel`,void 0),O([v()],yi.prototype,`rightValue`,void 0),O([v()],yi.prototype,`delta`,void 0),O([v()],yi.prototype,`trend`,void 0),yi=O([h(`mateu-comparison-card`)],yi);var bi=e=>{let t=e.metadata;return w`
         <mateu-comparison-card
-                heading="${t.title??v}"
-                leftLabel="${t.leftLabel??v}"
-                leftValue="${t.leftValue??v}"
-                rightLabel="${t.rightLabel??v}"
-                rightValue="${t.rightValue??v}"
-                delta="${t.delta??v}"
-                trend="${t.trend??v}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                heading="${t.title??_}"
+                leftLabel="${t.leftLabel??_}"
+                leftValue="${t.leftValue??_}"
+                rightLabel="${t.rightLabel??_}"
+                rightValue="${t.rightValue??_}"
+                delta="${t.delta??_}"
+                trend="${t.trend??_}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-comparison-card>
-    `},bi=h`
+    `},xi=m`
     .chip {
         display: inline-flex;
         align-items: center;
@@ -3523,7 +3523,7 @@ ${i}
         color: var(--lumo-contrast-80pct, #333);
         background: var(--lumo-contrast-10pct, rgba(0, 0, 0, .08));
     }
-`,xi=new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}),Si=e=>xi.format(e),Ci=(e,t)=>{let n=e<0?`-`:``,r=Si(Math.abs(e));return t?`${n}${t} ${r}`:`${n}${r}`},wi=(e,t)=>t?`${Si(e)} ${t}`:Si(e),Ti=class extends b{constructor(...e){super(...e),this.title=``,this.badges=[],this.facts=[]}static{this.styles=[bi,h`
+`,Si=new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}),Ci=e=>Si.format(e),wi=(e,t)=>{let n=e<0?`-`:``,r=Ci(Math.abs(e));return t?`${n}${t} ${r}`:`${n}${r}`},Ti=(e,t)=>t?`${Ci(e)} ${t}`:Ci(e),Ei=class extends y{constructor(...e){super(...e),this.title=``,this.badges=[],this.facts=[]}static{this.styles=[xi,m`
         :host { display: block; width: 100%; }
         .card {
             display: flex;
@@ -3579,34 +3579,34 @@ ${i}
             color: var(--lumo-primary-text-color, #1a73e8);
         }
         .metric .caption { font-size: var(--lumo-font-size-xs, .75rem); color: var(--lumo-secondary-text-color, #888); }
-    `]}render(){let e=!!(this.metricLabel||this.metricValue||this.metricCaption);return T`
+    `]}render(){let e=!!(this.metricLabel||this.metricValue||this.metricCaption);return w`
             <div class="card">
                 <div class="main">
                     <div class="title-row">
                         <span class="title">${this.title}</span>
-                        ${this.badges.map(e=>T`<span class="chip ${e.color??``}">${e.label}</span>`)}
+                        ${this.badges.map(e=>w`<span class="chip ${e.color??``}">${e.label}</span>`)}
                     </div>
-                    ${this.subtitle?T`<span class="subtitle">${this.subtitle}</span>`:v}
-                    ${this.facts.length?T`
+                    ${this.subtitle?w`<span class="subtitle">${this.subtitle}</span>`:_}
+                    ${this.facts.length?w`
                         <div class="facts">
-                            ${this.facts.map(e=>T`
+                            ${this.facts.map(e=>w`
                                 <div class="fact">
                                     <span class="label">${e.label}</span>
                                     <span class="value">${e.value}</span>
                                 </div>
                             `)}
                         </div>
-                    `:v}
+                    `:_}
                 </div>
-                ${e?T`
+                ${e?w`
                     <div class="metric">
-                        ${this.metricLabel?T`<span class="label">${this.metricLabel}</span>`:v}
-                        ${this.metricValue?T`<span class="value">${this.metricValue}</span>`:v}
-                        ${this.metricCaption?T`<span class="caption">${this.metricCaption}</span>`:v}
+                        ${this.metricLabel?w`<span class="label">${this.metricLabel}</span>`:_}
+                        ${this.metricValue?w`<span class="value">${this.metricValue}</span>`:_}
+                        ${this.metricCaption?w`<span class="caption">${this.metricCaption}</span>`:_}
                     </div>
-                `:v}
+                `:_}
             </div>
-        `}};k([y()],Ti.prototype,`title`,void 0),k([y({type:Array})],Ti.prototype,`badges`,void 0),k([y()],Ti.prototype,`subtitle`,void 0),k([y({type:Array})],Ti.prototype,`facts`,void 0),k([y()],Ti.prototype,`metricLabel`,void 0),k([y()],Ti.prototype,`metricValue`,void 0),k([y()],Ti.prototype,`metricCaption`,void 0),Ti=k([g(`mateu-entity-header`)],Ti);var Ei=e=>{if(e.__hoistedToPageHeader)return T``;let t=e.metadata;return T`
+        `}};O([v()],Ei.prototype,`title`,void 0),O([v({type:Array})],Ei.prototype,`badges`,void 0),O([v()],Ei.prototype,`subtitle`,void 0),O([v({type:Array})],Ei.prototype,`facts`,void 0),O([v()],Ei.prototype,`metricLabel`,void 0),O([v()],Ei.prototype,`metricValue`,void 0),O([v()],Ei.prototype,`metricCaption`,void 0),Ei=O([h(`mateu-entity-header`)],Ei);var Di=e=>{if(e.__hoistedToPageHeader)return w``;let t=e.metadata;return w`
         <mateu-entity-header
                 .title="${t.title??``}"
                 .badges="${t.badges??[]}"
@@ -3615,11 +3615,11 @@ ${i}
                 .metricLabel="${t.metricLabel}"
                 .metricValue="${t.metricValue}"
                 .metricCaption="${t.metricCaption}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-entity-header>
-    `},Di=class extends b{constructor(...e){super(...e),this.value=0,this.max=0}static{this.styles=h`
+    `},Oi=class extends y{constructor(...e){super(...e),this.value=0,this.max=0}static{this.styles=m`
         :host { display: block; width: 100%; }
         .meter { display: flex; flex-direction: column; gap: .35rem; }
         .label {
@@ -3641,16 +3641,16 @@ ${i}
         .fill.warning { background: var(--lumo-warning-color, #f59e0b); }
         .fill.error { background: var(--lumo-error-color, #e11d48); }
         .caption { font-size: var(--lumo-font-size-xs, .75rem); color: var(--lumo-secondary-text-color, #888); }
-    `}fillColor(){return this.dangerAt!=null&&this.value>=this.dangerAt?`error`:this.warnAt!=null&&this.value>=this.warnAt?`warning`:this.warnAt!=null||this.dangerAt!=null?`success`:`primary`}render(){let e=this.max>0?Math.min(Math.max(this.value/this.max,0),1):0,t=Math.round(e*100);return T`
+    `}fillColor(){return this.dangerAt!=null&&this.value>=this.dangerAt?`error`:this.warnAt!=null&&this.value>=this.warnAt?`warning`:this.warnAt!=null||this.dangerAt!=null?`success`:`primary`}render(){let e=this.max>0?Math.min(Math.max(this.value/this.max,0),1):0,t=Math.round(e*100);return w`
             <div class="meter">
-                ${this.label?T`<span class="label">${this.label}</span>`:v}
-                <span class="value">${wi(this.value,this.unit)}</span>
+                ${this.label?w`<span class="label">${this.label}</span>`:_}
+                <span class="value">${Ti(this.value,this.unit)}</span>
                 <div class="track">
                     <div class="fill ${this.fillColor()}" style="width: ${t}%"></div>
                 </div>
                 <span class="caption">${this.caption?this.caption:`${t}%`}</span>
             </div>
-        `}};k([y()],Di.prototype,`label`,void 0),k([y({type:Number})],Di.prototype,`value`,void 0),k([y({type:Number})],Di.prototype,`max`,void 0),k([y()],Di.prototype,`unit`,void 0),k([y()],Di.prototype,`caption`,void 0),k([y({type:Number})],Di.prototype,`warnAt`,void 0),k([y({type:Number})],Di.prototype,`dangerAt`,void 0),Di=k([g(`mateu-meter`)],Di);var Oi=e=>{let t=e.metadata;return T`
+        `}};O([v()],Oi.prototype,`label`,void 0),O([v({type:Number})],Oi.prototype,`value`,void 0),O([v({type:Number})],Oi.prototype,`max`,void 0),O([v()],Oi.prototype,`unit`,void 0),O([v()],Oi.prototype,`caption`,void 0),O([v({type:Number})],Oi.prototype,`warnAt`,void 0),O([v({type:Number})],Oi.prototype,`dangerAt`,void 0),Oi=O([h(`mateu-meter`)],Oi);var ki=e=>{let t=e.metadata;return w`
         <mateu-meter
                 .label="${t.label}"
                 .value="${t.value??0}"
@@ -3659,11 +3659,11 @@ ${i}
                 .caption="${t.caption}"
                 .warnAt="${t.warnAt}"
                 .dangerAt="${t.dangerAt}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-meter>
-    `},ki=class extends b{constructor(...e){super(...e),this.total=0,this.done=0}static{this.styles=h`
+    `},Ai=class extends y{constructor(...e){super(...e),this.total=0,this.done=0}static{this.styles=m`
         :host { display: block; width: 100%; }
         .banner {
             display: flex; align-items: center; gap: .8rem; flex-wrap: wrap;
@@ -3706,30 +3706,30 @@ ${i}
             white-space: nowrap;
         }
         button:hover { filter: brightness(1.08); }
-    `}runAction(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{}},bubbles:!0,composed:!0}))}render(){let e=this.total>0&&this.done>=this.total,t=!e&&!!this.actionLabel&&!!this.actionId;return T`
+    `}runAction(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{}},bubbles:!0,composed:!0}))}render(){let e=this.total>0&&this.done>=this.total,t=!e&&!!this.actionLabel&&!!this.actionId;return w`
             <div class="banner ${e?`complete`:``}">
                 <span class="icon">👥</span>
-                ${this.label?T`<span class="label">${this.label}</span>`:v}
+                ${this.label?w`<span class="label">${this.label}</span>`:_}
                 <div class="pills">
-                    ${Array.from({length:this.total},(e,t)=>T`
+                    ${Array.from({length:this.total},(e,t)=>w`
                         <span class="pill ${t+1<=this.done?`filled`:``}">${t+1}/${this.total}</span>
                     `)}
                 </div>
                 <span class="spacer"></span>
-                ${t?T`<button @click="${()=>this.runAction()}">${this.actionLabel} →</button>`:v}
+                ${t?w`<button @click="${()=>this.runAction()}">${this.actionLabel} →</button>`:_}
             </div>
-        `}};k([y()],ki.prototype,`label`,void 0),k([y({type:Number})],ki.prototype,`total`,void 0),k([y({type:Number})],ki.prototype,`done`,void 0),k([y()],ki.prototype,`actionLabel`,void 0),k([y()],ki.prototype,`actionId`,void 0),ki=k([g(`mateu-task-progress`)],ki);var Ai=e=>{let t=e.metadata;return T`
+        `}};O([v()],Ai.prototype,`label`,void 0),O([v({type:Number})],Ai.prototype,`total`,void 0),O([v({type:Number})],Ai.prototype,`done`,void 0),O([v()],Ai.prototype,`actionLabel`,void 0),O([v()],Ai.prototype,`actionId`,void 0),Ai=O([h(`mateu-task-progress`)],Ai);var ji=e=>{let t=e.metadata;return w`
         <mateu-task-progress
                 .label="${t.label}"
                 .total="${t.total??0}"
                 .done="${t.done??0}"
                 .actionLabel="${t.actionLabel}"
                 .actionId="${t.actionId}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-task-progress>
-    `},ji=class extends b{constructor(...e){super(...e),this.items=[],this.compact=!1,this.frameless=!1,this.columns=0,this.itemHeadingLevel=3}static{this.styles=[bi,z,h`
+    `},Mi=class extends y{constructor(...e){super(...e),this.items=[],this.compact=!1,this.frameless=!1,this.columns=0,this.itemHeadingLevel=3}static{this.styles=[xi,R,m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .list {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -3831,60 +3831,60 @@ ${i}
             cursor: pointer; font-size: 1rem;
         }
         .icon-action:hover { background: var(--lumo-contrast-5pct, rgba(0,0,0,.04)); }
-    `]}runAction(e,t){t&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_item:e.id}},bubbles:!0,composed:!0}))}rowClicked(e){this.rowActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.rowActionId,parameters:{_item:e.id}},bubbles:!0,composed:!0}))}renderItemAction(e,t,n,r){return!t||!n?v:r?T`
+    `]}runAction(e,t){t&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_item:e.id}},bubbles:!0,composed:!0}))}rowClicked(e){this.rowActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.rowActionId,parameters:{_item:e.id}},bubbles:!0,composed:!0}))}renderItemAction(e,t,n,r){return!t||!n?_:r?w`
                 <button class="icon-action" title="${t}" aria-label="${t}"
                     @click="${t=>{t.stopPropagation(),this.runAction(e,n)}}">
-                    ${I(r)}
-                </button>`:T`
+                    ${F(r)}
+                </button>`:w`
             <button class="row-action" title="${t}"
-                @click="${t=>{t.stopPropagation(),this.runAction(e,n)}}">${t}</button>`}render(){let e=this.columns>1||this.items.some(e=>e.actionId||e.actionId2||e.actionId3||(e.lines?.length??0)>0),t=this.itemHeadingLevel===4?`h4`:`h3`;return e?T`
+                @click="${t=>{t.stopPropagation(),this.runAction(e,n)}}">${t}</button>`}render(){let e=this.columns>1||this.items.some(e=>e.actionId||e.actionId2||e.actionId3||(e.lines?.length??0)>0),t=this.itemHeadingLevel===4?`h4`:`h3`;return e?w`
                 <div class="list stacked ${this.compact?`compact`:``} ${this.columns>1?`grid`:``}"
                      style="${this.columns>1?`grid-template-columns: repeat(auto-fit, minmax(min(18rem, calc(100% / ${this.columns} - 1.5rem)), 1fr));`:``}">
-                    ${this.items.map(e=>T`
+                    ${this.items.map(e=>w`
                         <div role="button" tabindex="0" class="cell ${(e.lines?.length??0)>0?`with-lines`:``} ${this.rowActionId?`clickable`:``}"
-                             @click="${()=>this.rowClicked(e)}" @keydown="${R(()=>this.rowClicked(e))}">
+                             @click="${()=>this.rowClicked(e)}" @keydown="${L(()=>this.rowClicked(e))}">
                             <div class="cell-title-row">
-                                ${t===`h4`?T`<h4 class="cell-title">${e.title}</h4>`:T`<h3 class="cell-title">${e.title}</h3>`}
-                                ${e.status?T`<span class="chip ${e.statusColor??``}">${e.status}</span>`:v}
+                                ${t===`h4`?w`<h4 class="cell-title">${e.title}</h4>`:w`<h3 class="cell-title">${e.title}</h3>`}
+                                ${e.status?w`<span class="chip ${e.statusColor??``}">${e.status}</span>`:_}
                             </div>
-                            ${e.description?T`<span class="cell-description">${e.description}</span>`:v}
-                            ${(e.lines??[]).map(e=>T`<span class="cell-line">${e}</span>`)}
-                            ${e.actionId||e.actionId2||e.actionId3?T`
+                            ${e.description?w`<span class="cell-description">${e.description}</span>`:_}
+                            ${(e.lines??[]).map(e=>w`<span class="cell-line">${e}</span>`)}
+                            ${e.actionId||e.actionId2||e.actionId3?w`
                                 <div class="cell-actions">
                                     ${this.renderItemAction(e,e.actionLabel,e.actionId,e.actionIcon)}
                                     ${this.renderItemAction(e,e.actionLabel2,e.actionId2,e.actionIcon2)}
                                     ${this.renderItemAction(e,e.actionLabel3,e.actionId3,e.actionIcon3)}
-                                </div>`:v}
+                                </div>`:_}
                         </div>
                     `)}
                 </div>
-            `:T`
+            `:w`
             <div class="list ${this.compact?`compact`:``} ${this.frameless?`frameless`:``}">
-                ${this.items.map(e=>T`
+                ${this.items.map(e=>w`
                     <div role="button" tabindex="0" class="row ${this.rowActionId?`clickable`:``}"
-                         @click="${()=>this.rowClicked(e)}" @keydown="${R(()=>this.rowClicked(e))}">
-                        ${e.avatar?T`<span class="avatar">${e.avatar}</span>`:e.icon?T`<span class="icon">${e.icon}</span>`:v}
+                         @click="${()=>this.rowClicked(e)}" @keydown="${L(()=>this.rowClicked(e))}">
+                        ${e.avatar?w`<span class="avatar">${e.avatar}</span>`:e.icon?w`<span class="icon">${e.icon}</span>`:_}
                         <div class="body">
                             <span class="title">${e.title}</span>
-                            ${e.description?T`<span class="description">${e.description}</span>`:v}
+                            ${e.description?w`<span class="description">${e.description}</span>`:_}
                         </div>
-                        ${e.status?T`<span class="chip ${e.statusColor??``}">${e.status}</span>`:v}
+                        ${e.status?w`<span class="chip ${e.statusColor??``}">${e.status}</span>`:_}
                     </div>
                 `)}
             </div>
-        `}};k([y({type:Array})],ji.prototype,`items`,void 0),k([y({type:Boolean})],ji.prototype,`compact`,void 0),k([y({type:Boolean})],ji.prototype,`frameless`,void 0),k([y()],ji.prototype,`rowActionId`,void 0),k([y({type:Number})],ji.prototype,`columns`,void 0),k([y({type:Number})],ji.prototype,`itemHeadingLevel`,void 0),ji=k([g(`mateu-status-list`)],ji);var Mi=e=>{let t=e.metadata;return T`
+        `}};O([v({type:Array})],Mi.prototype,`items`,void 0),O([v({type:Boolean})],Mi.prototype,`compact`,void 0),O([v({type:Boolean})],Mi.prototype,`frameless`,void 0),O([v()],Mi.prototype,`rowActionId`,void 0),O([v({type:Number})],Mi.prototype,`columns`,void 0),O([v({type:Number})],Mi.prototype,`itemHeadingLevel`,void 0),Mi=O([h(`mateu-status-list`)],Mi);var Ni=e=>{let t=e.metadata;return w`
         <mateu-status-list
                 .items="${t.items??[]}"
                 ?compact="${t.compact??!1}"
                 ?frameless="${t.frameless??!1}"
                 columns="${t.columns??0}"
                 itemHeadingLevel="${t.itemHeadingLevel??3}"
-                rowActionId="${S(t.rowActionId??void 0)}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                rowActionId="${x(t.rowActionId??void 0)}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-status-list>
-    `},Ni=class extends b{constructor(...e){super(...e),this.items=[]}static{this.styles=h`
+    `},Pi=class extends y{constructor(...e){super(...e),this.items=[]}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         ul {
             margin: 0; padding-inline-start: 1.2rem;
@@ -3895,24 +3895,24 @@ ${i}
             line-height: normal;
         }
         li::marker { color: var(--lumo-secondary-text-color, #888); }
-    `}render(){return T`
+    `}render(){return w`
             <ul>
-                ${this.items.map(e=>T`<li>${e}</li>`)}
+                ${this.items.map(e=>w`<li>${e}</li>`)}
             </ul>
-        `}};k([y({type:Array})],Ni.prototype,`items`,void 0),Ni=k([g(`mateu-bulleted-list`)],Ni);var Pi=e=>T`
+        `}};O([v({type:Array})],Pi.prototype,`items`,void 0),Pi=O([h(`mateu-bulleted-list`)],Pi);var Fi=e=>w`
         <mateu-bulleted-list
                 .items="${e.metadata.items??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-bulleted-list>
-    `,Fi=e=>{let t=e.metadata.attributes?.[`data-colspan`];return T`
+    `,Ii=e=>{let t=e.metadata.attributes?.[`data-colspan`];return w`
         <hr style="border: none; border-top: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1)); width: 100%; margin: var(--lumo-space-s, .5rem) 0; ${e.style??``}"
-            class="${e.cssClasses??v}"
-            id="${S(e.id??void 0)}"
-            data-colspan="${S(t)}"
-            slot="${e.slot??v}"/>
-    `},Ii={info:`ℹ`,success:`✓`,warning:`!`,danger:`!`},V=class extends b{constructor(...e){super(...e),this.text=``,this.theme=`info`,this.noIcon=!1,this.slim=!1,this.fullWidth=!1,this.hasContent=!1,this.inlineContent=!1}static{this.styles=h`
+            class="${e.cssClasses??_}"
+            id="${x(e.id??void 0)}"
+            data-colspan="${x(t)}"
+            slot="${e.slot??_}"/>
+    `},Li={info:`ℹ`,success:`✓`,warning:`!`,danger:`!`},B=class extends y{constructor(...e){super(...e),this.text=``,this.theme=`info`,this.noIcon=!1,this.slim=!1,this.fullWidth=!1,this.hasContent=!1,this.inlineContent=!1}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .notice {
             display: flex;
@@ -3975,34 +3975,34 @@ ${i}
         .warning .icon { background: #c98a1e; }
         .danger  { background: #f6e0da; } .danger .text, .danger .status   { color: #a5502e; }
         .danger  .icon  { background: #b25b3d; }
-    `}runAction(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId},bubbles:!0,composed:!0}))}render(){let e=!!this.text&&!!this.text.trim();if(!e&&!this.hasContent)return T``;let t=[`info`,`success`,`warning`,`danger`].includes(this.theme)?this.theme:`info`;return T`
+    `}runAction(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId},bubbles:!0,composed:!0}))}render(){let e=!!this.text&&!!this.text.trim();if(!e&&!this.hasContent)return w``;let t=[`info`,`success`,`warning`,`danger`].includes(this.theme)?this.theme:`info`;return w`
             <div class="notice ${t} ${this.slim?`slim`:``}">
-                ${this.noIcon?v:T`<span class="icon ${this.icon?`custom`:``}">${this.icon||Ii[t]}</span>`}
+                ${this.noIcon?_:w`<span class="icon ${this.icon?`custom`:``}">${this.icon||Li[t]}</span>`}
                 <div class="body ${this.inlineContent?`inline`:``}">
-                    ${e?T`<span class="text">${this.text}</span>`:v}
-                    ${this.hasContent?T`<div class="content"><slot></slot></div>`:v}
+                    ${e?w`<span class="text">${this.text}</span>`:_}
+                    ${this.hasContent?w`<div class="content"><slot></slot></div>`:_}
                 </div>
-                ${this.actionLabel&&this.actionId?T`<button class="notice-action" @click="${()=>this.runAction()}">${this.actionLabel}</button>`:this.status?T`<span class="status">${this.status}</span>`:v}
+                ${this.actionLabel&&this.actionId?w`<button class="notice-action" @click="${()=>this.runAction()}">${this.actionLabel}</button>`:this.status?w`<span class="status">${this.status}</span>`:_}
             </div>
-        `}};k([y()],V.prototype,`text`,void 0),k([y()],V.prototype,`theme`,void 0),k([y()],V.prototype,`icon`,void 0),k([y({type:Boolean})],V.prototype,`noIcon`,void 0),k([y()],V.prototype,`actionLabel`,void 0),k([y()],V.prototype,`actionId`,void 0),k([y()],V.prototype,`status`,void 0),k([y({type:Boolean})],V.prototype,`slim`,void 0),k([y({type:Boolean})],V.prototype,`fullWidth`,void 0),k([y({type:Boolean})],V.prototype,`hasContent`,void 0),k([y({type:Boolean})],V.prototype,`inlineContent`,void 0),V=k([g(`mateu-notice`)],V);var Li=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=rt(s.text??``,r,i,a,o)??``,l=t.children??[];return T`
+        `}};O([v()],B.prototype,`text`,void 0),O([v()],B.prototype,`theme`,void 0),O([v()],B.prototype,`icon`,void 0),O([v({type:Boolean})],B.prototype,`noIcon`,void 0),O([v()],B.prototype,`actionLabel`,void 0),O([v()],B.prototype,`actionId`,void 0),O([v()],B.prototype,`status`,void 0),O([v({type:Boolean})],B.prototype,`slim`,void 0),O([v({type:Boolean})],B.prototype,`fullWidth`,void 0),O([v({type:Boolean})],B.prototype,`hasContent`,void 0),O([v({type:Boolean})],B.prototype,`inlineContent`,void 0),B=O([h(`mateu-notice`)],B);var Ri=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=it(s.text??``,r,i,a,o)??``,l=t.children??[];return w`
         <mateu-notice
                 text="${c}"
                 theme="${s.theme??`info`}"
-                icon="${S(s.icon??void 0)}"
+                icon="${x(s.icon??void 0)}"
                 ?noIcon="${s.noIcon??!1}"
-                actionLabel="${S(s.actionLabel??void 0)}"
-                actionId="${S(s.actionId??void 0)}"
-                status="${S(s.status??void 0)}"
+                actionLabel="${x(s.actionLabel??void 0)}"
+                actionId="${x(s.actionId??void 0)}"
+                status="${x(s.status??void 0)}"
                 ?slim="${s.slim??!1}"
                 ?fullWidth="${s.fullWidth??!1}"
                 ?inlineContent="${s.inlineContent??!1}"
                 ?hasContent="${l.length>0}"
-                data-colspan="${s.fullWidth?`99`:v}"
-                style="${t.style??v}"
-                class="${t.cssClasses??v}"
-                slot="${t.slot??v}"
-        >${l.map(t=>F(e,t,n,r,i,a,o))}</mateu-notice>
-    `},Ri=class extends b{constructor(...e){super(...e),this.groups=[]}static{this.styles=[bi,z,h`
+                data-colspan="${s.fullWidth?`99`:_}"
+                style="${t.style??_}"
+                class="${t.cssClasses??_}"
+                slot="${t.slot??_}"
+        >${l.map(t=>P(e,t,n,r,i,a,o))}</mateu-notice>
+    `},zi=class extends y{constructor(...e){super(...e),this.groups=[]}static{this.styles=[xi,R,m`
         :host { display: block; width: 100%; }
         .rail { display: flex; flex-direction: column; gap: var(--lumo-space-m, 1rem); }
         .group { display: flex; flex-direction: column; gap: .45rem; }
@@ -4043,37 +4043,37 @@ ${i}
             color: var(--lumo-secondary-text-color, #888);
             white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
         }
-    `]}willUpdate(e){e.has(`groups`)&&(this.selectedId=this.groups.flatMap(e=>e.items??[]).find(e=>e.selected)?.id)}itemAction(e,t,n){e.stopPropagation(),t&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_item:n}},bubbles:!0,composed:!0}))}select(e){this.selectedId=e,this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{_item:e}},bubbles:!0,composed:!0}))}render(){return T`
+    `]}willUpdate(e){e.has(`groups`)&&(this.selectedId=this.groups.flatMap(e=>e.items??[]).find(e=>e.selected)?.id)}itemAction(e,t,n){e.stopPropagation(),t&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_item:n}},bubbles:!0,composed:!0}))}select(e){this.selectedId=e,this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{_item:e}},bubbles:!0,composed:!0}))}render(){return w`
             <div class="rail">
-                ${this.groups.map(e=>T`
+                ${this.groups.map(e=>w`
                     <div class="group" role="listbox">
-                        ${e.label?T`<span class="group-label">${e.label}</span>`:v}
-                        ${(e.items??[]).map(e=>T`
+                        ${e.label?w`<span class="group-label">${e.label}</span>`:_}
+                        ${(e.items??[]).map(e=>w`
                             <div role="option" tabindex="0" aria-selected="${e.id===this.selectedId}" class="card ${e.id===this.selectedId?`selected`:``}"
-                                 @click="${()=>this.select(e.id)}" @keydown="${R(()=>this.select(e.id))}">
+                                 @click="${()=>this.select(e.id)}" @keydown="${L(()=>this.select(e.id))}">
                                 <span class="title">${e.title}</span>
                                 <div class="meta">
-                                    ${e.caption?T`<span class="caption">${e.caption}</span>`:v}
-                                    ${(e.badges??[]).map(e=>T`<span class="chip ${e.color??``}">${e.label}</span>`)}
+                                    ${e.caption?w`<span class="caption">${e.caption}</span>`:_}
+                                    ${(e.badges??[]).map(e=>w`<span class="chip ${e.color??``}">${e.label}</span>`)}
                                 </div>
-                                ${e.actionLabel&&e.actionId?T`
+                                ${e.actionLabel&&e.actionId?w`
                                     <button class="item-action"
                                             @click="${t=>this.itemAction(t,e.actionId,e.id)}">${e.actionLabel}</button>
-                                `:v}
+                                `:_}
                             </div>
                         `)}
                     </div>
                 `)}
             </div>
-        `}};k([y()],Ri.prototype,`actionId`,void 0),k([y({type:Array})],Ri.prototype,`groups`,void 0),k([C()],Ri.prototype,`selectedId`,void 0),Ri=k([g(`mateu-task-queue`)],Ri);var zi=e=>{let t=e.metadata;return T`
+        `}};O([v()],zi.prototype,`actionId`,void 0),O([v({type:Array})],zi.prototype,`groups`,void 0),O([S()],zi.prototype,`selectedId`,void 0),zi=O([h(`mateu-task-queue`)],zi);var Bi=e=>{let t=e.metadata;return w`
         <mateu-task-queue
                 .actionId="${t.actionId}"
                 .groups="${t.groups??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-task-queue>
-    `},Bi=class extends b{constructor(...e){super(...e),this.columns=0,this.items=[]}static{this.styles=[bi,z,h`
+    `},Vi=class extends y{constructor(...e){super(...e),this.columns=0,this.items=[]}static{this.styles=[xi,R,m`
         /* explicit line-height: inside a form field wrapper the inherited one is the 44px
            field height, which blows up every text row */
         :host { display: block; width: 100%; line-height: var(--lumo-line-height-m, 1.4); }
@@ -4124,30 +4124,30 @@ ${i}
         .note.warning { color: var(--lumo-warning-text-color, #b45309); }
         .note.error { color: var(--lumo-error-text-color, #c5221f); }
         .note.contrast { color: var(--lumo-contrast-80pct, #333); }
-    `]}willUpdate(e){e.has(`items`)&&(this.selectedId=this.items.find(e=>e.selected)?.id)}select(e){e.disabled||(this.selectedId=e.id,this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{_item:e.id}},bubbles:!0,composed:!0})))}render(){return T`
+    `]}willUpdate(e){e.has(`items`)&&(this.selectedId=this.items.find(e=>e.selected)?.id)}select(e){e.disabled||(this.selectedId=e.id,this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{_item:e.id}},bubbles:!0,composed:!0})))}render(){return w`
             <div class="grid" style="${this.columns>0?`grid-template-columns: repeat(${this.columns}, minmax(0, 1fr));`:`grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));`}">
-                ${this.items.map(e=>T`
+                ${this.items.map(e=>w`
                     <div role="button" tabindex="0" class="cell ${e.disabled?`disabled`:``} ${e.recommended?`recommended`:``} ${e.id===this.selectedId?`selected`:``}"
-                         @click="${()=>this.select(e)}" @keydown="${R(()=>this.select(e))}">
-                        ${e.recommended?T`<span class="tag">${this.recommendedLabel||`Recommended`}</span>`:v}
+                         @click="${()=>this.select(e)}" @keydown="${L(()=>this.select(e))}">
+                        ${e.recommended?w`<span class="tag">${this.recommendedLabel||`Recommended`}</span>`:_}
                         <span class="title">${e.title}</span>
-                        ${e.subtitle?T`<span class="subtitle">${e.subtitle}</span>`:v}
-                        ${e.statusLabel?T`<span class="chip ${e.statusColor??``}">${e.statusLabel}</span>`:v}
-                        ${e.note?T`<span class="note ${e.noteColor??``}"><span class="dot"></span>${e.note}</span>`:v}
+                        ${e.subtitle?w`<span class="subtitle">${e.subtitle}</span>`:_}
+                        ${e.statusLabel?w`<span class="chip ${e.statusColor??``}">${e.statusLabel}</span>`:_}
+                        ${e.note?w`<span class="note ${e.noteColor??``}"><span class="dot"></span>${e.note}</span>`:_}
                     </div>
                 `)}
             </div>
-        `}};k([y()],Bi.prototype,`actionId`,void 0),k([y({type:Number})],Bi.prototype,`columns`,void 0),k([y()],Bi.prototype,`recommendedLabel`,void 0),k([y({type:Array})],Bi.prototype,`items`,void 0),k([C()],Bi.prototype,`selectedId`,void 0),Bi=k([g(`mateu-resource-grid`)],Bi);var Vi=e=>{let t=e.metadata;return T`
+        `}};O([v()],Vi.prototype,`actionId`,void 0),O([v({type:Number})],Vi.prototype,`columns`,void 0),O([v()],Vi.prototype,`recommendedLabel`,void 0),O([v({type:Array})],Vi.prototype,`items`,void 0),O([S()],Vi.prototype,`selectedId`,void 0),Vi=O([h(`mateu-resource-grid`)],Vi);var Hi=e=>{let t=e.metadata;return w`
         <mateu-resource-grid
                 .actionId="${t.actionId}"
                 .columns="${t.columns??0}"
                 .recommendedLabel="${t.recommendedLabel}"
                 .items="${t.items??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-resource-grid>
-    `},H=class extends b{constructor(...e){super(...e),this.title=``,this.features=[],this.current=!1,this.added=!1}static{this.styles=h`
+    `},V=class extends y{constructor(...e){super(...e),this.title=``,this.features=[],this.current=!1,this.added=!1}static{this.styles=m`
         /* explicit line-height: inside a form field wrapper the inherited one is the 44px
            field height, which blows up every text row */
         :host { display: block; width: 100%; line-height: var(--lumo-line-height-m, 1.4); }
@@ -4212,30 +4212,30 @@ ${i}
         button:hover { filter: brightness(1.08); }
         button.added { background: var(--lumo-success-color, #2e7d32); }
         .price { font-weight: 700; white-space: nowrap; font-variant-numeric: tabular-nums; }
-    `}runAction(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{}},bubbles:!0,composed:!0}))}render(){return T`
+    `}runAction(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{}},bubbles:!0,composed:!0}))}render(){return w`
             <div class="card ${this.current?``:`offer`}">
-                ${this.image?T`<img class="image" src="${this.image}" alt="${this.title}">`:v}
-                ${this.tag&&this.image?T`<span class="tag">${this.tag}</span>`:v}
+                ${this.image?w`<img class="image" src="${this.image}" alt="${this.title}">`:_}
+                ${this.tag&&this.image?w`<span class="tag">${this.tag}</span>`:_}
                 <div class="body">
-                    ${this.tag&&!this.image?T`<span class="tag static">${this.tag}</span>`:v}
+                    ${this.tag&&!this.image?w`<span class="tag static">${this.tag}</span>`:_}
                     <span class="title">${this.title}</span>
-                    ${this.subtitle?T`<span class="subtitle">${this.subtitle}</span>`:v}
-                    ${this.features.length?T`
+                    ${this.subtitle?w`<span class="subtitle">${this.subtitle}</span>`:_}
+                    ${this.features.length?w`
                         <div class="features">
-                            ${this.features.map(e=>T`<span class="feature">${e}</span>`)}
+                            ${this.features.map(e=>w`<span class="feature">${e}</span>`)}
                         </div>
-                    `:v}
+                    `:_}
                 </div>
                 <div class="footer">
-                    ${this.current?this.currentLabel?T`<span class="current-label">${this.currentLabel}</span>`:v:this.actionLabel&&this.actionId?T`
+                    ${this.current?this.currentLabel?w`<span class="current-label">${this.currentLabel}</span>`:_:this.actionLabel&&this.actionId?w`
                             <button class="${this.added?`added`:``}" @click="${()=>this.runAction()}">
                                 <span>${this.added&&this.addedLabel||this.actionLabel}</span>
-                                ${this.priceLabel?T`<span class="price">${this.priceLabel}</span>`:v}
+                                ${this.priceLabel?w`<span class="price">${this.priceLabel}</span>`:_}
                             </button>
-                        `:v}
+                        `:_}
                 </div>
             </div>
-        `}};k([y()],H.prototype,`tag`,void 0),k([y()],H.prototype,`title`,void 0),k([y()],H.prototype,`subtitle`,void 0),k([y()],H.prototype,`image`,void 0),k([y({type:Array})],H.prototype,`features`,void 0),k([y()],H.prototype,`priceLabel`,void 0),k([y()],H.prototype,`actionLabel`,void 0),k([y()],H.prototype,`actionId`,void 0),k([y({type:Boolean})],H.prototype,`current`,void 0),k([y()],H.prototype,`currentLabel`,void 0),k([y({type:Boolean})],H.prototype,`added`,void 0),k([y()],H.prototype,`addedLabel`,void 0),H=k([g(`mateu-offer-card`)],H);var Hi=e=>{let t=e.metadata;return T`
+        `}};O([v()],V.prototype,`tag`,void 0),O([v()],V.prototype,`title`,void 0),O([v()],V.prototype,`subtitle`,void 0),O([v()],V.prototype,`image`,void 0),O([v({type:Array})],V.prototype,`features`,void 0),O([v()],V.prototype,`priceLabel`,void 0),O([v()],V.prototype,`actionLabel`,void 0),O([v()],V.prototype,`actionId`,void 0),O([v({type:Boolean})],V.prototype,`current`,void 0),O([v()],V.prototype,`currentLabel`,void 0),O([v({type:Boolean})],V.prototype,`added`,void 0),O([v()],V.prototype,`addedLabel`,void 0),V=O([h(`mateu-offer-card`)],V);var Ui=e=>{let t=e.metadata;return w`
         <mateu-offer-card
                 .tag="${t.tag}"
                 .title="${t.title??``}"
@@ -4249,11 +4249,11 @@ ${i}
                 .currentLabel="${t.currentLabel}"
                 .added="${t.added??!1}"
                 .addedLabel="${t.addedLabel}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-offer-card>
-    `},Ui=class extends b{constructor(...e){super(...e),this.items=[],this.added=new Set}static{this.styles=h`
+    `},Wi=class extends y{constructor(...e){super(...e),this.items=[],this.added=new Set}static{this.styles=m`
         :host { display: block; width: 100%; }
         .header { display: flex; align-items: baseline; justify-content: flex-end; gap: .4rem; margin-bottom: .6rem; }
         .total-label { font-size: var(--lumo-font-size-s, .875rem); color: var(--lumo-secondary-text-color, #888); }
@@ -4318,20 +4318,20 @@ ${i}
             background: var(--lumo-primary-color, #1a73e8);
             color: var(--lumo-primary-contrast-color, #fff);
         }
-    `}willUpdate(e){e.has(`items`)&&(this.added=new Set(this.items.filter(e=>e.added).map(e=>e.id)))}total(){return this.items.filter(e=>e.id!=null&&this.added.has(e.id)).reduce((e,t)=>e+(t.price??0),0)}toggle(e){if(e.id==null)return;let t=new Set(this.added),n=!t.has(e.id);n?t.add(e.id):t.delete(e.id),this.added=t,this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{_item:e.id,_added:n,_total:this.total()}},bubbles:!0,composed:!0}))}render(){return T`
+    `}willUpdate(e){e.has(`items`)&&(this.added=new Set(this.items.filter(e=>e.added).map(e=>e.id)))}total(){return this.items.filter(e=>e.id!=null&&this.added.has(e.id)).reduce((e,t)=>e+(t.price??0),0)}toggle(e){if(e.id==null)return;let t=new Set(this.added),n=!t.has(e.id);n?t.add(e.id):t.delete(e.id),this.added=t,this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{_item:e.id,_added:n,_total:this.total()}},bubbles:!0,composed:!0}))}render(){return w`
             <div class="header">
-                ${this.totalLabel?T`<span class="total-label">${this.totalLabel}:</span>`:v}
-                <span class="total">${Ci(this.total(),this.currency)}</span>
+                ${this.totalLabel?w`<span class="total-label">${this.totalLabel}:</span>`:_}
+                <span class="total">${wi(this.total(),this.currency)}</span>
             </div>
             <div class="grid">
-                ${this.items.map(e=>{let t=e.id!=null&&this.added.has(e.id);return T`
+                ${this.items.map(e=>{let t=e.id!=null&&this.added.has(e.id);return w`
                         <div class="card ${t?`added`:``}">
-                            ${e.icon?T`<span class="icon">${e.icon}</span>`:v}
+                            ${e.icon?w`<span class="icon">${e.icon}</span>`:_}
                             <span class="title">${e.title}</span>
-                            ${e.description?T`<span class="description">${e.description}</span>`:v}
-                            ${e.includedLabel?T`<span class="included">${e.includedLabel}</span>`:T`
-                                    ${e.price==null?v:T`
-                                        <span class="price">${Ci(e.price,this.currency)}${e.unit?` / ${e.unit}`:``}</span>
+                            ${e.description?w`<span class="description">${e.description}</span>`:_}
+                            ${e.includedLabel?w`<span class="included">${e.includedLabel}</span>`:w`
+                                    ${e.price==null?_:w`
+                                        <span class="price">${wi(e.price,this.currency)}${e.unit?` / ${e.unit}`:``}</span>
                                     `}
                                     <button class="toggle ${t?`on`:``}" @click="${()=>this.toggle(e)}"
                                             aria-pressed="${t}">${t?`✓`:`+`}</button>
@@ -4339,17 +4339,17 @@ ${i}
                         </div>
                     `})}
             </div>
-        `}};k([y()],Ui.prototype,`totalLabel`,void 0),k([y()],Ui.prototype,`currency`,void 0),k([y()],Ui.prototype,`actionId`,void 0),k([y({type:Array})],Ui.prototype,`items`,void 0),k([C()],Ui.prototype,`added`,void 0),Ui=k([g(`mateu-addon-picker`)],Ui);var Wi=e=>{let t=e.metadata;return T`
+        `}};O([v()],Wi.prototype,`totalLabel`,void 0),O([v()],Wi.prototype,`currency`,void 0),O([v()],Wi.prototype,`actionId`,void 0),O([v({type:Array})],Wi.prototype,`items`,void 0),O([S()],Wi.prototype,`added`,void 0),Wi=O([h(`mateu-addon-picker`)],Wi);var Gi=e=>{let t=e.metadata;return w`
         <mateu-addon-picker
                 .totalLabel="${t.totalLabel}"
                 .currency="${t.currency}"
                 .actionId="${t.actionId}"
                 .items="${t.items??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-addon-picker>
-    `},Gi=class extends b{constructor(...e){super(...e),this.lines=[]}static{this.styles=h`
+    `},Ki=class extends y{constructor(...e){super(...e),this.lines=[]}static{this.styles=m`
         :host {
             display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem);
             /* an ancestor (e.g. a form-layout row) may set an inherited line-height like 44px —
@@ -4386,29 +4386,29 @@ ${i}
             color: var(--lumo-body-text-color, #111);
             white-space: nowrap;
         }
-    `}computedTotal(){return this.total==null?this.lines.filter(e=>!e.included).reduce((e,t)=>e+(t.amount??0),0):this.total}render(){return T`
-            ${this.lines.map(e=>T`
+    `}computedTotal(){return this.total==null?this.lines.filter(e=>!e.included).reduce((e,t)=>e+(t.amount??0),0):this.total}render(){return w`
+            ${this.lines.map(e=>w`
                 <div class="row">
                     <span class="dot"></span>
                     <span class="concept">${e.concept}</span>
-                    ${e.included?T`<span class="included-label">${e.includedLabel||`Included`}</span>`:T`<span class="amount ${(e.amount??0)<0?`negative`:``}">${Ci(e.amount??0,this.currency)}</span>`}
+                    ${e.included?w`<span class="included-label">${e.includedLabel||`Included`}</span>`:w`<span class="amount ${(e.amount??0)<0?`negative`:``}">${wi(e.amount??0,this.currency)}</span>`}
                 </div>
             `)}
             <div class="total-row">
                 <span class="total-label">${this.totalLabel||`Total`}</span>
-                <span class="total">${Ci(this.computedTotal(),this.currency)}</span>
+                <span class="total">${wi(this.computedTotal(),this.currency)}</span>
             </div>
-        `}};k([y()],Gi.prototype,`currency`,void 0),k([y()],Gi.prototype,`totalLabel`,void 0),k([y({type:Array})],Gi.prototype,`lines`,void 0),k([y({type:Number})],Gi.prototype,`total`,void 0),Gi=k([g(`mateu-ledger`)],Gi);var Ki=e=>{let t=e.metadata;return T`
+        `}};O([v()],Ki.prototype,`currency`,void 0),O([v()],Ki.prototype,`totalLabel`,void 0),O([v({type:Array})],Ki.prototype,`lines`,void 0),O([v({type:Number})],Ki.prototype,`total`,void 0),Ki=O([h(`mateu-ledger`)],Ki);var qi=e=>{let t=e.metadata;return w`
         <mateu-ledger
                 .currency="${t.currency}"
                 .totalLabel="${t.totalLabel}"
                 .lines="${t.lines??[]}"
                 .total="${t.total}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-ledger>
-    `},qi=class extends b{constructor(...e){super(...e),this.methods=[]}static{this.styles=h`
+    `},Ji=class extends y{constructor(...e){super(...e),this.methods=[]}static{this.styles=m`
         :host { display: block; width: 100%; }
         .bar { display: flex; align-items: stretch; gap: .6rem; flex-wrap: wrap; }
         .methods { display: flex; gap: .4rem; flex-wrap: wrap; }
@@ -4453,24 +4453,24 @@ ${i}
             white-space: nowrap;
         }
         .confirm:hover { filter: brightness(1.08); }
-    `}willUpdate(e){e.has(`selected`)&&(this.selectedId=this.selected)}confirm(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{_method:this.selectedId}},bubbles:!0,composed:!0}))}pick(e){this.selectedId=e,this.methodActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.methodActionId,parameters:{_method:e}},bubbles:!0,composed:!0}))}render(){return T`
+    `}willUpdate(e){e.has(`selected`)&&(this.selectedId=this.selected)}confirm(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{_method:this.selectedId}},bubbles:!0,composed:!0}))}pick(e){this.selectedId=e,this.methodActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.methodActionId,parameters:{_method:e}},bubbles:!0,composed:!0}))}render(){return w`
             <div class="bar">
                 <div class="methods">
-                    ${this.methods.map(e=>T`
+                    ${this.methods.map(e=>w`
                         <button class="method ${e.id===this.selectedId?`selected`:``}"
                                 @click="${()=>this.pick(e.id)}">${e.label}</button>
                     `)}
                 </div>
-                ${this.contextLabel||this.contextValue?T`
+                ${this.contextLabel||this.contextValue?w`
                     <div class="context">
-                        ${this.contextLabel?T`<span class="label">${this.contextLabel}</span>`:v}
-                        ${this.contextValue?T`<span class="value">${this.contextValue}</span>`:v}
+                        ${this.contextLabel?w`<span class="label">${this.contextLabel}</span>`:_}
+                        ${this.contextValue?w`<span class="value">${this.contextValue}</span>`:_}
                     </div>
-                `:v}
+                `:_}
                 <span class="spacer"></span>
-                ${this.confirmLabel&&this.actionId?T`<button class="confirm" @click="${()=>this.confirm()}">${this.confirmLabel}</button>`:v}
+                ${this.confirmLabel&&this.actionId?w`<button class="confirm" @click="${()=>this.confirm()}">${this.confirmLabel}</button>`:_}
             </div>
-        `}};k([y()],qi.prototype,`actionId`,void 0),k([y()],qi.prototype,`methodActionId`,void 0),k([y({type:Array})],qi.prototype,`methods`,void 0),k([y()],qi.prototype,`selected`,void 0),k([y()],qi.prototype,`contextLabel`,void 0),k([y()],qi.prototype,`contextValue`,void 0),k([y()],qi.prototype,`confirmLabel`,void 0),k([C()],qi.prototype,`selectedId`,void 0),qi=k([g(`mateu-payment-picker`)],qi);var Ji=e=>{let t=e.metadata;return T`
+        `}};O([v()],Ji.prototype,`actionId`,void 0),O([v()],Ji.prototype,`methodActionId`,void 0),O([v({type:Array})],Ji.prototype,`methods`,void 0),O([v()],Ji.prototype,`selected`,void 0),O([v()],Ji.prototype,`contextLabel`,void 0),O([v()],Ji.prototype,`contextValue`,void 0),O([v()],Ji.prototype,`confirmLabel`,void 0),O([S()],Ji.prototype,`selectedId`,void 0),Ji=O([h(`mateu-payment-picker`)],Ji);var Yi=e=>{let t=e.metadata;return w`
         <mateu-payment-picker
                 .actionId="${t.actionId}"
                 .methodActionId="${t.methodActionId}"
@@ -4479,11 +4479,11 @@ ${i}
                 .contextLabel="${t.contextLabel}"
                 .contextValue="${t.contextValue}"
                 .confirmLabel="${t.confirmLabel}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-payment-picker>
-    `},Yi=class extends b{constructor(...e){super(...e),this.items=[]}static{this.styles=h`
+    `},Xi=class extends y{constructor(...e){super(...e),this.items=[]}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .list {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -4519,32 +4519,32 @@ ${i}
             cursor: pointer; white-space: nowrap; flex: 0 0 auto;
         }
         button:hover { background: var(--lumo-warning-color-10pct, rgba(245,158,11,.25)); filter: brightness(.97); }
-    `}runAction(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{}},bubbles:!0,composed:!0}))}render(){return T`
+    `}runAction(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{}},bubbles:!0,composed:!0}))}render(){return w`
             <div class="list">
-                ${this.items.map(e=>T`
+                ${this.items.map(e=>w`
                     <div class="row">
                         <span class="dot ${e.status??`ok`}"></span>
                         <div class="body">
                             <span class="name">${e.name}</span>
-                            ${e.systems?.length?T`<span class="systems">${e.systems.join(` · `)}</span>`:v}
+                            ${e.systems?.length?w`<span class="systems">${e.systems.join(` · `)}</span>`:_}
                         </div>
                         <div class="counters">
                             <span class="counter ok">✓ ${e.ok??0} OK</span>
-                            ${(e.warnings??0)>0?T`<span class="counter warning">⚠ ${e.warnings} warnings</span>`:v}
-                            ${(e.errors??0)>0?T`<span class="counter error">⛔ ${e.errors} errors</span>`:v}
+                            ${(e.warnings??0)>0?w`<span class="counter warning">⚠ ${e.warnings} warnings</span>`:_}
+                            ${(e.errors??0)>0?w`<span class="counter error">⛔ ${e.errors} errors</span>`:_}
                         </div>
-                        ${e.actionLabel&&e.actionId?T`<button @click="${()=>this.runAction(e)}">${e.actionLabel}</button>`:v}
+                        ${e.actionLabel&&e.actionId?w`<button @click="${()=>this.runAction(e)}">${e.actionLabel}</button>`:_}
                     </div>
                 `)}
             </div>
-        `}};k([y({type:Array})],Yi.prototype,`items`,void 0),Yi=k([g(`mateu-process-monitor`)],Yi);var Xi=e=>T`
+        `}};O([v({type:Array})],Xi.prototype,`items`,void 0),Xi=O([h(`mateu-process-monitor`)],Xi);var Zi=e=>w`
         <mateu-process-monitor
                 .items="${e.metadata.items??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-process-monitor>
-    `,Zi=(e,t)=>{let n=e.style;return e.id&&(n&&!n.endsWith(`;`)&&(n+=`;`),n??=``,t[e.id+`.hidden`]==1&&(n+=`display: none;`)),n},Qi=(e,t)=>{let n={...e.metadata};if(e.id&&n){if(n.type==j.Button){let r=n;t[e.id+`.disabled`]==1&&(r.disabled=!0)}if(n.type==j.FormField){let r=n;t[e.id+`.disabled`]==1&&(r.disabled=!0)}}return n},U=e=>t=>e(t.container,t.component,t.baseUrl,t.state,t.data,t.appState,t.appData),$i={[j.Bpmn]:({component:e})=>hr(e),[j.Workflow]:({component:e})=>_r(e),[j.FormEditor]:({component:e})=>vr(e),[j.Page]:U(pr),[j.Div]:U(or),[j.Directory]:({component:e,baseUrl:t,state:n,data:r})=>ir(e,t,n,r),[j.FormLayout]:U(Wt),[j.HorizontalLayout]:U(Xt),[j.VerticalLayout]:U(Zt),[j.SplitLayout]:U(Qt),[j.MasterDetailLayout]:U($t),[j.TabLayout]:U(en),[j.AccordionLayout]:U(tn),[j.BoardLayout]:U(sn),[j.BoardLayoutRow]:U(cn),[j.BoardLayoutItem]:U(ln),[j.Scroller]:U(rn),[j.FullWidth]:U(an),[j.Container]:U(on),[j.Form]:({container:e,component:t,baseUrl:n,state:r,data:i,appState:a,appData:o})=>{let s=t.metadata;return T`<mateu-form
+    `,Qi=(e,t)=>{let n=e.style;return e.id&&(n&&!n.endsWith(`;`)&&(n+=`;`),n??=``,t[e.id+`.hidden`]==1&&(n+=`display: none;`)),n},$i=(e,t)=>{let n={...e.metadata};if(e.id&&n){if(n.type==A.Button){let r=n;t[e.id+`.disabled`]==1&&(r.disabled=!0)}if(n.type==A.FormField){let r=n;t[e.id+`.disabled`]==1&&(r.disabled=!0)}}return n},H=e=>t=>e(t.container,t.component,t.baseUrl,t.state,t.data,t.appState,t.appData),ea={[A.Bpmn]:({component:e})=>gr(e),[A.Workflow]:({component:e})=>vr(e),[A.FormEditor]:({component:e})=>yr(e),[A.Page]:H(mr),[A.Div]:H(sr),[A.Directory]:({component:e,baseUrl:t,state:n,data:r})=>ar(e,t,n,r),[A.FormLayout]:H(Gt),[A.HorizontalLayout]:H(Zt),[A.VerticalLayout]:H(Qt),[A.SplitLayout]:H($t),[A.MasterDetailLayout]:H(en),[A.TabLayout]:H(tn),[A.AccordionLayout]:H(nn),[A.BoardLayout]:H(cn),[A.BoardLayoutRow]:H(ln),[A.BoardLayoutItem]:H(un),[A.Scroller]:H(an),[A.FullWidth]:H(on),[A.Container]:H(sn),[A.Form]:({container:e,component:t,baseUrl:n,state:r,data:i,appState:a,appData:o})=>{let s=t.metadata;return w`<mateu-form
             id="${t.id}"
         baseUrl="${n}"
             .component="${t}"
@@ -4555,14 +4555,14 @@ ${i}
             .appdata="${o}"
             style="${t.style}"
             class="${t.cssClasses}"
-            slot="${t.slot??v}"
+            slot="${t.slot??_}"
             >
-                ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
-            ${s?.buttons?.map(t=>T`
-               ${F(e,{id:t.actionId,metadata:t,type:A.ClientSide,slot:`buttons`},void 0,r,i,a,o)}
+                ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
+            ${s?.buttons?.map(t=>w`
+               ${P(e,{id:t.actionId,metadata:t,type:k.ClientSide,slot:`buttons`},void 0,r,i,a,o)}
 `)}
 
-            </mateu-form>`},[j.Table]:({component:e,state:t,data:n})=>pn(e,(e.id?n?.[e.id]:void 0)?.page?.content??mn(e,t)),[j.Crud]:U(mr),[j.App]:({container:e,component:t,baseUrl:n,state:r,data:i,appState:a,appData:o})=>T`
+            </mateu-form>`},[A.Table]:({component:e,state:t,data:n})=>mn(e,(e.id?n?.[e.id]:void 0)?.page?.content??hn(e,t)),[A.Crud]:H(hr),[A.App]:({container:e,component:t,baseUrl:n,state:r,data:i,appState:a,appData:o})=>w`
             <mateu-app
                         id="${t.id}"
                         baseUrl="${n}"
@@ -4574,26 +4574,26 @@ ${i}
                         .appState="${a}"
                         .appData="${o}"
             >
-             ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
-         </mateu-app>`,[j.Element]:({container:e,component:t})=>Tn(e,t.metadata,t),[j.FormField]:({component:e,state:t})=>dr(e,t),[j.Text]:({component:e,state:t,data:n,appState:r,appData:i})=>Dn(e,t,n,r,i),[j.Avatar]:({component:e,state:t,data:n})=>lt(e,t,n),[j.Chat]:({component:e,state:t,data:n})=>gr(e,t,n),[j.AvatarGroup]:({component:e})=>ut(e),[j.Badge]:({component:e,state:t,data:n})=>dt(e,t,n),[j.Breadcrumbs]:({component:e})=>nr(e),[j.Anchor]:({component:e})=>On(e),[j.Button]:({component:e,state:t,data:n})=>Fn(e,t,n),[j.Card]:U(Ln),[j.Chart]:({component:e})=>Rn(e),[j.Icon]:({component:e})=>zn(e),[j.ConfirmDialog]:U(Wn),[j.ContextMenu]:U(vn),[j.CookieConsent]:({component:e})=>Gn(e),[j.Details]:U(Kn),[j.Dialog]:({component:e,baseUrl:t,state:n,data:r,appState:i,appData:a})=>qn(e,t,n,r,i,a),[j.Drawer]:({component:e,baseUrl:t,state:n,data:r,appState:i,appData:a})=>Jn(e,t,n,r,i,a),[j.Image]:({component:e})=>tr(e),[j.Map]:({component:e})=>er(e),[j.Markdown]:({component:e})=>Xn(e),[j.MicroFrontend]:({component:e})=>Yn(e),[j.Notification]:({component:e})=>Zn(e),[j.ProgressBar]:({component:e,state:t})=>Qn(e,t),[j.Popover]:U($n),[j.CarouselLayout]:U(rr),[j.Tooltip]:U(xn),[j.MessageInput]:({component:e})=>bn(e),[j.MessageList]:({component:e})=>hn(e),[j.CustomField]:U(yn),[j.MenuBar]:({container:e,component:t,baseUrl:n,state:r,data:i})=>_n(e,t,n,r,i),[j.Grid]:({component:e,state:t})=>pn(e,mn(e,t)),[j.VirtualList]:U(un),[j.FormSection]:U(sr),[j.FormSubSection]:U(cr),[j.MetricCard]:({component:e})=>Cr(e),[j.Scoreboard]:U(wr),[j.DashboardPanel]:U(Tr),[j.DashboardLayout]:U(Er),[j.FoldoutLayout]:U(Or),[j.ContentLayout]:U(kr),[j.HeroSection]:U(Ar),[j.EmptyState]:({component:e})=>St(e),[j.Skeleton]:({component:e})=>Ct(e),[j.Gantt]:({component:e})=>Nr(e),[j.PlanningBoard]:({component:e})=>Fr(e),[j.Kanban]:({component:e})=>Lr(e),[j.Timeline]:({component:e})=>zr(e),[j.ProgressSteps]:({component:e})=>Vr(e),[j.Stat]:({component:e})=>Ur(e),[j.Calendar]:({component:e})=>Gr(e),[j.PricingTable]:({component:e})=>qr(e),[j.OrgChart]:({component:e})=>Yr(e),[j.Heatmap]:({component:e})=>Qr(e),[j.Funnel]:({component:e})=>ei(e),[j.TrendChart]:({component:e})=>ni(e),[j.FeatureGrid]:({component:e})=>ii(e),[j.Testimonials]:({component:e})=>oi(e),[j.Faq]:({component:e})=>ci(e),[j.CalloutCard]:({component:e})=>ui(e),[j.CommentThread]:({component:e})=>fi(e),[j.FileList]:({component:e})=>hi(e),[j.Checklist]:({component:e})=>_i(e),[j.ComparisonCard]:({component:e})=>yi(e),[j.EntityHeader]:({component:e})=>Ei(e),[j.Meter]:({component:e})=>Oi(e),[j.TaskProgress]:({component:e})=>Ai(e),[j.StatusList]:({component:e})=>Mi(e),[j.BulletedList]:({component:e})=>Pi(e),[j.Separator]:({component:e})=>Fi(e),[j.Notice]:U(Li),[j.TaskQueue]:({component:e})=>zi(e),[j.ResourceGrid]:({component:e})=>Vi(e),[j.OfferCard]:({component:e})=>Hi(e),[j.AddOnPicker]:({component:e})=>Wi(e),[j.Ledger]:({component:e})=>Ki(e),[j.PaymentPicker]:({component:e})=>Ji(e),[j.ProcessMonitor]:({component:e})=>Xi(e)},ea=(e,t,n,r,i,a,o,s)=>{if(!t?.metadata)return t==null?(console.warn(`No metadata for component`,t),T`<p>No metadata for component</p>`):ea(e,{id:E(),metadata:t,type:A.ClientSide},n,r,i,a,o,s);let c=t.metadata.type,l={...t,style:Zi(t,i),metadata:Qi(t,i)},u=$i[c];return u?u({container:e,component:l,baseUrl:n,state:r,data:i,appState:a,appData:o,labelAlreadyRendered:s}):T`<p ${l?.slot??v}>Unknown metadata type ${c} for component ${l?.id}</p>`},ta=function(e){return e.NONE=`NONE`,e.INFO=`INFO`,e.SUCCESS=`SUCCESS`,e.WARNING=`WARNING`,e.DANGER=`DANGER`,e}({}),na=(e,t,n)=>{let r=e[n.path];return r?T`<span theme="badge pill ${ra(r.type)}">${r.message}</span>`:T``},ra=e=>{switch(e){case ta.SUCCESS:return`success`;case ta.WARNING:return`warning`;case ta.DANGER:return`error`;case ta.NONE:return`contrast`}return``},W=class extends b{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.respondToVisibility=(e,t)=>{var n={root:document.documentElement};new IntersectionObserver(e=>{e.forEach(e=>{t(e.intersectionRatio>0)})},n).observe(e)},this.keepAsking=!1,this.askToUpper=()=>{let e=this.data[this.id]?.page,t=e?.content?.length/e?.pageSize;this.dispatchEvent(new CustomEvent(`fetch-more-elements`,{detail:{params:{page:t,pageSize:this.metadata?.pageSize},callback:()=>{this.keepAsking&&this.askToUpper()}},bubbles:!0,composed:!0}))},this.renderItem=e=>e.card?ea(this,e.card,this.baseUrl,this.state,this.data,this.appState,this.appData,!1):e.title?T`<div class="neutral-card">
-                ${e.image?T`<img class="card-media" src="${e.image}" alt="" />`:v}
+             ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
+         </mateu-app>`,[A.Element]:({container:e,component:t})=>En(e,t.metadata,t),[A.FormField]:({component:e,state:t})=>fr(e,t),[A.Text]:({component:e,state:t,data:n,appState:r,appData:i})=>On(e,t,n,r,i),[A.Avatar]:({component:e,state:t,data:n})=>ut(e,t,n),[A.Chat]:({component:e,state:t,data:n})=>_r(e,t,n),[A.AvatarGroup]:({component:e})=>dt(e),[A.Badge]:({component:e,state:t,data:n})=>ft(e,t,n),[A.Breadcrumbs]:({component:e})=>rr(e),[A.Anchor]:({component:e})=>kn(e),[A.Button]:({component:e,state:t,data:n})=>In(e,t,n),[A.Card]:H(Rn),[A.Chart]:({component:e})=>zn(e),[A.Icon]:({component:e})=>Bn(e),[A.ConfirmDialog]:H(Gn),[A.ContextMenu]:H(yn),[A.CookieConsent]:({component:e})=>Kn(e),[A.Details]:H(qn),[A.Dialog]:({component:e,baseUrl:t,state:n,data:r,appState:i,appData:a})=>Jn(e,t,n,r,i,a),[A.Drawer]:({component:e,baseUrl:t,state:n,data:r,appState:i,appData:a})=>Yn(e,t,n,r,i,a),[A.Image]:({component:e})=>nr(e),[A.Map]:({component:e})=>tr(e),[A.Markdown]:({component:e})=>Zn(e),[A.MicroFrontend]:({component:e})=>Xn(e),[A.Notification]:({component:e})=>Qn(e),[A.ProgressBar]:({component:e,state:t})=>$n(e,t),[A.Popover]:H(er),[A.CarouselLayout]:H(ir),[A.Tooltip]:H(Sn),[A.MessageInput]:({component:e})=>xn(e),[A.MessageList]:({component:e})=>gn(e),[A.CustomField]:H(bn),[A.MenuBar]:({container:e,component:t,baseUrl:n,state:r,data:i})=>vn(e,t,n,r,i),[A.Grid]:({component:e,state:t})=>mn(e,hn(e,t)),[A.VirtualList]:H(dn),[A.FormSection]:H(cr),[A.FormSubSection]:H(lr),[A.MetricCard]:({component:e})=>wr(e),[A.Scoreboard]:H(Tr),[A.DashboardPanel]:H(Er),[A.DashboardLayout]:H(Dr),[A.FoldoutLayout]:H(kr),[A.ContentLayout]:H(Ar),[A.HeroSection]:H(jr),[A.EmptyState]:({component:e})=>Ct(e),[A.Skeleton]:({component:e})=>wt(e),[A.Gantt]:({component:e})=>Pr(e),[A.PlanningBoard]:({component:e})=>Ir(e),[A.Kanban]:({component:e})=>Rr(e),[A.Timeline]:({component:e})=>Br(e),[A.ProgressSteps]:({component:e})=>Hr(e),[A.Stat]:({component:e})=>Wr(e),[A.Calendar]:({component:e})=>Kr(e),[A.PricingTable]:({component:e})=>Jr(e),[A.OrgChart]:({component:e})=>Xr(e),[A.Heatmap]:({component:e})=>$r(e),[A.Funnel]:({component:e})=>ti(e),[A.TrendChart]:({component:e})=>ri(e),[A.FeatureGrid]:({component:e})=>ai(e),[A.Testimonials]:({component:e})=>si(e),[A.Faq]:({component:e})=>li(e),[A.CalloutCard]:({component:e})=>di(e),[A.CommentThread]:({component:e})=>pi(e),[A.FileList]:({component:e})=>gi(e),[A.Checklist]:({component:e})=>vi(e),[A.ComparisonCard]:({component:e})=>bi(e),[A.EntityHeader]:({component:e})=>Di(e),[A.Meter]:({component:e})=>ki(e),[A.TaskProgress]:({component:e})=>ji(e),[A.StatusList]:({component:e})=>Ni(e),[A.BulletedList]:({component:e})=>Fi(e),[A.Separator]:({component:e})=>Ii(e),[A.Notice]:H(Ri),[A.TaskQueue]:({component:e})=>Bi(e),[A.ResourceGrid]:({component:e})=>Hi(e),[A.OfferCard]:({component:e})=>Ui(e),[A.AddOnPicker]:({component:e})=>Gi(e),[A.Ledger]:({component:e})=>qi(e),[A.PaymentPicker]:({component:e})=>Yi(e),[A.ProcessMonitor]:({component:e})=>Zi(e)},ta=(e,t,n,r,i,a,o,s)=>{if(!t?.metadata)return t==null?(console.warn(`No metadata for component`,t),w`<p>No metadata for component</p>`):ta(e,{id:T(),metadata:t,type:k.ClientSide},n,r,i,a,o,s);let c=t.metadata.type,l={...t,style:Qi(t,i),metadata:$i(t,i)},u=ea[c];return u?u({container:e,component:l,baseUrl:n,state:r,data:i,appState:a,appData:o,labelAlreadyRendered:s}):w`<p ${l?.slot??_}>Unknown metadata type ${c} for component ${l?.id}</p>`},na=function(e){return e.NONE=`NONE`,e.INFO=`INFO`,e.SUCCESS=`SUCCESS`,e.WARNING=`WARNING`,e.DANGER=`DANGER`,e}({}),ra=(e,t,n)=>{let r=e[n.path];return r?w`<span theme="badge pill ${ia(r.type)}">${r.message}</span>`:w``},ia=e=>{switch(e){case na.SUCCESS:return`success`;case na.WARNING:return`warning`;case na.DANGER:return`error`;case na.NONE:return`contrast`}return``},U=class extends y{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.respondToVisibility=(e,t)=>{var n={root:document.documentElement};new IntersectionObserver(e=>{e.forEach(e=>{t(e.intersectionRatio>0)})},n).observe(e)},this.keepAsking=!1,this.askToUpper=()=>{let e=this.data[this.id]?.page,t=e?.content?.length/e?.pageSize;this.dispatchEvent(new CustomEvent(`fetch-more-elements`,{detail:{params:{page:t,pageSize:this.metadata?.pageSize},callback:()=>{this.keepAsking&&this.askToUpper()}},bubbles:!0,composed:!0}))},this.renderItem=e=>e.card?ta(this,e.card,this.baseUrl,this.state,this.data,this.appState,this.appData,!1):e.title?w`<div class="neutral-card">
+                ${e.image?w`<img class="card-media" src="${e.image}" alt="" />`:_}
                 <div class="card-body">
                     <div class="card-head">
-                        ${e.title?T`<span class="card-title">${e.title}</span>`:v}
-                        ${e.status?T`<span theme="badge ${ra(e.status.type)}">${e.status.message}</span>`:v}
+                        ${e.title?w`<span class="card-title">${e.title}</span>`:_}
+                        ${e.status?w`<span theme="badge ${ia(e.status.type)}">${e.status.message}</span>`:_}
                     </div>
-                    ${e.subtitle?T`<div class="card-subtitle">${e.subtitle}</div>`:v}
-                    ${e.content?T`<div>${e.content}</div>`:v}
+                    ${e.subtitle?w`<div class="card-subtitle">${e.subtitle}</div>`:_}
+                    ${e.content?w`<div>${e.content}</div>`:_}
                 </div>
-        </div>`:T`${e}`,this.hasMore=!1,this.clickedOnCard=e=>{this.state[this.id+`_selected_items`]=[e],this.metadata?.onRowSelectionChangedActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.metadata?.onRowSelectionChangedActionId},bubbles:!0,composed:!0}))}}updated(e){super.updated(e);let t=this.data[this.id]?.page;this.hasMore=t?.content?.length<t?.totalElements}firstUpdated(e){super.firstUpdated(e),this.respondToVisibility(this.askForMore,e=>{this.keepAsking=e,e&&this.askToUpper()})}render(){return T`
+        </div>`:w`${e}`,this.hasMore=!1,this.clickedOnCard=e=>{this.state[this.id+`_selected_items`]=[e],this.metadata?.onRowSelectionChangedActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.metadata?.onRowSelectionChangedActionId},bubbles:!0,composed:!0}))}}updated(e){super.updated(e);let t=this.data[this.id]?.page;this.hasMore=t?.content?.length<t?.totalElements}firstUpdated(e){super.firstUpdated(e),this.respondToVisibility(this.askForMore,e=>{this.keepAsking=e,e&&this.askToUpper()})}render(){return w`
             <div class="card-container">
-                ${(this.data[this.id]?.page)?.content?.map(e=>T`<div role="button" tabindex="0" @click="${()=>this.clickedOnCard(e)}" @keydown="${R(()=>this.clickedOnCard(e))}" class="car-container">${this.renderItem(e)}</div>`)}
+                ${(this.data[this.id]?.page)?.content?.map(e=>w`<div role="button" tabindex="0" @click="${()=>this.clickedOnCard(e)}" @keydown="${L(()=>this.clickedOnCard(e))}" class="car-container">${this.renderItem(e)}</div>`)}
                 <div id="ask-for-more" style="display: ${this.hasMore?`flex`:`none`}; width: 100%; justify-content: center; padding: var(--lumo-space-m); color: var(--lumo-secondary-text-color); font-size: var(--lumo-font-size-s);">Loading more…</div>
             </div>
 
             <slot></slot>
-       `}static{this.styles=h`
-        ${de}
+       `}static{this.styles=m`
+        ${fe}
         
         .card-container {
             display: flex;
@@ -4617,147 +4617,147 @@ ${i}
         .neutral-card .card-title { font-weight: 600; }
         .neutral-card .card-subtitle { color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-s, .875rem); }
     
-        ${z}
-    `}};k([y()],W.prototype,`id`,void 0),k([y()],W.prototype,`metadata`,void 0),k([y()],W.prototype,`baseUrl`,void 0),k([y()],W.prototype,`state`,void 0),k([y()],W.prototype,`data`,void 0),k([y()],W.prototype,`appState`,void 0),k([y()],W.prototype,`appData`,void 0),k([y()],W.prototype,`emptyStateMessage`,void 0),k([C()],W.prototype,`keepAsking`,void 0),k([x(`#ask-for-more`)],W.prototype,`askForMore`,void 0),k([C()],W.prototype,`hasMore`,void 0),W=k([g(`mateu-card-list`)],W);var ia={show:e=>console.debug(`[mateu] no notifier registered, dropping toast:`,e.text)};function aa(e){ia=e}function oa(e,t){ia.show(e,t)}var sa=function(e){return e.none=`none`,e.success=`success`,e.error=`error`,e.warning=`warning`,e.contrast=`contrast`,e.normal=`normal`,e}({}),ca=function(e){return e.primary=`primary`,e.secondary=`secondary`,e.tertiary=`tertiary`,e.tertiaryInline=`tertiaryInline`,e}({});function la(e){if(e.weight!=null)return e.weight;let t=e.stereotype??``;if(t===`icon`)return 1;if(t===`image`)return 4;if(t===`html`||t===`richText`||t===`markdown`||t===`textarea`)return 5;if(t===`link`)return 2.5;if(t===`combobox`||t===`select`)return 2;let n=e.dataType??``;return n===`bool`?1:n===`status`||n===`integer`?1.5:n===`number`||n===`date`||n===`money`?2:n===`dateTime`||n===`dateRange`?2.5:3}function ua(e,t){if(e.length===0)return`table`;let n=e.reduce((e,t)=>e+la(t),0)/(t/76);if(n<=1.1)return`table`;if(n>1.6||e.length>10)return`masterDetail`;let r=e.filter(e=>e.identifier||(e.priority??2**53-1)<=2),i=r.reduce((e,t)=>e+la(t),0);return r.length>0&&i<=8?`list`:e.some(e=>e.stereotype===`image`||e.stereotype===`html`)||r.length===0&&e.length>=4&&e.length<=8?`cards`:`masterDetail`}function da(e){return e.filter(e=>e.identifier||(e.priority??2**53-1)<=2).sort((e,t)=>(e.priority??2**53-1)-(t.priority??2**53-1))}function fa(e){let t=da(e);return t.length>0?t:e.slice(0,3)}var pa={asc:`ascending`,desc:`descending`},G=class extends b{constructor(...e){super(...e),this.component=void 0,this.standalone=!1,this.state={},this.data={},this.appState={},this.appData={},this.showImportDialog=!1,this.availableWidthPx=1024,this.selectedItem=null,this._columnPrefsRevision=0,this._prefsRevisionApplied=-1,this.search=()=>{let e=this.component.metadata;this.state={...this.state,size:e.pageSize,page:0,crud_selected_items:[]},this._syncStateToUrl(e),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`search`,parameters:{crudId:this.id,_searchState:{...this.state}}},bubbles:!0,composed:!0}))},this.notify=e=>{oa({text:e,position:`bottomEnd`,variant:`error`,duration:3e3},this)},this.handleSearchRequested=e=>{this.state={...this.state,crud_selected_items:[]};let t=this.component.metadata;this._syncStateToUrl(t),!t.infiniteScrolling&&this.data?.[this.id]?.page&&(this.data[this.id].page.content=[]),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`search`,parameters:{crudId:this.id,_searchState:{...this.state}},callback:e},bubbles:!0,composed:!0}))},this.fetchMoreElements=e=>{let{params:t,callback:n}=e.detail;this.state={...this.state,size:t.pageSize,page:t.page},this.handleSearchRequested(n)},this.directionChanged=e=>{let t=e.detail.grid._sorters;this.state={...this.state,sort:t.map(e=>({fieldId:e.__data.path,direction:e.__data.direction?pa[e.__data.direction]:void 0}))},this.handleSearchRequested(void 0)},this._initializedForComponentId=void 0,this.evalLabel=e=>M(e,this.state,this.data),this.handleToolbarButtonClick=e=>{if(e===`import`){this.showImportDialog=!0;return}this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.handleImportUploadSuccess=e=>{let t=e.detail.xhr.responseText;this.showImportDialog=!1,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`process-import`,parameters:{fileId:t}},bubbles:!0,composed:!0}))}}get columnPrefsScope(){return window.location.pathname}get effectiveComponent(){let e=this.component,t=e?.metadata;if(!e||!t?.columns)return e;if(this._prefsSource===e&&this._prefsRevisionApplied===this._columnPrefsRevision)return this._prefsApplied;let n=It(this.columnPrefsScope),r=Bt(t.columns,n,e=>e.metadata??{});return this._prefsApplied=r===t.columns?e:{...e,metadata:{...t,columns:r}},this._prefsSource=e,this._prefsRevisionApplied=this._columnPrefsRevision,this._prefsApplied}get columnChooserEntries(){return(this.component?.metadata?.columns??[]).map(e=>{let t=e.metadata??{},n=t.id??e.id;return n?{id:n,label:t.label??n,protected:zt(t)}:void 0}).filter(e=>!!e)}renderColumnChooser(){let e=this.columnChooserEntries;return e.filter(e=>!e.protected).length===0?v:T`
+        ${R}
+    `}};O([v()],U.prototype,`id`,void 0),O([v()],U.prototype,`metadata`,void 0),O([v()],U.prototype,`baseUrl`,void 0),O([v()],U.prototype,`state`,void 0),O([v()],U.prototype,`data`,void 0),O([v()],U.prototype,`appState`,void 0),O([v()],U.prototype,`appData`,void 0),O([v()],U.prototype,`emptyStateMessage`,void 0),O([S()],U.prototype,`keepAsking`,void 0),O([b(`#ask-for-more`)],U.prototype,`askForMore`,void 0),O([S()],U.prototype,`hasMore`,void 0),U=O([h(`mateu-card-list`)],U);var aa={show:e=>console.debug(`[mateu] no notifier registered, dropping toast:`,e.text)};function oa(e){aa=e}function sa(e,t){aa.show(e,t)}var ca=function(e){return e.none=`none`,e.success=`success`,e.error=`error`,e.warning=`warning`,e.contrast=`contrast`,e.normal=`normal`,e}({}),la=function(e){return e.primary=`primary`,e.secondary=`secondary`,e.tertiary=`tertiary`,e.tertiaryInline=`tertiaryInline`,e}({});function ua(e){if(e.weight!=null)return e.weight;let t=e.stereotype??``;if(t===`icon`)return 1;if(t===`image`)return 4;if(t===`html`||t===`richText`||t===`markdown`||t===`textarea`)return 5;if(t===`link`)return 2.5;if(t===`combobox`||t===`select`)return 2;let n=e.dataType??``;return n===`bool`?1:n===`status`||n===`integer`?1.5:n===`number`||n===`date`||n===`money`?2:n===`dateTime`||n===`dateRange`?2.5:3}function da(e,t){if(e.length===0)return`table`;let n=e.reduce((e,t)=>e+ua(t),0)/(t/76);if(n<=1.1)return`table`;if(n>1.6||e.length>10)return`masterDetail`;let r=e.filter(e=>e.identifier||(e.priority??2**53-1)<=2),i=r.reduce((e,t)=>e+ua(t),0);return r.length>0&&i<=8?`list`:e.some(e=>e.stereotype===`image`||e.stereotype===`html`)||r.length===0&&e.length>=4&&e.length<=8?`cards`:`masterDetail`}function fa(e){return e.filter(e=>e.identifier||(e.priority??2**53-1)<=2).sort((e,t)=>(e.priority??2**53-1)-(t.priority??2**53-1))}function pa(e){let t=fa(e);return t.length>0?t:e.slice(0,3)}var ma={asc:`ascending`,desc:`descending`},W=class extends y{constructor(...e){super(...e),this.component=void 0,this.standalone=!1,this.state={},this.data={},this.appState={},this.appData={},this.showImportDialog=!1,this.availableWidthPx=1024,this.selectedItem=null,this._columnPrefsRevision=0,this._prefsRevisionApplied=-1,this.search=()=>{let e=this.component.metadata;this.state={...this.state,size:e.pageSize,page:0,crud_selected_items:[]},this._syncStateToUrl(e),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`search`,parameters:{crudId:this.id,_searchState:{...this.state}}},bubbles:!0,composed:!0}))},this.notify=e=>{sa({text:e,position:`bottomEnd`,variant:`error`,duration:3e3},this)},this.handleSearchRequested=e=>{this.state={...this.state,crud_selected_items:[]};let t=this.component.metadata;this._syncStateToUrl(t),!t.infiniteScrolling&&this.data?.[this.id]?.page&&(this.data[this.id].page.content=[]),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`search`,parameters:{crudId:this.id,_searchState:{...this.state}},callback:e},bubbles:!0,composed:!0}))},this.fetchMoreElements=e=>{let{params:t,callback:n}=e.detail;this.state={...this.state,size:t.pageSize,page:t.page},this.handleSearchRequested(n)},this.directionChanged=e=>{let t=e.detail.grid._sorters;this.state={...this.state,sort:t.map(e=>({fieldId:e.__data.path,direction:e.__data.direction?ma[e.__data.direction]:void 0}))},this.handleSearchRequested(void 0)},this._initializedForComponentId=void 0,this.evalLabel=e=>j(e,this.state,this.data),this.handleToolbarButtonClick=e=>{if(e===`import`){this.showImportDialog=!0;return}this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.handleImportUploadSuccess=e=>{let t=e.detail.xhr.responseText;this.showImportDialog=!1,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`process-import`,parameters:{fileId:t}},bubbles:!0,composed:!0}))}}get columnPrefsScope(){return window.location.pathname}get effectiveComponent(){let e=this.component,t=e?.metadata;if(!e||!t?.columns)return e;if(this._prefsSource===e&&this._prefsRevisionApplied===this._columnPrefsRevision)return this._prefsApplied;let n=Lt(this.columnPrefsScope),r=Vt(t.columns,n,e=>e.metadata??{});return this._prefsApplied=r===t.columns?e:{...e,metadata:{...t,columns:r}},this._prefsSource=e,this._prefsRevisionApplied=this._columnPrefsRevision,this._prefsApplied}get columnChooserEntries(){return(this.component?.metadata?.columns??[]).map(e=>{let t=e.metadata??{},n=t.id??e.id;return n?{id:n,label:t.label??n,protected:Bt(t)}:void 0}).filter(e=>!!e)}renderColumnChooser(){let e=this.columnChooserEntries;return e.filter(e=>!e.protected).length===0?_:w`
             <mateu-column-chooser
                 .columns="${e}"
                 .scope="${this.columnPrefsScope}"
                 @column-prefs-changed="${e=>{e.stopPropagation(),this._columnPrefsRevision++}}"
             ></mateu-column-chooser>
-        `}get cols(){return(this.effectiveComponent?.metadata)?.columns?.map(e=>e.metadata)??[]}get identifierFieldName(){let e=this.cols.find(e=>e.identifier);return e?e.id:this.cols.find(e=>e.id===`id`)?.id}get effectiveGridLayout(){let e=this.component?.metadata,t=e?.gridLayout??`auto`;return t===`auto`?e?.crudlType===`card`?`cards`:ua(this.cols,this.availableWidthPx):t}connectedCallback(){super.connectedCallback(),this.resizeObserver=new ResizeObserver(e=>{let t=e[0]?.contentRect.width;t&&Math.abs(t-this.availableWidthPx)>10&&(this.availableWidthPx=t)}),this.resizeObserver.observe(this)}disconnectedCallback(){super.disconnectedCallback(),this.resizeObserver?.disconnect()}_filterIds(e){return new Set([`searchText`,...(e.filters??[]).flatMap(e=>e.stereotype===`dateRange`||e.stereotype===`numberRange`?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId])])}_syncStateToUrl(e){let t=this._filterIds(e),n=new URLSearchParams(window.location.search);t.forEach(e=>n.delete(e)),n.delete(`page`),n.delete(`sort`),t.forEach(e=>{let t=this.state[e];t!=null&&t!==``&&n.set(e,String(t))});let r=this.state.page;r&&r>0&&n.set(`page`,String(r));let i=this.state.sort;if(i&&i.length>0){let e=i.filter(e=>e.fieldId&&e.direction).map(e=>`${e.fieldId}:${e.direction}`).join(`,`);e&&n.set(`sort`,e)}let a=n.toString(),o=a?`${window.location.pathname}?${a}`:window.location.pathname;window.location.pathname+window.location.search!==o&&history.replaceState(null,``,o)}_initStateFromUrl(e,t){let n=new URLSearchParams(window.location.search),r=this._filterIds(e),i={...t};n.forEach((e,t)=>{r.has(t)&&(i[t]=e)});let a=n.get(`page`);if(a!==null){let e=parseInt(a,10);!isNaN(e)&&e>0&&(i.page=e)}let o=n.get(`sort`);if(o){let e=o.split(`,`).map(e=>{let[t,n]=e.split(`:`);return t&&n?{fieldId:t,direction:n}:null}).filter(Boolean);e.length>0&&(i.sort=e)}return i}pageChanged(e){this.state={...this.state,page:e.detail.page},this.handleSearchRequested(void 0)}updated(e){if(super.updated(e),e.has(`component`)){let e=this.component?.id;if(e!==this._initializedForComponentId){this._initializedForComponentId=e;let t=this.component?.metadata,n=t.initialPage&&t.initialPage>0?t.initialPage:0;this.state=this._initStateFromUrl(t,{...this.state,size:t.pageSize,page:n,sort:[]}),(this.state.page!==n||this.state.sort?.length>0||[...this._filterIds(t)].some(e=>this.state[e]!=null))&&this.handleSearchRequested(void 0)}}}render(){let e=e=>{let t=[];return e.color&&e.color!==sa.normal&&t.push(e.color),e.buttonStyle&&t.push(e.buttonStyle===ca.tertiaryInline?`tertiary-inline`:e.buttonStyle),t.length?t.join(` `):void 0},t=e=>e===`back`||e===`backToList`||!!e&&e.startsWith(`cancel`),n=t=>P.get()?.renderToolbarButton?.(t,this.evalLabel(t.label),()=>this.handleToolbarButtonClick(t.actionId))||T`
+        `}get cols(){return(this.effectiveComponent?.metadata)?.columns?.map(e=>e.metadata)??[]}get identifierFieldName(){let e=this.cols.find(e=>e.identifier);return e?e.id:this.cols.find(e=>e.id===`id`)?.id}get effectiveGridLayout(){let e=this.component?.metadata,t=e?.gridLayout??`auto`;return t===`auto`?e?.crudlType===`card`?`cards`:da(this.cols,this.availableWidthPx):t}connectedCallback(){super.connectedCallback(),this.resizeObserver=new ResizeObserver(e=>{let t=e[0]?.contentRect.width;t&&Math.abs(t-this.availableWidthPx)>10&&(this.availableWidthPx=t)}),this.resizeObserver.observe(this)}disconnectedCallback(){super.disconnectedCallback(),this.resizeObserver?.disconnect()}_filterIds(e){return new Set([`searchText`,...(e.filters??[]).flatMap(e=>e.stereotype===`dateRange`||e.stereotype===`numberRange`?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId])])}_syncStateToUrl(e){let t=this._filterIds(e),n=new URLSearchParams(window.location.search);t.forEach(e=>n.delete(e)),n.delete(`page`),n.delete(`sort`),t.forEach(e=>{let t=this.state[e];t!=null&&t!==``&&n.set(e,String(t))});let r=this.state.page;r&&r>0&&n.set(`page`,String(r));let i=this.state.sort;if(i&&i.length>0){let e=i.filter(e=>e.fieldId&&e.direction).map(e=>`${e.fieldId}:${e.direction}`).join(`,`);e&&n.set(`sort`,e)}let a=n.toString(),o=a?`${window.location.pathname}?${a}`:window.location.pathname;window.location.pathname+window.location.search!==o&&history.replaceState(null,``,o)}_initStateFromUrl(e,t){let n=new URLSearchParams(window.location.search),r=this._filterIds(e),i={...t};n.forEach((e,t)=>{r.has(t)&&(i[t]=e)});let a=n.get(`page`);if(a!==null){let e=parseInt(a,10);!isNaN(e)&&e>0&&(i.page=e)}let o=n.get(`sort`);if(o){let e=o.split(`,`).map(e=>{let[t,n]=e.split(`:`);return t&&n?{fieldId:t,direction:n}:null}).filter(Boolean);e.length>0&&(i.sort=e)}return i}pageChanged(e){this.state={...this.state,page:e.detail.page},this.handleSearchRequested(void 0)}updated(e){if(super.updated(e),e.has(`component`)){let e=this.component?.id;if(e!==this._initializedForComponentId){this._initializedForComponentId=e;let t=this.component?.metadata,n=t.initialPage&&t.initialPage>0?t.initialPage:0;this.state=this._initStateFromUrl(t,{...this.state,size:t.pageSize,page:n,sort:[]}),(this.state.page!==n||this.state.sort?.length>0||[...this._filterIds(t)].some(e=>this.state[e]!=null))&&this.handleSearchRequested(void 0)}}}render(){let e=e=>{let t=[];return e.color&&e.color!==ca.normal&&t.push(e.color),e.buttonStyle&&t.push(e.buttonStyle===la.tertiaryInline?`tertiary-inline`:e.buttonStyle),t.length?t.join(` `):void 0},t=e=>e===`back`||e===`backToList`||!!e&&e.startsWith(`cancel`),n=t=>N.get()?.renderToolbarButton?.(t,this.evalLabel(t.label),()=>this.handleToolbarButtonClick(t.actionId))||w`
                 <button class="crud-btn"
                         data-action-id="${t.id}"
-                        theme="${e(t)||v}"
+                        theme="${e(t)||_}"
                         @click="${()=>this.handleToolbarButtonClick(t.actionId)}"
                 >${this.evalLabel(t.label)}</button>
-            `;if(!this.component)return T`no component`;let r=this.effectiveComponent,i=r.metadata;i.serverSideOrdering=!0;let a=(()=>{let e=this;for(;e;){let t=e;if(t.tagName===`MATEU-PAGE`)return(t.component?.metadata?.toolbar?.length??0)>0;e=t.parentElement??(t.getRootNode?.()instanceof ShadowRoot?t.getRootNode().host:null)}return!1})()?[]:i?.toolbar??[],o=a.filter(e=>t(e.actionId)),s=a.filter(e=>!t(e.actionId)),c=o.length>0&&s.length>0,l=!!i?.title||!!i?.subtitle||a.length>0,u=this.effectiveGridLayout,d=this.cols,f=da(d),p=this.data[this.id]?.page?.content??[],m=this.state[this.component?.id]?.emptyStateMessage,ee=(e,t)=>{let n=t[e.id];return n==null?T``:e.dataType===`status`?T`<span theme="badge pill ${ra(n.type)}">${n.message}</span>`:e.dataType===`bool`?T`${n?`✓`:`✗`}`:typeof n==`object`?T`${n.label??n.name??n.message??``}`:T`${n}`},te=()=>{let e=this.identifierFieldName,t=this.state._selectedId??this.appState?._splitDetailId,n=f.find(e=>e.identifier)??f[0],r=e=>e.dataType===`action`||e.dataType===`actionGroup`||e.dataType===`menu`||e.stereotype===`button`,i=f.filter(e=>e!==n&&!r(e)),a=d.filter(e=>r(e)),o=(e,t,n)=>{e.stopPropagation(),e.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_clickedRow:n}},bubbles:!0,composed:!0}))},s=e=>{let t=[];for(let n of a){let r=e[n.id];if(n.dataType===`action`){let i=r?.methodNameInCrud?r:e.action?.methodNameInCrud?e.action:{methodNameInCrud:n.id,label:n.label,icon:null,disabled:!1};t.push(T`
-                            <button class="crud-btn" theme="tertiary small" title="${i.label||v}"
+            `;if(!this.component)return w`no component`;let r=this.effectiveComponent,i=r.metadata;i.serverSideOrdering=!0;let a=(()=>{let e=this;for(;e;){let t=e;if(t.tagName===`MATEU-PAGE`)return(t.component?.metadata?.toolbar?.length??0)>0;e=t.parentElement??(t.getRootNode?.()instanceof ShadowRoot?t.getRootNode().host:null)}return!1})()?[]:i?.toolbar??[],o=a.filter(e=>t(e.actionId)),s=a.filter(e=>!t(e.actionId)),c=o.length>0&&s.length>0,l=!!i?.title||!!i?.subtitle||a.length>0,u=this.effectiveGridLayout,d=this.cols,f=fa(d),p=this.data[this.id]?.page?.content??[],ee=this.state[this.component?.id]?.emptyStateMessage,te=(e,t)=>{let n=t[e.id];return n==null?w``:e.dataType===`status`?w`<span theme="badge pill ${ia(n.type)}">${n.message}</span>`:e.dataType===`bool`?w`${n?`✓`:`✗`}`:typeof n==`object`?w`${n.label??n.name??n.message??``}`:w`${n}`},ne=()=>{let e=this.identifierFieldName,t=this.state._selectedId??this.appState?._splitDetailId,n=f.find(e=>e.identifier)??f[0],r=e=>e.dataType===`action`||e.dataType===`actionGroup`||e.dataType===`menu`||e.stereotype===`button`,i=f.filter(e=>e!==n&&!r(e)),a=d.filter(e=>r(e)),o=(e,t,n)=>{e.stopPropagation(),e.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_clickedRow:n}},bubbles:!0,composed:!0}))},s=e=>{let t=[];for(let n of a){let r=e[n.id];if(n.dataType===`action`){let i=r?.methodNameInCrud?r:e.action?.methodNameInCrud?e.action:{methodNameInCrud:n.id,label:n.label,icon:null,disabled:!1};t.push(w`
+                            <button class="crud-btn" theme="tertiary small" title="${i.label||_}"
                                 @click="${t=>o(t,`action-on-row-`+i.methodNameInCrud,e)}">
-                                ${i.icon?I(i.icon):v}
-                                ${i.label??v}
-                            </button>`)}else(n.dataType===`actionGroup`||n.dataType===`menu`)&&(r?.actions??[]).forEach(n=>t.push(T`
-                            <button class="crud-btn" theme="tertiary small" title="${n.label||v}"
+                                ${i.icon?F(i.icon):_}
+                                ${i.label??_}
+                            </button>`)}else(n.dataType===`actionGroup`||n.dataType===`menu`)&&(r?.actions??[]).forEach(n=>t.push(w`
+                            <button class="crud-btn" theme="tertiary small" title="${n.label||_}"
                                 @click="${t=>o(t,`action-on-row-`+n.methodNameInCrud,e)}">
-                                ${n.icon?I(n.icon):v}
-                                ${n.label??v}
-                            </button>`))}return t.length?T`
+                                ${n.icon?F(n.icon):_}
+                                ${n.label??_}
+                            </button>`))}return t.length?w`
                     <div style="display: flex; flex-wrap: wrap; gap: var(--lumo-space-xs); margin-top: var(--lumo-space-xs);">
                         ${t}
-                    </div>`:v};return T`
+                    </div>`:_};return w`
                 <div class="m-listbox" style="width: 100%;">
-                    ${p.length===0?T`<div class="m-item" disabled>${xt(m)}</div>`:v}
-                    ${p.map(r=>T`
+                    ${p.length===0?w`<div class="m-item" disabled>${St(ee)}</div>`:_}
+                    ${p.map(r=>w`
                         <div role="button" tabindex="0" class="m-item"
                             ?selected="${e&&t!==void 0&&String(r[e])===String(t)}"
-                            @click="${()=>{e&&r[e]!==void 0&&(this.state={...this.state,_selectedId:String(r[e])}),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`view`,parameters:r},bubbles:!0,composed:!0}))}}" @keydown="${R(()=>{e&&r[e]!==void 0&&(this.state={...this.state,_selectedId:String(r[e])}),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`view`,parameters:r},bubbles:!0,composed:!0}))})}"
+                            @click="${()=>{e&&r[e]!==void 0&&(this.state={...this.state,_selectedId:String(r[e])}),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`view`,parameters:r},bubbles:!0,composed:!0}))}}" @keydown="${L(()=>{e&&r[e]!==void 0&&(this.state={...this.state,_selectedId:String(r[e])}),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`view`,parameters:r},bubbles:!0,composed:!0}))})}"
                             style="cursor: pointer;"
                         >
                             <div style="font-weight: 600;">${n?r[n.id]??``:``}</div>
                             <div style="font-size: var(--lumo-font-size-s); color: var(--lumo-secondary-text-color); display: flex; flex-wrap: wrap; gap: var(--lumo-space-xs); align-items: center;">
-                                ${i.map(e=>T`<span>${e.label}: ${ee(e,r)}</span>`)}
+                                ${i.map(e=>w`<span>${e.label}: ${te(e,r)}</span>`)}
                             </div>
                             ${s(r)}
                         </div>
                     `)}
-                </div>`},ne=(e,t,n)=>{let r=this.identifierFieldName;r&&n[r]!==void 0&&(this.state={...this.state,_selectedId:String(n[r])}),e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:n},bubbles:!0,composed:!0}))},h=()=>{let e=this.identifierFieldName,t=this.state._selectedId??this.appState?._splitDetailId,n=e=>!!e.actionId,r=e=>e.dataType===`action`||e.dataType===`actionGroup`||e.dataType===`menu`||e.stereotype===`button`,i=[...d.slice(0,6),...d.slice(6).filter(e=>r(e)||e.dataType===`status`)],a=i.filter(e=>e.stereotype===`image`),o=i.find(e=>e.identifier)??i[0],s=i.find(e=>e.id===`select`&&e.dataType===`action`),c=!!s,l=i.filter(e=>e!==o&&!a.includes(e)&&!n(e)&&!r(e)),u=i.filter(e=>r(e)&&!(c&&e===s)),f=(e,t,n)=>{e.stopPropagation(),e.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_clickedRow:n}},bubbles:!0,composed:!0}))},te=e=>{let t=[];for(let n of u){let r=e[n.id];if(n.dataType===`action`){let i=r?.methodNameInCrud?r:e.action?.methodNameInCrud?e.action:{methodNameInCrud:n.id,label:n.label,icon:null,disabled:!1};t.push(T`
-                            <button class="crud-btn" theme="tertiary" title="${i.label||v}"
+                </div>`},re=(e,t,n)=>{let r=this.identifierFieldName;r&&n[r]!==void 0&&(this.state={...this.state,_selectedId:String(n[r])}),e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:n},bubbles:!0,composed:!0}))},m=()=>{let e=this.identifierFieldName,t=this.state._selectedId??this.appState?._splitDetailId,n=e=>!!e.actionId,r=e=>e.dataType===`action`||e.dataType===`actionGroup`||e.dataType===`menu`||e.stereotype===`button`,i=[...d.slice(0,6),...d.slice(6).filter(e=>r(e)||e.dataType===`status`)],a=i.filter(e=>e.stereotype===`image`),o=i.find(e=>e.identifier)??i[0],s=i.find(e=>e.id===`select`&&e.dataType===`action`),c=!!s,l=i.filter(e=>e!==o&&!a.includes(e)&&!n(e)&&!r(e)),u=i.filter(e=>r(e)&&!(c&&e===s)),f=(e,t,n)=>{e.stopPropagation(),e.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_clickedRow:n}},bubbles:!0,composed:!0}))},ne=e=>{let t=[];for(let n of u){let r=e[n.id];if(n.dataType===`action`){let i=r?.methodNameInCrud?r:e.action?.methodNameInCrud?e.action:{methodNameInCrud:n.id,label:n.label,icon:null,disabled:!1};t.push(w`
+                            <button class="crud-btn" theme="tertiary" title="${i.label||_}"
                                 @click="${t=>f(t,`action-on-row-`+i.methodNameInCrud,e)}">
-                                ${i.icon?I(i.icon):v}
-                                ${i.label??v}
-                            </button>`)}else(n.dataType===`actionGroup`||n.dataType===`menu`)&&(r?.actions??[]).forEach(n=>t.push(T`
-                            <button class="crud-btn" theme="tertiary" title="${n.label||v}"
+                                ${i.icon?F(i.icon):_}
+                                ${i.label??_}
+                            </button>`)}else(n.dataType===`actionGroup`||n.dataType===`menu`)&&(r?.actions??[]).forEach(n=>t.push(w`
+                            <button class="crud-btn" theme="tertiary" title="${n.label||_}"
                                 @click="${t=>f(t,`action-on-row-`+n.methodNameInCrud,e)}">
-                                ${n.icon?I(n.icon):v}
-                                ${n.label??v}
-                            </button>`))}return t.length?T`
+                                ${n.icon?F(n.icon):_}
+                                ${n.label??_}
+                            </button>`))}return t.length?w`
                     <div style="display: flex; flex-wrap: wrap; gap: var(--lumo-space-xs); padding-top: var(--lumo-space-s); border-top: 1px solid var(--lumo-contrast-10pct);">
                         ${t}
-                    </div>`:v};return T`
+                    </div>`:_};return w`
                 <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: var(--lumo-space-m); padding: var(--lumo-space-s) 0;">
-                    ${p.length===0?T`<div style="grid-column: 1 / -1;">${xt(m)}</div>`:v}
-                    ${p.map(n=>T`
+                    ${p.length===0?w`<div style="grid-column: 1 / -1;">${St(ee)}</div>`:_}
+                    ${p.map(n=>w`
                         <div role="button" tabindex="0" class="crud-card"
                             ?data-selected="${e&&t!==void 0&&String(n[e])===String(t)}"
                             style="cursor: pointer;"
-                            @click="${e=>c?f(e,`action-on-row-select`,n):ne(e.target,`view`,n)}" @keydown="${R(e=>c?f(e,`action-on-row-select`,n):ne(e.target,`view`,n))}"
+                            @click="${e=>c?f(e,`action-on-row-select`,n):re(e.target,`view`,n)}" @keydown="${L(e=>c?f(e,`action-on-row-select`,n):re(e.target,`view`,n))}"
                         >
-                            ${a.length?T`<img src="${n[a[0].id]??``}" alt="" style="width: 100%; max-height: 160px; object-fit: cover; border-radius: var(--lumo-border-radius-m, 8px);" />`:v}
-                            ${o?T`<div class="crud-card-title">${n[o.id]??``}</div>`:v}
+                            ${a.length?w`<img src="${n[a[0].id]??``}" alt="" style="width: 100%; max-height: 160px; object-fit: cover; border-radius: var(--lumo-border-radius-m, 8px);" />`:_}
+                            ${o?w`<div class="crud-card-title">${n[o.id]??``}</div>`:_}
                             <div style="display: flex; flex-direction: column; gap: var(--lumo-space-xs); padding: var(--lumo-space-s) 0;">
-                                ${l.map(e=>T`
+                                ${l.map(e=>w`
                                     <div style="display: flex; gap: var(--lumo-space-s); font-size: var(--lumo-font-size-s);">
                                         <span style="color: var(--lumo-secondary-text-color); min-width: 80px;">${e.label}</span>
-                                        <span>${ee(e,n)}</span>
+                                        <span>${te(e,n)}</span>
                                     </div>
                                 `)}
                             </div>
-                            ${te(n)}
+                            ${ne(n)}
                         </div>
                     `)}
-                </div>`},g=()=>{let e=fa(d),t=e.find(e=>e.identifier)??e[0],n=e.filter(e=>e!==t);return T`
+                </div>`},h=()=>{let e=pa(d),t=e.find(e=>e.identifier)??e[0],n=e.filter(e=>e!==t);return w`
                 <div style="display: flex; height: 100%; min-height: 400px; gap: 0;">
                     <div style="width: 260px; flex-shrink: 0; border-right: 1px solid var(--lumo-contrast-20pct); overflow-y: auto;">
                         <div class="m-listbox" style="width: 100%;">
-                            ${p.length===0?T`<div class="m-item" disabled>${xt(m)}</div>`:v}
-                            ${p.map(e=>T`
+                            ${p.length===0?w`<div class="m-item" disabled>${St(ee)}</div>`:_}
+                            ${p.map(e=>w`
                                 <div role="button" tabindex="0" class="m-item"
                                     ?selected="${this.selectedItem===e}"
-                                    @click="${()=>{this.selectedItem=e}}" @keydown="${R(()=>{this.selectedItem=e})}"
+                                    @click="${()=>{this.selectedItem=e}}" @keydown="${L(()=>{this.selectedItem=e})}"
                                     style="cursor: pointer;"
                                 >
                                     <div style="font-weight: 600;">${t?e[t.id]??``:``}</div>
                                     <div style="font-size: var(--lumo-font-size-s); color: var(--lumo-secondary-text-color); display: flex; flex-wrap: wrap; gap: var(--lumo-space-xs); align-items: center;">
-                                        ${n.map(t=>T`${ee(t,e)} `)}
+                                        ${n.map(t=>w`${te(t,e)} `)}
                                     </div>
                                 </div>
                             `)}
                         </div>
                     </div>
                     <div style="flex: 1; padding: var(--lumo-space-m); overflow-y: auto;">
-                        ${this.selectedItem?T`
+                        ${this.selectedItem?w`
                             <div class="m-formlayout">
-                                ${d.map(e=>T`
+                                ${d.map(e=>w`
                                     <label style="display: flex; flex-direction: column; gap: .1rem; font-size: var(--lumo-font-size-s, .875rem);">
                                         <span style="color: var(--lumo-secondary-text-color, #667);">${e.label}</span>
                                         <span>${String(this.selectedItem[e.id]??``)}</span>
                                     </label>
                                 `)}
                             </div>
-                        `:T`
+                        `:w`
                             <p style="color: var(--lumo-secondary-text-color);">Select a row to view details.</p>
                         `}
                     </div>
-                </div>`},_=()=>{let e=this.identifierFieldName,t=this.state._selectedId??this.appState?._splitDetailId,n=d[0],r=d.slice(1),i=!!n?.actionId,a=e=>(e??[]).map(e=>{let t=Array.isArray(e.children)?e.children:[];return t.length>0?{...e,children:a(t)}:{...e,children:void 0}}),o=a(p),s=(t,n,r)=>{t.stopPropagation(),e&&n[e]!==void 0&&(this.state={...this.state,_selectedId:String(n[e])}),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:r,parameters:n},bubbles:!0,composed:!0}))},c=(a,o)=>T`
+                </div>`},g=()=>{let e=this.identifierFieldName,t=this.state._selectedId??this.appState?._splitDetailId,n=d[0],r=d.slice(1),i=!!n?.actionId,a=e=>(e??[]).map(e=>{let t=Array.isArray(e.children)?e.children:[];return t.length>0?{...e,children:a(t)}:{...e,children:void 0}}),o=a(p),s=(t,n,r)=>{t.stopPropagation(),e&&n[e]!==void 0&&(this.state={...this.state,_selectedId:String(n[e])}),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:r,parameters:n},bubbles:!0,composed:!0}))},c=(a,o)=>w`
                 <tr class="${e&&t!==void 0&&String(a[e])===String(t)?`selected`:``}"
                     style="cursor: pointer;" @click="${e=>s(e,a,`view`)}">
-                    ${n?T`<td style="padding-left: ${o*1.2+.6}rem;">${a[n.id]??``}</td>`:v}
-                    ${r.map(e=>e.id===`select`?T`<td><button class="crud-btn small" @click="${e=>{e.stopPropagation(),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-select`,parameters:{_clickedRow:a}},bubbles:!0,composed:!0}))}}">Select</button></td>`:T`<td>${a[e.id]??``}</td>`)}
-                    ${i?T`<td style="text-align: end;">${a?.viewable===!1?v:T`<button class="crud-btn small" @click="${e=>s(e,a,`view`)}">View</button>`}</td>`:v}
+                    ${n?w`<td style="padding-left: ${o*1.2+.6}rem;">${a[n.id]??``}</td>`:_}
+                    ${r.map(e=>e.id===`select`?w`<td><button class="crud-btn small" @click="${e=>{e.stopPropagation(),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-select`,parameters:{_clickedRow:a}},bubbles:!0,composed:!0}))}}">Select</button></td>`:w`<td>${a[e.id]??``}</td>`)}
+                    ${i?w`<td style="text-align: end;">${a?.viewable===!1?_:w`<button class="crud-btn small" @click="${e=>s(e,a,`view`)}">View</button>`}</td>`:_}
                 </tr>
                 ${(a.children??[]).map(e=>c(e,o+1))}
-            `;return T`
+            `;return w`
                 <table class="crud-table">
                     <thead><tr>
-                        ${n?T`<th>${n.label??v}</th>`:v}
-                        ${r.map(e=>T`<th>${e.label??v}</th>`)}
-                        ${i?T`<th></th>`:v}
+                        ${n?w`<th>${n.label??_}</th>`:_}
+                        ${r.map(e=>w`<th>${e.label??_}</th>`)}
+                        ${i?w`<th></th>`:_}
                     </tr></thead>
                     <tbody>
-                        ${o.length===0?T`<tr><td colspan="99" style="padding: 1.5rem; text-align: center; color: var(--lumo-secondary-text-color, #888);">${xt(m)}</td></tr>`:v}
+                        ${o.length===0?w`<tr><td colspan="99" style="padding: 1.5rem; text-align: center; color: var(--lumo-secondary-text-color, #888);">${St(ee)}</td></tr>`:_}
                         ${o.map(e=>c(e,0))}
                     </tbody>
-                </table>`},re=P.get()?.rendersCrudLayouts?.()===!0,y=T`
-            ${i.infiniteScrolling?T`
+                </table>`},ie=N.get()?.rendersCrudLayouts?.()===!0,v=w`
+            ${i.infiniteScrolling?w`
                 <div>${this.data[this.id]?.page?.totalElements} items found.</div>
-            `:v}
-            ${!re&&u===`list`?te():!re&&u===`cards`?i.contentHeight?T`
+            `:_}
+            ${!ie&&u===`list`?ne():!ie&&u===`cards`?i.contentHeight?w`
                 <div class="m-scroll" style="width: 100%; height: ${i.contentHeight};">
-                    ${h()}
+                    ${m()}
                 </div>
-            `:h():!re&&u===`masterDetail`?g():!re&&u===`tree`?(()=>{let e=P.get();return e?.renderTreeComponent?e.renderTreeComponent(this,{rows:p,columns:d.map(e=>({id:e.id,label:e.label})),idField:this.identifierFieldName,navigable:!!d[0]?.actionId,selectedId:this.state._selectedId??this.appState?._splitDetailId}):_()})():P.get()?.renderTableComponent(this,r,this.baseUrl,this.state,this.data,this.appState,this.appData)}
+            `:m():!ie&&u===`masterDetail`?h():!ie&&u===`tree`?(()=>{let e=N.get();return e?.renderTreeComponent?e.renderTreeComponent(this,{rows:p,columns:d.map(e=>({id:e.id,label:e.label})),idField:this.identifierFieldName,navigable:!!d[0]?.actionId,selectedId:this.state._selectedId??this.appState?._splitDetailId}):g()})():N.get()?.renderTableComponent(this,r,this.baseUrl,this.state,this.data,this.appState,this.appData)}
             <slot></slot>
-        `,b=i.infiniteScrolling?v:P.get()?.renderPagination(this,this.component),x=this.showImportDialog?T`
-            <div role="button" tabindex="0" class="crud-modal-backdrop" @click="${e=>{e.target===e.currentTarget&&(this.showImportDialog=!1)}}" @keydown="${R(e=>{e.target===e.currentTarget&&(this.showImportDialog=!1)})}">
+        `,y=i.infiniteScrolling?_:N.get()?.renderPagination(this,this.component),b=this.showImportDialog?w`
+            <div role="button" tabindex="0" class="crud-modal-backdrop" @click="${e=>{e.target===e.currentTarget&&(this.showImportDialog=!1)}}" @keydown="${L(e=>{e.target===e.currentTarget&&(this.showImportDialog=!1)})}">
                 <div class="crud-modal">
                     <h3 style="margin: 0 0 .75rem;">Import</h3>
                     <input type="file" @change="${e=>{let t=e.target.files?.[0];if(t){let e=new FormData;e.append(`file`,t),fetch(`/upload`,{method:`POST`,body:e}).then(e=>e.json()).then(e=>this.handleImportUploadSuccess({detail:e})).catch(()=>this.notify(`Import failed`))}}}">
@@ -4766,8 +4766,8 @@ ${i}
                     </div>
                 </div>
             </div>
-        `:v;return this.standalone?T`
-                ${x}
+        `:_;return this.standalone?w`
+                ${b}
                 <div style="border: var(--mateu-section-border, none); background: var(--mateu-section-bg, transparent); overflow: hidden; max-height: calc(100dvh - 12rem); width: 100%; box-sizing: border-box; padding: var(--mateu-section-padding, 0); display: flex; flex-direction: column;">
                     <div style="flex-shrink: 0;">
                         <mateu-content-header
@@ -4780,40 +4780,40 @@ ${i}
                         ></mateu-content-header>
                     </div>
                     <div style="flex-shrink: 0; display: flex; align-items: center; gap: var(--lumo-space-s, 0.5rem);">
-                        <div style="flex: 1; min-width: 0;">${P.get()?.renderFilterBar(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData,!0)}</div>
+                        <div style="flex: 1; min-width: 0;">${N.get()?.renderFilterBar(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData,!0)}</div>
                         ${this.renderColumnChooser()}
                     </div>
-                    <div style="flex: 1; overflow-y: auto; min-height: 0;">${y}</div>
-                    <div style="flex-shrink: 0;">${b}</div>
+                    <div style="flex: 1; overflow-y: auto; min-height: 0;">${v}</div>
+                    <div style="flex-shrink: 0;">${y}</div>
                 </div>
-            `:T`
-            ${x}
-            ${l?T`
+            `:w`
+            ${b}
+            ${l?w`
                     <div style="display: flex; gap: var(--lumo-space-m, 1rem); width: 100%; align-items: flex-end; padding-bottom: var(--lumo-space-m, 1rem);">
                         <div style="flex: 1; min-width: 0;">
-                            ${i?.title?T`
+                            ${i?.title?w`
                                 <h2 style="margin: 0; font-size: var(--lumo-font-size-xxl); font-weight: 700; color: var(--lumo-header-text-color); overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">${this.evalLabel(i.title)}</h2>
-                            `:v}
-                            ${i?.subtitle?T`
+                            `:_}
+                            ${i?.subtitle?w`
                                 <span style="display: block; color: var(--lumo-secondary-text-color); font-size: var(--lumo-font-size-s); margin-top: var(--lumo-space-xs);">${this.evalLabel(i.subtitle)}</span>
-                            `:v}
+                            `:_}
                         </div>
                         ${o.map(e=>n(e))}
-                        ${c?T`<span class="toolbar-divider"></span>`:v}
+                        ${c?w`<span class="toolbar-divider"></span>`:_}
                         ${s.map(e=>n(e))}
                         <slot></slot>
                     </div>
-                `:v}
+                `:_}
             <div style="border: var(--mateu-section-border, none); background: var(--mateu-section-bg, transparent); overflow: hidden; max-height: calc(100dvh - 12rem); padding: var(--mateu-section-padding, 0); display: flex; flex-direction: column;">
                 <div style="flex-shrink: 0; display: flex; align-items: center; gap: var(--lumo-space-s, 0.5rem);">
-                    <div style="flex: 1; min-width: 0;">${P.get()?.renderFilterBar(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData)}</div>
+                    <div style="flex: 1; min-width: 0;">${N.get()?.renderFilterBar(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData)}</div>
                     ${this.renderColumnChooser()}
                 </div>
-                <div style="flex: 1; overflow-y: auto; min-height: 0;">${y}</div>
-                <div style="flex-shrink: 0;">${b}</div>
+                <div style="flex: 1; overflow-y: auto; min-height: 0;">${v}</div>
+                <div style="flex-shrink: 0;">${y}</div>
             </div>
-        `}createRenderRoot(){return P.mustUseShadowRoot()?super.createRenderRoot():this}static{this.styles=h`
-        ${de}
+        `}createRenderRoot(){return N.mustUseShadowRoot()?super.createRenderRoot():this}static{this.styles=m`
+        ${fe}
         /* DS-neutral crud widgets (replace vaadin-button/card/grid/list-box/form-layout/dialog). */
         .crud-btn {
             font: inherit; font-weight: 500;
@@ -4866,16 +4866,16 @@ ${i}
             outline-offset: -2px;
         }
     
-        ${z}
-    `}};k([y()],G.prototype,`component`,void 0),k([y()],G.prototype,`baseUrl`,void 0),k([y({type:Boolean})],G.prototype,`standalone`,void 0),k([y()],G.prototype,`state`,void 0),k([y()],G.prototype,`data`,void 0),k([y()],G.prototype,`appState`,void 0),k([y()],G.prototype,`appData`,void 0),k([C()],G.prototype,`showImportDialog`,void 0),k([C()],G.prototype,`availableWidthPx`,void 0),k([C()],G.prototype,`selectedItem`,void 0),k([C()],G.prototype,`_columnPrefsRevision`,void 0),G=k([g(`mateu-table-crud`)],G);var ma=function(e){return e.OnLoad=`OnLoad`,e.OnSuccess=`OnSuccess`,e.OnError=`OnError`,e.OnValueChange=`OnValueChange`,e.OnCustomEvent=`OnCustomEvent`,e.AutoSave=`AutoSave`,e}({}),ha=class extends $e{constructor(...e){super(...e),this.state={},this.data={},this.appData={},this.appState={},this.triggerOnLoad=()=>{let e=this.component;this.registerCustomEventListeners(),e.triggers?.filter(e=>e.type==ma.OnLoad).forEach(e=>{if((!e.condition||this._evalExpr(e.condition))&&!e.triggered){let n=e;n.triggered=!0;var t=n.times-1;n.timeoutMillis>0?this.scheduleOnload(n,t,this.id):this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.actionId},bubbles:!0,composed:!0}))}})},this.scheduleOnload=(e,t,n)=>{if(n!=this.component?.id)return;let r=this.callbackToken;setTimeout(()=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,callbackToken:r},bubbles:!0,composed:!0}))},e.timeoutMillis)},this._registeredCustomEventListeners=[],this.customEventManager=e=>{if(!(e instanceof CustomEvent))return;let t=e,n=(this.component.triggers??[]).filter(e=>e.type==ma.OnCustomEvent).filter(e=>e.eventName==t.type).filter(e=>e.source!==`COMPONENT`||t.detail?.__source===e.from);n.length!==0&&(n.some(e=>!e.source||e.source===`SELF`)&&(e.stopPropagation(),e.preventDefault()),n.forEach(e=>{(!e.condition||this._evalExpr(e.condition))&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:t.detail},bubbles:!0,composed:!0}))}))}}_interpolationExtra(){return{appState:this.appState??{},appData:this.appData??{},component:this.component}}_evalExpr(e){return at(e,this.state??{},this.data??{},this._interpolationExtra())}_evalTemplate(e){return ot(e,this.state??{},this.data??{},this._interpolationExtra())}isOverlayChild(e){let t=e?.metadata?.type;return t==j.Drawer||t==j.Dialog}removeSelfFromOwnerChildren(){let e=this.component;if(!e)return!1;let t=t=>{if(t===e)return!0;let n=t;return e.id!=null&&n?.id==e.id&&this.isOverlayChild(n)},n=this.parentNode;for(;n;){let e=n instanceof ShadowRoot?n.host:n,r=e.component?.children;if(Array.isArray(r)){let n=r.findIndex(t);if(n>=0)return r.splice(n,1),e.requestUpdate?.(),!0}n=n instanceof ShadowRoot?e:n.parentNode}return!1}applyFragment(e){if(this.id==e.targetComponentId){if(e.component)if(Ge.Add==e.action){if(this.component){let t=this.component.children??(this.component.children=[]),n=e.component.id?t.findIndex(t=>t.id==e.component.id&&this.isOverlayChild(t)):-1;n>=0?(t[n]=e.component,this.component={...this.component}):t.push(e.component)}}else{if(this.callbackToken=E(),e.component?.type==A.ServerSide)if(this.component){let t=this.component,n=e.component,r=t.serverSideType==n.serverSideType?(t.children??[]).filter(e=>this.isOverlayChild(e)):[];t.actions=n.actions,t.type=n.type,t.rules=n.rules,t.triggers=n.triggers,t.serverSideType=n.serverSideType,t.route=n.route,t.initialData=n.initialData,t.validations=n.validations,t.cssClasses=n.cssClasses,t.slot=n.slot,t.style=n.style,t.children=r.length?[...n.children??[],...r]:n.children,(t.serverSideType!=n.serverSideType||t.id!=n.id)&&setTimeout(()=>this.triggerOnLoad())}else this.component=e.component,setTimeout(()=>this.triggerOnLoad());else{let t=[e.component];this.component&&(this.component.children=t)}e.action!==Ge.ReplaceKeepData&&(this.state={},this.data={})}if(e.state&&(this.state={...this.state,...e.state}),e.data){for(let t in e.data){let n=e.data[t]?.page;n?.pageNumber>0&&this.data[t]&&this.data[t].page.content&&(n.content?n.content=[...this.data[t].page.content,...n.content]:n.content=[...this.data[t].page.content])}this.data={...this.data,...e.data}}this.registerCustomEventListeners();let t=P.getAfterRenderHook();t&&setTimeout(()=>t(this)),this.requestUpdate()}}registerCustomEventListeners(){this._registeredCustomEventListeners.forEach(({target:e,name:t})=>e.removeEventListener(t,this.customEventManager)),this._registeredCustomEventListeners=[],this.component?.triggers?.filter(e=>e.type==ma.OnCustomEvent).forEach(e=>{let t=e.source===`DOCUMENT`||e.source===`COMPONENT`?document:this;t.addEventListener(e.eventName,this.customEventManager),this._registeredCustomEventListeners.push({target:t,name:e.eventName})})}disconnectedCallback(){this._registeredCustomEventListeners.forEach(({target:e,name:t})=>e.removeEventListener(t,this.customEventManager)),this._registeredCustomEventListeners=[],super.disconnectedCallback()}connectedCallback(){super.connectedCallback(),this.component&&this.registerCustomEventListeners()}};k([y()],ha.prototype,`state`,void 0),k([y()],ha.prototype,`data`,void 0),k([y()],ha.prototype,`appData`,void 0),k([y()],ha.prototype,`appState`,void 0);var ga=`mateu-recent-routes`,_a=8;function va(){try{return JSON.parse(localStorage.getItem(ga)??`{}`)}catch{return{}}}function ya(e){try{localStorage.setItem(ga,JSON.stringify(e))}catch{}}function ba(e){return va()[e||`_`]??[]}function xa(e,t){if(!t?.route||!t.label)return;let n=e||`_`,r=va(),i=(r[n]??[]).filter(e=>e.route!==t.route);i.unshift({route:t.route,label:t.label}),r[n]=i.slice(0,_a),ya(r)}var K=class extends b{constructor(...e){super(...e),this.baseUrl=``,this.open=!1,this.queryText=``,this.dataHits=[],this.loading=!1,this.selectedIndex=0,this.fabOffset=0,this.keydownHandler=null}connectedCallback(){super.connectedCallback(),this.keydownHandler=e=>{(e.metaKey||e.ctrlKey)&&(e.key===`k`||e.key===`K`)?(e.preventDefault(),this.toggle()):e.key===`Escape`&&this.open&&this.close()},document.addEventListener(`keydown`,this.keydownHandler),this.setupFabObserver()}disconnectedCallback(){super.disconnectedCallback(),this.keydownHandler&&document.removeEventListener(`keydown`,this.keydownHandler),clearTimeout(this.searchTimer),this.fabObserver?.disconnect(),this.fabObserver=void 0}setupFabObserver(){let e=this.getRootNode(),t=e instanceof ShadowRoot?e:document.body;this.measureFabStack(),this.fabObserver?.disconnect(),this.fabObserver=new MutationObserver(()=>this.measureFabStack()),this.fabObserver.observe(t,{childList:!0,subtree:!0})}measureFabStack(){let e=(this.getRootNode().querySelectorAll?.(`.ai-fab, .app-fab, .page-fab`).length??0)*4;e!==this.fabOffset&&(this.fabOffset=e)}updated(e){e.has(`open`)&&this.open&&requestAnimationFrame(()=>this.inputEl?.focus())}toggle(){this.open?this.close():this.openCenter()}openCenter(){this.open=!0,this.queryText=``,this.dataHits=[],this.selectedIndex=0}close(){this.open=!1,this.queryText=``,this.dataHits=[],clearTimeout(this.searchTimer)}flattenMenu(e,t){let n=[];for(let r of e??[])if(!r.separator)if(r.submenus&&r.submenus.length>0){let e=t?`${t} › ${r.label}`:r.label;n.push(...this.flattenMenu(r.submenus,e))}else r.route!==void 0&&r.route!==null&&n.push({label:r.label,breadcrumb:t,route:r.route});return n}onInput(e){this.queryText=e,this.selectedIndex=0;let t=e.trim();if(clearTimeout(this.searchTimer),!t||!this.app?.globalSearchEnabled){this.dataHits=[],this.loading=!1;return}this.loading=!0,this.searchTimer=setTimeout(()=>this.fetchGlobalSearch(t),250)}async fetchGlobalSearch(e){let t=this.app;if(!t?.globalSearchEnabled){this.loading=!1;return}try{let n=(await We.runAction(this.baseUrl??``,t.rootRoute??``,``,`_globalsearch`,`command-center`,void 0,t.serverSideType,{},{searchText:e},this,!0))?.fragments?.map(e=>e.data).find(e=>e&&e._globalsearch);this.dataHits=n?._globalsearch??[]}catch{this.dataHits=[]}finally{this.loading=!1}}navigateTo(e,t){xa(this.app?.serverSideType??``,{route:e,label:t}),this.close();for(let t of[`route-changed`,`navigate-to-requested`])this.dispatchEvent(new CustomEvent(t,{detail:{route:e},bubbles:!0,composed:!0}))}askAi(){let e=this.queryText.trim();this.close(),this.dispatchEvent(new CustomEvent(`mateu-open-ai`,{detail:{query:e},bubbles:!0,composed:!0}))}visibleTargets(e){if(!this.queryText.trim()){let e=this.flattenMenu(this.app?.menu,``).map(e=>({route:e.route,label:e.label})),t=ba(this.app?.serverSideType??``);return[...e,...t]}return[...e.map(e=>({route:e.route,label:e.label})),...this.dataHits.map(e=>({route:e.route,label:e.label}))]}onKeydown(e,t){if(e.key===`ArrowDown`)e.preventDefault(),this.selectedIndex=Math.min(this.selectedIndex+1,t.length-1);else if(e.key===`ArrowUp`)e.preventDefault(),this.selectedIndex=Math.max(this.selectedIndex-1,0);else if(e.key===`Enter`){let e=t[this.selectedIndex];e&&this.navigateTo(e.route,e.label)}}render(){return T`
+        ${R}
+    `}};O([v()],W.prototype,`component`,void 0),O([v()],W.prototype,`baseUrl`,void 0),O([v({type:Boolean})],W.prototype,`standalone`,void 0),O([v()],W.prototype,`state`,void 0),O([v()],W.prototype,`data`,void 0),O([v()],W.prototype,`appState`,void 0),O([v()],W.prototype,`appData`,void 0),O([S()],W.prototype,`showImportDialog`,void 0),O([S()],W.prototype,`availableWidthPx`,void 0),O([S()],W.prototype,`selectedItem`,void 0),O([S()],W.prototype,`_columnPrefsRevision`,void 0),W=O([h(`mateu-table-crud`)],W);var ha=function(e){return e.OnLoad=`OnLoad`,e.OnSuccess=`OnSuccess`,e.OnError=`OnError`,e.OnValueChange=`OnValueChange`,e.OnCustomEvent=`OnCustomEvent`,e.AutoSave=`AutoSave`,e}({}),ga=class extends et{constructor(...e){super(...e),this.state={},this.data={},this.appData={},this.appState={},this.triggerOnLoad=()=>{let e=this.component;this.registerCustomEventListeners(),e.triggers?.filter(e=>e.type==ha.OnLoad).forEach(e=>{if((!e.condition||this._evalExpr(e.condition))&&!e.triggered){let n=e;n.triggered=!0;var t=n.times-1;n.timeoutMillis>0?this.scheduleOnload(n,t,this.id):this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.actionId},bubbles:!0,composed:!0}))}})},this.scheduleOnload=(e,t,n)=>{if(n!=this.component?.id)return;let r=this.callbackToken;setTimeout(()=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,callbackToken:r},bubbles:!0,composed:!0}))},e.timeoutMillis)},this._registeredCustomEventListeners=[],this.customEventManager=e=>{if(!(e instanceof CustomEvent))return;let t=e,n=(this.component.triggers??[]).filter(e=>e.type==ha.OnCustomEvent).filter(e=>e.eventName==t.type).filter(e=>e.source!==`COMPONENT`||t.detail?.__source===e.from);n.length!==0&&(n.some(e=>!e.source||e.source===`SELF`)&&(e.stopPropagation(),e.preventDefault()),n.forEach(e=>{(!e.condition||this._evalExpr(e.condition))&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:t.detail},bubbles:!0,composed:!0}))}))}}_interpolationExtra(){return{appState:this.appState??{},appData:this.appData??{},component:this.component}}_evalExpr(e){return ot(e,this.state??{},this.data??{},this._interpolationExtra())}_evalTemplate(e){return st(e,this.state??{},this.data??{},this._interpolationExtra())}isOverlayChild(e){let t=e?.metadata?.type;return t==A.Drawer||t==A.Dialog}removeSelfFromOwnerChildren(){let e=this.component;if(!e)return!1;let t=t=>{if(t===e)return!0;let n=t;return e.id!=null&&n?.id==e.id&&this.isOverlayChild(n)},n=this.parentNode;for(;n;){let e=n instanceof ShadowRoot?n.host:n,r=e.component?.children;if(Array.isArray(r)){let n=r.findIndex(t);if(n>=0)return r.splice(n,1),e.requestUpdate?.(),!0}n=n instanceof ShadowRoot?e:n.parentNode}return!1}applyFragment(e){if(this.id==e.targetComponentId){if(e.component)if(Ke.Add==e.action){if(this.component){let t=this.component.children??(this.component.children=[]),n=e.component.id?t.findIndex(t=>t.id==e.component.id&&this.isOverlayChild(t)):-1;n>=0?(t[n]=e.component,this.component={...this.component}):t.push(e.component)}}else{this.callbackToken=T();let t=!1;if(e.component?.type==k.ServerSide)if(this.component){let n=this.component,r=e.component;t=n.serverSideType==r.serverSideType;let i=t?(n.children??[]).filter(e=>this.isOverlayChild(e)):[];n.actions=r.actions,n.type=r.type,n.rules=r.rules,n.triggers=r.triggers,n.serverSideType=r.serverSideType,n.route=r.route,n.initialData=r.initialData,n.validations=r.validations,n.cssClasses=r.cssClasses,n.slot=r.slot,n.style=r.style,n.children=i.length?[...r.children??[],...i]:r.children,(n.serverSideType!=r.serverSideType||n.id!=r.id)&&setTimeout(()=>this.triggerOnLoad())}else this.component=e.component,setTimeout(()=>this.triggerOnLoad());else{let t=[e.component];this.component&&(this.component.children=t)}e.action!==Ke.ReplaceKeepData&&!t&&(this.state={},this.data={})}if(e.state&&(this.state={...this.state,...e.state}),e.data){for(let t in e.data){let n=e.data[t]?.page;n?.pageNumber>0&&this.data[t]&&this.data[t].page.content&&(n.content?n.content=[...this.data[t].page.content,...n.content]:n.content=[...this.data[t].page.content])}this.data={...this.data,...e.data}}this.registerCustomEventListeners();let t=N.getAfterRenderHook();t&&setTimeout(()=>t(this)),this.requestUpdate()}}registerCustomEventListeners(){this._registeredCustomEventListeners.forEach(({target:e,name:t})=>e.removeEventListener(t,this.customEventManager)),this._registeredCustomEventListeners=[],this.component?.triggers?.filter(e=>e.type==ha.OnCustomEvent).forEach(e=>{let t=e.source===`DOCUMENT`||e.source===`COMPONENT`?document:this;t.addEventListener(e.eventName,this.customEventManager),this._registeredCustomEventListeners.push({target:t,name:e.eventName})})}disconnectedCallback(){this._registeredCustomEventListeners.forEach(({target:e,name:t})=>e.removeEventListener(t,this.customEventManager)),this._registeredCustomEventListeners=[],super.disconnectedCallback()}connectedCallback(){super.connectedCallback(),this.component&&this.registerCustomEventListeners()}};O([v()],ga.prototype,`state`,void 0),O([v()],ga.prototype,`data`,void 0),O([v()],ga.prototype,`appData`,void 0),O([v()],ga.prototype,`appState`,void 0);var _a=`mateu-recent-routes`,va=8;function ya(){try{return JSON.parse(localStorage.getItem(_a)??`{}`)}catch{return{}}}function ba(e){try{localStorage.setItem(_a,JSON.stringify(e))}catch{}}function xa(e){return ya()[e||`_`]??[]}function Sa(e,t){if(!t?.route||!t.label)return;let n=e||`_`,r=ya(),i=(r[n]??[]).filter(e=>e.route!==t.route);i.unshift({route:t.route,label:t.label}),r[n]=i.slice(0,va),ba(r)}var G=class extends y{constructor(...e){super(...e),this.baseUrl=``,this.open=!1,this.queryText=``,this.dataHits=[],this.loading=!1,this.selectedIndex=0,this.fabOffset=0,this.keydownHandler=null}connectedCallback(){super.connectedCallback(),this.keydownHandler=e=>{(e.metaKey||e.ctrlKey)&&(e.key===`k`||e.key===`K`)?(e.preventDefault(),this.toggle()):e.key===`Escape`&&this.open&&this.close()},document.addEventListener(`keydown`,this.keydownHandler),this.setupFabObserver()}disconnectedCallback(){super.disconnectedCallback(),this.keydownHandler&&document.removeEventListener(`keydown`,this.keydownHandler),clearTimeout(this.searchTimer),this.fabObserver?.disconnect(),this.fabObserver=void 0}setupFabObserver(){let e=this.getRootNode(),t=e instanceof ShadowRoot?e:document.body;this.measureFabStack(),this.fabObserver?.disconnect(),this.fabObserver=new MutationObserver(()=>this.measureFabStack()),this.fabObserver.observe(t,{childList:!0,subtree:!0})}measureFabStack(){let e=(this.getRootNode().querySelectorAll?.(`.ai-fab, .app-fab, .page-fab`).length??0)*4;e!==this.fabOffset&&(this.fabOffset=e)}updated(e){e.has(`open`)&&this.open&&requestAnimationFrame(()=>this.inputEl?.focus())}toggle(){this.open?this.close():this.openCenter()}openCenter(){this.open=!0,this.queryText=``,this.dataHits=[],this.selectedIndex=0}close(){this.open=!1,this.queryText=``,this.dataHits=[],clearTimeout(this.searchTimer)}flattenMenu(e,t){let n=[];for(let r of e??[])if(!r.separator)if(r.submenus&&r.submenus.length>0){let e=t?`${t} › ${r.label}`:r.label;n.push(...this.flattenMenu(r.submenus,e))}else r.route!==void 0&&r.route!==null&&n.push({label:r.label,breadcrumb:t,route:r.route});return n}onInput(e){this.queryText=e,this.selectedIndex=0;let t=e.trim();if(clearTimeout(this.searchTimer),!t||!this.app?.globalSearchEnabled){this.dataHits=[],this.loading=!1;return}this.loading=!0,this.searchTimer=setTimeout(()=>this.fetchGlobalSearch(t),250)}async fetchGlobalSearch(e){let t=this.app;if(!t?.globalSearchEnabled){this.loading=!1;return}try{let n=(await Ge.runAction(this.baseUrl??``,t.rootRoute??``,``,`_globalsearch`,`command-center`,void 0,t.serverSideType,{},{searchText:e},this,!0))?.fragments?.map(e=>e.data).find(e=>e&&e._globalsearch);this.dataHits=n?._globalsearch??[]}catch{this.dataHits=[]}finally{this.loading=!1}}navigateTo(e,t){Sa(this.app?.serverSideType??``,{route:e,label:t}),this.close();for(let t of[`route-changed`,`navigate-to-requested`])this.dispatchEvent(new CustomEvent(t,{detail:{route:e},bubbles:!0,composed:!0}))}askAi(){let e=this.queryText.trim();this.close(),this.dispatchEvent(new CustomEvent(`mateu-open-ai`,{detail:{query:e},bubbles:!0,composed:!0}))}visibleTargets(e){if(!this.queryText.trim()){let e=this.flattenMenu(this.app?.menu,``).map(e=>({route:e.route,label:e.label})),t=xa(this.app?.serverSideType??``);return[...e,...t]}return[...e.map(e=>({route:e.route,label:e.label})),...this.dataHits.map(e=>({route:e.route,label:e.label}))]}onKeydown(e,t){if(e.key===`ArrowDown`)e.preventDefault(),this.selectedIndex=Math.min(this.selectedIndex+1,t.length-1);else if(e.key===`ArrowUp`)e.preventDefault(),this.selectedIndex=Math.max(this.selectedIndex-1,0);else if(e.key===`Enter`){let e=t[this.selectedIndex];e&&this.navigateTo(e.route,e.label)}}render(){return w`
             <button class="cc-fab" style="bottom: ${1.5+this.fabOffset}rem;"
                 @click=${()=>this.openCenter()} title="Buscar y navegar (⌘K)" aria-label="Command center">
                 ${this.fabIcon()}
             </button>
-            ${this.open?this.renderOverlay():v}
-        `}fabIcon(){return T`<svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            ${this.open?this.renderOverlay():_}
+        `}fabIcon(){return w`<svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="11" cy="11" r="7"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line>
-        </svg>`}renderOverlay(){let e=this.queryText.trim().toLowerCase(),t=e?this.flattenMenu(this.app?.menu,``).filter(t=>t.label.toLowerCase().includes(e)||t.breadcrumb.toLowerCase().includes(e)):[],n=this.visibleTargets(t);return T`
+        </svg>`}renderOverlay(){let e=this.queryText.trim().toLowerCase(),t=e?this.flattenMenu(this.app?.menu,``).filter(t=>t.label.toLowerCase().includes(e)||t.breadcrumb.toLowerCase().includes(e)):[],n=this.visibleTargets(t);return w`
             <div class="cc-backdrop" @click=${()=>this.close()}>
                 <div class="cc-panel" @click=${e=>e.stopPropagation()}>
                     <div class="cc-bar">
@@ -4885,7 +4885,7 @@ ${i}
                         <input class="cc-input" .value=${this.queryText} placeholder="Buscar pantallas, datos y acciones…"
                             @input=${e=>this.onInput(e.target.value)}
                             @keydown=${e=>this.onKeydown(e,n)}>
-                        ${this.queryText?T`<button class="cc-icon-btn" @click=${()=>this.onInput(``)} title="Limpiar">${this.clearIcon()}</button>`:v}
+                        ${this.queryText?w`<button class="cc-icon-btn" @click=${()=>this.onInput(``)} title="Limpiar">${this.clearIcon()}</button>`:_}
                     </div>
                     <div class="cc-body">
                         ${e?this.renderResults(t):this.renderDefault()}
@@ -4893,57 +4893,57 @@ ${i}
                 </div>
                 <button class="cc-close" @click=${()=>this.close()} title="Cerrar">${this.clearIcon()}</button>
             </div>
-        `}renderDefault(){let e=this.flattenMenu(this.app?.menu,``),t=ba(this.app?.serverSideType??``),n=-1;return T`
+        `}renderDefault(){let e=this.flattenMenu(this.app?.menu,``),t=xa(this.app?.serverSideType??``),n=-1;return w`
             <div class="cc-columns">
                 <div class="cc-col">
                     <div class="cc-section-title">Ir a</div>
                     <div class="cc-tiles">
-                        ${e.map(e=>{n++;let t=n;return T`
+                        ${e.map(e=>{n++;let t=n;return w`
                             <button class="cc-tile ${t===this.selectedIndex?`cc-sel`:``}"
                                 @click=${()=>this.navigateTo(e.route,e.label)}
                                 @mouseenter=${()=>{this.selectedIndex=t}}>
                                 <span class="cc-tile-label">${e.label}</span>
-                                ${e.breadcrumb?T`<span class="cc-sub">${e.breadcrumb}</span>`:v}
+                                ${e.breadcrumb?w`<span class="cc-sub">${e.breadcrumb}</span>`:_}
                             </button>`})}
-                        ${e.length===0?T`<div class="cc-empty">Sin opciones de menú.</div>`:v}
+                        ${e.length===0?w`<div class="cc-empty">Sin opciones de menú.</div>`:_}
                     </div>
                 </div>
-                ${t.length>0?T`
+                ${t.length>0?w`
                     <div class="cc-col cc-col--recent">
                         <div class="cc-section-title">Recientes</div>
-                        ${t.map(e=>{n++;let t=n;return T`
+                        ${t.map(e=>{n++;let t=n;return w`
                             <button class="cc-row ${t===this.selectedIndex?`cc-sel`:``}"
                                 @click=${()=>this.navigateTo(e.route,e.label)}
                                 @mouseenter=${()=>{this.selectedIndex=t}}>
                                 <span class="cc-tile-label">${e.label}</span>
                             </button>`})}
-                    </div>`:v}
+                    </div>`:_}
             </div>
-        `}renderResults(e){if(this.loading&&this.dataHits.length===0&&e.length===0)return T`<div class="cc-list">${[0,1,2,3].map(()=>T`<div class="cc-skeleton"></div>`)}</div>`;let t=e.length===0&&this.dataHits.length===0;return T`
+        `}renderResults(e){if(this.loading&&this.dataHits.length===0&&e.length===0)return w`<div class="cc-list">${[0,1,2,3].map(()=>w`<div class="cc-skeleton"></div>`)}</div>`;let t=e.length===0&&this.dataHits.length===0;return w`
             <div class="cc-list">
-                ${this.app?.sseUrl?T`
+                ${this.app?.sseUrl?w`
                     <button class="cc-row cc-ask-ai" @click=${()=>this.askAi()}>
                         ${this.aiIcon()}<span class="cc-tile-label">Preguntar a la IA: “${this.queryText.trim()}”</span>
-                    </button>`:v}
-                ${e.length>0?T`<div class="cc-section-title">Pantallas</div>`:v}
-                ${e.map((e,t)=>T`
+                    </button>`:_}
+                ${e.length>0?w`<div class="cc-section-title">Pantallas</div>`:_}
+                ${e.map((e,t)=>w`
                     <button class="cc-row ${t===this.selectedIndex?`cc-sel`:``}"
                         @click=${()=>this.navigateTo(e.route,e.label)}
                         @mouseenter=${()=>{this.selectedIndex=t}}>
                         <span class="cc-tile-label">${e.label}</span>
-                        ${e.breadcrumb?T`<span class="cc-sub">${e.breadcrumb}</span>`:v}
+                        ${e.breadcrumb?w`<span class="cc-sub">${e.breadcrumb}</span>`:_}
                     </button>`)}
                 ${this.renderDataHits(e.length)}
-                ${t?T`<div class="cc-empty">No encontramos coincidencias para “${this.queryText.trim()}”.</div>`:v}
+                ${t?w`<div class="cc-empty">No encontramos coincidencias para “${this.queryText.trim()}”.</div>`:_}
             </div>
-        `}renderDataHits(e){if(this.dataHits.length===0)return v;let t;return T`${this.dataHits.map((n,r)=>{let i=e+r,a=n.category&&n.category!==t;return t=n.category,T`
-                ${a?T`<div class="cc-section-title">${n.category}</div>`:v}
+        `}renderDataHits(e){if(this.dataHits.length===0)return _;let t;return w`${this.dataHits.map((n,r)=>{let i=e+r,a=n.category&&n.category!==t;return t=n.category,w`
+                ${a?w`<div class="cc-section-title">${n.category}</div>`:_}
                 <button class="cc-row ${i===this.selectedIndex?`cc-sel`:``}"
                     @click=${()=>this.navigateTo(n.route,n.label)}
                     @mouseenter=${()=>{this.selectedIndex=i}}>
                     <span class="cc-tile-label">${n.label}</span>
-                    ${n.description?T`<span class="cc-sub">${n.description}</span>`:v}
-                </button>`})}`}searchGlyph(){return T`<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="11" cy="11" r="7"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>`}backIcon(){return T`<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>`}clearIcon(){return T`<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>`}aiIcon(){return T`<svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><path d="M12 2l1.9 4.7L19 8.5l-4.1 2.3L12 15l-1.9-4.2L6 8.5l5.1-1.8z"></path></svg>`}static{this.styles=h`
+                    ${n.description?w`<span class="cc-sub">${n.description}</span>`:_}
+                </button>`})}`}searchGlyph(){return w`<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="11" cy="11" r="7"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>`}backIcon(){return w`<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>`}clearIcon(){return w`<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>`}aiIcon(){return w`<svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><path d="M12 2l1.9 4.7L19 8.5l-4.1 2.3L12 15l-1.9-4.2L6 8.5l5.1-1.8z"></path></svg>`}static{this.styles=m`
         :host { --cc-accent: var(--lumo-primary-color, #3b82f6); }
 
         .cc-fab {
@@ -5028,12 +5028,12 @@ ${i}
             display: flex; align-items: center; justify-content: center; cursor: pointer; z-index: 1110;
         }
         .cc-close:hover { background: rgba(0,0,0,0.75); }
-    `}};k([y({attribute:!1})],K.prototype,`app`,void 0),k([y()],K.prototype,`baseUrl`,void 0),k([C()],K.prototype,`open`,void 0),k([C()],K.prototype,`queryText`,void 0),k([C()],K.prototype,`dataHits`,void 0),k([C()],K.prototype,`loading`,void 0),k([C()],K.prototype,`selectedIndex`,void 0),k([C()],K.prototype,`fabOffset`,void 0),k([x(`.cc-input`)],K.prototype,`inputEl`,void 0),K=k([g(`mateu-command-center`)],K);var Sa=null;function Ca(e){let t=e.component?.metadata;t&&(t.commandCenterEnabled||t.chromeless)&&t.variant!==`MEDIATOR`?((!Sa||!Sa.isConnected)&&(Sa=document.createElement(`mateu-command-center`),e.renderRoot.appendChild(Sa)),Sa.app=t,Sa.baseUrl=e.baseUrl??``):Sa&&e.renderRoot.contains(Sa)&&(Sa.remove(),Sa=null)}var wa=class extends b{constructor(...e){super(...e),this.fetchStarted=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!0},this.fetchFinished=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!1},this.fetchFailed=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!1;let t=e.detail??{},n=t.failure??Pe(t.reason,{online:Be.isOnline()});if(n.kind===`cancelled`)return;let r=t.retry;oa({text:n.message,variant:`error`,duration:r?8e3:5e3,position:`bottomEnd`,...r?{actionLabel:`Retry`,onAction:r}:{}},this)}}connectedCallback(){super.connectedCallback(),this.addEventListener(`backend-called-event`,this.fetchStarted),this.addEventListener(`backend-succeeded-event`,this.fetchFinished),this.addEventListener(`backend-cancelled-event`,this.fetchFinished),this.addEventListener(`backend-failed-event`,this.fetchFailed)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`backend-called-event`,this.fetchStarted),this.removeEventListener(`backend-succeeded-event`,this.fetchFinished),this.removeEventListener(`backend-cancelled-event`,this.fetchFinished),this.removeEventListener(`backend-failed-event`,this.fetchFailed)}render(){return T`<div class="loader-container">
+    `}};O([v({attribute:!1})],G.prototype,`app`,void 0),O([v()],G.prototype,`baseUrl`,void 0),O([S()],G.prototype,`open`,void 0),O([S()],G.prototype,`queryText`,void 0),O([S()],G.prototype,`dataHits`,void 0),O([S()],G.prototype,`loading`,void 0),O([S()],G.prototype,`selectedIndex`,void 0),O([S()],G.prototype,`fabOffset`,void 0),O([b(`.cc-input`)],G.prototype,`inputEl`,void 0),G=O([h(`mateu-command-center`)],G);var Ca=null;function wa(e){let t=e.component?.metadata;t&&(t.commandCenterEnabled||t.chromeless)&&t.variant!==`MEDIATOR`?((!Ca||!Ca.isConnected)&&(Ca=document.createElement(`mateu-command-center`),e.renderRoot.appendChild(Ca)),Ca.app=t,Ca.baseUrl=e.baseUrl??``):Ca&&e.renderRoot.contains(Ca)&&(Ca.remove(),Ca=null)}var Ta=class extends y{constructor(...e){super(...e),this.fetchStarted=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!0},this.fetchFinished=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!1},this.fetchFailed=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!1;let t=e.detail??{},n=t.failure??Fe(t.reason,{online:Ve.isOnline()});if(n.kind===`cancelled`)return;let r=t.retry;sa({text:n.message,variant:`error`,duration:r?8e3:5e3,position:`bottomEnd`,...r?{actionLabel:`Retry`,onAction:r}:{}},this)}}connectedCallback(){super.connectedCallback(),this.addEventListener(`backend-called-event`,this.fetchStarted),this.addEventListener(`backend-succeeded-event`,this.fetchFinished),this.addEventListener(`backend-cancelled-event`,this.fetchFinished),this.addEventListener(`backend-failed-event`,this.fetchFailed)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`backend-called-event`,this.fetchStarted),this.removeEventListener(`backend-succeeded-event`,this.fetchFinished),this.removeEventListener(`backend-cancelled-event`,this.fetchFinished),this.removeEventListener(`backend-failed-event`,this.fetchFailed)}render(){return w`<div class="loader-container">
             <div style="display: flex; flex-direction: column;">
                 <slot></slot>
                 <div class="loader-frame ${this.loading?`delayed-show`:``}" style="${this.loading?`pointer-events: all;`:`display: none;`}"><div class="loader"></div></div>
             </div>
-        </div>`}static{this.styles=h`
+        </div>`}static{this.styles=m`
         :host {
         }
 
@@ -5096,11 +5096,11 @@ ${i}
             animation: l5 1s infinite;
         }
         @keyframes l5 {to{transform: rotate(.5turn)}}
-  `}};k([C()],wa.prototype,`loading`,void 0),wa=k([g(`mateu-api-caller`)],wa);var Ta=new class{constructor(){this._dirty=!1,this._installed=!1,this.message=`You have unsaved changes. Are you sure you want to leave this page?`,this._onDirty=()=>{this._dirty=!0},this._onClean=()=>{this._dirty=!1},this._onBeforeUnload=e=>{this._dirty&&(e.preventDefault(),e.returnValue=``)}}install(){this._installed||(this._installed=!0,document.addEventListener(`dirty`,this._onDirty),document.addEventListener(`clean`,this._onClean),window.addEventListener(`beforeunload`,this._onBeforeUnload))}get dirty(){return this._dirty}markDirty(){this._dirty=!0}markClean(){this._dirty=!1}confirmLeave(){if(!this._dirty)return!0;let e=window.confirm(this.message);return e&&(this._dirty=!1),e}},Ea,q=class extends ha{static{Ea=this}constructor(...e){super(...e),this.filter=``,this.instant=void 0,this.selectedConsumedRoute=void 0,this.selectedRoute=void 0,this.selectedUriPrefix=void 0,this.selectedBaseUrl=void 0,this.selectedServerSideType=void 0,this.selectedParams=void 0,this.tilesMenuOption=null,this.railOpenOption=null,this.commandPaletteOpen=!1,this.commandPaletteQuery=``,this.commandPaletteSelectedIndex=0,this.commandPaletteDataHits=[],this.openDataHit=e=>{Ta.confirmLeave()&&(this.commandPaletteOpen=!1,this.commandPaletteQuery=``,this.commandPaletteDataHits=[],this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:e.route},bubbles:!0,composed:!0})),this.dispatchEvent(new CustomEvent(`navigate-to-requested`,{detail:{route:e.route},bubbles:!0,composed:!0})))},this._commandPaletteHandler=null,this.pageCompact=!1,this._compactHandler=e=>{this.pageCompact=e.detail?.compact??!1},this._openAiHandler=()=>{this.chatOpen||this.showHideIa()},this.isDark=document.documentElement.getAttribute(`theme`)===`dark`,this.chatOpen=!1,this.toggleTheme=()=>{this.isDark=!this.isDark;let e=this.isDark?`dark`:`light`;document.documentElement.setAttribute(`theme`,e),localStorage.setItem(`mateu-theme`,e)},this.showHideIa=()=>{this.chat&&(this.chatOpen=!this.chatOpen,this.chat.slot=this.chatOpen?`detail`:`detail-hidden`)},this.runAction=e=>{let t=this.renderRoot.querySelector?.(`mateu-component`);t&&t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.getSelectedOption=e=>{if(e)for(let t=0;t<e.length;t++){let n=e[t];if(this.selectedRoute?this.isActiveOption(n):n.selected)return n;let r=this.getSelectedOption(n.submenus);if(r)return r}return null},this.itemSelected=e=>{let t=e.detail.value;this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix)},this.itemSelectedTiles=e=>{let t=e.detail.value._menuOption;t.submenus&&t.submenus.length>0?this.tilesMenuOption=t:(this.tilesMenuOption=null,this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix))},this.mapItemsForTiles=e=>e.map(e=>({text:e.label,consumedRoute:e.consumedRoute,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:e.selected,_menuOption:e})),this.flattenMenuForPalette=(e,t)=>{let n=[];for(let r of e)if(!r.separator)if(r.submenus&&r.submenus.length>0){let e=t?`${t} › ${r.label}`:r.label;n.push(...this.flattenMenuForPalette(r.submenus,e))}else n.push({label:r.label,breadcrumb:t,consumedRoute:r.consumedRoute,route:r.route,actionId:r.actionId,baseUrl:r.baseUrl,serverSideType:r.serverSideType,uriPrefix:r.uriPrefix});return n},this.handleCommandPaletteKeydown=(e,t)=>{let n=Math.min(t.length,10),r=n+Math.min(this.commandPaletteDataHits.length,8);if(e.key===`ArrowDown`)e.preventDefault(),this.commandPaletteSelectedIndex=Math.min(this.commandPaletteSelectedIndex+1,r-1);else if(e.key===`ArrowUp`)e.preventDefault(),this.commandPaletteSelectedIndex=Math.max(this.commandPaletteSelectedIndex-1,0);else if(e.key===`Enter`){if(this.commandPaletteSelectedIndex>=n){let e=this.commandPaletteDataHits[this.commandPaletteSelectedIndex-n];e&&this.openDataHit(e);return}let e=t[this.commandPaletteSelectedIndex];e&&(this.selectRoute(e.consumedRoute,e.route,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix),this.commandPaletteOpen=!1,this.commandPaletteQuery=``)}},this.renderCommandPalette=()=>{if(!this.commandPaletteOpen)return v;let e=this.component?.metadata;if(e?.commandCenterEnabled||!e?.menu)return v;let t=this.flattenMenuForPalette(e.menu,``),n=this.commandPaletteQuery.toLowerCase(),r=n?t.filter(e=>e.label.toLowerCase().includes(n)||e.breadcrumb.toLowerCase().includes(n)):t;return T`
+  `}};O([S()],Ta.prototype,`loading`,void 0),Ta=O([h(`mateu-api-caller`)],Ta);var Ea=new class{constructor(){this._dirty=!1,this._installed=!1,this.message=`You have unsaved changes. Are you sure you want to leave this page?`,this._onDirty=()=>{this._dirty=!0},this._onClean=()=>{this._dirty=!1},this._onBeforeUnload=e=>{this._dirty&&(e.preventDefault(),e.returnValue=``)}}install(){this._installed||(this._installed=!0,document.addEventListener(`dirty`,this._onDirty),document.addEventListener(`clean`,this._onClean),window.addEventListener(`beforeunload`,this._onBeforeUnload))}get dirty(){return this._dirty}markDirty(){this._dirty=!0}markClean(){this._dirty=!1}confirmLeave(){if(!this._dirty)return!0;let e=window.confirm(this.message);return e&&(this._dirty=!1),e}},Da,K=class extends ga{static{Da=this}constructor(...e){super(...e),this.filter=``,this.instant=void 0,this.selectedConsumedRoute=void 0,this.selectedRoute=void 0,this.selectedUriPrefix=void 0,this.selectedBaseUrl=void 0,this.selectedServerSideType=void 0,this.selectedParams=void 0,this.tilesMenuOption=null,this.railOpenOption=null,this.commandPaletteOpen=!1,this.commandPaletteQuery=``,this.commandPaletteSelectedIndex=0,this.commandPaletteDataHits=[],this.openDataHit=e=>{Ea.confirmLeave()&&(this.commandPaletteOpen=!1,this.commandPaletteQuery=``,this.commandPaletteDataHits=[],this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:e.route},bubbles:!0,composed:!0})),this.dispatchEvent(new CustomEvent(`navigate-to-requested`,{detail:{route:e.route},bubbles:!0,composed:!0})))},this._commandPaletteHandler=null,this.pageCompact=!1,this._compactHandler=e=>{this.pageCompact=e.detail?.compact??!1},this._openAiHandler=()=>{this.chatOpen||this.showHideIa()},this.isDark=document.documentElement.getAttribute(`theme`)===`dark`,this.chatOpen=!1,this.toggleTheme=()=>{this.isDark=!this.isDark;let e=this.isDark?`dark`:`light`;document.documentElement.setAttribute(`theme`,e),localStorage.setItem(`mateu-theme`,e)},this.showHideIa=()=>{this.chat&&(this.chatOpen=!this.chatOpen,this.chat.slot=this.chatOpen?`detail`:`detail-hidden`)},this.runAction=e=>{let t=this.renderRoot.querySelector?.(`mateu-component`);t&&t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.getSelectedOption=e=>{if(e)for(let t=0;t<e.length;t++){let n=e[t];if(this.selectedRoute?this.isActiveOption(n):n.selected)return n;let r=this.getSelectedOption(n.submenus);if(r)return r}return null},this.itemSelected=e=>{let t=e.detail.value;this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix)},this.itemSelectedTiles=e=>{let t=e.detail.value._menuOption;t.submenus&&t.submenus.length>0?this.tilesMenuOption=t:(this.tilesMenuOption=null,this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix))},this.mapItemsForTiles=e=>e.map(e=>({text:e.label,consumedRoute:e.consumedRoute,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:e.selected,_menuOption:e})),this.flattenMenuForPalette=(e,t)=>{let n=[];for(let r of e)if(!r.separator)if(r.submenus&&r.submenus.length>0){let e=t?`${t} › ${r.label}`:r.label;n.push(...this.flattenMenuForPalette(r.submenus,e))}else n.push({label:r.label,breadcrumb:t,consumedRoute:r.consumedRoute,route:r.route,actionId:r.actionId,baseUrl:r.baseUrl,serverSideType:r.serverSideType,uriPrefix:r.uriPrefix});return n},this.handleCommandPaletteKeydown=(e,t)=>{let n=Math.min(t.length,10),r=n+Math.min(this.commandPaletteDataHits.length,8);if(e.key===`ArrowDown`)e.preventDefault(),this.commandPaletteSelectedIndex=Math.min(this.commandPaletteSelectedIndex+1,r-1);else if(e.key===`ArrowUp`)e.preventDefault(),this.commandPaletteSelectedIndex=Math.max(this.commandPaletteSelectedIndex-1,0);else if(e.key===`Enter`){if(this.commandPaletteSelectedIndex>=n){let e=this.commandPaletteDataHits[this.commandPaletteSelectedIndex-n];e&&this.openDataHit(e);return}let e=t[this.commandPaletteSelectedIndex];e&&(this.selectRoute(e.consumedRoute,e.route,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix),this.commandPaletteOpen=!1,this.commandPaletteQuery=``)}},this.renderCommandPalette=()=>{if(!this.commandPaletteOpen)return _;let e=this.component?.metadata;if(e?.commandCenterEnabled||!e?.menu)return _;let t=this.flattenMenuForPalette(e.menu,``),n=this.commandPaletteQuery.toLowerCase(),r=n?t.filter(e=>e.label.toLowerCase().includes(n)||e.breadcrumb.toLowerCase().includes(n)):t;return w`
             <div class="cmd-backdrop" @click=${()=>{this.commandPaletteOpen=!1,this.commandPaletteQuery=``}}>
                 <div class="cmd-palette" @click=${e=>e.stopPropagation()}>
                     <div class="cmd-search-wrapper">
-                        ${I(`vaadin:search`,void 0,`cmd-search-icon`)}
+                        ${F(`vaadin:search`,void 0,`cmd-search-icon`)}
                         <input
                             class="cmd-input"
                             placeholder="Go to…"
@@ -5110,89 +5110,89 @@ ${i}
                         >
                     </div>
                     <div class="cmd-results">
-                        ${r.slice(0,10).map((e,t)=>T`
+                        ${r.slice(0,10).map((e,t)=>w`
                             <div class="cmd-result ${t===this.commandPaletteSelectedIndex?`cmd-result--selected`:``}"
                                 @click=${()=>{this.selectRoute(e.consumedRoute,e.route,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix),this.commandPaletteOpen=!1,this.commandPaletteQuery=``}}
                                 @mouseenter=${()=>{this.commandPaletteSelectedIndex=t}}
                             >
                                 <span class="cmd-result-label">${e.label}</span>
-                                ${e.breadcrumb?T`<span class="cmd-result-breadcrumb">${e.breadcrumb}</span>`:v}
+                                ${e.breadcrumb?w`<span class="cmd-result-breadcrumb">${e.breadcrumb}</span>`:_}
                             </div>
                         `)}
-                        ${n&&this.commandPaletteDataHits.length>0?T`
-                            ${this.commandPaletteDataHits.slice(0,8).map((e,t)=>{let n=Math.min(r.length,10)+t,i=this.commandPaletteDataHits[t-1];return T`
-                                    ${e.category&&e.category!==i?.category?T`
-                                        <div class="cmd-category">${e.category}</div>`:v}
+                        ${n&&this.commandPaletteDataHits.length>0?w`
+                            ${this.commandPaletteDataHits.slice(0,8).map((e,t)=>{let n=Math.min(r.length,10)+t,i=this.commandPaletteDataHits[t-1];return w`
+                                    ${e.category&&e.category!==i?.category?w`
+                                        <div class="cmd-category">${e.category}</div>`:_}
                                     <div class="cmd-result ${n===this.commandPaletteSelectedIndex?`cmd-result--selected`:``}"
                                          @click=${()=>this.openDataHit(e)}
                                          @mouseenter=${()=>{this.commandPaletteSelectedIndex=n}}
                                     >
                                         <span class="cmd-result-label">${e.label}</span>
-                                        ${e.description?T`<span class="cmd-result-breadcrumb">${e.description}</span>`:v}
-                                    </div>`})}`:v}
-                        ${r.length===0&&this.commandPaletteDataHits.length===0?T`<div class="cmd-empty">No results for "${this.commandPaletteQuery}"</div>`:v}
+                                        ${e.description?w`<span class="cmd-result-breadcrumb">${e.description}</span>`:_}
+                                    </div>`})}`:_}
+                        ${r.length===0&&this.commandPaletteDataHits.length===0?w`<div class="cmd-empty">No results for "${this.commandPaletteQuery}"</div>`:_}
                     </div>
                 </div>
             </div>
-        `},this.renderRail=e=>T`
+        `},this.renderRail=e=>w`
             <div class="nav-rail">
                 ${e.map(e=>this.renderRailItem(e))}
             </div>
-        `,this.renderRailItem=e=>T`
+        `,this.renderRailItem=e=>w`
             <div class="rail-item ${(e.submenus?.length>0?this.railOpenOption?.label===e.label:e.selected)?`rail-item--active`:``}"
                 @click=${()=>{e.submenus&&e.submenus.length>0?this.railOpenOption=this.railOpenOption?.label===e.label?null:e:(this.railOpenOption=null,this.selectRoute(e.consumedRoute,e.route,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix))}}
             >
-                ${e.icon?I(e.icon,void 0,`rail-icon`):T`<div class="rail-icon-placeholder">${e.label.charAt(0).toUpperCase()}</div>`}
+                ${e.icon?F(e.icon,void 0,`rail-icon`):w`<div class="rail-icon-placeholder">${e.label.charAt(0).toUpperCase()}</div>`}
                 <span class="rail-label">${e.label}</span>
             </div>
-        `,this.renderRailSubPanel=e=>T`
+        `,this.renderRailSubPanel=e=>w`
             <div class="rail-sub-panel">
                 <div class="rail-sub-title">${e.label}</div>
-                ${e.submenus.map(e=>T`
+                ${e.submenus.map(e=>w`
                     <div class="rail-sub-item ${e.selected?`rail-sub-item--active`:``}"
                         @click=${()=>{e.submenus&&e.submenus.length>0?this.railOpenOption=e:this.selectRoute(e.consumedRoute,e.route,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix)}}
                     >${e.label}</div>
                 `)}
             </div>
-        `,this.renderTilesHub=e=>T`
+        `,this.renderTilesHub=e=>w`
             <div style="padding: 2rem;">
                 <h2 style="margin-top: 0; margin-bottom: 1.5rem;">${e.label}</h2>
                 <div class="tiles-hub-grid">
-                    ${e.submenus.map(e=>T`
+                    ${e.submenus.map(e=>w`
                         <div class="nav-tile"
                             @click=${()=>{e.submenus&&e.submenus.length>0?this.tilesMenuOption=e:(this.tilesMenuOption=null,this.selectRoute(e.consumedRoute,e.route,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix))}}
                         >
-                            ${e.icon?I(e.icon,`font-size: 2rem; color: var(--lumo-primary-color); display: block; margin-bottom: 0.75rem;`):v}
+                            ${e.icon?F(e.icon,`font-size: 2rem; color: var(--lumo-primary-color); display: block; margin-bottom: 0.75rem;`):_}
                             <div class="nav-tile-title">${e.label}</div>
-                            ${e.description?T`<div class="nav-tile-desc">${e.description}</div>`:v}
+                            ${e.description?w`<div class="nav-tile-desc">${e.description}</div>`:_}
                         </div>
                     `)}
                 </div>
             </div>
-        `,this.goHome=()=>{Ta.confirmLeave()&&(window.history.pushState(null,``,`/`),window.dispatchEvent(new PopStateEvent(`popstate`,{state:null})))},this.selectRoute=(e,t,n,r,i,a)=>{Ta.confirmLeave()&&this._selectRoute(e,t,n,r,i,a)},this._selectRoute=(e,t,n,r,i,a)=>{{this.selectedConsumedRoute=e,this.selectedBaseUrl=r,this.selectedRoute=t,this.selectedServerSideType=i,this.selectedUriPrefix=a,this.instant=E(),this.state&&this.state._route!=null&&(this.state._route=void 0);let n=this.baseUrl??``;n.indexOf(`://`)<0&&(n.startsWith(`/`)||(n=`/`+n),n=window.location.origin+n),n.endsWith(`/`)&&(t??``).startsWith(`/`)&&(t=(t??``).substring(1));let o=new URL(n+t);if(e&&o.pathname.startsWith(e)){let t=o.pathname.substring(e.length);o=new URL(o.origin+(t||`/`))}if((window.location.pathname||o.pathname)&&window.location.pathname!=o.pathname){let e=o.pathname;o.search&&(e+=o.search),e&&!e.startsWith(`/`)&&(e=`/`+e),this.baseUrl&&e.startsWith(this.baseUrl)&&(e=e.substring(this.baseUrl.length));let t=e;this.selectedUriPrefix&&(t=t.startsWith(`/`)&&this.selectedUriPrefix.endsWith(`/`)?this.selectedUriPrefix+t.substring(1):!t.startsWith(`/`)&&!this.selectedUriPrefix.endsWith(`/`)?this.selectedUriPrefix+`/`+t:this.selectedUriPrefix+t),t==`/_page`&&(t=``),this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0}))}}},this.isActiveOption=e=>this.selectedRoute?!!e.route&&(this.selectedRoute==e.route||this.selectedRoute.startsWith(e.route+`/`)):!!e.selected,this.mapItems=(e,t)=>e.map(e=>{if(e.submenus&&e.submenus.length>0){let n=this.mapItems(e.submenus,t);return t&&e.label.toLowerCase().includes(t)&&(n=this.mapItems(e.submenus,``)),n&&n.length>0?{consumedRoute:e.consumedRoute,text:e.label,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:t||this.isActiveOption(e),children:n}:void 0}if(e.separator)return t?void 0:{component:`hr`};if(!t||e.label.toLowerCase().includes(t))return{consumedRoute:e.consumedRoute,text:e.label,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:t||this.isActiveOption(e)}}).filter(e=>e!=null),this.getSelectedIndex=e=>{if(!e)return NaN;let t=e=>{let t=(e??``).trim();return t.length>1&&t.endsWith(`/`)&&(t=t.slice(0,-1)),t},n=t(this.selectedRoute??window.location.pathname),r=NaN,i=-1;for(let a=0;a<e.length;a++){let o=t(e[a].route);o!==``&&(n===o||n.startsWith(o+`/`))&&o.length>i&&(i=o.length,r=a)}if(!Number.isNaN(r))return r;let a=this.getSelectedOption(e);return a?e.indexOf(a):NaN},this.renderOptionOnLeftMenu=e=>e.submenus&&e.submenus.length>0?T`
+        `,this.goHome=()=>{Ea.confirmLeave()&&(window.history.pushState(null,``,`/`),window.dispatchEvent(new PopStateEvent(`popstate`,{state:null})))},this.selectRoute=(e,t,n,r,i,a)=>{Ea.confirmLeave()&&this._selectRoute(e,t,n,r,i,a)},this._selectRoute=(e,t,n,r,i,a)=>{{this.selectedConsumedRoute=e,this.selectedBaseUrl=r,this.selectedRoute=t,this.selectedServerSideType=i,this.selectedUriPrefix=a,this.instant=T(),this.state&&this.state._route!=null&&(this.state._route=void 0);let n=this.baseUrl??``;n.indexOf(`://`)<0&&(n.startsWith(`/`)||(n=`/`+n),n=window.location.origin+n),n.endsWith(`/`)&&(t??``).startsWith(`/`)&&(t=(t??``).substring(1));let o=new URL(n+t);if(e&&o.pathname.startsWith(e)){let t=o.pathname.substring(e.length);o=new URL(o.origin+(t||`/`))}if((window.location.pathname||o.pathname)&&window.location.pathname!=o.pathname){let e=o.pathname;o.search&&(e+=o.search),e&&!e.startsWith(`/`)&&(e=`/`+e),this.baseUrl&&e.startsWith(this.baseUrl)&&(e=e.substring(this.baseUrl.length));let t=e;this.selectedUriPrefix&&(t=t.startsWith(`/`)&&this.selectedUriPrefix.endsWith(`/`)?this.selectedUriPrefix+t.substring(1):!t.startsWith(`/`)&&!this.selectedUriPrefix.endsWith(`/`)?this.selectedUriPrefix+`/`+t:this.selectedUriPrefix+t),t==`/_page`&&(t=``),this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0}))}}},this.isActiveOption=e=>this.selectedRoute?!!e.route&&(this.selectedRoute==e.route||this.selectedRoute.startsWith(e.route+`/`)):!!e.selected,this.mapItems=(e,t)=>e.map(e=>{if(e.submenus&&e.submenus.length>0){let n=this.mapItems(e.submenus,t);return t&&e.label.toLowerCase().includes(t)&&(n=this.mapItems(e.submenus,``)),n&&n.length>0?{consumedRoute:e.consumedRoute,text:e.label,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:t||this.isActiveOption(e),children:n}:void 0}if(e.separator)return t?void 0:{component:`hr`};if(!t||e.label.toLowerCase().includes(t))return{consumedRoute:e.consumedRoute,text:e.label,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:t||this.isActiveOption(e)}}).filter(e=>e!=null),this.getSelectedIndex=e=>{if(!e)return NaN;let t=e=>{let t=(e??``).trim();return t.length>1&&t.endsWith(`/`)&&(t=t.slice(0,-1)),t},n=t(this.selectedRoute??window.location.pathname),r=NaN,i=-1;for(let a=0;a<e.length;a++){let o=t(e[a].route);o!==``&&(n===o||n.startsWith(o+`/`))&&o.length>i&&(i=o.length,r=a)}if(!Number.isNaN(r))return r;let a=this.getSelectedOption(e);return a?e.indexOf(a):NaN},this.renderOptionOnLeftMenu=e=>e.submenus&&e.submenus.length>0?w`
                 <details open class="left-menu-group">
                     <summary>${e.label}</summary>
                     <div class="left-menu-children">
-                        ${e.submenus.map(e=>T`${this.renderOptionOnLeftMenu(e)}`)}
+                        ${e.submenus.map(e=>w`${this.renderOptionOnLeftMenu(e)}`)}
                     </div>
                 </details>
-`:T`<button class="left-menu-item"
+`:w`<button class="left-menu-item"
                 @click="${()=>this.selectRoute(e.consumedRoute,e.route,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix)}"
-        >${e.label}</button>`,this.navItemSelected=e=>{if(e.path==this.selectedRoute&&e.consumedRoute==this.selectedConsumedRoute&&e.baseUrl==this.selectedBaseUrl&&e.serverSideType==this.selectedServerSideType){let e=this.shadowRoot?.querySelector(`mateu-ux`);e&&e.setAttribute(`instant`,E())}else this.selectRoute(e.consumedRoute,e.path,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix);this.component.metadata.drawerClosed&&this.vaadinAppLayout&&(this.vaadinAppLayout.drawerOpened=!1)},this.renderSideNav=(e,t)=>e?T`
-            ${e.map(e=>{let t=e;return T`
+        >${e.label}</button>`,this.navItemSelected=e=>{if(e.path==this.selectedRoute&&e.consumedRoute==this.selectedConsumedRoute&&e.baseUrl==this.selectedBaseUrl&&e.serverSideType==this.selectedServerSideType){let e=this.shadowRoot?.querySelector(`mateu-ux`);e&&e.setAttribute(`instant`,T())}else this.selectRoute(e.consumedRoute,e.path,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix);this.component.metadata.drawerClosed&&this.vaadinAppLayout&&(this.vaadinAppLayout.drawerOpened=!1)},this.renderSideNav=(e,t)=>e?w`
+            ${e.map(e=>{let t=e;return w`
 
-                        ${t.component==`hr`?T`<hr/>`:T`
+                        ${t.component==`hr`?w`<hr/>`:w`
                                 <div class="side-nav-item ${t.selected?`side-nav-item--active`:``}">
                                     <button class="side-nav-link"
                                             @click="${()=>{t.route&&!t.children&&this.selectRoute(void 0,t.route,void 0,this.baseUrl,void 0,void 0)}}">
-                                        ${t.icon?I(`vaadin:dashboard`,`margin-right:.5rem;`):v}${t.text}
+                                        ${t.icon?F(`vaadin:dashboard`,`margin-right:.5rem;`):_}${t.text}
                                     </button>
-                                    ${t.children?T`<div class="side-nav-children">${this.renderSideNav(t.children,`children`)}</div>`:v}
+                                    ${t.children?w`<div class="side-nav-children">${this.renderSideNav(t.children,`children`)}</div>`:_}
                                 </div>
                         `}
 
-                            `})}`:v,this.updateRoute=e=>{e.preventDefault(),e.stopPropagation();var t=e.detail;this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix)}}createRenderRoot(){return P.mustUseShadowRoot()?super.createRenderRoot():(Ea.injectLightDomStyles(),this)}static{this.lightDomStylesInjected=!1}static injectLightDomStyles(){if(Ea.lightDomStylesInjected||typeof document>`u`||(Ea.lightDomStylesInjected=!0,document.getElementById(`mateu-app-light-styles`)))return;let e=Ea.styles,t=Array.isArray(e)?e.map(e=>e?.cssText??``).join(`
-`):e?.cssText??``;if(!t)return;let n=document.createElement(`style`);n.id=`mateu-app-light-styles`,n.textContent=t,document.head.appendChild(n)}fetchGlobalSearch(e){let t=this.component?.metadata;if(t?.globalSearchEnabled){if(clearTimeout(this._globalSearchTimer),!e){this.commandPaletteDataHits=[];return}this._globalSearchTimer=setTimeout(async()=>{try{let n=(await We.runAction(this.baseUrl??``,t.rootRoute??``,``,`_globalsearch`,`cmd-palette`,void 0,t.serverSideType,{},{searchText:e},this,!0))?.fragments?.map(e=>e.data).find(e=>e&&e._globalsearch);this.commandPaletteDataHits=n?._globalsearch??[]}catch{this.commandPaletteDataHits=[]}},250)}}connectedCallback(){super.connectedCallback(),this.isDark=document.documentElement.getAttribute(`theme`)===`dark`,this._commandPaletteHandler=e=>{this.component?.metadata?.commandCenterEnabled||((e.metaKey||e.ctrlKey)&&e.key===`k`&&(e.preventDefault(),this.commandPaletteOpen=!this.commandPaletteOpen,this.commandPaletteQuery=``,this.commandPaletteSelectedIndex=0),e.key===`Escape`&&this.commandPaletteOpen&&(this.commandPaletteOpen=!1,this.commandPaletteQuery=``))},document.addEventListener(`keydown`,this._commandPaletteHandler),Ta.install(),this.addEventListener(`compact-changed`,this._compactHandler),this.addEventListener(`mateu-open-ai`,this._openAiHandler)}disconnectedCallback(){super.disconnectedCallback(),this._commandPaletteHandler&&document.removeEventListener(`keydown`,this._commandPaletteHandler),this.removeEventListener(`compact-changed`,this._compactHandler),this.removeEventListener(`mateu-open-ai`,this._openAiHandler)}updated(e){if(super.updated(e),Ca(this),this.component){let t=this.component.metadata;if(t){let n=t;if(n.favicon){let e=document.querySelector(`link[rel~='icon']`);e||(e=document.createElement(`link`),e.rel=`icon`,document.head.appendChild(e)),e.href=n.favicon}e.has(`component`)&&(this.selectedRoute=n.homeRoute,this.selectedConsumedRoute=n.homeConsumedRoute,this.selectedServerSideType=n.homeServerSideType,this.selectedBaseUrl=n.homeBaseUrl,this.selectedUriPrefix=n.homeUriPrefix)}}e.has(`commandPaletteOpen`)&&this.commandPaletteOpen&&setTimeout(()=>{this.renderRoot.querySelector(`.cmd-input`)?.focus()},0)}render(){return P.get()?.renderAppComponent(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData)}static{this.styles=h`
+                            `})}`:_,this.updateRoute=e=>{e.preventDefault(),e.stopPropagation();var t=e.detail;this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix)}}createRenderRoot(){return N.mustUseShadowRoot()?super.createRenderRoot():(Da.injectLightDomStyles(),this)}static{this.lightDomStylesInjected=!1}static injectLightDomStyles(){if(Da.lightDomStylesInjected||typeof document>`u`||(Da.lightDomStylesInjected=!0,document.getElementById(`mateu-app-light-styles`)))return;let e=Da.styles,t=Array.isArray(e)?e.map(e=>e?.cssText??``).join(`
+`):e?.cssText??``;if(!t)return;let n=document.createElement(`style`);n.id=`mateu-app-light-styles`,n.textContent=t,document.head.appendChild(n)}fetchGlobalSearch(e){let t=this.component?.metadata;if(t?.globalSearchEnabled){if(clearTimeout(this._globalSearchTimer),!e){this.commandPaletteDataHits=[];return}this._globalSearchTimer=setTimeout(async()=>{try{let n=(await Ge.runAction(this.baseUrl??``,t.rootRoute??``,``,`_globalsearch`,`cmd-palette`,void 0,t.serverSideType,{},{searchText:e},this,!0))?.fragments?.map(e=>e.data).find(e=>e&&e._globalsearch);this.commandPaletteDataHits=n?._globalsearch??[]}catch{this.commandPaletteDataHits=[]}},250)}}connectedCallback(){super.connectedCallback(),this.isDark=document.documentElement.getAttribute(`theme`)===`dark`,this._commandPaletteHandler=e=>{this.component?.metadata?.commandCenterEnabled||((e.metaKey||e.ctrlKey)&&e.key===`k`&&(e.preventDefault(),this.commandPaletteOpen=!this.commandPaletteOpen,this.commandPaletteQuery=``,this.commandPaletteSelectedIndex=0),e.key===`Escape`&&this.commandPaletteOpen&&(this.commandPaletteOpen=!1,this.commandPaletteQuery=``))},document.addEventListener(`keydown`,this._commandPaletteHandler),Ea.install(),this.addEventListener(`compact-changed`,this._compactHandler),this.addEventListener(`mateu-open-ai`,this._openAiHandler)}disconnectedCallback(){super.disconnectedCallback(),this._commandPaletteHandler&&document.removeEventListener(`keydown`,this._commandPaletteHandler),this.removeEventListener(`compact-changed`,this._compactHandler),this.removeEventListener(`mateu-open-ai`,this._openAiHandler)}updated(e){if(super.updated(e),wa(this),this.component){let t=this.component.metadata;if(t){let n=t;if(n.favicon){let e=document.querySelector(`link[rel~='icon']`);e||(e=document.createElement(`link`),e.rel=`icon`,document.head.appendChild(e)),e.href=n.favicon}e.has(`component`)&&(this.selectedRoute=n.homeRoute,this.selectedConsumedRoute=n.homeConsumedRoute,this.selectedServerSideType=n.homeServerSideType,this.selectedBaseUrl=n.homeBaseUrl,this.selectedUriPrefix=n.homeUriPrefix)}}e.has(`commandPaletteOpen`)&&this.commandPaletteOpen&&setTimeout(()=>{this.renderRoot.querySelector(`.cmd-input`)?.focus()},0)}render(){return N.get()?.renderAppComponent(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData)}static{this.styles=m`
         /* DS-neutral app chrome (replaces vaadin-app-layout / menu-bar / tabs / side-nav). */
         .m-hl { display: flex; flex-direction: row; }
         .m-vl { display: flex; flex-direction: column; }
@@ -5542,14 +5542,14 @@ ${i}
             transform: scale(1.08);
         }
 
-  `}};k([C()],q.prototype,`filter`,void 0),k([C()],q.prototype,`instant`,void 0),k([C()],q.prototype,`selectedConsumedRoute`,void 0),k([C()],q.prototype,`selectedRoute`,void 0),k([C()],q.prototype,`selectedUriPrefix`,void 0),k([C()],q.prototype,`selectedBaseUrl`,void 0),k([C()],q.prototype,`selectedServerSideType`,void 0),k([C()],q.prototype,`selectedParams`,void 0),k([C()],q.prototype,`tilesMenuOption`,void 0),k([C()],q.prototype,`railOpenOption`,void 0),k([C()],q.prototype,`commandPaletteOpen`,void 0),k([C()],q.prototype,`commandPaletteQuery`,void 0),k([C()],q.prototype,`commandPaletteSelectedIndex`,void 0),k([C()],q.prototype,`commandPaletteDataHits`,void 0),k([C()],q.prototype,`pageCompact`,void 0),k([x(`mateu-chat`)],q.prototype,`chat`,void 0),k([C()],q.prototype,`isDark`,void 0),k([C()],q.prototype,`chatOpen`,void 0),k([x(`.mateu-app-layout`)],q.prototype,`vaadinAppLayout`,void 0),q=Ea=k([g(`mateu-app`)],q);var Da=class extends b{constructor(...e){super(...e),this.message=`This website uses cookies.`,this.dismiss=`Ok. Thanks :).`,this.learnMore=`Learn more`,this.learnMoreLink=`https://cookiesandyou.com/`,this.showLearnMore=!0,this.position=`top`,this.cookieName=`mateu-cookieconsent`}updated(e){super.updated(e)}connectedCallback(){super.connectedCallback(),this._css=document.createElement(`style`),this._css.innerText=`.cc-window{opacity:1;transition:opacity 1s ease}.cc-window.cc-invisible{opacity:0}.cc-animate.cc-revoke{transition:transform 1s ease}.cc-animate.cc-revoke.cc-top{transform:translateY(-2em)}.cc-animate.cc-revoke.cc-bottom{transform:translateY(2em)}.cc-animate.cc-revoke.cc-active.cc-bottom,.cc-animate.cc-revoke.cc-active.cc-top,.cc-revoke:hover{transform:translateY(0)}.cc-grower{max-height:0;overflow:hidden;transition:max-height 1s}.cc-link,.cc-revoke:hover{text-decoration:underline}.cc-revoke,.cc-window{position:fixed;overflow:hidden;box-sizing:border-box;font-family:Helvetica,Calibri,Arial,sans-serif;font-size:16px;line-height:1.5em;display:flex;flex-wrap:nowrap;z-index:9999}.cc-window.cc-static{position:static}.cc-window.cc-floating{padding:2em;max-width:24em;flex-direction:column}.cc-window.cc-banner{padding:1em 1.8em;width:100%;flex-direction:row}.cc-revoke{padding:.5em}.cc-header{font-size:18px;font-weight:700}.cc-btn,.cc-close,.cc-link,.cc-revoke{cursor:pointer}.cc-link{opacity:.8;display:inline-block;padding:.2em}.cc-link:hover{opacity:1}.cc-link:active,.cc-link:visited{color:initial}.cc-btn{display:block;padding:.4em .8em;font-size:.9em;font-weight:700;border-width:2px;border-style:solid;text-align:center;white-space:nowrap}.cc-banner .cc-btn:last-child{min-width:140px}.cc-highlight .cc-btn:first-child{background-color:transparent;border-color:transparent}.cc-highlight .cc-btn:first-child:focus,.cc-highlight .cc-btn:first-child:hover{background-color:transparent;text-decoration:underline}.cc-close{display:block;position:absolute;top:.5em;right:.5em;font-size:1.6em;opacity:.9;line-height:.75}.cc-close:focus,.cc-close:hover{opacity:1}.cc-revoke.cc-top{top:0;left:3em;border-bottom-left-radius:.5em;border-bottom-right-radius:.5em}.cc-revoke.cc-bottom{bottom:0;left:3em;border-top-left-radius:.5em;border-top-right-radius:.5em}.cc-revoke.cc-left{left:3em;right:unset}.cc-revoke.cc-right{right:3em;left:unset}.cc-top{top:1em}.cc-left{left:1em}.cc-right{right:1em}.cc-bottom{bottom:1em}.cc-floating>.cc-link{margin-bottom:1em}.cc-floating .cc-message{display:block;margin-bottom:1em}.cc-window.cc-floating .cc-compliance{flex:1 0 auto}.cc-window.cc-banner{align-items:center}.cc-banner.cc-top{left:0;right:0;top:0}.cc-banner.cc-bottom{left:0;right:0;bottom:0}.cc-banner .cc-message{flex:1}.cc-compliance{display:flex;align-items:center;align-content:space-between}.cc-compliance>.cc-btn{flex:1}.cc-btn+.cc-btn{margin-left:.5em}@media print{.cc-revoke,.cc-window{display:none}}@media screen and (max-width:900px){.cc-btn{white-space:normal}}@media screen and (max-width:414px) and (orientation:portrait),screen and (max-width:736px) and (orientation:landscape){.cc-window.cc-top{top:0}.cc-window.cc-bottom{bottom:0}.cc-window.cc-banner,.cc-window.cc-left,.cc-window.cc-right{left:0;right:0}.cc-window.cc-banner{flex-direction:column}.cc-window.cc-banner .cc-compliance{flex:1}.cc-window.cc-floating{max-width:none}.cc-window .cc-message{margin-bottom:1em}.cc-window.cc-banner{align-items:unset}}.cc-floating.cc-theme-classic{padding:1.2em;border-radius:5px}.cc-floating.cc-type-info.cc-theme-classic .cc-compliance{text-align:center;display:inline;flex:none}.cc-theme-classic .cc-btn{border-radius:5px}.cc-theme-classic .cc-btn:last-child{min-width:140px}.cc-floating.cc-type-info.cc-theme-classic .cc-btn{display:inline-block}.cc-theme-edgeless.cc-window{padding:0}.cc-floating.cc-theme-edgeless .cc-message{margin:2em 2em 1.5em}.cc-banner.cc-theme-edgeless .cc-btn{margin:0;padding:.8em 1.8em;height:100%}.cc-banner.cc-theme-edgeless .cc-message{margin-left:1em}.cc-floating.cc-theme-edgeless .cc-btn+.cc-btn{margin-left:0}`,document.head.appendChild(this._css),this.__updatePopup()}disconnectedCallback(){super.disconnectedCallback(),this.__closePopup(),this._css.isConnected&&this._css.remove()}__closePopup(){let e=this.popup;e&&e.parentNode?.removeChild(e)}_show(){let e=this.popup;e&&(e.classList.remove(`cc-invisible`),e.style.display=``)}__updatePopup(){this.__closePopup(),window.cookieconsent.initialise({palette:{popup:{background:`#000`},button:{background:`rgba(22, 118, 243, 0.95)`,hover:`rgba(22, 118, 243, 1)`}},showLink:this.showLearnMore,content:{message:this.message,dismiss:this.dismiss,link:this.learnMore,href:this.learnMoreLink},cookie:{name:this.cookieName},position:this.position,elements:{messagelink:`<span id="cookieconsent:desc" class="cc-message">${this.message} <a tabindex="0" class="cc-link" href="${this.learnMoreLink}" target="_blank" rel="noopener noreferrer nofollow">${this.learnMore}</a></span>`,dismiss:`<a tabindex="0" class="cc-btn cc-dismiss">${this.dismiss}</a>`}});let e=this.popup;if(e){e.setAttribute(`role`,`alert`);let t=e.querySelector(`a.cc-btn`);t?.addEventListener(`keydown`,e=>{let n=e.keyCode||e.which;(n===32||n===13)&&t.click()})}}render(){return T`
-       `}static{this.styles=h`
-  `}};k([y()],Da.prototype,`message`,void 0),k([y()],Da.prototype,`dismiss`,void 0),k([y()],Da.prototype,`learnMore`,void 0),k([y()],Da.prototype,`learnMoreLink`,void 0),k([y()],Da.prototype,`showLearnMore`,void 0),k([y()],Da.prototype,`position`,void 0),k([y()],Da.prototype,`cookieName`,void 0),k([C()],Da.prototype,`_css`,void 0),k([x(`[aria-label="cookieconsent"]`)],Da.prototype,`popup`,void 0),Da=k([g(`mateu-cookie-consent`)],Da);var Oa=class extends b{constructor(...e){super(...e),this.redispatchEvent=e=>{e instanceof CustomEvent&&(e.stopPropagation(),e.preventDefault(),this.target?.dispatchEvent(new CustomEvent(e.type,{detail:e.detail,bubbles:!0,composed:!0})))}}connectedCallback(){super.connectedCallback(),this.addEventListener(`value-changed`,this.redispatchEvent),this.addEventListener(`data-changed`,this.redispatchEvent),this.addEventListener(`action-requested`,this.redispatchEvent),this.addEventListener(`server-side-action-requested`,this.redispatchEvent),this.addEventListener(`route-changed`,this.redispatchEvent),this.addEventListener(`close-modal-requested`,this.redispatchEvent)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`value-changed`,this.redispatchEvent),this.removeEventListener(`data-changed`,this.redispatchEvent),this.removeEventListener(`action-requested`,this.redispatchEvent),this.removeEventListener(`server-side-action-requested`,this.redispatchEvent),this.removeEventListener(`route-changed`,this.redispatchEvent)}render(){return T`<slot></slot>`}static{this.styles=h`
+  `}};O([S()],K.prototype,`filter`,void 0),O([S()],K.prototype,`instant`,void 0),O([S()],K.prototype,`selectedConsumedRoute`,void 0),O([S()],K.prototype,`selectedRoute`,void 0),O([S()],K.prototype,`selectedUriPrefix`,void 0),O([S()],K.prototype,`selectedBaseUrl`,void 0),O([S()],K.prototype,`selectedServerSideType`,void 0),O([S()],K.prototype,`selectedParams`,void 0),O([S()],K.prototype,`tilesMenuOption`,void 0),O([S()],K.prototype,`railOpenOption`,void 0),O([S()],K.prototype,`commandPaletteOpen`,void 0),O([S()],K.prototype,`commandPaletteQuery`,void 0),O([S()],K.prototype,`commandPaletteSelectedIndex`,void 0),O([S()],K.prototype,`commandPaletteDataHits`,void 0),O([S()],K.prototype,`pageCompact`,void 0),O([b(`mateu-chat`)],K.prototype,`chat`,void 0),O([S()],K.prototype,`isDark`,void 0),O([S()],K.prototype,`chatOpen`,void 0),O([b(`.mateu-app-layout`)],K.prototype,`vaadinAppLayout`,void 0),K=Da=O([h(`mateu-app`)],K);var Oa=class extends y{constructor(...e){super(...e),this.message=`This website uses cookies.`,this.dismiss=`Ok. Thanks :).`,this.learnMore=`Learn more`,this.learnMoreLink=`https://cookiesandyou.com/`,this.showLearnMore=!0,this.position=`top`,this.cookieName=`mateu-cookieconsent`}updated(e){super.updated(e)}connectedCallback(){super.connectedCallback(),this._css=document.createElement(`style`),this._css.innerText=`.cc-window{opacity:1;transition:opacity 1s ease}.cc-window.cc-invisible{opacity:0}.cc-animate.cc-revoke{transition:transform 1s ease}.cc-animate.cc-revoke.cc-top{transform:translateY(-2em)}.cc-animate.cc-revoke.cc-bottom{transform:translateY(2em)}.cc-animate.cc-revoke.cc-active.cc-bottom,.cc-animate.cc-revoke.cc-active.cc-top,.cc-revoke:hover{transform:translateY(0)}.cc-grower{max-height:0;overflow:hidden;transition:max-height 1s}.cc-link,.cc-revoke:hover{text-decoration:underline}.cc-revoke,.cc-window{position:fixed;overflow:hidden;box-sizing:border-box;font-family:Helvetica,Calibri,Arial,sans-serif;font-size:16px;line-height:1.5em;display:flex;flex-wrap:nowrap;z-index:9999}.cc-window.cc-static{position:static}.cc-window.cc-floating{padding:2em;max-width:24em;flex-direction:column}.cc-window.cc-banner{padding:1em 1.8em;width:100%;flex-direction:row}.cc-revoke{padding:.5em}.cc-header{font-size:18px;font-weight:700}.cc-btn,.cc-close,.cc-link,.cc-revoke{cursor:pointer}.cc-link{opacity:.8;display:inline-block;padding:.2em}.cc-link:hover{opacity:1}.cc-link:active,.cc-link:visited{color:initial}.cc-btn{display:block;padding:.4em .8em;font-size:.9em;font-weight:700;border-width:2px;border-style:solid;text-align:center;white-space:nowrap}.cc-banner .cc-btn:last-child{min-width:140px}.cc-highlight .cc-btn:first-child{background-color:transparent;border-color:transparent}.cc-highlight .cc-btn:first-child:focus,.cc-highlight .cc-btn:first-child:hover{background-color:transparent;text-decoration:underline}.cc-close{display:block;position:absolute;top:.5em;right:.5em;font-size:1.6em;opacity:.9;line-height:.75}.cc-close:focus,.cc-close:hover{opacity:1}.cc-revoke.cc-top{top:0;left:3em;border-bottom-left-radius:.5em;border-bottom-right-radius:.5em}.cc-revoke.cc-bottom{bottom:0;left:3em;border-top-left-radius:.5em;border-top-right-radius:.5em}.cc-revoke.cc-left{left:3em;right:unset}.cc-revoke.cc-right{right:3em;left:unset}.cc-top{top:1em}.cc-left{left:1em}.cc-right{right:1em}.cc-bottom{bottom:1em}.cc-floating>.cc-link{margin-bottom:1em}.cc-floating .cc-message{display:block;margin-bottom:1em}.cc-window.cc-floating .cc-compliance{flex:1 0 auto}.cc-window.cc-banner{align-items:center}.cc-banner.cc-top{left:0;right:0;top:0}.cc-banner.cc-bottom{left:0;right:0;bottom:0}.cc-banner .cc-message{flex:1}.cc-compliance{display:flex;align-items:center;align-content:space-between}.cc-compliance>.cc-btn{flex:1}.cc-btn+.cc-btn{margin-left:.5em}@media print{.cc-revoke,.cc-window{display:none}}@media screen and (max-width:900px){.cc-btn{white-space:normal}}@media screen and (max-width:414px) and (orientation:portrait),screen and (max-width:736px) and (orientation:landscape){.cc-window.cc-top{top:0}.cc-window.cc-bottom{bottom:0}.cc-window.cc-banner,.cc-window.cc-left,.cc-window.cc-right{left:0;right:0}.cc-window.cc-banner{flex-direction:column}.cc-window.cc-banner .cc-compliance{flex:1}.cc-window.cc-floating{max-width:none}.cc-window .cc-message{margin-bottom:1em}.cc-window.cc-banner{align-items:unset}}.cc-floating.cc-theme-classic{padding:1.2em;border-radius:5px}.cc-floating.cc-type-info.cc-theme-classic .cc-compliance{text-align:center;display:inline;flex:none}.cc-theme-classic .cc-btn{border-radius:5px}.cc-theme-classic .cc-btn:last-child{min-width:140px}.cc-floating.cc-type-info.cc-theme-classic .cc-btn{display:inline-block}.cc-theme-edgeless.cc-window{padding:0}.cc-floating.cc-theme-edgeless .cc-message{margin:2em 2em 1.5em}.cc-banner.cc-theme-edgeless .cc-btn{margin:0;padding:.8em 1.8em;height:100%}.cc-banner.cc-theme-edgeless .cc-message{margin-left:1em}.cc-floating.cc-theme-edgeless .cc-btn+.cc-btn{margin-left:0}`,document.head.appendChild(this._css),this.__updatePopup()}disconnectedCallback(){super.disconnectedCallback(),this.__closePopup(),this._css.isConnected&&this._css.remove()}__closePopup(){let e=this.popup;e&&e.parentNode?.removeChild(e)}_show(){let e=this.popup;e&&(e.classList.remove(`cc-invisible`),e.style.display=``)}__updatePopup(){this.__closePopup(),window.cookieconsent.initialise({palette:{popup:{background:`#000`},button:{background:`rgba(22, 118, 243, 0.95)`,hover:`rgba(22, 118, 243, 1)`}},showLink:this.showLearnMore,content:{message:this.message,dismiss:this.dismiss,link:this.learnMore,href:this.learnMoreLink},cookie:{name:this.cookieName},position:this.position,elements:{messagelink:`<span id="cookieconsent:desc" class="cc-message">${this.message} <a tabindex="0" class="cc-link" href="${this.learnMoreLink}" target="_blank" rel="noopener noreferrer nofollow">${this.learnMore}</a></span>`,dismiss:`<a tabindex="0" class="cc-btn cc-dismiss">${this.dismiss}</a>`}});let e=this.popup;if(e){e.setAttribute(`role`,`alert`);let t=e.querySelector(`a.cc-btn`);t?.addEventListener(`keydown`,e=>{let n=e.keyCode||e.which;(n===32||n===13)&&t.click()})}}render(){return w`
+       `}static{this.styles=m`
+  `}};O([v()],Oa.prototype,`message`,void 0),O([v()],Oa.prototype,`dismiss`,void 0),O([v()],Oa.prototype,`learnMore`,void 0),O([v()],Oa.prototype,`learnMoreLink`,void 0),O([v()],Oa.prototype,`showLearnMore`,void 0),O([v()],Oa.prototype,`position`,void 0),O([v()],Oa.prototype,`cookieName`,void 0),O([S()],Oa.prototype,`_css`,void 0),O([b(`[aria-label="cookieconsent"]`)],Oa.prototype,`popup`,void 0),Oa=O([h(`mateu-cookie-consent`)],Oa);var ka=class extends y{constructor(...e){super(...e),this.redispatchEvent=e=>{e instanceof CustomEvent&&(e.stopPropagation(),e.preventDefault(),this.target?.dispatchEvent(new CustomEvent(e.type,{detail:e.detail,bubbles:!0,composed:!0})))}}connectedCallback(){super.connectedCallback(),this.addEventListener(`value-changed`,this.redispatchEvent),this.addEventListener(`data-changed`,this.redispatchEvent),this.addEventListener(`action-requested`,this.redispatchEvent),this.addEventListener(`server-side-action-requested`,this.redispatchEvent),this.addEventListener(`route-changed`,this.redispatchEvent),this.addEventListener(`close-modal-requested`,this.redispatchEvent)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`value-changed`,this.redispatchEvent),this.removeEventListener(`data-changed`,this.redispatchEvent),this.removeEventListener(`action-requested`,this.redispatchEvent),this.removeEventListener(`server-side-action-requested`,this.redispatchEvent),this.removeEventListener(`route-changed`,this.redispatchEvent)}render(){return w`<slot></slot>`}static{this.styles=m`
         :host {
             /* width: 100%; */
             display: inline-block;
         }
-  `}};k([y()],Oa.prototype,`target`,void 0),Oa=k([g(`mateu-event-interceptor`)],Oa);var ka=[`a[href]`,`button`,`input`,`select`,`textarea`,`[tabindex]`,`vaadin-button`,`vaadin-text-field`,`vaadin-combo-box`,`vaadin-select`,`vaadin-checkbox`,`vaadin-date-picker`,`ui5-button`,`oj-c-button`].join(`,`),Aa=e=>{let t=e;return t.hidden||t.hasAttribute(`disabled`)||t.getAttribute(`aria-hidden`)===`true`||t.getAttribute(`tabindex`)===`-1`?!1:!!(t.offsetParent||t.getClientRects().length)},ja=e=>{let t=[],n=e=>{e.querySelectorAll(`*`).forEach(e=>{e.matches(ka)&&Aa(e)&&t.push(e),e.shadowRoot&&n(e.shadowRoot),e instanceof HTMLSlotElement&&e.assignedElements().forEach(e=>{e.matches(ka)&&Aa(e)&&t.push(e),n(e)})})};return n(e),t.filter((e,n)=>t.indexOf(e)===n)},Ma=(e,t={})=>{let n=Na(),r=[],i=()=>{r=ja(e)},a=t=>{if(t.key!==`Tab`)return;if(i(),r.length===0){t.preventDefault(),e.focus();return}let n=r[0],a=r[r.length-1],o=Na();t.shiftKey&&(o===n||!o||!Pa(o,e))?(t.preventDefault(),a.focus()):!t.shiftKey&&o===a&&(t.preventDefault(),n.focus())};return e.addEventListener(`keydown`,a),requestAnimationFrame(()=>{i();let n=t.initialFocus?.()??r[0];n?n.focus():(e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus())}),{refresh:i,release(){e.removeEventListener(`keydown`,a);let t=Na();(!t||t===document.body||Pa(t,e))&&n?.focus?.()}}},Na=()=>{let e=document.activeElement;for(;e?.shadowRoot?.activeElement;)e=e.shadowRoot.activeElement;return e},Pa=(e,t)=>{let n=e;for(;n;){if(n===t)return!0;n=n.parentNode??n.host??null}return!1},Fa=class extends ha{constructor(...e){super(...e),this.opened=!0,this.close=()=>{this.opened=!1,this.releaseFocusTrap(),setTimeout(()=>{this.removeSelfFromOwnerChildren()||this.parentElement?.removeChild(this)},500)},this.onKeydown=e=>{e.key===`Escape`&&this.opened&&(e.stopPropagation(),this.close())}}connectedCallback(){super.connectedCallback(),this.addEventListener(`keydown`,this.onKeydown)}disconnectedCallback(){super.disconnectedCallback(),this.releaseFocusTrap()}releaseFocusTrap(){this.focusTrap?.release(),this.focusTrap=void 0}applyFragment(e){super.applyFragment(e);let t=e.state?._closeAfterMillis;t&&setTimeout(()=>this.close(),t)}updated(e){if(super.updated(e),e.has(`component`)&&this.component){let e=this.component.metadata;this.state=e.initialData}let t=this.renderRoot.querySelector(`[role="dialog"]`),n=this.component?.metadata?.modeless;this.opened&&t&&!this.focusTrap&&!n?this.focusTrap=Ma(t):this.focusTrap&&this.opened&&this.focusTrap.refresh()}render(){if(!this.opened)return T``;let e=this.component.metadata,t=rt(e.headerTitle,this.state,this.data,this.appState,this.appData),n=!!(t||e.header||e.closeButtonOnHeader),r=[e.width?`width:${e.width};`:`min-width:min(90vw,28rem);`,e.height?`height:${e.height};`:``,e.top?`margin-top:${e.top};`:``].join(``);return T`
+  `}};O([v()],ka.prototype,`target`,void 0),ka=O([h(`mateu-event-interceptor`)],ka);var Aa=[`a[href]`,`button`,`input`,`select`,`textarea`,`[tabindex]`,`vaadin-button`,`vaadin-text-field`,`vaadin-combo-box`,`vaadin-select`,`vaadin-checkbox`,`vaadin-date-picker`,`ui5-button`,`oj-c-button`].join(`,`),ja=e=>{let t=e;return t.hidden||t.hasAttribute(`disabled`)||t.getAttribute(`aria-hidden`)===`true`||t.getAttribute(`tabindex`)===`-1`?!1:!!(t.offsetParent||t.getClientRects().length)},Ma=e=>{let t=[],n=e=>{e.querySelectorAll(`*`).forEach(e=>{e.matches(Aa)&&ja(e)&&t.push(e),e.shadowRoot&&n(e.shadowRoot),e instanceof HTMLSlotElement&&e.assignedElements().forEach(e=>{e.matches(Aa)&&ja(e)&&t.push(e),n(e)})})};return n(e),t.filter((e,n)=>t.indexOf(e)===n)},Na=(e,t={})=>{let n=Pa(),r=[],i=()=>{r=Ma(e)},a=t=>{if(t.key!==`Tab`)return;if(i(),r.length===0){t.preventDefault(),e.focus();return}let n=r[0],a=r[r.length-1],o=Pa();t.shiftKey&&(o===n||!o||!Fa(o,e))?(t.preventDefault(),a.focus()):!t.shiftKey&&o===a&&(t.preventDefault(),n.focus())};return e.addEventListener(`keydown`,a),requestAnimationFrame(()=>{i();let n=t.initialFocus?.()??r[0];n?n.focus():(e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus())}),{refresh:i,release(){e.removeEventListener(`keydown`,a);let t=Pa();(!t||t===document.body||Fa(t,e))&&n?.focus?.()}}},Pa=()=>{let e=document.activeElement;for(;e?.shadowRoot?.activeElement;)e=e.shadowRoot.activeElement;return e},Fa=(e,t)=>{let n=e;for(;n;){if(n===t)return!0;n=n.parentNode??n.host??null}return!1},Ia=class extends ga{constructor(...e){super(...e),this.opened=!0,this.close=()=>{this.opened=!1,this.releaseFocusTrap(),setTimeout(()=>{this.removeSelfFromOwnerChildren()||this.parentElement?.removeChild(this)},500)},this.onKeydown=e=>{e.key===`Escape`&&this.opened&&(e.stopPropagation(),this.close())}}connectedCallback(){super.connectedCallback(),this.addEventListener(`keydown`,this.onKeydown)}disconnectedCallback(){super.disconnectedCallback(),this.releaseFocusTrap()}releaseFocusTrap(){this.focusTrap?.release(),this.focusTrap=void 0}applyFragment(e){super.applyFragment(e);let t=e.state?._closeAfterMillis;t&&setTimeout(()=>this.close(),t)}updated(e){if(super.updated(e),e.has(`component`)&&this.component){let e=this.component.metadata;this.state=e.initialData}let t=this.renderRoot.querySelector(`[role="dialog"]`),n=this.component?.metadata?.modeless;this.opened&&t&&!this.focusTrap&&!n?this.focusTrap=Na(t):this.focusTrap&&this.opened&&this.focusTrap.refresh()}render(){if(!this.opened)return w``;let e=this.component.metadata,t=it(e.headerTitle,this.state,this.data,this.appState,this.appData),n=!!(t||e.header||e.closeButtonOnHeader),r=[e.width?`width:${e.width};`:`min-width:min(90vw,28rem);`,e.height?`height:${e.height};`:``,e.top?`margin-top:${e.top};`:``].join(``);return w`
             <div class="backdrop ${e.modeless?`modeless`:``}"
                  @click="${t=>{!e.modeless&&t.target===t.currentTarget&&this.close()}}">
                 <div class="dialog ${e.noPadding?`no-padding`:``} ${this.component?.cssClasses??``}"
@@ -5557,29 +5557,29 @@ ${i}
                      aria-modal="${e.modeless?`false`:`true`}"
                      aria-label="${t||`Dialog`}"
                      style="${r} ${this.component?.style??``}">
-                    ${n?T`
+                    ${n?w`
                         <div class="dialog-header">
                             <mateu-event-interceptor .target="${this}" style="flex:1; min-width:0;">
-                                ${t?T`<span class="dialog-title">${t}</span>`:v}
-                                ${e.header?F(this,e.header,this.baseUrl,this.state,this.data,this.appState,this.appData):v}
+                                ${t?w`<span class="dialog-title">${t}</span>`:_}
+                                ${e.header?P(this,e.header,this.baseUrl,this.state,this.data,this.appState,this.appData):_}
                             </mateu-event-interceptor>
-                            ${e.closeButtonOnHeader?T`<button class="dialog-close" @click="${this.close}" aria-label="Close">✕</button>`:v}
-                        </div>`:v}
-                    ${e.content?T`
+                            ${e.closeButtonOnHeader?w`<button class="dialog-close" @click="${this.close}" aria-label="Close">✕</button>`:_}
+                        </div>`:_}
+                    ${e.content?w`
                         <div class="dialog-body">
                             <mateu-event-interceptor .target="${this}" style="--mateu-section-border: none; width:100%;">
-                                ${F(this,e.content,this.baseUrl,this.state,this.data,this.appState,this.appData)}
+                                ${P(this,e.content,this.baseUrl,this.state,this.data,this.appState,this.appData)}
                             </mateu-event-interceptor>
-                        </div>`:v}
-                    ${e.footer?T`
+                        </div>`:_}
+                    ${e.footer?w`
                         <div class="dialog-footer">
                             <mateu-event-interceptor .target="${this}" style="width:100%;">
-                                ${F(this,e.footer,this.baseUrl,this.state,this.data,this.appState,this.appData)}
+                                ${P(this,e.footer,this.baseUrl,this.state,this.data,this.appState,this.appData)}
                             </mateu-event-interceptor>
-                        </div>`:v}
+                        </div>`:_}
                 </div>
             </div>
-        `}static{this.styles=h`
+        `}static{this.styles=m`
         .backdrop {
             position: fixed; inset: 0; z-index: 1000;
             display: flex; align-items: center; justify-content: center;
@@ -5604,66 +5604,66 @@ ${i}
         .dialog-body { padding: .5rem 1.2rem; flex: 1; }
         .dialog.no-padding .dialog-body { padding: 0; }
         .dialog-footer { padding: .5rem 1.2rem 1rem; display: flex; justify-content: flex-end; gap: .5rem; }
-    `}};k([C()],Fa.prototype,`opened`,void 0),Fa=k([g(`mateu-dialog`)],Fa);var Ia,La=class extends ha{static{Ia=this}constructor(...e){super(...e),this.opened=!1,this.maximizeSteps=0,this.collapsed=!1,this.pagerMenuOpen=!1,this.onGuidedProgress=e=>{let t=e.detail;t&&t.total>0&&(this.guidedProgress=t)},this.close=()=>{this.opened=!1,this.releaseLayoutInset(),this.releaseFocusTrap(),setTimeout(()=>{this.removeSelfFromOwnerChildren()||this.parentElement?.removeChild(this)},300)},this._escListener=e=>{if(e.key!==`Escape`)return;let t=this.getRootNode().querySelectorAll(`mateu-drawer, mateu-dialog`);t[t.length-1]===this&&(e.stopPropagation(),this.close())}}jumpToStep(e){this.pagerMenuOpen=!1,e&&(this.renderRoot.querySelector(`.content mateu-component`)??this.renderRoot.querySelector(`mateu-component`))?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`goToStep`,parameters:{_stepId:e}},bubbles:!0,composed:!0}))}static{this.SIZE_LADDER=[`s`,`m`,`l`,`xl`]}static{this.SIZE_WIDTHS={s:`464px`,m:`648px`,l:`968px`,xl:`90vw`}}effectiveWidth(e){if(e.width)return e.width;if(!e.size)return;let t=Ia.SIZE_LADDER,n=Math.max(0,t.indexOf(e.size)),r=Math.min(t.length-1,n+this.maximizeSteps);return Ia.SIZE_WIDTHS[t[r]]}canMaximize(e){if(!e.maximizable)return!1;let t=Ia.SIZE_LADDER;return Math.max(0,t.indexOf(e.size??`m`))+this.maximizeSteps<t.length-1}firstUpdated(){requestAnimationFrame(()=>this.opened=!0),this.addEventListener(`mateu-guided-progress`,this.onGuidedProgress);let e=this.component?.metadata;e&&requestAnimationFrame(()=>this.applyLayoutInset(e))}releaseFocusTrap(){this.focusTrap?.release(),this.focusTrap=void 0}applyLayoutInset(e){if(!e.layout)return;let t=document.querySelector(`mateu-ui`);if(!t)return;let n=e.position??`end`,r=n===`bottom`?`var(--mateu-drawer-height, 50vh)`:this.effectiveWidth(e)??`648px`;this._insetProp=n===`start`?`paddingLeft`:n===`bottom`?`paddingBottom`:`paddingRight`,t.style.transition=`padding .25s ease`,t.style[this._insetProp]=r}releaseLayoutInset(){if(!this._insetProp)return;let e=document.querySelector(`mateu-ui`);e&&(e.style[this._insetProp]=``),this._insetProp=void 0}applyFragment(e){super.applyFragment(e);let t=e.state?._closeAfterMillis;t&&setTimeout(()=>this.close(),t)}updated(e){if(super.updated(e),e.has(`component`)&&this.component){let e=this.component.metadata;this.state=e.initialData}let t=this.component?.metadata,n=this.renderRoot.querySelector(`[role="dialog"]`);this.opened&&n&&!t?.modeless&&!t?.layout&&!this.focusTrap?this.focusTrap=Ma(n):this.focusTrap&&this.opened&&this.focusTrap.refresh()}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._escListener)}disconnectedCallback(){document.removeEventListener(`keydown`,this._escListener),this.releaseLayoutInset(),this.releaseFocusTrap(),super.disconnectedCallback()}render(){let e=this.component.metadata,t=e.position??`end`,n=rt(e.headerTitle,this.state,this.data,this.appState,this.appData),r=rt(e.subtitle,this.state,this.data,this.appState,this.appData),i=this.effectiveWidth(e),a=e.peerNav&&(e.peerNav.prevRoute||e.peerNav.nextRoute)?e.peerNav:void 0;return T`
-        ${e.modeless||e.layout?v:T`
+    `}};O([S()],Ia.prototype,`opened`,void 0),Ia=O([h(`mateu-dialog`)],Ia);var La,Ra=class extends ga{static{La=this}constructor(...e){super(...e),this.opened=!1,this.maximizeSteps=0,this.collapsed=!1,this.pagerMenuOpen=!1,this.onGuidedProgress=e=>{let t=e.detail;t&&t.total>0&&(this.guidedProgress=t)},this.close=()=>{this.opened=!1,this.releaseLayoutInset(),this.releaseFocusTrap(),setTimeout(()=>{this.removeSelfFromOwnerChildren()||this.parentElement?.removeChild(this)},300)},this._escListener=e=>{if(e.key!==`Escape`)return;let t=this.getRootNode().querySelectorAll(`mateu-drawer, mateu-dialog`);t[t.length-1]===this&&(e.stopPropagation(),this.close())}}jumpToStep(e){this.pagerMenuOpen=!1,e&&(this.renderRoot.querySelector(`.content mateu-component`)??this.renderRoot.querySelector(`mateu-component`))?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`goToStep`,parameters:{_stepId:e}},bubbles:!0,composed:!0}))}static{this.SIZE_LADDER=[`s`,`m`,`l`,`xl`]}static{this.SIZE_WIDTHS={s:`464px`,m:`648px`,l:`968px`,xl:`90vw`}}effectiveWidth(e){if(e.width)return e.width;if(!e.size)return;let t=La.SIZE_LADDER,n=Math.max(0,t.indexOf(e.size)),r=Math.min(t.length-1,n+this.maximizeSteps);return La.SIZE_WIDTHS[t[r]]}canMaximize(e){if(!e.maximizable)return!1;let t=La.SIZE_LADDER;return Math.max(0,t.indexOf(e.size??`m`))+this.maximizeSteps<t.length-1}firstUpdated(){requestAnimationFrame(()=>this.opened=!0),this.addEventListener(`mateu-guided-progress`,this.onGuidedProgress);let e=this.component?.metadata;e&&requestAnimationFrame(()=>this.applyLayoutInset(e))}releaseFocusTrap(){this.focusTrap?.release(),this.focusTrap=void 0}applyLayoutInset(e){if(!e.layout)return;let t=document.querySelector(`mateu-ui`);if(!t)return;let n=e.position??`end`,r=n===`bottom`?`var(--mateu-drawer-height, 50vh)`:this.effectiveWidth(e)??`648px`;this._insetProp=n===`start`?`paddingLeft`:n===`bottom`?`paddingBottom`:`paddingRight`,t.style.transition=`padding .25s ease`,t.style[this._insetProp]=r}releaseLayoutInset(){if(!this._insetProp)return;let e=document.querySelector(`mateu-ui`);e&&(e.style[this._insetProp]=``),this._insetProp=void 0}applyFragment(e){super.applyFragment(e);let t=e.state?._closeAfterMillis;t&&setTimeout(()=>this.close(),t)}updated(e){if(super.updated(e),e.has(`component`)&&this.component){let e=this.component.metadata;this.state=e.initialData}let t=this.component?.metadata,n=this.renderRoot.querySelector(`[role="dialog"]`);this.opened&&n&&!t?.modeless&&!t?.layout&&!this.focusTrap?this.focusTrap=Na(n):this.focusTrap&&this.opened&&this.focusTrap.refresh()}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._escListener)}disconnectedCallback(){document.removeEventListener(`keydown`,this._escListener),this.releaseLayoutInset(),this.releaseFocusTrap(),super.disconnectedCallback()}render(){let e=this.component.metadata,t=e.position??`end`,n=it(e.headerTitle,this.state,this.data,this.appState,this.appData),r=it(e.subtitle,this.state,this.data,this.appState,this.appData),i=this.effectiveWidth(e),a=e.peerNav&&(e.peerNav.prevRoute||e.peerNav.nextRoute)?e.peerNav:void 0;return w`
+        ${e.modeless||e.layout?_:w`
             <div class="backdrop ${this.opened?`open`:``}" @click="${this.close}"></div>
         `}
         <section
                 class="panel ${t} ${this.opened?`open`:``} ${this.collapsed?`collapsed`:``} ${this.component?.cssClasses??``}"
                 role="dialog"
                 aria-modal="${!e.modeless}"
-                aria-label="${n??v}"
+                aria-label="${n??_}"
                 style="${i&&t!==`bottom`?`width: ${i};`:``}${this.component?.style??``}"
         >
             <header>
-                ${n?T`<div class="titles"><h3>${n}</h3>${r?T`<span class="subtitle">${r}</span>`:v}</div>`:T`<span class="spacer"></span>`}
-                ${this.guidedProgress&&this.guidedProgress.total>1?T`
+                ${n?w`<div class="titles"><h3>${n}</h3>${r?w`<span class="subtitle">${r}</span>`:_}</div>`:w`<span class="spacer"></span>`}
+                ${this.guidedProgress&&this.guidedProgress.total>1?w`
                     <div class="guided-pager-wrap">
                         <button class="guided-pager" aria-haspopup="true" aria-expanded="${this.pagerMenuOpen}"
                                 aria-label="Step ${this.guidedProgress.current} of ${this.guidedProgress.total}"
                                 @click="${()=>this.pagerMenuOpen=!this.pagerMenuOpen}">${this.guidedProgress.current} | ${this.guidedProgress.total}<span class="caret">▾</span></button>
-                        ${this.pagerMenuOpen&&this.guidedProgress.steps?T`
+                        ${this.pagerMenuOpen&&this.guidedProgress.steps?w`
                             <div class="guided-pager-menu">
-                                ${this.guidedProgress.steps.map((e,t)=>T`
+                                ${this.guidedProgress.steps.map((e,t)=>w`
                                     <button class="guided-pager-item ${e.status}" ?disabled="${e.status!==`done`}"
                                             @click="${()=>this.jumpToStep(e.id)}"><span class="pager-dot">${e.status===`done`?`✓`:t+1}</span>${e.title??`Step ${t+1}`}</button>
                                 `)}
                             </div>
-                        `:v}
+                        `:_}
                     </div>
-                `:v}
-                ${e.header?T`
-                    <mateu-event-interceptor .target="${this}">${F(this,e.header,this.baseUrl,this.state,this.data,this.appState,this.appData)}</mateu-event-interceptor>
-                `:v}
-                ${a?T`
+                `:_}
+                ${e.header?w`
+                    <mateu-event-interceptor .target="${this}">${P(this,e.header,this.baseUrl,this.state,this.data,this.appState,this.appData)}</mateu-event-interceptor>
+                `:_}
+                ${a?w`
                     <button class="drawer-icon" aria-label="${a.prevLabel??`Previous`}" title="${a.prevLabel??`Previous`}"
                             ?disabled="${!a.prevRoute}" @click="${()=>{a.prevRoute&&(window.location.href=a.prevRoute)}}">‹</button>
                     <button class="drawer-icon" aria-label="${a.nextLabel??`Next`}" title="${a.nextLabel??`Next`}"
                             ?disabled="${!a.nextRoute}" @click="${()=>{a.nextRoute&&(window.location.href=a.nextRoute)}}">›</button>
-                `:v}
-                ${e.collapsible?T`
+                `:_}
+                ${e.collapsible?w`
                     <button class="drawer-icon" aria-label="${this.collapsed?`Expand`:`Collapse`}" title="${this.collapsed?`Expand`:`Collapse`}"
                             @click="${()=>this.collapsed=!this.collapsed}">${this.collapsed?`▴`:`▾`}</button>
-                `:v}
-                ${this.canMaximize(e)?T`
+                `:_}
+                ${this.canMaximize(e)?w`
                     <button class="drawer-icon" aria-label="Maximize" title="Maximize" @click="${()=>this.maximizeSteps++}">⤢</button>
-                `:v}
+                `:_}
                 <button class="drawer-close" aria-label="Close" @click="${this.close}">✕</button>
             </header>
-            ${this.collapsed?v:T`
+            ${this.collapsed?_:w`
             <div class="content ${e.noPadding?`no-padding`:``}">
-                ${e.content?T`
-                    <mateu-event-interceptor .target="${this}" style="--mateu-section-border: none; width: 100%;">${F(this,e.content,this.baseUrl,this.state,this.data,this.appState,this.appData)}</mateu-event-interceptor>
-                `:v}
+                ${e.content?w`
+                    <mateu-event-interceptor .target="${this}" style="--mateu-section-border: none; width: 100%;">${P(this,e.content,this.baseUrl,this.state,this.data,this.appState,this.appData)}</mateu-event-interceptor>
+                `:_}
             </div>
-            ${e.footer?T`
+            ${e.footer?w`
                 <footer>
-                    <mateu-event-interceptor .target="${this}" style="width: 100%;">${F(this,e.footer,this.baseUrl,this.state,this.data,this.appState,this.appData)}</mateu-event-interceptor>
+                    <mateu-event-interceptor .target="${this}" style="width: 100%;">${P(this,e.footer,this.baseUrl,this.state,this.data,this.appState,this.appData)}</mateu-event-interceptor>
                 </footer>
-            `:v}
+            `:_}
             `}
         </section>
-       `}static{this.styles=h`
+       `}static{this.styles=m`
         .drawer-close {
             border: none;
             background: transparent;
@@ -5882,19 +5882,19 @@ ${i}
             display: flex;
             justify-content: flex-end;
         }
-  `}};k([C()],La.prototype,`opened`,void 0),k([C()],La.prototype,`maximizeSteps`,void 0),k([C()],La.prototype,`collapsed`,void 0),k([C()],La.prototype,`guidedProgress`,void 0),k([C()],La.prototype,`pagerMenuOpen`,void 0),La=Ia=k([g(`mateu-drawer`)],La);function Ra(e){if(e.parentElement)return e.parentElement;let t=e.getRootNode();return t instanceof ShadowRoot?t.host:null}var J=class extends b{constructor(...e){super(...e),this.appState={},this.appData={},this.standalone=!1,this.actionBanners=[],this.dismissedStaticBannerIndices=new Set,this._tocEntries=[],this._activeToc=0,this._tocVisible=!1,this._tocRebuildScheduled=!1,this._headerH=0,this._onResize=()=>this._layoutStickyTops(),this._tocLocked=!1,this._unlockToc=e=>{if(e&&e.type===`keydown`){let t=e;if(t.ctrlKey&&t.altKey&&!t.shiftKey&&!t.metaKey&&/^(?:Digit|Numpad)[1-9]$/.test(t.code))return}this._tocLocked=!1},this._actionBannerTimers=[],this._staticBannerTimers=[],this._bannersHandler=e=>{let t=e.detail,n=t.banners??[],r=t.append??!1;r?this.actionBanners=[...this.actionBanners,...n]:(this._clearActionBannerTimers(),this.actionBanners=n);let i=r?this.actionBanners.length-n.length:0;n.forEach((e,t)=>{if(e.timeoutSeconds&&e.timeoutSeconds>0){let n=i+t;this._actionBannerTimers.push(setTimeout(()=>{this.actionBanners=this.actionBanners.filter((e,t)=>t!==n)},e.timeoutSeconds*1e3))}})},this._onTocKey=e=>{if(!this._tocVisible||!e.ctrlKey||!e.altKey||e.shiftKey||e.metaKey)return;let t=/^(?:Digit|Numpad)([1-9])$/.exec(e.code);if(!t)return;let n=parseInt(t[1],10)-1;n>=this._tocEntries.length||(e.preventDefault(),this._scrollToSection(n))},this._onScrollSpy=()=>{if(this._tocLocked)return;let e=this._sectionCards();if(!e.length)return;let t=this.shadowRoot?.querySelector(`mateu-content-header`),n=t?t.getBoundingClientRect().bottom:0;for(let t of e){if(!t.classList.contains(`mateu-section--sticky`))continue;let e=t.getBoundingClientRect();e.top<=n+12+2&&(n=Math.max(n,e.bottom))}let r=n+12+4,i=0;this._tocEntries.forEach((e,t)=>{e.el.getBoundingClientRect().top<=r&&(i=t)}),this._activeToc=i}}connectedCallback(){super.connectedCallback(),document.addEventListener(`page-banners-received`,this._bannersHandler),window.addEventListener(`resize`,this._onResize),document.addEventListener(`keydown`,this._onTocKey)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`page-banners-received`,this._bannersHandler),window.removeEventListener(`resize`,this._onResize),document.removeEventListener(`keydown`,this._onTocKey),this._clearAllTimers(),this._teardownScrollSpy()}updated(e){if(super.updated(e),e.has(`component`)&&e.get(`component`)!==void 0&&(this._clearAllTimers(),this.actionBanners=[],this.dismissedStaticBannerIndices=new Set),e.has(`component`)){let e=this.component?.metadata?.level??0;this.toggleAttribute(`data-nested`,e>0),this._scheduleStaticBannerTimeouts();let t=this.component?.metadata?.pageWidth===`edgeToEdge`;this.toggleAttribute(`data-edge`,t),this.dispatchEvent(new CustomEvent(`compact-changed`,{detail:{compact:!!this.component?.style?.includes(`--mateu-compact:1`)||t},bubbles:!0,composed:!0})),this._scheduleTocRebuild()}}_scheduleStaticBannerTimeouts(){this._staticBannerTimers.forEach(e=>clearTimeout(e)),this._staticBannerTimers=[],(this.component?.metadata?.banners??[]).forEach((e,t)=>{e.timeoutSeconds&&e.timeoutSeconds>0&&this._staticBannerTimers.push(setTimeout(()=>{this.dismissedStaticBannerIndices=new Set([...this.dismissedStaticBannerIndices,t])},e.timeoutSeconds*1e3))})}_clearActionBannerTimers(){this._actionBannerTimers.forEach(e=>clearTimeout(e)),this._actionBannerTimers=[]}_clearAllTimers(){this._clearActionBannerTimers(),this._staticBannerTimers.forEach(e=>clearTimeout(e)),this._staticBannerTimers=[]}_dismissActionBanner(e){this.actionBanners=this.actionBanners.filter((t,n)=>n!==e)}_dismissStaticBanner(e){this.dismissedStaticBannerIndices=new Set([...this.dismissedStaticBannerIndices,e])}bannerThemeClass(e){let t=e.theme?.toLowerCase()??`info`;return t===`none`?``:t}_evalBannerText(e){return M(e,this.state,this.data)}_renderBanner(e,t){let n=this._evalBannerText(e.title),r=this._evalBannerText(e.description);return T`
+  `}};O([S()],Ra.prototype,`opened`,void 0),O([S()],Ra.prototype,`maximizeSteps`,void 0),O([S()],Ra.prototype,`collapsed`,void 0),O([S()],Ra.prototype,`guidedProgress`,void 0),O([S()],Ra.prototype,`pagerMenuOpen`,void 0),Ra=La=O([h(`mateu-drawer`)],Ra);function za(e){if(e.parentElement)return e.parentElement;let t=e.getRootNode();return t instanceof ShadowRoot?t.host:null}var q=class extends y{constructor(...e){super(...e),this.appState={},this.appData={},this.standalone=!1,this.actionBanners=[],this.dismissedStaticBannerIndices=new Set,this._tocEntries=[],this._activeToc=0,this._tocVisible=!1,this._tocRebuildScheduled=!1,this._headerH=0,this._onResize=()=>this._layoutStickyTops(),this._tocLocked=!1,this._unlockToc=e=>{if(e&&e.type===`keydown`){let t=e;if(t.ctrlKey&&t.altKey&&!t.shiftKey&&!t.metaKey&&/^(?:Digit|Numpad)[1-9]$/.test(t.code))return}this._tocLocked=!1},this._actionBannerTimers=[],this._staticBannerTimers=[],this._bannersHandler=e=>{let t=e.detail,n=t.banners??[],r=t.append??!1;r?this.actionBanners=[...this.actionBanners,...n]:(this._clearActionBannerTimers(),this.actionBanners=n);let i=r?this.actionBanners.length-n.length:0;n.forEach((e,t)=>{if(e.timeoutSeconds&&e.timeoutSeconds>0){let n=i+t;this._actionBannerTimers.push(setTimeout(()=>{this.actionBanners=this.actionBanners.filter((e,t)=>t!==n)},e.timeoutSeconds*1e3))}})},this._onTocKey=e=>{if(!this._tocVisible||!e.ctrlKey||!e.altKey||e.shiftKey||e.metaKey)return;let t=/^(?:Digit|Numpad)([1-9])$/.exec(e.code);if(!t)return;let n=parseInt(t[1],10)-1;n>=this._tocEntries.length||(e.preventDefault(),this._scrollToSection(n))},this._onScrollSpy=()=>{if(this._tocLocked)return;let e=this._sectionCards();if(!e.length)return;let t=this.shadowRoot?.querySelector(`mateu-content-header`),n=t?t.getBoundingClientRect().bottom:0;for(let t of e){if(!t.classList.contains(`mateu-section--sticky`))continue;let e=t.getBoundingClientRect();e.top<=n+12+2&&(n=Math.max(n,e.bottom))}let r=n+12+4,i=0;this._tocEntries.forEach((e,t)=>{e.el.getBoundingClientRect().top<=r&&(i=t)}),this._activeToc=i}}connectedCallback(){super.connectedCallback(),document.addEventListener(`page-banners-received`,this._bannersHandler),window.addEventListener(`resize`,this._onResize),document.addEventListener(`keydown`,this._onTocKey)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`page-banners-received`,this._bannersHandler),window.removeEventListener(`resize`,this._onResize),document.removeEventListener(`keydown`,this._onTocKey),this._clearAllTimers(),this._teardownScrollSpy()}updated(e){if(super.updated(e),e.has(`component`)&&e.get(`component`)!==void 0&&(this._clearAllTimers(),this.actionBanners=[],this.dismissedStaticBannerIndices=new Set),e.has(`component`)){let e=this.component?.metadata?.level??0;this.toggleAttribute(`data-nested`,e>0),this._scheduleStaticBannerTimeouts();let t=this.component?.metadata?.pageWidth===`edgeToEdge`;this.toggleAttribute(`data-edge`,t),this.dispatchEvent(new CustomEvent(`compact-changed`,{detail:{compact:!!this.component?.style?.includes(`--mateu-compact:1`)||t},bubbles:!0,composed:!0})),this._scheduleTocRebuild()}}_scheduleStaticBannerTimeouts(){this._staticBannerTimers.forEach(e=>clearTimeout(e)),this._staticBannerTimers=[],(this.component?.metadata?.banners??[]).forEach((e,t)=>{e.timeoutSeconds&&e.timeoutSeconds>0&&this._staticBannerTimers.push(setTimeout(()=>{this.dismissedStaticBannerIndices=new Set([...this.dismissedStaticBannerIndices,t])},e.timeoutSeconds*1e3))})}_clearActionBannerTimers(){this._actionBannerTimers.forEach(e=>clearTimeout(e)),this._actionBannerTimers=[]}_clearAllTimers(){this._clearActionBannerTimers(),this._staticBannerTimers.forEach(e=>clearTimeout(e)),this._staticBannerTimers=[]}_dismissActionBanner(e){this.actionBanners=this.actionBanners.filter((t,n)=>n!==e)}_dismissStaticBanner(e){this.dismissedStaticBannerIndices=new Set([...this.dismissedStaticBannerIndices,e])}bannerThemeClass(e){let t=e.theme?.toLowerCase()??`info`;return t===`none`?``:t}_evalBannerText(e){return j(e,this.state,this.data)}_renderBanner(e,t){let n=this._evalBannerText(e.title),r=this._evalBannerText(e.description);return w`
             <div class="page-banner page-banner--${this.bannerThemeClass(e)}">
-                ${n||e.hasCloseButton?T`
+                ${n||e.hasCloseButton?w`
                     <div style="display: flex; align-items: center; justify-content: space-between; color: #1a1a1a; width: 100%;">
                         <span style="font-weight: 600;">${n??``}</span>
-                        ${e.hasCloseButton?T`
+                        ${e.hasCloseButton?w`
                             <button class="banner-close" @click=${t} title="Dismiss" aria-label="Dismiss">✕</button>
-                        `:v}
+                        `:_}
                     </div>
-                `:v}
-                ${r?T`<p>${r}</p>`:v}
+                `:_}
+                ${r?w`<p>${r}</p>`:_}
             </div>
-        `}_onSlotChange(){this._scheduleTocRebuild()}_scheduleTocRebuild(){this._tocRebuildScheduled||(this._tocRebuildScheduled=!0,requestAnimationFrame(()=>{this._tocRebuildScheduled=!1,this._rebuildToc()}))}_sectionCards(){return Array.from(this.querySelectorAll(`.mateu-section`))}_sectionTitle(e){return e.querySelector(`[slot="title"]`)?.textContent?.trim()||e.querySelector(`h1,h2,h3,h4,h5,h6`)?.textContent?.trim()||void 0}_rebuildToc(){let e=this._sectionCards(),t=e.map(e=>({title:this._sectionTitle(e),el:e})).filter(e=>!!e.title),n=this.component?.metadata?.toc,r=t.length>4&&e.every(e=>!e.closest(`vaadin-horizontal-layout`)),i=(n===!0||n!==!1&&r)&&t.length>0;this._tocEntries=t,this._tocVisible=i,this._activeToc>=t.length&&(this._activeToc=0),this._teardownScrollSpy(),i?requestAnimationFrame(()=>{this._layoutStickyTops(),this._setupScrollSpy()}):this._layoutStickyTops()}_layoutStickyTops(){let e=this.shadowRoot?.querySelector(`mateu-content-header`);this._headerH=this._tocVisible&&e?e.offsetHeight:0,this.style.setProperty(`--mateu-header-h`,this._headerH+`px`);let t=this._headerH+12;for(let e of this._sectionCards())e.classList.contains(`mateu-section--sticky`)&&(e.style.top=t+`px`,t+=e.offsetHeight+12)}_scrollContainer(){let e=Ra(this);for(;e;){let t=getComputedStyle(e).overflowY;if((t===`auto`||t===`scroll`)&&e.scrollHeight>e.clientHeight)return e;e=Ra(e)}return null}_setupScrollSpy(){this._tocEntries.length&&(this._spyTarget=this._scrollContainer()??window,this._spyTarget.addEventListener(`scroll`,this._onScrollSpy,{passive:!0}),window.addEventListener(`wheel`,this._unlockToc,{passive:!0}),window.addEventListener(`touchstart`,this._unlockToc,{passive:!0}),window.addEventListener(`keydown`,this._unlockToc),this._onScrollSpy())}_teardownScrollSpy(){this._spyTarget?.removeEventListener(`scroll`,this._onScrollSpy),window.removeEventListener(`wheel`,this._unlockToc),window.removeEventListener(`touchstart`,this._unlockToc),window.removeEventListener(`keydown`,this._unlockToc),this._spyTarget=void 0}_scrollToSection(e){let t=this._tocEntries[e];if(!t)return;this._activeToc=e,this._tocLocked=!0;let n=this._headerH+12;for(let e of this._sectionCards()){if(e===t.el)break;e.classList.contains(`mateu-section--sticky`)&&(n+=e.offsetHeight+12)}let r=this._scrollContainer(),i=r?r.getBoundingClientRect().top:0,a=t.el.getBoundingClientRect().top-i-n;(r??window).scrollBy({top:a,behavior:`smooth`})}_showHeaderBand(){let e=this.component?.metadata,t=!!(e?.title||e?.subtitle||e?.toolbar?.length),n=!!this.component?.children?.some(e=>e.metadata?.type===j.Crud);return t&&!n&&!this._hasWelcomeBanner()}_hasWelcomeBanner(){let e=t=>t?.metadata?.type===j.HeroSection||(t?.children??[]).some(e);return(this.component?.children??[]).some(e)}render(){let e=this.component?.metadata,t=[...(e?.banners??[]).map((e,t)=>({banner:e,index:t})).filter(({index:e})=>!this.dismissedStaticBannerIndices.has(e)).map(({banner:e,index:t})=>({banner:e,onDismiss:()=>this._dismissStaticBanner(t)})),...this.actionBanners.map((e,t)=>({banner:e,onDismiss:()=>this._dismissActionBanner(t)}))];return T`<div style="display: flex; flex-direction: column; width: 100%;">${T`
+        `}_onSlotChange(){this._scheduleTocRebuild()}_scheduleTocRebuild(){this._tocRebuildScheduled||(this._tocRebuildScheduled=!0,requestAnimationFrame(()=>{this._tocRebuildScheduled=!1,this._rebuildToc()}))}_sectionCards(){return Array.from(this.querySelectorAll(`.mateu-section`))}_sectionTitle(e){return e.querySelector(`[slot="title"]`)?.textContent?.trim()||e.querySelector(`h1,h2,h3,h4,h5,h6`)?.textContent?.trim()||void 0}_rebuildToc(){let e=this._sectionCards(),t=e.map(e=>({title:this._sectionTitle(e),el:e})).filter(e=>!!e.title),n=this.component?.metadata?.toc,r=t.length>4&&e.every(e=>!e.closest(`vaadin-horizontal-layout`)),i=(n===!0||n!==!1&&r)&&t.length>0;this._tocEntries=t,this._tocVisible=i,this._activeToc>=t.length&&(this._activeToc=0),this._teardownScrollSpy(),i?requestAnimationFrame(()=>{this._layoutStickyTops(),this._setupScrollSpy()}):this._layoutStickyTops()}_layoutStickyTops(){let e=this.shadowRoot?.querySelector(`mateu-content-header`);this._headerH=this._tocVisible&&e?e.offsetHeight:0,this.style.setProperty(`--mateu-header-h`,this._headerH+`px`);let t=this._headerH+12;for(let e of this._sectionCards())e.classList.contains(`mateu-section--sticky`)&&(e.style.top=t+`px`,t+=e.offsetHeight+12)}_scrollContainer(){let e=za(this);for(;e;){let t=getComputedStyle(e).overflowY;if((t===`auto`||t===`scroll`)&&e.scrollHeight>e.clientHeight)return e;e=za(e)}return null}_setupScrollSpy(){this._tocEntries.length&&(this._spyTarget=this._scrollContainer()??window,this._spyTarget.addEventListener(`scroll`,this._onScrollSpy,{passive:!0}),window.addEventListener(`wheel`,this._unlockToc,{passive:!0}),window.addEventListener(`touchstart`,this._unlockToc,{passive:!0}),window.addEventListener(`keydown`,this._unlockToc),this._onScrollSpy())}_teardownScrollSpy(){this._spyTarget?.removeEventListener(`scroll`,this._onScrollSpy),window.removeEventListener(`wheel`,this._unlockToc),window.removeEventListener(`touchstart`,this._unlockToc),window.removeEventListener(`keydown`,this._unlockToc),this._spyTarget=void 0}_scrollToSection(e){let t=this._tocEntries[e];if(!t)return;this._activeToc=e,this._tocLocked=!0;let n=this._headerH+12;for(let e of this._sectionCards()){if(e===t.el)break;e.classList.contains(`mateu-section--sticky`)&&(n+=e.offsetHeight+12)}let r=this._scrollContainer(),i=r?r.getBoundingClientRect().top:0,a=t.el.getBoundingClientRect().top-i-n;(r??window).scrollBy({top:a,behavior:`smooth`})}_showHeaderBand(){let e=this.component?.metadata,t=!!(e?.title||e?.subtitle||e?.toolbar?.length),n=!!this.component?.children?.some(e=>e.metadata?.type===A.Crud);return t&&!n&&!this._hasWelcomeBanner()}_hasWelcomeBanner(){let e=t=>t?.metadata?.type===A.HeroSection||(t?.children??[]).some(e);return(this.component?.children??[]).some(e)}render(){let e=this.component?.metadata,t=[...(e?.banners??[]).map((e,t)=>({banner:e,index:t})).filter(({index:e})=>!this.dismissedStaticBannerIndices.has(e)).map(({banner:e,index:t})=>({banner:e,onDismiss:()=>this._dismissStaticBanner(t)})),...this.actionBanners.map((e,t)=>({banner:e,onDismiss:()=>this._dismissActionBanner(t)}))];return w`<div style="display: flex; flex-direction: column; width: 100%;">${w`
             <div class="page-header-wrap">
                 <mateu-content-header
                     class="${this._tocVisible?`sticky-header`:``}"
@@ -5905,15 +5905,15 @@ ${i}
                     .appState="${this.appState}"
                     .appData="${this.appData}"
                 ></mateu-content-header>
-                ${this._showHeaderBand()?T`
+                ${this._showHeaderBand()?w`
                     <div class="page-header-band" aria-hidden="true"></div>
-                `:v}
+                `:_}
             </div>
-            ${t.length>0?T`
+            ${t.length>0?w`
                 <div class="page-banners">
                     ${t.map(({banner:e,onDismiss:t})=>this._renderBanner(e,t))}
                 </div>
-            `:v}
+            `:_}
             <div class="page-body ${this._tocVisible?`with-toc`:``}">
                 <div class="form-content">
                     <slot @slotchange=${this._onSlotChange}></slot>
@@ -5921,25 +5921,25 @@ ${i}
                         <slot name="buttons"></slot>
                     </div>
                 </div>
-                ${this._tocVisible?T`
+                ${this._tocVisible?w`
                     <aside class="page-toc">
                         <nav>
-                            ${this._tocEntries.map((e,t)=>T`
+                            ${this._tocEntries.map((e,t)=>w`
                                 <a class="page-toc__item ${t===this._activeToc?`is-active`:``}"
                                    @click=${()=>this._scrollToSection(t)}
                                    title=${t<9?`${e.title} (Ctrl+Alt+${t+1})`:e.title}>
                                     <span class="page-toc__label">${e.title}</span>
-                                    ${t<9?T`<span class="page-toc__key">${t+1}</span>`:v}
+                                    ${t<9?w`<span class="page-toc__key">${t+1}</span>`:_}
                                 </a>
                             `)}
                         </nav>
                     </aside>
-                `:v}
+                `:_}
             </div>
             <div class="form-footer">
-                ${e?.footer?.map(e=>F(this,e,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData))}
+                ${e?.footer?.map(e=>P(this,e,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData))}
             </div>
-        `}</div>`}static{this.styles=h`
+        `}</div>`}static{this.styles=m`
         /* Design-system hook: background behind the page header (the RDS "Header + Background"
            band) — transparent by default; the Redwood renderer paints it with the canvas color
            via a custom property, so the header reads as part of the canvas and the content slab
@@ -6138,7 +6138,7 @@ ${i}
             background: #fdf2f2;
             border-leftx: 4px solid var(--lumo-error-color);
         }
-    `}};k([y()],J.prototype,`component`,void 0),k([y()],J.prototype,`baseUrl`,void 0),k([y()],J.prototype,`state`,void 0),k([y()],J.prototype,`data`,void 0),k([y()],J.prototype,`appState`,void 0),k([y()],J.prototype,`appData`,void 0),k([y()],J.prototype,`value`,void 0),k([y({type:Boolean})],J.prototype,`standalone`,void 0),k([C()],J.prototype,`actionBanners`,void 0),k([C()],J.prototype,`dismissedStaticBannerIndices`,void 0),k([C()],J.prototype,`_tocEntries`,void 0),k([C()],J.prototype,`_activeToc`,void 0),k([C()],J.prototype,`_tocVisible`,void 0),J=k([g(`mateu-page`)],J);var za=h`
+    `}};O([v()],q.prototype,`component`,void 0),O([v()],q.prototype,`baseUrl`,void 0),O([v()],q.prototype,`state`,void 0),O([v()],q.prototype,`data`,void 0),O([v()],q.prototype,`appState`,void 0),O([v()],q.prototype,`appData`,void 0),O([v()],q.prototype,`value`,void 0),O([v({type:Boolean})],q.prototype,`standalone`,void 0),O([S()],q.prototype,`actionBanners`,void 0),O([S()],q.prototype,`dismissedStaticBannerIndices`,void 0),O([S()],q.prototype,`_tocEntries`,void 0),O([S()],q.prototype,`_activeToc`,void 0),O([S()],q.prototype,`_tocVisible`,void 0),q=O([h(`mateu-page`)],q);var Ba=m`
     .nbtn {
         display: inline-flex;
         align-items: center;
@@ -6167,47 +6167,47 @@ ${i}
     }
     .nbtn.primary:hover { background: var(--lumo-primary-color, #1676f3); filter: brightness(1.08); }
     .nbtn svg { width: 1em; height: 1em; flex-shrink: 0; }
-`,Ba=e=>w`
+`,Va=e=>C`
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-         stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${e}</svg>`,Va=Ba(w`
+         stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${e}</svg>`,Ha=Va(C`
     <circle cx="12" cy="12" r="3"></circle>
-    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path>`),Ha=Ba(w`
+    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path>`),Ua=Va(C`
     <line x1="12" y1="5" x2="12" y2="19"></line>
-    <line x1="5" y1="12" x2="19" y2="12"></line>`),Ua=Ba(w`
+    <line x1="5" y1="12" x2="19" y2="12"></line>`),Wa=Va(C`
     <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
     <polyline points="7 10 12 15 17 10"></polyline>
-    <line x1="12" y1="15" x2="12" y2="3"></line>`);Ba(w`
+    <line x1="12" y1="15" x2="12" y2="3"></line>`);Va(C`
     <rect x="9" y="2" width="6" height="5" rx="1"></rect>
     <rect x="2" y="17" width="6" height="5" rx="1"></rect>
     <rect x="16" y="17" width="6" height="5" rx="1"></rect>
-    <path d="M12 7v4M5 17v-3h14v3M12 11v3"></path>`);var Wa=Ba(w`
+    <path d="M12 7v4M5 17v-3h14v3M12 11v3"></path>`);var Ga=Va(C`
     <rect x="9" y="2" width="6" height="12" rx="3"></rect>
     <path d="M5 10v1a7 7 0 0 0 14 0v-1"></path>
-    <line x1="12" y1="18" x2="12" y2="22"></line>`),Ga=Ba(w`
+    <line x1="12" y1="18" x2="12" y2="22"></line>`),Ka=Va(C`
     <line x1="18" y1="6" x2="6" y2="18"></line>
-    <line x1="6" y1="6" x2="18" y2="18"></line>`),Ka=[`#e91e63`,`#1676f3`,`#10b981`,`#8b5cf6`,`#f59e0b`,`#ef4444`],qa=e=>Ka[Math.abs(e??0)%Ka.length],Ja=e=>(e??`?`).split(/\s+/).filter(e=>e).map(e=>e[0]).slice(0,2).join(``).toUpperCase()||`?`,Y=class extends b{constructor(...e){super(...e),this.localAgentUrl=`http://127.0.0.1:8776`,this.localAgentAlive=!1,this.menu=[],this.chatSessionId=E(),this.menuContextSent=!1,this.attachments=[],this.uploading=!1,this.expanded=!1,this.toggleExpanded=()=>{this.expanded=!this.expanded},this.items=[],this.listening=!1,this.recognitionAvailable=!1,this.loading=!1,this.elapsedSeconds=0,this.startListening=()=>{this.recognition&&(this.listening?(this.recognition.stop(),this.listening=!1):(this.recognition.start(),this.listening=!0))},this.onSpeechResult=e=>{if(this.recognition){let t=e,n=t.results[t.results[0].length-1][0].transcript;this.messageInputElement&&(this.messageInputElement.value=n,this.send(new CustomEvent(`submit`,{detail:{value:n},bubbles:!0,composed:!0})))}},this.probeLocalAgent=async()=>{if(this.localAgentUrl)try{let e=new AbortController,t=setTimeout(()=>e.abort(),1200),n=await fetch(this.localAgentUrl+`/health`,{signal:e.signal});clearTimeout(t),this.localAgentAlive=n.ok}catch{this.localAgentAlive=!1}},this.pickFiles=()=>this.fileInputElement?.click(),this.onFilesPicked=async e=>{let t=e.target,n=Array.from(t.files??[]);if(t.value=``,!(!n.length||!this.uploadUrl)){this.uploading=!0;try{let e=new FormData;e.append(`sessionId`,this.chatSessionId);for(let t of n)e.append(`files`,t,t.name);let t={},r=localStorage.getItem(`__mateu_auth_token`);r&&(t.Authorization=`Bearer `+r);let i=sessionStorage.getItem(`__mateu_sesion_id`);i&&(t[`X-Session-Id`]=i);let a=await fetch(this.uploadUrl,{method:`POST`,headers:t,body:e});if(!a.ok)throw Error(`Upload failed: ${a.status}`);let o=((await a.json()).files??[]).filter(e=>e&&e.path);this.attachments=[...this.attachments,...o]}catch(e){this.addMessage(`⚠️ No se pudieron subir los ficheros: ${e instanceof Error?e.message:e}`,`agent`)}finally{this.uploading=!1}}},this.removeAttachment=e=>{this.attachments=this.attachments.filter(t=>t.path!==e)},this.send=async e=>{this.messageInputElement?.setAttribute(`disabled`,`disabled`);let t=e.detail.value.trim(),n=this.localAgentAlive?this.localAgentUrl+`/mateu/agent/stream`:this.sseUrl,r=this.attachments;if(!t&&r.length===0||!n)return;let i=r.length?`${t}${t?`
+    <line x1="6" y1="6" x2="18" y2="18"></line>`),qa=[`#e91e63`,`#1676f3`,`#10b981`,`#8b5cf6`,`#f59e0b`,`#ef4444`],Ja=e=>qa[Math.abs(e??0)%qa.length],Ya=e=>(e??`?`).split(/\s+/).filter(e=>e).map(e=>e[0]).slice(0,2).join(``).toUpperCase()||`?`,J=class extends y{constructor(...e){super(...e),this.localAgentUrl=`http://127.0.0.1:8776`,this.localAgentAlive=!1,this.menu=[],this.chatSessionId=T(),this.menuContextSent=!1,this.attachments=[],this.uploading=!1,this.expanded=!1,this.toggleExpanded=()=>{this.expanded=!this.expanded},this.items=[],this.listening=!1,this.recognitionAvailable=!1,this.loading=!1,this.elapsedSeconds=0,this.startListening=()=>{this.recognition&&(this.listening?(this.recognition.stop(),this.listening=!1):(this.recognition.start(),this.listening=!0))},this.onSpeechResult=e=>{if(this.recognition){let t=e,n=t.results[t.results[0].length-1][0].transcript;this.messageInputElement&&(this.messageInputElement.value=n,this.send(new CustomEvent(`submit`,{detail:{value:n},bubbles:!0,composed:!0})))}},this.probeLocalAgent=async()=>{if(this.localAgentUrl)try{let e=new AbortController,t=setTimeout(()=>e.abort(),1200),n=await fetch(this.localAgentUrl+`/health`,{signal:e.signal});clearTimeout(t),this.localAgentAlive=n.ok}catch{this.localAgentAlive=!1}},this.pickFiles=()=>this.fileInputElement?.click(),this.onFilesPicked=async e=>{let t=e.target,n=Array.from(t.files??[]);if(t.value=``,!(!n.length||!this.uploadUrl)){this.uploading=!0;try{let e=new FormData;e.append(`sessionId`,this.chatSessionId);for(let t of n)e.append(`files`,t,t.name);let t={},r=localStorage.getItem(`__mateu_auth_token`);r&&(t.Authorization=`Bearer `+r);let i=sessionStorage.getItem(`__mateu_sesion_id`);i&&(t[`X-Session-Id`]=i);let a=await fetch(this.uploadUrl,{method:`POST`,headers:t,body:e});if(!a.ok)throw Error(`Upload failed: ${a.status}`);let o=((await a.json()).files??[]).filter(e=>e&&e.path);this.attachments=[...this.attachments,...o]}catch(e){this.addMessage(`⚠️ No se pudieron subir los ficheros: ${e instanceof Error?e.message:e}`,`agent`)}finally{this.uploading=!1}}},this.removeAttachment=e=>{this.attachments=this.attachments.filter(t=>t.path!==e)},this.send=async e=>{this.messageInputElement?.setAttribute(`disabled`,`disabled`);let t=e.detail.value.trim(),n=this.localAgentAlive?this.localAgentUrl+`/mateu/agent/stream`:this.sseUrl,r=this.attachments;if(!t&&r.length===0||!n)return;let i=r.length?`${t}${t?`
 
 `:``}📎 ${r.map(e=>e.name).join(`, `)}`:t;this.addMessage(i,`user`),this.attachments=[];let a=this.addMessage(``,`agent`);this.startLoading();let o=``;try{let e={Accept:`text/event-stream`,"Content-Type":`application/json`},i=localStorage.getItem(`__mateu_auth_token`);i&&(e.Authorization=`Bearer `+i);let s=sessionStorage.getItem(`__mateu_sesion_id`);s&&(e[`X-Session-Id`]=s);let c=this.contextProvider?.(),l=JSON.stringify({message:t,sessionId:this.chatSessionId,...r.length&&{attachments:r},...c!=null&&{context:c},...this.mcpUrl&&{mcpUrl:new URL(this.mcpUrl,window.location.origin).href},...!this.menuContextSent&&{menuContext:this.buildMenuContext(this.menu)}});this.menuContextSent=!0;let u=await fetch(n,{method:`POST`,headers:e,body:l});if(!u.ok){let e=await u.text();throw Error(`Servidor respondió ${u.status}: ${e}`)}let d=u.body?.getReader();if(!d)throw Error(`No se pudo obtener el reader del stream.`);let f=new TextDecoder,p=``;for(;;){let{done:e,value:t}=await d.read();if(e){if(p.trim().startsWith(`data:`)){let e=p.trim().slice(5).trim(),t=this.tryParseTokenUsage(e),n=!t&&this.tryParseCustomEvent(e);t?this.tokenUsage={...this.tokenUsage,...t}:n?n.event===`agent-error`?(o=`⚠️ `+(n.detail?.message??`Error desconocido del agente`),this.updateMessage(a,o)):this.dispatchEvent(new CustomEvent(n.event,{detail:n.detail,bubbles:!0,composed:!0})):(o+=e,this.updateMessage(a,o))}break}let n=f.decode(t,{stream:!0});p+=n;let r=p.split(`
 `);p=r.pop()||``;let i=!1;for(let e of r)if(e.trim().startsWith(`data:`)){let t=e.trim().slice(5).trim(),n=this.tryParseTokenUsage(t),r=!n&&this.tryParseCustomEvent(t);n?this.tokenUsage={...this.tokenUsage,...n}:r?r.event===`agent-error`?(o=`⚠️ `+(r.detail?.message??`Error desconocido del agente`),this.updateMessage(a,o)):this.dispatchEvent(new CustomEvent(r.event,{detail:r.detail,bubbles:!0,composed:!0})):(o+=t+`
-`,i=!0)}i&&this.updateMessage(a,o)}o||this.updateMessage(a,`⚠️ El agente no devolvió ninguna respuesta. Comprueba que el LLM está configurado correctamente (API key).`)}catch(e){console.error(`Error en el flujo SSE:`,e);let t=e?.message??String(e);(t===`Failed to fetch`||t===`network error`||t===`Load failed`)&&!o?this.updateMessage(a,`⚠️ No se recibió respuesta del agente. El servidor cerró la conexión sin enviar datos — comprueba que el LLM tiene la API key configurada y está disponible.`):this.updateMessage(a,`⚠️ Error: `+t)}finally{this.stopLoading(),setTimeout(()=>{this.messageInputElement&&(this.messageInputElement.value=``)},250),this.messageInputElement?.removeAttribute(`disabled`),this.messageInputElement?.focus()}},this.closeChat=()=>{this.dispatchEvent(new CustomEvent(`close-requested`,{bubbles:!0,composed:!0}))},this.submitFromInput=()=>{let e=this.messageInputElement?.value?.trim()??``;e&&this.send(new CustomEvent(`submit`,{detail:{value:e},bubbles:!0,composed:!0}))},this.onInputKeydown=e=>{e.key===`Enter`&&(e.preventDefault(),this.submitFromInput())}}connectedCallback(){super.connectedCallback(),this.probeLocalAgent();let e=window.SpeechRecognition||window.webkitSpeechRecognition;if(e){let t=new e;this.recognition=t,t.lang=`es-ES`,t.onend=()=>{setTimeout(()=>{if(this.listening&&this.recognition)try{this.recognition.start()}catch{}},250)},this.recognitionAvailable=!0,t.onresult=this.onSpeechResult,t.onerror=e=>{console.error(`Error de reconocimiento: `+e.error),this.listening&&this.recognition&&setTimeout(()=>{this.recognition.start()},250)}}}scrollBottom(){setTimeout(()=>{this.scrollContainer&&this.scrollContainer.scrollTo({top:this.scrollContainer.scrollHeight,behavior:`smooth`})},0)}addMessage(e,t){let n={text:e,time:new Date().toLocaleTimeString(),userName:t.includes(`agent`)?`Asistente`:`Tú`,userColorIndex:t.includes(`agent`)?2:1};return this.items=[...this.items,n],this.scrollBottom(),this.items.length-1}updateMessage(e,t){this.items=this.items.map((n,r)=>r===e?{...n,text:t}:n),this.scrollBottom()}tryParseCustomEvent(e){let t=e.trim();if(!t.startsWith(`{`))return null;try{let e=JSON.parse(t);if(typeof e.event==`string`)return{event:e.event,detail:e.detail??{}}}catch{}return null}tryParseTokenUsage(e){let t=e.trim();if(!t.startsWith(`{`))return null;try{let e=JSON.parse(t);if(`inputTokens`in e||`outputTokens`in e||`totalTokens`in e)return e}catch{}return null}buildMenuContext(e,t=[]){let n=[];for(let r of e){if(r.separator||r.remote)continue;let e=[...t,r.label];if(r.submenus&&r.submenus.length>0)n.push(...this.buildMenuContext(r.submenus,e));else{let t={path:e,navigation:{route:r.route,consumedRoute:r.consumedRoute,actionId:r.actionId??``,baseUrl:r.baseUrl,serverSideType:r.serverSideType,uriPrefix:r.uriPrefix}};r.description&&(t.description=r.description),n.push(t)}}return n}startLoading(){this.loading=!0,this.elapsedSeconds=0,this._elapsedTimer=setInterval(()=>{this.elapsedSeconds++},1e3)}stopLoading(){this.loading=!1,clearInterval(this._elapsedTimer),this._elapsedTimer=void 0}render(){return T`
+`,i=!0)}i&&this.updateMessage(a,o)}o||this.updateMessage(a,`⚠️ El agente no devolvió ninguna respuesta. Comprueba que el LLM está configurado correctamente (API key).`)}catch(e){console.error(`Error en el flujo SSE:`,e);let t=e?.message??String(e);(t===`Failed to fetch`||t===`network error`||t===`Load failed`)&&!o?this.updateMessage(a,`⚠️ No se recibió respuesta del agente. El servidor cerró la conexión sin enviar datos — comprueba que el LLM tiene la API key configurada y está disponible.`):this.updateMessage(a,`⚠️ Error: `+t)}finally{this.stopLoading(),setTimeout(()=>{this.messageInputElement&&(this.messageInputElement.value=``)},250),this.messageInputElement?.removeAttribute(`disabled`),this.messageInputElement?.focus()}},this.closeChat=()=>{this.dispatchEvent(new CustomEvent(`close-requested`,{bubbles:!0,composed:!0}))},this.submitFromInput=()=>{let e=this.messageInputElement?.value?.trim()??``;e&&this.send(new CustomEvent(`submit`,{detail:{value:e},bubbles:!0,composed:!0}))},this.onInputKeydown=e=>{e.key===`Enter`&&(e.preventDefault(),this.submitFromInput())}}connectedCallback(){super.connectedCallback(),this.probeLocalAgent();let e=window.SpeechRecognition||window.webkitSpeechRecognition;if(e){let t=new e;this.recognition=t,t.lang=`es-ES`,t.onend=()=>{setTimeout(()=>{if(this.listening&&this.recognition)try{this.recognition.start()}catch{}},250)},this.recognitionAvailable=!0,t.onresult=this.onSpeechResult,t.onerror=e=>{console.error(`Error de reconocimiento: `+e.error),this.listening&&this.recognition&&setTimeout(()=>{this.recognition.start()},250)}}}scrollBottom(){setTimeout(()=>{this.scrollContainer&&this.scrollContainer.scrollTo({top:this.scrollContainer.scrollHeight,behavior:`smooth`})},0)}addMessage(e,t){let n={text:e,time:new Date().toLocaleTimeString(),userName:t.includes(`agent`)?`Asistente`:`Tú`,userColorIndex:t.includes(`agent`)?2:1};return this.items=[...this.items,n],this.scrollBottom(),this.items.length-1}updateMessage(e,t){this.items=this.items.map((n,r)=>r===e?{...n,text:t}:n),this.scrollBottom()}tryParseCustomEvent(e){let t=e.trim();if(!t.startsWith(`{`))return null;try{let e=JSON.parse(t);if(typeof e.event==`string`)return{event:e.event,detail:e.detail??{}}}catch{}return null}tryParseTokenUsage(e){let t=e.trim();if(!t.startsWith(`{`))return null;try{let e=JSON.parse(t);if(`inputTokens`in e||`outputTokens`in e||`totalTokens`in e)return e}catch{}return null}buildMenuContext(e,t=[]){let n=[];for(let r of e){if(r.separator||r.remote)continue;let e=[...t,r.label];if(r.submenus&&r.submenus.length>0)n.push(...this.buildMenuContext(r.submenus,e));else{let t={path:e,navigation:{route:r.route,consumedRoute:r.consumedRoute,actionId:r.actionId??``,baseUrl:r.baseUrl,serverSideType:r.serverSideType,uriPrefix:r.uriPrefix}};r.description&&(t.description=r.description),n.push(t)}}return n}startLoading(){this.loading=!0,this.elapsedSeconds=0,this._elapsedTimer=setInterval(()=>{this.elapsedSeconds++},1e3)}stopLoading(){this.loading=!1,clearInterval(this._elapsedTimer),this._elapsedTimer=void 0}render(){return w`
             <div class="chat-container">
                 <div class="chat-header">
                     <span class="chat-title">AI Assistant</span>
-                    ${this.localAgentAlive?T`<span class="local-agent-badge" title="Hablando con tu CLI local (companion en ${this.localAgentUrl}) — sin api key">agente local</span>`:v}
+                    ${this.localAgentAlive?w`<span class="local-agent-badge" title="Hablando con tu CLI local (companion en ${this.localAgentUrl}) — sin api key">agente local</span>`:_}
                     <button class="chat-icon-btn" @click="${this.toggleExpanded}"
                             title="${this.expanded?`Contraer`:`Expandir a pantalla completa`}"
                             aria-label="${this.expanded?`Contraer el chat`:`Expandir el chat`}">
                         ${this.expanded?`⤡`:`⤢`}
                     </button>
                     <button class="chat-close" @click="${this.closeChat}" title="Cerrar">
-                        ${Ga}
+                        ${Ka}
                     </button>
                 </div>
                 <div class="scroll-container">
                     <div class="message-list" role="list">
-                        ${this.items.map(e=>T`
+                        ${this.items.map(e=>w`
                             <div class="message" role="listitem">
-                                <div class="avatar" style="background: ${qa(e.userColorIndex)};">${Ja(e.userName)}</div>
+                                <div class="avatar" style="background: ${Ja(e.userColorIndex)};">${Ya(e.userName)}</div>
                                 <div class="message-body">
                                     <div class="message-meta">
                                         <span class="message-name">${e.userName}</span>
@@ -6219,43 +6219,43 @@ ${i}
                         `)}
                     </div>
                 </div>
-                ${this.tokenUsage?T`
+                ${this.tokenUsage?w`
                     <div class="token-bar">
                         <span class="token-label">Tokens:</span>
-                        ${this.tokenUsage.inputTokens==null?v:T`<span class="token-chip">in&nbsp;<strong>${this.tokenUsage.inputTokens}</strong></span>`}
-                        ${this.tokenUsage.outputTokens==null?v:T`<span class="token-chip">out&nbsp;<strong>${this.tokenUsage.outputTokens}</strong></span>`}
-                        ${this.tokenUsage.totalTokens==null?v:T`<span class="token-chip">total&nbsp;<strong>${this.tokenUsage.totalTokens}</strong></span>`}
+                        ${this.tokenUsage.inputTokens==null?_:w`<span class="token-chip">in&nbsp;<strong>${this.tokenUsage.inputTokens}</strong></span>`}
+                        ${this.tokenUsage.outputTokens==null?_:w`<span class="token-chip">out&nbsp;<strong>${this.tokenUsage.outputTokens}</strong></span>`}
+                        ${this.tokenUsage.totalTokens==null?_:w`<span class="token-chip">total&nbsp;<strong>${this.tokenUsage.totalTokens}</strong></span>`}
                     </div>
-                `:v}
-                ${this.loading?T`
+                `:_}
+                ${this.loading?w`
                     <div class="loading-bar">
                         <span class="spinner"></span>
                         <span class="loading-text">Thinking… ${this.elapsedSeconds}s</span>
                     </div>
-                `:v}
-                ${this.attachments.length?T`
+                `:_}
+                ${this.attachments.length?w`
                     <div class="attachments">
-                        ${this.attachments.map(e=>T`
+                        ${this.attachments.map(e=>w`
                             <span class="attachment-chip" title="${e.path}">
                                 📎 ${e.name}
                                 <button class="attachment-remove" @click="${()=>this.removeAttachment(e.path)}" aria-label="Quitar ${e.name}">✕</button>
                             </span>`)}
                     </div>
-                `:v}
+                `:_}
                 <div class="input-bar">
-                    ${this.uploadUrl?T`
+                    ${this.uploadUrl?w`
                         <button class="mic-btn" title="Adjuntar ficheros"
                                 @click="${this.pickFiles}" ?disabled="${this.uploading}"
                                 aria-label="Adjuntar ficheros">${this.uploading?`…`:`📎`}</button>
                         <input class="file-input" type="file" multiple hidden
                                @change="${this.onFilesPicked}"/>
-                    `:v}
+                    `:_}
                     <button class="mic-btn"
                             title="Dictar"
                             style="color: ${this.listening?`red`:`var(--lumo-contrast-50pct, #767676)`};"
                             @click="${this.startListening}"
                             ?disabled="${!this.recognitionAvailable}"
-                    >${Wa}</button>
+                    >${Ga}</button>
                     <input class="msg-input"
                            placeholder="Message"
                            aria-label="Message"
@@ -6263,7 +6263,7 @@ ${i}
                     <button class="nbtn primary" ?disabled="${this.loading}" @click="${this.submitFromInput}">Send</button>
                 </div>
             </div>
-        `}static{this.styles=[za,h`
+        `}static{this.styles=[Ba,m`
         :host {
             display: block;
             height: 100%;
@@ -6588,14 +6588,14 @@ ${i}
         @keyframes spin {
             to { transform: rotate(360deg); }
         }
-    `]}};k([y({attribute:!1})],Y.prototype,`contextProvider`,void 0),k([y()],Y.prototype,`localAgentUrl`,void 0),k([y({attribute:!1})],Y.prototype,`mcpUrl`,void 0),k([C()],Y.prototype,`localAgentAlive`,void 0),k([y()],Y.prototype,`sseUrl`,void 0),k([y()],Y.prototype,`uploadUrl`,void 0),k([y({attribute:!1})],Y.prototype,`menu`,void 0),k([C()],Y.prototype,`attachments`,void 0),k([C()],Y.prototype,`uploading`,void 0),k([x(`.file-input`)],Y.prototype,`fileInputElement`,void 0),k([y({type:Boolean,reflect:!0})],Y.prototype,`expanded`,void 0),k([y()],Y.prototype,`items`,void 0),k([x(`.scroll-container`)],Y.prototype,`scrollContainer`,void 0),k([x(`.msg-input`)],Y.prototype,`messageInputElement`,void 0),k([C()],Y.prototype,`recognition`,void 0),k([C()],Y.prototype,`listening`,void 0),k([C()],Y.prototype,`recognitionAvailable`,void 0),k([C()],Y.prototype,`loading`,void 0),k([C()],Y.prototype,`elapsedSeconds`,void 0),k([C()],Y.prototype,`tokenUsage`,void 0),Y=k([g(`mateu-chat`)],Y);var Ya=class extends b{updated(e){super.updated(e),this.chart&&=(this.chart.destroy(),void 0),this.data&&this.createChart(this.data)}async createChart(e){let[{default:t}]=await Promise.all([D(()=>import(`./vendor-chartjs.js`).then(e=>e.n),__vite__mapDeps([3,1])),D(()=>import(`./vendor-chartjs.js`).then(e=>e.t),__vite__mapDeps([3,1]))]);if(e!==this.data)return;this.chart&&this.chart.destroy();let n={type:this.type,data:this.data,options:this.options};this.chart=new t(this.chartElement,n)}handleSlotChange(){}render(){return T`
+    `]}};O([v({attribute:!1})],J.prototype,`contextProvider`,void 0),O([v()],J.prototype,`localAgentUrl`,void 0),O([v({attribute:!1})],J.prototype,`mcpUrl`,void 0),O([S()],J.prototype,`localAgentAlive`,void 0),O([v()],J.prototype,`sseUrl`,void 0),O([v()],J.prototype,`uploadUrl`,void 0),O([v({attribute:!1})],J.prototype,`menu`,void 0),O([S()],J.prototype,`attachments`,void 0),O([S()],J.prototype,`uploading`,void 0),O([b(`.file-input`)],J.prototype,`fileInputElement`,void 0),O([v({type:Boolean,reflect:!0})],J.prototype,`expanded`,void 0),O([v()],J.prototype,`items`,void 0),O([b(`.scroll-container`)],J.prototype,`scrollContainer`,void 0),O([b(`.msg-input`)],J.prototype,`messageInputElement`,void 0),O([S()],J.prototype,`recognition`,void 0),O([S()],J.prototype,`listening`,void 0),O([S()],J.prototype,`recognitionAvailable`,void 0),O([S()],J.prototype,`loading`,void 0),O([S()],J.prototype,`elapsedSeconds`,void 0),O([S()],J.prototype,`tokenUsage`,void 0),J=O([h(`mateu-chat`)],J);var Xa=class extends y{updated(e){super.updated(e),this.chart&&=(this.chart.destroy(),void 0),this.data&&this.createChart(this.data)}async createChart(e){let[{default:t}]=await Promise.all([E(()=>import(`./vendor-chartjs.js`).then(e=>e.n),__vite__mapDeps([3,1])),E(()=>import(`./vendor-chartjs.js`).then(e=>e.t),__vite__mapDeps([3,1]))]);if(e!==this.data)return;this.chart&&this.chart.destroy();let n={type:this.type,data:this.data,options:this.options};this.chart=new t(this.chartElement,n)}handleSlotChange(){}render(){return w`
             <div class="container">
                 <canvas id="chart"></canvas>
             </div>
             <div style="display: none;">
                 <slot @slotchange=${this.handleSlotChange}></slot>
             </div>
-       `}static{this.styles=h`
+       `}static{this.styles=m`
     /* the host's inline height (Chart.style) must reach the canvas parent — chart.js
        measures .container to size the canvas when maintainAspectRatio is false */
     :host {
@@ -6605,7 +6605,7 @@ ${i}
         height: 100%;
         position: relative;
     }
-  `}};k([y()],Ya.prototype,`type`,void 0),k([y()],Ya.prototype,`data`,void 0),k([y()],Ya.prototype,`options`,void 0),k([x(`#chart`)],Ya.prototype,`chartElement`,void 0),Ya=k([g(`mateu-chart`)],Ya);var Xa=class extends b{updated(e){super.updated(e),this.chart&&=(this.chart.destroy(),void 0),this.xml&&this.createViewer(this.xml)}async createViewer(e){let{default:t}=await D(async()=>{let{default:e}=await import(`./vendor-diagrams.js`).then(e=>e.t);return{default:e}},__vite__mapDeps([4,1,2]));if(e!==this.xml)return;this.chart&&this.chart.destroy();let n={container:this.divElement};this.chart=new t(n),this.chart.importXML(e)}handleSlotChange(){}render(){return T`
+  `}};O([v()],Xa.prototype,`type`,void 0),O([v()],Xa.prototype,`data`,void 0),O([v()],Xa.prototype,`options`,void 0),O([b(`#chart`)],Xa.prototype,`chartElement`,void 0),Xa=O([h(`mateu-chart`)],Xa);var Za=class extends y{updated(e){super.updated(e),this.chart&&=(this.chart.destroy(),void 0),this.xml&&this.createViewer(this.xml)}async createViewer(e){let{default:t}=await E(async()=>{let{default:e}=await import(`./vendor-diagrams.js`).then(e=>e.t);return{default:e}},__vite__mapDeps([4,1,2]));if(e!==this.xml)return;this.chart&&this.chart.destroy();let n={container:this.divElement};this.chart=new t(n),this.chart.importXML(e)}handleSlotChange(){}render(){return w`
             <div class="container" style="width: 20rem; height: 15rem; overflow: auto;">
                 <!-- BPMN diagram container -->
                 <div id="canvas" style="width: 60rem; height: 30rem; zoom: 0.5;"></div>
@@ -6613,8 +6613,8 @@ ${i}
             <div style="display: none;">
                 <slot @slotchange=${this.handleSlotChange}></slot>
             </div>
-       `}static{this.styles=h`
-  `}};k([y()],Xa.prototype,`xml`,void 0),k([x(`#canvas`)],Xa.prototype,`divElement`,void 0),Xa=k([g(`mateu-bpmn`)],Xa);var Za=160,Qa=56,$a=220,eo=110,to=60,no={ACTION:`#3B82F6`,JOIN:`#8B5CF6`,FORK:`#F59E0B`,END:`#EF4444`,USER_TASK:`#10B981`,PROCESS:`#6366F1`},ro={ACTION:`▶`,JOIN:`⟨`,FORK:`⟩`,END:`◼`,USER_TASK:`👤`,PROCESS:`⚙`},io=[`ACTION`,`JOIN`,`FORK`,`END`,`USER_TASK`,`PROCESS`];function ao(){return`step-`+Math.random().toString(36).slice(2,8)}var oo=class extends b{constructor(...e){super(...e),this.value=`{"name":"New Workflow","steps":[]}`,this.wf={name:`New Workflow`,steps:[]},this.positions={},this.selectedId=null,this.showMeta=!1,this.draggingId=null,this.dragOffset={x:0,y:0},this.svgEl=null,this.onMouseMove=e=>{if(!this.draggingId||!this.svgEl)return;let t=this.toSvgPoint(e);this.positions={...this.positions,[this.draggingId]:{x:Math.max(0,t.x-this.dragOffset.x),y:Math.max(0,t.y-this.dragOffset.y)}}},this.onMouseUp=()=>{this.draggingId=null,window.removeEventListener(`mousemove`,this.onMouseMove),window.removeEventListener(`mouseup`,this.onMouseUp)}}updated(e){if(e.has(`value`)){try{this.wf=JSON.parse(this.value)}catch{}this.autoLayout()}}autoLayout(){let e=this.wf.steps??[],t={};e.forEach(e=>{t[e.id]=0});let n=!0;for(;n;)n=!1,e.forEach(e=>{if(e.preconditionStepId!=null&&t[e.preconditionStepId]!==void 0){let r=t[e.preconditionStepId]+1;r>t[e.id]&&(t[e.id]=r,n=!0)}});let r={};e.forEach(e=>{let n=t[e.id]??0;(r[n]??=[]).push(e.id)});let i={...this.positions},a=!1;Object.entries(r).forEach(([e,t])=>{let n=Number(e);t.forEach((e,t)=>{i[e]||(i[e]={x:to+n*$a,y:to+t*eo},a=!0)})}),a&&(this.positions=i)}emit(){let e=JSON.stringify(this.wf,null,2);this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e},bubbles:!0,composed:!0}))}updateWf(e){this.wf={...this.wf,...e},this.emit()}updateStep(e,t){this.wf={...this.wf,steps:this.wf.steps.map(n=>n.id===e?{...n,...t}:n)},this.emit()}addStep(){let e=ao(),t={id:e,type:`ACTION`,name:`New Step`};this.wf={...this.wf,steps:[...this.wf.steps??[],t]};let n=Object.values(this.positions).map(e=>e.y),r=n.length?Math.max(...n)+eo:to;this.positions={...this.positions,[e]:{x:to,y:r}},this.selectedId=e,this.emit()}deleteStep(e){this.wf={...this.wf,steps:this.wf.steps.filter(t=>t.id!==e).map(t=>t.preconditionStepId===e?{...t,preconditionStepId:void 0}:t)};let{[e]:t,...n}=this.positions;this.positions=n,this.selectedId===e&&(this.selectedId=null),this.emit()}onNodeMouseDown(e,t){e.preventDefault(),this.draggingId=t;let n=this.positions[t]??{x:0,y:0},r=this.toSvgPoint(e);this.dragOffset={x:r.x-n.x,y:r.y-n.y},this.svgEl=e.currentTarget.closest(`svg`),window.addEventListener(`mousemove`,this.onMouseMove),window.addEventListener(`mouseup`,this.onMouseUp)}toSvgPoint(e){if(!this.svgEl)return{x:0,y:0};let t=this.svgEl.getBoundingClientRect();return{x:e.clientX-t.left,y:e.clientY-t.top}}canvasSize(){let e=Object.values(this.positions),t=e.length?Math.max(...e.map(e=>e.x))+Za+to:600,n=e.length?Math.max(...e.map(e=>e.y))+Qa+to:400;return{w:Math.max(t,600),h:Math.max(n,400)}}render(){let{w:e,h:t}=this.canvasSize(),n=this.wf.steps??[];return T`
+       `}static{this.styles=m`
+  `}};O([v()],Za.prototype,`xml`,void 0),O([b(`#canvas`)],Za.prototype,`divElement`,void 0),Za=O([h(`mateu-bpmn`)],Za);var Qa=160,$a=56,eo=220,to=110,no=60,ro={ACTION:`#3B82F6`,JOIN:`#8B5CF6`,FORK:`#F59E0B`,END:`#EF4444`,USER_TASK:`#10B981`,PROCESS:`#6366F1`},io={ACTION:`▶`,JOIN:`⟨`,FORK:`⟩`,END:`◼`,USER_TASK:`👤`,PROCESS:`⚙`},ao=[`ACTION`,`JOIN`,`FORK`,`END`,`USER_TASK`,`PROCESS`];function oo(){return`step-`+Math.random().toString(36).slice(2,8)}var so=class extends y{constructor(...e){super(...e),this.value=`{"name":"New Workflow","steps":[]}`,this.wf={name:`New Workflow`,steps:[]},this.positions={},this.selectedId=null,this.showMeta=!1,this.draggingId=null,this.dragOffset={x:0,y:0},this.svgEl=null,this.onMouseMove=e=>{if(!this.draggingId||!this.svgEl)return;let t=this.toSvgPoint(e);this.positions={...this.positions,[this.draggingId]:{x:Math.max(0,t.x-this.dragOffset.x),y:Math.max(0,t.y-this.dragOffset.y)}}},this.onMouseUp=()=>{this.draggingId=null,window.removeEventListener(`mousemove`,this.onMouseMove),window.removeEventListener(`mouseup`,this.onMouseUp)}}updated(e){if(e.has(`value`)){try{this.wf=JSON.parse(this.value)}catch{}this.autoLayout()}}autoLayout(){let e=this.wf.steps??[],t={};e.forEach(e=>{t[e.id]=0});let n=!0;for(;n;)n=!1,e.forEach(e=>{if(e.preconditionStepId!=null&&t[e.preconditionStepId]!==void 0){let r=t[e.preconditionStepId]+1;r>t[e.id]&&(t[e.id]=r,n=!0)}});let r={};e.forEach(e=>{let n=t[e.id]??0;(r[n]??=[]).push(e.id)});let i={...this.positions},a=!1;Object.entries(r).forEach(([e,t])=>{let n=Number(e);t.forEach((e,t)=>{i[e]||(i[e]={x:no+n*eo,y:no+t*to},a=!0)})}),a&&(this.positions=i)}emit(){let e=JSON.stringify(this.wf,null,2);this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e},bubbles:!0,composed:!0}))}updateWf(e){this.wf={...this.wf,...e},this.emit()}updateStep(e,t){this.wf={...this.wf,steps:this.wf.steps.map(n=>n.id===e?{...n,...t}:n)},this.emit()}addStep(){let e=oo(),t={id:e,type:`ACTION`,name:`New Step`};this.wf={...this.wf,steps:[...this.wf.steps??[],t]};let n=Object.values(this.positions).map(e=>e.y),r=n.length?Math.max(...n)+to:no;this.positions={...this.positions,[e]:{x:no,y:r}},this.selectedId=e,this.emit()}deleteStep(e){this.wf={...this.wf,steps:this.wf.steps.filter(t=>t.id!==e).map(t=>t.preconditionStepId===e?{...t,preconditionStepId:void 0}:t)};let{[e]:t,...n}=this.positions;this.positions=n,this.selectedId===e&&(this.selectedId=null),this.emit()}onNodeMouseDown(e,t){e.preventDefault(),this.draggingId=t;let n=this.positions[t]??{x:0,y:0},r=this.toSvgPoint(e);this.dragOffset={x:r.x-n.x,y:r.y-n.y},this.svgEl=e.currentTarget.closest(`svg`),window.addEventListener(`mousemove`,this.onMouseMove),window.addEventListener(`mouseup`,this.onMouseUp)}toSvgPoint(e){if(!this.svgEl)return{x:0,y:0};let t=this.svgEl.getBoundingClientRect();return{x:e.clientX-t.left,y:e.clientY-t.top}}canvasSize(){let e=Object.values(this.positions),t=e.length?Math.max(...e.map(e=>e.x))+Qa+no:600,n=e.length?Math.max(...e.map(e=>e.y))+$a+no:400;return{w:Math.max(t,600),h:Math.max(n,400)}}render(){let{w:e,h:t}=this.canvasSize(),n=this.wf.steps??[];return w`
             <div class="root">
                 ${this.renderToolbar()}
                 ${this.showMeta?this.renderMeta():``}
@@ -6635,25 +6635,25 @@ ${i}
                     ${this.selectedId?this.renderPanel():``}
                 </div>
             </div>
-        `}renderToolbar(){let e=this.wf.status??`DRAFT`;return T`
+        `}renderToolbar(){let e=this.wf.status??`DRAFT`;return w`
             <div class="toolbar">
                 <span class="wf-name">${this.wf.name}</span>
                 <span class="badge badge-${e.toLowerCase()}">${e}</span>
                 <div style="flex:1"></div>
                 <button class="nbtn" @click="${()=>this.showMeta=!this.showMeta}">
-                    ${Va}
+                    ${Ha}
                     Settings
                 </button>
                 <button class="nbtn primary" @click="${()=>this.addStep()}">
-                    ${Ha}
+                    ${Ua}
                     Add Step
                 </button>
                 <button class="nbtn" @click="${()=>this.exportJson()}">
-                    ${Ua}
+                    ${Wa}
                     Export
                 </button>
             </div>
-        `}renderMeta(){let e=this.wf;return T`
+        `}renderMeta(){let e=this.wf;return w`
             <div class="meta-panel">
                 <div class="meta-grid">
                     <label>Name</label>
@@ -6662,13 +6662,13 @@ ${i}
                     <textarea class="inp" rows="2" @change="${e=>this.updateWf({description:e.target.value})}">${e.description??``}</textarea>
                     <label>Status</label>
                     <select class="inp" @change="${e=>this.updateWf({status:e.target.value})}">
-                        ${[`DRAFT`,`ACTIVE`,`DISABLED`,`ARCHIVED`].map(t=>T`
+                        ${[`DRAFT`,`ACTIVE`,`DISABLED`,`ARCHIVED`].map(t=>w`
                             <option value="${t}" ?selected="${e.status===t}">${t}</option>`)}
                     </select>
                     <label>Limit concurrent</label>
                     <input type="checkbox" ?checked="${e.limitConcurrentExecutions}"
                            @change="${e=>this.updateWf({limitConcurrentExecutions:e.target.checked})}"/>
-                    ${e.limitConcurrentExecutions?T`
+                    ${e.limitConcurrentExecutions?w`
                         <label>Max concurrent</label>
                         <input class="inp" type="number" min="0" .value="${String(e.maxConcurrentExecutions??0)}"
                                @change="${e=>this.updateWf({maxConcurrentExecutions:Number(e.target.value)})}"/>
@@ -6678,38 +6678,38 @@ ${i}
                     `:``}
                 </div>
             </div>
-        `}renderArrow(e){if(!e.preconditionStepId)return w``;let t=this.positions[e.preconditionStepId],n=this.positions[e.id];if(!t||!n)return w``;let r=t.x+Za,i=t.y+Qa/2,a=n.x,o=n.y+Qa/2,s=(r+a)/2;return w`
+        `}renderArrow(e){if(!e.preconditionStepId)return C``;let t=this.positions[e.preconditionStepId],n=this.positions[e.id];if(!t||!n)return C``;let r=t.x+Qa,i=t.y+$a/2,a=n.x,o=n.y+$a/2,s=(r+a)/2;return C`
             <path d="M${r},${i} C${s},${i} ${s},${o} ${a},${o}"
                   fill="none" stroke="#94a3b8" stroke-width="2"
                   marker-end="url(#arrow)"/>
-        `}renderNode(e){let t=this.positions[e.id]??{x:to,y:to},n=no[e.type]??`#64748b`,r=ro[e.type]??`•`,i=this.selectedId===e.id;return w`
+        `}renderNode(e){let t=this.positions[e.id]??{x:no,y:no},n=ro[e.type]??`#64748b`,r=io[e.type]??`•`,i=this.selectedId===e.id;return C`
             <g transform="translate(${t.x},${t.y})"
                style="cursor:grab"
                @mousedown="${t=>this.onNodeMouseDown(t,e.id)}"
                @click="${t=>{t.stopPropagation(),this.selectedId=e.id}}">
-                <rect width="${Za}" height="${Qa}" rx="8"
+                <rect width="${Qa}" height="${$a}" rx="8"
                       fill="white"
                       stroke="${i?n:`#e2e8f0`}"
                       stroke-width="${i?2.5:1.5}"
                       filter="url(#shadow)"/>
                 <!-- type badge -->
-                <rect x="0" y="0" width="32" height="${Qa}" rx="8" fill="${n}" clip-path="inset(0 -8px 0 0 round 8px)"/>
-                <rect x="24" y="0" width="8" height="${Qa}" fill="${n}"/>
+                <rect x="0" y="0" width="32" height="${$a}" rx="8" fill="${n}" clip-path="inset(0 -8px 0 0 round 8px)"/>
+                <rect x="24" y="0" width="8" height="${$a}" fill="${n}"/>
                 <text x="16" y="${33}" text-anchor="middle"
                       font-size="14" fill="white">${r}</text>
                 <!-- name -->
-                <text x="44" y="${Qa/2-6}" font-size="11" fill="#1e293b" font-weight="600">
+                <text x="44" y="${$a/2-6}" font-size="11" fill="#1e293b" font-weight="600">
                     ${e.name.length>16?e.name.slice(0,15)+`…`:e.name}
                 </text>
                 <text x="44" y="${36}" font-size="9" fill="#94a3b8">${e.id}</text>
                 <text x="44" y="${48}" font-size="9" fill="${n}">${e.type}</text>
             </g>
-        `}renderPanel(){let e=this.wf.steps.find(e=>e.id===this.selectedId);if(!e)return``;let t=this.wf.steps.filter(t=>t.id!==e.id),n=(e,t)=>T`
+        `}renderPanel(){let e=this.wf.steps.find(e=>e.id===this.selectedId);if(!e)return``;let t=this.wf.steps.filter(t=>t.id!==e.id),n=(e,t)=>w`
             <div class="field">
                 <label class="field-label">${e}</label>
                 ${t}
             </div>
-        `;return T`
+        `;return w`
             <div class="properties">
                 <div class="prop-header">
                     <span>Step Properties</span>
@@ -6718,21 +6718,21 @@ ${i}
                     <button class="close-btn" @click="${()=>this.selectedId=null}">✕</button>
                 </div>
                 <div class="prop-body">
-                    ${n(`ID`,T`<input class="inp" readonly .value="${e.id}"/>`)}
-                    ${n(`Name`,T`<input class="inp" .value="${e.name}"
+                    ${n(`ID`,w`<input class="inp" readonly .value="${e.id}"/>`)}
+                    ${n(`Name`,w`<input class="inp" .value="${e.name}"
                         @change="${t=>this.updateStep(e.id,{name:t.target.value})}"/>`)}
-                    ${n(`Type`,T`
+                    ${n(`Type`,w`
                         <select class="inp" @change="${t=>this.updateStep(e.id,{type:t.target.value})}">
-                            ${io.map(t=>T`<option value="${t}" ?selected="${e.type===t}">${t}</option>`)}
+                            ${ao.map(t=>w`<option value="${t}" ?selected="${e.type===t}">${t}</option>`)}
                         </select>`)}
-                    ${n(`Description`,T`<textarea class="inp" rows="2"
+                    ${n(`Description`,w`<textarea class="inp" rows="2"
                         @change="${t=>this.updateStep(e.id,{description:t.target.value})}">${e.description??``}</textarea>`)}
-                    ${n(`Precondition step`,T`
+                    ${n(`Precondition step`,w`
                         <select class="inp" @change="${t=>this.updateStep(e.id,{preconditionStepId:t.target.value||void 0})}">
                             <option value="">— none —</option>
-                            ${t.map(t=>T`<option value="${t.id}" ?selected="${e.preconditionStepId===t.id}">${t.name} (${t.id})</option>`)}
+                            ${t.map(t=>w`<option value="${t.id}" ?selected="${e.preconditionStepId===t.id}">${t.name} (${t.id})</option>`)}
                         </select>`)}
-                    ${n(`Precondition expression`,T`<input class="inp" placeholder="JEXL expression"
+                    ${n(`Precondition expression`,w`<input class="inp" placeholder="JEXL expression"
                         .value="${e.preconditionExpression??``}"
                         @change="${t=>this.updateStep(e.id,{preconditionExpression:t.target.value||void 0})}"/>`)}
                     <div class="field row">
@@ -6740,10 +6740,10 @@ ${i}
                         <input type="checkbox" ?checked="${e.parallel}"
                                @change="${t=>this.updateStep(e.id,{parallel:t.target.checked})}"/>
                     </div>
-                    ${n(`Timeout (ms)`,T`<input class="inp" type="number" min="0"
+                    ${n(`Timeout (ms)`,w`<input class="inp" type="number" min="0"
                         .value="${String(e.timeout??0)}"
                         @change="${t=>this.updateStep(e.id,{timeout:Number(t.target.value)})}"/>`)}
-                    ${n(`Retries`,T`<input class="inp" type="number" min="0"
+                    ${n(`Retries`,w`<input class="inp" type="number" min="0"
                         .value="${String(e.retries??0)}"
                         @change="${t=>this.updateStep(e.id,{retries:Number(t.target.value)})}"/>`)}
                     <div class="field row">
@@ -6751,24 +6751,24 @@ ${i}
                         <input type="checkbox" ?checked="${e.rollbackable}"
                                @change="${t=>this.updateStep(e.id,{rollbackable:t.target.checked})}"/>
                     </div>
-                    ${e.rollbackable?n(`Compensation step`,T`
+                    ${e.rollbackable?n(`Compensation step`,w`
                         <select class="inp" @change="${t=>this.updateStep(e.id,{compensationStepId:t.target.value||void 0})}">
                             <option value="">— none —</option>
-                            ${t.map(t=>T`<option value="${t.id}" ?selected="${e.compensationStepId===t.id}">${t.name} (${t.id})</option>`)}
+                            ${t.map(t=>w`<option value="${t.id}" ?selected="${e.compensationStepId===t.id}">${t.name} (${t.id})</option>`)}
                         </select>`):``}
 
-                    ${e.type===`ACTION`?n(`Topic`,T`<input class="inp" placeholder="kafka.topic.name"
+                    ${e.type===`ACTION`?n(`Topic`,w`<input class="inp" placeholder="kafka.topic.name"
                         .value="${e.topic??``}"
                         @change="${t=>this.updateStep(e.id,{topic:t.target.value||void 0})}"/>`):``}
-                    ${e.type===`USER_TASK`?n(`Form ID`,T`<input class="inp"
+                    ${e.type===`USER_TASK`?n(`Form ID`,w`<input class="inp"
                         .value="${e.formId??``}"
                         @change="${t=>this.updateStep(e.id,{formId:t.target.value||void 0})}"/>`):``}
-                    ${e.type===`PROCESS`?n(`Child workflow ID`,T`<input class="inp"
+                    ${e.type===`PROCESS`?n(`Child workflow ID`,w`<input class="inp"
                         .value="${e.childWorkflowDefinitionId??``}"
                         @change="${t=>this.updateStep(e.id,{childWorkflowDefinitionId:t.target.value||void 0})}"/>`):``}
                 </div>
             </div>
-        `}exportJson(){let e=JSON.stringify(this.wf,null,2),t=new Blob([e],{type:`application/json`}),n=URL.createObjectURL(t),r=document.createElement(`a`);r.href=n,r.download=(this.wf.name??`workflow`).replace(/\s+/g,`-`).toLowerCase()+`.json`,r.click(),URL.revokeObjectURL(n)}static{this.styles=[za,h`
+        `}exportJson(){let e=JSON.stringify(this.wf,null,2),t=new Blob([e],{type:`application/json`}),n=URL.createObjectURL(t),r=document.createElement(`a`);r.href=n,r.download=(this.wf.name??`workflow`).replace(/\s+/g,`-`).toLowerCase()+`.json`,r.click(),URL.revokeObjectURL(n)}static{this.styles=[Ba,m`
         :host { display: block; height: 100%; font-family: var(--lumo-font-family, sans-serif); }
 
         .root { display: flex; flex-direction: column; height: 100%; background: var(--lumo-base-color, #fff); }
@@ -6846,33 +6846,33 @@ ${i}
         .inp:focus { border-color: #3B82F6; }
         textarea.inp { resize: vertical; }
         input[readonly].inp { background: #f8fafc; color: #94a3b8; }
-    `]}};k([y()],oo.prototype,`value`,void 0),k([C()],oo.prototype,`wf`,void 0),k([C()],oo.prototype,`positions`,void 0),k([C()],oo.prototype,`selectedId`,void 0),k([C()],oo.prototype,`showMeta`,void 0),oo=k([g(`mateu-workflow`)],oo);var so=[`string`,`integer`,`number`,`bool`,`date`,`time`,`dateTime`,`dateRange`,`money`,`file`,`array`,`status`,`component`,`menu`,`range`,`action`,`actionGroup`],co=[`regular`,`radio`,`checkbox`,`textarea`,`toggle`,`combobox`,`select`,`email`,`password`,`richText`,`listBox`,`html`,`markdown`,`image`,`icon`,`link`,`money`,`grid`,`color`,`choice`,`popover`,`slider`,`button`,`stars`],lo={string:`#3B82F6`,integer:`#8B5CF6`,number:`#6366F1`,bool:`#10B981`,date:`#F59E0B`,time:`#F59E0B`,dateTime:`#F59E0B`,dateRange:`#F59E0B`,money:`#EF4444`,file:`#64748B`,array:`#0EA5E9`,status:`#EC4899`,component:`#14B8A6`,menu:`#94A3B8`,range:`#A855F7`,action:`#F97316`,actionGroup:`#FB923C`};function uo(){return`field-`+Math.random().toString(36).slice(2,8)}var fo=class extends b{constructor(...e){super(...e),this.value=`{"name":"New Form","fields":[]}`,this.form={name:`New Form`,fields:[]},this.selectedId=null,this.showMeta=!1,this.sortable=null,this.listEl=null}updated(e){if(e.has(`value`))try{this.form=JSON.parse(this.value)}catch{}this.attachSortable()}disconnectedCallback(){super.disconnectedCallback(),this.sortable?.destroy(),this.sortable=null}attachSortable(){let e=this.shadowRoot?.querySelector(`.field-list`);!e||e===this.listEl||(this.listEl=e,this.sortable?.destroy(),this.sortable=se.create(e,{animation:150,handle:`.drag-handle`,ghostClass:`sortable-ghost`,onEnd:e=>{let{oldIndex:t,newIndex:n}=e;if(t===void 0||n===void 0||t===n)return;let r=[...this.form.fields],[i]=r.splice(t,1);r.splice(n,0,i),this.form={...this.form,fields:r},this.emit()}}))}emit(){let e=JSON.stringify(this.form,null,2);this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e},bubbles:!0,composed:!0}))}updateForm(e){this.form={...this.form,...e},this.emit()}updateField(e,t){this.form={...this.form,fields:this.form.fields.map(n=>n.id===e?{...n,...t}:n)},this.emit()}addField(){let e=uo(),t={id:e,label:`New Field`,dataType:`string`};this.form={...this.form,fields:[...this.form.fields,t]},this.selectedId=e,this.emit()}deleteField(e){this.form={...this.form,fields:this.form.fields.filter(t=>t.id!==e)},this.selectedId===e&&(this.selectedId=null),this.emit()}duplicateField(e){let t=this.form.fields.find(t=>t.id===e);if(!t)return;let n={...t,id:uo(),label:t.label+` (copy)`},r=this.form.fields.findIndex(t=>t.id===e),i=[...this.form.fields];i.splice(r+1,0,n),this.form={...this.form,fields:i},this.selectedId=n.id,this.emit()}render(){return T`
+    `]}};O([v()],so.prototype,`value`,void 0),O([S()],so.prototype,`wf`,void 0),O([S()],so.prototype,`positions`,void 0),O([S()],so.prototype,`selectedId`,void 0),O([S()],so.prototype,`showMeta`,void 0),so=O([h(`mateu-workflow`)],so);var co=[`string`,`integer`,`number`,`bool`,`date`,`time`,`dateTime`,`dateRange`,`money`,`file`,`array`,`status`,`component`,`menu`,`range`,`action`,`actionGroup`],lo=[`regular`,`radio`,`checkbox`,`textarea`,`toggle`,`combobox`,`select`,`email`,`password`,`richText`,`listBox`,`html`,`markdown`,`image`,`icon`,`link`,`money`,`grid`,`color`,`choice`,`popover`,`slider`,`button`,`stars`],uo={string:`#3B82F6`,integer:`#8B5CF6`,number:`#6366F1`,bool:`#10B981`,date:`#F59E0B`,time:`#F59E0B`,dateTime:`#F59E0B`,dateRange:`#F59E0B`,money:`#EF4444`,file:`#64748B`,array:`#0EA5E9`,status:`#EC4899`,component:`#14B8A6`,menu:`#94A3B8`,range:`#A855F7`,action:`#F97316`,actionGroup:`#FB923C`};function fo(){return`field-`+Math.random().toString(36).slice(2,8)}var po=class extends y{constructor(...e){super(...e),this.value=`{"name":"New Form","fields":[]}`,this.form={name:`New Form`,fields:[]},this.selectedId=null,this.showMeta=!1,this.sortable=null,this.listEl=null}updated(e){if(e.has(`value`))try{this.form=JSON.parse(this.value)}catch{}this.attachSortable()}disconnectedCallback(){super.disconnectedCallback(),this.sortable?.destroy(),this.sortable=null}attachSortable(){let e=this.shadowRoot?.querySelector(`.field-list`);!e||e===this.listEl||(this.listEl=e,this.sortable?.destroy(),this.sortable=ce.create(e,{animation:150,handle:`.drag-handle`,ghostClass:`sortable-ghost`,onEnd:e=>{let{oldIndex:t,newIndex:n}=e;if(t===void 0||n===void 0||t===n)return;let r=[...this.form.fields],[i]=r.splice(t,1);r.splice(n,0,i),this.form={...this.form,fields:r},this.emit()}}))}emit(){let e=JSON.stringify(this.form,null,2);this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e},bubbles:!0,composed:!0}))}updateForm(e){this.form={...this.form,...e},this.emit()}updateField(e,t){this.form={...this.form,fields:this.form.fields.map(n=>n.id===e?{...n,...t}:n)},this.emit()}addField(){let e=fo(),t={id:e,label:`New Field`,dataType:`string`};this.form={...this.form,fields:[...this.form.fields,t]},this.selectedId=e,this.emit()}deleteField(e){this.form={...this.form,fields:this.form.fields.filter(t=>t.id!==e)},this.selectedId===e&&(this.selectedId=null),this.emit()}duplicateField(e){let t=this.form.fields.find(t=>t.id===e);if(!t)return;let n={...t,id:fo(),label:t.label+` (copy)`},r=this.form.fields.findIndex(t=>t.id===e),i=[...this.form.fields];i.splice(r+1,0,n),this.form={...this.form,fields:i},this.selectedId=n.id,this.emit()}render(){return w`
             <div class="root">
                 ${this.renderToolbar()}
-                ${this.showMeta?this.renderMeta():v}
+                ${this.showMeta?this.renderMeta():_}
                 <div class="workspace">
                     ${this.renderList()}
-                    ${this.selectedId?this.renderPanel():v}
+                    ${this.selectedId?this.renderPanel():_}
                 </div>
             </div>
-        `}renderToolbar(){return T`
+        `}renderToolbar(){return w`
             <div class="toolbar">
                 <span class="form-name">${this.form.name}</span>
                 <div style="flex:1"></div>
                 <button class="nbtn" @click="${()=>this.showMeta=!this.showMeta}">
-                    ${Va}
+                    ${Ha}
                     Settings
                 </button>
                 <button class="nbtn primary" @click="${()=>this.addField()}">
-                    ${Ha}
+                    ${Ua}
                     Add Field
                 </button>
                 <button class="nbtn" @click="${()=>this.exportJson()}">
-                    ${Ua}
+                    ${Wa}
                     Export
                 </button>
             </div>
-        `}renderMeta(){let e=this.form;return T`
+        `}renderMeta(){let e=this.form;return w`
             <div class="meta-panel">
                 <div class="meta-grid">
                     <label>Name</label>
@@ -6883,58 +6883,58 @@ ${i}
                               @change="${e=>this.updateForm({description:e.target.value})}">${e.description??``}</textarea>
                 </div>
             </div>
-        `}renderList(){let e=this.form.fields;return T`
+        `}renderList(){let e=this.form.fields;return w`
             <div class="list-wrap">
-                ${e.length===0?T`
+                ${e.length===0?w`
                     <div class="empty">
                         No fields yet. Click <strong>Add Field</strong> to start.
-                    </div>`:v}
+                    </div>`:_}
                 <div class="field-list">
                     ${e.map(e=>this.renderRow(e))}
                 </div>
             </div>
-        `}renderRow(e){let t=lo[e.dataType]??`#64748b`;return T`
+        `}renderRow(e){let t=uo[e.dataType]??`#64748b`;return w`
             <div role="button" tabindex="0" class="field-row ${this.selectedId===e.id?`selected`:``}"
                  data-id="${e.id}"
-                 @click="${()=>this.selectedId=this.selectedId===e.id?null:e.id}" @keydown="${R(()=>this.selectedId=this.selectedId===e.id?null:e.id)}">
+                 @click="${()=>this.selectedId=this.selectedId===e.id?null:e.id}" @keydown="${L(()=>this.selectedId=this.selectedId===e.id?null:e.id)}">
                 <span class="drag-handle" title="Drag to reorder">⠿</span>
                 <span class="type-badge" style="background:${t}">${e.dataType}</span>
                 <span class="field-label-text">${e.label}</span>
                 <span class="field-id-text">${e.id}</span>
-                ${e.required?T`<span class="required-badge">required</span>`:v}
-                ${e.stereotype&&e.stereotype!==`regular`?T`<span class="stereo-badge">${e.stereotype}</span>`:v}
+                ${e.required?w`<span class="required-badge">required</span>`:_}
+                ${e.stereotype&&e.stereotype!==`regular`?w`<span class="stereo-badge">${e.stereotype}</span>`:_}
                 <div style="flex:1"></div>
                 <button class="row-btn" title="Duplicate"
                         @click="${t=>{t.stopPropagation(),this.duplicateField(e.id)}}">⧉</button>
                 <button class="row-btn danger" title="Delete"
                         @click="${t=>{t.stopPropagation(),this.deleteField(e.id)}}">🗑</button>
             </div>
-        `}renderPanel(){let e=this.form.fields.find(e=>e.id===this.selectedId);if(!e)return v;let t=(e,t)=>T`
+        `}renderPanel(){let e=this.form.fields.find(e=>e.id===this.selectedId);if(!e)return _;let t=(e,t)=>w`
             <div class="prop-field">
                 <label class="prop-label">${e}</label>
                 ${t}
             </div>
-        `;return T`
+        `;return w`
             <div class="properties">
                 <div class="prop-header">
                     <span>Field Properties</span>
                     <button class="close-btn" @click="${()=>this.selectedId=null}">✕</button>
                 </div>
                 <div class="prop-body">
-                    ${t(`ID`,T`<input class="inp" readonly .value="${e.id}"/>`)}
-                    ${t(`Label`,T`
+                    ${t(`ID`,w`<input class="inp" readonly .value="${e.id}"/>`)}
+                    ${t(`Label`,w`
                         <input class="inp" .value="${e.label}"
                                @change="${t=>this.updateField(e.id,{label:t.target.value})}"/>`)}
-                    ${t(`Data type`,T`
+                    ${t(`Data type`,w`
                         <select class="inp"
                                 @change="${t=>this.updateField(e.id,{dataType:t.target.value})}">
-                            ${so.map(t=>T`
+                            ${co.map(t=>w`
                                 <option value="${t}" ?selected="${e.dataType===t}">${t}</option>`)}
                         </select>`)}
-                    ${t(`Stereotype`,T`
+                    ${t(`Stereotype`,w`
                         <select class="inp"
                                 @change="${t=>this.updateField(e.id,{stereotype:t.target.value||void 0})}">
-                            ${co.map(t=>T`
+                            ${lo.map(t=>w`
                                 <option value="${t}" ?selected="${(e.stereotype??`regular`)===t}">${t}</option>`)}
                         </select>`)}
                     <div class="prop-field row">
@@ -6942,12 +6942,12 @@ ${i}
                         <input type="checkbox" ?checked="${e.required}"
                                @change="${t=>this.updateField(e.id,{required:t.target.checked})}"/>
                     </div>
-                    ${t(`Description / hint`,T`
+                    ${t(`Description / hint`,w`
                         <textarea class="inp" rows="3"
                                   @change="${t=>this.updateField(e.id,{description:t.target.value||void 0})}">${e.description??``}</textarea>`)}
                 </div>
             </div>
-        `}exportJson(){let e=JSON.stringify(this.form,null,2),t=new Blob([e],{type:`application/json`}),n=URL.createObjectURL(t),r=document.createElement(`a`);r.href=n,r.download=(this.form.name??`form`).replace(/\s+/g,`-`).toLowerCase()+`.json`,r.click(),URL.revokeObjectURL(n)}static{this.styles=[za,z,h`
+        `}exportJson(){let e=JSON.stringify(this.form,null,2),t=new Blob([e],{type:`application/json`}),n=URL.createObjectURL(t),r=document.createElement(`a`);r.href=n,r.download=(this.form.name??`form`).replace(/\s+/g,`-`).toLowerCase()+`.json`,r.click(),URL.revokeObjectURL(n)}static{this.styles=[Ba,R,m`
         :host { display: block; height: 100%; font-family: var(--lumo-font-family, sans-serif); }
 
         .root { display: flex; flex-direction: column; height: 100%; background: var(--lumo-base-color, #fff); }
@@ -7062,12 +7062,12 @@ ${i}
         .inp:focus { border-color: #3B82F6; }
         textarea.inp { resize: vertical; }
         input[readonly].inp { background: #f8fafc; color: #94a3b8; }
-    `]}};k([y()],fo.prototype,`value`,void 0),k([C()],fo.prototype,`form`,void 0),k([C()],fo.prototype,`selectedId`,void 0),k([C()],fo.prototype,`showMeta`,void 0),fo=k([g(`mateu-form-editor`)],fo);var po=class extends b{constructor(...e){super(...e),this.appState={},this.appData={},this.open=!1,this.activeTab=`appstate`,this.hoveredTag=``,this.hoveredId=``,this.hoveredState=null,this.hoveredData=null,this.hoveredMeta=null,this._prevTarget=null,this._onMouseover=e=>{let t=e.target;for(;t&&!(t.tagName?.toLowerCase().startsWith(`mateu-`)&&t!==this);)t=t.parentElement;if(t===this||t===null){t===null&&this._prevTarget&&(this._prevTarget.style.outline=``,this._prevTarget.style.outlineOffset=``,this._prevTarget=null,this.hoveredTag=``,this.hoveredId=``,this.hoveredState=null,this.hoveredData=null,this.hoveredMeta=null);return}t!==this._prevTarget&&(this._prevTarget&&(this._prevTarget.style.outline=``,this._prevTarget.style.outlineOffset=``),this._prevTarget=t,t.style.outline=`2px solid #0070f3`,t.style.outlineOffset=`-2px`,this.hoveredTag=t.tagName.toLowerCase(),this.hoveredId=t.id||``,this.hoveredState=t.state,this.hoveredData=t.data,this.hoveredMeta=t.component?.metadata)}}connectedCallback(){super.connectedCallback(),document.addEventListener(`mouseover`,this._onMouseover,!0)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`mouseover`,this._onMouseover,!0),this._prevTarget&&=(this._prevTarget.style.outline=``,null)}_fmt(e){try{return JSON.stringify(e,null,2)??`null`}catch{return String(e)}}_renderTab(e,t){return T`
+    `]}};O([v()],po.prototype,`value`,void 0),O([S()],po.prototype,`form`,void 0),O([S()],po.prototype,`selectedId`,void 0),O([S()],po.prototype,`showMeta`,void 0),po=O([h(`mateu-form-editor`)],po);var mo=class extends y{constructor(...e){super(...e),this.appState={},this.appData={},this.open=!1,this.activeTab=`appstate`,this.hoveredTag=``,this.hoveredId=``,this.hoveredState=null,this.hoveredData=null,this.hoveredMeta=null,this._prevTarget=null,this._onMouseover=e=>{let t=e.target;for(;t&&!(t.tagName?.toLowerCase().startsWith(`mateu-`)&&t!==this);)t=t.parentElement;if(t===this||t===null){t===null&&this._prevTarget&&(this._prevTarget.style.outline=``,this._prevTarget.style.outlineOffset=``,this._prevTarget=null,this.hoveredTag=``,this.hoveredId=``,this.hoveredState=null,this.hoveredData=null,this.hoveredMeta=null);return}t!==this._prevTarget&&(this._prevTarget&&(this._prevTarget.style.outline=``,this._prevTarget.style.outlineOffset=``),this._prevTarget=t,t.style.outline=`2px solid #0070f3`,t.style.outlineOffset=`-2px`,this.hoveredTag=t.tagName.toLowerCase(),this.hoveredId=t.id||``,this.hoveredState=t.state,this.hoveredData=t.data,this.hoveredMeta=t.component?.metadata)}}connectedCallback(){super.connectedCallback(),document.addEventListener(`mouseover`,this._onMouseover,!0)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`mouseover`,this._onMouseover,!0),this._prevTarget&&=(this._prevTarget.style.outline=``,null)}_fmt(e){try{return JSON.stringify(e,null,2)??`null`}catch{return String(e)}}_renderTab(e,t){return w`
             <button class="tab ${this.activeTab===e?`tab--active`:``}"
                 @click=${()=>{this.activeTab=e}}>
                 ${t}
             </button>
-        `}render(){return this.open?T`
+        `}render(){return this.open?w`
                 <div class="panel">
                     <div class="panel-header">
                         <span class="panel-title">🐛 Mateu Debug</span>
@@ -7079,14 +7079,14 @@ ${i}
                         ${this._renderTab(`inspector`,`Inspector`)}
                     </div>
                     <div class="content">
-                        ${this.activeTab===`appstate`?T`
+                        ${this.activeTab===`appstate`?w`
                             <pre class="json">${this._fmt(this.appState)}</pre>
-                        `:v}
-                        ${this.activeTab===`appdata`?T`
+                        `:_}
+                        ${this.activeTab===`appdata`?w`
                             <pre class="json">${this._fmt(this.appData)}</pre>
-                        `:v}
-                        ${this.activeTab===`inspector`?T`
-                            ${this.hoveredTag?T`
+                        `:_}
+                        ${this.activeTab===`inspector`?w`
+                            ${this.hoveredTag?w`
                                 <div class="inspector-tag">&lt;${this.hoveredTag}${this.hoveredId?` id="${this.hoveredId}"`:``}&gt;</div>
                                 <div class="section-label">state</div>
                                 <pre class="json">${this._fmt(this.hoveredState)}</pre>
@@ -7094,15 +7094,15 @@ ${i}
                                 <pre class="json">${this._fmt(this.hoveredData)}</pre>
                                 <div class="section-label">metadata</div>
                                 <pre class="json">${this._fmt(this.hoveredMeta)}</pre>
-                            `:T`
+                            `:w`
                                 <div class="inspector-hint">Hover a mateu-* element to inspect it</div>
                             `}
-                        `:v}
+                        `:_}
                     </div>
                 </div>
-            `:T`
+            `:w`
             <button class="fab" @click=${()=>{this.open=!0}} title="Mateu Debug">🐛</button>
-        `}static{this.styles=h`
+        `}static{this.styles=m`
         :host {
             position: fixed;
             z-index: 9999;
@@ -7235,7 +7235,7 @@ ${i}
             border-bottom: 1px solid #2a2a3a;
         }
         .section-label:first-of-type { margin-top: 0; }
-    `}};k([y()],po.prototype,`appState`,void 0),k([y()],po.prototype,`appData`,void 0),k([C()],po.prototype,`open`,void 0),k([C()],po.prototype,`activeTab`,void 0),k([C()],po.prototype,`hoveredTag`,void 0),k([C()],po.prototype,`hoveredId`,void 0),k([C()],po.prototype,`hoveredState`,void 0),k([C()],po.prototype,`hoveredData`,void 0),k([C()],po.prototype,`hoveredMeta`,void 0),po=k([g(`mateu-debug-overlay`)],po);var mo=function(e){return e.SetAppDataValue=`SetAppDataValue`,e.SetAppStateValue=`SetAppStateValue`,e.SetDataValue=`SetDataValue`,e.RunAction=`RunAction`,e.RunJS=`RunJS`,e.SetAttributeValue=`SetAttributeValue`,e.SetStateValue=`SetStateValue`,e.SetCssClass=`SetCssClass`,e.SetStyle=`SetStyle`,e}({}),ho=function(e){return e.required=`required`,e.disabled=`disabled`,e.hidden=`hidden`,e.pattern=`pattern`,e.minValue=`minValue`,e.maxValue=`maxValue`,e.minLength=`minLength`,e.maxLength=`maxLength`,e.css=`css`,e.style=`style`,e.theme=`theme`,e.errorMessage=`errorMessage`,e.description=`description`,e.none=`none`,e}({}),go=function(e){return e.Continue=`Continue`,e.Stop=`Stop`,e}({}),_o=12e4,vo=(e,t)=>`${e??`_`}::${t}`,yo=new class{constructor(){this.started=new Map,this.listeners=new Set}begin(e,t=Date.now()){let n=this.started.get(e);return n!==void 0&&t-n<_o?!1:(this.started.set(e,t),this.emit(),!0)}end(e){this.started.delete(e)&&this.emit()}isPending(e,t=Date.now()){let n=this.started.get(e);return n!==void 0&&t-n<_o}snapshot(){return new Set(this.started.keys())}subscribe(e){return this.listeners.add(e),()=>this.listeners.delete(e)}reset(){this.started.clear(),this.emit()}emit(){let e=this.snapshot();this.listeners.forEach(t=>t(e))}},bo=`data-mateu-pending-styles`,xo=`
+    `}};O([v()],mo.prototype,`appState`,void 0),O([v()],mo.prototype,`appData`,void 0),O([S()],mo.prototype,`open`,void 0),O([S()],mo.prototype,`activeTab`,void 0),O([S()],mo.prototype,`hoveredTag`,void 0),O([S()],mo.prototype,`hoveredId`,void 0),O([S()],mo.prototype,`hoveredState`,void 0),O([S()],mo.prototype,`hoveredData`,void 0),O([S()],mo.prototype,`hoveredMeta`,void 0),mo=O([h(`mateu-debug-overlay`)],mo);var ho=function(e){return e.SetAppDataValue=`SetAppDataValue`,e.SetAppStateValue=`SetAppStateValue`,e.SetDataValue=`SetDataValue`,e.RunAction=`RunAction`,e.RunJS=`RunJS`,e.SetAttributeValue=`SetAttributeValue`,e.SetStateValue=`SetStateValue`,e.SetCssClass=`SetCssClass`,e.SetStyle=`SetStyle`,e}({}),go=function(e){return e.required=`required`,e.disabled=`disabled`,e.hidden=`hidden`,e.pattern=`pattern`,e.minValue=`minValue`,e.maxValue=`maxValue`,e.minLength=`minLength`,e.maxLength=`maxLength`,e.css=`css`,e.style=`style`,e.theme=`theme`,e.errorMessage=`errorMessage`,e.description=`description`,e.none=`none`,e}({}),_o=function(e){return e.Continue=`Continue`,e.Stop=`Stop`,e}({}),vo=12e4,yo=(e,t)=>`${e??`_`}::${t}`,bo=new class{constructor(){this.started=new Map,this.listeners=new Set}begin(e,t=Date.now()){let n=this.started.get(e);return n!==void 0&&t-n<vo?!1:(this.started.set(e,t),this.emit(),!0)}end(e){this.started.delete(e)&&this.emit()}isPending(e,t=Date.now()){let n=this.started.get(e);return n!==void 0&&t-n<vo}snapshot(){return new Set(this.started.keys())}subscribe(e){return this.listeners.add(e),()=>this.listeners.delete(e)}reset(){this.started.clear(),this.emit()}emit(){let e=this.snapshot();this.listeners.forEach(t=>t(e))}},xo=`data-mateu-pending-styles`,So=`
 [data-mateu-pending] {
     pointer-events: none;
     cursor: progress;
@@ -7249,9 +7249,9 @@ ${i}
     0%, 100% { opacity: .45; }
     50% { opacity: .85; }
 }
-`,So=new WeakSet,Co=e=>{if(So.has(e))return;So.add(e);let t=e;if(typeof CSSStyleSheet<`u`&&Array.isArray(t.adoptedStyleSheets))try{let e=new CSSStyleSheet;e.replaceSync(xo),t.adoptedStyleSheets=[...t.adoptedStyleSheets,e];return}catch{}let n=e instanceof Document?e.head:e;if(!n)return;let r=document.createElement(`style`);r.setAttribute(bo,``),r.textContent=xo,n.appendChild(r)},wo=e=>{let t=e.getRootNode();if(t instanceof ShadowRoot||t instanceof Document)return t},To=e=>{if(!e||e.hasAttribute(`data-mateu-pending`))return;let t=wo(e);t&&Co(t),e.setAttribute(`data-mateu-pending`,``),e.setAttribute(`aria-busy`,`true`)},Eo=e=>{e&&(e.removeAttribute(`data-mateu-pending`),e.removeAttribute(`aria-busy`))},Do=e=>{let t=(typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target;return t instanceof Element?t:void 0},Oo=[`button`,`a[href]`,`[role="button"]`,`[role="menuitem"]`,`input[type="button"]`,`input[type="submit"]`,`vaadin-button`,`vaadin-menu-bar-button`,`ui5-button`,`oj-c-button`,`oj-button`].join(`, `),ko=e=>{if(!(!e||typeof e.closest!=`function`))return e.closest(Oo)??void 0},Ao=null,jo=class extends ha{constructor(...e){super(...e),this.baseUrl=``,this.route=``,this.consumedRoute=``,this.formerState={},this.applyRules=()=>{let e=this.component.rules;if(e&&e.length>0){let t=this.state,n=this.data,r=this.appState,i=this.appData,a=this.component,o=e=>at(e,t,n,{appState:r,appData:i,component:a}),s=e=>it(e,t,n,r,i,{component:a}),c=[`state`,`data`,`appState`,`appData`,`component`],l=[t,n,r,i,a],u={...this.state},d={...this.data},f=!1,p=!1;for(let t=0;t<e.length;t++){let n=e[t];try{if(o(n.filter)){if(mo.SetStateValue==n.action||mo.SetDataValue==n.action){let e=mo.SetStateValue==n.action?u:d,t=n.fieldName.split(`,`);for(let r=0;r<t.length;r++){let i=t[r];if(!e[i]||e[i]!=n.value){let t=n.expression?s(n.expression):n.value,r=ho.none==n.fieldAttribute?i:i+`.`+n.fieldAttribute;t!=e[r]&&(e[r]=t,mo.SetStateValue==n.action&&(f=!0),mo.SetDataValue==n.action&&(p=!0))}}}if(mo.RunAction==n.action&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.actionId},bubbles:!0,composed:!0})),mo.RunJS==n.action&&Function(...c,n.value)(...l),mo.SetAttributeValue==n.action){let e=n.expression?o(n.expression):n.value;if(n.fieldAttribute==`disabled`){e?this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(n.fieldAttribute,`disabled`):this.shadowRoot?.getElementById(n.fieldName)?.removeAttribute(n.fieldAttribute);continue}this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(n.fieldAttribute,e)}if(mo.SetCssClass==n.action&&this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(`class`,n.value),mo.SetStyle==n.action&&this.shadowRoot?.getElementById(n.fieldName)?.style.setProperty(n.expression,n.value),go.Stop==n.result)break}}catch(e){console.error(`rule failed`,n,e)}}f&&(this.state=u),p&&(this.data=d),f&&this.checkValidations()}},this.skipValidation=(e,t)=>e&&t.fieldId&&!e.includes(t.fieldId)||!e&&t.fieldId&&t.fieldId.includes(`-`),this.checkValidations=e=>{let t=e?e.split(`,`):void 0,n=this.component.validations,r=!0,i=!1,a=this.data??{},o={...this.data??{},errors:{}};if(n){for(let e=0;e<n.length;e++){let r=n[e];if(this.skipValidation(t,r))continue;let i=(r.fieldId??`_component`).split(`,`);for(let e=0;e<i.length;e++){let t=i[e];o.errors[t]=[]}}for(let e=0;e<n.length;e++){let i=n[e];if(!this.skipValidation(t,i))try{let e=i.condition&&i.condition.includes("${")?this._evalTemplate(i.condition):this._evalExpr(i.condition);if(i.condition&&!e){r=!1;let e=(i.fieldId??`_component`).split(`,`);for(let t=0;t<e.length;t++){let n=e[t],r=o.errors[n];if(r||(o.errors[n]=[]),r=o.errors[n],!a[n]){let e=i.message;try{e=this._evalTemplate(i.message)}catch{}r.push(e)}}}}catch(e){console.error(`validation failed`,i,e)}}for(let e=0;e<n.length;e++){let r=n[e];if(this.skipValidation(t,r))continue;let s=(r.fieldId??`_component`).split(`,`);for(let e=0;e<s.length;e++){let t=s[e];if((a.errors||o.errors==``)&&[t].join(`,`)){i=!0;break}}}(a.errors||o.errors==``)&&[`_component`].join(`,`)&&(i=!0)}o._valid=r,o._valid!=a._valid&&(i=!0),i&&(this.data=o)},this._autoSaveTimers=new Map,this.onChange=()=>{this.applyRules()},this.closeModalRequestedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.closeModal()},this.resetFilters=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail,n={};t.fieldIds.forEach(e=>{n[e]=void 0}),n.searchText=void 0,this.state={...this.state,...n}}},this.dataChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail,n={};n[t.key]=t.value,e.type==`data-changed`&&(this.data={...this.data,...n})}},this.valueChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail;if(e.type==`value-changed`){let n={...this.state};n[t.fieldId]=t.value,this.state=n,(this.state[t.fieldId]||this.formerState[t.fieldId])&&this.state[t.fieldId]!=this.formerState[t.fieldId]&&this.component?.confirmOnNavigationIfDirty&&this.dispatchEvent(new CustomEvent(`dirty`,{detail:e.detail,bubbles:!0,composed:!0}));let r=this.component;r.triggers?.filter(e=>e.type==ma.OnValueChange).filter(e=>!e.propertyName||t.fieldId==e.propertyName).forEach(e=>{(!e.condition||this._evalExpr(e.condition))&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))}),r.triggers?.filter(e=>e.type==ma.AutoSave).forEach(e=>{let t=e.actionId,n=this._autoSaveTimers.get(t);n!==void 0&&clearTimeout(n),this._autoSaveTimers.set(t,setTimeout(()=>{this._autoSaveTimers.delete(t),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))},e.debounceMillis??800))})}}},this.actionRequestedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.manageActionRequestedEvent(e)},this.manageActionRequestedEvent=e=>{let t=e.detail,n=t?._originElement??Do(e);if(e.type==`action-requested`){e.preventDefault(),e.stopPropagation();let r=this.component,i=r.actions?.find(e=>e.id==t.actionId)??r.actions?.find(e=>e.id.endsWith(`*`)&&t.actionId.startsWith(e.id.replace(`*`,``)));if(i){if(i&&i.rowsSelectedRequired&&(!this.state.crud_selected_items||this.state.crud_selected_items.length==0)){this.notify(`You first need to select some rows`);return}if(i&&i.validationRequired){let e=Ao??this;if(Ao=null,e.checkValidations(i.fieldsToValidate),!e.data._valid){e.notifyValidationErrors();return}}Ao=null;let e={...t,initiatorComponentId:this.id};i&&i.confirmationRequired?this.callAfterConfirmation(i,()=>this.requestActionCallToServerOrBubble(e,r,i,n)):this.requestActionCallToServerOrBubble(e,r,i,n)}else{let r={...t.parameters};r.initiatorState||=this.state,Ao||=this,this.dispatchEvent(new CustomEvent(e.type,{detail:{...e.detail,_originElement:n,parameters:r},bubbles:!0,composed:!0}))}}},this.buildFieldLabelMap=()=>{let e={},t=n=>{if(n)for(let r of n){let n=r.metadata;if(n?.type===j.FormField){let t=n;t.fieldId&&t.label&&(e[t.fieldId]=t.label)}t(r.children)}};return t(this.component?.children),e},this.notifyValidationErrors=()=>{let e=this.data?.errors??{},t=this.buildFieldLabelMap(),n=[];if(Object.entries(e).forEach(([e,r])=>{if(!Array.isArray(r))return;let i=e===`_component`?void 0:t[e]??e;r.forEach(e=>{e&&!n.some(t=>t.label===i&&t.msg===e)&&n.push({label:i,msg:e})})}),n.length===0){this.notify(`There are validation errors`);return}oa({text:`There are validation errors
+`,Co=new WeakSet,wo=e=>{if(Co.has(e))return;Co.add(e);let t=e;if(typeof CSSStyleSheet<`u`&&Array.isArray(t.adoptedStyleSheets))try{let e=new CSSStyleSheet;e.replaceSync(So),t.adoptedStyleSheets=[...t.adoptedStyleSheets,e];return}catch{}let n=e instanceof Document?e.head:e;if(!n)return;let r=document.createElement(`style`);r.setAttribute(xo,``),r.textContent=So,n.appendChild(r)},To=e=>{let t=e.getRootNode();if(t instanceof ShadowRoot||t instanceof Document)return t},Eo=e=>{if(!e||e.hasAttribute(`data-mateu-pending`))return;let t=To(e);t&&wo(t),e.setAttribute(`data-mateu-pending`,``),e.setAttribute(`aria-busy`,`true`)},Do=e=>{e&&(e.removeAttribute(`data-mateu-pending`),e.removeAttribute(`aria-busy`))},Oo=e=>{let t=(typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target;return t instanceof Element?t:void 0},ko=[`button`,`a[href]`,`[role="button"]`,`[role="menuitem"]`,`input[type="button"]`,`input[type="submit"]`,`vaadin-button`,`vaadin-menu-bar-button`,`ui5-button`,`oj-c-button`,`oj-button`].join(`, `),Ao=e=>{if(!(!e||typeof e.closest!=`function`))return e.closest(ko)??void 0},jo=null,Mo=class extends ga{constructor(...e){super(...e),this.baseUrl=``,this.route=``,this.consumedRoute=``,this.formerState={},this.applyRules=()=>{let e=this.component.rules;if(e&&e.length>0){let t=this.state,n=this.data,r=this.appState,i=this.appData,a=this.component,o=e=>ot(e,t,n,{appState:r,appData:i,component:a}),s=e=>at(e,t,n,r,i,{component:a}),c=[`state`,`data`,`appState`,`appData`,`component`],l=[t,n,r,i,a],u={...this.state},d={...this.data},f=!1,p=!1;for(let t=0;t<e.length;t++){let n=e[t];try{if(o(n.filter)){if(ho.SetStateValue==n.action||ho.SetDataValue==n.action){let e=ho.SetStateValue==n.action?u:d,t=n.fieldName.split(`,`);for(let r=0;r<t.length;r++){let i=t[r];if(!e[i]||e[i]!=n.value){let t=n.expression?s(n.expression):n.value,r=go.none==n.fieldAttribute?i:i+`.`+n.fieldAttribute;t!=e[r]&&(e[r]=t,ho.SetStateValue==n.action&&(f=!0),ho.SetDataValue==n.action&&(p=!0))}}}if(ho.RunAction==n.action&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.actionId},bubbles:!0,composed:!0})),ho.RunJS==n.action&&Function(...c,n.value)(...l),ho.SetAttributeValue==n.action){let e=n.expression?o(n.expression):n.value;if(n.fieldAttribute==`disabled`){e?this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(n.fieldAttribute,`disabled`):this.shadowRoot?.getElementById(n.fieldName)?.removeAttribute(n.fieldAttribute);continue}this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(n.fieldAttribute,e)}if(ho.SetCssClass==n.action&&this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(`class`,n.value),ho.SetStyle==n.action&&this.shadowRoot?.getElementById(n.fieldName)?.style.setProperty(n.expression,n.value),_o.Stop==n.result)break}}catch(e){console.error(`rule failed`,n,e)}}f&&(this.state=u),p&&(this.data=d),f&&this.checkValidations()}},this.skipValidation=(e,t)=>e&&t.fieldId&&!e.includes(t.fieldId)||!e&&t.fieldId&&t.fieldId.includes(`-`),this.checkValidations=e=>{let t=e?e.split(`,`):void 0,n=this.component.validations,r=!0,i=!1,a=this.data??{},o={...this.data??{},errors:{}};if(n){for(let e=0;e<n.length;e++){let r=n[e];if(this.skipValidation(t,r))continue;let i=(r.fieldId??`_component`).split(`,`);for(let e=0;e<i.length;e++){let t=i[e];o.errors[t]=[]}}for(let e=0;e<n.length;e++){let i=n[e];if(!this.skipValidation(t,i))try{let e=i.condition&&i.condition.includes("${")?this._evalTemplate(i.condition):this._evalExpr(i.condition);if(i.condition&&!e){r=!1;let e=(i.fieldId??`_component`).split(`,`);for(let t=0;t<e.length;t++){let n=e[t],r=o.errors[n];if(r||(o.errors[n]=[]),r=o.errors[n],!a[n]){let e=i.message;try{e=this._evalTemplate(i.message)}catch{}r.push(e)}}}}catch(e){console.error(`validation failed`,i,e)}}for(let e=0;e<n.length;e++){let r=n[e];if(this.skipValidation(t,r))continue;let s=(r.fieldId??`_component`).split(`,`);for(let e=0;e<s.length;e++){let t=s[e];if((a.errors||o.errors==``)&&[t].join(`,`)){i=!0;break}}}(a.errors||o.errors==``)&&[`_component`].join(`,`)&&(i=!0)}o._valid=r,o._valid!=a._valid&&(i=!0),i&&(this.data=o)},this._autoSaveTimers=new Map,this.onChange=()=>{this.applyRules()},this.closeModalRequestedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.closeModal()},this.resetFilters=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail,n={};t.fieldIds.forEach(e=>{n[e]=void 0}),n.searchText=void 0,this.state={...this.state,...n}}},this.dataChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail,n={};n[t.key]=t.value,e.type==`data-changed`&&(this.data={...this.data,...n})}},this.valueChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail;if(e.type==`value-changed`){let n={...this.state};n[t.fieldId]=t.value,this.state=n,(this.state[t.fieldId]||this.formerState[t.fieldId])&&this.state[t.fieldId]!=this.formerState[t.fieldId]&&this.component?.confirmOnNavigationIfDirty&&this.dispatchEvent(new CustomEvent(`dirty`,{detail:e.detail,bubbles:!0,composed:!0}));let r=this.component;r.triggers?.filter(e=>e.type==ha.OnValueChange).filter(e=>!e.propertyName||t.fieldId==e.propertyName).forEach(e=>{(!e.condition||this._evalExpr(e.condition))&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))}),r.triggers?.filter(e=>e.type==ha.AutoSave).forEach(e=>{let t=e.actionId,n=this._autoSaveTimers.get(t);n!==void 0&&clearTimeout(n),this._autoSaveTimers.set(t,setTimeout(()=>{this._autoSaveTimers.delete(t),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))},e.debounceMillis??800))})}}},this.actionRequestedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.manageActionRequestedEvent(e)},this.manageActionRequestedEvent=e=>{let t=e.detail,n=t?._originElement??Oo(e);if(e.type==`action-requested`){e.preventDefault(),e.stopPropagation();let r=this.component,i=r.actions?.find(e=>e.id==t.actionId)??r.actions?.find(e=>e.id.endsWith(`*`)&&t.actionId.startsWith(e.id.replace(`*`,``)));if(i){if(i&&i.rowsSelectedRequired&&(!this.state.crud_selected_items||this.state.crud_selected_items.length==0)){this.notify(`You first need to select some rows`);return}if(i&&i.validationRequired){let e=jo??this;if(jo=null,e.checkValidations(i.fieldsToValidate),!e.data._valid){e.notifyValidationErrors();return}}jo=null;let e={...t,initiatorComponentId:this.id};i&&i.confirmationRequired?this.callAfterConfirmation(i,()=>this.requestActionCallToServerOrBubble(e,r,i,n)):this.requestActionCallToServerOrBubble(e,r,i,n)}else{let r={...t.parameters};r.initiatorState||=this.state,jo||=this,this.dispatchEvent(new CustomEvent(e.type,{detail:{...e.detail,_originElement:n,parameters:r},bubbles:!0,composed:!0}))}}},this.buildFieldLabelMap=()=>{let e={},t=n=>{if(n)for(let r of n){let n=r.metadata;if(n?.type===A.FormField){let t=n;t.fieldId&&t.label&&(e[t.fieldId]=t.label)}t(r.children)}};return t(this.component?.children),e},this.notifyValidationErrors=()=>{let e=this.data?.errors??{},t=this.buildFieldLabelMap(),n=[];if(Object.entries(e).forEach(([e,r])=>{if(!Array.isArray(r))return;let i=e===`_component`?void 0:t[e]??e;r.forEach(e=>{e&&!n.some(t=>t.label===i&&t.msg===e)&&n.push({label:i,msg:e})})}),n.length===0){this.notify(`There are validation errors`);return}sa({text:`There are validation errors
 `+n.map(({label:e,msg:t})=>e?`• ${e}: ${t}`:`• ${t}`).join(`
-`),variant:`error`,position:`bottomEnd`,duration:Math.max(3e3,1500+n.length*1e3)},this),this.focusFirstInvalidField()},this.notify=e=>{oa({text:e,variant:`error`,position:`bottomEnd`,duration:3e3},this)},this.callAfterConfirmation=(e,t)=>{let n=`One moment, please`,r=`Are you sure?`,i=`Yes`,a=`No`;e.confirmationTexts&&(n=e.confirmationTexts.title,r=e.confirmationTexts.message,i=e.confirmationTexts.confirmationText,a=e.confirmationTexts.denialText);let o=document.createElement(`div`);o.style.cssText=`position:fixed;inset:0;z-index:1100;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.35);padding:1rem;`;let s=document.createElement(`div`);s.style.cssText=`background:var(--lumo-base-color,#fff);color:var(--lumo-body-text-color,#1a1a1a);border-radius:var(--lumo-border-radius-l,12px);box-shadow:var(--lumo-box-shadow-xl,0 12px 40px rgba(0,0,0,.3));padding:1.2rem;max-width:min(90vw,26rem);`;let c=()=>{o.parentElement&&document.body.removeChild(o)},l=`font:inherit;font-weight:600;padding:.45rem 1rem;border-radius:var(--lumo-border-radius-m,6px);cursor:pointer;`;re(T`
+`),variant:`error`,position:`bottomEnd`,duration:Math.max(3e3,1500+n.length*1e3)},this),this.focusFirstInvalidField()},this.notify=e=>{sa({text:e,variant:`error`,position:`bottomEnd`,duration:3e3},this)},this.callAfterConfirmation=(e,t)=>{let n=`One moment, please`,r=`Are you sure?`,i=`Yes`,a=`No`;e.confirmationTexts&&(n=e.confirmationTexts.title,r=e.confirmationTexts.message,i=e.confirmationTexts.confirmationText,a=e.confirmationTexts.denialText);let o=document.createElement(`div`);o.style.cssText=`position:fixed;inset:0;z-index:1100;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.35);padding:1rem;`;let s=document.createElement(`div`);s.style.cssText=`background:var(--lumo-base-color,#fff);color:var(--lumo-body-text-color,#1a1a1a);border-radius:var(--lumo-border-radius-l,12px);box-shadow:var(--lumo-box-shadow-xl,0 12px 40px rgba(0,0,0,.3));padding:1.2rem;max-width:min(90vw,26rem);`;let c=()=>{o.parentElement&&document.body.removeChild(o)},l=`font:inherit;font-weight:600;padding:.45rem 1rem;border-radius:var(--lumo-border-radius-m,6px);cursor:pointer;`;ie(w`
             <h3 style="margin:0 0 .5rem;">${n}</h3>
             <div style="margin-bottom:1.2rem;">${r}</div>
             <div style="display:flex;justify-content:flex-end;gap:.5rem;">
@@ -7260,24 +7260,24 @@ ${i}
                 <button style="${l}border:none;background:var(--lumo-primary-color,#1676f3);color:var(--lumo-primary-contrast-color,#fff);"
                         @click="${()=>{c(),t()}}">${i}</button>
             </div>
-        `,s),o.appendChild(s),o.addEventListener(`click`,e=>{e.target===o&&c()}),document.body.appendChild(o)},this.requestActionCallToServerOrBubble=(e,t,n,r)=>{if(n&&n.bubble){let t={...e.parameters};t.initiatorState||=this.state,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{...e,_originElement:r,parameters:t},bubbles:!0,composed:!0}))}else this.requestActionCallToServer(e,t,n,r)},this.requestActionCallToServer=(e,t,n,r)=>{if(n&&n.href){window.location.href=n.href;return}if(n&&n.js)try{Function(`state`,`data`,`appState`,`appData`,`component`,n.js).call(this,this.state??{},this.data??{},this.appState??{},this.appData??{},this.component),this.state={...this.state},this.data={...this.data}}catch(e){console.error(`when evaluating `+n.js,e,this.component,this.state,this.data)}if(n&&n.customEvent&&this.dispatchEvent(new CustomEvent(n.customEvent.name,{detail:n.customEvent.detail,bubbles:!0,composed:!0})),!(n&&(n.js||n.customEvent))){if(e.actionId==`search`){let t=e.parameters?._searchState;t?this.state={...this.state,...t}:this.state.size||(this.state={...this.state,size:10,page:0,sort:[]})}if(!n?.background){if(!Le(e.actionId,n?.idempotent)&&!yo.begin(vo(this.id,e.actionId)))return;let t=ko(r);this._pendingOrigins.set(e.actionId,t),To(t)}this.dispatchEvent(new CustomEvent(`server-side-action-requested`,{detail:{route:this.route,consumedRoute:this.consumedRoute,componentState:{...this.state},parameters:e.parameters??{},actionId:e.actionId,serverSideType:t.serverSideType,serverSideComponentRoute:t.route,initiatorComponentId:e.initiatorComponentId??t.id,initiator:this,background:n?.background,sse:n?.sse,timeoutMillis:n?.timeoutMillis,idempotent:n?.idempotent,callback:e.callback,callbackonly:e.callbackonly,callbackToken:e.callbackToken??this.callbackToken},bubbles:!0,composed:!0}))}},this.handleBackendSucceeded=e=>{e.detail.actionId&&this.component.triggers?.filter(e=>e.type==ma.OnSuccess).filter(t=>e.detail.actionId==t.calledActionId).forEach(t=>{if(!t.condition||this._evalExpr(t.condition))if(e.preventDefault(),e.stopPropagation(),t.timeoutMillis>0){let e=this.callbackToken;setTimeout(()=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,callbackToken:e},bubbles:!0,composed:!0}))},t.timeoutMillis)}else this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))})},this.handleBackendFailed=e=>{e.detail.actionId&&this.component.triggers?.filter(e=>e.type==ma.OnError).filter(t=>e.detail.actionId==t.calledActionId).forEach(t=>{(!t.condition||this._evalExpr(t.condition))&&(e.preventDefault(),e.stopPropagation(),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0})))})},this._pendingOrigins=new Map,this._backendSettledListener=e=>{((typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target)===this&&this._releasePending(e.detail?.actionId)},this._keydownListener=e=>{if(this._handleTabShortcut(e))return;let t=this.component;if(t)for(let n of t.actions??[]){let t=n.shortcut||(n.runOnEnter?`enter`:null);if(t&&this._shortcutMatchesEvent(t,e)){e.preventDefault(),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.id},bubbles:!0,composed:!0}));return}}}}createRenderRoot(){return P.mustUseShadowRoot()?super.createRenderRoot():this}updated(e){super.updated(e),e.has(`state`)&&this.state&&JSON.stringify(this.state)!=JSON.stringify({})&&this.onChange(),e.has(`component`)&&(this.formerState={...this.state},this.component?.confirmOnNavigationIfDirty&&this.dispatchEvent(new CustomEvent(`clean`,{detail:{},bubbles:!0,composed:!0})),setTimeout(()=>this.triggerOnLoad()))}focusFirstInvalidField(){let e=t=>requestAnimationFrame(()=>{let n=this.findFirstInvalid(this.renderRoot);if(n){n.focus?.(),n.scrollIntoView?.({block:`center`,behavior:`smooth`});return}t>0&&e(t-1)});e(3)}findFirstInvalid(e){if(!e?.querySelectorAll)return null;for(let t of Array.from(e.querySelectorAll(`*`))){if(t.invalid===!0)return t;if(t.shadowRoot){let e=this.findFirstInvalid(t.shadowRoot);if(e)return e}}return null}_releasePending(e){(e===void 0?Array.from(this._pendingOrigins.keys()):[e]).forEach(e=>{yo.end(vo(this.id,e)),Eo(this._pendingOrigins.get(e)),this._pendingOrigins.delete(e)})}_shortcutMatchesEvent(e,t){return An(e,t)}_collectShortcutTabs(){let e=this.renderRoot;if(!e)return[];let t=Array.from(e.querySelectorAll(`vaadin-tab[data-shortcut]`));return e.querySelectorAll(`mateu-drawer, mateu-dialog`).forEach(e=>{let n=e.shadowRoot;n&&t.push(...Array.from(n.querySelectorAll(`vaadin-tab[data-shortcut]`)))}),t}_handleTabShortcut(e){let t=this._collectShortcutTabs();if(t.length===0)return!1;for(let n of Array.from(t)){let t=n.dataset.shortcut;if(!t||!this._shortcutMatchesEvent(t,e))continue;let r=n.closest(`vaadin-tabs`);if(!r)continue;let i=Array.from(r.querySelectorAll(`vaadin-tab`)).indexOf(n);if(!(i<0))return e.preventDefault(),r.selected=i,!0}return!1}connectedCallback(){super.connectedCallback(),this.addEventListener(`backend-call-succeeded`,this.handleBackendSucceeded),this.addEventListener(`backend-call-failed`,this.handleBackendFailed),this.addEventListener(`backend-succeeded-event`,this._backendSettledListener),this.addEventListener(`backend-failed-event`,this._backendSettledListener),this.addEventListener(`backend-cancelled-event`,this._backendSettledListener),document.addEventListener(`keydown`,this._keydownListener)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`backend-call-succeeded`,this.handleBackendSucceeded),this.removeEventListener(`backend-call-failed`,this.handleBackendFailed),this.removeEventListener(`backend-succeeded-event`,this._backendSettledListener),this.removeEventListener(`backend-failed-event`,this._backendSettledListener),this.removeEventListener(`backend-cancelled-event`,this._backendSettledListener),document.removeEventListener(`keydown`,this._keydownListener),this._releasePending()}render(){return T`<div>
+        `,s),o.appendChild(s),o.addEventListener(`click`,e=>{e.target===o&&c()}),document.body.appendChild(o)},this.requestActionCallToServerOrBubble=(e,t,n,r)=>{if(n&&n.bubble){let t={...e.parameters};t.initiatorState||=this.state,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{...e,_originElement:r,parameters:t},bubbles:!0,composed:!0}))}else this.requestActionCallToServer(e,t,n,r)},this.requestActionCallToServer=(e,t,n,r)=>{if(n&&n.href){window.location.href=n.href;return}if(n&&n.js)try{Function(`state`,`data`,`appState`,`appData`,`component`,n.js).call(this,this.state??{},this.data??{},this.appState??{},this.appData??{},this.component),this.state={...this.state},this.data={...this.data}}catch(e){console.error(`when evaluating `+n.js,e,this.component,this.state,this.data)}if(n&&n.customEvent&&this.dispatchEvent(new CustomEvent(n.customEvent.name,{detail:n.customEvent.detail,bubbles:!0,composed:!0})),!(n&&(n.js||n.customEvent))){if(e.actionId==`search`){let t=e.parameters?._searchState;t?this.state={...this.state,...t}:this.state.size||(this.state={...this.state,size:10,page:0,sort:[]})}if(!n?.background){if(!Re(e.actionId,n?.idempotent)&&!bo.begin(yo(this.id,e.actionId)))return;let t=Ao(r);this._pendingOrigins.set(e.actionId,t),Eo(t)}this.dispatchEvent(new CustomEvent(`server-side-action-requested`,{detail:{route:this.route,consumedRoute:this.consumedRoute,componentState:{...this.state},parameters:e.parameters??{},actionId:e.actionId,serverSideType:t.serverSideType,serverSideComponentRoute:t.route,initiatorComponentId:e.initiatorComponentId??t.id,initiator:this,background:n?.background,sse:n?.sse,timeoutMillis:n?.timeoutMillis,idempotent:n?.idempotent,callback:e.callback,callbackonly:e.callbackonly,callbackToken:e.callbackToken??this.callbackToken},bubbles:!0,composed:!0}))}},this.handleBackendSucceeded=e=>{e.detail.actionId&&this.component.triggers?.filter(e=>e.type==ha.OnSuccess).filter(t=>e.detail.actionId==t.calledActionId).forEach(t=>{if(!t.condition||this._evalExpr(t.condition))if(e.preventDefault(),e.stopPropagation(),t.timeoutMillis>0){let e=this.callbackToken;setTimeout(()=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,callbackToken:e},bubbles:!0,composed:!0}))},t.timeoutMillis)}else this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))})},this.handleBackendFailed=e=>{e.detail.actionId&&this.component.triggers?.filter(e=>e.type==ha.OnError).filter(t=>e.detail.actionId==t.calledActionId).forEach(t=>{(!t.condition||this._evalExpr(t.condition))&&(e.preventDefault(),e.stopPropagation(),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0})))})},this._pendingOrigins=new Map,this._backendSettledListener=e=>{((typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target)===this&&this._releasePending(e.detail?.actionId)},this._keydownListener=e=>{if(this._handleTabShortcut(e))return;let t=this.component;if(t)for(let n of t.actions??[]){let t=n.shortcut||(n.runOnEnter?`enter`:null);if(t&&this._shortcutMatchesEvent(t,e)){e.preventDefault(),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.id},bubbles:!0,composed:!0}));return}}}}createRenderRoot(){return N.mustUseShadowRoot()?super.createRenderRoot():this}updated(e){super.updated(e),e.has(`state`)&&this.state&&JSON.stringify(this.state)!=JSON.stringify({})&&this.onChange(),e.has(`component`)&&(this.formerState={...this.state},this.component?.confirmOnNavigationIfDirty&&this.dispatchEvent(new CustomEvent(`clean`,{detail:{},bubbles:!0,composed:!0})),setTimeout(()=>this.triggerOnLoad()))}focusFirstInvalidField(){let e=t=>requestAnimationFrame(()=>{let n=this.findFirstInvalid(this.renderRoot);if(n){n.focus?.(),n.scrollIntoView?.({block:`center`,behavior:`smooth`});return}t>0&&e(t-1)});e(3)}findFirstInvalid(e){if(!e?.querySelectorAll)return null;for(let t of Array.from(e.querySelectorAll(`*`))){if(t.invalid===!0)return t;if(t.shadowRoot){let e=this.findFirstInvalid(t.shadowRoot);if(e)return e}}return null}_releasePending(e){(e===void 0?Array.from(this._pendingOrigins.keys()):[e]).forEach(e=>{bo.end(yo(this.id,e)),Do(this._pendingOrigins.get(e)),this._pendingOrigins.delete(e)})}_shortcutMatchesEvent(e,t){return jn(e,t)}_collectShortcutTabs(){let e=this.renderRoot;if(!e)return[];let t=Array.from(e.querySelectorAll(`vaadin-tab[data-shortcut]`));return e.querySelectorAll(`mateu-drawer, mateu-dialog`).forEach(e=>{let n=e.shadowRoot;n&&t.push(...Array.from(n.querySelectorAll(`vaadin-tab[data-shortcut]`)))}),t}_handleTabShortcut(e){let t=this._collectShortcutTabs();if(t.length===0)return!1;for(let n of Array.from(t)){let t=n.dataset.shortcut;if(!t||!this._shortcutMatchesEvent(t,e))continue;let r=n.closest(`vaadin-tabs`);if(!r)continue;let i=Array.from(r.querySelectorAll(`vaadin-tab`)).indexOf(n);if(!(i<0))return e.preventDefault(),r.selected=i,!0}return!1}connectedCallback(){super.connectedCallback(),this.addEventListener(`backend-call-succeeded`,this.handleBackendSucceeded),this.addEventListener(`backend-call-failed`,this.handleBackendFailed),this.addEventListener(`backend-succeeded-event`,this._backendSettledListener),this.addEventListener(`backend-failed-event`,this._backendSettledListener),this.addEventListener(`backend-cancelled-event`,this._backendSettledListener),document.addEventListener(`keydown`,this._keydownListener)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`backend-call-succeeded`,this.handleBackendSucceeded),this.removeEventListener(`backend-call-failed`,this.handleBackendFailed),this.removeEventListener(`backend-succeeded-event`,this._backendSettledListener),this.removeEventListener(`backend-failed-event`,this._backendSettledListener),this.removeEventListener(`backend-cancelled-event`,this._backendSettledListener),document.removeEventListener(`keydown`,this._keydownListener),this._releasePending()}render(){return w`<div>
             <div>${this._render()}</div>
-            ${this.data&&this.data.errors&&this.data.errors._component&&this.data.errors._component.length>0?T`
-                <div><ul>${this.data.errors._component.map(e=>T`<li>${e}</li>`)}</ul></div>
-            `:v}</div>`}_render(){if(this.component?.type==A.ClientSide){let e=this.component;return e.metadata?.type==j.Page?pr(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!0):e.metadata?.type==j.Crud?mr(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!0):P.get()?.renderClientSideComponent(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!1)}return T`
+            ${this.data&&this.data.errors&&this.data.errors._component&&this.data.errors._component.length>0?w`
+                <div><ul>${this.data.errors._component.map(e=>w`<li>${e}</li>`)}</ul></div>
+            `:_}</div>`}_render(){if(this.component?.type==k.ClientSide){let e=this.component;return e.metadata?.type==A.Page?mr(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!0):e.metadata?.type==A.Crud?hr(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!0):N.get()?.renderClientSideComponent(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!1)}return w`
             <mateu-api-caller 
                     @value-changed="${this.valueChangedListener}"
                     @data-changed="${this.dataChangedListener}"
                     @close-modal-requested="${this.closeModalRequestedListener}"
                     @filter-reset-requested="${this.resetFilters}"
                     @action-requested="${this.actionRequestedListener}">
-            ${this.component?.children?.map(e=>{if(e.type==A.ClientSide){let t=e;if(t.metadata?.type==j.Page)return pr(this,t,this.baseUrl,this.state,this.data,this.appState,this.appData,!0);if(t.metadata?.type==j.Crud)return mr(this,t,this.baseUrl,this.state,this.data,this.appState,this.appData,!0)}return F(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData)})}
+            ${this.component?.children?.map(e=>{if(e.type==k.ClientSide){let t=e;if(t.metadata?.type==A.Page)return mr(this,t,this.baseUrl,this.state,this.data,this.appState,this.appData,!0);if(t.metadata?.type==A.Crud)return hr(this,t,this.baseUrl,this.state,this.data,this.appState,this.appData,!0)}return P(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData)})}
             </mateu-api-caller>
-        `}static{this.styles=h`
+        `}static{this.styles=m`
         :host {
         }
 
-        ${ie(de.cssText)}
+        ${ae(fe.cssText)}
         
         vaadin-card.image-on-right::part(media) {
             grid-column: 3;
@@ -7308,16 +7308,16 @@ ${i}
             padding-block: var(--lumo-space-xs);
             box-shadow: 0 1px 0 0 var(--lumo-contrast-10pct, rgba(0, 0, 0, 0.1));
         }
-  `}};k([y()],jo.prototype,`baseUrl`,void 0),k([y()],jo.prototype,`route`,void 0),k([y()],jo.prototype,`consumedRoute`,void 0),jo=k([g(`mateu-component`)],jo);var Mo=e=>{if(e)try{return JSON.parse(e)}catch{return{value:e}}else return{}},No=new class{async handle(e,t){return await e.runAction(t.baseUrl,t.route,t.consumedRoute,t.actionId,t.initiatorComponentId,t.appState,t.serverSideType,t.componentState,t.parameters,t.initiator,t.background,t.options)}},Po=new class{constructor(){this.handleUIIncrement=(e,t,n)=>{if(e?.fragments?.forEach(e=>{le.next({command:void 0,fragment:e,ui:void 0,error:void 0,callbackToken:n})}),e?.appState&&(O.value={...e.appState},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))),e?.appData){let n=e?.appData;ue.value={...e.appData,...n},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))}e?.messages?.forEach(e=>{oa({text:e.text,position:e.position,variant:e.variant,duration:e.duration,undoLabel:e.undoLabel,undoActionId:e.undoActionId,undoParameters:e.undoParameters},t)}),e?.banners&&e.banners.length>0&&document.dispatchEvent(new CustomEvent(`page-banners-received`,{detail:{banners:e.banners,append:e.appendBanners??!1},bubbles:!1,composed:!1})),e?.commands?.forEach(e=>{le.next({command:e,fragment:void 0,ui:void 0,error:void 0,callbackToken:n})})}}async runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,m,ee={}){let te=()=>{this.runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,m,ee)};try{let o=await No.handle(e,{baseUrl:t,route:n,consumedRoute:r,actionId:i,appState:O.value,initiatorComponentId:a,componentState:c,parameters:l,serverSideType:s,initiator:u,background:d,options:{...ee,retry:te}});f&&f(o),p||this.handleUIIncrement(o,u,m),o.messages&&o.messages.length==1&&o.messages[0].variant==`error`&&u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-succeeded`,{detail:{actionId:i,evevntId:E()},bubbles:!0,composed:!0}))}catch(e){console.warn(`Action request failed`,e),e?.__mateuReported||u.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:i,reason:this.serialize(e),retry:te}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))}}serialize(e){return e?.message?e:JSON.stringify(e)}},Fo=new class{constructor(){this.handleUIIncrement=(e,t,n)=>{if(e?.messages?.forEach(e=>{oa({text:e.text,position:e.position,variant:e.variant,duration:e.duration,undoLabel:e.undoLabel,undoActionId:e.undoActionId,undoParameters:e.undoParameters},t)}),e?.banners&&e.banners.length>0&&document.dispatchEvent(new CustomEvent(`page-banners-received`,{detail:{banners:e.banners,append:e.appendBanners??!1},bubbles:!1,composed:!1})),e?.commands?.forEach(e=>{le.next({command:e,fragment:void 0,ui:void 0,error:void 0,callbackToken:n})}),e?.fragments?.forEach(e=>{le.next({command:void 0,fragment:e,ui:void 0,error:void 0,callbackToken:n})}),e?.appState&&(O.value={...e.appState},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))),e?.appData){let n=e?.appData;ue.value={...e.appData,...n},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))}}}async runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,m,ee={}){let te=()=>{this.runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,m,ee)};if(n){n||=`_no_route`,n&&n.startsWith(`/`)&&(n=n.substring(1));let e={serverSideType:s,appState:O.value,componentState:c,parameters:l,initiatorComponentId:a,consumedRoute:r,route:`/`+n,actionId:i};d||u.dispatchEvent(new CustomEvent(`backend-called-event`,{bubbles:!0,composed:!0,detail:{}})),fetch(t+`/mateu/v3/sse/`+n,{method:`POST`,headers:{Accept:`text/event-stream`,"Content-Type":`application/json`},body:JSON.stringify(e)}).then(async e=>{let t=e.body?.pipeThrough(new TextDecoderStream).getReader();if(t){let e=``;for(;;){let{value:n,done:r}=await t.read();if(r)break;e+=n;let a=e.split(`
+  `}};O([v()],Mo.prototype,`baseUrl`,void 0),O([v()],Mo.prototype,`route`,void 0),O([v()],Mo.prototype,`consumedRoute`,void 0),Mo=O([h(`mateu-component`)],Mo);var No=e=>{if(e)try{return JSON.parse(e)}catch{return{value:e}}else return{}},Po=new class{async handle(e,t){return await e.runAction(t.baseUrl,t.route,t.consumedRoute,t.actionId,t.initiatorComponentId,t.appState,t.serverSideType,t.componentState,t.parameters,t.initiator,t.background,t.options)}},Fo=new class{constructor(){this.handleUIIncrement=(e,t,n)=>{if(e?.fragments?.forEach(e=>{ue.next({command:void 0,fragment:e,ui:void 0,error:void 0,callbackToken:n})}),e?.appState&&(D.value={...e.appState},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))),e?.appData){let n=e?.appData;de.value={...e.appData,...n},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))}e?.messages?.forEach(e=>{sa({text:e.text,position:e.position,variant:e.variant,duration:e.duration,undoLabel:e.undoLabel,undoActionId:e.undoActionId,undoParameters:e.undoParameters},t)}),e?.banners&&e.banners.length>0&&document.dispatchEvent(new CustomEvent(`page-banners-received`,{detail:{banners:e.banners,append:e.appendBanners??!1},bubbles:!1,composed:!1})),e?.commands?.forEach(e=>{ue.next({command:e,fragment:void 0,ui:void 0,error:void 0,callbackToken:n})})}}async runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,te={}){let ne=()=>{this.runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,te)};try{let o=await Po.handle(e,{baseUrl:t,route:n,consumedRoute:r,actionId:i,appState:D.value,initiatorComponentId:a,componentState:c,parameters:l,serverSideType:s,initiator:u,background:d,options:{...te,retry:ne}});f&&f(o),p||this.handleUIIncrement(o,u,ee),o.messages&&o.messages.length==1&&o.messages[0].variant==`error`&&u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-succeeded`,{detail:{actionId:i,evevntId:T()},bubbles:!0,composed:!0}))}catch(e){console.warn(`Action request failed`,e),e?.__mateuReported||u.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:i,reason:this.serialize(e),retry:ne}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))}}serialize(e){return e?.message?e:JSON.stringify(e)}},Io=new class{constructor(){this.handleUIIncrement=(e,t,n)=>{if(e?.messages?.forEach(e=>{sa({text:e.text,position:e.position,variant:e.variant,duration:e.duration,undoLabel:e.undoLabel,undoActionId:e.undoActionId,undoParameters:e.undoParameters},t)}),e?.banners&&e.banners.length>0&&document.dispatchEvent(new CustomEvent(`page-banners-received`,{detail:{banners:e.banners,append:e.appendBanners??!1},bubbles:!1,composed:!1})),e?.commands?.forEach(e=>{ue.next({command:e,fragment:void 0,ui:void 0,error:void 0,callbackToken:n})}),e?.fragments?.forEach(e=>{ue.next({command:void 0,fragment:e,ui:void 0,error:void 0,callbackToken:n})}),e?.appState&&(D.value={...e.appState},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))),e?.appData){let n=e?.appData;de.value={...e.appData,...n},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))}}}async runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,te={}){let ne=()=>{this.runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,te)};if(n){n||=`_no_route`,n&&n.startsWith(`/`)&&(n=n.substring(1));let e={serverSideType:s,appState:D.value,componentState:c,parameters:l,initiatorComponentId:a,consumedRoute:r,route:`/`+n,actionId:i};d||u.dispatchEvent(new CustomEvent(`backend-called-event`,{bubbles:!0,composed:!0,detail:{}})),fetch(t+`/mateu/v3/sse/`+n,{method:`POST`,headers:{Accept:`text/event-stream`,"Content-Type":`application/json`},body:JSON.stringify(e)}).then(async e=>{let t=e.body?.pipeThrough(new TextDecoderStream).getReader();if(t){let e=``;for(;;){let{value:n,done:r}=await t.read();if(r)break;e+=n;let a=e.split(`
 
-`);e=a.pop()??``;for(let e of a){let t=e.trim();if(t)if(t.startsWith(`data:`)){let e=JSON.parse(t.substring(5).trim());f&&f(e),p||this.handleUIIncrement(e,u,m),e.messages&&e.messages.length==1&&e.messages[0].variant==`error`&&u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))}else{let e=t;try{let n=JSON.parse(t);e=n.message,n._embedded?.errors?.length>0&&n._embedded.errors[0].message&&(e=n._embedded.errors[0].message)}catch{}throw Error(e)}}}}d||u.dispatchEvent(new CustomEvent(`backend-succeeded-event`,{bubbles:!0,composed:!0,detail:{actionId:i}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-succeeded`,{detail:{actionId:i},bubbles:!0,composed:!0}))}).catch(e=>{u.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:i,reason:this.serialize(e),retry:te}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))})}}serialize(e){return e?.message?e:JSON.stringify(e)}},Io={fixed:`fixed`,fullWidth:`full`,edgeToEdge:`edge`},Lo=new Set([j.Gantt,j.PlanningBoard,j.Kanban,j.Bpmn,j.Workflow,j.Map]),Ro={landing:`fixed`,form:`fixed`,process:`fixed`},zo=e=>e?Io[e]:void 0,Bo=e=>e.type==A.ClientSide?e.metadata:void 0,Vo=e=>{let t=Bo(e);if(t?.type==j.Page){let e=zo(t.pageWidth);if(e)return e}for(let t of e.children??[]){let e=Vo(t);if(e)return e}},Ho=e=>{let t=e.pageType;if(t)return t;let n=e=>{let t=Bo(e);if(t?.type==j.Page&&t.pageType)return t.pageType;for(let t of e.children??[]){let e=n(t);if(e)return e}};return n(e)},Uo=e=>{let t=Bo(e);if(t?.type!=j.Crud)return!1;let n=t;return n.compact?!0:(n.columns??[]).some(e=>e.metadata?.editable)},Wo=(e,t)=>t(e)||(e.children??[]).some(e=>Wo(e,t)),Go=e=>!!e&&Wo(e,e=>Bo(e)?.type==j.HeroSection),Ko=e=>Bo(e)?.type==j.App||(e.children??[]).some(e=>Bo(e)?.type==j.App),qo=(e,t)=>e?(zo(e.pageWidth)??Vo(e))||(t?.top&&Ko(e)?`edge`:Ro[Ho(e)??``]||(Wo(e,e=>{let t=Bo(e)?.type;return t!=null&&Lo.has(t)})?`edge`:Wo(e,Uo)?`full`:`fixed`)):`fixed`,Jo,X=class extends Qe{static{Jo=this}constructor(...e){super(...e),this.consumedRoute=``,this.serverSideType=void 0,this.uriPrefix=void 0,this.overrides=void 0,this.homeRoute=void 0,this.route=void 0,this.top=void 0,this.appState={},this.appData={},this.preventNavigation=!1,this.overridesParsed={},this.fragment=void 0,this.showSkeleton=!1,this.pendingRouteFocus=!1,this.hasRenderedContent=!1,this.loadLifecycleListener=e=>{if(((typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target)===this)if(clearTimeout(this.skeletonTimer),e.type===`backend-called-event`){if(this.fragment?.component)return;this.skeletonTimer=setTimeout(()=>{this.showSkeleton=!0},Jo.SKELETON_DELAY_MS)}else this.showSkeleton=!1},this.actionRequestedListener=e=>{e instanceof CustomEvent&&(e.preventDefault(),e.stopPropagation(),this.manageActionEvent(e))},this.historyPushed=e=>{e instanceof CustomEvent&&(e.preventDefault(),e.stopPropagation(),this.preventNavigation=!0,this.route=e.detail.route)},this.routeChangedListener=e=>{if(e instanceof CustomEvent){e.preventDefault(),e.stopPropagation();let t=e.detail.route;typeof t==`string`&&(t===``||t.startsWith(`/`))&&this.consumedRoute&&this.consumedRoute!==`_empty`&&this.consumedRoute.startsWith(`/`)&&!t.startsWith(this.consumedRoute)&&(t=this.consumedRoute+t),this.uriPrefix&&(t=t.startsWith(`/`)&&this.uriPrefix.endsWith(`/`)?this.uriPrefix+t.substring(1):!t.startsWith(`/`)&&!this.uriPrefix.endsWith(`/`)?this.uriPrefix+`/`+t:this.uriPrefix+t),this.dispatchEvent(new CustomEvent(`url-update-requested`,{detail:{route:t},bubbles:!0,composed:!0}))}},this.backendFailedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&e.detail.actionId==``&&(this.fragment={targetComponentId:this.id,data:{},state:{},component:{type:A.ClientSide,metadata:{type:j.Element,name:`div`,content:`Not found`},id:`fieldId`},action:Ge.Replace,containerId:void 0})},this.detail1=void 0,this.manageActionEvent=e=>{e.preventDefault(),e.stopPropagation(),this.detail1=e.detail;let t=this.detail1;if(e.type==`server-side-action-requested`){let e=Po;t.sse&&(e=Fo),e.runAction(We,this.baseUrl,t.route??``,t.consumedRoute,t.actionId,t.initiatorComponentId,this.getCustomisedAppState(),t.serverSideType,t.componentState,t.parameters,t.initiator,t.background,t.callback,t.callbackonly,t.callbackToken,{timeoutMillis:t.timeoutMillis,idempotent:t.idempotent})}},this.getCustomisedAppState=()=>{let e={...O.value};if(this.overrides){let t=Mo(this.overrides);e={...e,...t}}return e}}manageActionRequestedEvent(e){throw Error(`Method not implemented.`)}createRenderRoot(){return P.mustUseShadowRoot()?super.createRenderRoot():this}focusNewContent(){requestAnimationFrame(()=>{let e=this.renderRoot?.querySelector?.(`h1, h2, [role="heading"]`)??this;e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus?.({preventScroll:!0})})}static{this.SKELETON_DELAY_MS=400}connectedCallback(){super.connectedCallback(),this.overridesParsed=Mo(this.overrides),this.addEventListener(`server-side-action-requested`,this.actionRequestedListener),this.addEventListener(`backend-call-failed`,this.backendFailedListener),this.addEventListener(`history-pushed`,this.historyPushed),this.addEventListener(`route-changed`,this.routeChangedListener),this.addEventListener(`backend-called-event`,this.loadLifecycleListener),this.addEventListener(`backend-succeeded-event`,this.loadLifecycleListener),this.addEventListener(`backend-failed-event`,this.loadLifecycleListener),this.addEventListener(`backend-cancelled-event`,this.loadLifecycleListener)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`server-side-action-requested`,this.actionRequestedListener),this.removeEventListener(`backend-call-failed`,this.backendFailedListener),this.removeEventListener(`history-pushed`,this.historyPushed),this.removeEventListener(`route-changed`,this.routeChangedListener),this.removeEventListener(`backend-called-event`,this.loadLifecycleListener),this.removeEventListener(`backend-succeeded-event`,this.loadLifecycleListener),this.removeEventListener(`backend-failed-event`,this.loadLifecycleListener),this.removeEventListener(`backend-cancelled-event`,this.loadLifecycleListener),clearTimeout(this.skeletonTimer)}shouldUpdate(e){if(this.fragment?.component&&[...e.keys()].every(e=>e===`appState`||e===`appData`)){let t=this.renderRoot.querySelector(`mateu-component`);if(t)return e.has(`appState`)&&(t.appState=this.appState),e.has(`appData`)&&(t.appData=this.appData),!1}return!0}updated(e){(e.has(`id`)||e.has(`baseurl`)||e.has(`route`)||e.has(`consumedRoute`)||e.has(`instant`))&&(this.preventNavigation||(this.callbackToken=this.instant||E(),this.manageActionEvent(new CustomEvent(`server-side-action-requested`,{detail:{route:this.route,consumedRoute:this.consumedRoute,userData:void 0,actionId:``,serverSideType:this.serverSideType,initiatorComponentId:this.id,initiator:this,componentState:this.initialState,callbackToken:this.callbackToken},bubbles:!0,composed:!0})))),e.has(`route`)&&this.top&&(this.preventNavigation||(this.pendingRouteFocus=!0),this.preventNavigation||this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:this.route},bubbles:!0,composed:!0}))),this.preventNavigation&&=!1}applyFragment(e){if(!e.component&&this.fragment?.component){this.fragment={...this.fragment,state:{...this.fragment.state??{},...e.state??{}},data:{...this.fragment.data??{},...e.data??{}}};return}this.fragment=e,e.component&&(this.pendingRouteFocus&&this.hasRenderedContent&&this.focusNewContent(),this.pendingRouteFocus=!1,this.hasRenderedContent=!0),e.component&&(this.dataset.pageWidth=qo(e.component,{top:this.top}),this.dataset.pageType=Ho(e.component)??``,this.dataset.hasWelcomeBanner=String(Go(e.component)))}render(){return!this.fragment?.component&&this.showSkeleton?T`
+`);e=a.pop()??``;for(let e of a){let t=e.trim();if(t)if(t.startsWith(`data:`)){let e=JSON.parse(t.substring(5).trim());f&&f(e),p||this.handleUIIncrement(e,u,ee),e.messages&&e.messages.length==1&&e.messages[0].variant==`error`&&u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))}else{let e=t;try{let n=JSON.parse(t);e=n.message,n._embedded?.errors?.length>0&&n._embedded.errors[0].message&&(e=n._embedded.errors[0].message)}catch{}throw Error(e)}}}}d||u.dispatchEvent(new CustomEvent(`backend-succeeded-event`,{bubbles:!0,composed:!0,detail:{actionId:i}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-succeeded`,{detail:{actionId:i},bubbles:!0,composed:!0}))}).catch(e=>{u.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:i,reason:this.serialize(e),retry:ne}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))})}}serialize(e){return e?.message?e:JSON.stringify(e)}},Lo={fixed:`fixed`,fullWidth:`full`,edgeToEdge:`edge`},Ro=new Set([A.Gantt,A.PlanningBoard,A.Kanban,A.Bpmn,A.Workflow,A.Map]),zo={landing:`fixed`,form:`fixed`,process:`fixed`},Bo=e=>e?Lo[e]:void 0,Vo=e=>e.type==k.ClientSide?e.metadata:void 0,Ho=e=>{let t=Vo(e);if(t?.type==A.Page){let e=Bo(t.pageWidth);if(e)return e}for(let t of e.children??[]){let e=Ho(t);if(e)return e}},Uo=e=>{let t=e.pageType;if(t)return t;let n=e=>{let t=Vo(e);if(t?.type==A.Page&&t.pageType)return t.pageType;for(let t of e.children??[]){let e=n(t);if(e)return e}};return n(e)},Wo=e=>{let t=Vo(e);if(t?.type!=A.Crud)return!1;let n=t;return n.compact?!0:(n.columns??[]).some(e=>e.metadata?.editable)},Go=(e,t)=>t(e)||(e.children??[]).some(e=>Go(e,t)),Ko=e=>!!e&&Go(e,e=>Vo(e)?.type==A.HeroSection),qo=e=>Vo(e)?.type==A.App||(e.children??[]).some(e=>Vo(e)?.type==A.App),Jo=(e,t)=>e?(Bo(e.pageWidth)??Ho(e))||(t?.top&&qo(e)?`edge`:zo[Uo(e)??``]||(Go(e,e=>{let t=Vo(e)?.type;return t!=null&&Ro.has(t)})?`edge`:Go(e,Wo)?`full`:`fixed`)):`fixed`,Yo=`mateu-route-structure-cache`,Xo=1,Zo=50,Qo=(()=>{try{return localStorage.getItem(`mateu-route-structure-cache-off`)!==`1`}catch{return!0}})(),$o=()=>{try{return JSON.parse(localStorage.getItem(Yo)??`{}`)}catch{return{}}},es=e=>{try{localStorage.setItem(Yo,JSON.stringify(e))}catch{try{let t=Object.entries(e).sort((e,t)=>t[1].t-e[1].t).slice(0,Math.floor(Zo/2));localStorage.setItem(Yo,JSON.stringify(Object.fromEntries(t)))}catch{}}},ts=e=>{let t=e.initialState&&Object.keys(e.initialState).length?`#`+is(JSON.stringify(e.initialState)):``;return[e.baseUrl,e.consumedRoute??``,e.route??``,e.serverSideType??``].join(`|`)+t},ns=e=>{if(!Qo)return;let t=$o()[e];if(!(!t||t.v!==Xo))return{component:t.component,hash:t.hash}},rs=(e,t,n)=>{if(!Qo)return;let r=$o();r[e]={v:Xo,t:Date.now(),component:t,hash:n};let i=Object.keys(r);if(i.length>Zo){let e=i.sort((e,t)=>r[e].t-r[t].t).slice(0,i.length-Zo);for(let t of e)delete r[t]}es(r)},is=e=>{let t=2166136261;for(let n=0;n<e.length;n++)t^=e.charCodeAt(n),t=Math.imul(t,16777619);return(t>>>0).toString(36)},as=30,os=new Map,ss=!0,cs=e=>{if(ss)return os.get(e)},ls=(e,t)=>{if(ss&&(os.delete(e),os.set(e,t),os.size>as)){let e=os.keys().next().value;e!==void 0&&os.delete(e)}},us,Y=class extends $e{static{us=this}constructor(...e){super(...e),this.consumedRoute=``,this.serverSideType=void 0,this.uriPrefix=void 0,this.overrides=void 0,this.homeRoute=void 0,this.route=void 0,this.top=void 0,this.appState={},this.appData={},this.preventNavigation=!1,this.overridesParsed={},this.fragment=void 0,this.showSkeleton=!1,this.pendingRouteFocus=!1,this.hasRenderedContent=!1,this.loadLifecycleListener=e=>{if(((typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target)===this)if(clearTimeout(this.skeletonTimer),e.type===`backend-called-event`){if(this.fragment?.component)return;this.skeletonTimer=setTimeout(()=>{this.showSkeleton=!0},us.SKELETON_DELAY_MS)}else this.showSkeleton=!1},this.actionRequestedListener=e=>{e instanceof CustomEvent&&(e.preventDefault(),e.stopPropagation(),this.manageActionEvent(e))},this.historyPushed=e=>{e instanceof CustomEvent&&(e.preventDefault(),e.stopPropagation(),this.preventNavigation=!0,this.route=e.detail.route)},this.routeChangedListener=e=>{if(e instanceof CustomEvent){e.preventDefault(),e.stopPropagation();let t=e.detail.route;typeof t==`string`&&(t===``||t.startsWith(`/`))&&this.consumedRoute&&this.consumedRoute!==`_empty`&&this.consumedRoute.startsWith(`/`)&&!t.startsWith(this.consumedRoute)&&(t=this.consumedRoute+t),this.uriPrefix&&(t=t.startsWith(`/`)&&this.uriPrefix.endsWith(`/`)?this.uriPrefix+t.substring(1):!t.startsWith(`/`)&&!this.uriPrefix.endsWith(`/`)?this.uriPrefix+`/`+t:this.uriPrefix+t),this.dispatchEvent(new CustomEvent(`url-update-requested`,{detail:{route:t},bubbles:!0,composed:!0}))}},this.backendFailedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&e.detail.actionId==``&&(this.fragment={targetComponentId:this.id,data:{},state:{},component:{type:k.ClientSide,metadata:{type:A.Element,name:`div`,content:`Not found`},id:`fieldId`},action:Ke.Replace,containerId:void 0})},this.detail1=void 0,this.manageActionEvent=e=>{e.preventDefault(),e.stopPropagation(),this.detail1=e.detail;let t=this.detail1;if(e.type==`server-side-action-requested`){let e=Fo;t.sse&&(e=Io),e.runAction(Ge,this.baseUrl,t.route??``,t.consumedRoute,t.actionId,t.initiatorComponentId,this.getCustomisedAppState(),t.serverSideType,t.componentState,t.parameters,t.initiator,t.background,t.callback,t.callbackonly,t.callbackToken,{timeoutMillis:t.timeoutMillis,idempotent:t.idempotent,knownStructureHash:t.knownStructureHash})}},this.getCustomisedAppState=()=>{let e={...D.value};if(this.overrides){let t=No(this.overrides);e={...e,...t}}return e}}manageActionRequestedEvent(e){throw Error(`Method not implemented.`)}createRenderRoot(){return N.mustUseShadowRoot()?super.createRenderRoot():this}structureCacheKey(){return ts({baseUrl:this.baseUrl,consumedRoute:this.consumedRoute,route:this.route,serverSideType:this.serverSideType,initialState:this.initialState})}focusNewContent(){requestAnimationFrame(()=>{let e=this.renderRoot?.querySelector?.(`h1, h2, [role="heading"]`)??this;e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus?.({preventScroll:!0})})}static{this.SKELETON_DELAY_MS=400}connectedCallback(){super.connectedCallback(),this.overridesParsed=No(this.overrides),this.addEventListener(`server-side-action-requested`,this.actionRequestedListener),this.addEventListener(`backend-call-failed`,this.backendFailedListener),this.addEventListener(`history-pushed`,this.historyPushed),this.addEventListener(`route-changed`,this.routeChangedListener),this.addEventListener(`backend-called-event`,this.loadLifecycleListener),this.addEventListener(`backend-succeeded-event`,this.loadLifecycleListener),this.addEventListener(`backend-failed-event`,this.loadLifecycleListener),this.addEventListener(`backend-cancelled-event`,this.loadLifecycleListener)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`server-side-action-requested`,this.actionRequestedListener),this.removeEventListener(`backend-call-failed`,this.backendFailedListener),this.removeEventListener(`history-pushed`,this.historyPushed),this.removeEventListener(`route-changed`,this.routeChangedListener),this.removeEventListener(`backend-called-event`,this.loadLifecycleListener),this.removeEventListener(`backend-succeeded-event`,this.loadLifecycleListener),this.removeEventListener(`backend-failed-event`,this.loadLifecycleListener),this.removeEventListener(`backend-cancelled-event`,this.loadLifecycleListener),clearTimeout(this.skeletonTimer)}shouldUpdate(e){if(this.fragment?.component&&[...e.keys()].every(e=>e===`appState`||e===`appData`)){let t=this.renderRoot.querySelector(`mateu-component`);if(t)return e.has(`appState`)&&(t.appState=this.appState),e.has(`appData`)&&(t.appData=this.appData),!1}return!0}updated(e){if((e.has(`id`)||e.has(`baseurl`)||e.has(`route`)||e.has(`consumedRoute`)||e.has(`instant`))&&!this.preventNavigation){this.callbackToken=this.instant||T();let e=this.structureCacheKey(),t=e===this.lastAuthoritativeKey?void 0:cs(e);if(t)queueMicrotask(()=>this.applyFragment(t));else{if(e!==this.lastAuthoritativeKey){let t=ns(e);this.currentStructureHash=t?.hash,t&&(this.fragment={targetComponentId:this.id,component:t.component,state:{},data:{},action:Ke.Replace,containerId:void 0})}this.manageActionEvent(new CustomEvent(`server-side-action-requested`,{detail:{route:this.route,consumedRoute:this.consumedRoute,userData:void 0,actionId:``,serverSideType:this.serverSideType,initiatorComponentId:this.id,initiator:this,componentState:this.initialState,knownStructureHash:this.currentStructureHash,callbackToken:this.callbackToken},bubbles:!0,composed:!0}))}}e.has(`route`)&&this.top&&(this.preventNavigation||(this.pendingRouteFocus=!0),this.preventNavigation||this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:this.route},bubbles:!0,composed:!0}))),this.preventNavigation&&=!1}applyFragment(e){if(!e.component&&this.fragment?.component){this.fragment={...this.fragment,state:{...this.fragment.state??{},...e.state??{}},data:{...this.fragment.data??{},...e.data??{}}};return}if(this.fragment=e,e.component){if(e.action!==Ke.Add){let t=this.structureCacheKey(),n=e.component.structureHash;rs(t,e.component,n),this.lastAuthoritativeKey=t,this.currentStructureHash=n,e.component.staticView&&ls(t,e)}this.pendingRouteFocus&&this.hasRenderedContent&&this.focusNewContent(),this.pendingRouteFocus=!1,this.hasRenderedContent=!0}e.component&&(this.dataset.pageWidth=Jo(e.component,{top:this.top}),this.dataset.pageType=Uo(e.component)??``,this.dataset.hasWelcomeBanner=String(Ko(e.component)))}render(){return!this.fragment?.component&&this.showSkeleton?w`
                 <div class="route-skeleton" aria-busy="true" aria-live="polite">
                     <mateu-skeleton variant="text" count="1"></mateu-skeleton>
                     <mateu-skeleton variant="form" count="4"></mateu-skeleton>
                 </div>
-            `:T`
-           ${this.fragment?.component?F(this,this.fragment?.component,this.baseUrl,this.fragment?.state??{},this.fragment?.data??{},this.appState,this.appData):v}
-       `}static{this.styles=h`
+            `:w`
+           ${this.fragment?.component?P(this,this.fragment?.component,this.baseUrl,this.fragment?.state??{},this.fragment?.data??{},this.appState,this.appData):_}
+       `}static{this.styles=m`
         :host {
             display: block;
             min-height: 100%;
@@ -7350,10 +7350,10 @@ ${i}
             max-width: 16rem;
             margin-block-end: var(--lumo-space-l, 1.5rem);
         }
-  `}};k([y()],X.prototype,`consumedRoute`,void 0),k([y()],X.prototype,`serverSideType`,void 0),k([y()],X.prototype,`uriPrefix`,void 0),k([y()],X.prototype,`overrides`,void 0),k([y()],X.prototype,`homeRoute`,void 0),k([y()],X.prototype,`route`,void 0),k([y()],X.prototype,`top`,void 0),k([y()],X.prototype,`instant`,void 0),k([y()],X.prototype,`initialState`,void 0),k([y()],X.prototype,`appState`,void 0),k([y()],X.prototype,`appData`,void 0),k([C()],X.prototype,`fragment`,void 0),k([C()],X.prototype,`showSkeleton`,void 0),X=Jo=k([g(`mateu-ux`)],X);function Yo(e){let t=`var(--lumo-space-m, 1rem)`,n={left:`50%`,transform:`translateX(-50%)`};switch(e){case`topStart`:return{top:t,left:t};case`topCenter`:return{top:t,...n};case`topEnd`:return{top:t,right:t};case`topStretch`:return{top:t,left:t,right:t};case`middle`:return{top:`50%`,left:`50%`,transform:`translate(-50%, -50%)`};case`bottomStart`:return{bottom:t,left:t};case`bottomCenter`:return{bottom:t,...n};case`bottomStretch`:return{bottom:t,left:t,right:t};default:return{bottom:t,right:t}}}function Xo(e){switch(e){case`success`:return{bg:`var(--lumo-success-color, #2e7d32)`,fg:`#fff`};case`error`:return{bg:`var(--lumo-error-color, #c62828)`,fg:`#fff`};case`warning`:return{bg:`var(--lumo-warning-color, #f9a825)`,fg:`#1a1a1a`};case`contrast`:return{bg:`var(--lumo-contrast-90pct, #1a1a1a)`,fg:`#fff`};default:return{bg:`var(--lumo-base-color, #fff)`,fg:`var(--lumo-body-text-color, #1a1a1a)`}}}var Zo={show(e,t){let{bg:n,fg:r}=Xo(e.variant),i=Yo(e.position),a=document.createElement(`div`),o=e.variant===`error`;a.setAttribute(`role`,o?`alert`:`status`),a.setAttribute(`aria-live`,o?`assertive`:`polite`),a.setAttribute(`aria-atomic`,`true`),Object.assign(a.style,{position:`fixed`,zIndex:`2000`,display:`flex`,alignItems:`center`,gap:`0.75rem`,maxWidth:`min(90vw, 28rem)`,padding:`0.7rem 1rem`,borderRadius:`var(--lumo-border-radius-m, 8px)`,boxShadow:`var(--lumo-box-shadow-m, 0 4px 16px rgba(0,0,0,0.2))`,background:n,color:r,font:`inherit`,fontSize:`var(--lumo-font-size-s, 0.875rem)`,opacity:`0`,transition:`opacity 0.2s ease`,...i});let s=document.createElement(`span`);s.textContent=e.text,a.appendChild(s);let c=()=>{a.style.opacity=`0`,setTimeout(()=>a.remove(),200)},l=e.onAction?{label:e.actionLabel??`Retry`,run:e.onAction}:e.undoActionId?{label:e.undoLabel??`Undo`,run:()=>t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.undoActionId,parameters:e.undoParameters??{}},bubbles:!0,composed:!0}))}:void 0;if(l){let e=document.createElement(`button`);e.textContent=l.label,e.style.cssText=`margin-left: 0.25rem; background: none; border: 1px solid currentColor; border-radius: var(--lumo-border-radius-s, 4px); color: inherit; cursor: pointer; padding: 0.15rem 0.6rem; font: inherit; font-weight: 600;`,e.addEventListener(`click`,()=>{l.run(),c()}),a.appendChild(e)}document.body.appendChild(a),requestAnimationFrame(()=>{a.style.opacity=`1`});let u=e.duration??(l?1e4:5e3);u>0&&setTimeout(c,u)}};function Qo(){aa(Zo)}var $o=class extends b{constructor(...e){super(...e),this.online=!0,this.recovered=!1}connectedCallback(){super.connectedCallback(),this.online=Be.isOnline(),this.unsubscribe=Be.subscribe(e=>{let t=!this.online;this.online=e,e&&t&&(this.recovered=!0,clearTimeout(this.recoveredTimer),this.recoveredTimer=setTimeout(()=>{this.recovered=!1},4e3))})}disconnectedCallback(){super.disconnectedCallback(),this.unsubscribe?.(),clearTimeout(this.recoveredTimer),this.releaseSpace()}updated(){let e=this.renderRoot.querySelector(`.bar`);if(!e){this.releaseSpace();return}document.body.style.setProperty(`padding-block-start`,`${e.offsetHeight}px`)}releaseSpace(){typeof document<`u`&&document.body?.style.removeProperty(`padding-block-start`)}render(){if(this.online&&!this.recovered)return v;let e=!this.online;return T`<div class="bar ${e?`offline`:`back`}" role="status" aria-live="polite">
+  `}};O([v()],Y.prototype,`consumedRoute`,void 0),O([v()],Y.prototype,`serverSideType`,void 0),O([v()],Y.prototype,`uriPrefix`,void 0),O([v()],Y.prototype,`overrides`,void 0),O([v()],Y.prototype,`homeRoute`,void 0),O([v()],Y.prototype,`route`,void 0),O([v()],Y.prototype,`top`,void 0),O([v()],Y.prototype,`instant`,void 0),O([v()],Y.prototype,`initialState`,void 0),O([v()],Y.prototype,`appState`,void 0),O([v()],Y.prototype,`appData`,void 0),O([S()],Y.prototype,`fragment`,void 0),O([S()],Y.prototype,`showSkeleton`,void 0),Y=us=O([h(`mateu-ux`)],Y);function ds(e){let t=`var(--lumo-space-m, 1rem)`,n={left:`50%`,transform:`translateX(-50%)`};switch(e){case`topStart`:return{top:t,left:t};case`topCenter`:return{top:t,...n};case`topEnd`:return{top:t,right:t};case`topStretch`:return{top:t,left:t,right:t};case`middle`:return{top:`50%`,left:`50%`,transform:`translate(-50%, -50%)`};case`bottomStart`:return{bottom:t,left:t};case`bottomCenter`:return{bottom:t,...n};case`bottomStretch`:return{bottom:t,left:t,right:t};default:return{bottom:t,right:t}}}function fs(e){switch(e){case`success`:return{bg:`var(--lumo-success-color, #2e7d32)`,fg:`#fff`};case`error`:return{bg:`var(--lumo-error-color, #c62828)`,fg:`#fff`};case`warning`:return{bg:`var(--lumo-warning-color, #f9a825)`,fg:`#1a1a1a`};case`contrast`:return{bg:`var(--lumo-contrast-90pct, #1a1a1a)`,fg:`#fff`};default:return{bg:`var(--lumo-base-color, #fff)`,fg:`var(--lumo-body-text-color, #1a1a1a)`}}}var ps={show(e,t){let{bg:n,fg:r}=fs(e.variant),i=ds(e.position),a=document.createElement(`div`),o=e.variant===`error`;a.setAttribute(`role`,o?`alert`:`status`),a.setAttribute(`aria-live`,o?`assertive`:`polite`),a.setAttribute(`aria-atomic`,`true`),Object.assign(a.style,{position:`fixed`,zIndex:`2000`,display:`flex`,alignItems:`center`,gap:`0.75rem`,maxWidth:`min(90vw, 28rem)`,padding:`0.7rem 1rem`,borderRadius:`var(--lumo-border-radius-m, 8px)`,boxShadow:`var(--lumo-box-shadow-m, 0 4px 16px rgba(0,0,0,0.2))`,background:n,color:r,font:`inherit`,fontSize:`var(--lumo-font-size-s, 0.875rem)`,opacity:`0`,transition:`opacity 0.2s ease`,...i});let s=document.createElement(`span`);s.textContent=e.text,a.appendChild(s);let c=()=>{a.style.opacity=`0`,setTimeout(()=>a.remove(),200)},l=e.onAction?{label:e.actionLabel??`Retry`,run:e.onAction}:e.undoActionId?{label:e.undoLabel??`Undo`,run:()=>t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.undoActionId,parameters:e.undoParameters??{}},bubbles:!0,composed:!0}))}:void 0;if(l){let e=document.createElement(`button`);e.textContent=l.label,e.style.cssText=`margin-left: 0.25rem; background: none; border: 1px solid currentColor; border-radius: var(--lumo-border-radius-s, 4px); color: inherit; cursor: pointer; padding: 0.15rem 0.6rem; font: inherit; font-weight: 600;`,e.addEventListener(`click`,()=>{l.run(),c()}),a.appendChild(e)}document.body.appendChild(a),requestAnimationFrame(()=>{a.style.opacity=`1`});let u=e.duration??(l?1e4:5e3);u>0&&setTimeout(c,u)}};function ms(){oa(ps)}var hs=class extends y{constructor(...e){super(...e),this.online=!0,this.recovered=!1}connectedCallback(){super.connectedCallback(),this.online=Ve.isOnline(),this.unsubscribe=Ve.subscribe(e=>{let t=!this.online;this.online=e,e&&t&&(this.recovered=!0,clearTimeout(this.recoveredTimer),this.recoveredTimer=setTimeout(()=>{this.recovered=!1},4e3))})}disconnectedCallback(){super.disconnectedCallback(),this.unsubscribe?.(),clearTimeout(this.recoveredTimer),this.releaseSpace()}updated(){let e=this.renderRoot.querySelector(`.bar`);if(!e){this.releaseSpace();return}document.body.style.setProperty(`padding-block-start`,`${e.offsetHeight}px`)}releaseSpace(){typeof document<`u`&&document.body?.style.removeProperty(`padding-block-start`)}render(){if(this.online&&!this.recovered)return _;let e=!this.online;return w`<div class="bar ${e?`offline`:`back`}" role="status" aria-live="polite">
             <span class="dot"></span>
             <span>${e?`No connection — changes you make now will not be saved.`:`Connection restored.`}</span>
-        </div>`}static{this.styles=h`
+        </div>`}static{this.styles=m`
         :host {
             position: fixed;
             inset-block-start: 0;
@@ -7392,7 +7392,7 @@ ${i}
         @media (prefers-reduced-motion: reduce) {
             .bar, .bar.offline .dot { animation: none; }
         }
-    `}};k([C()],$o.prototype,`online`,void 0),k([C()],$o.prototype,`recovered`,void 0),$o=k([g(`mateu-connectivity-banner`)],$o);var es=null;function ts(){if(!(typeof document>`u`)&&!(es&&es.isConnected)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>ts(),{once:!0});return}es=document.createElement(`mateu-connectivity-banner`),document.body.appendChild(es)}}var ns,rs=class extends b{static{ns=this}constructor(...e){super(...e),this.skip=()=>{let e=this.findContent();e&&(e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus(),e.scrollIntoView({block:`start`}))}}static{this.TARGETS=[`.app-content`,`mateu-page`,`mateu-ux`,`mateu-component`]}findContent(){let e=new Set,t=n=>{if(e.has(n))return null;e.add(n);for(let e of ns.TARGETS){let t=n.querySelector?.(e);if(t&&t!==this)return t}for(let e of Array.from(n.querySelectorAll?.(`*`)??[]))if(e.shadowRoot){let n=t(e.shadowRoot);if(n)return n}return null};return t(document)}render(){return T`<button class="skip" @click="${this.skip}">Skip to content</button>`}static{this.styles=h`
+    `}};O([S()],hs.prototype,`online`,void 0),O([S()],hs.prototype,`recovered`,void 0),hs=O([h(`mateu-connectivity-banner`)],hs);var gs=null;function _s(){if(!(typeof document>`u`)&&!(gs&&gs.isConnected)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>_s(),{once:!0});return}gs=document.createElement(`mateu-connectivity-banner`),document.body.appendChild(gs)}}var vs,ys=class extends y{static{vs=this}constructor(...e){super(...e),this.skip=()=>{let e=this.findContent();e&&(e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus(),e.scrollIntoView({block:`start`}))}}static{this.TARGETS=[`.app-content`,`mateu-page`,`mateu-ux`,`mateu-component`]}findContent(){let e=new Set,t=n=>{if(e.has(n))return null;e.add(n);for(let e of vs.TARGETS){let t=n.querySelector?.(e);if(t&&t!==this)return t}for(let e of Array.from(n.querySelectorAll?.(`*`)??[]))if(e.shadowRoot){let n=t(e.shadowRoot);if(n)return n}return null};return t(document)}render(){return w`<button class="skip" @click="${this.skip}">Skip to content</button>`}static{this.styles=m`
         :host {
             position: fixed;
             inset-block-start: 0;
@@ -7425,7 +7425,7 @@ ${i}
             outline: 2px solid var(--lumo-body-text-color, #161513);
             outline-offset: 2px;
         }
-    `}};rs=ns=k([g(`mateu-skip-link`)],rs);var is=null;function as(){if(!(typeof document>`u`)&&!(is&&is.isConnected)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>as(),{once:!0});return}is=document.createElement(`mateu-skip-link`),document.body.insertBefore(is,document.body.firstChild)}}Qo(),ts(),Xe(),as();var os=class extends b{constructor(...e){super(...e),this.baseUrl=``,this.route=void 0,this.consumedRoute=`_empty`,this.config=void 0,this.top=`true`,this.pathPrefix=void 0,this.debug=!1,this._lastUrl=``,this.routeChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.top==`true`){let t=e.detail.route,n=this.baseUrl??``;!t||t.startsWith(`/`)?n=window.location.origin+(this.pathPrefix??``):(t=(this.pathPrefix??``)+t,n.indexOf(`://`)<0&&(n.startsWith(`/`)||(n=`/`+n),n=window.location.origin+n)),t.startsWith(this.pathPrefix+`/`)&&(t=t.substring(this.pathPrefix?.length)),n.endsWith(`/`)&&t.startsWith(`/`)&&(t=t.substring(1));let r=new URL(n+t);if((window.location.pathname||r.pathname)&&window.location.pathname!=r.pathname){let e=r.pathname;r.search&&(e+=r.search),e&&!e.startsWith(`/`)&&(e=`/`+e),window.history.pushState({},``,e),this._lastUrl=window.location.href}}},this.navigateToRequestedListener=e=>{if(e.preventDefault(),e.stopPropagation(),Ta.markClean(),e instanceof CustomEvent){let t=e.detail.route,n=this.renderRoot.querySelector(`mateu-ux`);n&&(n.setAttribute(`route`,t),n.setAttribute(`instant`,E()))}}}createRenderRoot(){return P.mustUseShadowRoot()?super.createRenderRoot():this}connectedCallback(){if(super.connectedCallback(),Ta.install(),this._lastUrl=window.location.href,window.onpopstate=e=>{if(!Ta.confirmLeave()){window.history.pushState({},``,this._lastUrl);return}let t=e.target;this.loadUrl(t)},this.top==`true`?this.loadUrl(window):this.route&&(this.consumedRoute=``),this.config)try{let e=JSON.parse(this.config);O.value={...O.value,...e}}catch{O.value={...O.value,config:this.config}}this.addEventListener(`url-update-requested`,this.routeChangedListener),this.addEventListener(`navigate-to-requested`,this.navigateToRequestedListener)}disconnectedCallback(){super.disconnectedCallback(),this.upstreamSubscription?.unsubscribe(),this.removeEventListener(`url-update-requested`,this.routeChangedListener),this.removeEventListener(`navigate-to-requested`,this.navigateToRequestedListener)}loadUrl(e){if(this.route=this.extractRouteFromUrl(e),this.setAttribute(`route`,this.route),this.instant=E(),this._lastUrl=e.location.href,e.location.search){let t=new URLSearchParams(e.location.search).get(`overrides`);if(t&&(this.config=t,this.config))try{let e=JSON.parse(this.config);O.value={...O.value,...e}}catch{O.value={...O.value,config:this.config}}}}extractRouteFromUrl(e){return this.addQueryParams(this.extractRouteWithoutParamsFromUrl(e),e.location)}extractRouteWithoutParamsFromUrl(e){let t=this.extractGrossRouteFromUrl(e);return this.pathPrefix&&t.startsWith(this.pathPrefix)?t.substring(this.pathPrefix.length):t==`/`?``:t}addQueryParams(e,t){return e+(t.search?``+t.search:``)}extractGrossRouteFromUrl(e){let t=e.location.pathname,n=this.baseUrl&&(this.baseUrl.startsWith(`http://`)||this.baseUrl.startsWith(`https://`))?this.baseUrl.substring(this.getContextPathStartingIndex(this.baseUrl)):this.baseUrl;return t.startsWith(n)?t.substring(n.length):t}getContextPathStartingIndex(e){return e.startsWith(`http:`)?e.indexOf(`/`,7):e.startsWith(`https:`)?e.indexOf(`/`,8):0}render(){return T`
+    `}};ys=vs=O([h(`mateu-skip-link`)],ys);var bs=null;function xs(){if(!(typeof document>`u`)&&!(bs&&bs.isConnected)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>xs(),{once:!0});return}bs=document.createElement(`mateu-skip-link`),document.body.insertBefore(bs,document.body.firstChild)}}ms(),_s(),Ze(),xs();var Ss=class extends y{constructor(...e){super(...e),this.baseUrl=``,this.route=void 0,this.consumedRoute=`_empty`,this.config=void 0,this.top=`true`,this.pathPrefix=void 0,this.debug=!1,this._lastUrl=``,this.routeChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.top==`true`){let t=e.detail.route,n=this.baseUrl??``;!t||t.startsWith(`/`)?n=window.location.origin+(this.pathPrefix??``):(t=(this.pathPrefix??``)+t,n.indexOf(`://`)<0&&(n.startsWith(`/`)||(n=`/`+n),n=window.location.origin+n)),t.startsWith(this.pathPrefix+`/`)&&(t=t.substring(this.pathPrefix?.length)),n.endsWith(`/`)&&t.startsWith(`/`)&&(t=t.substring(1));let r=new URL(n+t);if((window.location.pathname||r.pathname)&&window.location.pathname!=r.pathname){let e=r.pathname;r.search&&(e+=r.search),e&&!e.startsWith(`/`)&&(e=`/`+e),window.history.pushState({},``,e),this._lastUrl=window.location.href}}},this.navigateToRequestedListener=e=>{if(e.preventDefault(),e.stopPropagation(),Ea.markClean(),e instanceof CustomEvent){let t=e.detail.route,n=this.renderRoot.querySelector(`mateu-ux`);n&&(n.setAttribute(`route`,t),n.setAttribute(`instant`,T()))}}}createRenderRoot(){return N.mustUseShadowRoot()?super.createRenderRoot():this}connectedCallback(){if(super.connectedCallback(),Ea.install(),this._lastUrl=window.location.href,window.onpopstate=e=>{if(!Ea.confirmLeave()){window.history.pushState({},``,this._lastUrl);return}let t=e.target;this.loadUrl(t)},this.top==`true`?this.loadUrl(window):this.route&&(this.consumedRoute=``),this.config)try{let e=JSON.parse(this.config);D.value={...D.value,...e}}catch{D.value={...D.value,config:this.config}}this.addEventListener(`url-update-requested`,this.routeChangedListener),this.addEventListener(`navigate-to-requested`,this.navigateToRequestedListener)}disconnectedCallback(){super.disconnectedCallback(),this.upstreamSubscription?.unsubscribe(),this.removeEventListener(`url-update-requested`,this.routeChangedListener),this.removeEventListener(`navigate-to-requested`,this.navigateToRequestedListener)}loadUrl(e){if(this.route=this.extractRouteFromUrl(e),this.setAttribute(`route`,this.route),this.instant=T(),this._lastUrl=e.location.href,e.location.search){let t=new URLSearchParams(e.location.search).get(`overrides`);if(t&&(this.config=t,this.config))try{let e=JSON.parse(this.config);D.value={...D.value,...e}}catch{D.value={...D.value,config:this.config}}}}extractRouteFromUrl(e){return this.addQueryParams(this.extractRouteWithoutParamsFromUrl(e),e.location)}extractRouteWithoutParamsFromUrl(e){let t=this.extractGrossRouteFromUrl(e);return this.pathPrefix&&t.startsWith(this.pathPrefix)?t.substring(this.pathPrefix.length):t==`/`?``:t}addQueryParams(e,t){return e+(t.search?``+t.search:``)}extractGrossRouteFromUrl(e){let t=e.location.pathname,n=this.baseUrl&&(this.baseUrl.startsWith(`http://`)||this.baseUrl.startsWith(`https://`))?this.baseUrl.substring(this.getContextPathStartingIndex(this.baseUrl)):this.baseUrl;return t.startsWith(n)?t.substring(n.length):t}getContextPathStartingIndex(e){return e.startsWith(`http:`)?e.indexOf(`/`,7):e.startsWith(`https:`)?e.indexOf(`/`,8):0}render(){return w`
            <mateu-api-caller>
                 <mateu-ux id="_ux"
                           baseurl="${this.baseUrl}"
@@ -7435,43 +7435,43 @@ ${i}
                           top="${this.top}"
                           style="width: 100%;"
                           @app-data-updated="${()=>this.requestUpdate()}"
-                          .appData="${ue.value}"
-                          .appState="${O.value}"
+                          .appData="${de.value}"
+                          .appState="${D.value}"
                 ></mateu-ux>
            </mateu-api-caller>
-           ${this.debug?T`
+           ${this.debug?w`
                <mateu-debug-overlay
-                   .appState="${O.value}"
-                   .appData="${ue.value}"
+                   .appState="${D.value}"
+                   .appData="${de.value}"
                ></mateu-debug-overlay>
-           `:v}
-       `}static{this.styles=h`
+           `:_}
+       `}static{this.styles=m`
         :host {
             --lumo-clickable-cursor: pointer;
         }
-  `}};k([y()],os.prototype,`baseUrl`,void 0),k([y()],os.prototype,`route`,void 0),k([y()],os.prototype,`consumedRoute`,void 0),k([y()],os.prototype,`config`,void 0),k([y()],os.prototype,`top`,void 0),k([y()],os.prototype,`pathPrefix`,void 0),k([C()],os.prototype,`instant`,void 0),k([y({type:Boolean})],os.prototype,`debug`,void 0),os=k([g(`mateu-ui`)],os);var ss,cs=class extends b{static{ss=this}constructor(...e){super(...e),this.baseUrl=``,this.opened=!1,this.searchText=``}static{this.SEARCHABLE_THRESHOLD=7}connectedCallback(){super.connectedCallback(),Ee()}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick(),this.searchTimer&&clearTimeout(this.searchTimer)}currentValue(){return String(Se()[this.selector.fieldName]??``)}currentLabel(){let e=this.currentValue();if(!e)return`—`;let t=(this.searchedOptions??this.selector.options)?.find(t=>String(t.value)===e);if(t)return t.label;let n=Ce()[this.selector.fieldName];return n===void 0?e:String(n)}pick(e,t){we(this.selector.fieldName,e,t),window.location.reload()}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}openPanel(){this.opened||(this.opened=!0,this.searchText=``,this.searchedOptions=void 0,this.remoteSearch(),this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick),this.updateComplete.then(()=>this.renderRoot.querySelector(`input.picker-search`)?.focus()))}closePanel(){this.detachOutsideClick(),this.opened=!1}onSearchInput(e){this.searchText=e.target.value,this.searchTimer&&clearTimeout(this.searchTimer),this.searchTimer=setTimeout(()=>this.remoteSearch(),300)}async remoteSearch(){let e=this.app;if(e?.serverSideType)try{let t=await We.runAction(this.baseUrl??``,e.rootRoute??e.initialRoute??``,``,`_appcontext-search-${this.selector.fieldName}`,`appcontext-${this.selector.fieldName}`,void 0,e.serverSideType,{},{searchText:this.searchText},this,!0);for(let e of t?.fragments??[]){let t=e.data?.[`_appcontext_${this.selector.fieldName}`]?.content;if(Array.isArray(t)){this.searchedOptions=t.map(e=>({value:e.value,label:e.label??String(e.value)}));return}}}catch{}}visibleOptions(){let e=this.searchedOptions??this.selector.options??[],t=this.searchText.trim().toLowerCase();return t?e.filter(e=>e.label.toLowerCase().includes(t)):e}renderPanel(){let e=this.currentValue(),t=this.visibleOptions();return T`
+  `}};O([v()],Ss.prototype,`baseUrl`,void 0),O([v()],Ss.prototype,`route`,void 0),O([v()],Ss.prototype,`consumedRoute`,void 0),O([v()],Ss.prototype,`config`,void 0),O([v()],Ss.prototype,`top`,void 0),O([v()],Ss.prototype,`pathPrefix`,void 0),O([S()],Ss.prototype,`instant`,void 0),O([v({type:Boolean})],Ss.prototype,`debug`,void 0),Ss=O([h(`mateu-ui`)],Ss);var Cs,ws=class extends y{static{Cs=this}constructor(...e){super(...e),this.baseUrl=``,this.opened=!1,this.searchText=``}static{this.SEARCHABLE_THRESHOLD=7}connectedCallback(){super.connectedCallback(),De()}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick(),this.searchTimer&&clearTimeout(this.searchTimer)}currentValue(){return String(Ce()[this.selector.fieldName]??``)}currentLabel(){let e=this.currentValue();if(!e)return`—`;let t=(this.searchedOptions??this.selector.options)?.find(t=>String(t.value)===e);if(t)return t.label;let n=we()[this.selector.fieldName];return n===void 0?e:String(n)}pick(e,t){Te(this.selector.fieldName,e,t),window.location.reload()}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}openPanel(){this.opened||(this.opened=!0,this.searchText=``,this.searchedOptions=void 0,this.remoteSearch(),this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick),this.updateComplete.then(()=>this.renderRoot.querySelector(`input.picker-search`)?.focus()))}closePanel(){this.detachOutsideClick(),this.opened=!1}onSearchInput(e){this.searchText=e.target.value,this.searchTimer&&clearTimeout(this.searchTimer),this.searchTimer=setTimeout(()=>this.remoteSearch(),300)}async remoteSearch(){let e=this.app;if(e?.serverSideType)try{let t=await Ge.runAction(this.baseUrl??``,e.rootRoute??e.initialRoute??``,``,`_appcontext-search-${this.selector.fieldName}`,`appcontext-${this.selector.fieldName}`,void 0,e.serverSideType,{},{searchText:this.searchText},this,!0);for(let e of t?.fragments??[]){let t=e.data?.[`_appcontext_${this.selector.fieldName}`]?.content;if(Array.isArray(t)){this.searchedOptions=t.map(e=>({value:e.value,label:e.label??String(e.value)}));return}}}catch{}}visibleOptions(){let e=this.searchedOptions??this.selector.options??[],t=this.searchText.trim().toLowerCase();return t?e.filter(e=>e.label.toLowerCase().includes(t)):e}renderPanel(){let e=this.currentValue(),t=this.visibleOptions();return w`
             <div class="panel">
-                ${this.searchText!==``||t.length>ss.SEARCHABLE_THRESHOLD?T`
+                ${this.searchText!==``||t.length>Cs.SEARCHABLE_THRESHOLD?w`
                     <input class="picker-search" type="text" placeholder="Search"
                            .value="${this.searchText}"
                            @input="${this.onSearchInput}"
-                           @keydown="${e=>{e.key===`Escape`&&this.closePanel()}}"/>`:v}
+                           @keydown="${e=>{e.key===`Escape`&&this.closePanel()}}"/>`:_}
                 <div class="options">
-                    ${e?T`
-                        <div class="option option--clear" @click="${()=>this.pick(``)}">— (clear)</div>`:v}
-                    ${t.map(t=>T`
+                    ${e?w`
+                        <div class="option option--clear" @click="${()=>this.pick(``)}">— (clear)</div>`:_}
+                    ${t.map(t=>w`
                         <div class="option ${e===String(t.value)?`option--selected`:``}"
                              @click="${()=>this.pick(t.value,t.label)}">${t.label}</div>`)}
                 </div>
-            </div>`}render(){return this.selector?T`
+            </div>`}render(){return this.selector?w`
             <label class="root">
                 <span class="label">${this.selector.label}</span>
                 <button class="picker-button"
                         @click="${()=>this.opened?this.closePanel():this.openPanel()}">
                     ${this.currentLabel()} <span aria-hidden="true" class="caret">▾</span>
                 </button>
-                ${this.opened?this.renderPanel():v}
-            </label>`:T``}static{this.styles=h`
+                ${this.opened?this.renderPanel():_}
+            </label>`:w``}static{this.styles=m`
         :host {
             display: inline-flex;
             position: relative;
@@ -7543,30 +7543,30 @@ ${i}
         .option--clear {
             color: var(--lumo-secondary-text-color, rgba(0, 0, 0, 0.55));
         }
-    `}};k([y()],cs.prototype,`selector`,void 0),k([y()],cs.prototype,`app`,void 0),k([y()],cs.prototype,`baseUrl`,void 0),k([C()],cs.prototype,`opened`,void 0),k([C()],cs.prototype,`searchText`,void 0),k([C()],cs.prototype,`searchedOptions`,void 0),cs=ss=k([g(`mateu-app-context-picker`)],cs);var ls=class extends b{constructor(...e){super(...e),this.baseUrl=``,this.opened=!1,this.notifications=[],this.fetched=!1}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}updated(){!this.fetched&&this.app?.serverSideType&&(this.fetched=!0,this.refresh())}unreadCount(){return this.notifications.filter(e=>e.unread).length}async runNotificationsAction(e,t){let n=this.app;if(n?.serverSideType)try{let r=await We.runAction(this.baseUrl??``,n.rootRoute??n.initialRoute??``,``,e,`notification-bell`,void 0,n.serverSideType,{},t,this,!0);for(let e of r?.fragments??[]){let t=e.data?._notifications;if(Array.isArray(t)){this.notifications=t;return}}}catch{}}refresh(){return this.runNotificationsAction(`_notifications-list`,{})}markRead(e){return this.runNotificationsAction(`_notifications-read`,{ids:e})}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}openPanel(){this.opened||(this.opened=!0,this.refresh(),this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick))}closePanel(){this.detachOutsideClick(),this.opened=!1}async entryClicked(e){e.unread&&await this.markRead([e.id]);let t=e.route;if(t){if(!Ta.confirmLeave())return;this.closePanel(),this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0})),this.dispatchEvent(new CustomEvent(`navigate-to-requested`,{detail:{route:t},bubbles:!0,composed:!0}))}}renderEntry(e){return T`
+    `}};O([v()],ws.prototype,`selector`,void 0),O([v()],ws.prototype,`app`,void 0),O([v()],ws.prototype,`baseUrl`,void 0),O([S()],ws.prototype,`opened`,void 0),O([S()],ws.prototype,`searchText`,void 0),O([S()],ws.prototype,`searchedOptions`,void 0),ws=Cs=O([h(`mateu-app-context-picker`)],ws);var Ts=class extends y{constructor(...e){super(...e),this.baseUrl=``,this.opened=!1,this.notifications=[],this.fetched=!1}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}updated(){!this.fetched&&this.app?.serverSideType&&(this.fetched=!0,this.refresh())}unreadCount(){return this.notifications.filter(e=>e.unread).length}async runNotificationsAction(e,t){let n=this.app;if(n?.serverSideType)try{let r=await Ge.runAction(this.baseUrl??``,n.rootRoute??n.initialRoute??``,``,e,`notification-bell`,void 0,n.serverSideType,{},t,this,!0);for(let e of r?.fragments??[]){let t=e.data?._notifications;if(Array.isArray(t)){this.notifications=t;return}}}catch{}}refresh(){return this.runNotificationsAction(`_notifications-list`,{})}markRead(e){return this.runNotificationsAction(`_notifications-read`,{ids:e})}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}openPanel(){this.opened||(this.opened=!0,this.refresh(),this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick))}closePanel(){this.detachOutsideClick(),this.opened=!1}async entryClicked(e){e.unread&&await this.markRead([e.id]);let t=e.route;if(t){if(!Ea.confirmLeave())return;this.closePanel(),this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0})),this.dispatchEvent(new CustomEvent(`navigate-to-requested`,{detail:{route:t},bubbles:!0,composed:!0}))}}renderEntry(e){return w`
             <div role="button" tabindex="0" class="entry ${e.unread?`entry--unread`:``}"
-                 @click="${()=>this.entryClicked(e)}" @keydown="${R(()=>this.entryClicked(e))}">
+                 @click="${()=>this.entryClicked(e)}" @keydown="${L(()=>this.entryClicked(e))}">
                 <span class="unread-dot" aria-hidden="true"></span>
                 <div class="entry-body">
                     <div class="entry-top">
                         <span class="entry-title">${e.title}</span>
-                        ${e.when?T`<span class="entry-when">${e.when}</span>`:v}
+                        ${e.when?w`<span class="entry-when">${e.when}</span>`:_}
                     </div>
-                    ${e.text?T`<div class="entry-text">${e.text}</div>`:v}
+                    ${e.text?w`<div class="entry-text">${e.text}</div>`:_}
                 </div>
-            </div>`}renderPanel(){return T`
+            </div>`}renderPanel(){return w`
             <div class="panel">
                 <div class="entries">
-                    ${this.notifications.length===0?T`
-                        <div class="empty">No notifications</div>`:v}
+                    ${this.notifications.length===0?w`
+                        <div class="empty">No notifications</div>`:_}
                     ${this.notifications.map(e=>this.renderEntry(e))}
                 </div>
-                ${this.notifications.length>0?T`
+                ${this.notifications.length>0?w`
                     <div class="footer">
                         <button class="mark-all" ?disabled="${this.unreadCount()===0}"
                                 @click="${()=>this.markRead(`all`)}">Mark all read</button>
-                    </div>`:v}
-            </div>`}render(){let e=this.unreadCount();return T`
+                    </div>`:_}
+            </div>`}render(){let e=this.unreadCount();return w`
             <div class="root">
                 <button class="bell-button" title="Notifications" aria-label="Notifications"
                         @click="${()=>this.opened?this.closePanel():this.openPanel()}">
@@ -7576,10 +7576,10 @@ ${i}
                         <path d="M18 8a6 6 0 0 0-12 0c0 7-3 9-3 9h18s-3-2-3-9"></path>
                         <path d="M13.73 21a2 2 0 0 1-3.46 0"></path>
                     </svg>
-                    ${e>0?T`<span class="badge">${e>99?`99+`:e}</span>`:v}
+                    ${e>0?w`<span class="badge">${e>99?`99+`:e}</span>`:_}
                 </button>
-                ${this.opened?this.renderPanel():v}
-            </div>`}static{this.styles=h`
+                ${this.opened?this.renderPanel():_}
+            </div>`}static{this.styles=m`
         :host {
             display: inline-flex;
             position: relative;
@@ -7730,48 +7730,48 @@ ${i}
             cursor: default;
         }
     
-        ${z}
-    `}};k([y()],ls.prototype,`app`,void 0),k([y()],ls.prototype,`baseUrl`,void 0),k([C()],ls.prototype,`opened`,void 0),k([C()],ls.prototype,`notifications`,void 0),ls=k([g(`mateu-notification-bell`)],ls);var us=e=>{if(!e||!(`querySelectorAll`in e))return null;for(let t of e.querySelectorAll(`*`)){if(t.tagName?.toLowerCase()===`mateu-component`)return t;let e=us(t.shadowRoot);if(e)return e}return null},ds=async(e,t,n)=>{let r=us(t.renderRoot??t);await Fo.runAction(We,t.baseUrl??``,e.rootRoute||`_no_route`,``,n,r?.id??`app-header-action`,{},e.serverSideType??``,{},{},r??t,!0,void 0,!1,``)},fs=async(e,t,n)=>{try{await ds(e,t,n)}catch(e){oa({text:`La acción falló: `+e,position:`bottomStart`,duration:6e3,variant:`error`},t)}},ps=(e,t)=>{let n=e.contextSelectors??[],r=e.contextActions??[];return n.length===0&&r.length===0&&!e.notificationsEnabled?v:T`${e.notificationsEnabled?T`
-        <mateu-notification-bell .app="${e}" .baseUrl="${t.baseUrl??``}"></mateu-notification-bell>`:v}${n.map(n=>T`
-        <mateu-app-context-picker .selector="${n}" .app="${e}" .baseUrl="${t.baseUrl??``}"></mateu-app-context-picker>`)}${r.map(n=>(n.children?.length??0)>0?T`
+        ${R}
+    `}};O([v()],Ts.prototype,`app`,void 0),O([v()],Ts.prototype,`baseUrl`,void 0),O([S()],Ts.prototype,`opened`,void 0),O([S()],Ts.prototype,`notifications`,void 0),Ts=O([h(`mateu-notification-bell`)],Ts);var Es=e=>{if(!e||!(`querySelectorAll`in e))return null;for(let t of e.querySelectorAll(`*`)){if(t.tagName?.toLowerCase()===`mateu-component`)return t;let e=Es(t.shadowRoot);if(e)return e}return null},Ds=async(e,t,n)=>{let r=Es(t.renderRoot??t);await Io.runAction(Ge,t.baseUrl??``,e.rootRoute||`_no_route`,``,n,r?.id??`app-header-action`,{},e.serverSideType??``,{},{},r??t,!0,void 0,!1,``)},Os=async(e,t,n)=>{try{await Ds(e,t,n)}catch(e){sa({text:`La acción falló: `+e,position:`bottomStart`,duration:6e3,variant:`error`},t)}},ks=(e,t)=>{let n=e.contextSelectors??[],r=e.contextActions??[];return n.length===0&&r.length===0&&!e.notificationsEnabled?_:w`${e.notificationsEnabled?w`
+        <mateu-notification-bell .app="${e}" .baseUrl="${t.baseUrl??``}"></mateu-notification-bell>`:_}${n.map(n=>w`
+        <mateu-app-context-picker .selector="${n}" .app="${e}" .baseUrl="${t.baseUrl??``}"></mateu-app-context-picker>`)}${r.map(n=>(n.children?.length??0)>0?w`
         <details class="mateu-nav-group" style="margin-left: 0.5rem; flex-shrink: 0;">
             <summary class="app-header-action-btn">${n.label} ▾</summary>
             <div class="mateu-nav-panel" style="right: 0; left: auto;">
-                ${n.children.map(n=>T`
-                    <button class="mateu-nav-item" @click="${()=>n.actionId&&fs(e,t,n.actionId)}">${n.label}</button>`)}
+                ${n.children.map(n=>w`
+                    <button class="mateu-nav-item" @click="${()=>n.actionId&&Os(e,t,n.actionId)}">${n.label}</button>`)}
             </div>
-        </details>`:T`
+        </details>`:w`
         <button class="app-header-action-btn" style="margin-left: 0.5rem; flex-shrink: 0;"
-            @click="${()=>n.actionId&&fs(e,t,n.actionId)}" title="${n.label}">${n.icon?I(n.icon):v}${n.label}</button>`)}`},ms=(e,t)=>T`
+            @click="${()=>n.actionId&&Os(e,t,n.actionId)}" title="${n.label}">${n.icon?F(n.icon):_}${n.label}</button>`)}`},As=(e,t)=>w`
     <button class="mateu-nav-item ${e.selected?`mateu-nav-item--active`:``}"
             ?disabled="${e.disabled}"
-            @click="${()=>t(e)}">${e.text}</button>`,hs=(e,t,n=``)=>T`
+            @click="${()=>t(e)}">${e.text}</button>`,js=(e,t,n=``)=>w`
     <nav class="mateu-nav ${n}">
-        ${e.map(e=>(e.children?.length??0)>0?T`<details class="mateu-nav-group">
+        ${e.map(e=>(e.children?.length??0)>0?w`<details class="mateu-nav-group">
                        <summary class="mateu-nav-item">${e.text} ▾</summary>
                        <div class="mateu-nav-panel">
-                           ${e.children.map(e=>ms(e,t))}
+                           ${e.children.map(e=>As(e,t))}
                        </div>
-                   </details>`:ms(e,t))}
-    </nav>`,gs=(e,t)=>n=>t.call(e,{detail:{value:n}}),_s=(e,t)=>e.themeToggle?T`
+                   </details>`:As(e,t))}
+    </nav>`,Ms=(e,t)=>n=>t.call(e,{detail:{value:n}}),Ns=(e,t)=>e.themeToggle?w`
         <button class="app-chrome-icon-btn" @click="${t.toggleTheme}"
             title="${t.isDark?`Switch to light mode`:`Switch to dark mode`}"
             style="margin-left: 0.5rem; margin-right: 0.5rem; flex-shrink: 0;">
-            ${I(t.isDark?`vaadin:sun-o`:`vaadin:moon`,`color: var(--lumo-body-text-color);`)}
+            ${F(t.isDark?`vaadin:sun-o`:`vaadin:moon`,`color: var(--lumo-body-text-color);`)}
         </button>
-    `:v,vs=(e,t)=>{t.filter!=e.detail.value&&(t.filter=e.detail.value)},ys=(e,t,n)=>{let r=bs(e,t,n),i=Z(t,n);return r==`list`||r==i?`new`:r},bs=(e,t,n)=>{let r=e?._route;if(r!=null&&(r===``||r.startsWith(`/`))){let e=n.homeRoute??``,i=e.indexOf(`?`),a=i>=0?e.substring(i+1):``,o=Z(t,n)+r;return a?o+(o.indexOf(`?`)>=0?`&`:`?`)+a:o}return t.selectedRoute?t.selectedRoute:n.homeRoute},Z=(e,t)=>e.selectedRoute?e.selectedConsumedRoute??t.route:t.homeConsumedRoute,xs=(e,t)=>e.selectedRoute?e.selectedBaseUrl??e.baseUrl:t.homeBaseUrl,Ss=(e,t)=>e.selectedRoute?e.selectedServerSideType??t.serverSideType:t.homeServerSideType,Cs=(e,t)=>e.selectedRoute?e.selectedUriPrefix:t.homeUriPrefix,ws=(e,t,n,r,i,a,o)=>{if(t.chromeless)return T`
+    `:_,Ps=(e,t)=>{t.filter!=e.detail.value&&(t.filter=e.detail.value)},Fs=(e,t,n)=>{let r=Is(e,t,n),i=X(t,n);return r==`list`||r==i?`new`:r},Is=(e,t,n)=>{let r=e?._route;if(r!=null&&(r===``||r.startsWith(`/`))){let e=n.homeRoute??``,i=e.indexOf(`?`),a=i>=0?e.substring(i+1):``,o=X(t,n)+r;return a?o+(o.indexOf(`?`)>=0?`&`:`?`)+a:o}return t.selectedRoute?t.selectedRoute:n.homeRoute},X=(e,t)=>e.selectedRoute?e.selectedConsumedRoute??t.route:t.homeConsumedRoute,Ls=(e,t)=>e.selectedRoute?e.selectedBaseUrl??e.baseUrl:t.homeBaseUrl,Rs=(e,t)=>e.selectedRoute?e.selectedServerSideType??t.serverSideType:t.homeServerSideType,zs=(e,t)=>e.selectedRoute?e.selectedUriPrefix:t.homeUriPrefix,Bs=(e,t,n,r,i,a,o)=>{if(t.chromeless)return w`
             <div class="app chromeless">
                 <div role="main" class="${`app-content`+(e.pageCompact?` no-padding`:``)}" style="height: 100%;">
                     <div class="m-md">
                         <div class="m-scroll" style="height: 100%;">
                             <mateu-api-caller>
                                 <mateu-ux
-                                        route="${bs(r,e,t)}"
+                                        route="${Is(r,e,t)}"
                                         id="ux_${e.id}"
-                                        baseUrl="${xs(e,t)}"
-                                        consumedRoute="${Z(e,t)}"
-                                        serverSideType="${Ss(e,t)}"
-                                        uriPrefix="${Cs(e,t)}"
+                                        baseUrl="${Ls(e,t)}"
+                                        consumedRoute="${X(e,t)}"
+                                        serverSideType="${Rs(e,t)}"
+                                        uriPrefix="${zs(e,t)}"
                                         style="width: 100%;"
                                         .appState="${a}"
                                         .appData="${o}"
@@ -7780,25 +7780,25 @@ ${i}
                                 ></mateu-ux>
                             </mateu-api-caller>
                         </div>
-                        ${t.sseUrl?T`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:v}
+                        ${t.sseUrl?w`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:_}
                     </div>
                 </div>
                 <slot></slot>
             </div>
-        `;let s=e.mapItems(t.menu,e.filter?.toLowerCase()??``),c=Z(e,t),l=ys(r,e,t),u=l&&l!==`new`&&l.startsWith(c+`/`)?l.substring(c.length+1).split(`/`)[0]:void 0;return T`
-                    ${t.variant==Ke.MEDIATOR?T`
+        `;let s=e.mapItems(t.menu,e.filter?.toLowerCase()??``),c=X(e,t),l=Fs(r,e,t),u=l&&l!==`new`&&l.startsWith(c+`/`)?l.substring(c.length+1).split(`/`)[0]:void 0;return w`
+                    ${t.variant==qe.MEDIATOR?w`
 
-                        ${t.layout==`SPLIT`?T`
+                        ${t.layout==`SPLIT`?w`
                             <div class="m-md">
                                 <mateu-api-caller>
                                     <div style="display: block; width: calc(100% - 1rem);">
                                     <mateu-ux
-                                            route="${Z(e,t)}"
+                                            route="${X(e,t)}"
                                             id="ux_${e.id}"
-                                            baseUrl="${xs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Ss(e,t)}"
-                                            uriPrefix="${Cs(e,t)}"
+                                            baseUrl="${Ls(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Rs(e,t)}"
+                                            uriPrefix="${zs(e,t)}"
                                             style="width: 100%;"
                                             .appState="${{...a,_splitDetailId:u}}"
                                             .appData="${o}"
@@ -7810,12 +7810,12 @@ ${i}
                                 <mateu-api-caller slot="detail">
                                     <div style="padding-left: 1rem; width: calc(100% - 1rem);">
                                     <mateu-ux
-                                            route="${ys(r,e,t)}"
+                                            route="${Fs(r,e,t)}"
                                             id="ux_${e.id}_detail"
-                                            baseUrl="${xs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Ss(e,t)}"
-                                            uriPrefix="${Cs(e,t)}"
+                                            baseUrl="${Ls(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Rs(e,t)}"
+                                            uriPrefix="${zs(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -7826,15 +7826,15 @@ ${i}
                                 </mateu-api-caller>
 
                             </div>
-                        `:T`
+                        `:w`
                             <mateu-api-caller>
                                 <mateu-ux
-                                        route="${bs(r,e,t)}"
+                                        route="${Is(r,e,t)}"
                                         id="ux_${e.id}"
-                                        baseUrl="${xs(e,t)}"
-                                        consumedRoute="${Z(e,t)}"
-                                        serverSideType="${Ss(e,t)}"
-                                        uriPrefix="${Cs(e,t)}"
+                                        baseUrl="${Ls(e,t)}"
+                                        consumedRoute="${X(e,t)}"
+                                        serverSideType="${Rs(e,t)}"
+                                        uriPrefix="${zs(e,t)}"
                                         style="width: 100%;"
                                         .appState="${a}"
                                         .appData="${o}"
@@ -7845,28 +7845,28 @@ ${i}
                             </mateu-api-caller>
                         `}
                         
-`:v}
-            ${t.variant==Ke.HAMBURGUER_MENU?T`
+`:_}
+            ${t.variant==qe.HAMBURGUER_MENU?w`
                 <div class="mateu-app-layout m-app-layout ${t.drawerClosed?``:`drawer-open`} ${t?.cssClasses}" style="${t?.style}">
                     <header class="app-navbar">
                         <button class="drawer-toggle" title="Menu"
                                 @click="${e=>e.currentTarget.closest(`.m-app-layout`)?.classList.toggle(`drawer-open`)}">
-                            ${I(`vaadin:menu`)}
+                            ${F(`vaadin:menu`)}
                         </button>
                         <h2 style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; margin: 0 .5rem;">${t.title}</h2><p style="margin: 0;">${t.subtitle}</p>
                         <div class="m-hl" style="margin-left: auto; align-items: center;">
                             <slot name="widgets"></slot>
-                            ${ps(t,e)}${_s(t,e)}
+                            ${ks(t,e)}${Ns(t,e)}
                         </div>
                     </header>
                     <div class="app-body">
                         <aside class="app-drawer p-s" @navigation-requested="${e.updateRoute}">
-                            ${t.menu&&t.totalMenuOptions>10?T`
+                            ${t.menu&&t.totalMenuOptions>10?w`
                                 <div style="position: sticky; top: 0; z-index: 2; background: var(--lumo-base-color); padding: .25rem 0 .5rem;">
                                     <input class="drawer-search" placeholder="Search…" style="width: calc(100% - 20px); margin: 0 10px;"
-                                           @input="${t=>vs({detail:{value:t.target.value}},e)}">
+                                           @input="${t=>Ps({detail:{value:t.target.value}},e)}">
                                 </div>
-                                `:v}
+                                `:_}
                             <nav class="side-nav">
                                 ${e.renderSideNav(s,void 0)}
                             </nav>
@@ -7876,12 +7876,12 @@ ${i}
                                 <div class="m-scroll" style="height: 100%;">
                                     <mateu-api-caller>
                                         <mateu-ux
-                                                route="${bs(r,e,t)}"
+                                                route="${Is(r,e,t)}"
                                                 id="ux_${e.id}"
-                                                baseUrl="${xs(e,t)}"
-                                                consumedRoute="${Z(e,t)}"
-                                                serverSideType="${Ss(e,t)}"
-                                                uriPrefix="${Cs(e,t)}"
+                                                baseUrl="${Ls(e,t)}"
+                                                consumedRoute="${X(e,t)}"
+                                                serverSideType="${Rs(e,t)}"
+                                                uriPrefix="${zs(e,t)}"
                                                 style="width: 100%;"
                                                 .appState="${a}"
                                                 .appData="${o}"
@@ -7890,15 +7890,15 @@ ${i}
                                         ></mateu-ux>
                                     </mateu-api-caller>
                                 </div>
-                                ${t.sseUrl?T`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" class="" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:v}
+                                ${t.sseUrl?w`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" class="" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:_}
                             </div>
                         </div>
                     </div>
                 </div>
 
-            `:v}
+            `:_}
             
-            ${t.variant==Ke.MENU_ON_TOP?T`
+            ${t.variant==qe.MENU_ON_TOP?w`
                 <div class="m-vl" style="width: 100%; height: 100vh; overflow: hidden;">
                     <div class="m-hl"
                             style="width: 100%; height: 4rem; flex-shrink: 0; align-items: center; border-bottom: 1px solid var(--lumo-disabled-text-color); background-color: var(--lumo-base-color);"
@@ -7906,14 +7906,14 @@ ${i}
                             @navigation-requested="${e.updateRoute}">
                         <a href="javascript: void(0);" @click="${()=>e.goHome()}" style="text-decoration: none; color: inherit; flex-shrink: 0;">
                         <div class="m-hl" style="align-items: center;">
-                            ${t.logo?T`<img src="${t.logo}" alt="logo" height="28px" style="margin-left: 10px;">`:v}
-                            ${t.title?T`<h2 style="margin: 0 var(--lumo-space-l, 1.5rem) 0 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;">${t.title}</h2>`:v}
+                            ${t.logo?w`<img src="${t.logo}" alt="logo" height="28px" style="margin-left: 10px;">`:_}
+                            ${t.title?w`<h2 style="margin: 0 var(--lumo-space-l, 1.5rem) 0 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;">${t.title}</h2>`:_}
                         </div>
                         </a>
-                        ${(()=>{let t=gs(e,e.itemSelected);return P.get()?.renderTopNav?.(s,t,`menu-on-top`)??hs(s,t,`menu-on-top`)})()}
+                        ${(()=>{let t=Ms(e,e.itemSelected);return N.get()?.renderTopNav?.(s,t,`menu-on-top`)??js(s,t,`menu-on-top`)})()}
                         <div class="m-hl" style="margin-left: auto; flex-shrink: 0; align-items: center;">
                             <slot name="widgets"></slot>
-                            ${ps(t,e)}${_s(t,e)}
+                            ${ks(t,e)}${Ns(t,e)}
                         </div>
                     </div>
                     <div style="flex: 1; min-height: 0; overflow-y: auto; overflow-x: hidden; box-sizing: border-box; width: 100%;">
@@ -7921,12 +7921,12 @@ ${i}
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${bs(r,e,t)}"
+                                            route="${Is(r,e,t)}"
                                             id="ux_${e.id}"
-                                            baseUrl="${xs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Ss(e,t)}"
-                                            uriPrefix="${Cs(e,t)}"
+                                            baseUrl="${Ls(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Rs(e,t)}"
+                                            uriPrefix="${zs(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -7935,14 +7935,14 @@ ${i}
                                     ></mateu-ux>
                                 </mateu-api-caller>
                             </div>
-                            ${t.sseUrl?T`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" class="" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:v}
+                            ${t.sseUrl?w`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" class="" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:_}
                         </div>
                     </div>
                 </div>
 
-            `:v}
+            `:_}
 
-            ${t.variant==Ke.TILES?T`
+            ${t.variant==qe.TILES?w`
                 <div class="m-vl" style="width: 100%; height: 100vh; overflow: hidden;">
                     <div class="m-hl"
                             style="width: 100%; height: 4rem; flex-shrink: 0; align-items: center; border-bottom: 1px solid var(--lumo-disabled-text-color); background-color: var(--lumo-base-color);"
@@ -7950,28 +7950,28 @@ ${i}
                             @navigation-requested="${e.updateRoute}">
                         <a href="javascript: void(0);" @click="${()=>{e.goHome(),e.tilesMenuOption=null}}" style="text-decoration: none; color: inherit; flex-shrink: 0;">
                         <div class="m-hl" style="align-items: center;">
-                            ${t.logo?T`<img src="${t.logo}" alt="logo" height="28px" style="margin-left: 10px;">`:v}
-                            ${t.title?T`<h2 style="margin: 0 var(--lumo-space-l, 1.5rem) 0 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;">${t.title}</h2>`:v}
+                            ${t.logo?w`<img src="${t.logo}" alt="logo" height="28px" style="margin-left: 10px;">`:_}
+                            ${t.title?w`<h2 style="margin: 0 var(--lumo-space-l, 1.5rem) 0 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;">${t.title}</h2>`:_}
                         </div>
                         </a>
-                        ${hs(e.mapItemsForTiles(t.menu),gs(e,e.itemSelectedTiles),`menu-on-top`)}
+                        ${js(e.mapItemsForTiles(t.menu),Ms(e,e.itemSelectedTiles),`menu-on-top`)}
                         <div class="m-hl" style="margin-left: auto; flex-shrink: 0; align-items: center;">
                             <slot name="widgets"></slot>
-                            ${ps(t,e)}${_s(t,e)}
+                            ${ks(t,e)}${Ns(t,e)}
                         </div>
                     </div>
                     <div style="flex: 1; min-height: 0; overflow-y: auto; overflow-x: hidden; box-sizing: border-box; width: 100%;">
-                        ${e.tilesMenuOption?e.renderTilesHub(e.tilesMenuOption):T`
+                        ${e.tilesMenuOption?e.renderTilesHub(e.tilesMenuOption):w`
                         <div class="m-md">
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${bs(r,e,t)}"
+                                            route="${Is(r,e,t)}"
                                             id="ux_${e.id}"
-                                            baseUrl="${xs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Ss(e,t)}"
-                                            uriPrefix="${Cs(e,t)}"
+                                            baseUrl="${Ls(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Rs(e,t)}"
+                                            uriPrefix="${zs(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -7980,28 +7980,28 @@ ${i}
                                     ></mateu-ux>
                                 </mateu-api-caller>
                             </div>
-                            ${t.sseUrl?T`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" class="" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:v}
+                            ${t.sseUrl?w`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" class="" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:_}
                         </div>
                         `}
                     </div>
                 </div>
-            `:v}
+            `:_}
 
-            ${t.variant==Ke.RAIL?T`
+            ${t.variant==qe.RAIL?w`
                 <div style="display: flex; width: 100%; height: 100vh; overflow: hidden;">
                     ${e.renderRail(t.menu)}
-                    ${e.railOpenOption?e.renderRailSubPanel(e.railOpenOption):v}
+                    ${e.railOpenOption?e.renderRailSubPanel(e.railOpenOption):_}
                     <div style="flex: 1; overflow: hidden; padding: 2rem 2rem 0; height: 100vh; box-sizing: border-box; background-color: var(--lumo-contrast-10pct);">
                         <div class="m-md">
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${bs(r,e,t)}"
+                                            route="${Is(r,e,t)}"
                                             id="ux_${e.id}"
-                                            baseUrl="${xs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Ss(e,t)}"
-                                            uriPrefix="${Cs(e,t)}"
+                                            baseUrl="${Ls(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Rs(e,t)}"
+                                            uriPrefix="${zs(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -8010,20 +8010,20 @@ ${i}
                                     ></mateu-ux>
                                 </mateu-api-caller>
                             </div>
-                            ${t.sseUrl?T`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" class="" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:v}
+                            ${t.sseUrl?w`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" class="" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:_}
                         </div>
                     </div>
                 </div>
-            `:v}
+            `:_}
 
-            ${t.variant==Ke.MENU_ON_LEFT?T`
+            ${t.variant==qe.MENU_ON_LEFT?w`
 
                 <div class="m-hl">
                     <div class="m-scroll" style="width: 16em; border-right: 2px solid var(--lumo-contrast-5pct);">
                         <div class="m-vl"
                                 @navigation-requested="${e.updateRoute}">
                             ${t.menu.map(t=>e.renderOptionOnLeftMenu(t))}
-                            ${ps(t,e)}${_s(t,e)}
+                            ${ks(t,e)}${Ns(t,e)}
                         </div>
                     </div>
                     <div role="main" class="${`app-content`+(e.pageCompact?` no-padding`:``)}">
@@ -8031,12 +8031,12 @@ ${i}
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${bs(r,e,t)}"
+                                            route="${Is(r,e,t)}"
                                             id="ux_${e.id}"
-                                            baseUrl="${xs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Ss(e,t)}"
-                                            uriPrefix="${Cs(e,t)}"
+                                            baseUrl="${Ls(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Rs(e,t)}"
+                                            uriPrefix="${zs(e,t)}"
                                             style="width: 100%; padding: 1em;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -8045,15 +8045,15 @@ ${i}
                                     ></mateu-ux>
                                 </mateu-api-caller>
                             </div>
-                            ${t.sseUrl?T`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" class="" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:v}
+                            ${t.sseUrl?w`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" class="" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:_}
                         </div>
                     </div>
                 </div>
 
 
-            `:v}
+            `:_}
 
-            ${t.variant==Ke.TABS?T`
+            ${t.variant==qe.TABS?w`
                 <!--
                 
                 box-shadow: inset 0 -1px 0 0 var(--lumo-contrast-10pct);
@@ -8068,19 +8068,19 @@ ${i}
                                 @navigation-requested="${e.updateRoute}">
                             <a href="javascript: void(0);" @click="${()=>e.goHome()}" style="text-decoration: none; color: inherit; flex-shrink: 0;">
                             <div class="m-hl" style="align-items: center;">
-                                ${t.logo?T`<img src="${t.logo}" alt="logo" height="28px" style="margin-left: 10px;">`:v}
-                                ${t.title?T`<h2 style="margin: 0 var(--lumo-space-l, 1.5rem) 0 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;">${t.title}</h2>`:v}
+                                ${t.logo?w`<img src="${t.logo}" alt="logo" height="28px" style="margin-left: 10px;">`:_}
+                                ${t.title?w`<h2 style="margin: 0 var(--lumo-space-l, 1.5rem) 0 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;">${t.title}</h2>`:_}
                             </div>
                             </a>
                             <nav class="mateu-tabs ${e.component?.cssClasses??``}" style="flex-grow: 1; min-width: 0; margin-left: 1.5rem;">
-                                ${t.menu.map((n,r)=>T`
+                                ${t.menu.map((n,r)=>w`
                                 <button class="mateu-tab ${r===e.getSelectedIndex(t.menu)?`mateu-tab--active`:``}"
                                         @click="${()=>e.selectRoute(n.consumedRoute,n.route,n.actionId,n.baseUrl,n.serverSideType,n.uriPrefix)}"
                                 >${n.label}</button>`)}
                             </nav>
                             <div class="m-hl" style="flex-shrink: 0; align-items: center;">
                                 <slot name="widgets"></slot>
-                                ${ps(t,e)}${_s(t,e)}
+                                ${ks(t,e)}${Ns(t,e)}
                             </div>
                         </div>
                     </div>
@@ -8089,12 +8089,12 @@ ${i}
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${bs(r,e,t)}"
+                                            route="${Is(r,e,t)}"
                                             id="ux_${e.id}"
-                                            baseUrl="${xs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Ss(e,t)}"
-                                            uriPrefix="${Cs(e,t)}"
+                                            baseUrl="${Ls(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Rs(e,t)}"
+                                            uriPrefix="${zs(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -8103,28 +8103,28 @@ ${i}
                                     ></mateu-ux>
                                 </mateu-api-caller>
                             </div>
-                            ${t.sseUrl?T`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" class="" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:v}
+                            ${t.sseUrl?w`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" class="" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:_}
                         </div>
                     </div>
                 </div>
             
-            `:v}
+            `:_}
 
-            ${t.fabs?.map((n,r)=>T`
+            ${t.fabs?.map((n,r)=>w`
                 <button class="app-fab" style="bottom: ${(t.sseUrl?5.5:1.5)+r*4}rem; right: 1.5rem;"
                     @click="${()=>e.runAction(n.actionId)}"
                     title="${n.label}">
-                    ${I(n.icon)}
+                    ${F(n.icon)}
                 </button>
             `)}
-            ${t.sseUrl&&!e.chatOpen?T`
+            ${t.sseUrl&&!e.chatOpen?w`
                 <button class="ai-fab" @click="${e.showHideIa}" title="Asistente IA">
-                    ${I(`vaadin:comments-o`)}
+                    ${F(`vaadin:comments-o`)}
                 </button>
-            `:v}
+            `:_}
             ${e.renderCommandPalette()}
             <slot></slot>
-       `},Ts=(e,t)=>t!=null&&e!=null&&!e.has(t),Es=typeof HTMLElement<`u`?HTMLElement:class{},Ds=class extends Es{static get observedAttributes(){return[`type`,`renderer`]}connectedCallback(){this.render()}attributeChangedCallback(){this.render()}render(){let e=this.getAttribute(`type`)??`unknown`,t=this.getAttribute(`renderer`)??`unknown`;this.shadowRoot||this.attachShadow({mode:`open`}),this.shadowRoot.innerHTML=`
+       `},Vs=(e,t)=>t!=null&&e!=null&&!e.has(t),Hs=typeof HTMLElement<`u`?HTMLElement:class{},Us=class extends Hs{static get observedAttributes(){return[`type`,`renderer`]}connectedCallback(){this.render()}attributeChangedCallback(){this.render()}render(){let e=this.getAttribute(`type`)??`unknown`,t=this.getAttribute(`renderer`)??`unknown`;this.shadowRoot||this.attachShadow({mode:`open`}),this.shadowRoot.innerHTML=`
             <style>
                 :host { display: block; }
                 .mateu-unsupported {
@@ -8143,12 +8143,12 @@ ${i}
             <div class="mateu-unsupported" role="note">
                 ⚠ Component “${e}” is not supported by the “${t}” renderer yet.
             </div>
-        `}};typeof customElements<`u`&&!customElements.get(`mateu-unsupported`)&&customElements.define(`mateu-unsupported`,Ds);var Os=new Set,ks=(e,t,n)=>{let r=`${n}/${t}`;return Os.has(r)||(Os.add(r),console.warn(`[mateu] Component type "${t}" is not supported by the "${n}" renderer — rendering <mateu-unsupported> placeholder.`)),T`<mateu-unsupported
+        `}};typeof customElements<`u`&&!customElements.get(`mateu-unsupported`)&&customElements.define(`mateu-unsupported`,Us);var Ws=new Set,Gs=(e,t,n)=>{let r=`${n}/${t}`;return Ws.has(r)||(Ws.add(r),console.warn(`[mateu] Component type "${t}" is not supported by the "${n}" renderer — rendering <mateu-unsupported> placeholder.`)),w`<mateu-unsupported
             type="${t}"
             renderer="${n}"
-            data-component-id="${e?.id??v}"
-            slot="${e?.slot??v}"
-    ></mateu-unsupported>`},As=class{renderFilterBar(e,t,n,r,i,a,o,s){let c=t?.metadata;return T`
+            data-component-id="${e?.id??_}"
+            slot="${e?.slot??_}"
+    ></mateu-unsupported>`},Ks=class{renderFilterBar(e,t,n,r,i,a,o,s){let c=t?.metadata;return w`
             <mateu-filter-bar
                 .metadata="${c}"
                 @search-requested="${e.search}"
@@ -8160,9 +8160,9 @@ ${i}
                 .appData="${o}"
                 ?searchOnly="${s??!1}"
             >
-                ${c?.header?.map(t=>F(e,t,n,r,i,a,o))}
+                ${c?.header?.map(t=>P(e,t,n,r,i,a,o))}
             </mateu-filter-bar>
-        `}renderPagination(e,t){return T`
+        `}renderPagination(e,t){return w`
         <mateu-pagination
                 @page-changed="${e.pageChanged}"
                 @fetch-more-elements="${e.fetchMoreElements}"
@@ -8171,80 +8171,80 @@ ${i}
                 data-testid="pagination"
                 .pageNumber="${e.data[t?.id]?.page?.pageNumber??0}"
         ></mateu-pagination>
-        `}renderTableComponent(e,t,n,r,i,a,o){return pn(t,(e.data?.[e.id])?.page?.content??[],r[t?.id]?.emptyStateMessage)}rendererName(){return this.constructor?.name??`unknown`}supportedClientSideTypes(){}renderClientSideComponent(e,t,n,r,i,a,o,s){let c=t?.metadata?.type??t?.type,l=Object.values(j).includes(c)?c:void 0;return Ts(this.supportedClientSideTypes(),l)?ks(t,l,this.rendererName()):ea(e,t,n,r,i,a,o,s)}renderAppComponent(e,t,n,r,i,a,o){return ws(e,t?.metadata,n,r,i,a,o)}},js=(e,t,n,r,i,a,o)=>T`
+        `}renderTableComponent(e,t,n,r,i,a,o){return mn(t,(e.data?.[e.id])?.page?.content??[],r[t?.id]?.emptyStateMessage)}rendererName(){return this.constructor?.name??`unknown`}supportedClientSideTypes(){}renderClientSideComponent(e,t,n,r,i,a,o,s){let c=t?.metadata?.type??t?.type,l=Object.values(A).includes(c)?c:void 0;return Vs(this.supportedClientSideTypes(),l)?Gs(t,l,this.rendererName()):ta(e,t,n,r,i,a,o,s)}renderAppComponent(e,t,n,r,i,a,o){return Bs(e,t?.metadata,n,r,i,a,o)}},qs=(e,t,n,r,i,a,o)=>w`
         <vaadin-virtual-list
                 .items="${t.metadata.page.content}"
-                ${te(t=>T`${F(e,t,n,r,i,a,o)}`,[])}
+                ${ne(t=>w`${P(e,t,n,r,i,a,o)}`,[])}
                 style="${t.style}" class="${t.cssClasses}"
-                slot="${t.slot??v}"
+                slot="${t.slot??_}"
         ></vaadin-virtual-list>
-    `,Ms=e=>{let t=e.metadata;return T`
+    `,Js=e=>{let t=e.metadata;return w`
         <vaadin-notification
                 .opened="${!0}"
-                slot="${e.slot??v}"
+                slot="${e.slot??_}"
                 style="${e.style}"
                 class="${e.cssClasses}"
-                ${c(()=>T`
+                ${c(()=>w`
                     <vaadin-horizontal-layout theme="spacing" style="align-items: center;">
                         <h3>${t.title}</h3>
                         <div>${t.text}</div>
                     </vaadin-horizontal-layout>
                 `,[])}
         ></vaadin-notification>
-    `},Ns=(e,t={})=>{let n=e.metadata,r=n.valueKey?t[n.valueKey]:n.value;return T`
+    `},Ys=(e,t={})=>{let n=e.metadata,r=n.valueKey?t[n.valueKey]:n.value;return w`
         <div style="${e.style}">
         <vaadin-progress-bar
                 ?indeterminate="${n.indeterminate}"
-                min="${n.min&&n.min!=0?n.min:v}"
-                max="${n.max&&n.max!=0?n.max:v}"
-                value="${r??v}"
+                min="${n.min&&n.min!=0?n.min:_}"
+                max="${n.max&&n.max!=0?n.max:_}"
+                value="${r??_}"
                 style="${e.style}"
                 class="${e.cssClasses}"
-                slot="${e.slot??v}"
+                slot="${e.slot??_}"
         ></vaadin-progress-bar>
-        ${n.text?T`<span class="text-secondary text-xs" id="sublbl">
+        ${n.text?w`<span class="text-secondary text-xs" id="sublbl">
     ${n.text}
-  </span>`:v}
+  </span>`:_}
         </div>
-    `},Ps=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+    `},Xs=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <vaadin-details
                 ?opened="${s.opened}"
                 style="${t.style}"
                 class="${t.cssClasses}"
-                slot="${t.slot??v}"
+                slot="${t.slot??_}"
         >
             <vaadin-details-summary slot="summary">
-            ${F(e,s.summary,n,r,i,a,o)}
+            ${P(e,s.summary,n,r,i,a,o)}
             </vaadin-details-summary>
-            ${F(e,s.content,n,r,i,a,o)}
+            ${P(e,s.content,n,r,i,a,o)}
         </vaadin-details>
-            `},Fs=(e,t,n)=>{let r=e.metadata;return T`<vaadin-avatar
+            `},Zs=(e,t,n)=>{let r=e.metadata;return w`<vaadin-avatar
             img="${r.image}"
-            name="${N(r.name,t,n)}"
+            name="${M(r.name,t,n)}"
             abbr="${r.abbreviation}"
             style="${e.style}" class="${e.cssClasses}"
-            slot="${e.slot??v}"
-    ></vaadin-avatar>`},Is=e=>{let t=e.metadata;return T`<vaadin-avatar-group max-items-visible="${t.maxItemsVisible}"
+            slot="${e.slot??_}"
+    ></vaadin-avatar>`},Qs=e=>{let t=e.metadata;return w`<vaadin-avatar-group max-items-visible="${t.maxItemsVisible}"
                                      .items="${t.avatars}"
                                      style="${e.style}" class="${e.cssClasses}"
-                                     slot="${e.slot??v}">
-    </vaadin-avatar-group>`},Ls=(e,t,n,r,i,a,o)=>{let s=t.metadata;if(!s)return T``;let c=``;return s.variants?.map(e=>e==`stretchMedia`?`stretch-media`:e==`coverMedia`?`cover-media`:e).forEach(e=>c+=` `+e),c=c.trim(),T`
+                                     slot="${e.slot??_}">
+    </vaadin-avatar-group>`},$s=(e,t,n,r,i,a,o)=>{let s=t.metadata;if(!s)return w``;let c=``;return s.variants?.map(e=>e==`stretchMedia`?`stretch-media`:e==`coverMedia`?`cover-media`:e).forEach(e=>c+=` `+e),c=c.trim(),w`
         <vaadin-card
                 style="${t.style}"
                 class="${t.cssClasses}"
                 theme="${c}"
-                slot="${t.slot??v}"
+                slot="${t.slot??_}"
         >
-            ${s.media?pt(e,s.media,n,r,i,a,o,`media`,!1):v}
-            ${s.title?pt(e,s.title,n,r,i,a,o,`title`,!1):v}
-            ${s.subtitle?pt(e,s.subtitle,n,r,i,a,o,`subtitle`,!1):v}
-            ${s.header?pt(e,s.header,n,r,i,a,o,`header`,!1):v}
-            ${s.headerPrefix?pt(e,s.headerPrefix,n,r,i,a,o,`header-prefix`,!1):v}
-            ${s.headerSuffix?pt(e,s.headerSuffix,n,r,i,a,o,`header-suffix`,!1):v}
-            ${s.footer?pt(e,s.footer,n,r,i,a,o,`footer`,!1):v}
-            ${s.content?F(e,s.content,n,r,i,a,o,!1):v}
+            ${s.media?mt(e,s.media,n,r,i,a,o,`media`,!1):_}
+            ${s.title?mt(e,s.title,n,r,i,a,o,`title`,!1):_}
+            ${s.subtitle?mt(e,s.subtitle,n,r,i,a,o,`subtitle`,!1):_}
+            ${s.header?mt(e,s.header,n,r,i,a,o,`header`,!1):_}
+            ${s.headerPrefix?mt(e,s.headerPrefix,n,r,i,a,o,`header-prefix`,!1):_}
+            ${s.headerSuffix?mt(e,s.headerSuffix,n,r,i,a,o,`header-suffix`,!1):_}
+            ${s.footer?mt(e,s.footer,n,r,i,a,o,`footer`,!1):_}
+            ${s.content?P(e,s.content,n,r,i,a,o,!1):_}
         </vaadin-card>
-    `},Rs=e=>e>0&&e<640?`accordion`:`tabs`,zs=class extends b{constructor(...e){super(...e),this.tabLabels=[],this.mode=`tabs`,this.selected=0,this.selectedChangedListener=e=>{let t=e.detail?.value;typeof t==`number`&&t>=0&&(this.selected=t)}}connectedCallback(){super.connectedCallback(),this.resizeObserver=new ResizeObserver(e=>{for(let t of e)this.mode=Rs(t.contentRect.width)}),this.resizeObserver.observe(this)}disconnectedCallback(){super.disconnectedCallback(),this.resizeObserver?.disconnect(),this.resizeObserver=void 0,this.detachTabsListener()}detachTabsListener(){this.slottedTabs?.removeEventListener(`selected-changed`,this.selectedChangedListener),this.slottedTabs=void 0}tabsSlotChanged(e){this.detachTabsListener();let t=e.target.assignedElements().find(e=>`selected`in e);t&&(this.slottedTabs=t,t.addEventListener(`selected-changed`,this.selectedChangedListener),t.selected=this.selected)}select(e){this.selected=e,this.slottedTabs&&(this.slottedTabs.selected=e)}updated(){this.slottedTabs&&this.slottedTabs.selected!=this.selected&&(this.slottedTabs.selected=this.selected)}static{this.styles=h`
+    `},ec=e=>e>0&&e<640?`accordion`:`tabs`,tc=class extends y{constructor(...e){super(...e),this.tabLabels=[],this.mode=`tabs`,this.selected=0,this.selectedChangedListener=e=>{let t=e.detail?.value;typeof t==`number`&&t>=0&&(this.selected=t)}}connectedCallback(){super.connectedCallback(),this.resizeObserver=new ResizeObserver(e=>{for(let t of e)this.mode=ec(t.contentRect.width)}),this.resizeObserver.observe(this)}disconnectedCallback(){super.disconnectedCallback(),this.resizeObserver?.disconnect(),this.resizeObserver=void 0,this.detachTabsListener()}detachTabsListener(){this.slottedTabs?.removeEventListener(`selected-changed`,this.selectedChangedListener),this.slottedTabs=void 0}tabsSlotChanged(e){this.detachTabsListener();let t=e.target.assignedElements().find(e=>`selected`in e);t&&(this.slottedTabs=t,t.addEventListener(`selected-changed`,this.selectedChangedListener),t.selected=this.selected)}select(e){this.selected=e,this.slottedTabs&&(this.slottedTabs.selected=e)}updated(){this.slottedTabs&&this.slottedTabs.selected!=this.selected&&(this.slottedTabs.selected=this.selected)}static{this.styles=m`
         :host {
             display: block;
         }
@@ -8299,26 +8299,26 @@ ${i}
         .acc-body[hidden] {
             display: none;
         }
-    `}render(){return T`
+    `}render(){return w`
             <div class="strip" ?hidden="${this.mode!=`tabs`}">
                 <slot name="tabs" @slotchange="${this.tabsSlotChanged}"></slot>
             </div>
-            ${this.mode==`tabs`?T`
-                ${this.tabLabels.map((e,t)=>T`
+            ${this.mode==`tabs`?w`
+                ${this.tabLabels.map((e,t)=>w`
                     <div class="panel" ?hidden="${t!=this.selected}">
                         <slot name="panel-${t}"></slot>
                     </div>
                 `)}
-            `:T`
+            `:w`
                 <div class="accordion" part="accordion">
-                    ${this.tabLabels.map((e,t)=>T`
+                    ${this.tabLabels.map((e,t)=>w`
                         <div class="acc-item">
                             <button class="acc-header"
                                     aria-expanded="${t==this.selected}"
                                     aria-controls="acc-body-${t}"
                                     @click="${()=>this.select(t)}"
                             >
-                                <span>${e??v}</span>
+                                <span>${e??_}</span>
                                 <span class="chevron">⟩</span>
                             </button>
                             <div class="acc-body" id="acc-body-${t}" ?hidden="${t!=this.selected}">
@@ -8328,178 +8328,178 @@ ${i}
                     `)}
                 </div>
             `}
-        `}};k([y({type:Array})],zs.prototype,`tabLabels`,void 0),k([C()],zs.prototype,`mode`,void 0),k([C()],zs.prototype,`selected`,void 0),zs=k([g(`mateu-adaptive-tabs`)],zs);var Bs=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;c??=``,s.columnSpacing&&(c+=`--vaadin-form-layout-column-spacing: `+s.columnSpacing+`;`);let l=s.itemRowSpacing&&s.itemRowSpacing!==`0`?s.itemRowSpacing:`var(--lumo-space-m)`;return c+=`--vaadin-form-layout-row-spacing: `+l+`;`,s.itemLabelSpacing&&(c+=`--vaadin-form-layout-label-spacing: `+s.itemLabelSpacing+`;`),s.labelsAside&&(c+=`--vaadin-form-item-label-width: 10rem;`),s.fullWidth&&(c+=`width: 100%;`),T`
+        `}};O([v({type:Array})],tc.prototype,`tabLabels`,void 0),O([S()],tc.prototype,`mode`,void 0),O([S()],tc.prototype,`selected`,void 0),tc=O([h(`mateu-adaptive-tabs`)],tc);var nc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;c??=``,s.columnSpacing&&(c+=`--vaadin-form-layout-column-spacing: `+s.columnSpacing+`;`);let l=s.itemRowSpacing&&s.itemRowSpacing!==`0`?s.itemRowSpacing:`var(--lumo-space-m)`;return c+=`--vaadin-form-layout-row-spacing: `+l+`;`,s.itemLabelSpacing&&(c+=`--vaadin-form-layout-label-spacing: `+s.itemLabelSpacing+`;`),s.labelsAside&&(c+=`--vaadin-form-item-label-width: 10rem;`),s.fullWidth&&(c+=`width: 100%;`),w`
                <vaadin-form-layout 
-                       .responsiveSteps="${s.responsiveSteps||v}"  
-                       style="${c||v}" 
+                       .responsiveSteps="${s.responsiveSteps||_}"  
+                       style="${c||_}" 
                        class="${t.cssClasses}"
-                       max-columns="${s.maxColumns&&s.maxColumns>0?s.maxColumns:v}"
-                       auto-responsive="${s.autoResponsive||v}"
-                       column-width="${s.columnWidth||v}"
-                       expand-columns="${s.expandColumns||v}"
-                       expand-fields="${s.expandFields||!s.labelsAside||v}"
-                       labels-aside="${s.labelsAside||v}"
-                       slot="${t.slot||v}"
+                       max-columns="${s.maxColumns&&s.maxColumns>0?s.maxColumns:_}"
+                       auto-responsive="${s.autoResponsive||_}"
+                       column-width="${s.columnWidth||_}"
+                       expand-columns="${s.expandColumns||_}"
+                       expand-fields="${s.expandFields||!s.labelsAside||_}"
+                       labels-aside="${s.labelsAside||_}"
+                       slot="${t.slot||_}"
                >
-                   ${t.children?.map(t=>Vs(s,e,t,n,r,i,a,o))}
+                   ${t.children?.map(t=>rc(s,e,t,n,r,i,a,o))}
                </vaadin-form-layout>
-            `},Vs=(e,t,n,r,i,a,o,s)=>n.type==A.ClientSide&&n.metadata?.type==j.FormRow?Us(e,t,n,r,i,a,o,s):e.labelsAside?Hs(t,n,r,i,a,o,s):F(t,n,r,i,a,o,s),Hs=(e,t,n,r,i,a,o)=>{if(t.type==A.ClientSide&&t.metadata?.type==j.FormField&&t.metadata.label){let s=t.metadata,c=s.label?.includes("${")?e._evalTemplate(s.label):s.label;return T`
+            `},rc=(e,t,n,r,i,a,o,s)=>n.type==k.ClientSide&&n.metadata?.type==A.FormRow?ac(e,t,n,r,i,a,o,s):e.labelsAside?ic(t,n,r,i,a,o,s):P(t,n,r,i,a,o,s),ic=(e,t,n,r,i,a,o)=>{if(t.type==k.ClientSide&&t.metadata?.type==A.FormField&&t.metadata.label){let s=t.metadata,c=s.label?.includes("${")?e._evalTemplate(s.label):s.label;return w`
                        <vaadin-form-item data-colspan="${s.colspan}">
                            <label slot="label">${c}</label>
-                           ${F(e,t,n,r,i,a,o,!0)}
+                           ${P(e,t,n,r,i,a,o,!0)}
                        </vaadin-form-item>
-                   `}return F(e,t,n,r,i,a,o)},Us=(e,t,n,r,i,a,o,s)=>T`
+                   `}return P(e,t,n,r,i,a,o)},ac=(e,t,n,r,i,a,o,s)=>w`
         <vaadin-form-row>
-            ${n.children?.map(n=>Vs(e,t,n,r,i,a,o,s))}
+            ${n.children?.map(n=>rc(e,t,n,r,i,a,o,s))}
         </vaadin-form-row>
-            `,Ws=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=(s.padding?` padding`:``)+(s.spacing?` spacing`:``)+(s.spacingVariant?` spacing-`+s.spacingVariant:``)+(s.wrap?` wrap`:``),l=t.style;return s.fullWidth&&(l=l?`width: 100%;`+l:`width: 100%;`),s.justification&&(l=l?`justify-content: `+s.justification+`;`+l:`justify-content: `+s.justification+`;`),s.verticalAlignment&&(l=l?`align-items: `+s.verticalAlignment+`;`+l:`align-items: `+s.verticalAlignment+`;`),T`
+            `,oc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=(s.padding?` padding`:``)+(s.spacing?` spacing`:``)+(s.spacingVariant?` spacing-`+s.spacingVariant:``)+(s.wrap?` wrap`:``),l=t.style;return s.fullWidth&&(l=l?`width: 100%;`+l:`width: 100%;`),s.justification&&(l=l?`justify-content: `+s.justification+`;`+l:`justify-content: `+s.justification+`;`),s.verticalAlignment&&(l=l?`align-items: `+s.verticalAlignment+`;`+l:`align-items: `+s.verticalAlignment+`;`),w`
                <vaadin-horizontal-layout 
                        style="${l}" 
                        class="${t.cssClasses}"
                        theme="${c}"
-                       slot="${t.slot??v}"
+                       slot="${t.slot??_}"
                >
-                   ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+                   ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
                </vaadin-horizontal-layout>
-            `},Gs=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=(s.padding?` padding`:``)+(s.spacing?` spacing`:``)+(s.spacingVariant?` spacing-`+s.spacingVariant:``)+(s.wrap?` wrap`:``),l=t.style;return s.fullWidth&&(l=l?`width: 100%;`+l:`width: 100%;`),s.justification&&(l=l?`justify-content: `+s.justification+`;`+l:`justify-content: `+s.justification+`;`),s.horizontalAlignment&&(l=l?`align-items: `+s.horizontalAlignment+`;`+l:`align-items: `+s.horizontalAlignment+`;`),T`
+            `},sc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=(s.padding?` padding`:``)+(s.spacing?` spacing`:``)+(s.spacingVariant?` spacing-`+s.spacingVariant:``)+(s.wrap?` wrap`:``),l=t.style;return s.fullWidth&&(l=l?`width: 100%;`+l:`width: 100%;`),s.justification&&(l=l?`justify-content: `+s.justification+`;`+l:`justify-content: `+s.justification+`;`),s.horizontalAlignment&&(l=l?`align-items: `+s.horizontalAlignment+`;`+l:`align-items: `+s.horizontalAlignment+`;`),w`
         <vaadin-vertical-layout
                 style="${l}"
                 class="${t.cssClasses}"
                 theme="${c}"
-                slot="${t.slot??v}"
+                slot="${t.slot??_}"
         >
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </vaadin-vertical-layout>
-    `},Ks=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;return s.fullWidth&&(c=c?`width: 100%;`+c:`width: 100%;`),T`
+    `},cc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;return s.fullWidth&&(c=c?`width: 100%;`+c:`width: 100%;`),w`
                <vaadin-split-layout 
                        style="${c}" 
                        class="${t.cssClasses}"
-                       orientation="${s.orientation??v}"
-                       theme="${s.variant??v}"
-                       slot="${t.slot??v}"
+                       orientation="${s.orientation??_}"
+                       theme="${s.variant??_}"
+                       slot="${t.slot??_}"
                >
-                   <master-content>${F(e,t.children[0],n,r,i,a,o)}</master-content>
-                   <detail-content>${F(e,t.children[1],n,r,i,a,o)}</detail-content>
+                   <master-content>${P(e,t.children[0],n,r,i,a,o)}</master-content>
+                   <detail-content>${P(e,t.children[1],n,r,i,a,o)}</detail-content>
                </vaadin-split-layout>
-            `},qs=(e,t,n,r,i,a,o)=>{let s=t.children&&t.children.length>1?t.children[1]:null,c=i?.detailComponent??null,l=!!i?.hasDetail||!!s,u=c??s;return T`
+            `},lc=(e,t,n,r,i,a,o)=>{let s=t.children&&t.children.length>1?t.children[1]:null,c=i?.detailComponent??null,l=!!i?.hasDetail||!!s,u=c??s;return w`
                <vaadin-master-detail-layout ?has-detail="${l}"
                                             style="${t.style}"
                                             class="${t.cssClasses}"
-                                            slot="${t.slot??v}">
-                   <div>${F(e,t.children[0],n,r,i,a,o)}</div>
-                   ${l&&u?T`<div slot="detail">${F(e,u,n,r,i,a,o)}</div>`:T`<div slot="detail" style="display: flex; align-items: center; justify-content: center; height: 100%; color: var(--lumo-secondary-text-color); font-size: var(--lumo-font-size-s);">Select an item to view details</div>`}
+                                            slot="${t.slot??_}">
+                   <div>${P(e,t.children[0],n,r,i,a,o)}</div>
+                   ${l&&u?w`<div slot="detail">${P(e,u,n,r,i,a,o)}</div>`:w`<div slot="detail" style="display: flex; align-items: center; justify-content: center; height: 100%; color: var(--lumo-secondary-text-color); font-size: var(--lumo-font-size-s);">Select an item to view details</div>`}
                </vaadin-master-detail-layout>
-            `},Js=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;c??=``,s.fullWidth&&(c+=`width: 100%;`);let l=s.variant;l==`equalWidth`&&(l=`equal-width-tabs`);let u=Math.max(0,(t.children??[]).findIndex(e=>e.metadata.active)),d=e=>{e.target.selected=u};if(s.adaptable){let u=(t.children??[]).map(t=>{let n=t.metadata.label;return n?.includes("${")?e._evalTemplate(n):n});return T`
+            `},uc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;c??=``,s.fullWidth&&(c+=`width: 100%;`);let l=s.variant;l==`equalWidth`&&(l=`equal-width-tabs`);let u=Math.max(0,(t.children??[]).findIndex(e=>e.metadata.active)),d=e=>{e.target.selected=u};if(s.adaptable){let u=(t.children??[]).map(t=>{let n=t.metadata.label;return n?.includes("${")?e._evalTemplate(n):n});return w`
             <mateu-adaptive-tabs
                     .tabLabels="${u}"
                     style="${c}"
                     class="${t.cssClasses}"
-                    slot="${t.slot??v}"
+                    slot="${t.slot??_}"
             >
                 <vaadin-tabs slot="tabs"
-                             theme="${l??v}"
-                             orientation="${s.orientation??v}"
+                             theme="${l??_}"
+                             orientation="${s.orientation??_}"
                              @items-changed=${d}
                 >
-                    ${t.children?.map(e=>e).map((e,t)=>{let n=e.metadata.shortcut;return T`
+                    ${t.children?.map(e=>e).map((e,t)=>{let n=e.metadata.shortcut;return w`
                         <vaadin-tab id="${u[t]}"
                                     style="${e.style}"
                                     class="${e.cssClasses}"
-                                    data-shortcut="${n??v}"
+                                    data-shortcut="${n??_}"
                         >${u[t]}</vaadin-tab>`})}
                 </vaadin-tabs>
 
-                ${t.children?.map((t,s)=>T`
+                ${t.children?.map((t,s)=>w`
                     <div slot="panel-${s}" style="padding: var(--lumo-space-m) 0;">
-                        ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+                        ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
                     </div>`)}
             </mateu-adaptive-tabs>
-                `}return T`
+                `}return w`
         <vaadin-tabsheet
-                theme="${l??v}"
+                theme="${l??_}"
                 style="${c}"
-                slot="${t.slot??v}"
+                slot="${t.slot??_}"
         >
             <vaadin-tabs slot="tabs"
                          style="${c}"
                          class="${t.cssClasses}"
-                         orientation="${s.orientation??v}"
+                         orientation="${s.orientation??_}"
                          @items-changed=${d}
             >
-                ${t.children?.map(e=>e).map(t=>{let n=t.metadata.label,r=n?.includes("${")?e._evalTemplate(n):n,i=t.metadata.shortcut;return T`
+                ${t.children?.map(e=>e).map(t=>{let n=t.metadata.label,r=n?.includes("${")?e._evalTemplate(n):n,i=t.metadata.shortcut;return w`
                     <vaadin-tab id="${r}"
                                 style="${t.style}"
                                 class="${t.cssClasses}"
-                                data-shortcut="${i??v}"
+                                data-shortcut="${i??_}"
                     >${r}</vaadin-tab>`})}
             </vaadin-tabs>
 
-            ${t.children?.map(t=>Ys(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>dc(e,t,n,r,i,a,o))}
         </vaadin-tabsheet>
-            `},Ys=(e,t,n,r,i,a,o)=>{let s=t.metadata.label;return T`
+            `},dc=(e,t,n,r,i,a,o)=>{let s=t.metadata.label;return w`
         <div tab="${s?.includes("${")?e._evalTemplate(s):s}" style="padding: var(--lumo-space-m) 0;">
-                   ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+                   ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
                </div>
-            `},Xs=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;s.fullWidth&&(c=c?`width: 100%;`+c:`width: 100%;`);let l=0;if(t.children){for(let e=0;e<t.children.length;e++)if(t.children[e].metadata?.active){l=e;break}}return T`
+            `},fc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;s.fullWidth&&(c=c?`width: 100%;`+c:`width: 100%;`);let l=0;if(t.children){for(let e=0;e<t.children.length;e++)if(t.children[e].metadata?.active){l=e;break}}return w`
                <vaadin-accordion
                        style="${t.style}"
                        class="${t.cssClasses}"
                        opened="${l}"
-                       slot="${t.slot??v}"
+                       slot="${t.slot??_}"
                >
-                   ${t.children?.map(t=>Zs(e,t,n,r,i,a,o,s.variant))}
+                   ${t.children?.map(t=>pc(e,t,n,r,i,a,o,s.variant))}
                </vaadin-accordion>
-            `},Zs=(e,t,n,r,i,a,o,s)=>{let c=t.metadata,l=c.label?.includes("${")?e._evalTemplate(c.label):c.label;return T`
+            `},pc=(e,t,n,r,i,a,o,s)=>{let c=t.metadata,l=c.label?.includes("${")?e._evalTemplate(c.label):c.label;return w`
         <vaadin-accordion-panel style="${t.style}"
                                 class="${t.cssClasses}"
-                                theme="${s??v}"
+                                theme="${s??_}"
                                 ?opened="${c.active}"
                                 ?disabled="${c.disabled}">
             <vaadin-accordion-heading slot="summary">${l}</vaadin-accordion-heading>
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </vaadin-accordion-panel>
-            `},Qs=(e,t,n,r,i,a,o)=>T`
+            `},mc=(e,t,n,r,i,a,o)=>w`
                <vaadin-scroller style="${t.style}" 
                                 class="${t.cssClasses}"
-                                slot="${t.slot??v}">
-                   ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+                                slot="${t.slot??_}">
+                   ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
                </vaadin-scroller>
-            `,$s=(e,t,n,r,i,a,o)=>T`
+            `,hc=(e,t,n,r,i,a,o)=>w`
         <vaadin-board style="${t.style}" 
                       class="${t.cssClasses}"
-                      slot="${t.slot??v}">
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+                      slot="${t.slot??_}">
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </vaadin-board>
-            `,ec=(e,t,n,r,i,a,o)=>T`
+            `,gc=(e,t,n,r,i,a,o)=>w`
         <vaadin-board-row style="${t.style}" class="${t.cssClasses}">
-                   ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+                   ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
                </vaadin-board-row>
-            `,tc=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+            `,_c=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <div style="${t.style}" 
              class="${t.cssClasses}"
-             board-cols="${s.boardCols??v}"
+             board-cols="${s.boardCols??_}"
         >
-                   ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+                   ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
                </div>
-            `},nc=(e,t,n)=>T`
+            `},vc=(e,t,n)=>w`
     <vaadin-menu-bar
         .items=${e}
-        class="${n??v}"
+        class="${n??_}"
         @item-selected=${e=>t(e.detail.value)}>
-    </vaadin-menu-bar>`,rc=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
-        <vaadin-context-menu .items=${oc(e,s.menu,n,r,i,a,o)} 
+    </vaadin-menu-bar>`,yc=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+        <vaadin-context-menu .items=${Sc(e,s.menu,n,r,i,a,o)} 
                              style="${t.style}" 
                              class="${t.cssClasses}"
-                             open-on="${s.activateOnLeftClick?`click`:v}"
-                             slot="${t.slot??v}">
-            ${F(e,s.wrapped,n,r,i,a,o)}
+                             open-on="${s.activateOnLeftClick?`click`:_}"
+                             slot="${t.slot??_}">
+            ${P(e,s.wrapped,n,r,i,a,o)}
         </vaadin-context-menu>
-            `},ic=(e,t,n,r,i)=>{let a=t.metadata;return T`
-        <vaadin-menu-bar .items=${oc(e,a.options,n,r,i,O,ue)}
+            `},bc=(e,t,n,r,i)=>{let a=t.metadata;return w`
+        <vaadin-menu-bar .items=${Sc(e,a.options,n,r,i,D,de)}
                          style="${t.style}" class="${t.cssClasses}"
-                         slot="${t.slot??v}">
+                         slot="${t.slot??_}">
         </vaadin-menu-bar>
-            `},ac=(e,t,n,r,i,a,o)=>{let s=document.createElement(`vaadin-context-menu-item`);return re(F(e,t,n,r,i,a,o),s),s},oc=(e,t,n,r,i,a,o)=>t.map(t=>t.submenus?{text:t.component?void 0:t.label,route:t.path,checked:t.selected,disabled:t.disabled,className:t.className,component:t.component?ac(e,t.component,n,r,i,a,o):void 0,children:oc(e,t.submenus,n,r,i,a,o)}:t.separator?{component:`hr`}:{text:t.component?void 0:t.label,route:t.path,checked:t.selected,disabled:t.disabled,className:t.className,component:t.component?ac(e,t.component,n,r,i,a,o):void 0}),sc=class extends b{constructor(...e){super(...e),this.fieldId=``,this.signing=!1,this.hasStrokes=!1,this.drawing=!1,this.startStroke=e=>{let t=e.target;this.ensureCanvasSize(t),t.setPointerCapture(e.pointerId),this.drawing=!0;let n=t.getContext(`2d`);n.lineWidth=2,n.lineCap=`round`,n.lineJoin=`round`,n.strokeStyle=getComputedStyle(this).getPropertyValue(`--lumo-body-text-color`)||`#1a1a1a`;let[r,i]=this.pointerPosition(e);n.beginPath(),n.moveTo(r,i),e.preventDefault()},this.stroke=e=>{if(!this.drawing)return;let t=e.target.getContext(`2d`),[n,r]=this.pointerPosition(e);t.lineTo(n,r),t.stroke(),this.hasStrokes=!0,e.preventDefault()},this.endStroke=e=>{this.drawing=!1,e.target.releasePointerCapture(e.pointerId)}}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}canvas(){return this.renderRoot.querySelector(`canvas`)}pointerPosition(e){let t=e.target.getBoundingClientRect();return[e.clientX-t.left,e.clientY-t.top]}ensureCanvasSize(e){let t=e.getBoundingClientRect();(e.width!==Math.round(t.width)||e.height!==Math.round(t.height))&&(e.width=Math.round(t.width),e.height=Math.round(t.height))}clear(){let e=this.canvas();e&&e.getContext(`2d`).clearRect(0,0,e.width,e.height),this.hasStrokes=!1}accept(){let e=this.canvas();!e||!this.hasStrokes||(this.signing=!1,this.emit(e.toDataURL(`image/png`)))}renderPad(){return T`
+            `},xc=(e,t,n,r,i,a,o)=>{let s=document.createElement(`vaadin-context-menu-item`);return ie(P(e,t,n,r,i,a,o),s),s},Sc=(e,t,n,r,i,a,o)=>t.map(t=>t.submenus?{text:t.component?void 0:t.label,route:t.path,checked:t.selected,disabled:t.disabled,className:t.className,component:t.component?xc(e,t.component,n,r,i,a,o):void 0,children:Sc(e,t.submenus,n,r,i,a,o)}:t.separator?{component:`hr`}:{text:t.component?void 0:t.label,route:t.path,checked:t.selected,disabled:t.disabled,className:t.className,component:t.component?xc(e,t.component,n,r,i,a,o):void 0}),Cc=class extends y{constructor(...e){super(...e),this.fieldId=``,this.signing=!1,this.hasStrokes=!1,this.drawing=!1,this.startStroke=e=>{let t=e.target;this.ensureCanvasSize(t),t.setPointerCapture(e.pointerId),this.drawing=!0;let n=t.getContext(`2d`);n.lineWidth=2,n.lineCap=`round`,n.lineJoin=`round`,n.strokeStyle=getComputedStyle(this).getPropertyValue(`--lumo-body-text-color`)||`#1a1a1a`;let[r,i]=this.pointerPosition(e);n.beginPath(),n.moveTo(r,i),e.preventDefault()},this.stroke=e=>{if(!this.drawing)return;let t=e.target.getContext(`2d`),[n,r]=this.pointerPosition(e);t.lineTo(n,r),t.stroke(),this.hasStrokes=!0,e.preventDefault()},this.endStroke=e=>{this.drawing=!1,e.target.releasePointerCapture(e.pointerId)}}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}canvas(){return this.renderRoot.querySelector(`canvas`)}pointerPosition(e){let t=e.target.getBoundingClientRect();return[e.clientX-t.left,e.clientY-t.top]}ensureCanvasSize(e){let t=e.getBoundingClientRect();(e.width!==Math.round(t.width)||e.height!==Math.round(t.height))&&(e.width=Math.round(t.width),e.height=Math.round(t.height))}clear(){let e=this.canvas();e&&e.getContext(`2d`).clearRect(0,0,e.width,e.height),this.hasStrokes=!1}accept(){let e=this.canvas();!e||!this.hasStrokes||(this.signing=!1,this.emit(e.toDataURL(`image/png`)))}renderPad(){return w`
             <canvas class="pad"
                     @pointerdown="${this.startStroke}"
                     @pointermove="${this.stroke}"
@@ -8509,14 +8509,14 @@ ${i}
                 <button class="button" @click="${this.clear}">Clear</button>
                 <button class="button button--primary" ?disabled="${!this.hasStrokes}"
                         @click="${this.accept}">Accept</button>
-                ${this.value?T`
-                    <button class="button" @click="${()=>{this.signing=!1}}">Cancel</button>`:v}
-            </div>`}render(){let e=this.value!=null&&this.value!==``;return this.signing||!e?this.renderPad():T`
+                ${this.value?w`
+                    <button class="button" @click="${()=>{this.signing=!1}}">Cancel</button>`:_}
+            </div>`}render(){let e=this.value!=null&&this.value!==``;return this.signing||!e?this.renderPad():w`
             <img class="preview" src="${this.value}" alt="Signature"/>
             <div class="actions">
                 <button class="button" @click="${()=>{this.signing=!0,this.hasStrokes=!1,this.updateComplete.then(()=>this.clear())}}">Sign again</button>
                 <button class="button button--danger" @click="${()=>this.emit(``)}">Delete</button>
-            </div>`}static{this.styles=h`
+            </div>`}static{this.styles=m`
         :host {
             display: block;
             max-width: 420px;
@@ -8566,19 +8566,19 @@ ${i}
         .button--danger {
             color: var(--lumo-error-text-color, rgb(179, 49, 31));
         }
-    `}};k([y()],sc.prototype,`fieldId`,void 0),k([y()],sc.prototype,`value`,void 0),k([C()],sc.prototype,`signing`,void 0),k([C()],sc.prototype,`hasStrokes`,void 0),sc=k([g(`mateu-signature-pad`)],sc);var cc=class extends b{constructor(...e){super(...e),this.fieldId=``,this.options=[],this.leavesOnly=!1,this.opened=!1,this.expandedItems=[],this._normalized=[],this.dataProvider=(e,t)=>{let n=e.parentItem?e.parentItem.children??[]:this.normalized;t(n,n.length)}}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}get normalized(){return this._optsSource!==this.options&&(this._optsSource=this.options,this._normalized=this.normalizeOptions(this.options??[])),this._normalized}normalizeOptions(e){return e.map(e=>{let t=e.children&&e.children.length?this.normalizeOptions(e.children):void 0;return{...e,children:t}})}ancestorsOf(e,t){for(let n of t){if(String(n.value)===e)return[];let t=n.children?this.ancestorsOf(e,n.children):null;if(t!=null)return[n,...t]}return null}labelOf(e,t){for(let n of t){if(String(n.value)===e)return n.label;let t=n.children?this.labelOf(e,n.children):null;if(t!=null)return t}return null}open(){this.opened||(this.expandedItems=this.value==null?[]:this.ancestorsOf(String(this.value),this.normalized)??[],this.opened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.close()},document.addEventListener(`mousedown`,this.outsideClick))}close(){this.detachOutsideClick(),this.opened=!1}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}pick(e){this.close(),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e.value,fieldId:this.fieldId},bubbles:!0,composed:!0}))}clear(){this.close(),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:void 0,fieldId:this.fieldId},bubbles:!0,composed:!0}))}onActiveItemChanged(e){let t=e.detail.value;if(t){if((t.children?.length??0)>0&&this.leavesOnly){this.expandedItems=this.expandedItems.includes(t)?this.expandedItems.filter(e=>e!==t):[...this.expandedItems,t],e.target.activeItem=null;return}this.pick(t)}}render(){let e=this.value!=null&&this.value!==``?this.labelOf(String(this.value),this.normalized)??String(this.value):``;return T`
+    `}};O([v()],Cc.prototype,`fieldId`,void 0),O([v()],Cc.prototype,`value`,void 0),O([S()],Cc.prototype,`signing`,void 0),O([S()],Cc.prototype,`hasStrokes`,void 0),Cc=O([h(`mateu-signature-pad`)],Cc);var wc=class extends y{constructor(...e){super(...e),this.fieldId=``,this.options=[],this.leavesOnly=!1,this.opened=!1,this.expandedItems=[],this._normalized=[],this.dataProvider=(e,t)=>{let n=e.parentItem?e.parentItem.children??[]:this.normalized;t(n,n.length)}}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}get normalized(){return this._optsSource!==this.options&&(this._optsSource=this.options,this._normalized=this.normalizeOptions(this.options??[])),this._normalized}normalizeOptions(e){return e.map(e=>{let t=e.children&&e.children.length?this.normalizeOptions(e.children):void 0;return{...e,children:t}})}ancestorsOf(e,t){for(let n of t){if(String(n.value)===e)return[];let t=n.children?this.ancestorsOf(e,n.children):null;if(t!=null)return[n,...t]}return null}labelOf(e,t){for(let n of t){if(String(n.value)===e)return n.label;let t=n.children?this.labelOf(e,n.children):null;if(t!=null)return t}return null}open(){this.opened||(this.expandedItems=this.value==null?[]:this.ancestorsOf(String(this.value),this.normalized)??[],this.opened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.close()},document.addEventListener(`mousedown`,this.outsideClick))}close(){this.detachOutsideClick(),this.opened=!1}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}pick(e){this.close(),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e.value,fieldId:this.fieldId},bubbles:!0,composed:!0}))}clear(){this.close(),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:void 0,fieldId:this.fieldId},bubbles:!0,composed:!0}))}onActiveItemChanged(e){let t=e.detail.value;if(t){if((t.children?.length??0)>0&&this.leavesOnly){this.expandedItems=this.expandedItems.includes(t)?this.expandedItems.filter(e=>e!==t):[...this.expandedItems,t],e.target.activeItem=null;return}this.pick(t)}}render(){let e=this.value!=null&&this.value!==``?this.labelOf(String(this.value),this.normalized)??String(this.value):``;return w`
             <div class="root">
                 <vaadin-button class="control" theme="tertiary"
                                @click="${()=>this.opened?this.close():this.open()}">
                     <span class="${e?``:`placeholder`}">${e||`—`}</span>
                     <span class="chevron" slot="suffix" aria-hidden="true">▾</span>
                 </vaadin-button>
-                ${this.opened?T`
+                ${this.opened?w`
                     <div class="panel">
-                        ${this.value?T`
+                        ${this.value?w`
                             <div class="clear-row">
                                 <vaadin-button theme="tertiary small" @click="${this.clear}">— Clear</vaadin-button>
-                            </div>`:v}
+                            </div>`:_}
                         <vaadin-grid
                                 theme="compact no-border no-row-borders"
                                 all-rows-visible
@@ -8589,8 +8589,8 @@ ${i}
                                 @active-item-changed="${this.onActiveItemChanged}">
                             <vaadin-grid-tree-column path="label"></vaadin-grid-tree-column>
                         </vaadin-grid>
-                    </div>`:v}
-            </div>`}static{this.styles=h`
+                    </div>`:_}
+            </div>`}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -8637,29 +8637,29 @@ ${i}
             min-width: 16rem;
             max-height: 18rem;
         }
-    `}};k([y()],cc.prototype,`fieldId`,void 0),k([y()],cc.prototype,`value`,void 0),k([y()],cc.prototype,`options`,void 0),k([y({type:Boolean})],cc.prototype,`leavesOnly`,void 0),k([C()],cc.prototype,`opened`,void 0),k([C()],cc.prototype,`expandedItems`,void 0),cc=k([g(`mateu-vaadin-tree-select`)],cc);var lc=class extends b{constructor(...e){super(...e),this.fieldId=``,this.cameraOpen=!1,this.cameraError=!1,this.fileFallback=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>this.emit(r.result),r.readAsDataURL(n),t.value=``}}disconnectedCallback(){super.disconnectedCallback(),this.stopStream()}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}stopStream(){this.stream?.getTracks().forEach(e=>e.stop()),this.stream=void 0}async openCamera(){this.cameraError=!1;try{this.stream=await navigator.mediaDevices.getUserMedia({video:{facingMode:`environment`},audio:!1}),this.cameraOpen=!0,await this.updateComplete;let e=this.renderRoot.querySelector(`video`);e&&(e.srcObject=this.stream,await e.play())}catch{this.stopStream(),this.cameraOpen=!1,this.cameraError=!0}}closeCamera(){this.stopStream(),this.cameraOpen=!1}shoot(){let e=this.renderRoot.querySelector(`video`);if(!e||e.videoWidth===0)return;let t=document.createElement(`canvas`);t.width=e.videoWidth,t.height=e.videoHeight,t.getContext(`2d`).drawImage(e,0,0),this.closeCamera(),this.emit(t.toDataURL(`image/jpeg`,.9))}triggerFallback(){this.renderRoot.querySelector(`input[type=file]`)?.click()}render(){let e=this.value!=null&&this.value!==``;return T`
+    `}};O([v()],wc.prototype,`fieldId`,void 0),O([v()],wc.prototype,`value`,void 0),O([v()],wc.prototype,`options`,void 0),O([v({type:Boolean})],wc.prototype,`leavesOnly`,void 0),O([S()],wc.prototype,`opened`,void 0),O([S()],wc.prototype,`expandedItems`,void 0),wc=O([h(`mateu-vaadin-tree-select`)],wc);var Tc=class extends y{constructor(...e){super(...e),this.fieldId=``,this.cameraOpen=!1,this.cameraError=!1,this.fileFallback=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>this.emit(r.result),r.readAsDataURL(n),t.value=``}}disconnectedCallback(){super.disconnectedCallback(),this.stopStream()}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}stopStream(){this.stream?.getTracks().forEach(e=>e.stop()),this.stream=void 0}async openCamera(){this.cameraError=!1;try{this.stream=await navigator.mediaDevices.getUserMedia({video:{facingMode:`environment`},audio:!1}),this.cameraOpen=!0,await this.updateComplete;let e=this.renderRoot.querySelector(`video`);e&&(e.srcObject=this.stream,await e.play())}catch{this.stopStream(),this.cameraOpen=!1,this.cameraError=!0}}closeCamera(){this.stopStream(),this.cameraOpen=!1}shoot(){let e=this.renderRoot.querySelector(`video`);if(!e||e.videoWidth===0)return;let t=document.createElement(`canvas`);t.width=e.videoWidth,t.height=e.videoHeight,t.getContext(`2d`).drawImage(e,0,0),this.closeCamera(),this.emit(t.toDataURL(`image/jpeg`,.9))}triggerFallback(){this.renderRoot.querySelector(`input[type=file]`)?.click()}render(){let e=this.value!=null&&this.value!==``;return w`
             <input type="file" accept="image/*" capture="environment" style="display: none;"
                    @change="${this.fileFallback}">
-            ${this.cameraOpen?T`
+            ${this.cameraOpen?w`
                 <video class="viewfinder" playsinline muted></video>
                 <div class="actions">
                     <button class="button button--primary" @click="${this.shoot}">Capture</button>
                     <button class="button" @click="${this.closeCamera}">Cancel</button>
                 </div>
-            `:T`
-                ${e?T`<img class="preview" src="${this.value}" alt="Photo"/>`:T`<div class="placeholder" aria-hidden="true">📷</div>`}
+            `:w`
+                ${e?w`<img class="preview" src="${this.value}" alt="Photo"/>`:w`<div class="placeholder" aria-hidden="true">📷</div>`}
                 <div class="actions">
                     <button class="button button--primary" @click="${this.openCamera}">
                         ${e?`Retake`:`Take photo`}
                     </button>
-                    ${this.cameraError?T`
-                        <button class="button" @click="${this.triggerFallback}">Use file / native camera</button>`:v}
-                    ${e?T`
-                        <button class="button button--danger" @click="${()=>this.emit(``)}">Delete</button>`:v}
+                    ${this.cameraError?w`
+                        <button class="button" @click="${this.triggerFallback}">Use file / native camera</button>`:_}
+                    ${e?w`
+                        <button class="button button--danger" @click="${()=>this.emit(``)}">Delete</button>`:_}
                 </div>
-                ${this.cameraError?T`
-                    <div class="error-hint">Camera unavailable — the file picker opens the device camera on phones.</div>`:v}
-            `}`}static{this.styles=h`
+                ${this.cameraError?w`
+                    <div class="error-hint">Camera unavailable — the file picker opens the device camera on phones.</div>`:_}
+            `}`}static{this.styles=m`
         :host {
             display: block;
             max-width: 420px;
@@ -8715,17 +8715,17 @@ ${i}
             font-size: var(--lumo-font-size-xs, 0.75rem);
             color: var(--lumo-secondary-text-color, rgba(0, 0, 0, 0.6));
         }
-    `}};k([y()],lc.prototype,`fieldId`,void 0),k([y()],lc.prototype,`value`,void 0),k([C()],lc.prototype,`cameraOpen`,void 0),k([C()],lc.prototype,`cameraError`,void 0),lc=k([g(`mateu-camera-capture`)],lc);var uc,dc=(e,t)=>{if(!e)return;if(Array.isArray(e)){let n=e.find(e=>e.key==t);return n?.value==null?void 0:String(n.value)}let n=e[t];return n==null?void 0:String(n)},fc=class extends b{static{uc=this}constructor(...e){super(...e),this.fieldId=``,this.editable=!0,this.filePicked=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>{let e=r.result,t=e.indexOf(`,`),i=e.substring(0,t).replace(`;base64`,`;name=${encodeURIComponent(n.name)};base64`);this.emit(i+e.substring(t))},r.readAsDataURL(n),t.value=``}}static fileName(e){if(!e)return``;if(e.startsWith(`data:`)){let t=e.indexOf(`,`),n=e.substring(5,t<0?e.length:t).split(`;`).find(e=>e.startsWith(`name=`));if(n)try{return decodeURIComponent(n.substring(5))}catch{return n.substring(5)}return`Attached file`}return e.split(`/`).pop()||e}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}triggerPick(){this.renderRoot.querySelector(`input[type=file]`)?.click()}render(){let e=this.value!=null&&this.value!==``,t=uc.fileName(this.value),n=e&&this.value.startsWith(`data:`),r=e?T`<span class="file" title="${t}">📄 ${n?T`<a href="${this.value}" download="${t}">${t}</a>`:T`<a href="${this.value}" target="_blank">${t}</a>`}</span>`:v;return this.editable?T`
-            <input type="file" accept="${this.accept||v}" style="display: none;"
+    `}};O([v()],Tc.prototype,`fieldId`,void 0),O([v()],Tc.prototype,`value`,void 0),O([S()],Tc.prototype,`cameraOpen`,void 0),O([S()],Tc.prototype,`cameraError`,void 0),Tc=O([h(`mateu-camera-capture`)],Tc);var Ec,Dc=(e,t)=>{if(!e)return;if(Array.isArray(e)){let n=e.find(e=>e.key==t);return n?.value==null?void 0:String(n.value)}let n=e[t];return n==null?void 0:String(n)},Oc=class extends y{static{Ec=this}constructor(...e){super(...e),this.fieldId=``,this.editable=!0,this.filePicked=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>{let e=r.result,t=e.indexOf(`,`),i=e.substring(0,t).replace(`;base64`,`;name=${encodeURIComponent(n.name)};base64`);this.emit(i+e.substring(t))},r.readAsDataURL(n),t.value=``}}static fileName(e){if(!e)return``;if(e.startsWith(`data:`)){let t=e.indexOf(`,`),n=e.substring(5,t<0?e.length:t).split(`;`).find(e=>e.startsWith(`name=`));if(n)try{return decodeURIComponent(n.substring(5))}catch{return n.substring(5)}return`Attached file`}return e.split(`/`).pop()||e}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}triggerPick(){this.renderRoot.querySelector(`input[type=file]`)?.click()}render(){let e=this.value!=null&&this.value!==``,t=Ec.fileName(this.value),n=e&&this.value.startsWith(`data:`),r=e?w`<span class="file" title="${t}">📄 ${n?w`<a href="${this.value}" download="${t}">${t}</a>`:w`<a href="${this.value}" target="_blank">${t}</a>`}</span>`:_;return this.editable?w`
+            <input type="file" accept="${this.accept||_}" style="display: none;"
                    @change="${this.filePicked}">
             <div class="row">
                 ${r}
                 <button class="button" @click="${this.triggerPick}">
                     ${e?`Replace`:`Choose file`}
                 </button>
-                ${e?T`
-                    <button class="button button--danger" @click="${()=>this.emit(``)}">Remove</button>`:v}
-            </div>`:T`${e?r:T`<span class="empty">—</span>`}`}static{this.styles=h`
+                ${e?w`
+                    <button class="button button--danger" @click="${()=>this.emit(``)}">Remove</button>`:_}
+            </div>`:w`${e?r:w`<span class="empty">—</span>`}`}static{this.styles=m`
         :host {
             display: block;
         }
@@ -8763,114 +8763,114 @@ ${i}
         .button--danger {
             color: var(--lumo-error-text-color, rgb(179, 49, 31));
         }
-    `}};k([y()],fc.prototype,`fieldId`,void 0),k([y()],fc.prototype,`value`,void 0),k([y()],fc.prototype,`accept`,void 0),k([y({type:Boolean})],fc.prototype,`editable`,void 0),fc=uc=k([g(`mateu-file-upload`)],fc);var pc=e=>!!e&&typeof e==`object`&&`__mateuGroup`in e,mc=e=>String(e??``),hc=(e,t,n)=>{let r=e??[];if(!t||!n||n.length===0)return r;let i=[],a,o=!1;return r.forEach((e,s)=>{let c=mc(e?.[t]);if(!o||c!==a){let e=n.find(e=>mc(e.value)===c)??{value:c,count:r.filter(e=>mc(e?.[t])===c).length,aggregates:{}};i.push({__mateuGroup:e,__mateuGroupBy:t,_rowNumber:`__mateuGroup:${s}:${c}`}),o=!0,a=c}i.push(e)}),i},gc=(e,t)=>e==null?``:t.dataType===`money`||t.stereotype===`money`?new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e):t.aggregate===`count`?new Intl.NumberFormat(void 0,{maximumFractionDigits:0}).format(Math.round(e)):new Intl.NumberFormat(void 0,{maximumFractionDigits:2}).format(e),_c=(e,t)=>e&&t.includes(e)?e:t.find(e=>!!e),vc=(e,t,n)=>{let r=e.__mateuGroup;return t.id===n?`${r.value} (${r.count})`:t.aggregate?gc(r.aggregates?.[t.id],t):``},yc=(e,t,n)=>{let r=t?.aggregates;if(!r||!e.some(e=>e.aggregate))return;let i={};e.forEach(e=>{e.aggregate&&r[e.id]!=null&&(i[e.id]=gc(r[e.id],e))});let a=e[0];if(a&&i[a.id]===void 0){let e=t?.page?.totalElements;i[a.id]=n&&a.id===n&&e!=null?`Total (${e})`:`Total`}return i},bc=(e,t,n)=>I(e[n.path]?`vaadin:check`:`vaadin:minus`,`height: 16px; width: 16px; color: var(--lumo-body-text-color);`),xc=(e,t,n,r,i)=>{let a=e[n.path],o=a;return r==`money`&&a&&a.locale&&a.currency?o=new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(a.value):i==`money`&&(o=new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(a)),T`${o}`},Sc=(e,t,n)=>{e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:n},bubbles:!0,composed:!0}))},Cc=(e,t,n,r,i,a)=>{let o=n.xcolumn??a;if(o.text)return o.actionId?T`<a href="javascript: void(0);" @click="${t=>Sc(n,o,e)}">${o.text}</a>`:T`<a href="${e[n.path]}">${o.text}</a>`;if(r==`string`){if(o.actionId)return T`<a href="javascript: void(0);" @click="${t=>Sc(n,o,e)}">${e[n.path]}</a>`;let t=e[n.path];return T`<a href="${t}">${t}</a>`}let s=e[n.path];return T`<a href="${s.href}">${s.text}</a>`},wc=(e,t,n,r,i)=>{let a=e[n.path];return r==`string`?a.split(`,`).map(e=>I(e,`width: 16px;`)):a.split(`,`).map(e=>I(e.icon,`width: 16px;`))},Tc=(e,t,n,r,i)=>{let a=e[n.path];return T`${_(a)}`},Ec=(e,t,n,r,i,a)=>r==`string`?T`<img src="${e[n.path]}" style="${`max-height: 40px; `+(a.style??``)}">`:T`<img src="${e[n.path].src}" style="${a.style??``}">`,Dc=e=>{let t={_clickedRow:e.target.row};e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+e.detail.value.methodNameInCrud,parameters:t},bubbles:!0,composed:!0}))},Oc=e=>{let t={_clickedRow:e.target.row},n=e.target.action;e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+n.methodNameInCrud,parameters:t},bubbles:!0,composed:!0}))},kc=e=>{let t=document.createElement(`vaadin-context-menu-item`),n=document.createElement(`vaadin-icon`);return n.style.color=`var(--lumo-secondary-text-color)`,n.style.marginInlineEnd=`var(--lumo-space-s)`,n.style.padding=`var(--lumo-space-xs)`,n.setAttribute(`icon`,e.icon),t.appendChild(n),e.label&&t.appendChild(document.createTextNode(e.label)),t.disabled=e.disabled,t},Ac=(e,t,n)=>{let r=e[n.path]?.actions?.map(e=>e.icon?{component:kc(e),methodNameInCrud:e.methodNameInCrud}:{...e,text:e.label});return!r||r.length==0?T``:T`
+    `}};O([v()],Oc.prototype,`fieldId`,void 0),O([v()],Oc.prototype,`value`,void 0),O([v()],Oc.prototype,`accept`,void 0),O([v({type:Boolean})],Oc.prototype,`editable`,void 0),Oc=Ec=O([h(`mateu-file-upload`)],Oc);function kc(e,t){return t?t.split(`.`).reduce((e,t)=>typeof e==`object`&&e?e[t]:void 0,e):e}function Ac(e,t,n=`value`,r=`label`){let i=kc(e,t);return Array.isArray(i)?i.map(e=>{if(typeof e==`object`&&e){let t=kc(e,n),i=kc(e,r);return{value:t??i,label:String(i??t??``)}}return{value:e,label:String(e)}}):[]}async function jc(e,t=e=>e,n=fetch){let r=t(e.url)??e.url,i=(e.method||`GET`).toUpperCase(),a={};for(let[n,r]of Object.entries(e.headers??{}))a[n]=t(r)??r;let o={method:i,headers:a};i!==`GET`&&i!==`HEAD`&&e.body&&(o.body=t(e.body)??e.body);let s=await n(r,o);if(!s.ok)throw Error(`External options fetch failed: ${s.status}`);return Ac(await s.json(),e.itemsPath,e.valuePath,e.labelPath)}var Mc=e=>!!e&&typeof e==`object`&&`__mateuGroup`in e,Nc=e=>String(e??``),Pc=(e,t,n)=>{let r=e??[];if(!t||!n||n.length===0)return r;let i=[],a,o=!1;return r.forEach((e,s)=>{let c=Nc(e?.[t]);if(!o||c!==a){let e=n.find(e=>Nc(e.value)===c)??{value:c,count:r.filter(e=>Nc(e?.[t])===c).length,aggregates:{}};i.push({__mateuGroup:e,__mateuGroupBy:t,_rowNumber:`__mateuGroup:${s}:${c}`}),o=!0,a=c}i.push(e)}),i},Fc=(e,t)=>e==null?``:t.dataType===`money`||t.stereotype===`money`?new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e):t.aggregate===`count`?new Intl.NumberFormat(void 0,{maximumFractionDigits:0}).format(Math.round(e)):new Intl.NumberFormat(void 0,{maximumFractionDigits:2}).format(e),Ic=(e,t)=>e&&t.includes(e)?e:t.find(e=>!!e),Lc=(e,t,n)=>{let r=e.__mateuGroup;return t.id===n?`${r.value} (${r.count})`:t.aggregate?Fc(r.aggregates?.[t.id],t):``},Rc=(e,t,n)=>{let r=t?.aggregates;if(!r||!e.some(e=>e.aggregate))return;let i={};e.forEach(e=>{e.aggregate&&r[e.id]!=null&&(i[e.id]=Fc(r[e.id],e))});let a=e[0];if(a&&i[a.id]===void 0){let e=t?.page?.totalElements;i[a.id]=n&&a.id===n&&e!=null?`Total (${e})`:`Total`}return i},zc=(e,t,n)=>F(e[n.path]?`vaadin:check`:`vaadin:minus`,`height: 16px; width: 16px; color: var(--lumo-body-text-color);`),Bc=(e,t,n,r,i)=>{let a=e[n.path],o=a;return r==`money`&&a&&a.locale&&a.currency?o=new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(a.value):i==`money`&&(o=new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(a)),w`${o}`},Vc=(e,t,n)=>{e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:n},bubbles:!0,composed:!0}))},Hc=(e,t,n,r,i,a)=>{let o=n.xcolumn??a;if(o.text)return o.actionId?w`<a href="javascript: void(0);" @click="${t=>Vc(n,o,e)}">${o.text}</a>`:w`<a href="${e[n.path]}">${o.text}</a>`;if(r==`string`){if(o.actionId)return w`<a href="javascript: void(0);" @click="${t=>Vc(n,o,e)}">${e[n.path]}</a>`;let t=e[n.path];return w`<a href="${t}">${t}</a>`}let s=e[n.path];return w`<a href="${s.href}">${s.text}</a>`},Uc=(e,t,n,r,i)=>{let a=e[n.path];return r==`string`?a.split(`,`).map(e=>F(e,`width: 16px;`)):a.split(`,`).map(e=>F(e.icon,`width: 16px;`))},Wc=(e,t,n,r,i)=>{let a=e[n.path];return w`${g(a)}`},Gc=(e,t,n,r,i,a)=>r==`string`?w`<img src="${e[n.path]}" style="${`max-height: 40px; `+(a.style??``)}">`:w`<img src="${e[n.path].src}" style="${a.style??``}">`,Kc=e=>{let t={_clickedRow:e.target.row};e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+e.detail.value.methodNameInCrud,parameters:t},bubbles:!0,composed:!0}))},qc=e=>{let t={_clickedRow:e.target.row},n=e.target.action;e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+n.methodNameInCrud,parameters:t},bubbles:!0,composed:!0}))},Jc=e=>{let t=document.createElement(`vaadin-context-menu-item`),n=document.createElement(`vaadin-icon`);return n.style.color=`var(--lumo-secondary-text-color)`,n.style.marginInlineEnd=`var(--lumo-space-s)`,n.style.padding=`var(--lumo-space-xs)`,n.setAttribute(`icon`,e.icon),t.appendChild(n),e.label&&t.appendChild(document.createTextNode(e.label)),t.disabled=e.disabled,t},Yc=(e,t,n)=>{let r=e[n.path]?.actions?.map(e=>e.icon?{component:Jc(e),methodNameInCrud:e.methodNameInCrud}:{...e,text:e.label});return!r||r.length==0?w``:w`
                                      <vaadin-menu-bar
                                          .items=${[{text:`···`,children:r}]}
                                          theme="tertiary"
                                          .row="${e}"
                                          data-testid="menubar-${n.path}"
-                                         @item-selected="${Dc}"
+                                         @item-selected="${Kc}"
                                      ></vaadin-menu-bar>
-                                   `},jc=(e,t,n)=>{if(n.path==`select`)return T`
-         <vaadin-button theme="tertiary" title="Select" @click="${Oc}" .row="${e}" .action="${{actionId:n.path,icon:``,label:`Select`,disabled:!1,methodNameInCrud:`select`}}">
+                                   `},Xc=(e,t,n)=>{if(n.path==`select`)return w`
+         <vaadin-button theme="tertiary" title="Select" @click="${qc}" .row="${e}" .action="${{actionId:n.path,icon:``,label:`Select`,disabled:!1,methodNameInCrud:`select`}}">
              Select
          </vaadin-button>
-    `;let r=n.path&&e[n.path]?.methodNameInCrud?e[n.path]:e.action;return r?T`
-         <vaadin-button theme="tertiary${r.icon&&!r.label?` icon`:``}" title="${r.label||v}" @click="${Oc}" .row="${e}" .action="${r}">
-             ${r.icon?T`<vaadin-icon icon="${r.icon}"></vaadin-icon>`:v}
-             ${r.label?r.label:v}
+    `;let r=n.path&&e[n.path]?.methodNameInCrud?e[n.path]:e.action;return r?w`
+         <vaadin-button theme="tertiary${r.icon&&!r.label?` icon`:``}" title="${r.label||_}" @click="${qc}" .row="${e}" .action="${r}">
+             ${r.icon?w`<vaadin-icon icon="${r.icon}"></vaadin-icon>`:_}
+             ${r.label?r.label:_}
          </vaadin-button>
-    `:T``},Mc=(e,t,n)=>{e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:n},bubbles:!0,composed:!0}))},Nc=(e,t,n,r,i,a)=>{let o=n.xcolumn??a;if(o.actionId)return T`
-            <vaadin-button theme="tertiary" @click="${t=>Mc(n,o,e)}" .row="${e}">
+    `:w``},Zc=(e,t,n)=>{e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:n},bubbles:!0,composed:!0}))},Qc=(e,t,n,r,i,a)=>{let o=n.xcolumn??a;if(o.actionId)return w`
+            <vaadin-button theme="tertiary" @click="${t=>Zc(n,o,e)}" .row="${e}">
                 ${o.text||e[n.path]}
             </vaadin-button>
-        `;let s=e[n.path];return T`<a href="${s}">${o.text||s}</a>`},Pc=(e,t,n,r,i,a,o,s,c)=>{let l=e[n.path];return F(r,l,i,a,o,s,c)},Fc=new WeakMap,Ic=(e,t)=>Fc.get(e)?.[t],Lc=(e,t,n)=>{let r=Fc.get(e);r||(r={},Fc.set(e,r)),r[t]=n},Rc=e=>{if(e==null||e===``)return null;let t=Number(e);return Number.isNaN(t)?null:t},zc=(e,t,n,r)=>{let i=n?.field?.fieldId,a=a=>{if(e[t.id]===a||e[t.id]==null&&(a===``||a==null))return;if(e[t.id]=a,!i){n.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`update-row`,parameters:{_editedRow:{...e}}},bubbles:!0,composed:!0}));return}let o=(n?.state??r)[i];n.dispatchEvent(new CustomEvent(`value-changed`,{detail:{fieldId:i,value:Array.isArray(o)?[...o]:o},bubbles:!0,composed:!0}))},o=e[t.id],s=o==null?``:String(o);switch(t.editorType){case`boolean`:return T`<vaadin-checkbox ?checked=${!!o} @checked-changed=${e=>a(e.detail.value)}></vaadin-checkbox>`;case`integer`:return T`<vaadin-integer-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(Rc(e.target.value))}></vaadin-integer-field>`;case`number`:return T`<vaadin-number-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(Rc(e.target.value))}></vaadin-number-field>`;case`date`:return T`<vaadin-date-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-date-picker>`;case`time`:return T`<vaadin-time-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-time-picker>`;case`datetime`:return T`<vaadin-date-time-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-date-time-picker>`;case`select`:return T`<vaadin-combo-box
+        `;let s=e[n.path];return w`<a href="${s}">${o.text||s}</a>`},$c=(e,t,n,r,i,a,o,s,c)=>{let l=e[n.path];return P(r,l,i,a,o,s,c)},el=new WeakMap,tl=(e,t)=>el.get(e)?.[t],nl=(e,t,n)=>{let r=el.get(e);r||(r={},el.set(e,r)),r[t]=n},rl=e=>{if(e==null||e===``)return null;let t=Number(e);return Number.isNaN(t)?null:t},il=(e,t,n,r)=>{let i=n?.field?.fieldId,a=a=>{if(e[t.id]===a||e[t.id]==null&&(a===``||a==null))return;if(e[t.id]=a,!i){n.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`update-row`,parameters:{_editedRow:{...e}}},bubbles:!0,composed:!0}));return}let o=(n?.state??r)[i];n.dispatchEvent(new CustomEvent(`value-changed`,{detail:{fieldId:i,value:Array.isArray(o)?[...o]:o},bubbles:!0,composed:!0}))},o=e[t.id],s=o==null?``:String(o);switch(t.editorType){case`boolean`:return w`<vaadin-checkbox ?checked=${!!o} @checked-changed=${e=>a(e.detail.value)}></vaadin-checkbox>`;case`integer`:return w`<vaadin-integer-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(rl(e.target.value))}></vaadin-integer-field>`;case`number`:return w`<vaadin-number-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(rl(e.target.value))}></vaadin-number-field>`;case`date`:return w`<vaadin-date-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-date-picker>`;case`time`:return w`<vaadin-time-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-time-picker>`;case`datetime`:return w`<vaadin-date-time-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-date-time-picker>`;case`select`:return w`<vaadin-combo-box
                 theme="small" style="width:100%;"
                 .items=${(t.editorOptions??[]).map(e=>({label:e.label,value:String(e.value)}))}
                 item-label-path="label" item-value-path="value"
                 .value=${s}
-                @value-changed=${e=>a(e.detail.value)}></vaadin-combo-box>`;case`lookup`:{let r=n?.field?.fieldId,i=`search-${r}-${t.id}`,o=`${r}-${t.id}`;return T`<vaadin-combo-box
+                @value-changed=${e=>a(e.detail.value)}></vaadin-combo-box>`;case`lookup`:{let r=n?.field?.fieldId,i=`search-${r}-${t.id}`,o=`${r}-${t.id}`;return w`<vaadin-combo-box
                 theme="small" style="width:100%;"
                 item-label-path="label" item-id-path="value"
                 .dataProvider=${(e,t)=>{n.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:i,parameters:{searchText:e.filter,size:e.pageSize,page:e.page},callback:e=>{let n=e?.fragments?.[0]?.data?.[o];t(n?.content??[],n?.totalElements??0)},callbackonly:!0},bubbles:!0,composed:!0}))}}
-                .selectedItem=${(t.editorOptions??[]).find(e=>String(e.value)===s)??(s?{value:s,label:Ic(e,t.id)??s}:void 0)}
-                @selected-item-changed=${n=>{let r=n.detail.value,i=r?r.value:null;String(i??``)!==s&&(r&&Lc(e,t.id,r.label),a(i))}}></vaadin-combo-box>`}default:return T`<vaadin-text-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(e.target.value)}></vaadin-text-field>`}},Bc=e=>m(()=>T`<span title="${e}" style="white-space:normal;overflow-wrap:break-word;">${e}</span>`,[e]),Vc=e=>e===void 0?v:d(()=>T`<span style="font-weight: 600; white-space: nowrap;">${e}</span>`,[e]),Hc=e=>{e.preventDefault(),e.stopPropagation(),e.currentTarget?.dispatchEvent(new CustomEvent(`sort-direction-changed`,{detail:{grid:e.currentTarget.parentElement},bubbles:!0,composed:!0}))},Uc=(e,t,n,r,i,a,o,s)=>T`
-<vaadin-grid-column-group header="${M(e.label,r,i)}">
-    ${e.columns.map(e=>Gc(e.metadata,t,n,r,i,a,o,s?.[e.metadata?.id]))}
+                .selectedItem=${(t.editorOptions??[]).find(e=>String(e.value)===s)??(s?{value:s,label:tl(e,t.id)??s}:void 0)}
+                @selected-item-changed=${n=>{let r=n.detail.value,i=r?r.value:null;String(i??``)!==s&&(r&&nl(e,t.id,r.label),a(i))}}></vaadin-combo-box>`}default:return w`<vaadin-text-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(e.target.value)}></vaadin-text-field>`}},al=e=>ee(()=>w`<span title="${e}" style="white-space:normal;overflow-wrap:break-word;">${e}</span>`,[e]),ol=e=>e===void 0?_:d(()=>w`<span style="font-weight: 600; white-space: nowrap;">${e}</span>`,[e]),sl=e=>{e.preventDefault(),e.stopPropagation(),e.currentTarget?.dispatchEvent(new CustomEvent(`sort-direction-changed`,{detail:{grid:e.currentTarget.parentElement},bubbles:!0,composed:!0}))},cl=(e,t,n,r,i,a,o,s)=>w`
+<vaadin-grid-column-group header="${j(e.label,r,i)}">
+    ${e.columns.map(e=>ul(e.metadata,t,n,r,i,a,o,s?.[e.metadata?.id]))}
 </vaadin-grid-column-group>
-`,Wc=(e,t,n,r,i,a,o,s)=>j.GridGroupColumn==e.metadata?.type?Uc(e.metadata,t,n,r,i,a,o,s):Gc(e.metadata,t,n,r,i,a,o,s?.[e.metadata?.id]),Gc=(e,n,r,i,a,o,s,c)=>{let l=M(e.label,i,a);return e.sortable?T`
+`,ll=(e,t,n,r,i,a,o,s)=>A.GridGroupColumn==e.metadata?.type?cl(e.metadata,t,n,r,i,a,o,s):ul(e.metadata,t,n,r,i,a,o,s?.[e.metadata?.id]),ul=(e,n,r,i,a,o,s,c)=>{let l=j(e.label,i,a);return e.sortable?w`
                         <vaadin-grid-sort-column
                                 path="${e.id}"
-                                text-align="${e.align??v}"
+                                text-align="${e.align??_}"
                                 ?frozen="${e.frozen}"
                                 ?frozen-to-end="${e.frozenToEnd}"
                                 ?auto-width="${e.autoWidth}"
-                                flex-grow="${e.flexGrow??v}"
+                                flex-grow="${e.flexGrow??_}"
                                 ?resizable="${e.resizable}"
-                                width="${e.width??v}"
-                                @direction-changed="${Hc}"
+                                width="${e.width??_}"
+                                @direction-changed="${sl}"
                                 data-data-type="${e.dataType}"
                                 data-stereotype="${e.stereotype}"
-                                ${Bc(l)}
-                                ${Vc(c)}
-                                ${t((t,c,l)=>Kc(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
+                                ${al(l)}
+                                ${ol(c)}
+                                ${t((t,c,l)=>dl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
                         ></vaadin-grid-sort-column>
-                    `:e.filterable?T`
+                    `:e.filterable?w`
                         <vaadin-grid-filter-column
                                 path="${e.id}"
-                                text-align="${e.align??v}"
+                                text-align="${e.align??_}"
                                 ?frozen="${e.frozen}"
                                 ?frozen-to-end="${e.frozenToEnd}"
                                 ?auto-width="${e.autoWidth}"
-                                flex-grow="${e.flexGrow??v}"
+                                flex-grow="${e.flexGrow??_}"
                                 ?resizable="${e.resizable}"
-                                width="${e.width??v}"
+                                width="${e.width??_}"
                                 data-data-type="${e.dataType}"
                                 data-stereotype="${e.stereotype}"
-                                ${Bc(l)}
-                                ${Vc(c)}
-                                ${t((t,c,l)=>Kc(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
+                                ${al(l)}
+                                ${ol(c)}
+                                ${t((t,c,l)=>dl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
                         ></vaadin-grid-filter-column>
-                    `:T`
+                    `:w`
                         <vaadin-grid-column
                                 path="${e.id}"
-                                text-align="${e.align??v}"
+                                text-align="${e.align??_}"
                                 ?frozen="${e.frozen}"
                                 ?frozen-to-end="${e.frozenToEnd}"
                                 ?auto-width="${e.autoWidth}"
-                                flex-grow="${e.flexGrow??v}"
+                                flex-grow="${e.flexGrow??_}"
                                 ?resizable="${e.resizable}"
-                                width="${e.width??v}"
+                                width="${e.width??_}"
                                 data-data-type="${e.dataType}"
                                 data-stereotype="${e.stereotype}"
                                 .xcolumn="${e}"
-                                ${Bc(l)}
-                                ${Vc(c)}
-                                ${t((t,c,l)=>Kc(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
+                                ${al(l)}
+                                ${ol(c)}
+                                ${t((t,c,l)=>dl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
                         ></vaadin-grid-column>
-                    `},Kc=(e,t,n,r,i,a,o,s,c,l)=>{let u=n.dataset.dataType??``,d=n.dataset.stereotype??``;if(pc(e)){let t=i?.metadata,n=(t?.columns??[]).flatMap(e=>e?.metadata?.type===j.GridGroupColumn?(e.metadata.columns??[]).map(e=>e?.metadata?.id):[e?.metadata?.id]),a=vc(e,r,_c(e.__mateuGroupBy,n)),o=e.__mateuGroup.hiddenActions??[],s=r.id===n[n.length-1]?(t?.groupActions??[]).filter(e=>!o.includes(e.actionId??e.id)):[];return s.length?T`<span style="display: flex; align-items: center; justify-content: flex-end; gap: var(--lumo-space-s); overflow: hidden;">
-                ${a?T`<span style="font-weight: 600;">${a}</span>`:v}
-                ${s.map(t=>T`
+                    `},dl=(e,t,n,r,i,a,o,s,c,l)=>{let u=n.dataset.dataType??``,d=n.dataset.stereotype??``;if(Mc(e)){let t=i?.metadata,n=(t?.columns??[]).flatMap(e=>e?.metadata?.type===A.GridGroupColumn?(e.metadata.columns??[]).map(e=>e?.metadata?.id):[e?.metadata?.id]),a=Lc(e,r,Ic(e.__mateuGroupBy,n)),o=e.__mateuGroup.hiddenActions??[],s=r.id===n[n.length-1]?(t?.groupActions??[]).filter(e=>!o.includes(e.actionId??e.id)):[];return s.length?w`<span style="display: flex; align-items: center; justify-content: flex-end; gap: var(--lumo-space-s); overflow: hidden;">
+                ${a?w`<span style="font-weight: 600;">${a}</span>`:_}
+                ${s.map(t=>w`
                     <vaadin-button theme="tertiary small" style="flex-shrink: 0;"
                         @click="${n=>{n.stopPropagation(),n.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+(t.actionId??t.id),parameters:{_groupValue:e.__mateuGroup.value}},bubbles:!0,composed:!0}))}}">${t.label??t.caption??``}</vaadin-button>
                 `)}
-            </span>`:T`<span title="${a}" style="font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block;">${a}</span>`}if(r.editable)return zc(e,r,i,o);if(u==`status`)return na(e,t,n);if(u==`bool`)return bc(e,t,n);if(u==`money`||d==`money`)return xc(e,t,n,u,d);if(u==`link`||d==`link`)return Cc(e,t,n,u,d,r);if(u==`icon`||d==`icon`)return wc(e,t,n,u,d);if(d==`html`)return Tc(e,t,n,u,d);if(d==`image`)return Ec(e,t,n,u,d,r);if(u==`menu`)return Ac(e,t,n);if(u==`component`)return Pc(e,t,n,i,a,o,s,c,l);if(u==`action`)return jc(e,t,n);if(u==`actionGroup`)return Ac(e,t,n);if(d==`button`||r.actionId)return Nc(e,t,n,u,d,r);let f=e[n.path];return T`<span title="${f}" style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block;">${f}</span>`},qc=()=>{let e=document.activeElement;for(;e?.shadowRoot?.activeElement;)e=e.shadowRoot.activeElement;return e},Jc=(e,t)=>{let n=t;for(;n;){if(n===e)return!0;n=n.assignedSlot??n.parentNode??n.host??null}return!1},Yc=class extends $e{constructor(...e){super(...e),this.state={},this.data={},this.appState={},this.appData={},this.detailsOpenedItems=[],this.hoveredItem=null,this.onGridHoverMove=e=>{let t=e.currentTarget,n=t.getEventContext(e)?.item??null;n!==this.hoveredItem&&(this.hoveredItem=n,t.generateCellPartNames())},this.onGridHoverLeave=e=>{this.hoveredItem!==null&&(this.hoveredItem=null,e.currentTarget.generateCellPartNames())},this.hoverCellPartNameGenerator=(e,t)=>t?.item!=null&&t.item===this.hoveredItem?`hovered-cell`:``,this._onRowKey=e=>{let t=this.field?.rowSelectionShortcut;if(!t||!this.field?.onItemSelectionActionId||!this._isRowShortcutRelevant()||!kn(t,e))return;let n=/^(?:Digit|Numpad)([1-9])$/.exec(e.code);if(!n)return;let r=this.currentItems(),i=parseInt(n[1],10)-1;i>=r.length||(e.preventDefault(),this.selectRow(r[i]))},this.handleButtonClick=e=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))}}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._onRowKey)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`keydown`,this._onRowKey)}currentItems(){return this.field?.remoteCoordinates?this.data?.[this.id]?.content??[]:this.field?.fieldId&&this.state?this.state[this.field.fieldId]??[]:[]}selectRow(e){!e||!this.field?.onItemSelectionActionId||(this.selectedItems=[e],this.state[this.id+`_selected_items`]=[e],this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.field.onItemSelectionActionId,parameters:{_clickedRow:e}},bubbles:!0,composed:!0})))}_isRowShortcutRelevant(){if(this.offsetParent===null&&this.getClientRects().length===0)return!1;let e=qc();if(e&&e!==document.body&&!Jc(this,e)){let t=e.tagName?.toLowerCase()??``;if(e.isContentEditable||/^(input|textarea|select)$/.test(t)||t.startsWith(`vaadin-`)&&/(field|combo|picker|area|select)/.test(t))return!1}return!0}handleItemToggle(e){let{item:t,selected:n,shiftKey:r}=e.detail;if(this.rangeStartItem??=t,r){let e=[];this.field?.fieldId&&this.state&&this.state[this.field.fieldId]&&(e=this.state[this.field.fieldId]);let[r,i]=[this.rangeStartItem,t].map(t=>e.indexOf(t)).sort((e,t)=>e-t),a=e.slice(r,i+1),o=new Set(this.selectedItems);a.forEach(e=>{n?o.add(e):o.delete(e)}),this.selectedItems=[...o],this.state[this.id+`_selected_items`]=this.selectedItems}this.rangeStartItem=t}render(){let e=[];this.field?.fieldId&&this.state&&this.state[this.field.fieldId]&&(e=this.state[this.field.fieldId]);let t=this.state[this.field?.fieldId+`_show_detail`]||this.state._show_detail&&this.state._show_detail[this.field.fieldId];if(this.field?.remoteCoordinates){let t=this.field.remoteCoordinates;this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements?e=this.data[this.id].content:this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}if(Array.isArray(e)&&e.forEach((e,t)=>{e&&typeof e==`object`&&e._rowNumber===void 0&&(e._rowNumber=t)}),this.field?.inlineEditing)return this.renderMaster(e);if(this.field?.formPosition&&this.field?.formPosition.startsWith(`modal`)){let n=this;return T`
+            </span>`:w`<span title="${a}" style="font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block;">${a}</span>`}if(r.editable)return il(e,r,i,o);if(u==`status`)return ra(e,t,n);if(u==`bool`)return zc(e,t,n);if(u==`money`||d==`money`)return Bc(e,t,n,u,d);if(u==`link`||d==`link`)return Hc(e,t,n,u,d,r);if(u==`icon`||d==`icon`)return Uc(e,t,n,u,d);if(d==`html`)return Wc(e,t,n,u,d);if(d==`image`)return Gc(e,t,n,u,d,r);if(u==`menu`)return Yc(e,t,n);if(u==`component`)return $c(e,t,n,i,a,o,s,c,l);if(u==`action`)return Xc(e,t,n);if(u==`actionGroup`)return Yc(e,t,n);if(d==`button`||r.actionId)return Qc(e,t,n,u,d,r);let f=e[n.path];return w`<span title="${f}" style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block;">${f}</span>`},fl=()=>{let e=document.activeElement;for(;e?.shadowRoot?.activeElement;)e=e.shadowRoot.activeElement;return e},pl=(e,t)=>{let n=t;for(;n;){if(n===e)return!0;n=n.assignedSlot??n.parentNode??n.host??null}return!1},ml=class extends et{constructor(...e){super(...e),this.state={},this.data={},this.appState={},this.appData={},this.detailsOpenedItems=[],this.hoveredItem=null,this.onGridHoverMove=e=>{let t=e.currentTarget,n=t.getEventContext(e)?.item??null;n!==this.hoveredItem&&(this.hoveredItem=n,t.generateCellPartNames())},this.onGridHoverLeave=e=>{this.hoveredItem!==null&&(this.hoveredItem=null,e.currentTarget.generateCellPartNames())},this.hoverCellPartNameGenerator=(e,t)=>t?.item!=null&&t.item===this.hoveredItem?`hovered-cell`:``,this._onRowKey=e=>{let t=this.field?.rowSelectionShortcut;if(!t||!this.field?.onItemSelectionActionId||!this._isRowShortcutRelevant()||!An(t,e))return;let n=/^(?:Digit|Numpad)([1-9])$/.exec(e.code);if(!n)return;let r=this.currentItems(),i=parseInt(n[1],10)-1;i>=r.length||(e.preventDefault(),this.selectRow(r[i]))},this.handleButtonClick=e=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))}}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._onRowKey)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`keydown`,this._onRowKey)}currentItems(){return this.field?.remoteCoordinates?this.data?.[this.id]?.content??[]:this.field?.fieldId&&this.state?this.state[this.field.fieldId]??[]:[]}selectRow(e){!e||!this.field?.onItemSelectionActionId||(this.selectedItems=[e],this.state[this.id+`_selected_items`]=[e],this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.field.onItemSelectionActionId,parameters:{_clickedRow:e}},bubbles:!0,composed:!0})))}_isRowShortcutRelevant(){if(this.offsetParent===null&&this.getClientRects().length===0)return!1;let e=fl();if(e&&e!==document.body&&!pl(this,e)){let t=e.tagName?.toLowerCase()??``;if(e.isContentEditable||/^(input|textarea|select)$/.test(t)||t.startsWith(`vaadin-`)&&/(field|combo|picker|area|select)/.test(t))return!1}return!0}handleItemToggle(e){let{item:t,selected:n,shiftKey:r}=e.detail;if(this.rangeStartItem??=t,r){let e=[];this.field?.fieldId&&this.state&&this.state[this.field.fieldId]&&(e=this.state[this.field.fieldId]);let[r,i]=[this.rangeStartItem,t].map(t=>e.indexOf(t)).sort((e,t)=>e-t),a=e.slice(r,i+1),o=new Set(this.selectedItems);a.forEach(e=>{n?o.add(e):o.delete(e)}),this.selectedItems=[...o],this.state[this.id+`_selected_items`]=this.selectedItems}this.rangeStartItem=t}render(){let e=[];this.field?.fieldId&&this.state&&this.state[this.field.fieldId]&&(e=this.state[this.field.fieldId]);let t=this.state[this.field?.fieldId+`_show_detail`]||this.state._show_detail&&this.state._show_detail[this.field.fieldId];if(this.field?.remoteCoordinates){let t=this.field.remoteCoordinates;this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements?e=this.data[this.id].content:this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}if(Array.isArray(e)&&e.forEach((e,t)=>{e&&typeof e==`object`&&e._rowNumber===void 0&&(e._rowNumber=t)}),this.field?.inlineEditing)return this.renderMaster(e);if(this.field?.formPosition&&this.field?.formPosition.startsWith(`modal`)){let n=this;return w`
 
                 ${this.renderMaster(e)}
 
                 <vaadin-dialog
                         .opened="${t}"
                         @closed="${()=>{n.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.field?.fieldId+`_cancel`},bubbles:!0,composed:!0}))}}"
-                        ${s(()=>T`
+                        ${s(()=>w`
                             <mateu-event-interceptor .target="${n}">
                                 <div id="container" style="${this.field?.formStyle??`display: contents;`}">
                                     <mateu-component id="${this.field?.fieldId}-container"></mateu-component>
                                 </div>
                             </mateu-event-interceptor>
-                            `,[()=>E()])}
+                            `,[()=>T()])}
                 ></vaadin-dialog>
                 
-            `}else{let n=this.field?.formPosition==`left`||this.field?.formPosition==`right`?`horizontal`:`vertical`;return T`
+            `}else{let n=this.field?.formPosition==`left`||this.field?.formPosition==`right`?`horizontal`:`vertical`;return w`
             <vaadin-master-detail-layout
                     style="overflow: unset; width: 100%; ${t&&this.field?.minHeightWhenDetailVisible?`min-height: `+this.field?.minHeightWhenDetailVisible+`;`:``}"
                     orientation="${n}"
@@ -8884,14 +8884,14 @@ ${i}
                 </div>
                 
                 
-            </vaadin-master-detail-layout>`}}renderMaster(e){let r=this.selectedItems||[];return T`<vaadin-vertical-layout style="width: 100%;">
+            </vaadin-master-detail-layout>`}}renderMaster(e){let r=this.selectedItems||[];return w`<vaadin-vertical-layout style="width: 100%;">
             <!-- The field label is rendered by the surrounding mateu-field wrapper; rendering it
                  here too would duplicate it (e.g. "Guests / Guests"). -->
             <vaadin-grid
                     ?clickable="${!!this.field?.onItemSelectionActionId}"
-                    .cellPartNameGenerator="${S(this.field?.onItemSelectionActionId?this.hoverCellPartNameGenerator:void 0)}"
-                    @mousemove="${S(this.field?.onItemSelectionActionId?this.onGridHoverMove:void 0)}"
-                    @mouseleave="${S(this.field?.onItemSelectionActionId?this.onGridHoverLeave:void 0)}"
+                    .cellPartNameGenerator="${x(this.field?.onItemSelectionActionId?this.hoverCellPartNameGenerator:void 0)}"
+                    @mousemove="${x(this.field?.onItemSelectionActionId?this.onGridHoverMove:void 0)}"
+                    @mouseleave="${x(this.field?.onItemSelectionActionId?this.onGridHoverLeave:void 0)}"
                     style="${this.field?.onItemSelectionActionId?`cursor: pointer;`:``}${this.field?.style??``}"
                     class="${this.field?.cssClasses}"
                     .items="${e}"
@@ -8899,33 +8899,33 @@ ${i}
                     item-id-path="${this.field?.itemIdPath}"
                     @selected-items-changed="${e=>{this.selectedItems=e.detail.value,this.state[this.id+`_selected_items`]=this.selectedItems}}"
                     @item-toggle="${this.handleItemToggle}"
-                    @click="${S(this.field?.onItemSelectionActionId?e=>{let t=e.currentTarget.getEventContext(e)?.item;t&&this.selectRow(t)}:void 0)}"
-                    @active-item-changed="${S(this.field?.detailPath&&!this.field?.useButtonForDetail?e=>{if(this.field?.detailPath){let t=e.detail.value;t?this.detailsOpenedItems=[t]:this.detailsOpenedItems=[]}}:void 0)}"
+                    @click="${x(this.field?.onItemSelectionActionId?e=>{let t=e.currentTarget.getEventContext(e)?.item;t&&this.selectRow(t)}:void 0)}"
+                    @active-item-changed="${x(this.field?.detailPath&&!this.field?.useButtonForDetail?e=>{if(this.field?.detailPath){let t=e.detail.value;t?this.detailsOpenedItems=[t]:this.detailsOpenedItems=[]}}:void 0)}"
                     .detailsOpenedItems="${this.detailsOpenedItems}"
-                    ${S(this.field?.detailPath?n(e=>T`${F(this,e[this.field?.detailPath],this.baseUrl,this.state,this.data,this.appState,this.appData)}`):void 0)}
+                    ${x(this.field?.detailPath?n(e=>w`${P(this,e[this.field?.detailPath],this.baseUrl,this.state,this.data,this.appState,this.appData)}`):void 0)}
                     ?all-rows-visible=${e?.length<10}
             >
                 <span slot="empty-state">${this.field?.label?`No ${this.field.label.toLowerCase()} added yet.`:`No items added yet.`}</span>
-                ${this.field?.readOnly||this.field?.inlineEditing?v:T`
+                ${this.field?.readOnly||this.field?.inlineEditing?_:w`
                     <vaadin-grid-selection-column drag-select></vaadin-grid-selection-column>
                 `}
-                ${this.field?.columns?.map(e=>Wc(e,this,this.baseUrl,this.state,this.data,this.appState,this.appData))}
+                ${this.field?.columns?.map(e=>ll(e,this,this.baseUrl,this.state,this.data,this.appState,this.appData))}
 
-                ${this.field?.inlineEditing&&!this.field?.readOnly?T`
+                ${this.field?.inlineEditing&&!this.field?.readOnly?w`
                     <vaadin-grid-column width="3.5rem" flex-grow="0" frozen-to-end
-                            ${t(e=>T`
+                            ${t(e=>w`
                                 <vaadin-button theme="tertiary icon error" title="Remove row"
                                     @click="${()=>{this.state[this.id+`_selected_items`]=[e],this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.id+`_remove`},bubbles:!0,composed:!0}))}}">
                                     <vaadin-icon icon="vaadin:trash"></vaadin-icon>
                                 </vaadin-button>`,[])}
                     ></vaadin-grid-column>
-                `:v}
+                `:_}
 
-                ${this.field?.useButtonForDetail?T`
+                ${this.field?.useButtonForDetail?w`
                     <vaadin-grid-column
                             width="44px"
                             flex-grow="0"
-                            ${t((e,{detailsOpened:t})=>T`
+                            ${t((e,{detailsOpened:t})=>w`
               <vaadin-button
                 theme="tertiary icon"
                 title="${t?`Collapse`:`Expand`}"
@@ -8939,16 +8939,16 @@ ${i}
               </vaadin-button>
             `,[])}
                     ></vaadin-grid-column>
-                `:v}
+                `:_}
 
             </vaadin-grid>
-            ${this.field?.readOnly?v:this.field?.inlineEditing?T`
+            ${this.field?.readOnly?_:this.field?.inlineEditing?w`
                     <vaadin-horizontal-layout theme="spacing">
                         <!-- Inline mode: rows are removed with the per-row trash button, so the
                              toolbar only needs the "add" action. -->
                         <vaadin-button theme="tertiary icon" title="Add row" @click="${()=>this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.id+`_add`},bubbles:!0,composed:!0}))}"><vaadin-icon icon="vaadin:plus"></vaadin-icon></vaadin-button>
                     </vaadin-horizontal-layout>
-                `:T`
+                `:w`
                     <vaadin-horizontal-layout theme="spacing">
                         <vaadin-button theme="tertiary icon" @click="${()=>this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.id+`_add`},bubbles:!0,composed:!0}))}"><vaadin-icon icon="vaadin:plus"></vaadin-icon></vaadin-button>
                         <vaadin-button theme="tertiary icon error" @click="${()=>this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.id+`_remove`},bubbles:!0,composed:!0}))}"><vaadin-icon icon="vaadin:minus"></vaadin-icon></vaadin-button>
@@ -8956,8 +8956,8 @@ ${i}
                         <vaadin-button theme="tertiary icon" title="Move down" @click="${()=>this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.id+`_move-down`},bubbles:!0,composed:!0}))}"><vaadin-icon icon="vaadin:arrow-down"></vaadin-icon></vaadin-button>
                     </vaadin-horizontal-layout>
                 `}
-        </vaadin-vertical-layout>`}static{this.styles=h`
-        ${de}
+        </vaadin-vertical-layout>`}static{this.styles=m`
+        ${fe}
 
         /* Clickable grids (a row-selection action is wired) give visual feedback: the host sets a
            pointer cursor (inline, inherited by the slotted cell content), and the cells of the
@@ -8966,17 +8966,17 @@ ${i}
             background-color: var(--lumo-primary-color-10pct);
             cursor: pointer;
         }
-    `}};k([y()],Yc.prototype,`field`,void 0),k([y()],Yc.prototype,`state`,void 0),k([y()],Yc.prototype,`data`,void 0),k([y()],Yc.prototype,`appState`,void 0),k([y()],Yc.prototype,`appData`,void 0),k([y()],Yc.prototype,`selectedItems`,void 0),k([C()],Yc.prototype,`detailsOpenedItems`,void 0),Yc=k([g(`mateu-grid`)],Yc);var Xc=class extends b{constructor(...e){super(...e),this.getNewValue=e=>{if(this.field?.dataType==`array`){if(!this.value)return[e];let t=this.value;return t.indexOf(e)>=0?t.filter(t=>t!==e):[...t,e]}return e}}render(){let e=this.field?.options;if(this.field?.remoteCoordinates){let t=this.field.remoteCoordinates;this.data?.[this.field.fieldId]&&this.data[this.field.fieldId].content&&this.data[this.field.fieldId].totalElements?e=this.data[this.field.fieldId].content:this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}return T`
+    `}};O([v()],ml.prototype,`field`,void 0),O([v()],ml.prototype,`state`,void 0),O([v()],ml.prototype,`data`,void 0),O([v()],ml.prototype,`appState`,void 0),O([v()],ml.prototype,`appData`,void 0),O([v()],ml.prototype,`selectedItems`,void 0),O([S()],ml.prototype,`detailsOpenedItems`,void 0),ml=O([h(`mateu-grid`)],ml);var hl=class extends y{constructor(...e){super(...e),this.getNewValue=e=>{if(this.field?.dataType==`array`){if(!this.value)return[e];let t=this.value;return t.indexOf(e)>=0?t.filter(t=>t!==e):[...t,e]}return e}}render(){let e=this.field?.options;if(this.field?.remoteCoordinates){let t=this.field.remoteCoordinates;this.data?.[this.field.fieldId]&&this.data[this.field.fieldId].content&&this.data[this.field.fieldId].totalElements?e=this.data[this.field.fieldId].content:this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}return w`
         <div style="display: flex; gap: 1rem; padding: 1rem; flex-wrap: wrap; ${this.field?.attributes?.divStyle}">
-                                    ${e?.map(e=>T`
+                                    ${e?.map(e=>w`
                             <div role="button" tabindex="0" 
                                     class="choice ${this.value==e.value||Array.isArray(this.value)&&this.value.includes(e.value)?`selected`:``}"
-                                    @click="${()=>this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.getNewValue(e.value),fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}" @keydown="${R(()=>this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.getNewValue(e.value),fieldId:this.field?.fieldId},bubbles:!0,composed:!0})))}"
-                            >${e.description||e.image?T`
+                                    @click="${()=>this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.getNewValue(e.value),fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}" @keydown="${L(()=>this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.getNewValue(e.value),fieldId:this.field?.fieldId},bubbles:!0,composed:!0})))}"
+                            >${e.description||e.image?w`
                                 <div style="display: flex; align-items: center; gap: var(--lumo-space-m, 1rem);">
-                                    ${e.image?T`
+                                    ${e.image?w`
                                             <img src="${e.image}" alt="${e.label}" style="${e.imageStyle??`width: 2rem;`}" />
-                                        `:v}
+                                        `:_}
                                     <div style="display: flex; flex-direction: column;">
                                         <span> ${e.label} </span>
                                         <span
@@ -8990,7 +8990,7 @@ ${i}
                         `)}
                                 </div>
 
-       `}static{this.styles=h`
+       `}static{this.styles=m`
         .choice {
             min-width: 10rem;
             min-height: 5rem;
@@ -9013,8 +9013,8 @@ ${i}
             border: 1px solid var(--lumo-shade-20pct);
         }
   
-        ${z}
-    `}};k([y()],Xc.prototype,`field`,void 0),k([y()],Xc.prototype,`baseUrl`,void 0),k([y()],Xc.prototype,`state`,void 0),k([y()],Xc.prototype,`data`,void 0),k([y()],Xc.prototype,`value`,void 0),Xc=k([g(`mateu-choice`)],Xc);var Zc=class extends b{constructor(...e){super(...e),this.currencyChanged=e=>{this.value||={value:0,currency:`EUR`,locale:`es-ES`},this.value.currency=e.detail.value,this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:{...this.value},fieldId:this.fieldId}}))},this.valueChanged=e=>{this.value||={value:0,currency:`EUR`,locale:`es-ES`},e.detail.value&&(this.value.value=e.detail.value?parseFloat(e.detail.value):0,this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:{...this.value},fieldId:this.fieldId}})))}}render(){return T`
+        ${R}
+    `}};O([v()],hl.prototype,`field`,void 0),O([v()],hl.prototype,`baseUrl`,void 0),O([v()],hl.prototype,`state`,void 0),O([v()],hl.prototype,`data`,void 0),O([v()],hl.prototype,`value`,void 0),hl=O([h(`mateu-choice`)],hl);var gl=class extends y{constructor(...e){super(...e),this.currencyChanged=e=>{this.value||={value:0,currency:`EUR`,locale:`es-ES`},this.value.currency=e.detail.value,this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:{...this.value},fieldId:this.fieldId}}))},this.valueChanged=e=>{this.value||={value:0,currency:`EUR`,locale:`es-ES`},e.detail.value&&(this.value.value=e.detail.value?parseFloat(e.detail.value):0,this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:{...this.value},fieldId:this.fieldId}})))}}render(){return w`
             <vaadin-number-field
                     id="${this.fieldId}"
                     label="${this.label}"
@@ -9022,7 +9022,7 @@ ${i}
                     .value="${this.value?.value}"
                     .helperText="${this.helperText}"
                     ?autofocus="${this.autofocus}"
-                    ?required="${this.required||v}"
+                    ?required="${this.required||_}"
                     theme="align-right"
             ><div slot="prefix"><vaadin-select
                     item-label-path="label"
@@ -9033,11 +9033,11 @@ ${i}
                     style="max-width: 100px;"
                     theme="small"
             ></vaadin-select></div></vaadin-number-field>
-       `}static{this.styles=h`
-  `}};k([y()],Zc.prototype,`fieldId`,void 0),k([y()],Zc.prototype,`label`,void 0),k([y()],Zc.prototype,`state`,void 0),k([y()],Zc.prototype,`data`,void 0),k([y()],Zc.prototype,`value`,void 0),k([y()],Zc.prototype,`autoFocus`,void 0),k([y()],Zc.prototype,`required`,void 0),k([y()],Zc.prototype,`colspan`,void 0),k([y()],Zc.prototype,`helperText`,void 0),Zc=k([g(`mateu-money-field`)],Zc);var Qc=`vaadin:abacus.vaadin:absolute-position.vaadin:academy-cap.vaadin:accessibility.vaadin:accordion-menu.vaadin:add-dock.vaadin:adjust.vaadin:adobe-flash.vaadin:airplane.vaadin:alarm.vaadin:align-center.vaadin:align-justify.vaadin:align-left.vaadin:align-right.vaadin:alt-a.vaadin:alt.vaadin:ambulance.vaadin:anchor.vaadin:angle-double-down.vaadin:angle-double-left.vaadin:angle-double-right.vaadin:angle-double-up.vaadin:angle-down.vaadin:angle-left.vaadin:angle-right.vaadin:angle-up.vaadin:archive.vaadin:archives.vaadin:area-select.vaadin:arrow-backward.vaadin:arrow-circle-down-o.vaadin:arrow-circle-down.vaadin:arrow-circle-left-o.vaadin:arrow-circle-left.vaadin:arrow-circle-right-o.vaadin:arrow-circle-right.vaadin:arrow-circle-up-o.vaadin:arrow-circle-up.vaadin:arrow-down.vaadin:arrow-forward.vaadin:arrow-left.vaadin:arrow-long-down.vaadin:arrow-long-left.vaadin:arrow-right.vaadin:arrow-up.vaadin:arrows-cross.vaadin:arrows-long-h.vaadin:arrows-long-right.vaadin:arrows-long-up.vaadin:arrows-long-v.vaadin:arrows.vaadin:asterisk.vaadin:at.vaadin:automation.vaadin:backspace-a.vaadin:backspace.vaadin:backwards.vaadin:ban.vaadin:bar-chart-h.vaadin:bar-chart-v.vaadin:bar-chart.vaadin:barcode.vaadin:bed.vaadin:bell-o.vaadin:bell-slash-o.vaadin:bell-slash.vaadin:bell.vaadin:boat.vaadin:bold.vaadin:bolt.vaadin:bomb.vaadin:book-dollar.vaadin:book-percent.vaadin:book.vaadin:bookmark-o.vaadin:bookmark.vaadin:briefcase.vaadin:browser.vaadin:bug-o.vaadin:bug.vaadin:building-o.vaadin:building.vaadin:bullets.vaadin:bullseye.vaadin:bus.vaadin:buss.vaadin:button.vaadin:calc-book.vaadin:calc.vaadin:calendar-briefcase.vaadin:calendar-clock.vaadin:calendar-envelope.vaadin:calendar-o.vaadin:calendar-user.vaadin:calendar.vaadin:camera.vaadin:car.vaadin:caret-down.vaadin:caret-left.vaadin:caret-right.vaadin:caret-square-down-o.vaadin:caret-square-left-o.vaadin:caret-square-right-o.vaadin:caret-square-up-o.vaadin:caret-up.vaadin:cart-o.vaadin:cart.vaadin:cash.vaadin:chart-3d.vaadin:chart-grid.vaadin:chart-line.vaadin:chart-timeline.vaadin:chart.vaadin:chat.vaadin:check-circle-o.vaadin:check-circle.vaadin:check-square-o.vaadin:check-square.vaadin:check.vaadin:chevron-circle-down-o.vaadin:chevron-circle-down.vaadin:chevron-circle-left-o.vaadin:chevron-circle-left.vaadin:chevron-circle-right-o.vaadin:chevron-circle-right.vaadin:chevron-circle-up-o.vaadin:chevron-circle-up.vaadin:chevron-down-small.vaadin:chevron-down.vaadin:chevron-left-small.vaadin:chevron-left.vaadin:chevron-right-small.vaadin:chevron-right.vaadin:chevron-up-small.vaadin:chevron-up.vaadin:child.vaadin:circle-thin.vaadin:circle.vaadin:clipboard-check.vaadin:clipboard-cross.vaadin:clipboard-heart.vaadin:clipboard-pulse.vaadin:clipboard-text.vaadin:clipboard-user.vaadin:clipboard.vaadin:clock.vaadin:close-big.vaadin:close-circle-o.vaadin:close-circle.vaadin:close-small.vaadin:close.vaadin:cloud-download-o.vaadin:cloud-download.vaadin:cloud-o.vaadin:cloud-upload-o.vaadin:cloud-upload.vaadin:cloud.vaadin:cluster.vaadin:code.vaadin:coffee.vaadin:cog-o.vaadin:cog.vaadin:cogs.vaadin:coin-piles.vaadin:coins.vaadin:combobox.vaadin:comment-ellipsis-o.vaadin:comment-ellipsis.vaadin:comment-o.vaadin:comment.vaadin:comments-o.vaadin:comments.vaadin:compile.vaadin:compress-square.vaadin:compress.vaadin:connect-o.vaadin:connect.vaadin:controller.vaadin:copy-o.vaadin:copy.vaadin:copyright.vaadin:corner-lower-left.vaadin:corner-lower-right.vaadin:corner-upper-left.vaadin:corner-upper-right.vaadin:credit-card.vaadin:crop.vaadin:cross-cutlery.vaadin:crosshairs.vaadin:css.vaadin:ctrl-a.vaadin:ctrl.vaadin:cube.vaadin:cubes.vaadin:curly-brackets.vaadin:cursor-o.vaadin:cursor.vaadin:cutlery.vaadin:dashboard.vaadin:database.vaadin:date-input.vaadin:deindent.vaadin:del-a.vaadin:del.vaadin:dental-chair.vaadin:desktop.vaadin:diamond-o.vaadin:diamond.vaadin:diploma-scroll.vaadin:diploma.vaadin:disc.vaadin:doctor-briefcase.vaadin:doctor.vaadin:dollar.vaadin:dot-circle.vaadin:download-alt.vaadin:download.vaadin:drop.vaadin:edit.vaadin:eject.vaadin:elastic.vaadin:ellipsis-circle-o.vaadin:ellipsis-circle.vaadin:ellipsis-dots-h.vaadin:ellipsis-dots-v.vaadin:ellipsis-h.vaadin:ellipsis-v.vaadin:enter-arrow.vaadin:enter.vaadin:envelope-o.vaadin:envelope-open-o.vaadin:envelope-open.vaadin:envelope.vaadin:envelopes-o.vaadin:envelopes.vaadin:eraser.vaadin:esc-a.vaadin:esc.vaadin:euro.vaadin:exchange.vaadin:exclamation-circle-o.vaadin:exclamation-circle.vaadin:exclamation.vaadin:exit-o.vaadin:exit.vaadin:expand-full.vaadin:expand-square.vaadin:expand.vaadin:external-browser.vaadin:external-link.vaadin:eye-slash.vaadin:eye.vaadin:eyedropper.vaadin:facebook-square.vaadin:facebook.vaadin:factory.vaadin:family.vaadin:fast-backward.vaadin:fast-forward.vaadin:female.vaadin:file-add.vaadin:file-code.vaadin:file-font.vaadin:file-movie.vaadin:file-o.vaadin:file-picture.vaadin:file-presentation.vaadin:file-process.vaadin:file-refresh.vaadin:file-remove.vaadin:file-search.vaadin:file-sound.vaadin:file-start.vaadin:file-table.vaadin:file-text-o.vaadin:file-text.vaadin:file-tree-small.vaadin:file-tree-sub.vaadin:file-tree.vaadin:file-zip.vaadin:file.vaadin:fill.vaadin:film.vaadin:filter.vaadin:fire.vaadin:flag-checkered.vaadin:flag-o.vaadin:flag.vaadin:flash.vaadin:flask.vaadin:flight-landing.vaadin:flight-takeoff.vaadin:flip-h.vaadin:flip-v.vaadin:folder-add.vaadin:folder-o.vaadin:folder-open-o.vaadin:folder-open.vaadin:folder-remove.vaadin:folder-search.vaadin:folder.vaadin:font.vaadin:form.vaadin:forward.vaadin:frown-o.vaadin:funcion.vaadin:function.vaadin:funnel.vaadin:gamepad.vaadin:gavel.vaadin:gift.vaadin:glass.vaadin:glasses.vaadin:globe-wire.vaadin:globe.vaadin:golf.vaadin:google-plus-square.vaadin:google-plus.vaadin:grab.vaadin:grid-bevel.vaadin:grid-big-o.vaadin:grid-big.vaadin:grid-h.vaadin:grid-small-o.vaadin:grid-small.vaadin:grid-v.vaadin:grid.vaadin:group.vaadin:hammer.vaadin:hand.vaadin:handle-corner.vaadin:hands-up.vaadin:handshake.vaadin:harddrive-o.vaadin:harddrive.vaadin:hash.vaadin:header.vaadin:headphones.vaadin:headset.vaadin:health-card.vaadin:heart-o.vaadin:heart.vaadin:home-o.vaadin:home.vaadin:hospital.vaadin:hourglass-empty.vaadin:hourglass-end.vaadin:hourglass-start.vaadin:hourglass.vaadin:inbox.vaadin:indent.vaadin:info-circle-o.vaadin:info-circle.vaadin:info.vaadin:input.vaadin:insert.vaadin:institution.vaadin:invoice.vaadin:italic.vaadin:key-o.vaadin:key.vaadin:keyboard-o.vaadin:keyboard.vaadin:laptop.vaadin:layout.vaadin:level-down-bold.vaadin:level-down.vaadin:level-left-bold.vaadin:level-left.vaadin:level-right-bold.vaadin:level-right.vaadin:level-up-bold.vaadin:level-up.vaadin:lifebuoy.vaadin:lightbulb.vaadin:line-bar-chart.vaadin:line-chart.vaadin:line-h.vaadin:line-v.vaadin:lines-list.vaadin:lines.vaadin:link.vaadin:list-ol.vaadin:list-select.vaadin:list-ul.vaadin:list.vaadin:location-arrow-circle-o.vaadin:location-arrow-circle.vaadin:location-arrow.vaadin:lock.vaadin:magic.vaadin:magnet.vaadin:mailbox.vaadin:male.vaadin:map-marker.vaadin:margin-bottom.vaadin:margin-left.vaadin:margin-right.vaadin:margin-top.vaadin:margin.vaadin:medal.vaadin:megafone.vaadin:megaphone.vaadin:meh-o.vaadin:menu.vaadin:microphone.vaadin:minus-circle-o.vaadin:minus-circle.vaadin:minus-square-o.vaadin:minus.vaadin:mobile-browser.vaadin:mobile-retro.vaadin:mobile.vaadin:modal-list.vaadin:modal.vaadin:money-deposit.vaadin:money-exchange.vaadin:money-withdraw.vaadin:money.vaadin:moon-o.vaadin:moon.vaadin:morning.vaadin:movie.vaadin:music.vaadin:mute.vaadin:native-button.vaadin:newspaper.vaadin:notebook.vaadin:nurse.vaadin:office.vaadin:open-book.vaadin:option-a.vaadin:option.vaadin:options.vaadin:orientation.vaadin:out.vaadin:outbox.vaadin:package.vaadin:padding-bottom.vaadin:padding-left.vaadin:padding-right.vaadin:padding-top.vaadin:padding.vaadin:paint-roll.vaadin:paintbrush.vaadin:palete.vaadin:palette.vaadin:panel.vaadin:paperclip.vaadin:paperplane-o.vaadin:paperplane.vaadin:paragraph.vaadin:password.vaadin:paste.vaadin:pause.vaadin:pencil.vaadin:phone-landline.vaadin:phone.vaadin:picture.vaadin:pie-bar-chart.vaadin:pie-chart.vaadin:piggy-bank-coin.vaadin:piggy-bank.vaadin:pill.vaadin:pills.vaadin:pin-post.vaadin:pin.vaadin:play-circle-o.vaadin:play-circle.vaadin:play.vaadin:plug.vaadin:plus-circle-o.vaadin:plus-circle.vaadin:plus-minus.vaadin:plus-square-o.vaadin:plus.vaadin:pointer.vaadin:power-off.vaadin:presentation.vaadin:print.vaadin:progressbar.vaadin:puzzle-piece.vaadin:pyramid-chart.vaadin:qrcode.vaadin:question-circle-o.vaadin:question-circle.vaadin:question.vaadin:quote-left.vaadin:quote-right.vaadin:random.vaadin:raster-lower-left.vaadin:raster.vaadin:records.vaadin:recycle.vaadin:refresh.vaadin:reply-all.vaadin:reply.vaadin:resize-h.vaadin:resize-v.vaadin:retweet.vaadin:rhombus.vaadin:road-branch.vaadin:road-branches.vaadin:road-split.vaadin:road.vaadin:rocket.vaadin:rotate-left.vaadin:rotate-right.vaadin:rss-square.vaadin:rss.vaadin:safe-lock.vaadin:safe.vaadin:scale-unbalance.vaadin:scale.vaadin:scatter-chart.vaadin:scissors.vaadin:screwdriver.vaadin:search-minus.vaadin:search-plus.vaadin:search.vaadin:select.vaadin:server.vaadin:share-square.vaadin:share.vaadin:shield.vaadin:shift-arrow.vaadin:shift.vaadin:shop.vaadin:sign-in-alt.vaadin:sign-in.vaadin:sign-out-alt.vaadin:sign-out.vaadin:signal.vaadin:sitemap.vaadin:slider.vaadin:sliders.vaadin:smiley-o.vaadin:sort.vaadin:sound-disable.vaadin:spark-line.vaadin:specialist.vaadin:spinner-arc.vaadin:spinner-third.vaadin:spinner.vaadin:spline-area-chart.vaadin:spline-chart.vaadin:split-h.vaadin:split-v.vaadin:split.vaadin:spoon.vaadin:square-shadow.vaadin:star-half-left-o.vaadin:star-half-left.vaadin:star-half-right-o.vaadin:star-half-right.vaadin:star-o.vaadin:star.vaadin:start-cog.vaadin:step-backward.vaadin:step-forward.vaadin:stethoscope.vaadin:stock.vaadin:stop-cog.vaadin:stop.vaadin:stopwatch.vaadin:storage.vaadin:strikethrough.vaadin:subscript.vaadin:suitcase.vaadin:sun-down.vaadin:sun-o.vaadin:sun-rise.vaadin:superscript.vaadin:sword.vaadin:tab-a.vaadin:tab.vaadin:table.vaadin:tablet.vaadin:tabs.vaadin:tag.vaadin:tags.vaadin:tasks.vaadin:taxi.vaadin:teeth.vaadin:terminal.vaadin:text-height.vaadin:text-input.vaadin:text-label.vaadin:text-width.vaadin:thin-square.vaadin:thumbs-down-o.vaadin:thumbs-down.vaadin:thumbs-up-o.vaadin:thumbs-up.vaadin:ticket.vaadin:time-backward.vaadin:time-forward.vaadin:timer.vaadin:toolbox.vaadin:tools.vaadin:tooth.vaadin:touch.vaadin:train.vaadin:trash.vaadin:tree-table.vaadin:trendind-down.vaadin:trending-down.vaadin:trending-up.vaadin:trophy.vaadin:truck.vaadin:twin-col-select.vaadin:twitter-square.vaadin:twitter.vaadin:umbrella.vaadin:underline.vaadin:unlink.vaadin:unlock.vaadin:upload-alt.vaadin:upload.vaadin:user-card.vaadin:user-check.vaadin:user-clock.vaadin:user-heart.vaadin:user-star.vaadin:user.vaadin:users.vaadin:vaadin-h.vaadin:vaadin-v.vaadin:viewport.vaadin:vimeo-square.vaadin:vimeo.vaadin:volume-down.vaadin:volume-off.vaadin:volume-up.vaadin:volume.vaadin:wallet.vaadin:warning.vaadin:workplace.vaadin:wrench.vaadin:youtube-square.vaadin:youtube`.split(`.`),$c=null,el=()=>($c||=Promise.all([D(()=>import(`./vendor-ui5.js`).then(e=>e.n),__vite__mapDeps([5,1])),D(()=>import(`./vendor-ui5.js`).then(e=>e.t),__vite__mapDeps([5,1]))]),$c),Q=class extends b{constructor(...e){super(...e),this.ui5FieldComponentsReady=!1,this.component=void 0,this.field=void 0,this.baseUrl=void 0,this.state={},this.data={},this.appState={},this.appData={},this.colorPickerOpened=!1,this.colorPickerValue=void 0,this.comboData=[],this._comboFilter=``,this.rendered=!1,this.renderColorPicker=()=>{this.loadUi5FieldComponents();let e=this.field?.fieldId;return T`
+       `}static{this.styles=m`
+  `}};O([v()],gl.prototype,`fieldId`,void 0),O([v()],gl.prototype,`label`,void 0),O([v()],gl.prototype,`state`,void 0),O([v()],gl.prototype,`data`,void 0),O([v()],gl.prototype,`value`,void 0),O([v()],gl.prototype,`autoFocus`,void 0),O([v()],gl.prototype,`required`,void 0),O([v()],gl.prototype,`colspan`,void 0),O([v()],gl.prototype,`helperText`,void 0),gl=O([h(`mateu-money-field`)],gl);var _l=`vaadin:abacus.vaadin:absolute-position.vaadin:academy-cap.vaadin:accessibility.vaadin:accordion-menu.vaadin:add-dock.vaadin:adjust.vaadin:adobe-flash.vaadin:airplane.vaadin:alarm.vaadin:align-center.vaadin:align-justify.vaadin:align-left.vaadin:align-right.vaadin:alt-a.vaadin:alt.vaadin:ambulance.vaadin:anchor.vaadin:angle-double-down.vaadin:angle-double-left.vaadin:angle-double-right.vaadin:angle-double-up.vaadin:angle-down.vaadin:angle-left.vaadin:angle-right.vaadin:angle-up.vaadin:archive.vaadin:archives.vaadin:area-select.vaadin:arrow-backward.vaadin:arrow-circle-down-o.vaadin:arrow-circle-down.vaadin:arrow-circle-left-o.vaadin:arrow-circle-left.vaadin:arrow-circle-right-o.vaadin:arrow-circle-right.vaadin:arrow-circle-up-o.vaadin:arrow-circle-up.vaadin:arrow-down.vaadin:arrow-forward.vaadin:arrow-left.vaadin:arrow-long-down.vaadin:arrow-long-left.vaadin:arrow-right.vaadin:arrow-up.vaadin:arrows-cross.vaadin:arrows-long-h.vaadin:arrows-long-right.vaadin:arrows-long-up.vaadin:arrows-long-v.vaadin:arrows.vaadin:asterisk.vaadin:at.vaadin:automation.vaadin:backspace-a.vaadin:backspace.vaadin:backwards.vaadin:ban.vaadin:bar-chart-h.vaadin:bar-chart-v.vaadin:bar-chart.vaadin:barcode.vaadin:bed.vaadin:bell-o.vaadin:bell-slash-o.vaadin:bell-slash.vaadin:bell.vaadin:boat.vaadin:bold.vaadin:bolt.vaadin:bomb.vaadin:book-dollar.vaadin:book-percent.vaadin:book.vaadin:bookmark-o.vaadin:bookmark.vaadin:briefcase.vaadin:browser.vaadin:bug-o.vaadin:bug.vaadin:building-o.vaadin:building.vaadin:bullets.vaadin:bullseye.vaadin:bus.vaadin:buss.vaadin:button.vaadin:calc-book.vaadin:calc.vaadin:calendar-briefcase.vaadin:calendar-clock.vaadin:calendar-envelope.vaadin:calendar-o.vaadin:calendar-user.vaadin:calendar.vaadin:camera.vaadin:car.vaadin:caret-down.vaadin:caret-left.vaadin:caret-right.vaadin:caret-square-down-o.vaadin:caret-square-left-o.vaadin:caret-square-right-o.vaadin:caret-square-up-o.vaadin:caret-up.vaadin:cart-o.vaadin:cart.vaadin:cash.vaadin:chart-3d.vaadin:chart-grid.vaadin:chart-line.vaadin:chart-timeline.vaadin:chart.vaadin:chat.vaadin:check-circle-o.vaadin:check-circle.vaadin:check-square-o.vaadin:check-square.vaadin:check.vaadin:chevron-circle-down-o.vaadin:chevron-circle-down.vaadin:chevron-circle-left-o.vaadin:chevron-circle-left.vaadin:chevron-circle-right-o.vaadin:chevron-circle-right.vaadin:chevron-circle-up-o.vaadin:chevron-circle-up.vaadin:chevron-down-small.vaadin:chevron-down.vaadin:chevron-left-small.vaadin:chevron-left.vaadin:chevron-right-small.vaadin:chevron-right.vaadin:chevron-up-small.vaadin:chevron-up.vaadin:child.vaadin:circle-thin.vaadin:circle.vaadin:clipboard-check.vaadin:clipboard-cross.vaadin:clipboard-heart.vaadin:clipboard-pulse.vaadin:clipboard-text.vaadin:clipboard-user.vaadin:clipboard.vaadin:clock.vaadin:close-big.vaadin:close-circle-o.vaadin:close-circle.vaadin:close-small.vaadin:close.vaadin:cloud-download-o.vaadin:cloud-download.vaadin:cloud-o.vaadin:cloud-upload-o.vaadin:cloud-upload.vaadin:cloud.vaadin:cluster.vaadin:code.vaadin:coffee.vaadin:cog-o.vaadin:cog.vaadin:cogs.vaadin:coin-piles.vaadin:coins.vaadin:combobox.vaadin:comment-ellipsis-o.vaadin:comment-ellipsis.vaadin:comment-o.vaadin:comment.vaadin:comments-o.vaadin:comments.vaadin:compile.vaadin:compress-square.vaadin:compress.vaadin:connect-o.vaadin:connect.vaadin:controller.vaadin:copy-o.vaadin:copy.vaadin:copyright.vaadin:corner-lower-left.vaadin:corner-lower-right.vaadin:corner-upper-left.vaadin:corner-upper-right.vaadin:credit-card.vaadin:crop.vaadin:cross-cutlery.vaadin:crosshairs.vaadin:css.vaadin:ctrl-a.vaadin:ctrl.vaadin:cube.vaadin:cubes.vaadin:curly-brackets.vaadin:cursor-o.vaadin:cursor.vaadin:cutlery.vaadin:dashboard.vaadin:database.vaadin:date-input.vaadin:deindent.vaadin:del-a.vaadin:del.vaadin:dental-chair.vaadin:desktop.vaadin:diamond-o.vaadin:diamond.vaadin:diploma-scroll.vaadin:diploma.vaadin:disc.vaadin:doctor-briefcase.vaadin:doctor.vaadin:dollar.vaadin:dot-circle.vaadin:download-alt.vaadin:download.vaadin:drop.vaadin:edit.vaadin:eject.vaadin:elastic.vaadin:ellipsis-circle-o.vaadin:ellipsis-circle.vaadin:ellipsis-dots-h.vaadin:ellipsis-dots-v.vaadin:ellipsis-h.vaadin:ellipsis-v.vaadin:enter-arrow.vaadin:enter.vaadin:envelope-o.vaadin:envelope-open-o.vaadin:envelope-open.vaadin:envelope.vaadin:envelopes-o.vaadin:envelopes.vaadin:eraser.vaadin:esc-a.vaadin:esc.vaadin:euro.vaadin:exchange.vaadin:exclamation-circle-o.vaadin:exclamation-circle.vaadin:exclamation.vaadin:exit-o.vaadin:exit.vaadin:expand-full.vaadin:expand-square.vaadin:expand.vaadin:external-browser.vaadin:external-link.vaadin:eye-slash.vaadin:eye.vaadin:eyedropper.vaadin:facebook-square.vaadin:facebook.vaadin:factory.vaadin:family.vaadin:fast-backward.vaadin:fast-forward.vaadin:female.vaadin:file-add.vaadin:file-code.vaadin:file-font.vaadin:file-movie.vaadin:file-o.vaadin:file-picture.vaadin:file-presentation.vaadin:file-process.vaadin:file-refresh.vaadin:file-remove.vaadin:file-search.vaadin:file-sound.vaadin:file-start.vaadin:file-table.vaadin:file-text-o.vaadin:file-text.vaadin:file-tree-small.vaadin:file-tree-sub.vaadin:file-tree.vaadin:file-zip.vaadin:file.vaadin:fill.vaadin:film.vaadin:filter.vaadin:fire.vaadin:flag-checkered.vaadin:flag-o.vaadin:flag.vaadin:flash.vaadin:flask.vaadin:flight-landing.vaadin:flight-takeoff.vaadin:flip-h.vaadin:flip-v.vaadin:folder-add.vaadin:folder-o.vaadin:folder-open-o.vaadin:folder-open.vaadin:folder-remove.vaadin:folder-search.vaadin:folder.vaadin:font.vaadin:form.vaadin:forward.vaadin:frown-o.vaadin:funcion.vaadin:function.vaadin:funnel.vaadin:gamepad.vaadin:gavel.vaadin:gift.vaadin:glass.vaadin:glasses.vaadin:globe-wire.vaadin:globe.vaadin:golf.vaadin:google-plus-square.vaadin:google-plus.vaadin:grab.vaadin:grid-bevel.vaadin:grid-big-o.vaadin:grid-big.vaadin:grid-h.vaadin:grid-small-o.vaadin:grid-small.vaadin:grid-v.vaadin:grid.vaadin:group.vaadin:hammer.vaadin:hand.vaadin:handle-corner.vaadin:hands-up.vaadin:handshake.vaadin:harddrive-o.vaadin:harddrive.vaadin:hash.vaadin:header.vaadin:headphones.vaadin:headset.vaadin:health-card.vaadin:heart-o.vaadin:heart.vaadin:home-o.vaadin:home.vaadin:hospital.vaadin:hourglass-empty.vaadin:hourglass-end.vaadin:hourglass-start.vaadin:hourglass.vaadin:inbox.vaadin:indent.vaadin:info-circle-o.vaadin:info-circle.vaadin:info.vaadin:input.vaadin:insert.vaadin:institution.vaadin:invoice.vaadin:italic.vaadin:key-o.vaadin:key.vaadin:keyboard-o.vaadin:keyboard.vaadin:laptop.vaadin:layout.vaadin:level-down-bold.vaadin:level-down.vaadin:level-left-bold.vaadin:level-left.vaadin:level-right-bold.vaadin:level-right.vaadin:level-up-bold.vaadin:level-up.vaadin:lifebuoy.vaadin:lightbulb.vaadin:line-bar-chart.vaadin:line-chart.vaadin:line-h.vaadin:line-v.vaadin:lines-list.vaadin:lines.vaadin:link.vaadin:list-ol.vaadin:list-select.vaadin:list-ul.vaadin:list.vaadin:location-arrow-circle-o.vaadin:location-arrow-circle.vaadin:location-arrow.vaadin:lock.vaadin:magic.vaadin:magnet.vaadin:mailbox.vaadin:male.vaadin:map-marker.vaadin:margin-bottom.vaadin:margin-left.vaadin:margin-right.vaadin:margin-top.vaadin:margin.vaadin:medal.vaadin:megafone.vaadin:megaphone.vaadin:meh-o.vaadin:menu.vaadin:microphone.vaadin:minus-circle-o.vaadin:minus-circle.vaadin:minus-square-o.vaadin:minus.vaadin:mobile-browser.vaadin:mobile-retro.vaadin:mobile.vaadin:modal-list.vaadin:modal.vaadin:money-deposit.vaadin:money-exchange.vaadin:money-withdraw.vaadin:money.vaadin:moon-o.vaadin:moon.vaadin:morning.vaadin:movie.vaadin:music.vaadin:mute.vaadin:native-button.vaadin:newspaper.vaadin:notebook.vaadin:nurse.vaadin:office.vaadin:open-book.vaadin:option-a.vaadin:option.vaadin:options.vaadin:orientation.vaadin:out.vaadin:outbox.vaadin:package.vaadin:padding-bottom.vaadin:padding-left.vaadin:padding-right.vaadin:padding-top.vaadin:padding.vaadin:paint-roll.vaadin:paintbrush.vaadin:palete.vaadin:palette.vaadin:panel.vaadin:paperclip.vaadin:paperplane-o.vaadin:paperplane.vaadin:paragraph.vaadin:password.vaadin:paste.vaadin:pause.vaadin:pencil.vaadin:phone-landline.vaadin:phone.vaadin:picture.vaadin:pie-bar-chart.vaadin:pie-chart.vaadin:piggy-bank-coin.vaadin:piggy-bank.vaadin:pill.vaadin:pills.vaadin:pin-post.vaadin:pin.vaadin:play-circle-o.vaadin:play-circle.vaadin:play.vaadin:plug.vaadin:plus-circle-o.vaadin:plus-circle.vaadin:plus-minus.vaadin:plus-square-o.vaadin:plus.vaadin:pointer.vaadin:power-off.vaadin:presentation.vaadin:print.vaadin:progressbar.vaadin:puzzle-piece.vaadin:pyramid-chart.vaadin:qrcode.vaadin:question-circle-o.vaadin:question-circle.vaadin:question.vaadin:quote-left.vaadin:quote-right.vaadin:random.vaadin:raster-lower-left.vaadin:raster.vaadin:records.vaadin:recycle.vaadin:refresh.vaadin:reply-all.vaadin:reply.vaadin:resize-h.vaadin:resize-v.vaadin:retweet.vaadin:rhombus.vaadin:road-branch.vaadin:road-branches.vaadin:road-split.vaadin:road.vaadin:rocket.vaadin:rotate-left.vaadin:rotate-right.vaadin:rss-square.vaadin:rss.vaadin:safe-lock.vaadin:safe.vaadin:scale-unbalance.vaadin:scale.vaadin:scatter-chart.vaadin:scissors.vaadin:screwdriver.vaadin:search-minus.vaadin:search-plus.vaadin:search.vaadin:select.vaadin:server.vaadin:share-square.vaadin:share.vaadin:shield.vaadin:shift-arrow.vaadin:shift.vaadin:shop.vaadin:sign-in-alt.vaadin:sign-in.vaadin:sign-out-alt.vaadin:sign-out.vaadin:signal.vaadin:sitemap.vaadin:slider.vaadin:sliders.vaadin:smiley-o.vaadin:sort.vaadin:sound-disable.vaadin:spark-line.vaadin:specialist.vaadin:spinner-arc.vaadin:spinner-third.vaadin:spinner.vaadin:spline-area-chart.vaadin:spline-chart.vaadin:split-h.vaadin:split-v.vaadin:split.vaadin:spoon.vaadin:square-shadow.vaadin:star-half-left-o.vaadin:star-half-left.vaadin:star-half-right-o.vaadin:star-half-right.vaadin:star-o.vaadin:star.vaadin:start-cog.vaadin:step-backward.vaadin:step-forward.vaadin:stethoscope.vaadin:stock.vaadin:stop-cog.vaadin:stop.vaadin:stopwatch.vaadin:storage.vaadin:strikethrough.vaadin:subscript.vaadin:suitcase.vaadin:sun-down.vaadin:sun-o.vaadin:sun-rise.vaadin:superscript.vaadin:sword.vaadin:tab-a.vaadin:tab.vaadin:table.vaadin:tablet.vaadin:tabs.vaadin:tag.vaadin:tags.vaadin:tasks.vaadin:taxi.vaadin:teeth.vaadin:terminal.vaadin:text-height.vaadin:text-input.vaadin:text-label.vaadin:text-width.vaadin:thin-square.vaadin:thumbs-down-o.vaadin:thumbs-down.vaadin:thumbs-up-o.vaadin:thumbs-up.vaadin:ticket.vaadin:time-backward.vaadin:time-forward.vaadin:timer.vaadin:toolbox.vaadin:tools.vaadin:tooth.vaadin:touch.vaadin:train.vaadin:trash.vaadin:tree-table.vaadin:trendind-down.vaadin:trending-down.vaadin:trending-up.vaadin:trophy.vaadin:truck.vaadin:twin-col-select.vaadin:twitter-square.vaadin:twitter.vaadin:umbrella.vaadin:underline.vaadin:unlink.vaadin:unlock.vaadin:upload-alt.vaadin:upload.vaadin:user-card.vaadin:user-check.vaadin:user-clock.vaadin:user-heart.vaadin:user-star.vaadin:user.vaadin:users.vaadin:vaadin-h.vaadin:vaadin-v.vaadin:viewport.vaadin:vimeo-square.vaadin:vimeo.vaadin:volume-down.vaadin:volume-off.vaadin:volume-up.vaadin:volume.vaadin:wallet.vaadin:warning.vaadin:workplace.vaadin:wrench.vaadin:youtube-square.vaadin:youtube`.split(`.`),vl=null,yl=()=>(vl||=Promise.all([E(()=>import(`./vendor-ui5.js`).then(e=>e.n),__vite__mapDeps([5,1])),E(()=>import(`./vendor-ui5.js`).then(e=>e.t),__vite__mapDeps([5,1]))]),vl),Z=class extends y{constructor(...e){super(...e),this.ui5FieldComponentsReady=!1,this.component=void 0,this.field=void 0,this.baseUrl=void 0,this.state={},this.data={},this.appState={},this.appData={},this.colorPickerOpened=!1,this.colorPickerValue=void 0,this.comboData=[],this._comboFilter=``,this.rendered=!1,this.renderColorPicker=()=>{this.loadUi5FieldComponents();let e=this.field?.fieldId;return w`
             <ui5-color-picker value="${this.state&&e in this.state?this.state[e]:this.field?.initialValue}" @change="${e=>this.colorPickerValue=e.target.value}">Picker</ui5-color-picker>
-        `},this.saveColor=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.colorPickerValue,fieldId:this.field.fieldId},bubbles:!0,composed:!0})),this.colorPickerOpened=!1},this.renderColorPickerFooter=()=>T`<vaadin-button @click="${()=>this.colorPickerOpened=!1}">Cancel</vaadin-button>
-        <vaadin-button theme="primary" @click="${this.saveColor}">Save</vaadin-button>`,this.checked=e=>{let t=e.target;this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t.checked,fieldId:this.field.fieldId},bubbles:!0,composed:!0}))},this.convert=e=>this.field?.dataType==`integer`?parseInt(e):e,this.multiComboBoxValueChanged=e=>{if(this.rendered){let t=this.field?.fieldId,n=this.state&&t in this.state?this.state[t]:this.field?.initialValue,r;e.detail.value&&(r=e.detail.value.map(e=>e.value),r&&r.length>0&&(this.data[this.id]||(this.data[this.id]={}),this.data[this.id].content||(this.data[this.id].content=[]),this.data[this.id]&&this.data[this.id].content&&e.detail.value.forEach(e=>{this.data[this.id].content?.find(t=>e.value==t.value)||this.data[this.id].content.push(e)}))),this.compareArrays(r,n)||this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}},this.valueChanged=e=>{this.rendered&&e.detail.value!==void 0&&e.detail.value!=this.state[this.field.fieldId]&&this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.convert(e.detail.value),fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.selectedItems=e=>{if(e&&e.length>0)if(this.field?.remoteCoordinates){if(this.comboData&&this.comboData.length>0)return this.comboData?.filter(t=>e.indexOf(t.value)>=0);if(this.data[this.id]&&this.data[this.id].content&&this.data[this.id].content.length>0)return this.data[this.id].content.filter(t=>e.indexOf(t.value)>=0)}else return this.field?.options?.filter(t=>e.indexOf(t.value)>=0);return[]},this.selectedIndex=e=>{if(e)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content){let t=this.data[this.id].content.find(t=>t.value==e);if(t)return this.data[this.id].content.indexOf(t)}}else{let t=this.field?.options?.find(t=>t.value==e);if(t)return this.field?.options?.indexOf(t)}},this.selectedIndexes=e=>{if(e&&e.length>0)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content)return this.data[this.id].content.filter(t=>e.indexOf(t.value)>=0).map(e=>this.data[this.id].content.indexOf(e))}else return this.field?.options?.filter(t=>e.indexOf(t.value)>=0).map(e=>this.field?.options?.indexOf(e));return[]},this.compareArrays=(e,t)=>this.falsy(e)&&this.falsy(t)||e&&t&&e.length===t.length&&e.every((e,n)=>e===t[n]),this.falsy=e=>!e||e.length==0,this.listItemsSelected=e=>{let t=this.field?.fieldId,n=this.state&&t in this.state?this.state[t]:this.field?.initialValue,r;this.rendered&&(e.detail.value&&(this.field?.remoteCoordinates?this.data[this.id]&&this.data[this.id].content&&(r=e.detail.value.map(e=>this.data[this.id].content[e].value)):r=e.detail.value.map(e=>this.field.options[e].value)),this.compareArrays(r,n)||this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r,fieldId:this.field?.fieldId},bubbles:!0,composed:!0})))},this.listItemSelected=e=>{let t;if(e.detail.value||e.detail.value==0)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content){let n=this.data[this.id].content[e.detail.value];n&&(t=n.value)}}else{let n=this.field.options[e.detail.value];n&&(t=n.value)}this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.mapPosition=e=>{switch(e){case`topStretch`:return`top-stretch`;case`topStart`:return`top-start`;case`topCenter`:return`top-center`;case`topEnd`:return`top-end`;case`middle`:return`middle`;case`bottomStart`:return`bottom-start`;case`bottomEnd`:return`bottom-end`;case`bottomStretch`:return`bottom-stretch`;case`bottomCenter`:return`bottom-center`}return`bottom-end`},this.helperShownInControl=!1,this.lastAnnouncedError=``,this.controlOwnsValidity=!1,this.fileUploaded=e=>{let t=this.field?.fieldId??``,n=this.state[t];n.push({id:e.detail.xhr.responseText,name:e.detail.file.name}),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:n,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.fileChanged=e=>{let t=this.field?.fieldId??``,n=(e.detail.value??[]).filter(e=>e.id).map(e=>e.id),r=(this.state[t]??[]).map(e=>e.id);if(!this.compareArrays(r,n)){let t=(e.detail.value??[]).filter(e=>e.id).map(e=>({id:e.id,name:e.name}));this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}},this.triggerImageUpload=()=>{(this.renderRoot?.querySelector(`input[type="file"]`))?.click()},this.imageUpload=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r.result,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},r.readAsDataURL(n),t.value=``},this.imageDelete=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:``,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.iconComboboxRenderer=e=>T`
+        `},this.saveColor=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.colorPickerValue,fieldId:this.field.fieldId},bubbles:!0,composed:!0})),this.colorPickerOpened=!1},this.renderColorPickerFooter=()=>w`<vaadin-button @click="${()=>this.colorPickerOpened=!1}">Cancel</vaadin-button>
+        <vaadin-button theme="primary" @click="${this.saveColor}">Save</vaadin-button>`,this.checked=e=>{let t=e.target;this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t.checked,fieldId:this.field.fieldId},bubbles:!0,composed:!0}))},this.convert=e=>this.field?.dataType==`integer`?parseInt(e):e,this.multiComboBoxValueChanged=e=>{if(this.rendered){let t=this.field?.fieldId,n=this.state&&t in this.state?this.state[t]:this.field?.initialValue,r;e.detail.value&&(r=e.detail.value.map(e=>e.value),r&&r.length>0&&(this.data[this.id]||(this.data[this.id]={}),this.data[this.id].content||(this.data[this.id].content=[]),this.data[this.id]&&this.data[this.id].content&&e.detail.value.forEach(e=>{this.data[this.id].content?.find(t=>e.value==t.value)||this.data[this.id].content.push(e)}))),this.compareArrays(r,n)||this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}},this.valueChanged=e=>{this.rendered&&e.detail.value!==void 0&&e.detail.value!=this.state[this.field.fieldId]&&this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.convert(e.detail.value),fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.selectedItems=e=>{if(e&&e.length>0)if(this.field?.remoteCoordinates){if(this.comboData&&this.comboData.length>0)return this.comboData?.filter(t=>e.indexOf(t.value)>=0);if(this.data[this.id]&&this.data[this.id].content&&this.data[this.id].content.length>0)return this.data[this.id].content.filter(t=>e.indexOf(t.value)>=0)}else return this.field?.options?.filter(t=>e.indexOf(t.value)>=0);return[]},this.selectedIndex=e=>{if(e)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content){let t=this.data[this.id].content.find(t=>t.value==e);if(t)return this.data[this.id].content.indexOf(t)}}else{let t=this.field?.options?.find(t=>t.value==e);if(t)return this.field?.options?.indexOf(t)}},this.selectedIndexes=e=>{if(e&&e.length>0)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content)return this.data[this.id].content.filter(t=>e.indexOf(t.value)>=0).map(e=>this.data[this.id].content.indexOf(e))}else return this.field?.options?.filter(t=>e.indexOf(t.value)>=0).map(e=>this.field?.options?.indexOf(e));return[]},this.compareArrays=(e,t)=>this.falsy(e)&&this.falsy(t)||e&&t&&e.length===t.length&&e.every((e,n)=>e===t[n]),this.falsy=e=>!e||e.length==0,this.listItemsSelected=e=>{let t=this.field?.fieldId,n=this.state&&t in this.state?this.state[t]:this.field?.initialValue,r;this.rendered&&(e.detail.value&&(this.field?.remoteCoordinates?this.data[this.id]&&this.data[this.id].content&&(r=e.detail.value.map(e=>this.data[this.id].content[e].value)):r=e.detail.value.map(e=>this.field.options[e].value)),this.compareArrays(r,n)||this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r,fieldId:this.field?.fieldId},bubbles:!0,composed:!0})))},this.listItemSelected=e=>{let t;if(e.detail.value||e.detail.value==0)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content){let n=this.data[this.id].content[e.detail.value];n&&(t=n.value)}}else{let n=this.field.options[e.detail.value];n&&(t=n.value)}this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.mapPosition=e=>{switch(e){case`topStretch`:return`top-stretch`;case`topStart`:return`top-start`;case`topCenter`:return`top-center`;case`topEnd`:return`top-end`;case`middle`:return`middle`;case`bottomStart`:return`bottom-start`;case`bottomEnd`:return`bottom-end`;case`bottomStretch`:return`bottom-stretch`;case`bottomCenter`:return`bottom-center`}return`bottom-end`},this.helperShownInControl=!1,this.lastAnnouncedError=``,this.controlOwnsValidity=!1,this.fileUploaded=e=>{let t=this.field?.fieldId??``,n=this.state[t];n.push({id:e.detail.xhr.responseText,name:e.detail.file.name}),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:n,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.fileChanged=e=>{let t=this.field?.fieldId??``,n=(e.detail.value??[]).filter(e=>e.id).map(e=>e.id),r=(this.state[t]??[]).map(e=>e.id);if(!this.compareArrays(r,n)){let t=(e.detail.value??[]).filter(e=>e.id).map(e=>({id:e.id,name:e.name}));this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}},this.triggerImageUpload=()=>{(this.renderRoot?.querySelector(`input[type="file"]`))?.click()},this.imageUpload=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r.result,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},r.readAsDataURL(n),t.value=``},this.imageDelete=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:``,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.iconComboboxRenderer=e=>w`
   <div style="display: flex;">
       <vaadin-icon
               icon="${e}"
@@ -9050,12 +9050,12 @@ ${i}
       </div>
     </div>
   </div>
-`,this.comboRenderer=e=>T`
-        ${e.description||e.image||e.icon?T`
+`,this.comboRenderer=e=>w`
+        ${e.description||e.image||e.icon?w`
             <vaadin-horizontal-layout theme="spacing">
-                ${e.icon?T`<div><vaadin-icon icon="${e.icon}"></vaadin-icon></div>
-                                    `:v}
-                ${e.image?T`
+                ${e.icon?w`<div><vaadin-icon icon="${e.icon}"></vaadin-icon></div>
+                                    `:_}
+                ${e.image?w`
                     <div>
                     <img
                             style="width: var(--lumo-size-m); margin-right: var(--lumo-space-s);"
@@ -9063,75 +9063,75 @@ ${i}
                             alt="${e.label}"
                     />
                     </div>
-                                        `:v}
+                                        `:_}
                 <div>
                     ${e.label}
-                    ${e.description?T`
+                    ${e.description?w`
             <div style="font-size: var(--lumo-font-size-s); color: var(--lumo-secondary-text-color);">
                 ${e.description}
             </div>
-        `:v}
+        `:_}
                 </div>
 
             </vaadin-horizontal-layout>
                             `:e.label}
-`,this.filteredIcons=[],this.navLinkOffset=null,this.iconFilterChanged=e=>{this.filteredIcons=Qc.filter(t=>!e.detail.value||t.indexOf(e.detail.value)>=0)}}loadUi5FieldComponents(){this.ui5FieldComponentsReady||el().then(()=>{this.ui5FieldComponentsReady=!0})}remoteComboDataProvider(e){return(t,n)=>{let{filter:i,page:a,pageSize:o}=t,s=i??``;this._comboFilter=s,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{searchText:i,fieldId:this.field?.fieldId,size:o,page:a,sort:void 0},callback:e=>{if(s===this._comboFilter)if(e?.messages?.forEach(e=>{r.show(e.text,{position:e.position?this.mapPosition(e.position):void 0,theme:e.variant,duration:e.duration})}),!e.fragments||e.fragments.length==0)this.comboData=[],n([],0);else{let t=e.fragments[0].data?.[this.id];this.comboData=t?.content,n(t?.content,t?.totalElements)}},callbackonly:!0},bubbles:!0,composed:!0}))}}disconnectedCallback(){super.disconnectedCallback(),this.rendered=!1}renderNavLink(){let e=this.field?.link;if(!e?.href)return v;let t=M(e.href,this.state,this.data)??e.href,n=M(e.title,this.state,this.data)||t,r=e.icon||(t.startsWith(`http`)?`vaadin:external-link`:`vaadin:link`),i=this.navLinkOffset??`calc(var(--lumo-font-size-s) * 1.6 + (var(--lumo-size-m) - var(--lumo-icon-size-s)) / 2)`;return T`<a
+`,this.filteredIcons=[],this.navLinkOffset=null,this.iconFilterChanged=e=>{this.filteredIcons=_l.filter(t=>!e.detail.value||t.indexOf(e.detail.value)>=0)}}loadUi5FieldComponents(){this.ui5FieldComponentsReady||yl().then(()=>{this.ui5FieldComponentsReady=!0})}remoteComboDataProvider(e){return(t,n)=>{let{filter:i,page:a,pageSize:o}=t,s=i??``;this._comboFilter=s,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{searchText:i,fieldId:this.field?.fieldId,size:o,page:a,sort:void 0},callback:e=>{if(s===this._comboFilter)if(e?.messages?.forEach(e=>{r.show(e.text,{position:e.position?this.mapPosition(e.position):void 0,theme:e.variant,duration:e.duration})}),!e.fragments||e.fragments.length==0)this.comboData=[],n([],0);else{let t=e.fragments[0].data?.[this.id];this.comboData=t?.content,n(t?.content,t?.totalElements)}},callbackonly:!0},bubbles:!0,composed:!0}))}}disconnectedCallback(){super.disconnectedCallback(),this.rendered=!1}renderNavLink(){let e=this.field?.link;if(!e?.href)return _;let t=j(e.href,this.state,this.data)??e.href,n=j(e.title,this.state,this.data)||t,r=e.icon||(t.startsWith(`http`)?`vaadin:external-link`:`vaadin:link`),i=this.navLinkOffset??`calc(var(--lumo-font-size-s) * 1.6 + (var(--lumo-size-m) - var(--lumo-icon-size-s)) / 2)`;return w`<a
                 data-navlink
                 href="${t}"
                 title="${n}"
-                target="${S(e.target||void 0)}"
+                target="${x(e.target||void 0)}"
                 style="display: flex; align-items: center; color: var(--lumo-secondary-text-color); align-self: flex-start; margin-top: ${i};"
-        ><vaadin-icon icon="${r}" style="width: var(--lumo-icon-size-s); height: var(--lumo-icon-size-s);"></vaadin-icon></a>`}positionNavLink(){let e=this.renderRoot?.querySelector(`a[data-navlink]`);e&&setTimeout(()=>{let t=e.parentElement,n=t?.firstElementChild?.firstElementChild;if(!t||!n)return;let r=(n.shadowRoot?.querySelector(`[part="input-field"]`)??n).getBoundingClientRect();if(r.height===0)return;let i=Math.max(0,r.top+r.height/2-e.offsetHeight/2-t.getBoundingClientRect().top),a=`${Math.round(i)}px`;this.navLinkOffset!==a&&(this.navLinkOffset=a)})}helperText(){return this.helperShownInControl=!0,N(this.field?.description??``,this.state,this.data)??``}fieldErrors(){let e=this.field?.fieldId??``,t=this.data?.errors?.[e];return Array.isArray(t)?t.filter(e=>!!e):[]}validatableControl(){let e=this.renderRoot.querySelectorAll(`*`);for(let t of e)if(`invalid`in t&&`errorMessage`in t)return t;return null}applyValidationState(){let e=this.fieldErrors(),t=this.validatableControl();if(!t){this.lastAnnouncedError=e.join(`. `);return}let n=e.join(`. `);if(t.errorMessage=n,t.invalid=e.length>0,n&&n!==this.lastAnnouncedError){let e=(this.field?.label??``).toString().trim();Ze(e?`${e}: ${n}`:n,{politeness:`assertive`})}this.lastAnnouncedError=n}render(){this.rendered=!0;let e=this.renderNavLink();this.helperShownInControl=!1;let t=this.renderField(),n=this.field?.description&&!this.helperShownInControl?N(this.field.description,this.state,this.data):void 0,r=this.fieldErrors(),i=r.length>0&&!this.controlOwnsValidity;return T`<div style="display: block;">
-            <div style="${e===v?``:`display: flex; gap: var(--lumo-space-xs);`}"><div style="flex: 1; min-width: 0;">${t}</div>${e}</div>
-            ${n?T`
+        ><vaadin-icon icon="${r}" style="width: var(--lumo-icon-size-s); height: var(--lumo-icon-size-s);"></vaadin-icon></a>`}positionNavLink(){let e=this.renderRoot?.querySelector(`a[data-navlink]`);e&&setTimeout(()=>{let t=e.parentElement,n=t?.firstElementChild?.firstElementChild;if(!t||!n)return;let r=(n.shadowRoot?.querySelector(`[part="input-field"]`)??n).getBoundingClientRect();if(r.height===0)return;let i=Math.max(0,r.top+r.height/2-e.offsetHeight/2-t.getBoundingClientRect().top),a=`${Math.round(i)}px`;this.navLinkOffset!==a&&(this.navLinkOffset=a)})}helperText(){return this.helperShownInControl=!0,M(this.field?.description??``,this.state,this.data)??``}fieldErrors(){let e=this.field?.fieldId??``,t=this.data?.errors?.[e];return Array.isArray(t)?t.filter(e=>!!e):[]}validatableControl(){let e=this.renderRoot.querySelectorAll(`*`);for(let t of e)if(`invalid`in t&&`errorMessage`in t)return t;return null}applyValidationState(){let e=this.fieldErrors(),t=this.validatableControl();if(!t){this.lastAnnouncedError=e.join(`. `);return}let n=e.join(`. `);if(t.errorMessage=n,t.invalid=e.length>0,n&&n!==this.lastAnnouncedError){let e=(this.field?.label??``).toString().trim();Qe(e?`${e}: ${n}`:n,{politeness:`assertive`})}this.lastAnnouncedError=n}render(){this.rendered=!0;let e=this.renderNavLink();this.helperShownInControl=!1;let t=this.renderField(),n=this.field?.description&&!this.helperShownInControl?M(this.field.description,this.state,this.data):void 0,r=this.fieldErrors(),i=r.length>0&&!this.controlOwnsValidity;return w`<div style="display: block;">
+            <div style="${e===_?``:`display: flex; gap: var(--lumo-space-xs);`}"><div style="flex: 1; min-width: 0;">${t}</div>${e}</div>
+            ${n?w`
                 <div style="font-size: var(--lumo-font-size-xs); color: var(--lumo-secondary-text-color); margin-top: var(--lumo-space-xs);">${n}</div>
-            `:v}
-            ${i?T`
-                <div role="alert"><ul>${r.map(e=>T`<li>${e}</li>`)}</ul></div>
-            `:v}
-        </div>`}async firstUpdated(){this.filteredIcons=Qc}update(e){e.has(`component`)&&(this.rendered=!1),super.update(e)}updated(e){super.updated(e),this.positionNavLink(),this.applyValidationState(),this.controlOwnsValidity=!!this.validatableControl()}renderField(){let e=this.field?.fieldId??``,t=this.state&&e in this.state?this.state[e]:this.field?.initialValue,n=M(this.field?.label+``,this.state,this.data),r=this.labelAlreadyRendered||!n||n==`null`?v:n;return this.field?.propertyRow?this.renderPropertyRowField(e,t,r,n):this.field?.stereotype==`badge`?this.renderBadgeField(e,t,r,n):this.field?.stereotype==`plainText`?this.renderPlainTextField(e,t,r,n):this.field?.stereotype==`bulletedList`?this.renderBulletedListField(e,t,r,n):this.field?.readOnly&&this.field.stereotype!=`grid`&&this.field.dataType!=`status`&&this.field?.dataType!=`money`?this.renderReadOnlyField(e,t,r,n):this.field?.dataType==`file`?this.renderFileField(e,t,r,n):this.field?.dataType==`string`?this.renderStringField(e,t,r,n):this.field?.dataType==`number`?this.renderNumberField(e,t,r,n):this.field?.dataType==`integer`?this.renderIntegerField(e,t,r,n):this.field?.dataType==`bool`?this.renderBoolField(e,t,r,n):this.field?.dataType==`dateRange`?this.renderDateRangeField(e,t,r,n):this.field?.dataType==`date`?this.renderDateField(e,t,r,n):this.field?.dataType==`dateTime`?this.renderDateTimeField(e,t,r,n):this.field?.dataType==`time`?this.renderTimeField(e,t,r,n):this.field?.dataType==`array`?this.renderArrayField(e,t,r,n):this.field?.dataType==`money`?this.renderMoneyField(e,t,r,n):this.field?.dataType==`status`?this.renderStatusField(e,t,r,n):this.field?.dataType==`range`?this.renderRangeField(e,t,r,n):T`<p>Unknown field type ${this.field?.dataType} / ${this.field?.stereotype}</p>`}renderBadgeField(e,t,n,r){if(!this.field)return T``;let i=t===!0||t===`true`;return T`<vaadin-custom-field
+            `:_}
+            ${i?w`
+                <div role="alert"><ul>${r.map(e=>w`<li>${e}</li>`)}</ul></div>
+            `:_}
+        </div>`}async firstUpdated(){this.filteredIcons=_l}update(e){e.has(`component`)&&(this.rendered=!1),super.update(e)}updated(e){super.updated(e),this.positionNavLink(),this.applyValidationState(),this.controlOwnsValidity=!!this.validatableControl()}renderField(){let e=this.field?.fieldId??``,t=this.state&&e in this.state?this.state[e]:this.field?.initialValue,n=j(this.field?.label+``,this.state,this.data),r=this.labelAlreadyRendered||!n||n==`null`?_:n;return this.field?.propertyRow?this.renderPropertyRowField(e,t,r,n):this.field?.stereotype==`badge`?this.renderBadgeField(e,t,r,n):this.field?.stereotype==`plainText`?this.renderPlainTextField(e,t,r,n):this.field?.stereotype==`bulletedList`?this.renderBulletedListField(e,t,r,n):this.field?.readOnly&&this.field.stereotype!=`grid`&&this.field.dataType!=`status`&&this.field?.dataType!=`money`?this.renderReadOnlyField(e,t,r,n):this.field?.dataType==`file`?this.renderFileField(e,t,r,n):this.field?.dataType==`string`?this.renderStringField(e,t,r,n):this.field?.dataType==`number`?this.renderNumberField(e,t,r,n):this.field?.dataType==`integer`?this.renderIntegerField(e,t,r,n):this.field?.dataType==`bool`?this.renderBoolField(e,t,r,n):this.field?.dataType==`dateRange`?this.renderDateRangeField(e,t,r,n):this.field?.dataType==`date`?this.renderDateField(e,t,r,n):this.field?.dataType==`dateTime`?this.renderDateTimeField(e,t,r,n):this.field?.dataType==`time`?this.renderTimeField(e,t,r,n):this.field?.dataType==`array`?this.renderArrayField(e,t,r,n):this.field?.dataType==`money`?this.renderMoneyField(e,t,r,n):this.field?.dataType==`status`?this.renderStatusField(e,t,r,n):this.field?.dataType==`range`?this.renderRangeField(e,t,r,n):w`<p>Unknown field type ${this.field?.dataType} / ${this.field?.stereotype}</p>`}renderBadgeField(e,t,n,r){if(!this.field)return w``;let i=t===!0||t===`true`;return w`<vaadin-custom-field
                     id="${this.field.fieldId}"
                     .helperText="${this.helperText()}"
                     data-colspan="${this.field?.colspan}"
                     style="${this.field?.style}"
             ><span theme="badge ${i?`success`:``} pill" style="${i?``:`opacity: 0.4;`}">${r}</span>
-            </vaadin-custom-field>`}renderPropertyRowField(e,t,n,r){if(!this.field)return T``;let i=N(t,this.state,this.data),a=i&&typeof i==`object`&&`value`in i?i:null;i&&i.value&&(i=i.value);let o=this.field?.dataType==`bool`||i===!0||i===!1,s=this.field?.dataType==`money`,c=i!=null&&i!==``,l=c?String(i):`—`;if(s&&c){let e=typeof i==`number`?i:parseFloat(String(i));isNaN(e)||(l=a&&a.locale&&a.currency?new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(e):new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e))}let u=o?T`<vaadin-icon icon="${i===!0||i===`true`?`vaadin:check`:`vaadin:minus`}" style="height: 16px; width: 16px;"></vaadin-icon>`:T`<span style="font-weight: 500; text-align: right; word-break: break-word; margin-left: auto;${s?` font-variant-numeric: tabular-nums;`:``}">${l}</span>`,d=r&&r!=`null`;return T`<div
+            </vaadin-custom-field>`}renderPropertyRowField(e,t,n,r){if(!this.field)return w``;let i=M(t,this.state,this.data),a=i&&typeof i==`object`&&`value`in i?i:null;i&&i.value&&(i=i.value);let o=this.field?.dataType==`bool`||i===!0||i===!1,s=this.field?.dataType==`money`,c=i!=null&&i!==``,l=c?String(i):`—`;if(s&&c){let e=typeof i==`number`?i:parseFloat(String(i));isNaN(e)||(l=a&&a.locale&&a.currency?new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(e):new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e))}let u=o?w`<vaadin-icon icon="${i===!0||i===`true`?`vaadin:check`:`vaadin:minus`}" style="height: 16px; width: 16px;"></vaadin-icon>`:w`<span style="font-weight: 500; text-align: right; word-break: break-word; margin-left: auto;${s?` font-variant-numeric: tabular-nums;`:``}">${l}</span>`,d=r&&r!=`null`;return w`<div
                     id="${this.field.fieldId}"
                     data-colspan="${this.field?.colspan}"
                     style="display: flex; justify-content: space-between; align-items: baseline; gap: 1rem; width: 100%; padding: 0.4rem 0; border-bottom: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.08)); font-size: var(--lumo-font-size-s, .875rem); ${this.field?.style}"
-            >${d?T`<span style="color: var(--lumo-secondary-text-color, #888); white-space: nowrap;">${r}</span>`:v}${u}</div>`}renderBulletedListField(e,t,n,r){if(!this.field)return T``;let i=N(t,this.state,this.data),a=Array.isArray(i)?i.map(e=>String(e)):i!=null&&i!==``?[String(i)]:[];return T`<vaadin-custom-field
+            >${d?w`<span style="color: var(--lumo-secondary-text-color, #888); white-space: nowrap;">${r}</span>`:_}${u}</div>`}renderBulletedListField(e,t,n,r){if(!this.field)return w``;let i=M(t,this.state,this.data),a=Array.isArray(i)?i.map(e=>String(e)):i!=null&&i!==``?[String(i)]:[];return w`<vaadin-custom-field
                     id="${this.field.fieldId}"
                     label="${n}"
                     .helperText="${this.helperText()}"
                     data-colspan="${this.field?.colspan}"
                     style="${this.field?.style}"
             ><mateu-bulleted-list .items="${a}"></mateu-bulleted-list>
-            </vaadin-custom-field>`}renderPlainTextField(e,t,n,r){if(!this.field)return T``;let i=N(t,this.state,this.data),a=i&&typeof i==`object`&&`value`in i?i:null;i&&i.value&&(i=i.value);let o=this.field?.dataType==`bool`||i===!0||i===!1,s=this.field?.dataType==`money`,c=i!=null&&i!==``,l=c?String(i):`—`;if(s&&c){let e=typeof i==`number`?i:parseFloat(String(i));isNaN(e)||(l=a&&a.locale&&a.currency?new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(e):new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e))}let u=o?T`<vaadin-icon icon="${i===!0||i===`true`?`vaadin:check`:`vaadin:minus`}" style="height: 16px; width: 16px;"></vaadin-icon>`:this.field?.multiline?T`<span style="font-weight: 500; white-space: pre-wrap; word-break: break-word;">${l}</span>`:T`<span style="font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;${s?` font-variant-numeric: tabular-nums;`:``}">${l}</span>`;return T`<vaadin-custom-field
+            </vaadin-custom-field>`}renderPlainTextField(e,t,n,r){if(!this.field)return w``;let i=M(t,this.state,this.data),a=i&&typeof i==`object`&&`value`in i?i:null;i&&i.value&&(i=i.value);let o=this.field?.dataType==`bool`||i===!0||i===!1,s=this.field?.dataType==`money`,c=i!=null&&i!==``,l=c?String(i):`—`;if(s&&c){let e=typeof i==`number`?i:parseFloat(String(i));isNaN(e)||(l=a&&a.locale&&a.currency?new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(e):new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e))}let u=o?w`<vaadin-icon icon="${i===!0||i===`true`?`vaadin:check`:`vaadin:minus`}" style="height: 16px; width: 16px;"></vaadin-icon>`:this.field?.multiline?w`<span style="font-weight: 500; white-space: pre-wrap; word-break: break-word;">${l}</span>`:w`<span style="font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;${s?` font-variant-numeric: tabular-nums;`:``}">${l}</span>`;return w`<vaadin-custom-field
                     id="${this.field.fieldId}"
                     label="${n}"
                     data-colspan="${this.field?.colspan}"
                     style="${s?`text-align: right; `:``}${this.field?.style}"
-            >${u}</vaadin-custom-field>`}renderReadOnlyField(e,t,n,r){if(!this.field)return T``;let i=N(t,this.state,this.data)||this.data[e];if(i&&i.value&&(i=i.value),this.field.stereotype==`fileUpload`)return T`<vaadin-custom-field
+            >${u}</vaadin-custom-field>`}renderReadOnlyField(e,t,n,r){if(!this.field)return w``;let i=M(t,this.state,this.data)||this.data[e];if(i&&i.value&&(i=i.value),this.field.stereotype==`fileUpload`)return w`<vaadin-custom-field
                         id="${this.field.fieldId}"
                         label="${n}"
                         .helperText="${this.helperText()}"
                         data-colspan="${this.field.colspan}"
                 ><mateu-file-upload .fieldId="${this.field.fieldId}" .value="${i}" .editable="${!1}"></mateu-file-upload>
-                </vaadin-custom-field>`;if(this.field.stereotype==`image`||this.field.stereotype==`uploadableImage`||this.field.stereotype==`signature`||this.field.stereotype==`camera`)return T`<vaadin-custom-field
+                </vaadin-custom-field>`;if(this.field.stereotype==`image`||this.field.stereotype==`uploadableImage`||this.field.stereotype==`signature`||this.field.stereotype==`camera`)return w`<vaadin-custom-field
                         id="${this.field.fieldId}"
                         label="${n}"
-                        required="${this.field.required||v}"
+                        required="${this.field.required||_}"
                         .helperText="${this.helperText()}"
                         data-colspan="${this.field.colspan}"
                 ><img src="${i}" id="${this.field.fieldId}_img" style="${this.field.style}">
-                </vaadin-custom-field>`;if(this.field.dataType==`bool`)return T`<vaadin-custom-field
+                </vaadin-custom-field>`;if(this.field.dataType==`bool`)return w`<vaadin-custom-field
                         id="${this.field.fieldId}"
                         label="${n}"
-                        required="${this.field.required||v}"
+                        required="${this.field.required||_}"
                         .helperText="${this.helperText()}"
                         data-colspan="${this.field.colspan}"
                 ><vaadin-icon icon="${i?`vaadin:check`:`vaadin:minus`}" style="height: 20px;"></vaadin-icon>
-                </vaadin-custom-field>`;let a=i==null?``:String(i);return T`
+                </vaadin-custom-field>`;let a=i==null?``:String(i);return w`
                 <vaadin-text-field
                         id="${this.field.fieldId}"
                         label="${n}"
@@ -9140,14 +9140,14 @@ ${i}
                         style="${this.field.style}"
                         .helperText="${this.helperText()}"
                         data-colspan="${this.field.colspan}"
-                >${a.length>15?T`<vaadin-icon
+                >${a.length>15?w`<vaadin-icon
                         slot="suffix"
                         icon="vaadin:copy"
                         title="Copiar"
                         style="cursor: pointer; color: var(--lumo-secondary-text-color);"
                         @click="${()=>this.copyValue(a)}"
-                ></vaadin-icon>`:v}</vaadin-text-field>
-`}copyValue(e){navigator.clipboard.writeText(e).then(()=>r.show(`Copied`,{position:`bottom-end`,theme:`success`,duration:2e3})).catch(()=>{})}renderFileField(e,t,n,r){if(!this.field)return T``;let i=t?.map(e=>({id:e.id,name:e.name,type:``,uploadTarget:``,complete:!0}))??[];return T`
+                ></vaadin-icon>`:_}</vaadin-text-field>
+`}copyValue(e){navigator.clipboard.writeText(e).then(()=>r.show(`Copied`,{position:`bottom-end`,theme:`success`,duration:2e3})).catch(()=>{})}renderFileField(e,t,n,r){if(!this.field)return w``;let i=t?.map(e=>({id:e.id,name:e.name,type:``,uploadTarget:``,complete:!0}))??[];return w`
                 <vaadin-custom-field
                         label="${n}"
                         .helperText="${this.helperText()}"
@@ -9160,11 +9160,11 @@ ${i}
                             @files-changed="${this.fileChanged}"
                     ></vaadin-upload>
                 </vaadin-custom-field>
-            `}renderStringField(e,t,n,r){if(!this.field)return T``;if(this.field?.stereotype==`searchable`)return T`
+            `}renderStringField(e,t,n,r){if(!this.field)return w``;if(this.field?.stereotype==`searchable`)return w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
-                            required="${this.field.required||v}"
+                            required="${this.field.required||_}"
                             .helperText="${this.helperText()}"
                             data-colspan="${this.field.colspan}"
                     >
@@ -9174,7 +9174,21 @@ ${i}
                             <vaadin-button theme="icon" @click="${e=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`codesearch-`+this.field?.fieldId,parameters:{}},bubbles:!0,composed:!0}))}}"><vaadin-icon icon="lumo:search"></vaadin-icon></vaadin-button>
                         </vaadin-horizontal-layout>
                     </vaadin-custom-field>
-                `;if(this.field?.stereotype==`select`){if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates;this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements||this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}));let r=t;return t&&t.value&&(r=t.value),T`
+                `;if(this.field?.stereotype==`select`){if(this.field?.optionsSource){let e=this.field.optionsSource,r=j(e.url,this.state,this.data)??e.url;this.data[this.id]?.sourceSignature!==r&&(this.data[this.id]={content:this.data[this.id]?.content??[],sourceSignature:r},jc(e,e=>j(e,this.state,this.data)).then(e=>{this.data[this.id]={content:e,totalElements:e.length,sourceSignature:r},this.requestUpdate()}).catch(e=>console.warn(`mateu: external options fetch failed`,e)));let i=t;return t&&t.value&&(i=t.value),w`
+                    <vaadin-select
+                            id="${this.field.fieldId}"
+                            label="${n}"
+                            item-label-path="label"
+                            item-value-path="value"
+                            .items="${this.data[this.id]?.content??[]}"
+                            .helperText="${this.helperText()}"
+                            @value-changed="${this.valueChanged}"
+                            .value="${i}"
+                            ?autofocus="${this.field.wantsFocus}"
+                            required="${this.field.required||_}"
+                            data-colspan="${this.field.colspan}"
+                    ></vaadin-select>
+                    `}if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates;this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements||this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}));let r=t;return t&&t.value&&(r=t.value),w`
                     <vaadin-select
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9185,10 +9199,10 @@ ${i}
                             @value-changed="${this.valueChanged}"
                             .value="${r}"
                             ?autofocus="${this.field.wantsFocus}"
-                            required="${this.field.required||v}"
+                            required="${this.field.required||_}"
                             data-colspan="${this.field.colspan}"
                     ></vaadin-select>
-                    `}let e=t;return t&&t.value&&(e=t.value),T`
+                    `}let e=t;return t&&t.value&&(e=t.value),w`
                     <vaadin-select
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9199,21 +9213,21 @@ ${i}
                             @value-changed="${this.valueChanged}"
                             .value="${e}"
                             ?autofocus="${this.field.wantsFocus}"
-                            required="${this.field.required||v}"
+                            required="${this.field.required||_}"
                             data-colspan="${this.field.colspan}"
                     ></vaadin-select>
-                `}if(this.field?.stereotype==`markdown`)return T`
+                `}if(this.field?.stereotype==`markdown`)return w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
-                            required="${this.field.required||v}"
+                            required="${this.field.required||_}"
                             .helperText="${this.helperText()}"
                             data-colspan="${this.field.colspan}"
                     ><vaadin-markdown
                             .content="${t}"
                     ></vaadin-markdown>
                     </vaadin-custom-field>
-                `;if(this.field?.stereotype==`combobox`){if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates,r;this.data[this.id]&&this.data[this.id].content&&(r=this.data[this.id].content.find(e=>e.value==t)),!r&&this.comboData&&(r=this.comboData.find(e=>e.value==t)),!r&&t&&(r={value:t,label:this.data[this.id+`-label`]??t});let i=this.remoteComboDataProvider(e.action);return T`
+                `;if(this.field?.stereotype==`combobox`){if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates,r;this.data[this.id]&&this.data[this.id].content&&(r=this.data[this.id].content.find(e=>e.value==t)),!r&&this.comboData&&(r=this.comboData.find(e=>e.value==t)),!r&&t&&(r={value:t,label:this.data[this.id+`-label`]??t});let i=this.remoteComboDataProvider(e.action);return w`
                     <vaadin-combo-box
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9224,13 +9238,13 @@ ${i}
                             .helperText="${this.helperText()}"
                             @value-changed="${this.valueChanged}"
                             ?autofocus="${this.field.wantsFocus}"
-                            ?required="${this.field.required||v}"
+                            ?required="${this.field.required||_}"
                             data-colspan="${this.field.colspan}"
                             style="${this.field.style}"
                             @keyup="${e=>{if(e.key==`Backspace`){let t=e.currentTarget;t.inputElement.value||(t.value=``)}}}"
                             ${u(this.comboRenderer,[])}
                     ></vaadin-combo-box>
-                    `}return T`
+                    `}return w`
                     <vaadin-combo-box
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9241,12 +9255,12 @@ ${i}
                             @value-changed="${this.valueChanged}"
                             .value="${t}"
                             ?autofocus="${this.field.wantsFocus}"
-                            required="${this.field.required||v}"
+                            required="${this.field.required||_}"
                             data-colspan="${this.field.colspan}"
                             style="${this.field.style}"
                             ${u(this.comboRenderer,[])}
                     ></vaadin-combo-box>
-                    `}if(this.field?.stereotype==`listBox`){if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates;return this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements||this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0})),T`
+                    `}if(this.field?.stereotype==`listBox`){if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates;return this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements||this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0})),w`
                         <vaadin-custom-field
                                 label="${n}"
                                 .helperText="${this.helperText()}"
@@ -9254,19 +9268,19 @@ ${i}
                         >
                     <vaadin-list-box
                             id="${this.field.fieldId}"
-                            selected="${S(this.selectedIndex(t))}"
+                            selected="${x(this.selectedIndex(t))}"
                             @selected-changed="${this.listItemSelected}"
                             ?autofocus="${this.field.wantsFocus}"
                     >
-                        ${this.data[this.id]?.content?.map(e=>T`
-                            <vaadin-item>${e.description||e.image||e.icon?T`
+                        ${this.data[this.id]?.content?.map(e=>w`
+                            <vaadin-item>${e.description||e.image||e.icon?w`
                                 <vaadin-horizontal-layout style="align-items: center;" theme="spacing">
-                                    ${e.icon?T`
+                                    ${e.icon?w`
                                         <vaadin-icon icon="${e.icon}"></vaadin-icon>
-                                    `:v}
-                                    ${e.image?T`
+                                    `:_}
+                                    ${e.image?w`
                                             <img src="${e.image}" alt="${e.label}" style="width: 2rem;" />
-                                        `:v}
+                                        `:_}
                                     <vaadin-vertical-layout>
                                         <span> ${e.label} </span>
                                         <span
@@ -9280,7 +9294,7 @@ ${i}
                         `)}
                     </vaadin-list-box>
                         </vaadin-custom-field>
-                    `}return T`
+                    `}return w`
                     <vaadin-custom-field
                             label="${n}"
                             .helperText="${this.helperText()}"
@@ -9288,19 +9302,19 @@ ${i}
                     >
                     <vaadin-list-box
                             id="${this.field.fieldId}"
-                            selected="${S(this.selectedIndex(t))}"
+                            selected="${x(this.selectedIndex(t))}"
                             @selected-changed="${this.listItemSelected}"
                             ?autofocus="${this.field.wantsFocus}"
                     >
-                        ${this.field.options?.map(e=>T`
-                            <vaadin-item>${e.description||e.image||e.icon?T`
+                        ${this.field.options?.map(e=>w`
+                            <vaadin-item>${e.description||e.image||e.icon?w`
                                 <vaadin-horizontal-layout style="align-items: center;" theme="spacing">
-                                    ${e.icon?T`
+                                    ${e.icon?w`
                                         <vaadin-icon icon="${e.icon}"></vaadin-icon>
-                                    `:v}
-                                    ${e.image?T`
+                                    `:_}
+                                    ${e.image?w`
                                             <img src="${e.image}" alt="${e.label}" style="width: 2rem;" />
-                                        `:v}
+                                        `:_}
                                     <vaadin-vertical-layout>
                                         <span> ${e.label} </span>
                                         <span
@@ -9314,7 +9328,7 @@ ${i}
                         `)}
                     </vaadin-list-box>
                     </vaadin-custom-field>
-                `}if(this.field?.stereotype==`radio`){if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates;return this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements||this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0})),T`
+                `}if(this.field?.stereotype==`radio`){if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates;return this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements||this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0})),w`
                     <vaadin-radio-group
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9323,31 +9337,31 @@ ${i}
                             .helperText="${this.helperText()}"
                             theme="horizontal"
                             ?autofocus="${this.field.wantsFocus}"
-                            required="${this.field.required||v}"
+                            required="${this.field.required||_}"
                             data-colspan="${this.field.colspan}"
                     >
-                        ${this.data[this.id]?.content?.map(e=>T`
+                        ${this.data[this.id]?.content?.map(e=>w`
                             <vaadin-radio-button value="${e.value}" label="${e.label}" ?checked="${e&&t&&e.value===t}">
-                                ${e.description||e.image||e.icon?T`
+                                ${e.description||e.image||e.icon?w`
                                     <label slot="label">
                                         <vaadin-horizontal-layout theme="spacing">
-                                            ${e.icon?T`
+                                            ${e.icon?w`
                                                 <vaadin-icon icon="${e.icon}"></vaadin-icon>
-                                            `:v}
-                                            ${e.image?T`
+                                            `:_}
+                                            ${e.image?w`
                                                 <img src="${e.image}" alt="${e.label}" style="height: 1rem;" />
-                                            `:v}
+                                            `:_}
                                             <span>${e.label}</span>
                                         </vaadin-horizontal-layout>
-                                        ${e.description?T`
+                                        ${e.description?w`
                                             <div>${e.description}</div>
-                                        `:v}
+                                        `:_}
                                     </label>
-                                `:v}
+                                `:_}
                             </vaadin-radio-button>
                         `)}
 </vaadin-radio-group>
-                    `}return T`
+                    `}return w`
                     <vaadin-radio-group
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9355,34 +9369,34 @@ ${i}
                             .value="${t}"
                             .helperText="${this.helperText()}"
                             ?autofocus="${this.field.wantsFocus}"
-                            required="${this.field.required||v}"
+                            required="${this.field.required||_}"
                             data-colspan="${this.field.colspan}"
                     >
-                        ${this.field.options?.map(e=>T`
+                        ${this.field.options?.map(e=>w`
                             <vaadin-radio-button value="${e.value}" label="${e.label}">
-                                ${e.description||e.image||e.icon?T`
+                                ${e.description||e.image||e.icon?w`
                                     <label slot="label">
                                         <vaadin-horizontal-layout theme="spacing">
-                                            ${e.icon?T`
+                                            ${e.icon?w`
                                                 <vaadin-icon icon="${e.icon}"></vaadin-icon>
-                                            `:v}
-                                            ${e.image?T`
+                                            `:_}
+                                            ${e.image?w`
                                                 <img src="${e.image}" alt="${e.label}" style="height: 1rem;" />
-                                            `:v}
+                                            `:_}
                                             <span>${e.label}</span>
                                         </vaadin-horizontal-layout>
-                                        ${e.description?T`
+                                        ${e.description?w`
                                             <div>${e.description}</div>
-                                        `:v}
+                                        `:_}
                                     </label>
-                                `:v}
+                                `:_}
                             </vaadin-radio-button>
                         `)}
 </vaadin-radio-group>
-                    `}if(this.field.stereotype==`popover`)return T`<vaadin-custom-field
+                    `}if(this.field.stereotype==`popover`)return w`<vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
-                            required="${this.field.required||v}"
+                            required="${this.field.required||_}"
                             .helperText="${this.helperText()}"
                             data-colspan="${this.field.colspan}"
                     >
@@ -9399,7 +9413,7 @@ ${i}
                             accessible-name-ref="notifications-heading"
                             content-width="300px"
                             position="bottom"
-                            ${ee(()=>T`
+                            ${te(()=>w`
                                 <mateu-event-interceptor .target="${this}">
                                 <mateu-choice
                                         .field="${this.field}"
@@ -9409,12 +9423,12 @@ ${i}
                             `,[])}
                     ></vaadin-popover>
                     </vaadin-custom-field>
-                `;if(this.field?.stereotype==`choice`)return T`
+                `;if(this.field?.stereotype==`choice`)return w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
                             .helperText="${this.helperText()}"
-                            required="${this.field.required||v}"
+                            required="${this.field.required||_}"
                             data-colspan="${this.field.colspan}"
                     >
                         <mateu-choice
@@ -9427,7 +9441,7 @@ ${i}
                         ></mateu-choice>
                         
                     </vaadin-custom-field>
-                    `;if(this.field?.stereotype==`richText`)return T`
+                    `;if(this.field?.stereotype==`richText`)return w`
                     <vaadin-custom-field
                             label="${n}"
                             .helperText="${this.helperText()}"
@@ -9439,7 +9453,7 @@ ${i}
                             @value-changed="${this.valueChanged}"
                             ?autofocus="${this.field.wantsFocus}"
                     ></vaadin-rich-text-editor>
-                    </vaadin-custom-field>`;if(this.field?.stereotype==`textarea`)return T`
+                    </vaadin-custom-field>`;if(this.field?.stereotype==`textarea`)return w`
                     <vaadin-text-area
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9448,11 +9462,11 @@ ${i}
                             .helperText="${this.helperText()}"
                             @value-changed="${this.valueChanged}"
                             ?autofocus="${this.field.wantsFocus}"
-                            required="${this.field.required||v}"
+                            required="${this.field.required||_}"
                             data-colspan="${this.field.colspan}"
                             rows="4"
                             style="width: 100%;"
-                    ></vaadin-text-area>`;if(this.field?.stereotype==`email`)return T`
+                    ></vaadin-text-area>`;if(this.field?.stereotype==`email`)return w`
                     <vaadin-email-field
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9460,19 +9474,19 @@ ${i}
                             value="${t}"
                             .helperText="${this.helperText()}"
                             ?autofocus="${this.field.wantsFocus}"
-                            required="${this.field.required||v}"
+                            required="${this.field.required||_}"
                             data-colspan="${this.field.colspan}"
                     ></vaadin-email-field>
-                `;if(this.field?.stereotype==`link`)return this.field.readOnly?T`<vaadin-custom-field
+                `;if(this.field?.stereotype==`link`)return this.field.readOnly?w`<vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
                             .helperText="${this.helperText()}"
                             data-colspan="${this.field.colspan}"
-                    ><a href="${t}">${t}</a></vaadin-custom-field>`:T`
+                    ><a href="${t}">${t}</a></vaadin-custom-field>`:w`
                             <vaadin-text-field
                                     id="${this.field.fieldId}"
                                     label="${n}"
-                                    required="${this.field.required||v}"
+                                    required="${this.field.required||_}"
                                     @value-changed="${this.valueChanged}"
                                     value="${t}"
                                     .helperText="${this.helperText()}"
@@ -9484,14 +9498,14 @@ ${i}
                                              @click="${()=>window.open(t,`_blank`)?.focus()}"
                                 ></vaadin-icon>
                             </vaadin-text-field>
-                `;if(this.field?.stereotype==`icon`)return this.field.readOnly?T`<vaadin-icon
+                `;if(this.field?.stereotype==`icon`)return this.field.readOnly?w`<vaadin-icon
                                              icon="${t}"
                                              data-colspan="${this.field.colspan}"
-                    ></vaadin-icon>`:T`
+                    ></vaadin-icon>`:w`
                     <vaadin-combo-box
                                     id="${this.field.fieldId}"
                                     label="${n}"
-                                    required="${this.field.required||v}"
+                                    required="${this.field.required||_}"
                                     @value-changed="${this.valueChanged}"
                                     value="${t}"
                                     .helperText="${this.helperText()}"
@@ -9503,9 +9517,9 @@ ${i}
                             @filter-changed="${this.iconFilterChanged}"
                             ${u(this.iconComboboxRenderer,[])}
                     >
-                        ${t?T`<vaadin-icon slot="prefix" icon="${t}"></vaadin-icon>`:v}
+                        ${t?w`<vaadin-icon slot="prefix" icon="${t}"></vaadin-icon>`:_}
                     </vaadin-combo-box>
-                `;if(this.field?.stereotype==`password`)return T`
+                `;if(this.field?.stereotype==`password`)return w`
                     <vaadin-password-field
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9513,17 +9527,17 @@ ${i}
                             value="${t}"
                             .helperText="${this.helperText()}"
                             ?autofocus="${this.field.wantsFocus}"
-                            required="${this.field.required||v}"
+                            required="${this.field.required||_}"
                             data-colspan="${this.field.colspan}"
                     ></vaadin-password-field>
-                `;if(this.field?.stereotype==`html`)return T`
+                `;if(this.field?.stereotype==`html`)return w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
                             .helperText="${this.helperText()}"
                             data-colspan="${this.field.colspan}"
-                    ><div style="line-height: 20px; margin-top: 5px; margin-bottom: 24px;">${_(``+t)}</div></vaadin-custom-field>
-                `;if(this.field?.stereotype==`image`)return T`
+                    ><div style="line-height: 20px; margin-top: 5px; margin-bottom: 24px;">${g(``+t)}</div></vaadin-custom-field>
+                `;if(this.field?.stereotype==`image`)return w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9532,10 +9546,10 @@ ${i}
                     ><img
                             src="${t}"
                             style="${this.component?.style}" class="${this.component?.cssClasses}"></vaadin-custom-field>
-                `;if(this.field?.stereotype==`treeSelect`){let e=this.helperText();return T`
+                `;if(this.field?.stereotype==`treeSelect`){let e=this.helperText();return w`
                     <div class="tree-field" id="${this.field.fieldId}" data-colspan="${this.field.colspan}">
-                        ${n?T`
-                            <span class="tree-field__label">${n}${this.field.required?T`<span class="tree-field__required"> •</span>`:v}</span>`:v}
+                        ${n?w`
+                            <span class="tree-field__label">${n}${this.field.required?w`<span class="tree-field__required"> •</span>`:_}</span>`:_}
                         <mateu-vaadin-tree-select
                                 style="width: 100%;"
                                 .fieldId="${this.field.fieldId}"
@@ -9543,9 +9557,9 @@ ${i}
                                 .options="${this.field.options??[]}"
                                 .leavesOnly="${this.field.treeLeavesOnly??!1}"
                         ></mateu-vaadin-tree-select>
-                        ${e?T`<span class="tree-field__helper">${e}</span>`:v}
+                        ${e?w`<span class="tree-field__helper">${e}</span>`:_}
                     </div>
-                `}if(this.field?.stereotype==`signature`)return T`
+                `}if(this.field?.stereotype==`signature`)return w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9554,7 +9568,7 @@ ${i}
                     >
                         <mateu-signature-pad .fieldId="${this.field.fieldId}" .value="${t}"></mateu-signature-pad>
                     </vaadin-custom-field>
-                `;if(this.field?.stereotype==`camera`)return T`
+                `;if(this.field?.stereotype==`camera`)return w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9563,7 +9577,7 @@ ${i}
                     >
                         <mateu-camera-capture .fieldId="${this.field.fieldId}" .value="${t}"></mateu-camera-capture>
                     </vaadin-custom-field>
-                `;if(this.field?.stereotype==`fileUpload`){let e=dc(this.field.attributes,`accept`);return T`
+                `;if(this.field?.stereotype==`fileUpload`){let e=Dc(this.field.attributes,`accept`);return w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9572,7 +9586,7 @@ ${i}
                     >
                         <mateu-file-upload .fieldId="${this.field.fieldId}" .value="${t}" .accept="${e}"></mateu-file-upload>
                     </vaadin-custom-field>
-                `}if(this.field?.stereotype==`uploadableImage`){let e=t!=null&&t!==``;return T`
+                `}if(this.field?.stereotype==`uploadableImage`){let e=t!=null&&t!==``;return w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9580,10 +9594,10 @@ ${i}
                             data-colspan="${this.field.colspan}"
                     >
                         <vaadin-vertical-layout style="align-items: stretch; gap: var(--lumo-space-s); max-width: 320px;">
-                            ${e?T`<img
+                            ${e?w`<img
                                     src="${t}"
                                     style="max-width: 100%; max-height: 240px; object-fit: contain; border: 1px solid var(--lumo-contrast-20pct); border-radius: var(--lumo-border-radius-m); ${this.field.style??``}"
-                                    class="${this.component?.cssClasses}">`:T`<div style="height: 135px; display: flex; align-items: center; justify-content: center; border: 1px dashed var(--lumo-contrast-30pct); border-radius: var(--lumo-border-radius-m); color: var(--lumo-secondary-text-color);">
+                                    class="${this.component?.cssClasses}">`:w`<div style="height: 135px; display: flex; align-items: center; justify-content: center; border: 1px dashed var(--lumo-contrast-30pct); border-radius: var(--lumo-border-radius-m); color: var(--lumo-secondary-text-color);">
                                     <vaadin-icon icon="vaadin:picture" style="height: 2rem; width: 2rem;"></vaadin-icon>
                                 </div>`}
                             <input type="file" accept="image/*" style="display: none;" @change="${this.imageUpload}">
@@ -9592,21 +9606,21 @@ ${i}
                                     <vaadin-icon icon="vaadin:upload" slot="prefix"></vaadin-icon>
                                     ${e?`Replace`:`Upload`}
                                 </vaadin-button>
-                                ${e?T`<vaadin-button theme="error tertiary" @click="${this.imageDelete}">
+                                ${e?w`<vaadin-button theme="error tertiary" @click="${this.imageDelete}">
                                     <vaadin-icon icon="vaadin:trash" slot="prefix"></vaadin-icon>
                                     Delete
-                                </vaadin-button>`:v}
+                                </vaadin-button>`:_}
                             </vaadin-horizontal-layout>
                         </vaadin-vertical-layout>
                     </vaadin-custom-field>
-                `}return this.field?.stereotype==`color`?this.field.readOnly?T`
+                `}return this.field?.stereotype==`color`?this.field.readOnly?w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
                             .helperText="${this.helperText()}"
                             data-colspan="${this.field.colspan}"
                     ><span style="background-color: ${t}; display: block; height: 20px; width: 40px; margin-top: 5px; margin-bottom: 24px; border: 1px solid var(--lumo-secondary-text-color)"></vaadin-custom-field>
-                `:T`
+                `:w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9627,7 +9641,7 @@ ${i}
   ${s(this.renderColorPicker,[])}
   ${p(this.renderColorPickerFooter,[])}
 ></vaadin-dialog>
-                `:T`
+                `:w`
                 <vaadin-text-field
                         id="${this.field.fieldId}"
                         label="${n}"
@@ -9635,44 +9649,44 @@ ${i}
                         value="${t}"
                         .helperText="${this.helperText()}"
                         ?autofocus="${this.field.wantsFocus}"
-                        ?required="${this.field.required||v}"
+                        ?required="${this.field.required||_}"
                         ?disabled="${this.field.disabled}"
                         data-colspan="${this.field.colspan}"
                         style="${this.field.style}"
                 ></vaadin-text-field>
-`}renderNumberField(e,t,n,r){return this.field?T`<vaadin-number-field
+`}renderNumberField(e,t,n,r){return this.field?w`<vaadin-number-field
                         id="${this.field.fieldId}"
                         label="${n}"
                         @value-changed="${this.valueChanged}"
                         value="${t}"
                         .helperText="${this.helperText()}"
                         ?autofocus="${this.field.wantsFocus}"
-                        ?required="${this.field.required||v}"
+                        ?required="${this.field.required||_}"
                         data-colspan="${this.field.colspan}"
-                        step="${this.field.step||v}"
+                        step="${this.field.step||_}"
                         ?step-buttons-visible="${this.field.stepButtonsVisible}"
-                        min="${this.field.min==null?v:this.field.min}"
-                        max="${this.field.max==null?v:this.field.max}"
-            ></vaadin-number-field>`:T``}renderIntegerField(e,t,n,r){if(!this.field)return T``;if(this.field.stereotype==`stars`){let e=t;return isNaN(e)&&(e=0),T`<vaadin-custom-field
+                        min="${this.field.min==null?_:this.field.min}"
+                        max="${this.field.max==null?_:this.field.max}"
+            ></vaadin-number-field>`:w``}renderIntegerField(e,t,n,r){if(!this.field)return w``;if(this.field.stereotype==`stars`){let e=t;return isNaN(e)&&(e=0),w`<vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
                             .helperText="${this.helperText()}"
                             data-colspan="${this.field.colspan}"
-                    >${[1,2,3,4,5].map(t=>T`
+                    >${[1,2,3,4,5].map(t=>w`
                     <vaadin-icon 
                             icon="vaadin:star" 
                             style="cursor: pointer; color: var(${t<=e?`--lumo-warning-color`:`--lumo-shade-30pct`});"
                             @click="${()=>this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:this.field.fieldId},bubbles:!0,composed:!0}))}"
                     
                     ></vaadin-icon>
-                `)}</vaadin-custom-field>`}if(this.field.stereotype==`slider`){let e=t;return isNaN(e)&&(e=0),T`
+                `)}</vaadin-custom-field>`}if(this.field.stereotype==`slider`){let e=t;return isNaN(e)&&(e=0),w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
                             .helperText="${this.helperText()}"
                             data-colspan="${this.field.colspan}"
                     ><input type="range" @input="${e=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e.target.value,fieldId:this.field.fieldId},bubbles:!0,composed:!0}))}}" min="${this.field.sliderMin??0}" max="${this.field.sliderMax??10}" value="${e??0}"/></vaadin-custom-field>
-                `}return T`
+                `}return w`
                 <vaadin-integer-field
                         id="${this.field.fieldId}"
                         label="${n}"
@@ -9680,18 +9694,18 @@ ${i}
                         value="${t}"
                         .helperText="${this.helperText()}"
                         ?autofocus="${this.field.wantsFocus}"
-                        ?required="${this.field.required||v}"
+                        ?required="${this.field.required||_}"
                         data-colspan="${this.field.colspan}"
-                        step="${this.field.step||v}"
+                        step="${this.field.step||_}"
                         ?step-buttons-visible="${this.field.stepButtonsVisible}"
-                        min="${this.field.min==null?v:this.field.min}"
-                        max="${this.field.max==null?v:this.field.max}"
+                        min="${this.field.min==null?_:this.field.min}"
+                        max="${this.field.max==null?_:this.field.max}"
                 ></vaadin-integer-field>
-            `}renderBoolField(e,t,n,r){return this.field?this.field.stereotype==`toggle`?T`
+            `}renderBoolField(e,t,n,r){return this.field?this.field.stereotype==`toggle`?w`
                     <vaadin-custom-field
                             label="${n}"
                             .helperText="${this.helperText()}"
-                            ?required="${this.field.required||v}"
+                            ?required="${this.field.required||_}"
                             data-colspan="${this.field.colspan}"
                     >
                         <paper-toggle-button id="${this.field.fieldId}"
@@ -9700,60 +9714,60 @@ ${i}
                                              @change=${this.checked}>
                         </paper-toggle-button>
                     </vaadin-custom-field>
-                `:T`
+                `:w`
                 <vaadin-checkbox
                         id="${this.field.fieldId}"
                         label="${n}"
                         .helperText="${this.helperText()}"
-                        ?required="${this.field.required||v}"
+                        ?required="${this.field.required||_}"
                         data-colspan="${this.field.colspan}"
                         @change="${this.checked}"
                         value="${t}"
                         ?checked=${t}
                         ?autofocus="${this.field.wantsFocus}"
                 ></vaadin-checkbox>
-            `:T``}renderDateRangeField(e,t,n,r){if(!this.field)return T``;let i=t?t.from+`;`+t.to:void 0;return T`<vcf-date-range-picker
+            `:w``}renderDateRangeField(e,t,n,r){if(!this.field)return w``;let i=t?t.from+`;`+t.to:void 0;return w`<vcf-date-range-picker
                     id="${this.field.fieldId}"
                     label="${n}"
                     @value-changed="${e=>{e.detail.value&&(e.detail.value={from:e.detail.value.split(`;`)[0],to:e.detail.value.split(`;`)[1]}),this.valueChanged(e)}}"
                     value="${i}"
                     .helperText="${this.helperText()}"
                     ?autofocus="${this.field.wantsFocus}"
-                    ?required="${this.field.required||v}"
+                    ?required="${this.field.required||_}"
                     data-colspan="${this.field.colspan}"
-            ></vcf-date-range-picker>`}renderDateField(e,t,n,r){return this.field?T`<vaadin-date-picker
+            ></vcf-date-range-picker>`}renderDateField(e,t,n,r){return this.field?w`<vaadin-date-picker
                         id="${this.field.fieldId}"
                         label="${n}"
                         @value-changed="${this.valueChanged}"
                         value="${t}"
                         .helperText="${this.helperText()}"
                         ?autofocus="${this.field.wantsFocus}"
-                        ?required="${this.field.required||v}"
+                        ?required="${this.field.required||_}"
                         data-colspan="${this.field.colspan}"
-            ></vaadin-date-picker>`:T``}renderDateTimeField(e,t,n,r){return this.field?T`<vaadin-date-time-picker
+            ></vaadin-date-picker>`:w``}renderDateTimeField(e,t,n,r){return this.field?w`<vaadin-date-time-picker
                         id="${this.field.fieldId}"
                         label="${n}"
                         @value-changed="${this.valueChanged}"
                         value="${t}"
                         .helperText="${this.helperText()}"
                         ?autofocus="${this.field.wantsFocus}"
-                        ?required="${this.field.required||v}"
+                        ?required="${this.field.required||_}"
                         data-colspan="${this.field.colspan}"
-            ></vaadin-date-time-picker>`:T``}renderTimeField(e,t,n,r){return this.field?T`<vaadin-time-picker
+            ></vaadin-date-time-picker>`:w``}renderTimeField(e,t,n,r){return this.field?w`<vaadin-time-picker
                         id="${this.field.fieldId}"
                         label="${n}"
                         @value-changed="${this.valueChanged}"
                         value="${t}"
                         .helperText="${this.helperText()}"
                         ?autofocus="${this.field.wantsFocus}"
-                        ?required="${this.field.required||v}"
+                        ?required="${this.field.required||_}"
                         data-colspan="${this.field.colspan}"
-            ></vaadin-time-picker>`:T``}renderArrayField(e,t,n,r){if(!this.field)return T``;if(this.field?.stereotype==`choice`)return T`
+            ></vaadin-time-picker>`:w``}renderArrayField(e,t,n,r){if(!this.field)return w``;if(this.field?.stereotype==`choice`)return w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
                             .helperText="${this.helperText()}"
-                            required="${this.field.required||v}"
+                            required="${this.field.required||_}"
                             data-colspan="${this.field.colspan}"
                     >
                         <mateu-choice
@@ -9766,7 +9780,7 @@ ${i}
                         ></mateu-choice>
                         
                     </vaadin-custom-field>
-                    `;if(this.field?.stereotype==`grid`)return T`
+                    `;if(this.field?.stereotype==`grid`)return w`
                     <vaadin-custom-field
                             label="${n}"
                             .helperText="${this.helperText()}"
@@ -9783,24 +9797,24 @@ ${i}
                             data-colspan="${this.field.colspan}"
                     ></mateu-grid>
                     </vaadin-custom-field>
-`;if(this.field?.stereotype==`listBox`){if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates;return this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements||this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0})),T`
+`;if(this.field?.stereotype==`listBox`){if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates;return this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements||this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0})),w`
                         <vaadin-custom-field
                                 label="${n}"
                                 .helperText="${this.helperText()}"
                                 data-colspan="${this.field.colspan}"
                         >
                     <vaadin-list-box multiple
-                                     .selectedValues="${S(this.selectedIndexes(t))}"
+                                     .selectedValues="${x(this.selectedIndexes(t))}"
                                      @selected-values-changed="${this.listItemsSelected}"
                             id="${this.field.fieldId}"
                             ?autofocus="${this.field.wantsFocus}"
                     >
-                        ${this.data[this.id]?.content?.map(e=>T`
+                        ${this.data[this.id]?.content?.map(e=>w`
                             <vaadin-item>${e.label}</vaadin-item>
                         `)}
                     </vaadin-list-box>
                         </vaadin-custom-field>
-                    `}return T`
+                    `}return w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9808,17 +9822,17 @@ ${i}
                             data-colspan="${this.field.colspan}"
                     >
                     <vaadin-list-box multiple
-                                     .selectedValues="${S(this.selectedIndexes(t))}"
+                                     .selectedValues="${x(this.selectedIndexes(t))}"
                                      @selected-values-changed="${this.listItemsSelected}"
                                      ?autofocus="${this.field.wantsFocus}"
                                      data-colspan="${this.field.colspan}"
                     >
-                        ${this.field.options?.map(e=>T`
+                        ${this.field.options?.map(e=>w`
                             <vaadin-item>${e.label}</vaadin-item>
                         `)}
                     </vaadin-list-box>
                     </vaadin-custom-field>
-                `}if(this.field?.stereotype==`combobox`){if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates;return T`
+                `}if(this.field?.stereotype==`combobox`){if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates;return w`
                         <vaadin-multi-select-combo-box
                             label="${n}"
                             item-label-path="label"
@@ -9828,7 +9842,7 @@ ${i}
                             .helperText="${this.helperText()}"
                             .selectedItems="${this.selectedItems(t)}"
                             ?autofocus="${this.field.wantsFocus}"
-                            ?required="${this.field.required||v}"
+                            ?required="${this.field.required||_}"
                             @selected-items-changed="${this.multiComboBoxValueChanged}"
                             data-colspan="${this.field.colspan}"
                             style="${this.field.style}"
@@ -9836,7 +9850,7 @@ ${i}
                             auto-expand-vertically
                             xselected-items-on-top
                     ></vaadin-multi-select-combo-box>
-                    `}return T`
+                    `}return w`
                     <vaadin-multi-select-combo-box
                             label="${n}"
                             item-label-path="label"
@@ -9845,7 +9859,7 @@ ${i}
                             .helperText="${this.helperText()}"
                             .selectedItems="${this.selectedItems(t)}"
                             ?autofocus="${this.field.wantsFocus}"
-                            ?required="${this.field.required||v}"
+                            ?required="${this.field.required||_}"
                             @selected-items-changed="${this.multiComboBoxValueChanged}"
                             data-colspan="${this.field.colspan}"
                             style="${this.field.style}"
@@ -9853,7 +9867,7 @@ ${i}
                             auto-expand-vertically
                             xselected-items-on-top
                     ></vaadin-multi-select-combo-box>
-                    `}if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates;return this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements||this.rendered||setTimeout(()=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}),T`
+                    `}if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates;return this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements||this.rendered||setTimeout(()=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}),w`
                     <vaadin-checkbox-group
                         id="${this.field.fieldId}"
                         label="${n}"
@@ -9861,19 +9875,19 @@ ${i}
                         @value-changed="${this.valueChanged}"
                         .helperText="${this.helperText()}"
                         ?autofocus="${this.field.wantsFocus}"
-                        ?required="${this.field.required||v}"
+                        ?required="${this.field.required||_}"
                         data-colspan="${this.field.colspan}"
                         .value="${t}"
                         class="mateu-checkbox-group-${this.field.optionsColumns>1?`multi-column`:``}"
                 >
-                        ${this.data[this.id]?.content?.map(e=>T`
+                        ${this.data[this.id]?.content?.map(e=>w`
                             <vaadin-checkbox
                                     value="${e.value}"
                                     label="${e.label}"
                             ></vaadin-checkbox>
                         `)}
                 </vaadin-checkbox-group>
-                    `}return T`
+                    `}return w`
                 <vaadin-checkbox-group
                         id="${this.field.fieldId}"
                         label="${n}"
@@ -9881,43 +9895,43 @@ ${i}
                         theme="vertical"
                         .helperText="${this.helperText()}"
                         ?autofocus="${this.field.wantsFocus}"
-                        ?required="${this.field.required||v}"
+                        ?required="${this.field.required||_}"
                         data-colspan="${this.field.colspan}"
                         class="mateu-checkbox-group-${this.field.optionsColumns>1?`multi-column`:``}"
                         .value="${t}"
                 >
-                        ${this.field.options?.map(e=>T`
+                        ${this.field.options?.map(e=>w`
                         <vaadin-checkbox 
                                 value="${e.value}" 
                                 label="${e.label}"
                         ></vaadin-checkbox>
                         `)}
                 </vaadin-checkbox-group>
-            `}renderMoneyField(e,t,n,r){if(!this.field)return T``;if(this.field.readOnly){let e=t,r=e;return r=e&&e.locale&&e.currency?new Intl.NumberFormat(e.locale,{style:`currency`,currency:e.currency}).format(e.value):new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e),T`<vaadin-custom-field
+            `}renderMoneyField(e,t,n,r){if(!this.field)return w``;if(this.field.readOnly){let e=t,r=e;return r=e&&e.locale&&e.currency?new Intl.NumberFormat(e.locale,{style:`currency`,currency:e.currency}).format(e.value):new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e),w`<vaadin-custom-field
                         id="${this.field.fieldId}"
                         label="${n}"
                         .helperText="${this.helperText()}"
                         data-colspan="${this.field.colspan}"
-                ><div style="width: 186px; text-align: right;">${r}</div></vaadin-custom-field>`}return T`<mateu-money-field
+                ><div style="width: 186px; text-align: right;">${r}</div></vaadin-custom-field>`}return w`<mateu-money-field
                         id="${this.field.fieldId}"
                         label="${n}"
                         @value-changed="${this.valueChanged}"
                         .value="${t}"
                         .helperText="${this.helperText()}"
                         ?autofocus="${this.field.wantsFocus}"
-                        ?required="${this.field.required||v}"
+                        ?required="${this.field.required||_}"
                         data-colspan="${this.field.colspan}"
-            ></mateu-money-field>`}renderStatusField(e,t,n,r){if(!this.field)return T``;let i=t;return T`
+            ></mateu-money-field>`}renderStatusField(e,t,n,r){if(!this.field)return w``;let i=t;return w`
                 <vaadin-custom-field
                         id="${this.field.fieldId}"
                         label="${n}"
-                        required="${this.field.required||v}"
+                        required="${this.field.required||_}"
                         .helperText="${this.helperText()}"
                         data-colspan="${this.field.colspan}"
                 >
-                    ${i?T`<span theme="badge pill ${ra(i.type)}">${i.message}</span>`:T``}                    
+                    ${i?w`<span theme="badge pill ${ia(i.type)}">${i.message}</span>`:w``}                    
                 </vaadin-custom-field>
-            `}renderRangeField(e,t,n,r){if(!this.field)return T``;this.loadUi5FieldComponents();let i=t;return T`
+            `}renderRangeField(e,t,n,r){if(!this.field)return w``;this.loadUi5FieldComponents();let i=t;return w`
                 <vaadin-custom-field
                         id="${this.field.fieldId}"
                         label="${n}"
@@ -9926,12 +9940,12 @@ ${i}
                 ><ui5-range-slider start-value="${i?.from??0}" end-value="${i?.to??0}" 
                                    min="${this.field.sliderMin??0}" 
                                    max="${this.field.sliderMax??10}"
-                                   step="${this.field.step||v}"
+                                   step="${this.field.step||_}"
                                    @change="${e=>{let t=e.target;this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:{from:t.startValue,to:t.endValue},fieldId:this.field.fieldId},bubbles:!0,composed:!0}))}}"
                                    style="min-width: 10rem;"
                 ></ui5-range-slider></vaadin-custom-field>
-            `}static{this.styles=h`
-        ${de}
+            `}static{this.styles=m`
+        ${fe}
 
         /* Fields fill the whole column width by default. Date, checkbox, numeric and money inputs
            are the exception — they keep their natural (narrower) width so a date/amount doesn't
@@ -10013,7 +10027,7 @@ ${i}
             text-overflow: clip;
             height: auto;
         }
-  `}};k([C()],Q.prototype,`ui5FieldComponentsReady`,void 0),k([y()],Q.prototype,`component`,void 0),k([y()],Q.prototype,`field`,void 0),k([y()],Q.prototype,`baseUrl`,void 0),k([y()],Q.prototype,`state`,void 0),k([y()],Q.prototype,`data`,void 0),k([y()],Q.prototype,`appState`,void 0),k([y()],Q.prototype,`appData`,void 0),k([y()],Q.prototype,`labelAlreadyRendered`,void 0),k([C()],Q.prototype,`colorPickerOpened`,void 0),k([C()],Q.prototype,`colorPickerValue`,void 0),k([C()],Q.prototype,`controlOwnsValidity`,void 0),k([C()],Q.prototype,`filteredIcons`,void 0),k([C()],Q.prototype,`navLinkOffset`,void 0),Q=k([g(`mateu-field`)],Q);var tl=(e,t,n,r,i,a,o,s)=>{let c=t.metadata;return T`
+  `}};O([S()],Z.prototype,`ui5FieldComponentsReady`,void 0),O([v()],Z.prototype,`component`,void 0),O([v()],Z.prototype,`field`,void 0),O([v()],Z.prototype,`baseUrl`,void 0),O([v()],Z.prototype,`state`,void 0),O([v()],Z.prototype,`data`,void 0),O([v()],Z.prototype,`appState`,void 0),O([v()],Z.prototype,`appData`,void 0),O([v()],Z.prototype,`labelAlreadyRendered`,void 0),O([S()],Z.prototype,`colorPickerOpened`,void 0),O([S()],Z.prototype,`colorPickerValue`,void 0),O([S()],Z.prototype,`controlOwnsValidity`,void 0),O([S()],Z.prototype,`filteredIcons`,void 0),O([S()],Z.prototype,`navLinkOffset`,void 0),Z=O([h(`mateu-field`)],Z);var bl=(e,t,n,r,i,a,o,s)=>{let c=t.metadata;return w`
         <mateu-field
                 id="${t.id}"
                 .component="${t}"
@@ -10022,75 +10036,75 @@ ${i}
                 .data="${i}"
                 .appState="${a}"
                 .appdata="${o}"
-                style="${Zi(t,i)}" class="${t.cssClasses}"
-                slot="${t.slot??v}"
+                style="${Qi(t,i)}" class="${t.cssClasses}"
+                slot="${t.slot??_}"
                 data-colspan="${c.colspan}"
-                colspan="${(c.colspan??1)>1?c.colspan:v}"
+                colspan="${(c.colspan??1)>1?c.colspan:_}"
                 .labelAlreadyRendered="${s}"
         >
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o,s))}
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o,s))}
         </mateu-field>
-    `},nl=(e,n,r,i,a,o,s)=>{let c=n.metadata;if(c.tree)return T`
+    `},xl=(e,n,r,i,a,o,s)=>{let c=n.metadata;if(c.tree)return w`
         <vaadin-grid style="${n.style}" class="${n.cssClasses}"
                      .itemHasChildrenPath="${`children`}" .dataProvider="${async(e,t)=>{let n=e.parentItem?e.parentItem.children:c.page.content;t(n,n.length)}}"
-                     slot="${n.slot??v}"
+                     slot="${n.slot??_}"
                      all-rows-visible
         >
-            ${c.content.map((n,c)=>{let l=n.metadata;return c>0?T`
+            ${c.content.map((n,c)=>{let l=n.metadata;return c>0?w`
             <vaadin-grid-column path="${n.id}"
-                                header="${l?.label??v}"
+                                header="${l?.label??_}"
                                 ?auto-width="${l?.autoWidth}"
-                                flex-grow="${l?.flexGrow??v}"
-                                width="${l?.width??v}"
+                                flex-grow="${l?.flexGrow??_}"
+                                width="${l?.width??_}"
                                 .column="${n.metadata}"
-                                ${t((t,n,c)=>Kc(t,n,c,l,e,r,i,a,o,s),[])}></vaadin-grid-column>
-`:T`
+                                ${t((t,n,c)=>dl(t,n,c,l,e,r,i,a,o,s),[])}></vaadin-grid-column>
+`:w`
             <vaadin-grid-tree-column path="${n.id}"
-                                header="${l?.label??v}"
+                                header="${l?.label??_}"
                                 ?auto-width="${l?.autoWidth}"
-                                flex-grow="${l?.flexGrow??v}"
-                                width="${l?.width??v}"
+                                flex-grow="${l?.flexGrow??_}"
+                                width="${l?.width??_}"
             ></vaadin-grid-tree-column>
 `})}
-            <span slot="empty-state">${xt()}</span>
+            <span slot="empty-state">${St()}</span>
         </vaadin-grid>
-    `;let l=c.page?.content;return n.id&&i&&i[n.id]&&(l=i[n.id]),l||=[],T`
+    `;let l=c.page?.content;return n.id&&i&&i[n.id]&&(l=i[n.id]),l||=[],w`
         <vaadin-grid 
                 style="${n.style}" 
                 class="${n.cssClasses}" 
                 .items="${l}"
                 all-rows-visible
         >
-            ${c?.content?.map(t=>Wc(t,e,r,i,a,o,s))}
+            ${c?.content?.map(t=>ll(t,e,r,i,a,o,s))}
         </vaadin-grid>
-    `},$=class extends b{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.detailsOpenedItems=[],this.pagesRequested=[],this.emptyArray=e=>!e||e.length==0,this.dataProvider=(e,t)=>{let n=this.data[this.id]?.page;if(this.metadata?.infiniteScrolling&&e.page>0){let r=!1;n&&n.content&&(n.content.length>=(e.page+1)*e.pageSize||n.content.length==n.totalElements)&&(t(n.content.slice(e.page*e.pageSize,(e.page+1)*e.pageSize),n.totalElements),r=!0,this.grid&&this.grid.recalculateColumnWidths()),r||this.pagesRequested.find(t=>t==e.page)||(this.pagesRequested.push(e.page),this.dispatchEvent(new CustomEvent(`fetch-more-elements`,{detail:{params:e,callback:()=>{this.data[this.id]?.page?.content&&(t(this.data[this.id].page.content.slice(e.page*e.pageSize,(e.page+1)*e.pageSize),this.data[this.id].page.totalElements),this.grid&&this.grid.recalculateColumnWidths())}},bubbles:!0,composed:!0})))}else{let e=this.metadata?.infiniteScrolling?n?.totalElements:n?.content?.length??0;t(n?.content??[],e),this.grid&&this.grid.recalculateColumnWidths()}},this._onActionRequested=e=>{let t=e.detail,n=this.identifierFieldName;if(!n||!t.parameters||t.actionId?.startsWith(`action-on-row-`))return;let r=t.parameters[n];r!==void 0&&(this.state._selectedId=String(r),this._applyCellPartNameGenerator(),this.grid?.requestContentUpdate())},this.tooltipGenerator=e=>{let t=``,{column:n,item:r}=e,i=this.metadata?.columns?.find(e=>e.metadata.id==n?.path);if(i?.metadata){let e=(i?.metadata).tooltipPath;e&&n&&r&&(t=r[e])}return t}}get identifierFieldName(){let e=this.metadata?.columns?.find(e=>e.metadata?.identifier);if(e)return e.metadata?.id;if(this.metadata?.columns?.find(e=>e.metadata?.id===`id`))return`id`}_applyCellPartNameGenerator(){if(!this.grid)return;let e=this.identifierFieldName,t=this.state?._selectedId??this.appState?._splitDetailId,n=!!this.metadata?.groupBy;e&&t!==void 0||n?this.grid.cellPartNameGenerator=(n,r)=>{let i=r.item;return pc(i)?`mateu-group-row`:e&&t!==void 0&&String(i[e])===String(t)?`selected-row`:``}:this.grid.cellPartNameGenerator=null}connectedCallback(){super.connectedCallback(),this.addEventListener(`action-requested`,this._onActionRequested)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`action-requested`,this._onActionRequested)}updated(e){super.updated(e),this._applyCellPartNameGenerator(),this.grid?.clearCache(),this.grid?.requestContentUpdate(),this.grid?.recalculateColumnWidths(),this.pagesRequested=[]}render(){let e=this.data[this.id],r=e?.page,i=this.metadata?.groupBy,a=this.metadata?.infiniteScrolling?void 0:r?.content?hc(r.content,i,e?.groups):r?.content,o=yc((this.metadata?.columns??[]).flatMap(e=>e.metadata?.type===j.GridGroupColumn?(e.metadata.columns??[]).map(e=>e.metadata):[e.metadata]),e,i),s=``;return this.metadata?.wrapCellContent&&(s+=` wrap-cell-content`),this.metadata?.compact&&(s+=` compact`),this.metadata?.noBorder&&(s+=` no-border`),this.metadata?.noRowBorder&&(s+=` no-row-borders`),this.metadata?.columnBorders&&(s+=` column-borders`),this.metadata?.rowStripes&&(s+=` row-stripes`),T`
+    `},Q=class extends y{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.detailsOpenedItems=[],this.pagesRequested=[],this.emptyArray=e=>!e||e.length==0,this.dataProvider=(e,t)=>{let n=this.data[this.id]?.page;if(this.metadata?.infiniteScrolling&&e.page>0){let r=!1;n&&n.content&&(n.content.length>=(e.page+1)*e.pageSize||n.content.length==n.totalElements)&&(t(n.content.slice(e.page*e.pageSize,(e.page+1)*e.pageSize),n.totalElements),r=!0,this.grid&&this.grid.recalculateColumnWidths()),r||this.pagesRequested.find(t=>t==e.page)||(this.pagesRequested.push(e.page),this.dispatchEvent(new CustomEvent(`fetch-more-elements`,{detail:{params:e,callback:()=>{this.data[this.id]?.page?.content&&(t(this.data[this.id].page.content.slice(e.page*e.pageSize,(e.page+1)*e.pageSize),this.data[this.id].page.totalElements),this.grid&&this.grid.recalculateColumnWidths())}},bubbles:!0,composed:!0})))}else{let e=this.metadata?.infiniteScrolling?n?.totalElements:n?.content?.length??0;t(n?.content??[],e),this.grid&&this.grid.recalculateColumnWidths()}},this._onActionRequested=e=>{let t=e.detail,n=this.identifierFieldName;if(!n||!t.parameters||t.actionId?.startsWith(`action-on-row-`))return;let r=t.parameters[n];r!==void 0&&(this.state._selectedId=String(r),this._applyCellPartNameGenerator(),this.grid?.requestContentUpdate())},this.tooltipGenerator=e=>{let t=``,{column:n,item:r}=e,i=this.metadata?.columns?.find(e=>e.metadata.id==n?.path);if(i?.metadata){let e=(i?.metadata).tooltipPath;e&&n&&r&&(t=r[e])}return t}}get identifierFieldName(){let e=this.metadata?.columns?.find(e=>e.metadata?.identifier);if(e)return e.metadata?.id;if(this.metadata?.columns?.find(e=>e.metadata?.id===`id`))return`id`}_applyCellPartNameGenerator(){if(!this.grid)return;let e=this.identifierFieldName,t=this.state?._selectedId??this.appState?._splitDetailId,n=!!this.metadata?.groupBy;e&&t!==void 0||n?this.grid.cellPartNameGenerator=(n,r)=>{let i=r.item;return Mc(i)?`mateu-group-row`:e&&t!==void 0&&String(i[e])===String(t)?`selected-row`:``}:this.grid.cellPartNameGenerator=null}connectedCallback(){super.connectedCallback(),this.addEventListener(`action-requested`,this._onActionRequested)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`action-requested`,this._onActionRequested)}updated(e){super.updated(e),this._applyCellPartNameGenerator(),this.grid?.clearCache(),this.grid?.requestContentUpdate(),this.grid?.recalculateColumnWidths(),this.pagesRequested=[]}render(){let e=this.data[this.id],r=e?.page,i=this.metadata?.groupBy,a=this.metadata?.infiniteScrolling?void 0:r?.content?Pc(r.content,i,e?.groups):r?.content,o=Rc((this.metadata?.columns??[]).flatMap(e=>e.metadata?.type===A.GridGroupColumn?(e.metadata.columns??[]).map(e=>e.metadata):[e.metadata]),e,i),s=``;return this.metadata?.wrapCellContent&&(s+=` wrap-cell-content`),this.metadata?.compact&&(s+=` compact`),this.metadata?.noBorder&&(s+=` no-border`),this.metadata?.noRowBorder&&(s+=` no-row-borders`),this.metadata?.columnBorders&&(s+=` column-borders`),this.metadata?.rowStripes&&(s+=` row-stripes`),w`
             <vaadin-grid
                     .items="${a}"
                     item-id-path="_rowNumber"
                     .selectedItems="${this.state[this.id+`_selected_items`]||[]}"
                     ?data-clickable-rows="${this.metadata?.detailPath&&!this.metadata?.useButtonForDetail}"
                     ?all-rows-visible="${this.metadata?.allRowsVisible}"
-                    column-rendering="${this.metadata?.lazyColumnRendering?`lazy`:v}"
+                    column-rendering="${this.metadata?.lazyColumnRendering?`lazy`:_}"
                     ?column-reordering-allowed="${this.metadata?.columnReorderingAllowed}"
                     .dataProvider="${this.metadata?.infiniteScrolling?this.dataProvider:void 0}"
                     page-size="${this.metadata?.pageSize}"
                     multi-sort-on-shift-click
-                    @selected-items-changed="${e=>{let t=(e.detail.value??[]).filter(e=>!pc(e));this.emptyArray(this.state[this.id+`_selected_items`])&&this.emptyArray(t)||(this.state[this.id+`_selected_items`]=t,this.metadata?.onRowSelectionChangedActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.metadata?.onRowSelectionChangedActionId},bubbles:!0,composed:!0})))}}"
-                    @active-item-changed="${S(this.metadata?.detailPath&&!this.metadata?.useButtonForDetail?e=>{if(this.metadata?.detailPath){let t=e.detail.value;if(t&&pc(t))return;t?this.detailsOpenedItems=[t]:this.detailsOpenedItems=[]}}:void 0)}"
+                    @selected-items-changed="${e=>{let t=(e.detail.value??[]).filter(e=>!Mc(e));this.emptyArray(this.state[this.id+`_selected_items`])&&this.emptyArray(t)||(this.state[this.id+`_selected_items`]=t,this.metadata?.onRowSelectionChangedActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.metadata?.onRowSelectionChangedActionId},bubbles:!0,composed:!0})))}}"
+                    @active-item-changed="${x(this.metadata?.detailPath&&!this.metadata?.useButtonForDetail?e=>{if(this.metadata?.detailPath){let t=e.detail.value;if(t&&Mc(t))return;t?this.detailsOpenedItems=[t]:this.detailsOpenedItems=[]}}:void 0)}"
                     .detailsOpenedItems="${this.detailsOpenedItems}"
-                    ${S(this.metadata?.detailPath?n(e=>T`${F(this,e[this.metadata?.detailPath],this.baseUrl,this.state,this.data,this.appState,this.appData)}`):void 0)}
+                    ${x(this.metadata?.detailPath?n(e=>w`${P(this,e[this.metadata?.detailPath],this.baseUrl,this.state,this.data,this.appState,this.appData)}`):void 0)}
                     theme="${s}"
                     style="${this.metadata?.gridStyle}"
             >
-                ${this.metadata?.rowsSelectionEnabled?T`
+                ${this.metadata?.rowsSelectionEnabled?w`
                     <vaadin-grid-selection-column></vaadin-grid-selection-column>
-                `:v}
-                ${this.metadata?.columns?.map(e=>Wc(e,this,this.baseUrl,this.state,this.data,this.appState,this.appData,o))}
-                ${this.metadata?.useButtonForDetail?T`
+                `:_}
+                ${this.metadata?.columns?.map(e=>ll(e,this,this.baseUrl,this.state,this.data,this.appState,this.appData,o))}
+                ${this.metadata?.useButtonForDetail?w`
                     <vaadin-grid-column
                             width="44px"
                             flex-grow="0"
-                            ${t((e,{detailsOpened:t})=>T`
+                            ${t((e,{detailsOpened:t})=>w`
               <vaadin-button
                 theme="tertiary icon"
                 title="${t?`Collapse`:`Expand`}"
@@ -10104,13 +10118,13 @@ ${i}
               </vaadin-button>
             `,[])}
                     ></vaadin-grid-column>
-                `:v}
-                <span slot="empty-state">${xt(this.emptyStateMessage??this.metadata?.emptyStateMessage)}</span>
-                ${this.metadata?.columns?.find(e=>e.metadata.tooltipPath)?T`<vaadin-tooltip slot="tooltip" .generator="${this.tooltipGenerator}"></vaadin-tooltip>`:v}
+                `:_}
+                <span slot="empty-state">${St(this.emptyStateMessage??this.metadata?.emptyStateMessage)}</span>
+                ${this.metadata?.columns?.find(e=>e.metadata.tooltipPath)?w`<vaadin-tooltip slot="tooltip" .generator="${this.tooltipGenerator}"></vaadin-tooltip>`:_}
             </vaadin-grid>
             <slot></slot>
-       `}static{this.styles=h`
-        ${de}
+       `}static{this.styles=m`
+        ${fe}
         vaadin-grid[data-clickable-rows]::part(row) {
             cursor: pointer;
         }
@@ -10124,7 +10138,7 @@ ${i}
             background-color: var(--lumo-contrast-5pct, rgba(0, 0, 0, 0.04));
             font-weight: 600;
         }
-  `}};k([y()],$.prototype,`id`,void 0),k([y()],$.prototype,`metadata`,void 0),k([y()],$.prototype,`baseUrl`,void 0),k([y()],$.prototype,`state`,void 0),k([y()],$.prototype,`data`,void 0),k([y()],$.prototype,`appState`,void 0),k([y()],$.prototype,`appData`,void 0),k([y()],$.prototype,`emptyStateMessage`,void 0),k([C()],$.prototype,`detailsOpenedItems`,void 0),k([x(`vaadin-grid`)],$.prototype,`grid`,void 0),$=k([g(`mateu-table`)],$);var rl=(e,t,n,r,i,a,o)=>T`
+  `}};O([v()],Q.prototype,`id`,void 0),O([v()],Q.prototype,`metadata`,void 0),O([v()],Q.prototype,`baseUrl`,void 0),O([v()],Q.prototype,`state`,void 0),O([v()],Q.prototype,`data`,void 0),O([v()],Q.prototype,`appState`,void 0),O([v()],Q.prototype,`appData`,void 0),O([v()],Q.prototype,`emptyStateMessage`,void 0),O([S()],Q.prototype,`detailsOpenedItems`,void 0),O([b(`vaadin-grid`)],Q.prototype,`grid`,void 0),Q=O([h(`mateu-table`)],Q);var Sl=(e,t,n,r,i,a,o)=>w`
     <mateu-table
             id="${t.id}"
             baseUrl="${n}"
@@ -10134,10 +10148,10 @@ ${i}
             .appState="${a}"
             .appDate="${o}"
             style="${t.style}" class="${t.cssClasses}"
-            slot="${t.slot??v}"
+            slot="${t.slot??_}"
     >
-        ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
-    </mateu-table>`,il=(e,t,n,r,i,a)=>T`
+        ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
+    </mateu-table>`,Cl=(e,t,n,r,i,a)=>w`
     <mateu-table id="${e.id}"
                  .metadata="${t?.metadata}"
                  .data="${e.data}"
@@ -10148,8 +10162,8 @@ ${i}
                  @sort-direction-changed="${e.directionChanged}"
                  @fetch-more-elements="${e.fetchMoreElements}"
                  baseUrl="${n}"
-    ></mateu-table>`,al=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
-        <div id="show-notifications" slot="${t.slot??v}">${F(e,s.wrapped,n,r,i,a,o)}</div>
+    ></mateu-table>`,wl=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+        <div id="show-notifications" slot="${t.slot??_}">${P(e,s.wrapped,n,r,i,a,o)}</div>
         <vaadin-popover
                 for="show-notifications"
                 theme="arrow no-padding"
@@ -10157,17 +10171,17 @@ ${i}
                 accessible-name-ref="notifications-heading"
                 content-width="300px"
                 position="bottom"
-                ${ee(()=>T`${F(e,s.content,n,r,i,a,o)}`,[])}
+                ${te(()=>w`${P(e,s.content,n,r,i,a,o)}`,[])}
                 style="${t.style}" class="${t.cssClasses}"
         ></vaadin-popover>
-    `},ol=(e,t,n)=>{let r=e;return T`
+    `},Tl=(e,t,n)=>{let r=e;return w`
         <vaadin-button
                 data-action-id="${r.id}"
-                theme="${mt(e)||v}"
+                theme="${ht(e)||_}"
                 @click="${n}"
                 ?disabled="${r.disabled}"
-        >${r.iconOnLeft?T`<vaadin-icon icon="${r.iconOnLeft}"></vaadin-icon>`:v}${t}${r.iconOnRight?T`<vaadin-icon icon="${r.iconOnRight}"></vaadin-icon>`:v}</vaadin-button>
-    `},sl=e=>T`
+        >${r.iconOnLeft?w`<vaadin-icon icon="${r.iconOnLeft}"></vaadin-icon>`:_}${t}${r.iconOnRight?w`<vaadin-icon icon="${r.iconOnRight}"></vaadin-icon>`:_}</vaadin-button>
+    `},El=e=>w`
     <div style="display: flex; gap: var(--lumo-space-xs, .25rem); align-items: center;" class="peer-nav">
         <vaadin-button theme="tertiary icon" class="peer-nav-prev" title="${e.prevLabel??`Previous`}"
                 ?disabled="${!e.prevRoute}"
@@ -10179,30 +10193,30 @@ ${i}
                 @click="${()=>{e.nextRoute&&(window.location.href=e.nextRoute)}}">
             <vaadin-icon icon="vaadin:angle-right"></vaadin-icon>
         </vaadin-button>
-    </div>`,cl={"vaadin:wifi":`vaadin:connect`,"vaadin:pen":`vaadin:pencil`,"vaadin:automation":`vaadin:cogs`},ll=(e,t,n)=>T`<vaadin-icon icon="${cl[e]??e}" style="${t??v}" class="${n??v}"></vaadin-icon>`,ul=(e,t,n)=>{let r=e.metadata,i=M(r.label,t,n),a=``;return r.buttonStyle&&(a+=` `+r.buttonStyle),r.color&&r.color!==`none`&&r.color!==`normal`&&(a+=` `+r.color),r.size&&r.size!==`none`&&r.size!==`normal`&&(a+=` `+r.size),T`<vaadin-button
+    </div>`,Dl={"vaadin:wifi":`vaadin:connect`,"vaadin:pen":`vaadin:pencil`,"vaadin:automation":`vaadin:cogs`},Ol=(e,t,n)=>w`<vaadin-icon icon="${Dl[e]??e}" style="${t??_}" class="${n??_}"></vaadin-icon>`,kl=(e,t,n)=>{let r=e.metadata,i=j(r.label,t,n),a=``;return r.buttonStyle&&(a+=` `+r.buttonStyle),r.color&&r.color!==`none`&&r.color!==`normal`&&(a+=` `+r.color),r.size&&r.size!==`none`&&r.size!==`normal`&&(a+=` `+r.size),w`<vaadin-button
             id="${e.id}"
             data-action-id="${r.actionId}"
-            @click="${e=>Mn(e,r)}"
+            @click="${e=>Nn(e,r)}"
             style="${e.style}"
             class="${e.cssClasses}"
             theme="${a}"
             ?disabled="${r.disabled}"
-            title="${r.shortcut?`${i} (${jn(r.shortcut)})`:v}"
-            slot="${e.slot??v}"
-    >${r.iconOnLeft?T`<vaadin-icon icon="${r.iconOnLeft}"></vaadin-icon>`:v}${i}${r.iconOnRight?T`<vaadin-icon icon="${r.iconOnRight}"></vaadin-icon>`:v}</vaadin-button>`},dl=e=>{let t=e.metadata;return T`
+            title="${r.shortcut?`${i} (${Mn(r.shortcut)})`:_}"
+            slot="${e.slot??_}"
+    >${r.iconOnLeft?w`<vaadin-icon icon="${r.iconOnLeft}"></vaadin-icon>`:_}${i}${r.iconOnRight?w`<vaadin-icon icon="${r.iconOnRight}"></vaadin-icon>`:_}</vaadin-button>`},Al=e=>{let t=e.metadata;return w`
         <vaadin-message-input
                 style="${e.style}" class="${e.cssClasses}"
-                slot="${e.slot??v}"
+                slot="${e.slot??_}"
                 @submit="${e=>{let n=e.detail?.value??``;!t.actionId||!n.trim()||e.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:{message:n}},bubbles:!0,composed:!0}))}}"
         ></vaadin-message-input>
-    `},fl=e=>{let t=(e.metadata.items??[]).map(e=>({text:e.text,time:e.time,userName:e.userName,userImg:e.userImg,userAbbr:e.userAbbr,userColorIndex:e.userColorIndex}));return T`
+    `},jl=e=>{let t=(e.metadata.items??[]).map(e=>({text:e.text,time:e.time,userName:e.userName,userImg:e.userImg,userAbbr:e.userAbbr,userColorIndex:e.userColorIndex}));return w`
         <vaadin-message-list
                 markdown
                 style="${e.style}" class="${e.cssClasses}"
-                slot="${e.slot??v}"
+                slot="${e.slot??_}"
                 .items="${t}"
         ></vaadin-message-list>
-    `},pl=(e,t)=>{e&&e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},ml=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!1;if(s.openedCondition)try{c=it(s.openedCondition,r,i,a,o)}catch(e){console.error(`when evaluating `+s.openedCondition+` :`+e+`, where data is `+i+` and state is `+r)}return T`
+    `},Ml=(e,t)=>{e&&e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},Nl=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!1;if(s.openedCondition)try{c=at(s.openedCondition,r,i,a,o)}catch(e){console.error(`when evaluating `+s.openedCondition+` :`+e+`, where data is `+i+` and state is `+r)}return w`
         <vaadin-confirm-dialog
                 header="${s.header}"
                 ?cancel-button-visible="${s.canCancel}"
@@ -10210,15 +10224,15 @@ ${i}
                 reject-text="${s.rejectText}"
                 confirm-text="${s.confirmText}"
                 .opened="${c}"
-                @confirm="${e=>pl(e.currentTarget,s.confirmActionId)}"
-                @reject="${e=>pl(e.currentTarget,s.rejectActionId)}"
-                @cancel="${e=>pl(e.currentTarget,s.cancelActionId)}"
+                @confirm="${e=>Ml(e.currentTarget,s.confirmActionId)}"
+                @reject="${e=>Ml(e.currentTarget,s.rejectActionId)}"
+                @cancel="${e=>Ml(e.currentTarget,s.cancelActionId)}"
                 style="${t.style}" class="${t.cssClasses}"
-                slot="${t.slot??v}"
+                slot="${t.slot??_}"
         >
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </vaadin-confirm-dialog>
-    `},hl=class extends b{constructor(...e){super(...e),this.panels=[],this.headerTitle=``,this.badges=[],this.navigation=null,this.overviewEditActionId=``,this._raf=0,this._snapping=!1,this._less=!1,this._more=!1,this._onScroll=()=>{this._raf||=requestAnimationFrame(()=>{this._raf=0,this._syncPin()})},this._onScrollEnd=()=>{this._snapping||this._snapToNearest()},this._fit=()=>{let e=this.getBoundingClientRect().top;this.style.setProperty(`--mateu-foldout-fill`,`${Math.max(240,window.innerHeight-e)}px`),this._syncPin()},this._onKeydown=e=>{if(e.key!==`ArrowRight`&&e.key!==`ArrowLeft`||e.defaultPrevented||e.ctrlKey||e.metaKey||e.altKey||this._isEditingContext())return;let t=this._rail;!t||t.scrollWidth<=t.clientWidth||(e.preventDefault(),this._step(e.key===`ArrowRight`?1:-1))}}navAction(e){e&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{}},bubbles:!0,composed:!0}))}_stride(){let e=this.renderRoot.querySelectorAll(`.section`);return e.length>1?e[1].offsetLeft:this._rail?.clientWidth??0}_boundaries(){let e=this._rail;if(!e)return[];let t=e.scrollWidth-e.clientWidth,n=[...this.renderRoot.querySelectorAll(`.section`)].map(e=>Math.max(0,Math.min(e.offsetLeft,t)));return[...new Set(n)]}_snapToNearest(){let e=this._rail;if(!e)return;let t=this._boundaries();if(!t.length)return;let n=t.reduce((t,n)=>Math.abs(n-e.scrollLeft)<Math.abs(t-e.scrollLeft)?n:t);Math.abs(n-e.scrollLeft)<1||(this._snapping=!0,e.scrollTo({left:n,behavior:`smooth`}),window.setTimeout(()=>{this._snapping=!1},400))}_syncPin(){let e=this._rail,t=this._first;if(!e||!t)return;let n=this._stride(),r=Math.min(e.scrollLeft,n);t.style.transform=r?`translateX(${r}px)`:``,t.classList.toggle(`floating`,e.scrollLeft>0);let i=e.scrollWidth-e.clientWidth,a=i>32;this._less=a&&e.scrollLeft>2,this._more=a&&e.scrollLeft<i-2}_step(e){let t=this._rail;if(!t)return;let n=this._boundaries();if(!n.length)return;let r=n.reduce((e,r,i)=>Math.abs(r-t.scrollLeft)<Math.abs(n[e]-t.scrollLeft)?i:e,0),i=n[Math.max(0,Math.min(r+e,n.length-1))];this._snapping=!0,t.scrollTo({left:i,behavior:`smooth`}),window.setTimeout(()=>{this._snapping=!1},400)}_isEditingContext(){let e=document.activeElement;for(;e&&e.shadowRoot&&e.shadowRoot.activeElement;)e=e.shadowRoot.activeElement;if(!e)return!1;let t=e.tagName;return t===`INPUT`||t===`TEXTAREA`||t===`SELECT`||e.isContentEditable}_sectionFlex(e,t){if(!e.width)return v;let n=parseFloat(e.width)||1;return t===this.panels.length-1&&n<22?`flex: 22 1 var(--mateu-foldout-overview-width, 22rem);`:`flex: ${n} 1 ${e.width};`}firstUpdated(){this._fit(),this._resizeObserver=new ResizeObserver(()=>this._syncPin()),this._rail&&this._resizeObserver.observe(this._rail);for(let e of this.renderRoot.querySelectorAll(`.section`))this._resizeObserver.observe(e)}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._onKeydown),window.addEventListener(`resize`,this._fit)}disconnectedCallback(){document.removeEventListener(`keydown`,this._onKeydown),window.removeEventListener(`resize`,this._fit),this._resizeObserver?.disconnect(),this._resizeObserver=void 0,this._raf&&=(cancelAnimationFrame(this._raf),0),super.disconnectedCallback()}static{this.styles=h`
+    `},$=class extends y{constructor(...e){super(...e),this.panels=[],this.headerTitle=``,this.badges=[],this.navigation=null,this.overviewEditActionId=``,this._raf=0,this._snapping=!1,this._less=!1,this._more=!1,this._onScroll=()=>{this._raf||=requestAnimationFrame(()=>{this._raf=0,this._syncPin()})},this._onScrollEnd=()=>{this._snapping||this._snapToNearest()},this._fit=()=>{let e=this.getBoundingClientRect().top;this.style.setProperty(`--mateu-foldout-fill`,`${Math.max(240,window.innerHeight-e)}px`),this._syncPin()},this._onKeydown=e=>{if(e.key!==`ArrowRight`&&e.key!==`ArrowLeft`||e.defaultPrevented||e.ctrlKey||e.metaKey||e.altKey||this._isEditingContext())return;let t=this._rail;!t||t.scrollWidth<=t.clientWidth||(e.preventDefault(),this._step(e.key===`ArrowRight`?1:-1))}}navAction(e){e&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{}},bubbles:!0,composed:!0}))}_stride(){let e=this.renderRoot.querySelectorAll(`.section`);return e.length>1?e[1].offsetLeft:this._rail?.clientWidth??0}_boundaries(){let e=this._rail;if(!e)return[];let t=e.scrollWidth-e.clientWidth,n=[...this.renderRoot.querySelectorAll(`.section`)].map(e=>Math.max(0,Math.min(e.offsetLeft,t)));return[...new Set(n)]}_snapToNearest(){let e=this._rail;if(!e)return;let t=this._boundaries();if(!t.length)return;let n=t.reduce((t,n)=>Math.abs(n-e.scrollLeft)<Math.abs(t-e.scrollLeft)?n:t);Math.abs(n-e.scrollLeft)<1||(this._snapping=!0,e.scrollTo({left:n,behavior:`smooth`}),window.setTimeout(()=>{this._snapping=!1},400))}_syncPin(){let e=this._rail,t=this._first;if(!e||!t)return;let n=this._stride(),r=Math.min(e.scrollLeft,n);t.style.transform=r?`translateX(${r}px)`:``,t.classList.toggle(`floating`,e.scrollLeft>0);let i=e.scrollWidth-e.clientWidth,a=i>32;this._less=a&&e.scrollLeft>2,this._more=a&&e.scrollLeft<i-2}_step(e){let t=this._rail;if(!t)return;let n=this._boundaries();if(!n.length)return;let r=n.reduce((e,r,i)=>Math.abs(r-t.scrollLeft)<Math.abs(n[e]-t.scrollLeft)?i:e,0),i=n[Math.max(0,Math.min(r+e,n.length-1))];this._snapping=!0,t.scrollTo({left:i,behavior:`smooth`}),window.setTimeout(()=>{this._snapping=!1},400)}_isEditingContext(){let e=document.activeElement;for(;e&&e.shadowRoot&&e.shadowRoot.activeElement;)e=e.shadowRoot.activeElement;if(!e)return!1;let t=e.tagName;return t===`INPUT`||t===`TEXTAREA`||t===`SELECT`||e.isContentEditable}_sectionFlex(e,t){if(!e.width)return _;let n=parseFloat(e.width)||1;return t===this.panels.length-1&&n<22?`flex: 22 1 var(--mateu-foldout-overview-width, 22rem);`:`flex: ${n} 1 ${e.width};`}firstUpdated(){this._fit(),this._resizeObserver=new ResizeObserver(()=>this._syncPin()),this._rail&&this._resizeObserver.observe(this._rail);for(let e of this.renderRoot.querySelectorAll(`.section`))this._resizeObserver.observe(e)}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._onKeydown),window.addEventListener(`resize`,this._fit)}disconnectedCallback(){document.removeEventListener(`keydown`,this._onKeydown),window.removeEventListener(`resize`,this._fit),this._resizeObserver?.disconnect(),this._resizeObserver=void 0,this._raf&&=(cancelAnimationFrame(this._raf),0),super.disconnectedCallback()}static{this.styles=m`
         :host {
             position: relative;
             display: flex;
@@ -10402,66 +10416,66 @@ ${i}
             width: 1.35rem;
             height: 1.35rem;
         }
-    `}render(){let e=this.navigation,t=!!(this.overviewEditActionId||e&&(e.parentActionId||e.previousActionId||e.nextActionId)),n=!!(this.headerTitle||t||this.badges.length);return T`
+    `}render(){let e=this.navigation,t=!!(this.overviewEditActionId||e&&(e.parentActionId||e.previousActionId||e.nextActionId)),n=!!(this.headerTitle||t||this.badges.length);return w`
             <div class="rail" part="rail" tabindex="0"
                  @scroll="${this._onScroll}" @scrollend="${this._onScrollEnd}">
                 <section class="section section--first" part="section overview">
-                    ${n?T`
+                    ${n?w`
                         <header class="section-head" part="section-head">
                             <div class="section-head-row">
-                                ${this.headerTitle?T`<h2 class="section-title">${this.headerTitle}</h2>`:T`<span></span>`}
-                                ${t?T`
+                                ${this.headerTitle?w`<h2 class="section-title">${this.headerTitle}</h2>`:w`<span></span>`}
+                                ${t?w`
                                     <div class="section-toolbar" part="section-toolbar">
-                                        ${e?.parentActionId?T`
+                                        ${e?.parentActionId?w`
                                             <button class="tb-parent" title="${e.parentLabel??`Back`}"
                                                     @click="${()=>this.navAction(e.parentActionId)}">
                                                 <span>‹</span><span>${e.parentLabel??`Back`}</span>
                                             </button>
-                                        `:v}
-                                        ${e?.previousActionId?T`
+                                        `:_}
+                                        ${e?.previousActionId?w`
                                             <button class="tb-move" title="Previous"
                                                     @click="${()=>this.navAction(e.previousActionId)}">‹</button>
-                                        `:v}
-                                        ${e?.nextActionId?T`
+                                        `:_}
+                                        ${e?.nextActionId?w`
                                             <button class="tb-move" title="Next"
                                                     @click="${()=>this.navAction(e.nextActionId)}">›</button>
-                                        `:v}
-                                        ${this.overviewEditActionId?T`
+                                        `:_}
+                                        ${this.overviewEditActionId?w`
                                             <button class="tb-edit" title="Edit"
                                                     @click="${()=>this.navAction(this.overviewEditActionId)}">
                                                 <span>✎</span><span>Edit</span>
                                             </button>
-                                        `:v}
+                                        `:_}
                                     </div>
-                                `:v}
+                                `:_}
                             </div>
-                            ${this.badges.length?T`
+                            ${this.badges.length?w`
                                 <div class="section-badges">
-                                    ${this.badges.map(e=>T`<span class="section-badge">${e}</span>`)}
+                                    ${this.badges.map(e=>w`<span class="section-badge">${e}</span>`)}
                                 </div>
-                            `:v}
+                            `:_}
                         </header>
-                    `:v}
+                    `:_}
                     <div class="overview-body">
                         <slot name="overview"></slot>
                     </div>
                 </section>
-                ${this.panels.map((e,t)=>T`
+                ${this.panels.map((e,t)=>w`
                     <section class="section" part="section panel"
                              style="${this._sectionFlex(e,t)}">
-                        ${e.title||e.subtitle?T`
+                        ${e.title||e.subtitle?w`
                             <div class="panel-header">
-                                ${e.title?T`<h3>${e.title}${e.subtitle?T` <span class="subtitle" style="font-weight: 400;">· ${e.subtitle}</span>`:v}</h3>`:v}
-                                ${!e.title&&e.subtitle?T`<div class="subtitle">${e.subtitle}</div>`:v}
+                                ${e.title?w`<h3>${e.title}${e.subtitle?w` <span class="subtitle" style="font-weight: 400;">· ${e.subtitle}</span>`:_}</h3>`:_}
+                                ${!e.title&&e.subtitle?w`<div class="subtitle">${e.subtitle}</div>`:_}
                             </div>
-                        `:v}
+                        `:_}
                         <div class="panel-body">
                             <slot name="panel-${t}"></slot>
                         </div>
                     </section>
                 `)}
             </div>
-            ${this._less?T`
+            ${this._less?w`
                 <button class="scroll-nav left" part="scroll-nav-left" title="Scroll left"
                         aria-label="Scroll left" @click="${()=>this._step(-1)}">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
@@ -10469,8 +10483,8 @@ ${i}
                         <polyline points="15 6 9 12 15 18"></polyline>
                     </svg>
                 </button>
-            `:v}
-            ${this._more?T`
+            `:_}
+            ${this._more?w`
                 <button class="scroll-nav right" part="scroll-nav-right" title="Scroll right"
                         aria-label="Scroll right" @click="${()=>this._step(1)}">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
@@ -10478,8 +10492,8 @@ ${i}
                         <polyline points="9 6 15 12 9 18"></polyline>
                     </svg>
                 </button>
-            `:v}
-        `}};k([y({type:Array})],hl.prototype,`panels`,void 0),k([y({type:String})],hl.prototype,`headerTitle`,void 0),k([y({type:Array})],hl.prototype,`badges`,void 0),k([y({attribute:!1})],hl.prototype,`navigation`,void 0),k([y({type:String})],hl.prototype,`overviewEditActionId`,void 0),k([x(`.rail`)],hl.prototype,`_rail`,void 0),k([x(`.section--first`)],hl.prototype,`_first`,void 0),k([C()],hl.prototype,`_less`,void 0),k([C()],hl.prototype,`_more`,void 0),hl=k([g(`mateu-vaadin-foldout`)],hl);var gl=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+            `:_}
+        `}};O([v({type:Array})],$.prototype,`panels`,void 0),O([v({type:String})],$.prototype,`headerTitle`,void 0),O([v({type:Array})],$.prototype,`badges`,void 0),O([v({attribute:!1})],$.prototype,`navigation`,void 0),O([v({type:String})],$.prototype,`overviewEditActionId`,void 0),O([b(`.rail`)],$.prototype,`_rail`,void 0),O([b(`.section--first`)],$.prototype,`_first`,void 0),O([S()],$.prototype,`_less`,void 0),O([S()],$.prototype,`_more`,void 0),$=O([h(`mateu-vaadin-foldout`)],$);var Pl=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <mateu-vaadin-foldout
                 .panels="${s.panels??[]}"
                 .headerTitle="${s.headerTitle??``}"
@@ -10488,11 +10502,11 @@ ${i}
                 overviewEditActionId="${s.overviewEditActionId??``}"
                 style="${t.style}"
                 class="${t.cssClasses}"
-                slot="${t.slot??v}"
+                slot="${t.slot??_}"
         >
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </mateu-vaadin-foldout>
-    `},_l=class extends b{constructor(...e){super(...e),this.rows=[],this.columns=[],this.navigable=!1,this.expandedItems=[],this._normalized=[],this.dataProvider=(e,t)=>{let n=e.parentItem?e.parentItem.children??[]:this.normalized;t(n,n.length)}}get normalized(){return this._src!==this.rows&&(this._src=this.rows,this._normalized=this.normalizeRows(this.rows??[])),this._normalized}normalizeRows(e){return(e??[]).map(e=>{let t=Array.isArray(e.children)&&e.children.length?this.normalizeRows(e.children):void 0;return{...e,children:t}})}collectGroups(e,t=[]){return e.forEach(e=>{e.children&&e.children.length&&(t.push(e),this.collectGroups(e.children,t))}),t}willUpdate(){this._expandedSrc!==this.rows&&(this._expandedSrc=this.rows,this.expandedItems=this.collectGroups(this.normalized))}updated(e){e.has(`rows`)&&this._grid?.clearCache?.()}dispatch(e,t){this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:t},bubbles:!0,composed:!0}))}render(){let e=this.columns??[],n=e[0],r=e.slice(1);return T`
+    `},Fl=class extends y{constructor(...e){super(...e),this.rows=[],this.columns=[],this.navigable=!1,this.expandedItems=[],this._normalized=[],this.dataProvider=(e,t)=>{let n=e.parentItem?e.parentItem.children??[]:this.normalized;t(n,n.length)}}get normalized(){return this._src!==this.rows&&(this._src=this.rows,this._normalized=this.normalizeRows(this.rows??[])),this._normalized}normalizeRows(e){return(e??[]).map(e=>{let t=Array.isArray(e.children)&&e.children.length?this.normalizeRows(e.children):void 0;return{...e,children:t}})}collectGroups(e,t=[]){return e.forEach(e=>{e.children&&e.children.length&&(t.push(e),this.collectGroups(e.children,t))}),t}willUpdate(){this._expandedSrc!==this.rows&&(this._expandedSrc=this.rows,this.expandedItems=this.collectGroups(this.normalized))}updated(e){e.has(`rows`)&&this._grid?.clearCache?.()}dispatch(e,t){this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:t},bubbles:!0,composed:!0}))}render(){let e=this.columns??[],n=e[0],r=e.slice(1);return w`
             <vaadin-grid
                     theme="compact no-row-borders"
                     all-rows-visible
@@ -10500,20 +10514,20 @@ ${i}
                     .itemHasChildrenPath="${`children`}"
                     .expandedItems="${this.expandedItems}"
                     @expanded-items-changed="${e=>{this.expandedItems=e.detail.value}}">
-                ${n?T`
+                ${n?w`
                     <vaadin-grid-tree-column path="${n.id}" header="${n.label??``}"
                                              auto-width flex-grow="0"></vaadin-grid-tree-column>
-                `:v}
-                ${r.map(e=>e.id===`select`?T`<vaadin-grid-column header="${e.label??``}" auto-width flex-grow="0" text-align="end"
-                              ${t(e=>T`<vaadin-button theme="tertiary small"
-                                          @click="${()=>this.dispatch(`action-on-row-select`,{_clickedRow:e})}">Select</vaadin-button>`,[])}></vaadin-grid-column>`:T`<vaadin-grid-column path="${e.id}" header="${e.label??``}"></vaadin-grid-column>`)}
-                ${this.navigable?T`
+                `:_}
+                ${r.map(e=>e.id===`select`?w`<vaadin-grid-column header="${e.label??``}" auto-width flex-grow="0" text-align="end"
+                              ${t(e=>w`<vaadin-button theme="tertiary small"
+                                          @click="${()=>this.dispatch(`action-on-row-select`,{_clickedRow:e})}">Select</vaadin-button>`,[])}></vaadin-grid-column>`:w`<vaadin-grid-column path="${e.id}" header="${e.label??``}"></vaadin-grid-column>`)}
+                ${this.navigable?w`
                     <vaadin-grid-column auto-width flex-grow="0" text-align="end"
-                          ${t(e=>e?.viewable===!1?T``:T`<vaadin-button theme="tertiary small"
+                          ${t(e=>e?.viewable===!1?w``:w`<vaadin-button theme="tertiary small"
                                           @click="${()=>this.dispatch(`view`,e)}">View</vaadin-button>`,[])}></vaadin-grid-column>
-                `:v}
+                `:_}
             </vaadin-grid>
-        `}static{this.styles=h`
+        `}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -10522,11 +10536,11 @@ ${i}
             max-height: min(60vh, 32rem);
             min-width: 22rem;
         }
-    `}};k([y({attribute:!1})],_l.prototype,`rows`,void 0),k([y({attribute:!1})],_l.prototype,`columns`,void 0),k([y()],_l.prototype,`idField`,void 0),k([y({type:Boolean})],_l.prototype,`navigable`,void 0),k([y()],_l.prototype,`selectedId`,void 0),k([C()],_l.prototype,`expandedItems`,void 0),k([x(`vaadin-grid`)],_l.prototype,`_grid`,void 0),_l=k([g(`mateu-vaadin-tree`)],_l);var vl={[j.VirtualList]:(e,t,n,r,i,a,o)=>js(e,t,n,r,i,a,o),[j.Notification]:(e,t)=>Ms(t),[j.ProgressBar]:(e,t,n,r)=>Ns(t,r),[j.Details]:(e,t,n,r,i,a,o)=>Ps(e,t,n,r,i,a,o),[j.Avatar]:(e,t,n,r,i)=>Fs(t,r,i),[j.AvatarGroup]:(e,t)=>Is(t),[j.Card]:(e,t,n,r,i,a,o)=>Ls(e,t,n,r,i,a,o),[j.Button]:(e,t,n,r,i)=>ul(t,r,i),[j.MessageInput]:(e,t)=>dl(t),[j.MessageList]:(e,t)=>fl(t),[j.ConfirmDialog]:(e,t,n,r,i,a,o)=>ml(e,t,n,r,i,a,o),[j.FormLayout]:(e,t,n,r,i,a,o)=>Bs(e,t,n,r,i,a,o),[j.HorizontalLayout]:(e,t,n,r,i,a,o)=>Ws(e,t,n,r,i,a,o),[j.VerticalLayout]:(e,t,n,r,i,a,o)=>Gs(e,t,n,r,i,a,o),[j.SplitLayout]:(e,t,n,r,i,a,o)=>Ks(e,t,n,r,i,a,o),[j.MasterDetailLayout]:(e,t,n,r,i,a,o)=>qs(e,t,n,r,i,a,o),[j.TabLayout]:(e,t,n,r,i,a,o)=>Js(e,t,n,r,i,a,o),[j.AccordionLayout]:(e,t,n,r,i,a,o)=>Xs(e,t,n,r,i,a,o),[j.BoardLayout]:(e,t,n,r,i,a,o)=>$s(e,t,n,r,i,a,o),[j.BoardLayoutRow]:(e,t,n,r,i,a,o)=>ec(e,t,n,r,i,a,o),[j.BoardLayoutItem]:(e,t,n,r,i,a,o)=>tc(e,t,n,r,i,a,o),[j.Scroller]:(e,t,n,r,i,a,o)=>Qs(e,t,n,r,i,a,o),[j.MenuBar]:(e,t,n,r,i)=>ic(e,t,n,r,i),[j.ContextMenu]:(e,t,n,r,i,a,o)=>rc(e,t,n,r,i,a,o),[j.FormField]:(e,t,n,r,i,a,o,s)=>tl(e,t,n,r,i,a,o,s),[j.Grid]:(e,t,n,r,i,a,o)=>nl(e,t,n,r,i,a,o),[j.Table]:(e,t,n,r,i,a,o)=>rl(e,t,n,r,i,a,o),[j.Popover]:(e,t,n,r,i,a,o)=>al(e,t,n,r,i,a,o),[j.FoldoutLayout]:(e,t,n,r,i,a,o)=>gl(e,t,n,r,i,a,o)},yl=class extends As{rendererName(){return`vaadin`}renderClientSideComponent(e,t,n,r,i,a,o,s){let c=t?.metadata?.type,l=c?vl[c]:void 0;return l&&t?l(e,t,n,r,i,a,o,s):super.renderClientSideComponent(e,t,n,r,i,a,o,s)}renderTableComponent(e,t,n,r,i,a,o){return il(e,t,n,r,a,o)}renderTreeComponent(e,t){return T`
+    `}};O([v({attribute:!1})],Fl.prototype,`rows`,void 0),O([v({attribute:!1})],Fl.prototype,`columns`,void 0),O([v()],Fl.prototype,`idField`,void 0),O([v({type:Boolean})],Fl.prototype,`navigable`,void 0),O([v()],Fl.prototype,`selectedId`,void 0),O([S()],Fl.prototype,`expandedItems`,void 0),O([b(`vaadin-grid`)],Fl.prototype,`_grid`,void 0),Fl=O([h(`mateu-vaadin-tree`)],Fl);var Il={[A.VirtualList]:(e,t,n,r,i,a,o)=>qs(e,t,n,r,i,a,o),[A.Notification]:(e,t)=>Js(t),[A.ProgressBar]:(e,t,n,r)=>Ys(t,r),[A.Details]:(e,t,n,r,i,a,o)=>Xs(e,t,n,r,i,a,o),[A.Avatar]:(e,t,n,r,i)=>Zs(t,r,i),[A.AvatarGroup]:(e,t)=>Qs(t),[A.Card]:(e,t,n,r,i,a,o)=>$s(e,t,n,r,i,a,o),[A.Button]:(e,t,n,r,i)=>kl(t,r,i),[A.MessageInput]:(e,t)=>Al(t),[A.MessageList]:(e,t)=>jl(t),[A.ConfirmDialog]:(e,t,n,r,i,a,o)=>Nl(e,t,n,r,i,a,o),[A.FormLayout]:(e,t,n,r,i,a,o)=>nc(e,t,n,r,i,a,o),[A.HorizontalLayout]:(e,t,n,r,i,a,o)=>oc(e,t,n,r,i,a,o),[A.VerticalLayout]:(e,t,n,r,i,a,o)=>sc(e,t,n,r,i,a,o),[A.SplitLayout]:(e,t,n,r,i,a,o)=>cc(e,t,n,r,i,a,o),[A.MasterDetailLayout]:(e,t,n,r,i,a,o)=>lc(e,t,n,r,i,a,o),[A.TabLayout]:(e,t,n,r,i,a,o)=>uc(e,t,n,r,i,a,o),[A.AccordionLayout]:(e,t,n,r,i,a,o)=>fc(e,t,n,r,i,a,o),[A.BoardLayout]:(e,t,n,r,i,a,o)=>hc(e,t,n,r,i,a,o),[A.BoardLayoutRow]:(e,t,n,r,i,a,o)=>gc(e,t,n,r,i,a,o),[A.BoardLayoutItem]:(e,t,n,r,i,a,o)=>_c(e,t,n,r,i,a,o),[A.Scroller]:(e,t,n,r,i,a,o)=>mc(e,t,n,r,i,a,o),[A.MenuBar]:(e,t,n,r,i)=>bc(e,t,n,r,i),[A.ContextMenu]:(e,t,n,r,i,a,o)=>yc(e,t,n,r,i,a,o),[A.FormField]:(e,t,n,r,i,a,o,s)=>bl(e,t,n,r,i,a,o,s),[A.Grid]:(e,t,n,r,i,a,o)=>xl(e,t,n,r,i,a,o),[A.Table]:(e,t,n,r,i,a,o)=>Sl(e,t,n,r,i,a,o),[A.Popover]:(e,t,n,r,i,a,o)=>wl(e,t,n,r,i,a,o),[A.FoldoutLayout]:(e,t,n,r,i,a,o)=>Pl(e,t,n,r,i,a,o)},Ll=class extends Ks{rendererName(){return`vaadin`}renderClientSideComponent(e,t,n,r,i,a,o,s){let c=t?.metadata?.type,l=c?Il[c]:void 0;return l&&t?l(e,t,n,r,i,a,o,s):super.renderClientSideComponent(e,t,n,r,i,a,o,s)}renderTableComponent(e,t,n,r,i,a,o){return Cl(e,t,n,r,a,o)}renderTreeComponent(e,t){return w`
             <mateu-vaadin-tree
                     .rows="${t.rows}"
                     .columns="${t.columns}"
                     .idField="${t.idField}"
                     .navigable="${t.navigable}"
                     .selectedId="${t.selectedId}"
-            ></mateu-vaadin-tree>`}renderToolbarButton(e,t,n){return ol(e,t,n)}renderPeerNav(e){return sl(e)}renderIcon(e,t,n){return ll(e,t,n)}renderTopNav(e,t,n){return nc(e,t,n)}};function bl(e){switch(e){case`topStretch`:return`top-stretch`;case`topStart`:return`top-start`;case`topCenter`:return`top-center`;case`topEnd`:return`top-end`;case`middle`:return`middle`;case`bottomStart`:return`bottom-start`;case`bottomEnd`:return`bottom-end`;case`bottomStretch`:return`bottom-stretch`;case`bottomCenter`:return`bottom-center`}return`bottom-end`}function xl(e,t){if(e.onAction)return{label:e.actionLabel??`Retry`,run:e.onAction};if(e.undoActionId)return{label:e.undoLabel??`Undo`,run:()=>t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.undoActionId,parameters:e.undoParameters??{}},bubbles:!0,composed:!0}))}}function Sl(e,t){let n=new r;n.position=bl(e.position),n.duration=e.duration??1e4,e.variant&&n.setAttribute(`theme`,e.variant),n.renderer=r=>{if(r.firstElementChild)return;let i=document.createElement(`span`);i.textContent=e.text;let a=xl(e,t),o=document.createElement(`button`);o.textContent=a.label,o.style.cssText=`margin-left: 0.75rem; background: none; border: 1px solid currentColor; border-radius: var(--lumo-border-radius-s, 4px); color: inherit; cursor: pointer; padding: 0.15rem 0.6rem; font: inherit; font-weight: 600;`,o.addEventListener(`click`,()=>{a.run(),n.opened=!1}),r.append(i,o)},document.body.appendChild(n),n.opened=!0,n.addEventListener(`opened-changed`,e=>{e.detail.value||n.remove()})}P.set(new yl),aa({show(e,t){if(Ze(e.text,{politeness:e.variant===`error`?`assertive`:`polite`}),e.undoActionId||e.onAction){Sl(e,t);return}r.show(e.text,{position:e.position?bl(e.position):`bottom-end`,theme:e.variant,duration:e.duration})}});
+            ></mateu-vaadin-tree>`}renderToolbarButton(e,t,n){return Tl(e,t,n)}renderPeerNav(e){return El(e)}renderIcon(e,t,n){return Ol(e,t,n)}renderTopNav(e,t,n){return vc(e,t,n)}};function Rl(e){switch(e){case`topStretch`:return`top-stretch`;case`topStart`:return`top-start`;case`topCenter`:return`top-center`;case`topEnd`:return`top-end`;case`middle`:return`middle`;case`bottomStart`:return`bottom-start`;case`bottomEnd`:return`bottom-end`;case`bottomStretch`:return`bottom-stretch`;case`bottomCenter`:return`bottom-center`}return`bottom-end`}function zl(e,t){if(e.onAction)return{label:e.actionLabel??`Retry`,run:e.onAction};if(e.undoActionId)return{label:e.undoLabel??`Undo`,run:()=>t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.undoActionId,parameters:e.undoParameters??{}},bubbles:!0,composed:!0}))}}function Bl(e,t){let n=new r;n.position=Rl(e.position),n.duration=e.duration??1e4,e.variant&&n.setAttribute(`theme`,e.variant),n.renderer=r=>{if(r.firstElementChild)return;let i=document.createElement(`span`);i.textContent=e.text;let a=zl(e,t),o=document.createElement(`button`);o.textContent=a.label,o.style.cssText=`margin-left: 0.75rem; background: none; border: 1px solid currentColor; border-radius: var(--lumo-border-radius-s, 4px); color: inherit; cursor: pointer; padding: 0.15rem 0.6rem; font: inherit; font-weight: 600;`,o.addEventListener(`click`,()=>{a.run(),n.opened=!1}),r.append(i,o)},document.body.appendChild(n),n.opened=!0,n.addEventListener(`opened-changed`,e=>{e.detail.value||n.remove()})}N.set(new Ll),oa({show(e,t){if(Qe(e.text,{politeness:e.variant===`error`?`assertive`:`polite`}),e.undoActionId||e.onAction){Bl(e,t);return}r.show(e.text,{position:e.position?Rl(e.position):`bottom-end`,theme:e.variant,duration:e.duration})}});

--- a/backend/shared/frontend/vaadin-lit/src/main/resources/static/assets/mateu-vaadin.js
+++ b/backend/shared/frontend/vaadin-lit/src/main/resources/static/assets/mateu-vaadin.js
@@ -1,19 +1,19 @@
 const __vite__mapDeps=(i,m=__vite__mapDeps,d=(m.f||(m.f=["assets/vendor-ol.js","assets/rolldown-runtime.js","assets/vendor.js","assets/vendor-chartjs.js","assets/vendor-diagrams.js","assets/vendor-ui5.js"])))=>i.map(i=>d[i]);
-import{_ as e,a as t,c as n,d as r,f as i,g as a,h as o,i as s,l as c,m as l,n as u,o as d,p as f,r as p,s as m,t as ee,u as te,v as ne}from"./vendor-vaadin.js";import{S as h,a as g,c as _,g as re,h as v,i as y,m as b,n as x,o as S,r as C,v as w,w as ie,y as T}from"./vendor-lit.js";import{c as ae,l as oe,o as se,s as E}from"./vendor.js";import{r as D}from"./vendor-ui5.js";(function(){let e=document.createElement(`link`).relList;if(e&&e.supports&&e.supports(`modulepreload`))return;for(let e of document.querySelectorAll(`link[rel="modulepreload"]`))n(e);new MutationObserver(e=>{for(let t of e)if(t.type===`childList`)for(let e of t.addedNodes)e.tagName===`LINK`&&e.rel===`modulepreload`&&n(e)}).observe(document,{childList:!0,subtree:!0});function t(e){let t={};return e.integrity&&(t.integrity=e.integrity),e.referrerPolicy&&(t.referrerPolicy=e.referrerPolicy),e.crossOrigin===`use-credentials`?t.credentials=`include`:e.crossOrigin===`anonymous`?t.credentials=`omit`:t.credentials=`same-origin`,t}function n(e){if(e.ep)return;e.ep=!0;let n=t(e);fetch(e.href,n)}})(),ne(`vaadin-card`,h`
+import{_ as e,a as t,c as n,d as r,f as i,g as a,h as o,i as s,l as c,m as l,n as u,o as d,p as f,r as p,s as ee,t as te,u as ne,v as re}from"./vendor-vaadin.js";import{S as m,a as h,c as g,g as ie,h as _,i as v,m as y,n as b,o as x,r as S,v as C,w as ae,y as w}from"./vendor-lit.js";import{c as oe,l as se,o as ce,s as T}from"./vendor.js";import{r as E}from"./vendor-ui5.js";(function(){let e=document.createElement(`link`).relList;if(e&&e.supports&&e.supports(`modulepreload`))return;for(let e of document.querySelectorAll(`link[rel="modulepreload"]`))n(e);new MutationObserver(e=>{for(let t of e)if(t.type===`childList`)for(let e of t.addedNodes)e.tagName===`LINK`&&e.rel===`modulepreload`&&n(e)}).observe(document,{childList:!0,subtree:!0});function t(e){let t={};return e.integrity&&(t.integrity=e.integrity),e.referrerPolicy&&(t.referrerPolicy=e.referrerPolicy),e.crossOrigin===`use-credentials`?t.credentials=`include`:e.crossOrigin===`anonymous`?t.credentials=`omit`:t.credentials=`same-origin`,t}function n(e){if(e.ep)return;e.ep=!0;let n=t(e);fetch(e.href,n)}})(),re(`vaadin-card`,m`
       :host(.mateu-section) {
         --vaadin-card-border-width: 0 !important;
         --vaadin-card-background: transparent !important;
         --vaadin-card-shadow: none !important;
         --vaadin-card-padding: 0 !important;
       }
-    `);var ce=document.createElement(`style`);ce.innerHTML=`
+    `);var le=document.createElement(`style`);le.innerHTML=`
 ${e.cssText}
 ${o.cssText}
 ${a.cssText}
 ${l.cssText}
 ${f}
 ${i}
-`,document.body.appendChild(ce);{let e=window.Vaadin;e&&((e.featureFlags??={}).masterDetailLayoutComponent=!0)}new class{constructor(){this.ui=void 0,this.loading=!1,this.config={},this.sharedData={},this.userData={},this.appData={},this.runtimeData={}}};var le=new oe,O={value:{}},ue={value:{}},de=h`
+`,document.body.appendChild(le);{let e=window.Vaadin;e&&((e.featureFlags??={}).masterDetailLayoutComponent=!0)}new class{constructor(){this.ui=void 0,this.loading=!1,this.config={},this.sharedData={},this.userData={},this.appData={},this.runtimeData={}}};var ue=new se,D={value:{}},de={value:{}},fe=m`
   [theme~='badge'] {
     display: inline-flex;
     align-items: center;
@@ -129,7 +129,7 @@ ${i}
   [theme~='badge'][theme~='pill'] {
     --lumo-border-radius-s: 1em;
   }
-`,fe={lon:0,lat:0},pe=e=>{if(!e)return;let t=e.split(`,`).map(e=>e.trim());if(t.length!==2)return;let n=Number(t[0]),r=Number(t[1]);if(!(t[0]===``||t[1]===``||!Number.isFinite(n)||!Number.isFinite(r)))return{lon:r,lat:n}},me=e=>{if(e==null||e.trim()===``)return 3;let t=Number(e);return Number.isFinite(t)?t:3};function k(e,t,n,r){var i=arguments.length,a=i<3?t:r===null?r=Object.getOwnPropertyDescriptor(t,n):r,o;if(typeof Reflect==`object`&&typeof Reflect.decorate==`function`)a=Reflect.decorate(e,t,n,r);else for(var s=e.length-1;s>=0;s--)(o=e[s])&&(a=(i<3?o(a):i>3?o(t,n,a):o(t,n))||a);return i>3&&a&&Object.defineProperty(t,n,a),a}var he=class extends b{constructor(...e){super(...e),this.renderSeq=0}updated(e){super.updated(e),this.createMap()}disconnectedCallback(){super.disconnectedCallback(),this.map?.setTarget(void 0),this.map=void 0}async createMap(){let e=++this.renderSeq,[{default:t},{default:n},{default:r},{default:i},{fromLonLat:a},{default:o}]=await Promise.all([D(()=>import(`./vendor-ol.js`).then(e=>e.i),__vite__mapDeps([0,1])),D(()=>import(`./vendor-ol.js`).then(e=>e.a),__vite__mapDeps([0,1])),D(()=>import(`./vendor-ol.js`).then(e=>e.r),__vite__mapDeps([0,1])),D(()=>import(`./vendor-ol.js`).then(e=>e.t),__vite__mapDeps([0,1])),D(()=>import(`./vendor-ol.js`).then(e=>e.o),__vite__mapDeps([0,1])),D(()=>import(`./vendor-ol.js`).then(e=>e.n),__vite__mapDeps([0,1]))]);if(e!==this.renderSeq||!this.isConnected)return;if(!this.shadowRoot.querySelector(`style[data-ol]`)){let e=document.createElement(`style`);e.setAttribute(`data-ol`,``),e.textContent=o,this.shadowRoot.appendChild(e)}this.map&&=(this.map.setTarget(void 0),void 0);let s=pe(this.position)??fe;this.map=new t({target:this.mapElement,layers:[new r({source:new i})],view:new n({center:a([s.lon,s.lat]),zoom:me(this.zoom)})})}render(){return T`<div id="map"></div>`}static{this.styles=h`
+`,pe={lon:0,lat:0},me=e=>{if(!e)return;let t=e.split(`,`).map(e=>e.trim());if(t.length!==2)return;let n=Number(t[0]),r=Number(t[1]);if(!(t[0]===``||t[1]===``||!Number.isFinite(n)||!Number.isFinite(r)))return{lon:r,lat:n}},he=e=>{if(e==null||e.trim()===``)return 3;let t=Number(e);return Number.isFinite(t)?t:3};function O(e,t,n,r){var i=arguments.length,a=i<3?t:r===null?r=Object.getOwnPropertyDescriptor(t,n):r,o;if(typeof Reflect==`object`&&typeof Reflect.decorate==`function`)a=Reflect.decorate(e,t,n,r);else for(var s=e.length-1;s>=0;s--)(o=e[s])&&(a=(i<3?o(a):i>3?o(t,n,a):o(t,n))||a);return i>3&&a&&Object.defineProperty(t,n,a),a}var ge=class extends y{constructor(...e){super(...e),this.renderSeq=0}updated(e){super.updated(e),this.createMap()}disconnectedCallback(){super.disconnectedCallback(),this.map?.setTarget(void 0),this.map=void 0}async createMap(){let e=++this.renderSeq,[{default:t},{default:n},{default:r},{default:i},{fromLonLat:a},{default:o}]=await Promise.all([E(()=>import(`./vendor-ol.js`).then(e=>e.i),__vite__mapDeps([0,1])),E(()=>import(`./vendor-ol.js`).then(e=>e.a),__vite__mapDeps([0,1])),E(()=>import(`./vendor-ol.js`).then(e=>e.r),__vite__mapDeps([0,1])),E(()=>import(`./vendor-ol.js`).then(e=>e.t),__vite__mapDeps([0,1])),E(()=>import(`./vendor-ol.js`).then(e=>e.o),__vite__mapDeps([0,1])),E(()=>import(`./vendor-ol.js`).then(e=>e.n),__vite__mapDeps([0,1]))]);if(e!==this.renderSeq||!this.isConnected)return;if(!this.shadowRoot.querySelector(`style[data-ol]`)){let e=document.createElement(`style`);e.setAttribute(`data-ol`,``),e.textContent=o,this.shadowRoot.appendChild(e)}this.map&&=(this.map.setTarget(void 0),void 0);let s=me(this.position)??pe;this.map=new t({target:this.mapElement,layers:[new r({source:new i})],view:new n({center:a([s.lon,s.lat]),zoom:he(this.zoom)})})}render(){return w`<div id="map"></div>`}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -139,23 +139,23 @@ ${i}
             width: 100%;
             height: 100%;
         }
-    `}};k([y()],he.prototype,`position`,void 0),k([y()],he.prototype,`zoom`,void 0),k([x(`#map`)],he.prototype,`mapElement`,void 0),he=k([g(`mateu-map`)],he);var ge=typeof HTMLElement<`u`?HTMLElement:class{},_e=class extends ge{static get observedAttributes(){return[`content`]}#e;#t=0;get content(){return this.#e}set content(e){this.#e=e,this.#n()}attributeChangedCallback(e,t,n){this.content=n??void 0}connectedCallback(){this.style.display=`block`,this.#n()}async#n(){if(!this.isConnected)return;let e=this.#e??``,t=++this.#t,[{marked:n},{default:r}]=await Promise.all([D(()=>import(`./vendor.js`).then(e=>e.n),__vite__mapDeps([2,1])),D(()=>import(`./vendor.js`).then(e=>e.a),__vite__mapDeps([2,1]))]);t===this.#t&&(this.innerHTML=r.sanitize(await n.parse(e),{USE_PROFILES:{html:!0,svg:!0,svgFilters:!0},CUSTOM_ELEMENT_HANDLING:{tagNameCheck:e=>!0}}))}};typeof customElements<`u`&&!customElements.get(`mateu-markdown`)&&customElements.define(`mateu-markdown`,_e);var A=function(e){return e.ServerSide=`ServerSide`,e.ClientSide=`ClientSide`,e}({}),j=function(e){return e.Page=`Page`,e.Div=`Div`,e.Element=`Element`,e.MicroFrontend=`MicroFrontend`,e.Form=`Form`,e.Crud=`Crud`,e.Result=`Result`,e.Card=`Card`,e.Directory=`Directory`,e.Stepper=`Stepper`,e.HorizontalLayout=`HorizontalLayout`,e.VerticalLayout=`VerticalLayout`,e.SplitLayout=`SplitLayout`,e.MasterDetailLayout=`MasterDetailLayout`,e.TabLayout=`TabLayout`,e.AccordionLayout=`AccordionLayout`,e.FormLayout=`FormLayout`,e.FormRow=`FormRow`,e.FormItem=`FormItem`,e.BoardLayout=`BoardLayout`,e.BoardLayoutRow=`BoardLayoutRow`,e.BoardLayoutItem=`BoardLayoutItem`,e.Scroller=`Scroller`,e.FullWidth=`FullWidth`,e.Container=`Container`,e.FormField=`FormField`,e.Table=`Table`,e.App=`App`,e.Text=`Text`,e.Avatar=`Avatar`,e.Chat=`Chat`,e.AvatarGroup=`AvatarGroup`,e.Badge=`Badge`,e.Breadcrumbs=`Breadcrumbs`,e.Anchor=`Anchor`,e.Button=`Button`,e.Chart=`Chart`,e.Icon=`Icon`,e.ConfirmDialog=`ConfirmDialog`,e.ContextMenu=`ContextMenu`,e.CookieConsent=`CookieConsent`,e.Details=`Details`,e.Dialog=`Dialog`,e.Drawer=`Drawer`,e.Image=`Image`,e.Map=`Map`,e.Markdown=`Markdown`,e.Notification=`Notification`,e.ProgressBar=`ProgressBar`,e.Popover=`Popover`,e.CarouselLayout=`CarouselLayout`,e.Tooltip=`Tooltip`,e.MessageInput=`MessageInput`,e.MessageList=`MessageList`,e.CustomField=`CustomField`,e.MenuBar=`MenuBar`,e.Grid=`Grid`,e.GridColumn=`GridColumn`,e.GridGroupColumn=`GridGroupColumn`,e.VirtualList=`VirtualList`,e.FormSection=`FormSection`,e.FormSubSection=`FormSubSection`,e.Bpmn=`Bpmn`,e.Workflow=`Workflow`,e.FormEditor=`FormEditor`,e.MetricCard=`MetricCard`,e.Scoreboard=`Scoreboard`,e.DashboardPanel=`DashboardPanel`,e.DashboardLayout=`DashboardLayout`,e.FoldoutLayout=`FoldoutLayout`,e.ContentLayout=`ContentLayout`,e.HeroSection=`HeroSection`,e.EmptyState=`EmptyState`,e.Skeleton=`Skeleton`,e.Gantt=`Gantt`,e.PlanningBoard=`PlanningBoard`,e.Kanban=`Kanban`,e.Timeline=`Timeline`,e.ProgressSteps=`ProgressSteps`,e.Stat=`Stat`,e.Calendar=`Calendar`,e.PricingTable=`PricingTable`,e.OrgChart=`OrgChart`,e.Heatmap=`Heatmap`,e.Funnel=`Funnel`,e.TrendChart=`TrendChart`,e.FeatureGrid=`FeatureGrid`,e.Testimonials=`Testimonials`,e.Faq=`Faq`,e.CalloutCard=`CalloutCard`,e.CommentThread=`CommentThread`,e.FileList=`FileList`,e.Checklist=`Checklist`,e.ComparisonCard=`ComparisonCard`,e.EntityHeader=`EntityHeader`,e.Meter=`Meter`,e.TaskProgress=`TaskProgress`,e.StatusList=`StatusList`,e.BulletedList=`BulletedList`,e.Separator=`Separator`,e.Notice=`Notice`,e.TaskQueue=`TaskQueue`,e.ResourceGrid=`ResourceGrid`,e.OfferCard=`OfferCard`,e.AddOnPicker=`AddOnPicker`,e.Ledger=`Ledger`,e.PaymentPicker=`PaymentPicker`,e.ProcessMonitor=`ProcessMonitor`,e}({}),ve=`mateu-app-context`,ye=`mateu-app-context-labels`,be=e=>{try{return JSON.parse(localStorage.getItem(e)??`{}`)}catch{return{}}},xe=(e,t)=>{try{localStorage.setItem(e,JSON.stringify(t))}catch{}},Se=()=>be(ve),Ce=()=>be(ye),we=(e,t,n)=>{let r=Se(),i=Ce();t==null||t===``?(delete r[e],delete i[e]):(r[e]=t,n!==void 0&&(i[e]=n)),xe(ve,r),xe(ye,i)},Te=!1,Ee=()=>{Te||(Te=!0,window.addEventListener(`storage`,e=>{e.key===ve&&e.newValue!==e.oldValue&&window.location.reload()}))},De,Oe=(e,t)=>new Promise((n,r)=>{let i=!1,a={retry:()=>{i||(i=!0,t().then(n,r))},giveUp:()=>{i||(i=!0,r(e))}};if(De){De(a);return}let o=new CustomEvent(`mateu-session-expired`,{detail:a,cancelable:!0,bubbles:!1});typeof document<`u`&&!document.dispatchEvent(o)||a.giveUp()}),ke=(e,t)=>e.includes(`json`)?!0:typeof t==`object`&&!!t,Ae=(e,t)=>{let n=e.finalUrl;if(!n)return;let r=t??(typeof window<`u`?window.location.href:void 0),i;try{i=new URL(e.requestedUrl,r).href}catch{return}if(i!==n&&!ke(e.contentType??``,e.data))return n},je=new class{constructor(){this.windowMs=4e3,this.threshold=12,this.events=[],this.reported=new Set}check(e,t=Date.now()){this.events.push({sig:e,t});let n=t-this.windowMs;this.events=this.events.filter(e=>e.t>=n);let r=0;for(let t of this.events)t.sig===e&&r++;if(r>=this.threshold){let t=!this.reported.has(e);return this.reported.add(e),{blocked:!0,firstTrip:t}}return this.reported.delete(e),{blocked:!1,firstTrip:!1}}reset(){this.events=[],this.reported.clear()}configure(e){e.windowMs!==void 0&&(this.windowMs=e.windowMs),e.threshold!==void 0&&(this.threshold=e.threshold)}},Me={offline:()=>`No connection. Your changes have not been sent — check your network and try again.`,timeout:()=>`The server is taking too long to answer. Your changes may not have been saved.`,server:e=>`The server could not complete the request${e?` (error ${e})`:``}. Please try again.`,unauthorized:()=>`Your session is no longer valid. Please sign in again.`,notFound:()=>`This is no longer available. It may have been moved or deleted.`,client:e=>`The request was rejected${e?` (error ${e})`:``}.`,cancelled:()=>``,unknown:()=>`Something went wrong. Please try again.`},Ne=new Set([`offline`,`timeout`,`server`]),Pe=(e,t={})=>{let n=e??{},r=n.response?.status,i=n.code,a=t.online??(typeof navigator<`u`&&typeof navigator.onLine==`boolean`?navigator.onLine:!0),o=e=>({kind:e,message:Me[e](r),retryable:Ne.has(e),status:r});return i===`ERR_CANCELED`?o(`cancelled`):i===`ECONNABORTED`||i===`ETIMEDOUT`||/timeout/i.test(n.message??``)?o(`timeout`):r===void 0?!a||i===`ERR_NETWORK`||/network error/i.test(n.message??``)?o(`offline`):o(`unknown`):o(r===401||r===403?`unauthorized`:r===404||r===410?`notFound`:r===408||r===429?`timeout`:r>=500?`server`:r>=400?`client`:`unknown`)},Fe=new Set([``,`__load__`,`search`,`_globalsearch`,`_notifications-list`]),Ie=[`_appcontext-search-`,`search-`],Le=(e,t)=>t===!0?!0:e==null?!1:Fe.has(e)?!0:Ie.some(t=>e.startsWith(t)),Re=(e,t=Math.random)=>{let n=300*3**Math.max(0,e-1);return Math.round(n*(.75+t()*.5))},ze=(e,t,n)=>!n.idempotent||t>2||!e.retryable?!1:e.kind===`timeout`||e.kind===`server`,Be=new class{constructor(){this.linkUp=!0,this.listeners=new Set,this.waiters=new Set,this.started=!1}start(){this.started||typeof window>`u`||(this.started=!0,this.linkUp=typeof navigator<`u`&&typeof navigator.onLine==`boolean`?navigator.onLine:!0,window.addEventListener(`online`,()=>{this.linkUp=!0,this.reachable=void 0,this.changed(),this.releaseWaiters()}),window.addEventListener(`offline`,()=>{this.linkUp=!1,this.changed()}))}isOnline(){return this.linkUp?this.reachable!==!1:!1}noteReachable(){let e=this.isOnline();this.reachable=!0,e||(this.changed(),this.releaseWaiters())}noteUnreachable(){let e=this.isOnline();this.reachable=!1,e&&this.changed()}subscribe(e){return this.listeners.add(e),()=>this.listeners.delete(e)}whenBack(e){return this.isOnline()?(e(),()=>{}):(this.waiters.add(e),()=>this.waiters.delete(e))}reset(){this.linkUp=!0,this.reachable=void 0,this.waiters.clear()}changed(){let e=this.isOnline();this.listeners.forEach(t=>t(e))}releaseWaiters(){let e=Array.from(this.waiters);this.waiters.clear(),e.forEach(e=>e())}};Be.start();var Ve=[],He=6e4,Ue=e=>new Promise(t=>setTimeout(t,e)),We=new class{constructor(){this.axiosInstance=ae.create({timeout:He}),this.axiosInstance.interceptors.request.use(e=>(this.addAuthToken(e),this.addSessionId(e),e)),this.axiosInstance.interceptors.response.use(e=>{let t=Ae({requestedUrl:this.axiosInstance.getUri(e.config),finalUrl:e.request?.responseURL,contentType:String(e.headers?.[`content-type`]??``),data:e.data});if(t)throw window.location.assign(t),Object.assign(Error(`session lost — redirecting to `+t),{code:`ERR_CANCELED`});return e},e=>{let t=e;if(t?.response?.status===401&&t.config&&!t.config.__mateuRetried){let n=t.config;return n.__mateuRetried=!0,Oe(e,()=>this.axiosInstance.request(n))}throw e})}addSessionId(e){let t=sessionStorage.getItem(`__mateu_sesion_id`);t||(t=E(),sessionStorage.setItem(`__mateu_sesion_id`,t)),e.headers[`X-Session-Id`]=t}addAuthToken(e){let t=localStorage.getItem(`__mateu_auth_token`);t&&(e.headers.Authorization=`Bearer `+t)}async wrap(e,t,n,r,i){return n||t.dispatchEvent(new CustomEvent(`backend-called-event`,{bubbles:!0,composed:!0,detail:{}})),e().then(e=>(t.dispatchEvent(new CustomEvent(`backend-succeeded-event`,{bubbles:!0,composed:!0,detail:{actionId:r}})),e)).catch(e=>{let n=Pe(e,{online:Be.isOnline()});throw n.kind==`cancelled`?t.dispatchEvent(new CustomEvent(`backend-cancelled-event`,{bubbles:!0,composed:!0,detail:{actionId:r}})):(e&&typeof e==`object`&&(e.__mateuReported=!0),t.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:r,reason:this.serialize(e),failure:n,retry:i}}))),e})}async sendWithRetry(e,t){let n=0;for(;;)try{let t=await e();return Be.noteReachable(),t}catch(e){let r=Pe(e,{online:Be.isOnline()});if(r.kind==`offline`&&Be.noteUnreachable(),n++,!ze(r,n,{idempotent:t}))throw e;await Ue(Re(n))}}serialize(e){return e?.message?e:JSON.stringify(e)}release(e){Ve=Ve.filter(t=>t!==e)}async get(e){let t=new AbortController;return Ve=[...Ve,t],this.axiosInstance.get(e,{signal:t.signal}).finally(()=>this.release(t))}async post(e,t,n){let r=new AbortController;return Ve=[...Ve,r],this.axiosInstance.post(e,t,{signal:r.signal,...n&&n>0?{timeout:n}:{}}).finally(()=>this.release(r))}async abortAll(){Ve.forEach(e=>e.abort()),Ve=[]}async runAction(e,t,n,r,i,a,o,s,c,l,u,d={}){t&&t.startsWith(`/`)&&(t=t.substring(1));let f=[e,t,n,o??``,r,i].join(``),p=je.check(f);if(p.blocked)return await this.abortAll(),p.firstTrip&&console.error(`[mateu] request loop detected — aborting repeated request`,f),{messages:p.firstTrip?[{title:``,text:`A repeating request was detected and stopped to protect the server. Reload the page or navigate elsewhere.`,position:`bottom-end`,variant:`error`,duration:6e3}]:[],commands:[],fragments:[],banners:[],appendBanners:!1,appData:void 0,appState:void 0};a={...Se(),...a};let m=e+`/mateu/v3/sync/`+(t&&t!=``?t:`_no_route`),ee={serverSideType:o,appState:a,componentState:s,parameters:c,initiatorComponentId:i,consumedRoute:n,route:t&&t!=``?`/`+t:``,actionId:r},te=Le(r,d.idempotent),ne=()=>this.post(m,ee,d.timeoutMillis).then(e=>e.data);return await this.wrap(()=>this.sendWithRetry(ne,te),l,u,r,d.retry)}},Ge=function(e){return e.Add=`Add`,e.Replace=`Replace`,e.ReplaceKeepData=`ReplaceKeepData`,e}({}),Ke=function(e){return e.HAMBURGUER_MENU=`HAMBURGUER_MENU`,e.MENU_ON_LEFT=`MENU_ON_LEFT`,e.MENU_ON_TOP=`MENU_ON_TOP`,e.TABS=`TABS`,e.TILES=`TILES`,e.RAIL=`RAIL`,e.AUTO=`AUTO`,e.MEDIATOR=`MEDIATOR`,e}({}),qe=new Map,Je=[`position:absolute`,`width:1px`,`height:1px`,`margin:-1px`,`padding:0`,`overflow:hidden`,`clip:rect(0 0 0 0)`,`clip-path:inset(50%)`,`white-space:nowrap`,`border:0`].join(`;`),Ye=e=>{if(typeof document>`u`||!document.body)return;let t=qe.get(e);return t?.isConnected?t:(t=document.createElement(`div`),t.setAttribute(`aria-live`,e),t.setAttribute(`aria-atomic`,`true`),t.setAttribute(`role`,e===`assertive`?`alert`:`status`),t.setAttribute(`data-mateu-live-region`,e),t.style.cssText=Je,document.body.appendChild(t),qe.set(e,t),t)},Xe=()=>{if(!(typeof document>`u`)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>Xe(),{once:!0});return}Ye(`polite`),Ye(`assertive`)}},Ze=(e,t={})=>{let n=(e??``).trim();if(!n)return;let r=Ye(t.politeness??`polite`);if(r){if(r.textContent===n){r.textContent=``,setTimeout(()=>{r.textContent=n},60);return}r.textContent=n}},Qe=class extends b{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.callbackToken=``,this.createElement=e=>{let t=e.data,n=document.createElement(t.name);for(let e in t.attributes)n.setAttribute(e,t.attributes[e]);for(let e in t.on)n.addEventListener(e,n=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.on[e],parameters:{event:n}},bubbles:!0,composed:!0}))});return n},this.closeModal=()=>{let e=(this.shadowRoot??this).querySelectorAll(`mateu-dialog, mateu-drawer`);if(e&&e.length>0){e[e.length-1].close();return}this.dispatchEvent(new CustomEvent(`close-modal-requested`,{bubbles:!0,composed:!0}))},this.changeFavicon=e=>{let t=document.querySelector(`link[rel="icon"]`);t===null?(t=document.createElement(`link`),t.setAttribute(`rel`,`icon`),t.setAttribute(`href`,e),document.head.appendChild(t)):t.setAttribute(`href`,e)}}connectedCallback(){super.connectedCallback(),this.upstreamSubscription=le.subscribe(e=>{if(e.command){let t=e.command;this.id==t.targetComponentId&&this.applyCommand(t)}if((!e.callbackToken||!this.callbackToken||e.callbackToken===this.callbackToken)&&e.fragment){let t=e.fragment;this.id==t.targetComponentId&&(this.applyFragment(t),this.completeMenu(t))}})}completeMenu(e){if(e.component&&e.component.type==A.ClientSide){let t=e.component,n=t.metadata;if(n?.type==j.App){let e=n,r=this.getRemoteMenus(e.menu);if(r.length>0){let n=r.map(e=>We.runAction(e.baseUrl,e.route,`_empty`,``,e.baseUrl+`#`+e.route,void 0,void 0,void 0,e.params,this,!0));Promise.all(n).then(n=>{e.menu=this.updateMenu(e.menu,n.map(e=>e.fragments).filter(e=>e).map(e=>e).flat()),e.variant=Ke.MENU_ON_TOP,le.next({fragment:{component:t,data:void 0,state:void 0,action:Ge.Replace,targetComponentId:this.id,containerId:void 0},callbackToken:this.callbackToken})})}}}}updateMenu(e,t){let n=[];return e.forEach(e=>{if(e.remote){let r=t.find(t=>t.targetComponentId==e.baseUrl+`#`+e.route);if(r&&r.component?.type==A.ClientSide){let t=r.component;if(t.metadata?.type==j.App){let r=t.metadata,i=e.serverSideType&&e.serverSideType!=``?e.serverSideType:r.serverSideType;this.changeBaseUrl(r.menu,e.baseUrl,i,e.route,r.route),n.push(...r.menu)}}}else n.push(e)}),n}changeBaseUrl(e,t,n,r,i){e.forEach(e=>{e.baseUrl||(e.submenus&&e.submenus.length>0?this.changeBaseUrl(e.submenus,t,n,r,i):(e.consumedRoute=i??``,e.baseUrl=t,e.serverSideType=n,e.uriPrefix=r))})}getRemoteMenus(e){let t=[];return e.forEach(e=>{e.remote&&t.push(e)}),t}disconnectedCallback(){super.disconnectedCallback(),this.upstreamSubscription?.unsubscribe()}applyCommand(e){if(e.type==`SetWindowTitle`&&(document.title=e.data,Ze(document.title)),e.type==`SetFavicon`&&this.changeFavicon(e.data),e.type==`DispatchEvent`&&this.dispatchNamedEvent(e.data),e.type==`NavigateTo`){let t=e.data;t&&(t.startsWith(`http:`)||t.startsWith(`https:`)?window.open(e.data,`_blank`):window.location.href=e.data)}if(e.type==`PushStateToHistory`){let t=e.data;t!==void 0&&this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0}))}if(e.type==`RunAction`){let t=e.data;if(t&&t.actionId)if(t.targetComponentId){let e={command:{type:`RunAction`,data:{actionId:t.actionId},targetComponentId:t.targetComponentId},fragment:void 0,ui:void 0,error:void 0,callbackToken:``};setTimeout(()=>le.next(e))}else this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:{}},bubbles:!0,composed:!0}))}if(e.type==`MarkAsDirty`&&this.dispatchEvent(new CustomEvent(`dirty`,{detail:{},bubbles:!0,composed:!0})),e.type==`MarkAsClean`&&this.dispatchEvent(new CustomEvent(`clean`,{detail:{},bubbles:!0,composed:!0})),e.type==`DownloadFile`){let t=e.data;if(t&&t.base64Content){let e=atob(t.base64Content),n=new Uint8Array(e.length);for(let t=0;t<e.length;t++)n[t]=e.charCodeAt(t);let r=new Blob([n],{type:t.mimeType}),i=URL.createObjectURL(r),a=document.createElement(`a`);a.href=i,a.download=t.filename??`export`,a.click(),URL.revokeObjectURL(i)}}if(e.type==`CloseModal`&&(this.closeModal(),this.dispatchNamedEvent(e.data)),e.type==`AddContentToHead`){let t=e.data;if(t&&t.name){if(t.attributes&&t.attributes.id&&document.getElementById(t.attributes.id))return;document.head.appendChild(this.createElement(e))}}if(e.type==`AddContentToBody`){let t=e.data;if(t&&t.name){if(t.attributes&&t.attributes.id&&document.getElementById(t.attributes.id))return;document.body.appendChild(this.createElement(e))}}}dispatchNamedEvent(e){if(e&&e.eventName){let t=this.component,n=t?.emitsName??t?.serverSideType,r=e.payload??e.detail;n&&r&&typeof r==`object`&&(r={...r,__source:n}),this.dispatchEvent(new CustomEvent(e.eventName,{detail:r,bubbles:!0,composed:!0}))}}};k([y()],Qe.prototype,`id`,void 0),k([y()],Qe.prototype,`baseUrl`,void 0);var $e=class extends Qe{applyFragment(e){}manageActionRequestedEvent(e){}};k([y()],$e.prototype,`component`,void 0);var et=(e,t)=>Function(...Object.keys(t),"return `"+e+"`")(...Object.values(t)),tt=(e,t,n)=>({state:e??{},data:t??{},...n});function M(e,t,n,r){if(!e?.includes("${"))return e;try{return et(e,tt(t,n,r))}catch(t){return console.warn(`Mateu: could not interpolate "${e}":`,t),e}}var nt=(e,t,n)=>{if(e&&e.indexOf("${")>=0)try{return et(e,tt(t,n))}catch(e){return e.message}return e},rt=(e,t,n,r,i)=>{if(!e)return e;let a=tt(t,n,{appState:r??{},appData:i??{}}),o=e;try{if(o=et(e,a),o.includes("${"))try{o=et(o,a)}catch(a){o=`when evaluating nested `+e+` :`+a+`, where data is `+n+` and state is `+t+` and app state is `+r+` and app data is `+i,console.error(a,o,t,n,r,i)}}catch(a){o=`when evaluating `+e+` :`+a+`, where data is `+n+` and state is `+t+` and app state is `+r+` and app data is `+i,console.error(a,o,t,n,r,i)}return o},it=(e,t,n,r,i,a)=>{let o=tt(t,n,{appState:r??{},appData:i??{},...a}),s=et(e,o);return Function(...Object.keys(o),`return (${s})`)(...Object.values(o))},at=(e,t,n,r)=>{let i=tt(t,n,r);return Function(...Object.keys(i),`return (${e})`)(...Object.values(i))},ot=(e,t,n,r)=>et(e,tt(t,n,r)),st=`display:inline-flex; align-items:center; justify-content:center; width:2rem; height:2rem; border-radius:50%; background:var(--lumo-contrast-10pct,#e0e0e0); color:var(--lumo-secondary-text-color,#555); font-size:.8rem; font-weight:600; overflow:hidden; flex:none;`,ct=(e,t)=>t||(typeof e==`string`&&e?e.trim().split(/\s+/).map(e=>e[0]).slice(0,2).join(``).toUpperCase():``),lt=(e,t,n)=>{let r=e.metadata,i=N(r.name,t,n);return T`<span style="${st}${e.style}" class="${e.cssClasses}"
-                      title="${i||v}" slot="${e.slot??v}">
-        ${r.image?T`<img src="${r.image}" alt="${i}" style="width:100%;height:100%;object-fit:cover;">`:ct(i,r.abbreviation)}
-    </span>`},N=(e,t,n)=>typeof e==`string`&&e.includes("${")?M(e,t,n):e,ut=e=>{let t=e.metadata,n=t.avatars??[],r=t.maxItemsVisible&&t.maxItemsVisible>0?t.maxItemsVisible:n.length,i=n.slice(0,r),a=n.length-i.length,o=`margin-left:-0.4rem; border:2px solid var(--lumo-base-color,#fff);`;return T`<span style="display:inline-flex; ${e.style}" class="${e.cssClasses}" slot="${e.slot??v}">
-        ${i.map(e=>T`<span style="${st}${o}" title="${e.name||v}">
-            ${e.img?T`<img src="${e.img}" style="width:100%;height:100%;object-fit:cover;">`:ct(e.name??``,e.abbr)}
+    `}};O([v()],ge.prototype,`position`,void 0),O([v()],ge.prototype,`zoom`,void 0),O([b(`#map`)],ge.prototype,`mapElement`,void 0),ge=O([h(`mateu-map`)],ge);var _e=typeof HTMLElement<`u`?HTMLElement:class{},ve=class extends _e{static get observedAttributes(){return[`content`]}#e;#t=0;get content(){return this.#e}set content(e){this.#e=e,this.#n()}attributeChangedCallback(e,t,n){this.content=n??void 0}connectedCallback(){this.style.display=`block`,this.#n()}async#n(){if(!this.isConnected)return;let e=this.#e??``,t=++this.#t,[{marked:n},{default:r}]=await Promise.all([E(()=>import(`./vendor.js`).then(e=>e.n),__vite__mapDeps([2,1])),E(()=>import(`./vendor.js`).then(e=>e.a),__vite__mapDeps([2,1]))]);t===this.#t&&(this.innerHTML=r.sanitize(await n.parse(e),{USE_PROFILES:{html:!0,svg:!0,svgFilters:!0},CUSTOM_ELEMENT_HANDLING:{tagNameCheck:e=>!0}}))}};typeof customElements<`u`&&!customElements.get(`mateu-markdown`)&&customElements.define(`mateu-markdown`,ve);var k=function(e){return e.ServerSide=`ServerSide`,e.ClientSide=`ClientSide`,e}({}),A=function(e){return e.Page=`Page`,e.Div=`Div`,e.Element=`Element`,e.MicroFrontend=`MicroFrontend`,e.Form=`Form`,e.Crud=`Crud`,e.Result=`Result`,e.Card=`Card`,e.Directory=`Directory`,e.Stepper=`Stepper`,e.HorizontalLayout=`HorizontalLayout`,e.VerticalLayout=`VerticalLayout`,e.SplitLayout=`SplitLayout`,e.MasterDetailLayout=`MasterDetailLayout`,e.TabLayout=`TabLayout`,e.AccordionLayout=`AccordionLayout`,e.FormLayout=`FormLayout`,e.FormRow=`FormRow`,e.FormItem=`FormItem`,e.BoardLayout=`BoardLayout`,e.BoardLayoutRow=`BoardLayoutRow`,e.BoardLayoutItem=`BoardLayoutItem`,e.Scroller=`Scroller`,e.FullWidth=`FullWidth`,e.Container=`Container`,e.FormField=`FormField`,e.Table=`Table`,e.App=`App`,e.Text=`Text`,e.Avatar=`Avatar`,e.Chat=`Chat`,e.AvatarGroup=`AvatarGroup`,e.Badge=`Badge`,e.Breadcrumbs=`Breadcrumbs`,e.Anchor=`Anchor`,e.Button=`Button`,e.Chart=`Chart`,e.Icon=`Icon`,e.ConfirmDialog=`ConfirmDialog`,e.ContextMenu=`ContextMenu`,e.CookieConsent=`CookieConsent`,e.Details=`Details`,e.Dialog=`Dialog`,e.Drawer=`Drawer`,e.Image=`Image`,e.Map=`Map`,e.Markdown=`Markdown`,e.Notification=`Notification`,e.ProgressBar=`ProgressBar`,e.Popover=`Popover`,e.CarouselLayout=`CarouselLayout`,e.Tooltip=`Tooltip`,e.MessageInput=`MessageInput`,e.MessageList=`MessageList`,e.CustomField=`CustomField`,e.MenuBar=`MenuBar`,e.Grid=`Grid`,e.GridColumn=`GridColumn`,e.GridGroupColumn=`GridGroupColumn`,e.VirtualList=`VirtualList`,e.FormSection=`FormSection`,e.FormSubSection=`FormSubSection`,e.Bpmn=`Bpmn`,e.Workflow=`Workflow`,e.FormEditor=`FormEditor`,e.MetricCard=`MetricCard`,e.Scoreboard=`Scoreboard`,e.DashboardPanel=`DashboardPanel`,e.DashboardLayout=`DashboardLayout`,e.FoldoutLayout=`FoldoutLayout`,e.ContentLayout=`ContentLayout`,e.HeroSection=`HeroSection`,e.EmptyState=`EmptyState`,e.Skeleton=`Skeleton`,e.Gantt=`Gantt`,e.PlanningBoard=`PlanningBoard`,e.Kanban=`Kanban`,e.Timeline=`Timeline`,e.ProgressSteps=`ProgressSteps`,e.Stat=`Stat`,e.Calendar=`Calendar`,e.PricingTable=`PricingTable`,e.OrgChart=`OrgChart`,e.Heatmap=`Heatmap`,e.Funnel=`Funnel`,e.TrendChart=`TrendChart`,e.FeatureGrid=`FeatureGrid`,e.Testimonials=`Testimonials`,e.Faq=`Faq`,e.CalloutCard=`CalloutCard`,e.CommentThread=`CommentThread`,e.FileList=`FileList`,e.Checklist=`Checklist`,e.ComparisonCard=`ComparisonCard`,e.EntityHeader=`EntityHeader`,e.Meter=`Meter`,e.TaskProgress=`TaskProgress`,e.StatusList=`StatusList`,e.BulletedList=`BulletedList`,e.Separator=`Separator`,e.Notice=`Notice`,e.TaskQueue=`TaskQueue`,e.ResourceGrid=`ResourceGrid`,e.OfferCard=`OfferCard`,e.AddOnPicker=`AddOnPicker`,e.Ledger=`Ledger`,e.PaymentPicker=`PaymentPicker`,e.ProcessMonitor=`ProcessMonitor`,e}({}),ye=`mateu-app-context`,be=`mateu-app-context-labels`,xe=e=>{try{return JSON.parse(localStorage.getItem(e)??`{}`)}catch{return{}}},Se=(e,t)=>{try{localStorage.setItem(e,JSON.stringify(t))}catch{}},Ce=()=>xe(ye),we=()=>xe(be),Te=(e,t,n)=>{let r=Ce(),i=we();t==null||t===``?(delete r[e],delete i[e]):(r[e]=t,n!==void 0&&(i[e]=n)),Se(ye,r),Se(be,i)},Ee=!1,De=()=>{Ee||(Ee=!0,window.addEventListener(`storage`,e=>{e.key===ye&&e.newValue!==e.oldValue&&window.location.reload()}))},Oe,ke=(e,t)=>new Promise((n,r)=>{let i=!1,a={retry:()=>{i||(i=!0,t().then(n,r))},giveUp:()=>{i||(i=!0,r(e))}};if(Oe){Oe(a);return}let o=new CustomEvent(`mateu-session-expired`,{detail:a,cancelable:!0,bubbles:!1});typeof document<`u`&&!document.dispatchEvent(o)||a.giveUp()}),Ae=(e,t)=>e.includes(`json`)?!0:typeof t==`object`&&!!t,je=(e,t)=>{let n=e.finalUrl;if(!n)return;let r=t??(typeof window<`u`?window.location.href:void 0),i;try{i=new URL(e.requestedUrl,r).href}catch{return}if(i!==n&&!Ae(e.contentType??``,e.data))return n},Me=new class{constructor(){this.windowMs=4e3,this.threshold=12,this.events=[],this.reported=new Set}check(e,t=Date.now()){this.events.push({sig:e,t});let n=t-this.windowMs;this.events=this.events.filter(e=>e.t>=n);let r=0;for(let t of this.events)t.sig===e&&r++;if(r>=this.threshold){let t=!this.reported.has(e);return this.reported.add(e),{blocked:!0,firstTrip:t}}return this.reported.delete(e),{blocked:!1,firstTrip:!1}}reset(){this.events=[],this.reported.clear()}configure(e){e.windowMs!==void 0&&(this.windowMs=e.windowMs),e.threshold!==void 0&&(this.threshold=e.threshold)}},Ne={offline:()=>`No connection. Your changes have not been sent — check your network and try again.`,timeout:()=>`The server is taking too long to answer. Your changes may not have been saved.`,server:e=>`The server could not complete the request${e?` (error ${e})`:``}. Please try again.`,unauthorized:()=>`Your session is no longer valid. Please sign in again.`,notFound:()=>`This is no longer available. It may have been moved or deleted.`,client:e=>`The request was rejected${e?` (error ${e})`:``}.`,cancelled:()=>``,unknown:()=>`Something went wrong. Please try again.`},Pe=new Set([`offline`,`timeout`,`server`]),Fe=(e,t={})=>{let n=e??{},r=n.response?.status,i=n.code,a=t.online??(typeof navigator<`u`&&typeof navigator.onLine==`boolean`?navigator.onLine:!0),o=e=>({kind:e,message:Ne[e](r),retryable:Pe.has(e),status:r});return i===`ERR_CANCELED`?o(`cancelled`):i===`ECONNABORTED`||i===`ETIMEDOUT`||/timeout/i.test(n.message??``)?o(`timeout`):r===void 0?!a||i===`ERR_NETWORK`||/network error/i.test(n.message??``)?o(`offline`):o(`unknown`):o(r===401||r===403?`unauthorized`:r===404||r===410?`notFound`:r===408||r===429?`timeout`:r>=500?`server`:r>=400?`client`:`unknown`)},Ie=new Set([``,`__load__`,`search`,`_globalsearch`,`_notifications-list`]),Le=[`_appcontext-search-`,`search-`],Re=(e,t)=>t===!0?!0:e==null?!1:Ie.has(e)?!0:Le.some(t=>e.startsWith(t)),ze=(e,t=Math.random)=>{let n=300*3**Math.max(0,e-1);return Math.round(n*(.75+t()*.5))},Be=(e,t,n)=>!n.idempotent||t>2||!e.retryable?!1:e.kind===`timeout`||e.kind===`server`,Ve=new class{constructor(){this.linkUp=!0,this.listeners=new Set,this.waiters=new Set,this.started=!1}start(){this.started||typeof window>`u`||(this.started=!0,this.linkUp=typeof navigator<`u`&&typeof navigator.onLine==`boolean`?navigator.onLine:!0,window.addEventListener(`online`,()=>{this.linkUp=!0,this.reachable=void 0,this.changed(),this.releaseWaiters()}),window.addEventListener(`offline`,()=>{this.linkUp=!1,this.changed()}))}isOnline(){return this.linkUp?this.reachable!==!1:!1}noteReachable(){let e=this.isOnline();this.reachable=!0,e||(this.changed(),this.releaseWaiters())}noteUnreachable(){let e=this.isOnline();this.reachable=!1,e&&this.changed()}subscribe(e){return this.listeners.add(e),()=>this.listeners.delete(e)}whenBack(e){return this.isOnline()?(e(),()=>{}):(this.waiters.add(e),()=>this.waiters.delete(e))}reset(){this.linkUp=!0,this.reachable=void 0,this.waiters.clear()}changed(){let e=this.isOnline();this.listeners.forEach(t=>t(e))}releaseWaiters(){let e=Array.from(this.waiters);this.waiters.clear(),e.forEach(e=>e())}};Ve.start();var He=[],Ue=6e4,We=e=>new Promise(t=>setTimeout(t,e)),Ge=new class{constructor(){this.axiosInstance=oe.create({timeout:Ue}),this.axiosInstance.interceptors.request.use(e=>(this.addAuthToken(e),this.addSessionId(e),e)),this.axiosInstance.interceptors.response.use(e=>{let t=je({requestedUrl:this.axiosInstance.getUri(e.config),finalUrl:e.request?.responseURL,contentType:String(e.headers?.[`content-type`]??``),data:e.data});if(t)throw window.location.assign(t),Object.assign(Error(`session lost — redirecting to `+t),{code:`ERR_CANCELED`});return e},e=>{let t=e;if(t?.response?.status===401&&t.config&&!t.config.__mateuRetried){let n=t.config;return n.__mateuRetried=!0,ke(e,()=>this.axiosInstance.request(n))}throw e})}addSessionId(e){let t=sessionStorage.getItem(`__mateu_sesion_id`);t||(t=T(),sessionStorage.setItem(`__mateu_sesion_id`,t)),e.headers[`X-Session-Id`]=t}addAuthToken(e){let t=localStorage.getItem(`__mateu_auth_token`);t&&(e.headers.Authorization=`Bearer `+t)}async wrap(e,t,n,r,i){return n||t.dispatchEvent(new CustomEvent(`backend-called-event`,{bubbles:!0,composed:!0,detail:{}})),e().then(e=>(t.dispatchEvent(new CustomEvent(`backend-succeeded-event`,{bubbles:!0,composed:!0,detail:{actionId:r}})),e)).catch(e=>{let n=Fe(e,{online:Ve.isOnline()});throw n.kind==`cancelled`?t.dispatchEvent(new CustomEvent(`backend-cancelled-event`,{bubbles:!0,composed:!0,detail:{actionId:r}})):(e&&typeof e==`object`&&(e.__mateuReported=!0),t.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:r,reason:this.serialize(e),failure:n,retry:i}}))),e})}async sendWithRetry(e,t){let n=0;for(;;)try{let t=await e();return Ve.noteReachable(),t}catch(e){let r=Fe(e,{online:Ve.isOnline()});if(r.kind==`offline`&&Ve.noteUnreachable(),n++,!Be(r,n,{idempotent:t}))throw e;await We(ze(n))}}serialize(e){return e?.message?e:JSON.stringify(e)}release(e){He=He.filter(t=>t!==e)}async get(e){let t=new AbortController;return He=[...He,t],this.axiosInstance.get(e,{signal:t.signal}).finally(()=>this.release(t))}async post(e,t,n){let r=new AbortController;return He=[...He,r],this.axiosInstance.post(e,t,{signal:r.signal,...n&&n>0?{timeout:n}:{}}).finally(()=>this.release(r))}async abortAll(){He.forEach(e=>e.abort()),He=[]}async runAction(e,t,n,r,i,a,o,s,c,l,u,d={}){t&&t.startsWith(`/`)&&(t=t.substring(1));let f=[e,t,n,o??``,r,i].join(``),p=Me.check(f);if(p.blocked)return await this.abortAll(),p.firstTrip&&console.error(`[mateu] request loop detected — aborting repeated request`,f),{messages:p.firstTrip?[{title:``,text:`A repeating request was detected and stopped to protect the server. Reload the page or navigate elsewhere.`,position:`bottom-end`,variant:`error`,duration:6e3}]:[],commands:[],fragments:[],banners:[],appendBanners:!1,appData:void 0,appState:void 0};a={...Ce(),...a};let ee=e+`/mateu/v3/sync/`+(t&&t!=``?t:`_no_route`),te={serverSideType:o,appState:a,componentState:s,parameters:c,initiatorComponentId:i,consumedRoute:n,route:t&&t!=``?`/`+t:``,actionId:r,knownStructureHash:d.knownStructureHash},ne=Re(r,d.idempotent),re=()=>this.post(ee,te,d.timeoutMillis).then(e=>e.data);return await this.wrap(()=>this.sendWithRetry(re,ne),l,u,r,d.retry)}},Ke=function(e){return e.Add=`Add`,e.Replace=`Replace`,e.ReplaceKeepData=`ReplaceKeepData`,e}({}),qe=function(e){return e.HAMBURGUER_MENU=`HAMBURGUER_MENU`,e.MENU_ON_LEFT=`MENU_ON_LEFT`,e.MENU_ON_TOP=`MENU_ON_TOP`,e.TABS=`TABS`,e.TILES=`TILES`,e.RAIL=`RAIL`,e.AUTO=`AUTO`,e.MEDIATOR=`MEDIATOR`,e}({}),Je=new Map,Ye=[`position:absolute`,`width:1px`,`height:1px`,`margin:-1px`,`padding:0`,`overflow:hidden`,`clip:rect(0 0 0 0)`,`clip-path:inset(50%)`,`white-space:nowrap`,`border:0`].join(`;`),Xe=e=>{if(typeof document>`u`||!document.body)return;let t=Je.get(e);return t?.isConnected?t:(t=document.createElement(`div`),t.setAttribute(`aria-live`,e),t.setAttribute(`aria-atomic`,`true`),t.setAttribute(`role`,e===`assertive`?`alert`:`status`),t.setAttribute(`data-mateu-live-region`,e),t.style.cssText=Ye,document.body.appendChild(t),Je.set(e,t),t)},Ze=()=>{if(!(typeof document>`u`)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>Ze(),{once:!0});return}Xe(`polite`),Xe(`assertive`)}},Qe=(e,t={})=>{let n=(e??``).trim();if(!n)return;let r=Xe(t.politeness??`polite`);if(r){if(r.textContent===n){r.textContent=``,setTimeout(()=>{r.textContent=n},60);return}r.textContent=n}},$e=class extends y{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.callbackToken=``,this.createElement=e=>{let t=e.data,n=document.createElement(t.name);for(let e in t.attributes)n.setAttribute(e,t.attributes[e]);for(let e in t.on)n.addEventListener(e,n=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.on[e],parameters:{event:n}},bubbles:!0,composed:!0}))});return n},this.closeModal=()=>{let e=(this.shadowRoot??this).querySelectorAll(`mateu-dialog, mateu-drawer`);if(e&&e.length>0){e[e.length-1].close();return}this.dispatchEvent(new CustomEvent(`close-modal-requested`,{bubbles:!0,composed:!0}))},this.changeFavicon=e=>{let t=document.querySelector(`link[rel="icon"]`);t===null?(t=document.createElement(`link`),t.setAttribute(`rel`,`icon`),t.setAttribute(`href`,e),document.head.appendChild(t)):t.setAttribute(`href`,e)}}connectedCallback(){super.connectedCallback(),this.upstreamSubscription=ue.subscribe(e=>{if(e.command){let t=e.command;this.id==t.targetComponentId&&this.applyCommand(t)}if((!e.callbackToken||!this.callbackToken||e.callbackToken===this.callbackToken)&&e.fragment){let t=e.fragment;this.id==t.targetComponentId&&(this.applyFragment(t),this.completeMenu(t))}})}completeMenu(e){if(e.component&&e.component.type==k.ClientSide){let t=e.component,n=t.metadata;if(n?.type==A.App){let e=n,r=this.getRemoteMenus(e.menu);if(r.length>0){let n=r.map(e=>Ge.runAction(e.baseUrl,e.route,`_empty`,``,e.baseUrl+`#`+e.route,void 0,void 0,void 0,e.params,this,!0));Promise.all(n).then(n=>{e.menu=this.updateMenu(e.menu,n.map(e=>e.fragments).filter(e=>e).map(e=>e).flat()),e.variant=qe.MENU_ON_TOP,ue.next({fragment:{component:t,data:void 0,state:void 0,action:Ke.Replace,targetComponentId:this.id,containerId:void 0},callbackToken:this.callbackToken})})}}}}updateMenu(e,t){let n=[];return e.forEach(e=>{if(e.remote){let r=t.find(t=>t.targetComponentId==e.baseUrl+`#`+e.route);if(r&&r.component?.type==k.ClientSide){let t=r.component;if(t.metadata?.type==A.App){let r=t.metadata,i=e.serverSideType&&e.serverSideType!=``?e.serverSideType:r.serverSideType;this.changeBaseUrl(r.menu,e.baseUrl,i,e.route,r.route),n.push(...r.menu)}}}else n.push(e)}),n}changeBaseUrl(e,t,n,r,i){e.forEach(e=>{e.baseUrl||(e.submenus&&e.submenus.length>0?this.changeBaseUrl(e.submenus,t,n,r,i):(e.consumedRoute=i??``,e.baseUrl=t,e.serverSideType=n,e.uriPrefix=r))})}getRemoteMenus(e){let t=[];return e.forEach(e=>{e.remote&&t.push(e)}),t}disconnectedCallback(){super.disconnectedCallback(),this.upstreamSubscription?.unsubscribe()}applyCommand(e){if(e.type==`SetWindowTitle`&&(document.title=e.data,Qe(document.title)),e.type==`SetFavicon`&&this.changeFavicon(e.data),e.type==`DispatchEvent`&&this.dispatchNamedEvent(e.data),e.type==`NavigateTo`){let t=e.data;t&&(t.startsWith(`http:`)||t.startsWith(`https:`)?window.open(e.data,`_blank`):window.location.href=e.data)}if(e.type==`PushStateToHistory`){let t=e.data;t!==void 0&&this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0}))}if(e.type==`RunAction`){let t=e.data;if(t&&t.actionId)if(t.targetComponentId){let e={command:{type:`RunAction`,data:{actionId:t.actionId},targetComponentId:t.targetComponentId},fragment:void 0,ui:void 0,error:void 0,callbackToken:``};setTimeout(()=>ue.next(e))}else this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:{}},bubbles:!0,composed:!0}))}if(e.type==`MarkAsDirty`&&this.dispatchEvent(new CustomEvent(`dirty`,{detail:{},bubbles:!0,composed:!0})),e.type==`MarkAsClean`&&this.dispatchEvent(new CustomEvent(`clean`,{detail:{},bubbles:!0,composed:!0})),e.type==`DownloadFile`){let t=e.data;if(t&&t.base64Content){let e=atob(t.base64Content),n=new Uint8Array(e.length);for(let t=0;t<e.length;t++)n[t]=e.charCodeAt(t);let r=new Blob([n],{type:t.mimeType}),i=URL.createObjectURL(r),a=document.createElement(`a`);a.href=i,a.download=t.filename??`export`,a.click(),URL.revokeObjectURL(i)}}if(e.type==`CloseModal`&&(this.closeModal(),this.dispatchNamedEvent(e.data)),e.type==`AddContentToHead`){let t=e.data;if(t&&t.name){if(t.attributes&&t.attributes.id&&document.getElementById(t.attributes.id))return;document.head.appendChild(this.createElement(e))}}if(e.type==`AddContentToBody`){let t=e.data;if(t&&t.name){if(t.attributes&&t.attributes.id&&document.getElementById(t.attributes.id))return;document.body.appendChild(this.createElement(e))}}}dispatchNamedEvent(e){if(e&&e.eventName){let t=this.component,n=t?.emitsName??t?.serverSideType,r=e.payload??e.detail;n&&r&&typeof r==`object`&&(r={...r,__source:n}),this.dispatchEvent(new CustomEvent(e.eventName,{detail:r,bubbles:!0,composed:!0}))}}};O([v()],$e.prototype,`id`,void 0),O([v()],$e.prototype,`baseUrl`,void 0);var et=class extends $e{applyFragment(e){}manageActionRequestedEvent(e){}};O([v()],et.prototype,`component`,void 0);var tt=(e,t)=>Function(...Object.keys(t),"return `"+e+"`")(...Object.values(t)),nt=(e,t,n)=>({state:e??{},data:t??{},...n});function j(e,t,n,r){if(!e?.includes("${"))return e;try{return tt(e,nt(t,n,r))}catch(t){return console.warn(`Mateu: could not interpolate "${e}":`,t),e}}var rt=(e,t,n)=>{if(e&&e.indexOf("${")>=0)try{return tt(e,nt(t,n))}catch(e){return e.message}return e},it=(e,t,n,r,i)=>{if(!e)return e;let a=nt(t,n,{appState:r??{},appData:i??{}}),o=e;try{if(o=tt(e,a),o.includes("${"))try{o=tt(o,a)}catch(a){o=`when evaluating nested `+e+` :`+a+`, where data is `+n+` and state is `+t+` and app state is `+r+` and app data is `+i,console.error(a,o,t,n,r,i)}}catch(a){o=`when evaluating `+e+` :`+a+`, where data is `+n+` and state is `+t+` and app state is `+r+` and app data is `+i,console.error(a,o,t,n,r,i)}return o},at=(e,t,n,r,i,a)=>{let o=nt(t,n,{appState:r??{},appData:i??{},...a}),s=tt(e,o);return Function(...Object.keys(o),`return (${s})`)(...Object.values(o))},ot=(e,t,n,r)=>{let i=nt(t,n,r);return Function(...Object.keys(i),`return (${e})`)(...Object.values(i))},st=(e,t,n,r)=>tt(e,nt(t,n,r)),ct=`display:inline-flex; align-items:center; justify-content:center; width:2rem; height:2rem; border-radius:50%; background:var(--lumo-contrast-10pct,#e0e0e0); color:var(--lumo-secondary-text-color,#555); font-size:.8rem; font-weight:600; overflow:hidden; flex:none;`,lt=(e,t)=>t||(typeof e==`string`&&e?e.trim().split(/\s+/).map(e=>e[0]).slice(0,2).join(``).toUpperCase():``),ut=(e,t,n)=>{let r=e.metadata,i=M(r.name,t,n);return w`<span style="${ct}${e.style}" class="${e.cssClasses}"
+                      title="${i||_}" slot="${e.slot??_}">
+        ${r.image?w`<img src="${r.image}" alt="${i}" style="width:100%;height:100%;object-fit:cover;">`:lt(i,r.abbreviation)}
+    </span>`},M=(e,t,n)=>typeof e==`string`&&e.includes("${")?j(e,t,n):e,dt=e=>{let t=e.metadata,n=t.avatars??[],r=t.maxItemsVisible&&t.maxItemsVisible>0?t.maxItemsVisible:n.length,i=n.slice(0,r),a=n.length-i.length,o=`margin-left:-0.4rem; border:2px solid var(--lumo-base-color,#fff);`;return w`<span style="display:inline-flex; ${e.style}" class="${e.cssClasses}" slot="${e.slot??_}">
+        ${i.map(e=>w`<span style="${ct}${o}" title="${e.name||_}">
+            ${e.img?w`<img src="${e.img}" style="width:100%;height:100%;object-fit:cover;">`:lt(e.name??``,e.abbr)}
         </span>`)}
-        ${a>0?T`<span style="${st}${o}">+${a}</span>`:v}
-    </span>`},dt=(e,t,n)=>{let r=e.metadata;return T`<span theme="badge ${r.color} ${r.pill?`pill`:``} ${r.small?`small`:``} ${r.primary?`primary`:``}"
+        ${a>0?w`<span style="${ct}${o}">+${a}</span>`:_}
+    </span>`},ft=(e,t,n)=>{let r=e.metadata;return w`<span theme="badge ${r.color} ${r.pill?`pill`:``} ${r.small?`small`:``} ${r.primary?`primary`:``}"
                       style="${e.style}" class="${e.cssClasses}"
-                      slot="${e.slot??v}">${N(r.text,t,n)}</span>`},ft=(e,t,n)=>{let r=N(e.text,t,n);if(!r)return v;let i=N(e.color,t,n);return i==`SUCCESS`&&(i=`success`),i==`ERROR`&&(i=`error`),i==`DANGER`&&(i=`error`),i==`WARNING`&&(i=`warning`),i==`INFO`&&(i=`info`),i==`PRIMARY`&&(i=`primary`),i==`SECONDARY`&&(i=`secondary`),i==`TERTIARY`&&(i=`tertiary`),i==`QUATERNARY`&&(i=`quaternary`),i==`LIGHT`&&(i=`light`),i==`DARK`&&(i=`dark`),T`<span theme="badge ${i} ${e.pill?`pill`:``} ${e.small?`small`:``} ${e.primary?`primary`:``}">${r}</span>`},P=new class{constructor(){this.afterRenderHook=void 0,this.useShadowRoot=!0,this.componentRenderer=void 0}set(e){if(this.componentRenderer=e,typeof window<`u`){let t=e.supportedClientSideTypes?.();window.__mateuRendererInfo={name:e.rendererName?.()??e.constructor?.name??`unknown`,supportedTypes:t?[...t].sort():null}}}get(){return this.componentRenderer}setUseShadowRoot(e){this.useShadowRoot=e}mustUseShadowRoot(){return this.useShadowRoot}setAfterRenderHook(e){this.afterRenderHook=e}getAfterRenderHook(){return this.afterRenderHook}},pt=(e,t,n,r,i,a,o,s,c)=>(t.slot=s,F(e,t,n,r,i,a,o,c)),F=(e,t,n,r,i,a,o,s)=>{if(!t)return T``;if(t.type==A.ClientSide)return P.get().renderClientSideComponent(e,t,n,r,i,a,o,s);let c=e.route,l=e.consumedRoute;return T`
+                      slot="${e.slot??_}">${M(r.text,t,n)}</span>`},pt=(e,t,n)=>{let r=M(e.text,t,n);if(!r)return _;let i=M(e.color,t,n);return i==`SUCCESS`&&(i=`success`),i==`ERROR`&&(i=`error`),i==`DANGER`&&(i=`error`),i==`WARNING`&&(i=`warning`),i==`INFO`&&(i=`info`),i==`PRIMARY`&&(i=`primary`),i==`SECONDARY`&&(i=`secondary`),i==`TERTIARY`&&(i=`tertiary`),i==`QUATERNARY`&&(i=`quaternary`),i==`LIGHT`&&(i=`light`),i==`DARK`&&(i=`dark`),w`<span theme="badge ${i} ${e.pill?`pill`:``} ${e.small?`small`:``} ${e.primary?`primary`:``}">${r}</span>`},N=new class{constructor(){this.afterRenderHook=void 0,this.useShadowRoot=!0,this.componentRenderer=void 0}set(e){if(this.componentRenderer=e,typeof window<`u`){let t=e.supportedClientSideTypes?.();window.__mateuRendererInfo={name:e.rendererName?.()??e.constructor?.name??`unknown`,supportedTypes:t?[...t].sort():null}}}get(){return this.componentRenderer}setUseShadowRoot(e){this.useShadowRoot=e}mustUseShadowRoot(){return this.useShadowRoot}setAfterRenderHook(e){this.afterRenderHook=e}getAfterRenderHook(){return this.afterRenderHook}},mt=(e,t,n,r,i,a,o,s,c)=>(t.slot=s,P(e,t,n,r,i,a,o,c)),P=(e,t,n,r,i,a,o,s)=>{if(!t)return w``;if(t.type==k.ClientSide)return N.get().renderClientSideComponent(e,t,n,r,i,a,o,s);let c=e.route,l=e.consumedRoute;return w`
         <mateu-component id="${t.id}"
                          .component="${t}"
                         route="${c}"
                          consumedRoute="${l}"
                          baseUrl="${n}"
-                         slot="${t.slot??v}"
+                         slot="${t.slot??_}"
                          style="${t.style}"
                          class="${t.cssClasses}"
                          .state="${{...t.initialData??{},...r}}"
@@ -163,29 +163,29 @@ ${i}
                          .appState="${a}"
                          .appData="${o}"
         >
-       </mateu-component>`},mt=e=>{let t=[];return e.color&&e.color!==`normal`&&e.color!==`none`&&t.push(e.color),e.buttonStyle&&t.push(e.buttonStyle===`tertiaryInline`?`tertiary-inline`:e.buttonStyle),e.size&&e.size!==`none`&&e.size!==`normal`&&t.push(e.size),t.length?t.join(` `):void 0},ht=e=>{let t=mt(e)??``,n=[];return t.includes(`primary`)&&n.push(`primary`),t.includes(`tertiary`)&&n.push(`tertiary`),(t.includes(`error`)||e.color===`error`)&&n.push(`danger`),n.join(` `)},gt=e=>e===`back`||e===`backToList`||!!e&&e.startsWith(`cancel`),_t=class extends b{constructor(...e){super(...e),this.appState={},this.appData={},this._overflowOpen=!1,this._onDocClick=e=>{e.composedPath().includes(this)||(this._overflowOpen=!1)},this.handleButtonClick=e=>{this._overflowOpen=!1,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.evalLabel=e=>M(e,this.state,this.data),this.renderBtn=e=>{if((this.data??{})[e.actionId+`.hidden`])return v;let t=this.evalLabel(e.label);return P.get()?.renderToolbarButton?.(e,t,()=>this.handleButtonClick(e.actionId))||T`
-        <button class="mtb ${ht(e)}"
+       </mateu-component>`},ht=e=>{let t=[];return e.color&&e.color!==`normal`&&e.color!==`none`&&t.push(e.color),e.buttonStyle&&t.push(e.buttonStyle===`tertiaryInline`?`tertiary-inline`:e.buttonStyle),e.size&&e.size!==`none`&&e.size!==`normal`&&t.push(e.size),t.length?t.join(` `):void 0},gt=e=>{let t=ht(e)??``,n=[];return t.includes(`primary`)&&n.push(`primary`),t.includes(`tertiary`)&&n.push(`tertiary`),(t.includes(`error`)||e.color===`error`)&&n.push(`danger`),n.join(` `)},_t=e=>e===`back`||e===`backToList`||!!e&&e.startsWith(`cancel`),vt=class extends y{constructor(...e){super(...e),this.appState={},this.appData={},this._overflowOpen=!1,this._onDocClick=e=>{e.composedPath().includes(this)||(this._overflowOpen=!1)},this.handleButtonClick=e=>{this._overflowOpen=!1,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.evalLabel=e=>j(e,this.state,this.data),this.renderBtn=e=>{if((this.data??{})[e.actionId+`.hidden`])return _;let t=this.evalLabel(e.label);return N.get()?.renderToolbarButton?.(e,t,()=>this.handleButtonClick(e.actionId))||w`
+        <button class="mtb ${gt(e)}"
                 data-action-id="${e.id}"
                 @click="${()=>this.handleButtonClick(e.actionId)}"
                 ?disabled="${e.disabled}"
         >${t}</button>
-    `},this.renderActions=e=>{let t=e.filter(e=>!(this.data??{})[e.actionId+`.hidden`]),n=t.filter(e=>e.buttonStyle===`primary`),r=t.filter(e=>e.buttonStyle!==`primary`);return r.length<2?T`${t.map(this.renderBtn)}`:T`
+    `},this.renderActions=e=>{let t=e.filter(e=>!(this.data??{})[e.actionId+`.hidden`]),n=t.filter(e=>e.buttonStyle===`primary`),r=t.filter(e=>e.buttonStyle!==`primary`);return r.length<2?w`${t.map(this.renderBtn)}`:w`
             ${n.map(this.renderBtn)}
             <div class="overflow-wrap">
                 <button class="mtb overflow-btn" title="Más acciones" aria-haspopup="true"
                         aria-expanded="${this._overflowOpen}"
                         @click="${e=>{e.stopPropagation(),this._overflowOpen=!this._overflowOpen}}">⋯</button>
-                ${this._overflowOpen?T`
+                ${this._overflowOpen?w`
                     <div class="overflow-menu">
-                        ${r.map(e=>T`
+                        ${r.map(e=>w`
                             <button class="overflow-item" ?disabled="${e.disabled}"
                                     data-action-id="${e.actionId}"
                                     @click="${()=>this.handleButtonClick(e.actionId)}">${this.evalLabel(e.label)}</button>
                         `)}
                     </div>
-                `:v}
+                `:_}
             </div>
-        `},this.renderPeerNav=e=>P.get()?.renderPeerNav?.(e)||T`
+        `},this.renderPeerNav=e=>N.get()?.renderPeerNav?.(e)||w`
             <div style="display: flex; gap: var(--lumo-space-xs, .25rem); align-items: center;" class="peer-nav">
                 <button class="mtb tertiary peer-nav-prev"
                         title="${e.prevLabel??`Previous`}"
@@ -196,71 +196,71 @@ ${i}
                         ?disabled="${!e.nextRoute}"
                         @click="${()=>{e.nextRoute&&(window.location.href=e.nextRoute)}}">›</button>
             </div>
-        `}connectedCallback(){super.connectedCallback(),document.addEventListener(`click`,this._onDocClick)}disconnectedCallback(){document.removeEventListener(`click`,this._onDocClick),super.disconnectedCallback()}render(){let e=this.metadata;if(!e)return T``;let t=e.peerNav&&(e.peerNav.prevRoute||e.peerNav.nextRoute)?e.peerNav:void 0,n=e.toolbar??[],r=n.filter(e=>gt(e.actionId)),i=n.filter(e=>!gt(e.actionId)),a=r.length>0&&i.length>0?T`<span class="toolbar-divider"></span>`:v,o=e.avatar||e.title||e.subtitle||e.kpis?.length>0||e.header?.length>0||n.length>0||!!t,s=e.level??0;return s>0?this.setAttribute(`data-nested`,``):this.removeAttribute(`data-nested`),T`
-            ${e.breadcrumbs&&e.breadcrumbs.length>0?T`
+        `}connectedCallback(){super.connectedCallback(),document.addEventListener(`click`,this._onDocClick)}disconnectedCallback(){document.removeEventListener(`click`,this._onDocClick),super.disconnectedCallback()}render(){let e=this.metadata;if(!e)return w``;let t=e.peerNav&&(e.peerNav.prevRoute||e.peerNav.nextRoute)?e.peerNav:void 0,n=e.toolbar??[],r=n.filter(e=>_t(e.actionId)),i=n.filter(e=>!_t(e.actionId)),a=r.length>0&&i.length>0?w`<span class="toolbar-divider"></span>`:_,o=e.avatar||e.title||e.subtitle||e.kpis?.length>0||e.header?.length>0||n.length>0||!!t,s=e.level??0;return s>0?this.setAttribute(`data-nested`,``):this.removeAttribute(`data-nested`),w`
+            ${e.breadcrumbs&&e.breadcrumbs.length>0?w`
                 <div style="display: flex; gap: var(--lumo-space-m, 1rem); width: 100%; align-items: center;" class="breadcrumbs-bar">
-                    ${e.breadcrumbs.map((e,t)=>T`
-                        ${t>0?T`<span>/</span>`:v}
-                        ${e.link?T`<button class="breadcrumb-link" @click="${()=>window.location.href=`${e.link}`}">${e.text}</button>`:T`<span>${e.text}</span>`}
+                    ${e.breadcrumbs.map((e,t)=>w`
+                        ${t>0?w`<span>/</span>`:_}
+                        ${e.link?w`<button class="breadcrumb-link" @click="${()=>window.location.href=`${e.link}`}">${e.text}</button>`:w`<span>${e.text}</span>`}
                     `)}
                 </div>
-            `:v}
-            ${e.noHeader?T`
+            `:_}
+            ${e.noHeader?w`
                 <div style="display: flex; gap: var(--lumo-space-m, 1rem); align-items: center;">
-                    ${e?.header?.map(e=>F(this,e,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData))}
-                    ${t?this.renderPeerNav(t):v}
+                    ${e?.header?.map(e=>P(this,e,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData))}
+                    ${t?this.renderPeerNav(t):_}
                     ${r.map(this.renderBtn)}
                     ${a}
                     ${this.renderActions(i)}
                 </div>
-            `:o?T`
+            `:o?w`
                 <div style="display: flex; gap: var(--lumo-space-m, 1rem); width: 100%; align-items: center; flex-wrap: wrap;" class="form-header">
-                    ${e.avatar?F(this,e.avatar,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData):v}
+                    ${e.avatar?P(this,e.avatar,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData):_}
                     <div style="flex: 1; min-width: min(22rem, 100%); overflow: hidden;">
-                        ${e?.title&&s==0?T`
+                        ${e?.title&&s==0?w`
                             <div style="display: flex; align-items: center; gap: var(--lumo-space-s, .5rem); min-width: 0;">
-                                <h2 style="margin: 0; margin-block-end: 0px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">${_(nt(e?.title,this.state??{},this.data??{}))}</h2>
-                                ${e.kpisBelow&&e.badges?.length?e.badges.map(e=>ft(e,this.state??{},this.data??{})):v}
-                            </div>`:v}
-                        ${e?.title&&s==1?T`<h3 style="margin: 0; margin-block-end: 0px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; width: 100%;">${_(nt(e?.title,this.state??{},this.data??{}))}</h3>`:v}
-                        ${e?.title&&s==2?T`<h4 style="margin: 0; margin-block-end: 0px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; width: 100%;">${_(nt(e?.title,this.state??{},this.data??{}))}</h4>`:v}
-                        ${e?.title&&s==3?T`<h5 style="margin: 0; margin-block-end: 0px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; width: 100%;">${_(nt(e?.title,this.state??{},this.data??{}))}</h5>`:v}
-                        ${e?.title&&s>3?T`<h6 style="margin: 0; margin-block-end: 0px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; width: 100%;">${_(nt(e?.title,this.state??{},this.data??{}))}</h6>`:v}
+                                <h2 style="margin: 0; margin-block-end: 0px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">${g(rt(e?.title,this.state??{},this.data??{}))}</h2>
+                                ${e.kpisBelow&&e.badges?.length?e.badges.map(e=>pt(e,this.state??{},this.data??{})):_}
+                            </div>`:_}
+                        ${e?.title&&s==1?w`<h3 style="margin: 0; margin-block-end: 0px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; width: 100%;">${g(rt(e?.title,this.state??{},this.data??{}))}</h3>`:_}
+                        ${e?.title&&s==2?w`<h4 style="margin: 0; margin-block-end: 0px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; width: 100%;">${g(rt(e?.title,this.state??{},this.data??{}))}</h4>`:_}
+                        ${e?.title&&s==3?w`<h5 style="margin: 0; margin-block-end: 0px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; width: 100%;">${g(rt(e?.title,this.state??{},this.data??{}))}</h5>`:_}
+                        ${e?.title&&s>3?w`<h6 style="margin: 0; margin-block-end: 0px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; width: 100%;">${g(rt(e?.title,this.state??{},this.data??{}))}</h6>`:_}
 
-                        ${e?.subtitle?T`<span style="display: inline-block; margin-block-end: 0.83em;">${_(nt(e?.subtitle,this.state??{},this.data??{}))}</span>`:v}
-                        ${e?.timestamp?T`<span class="page-timestamp" style="display: block; color: var(--lumo-secondary-text-color, #6b7280); font-size: var(--lumo-font-size-s, .875rem);">${_(nt(e.timestamp,this.state??{},this.data??{}))}</span>`:v}
+                        ${e?.subtitle?w`<span style="display: inline-block; margin-block-end: 0.83em;">${g(rt(e?.subtitle,this.state??{},this.data??{}))}</span>`:_}
+                        ${e?.timestamp?w`<span class="page-timestamp" style="display: block; color: var(--lumo-secondary-text-color, #6b7280); font-size: var(--lumo-font-size-s, .875rem);">${g(rt(e.timestamp,this.state??{},this.data??{}))}</span>`:_}
                     </div>
                     <div style="display: flex; gap: var(--lumo-space-m, 1rem); align-items: center;">
-                        ${e.kpisBelow?v:e?.kpis?.map(e=>T`
+                        ${e.kpisBelow?_:e?.kpis?.map(e=>w`
                             <div style="display: flex; flex-direction: column; align-items: center;">
                                 <div>${this.evalLabel(e.title)}</div>
-                                <div>${_(nt(e.text,this.state??{},this.data??{}))}</div>
+                                <div>${g(rt(e.text,this.state??{},this.data??{}))}</div>
                             </div>
                         `)}
-                        ${e?.header?.map(e=>F(this,e,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData))}
-                        ${t?this.renderPeerNav(t):v}
+                        ${e?.header?.map(e=>P(this,e,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData))}
+                        ${t?this.renderPeerNav(t):_}
                         ${r.map(this.renderBtn)}
                         ${a}
                         ${this.renderActions(i)}
                     </div>
                 </div>
-            `:v}
-            ${e.kpisBelow&&e?.kpis?.length?T`
+            `:_}
+            ${e.kpisBelow&&e?.kpis?.length?w`
                 <div class="kpi-row">
-                    ${e.kpis.map(e=>T`
+                    ${e.kpis.map(e=>w`
                         <div class="kpi-pair">
                             <span class="kpi-label">${this.evalLabel(e.title)}</span>
-                            <span class="kpi-value">${_(nt(e.text,this.state??{},this.data??{}))}</span>
+                            <span class="kpi-value">${g(rt(e.text,this.state??{},this.data??{}))}</span>
                         </div>
                     `)}
                 </div>
-            `:v}
-            ${e.badges&&e.badges.length>0&&!e.kpisBelow?T`
+            `:_}
+            ${e.badges&&e.badges.length>0&&!e.kpisBelow?w`
                 <div style="display: flex; gap: var(--lumo-space-s, .5rem); padding-bottom: var(--lumo-space-s, .5rem);">
-                    ${e.badges.map(e=>ft(e,this.state??{},this.data??{}))}
+                    ${e.badges.map(e=>pt(e,this.state??{},this.data??{}))}
                 </div>
-            `:v}
-        `}static{this.styles=h`
+            `:_}
+        `}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -372,8 +372,8 @@ ${i}
         .mtb.danger { color: var(--lumo-error-text-color, #c0392b); border-color: var(--lumo-error-color-50pct, rgba(192,57,43,.5)); }
         .mtb.danger.primary { background: var(--lumo-error-color, #c0392b); color: #fff; border-color: transparent; }
 
-        ${de}
-    `}};k([y()],_t.prototype,`metadata`,void 0),k([y()],_t.prototype,`baseUrl`,void 0),k([y()],_t.prototype,`state`,void 0),k([y()],_t.prototype,`data`,void 0),k([y()],_t.prototype,`appState`,void 0),k([y()],_t.prototype,`appData`,void 0),k([C()],_t.prototype,`_overflowOpen`,void 0),_t=k([g(`mateu-content-header`)],_t);var vt=class extends $e{constructor(...e){super(...e),this.state={},this.data={},this.appState={},this.appData={}}render(){let e=this.component?.metadata;return T`
+        ${fe}
+    `}};O([v()],vt.prototype,`metadata`,void 0),O([v()],vt.prototype,`baseUrl`,void 0),O([v()],vt.prototype,`state`,void 0),O([v()],vt.prototype,`data`,void 0),O([v()],vt.prototype,`appState`,void 0),O([v()],vt.prototype,`appData`,void 0),O([S()],vt.prototype,`_overflowOpen`,void 0),vt=O([h(`mateu-content-header`)],vt);var yt=class extends et{constructor(...e){super(...e),this.state={},this.data={},this.appState={},this.appData={}}render(){let e=this.component?.metadata;return w`
             <div class="mateu-vlayout ${this.component?.cssClasses??``}">
                 <mateu-content-header
                     .metadata="${e}"
@@ -390,7 +390,7 @@ ${i}
                     </div>
                 </div>
             </div>
-       `}static{this.styles=h`
+       `}static{this.styles=m`
         :host {
         }
 
@@ -419,7 +419,7 @@ ${i}
         .form-content {
             padding-bottom: 3rem;
         }
-    `}};k([y()],vt.prototype,`state`,void 0),k([y()],vt.prototype,`data`,void 0),k([y()],vt.prototype,`appState`,void 0),k([y()],vt.prototype,`appData`,void 0),vt=k([g(`mateu-form`)],vt);var yt=class extends b{constructor(...e){super(...e),this.variant=`text`,this.count=3}static{this.styles=h`
+    `}};O([v()],yt.prototype,`state`,void 0),O([v()],yt.prototype,`data`,void 0),O([v()],yt.prototype,`appState`,void 0),O([v()],yt.prototype,`appData`,void 0),yt=O([h(`mateu-form`)],yt);var bt=class extends y{constructor(...e){super(...e),this.variant=`text`,this.count=3}static{this.styles=m`
         :host {
             display: block;
             flex: 1 1 0;
@@ -448,37 +448,37 @@ ${i}
         .form-pair { display: flex; flex-direction: column; gap: .35em; margin: .9em 0; }
         .label { height: .8em; width: 30%; }
         .field { height: 2.25em; width: 100%; }
-    `}render(){let e=Array.from({length:Math.max(1,this.count)});return this.variant==`card`?T`${e.map(()=>T`<div class="bone card" style="margin: .5em 0;"></div>`)}`:this.variant==`grid`?T`${e.map(()=>T`<div class="bone row"></div>`)}`:this.variant==`form`?T`${e.map(()=>T`
+    `}render(){let e=Array.from({length:Math.max(1,this.count)});return this.variant==`card`?w`${e.map(()=>w`<div class="bone card" style="margin: .5em 0;"></div>`)}`:this.variant==`grid`?w`${e.map(()=>w`<div class="bone row"></div>`)}`:this.variant==`form`?w`${e.map(()=>w`
                 <div class="form-pair">
                     <div class="bone label"></div>
                     <div class="bone field"></div>
                 </div>
-            `)}`:T`${e.map(()=>T`<div class="bone line"></div>`)}`}};k([y()],yt.prototype,`variant`,void 0),k([y({type:Number})],yt.prototype,`count`,void 0),yt=k([g(`mateu-skeleton`)],yt);var bt=(e,t)=>{t&&e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},xt=(e,t,n,r,i,a)=>T`
+            `)}`:w`${e.map(()=>w`<div class="bone line"></div>`)}`}};O([v()],bt.prototype,`variant`,void 0),O([v({type:Number})],bt.prototype,`count`,void 0),bt=O([h(`mateu-skeleton`)],bt);var xt=(e,t)=>{t&&e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},St=(e,t,n,r,i,a)=>w`
         <div class="mateu-empty-state"
              style="display: flex; flex-direction: column; align-items: center; justify-content: center; gap: .35rem; padding: var(--lumo-space-l, 1.5rem); text-align: center; color: var(--lumo-secondary-text-color, #666);">
             <span style="font-size: 1.8rem; line-height: 1; opacity: .6;">${t??`🗂`}</span>
-            ${n?T`<span style="font-weight: 600; color: var(--lumo-body-text-color, #333);">${n}</span>`:v}
+            ${n?w`<span style="font-weight: 600; color: var(--lumo-body-text-color, #333);">${n}</span>`:_}
             <span style="font-size: var(--lumo-font-size-s, .875rem);">${r??e??`Nothing here yet.`}</span>
-            ${i&&a?T`
+            ${i&&a?w`
                 <button style="margin-top: .25rem; font: inherit; font-weight: 500; cursor: pointer; padding: .4rem .9rem; border: none; border-radius: var(--lumo-border-radius-m, 6px); background: transparent; color: var(--lumo-primary-text-color, #3b5bdb);"
-                        @click="${e=>bt(e,i)}">${a}</button>
-            `:v}
+                        @click="${e=>xt(e,i)}">${a}</button>
+            `:_}
         </div>
-    `,St=e=>{let t=e.metadata;return T`
-        <div style="${e.style??v}" class="${e.cssClasses??v}" slot="${e.slot??v}">
-            ${xt(void 0,t.icon,t.title,t.description,t.actionId,t.actionLabel)}
+    `,Ct=e=>{let t=e.metadata;return w`
+        <div style="${e.style??_}" class="${e.cssClasses??_}" slot="${e.slot??_}">
+            ${St(void 0,t.icon,t.title,t.description,t.actionId,t.actionLabel)}
         </div>
-    `},Ct=e=>{let t=e.metadata;return T`
+    `},wt=e=>{let t=e.metadata;return w`
         <mateu-skeleton
                 variant="${t.variant??`text`}"
                 count="${t.count&&t.count>0?t.count:3}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-skeleton>
-    `},I=(e,t,n,r)=>{if(!e)return T``;let i=P.get()?.renderIcon;if(i){let a=i.call(P.get(),e,t,n);return r?T`<span slot="${r}">${a}</span>`:a}return T`<span class="mateu-icon ${n??``}" data-icon="${e}" aria-hidden="true"
-                      style="display:inline-block; width:1em; height:1em; ${t??``}" slot="${r??v}"></span>`},wt=`mateu-saved-views`,Tt=()=>{try{return JSON.parse(localStorage.getItem(wt)??`{}`)}catch{return{}}},Et=e=>{try{localStorage.setItem(wt,JSON.stringify(e))}catch{}},Dt=e=>Tt()[e]??[],Ot=(e,t)=>{let n=t.name?.trim();if(!n||Object.keys(t.values??{}).length===0)return;let r=Tt(),i=(r[e]??[]).filter(e=>e.name!==n);i.push({...t,name:n}),r[e]=i,Et(r)},kt=(e,t)=>{let n=Tt(),r=(n[e]??[]).filter(e=>e.name!==t);r.length===0?delete n[e]:n[e]=r,Et(n)},At=(e,t)=>{let n=Tt();n[e]=(n[e]??[]).map(e=>({...e,isDefault:e.name===t&&!e.isDefault})),Et(n)},jt=e=>Dt(e).find(e=>e.isDefault),L=class extends b{constructor(...e){super(...e),this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.searchOnly=!1,this.panelOpened=!1,this.viewsOpened=!1,this.draftText=``,this.openPanel=()=>{this.panelOpened||this.filters.length===0||(this.panelOpened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick))},this.closePanel=()=>{this.detachOutsideClick(),this.panelOpened=!1,this.activeFilter=void 0},this.clearAllFilters=()=>{let e=this.filters.flatMap(e=>this.isRangeFilter(e)?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId]),t={searchText:void 0};e.forEach(e=>{t[e]=void 0}),this.state={...this.state,...t},this.dispatchEvent(new CustomEvent(`filter-reset-requested`,{detail:{fieldIds:e},bubbles:!0,composed:!0})),this.requestSearch()},this.keepFocus=e=>e.preventDefault()}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}get filters(){return this.metadata?.filters??[]}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}requestSearch(){this.closePanel(),this.dispatchEvent(new CustomEvent(`search-requested`,{detail:{},bubbles:!0,composed:!0}))}emitValueChanged(e,t){this.state={...this.state,[e]:t},this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:e},bubbles:!0,composed:!0}))}applyFilter(e,t){this.emitValueChanged(e,t),this.requestSearch()}removeChip(e){let t=this.filters.find(t=>t.fieldId===e);t&&this.isRangeFilter(t)?(this.emitValueChanged(`${e}_from`,void 0),this.emitValueChanged(`${e}_to`,void 0)):this.emitValueChanged(e,e===`searchText`?``:void 0),this.requestSearch()}commitText(e){this.emitValueChanged(`searchText`,e.value),this.draftText=``,e.value=``,this.requestSearch()}get viewsScope(){return window.location.pathname}allFilterKeys(){return[`searchText`,...this.filters.flatMap(e=>this.isRangeFilter(e)?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId])]}snapshotValues(){let e={};return this.state.searchText&&(e.searchText=this.state.searchText),this.filters.forEach(t=>{if(this.isSet(t))if(this.isRangeFilter(t)){let n=this.rangeBound(t,`from`),r=this.rangeBound(t,`to`);n&&(e[`${t.fieldId}_from`]=n),r&&(e[`${t.fieldId}_to`]=r)}else this.isMultiFilter(t)?e[t.fieldId]=this.multiValues(t):e[t.fieldId]=this.state[t.fieldId]}),e}applyView(e){let t=this.allFilterKeys(),n={};t.forEach(e=>{n[e]=void 0}),this.state={...this.state,...n},this.dispatchEvent(new CustomEvent(`filter-reset-requested`,{detail:{fieldIds:t},bubbles:!0,composed:!0})),Object.entries(e.values).forEach(([e,t])=>this.emitValueChanged(e,t)),this.viewsOpened=!1,this.detachOutsideClick(),this.requestSearch()}saveCurrentView(e){let t=e.value.trim();t&&(Ot(this.viewsScope,{name:t,values:this.snapshotValues()}),e.value=``,this.requestUpdate())}firstUpdated(){if(window.location.search)return;let e=jt(this.viewsScope);e&&setTimeout(()=>{this.state.searchText||this.filters.some(e=>this.isSet(e))||this.applyView(e)},0)}isBooleanFilter(e){return e.dataType===`boolean`||e.dataType===`bool`||e.stereotype===`checkbox`||e.stereotype===`toggle`}isNumericFilter(e){return[`integer`,`decimal`,`number`,`money`].includes(e.dataType??``)}isRangeFilter(e){return e.stereotype===`dateRange`||e.stereotype===`numberRange`}isMultiFilter(e){return e.stereotype===`multiSelect`}hasOptions(e){return(e.options?.length??0)>0}multiValues(e){let t=this.state[e.fieldId];return Array.isArray(t)?t.map(String):typeof t==`string`&&t!==``?t.split(`,`).map(e=>e.trim()).filter(e=>e):[]}rangeBound(e,t){let n=this.state[`${e.fieldId}_${t}`];return n==null?``:String(n)}isSet(e){if(this.isRangeFilter(e))return this.rangeBound(e,`from`)!==``||this.rangeBound(e,`to`)!==``;if(this.isMultiFilter(e))return this.multiValues(e).length>0;let t=this.state[e.fieldId];return t!=null&&t!==``&&!Number.isNaN(t)}getFilterDisplayValue(e,t){if(e.options?.length){let n=e.options.find(e=>e.value===String(t));if(n)return n.label??n.value}return typeof t==`boolean`?t?`Yes`:`No`:String(t)}conditionDisplay(e){if(this.isRangeFilter(e)){let t=this.rangeBound(e,`from`),n=this.rangeBound(e,`to`);return t&&n?`${t} – ${n}`:t?`≥ ${t}`:`≤ ${n}`}return this.isMultiFilter(e)?this.multiValues(e).map(t=>this.getFilterDisplayValue(e,t)).join(`, `):this.getFilterDisplayValue(e,this.state[e.fieldId])}labelOf(e){return M(e.label,this.state,this.data)||e.fieldId}panelRow(e,t,n=`panel-row`){return T`
-            <div class="${n}" @mousedown="${this.keepFocus}" @click="${t}">${e}</div>`}renderRangeWidget(e){let t=e.stereotype===`numberRange`?`number`:e.dataType===`dateTime`?`datetime-local`:e.dataType===`time`?`time`:`date`,n=t=>{let n=t.closest(`.panel-input-row`),r=n.querySelector(`input.range-from`).value,i=n.querySelector(`input.range-to`).value;this.emitValueChanged(`${e.fieldId}_from`,r===``?void 0:r),this.emitValueChanged(`${e.fieldId}_to`,i===``?void 0:i),this.requestSearch()},r=e=>{e.key===`Enter`&&n(e.target),e.key===`Escape`&&this.closePanel()};return T`
+    `},F=(e,t,n,r)=>{if(!e)return w``;let i=N.get()?.renderIcon;if(i){let a=i.call(N.get(),e,t,n);return r?w`<span slot="${r}">${a}</span>`:a}return w`<span class="mateu-icon ${n??``}" data-icon="${e}" aria-hidden="true"
+                      style="display:inline-block; width:1em; height:1em; ${t??``}" slot="${r??_}"></span>`},Tt=`mateu-saved-views`,Et=()=>{try{return JSON.parse(localStorage.getItem(Tt)??`{}`)}catch{return{}}},Dt=e=>{try{localStorage.setItem(Tt,JSON.stringify(e))}catch{}},Ot=e=>Et()[e]??[],kt=(e,t)=>{let n=t.name?.trim();if(!n||Object.keys(t.values??{}).length===0)return;let r=Et(),i=(r[e]??[]).filter(e=>e.name!==n);i.push({...t,name:n}),r[e]=i,Dt(r)},At=(e,t)=>{let n=Et(),r=(n[e]??[]).filter(e=>e.name!==t);r.length===0?delete n[e]:n[e]=r,Dt(n)},jt=(e,t)=>{let n=Et();n[e]=(n[e]??[]).map(e=>({...e,isDefault:e.name===t&&!e.isDefault})),Dt(n)},Mt=e=>Ot(e).find(e=>e.isDefault),I=class extends y{constructor(...e){super(...e),this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.searchOnly=!1,this.panelOpened=!1,this.viewsOpened=!1,this.draftText=``,this.openPanel=()=>{this.panelOpened||this.filters.length===0||(this.panelOpened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick))},this.closePanel=()=>{this.detachOutsideClick(),this.panelOpened=!1,this.activeFilter=void 0},this.clearAllFilters=()=>{let e=this.filters.flatMap(e=>this.isRangeFilter(e)?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId]),t={searchText:void 0};e.forEach(e=>{t[e]=void 0}),this.state={...this.state,...t},this.dispatchEvent(new CustomEvent(`filter-reset-requested`,{detail:{fieldIds:e},bubbles:!0,composed:!0})),this.requestSearch()},this.keepFocus=e=>e.preventDefault()}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}get filters(){return this.metadata?.filters??[]}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}requestSearch(){this.closePanel(),this.dispatchEvent(new CustomEvent(`search-requested`,{detail:{},bubbles:!0,composed:!0}))}emitValueChanged(e,t){this.state={...this.state,[e]:t},this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:e},bubbles:!0,composed:!0}))}applyFilter(e,t){this.emitValueChanged(e,t),this.requestSearch()}removeChip(e){let t=this.filters.find(t=>t.fieldId===e);t&&this.isRangeFilter(t)?(this.emitValueChanged(`${e}_from`,void 0),this.emitValueChanged(`${e}_to`,void 0)):this.emitValueChanged(e,e===`searchText`?``:void 0),this.requestSearch()}commitText(e){this.emitValueChanged(`searchText`,e.value),this.draftText=``,e.value=``,this.requestSearch()}get viewsScope(){return window.location.pathname}allFilterKeys(){return[`searchText`,...this.filters.flatMap(e=>this.isRangeFilter(e)?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId])]}snapshotValues(){let e={};return this.state.searchText&&(e.searchText=this.state.searchText),this.filters.forEach(t=>{if(this.isSet(t))if(this.isRangeFilter(t)){let n=this.rangeBound(t,`from`),r=this.rangeBound(t,`to`);n&&(e[`${t.fieldId}_from`]=n),r&&(e[`${t.fieldId}_to`]=r)}else this.isMultiFilter(t)?e[t.fieldId]=this.multiValues(t):e[t.fieldId]=this.state[t.fieldId]}),e}applyView(e){let t=this.allFilterKeys(),n={};t.forEach(e=>{n[e]=void 0}),this.state={...this.state,...n},this.dispatchEvent(new CustomEvent(`filter-reset-requested`,{detail:{fieldIds:t},bubbles:!0,composed:!0})),Object.entries(e.values).forEach(([e,t])=>this.emitValueChanged(e,t)),this.viewsOpened=!1,this.detachOutsideClick(),this.requestSearch()}saveCurrentView(e){let t=e.value.trim();t&&(kt(this.viewsScope,{name:t,values:this.snapshotValues()}),e.value=``,this.requestUpdate())}firstUpdated(){if(window.location.search)return;let e=Mt(this.viewsScope);e&&setTimeout(()=>{this.state.searchText||this.filters.some(e=>this.isSet(e))||this.applyView(e)},0)}isBooleanFilter(e){return e.dataType===`boolean`||e.dataType===`bool`||e.stereotype===`checkbox`||e.stereotype===`toggle`}isNumericFilter(e){return[`integer`,`decimal`,`number`,`money`].includes(e.dataType??``)}isRangeFilter(e){return e.stereotype===`dateRange`||e.stereotype===`numberRange`}isMultiFilter(e){return e.stereotype===`multiSelect`}hasOptions(e){return(e.options?.length??0)>0}multiValues(e){let t=this.state[e.fieldId];return Array.isArray(t)?t.map(String):typeof t==`string`&&t!==``?t.split(`,`).map(e=>e.trim()).filter(e=>e):[]}rangeBound(e,t){let n=this.state[`${e.fieldId}_${t}`];return n==null?``:String(n)}isSet(e){if(this.isRangeFilter(e))return this.rangeBound(e,`from`)!==``||this.rangeBound(e,`to`)!==``;if(this.isMultiFilter(e))return this.multiValues(e).length>0;let t=this.state[e.fieldId];return t!=null&&t!==``&&!Number.isNaN(t)}getFilterDisplayValue(e,t){if(e.options?.length){let n=e.options.find(e=>e.value===String(t));if(n)return n.label??n.value}return typeof t==`boolean`?t?`Yes`:`No`:String(t)}conditionDisplay(e){if(this.isRangeFilter(e)){let t=this.rangeBound(e,`from`),n=this.rangeBound(e,`to`);return t&&n?`${t} – ${n}`:t?`≥ ${t}`:`≤ ${n}`}return this.isMultiFilter(e)?this.multiValues(e).map(t=>this.getFilterDisplayValue(e,t)).join(`, `):this.getFilterDisplayValue(e,this.state[e.fieldId])}labelOf(e){return j(e.label,this.state,this.data)||e.fieldId}panelRow(e,t,n=`panel-row`){return w`
+            <div class="${n}" @mousedown="${this.keepFocus}" @click="${t}">${e}</div>`}renderRangeWidget(e){let t=e.stereotype===`numberRange`?`number`:e.dataType===`dateTime`?`datetime-local`:e.dataType===`time`?`time`:`date`,n=t=>{let n=t.closest(`.panel-input-row`),r=n.querySelector(`input.range-from`).value,i=n.querySelector(`input.range-to`).value;this.emitValueChanged(`${e.fieldId}_from`,r===``?void 0:r),this.emitValueChanged(`${e.fieldId}_to`,i===``?void 0:i),this.requestSearch()},r=e=>{e.key===`Enter`&&n(e.target),e.key===`Escape`&&this.closePanel()};return w`
             <div class="panel-input-row">
                 <input class="range-from" type="${t}" placeholder="From"
                        .value="${this.rangeBound(e,`from`)}"
@@ -492,13 +492,13 @@ ${i}
                 <button class="apply-button"
                         @mousedown="${this.keepFocus}"
                         @click="${e=>n(e.target)}">Apply</button>
-            </div>`}renderMultiWidget(e){let t=this.multiValues(e),n=n=>{let r=t.includes(n)?t.filter(e=>e!==n):[...t,n];this.emitValueChanged(e.fieldId,r.length>0?r:void 0),this.dispatchEvent(new CustomEvent(`search-requested`,{detail:{},bubbles:!0,composed:!0}))};return T`${(e.options??[]).map(e=>this.panelRow(T`
+            </div>`}renderMultiWidget(e){let t=this.multiValues(e),n=n=>{let r=t.includes(n)?t.filter(e=>e!==n):[...t,n];this.emitValueChanged(e.fieldId,r.length>0?r:void 0),this.dispatchEvent(new CustomEvent(`search-requested`,{detail:{},bubbles:!0,composed:!0}))};return w`${(e.options??[]).map(e=>this.panelRow(w`
             <span class="multi-check ${t.includes(e.value)?`multi-check--on`:``}"
                   aria-hidden="true">${t.includes(e.value)?`✓`:``}</span>
             ${e.label??e.value}
-        `,()=>n(e.value)))}`}renderActiveFilterWidget(e){if(this.isRangeFilter(e))return this.renderRangeWidget(e);if(this.isMultiFilter(e))return this.renderMultiWidget(e);if(this.hasOptions(e))return T`${e.options.map(t=>this.panelRow(t.label??t.value,()=>this.applyFilter(e.fieldId,t.value)))}`;if(this.isBooleanFilter(e))return T`
+        `,()=>n(e.value)))}`}renderActiveFilterWidget(e){if(this.isRangeFilter(e))return this.renderRangeWidget(e);if(this.isMultiFilter(e))return this.renderMultiWidget(e);if(this.hasOptions(e))return w`${e.options.map(t=>this.panelRow(t.label??t.value,()=>this.applyFilter(e.fieldId,t.value)))}`;if(this.isBooleanFilter(e))return w`
                 ${this.panelRow(`Yes`,()=>this.applyFilter(e.fieldId,!0))}
-                ${this.panelRow(`No`,()=>this.applyFilter(e.fieldId,!1))}`;let t=this.isNumericFilter(e),n=n=>{n.value!==``&&this.applyFilter(e.fieldId,t?Number(n.value):n.value)};return T`
+                ${this.panelRow(`No`,()=>this.applyFilter(e.fieldId,!1))}`;let t=this.isNumericFilter(e),n=n=>{n.value!==``&&this.applyFilter(e.fieldId,t?Number(n.value):n.value)};return w`
             <div class="panel-input-row">
                 <input type="${t?`number`:`text`}"
                        placeholder="${e.placeholder||this.labelOf(e)}"
@@ -507,29 +507,29 @@ ${i}
                 <button class="apply-button"
                         @mousedown="${this.keepFocus}"
                         @click="${e=>n(e.target.previousElementSibling)}">Apply</button>
-            </div>`}renderViewsPanel(){if(!this.viewsOpened)return v;let e=Dt(this.viewsScope),t=!!this.state.searchText||this.filters.some(e=>this.isSet(e));return T`
+            </div>`}renderViewsPanel(){if(!this.viewsOpened)return _;let e=Ot(this.viewsScope),t=!!this.state.searchText||this.filters.some(e=>this.isSet(e));return w`
             <div class="panel views-panel">
                 <div class="panel-caption">Saved views</div>
-                ${e.length===0?T`
-                    <div class="panel-row views-empty">No saved views yet</div>`:v}
-                ${e.map(e=>T`
+                ${e.length===0?w`
+                    <div class="panel-row views-empty">No saved views yet</div>`:_}
+                ${e.map(e=>w`
                     <div class="panel-row view-row" @mousedown="${this.keepFocus}">
                         <span class="view-name" @click="${()=>this.applyView(e)}">${e.name}</span>
                         <button class="view-star ${e.isDefault?`view-star--on`:``}"
                                 title="${e.isDefault?`Unset as default`:`Open this listing with this view`}"
-                                @click="${()=>{At(this.viewsScope,e.name),this.requestUpdate()}}">★</button>
+                                @click="${()=>{jt(this.viewsScope,e.name),this.requestUpdate()}}">★</button>
                         <button class="chip-remove" aria-label="Delete view ${e.name}"
-                                @click="${()=>{kt(this.viewsScope,e.name),this.requestUpdate()}}">✕</button>
+                                @click="${()=>{At(this.viewsScope,e.name),this.requestUpdate()}}">✕</button>
                     </div>`)}
-                ${t?T`
+                ${t?w`
                     <div class="panel-input-row" @mousedown="${e=>e.stopPropagation()}">
                         <input class="view-name-input" type="text" placeholder="Save current view as…"
                                @keydown="${e=>{e.key===`Enter`&&this.saveCurrentView(e.target),e.key===`Escape`&&(this.viewsOpened=!1)}}"/>
                         <button class="apply-button"
                                 @click="${e=>this.saveCurrentView(e.target.previousElementSibling)}">Save</button>
-                    </div>`:T`
+                    </div>`:w`
                     <div class="panel-row views-empty">Apply some filters to save a view</div>`}
-            </div>`}renderPanel(){if(!this.panelOpened||this.filters.length===0)return v;if(this.activeFilter){let e=this.activeFilter;return T`
+            </div>`}renderPanel(){if(!this.panelOpened||this.filters.length===0)return _;if(this.activeFilter){let e=this.activeFilter;return w`
                 <div class="panel">
                     <div class="panel-row panel-header"
                          @mousedown="${this.keepFocus}"
@@ -537,32 +537,32 @@ ${i}
                         <span aria-hidden="true">←</span> ${this.labelOf(e)}
                     </div>
                     ${this.renderActiveFilterWidget(e)}
-                </div>`}let e=!!this.state.searchText||this.filters.some(e=>this.isSet(e));return T`
+                </div>`}let e=!!this.state.searchText||this.filters.some(e=>this.isSet(e));return w`
             <div class="panel">
                 <div class="panel-caption">Filter by</div>
-                ${this.filters.map(e=>this.panelRow(T`
+                ${this.filters.map(e=>this.panelRow(w`
                     ${this.labelOf(e)}
-                    ${this.isSet(e)?T`<span class="current-value">${this.conditionDisplay(e)}</span>`:v}
+                    ${this.isSet(e)?w`<span class="current-value">${this.conditionDisplay(e)}</span>`:_}
                 `,()=>{this.activeFilter=e}))}
-                ${e?this.panelRow(`Clear filters`,this.clearAllFilters,`panel-row panel-footer`):v}
-            </div>`}render(){let e=[];return this.state.searchText&&e.push({fieldId:`searchText`,label:`Text`,display:String(this.state.searchText)}),this.filters.forEach(t=>{this.isSet(t)&&e.push({fieldId:t.fieldId,label:this.labelOf(t),display:this.conditionDisplay(t)})}),T`
+                ${e?this.panelRow(`Clear filters`,this.clearAllFilters,`panel-row panel-footer`):_}
+            </div>`}render(){let e=[];return this.state.searchText&&e.push({fieldId:`searchText`,label:`Text`,display:String(this.state.searchText)}),this.filters.forEach(t=>{this.isSet(t)&&e.push({fieldId:t.fieldId,label:this.labelOf(t),display:this.conditionDisplay(t)})}),w`
             <div class="smart-search">
                 <div class="bar"
                      @click="${e=>{e.currentTarget.querySelector(`input.free-text`)?.focus(),this.openPanel()}}">
                     <svg aria-hidden="true" class="magnifier" width="16" height="16" viewBox="0 0 24 24">
                         <path fill="currentColor" d="M15.5 14h-.79l-.28-.27a6.5 6.5 0 1 0-.7.7l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0A4.5 4.5 0 1 1 14 9.5 4.5 4.5 0 0 1 9.5 14z"/>
                     </svg>
-                    ${e.map(e=>T`
+                    ${e.map(e=>w`
                         <span theme="badge contrast pill" class="chip">
                             <span class="chip-label">${e.label}:</span> ${e.display}
                             <button class="chip-remove" aria-label="Remove filter ${e.label}"
                                     @mousedown="${this.keepFocus}"
                                     @click="${t=>{t.stopPropagation(),this.removeChip(e.fieldId)}}">✕</button>
                         </span>`)}
-                    ${this.metadata?.searchable===!1?v:T`
+                    ${this.metadata?.searchable===!1?_:w`
                         <input class="free-text" type="text" id="searchText"
                                placeholder="${e.length===0?`Search`:``}"
-                               autofocus="${this.metadata?.autoFocusOnSearchText?!0:v}"
+                               autofocus="${this.metadata?.autoFocusOnSearchText?!0:_}"
                                .value="${this.draftText??``}"
                                @input="${e=>{this.draftText=e.target.value,this.openPanel()}}"
                                @keydown="${e=>{e.key===`Enter`&&this.commitText(e.target),e.key===`Escape`&&this.closePanel()}}"/>
@@ -579,8 +579,8 @@ ${i}
                 ${this.renderViewsPanel()}
             </div>
             <slot></slot>
-        `}static{this.styles=h`
-        ${de}
+        `}static{this.styles=m`
+        ${fe}
         :host {
             width: 100%;
         }
@@ -776,7 +776,7 @@ ${i}
             padding: 0.35rem 0.75rem;
             cursor: pointer;
         }
-    `}};k([y()],L.prototype,`metadata`,void 0),k([y()],L.prototype,`baseUrl`,void 0),k([C()],L.prototype,`state`,void 0),k([C()],L.prototype,`data`,void 0),k([y()],L.prototype,`appState`,void 0),k([y()],L.prototype,`appData`,void 0),k([y({type:Boolean})],L.prototype,`searchOnly`,void 0),k([C()],L.prototype,`panelOpened`,void 0),k([C()],L.prototype,`viewsOpened`,void 0),k([C()],L.prototype,`activeFilter`,void 0),k([C()],L.prototype,`draftText`,void 0),L=k([g(`mateu-filter-bar`)],L);var Mt=`mateu-column-prefs`,Nt=()=>{try{let e=JSON.parse(localStorage.getItem(Mt)??`{}`);return e&&typeof e==`object`&&!Array.isArray(e)?e:{}}catch{return{}}},Pt=e=>{try{localStorage.setItem(Mt,JSON.stringify(e))}catch{}},Ft=e=>{if(!e||typeof e!=`object`)return;let t=e=>Array.isArray(e)?e.filter(e=>typeof e==`string`):[];return{hidden:t(e.hidden),order:t(e.order)}},It=e=>Ft(Nt()[e]),Lt=(e,t)=>{let n=Nt(),r=Ft(t);r.hidden.length===0&&r.order.length===0?delete n[e]:n[e]=r,Pt(n)},Rt=e=>{let t=Nt();delete t[e],Pt(t)},zt=e=>e?!!e.identifier||e.dataType===`action`||e.dataType===`actionGroup`||e.dataType===`menu`||e.id===`select`||e.id===`menu`:!1,Bt=(e,t,n=e=>e)=>{let r=Ft(t);if(!r||r.hidden.length===0&&r.order.length===0)return e;let i=e=>n(e)?.id??e.id,a=new Set(r.hidden),o=e.filter(e=>{let t=i(e);return!t||!a.has(t)||zt(n(e))});if(r.order.length===0)return o.length===e.length?e:o;let s=new Map;o.forEach(e=>{let t=i(e);t&&!s.has(t)&&s.set(t,e)});let c=[],l=new Set;return r.order.forEach(e=>{let t=s.get(e);t&&!l.has(t)&&(c.push(t),l.add(t))}),o.forEach(e=>{l.has(e)||(c.push(e),l.add(e))}),c.length===e.length&&c.every((t,n)=>t===e[n])?e:c},Vt=class extends b{constructor(...e){super(...e),this.columns=[],this.scope=``,this.panelOpened=!1,this.revision=0,this.togglePanel=()=>{if(this.panelOpened){this.closePanel();return}this.panelOpened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick)},this.closePanel=()=>{this.detachOutsideClick(),this.panelOpened=!1},this.reset=()=>{Rt(this.scope),this.revision++,this.dispatchEvent(new CustomEvent(`column-prefs-changed`,{bubbles:!0,composed:!0}))}}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}get prefs(){return It(this.scope)??{hidden:[],order:[]}}effectiveEntries(e){return Bt(this.columns,{hidden:[],order:e.order})}commit(e){Lt(this.scope,e),this.revision++,this.dispatchEvent(new CustomEvent(`column-prefs-changed`,{bubbles:!0,composed:!0}))}toggleVisibility(e){let t=this.prefs,n=t.hidden.includes(e)?t.hidden.filter(t=>t!==e):[...t.hidden,e];this.commit({...t,hidden:n})}move(e,t){let n=this.prefs,r=[...this.effectiveEntries(n)],i=r.findIndex(t=>t.id===e);if(i<0)return;let a=i+t;for(;a>=0&&a<r.length&&r[a].protected;)a+=t;if(a<0||a>=r.length)return;let o=r[i];r[i]=r[a],r[a]=o,this.commit({...n,order:r.map(e=>e.id)})}render(){this.revision;let e=this.prefs,t=this.effectiveEntries(e).filter(e=>!e.protected);if(t.length===0)return T``;let n=e.hidden.length>0||e.order.length>0;return T`
+    `}};O([v()],I.prototype,`metadata`,void 0),O([v()],I.prototype,`baseUrl`,void 0),O([S()],I.prototype,`state`,void 0),O([S()],I.prototype,`data`,void 0),O([v()],I.prototype,`appState`,void 0),O([v()],I.prototype,`appData`,void 0),O([v({type:Boolean})],I.prototype,`searchOnly`,void 0),O([S()],I.prototype,`panelOpened`,void 0),O([S()],I.prototype,`viewsOpened`,void 0),O([S()],I.prototype,`activeFilter`,void 0),O([S()],I.prototype,`draftText`,void 0),I=O([h(`mateu-filter-bar`)],I);var Nt=`mateu-column-prefs`,Pt=()=>{try{let e=JSON.parse(localStorage.getItem(Nt)??`{}`);return e&&typeof e==`object`&&!Array.isArray(e)?e:{}}catch{return{}}},Ft=e=>{try{localStorage.setItem(Nt,JSON.stringify(e))}catch{}},It=e=>{if(!e||typeof e!=`object`)return;let t=e=>Array.isArray(e)?e.filter(e=>typeof e==`string`):[];return{hidden:t(e.hidden),order:t(e.order)}},Lt=e=>It(Pt()[e]),Rt=(e,t)=>{let n=Pt(),r=It(t);r.hidden.length===0&&r.order.length===0?delete n[e]:n[e]=r,Ft(n)},zt=e=>{let t=Pt();delete t[e],Ft(t)},Bt=e=>e?!!e.identifier||e.dataType===`action`||e.dataType===`actionGroup`||e.dataType===`menu`||e.id===`select`||e.id===`menu`:!1,Vt=(e,t,n=e=>e)=>{let r=It(t);if(!r||r.hidden.length===0&&r.order.length===0)return e;let i=e=>n(e)?.id??e.id,a=new Set(r.hidden),o=e.filter(e=>{let t=i(e);return!t||!a.has(t)||Bt(n(e))});if(r.order.length===0)return o.length===e.length?e:o;let s=new Map;o.forEach(e=>{let t=i(e);t&&!s.has(t)&&s.set(t,e)});let c=[],l=new Set;return r.order.forEach(e=>{let t=s.get(e);t&&!l.has(t)&&(c.push(t),l.add(t))}),o.forEach(e=>{l.has(e)||(c.push(e),l.add(e))}),c.length===e.length&&c.every((t,n)=>t===e[n])?e:c},Ht=class extends y{constructor(...e){super(...e),this.columns=[],this.scope=``,this.panelOpened=!1,this.revision=0,this.togglePanel=()=>{if(this.panelOpened){this.closePanel();return}this.panelOpened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick)},this.closePanel=()=>{this.detachOutsideClick(),this.panelOpened=!1},this.reset=()=>{zt(this.scope),this.revision++,this.dispatchEvent(new CustomEvent(`column-prefs-changed`,{bubbles:!0,composed:!0}))}}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}get prefs(){return Lt(this.scope)??{hidden:[],order:[]}}effectiveEntries(e){return Vt(this.columns,{hidden:[],order:e.order})}commit(e){Rt(this.scope,e),this.revision++,this.dispatchEvent(new CustomEvent(`column-prefs-changed`,{bubbles:!0,composed:!0}))}toggleVisibility(e){let t=this.prefs,n=t.hidden.includes(e)?t.hidden.filter(t=>t!==e):[...t.hidden,e];this.commit({...t,hidden:n})}move(e,t){let n=this.prefs,r=[...this.effectiveEntries(n)],i=r.findIndex(t=>t.id===e);if(i<0)return;let a=i+t;for(;a>=0&&a<r.length&&r[a].protected;)a+=t;if(a<0||a>=r.length)return;let o=r[i];r[i]=r[a],r[a]=o,this.commit({...n,order:r.map(e=>e.id)})}render(){this.revision;let e=this.prefs,t=this.effectiveEntries(e).filter(e=>!e.protected);if(t.length===0)return w``;let n=e.hidden.length>0||e.order.length>0;return w`
             <div class="chooser">
                 <button
                     class="trigger ${n?`active`:``}"
@@ -793,10 +793,10 @@ ${i}
                         <rect x="11" y="2" width="4" height="12" rx="1" fill="currentColor" opacity="0.35"/>
                     </svg>
                 </button>
-                ${this.panelOpened?T`
+                ${this.panelOpened?w`
                     <div class="panel" role="menu">
                         <div class="panel-title">Columns</div>
-                        ${t.map((n,r)=>{let i=e.hidden.includes(n.id);return T`
+                        ${t.map((n,r)=>{let i=e.hidden.includes(n.id);return w`
                                 <div class="row" data-column-id="${n.id}">
                                     <label class="row-label">
                                         <input
@@ -818,9 +818,9 @@ ${i}
                             <button class="reset" type="button" ?disabled="${!n}" @click="${this.reset}">Reset</button>
                         </div>
                     </div>
-                `:v}
+                `:_}
             </div>
-        `}static{this.styles=h`
+        `}static{this.styles=m`
         :host {
             display: block;
             flex: none;
@@ -933,9 +933,9 @@ ${i}
             opacity: 0.4;
             cursor: default;
         }
-    `}};k([y()],Vt.prototype,`columns`,void 0),k([y()],Vt.prototype,`scope`,void 0),k([C()],Vt.prototype,`panelOpened`,void 0),k([C()],Vt.prototype,`revision`,void 0),Vt=k([g(`mateu-column-chooser`)],Vt);var Ht=class extends b{constructor(...e){super(...e),this.totalElements=0,this.pageSize=100,this.pageNumber=0,this.totalPages=0}updated(e){super.updated(e),(e.has(`totalElements`)||e.has(`pageSize`))&&(this.totalPages=Math.ceil(this.totalElements/this.pageSize))}dispatch(e){this.dispatchEvent(new CustomEvent(`page-changed`,{bubbles:!0,composed:!0,detail:{page:e}}))}render(){if(!this.totalElements)return v;let e=this.totalPages>1,t=this.pageNumber,n=t===0,r=t>=this.totalPages-1;return T`
+    `}};O([v()],Ht.prototype,`columns`,void 0),O([v()],Ht.prototype,`scope`,void 0),O([S()],Ht.prototype,`panelOpened`,void 0),O([S()],Ht.prototype,`revision`,void 0),Ht=O([h(`mateu-column-chooser`)],Ht);var Ut=class extends y{constructor(...e){super(...e),this.totalElements=0,this.pageSize=100,this.pageNumber=0,this.totalPages=0}updated(e){super.updated(e),(e.has(`totalElements`)||e.has(`pageSize`))&&(this.totalPages=Math.ceil(this.totalElements/this.pageSize))}dispatch(e){this.dispatchEvent(new CustomEvent(`page-changed`,{bubbles:!0,composed:!0,detail:{page:e}}))}render(){if(!this.totalElements)return _;let e=this.totalPages>1,t=this.pageNumber,n=t===0,r=t>=this.totalPages-1;return w`
             <div class="bar">
-                ${e?T`
+                ${e?w`
                     <button class="nav" title="First page" ?disabled="${n}"
                         @click="${()=>this.dispatch(0)}" data-testid="page-first">«</button>
                     <button class="nav" title="Previous page" ?disabled="${n}"
@@ -946,11 +946,11 @@ ${i}
                     <button class="nav" title="Last page" ?disabled="${r}"
                         @click="${()=>this.dispatch(this.totalPages-1)}" data-testid="page-last">»</button>
                     <span class="separator"></span>
-                `:v}
+                `:_}
                 <span class="total-count">${this.totalElements} item${this.totalElements===1?``:`s`}</span>
                 <slot></slot>
             </div>
-        `}static{this.styles=h`
+        `}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -997,301 +997,301 @@ ${i}
             align-self: center;
             margin: 0 4px;
         }
-    `}};k([y()],Ht.prototype,`totalElements`,void 0),k([y()],Ht.prototype,`pageSize`,void 0),k([y()],Ht.prototype,`pageNumber`,void 0),k([C()],Ht.prototype,`totalPages`,void 0),Ht=k([g(`mateu-pagination`)],Ht);var Ut=`var(--lumo-space-m, 1rem)`,Wt=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.columnWidth||`13rem`,l=`display: grid; grid-template-columns: ${s.maxColumns&&s.maxColumns>0?`repeat(${s.maxColumns}, minmax(0, 1fr))`:`repeat(auto-fill, minmax(min(100%, ${c}), 1fr))`}; gap: ${Ut} var(--lumo-space-l, 1.5rem); align-items: start;`;return s.labelsAside&&(l+=` --mateu-label-width: 10rem;`),s.fullWidth&&(l+=` width: 100%;`),l+=t.style??``,T`
-        <div style="${l}" class="${t.cssClasses}" slot="${t.slot||v}">
-            ${t.children?.map(t=>Gt(s,e,t,n,r,i,a,o))}
+    `}};O([v()],Ut.prototype,`totalElements`,void 0),O([v()],Ut.prototype,`pageSize`,void 0),O([v()],Ut.prototype,`pageNumber`,void 0),O([S()],Ut.prototype,`totalPages`,void 0),Ut=O([h(`mateu-pagination`)],Ut);var Wt=`var(--lumo-space-m, 1rem)`,Gt=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.columnWidth||`13rem`,l=`display: grid; grid-template-columns: ${s.maxColumns&&s.maxColumns>0?`repeat(${s.maxColumns}, minmax(0, 1fr))`:`repeat(auto-fill, minmax(min(100%, ${c}), 1fr))`}; gap: ${Wt} var(--lumo-space-l, 1.5rem); align-items: start;`;return s.labelsAside&&(l+=` --mateu-label-width: 10rem;`),s.fullWidth&&(l+=` width: 100%;`),l+=t.style??``,w`
+        <div style="${l}" class="${t.cssClasses}" slot="${t.slot||_}">
+            ${t.children?.map(t=>Kt(s,e,t,n,r,i,a,o))}
         </div>
-    `},Gt=(e,t,n,r,i,a,o,s)=>n.type==A.ClientSide&&n.metadata?.type==j.FormRow?Jt(e,t,n,r,i,a,o,s):T`<div style="grid-column: span ${Kt(n)}; min-width: 0;">${e.labelsAside?qt(t,n,r,i,a,o,s):F(t,n,r,i,a,o,s)}</div>`,Kt=e=>{if(e.type==A.ClientSide){let t=e.metadata;if(t?.type==j.FormField)return t.colspan||1}return 1},qt=(e,t,n,r,i,a,o)=>{if(t.type==A.ClientSide&&t.metadata?.type==j.FormField&&t.metadata.label){let s=t.metadata;return T`
-            <div style="display: flex; gap: ${Ut}; align-items: baseline;">
+    `},Kt=(e,t,n,r,i,a,o,s)=>n.type==k.ClientSide&&n.metadata?.type==A.FormRow?Yt(e,t,n,r,i,a,o,s):w`<div style="grid-column: span ${qt(n)}; min-width: 0;">${e.labelsAside?Jt(t,n,r,i,a,o,s):P(t,n,r,i,a,o,s)}</div>`,qt=e=>{if(e.type==k.ClientSide){let t=e.metadata;if(t?.type==A.FormField)return t.colspan||1}return 1},Jt=(e,t,n,r,i,a,o)=>{if(t.type==k.ClientSide&&t.metadata?.type==A.FormField&&t.metadata.label){let s=t.metadata;return w`
+            <div style="display: flex; gap: ${Wt}; align-items: baseline;">
                 <label style="flex: 0 0 var(--mateu-label-width, 10rem); color: var(--lumo-secondary-text-color, #667);">${s.label?.includes("${")?e._evalTemplate(s.label):s.label}</label>
-                <div style="flex: 1; min-width: 0;">${F(e,t,n,r,i,a,o,!0)}</div>
+                <div style="flex: 1; min-width: 0;">${P(e,t,n,r,i,a,o,!0)}</div>
             </div>
-        `}return F(e,t,n,r,i,a,o)},Jt=(e,t,n,r,i,a,o,s)=>T`
-        <div style="grid-column: 1 / -1; display: flex; gap: ${Ut}; flex-wrap: wrap;">
-            ${n.children?.map(c=>T`<div style="flex: 1 1 ${100/Math.max(1,n.children.length)}%; min-width: min(100%, 13rem);">${Gt(e,t,c,r,i,a,o,s)}</div>`)}
+        `}return P(e,t,n,r,i,a,o)},Yt=(e,t,n,r,i,a,o,s)=>w`
+        <div style="grid-column: 1 / -1; display: flex; gap: ${Wt}; flex-wrap: wrap;">
+            ${n.children?.map(c=>w`<div style="flex: 1 1 ${100/Math.max(1,n.children.length)}%; min-width: min(100%, 13rem);">${Kt(e,t,c,r,i,a,o,s)}</div>`)}
         </div>
-    `,Yt=(e,t,n,r,i,a,o,s)=>{let c=n.metadata,l=`display: flex; flex-direction: ${e};`;c.spacing&&(l+=` gap: ${Ut};`),c.padding&&(l+=` padding: var(--lumo-space-m, 1rem);`),c.wrap&&(l+=` flex-wrap: wrap;`),c.fullWidth&&(l+=` width: 100%;`),c.justification&&(l+=` justify-content: ${c.justification};`);let u=e===`row`?c.verticalAlignment:c.horizontalAlignment;return u&&(l+=` align-items: ${u};`),l+=n.style??``,T`
-        <div style="${l}" class="${n.cssClasses}" slot="${n.slot??v}">
-            ${n.children?.map(e=>F(t,e,r,i,a,o,s))}
+    `,Xt=(e,t,n,r,i,a,o,s)=>{let c=n.metadata,l=`display: flex; flex-direction: ${e};`;c.spacing&&(l+=` gap: ${Wt};`),c.padding&&(l+=` padding: var(--lumo-space-m, 1rem);`),c.wrap&&(l+=` flex-wrap: wrap;`),c.fullWidth&&(l+=` width: 100%;`),c.justification&&(l+=` justify-content: ${c.justification};`);let u=e===`row`?c.verticalAlignment:c.horizontalAlignment;return u&&(l+=` align-items: ${u};`),l+=n.style??``,w`
+        <div style="${l}" class="${n.cssClasses}" slot="${n.slot??_}">
+            ${n.children?.map(e=>P(t,e,r,i,a,o,s))}
         </div>
-    `},Xt=(e,t,n,r,i,a,o)=>Yt(`row`,e,t,n,r,i,a,o),Zt=(e,t,n,r,i,a,o)=>Yt(`column`,e,t,n,r,i,a,o),Qt=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=`display: flex; flex-direction: ${s.orientation===`vertical`?`column`:`row`}; gap: var(--lumo-space-s, 0.5rem);`;return s.fullWidth&&(c+=` width: 100%;`),c+=t.style??``,T`
-        <div style="${c}" class="${t.cssClasses}" slot="${t.slot??v}">
-            <div style="flex: 1; min-width: 0; min-height: 0;">${F(e,t.children[0],n,r,i,a,o)}</div>
-            <div style="flex: 1; min-width: 0; min-height: 0;">${F(e,t.children[1],n,r,i,a,o)}</div>
+    `},Zt=(e,t,n,r,i,a,o)=>Xt(`row`,e,t,n,r,i,a,o),Qt=(e,t,n,r,i,a,o)=>Xt(`column`,e,t,n,r,i,a,o),$t=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=`display: flex; flex-direction: ${s.orientation===`vertical`?`column`:`row`}; gap: var(--lumo-space-s, 0.5rem);`;return s.fullWidth&&(c+=` width: 100%;`),c+=t.style??``,w`
+        <div style="${c}" class="${t.cssClasses}" slot="${t.slot??_}">
+            <div style="flex: 1; min-width: 0; min-height: 0;">${P(e,t.children[0],n,r,i,a,o)}</div>
+            <div style="flex: 1; min-width: 0; min-height: 0;">${P(e,t.children[1],n,r,i,a,o)}</div>
         </div>
-    `},$t=(e,t,n,r,i,a,o)=>{let s=t.children&&t.children.length>1?t.children[1]:null,c=i?.detailComponent??null,l=!!i?.hasDetail||!!s,u=c??s;return T`
-        <div style="display: flex; gap: var(--lumo-space-m, 1rem); ${t.style??``}" class="${t.cssClasses}" slot="${t.slot??v}">
-            <div style="flex: 1; min-width: 0;">${F(e,t.children[0],n,r,i,a,o)}</div>
-            ${l&&u?T`<div style="flex: 1; min-width: 0;">${F(e,u,n,r,i,a,o)}</div>`:T`<div style="flex: 1; display: flex; align-items: center; justify-content: center; color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-s, .875rem);">Select an item to view details</div>`}
+    `},en=(e,t,n,r,i,a,o)=>{let s=t.children&&t.children.length>1?t.children[1]:null,c=i?.detailComponent??null,l=!!i?.hasDetail||!!s,u=c??s;return w`
+        <div style="display: flex; gap: var(--lumo-space-m, 1rem); ${t.style??``}" class="${t.cssClasses}" slot="${t.slot??_}">
+            <div style="flex: 1; min-width: 0;">${P(e,t.children[0],n,r,i,a,o)}</div>
+            ${l&&u?w`<div style="flex: 1; min-width: 0;">${P(e,u,n,r,i,a,o)}</div>`:w`<div style="flex: 1; display: flex; align-items: center; justify-content: center; color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-s, .875rem);">Select an item to view details</div>`}
         </div>
-    `},en=(e,t,n,r,i,a,o)=>{let s=t.style??``;t.metadata.fullWidth&&(s+=` width: 100%;`);let c=Math.max(0,(t.children??[]).findIndex(e=>e.metadata.active));return T`
-        <div style="${s}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${t.children?.map((t,s)=>{let l=t,u=l.metadata.label,d=u?.includes("${")?e._evalTemplate(u):u;return T`
+    `},tn=(e,t,n,r,i,a,o)=>{let s=t.style??``;t.metadata.fullWidth&&(s+=` width: 100%;`);let c=Math.max(0,(t.children??[]).findIndex(e=>e.metadata.active));return w`
+        <div style="${s}" class="${t.cssClasses}" slot="${t.slot??_}">
+            ${t.children?.map((t,s)=>{let l=t,u=l.metadata.label,d=u?.includes("${")?e._evalTemplate(u):u;return w`
                     <details ?open="${s===c}" style="border-bottom: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));">
                         <summary style="cursor: pointer; padding: var(--lumo-space-s, .5rem) 0; font-weight: 600;">${d}</summary>
                         <div style="padding: var(--lumo-space-m, 1rem) 0;">
-                            ${l.children?.map(t=>F(e,t,n,r,i,a,o))}
+                            ${l.children?.map(t=>P(e,t,n,r,i,a,o))}
                         </div>
                     </details>
                 `})}
         </div>
-    `},tn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style??``;return s.fullWidth&&(c+=` width: 100%;`),T`
-        <div style="${c}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${t.children?.map(t=>nn(e,t,n,r,i,a,o,s.variant))}
+    `},nn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style??``;return s.fullWidth&&(c+=` width: 100%;`),w`
+        <div style="${c}" class="${t.cssClasses}" slot="${t.slot??_}">
+            ${t.children?.map(t=>rn(e,t,n,r,i,a,o,s.variant))}
         </div>
-    `},nn=(e,t,n,r,i,a,o,s)=>{let c=t.metadata,l=c.label?.includes("${")?e._evalTemplate(c.label):c.label;return T`
+    `},rn=(e,t,n,r,i,a,o,s)=>{let c=t.metadata,l=c.label?.includes("${")?e._evalTemplate(c.label):c.label;return w`
         <details ?open="${c.active}" style="border-bottom: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1)); ${t.style??``}" class="${t.cssClasses}">
             <summary style="cursor: pointer; padding: var(--lumo-space-s, .5rem) 0; font-weight: 600; ${c.disabled?`pointer-events: none; opacity: .5;`:``}">${l}</summary>
             <div style="padding: var(--lumo-space-s, .5rem) 0;">
-                ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+                ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
             </div>
         </details>
-    `},rn=(e,t,n,r,i,a,o)=>T`
-        <div style="overflow: auto; ${t.style??``}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+    `},an=(e,t,n,r,i,a,o)=>w`
+        <div style="overflow: auto; ${t.style??``}" class="${t.cssClasses}" slot="${t.slot??_}">
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `,an=(e,t,n,r,i,a,o)=>T`
-        <div style="width: 100%; ${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+    `,on=(e,t,n,r,i,a,o)=>w`
+        <div style="width: 100%; ${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `,on=(e,t,n,r,i,a,o)=>T`
-        <div style="max-width: min(100%, 1200px); margin: auto; ${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+    `,sn=(e,t,n,r,i,a,o)=>w`
+        <div style="max-width: min(100%, 1200px); margin: auto; ${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `,sn=(e,t,n,r,i,a,o)=>T`
-        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr)); gap: ${Ut}; ${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+    `,cn=(e,t,n,r,i,a,o)=>w`
+        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr)); gap: ${Wt}; ${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `,cn=(e,t,n,r,i,a,o)=>T`
-        <div style="display: flex; gap: ${Ut}; flex-wrap: wrap; ${t.style}" class="${t.cssClasses}">
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+    `,ln=(e,t,n,r,i,a,o)=>w`
+        <div style="display: flex; gap: ${Wt}; flex-wrap: wrap; ${t.style}" class="${t.cssClasses}">
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `,ln=(e,t,n,r,i,a,o)=>T`
+    `,un=(e,t,n,r,i,a,o)=>w`
         <div style="flex: ${t.metadata.boardCols??1} 1 0; min-width: min(100%, 12rem); ${t.style}" class="${t.cssClasses}">
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `,un=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+    `,dn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <div
                 style="display: flex; flex-direction: column; overflow: auto; ${t.style}"
                 class="${t.cssClasses}"
-                slot="${t.slot??v}"
+                slot="${t.slot??_}"
         >
-            ${s.page.content.map(t=>F(e,t,n,r,i,a,o))}
+            ${s.page.content.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `},dn=e=>{let t=e.metadata;return(t?.content??t?.columns??[]).filter(e=>e&&e.metadata).map(e=>{let t=e.metadata;return{id:e.id??``,label:t?.label??e.id??``,autoWidth:t?.autoWidth,width:t?.width}})},fn=(e,t)=>{let n=e?.[t];return n==null?``:typeof n==`object`?n.text??n.label??n.value??``:String(n)},pn=(e,t,n)=>{let r=dn(e);return T`
-        <div style="overflow:auto; width:100%; ${e.style}" class="${e.cssClasses}" slot="${e.slot??v}">
+    `},fn=e=>{let t=e.metadata;return(t?.content??t?.columns??[]).filter(e=>e&&e.metadata).map(e=>{let t=e.metadata;return{id:e.id??``,label:t?.label??e.id??``,autoWidth:t?.autoWidth,width:t?.width}})},pn=(e,t)=>{let n=e?.[t];return n==null?``:typeof n==`object`?n.text??n.label??n.value??``:String(n)},mn=(e,t,n)=>{let r=fn(e);return w`
+        <div style="overflow:auto; width:100%; ${e.style}" class="${e.cssClasses}" slot="${e.slot??_}">
             <table style="border-collapse:collapse; width:100%; font-size: var(--lumo-font-size-s,.875rem);">
-                <thead><tr>${r.map(e=>T`<th style="${`text-align:left; padding:.45rem .6rem; border-bottom:2px solid var(--lumo-contrast-20pct,rgba(0,0,0,.2)); font-weight:600; white-space:nowrap; color: var(--lumo-secondary-text-color,#556);`}">${e.label}</th>`)}</tr></thead>
+                <thead><tr>${r.map(e=>w`<th style="${`text-align:left; padding:.45rem .6rem; border-bottom:2px solid var(--lumo-contrast-20pct,rgba(0,0,0,.2)); font-weight:600; white-space:nowrap; color: var(--lumo-secondary-text-color,#556);`}">${e.label}</th>`)}</tr></thead>
                 <tbody>
-                    ${(t??[]).length===0?T`<tr><td colspan="${Math.max(1,r.length)}" style="padding:1.5rem; text-align:center; color: var(--lumo-secondary-text-color,#888);">${n??`No data.`}</td></tr>`:t.map(e=>T`<tr>${r.map(t=>T`<td style="${`padding:.4rem .6rem; border-bottom:1px solid var(--lumo-contrast-10pct,rgba(0,0,0,.08)); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:24rem;`}" title="${fn(e,t.id)}">${fn(e,t.id)}</td>`)}</tr>`)}
+                    ${(t??[]).length===0?w`<tr><td colspan="${Math.max(1,r.length)}" style="padding:1.5rem; text-align:center; color: var(--lumo-secondary-text-color,#888);">${n??`No data.`}</td></tr>`:t.map(e=>w`<tr>${r.map(t=>w`<td style="${`padding:.4rem .6rem; border-bottom:1px solid var(--lumo-contrast-10pct,rgba(0,0,0,.08)); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:24rem;`}" title="${pn(e,t.id)}">${pn(e,t.id)}</td>`)}</tr>`)}
                 </tbody>
             </table>
         </div>
-    `},mn=(e,t)=>{let n=e.metadata;return e.id&&t&&t[e.id]?t[e.id]:n?.page?.content??[]},hn=e=>{let t=e.metadata.items??[];return T`
+    `},hn=(e,t)=>{let n=e.metadata;return e.id&&t&&t[e.id]?t[e.id]:n?.page?.content??[]},gn=e=>{let t=e.metadata.items??[];return w`
         <div class="mateu-message-list ${e.cssClasses??``}"
              style="display:flex; flex-direction:column; gap:.75rem; ${e.style??``}"
-             slot="${e.slot??v}">
-            ${t.map(e=>T`
+             slot="${e.slot??_}">
+            ${t.map(e=>w`
                 <div style="display:flex; gap:.6rem; align-items:flex-start;">
                     <span style="flex:0 0 auto; width:2rem; height:2rem; border-radius:50%; overflow:hidden; display:flex; align-items:center; justify-content:center; font-size:.8rem; background:var(--lumo-primary-color,#3b5bdb); color:var(--lumo-primary-contrast-color,#fff);">
-                        ${e.userImg?T`<img src="${e.userImg}" alt="" style="width:100%; height:100%; object-fit:cover;">`:e.userAbbr??(e.userName?e.userName.charAt(0):`?`)}
+                        ${e.userImg?w`<img src="${e.userImg}" alt="" style="width:100%; height:100%; object-fit:cover;">`:e.userAbbr??(e.userName?e.userName.charAt(0):`?`)}
                     </span>
                     <div style="min-width:0;">
                         <div style="display:flex; gap:.5rem; align-items:baseline;">
-                            ${e.userName?T`<span style="font-weight:600;">${e.userName}</span>`:v}
-                            ${e.time?T`<span style="font-size:var(--lumo-font-size-xs,.75rem); color:var(--lumo-secondary-text-color,#666);">${e.time}</span>`:v}
+                            ${e.userName?w`<span style="font-weight:600;">${e.userName}</span>`:_}
+                            ${e.time?w`<span style="font-size:var(--lumo-font-size-xs,.75rem); color:var(--lumo-secondary-text-color,#666);">${e.time}</span>`:_}
                         </div>
                         <div style="white-space:pre-wrap; overflow-wrap:anywhere;">${e.text}</div>
                     </div>
                 </div>
             `)}
         </div>
-    `},gn=(e,t,n,r,i,a,o)=>t.separator?T`<span style="align-self: stretch; width: 1px; background: var(--lumo-contrast-20pct, rgba(0,0,0,.2));"></span>`:t.submenus?T`
+    `},_n=(e,t,n,r,i,a,o)=>t.separator?w`<span style="align-self: stretch; width: 1px; background: var(--lumo-contrast-20pct, rgba(0,0,0,.2));"></span>`:t.submenus?w`
             <details style="position: relative;">
                 <summary style="cursor: pointer; list-style: none; padding: .35rem .7rem; border-radius: var(--lumo-border-radius-m, 6px);">
-                    ${t.component?F(e,t.component,n,r,i,a,o):t.label} ▾
+                    ${t.component?P(e,t.component,n,r,i,a,o):t.label} ▾
                 </summary>
                 <div style="display: flex; flex-direction: column; gap: .1rem; padding: .3rem; min-width: 10rem;
                             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1)); border-radius: var(--lumo-border-radius-m, 6px);
                             background: var(--lumo-base-color, #fff); box-shadow: var(--lumo-box-shadow-s, 0 2px 8px rgba(0,0,0,.15));">
-                    ${t.submenus.map(t=>gn(e,t,n,r,i,a,o))}
+                    ${t.submenus.map(t=>_n(e,t,n,r,i,a,o))}
                 </div>
             </details>
-        `:T`
+        `:w`
         <span class="${t.className??``}"
               style="cursor: ${t.disabled?`default`:`pointer`}; opacity: ${t.disabled?.5:1};
                      padding: .35rem .7rem; border-radius: var(--lumo-border-radius-m, 6px);
                      ${t.selected?`background: var(--lumo-primary-color-10pct, rgba(26,115,232,.12));`:``}">
-            ${t.component?F(e,t.component,n,r,i,a,o):t.label}
+            ${t.component?P(e,t.component,n,r,i,a,o):t.label}
         </span>
-    `,_n=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+    `,vn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <div style="display: flex; flex-wrap: wrap; gap: .25rem; align-items: center; ${t.style}"
-             class="${t.cssClasses}" slot="${t.slot??v}">
-            ${s.options?.map(t=>gn(e,t,n,r,i,a??{},o??{}))}
+             class="${t.cssClasses}" slot="${t.slot??_}">
+            ${s.options?.map(t=>_n(e,t,n,r,i,a??{},o??{}))}
         </div>
-    `},vn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
-        <div style="${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${F(e,s.wrapped,n,r,i,a,o)}
+    `},yn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+        <div style="${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
+            ${P(e,s.wrapped,n,r,i,a,o)}
         </div>
-    `},yn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.content?.metadata,l=c?.type==j.Notice&&c.fullWidth===!0;return T`
+    `},bn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.content?.metadata,l=c?.type==A.Notice&&c.fullWidth===!0;return w`
         <div style="display:flex; flex-direction:column; ${l?`width: 100%; `:``}${t.style}"
              class="${t.cssClasses}"
-             slot="${t.slot??v}"
-             data-colspan="${s.colspan||(l?99:v)}"
+             slot="${t.slot??_}"
+             data-colspan="${s.colspan||(l?99:_)}"
         >
-            ${s.label?T`<label style="font-size: var(--lumo-font-size-s,.875rem); color: var(--lumo-secondary-text-color,#667); margin-bottom:.15rem;">${s.label}</label>`:v}
-            ${F(e,s.content,n,r,i,a,o)}
+            ${s.label?w`<label style="font-size: var(--lumo-font-size-s,.875rem); color: var(--lumo-secondary-text-color,#667); margin-bottom:.15rem;">${s.label}</label>`:_}
+            ${P(e,s.content,n,r,i,a,o)}
         </div>
-            `},bn=e=>{let t=e.metadata,n=e=>{let n=e.closest(`.mateu-message-input`)?.querySelector(`input`),r=n?.value??``;!t.actionId||!r.trim()||(e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:{message:r}},bubbles:!0,composed:!0})),n&&(n.value=``))};return T`
+            `},xn=e=>{let t=e.metadata,n=e=>{let n=e.closest(`.mateu-message-input`)?.querySelector(`input`),r=n?.value??``;!t.actionId||!r.trim()||(e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:{message:r}},bubbles:!0,composed:!0})),n&&(n.value=``))};return w`
         <div class="mateu-message-input ${e.cssClasses??``}"
              style="display:flex; gap:.5rem; align-items:center; ${e.style??``}"
-             slot="${e.slot??v}">
+             slot="${e.slot??_}">
             <input type="text"
                    style="flex:1; min-width:0; font:inherit; padding:.5rem .75rem; border:1px solid var(--lumo-contrast-20pct,rgba(0,0,0,.16)); border-radius:var(--lumo-border-radius-m,6px); background:var(--lumo-base-color,#fff); color:var(--lumo-body-text-color,#161513);"
                    @keydown="${e=>{e.key===`Enter`&&!e.shiftKey&&(e.preventDefault(),n(e.currentTarget))}}">
             <button style="font:inherit; font-weight:500; cursor:pointer; padding:.5rem 1rem; border:none; border-radius:var(--lumo-border-radius-m,6px); background:var(--lumo-primary-color,#3b5bdb); color:var(--lumo-primary-contrast-color,#fff);"
                     @click="${e=>n(e.currentTarget)}">Send</button>
         </div>
-    `},xn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`<span title="${s.text}" style="${t.style}" class="${t.cssClasses}" slot="${t.slot??v}"
-        >${F(e,s.wrapped,n,r,i,a,o)}</span>`},Sn=e=>{if(e instanceof CustomEvent)return e.detail;let t={};for(let n in e){let r=e[n];[`number`,`string`,`boolean`].indexOf(typeof r)>=0&&(t[n]=e[n])}return t},Cn=(e,t,n)=>{for(let n in t.attributes)e.setAttribute(n,t.attributes[n]);n.style&&e.setAttribute(`style`,n.style),n.cssClasses&&e.setAttribute(`class`,n.cssClasses),n.slot&&e.setAttribute(`slot`,n.slot),t.content&&(t.html?e.innerHTML=t.content:e.append(t.content))},wn=e=>{let t=e.name,n=e.attributes?e.attributes.import:void 0;n&&t.includes(`-`)&&!customElements.get(t)&&D(()=>import(n),[])},Tn=(e,t,n)=>{wn(t);let r=t.name;return t.attributes&&t.attributes.id&&(r=`#`+t.attributes.id),setTimeout(()=>{let i=e.shadowRoot?.querySelector(`.element-container`)?.querySelector(r);if(i){for(;i.firstChild;)i.removeChild(i.lastChild);Cn(i,t,n)}else{let r=document.createElement(t.name);Cn(r,t,n);for(let n in t.on)r.addEventListener(n,r=>{let i=Sn(r);e.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.on[n],parameters:{event:i}},bubbles:!0,composed:!0}))});e.shadowRoot?.querySelector(`.element-container`)?.appendChild(r)}}),T`<div class="element-container"></div>`},En=function(e){return e.div=`div`,e.p=`p`,e.h1=`h1`,e.h2=`h2`,e.h3=`h3`,e.h4=`h4`,e.h5=`h5`,e.h6=`h6`,e.span=`span`,e}({}),Dn=(e,t,n,r,i)=>{let a=e.metadata,o=a.attributes?.[`data-colspan`],s=rt(a.text,t,n,r,i),c={xl:`var(--lumo-font-size-xl, 1.375rem)`,l:`var(--lumo-font-size-l, 1.125rem)`,s:`var(--lumo-font-size-s, .875rem)`,xs:`var(--lumo-font-size-xs, .8125rem)`},l=(a.size&&c[a.size]?`font-size: ${c[a.size]}; `:``)+(a.noMargins?`margin-block-start: 0; margin-block-end: 0; `:``);return En.h1==a.container?T`
+    `},Sn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`<span title="${s.text}" style="${t.style}" class="${t.cssClasses}" slot="${t.slot??_}"
+        >${P(e,s.wrapped,n,r,i,a,o)}</span>`},Cn=e=>{if(e instanceof CustomEvent)return e.detail;let t={};for(let n in e){let r=e[n];[`number`,`string`,`boolean`].indexOf(typeof r)>=0&&(t[n]=e[n])}return t},wn=(e,t,n)=>{for(let n in t.attributes)e.setAttribute(n,t.attributes[n]);n.style&&e.setAttribute(`style`,n.style),n.cssClasses&&e.setAttribute(`class`,n.cssClasses),n.slot&&e.setAttribute(`slot`,n.slot),t.content&&(t.html?e.innerHTML=t.content:e.append(t.content))},Tn=e=>{let t=e.name,n=e.attributes?e.attributes.import:void 0;n&&t.includes(`-`)&&!customElements.get(t)&&E(()=>import(n),[])},En=(e,t,n)=>{Tn(t);let r=t.name;return t.attributes&&t.attributes.id&&(r=`#`+t.attributes.id),setTimeout(()=>{let i=e.shadowRoot?.querySelector(`.element-container`)?.querySelector(r);if(i){for(;i.firstChild;)i.removeChild(i.lastChild);wn(i,t,n)}else{let r=document.createElement(t.name);wn(r,t,n);for(let n in t.on)r.addEventListener(n,r=>{let i=Cn(r);e.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.on[n],parameters:{event:i}},bubbles:!0,composed:!0}))});e.shadowRoot?.querySelector(`.element-container`)?.appendChild(r)}}),w`<div class="element-container"></div>`},Dn=function(e){return e.div=`div`,e.p=`p`,e.h1=`h1`,e.h2=`h2`,e.h3=`h3`,e.h4=`h4`,e.h5=`h5`,e.h6=`h6`,e.span=`span`,e}({}),On=(e,t,n,r,i)=>{let a=e.metadata,o=a.attributes?.[`data-colspan`],s=it(a.text,t,n,r,i),c={xl:`var(--lumo-font-size-xl, 1.375rem)`,l:`var(--lumo-font-size-l, 1.125rem)`,s:`var(--lumo-font-size-s, .875rem)`,xs:`var(--lumo-font-size-xs, .8125rem)`},l=(a.size&&c[a.size]?`font-size: ${c[a.size]}; `:``)+(a.noMargins?`margin-block-start: 0; margin-block-end: 0; `:``);return Dn.h1==a.container?w`
             <h1 style="${l}${e.style}" class="${e.cssClasses}"
-                id="${S(e.id)}"
-                data-colspan="${S(o)}"
-                slot="${e.slot??v}">
-                ${s??v}
+                id="${x(e.id)}"
+                data-colspan="${x(o)}"
+                slot="${e.slot??_}">
+                ${s??_}
             </h1>
-        `:En.h2==a.container?T`
+        `:Dn.h2==a.container?w`
             <h2 style="${l}${e.style}" class="${e.cssClasses}"
-                id="${S(e.id)}"
-                data-colspan="${S(o)}"
-                slot="${e.slot??v}">
-                ${s??v}
+                id="${x(e.id)}"
+                data-colspan="${x(o)}"
+                slot="${e.slot??_}">
+                ${s??_}
             </h2>
-        `:En.h3==a.container?T`
+        `:Dn.h3==a.container?w`
             <h3 style="${l}${e.style}" class="${e.cssClasses}"
-                id="${S(e.id)}"
-                data-colspan="${S(o)}"
-                slot="${e.slot??v}">
-                ${s??v}
+                id="${x(e.id)}"
+                data-colspan="${x(o)}"
+                slot="${e.slot??_}">
+                ${s??_}
             </h3>
-        `:En.h4==a.container?T`
+        `:Dn.h4==a.container?w`
             <h4 style="${l}${e.style}" class="${e.cssClasses}"
-                id="${S(e.id)}"
-                data-colspan="${S(o)}"
-                slot="${e.slot??v}">
-                ${s??v}
+                id="${x(e.id)}"
+                data-colspan="${x(o)}"
+                slot="${e.slot??_}">
+                ${s??_}
             </h4>
-        `:En.h5==a.container?T`
+        `:Dn.h5==a.container?w`
             <h5 style="${l}${e.style}" class="${e.cssClasses}"
-                id="${S(e.id)}"
-                data-colspan="${S(o)}"
-                slot="${e.slot??v}">
-                ${s??v}
+                id="${x(e.id)}"
+                data-colspan="${x(o)}"
+                slot="${e.slot??_}">
+                ${s??_}
             </h5>
-        `:En.h6==a.container?T`
+        `:Dn.h6==a.container?w`
             <h6 style="${l}${e.style}" class="${e.cssClasses}"
-                id="${S(e.id)}"
-                data-colspan="${S(o)}"
-                slot="${e.slot??v}">
-                ${s??v}
+                id="${x(e.id)}"
+                data-colspan="${x(o)}"
+                slot="${e.slot??_}">
+                ${s??_}
             </h6>
-        `:En.p==a.container?T`
+        `:Dn.p==a.container?w`
                <p style="${l}${e.style}" class="${e.cssClasses}"
-                  id="${S(e.id)}"
-                  data-colspan="${S(o)}"
-                  slot="${e.slot??v}">
-                   ${s??v}
+                  id="${x(e.id)}"
+                  data-colspan="${x(o)}"
+                  slot="${e.slot??_}">
+                   ${s??_}
                </p>
-            `:En.div==a.container?T`
+            `:Dn.div==a.container?w`
                <div style="${l}${e.style}" class="${e.cssClasses}"
-                    id="${S(e.id)}"
-                    data-colspan="${S(o)}"
-                    slot="${e.slot??v}">${s?_(s):v}</div>
-            `:En.span==a.container?T`
+                    id="${x(e.id)}"
+                    data-colspan="${x(o)}"
+                    slot="${e.slot??_}">${s?g(s):_}</div>
+            `:Dn.span==a.container?w`
                <span style="${l}${e.style}" class="${e.cssClasses}"
-                     id="${S(e.id)}"
-                     data-colspan="${S(o)}"
-                    slot="${e.slot??v}">${s??v}</span>
-            `:T`
+                     id="${x(e.id)}"
+                     data-colspan="${x(o)}"
+                    slot="${e.slot??_}">${s??_}</span>
+            `:w`
                <p
-                       id="${S(e.id)}"
-                       data-colspan="${S(o)}"
-                       slot="${e.slot??v}">
+                       id="${x(e.id)}"
+                       data-colspan="${x(o)}"
+                       slot="${e.slot??_}">
                    Unknown text container: ${a.container} 
                </p>
-            `},On=e=>{let t=e.metadata;return T`<a href="${t.url}" target="${t.target??v}"
-                   rel="${t.target===`_blank`?`noopener`:v}"
+            `},kn=e=>{let t=e.metadata;return w`<a href="${t.url}" target="${t.target??_}"
+                   rel="${t.target===`_blank`?`noopener`:_}"
                    style="${e.style}" class="${e.cssClasses}"
-                   slot="${e.slot??v}">${t.text}</a>`},kn=(e,t)=>{let n=e.toLowerCase().split(`+`);return t.ctrlKey===n.includes(`ctrl`)&&t.altKey===n.includes(`alt`)&&t.shiftKey===n.includes(`shift`)&&t.metaKey===n.includes(`meta`)},An=(e,t)=>{if(!kn(e,t))return!1;let n=e.toLowerCase().split(`+`),r=n[n.length-1];return!!(t.key.toLowerCase()===r||/^[a-z]$/.test(r)&&t.code===`Key`+r.toUpperCase()||/^[0-9]$/.test(r)&&(t.code===`Digit`+r||t.code===`Numpad`+r))},jn=e=>e?e.split(`+`).map(e=>e.length<=1?e.toUpperCase():e.charAt(0).toUpperCase()+e.slice(1)).join(`+`):void 0,Mn=(e,t)=>{let n=e.currentTarget.dataset.actionId;e.currentTarget?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:n,parameters:t.parameters},bubbles:!0,composed:!0}))},Nn=`display:inline-flex; align-items:center; justify-content:center; gap:.4em; box-sizing:border-box; font:inherit; font-weight:500; cursor:pointer; border-radius:var(--lumo-border-radius-m,6px); border:1px solid transparent; line-height:1; white-space:nowrap;`,Pn=e=>{let t=e.buttonStyle??``,n=e.color&&e.color!==`none`&&e.color!==`normal`?e.color:``,r=e.size,i=n===`success`?`var(--lumo-success-color,#1a7f37)`:n===`error`?`var(--lumo-error-color,#c5221f)`:n===`contrast`?`var(--lumo-contrast,#161513)`:`var(--lumo-primary-color,#3b5bdb)`,a=n===`success`?`var(--lumo-success-contrast-color,#fff)`:n===`error`?`var(--lumo-error-contrast-color,#fff)`:n===`contrast`?`var(--lumo-base-color,#fff)`:`var(--lumo-primary-contrast-color,#fff)`,o=n===`success`?`var(--lumo-success-text-color,#1a7f37)`:n===`error`?`var(--lumo-error-text-color,#c5221f)`:n===`contrast`?`var(--lumo-body-text-color,#161513)`:`var(--lumo-primary-text-color,#3b5bdb)`,s;return s=t===`primary`?`background:${i}; color:${a};`:t===`tertiary`||t===`tertiaryInline`?`background:transparent; color:${o};`:`background:var(--lumo-contrast-5pct,rgba(0,0,0,.04)); color:${o}; border-color:var(--lumo-contrast-20pct,rgba(0,0,0,.16));`,`${Nn}${s}${r===`small`?`padding:.25rem .6rem; font-size:var(--lumo-font-size-s,.875rem);`:r===`large`?`padding:.65rem 1.4rem; font-size:var(--lumo-font-size-l,1.125rem);`:`padding:.45rem 1rem; font-size:var(--lumo-font-size-m,1rem);`}`},Fn=(e,t,n)=>{let r=e.metadata,i=M(r.label,t,n);return T`<button
+                   slot="${e.slot??_}">${t.text}</a>`},An=(e,t)=>{let n=e.toLowerCase().split(`+`);return t.ctrlKey===n.includes(`ctrl`)&&t.altKey===n.includes(`alt`)&&t.shiftKey===n.includes(`shift`)&&t.metaKey===n.includes(`meta`)},jn=(e,t)=>{if(!An(e,t))return!1;let n=e.toLowerCase().split(`+`),r=n[n.length-1];return!!(t.key.toLowerCase()===r||/^[a-z]$/.test(r)&&t.code===`Key`+r.toUpperCase()||/^[0-9]$/.test(r)&&(t.code===`Digit`+r||t.code===`Numpad`+r))},Mn=e=>e?e.split(`+`).map(e=>e.length<=1?e.toUpperCase():e.charAt(0).toUpperCase()+e.slice(1)).join(`+`):void 0,Nn=(e,t)=>{let n=e.currentTarget.dataset.actionId;e.currentTarget?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:n,parameters:t.parameters},bubbles:!0,composed:!0}))},Pn=`display:inline-flex; align-items:center; justify-content:center; gap:.4em; box-sizing:border-box; font:inherit; font-weight:500; cursor:pointer; border-radius:var(--lumo-border-radius-m,6px); border:1px solid transparent; line-height:1; white-space:nowrap;`,Fn=e=>{let t=e.buttonStyle??``,n=e.color&&e.color!==`none`&&e.color!==`normal`?e.color:``,r=e.size,i=n===`success`?`var(--lumo-success-color,#1a7f37)`:n===`error`?`var(--lumo-error-color,#c5221f)`:n===`contrast`?`var(--lumo-contrast,#161513)`:`var(--lumo-primary-color,#3b5bdb)`,a=n===`success`?`var(--lumo-success-contrast-color,#fff)`:n===`error`?`var(--lumo-error-contrast-color,#fff)`:n===`contrast`?`var(--lumo-base-color,#fff)`:`var(--lumo-primary-contrast-color,#fff)`,o=n===`success`?`var(--lumo-success-text-color,#1a7f37)`:n===`error`?`var(--lumo-error-text-color,#c5221f)`:n===`contrast`?`var(--lumo-body-text-color,#161513)`:`var(--lumo-primary-text-color,#3b5bdb)`,s;return s=t===`primary`?`background:${i}; color:${a};`:t===`tertiary`||t===`tertiaryInline`?`background:transparent; color:${o};`:`background:var(--lumo-contrast-5pct,rgba(0,0,0,.04)); color:${o}; border-color:var(--lumo-contrast-20pct,rgba(0,0,0,.16));`,`${Pn}${s}${r===`small`?`padding:.25rem .6rem; font-size:var(--lumo-font-size-s,.875rem);`:r===`large`?`padding:.65rem 1.4rem; font-size:var(--lumo-font-size-l,1.125rem);`:`padding:.45rem 1rem; font-size:var(--lumo-font-size-m,1rem);`}`},In=(e,t,n)=>{let r=e.metadata,i=j(r.label,t,n);return w`<button
             id="${e.id}"
             data-action-id="${r.actionId}"
-            @click="${e=>Mn(e,r)}"
-            style="${Pn(r)}${e.style}"
+            @click="${e=>Nn(e,r)}"
+            style="${Fn(r)}${e.style}"
             class="${e.cssClasses}"
             ?disabled="${r.disabled}"
-            title="${r.shortcut?`${i} (${jn(r.shortcut)})`:v}"
-            slot="${e.slot??v}"
-    >${r.iconOnLeft?I(r.iconOnLeft):v}${i}${r.iconOnRight?I(r.iconOnRight):v}</button>`},In=`display:block; box-sizing:border-box; background:var(--lumo-base-color,#fff); border:1px solid var(--lumo-contrast-10pct,rgba(0,0,0,.1)); border-radius:var(--lumo-border-radius-l,12px); box-shadow:var(--lumo-box-shadow-xs,0 1px 3px rgba(0,0,0,.08)); overflow:hidden;`,Ln=(e,t,n,r,i,a,o)=>{let s=t.metadata;if(!s)return T``;let c=t=>t?F(e,t,n,r,i,a,o,!1):v,l=s.header||s.headerPrefix||s.headerSuffix||s.title||s.subtitle;return T`
-        <div style="${In}${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${s.media?c(s.media):v}
-            ${l?T`<div style="display:flex; align-items:flex-start; gap:.75rem; padding:1rem 1.25rem ${s.content||s.footer?`0`:`1rem`};">
-                ${s.headerPrefix?c(s.headerPrefix):v}
+            title="${r.shortcut?`${i} (${Mn(r.shortcut)})`:_}"
+            slot="${e.slot??_}"
+    >${r.iconOnLeft?F(r.iconOnLeft):_}${i}${r.iconOnRight?F(r.iconOnRight):_}</button>`},Ln=`display:block; box-sizing:border-box; background:var(--lumo-base-color,#fff); border:1px solid var(--lumo-contrast-10pct,rgba(0,0,0,.1)); border-radius:var(--lumo-border-radius-l,12px); box-shadow:var(--lumo-box-shadow-xs,0 1px 3px rgba(0,0,0,.08)); overflow:hidden;`,Rn=(e,t,n,r,i,a,o)=>{let s=t.metadata;if(!s)return w``;let c=t=>t?P(e,t,n,r,i,a,o,!1):_,l=s.header||s.headerPrefix||s.headerSuffix||s.title||s.subtitle;return w`
+        <div style="${Ln}${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
+            ${s.media?c(s.media):_}
+            ${l?w`<div style="display:flex; align-items:flex-start; gap:.75rem; padding:1rem 1.25rem ${s.content||s.footer?`0`:`1rem`};">
+                ${s.headerPrefix?c(s.headerPrefix):_}
                 <div style="flex:1; min-width:0;">
-                    ${s.header?c(s.header):v}
-                    ${s.title?T`<div style="font-weight:600; font-size:1.05rem; color:var(--lumo-body-text-color,#161513);">${c(s.title)}</div>`:v}
-                    ${s.subtitle?T`<div style="color:var(--lumo-secondary-text-color,#667);">${c(s.subtitle)}</div>`:v}
+                    ${s.header?c(s.header):_}
+                    ${s.title?w`<div style="font-weight:600; font-size:1.05rem; color:var(--lumo-body-text-color,#161513);">${c(s.title)}</div>`:_}
+                    ${s.subtitle?w`<div style="color:var(--lumo-secondary-text-color,#667);">${c(s.subtitle)}</div>`:_}
                 </div>
-                ${s.headerSuffix?c(s.headerSuffix):v}
-            </div>`:v}
-            ${s.content?T`<div style="padding:1rem 1.25rem;">${c(s.content)}</div>`:v}
-            ${s.footer?T`<div style="padding:0 1.25rem 1rem;">${c(s.footer)}</div>`:v}
+                ${s.headerSuffix?c(s.headerSuffix):_}
+            </div>`:_}
+            ${s.content?w`<div style="padding:1rem 1.25rem;">${c(s.content)}</div>`:_}
+            ${s.footer?w`<div style="padding:0 1.25rem 1rem;">${c(s.footer)}</div>`:_}
         </div>
-    `},Rn=e=>{let t=e.metadata;return T`
+    `},zn=e=>{let t=e.metadata;return w`
         <mateu-chart 
                 style="${e.style}" 
                 class="${e.cssClasses}"
-                slot="${e.slot??v}" 
+                slot="${e.slot??_}" 
                 type="${t.chartType}" 
                 .data="${t.chartData}" 
                 .options="${t.chartOptions}"
         >
         </mateu-chart>
-    `},zn=e=>{let t=e.metadata;return I(t.icon,e.style,e.cssClasses,e.slot)},Bn=(e,t)=>{e&&e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},Vn=`font:inherit; font-weight:500; cursor:pointer; padding:.45rem 1rem; border-radius:var(--lumo-border-radius-m,6px);`,Hn=`${Vn} background:var(--lumo-contrast-5pct,rgba(0,0,0,.04)); color:var(--lumo-body-text-color,#161513); border:1px solid var(--lumo-contrast-20pct,rgba(0,0,0,.16));`,Un=`${Vn} background:var(--lumo-primary-color,#3b5bdb); color:var(--lumo-primary-contrast-color,#fff); border:1px solid transparent;`,Wn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!1;if(s.openedCondition)try{c=it(s.openedCondition,r,i,a,o)}catch(e){console.error(`when evaluating `+s.openedCondition+` :`+e+`, where data is `+i+` and state is `+r)}return c?T`
+    `},Bn=e=>{let t=e.metadata;return F(t.icon,e.style,e.cssClasses,e.slot)},Vn=(e,t)=>{e&&e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},Hn=`font:inherit; font-weight:500; cursor:pointer; padding:.45rem 1rem; border-radius:var(--lumo-border-radius-m,6px);`,Un=`${Hn} background:var(--lumo-contrast-5pct,rgba(0,0,0,.04)); color:var(--lumo-body-text-color,#161513); border:1px solid var(--lumo-contrast-20pct,rgba(0,0,0,.16));`,Wn=`${Hn} background:var(--lumo-primary-color,#3b5bdb); color:var(--lumo-primary-contrast-color,#fff); border:1px solid transparent;`,Gn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!1;if(s.openedCondition)try{c=at(s.openedCondition,r,i,a,o)}catch(e){console.error(`when evaluating `+s.openedCondition+` :`+e+`, where data is `+i+` and state is `+r)}return c?w`
         <div class="mateu-confirm-dialog ${t.cssClasses??``}"
              style="position:fixed; inset:0; z-index:1000; display:flex; align-items:center; justify-content:center; background:rgba(0,0,0,.4); ${t.style??``}"
-             slot="${t.slot??v}">
+             slot="${t.slot??_}">
             <div style="background:var(--lumo-base-color,#fff); color:var(--lumo-body-text-color,#161513); border-radius:var(--lumo-border-radius-l,12px); box-shadow:var(--lumo-box-shadow-l,0 8px 24px rgba(0,0,0,.2)); width:100%; max-width:min(90vw,32rem); padding:1.5rem; box-sizing:border-box;">
-                ${s.header?T`<h3 style="margin:0 0 .75rem; font-size:1.15rem;">${s.header}</h3>`:v}
-                <div>${t.children?.map(t=>F(e,t,n,r,i,a,o))}</div>
+                ${s.header?w`<h3 style="margin:0 0 .75rem; font-size:1.15rem;">${s.header}</h3>`:_}
+                <div>${t.children?.map(t=>P(e,t,n,r,i,a,o))}</div>
                 <div style="display:flex; gap:.5rem; justify-content:flex-end; margin-top:1.25rem;">
-                    ${s.canCancel?T`<button style="${Hn}" @click="${e=>Bn(e.currentTarget,s.cancelActionId)}">${s.rejectText&&!s.canReject?s.rejectText:`Cancel`}</button>`:v}
-                    ${s.canReject?T`<button style="${Hn}" @click="${e=>Bn(e.currentTarget,s.rejectActionId)}">${s.rejectText||`No`}</button>`:v}
-                    <button style="${Un}" @click="${e=>Bn(e.currentTarget,s.confirmActionId)}">${s.confirmText||`OK`}</button>
+                    ${s.canCancel?w`<button style="${Un}" @click="${e=>Vn(e.currentTarget,s.cancelActionId)}">${s.rejectText&&!s.canReject?s.rejectText:`Cancel`}</button>`:_}
+                    ${s.canReject?w`<button style="${Un}" @click="${e=>Vn(e.currentTarget,s.rejectActionId)}">${s.rejectText||`No`}</button>`:_}
+                    <button style="${Wn}" @click="${e=>Vn(e.currentTarget,s.confirmActionId)}">${s.confirmText||`OK`}</button>
                 </div>
             </div>
         </div>
-    `:T``},Gn=e=>{let t=e.metadata,n;return t.position&&(n={Top:`top`,Bottom:`bottom`,TopLeft:`top-left`,TopRight:`top-right`,BottomLeft:`bottom-left`,BottomRight:`bottom-right`}[t.position]),T`
+    `:w``},Kn=e=>{let t=e.metadata,n;return t.position&&(n={Top:`top`,Bottom:`bottom`,TopLeft:`top-left`,TopRight:`top-right`,BottomLeft:`bottom-left`,BottomRight:`bottom-right`}[t.position]),w`
         <mateu-cookie-consent style="${e.style}" class="${e.cssClasses}"
-                               slot="${e.slot??v}"
-                               position="${n??v}"
-                               cookie-name="${t.cookieName??v}"
-                               .message="${t.message??v}"
-                               theme="${t.theme??v}"
-                               .learnMore="${t.learnMore??v}"
-                               .learnMoreLink="${t.learnMoreLink??v}"
-                               .dismiss="${t.dismiss??v}"
+                               slot="${e.slot??_}"
+                               position="${n??_}"
+                               cookie-name="${t.cookieName??_}"
+                               .message="${t.message??_}"
+                               theme="${t.theme??_}"
+                               .learnMore="${t.learnMore??_}"
+                               .learnMoreLink="${t.learnMoreLink??_}"
+                               .dismiss="${t.dismiss??_}"
         ></mateu-cookie-consent>
-    `},Kn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+    `},qn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <details
                 ?open="${s.opened}"
                 style="${t.style}"
                 class="${t.cssClasses}"
-                slot="${t.slot??v}"
+                slot="${t.slot??_}"
         >
-            <summary>${F(e,s.summary,n,r,i,a,o)}</summary>
-            ${F(e,s.content,n,r,i,a,o)}
+            <summary>${P(e,s.summary,n,r,i,a,o)}</summary>
+            ${P(e,s.content,n,r,i,a,o)}
         </details>
-            `},qn=(e,t,n,r,i,a)=>T`
+            `},Jn=(e,t,n,r,i,a)=>w`
         <mateu-dialog
                 id="${e.metadata.id}"
             .component="${e}"
@@ -1301,7 +1301,7 @@ ${i}
             .appState="${i}"
             .appdata="${a}"
         ></mateu-dialog>
-            `,Jn=(e,t,n,r,i,a)=>T`
+            `,Yn=(e,t,n,r,i,a)=>w`
         <mateu-drawer
                 id="${e.metadata.id}"
             .component="${e}"
@@ -1311,69 +1311,69 @@ ${i}
             .appState="${i}"
             .appdata="${a}"
         ></mateu-drawer>
-            `,Yn=e=>{let t=e.metadata;return T`
+            `,Xn=e=>{let t=e.metadata;return w`
         <mateu-api-caller>
         <mateu-ux baseUrl="${t.baseUrl}"  
                   route="${t.route}" 
                   consumedRoute="${t.consumedRoute}" 
-                  id="${E()}"
+                  id="${T()}"
                   serverSideType="${t.serverSideType}"
                   .appState="${t.appState}"
                   style="${e.style}" class="${e.cssClasses}"
-                  slot="${e.slot??v}"
+                  slot="${e.slot??_}"
         ></mateu-ux>
         </mateu-api-caller>
-            `},Xn=e=>T`
+            `},Zn=e=>w`
         <mateu-markdown .content=${e.metadata.markdown}
                         style="${e.style}" class="${e.cssClasses}"
-                        slot="${e.slot??v}"></mateu-markdown>
-            `,Zn=e=>{let t=e.metadata;return T`
+                        slot="${e.slot??_}"></mateu-markdown>
+            `,Qn=e=>{let t=e.metadata;return w`
         <div
             role="status"
-            slot="${e.slot??v}"
+            slot="${e.slot??_}"
             class="${e.cssClasses}"
             style="display: flex; align-items: center; gap: 0.6rem; padding: 0.6rem 0.9rem;
                    border-radius: var(--lumo-border-radius-m, 8px);
                    background: var(--lumo-contrast-5pct, rgba(0,0,0,0.05));
                    color: var(--lumo-body-text-color, #1a1a1a); ${e.style}"
         >
-            ${t.title?T`<strong>${t.title}</strong>`:v}
-            ${t.text?T`<span>${t.text}</span>`:v}
+            ${t.title?w`<strong>${t.title}</strong>`:_}
+            ${t.text?w`<span>${t.text}</span>`:_}
         </div>
-    `},Qn=(e,t={})=>{let n=e.metadata,r=n.valueKey?t[n.valueKey]:n.value,i=n.max&&n.max!=0?n.max:1,a=!n.indeterminate&&r!=null;return T`
-        <div style="${e.style}" class="${e.cssClasses}" slot="${e.slot??v}">
+    `},$n=(e,t={})=>{let n=e.metadata,r=n.valueKey?t[n.valueKey]:n.value,i=n.max&&n.max!=0?n.max:1,a=!n.indeterminate&&r!=null;return w`
+        <div style="${e.style}" class="${e.cssClasses}" slot="${e.slot??_}">
             <progress
                     style="width:100%;"
                     max="${i}"
-                    .value="${a?r:v}"
+                    .value="${a?r:_}"
             ></progress>
-            ${n.text?T`<span class="text-secondary text-xs" id="sublbl">
+            ${n.text?w`<span class="text-secondary text-xs" id="sublbl">
     ${n.text}
-  </span>`:v}
+  </span>`:_}
         </div>
-    `},$n=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
-        <details style="position: relative; ${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
-            <summary style="list-style: none; cursor: pointer;">${F(e,s.wrapped,n,r,i,a,o)}</summary>
+    `},er=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+        <details style="position: relative; ${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
+            <summary style="list-style: none; cursor: pointer;">${P(e,s.wrapped,n,r,i,a,o)}</summary>
             <div style="position: absolute; z-index: 100; min-width: 300px; margin-top: .25rem; padding: .6rem .8rem;
                         border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1)); border-radius: var(--lumo-border-radius-m, 8px);
                         background: var(--lumo-base-color, #fff); box-shadow: var(--lumo-box-shadow-m, 0 4px 16px rgba(0,0,0,.2));">
-                ${F(e,s.content,n,r,i,a,o)}
+                ${P(e,s.content,n,r,i,a,o)}
             </div>
         </details>
-    `},er=e=>{let t=e.metadata;return T`
+    `},tr=e=>{let t=e.metadata;return w`
         <mateu-map position="${t.position}" zoom="${t.zoom}"
                    style="${e.style}" class="${e.cssClasses}"
-                   slot="${e.slot??v}"></mateu-map>
-            `},tr=e=>T`
+                   slot="${e.slot??_}"></mateu-map>
+            `},nr=e=>w`
         <img src="${e.metadata.src}" style="${e.style}" class="${e.cssClasses}"
-             slot="${e.slot??v}">
-            `,nr=e=>{let t=e.metadata;return T`<div style="display:flex; align-items:center; gap:0.5rem;" slot="${e.slot??v}">
-        ${t.breadcrumbs.map(e=>T`
+             slot="${e.slot??_}">
+            `,rr=e=>{let t=e.metadata;return w`<div style="display:flex; align-items:center; gap:0.5rem;" slot="${e.slot??_}">
+        ${t.breadcrumbs.map(e=>w`
             <a href="${e.link}">${e.text}</a>
             <span>/</span>
         `)}
         <span style="${e.style}" class="${e.cssClasses}">${t.currentItemText}</span>
-    </div>`},rr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+    </div>`},ir=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <skeleton-carousel 
                 id="${t.id}"
                 ?dots = "${s.dots}" 
@@ -1382,77 +1382,77 @@ ${i}
                 style="${t.style}"
                 css="${t.cssClasses}"
         >
-            ${t.children?.map(t=>T`<div>${F(e,t,n,r,i,a,o)}</div>`)}
+            ${t.children?.map(t=>w`<div>${P(e,t,n,r,i,a,o)}</div>`)}
         </skeleton-carousel>
-    `},ir=(e,t,n,r)=>{let i=e.metadata;return T`
-        <div style="display: flex; gap: 3rem; ${e.style}" class="${e.cssClasses}" slot="${e.slot??v}">
-            ${i.menu.map(e=>ar(e))}
+    `},ar=(e,t,n,r)=>{let i=e.metadata;return w`
+        <div style="display: flex; gap: 3rem; ${e.style}" class="${e.cssClasses}" slot="${e.slot??_}">
+            ${i.menu.map(e=>or(e))}
         </div>
-            `},ar=e=>T`
-        ${e.submenus?T`
+            `},or=e=>w`
+        ${e.submenus?w`
                 <details open>
                     <summary>${e.label}</summary>
                     <div style="display:flex; flex-direction:column; gap:0.25rem; padding-left:0.5rem;">
-                        ${e.submenus.map(e=>ar(e))}
+                        ${e.submenus.map(e=>or(e))}
                     </div>
                 </details>
-            `:T`
+            `:w`
                 <a href="${e.path}">${e.label}</a>
         `}
-        `,or=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`<div
-                slot="${t.slot??v}"
+        `,sr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`<div
+                slot="${t.slot??_}"
                 style="${t.style}" class="${t.cssClasses}"
-        >${s.content?_(s.content):v}${t.children?.map(t=>F(e,t,n,r,i,a,o))}</div>
-    `},sr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.title?.includes("${")?e._evalTemplate(s.title):s.title;return T`<div
-                slot="${t.slot??v}"
+        >${s.content?g(s.content):_}${t.children?.map(t=>P(e,t,n,r,i,a,o))}</div>
+    `},cr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.title?.includes("${")?e._evalTemplate(s.title):s.title;return w`<div
+                slot="${t.slot??_}"
                 style="width: 100%; margin-bottom: var(--lumo-space-m); ${t.style}"
                 class="${t.cssClasses}"
         >
-        ${c?T`<div style="font-size: var(--lumo-font-size-l); font-weight: 600; color: var(--lumo-header-text-color); margin-bottom: var(--lumo-space-s);">${c}</div>`:v}
-        ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+        ${c?w`<div style="font-size: var(--lumo-font-size-l); font-weight: 600; color: var(--lumo-header-text-color); margin-bottom: var(--lumo-space-s);">${c}</div>`:_}
+        ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
     </div>
-    `},cr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.title?.includes("${")?e._evalTemplate(s.title):s.title;return T`
+    `},lr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.title?.includes("${")?e._evalTemplate(s.title):s.title;return w`
         <div
-                slot="${t.slot??v}"
+                slot="${t.slot??_}"
                 style="${t.style}" class="${t.cssClasses}"
         >
         <h4>${c}</h4>
-        ${t.children?.map(t=>F(e,t,n,r,i,a,o))}</div>
-    `},lr=(e,t,n)=>{n.dispatchEvent(new CustomEvent(`value-changed`,{detail:{fieldId:e,value:t},bubbles:!0,composed:!0}))},ur=e=>t=>{let n=t.target,r=n.type===`checkbox`?n.checked:n.value;lr(e.fieldId,r,n)},dr=(e,t)=>{let n=e.metadata,r=t?.[n.fieldId]??``,i=n,a=i.dataType,o=i.stereotype,s=!!i.readOnly,c=!!i.disabled,l=i.options,u=n.label?T`<label style="display:block; font-size: var(--lumo-font-size-s,.875rem); color: var(--lumo-secondary-text-color,#667); margin-bottom:.15rem;">${n.label}</label>`:v,d=`width:100%; box-sizing:border-box; padding:.4rem .6rem; border:1px solid var(--lumo-contrast-30pct,rgba(0,0,0,.3)); border-radius: var(--lumo-border-radius-m,6px); font:inherit; background: var(--lumo-base-color,#fff); color: var(--lumo-body-text-color,#1a1a1a);`,f;return f=s||o===`plainText`?T`<div style="padding:.4rem 0;">${String(r??``)}</div>`:a===`boolean`||o===`checkbox`||o===`badge`?T`<input type="checkbox" ?checked="${!!r}" ?disabled="${c}" @change="${ur(n)}">`:l&&l.length?T`
-            <select style="${d}" ?disabled="${c}" @change="${ur(n)}">
+        ${t.children?.map(t=>P(e,t,n,r,i,a,o))}</div>
+    `},ur=(e,t,n)=>{n.dispatchEvent(new CustomEvent(`value-changed`,{detail:{fieldId:e,value:t},bubbles:!0,composed:!0}))},dr=e=>t=>{let n=t.target,r=n.type===`checkbox`?n.checked:n.value;ur(e.fieldId,r,n)},fr=(e,t)=>{let n=e.metadata,r=t?.[n.fieldId]??``,i=n,a=i.dataType,o=i.stereotype,s=!!i.readOnly,c=!!i.disabled,l=i.options,u=n.label?w`<label style="display:block; font-size: var(--lumo-font-size-s,.875rem); color: var(--lumo-secondary-text-color,#667); margin-bottom:.15rem;">${n.label}</label>`:_,d=`width:100%; box-sizing:border-box; padding:.4rem .6rem; border:1px solid var(--lumo-contrast-30pct,rgba(0,0,0,.3)); border-radius: var(--lumo-border-radius-m,6px); font:inherit; background: var(--lumo-base-color,#fff); color: var(--lumo-body-text-color,#1a1a1a);`,f;return f=s||o===`plainText`?w`<div style="padding:.4rem 0;">${String(r??``)}</div>`:a===`boolean`||o===`checkbox`||o===`badge`?w`<input type="checkbox" ?checked="${!!r}" ?disabled="${c}" @change="${dr(n)}">`:l&&l.length?w`
+            <select style="${d}" ?disabled="${c}" @change="${dr(n)}">
                 <option value="">—</option>
-                ${l.map(e=>T`<option value="${e.value}" ?selected="${e.value===r}">${e.label}</option>`)}
-            </select>`:o===`textarea`||o===`richText`||o===`html`?T`<textarea style="${d}" rows="3" ?disabled="${c}" @input="${ur(n)}">${String(r??``)}</textarea>`:T`<input type="${a===`integer`||a===`number`||a===`double`||a===`money`?`number`:a===`date`?`date`:a===`datetime`?`datetime-local`:a===`time`?`time`:o===`password`?`password`:a===`email`?`email`:`text`}" style="${d}" .value="${String(r??``)}"
-                              placeholder="${i.placeholder??v}" ?disabled="${c}" @input="${ur(n)}">`,T`
-        <div style="${e.style}" class="${e.cssClasses}" slot="${e.slot??v}">
+                ${l.map(e=>w`<option value="${e.value}" ?selected="${e.value===r}">${e.label}</option>`)}
+            </select>`:o===`textarea`||o===`richText`||o===`html`?w`<textarea style="${d}" rows="3" ?disabled="${c}" @input="${dr(n)}">${String(r??``)}</textarea>`:w`<input type="${a===`integer`||a===`number`||a===`double`||a===`money`?`number`:a===`date`?`date`:a===`datetime`?`datetime-local`:a===`time`?`time`:o===`password`?`password`:a===`email`?`email`:`text`}" style="${d}" .value="${String(r??``)}"
+                              placeholder="${i.placeholder??_}" ?disabled="${c}" @input="${dr(n)}">`,w`
+        <div style="${e.style}" class="${e.cssClasses}" slot="${e.slot??_}">
             ${u}
             ${f}
         </div>
-    `},fr=e=>{let t=e.metadata;if((t?.level??0)>0)return e;let n=e=>{if(e?.metadata?.type===j.EntityHeader)return e;let t=e?.metadata?.content,r=[...e?.children??[],...Array.isArray(t)?t:t?[t]:[]];for(let e of r){let t=n(e);if(t)return t}},r;for(let t of e.children??[])if(r=n(t),r)break;if(!r)return e;let i=r.metadata;r.__hoistedToPageHeader=!0;let a=[...(i.facts??[]).filter(e=>e.label||e.value).map(e=>({title:e.label??``,text:e.value??``})),...i.metricLabel?[{title:i.metricLabel,text:i.metricValue??``}]:[]],o=(i.badges??[]).filter(e=>e.label).map(e=>({text:e.label,color:e.color})),s={...t,title:i.title||t.title,subtitle:i.subtitle??t.subtitle,kpis:[...t.kpis??[],...a],kpisBelow:!0,badges:[...t.badges??[],...o]};return{...e,metadata:s}},pr=(e,t,n,r,i,a,o,s)=>{let c=fr(t),l=c.metadata,u=l?.fabs??[];return T`<mateu-page
+    `},pr=e=>{let t=e.metadata;if((t?.level??0)>0)return e;let n=e=>{if(e?.metadata?.type===A.EntityHeader)return e;let t=e?.metadata?.content,r=[...e?.children??[],...Array.isArray(t)?t:t?[t]:[]];for(let e of r){let t=n(e);if(t)return t}},r;for(let t of e.children??[])if(r=n(t),r)break;if(!r)return e;let i=r.metadata;r.__hoistedToPageHeader=!0;let a=[...(i.facts??[]).filter(e=>e.label||e.value).map(e=>({title:e.label??``,text:e.value??``})),...i.metricLabel?[{title:i.metricLabel,text:i.metricValue??``}]:[]],o=(i.badges??[]).filter(e=>e.label).map(e=>({text:e.label,color:e.color})),s={...t,title:i.title||t.title,subtitle:i.subtitle??t.subtitle,kpis:[...t.kpis??[],...a],kpisBelow:!0,badges:[...t.badges??[],...o]};return{...e,metadata:s}},mr=(e,t,n,r,i,a,o,s)=>{let c=pr(t),l=c.metadata,u=l?.fabs??[];return w`<mateu-page
             .component="${c}"
             baseUrl="${n}"
             .state="${r}"
             .data="${i}"
             .appState="${a}"
             .appdata="${o}"
-            slot="${c.slot??v}"
+            slot="${c.slot??_}"
             style="${c.style}"
             class="${c.cssClasses}"
             ?standalone="${s??!1}"
     >
-        ${c.children?.map(t=>F(e,t,n,r,i,a,o))}
-        ${l?.buttons?.map(t=>T`
-                   ${F(e,{id:t.actionId,metadata:t,type:A.ClientSide,slot:`buttons`},void 0,r,i,a,o)}
+        ${c.children?.map(t=>P(e,t,n,r,i,a,o))}
+        ${l?.buttons?.map(t=>w`
+                   ${P(e,{id:t.actionId,metadata:t,type:k.ClientSide,slot:`buttons`},void 0,r,i,a,o)}
 `)}
-        ${u.map((t,n)=>T`
+        ${u.map((t,n)=>w`
             <button class="page-fab" style="position: fixed; bottom: ${1.5+n*4}rem; right: 5.5rem;"
                 @click="${()=>e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))}"
                 title="${t.label}">
-                ${I(t.icon)}
+                ${F(t.icon)}
             </button>
         `)}
 </mateu-page>
-    `},mr=(e,t,n,r,i,a,o,s)=>T`<mateu-table-crud
+    `},hr=(e,t,n,r,i,a,o,s)=>w`<mateu-table-crud
             id="${t.id}"
             baseUrl="${n}"
             .component="${t}"
@@ -1463,96 +1463,96 @@ ${i}
             .appdata="${o}"
             style="${t.style}"
             class="${t.cssClasses}"
-            slot="${t.slot??v}"
+            slot="${t.slot??_}"
             ?standalone="${s??!1}"
     >
-        ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
-    </mateu-table-crud>`,hr=e=>{let t=e.metadata;return T`
+        ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
+    </mateu-table-crud>`,gr=e=>{let t=e.metadata;return w`
         <mateu-bpmn
                 style="${e.style}"
                 class="${e.cssClasses}"
-                slot="${e.slot??v}"
+                slot="${e.slot??_}"
                 xml="${t.xml}"
         >
         </mateu-bpmn>
-    `},gr=(e,t,n)=>T`<mateu-chat sseUrl="${e.metadata.sseUrl}"
+    `},_r=(e,t,n)=>w`<mateu-chat sseUrl="${e.metadata.sseUrl}"
                             style="${e.style}" 
                             class="${e.cssClasses}" 
-                            slot="${e.slot??v}"></mateu-chat>`,_r=e=>{let t=e.metadata;return T`
+                            slot="${e.slot??_}"></mateu-chat>`,vr=e=>{let t=e.metadata;return w`
         <mateu-workflow
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
                 value="${t.value??`{"name":"New Workflow","steps":[]}`}"
         ></mateu-workflow>
-    `},vr=e=>{let t=e.metadata;return T`
+    `},yr=e=>{let t=e.metadata;return w`
         <mateu-form-editor
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
                 value="${t.value??`{"name":"New Form","fields":[]}`}"
         ></mateu-form-editor>
-    `},yr=`
+    `},br=`
     background: var(--lumo-base-color, #fff);
     border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.08));
     border-radius: var(--lumo-border-radius-l, 12px);
     padding: var(--lumo-space-m, 1rem);
     box-sizing: border-box;
-`,br=e=>e==`up`?`var(--lumo-success-text-color, #1a7f37)`:e==`down`?`var(--lumo-error-text-color, #c5221f)`:`var(--lumo-secondary-text-color, #666)`,xr=e=>e==`up`?`▲`:e==`down`?`▼`:``,Sr=(e,t)=>{t.actionId&&e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))},Cr=e=>{let t=e.metadata,n=!!t.actionId;return T`
+`,xr=e=>e==`up`?`var(--lumo-success-text-color, #1a7f37)`:e==`down`?`var(--lumo-error-text-color, #c5221f)`:`var(--lumo-secondary-text-color, #666)`,Sr=e=>e==`up`?`▲`:e==`down`?`▼`:``,Cr=(e,t)=>{t.actionId&&e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))},wr=e=>{let t=e.metadata,n=!!t.actionId;return w`
         <div class="mateu-metric-card ${e.cssClasses??``}"
-             style="${yr} display: flex; flex-direction: column; gap: .25rem; min-width: 11rem; flex: 1; ${n?`cursor: pointer;`:``} ${e.style??``}"
-             slot="${e.slot??v}"
-             role="${n?`button`:v}"
-             @click="${e=>Sr(e,t)}"
+             style="${br} display: flex; flex-direction: column; gap: .25rem; min-width: 11rem; flex: 1; ${n?`cursor: pointer;`:``} ${e.style??``}"
+             slot="${e.slot??_}"
+             role="${n?`button`:_}"
+             @click="${e=>Cr(e,t)}"
         >
             <div style="display: flex; align-items: center; justify-content: space-between; gap: .5rem;">
                 <span style="font-size: var(--lumo-font-size-s, .875rem); color: var(--lumo-secondary-text-color, #666);">${t.title}</span>
-                ${t.icon?I(t.icon,`color: var(--lumo-tertiary-text-color, #999); width: 1.1em; height: 1.1em;`):v}
+                ${t.icon?F(t.icon,`color: var(--lumo-tertiary-text-color, #999); width: 1.1em; height: 1.1em;`):_}
             </div>
             <div style="display: flex; align-items: baseline; gap: .35rem;">
                 <span style="font-size: var(--lumo-font-size-xxxl, 2rem); font-weight: 600; line-height: 1.1;">${t.value}</span>
-                ${t.unit?T`<span style="font-size: var(--lumo-font-size-m, 1rem); color: var(--lumo-secondary-text-color, #666);">${t.unit}</span>`:v}
+                ${t.unit?w`<span style="font-size: var(--lumo-font-size-m, 1rem); color: var(--lumo-secondary-text-color, #666);">${t.unit}</span>`:_}
             </div>
-            ${t.trend||t.trendLabel?T`
-                <span style="font-size: var(--lumo-font-size-s, .875rem); color: ${br(t.trend)};">
-                    ${xr(t.trend)} ${t.trendLabel??v}
+            ${t.trend||t.trendLabel?w`
+                <span style="font-size: var(--lumo-font-size-s, .875rem); color: ${xr(t.trend)};">
+                    ${Sr(t.trend)} ${t.trendLabel??_}
                 </span>
-            `:v}
-            ${t.description?T`<span style="font-size: var(--lumo-font-size-xs, .8rem); color: var(--lumo-tertiary-text-color, #999);">${t.description}</span>`:v}
+            `:_}
+            ${t.description?w`<span style="font-size: var(--lumo-font-size-xs, .8rem); color: var(--lumo-tertiary-text-color, #999);">${t.description}</span>`:_}
         </div>
-    `},wr=(e,t,n,r,i,a,o)=>T`
+    `},Tr=(e,t,n,r,i,a,o)=>w`
         <div class="mateu-scoreboard ${t.cssClasses??``}"
              style="display: flex; flex-wrap: wrap; gap: var(--lumo-space-m, 1rem); grid-column: 1 / -1; ${t.style??``}"
-             slot="${t.slot??v}"
+             slot="${t.slot??_}"
         >
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `,Tr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.colSpan&&s.colSpan>1?`grid-column: span ${s.colSpan};`:``,l=s.rowSpan&&s.rowSpan>1?`grid-row: span ${s.rowSpan};`:``,u=t.children??[];return u.length===1&&u[0].metadata?.type===`MetricCard`?T`
-            <div style="min-width: 0; ${c} ${l} ${t.style??``}" slot="${t.slot??v}">
-                ${F(e,u[0],n,r,i,a,o)}
-            </div>`:T`
+    `,Er=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.colSpan&&s.colSpan>1?`grid-column: span ${s.colSpan};`:``,l=s.rowSpan&&s.rowSpan>1?`grid-row: span ${s.rowSpan};`:``,u=t.children??[];return u.length===1&&u[0].metadata?.type===`MetricCard`?w`
+            <div style="min-width: 0; ${c} ${l} ${t.style??``}" slot="${t.slot??_}">
+                ${P(e,u[0],n,r,i,a,o)}
+            </div>`:w`
         <div class="mateu-dashboard-panel ${t.cssClasses??``}"
-             style="${yr} display: flex; flex-direction: column; gap: .5rem; min-width: 0; ${c} ${l} ${t.style??``}"
-             slot="${t.slot??v}"
+             style="${br} display: flex; flex-direction: column; gap: .5rem; min-width: 0; ${c} ${l} ${t.style??``}"
+             slot="${t.slot??_}"
         >
-            ${s.title?T`
+            ${s.title?w`
                 <div>
                     <h3 style="margin: 0; font-size: var(--lumo-font-size-l, 1.125rem);">${s.title}</h3>
-                    ${s.subtitle?T`<span style="font-size: var(--lumo-font-size-s, .875rem); color: var(--lumo-secondary-text-color, #666);">${s.subtitle}</span>`:v}
+                    ${s.subtitle?w`<span style="font-size: var(--lumo-font-size-s, .875rem); color: var(--lumo-secondary-text-color, #666);">${s.subtitle}</span>`:_}
                 </div>
-            `:v}
+            `:_}
             <div style="flex: 1; min-height: 0;">
-                ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+                ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
             </div>
         </div>
-    `},Er=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.columns&&s.columns>0?`repeat(${s.columns}, minmax(0, 1fr))`:`repeat(auto-fit, minmax(20rem, 1fr))`;return T`
+    `},Dr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.columns&&s.columns>0?`repeat(${s.columns}, minmax(0, 1fr))`:`repeat(auto-fit, minmax(20rem, 1fr))`;return w`
         <div class="mateu-dashboard ${t.cssClasses??``}"
              style="display: grid; grid-template-columns: ${c}; gap: var(--lumo-space-m, 1rem); align-items: stretch; ${t.style??``}"
-             slot="${t.slot??v}"
+             slot="${t.slot??_}"
         >
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `},Dr=class extends b{constructor(...e){super(...e),this.panels=[],this.headerTitle=``,this.badges=[],this.orientation=`vertical`,this.navigation=null,this.overviewEditActionId=``,this.openPanels=new Set,this.expandedPanel=null,this._onPopState=()=>{let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(e.startsWith(`expand=`)){let t=e.slice(7),n=this.panels.findIndex((e,n)=>this.panelAnchor(e,n)===t);this.expandedPanel=n>=0?n:null}else this.expandedPanel=null},this.initialized=!1}navAction(e){e&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{}},bubbles:!0,composed:!0}))}connectedCallback(){super.connectedCallback(),window.addEventListener(`popstate`,this._onPopState)}disconnectedCallback(){window.removeEventListener(`popstate`,this._onPopState),super.disconnectedCallback()}willUpdate(){if(!this.initialized&&this.panels.length){this.openPanels=new Set(this.panels.map((e,t)=>e.open?t:-1).filter(e=>e>=0));let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(e.startsWith(`expand=`)){let t=e.slice(7),n=this.panels.findIndex((e,n)=>this.panelAnchor(e,n)===t);n>=0&&(this.expandedPanel=n)}else if(e){let t=this.panels.findIndex((t,n)=>this.panelAnchor(t,n)===e);t>=0&&this.openPanels.add(t)}this.initialized=!0}}firstUpdated(){let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(!e)return;let t=this.renderRoot.querySelector(`[data-anchor="${CSS.escape(e)}"]`);t&&t.scrollIntoView({block:`nearest`})}panelAnchor(e,t){return(e.title??``).toLowerCase().replace(/[^a-z0-9]+/g,`-`).replace(/^-|-$/g,``)||`panel-${t}`}bookmarkPanel(e){let t=this.panelAnchor(this.panels[e],e);try{history.replaceState(history.state,``,`#`+t)}catch{}}clearBookmark(e){let t=this.panelAnchor(this.panels[e],e);if(decodeURIComponent((location.hash||``).replace(/^#/,``))===t)try{history.replaceState(history.state,``,location.pathname+location.search)}catch{}}expandPanel(e,t){t?.stopPropagation(),this.expandedPanel=e;let n=this.panelAnchor(this.panels[e],e);try{history.pushState(history.state,``,`#expand=`+n)}catch{}}collapsePanel(){try{history.back()}catch{this.expandedPanel=null}}toggle(e){let t=new Set(this.openPanels);t.has(e)?(t.delete(e),this.clearBookmark(e)):(t.add(e),this.bookmarkPanel(e)),this.openPanels=t}static{this.styles=h`
+    `},Or=class extends y{constructor(...e){super(...e),this.panels=[],this.headerTitle=``,this.badges=[],this.orientation=`vertical`,this.navigation=null,this.overviewEditActionId=``,this.openPanels=new Set,this.expandedPanel=null,this._onPopState=()=>{let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(e.startsWith(`expand=`)){let t=e.slice(7),n=this.panels.findIndex((e,n)=>this.panelAnchor(e,n)===t);this.expandedPanel=n>=0?n:null}else this.expandedPanel=null},this.initialized=!1}navAction(e){e&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{}},bubbles:!0,composed:!0}))}connectedCallback(){super.connectedCallback(),window.addEventListener(`popstate`,this._onPopState)}disconnectedCallback(){window.removeEventListener(`popstate`,this._onPopState),super.disconnectedCallback()}willUpdate(){if(!this.initialized&&this.panels.length){this.openPanels=new Set(this.panels.map((e,t)=>e.open?t:-1).filter(e=>e>=0));let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(e.startsWith(`expand=`)){let t=e.slice(7),n=this.panels.findIndex((e,n)=>this.panelAnchor(e,n)===t);n>=0&&(this.expandedPanel=n)}else if(e){let t=this.panels.findIndex((t,n)=>this.panelAnchor(t,n)===e);t>=0&&this.openPanels.add(t)}this.initialized=!0}}firstUpdated(){let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(!e)return;let t=this.renderRoot.querySelector(`[data-anchor="${CSS.escape(e)}"]`);t&&t.scrollIntoView({block:`nearest`})}panelAnchor(e,t){return(e.title??``).toLowerCase().replace(/[^a-z0-9]+/g,`-`).replace(/^-|-$/g,``)||`panel-${t}`}bookmarkPanel(e){let t=this.panelAnchor(this.panels[e],e);try{history.replaceState(history.state,``,`#`+t)}catch{}}clearBookmark(e){let t=this.panelAnchor(this.panels[e],e);if(decodeURIComponent((location.hash||``).replace(/^#/,``))===t)try{history.replaceState(history.state,``,location.pathname+location.search)}catch{}}expandPanel(e,t){t?.stopPropagation(),this.expandedPanel=e;let n=this.panelAnchor(this.panels[e],e);try{history.pushState(history.state,``,`#expand=`+n)}catch{}}collapsePanel(){try{history.back()}catch{this.expandedPanel=null}}toggle(e){let t=new Set(this.openPanels);t.has(e)?(t.delete(e),this.clearBookmark(e)):(t.add(e),this.bookmarkPanel(e)),this.openPanels=t}static{this.styles=m`
         :host {
             display: flex;
             flex-direction: column;
@@ -1851,7 +1851,7 @@ ${i}
             overflow: auto;
             padding: var(--mateu-foldout-panel-padding, var(--lumo-space-m, 1rem));
         }
-    `}render(){if(this.expandedPanel!=null&&this.panels[this.expandedPanel]){let e=this.panels[this.expandedPanel];return T`
+    `}render(){if(this.expandedPanel!=null&&this.panels[this.expandedPanel]){let e=this.panels[this.expandedPanel];return w`
                 <div class="expanded-view" part="expanded-view">
                     <div class="expanded-header">
                         <button class="nav-parent" title="Back"
@@ -1859,40 +1859,40 @@ ${i}
                             <span>‹</span><span>Back</span>
                         </button>
                         <span class="nav-title">${e.title}</span>
-                        ${e.subtitle?T`<span class="subtitle">${e.subtitle}</span>`:v}
+                        ${e.subtitle?w`<span class="subtitle">${e.subtitle}</span>`:_}
                     </div>
                     <div class="expanded-body">
                         <slot name="panel-${this.expandedPanel}"></slot>
                     </div>
                 </div>
-            `}let e=this.navigation;return T`
-            ${e?T`
+            `}let e=this.navigation;return w`
+            ${e?w`
                 <div class="nav-header" part="nav-header">
-                    ${e.parentActionId?T`
+                    ${e.parentActionId?w`
                         <button class="nav-parent" title="${e.parentLabel??`Back`}"
                                 @click="${()=>this.navAction(e.parentActionId)}">
                             <span>‹</span><span>${e.parentLabel??`Back`}</span>
                         </button>
-                    `:v}
-                    ${e.title?T`<span class="nav-title">${e.title}</span>`:v}
+                    `:_}
+                    ${e.title?w`<span class="nav-title">${e.title}</span>`:_}
                     <span class="nav-spacer"></span>
-                    ${e.previousActionId?T`
+                    ${e.previousActionId?w`
                         <button class="nav-move" title="Previous"
                                 @click="${()=>this.navAction(e.previousActionId)}">‹</button>
-                    `:v}
-                    ${e.nextActionId?T`
+                    `:_}
+                    ${e.nextActionId?w`
                         <button class="nav-move" title="Next"
                                 @click="${()=>this.navAction(e.nextActionId)}">›</button>
-                    `:v}
+                    `:_}
                 </div>
-            `:v}
-            ${this.headerTitle?T`
+            `:_}
+            ${this.headerTitle?w`
                 <div class="header-band" part="header-band">
                     <div class="header-content">
                         <h2 class="header-title">${this.headerTitle}</h2>
-                        ${this.badges.length?T`
+                        ${this.badges.length?w`
                             <div class="header-badges">
-                                ${this.badges.map(e=>T`<span class="header-badge">${e}</span>`)}
+                                ${this.badges.map(e=>w`<span class="header-badge">${e}</span>`)}
                             </div>
                         `:``}
                     </div>
@@ -1901,23 +1901,23 @@ ${i}
             `:``}
             <div class="columns" part="columns">
                 <div class="overview" part="overview">
-                    ${this.overviewEditActionId?T`
+                    ${this.overviewEditActionId?w`
                         <button class="overview-edit" title="Edit"
                                 @click="${()=>this.navAction(this.overviewEditActionId)}">
                             <span>✎</span><span>Edit</span>
                         </button>
-                    `:v}
+                    `:_}
                     <slot name="overview"></slot>
                 </div>
                 <div class="rail" part="rail">
-                    ${this.panels.map((e,t)=>this.openPanels.has(t)?T`
+                    ${this.panels.map((e,t)=>this.openPanels.has(t)?w`
                         <div class="panel" part="panel" data-anchor="${this.panelAnchor(e,t)}"
-                             style="${e.width?`flex-basis: ${e.width}; min-width: min(${e.width}, 100%);`:v}"
+                             style="${e.width?`flex-basis: ${e.width}; min-width: min(${e.width}, 100%);`:_}"
                              @click="${()=>this.bookmarkPanel(t)}">
                             <div class="panel-header">
                                 <div>
                                     <h3>${e.title}</h3>
-                                    ${e.subtitle?T`<div class="subtitle">${e.subtitle}</div>`:``}
+                                    ${e.subtitle?w`<div class="subtitle">${e.subtitle}</div>`:``}
                                 </div>
                                 <span class="panel-actions">
                                     <button class="panel-expand" title="Show all"
@@ -1929,7 +1929,7 @@ ${i}
                                 <slot name="panel-${t}"></slot>
                             </div>
                         </div>
-                    `:T`
+                    `:w`
                         <div class="strip" role="button" title="${e.title}"
                              data-anchor="${this.panelAnchor(e,t)}" @click="${()=>this.toggle(t)}">
                             <button class="fold" tabindex="-1">⟩</button>
@@ -1938,7 +1938,7 @@ ${i}
                     `)}
                 </div>
             </div>
-        `}};k([y({type:Array})],Dr.prototype,`panels`,void 0),k([y({type:String})],Dr.prototype,`headerTitle`,void 0),k([y({type:Array})],Dr.prototype,`badges`,void 0),k([y({type:String,reflect:!0})],Dr.prototype,`orientation`,void 0),k([y({attribute:!1})],Dr.prototype,`navigation`,void 0),k([y({type:String})],Dr.prototype,`overviewEditActionId`,void 0),k([C()],Dr.prototype,`openPanels`,void 0),k([C()],Dr.prototype,`expandedPanel`,void 0),Dr=k([g(`mateu-foldout`)],Dr);var Or=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+        `}};O([v({type:Array})],Or.prototype,`panels`,void 0),O([v({type:String})],Or.prototype,`headerTitle`,void 0),O([v({type:Array})],Or.prototype,`badges`,void 0),O([v({type:String,reflect:!0})],Or.prototype,`orientation`,void 0),O([v({attribute:!1})],Or.prototype,`navigation`,void 0),O([v({type:String})],Or.prototype,`overviewEditActionId`,void 0),O([S()],Or.prototype,`openPanels`,void 0),O([S()],Or.prototype,`expandedPanel`,void 0),Or=O([h(`mateu-foldout`)],Or);var kr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <mateu-foldout
                 .panels="${s.panels??[]}"
                 .headerTitle="${s.headerTitle??``}"
@@ -1948,45 +1948,45 @@ ${i}
                 orientation="${s.orientation??`vertical`}"
                 style="${t.style}"
                 class="${t.cssClasses}"
-                slot="${t.slot??v}"
+                slot="${t.slot??_}"
         >
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </mateu-foldout>
-    `},kr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.children??[],l=e=>c.filter(t=>(t.slot??``).startsWith(e)),u=l(`main-`),d=l(`aside-`),f=l(`footer-`),p=s.asideWidth&&s.asideWidth.trim()?s.asideWidth:`32%`,m=s.asidePosition===`start`,ee=s.asideSticky!==!1,te=t=>t.map(t=>F(e,t,n,r,i,a,o)),ne=T`
+    `},Ar=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.children??[],l=e=>c.filter(t=>(t.slot??``).startsWith(e)),u=l(`main-`),d=l(`aside-`),f=l(`footer-`),p=s.asideWidth&&s.asideWidth.trim()?s.asideWidth:`32%`,ee=s.asidePosition===`start`,te=s.asideSticky!==!1,ne=t=>t.map(t=>P(e,t,n,r,i,a,o)),re=w`
         <div class="mateu-content-main"
              style="flex: 1 1 0; min-width: min(20rem, 100%); box-sizing: border-box;">
-            ${te(u)}
-        </div>`,h=d.length?T`
+            ${ne(u)}
+        </div>`,m=d.length?w`
         <div class="mateu-content-aside"
-             style="flex: 0 1 calc(${p} - var(--lumo-space-m, 1rem)); min-width: min(18rem, 100%); box-sizing: border-box; ${ee?`position: sticky; top: 1rem; align-self: flex-start;`:``}">
-            ${te(d)}
-        </div>`:v;return T`
+             style="flex: 0 1 calc(${p} - var(--lumo-space-m, 1rem)); min-width: min(18rem, 100%); box-sizing: border-box; ${te?`position: sticky; top: 1rem; align-self: flex-start;`:``}">
+            ${ne(d)}
+        </div>`:_;return w`
         <div class="mateu-content-layout ${t.cssClasses??``}"
              style="${t.style??``}"
-             slot="${t.slot??v}">
+             slot="${t.slot??_}">
             <div style="display: flex; flex-wrap: wrap; gap: var(--lumo-space-m, 1rem); align-items: flex-start;">
-                ${m?[h,ne]:[ne,h]}
+                ${ee?[m,re]:[re,m]}
             </div>
-            ${f.length?T`
+            ${f.length?w`
                 <div class="mateu-content-footer"
                      style="flex-basis: 100%; margin-top: var(--lumo-space-m, 1rem);">
-                    ${te(f)}
-                </div>`:v}
+                    ${ne(f)}
+                </div>`:_}
         </div>
-    `},Ar=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!!s.image,l=c?`background-image: linear-gradient(rgba(0,0,0,.35), rgba(0,0,0,.35)), url('${s.image}'); background-size: cover; background-position: center; color: #fff;`:``,u=s.centered===!1?`flex-start`:`center`,d=s.centered===!1?`left`:`center`;return T`
+    `},jr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!!s.image,l=c?`background-image: linear-gradient(rgba(0,0,0,.35), rgba(0,0,0,.35)), url('${s.image}'); background-size: cover; background-position: center; color: #fff;`:``,u=s.centered===!1?`flex-start`:`center`,d=s.centered===!1?`left`:`center`;return w`
         <div class="mateu-hero ${t.cssClasses??``}"
              style="display: flex; flex-direction: column; align-items: ${u}; justify-content: center; gap: var(--lumo-space-m, 1rem); text-align: ${d}; padding: var(--lumo-space-xl, 2.5rem) var(--lumo-space-l, 1.5rem); border-radius: var(--lumo-border-radius-l, 12px); min-height: ${s.height??`12rem`}; box-sizing: border-box; ${l} ${t.style??``}"
-             slot="${t.slot??v}"
+             slot="${t.slot??_}"
         >
-            ${s.title?T`<h1 style="margin: 0; font-size: var(--lumo-font-size-xxxl, 2.5rem); line-height: 1.15;">${s.title}</h1>`:v}
-            ${s.subtitle?T`<p style="margin: 0; font-size: var(--lumo-font-size-l, 1.125rem); ${c?``:`color: var(--lumo-secondary-text-color, #666);`} max-width: 40rem;">${s.subtitle}</p>`:v}
-            ${t.children?.length?T`
+            ${s.title?w`<h1 style="margin: 0; font-size: var(--lumo-font-size-xxxl, 2.5rem); line-height: 1.15;">${s.title}</h1>`:_}
+            ${s.subtitle?w`<p style="margin: 0; font-size: var(--lumo-font-size-l, 1.125rem); ${c?``:`color: var(--lumo-secondary-text-color, #666);`} max-width: 40rem;">${s.subtitle}</p>`:_}
+            ${t.children?.length?w`
                 <div style="display: flex; gap: var(--lumo-space-s, .5rem); flex-wrap: wrap; justify-content: ${u}; width: 100%; max-width: 40rem;">
-                    ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+                    ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
                 </div>
-            `:v}
+            `:_}
         </div>
-    `},R=e=>t=>{if(t.key===`Enter`){e(t);return}(t.key===` `||t.key===`Spacebar`)&&(t.preventDefault(),e(t))},z=h`
+    `},L=e=>t=>{if(t.key===`Enter`){e(t);return}(t.key===` `||t.key===`Spacebar`)&&(t.preventDefault(),e(t))},R=m`
     [role="button"]:focus-visible,
     [role="option"]:focus-visible,
     [role="treeitem"]:focus-visible,
@@ -1997,7 +1997,7 @@ ${i}
         outline-offset: 2px;
         border-radius: var(--lumo-border-radius-s, 4px);
     }
-`,jr=1440*60*1e3,Mr=class extends b{constructor(...e){super(...e),this.tasks=[],this.onTaskSelectionActionId=``}selectTask(e){this.onTaskSelectionActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.onTaskSelectionActionId,parameters:{_clickedTaskId:e.id}},bubbles:!0,composed:!0}))}static{this.styles=h`
+`,Mr=1440*60*1e3,Nr=class extends y{constructor(...e){super(...e),this.tasks=[],this.onTaskSelectionActionId=``}selectTask(e){this.onTaskSelectionActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.onTaskSelectionActionId,parameters:{_clickedTaskId:e.id}},bubbles:!0,composed:!0}))}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2072,39 +2072,39 @@ ${i}
             opacity: .55;
         }
     
-        ${z}
-    `}range(){let e=this.tasks.flatMap(e=>[e.start,e.end]).filter(e=>!!e).map(e=>new Date(e+`T00:00:00`).getTime());return e.length?{min:Math.min(...e)-jr,max:Math.max(...e)+2*jr}:null}months(e,t){let n=[],r=new Date(e);for(r.setDate(1);r.getTime()<=t;){let i=Math.max(r.getTime(),e),a=new Date(r.getFullYear(),r.getMonth()+1,1),o=Math.min(a.getTime(),t);n.push({label:r.toLocaleDateString(void 0,{month:`short`,year:`2-digit`}),from:i,to:o}),r.setMonth(r.getMonth()+1)}return n}render(){let e=this.range();if(!e)return T``;let t=e.max-e.min,n=n=>(n-e.min)/t*100,r=Date.now();return T`
+        ${R}
+    `}range(){let e=this.tasks.flatMap(e=>[e.start,e.end]).filter(e=>!!e).map(e=>new Date(e+`T00:00:00`).getTime());return e.length?{min:Math.min(...e)-Mr,max:Math.max(...e)+2*Mr}:null}months(e,t){let n=[],r=new Date(e);for(r.setDate(1);r.getTime()<=t;){let i=Math.max(r.getTime(),e),a=new Date(r.getFullYear(),r.getMonth()+1,1),o=Math.min(a.getTime(),t);n.push({label:r.toLocaleDateString(void 0,{month:`short`,year:`2-digit`}),from:i,to:o}),r.setMonth(r.getMonth()+1)}return n}render(){let e=this.range();if(!e)return w``;let t=e.max-e.min,n=n=>(n-e.min)/t*100,r=Date.now();return w`
             <div class="frame">
                 <div class="head">Task</div>
                 <div class="head months">
-                    ${this.months(e.min,e.max).map(e=>T`
+                    ${this.months(e.min,e.max).map(e=>w`
                         <div class="month" style="width: ${(e.to-e.from)/t*100}%;">${e.label}</div>
                     `)}
                 </div>
-                ${this.tasks.map(i=>{let a=new Date(i.start+`T00:00:00`).getTime(),o=new Date(i.end+`T00:00:00`).getTime()+jr;return T`
+                ${this.tasks.map(i=>{let a=new Date(i.start+`T00:00:00`).getTime(),o=new Date(i.end+`T00:00:00`).getTime()+Mr;return w`
                         <div class="label" title="${i.title}">${i.title}</div>
                         <div class="lane">
-                            ${r>=e.min&&r<=e.max?T`<div class="today" style="left: ${n(r)}%;"></div>`:v}
+                            ${r>=e.min&&r<=e.max?w`<div class="today" style="left: ${n(r)}%;"></div>`:_}
                             <div role="button" tabindex="0"
                                  aria-label="${i.title}, ${i.start} to ${i.end}${i.progress?`, ${i.progress}% complete`:``}"
                                  class="bar ${this.onTaskSelectionActionId?`clickable`:``}"
                                  title="${i.title} · ${i.start} → ${i.end}${i.progress?` · ${i.progress}%`:``}"
-                                 @click="${()=>this.selectTask(i)}" @keydown="${R(()=>this.selectTask(i))}"
+                                 @click="${()=>this.selectTask(i)}" @keydown="${L(()=>this.selectTask(i))}"
                                  style="left: ${n(a)}%; width: ${(o-a)/t*100}%; ${i.color?`--mateu-gantt-fill: ${i.color};`:``}">
                                 <div class="fill" style="width: ${i.progress??0}%;"></div>
                             </div>
                         </div>
                     `})}
             </div>
-        `}};k([y({type:Array})],Mr.prototype,`tasks`,void 0),k([y()],Mr.prototype,`onTaskSelectionActionId`,void 0),Mr=k([g(`mateu-gantt`)],Mr);var Nr=e=>{let t=e.metadata;return T`
+        `}};O([v({type:Array})],Nr.prototype,`tasks`,void 0),O([v()],Nr.prototype,`onTaskSelectionActionId`,void 0),Nr=O([h(`mateu-gantt`)],Nr);var Pr=e=>{let t=e.metadata;return w`
         <mateu-gantt
                 .tasks="${t.tasks??[]}"
                 .onTaskSelectionActionId="${t.onTaskSelectionActionId??``}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-gantt>
-    `},B,Pr=class extends b{static{B=this}constructor(...e){super(...e),this.resources=[],this.blocks=[],this.drag=null,this.dragStartX=0,this.dragStartY=0,this.laneRects=[],this.onDragKeydown=e=>{e.key===`Escape`&&this.drag&&(e.stopPropagation(),this.endDrag())}}static{this.styles=h`
+    `},z,Fr=class extends y{static{z=this}constructor(...e){super(...e),this.resources=[],this.blocks=[],this.drag=null,this.dragStartX=0,this.dragStartY=0,this.laneRects=[],this.onDragKeydown=e=>{e.key===`Escape`&&this.drag&&(e.stopPropagation(),this.endDrag())}}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2246,10 +2246,10 @@ ${i}
             pointer-events: none;
             z-index: 2;
         }
-    `}static parse(e){return new Date(e+`T00:00:00`)}static iso(e){let t=e=>String(e).padStart(2,`0`);return`${e.getFullYear()}-${t(e.getMonth()+1)}-${t(e.getDate())}`}static addDays(e,t){return new Date(e.getFullYear(),e.getMonth(),e.getDate()+t)}static daysBetween(e,t){return Math.round((t.getTime()-e.getTime())/864e5)}window(){if(this.from&&this.to){let e=B.parse(this.from),t=B.daysBetween(e,B.parse(this.to))+1;return t>0?{from:e,days:t}:null}let e=this.blocks.flatMap(e=>[e.start,e.end]).filter(e=>!!e).map(e=>B.parse(e));if(!e.length)return null;let t=new Date(Math.min(...e.map(e=>e.getTime()))),n=new Date(Math.max(...e.map(e=>e.getTime())));return{from:t,days:B.daysBetween(t,n)+1}}onBlockPointerDown(e,t,n){if(!this.moveActionId&&!this.selectActionId||(e.preventDefault(),e.currentTarget.setPointerCapture(e.pointerId),this.dragStartX=e.clientX,this.dragStartY=e.clientY,!this.window()))return;let r=B.parse(t.start),i=B.parse(t.end),a=Math.max(1,B.daysBetween(r,i)+1);this.laneRects=[...this.renderRoot.querySelectorAll(`.lane[data-resource-id]`)].map(e=>({resourceId:e.dataset.resourceId,rect:e.getBoundingClientRect()}));let o=this.dayAt(t.resourceId,e.clientX)??n;this.drag={blockId:t.id,duration:a,grabOffsetDays:o-n,originResourceId:t.resourceId,originStartIdx:n,targetResourceId:t.resourceId,targetStartIdx:n,moved:!1},window.addEventListener(`keydown`,this.onDragKeydown)}dayAt(e,t){let n=this.laneRects.find(t=>t.resourceId===e),r=this.window();if(!n||!r||n.rect.width===0)return null;let i=Math.floor((t-n.rect.left)/n.rect.width*r.days);return Math.max(0,Math.min(r.days-1,i))}onBlockPointerMove(e){if(!this.drag||!this.drag.moved&&Math.abs(e.clientX-this.dragStartX)<4&&Math.abs(e.clientY-this.dragStartY)<4||!this.moveActionId)return;let t=this.window();if(!t)return;let n=this.laneRects.find(t=>e.clientY>=t.rect.top&&e.clientY<=t.rect.bottom)??this.laneRects.find(e=>e.resourceId===this.drag.targetResourceId);if(!n)return;let r=this.dayAt(n.resourceId,e.clientX);if(r==null)return;let i=Math.max(0,Math.min(t.days-this.drag.duration,r-this.drag.grabOffsetDays));this.drag={...this.drag,moved:!0,targetResourceId:n.resourceId,targetStartIdx:i}}onBlockPointerUp(e){let t=this.drag;if(this.endDrag(),!t)return;if(!t.moved){this.selectActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.selectActionId,parameters:{_blockId:e.id}},bubbles:!0,composed:!0}));return}if(!this.moveActionId||t.targetResourceId===t.originResourceId&&t.targetStartIdx===t.originStartIdx)return;let n=this.window();if(!n)return;let r=B.addDays(n.from,t.targetStartIdx),i=B.addDays(r,t.duration-1);this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.moveActionId,parameters:{_blockId:t.blockId,_resourceId:t.targetResourceId,_start:B.iso(r),_end:B.iso(i)}},bubbles:!0,composed:!0}))}endDrag(){this.drag=null,window.removeEventListener(`keydown`,this.onDragKeydown)}disconnectedCallback(){super.disconnectedCallback(),window.removeEventListener(`keydown`,this.onDragKeydown)}render(){let e=this.window();if(!e||!this.resources.length)return T``;let t=[...Array(e.days).keys()].map(t=>B.addDays(e.from,t)),n=new Date,r=B.daysBetween(e.from,new Date(n.getFullYear(),n.getMonth(),n.getDate())),i=r>=0&&r<e.days,a=[],o;return this.resources.forEach(n=>{n.group&&n.group!==o&&a.push(T`<div class="group">${n.group}</div>`),o=n.group,a.push(this.renderRow(n,e,t,i?r:null))}),T`
+    `}static parse(e){return new Date(e+`T00:00:00`)}static iso(e){let t=e=>String(e).padStart(2,`0`);return`${e.getFullYear()}-${t(e.getMonth()+1)}-${t(e.getDate())}`}static addDays(e,t){return new Date(e.getFullYear(),e.getMonth(),e.getDate()+t)}static daysBetween(e,t){return Math.round((t.getTime()-e.getTime())/864e5)}window(){if(this.from&&this.to){let e=z.parse(this.from),t=z.daysBetween(e,z.parse(this.to))+1;return t>0?{from:e,days:t}:null}let e=this.blocks.flatMap(e=>[e.start,e.end]).filter(e=>!!e).map(e=>z.parse(e));if(!e.length)return null;let t=new Date(Math.min(...e.map(e=>e.getTime()))),n=new Date(Math.max(...e.map(e=>e.getTime())));return{from:t,days:z.daysBetween(t,n)+1}}onBlockPointerDown(e,t,n){if(!this.moveActionId&&!this.selectActionId||(e.preventDefault(),e.currentTarget.setPointerCapture(e.pointerId),this.dragStartX=e.clientX,this.dragStartY=e.clientY,!this.window()))return;let r=z.parse(t.start),i=z.parse(t.end),a=Math.max(1,z.daysBetween(r,i)+1);this.laneRects=[...this.renderRoot.querySelectorAll(`.lane[data-resource-id]`)].map(e=>({resourceId:e.dataset.resourceId,rect:e.getBoundingClientRect()}));let o=this.dayAt(t.resourceId,e.clientX)??n;this.drag={blockId:t.id,duration:a,grabOffsetDays:o-n,originResourceId:t.resourceId,originStartIdx:n,targetResourceId:t.resourceId,targetStartIdx:n,moved:!1},window.addEventListener(`keydown`,this.onDragKeydown)}dayAt(e,t){let n=this.laneRects.find(t=>t.resourceId===e),r=this.window();if(!n||!r||n.rect.width===0)return null;let i=Math.floor((t-n.rect.left)/n.rect.width*r.days);return Math.max(0,Math.min(r.days-1,i))}onBlockPointerMove(e){if(!this.drag||!this.drag.moved&&Math.abs(e.clientX-this.dragStartX)<4&&Math.abs(e.clientY-this.dragStartY)<4||!this.moveActionId)return;let t=this.window();if(!t)return;let n=this.laneRects.find(t=>e.clientY>=t.rect.top&&e.clientY<=t.rect.bottom)??this.laneRects.find(e=>e.resourceId===this.drag.targetResourceId);if(!n)return;let r=this.dayAt(n.resourceId,e.clientX);if(r==null)return;let i=Math.max(0,Math.min(t.days-this.drag.duration,r-this.drag.grabOffsetDays));this.drag={...this.drag,moved:!0,targetResourceId:n.resourceId,targetStartIdx:i}}onBlockPointerUp(e){let t=this.drag;if(this.endDrag(),!t)return;if(!t.moved){this.selectActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.selectActionId,parameters:{_blockId:e.id}},bubbles:!0,composed:!0}));return}if(!this.moveActionId||t.targetResourceId===t.originResourceId&&t.targetStartIdx===t.originStartIdx)return;let n=this.window();if(!n)return;let r=z.addDays(n.from,t.targetStartIdx),i=z.addDays(r,t.duration-1);this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.moveActionId,parameters:{_blockId:t.blockId,_resourceId:t.targetResourceId,_start:z.iso(r),_end:z.iso(i)}},bubbles:!0,composed:!0}))}endDrag(){this.drag=null,window.removeEventListener(`keydown`,this.onDragKeydown)}disconnectedCallback(){super.disconnectedCallback(),window.removeEventListener(`keydown`,this.onDragKeydown)}render(){let e=this.window();if(!e||!this.resources.length)return w``;let t=[...Array(e.days).keys()].map(t=>z.addDays(e.from,t)),n=new Date,r=z.daysBetween(e.from,new Date(n.getFullYear(),n.getMonth(),n.getDate())),i=r>=0&&r<e.days,a=[],o;return this.resources.forEach(n=>{n.group&&n.group!==o&&a.push(w`<div class="group">${n.group}</div>`),o=n.group,a.push(this.renderRow(n,e,t,i?r:null))}),w`
             <div class="frame" style="grid-template-columns: minmax(8rem, 12rem) repeat(${e.days}, minmax(2.2rem, 1fr));">
                 <div class="corner">Resource</div>
-                ${t.map((e,t)=>T`
+                ${t.map((e,t)=>w`
                     <div class="day-head ${this.isWeekend(e)?`weekend`:``} ${t===r?`today`:``}">
                         <span class="dow">${e.toLocaleDateString(void 0,{weekday:`short`})}</span>
                         <span class="num">${e.getDate()}</span>
@@ -2257,14 +2257,14 @@ ${i}
                 `)}
                 ${a}
             </div>
-        `}isWeekend(e){return e.getDay()===0||e.getDay()===6}renderRow(e,t,n,r){let i=100/t.days,a=this.blocks.filter(t=>t.resourceId===e.id&&t.start&&t.end),o=this.drag?.moved&&this.drag.targetResourceId===e.id?this.drag:null;return T`
+        `}isWeekend(e){return e.getDay()===0||e.getDay()===6}renderRow(e,t,n,r){let i=100/t.days,a=this.blocks.filter(t=>t.resourceId===e.id&&t.start&&t.end),o=this.drag?.moved&&this.drag.targetResourceId===e.id?this.drag:null;return w`
             <div class="label" title="${e.label??``}">${e.label}</div>
             <div class="lane" data-resource-id="${e.id}">
                 <div class="cells">
-                    ${n.map(e=>T`<div class="cell ${this.isWeekend(e)?`weekend`:``}"></div>`)}
+                    ${n.map(e=>w`<div class="cell ${this.isWeekend(e)?`weekend`:``}"></div>`)}
                 </div>
-                ${r==null?v:T`<div class="today-line" style="left: ${(r+.5)*i}%;"></div>`}
-                ${a.map(e=>{let n=B.daysBetween(t.from,B.parse(e.start)),r=B.daysBetween(t.from,B.parse(e.end));if(r<0||n>=t.days)return v;let a=Math.max(0,n),o=Math.min(t.days-1,r),s=this.drag?.moved&&this.drag.blockId===e.id;return T`
+                ${r==null?_:w`<div class="today-line" style="left: ${(r+.5)*i}%;"></div>`}
+                ${a.map(e=>{let n=z.daysBetween(t.from,z.parse(e.start)),r=z.daysBetween(t.from,z.parse(e.end));if(r<0||n>=t.days)return _;let a=Math.max(0,n),o=Math.min(t.days-1,r),s=this.drag?.moved&&this.drag.blockId===e.id;return w`
                         <div class="block ${this.selectActionId?`clickable`:``} ${this.moveActionId?`draggable`:``} ${s?`dragging`:``}"
                              title="${e.label??``} · ${e.start} → ${e.end}${e.status?` · ${e.status}`:``}"
                              style="left: ${a*i}%; width: ${(o-a+1)*i}%; ${e.color?`--mateu-planning-block: ${e.color};`:``}"
@@ -2274,12 +2274,12 @@ ${i}
                              @pointercancel="${()=>this.endDrag()}"
                         >${e.label}</div>
                     `})}
-                ${o?T`
+                ${o?w`
                     <div class="ghost"
                          style="left: ${o.targetStartIdx*i}%; width: ${Math.min(o.duration,t.days-o.targetStartIdx)*i}%;"></div>
-                `:v}
+                `:_}
             </div>
-        `}};k([y({type:Array})],Pr.prototype,`resources`,void 0),k([y({type:Array})],Pr.prototype,`blocks`,void 0),k([y()],Pr.prototype,`from`,void 0),k([y()],Pr.prototype,`to`,void 0),k([y()],Pr.prototype,`moveActionId`,void 0),k([y()],Pr.prototype,`selectActionId`,void 0),k([C()],Pr.prototype,`drag`,void 0),Pr=B=k([g(`mateu-planning-board`)],Pr);var Fr=e=>{let t=e.metadata;return T`
+        `}};O([v({type:Array})],Fr.prototype,`resources`,void 0),O([v({type:Array})],Fr.prototype,`blocks`,void 0),O([v()],Fr.prototype,`from`,void 0),O([v()],Fr.prototype,`to`,void 0),O([v()],Fr.prototype,`moveActionId`,void 0),O([v()],Fr.prototype,`selectActionId`,void 0),O([S()],Fr.prototype,`drag`,void 0),Fr=z=O([h(`mateu-planning-board`)],Fr);var Ir=e=>{let t=e.metadata;return w`
         <mateu-planning-board
                 .resources="${t.resources??[]}"
                 .blocks="${t.blocks??[]}"
@@ -2287,11 +2287,11 @@ ${i}
                 .to="${t.to}"
                 .moveActionId="${t.moveActionId}"
                 .selectActionId="${t.selectActionId}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-planning-board>
-    `},Ir=class extends b{constructor(...e){super(...e),this.columns=[]}static{this.styles=h`
+    `},Lr=class extends y{constructor(...e){super(...e),this.columns=[]}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2374,35 +2374,35 @@ ${i}
             .card { background: var(--lumo-contrast-5pct, #2a2a2a); }
         }
     
-        ${z}
-    `}clickCard(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_clickedCard:e}},bubbles:!0,composed:!0}))}render(){return T`
+        ${R}
+    `}clickCard(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_clickedCard:e}},bubbles:!0,composed:!0}))}render(){return w`
             <div class="board">
-                ${this.columns.map(e=>T`
+                ${this.columns.map(e=>w`
                     <div class="column" style="${e.color?`--mateu-kanban-accent: ${e.color};`:``}">
                         <div class="column-head">
                             <span class="column-title" title="${e.title??``}">${e.title}</span>
                             <span class="count">${e.cards?.length??0}</span>
                         </div>
-                        ${(e.cards??[]).map(e=>T`
+                        ${(e.cards??[]).map(e=>w`
                             <div role="button" tabindex="0" class="card ${e.actionId?`clickable`:``}"
                                  style="${e.color?`--mateu-kanban-card-accent: ${e.color};`:``}"
-                                 @click="${()=>this.clickCard(e)}" @keydown="${R(()=>this.clickCard(e))}">
+                                 @click="${()=>this.clickCard(e)}" @keydown="${L(()=>this.clickCard(e))}">
                                 <span class="card-title">${e.title}</span>
-                                ${e.description?T`<span class="card-desc">${e.description}</span>`:v}
-                                ${e.badge?T`<span class="badge">${e.badge}</span>`:v}
+                                ${e.description?w`<span class="card-desc">${e.description}</span>`:_}
+                                ${e.badge?w`<span class="badge">${e.badge}</span>`:_}
                             </div>
                         `)}
                     </div>
                 `)}
             </div>
-        `}};k([y({type:Array})],Ir.prototype,`columns`,void 0),Ir=k([g(`mateu-kanban`)],Ir);var Lr=e=>T`
+        `}};O([v({type:Array})],Lr.prototype,`columns`,void 0),Lr=O([h(`mateu-kanban`)],Lr);var Rr=e=>w`
         <mateu-kanban
                 .columns="${e.metadata.columns??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-kanban>
-    `,Rr=class extends b{constructor(...e){super(...e),this.items=[]}static{this.styles=h`
+    `,zr=class extends y{constructor(...e){super(...e),this.items=[]}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2474,33 +2474,33 @@ ${i}
             margin-top: .15rem;
         }
     
-        ${z}
-    `}clickItem(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_clickedItem:e}},bubbles:!0,composed:!0}))}render(){return T`
+        ${R}
+    `}clickItem(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_clickedItem:e}},bubbles:!0,composed:!0}))}render(){return w`
             <div class="feed">
-                ${this.items.map(e=>T`
+                ${this.items.map(e=>w`
                     <div class="item ${e.actionId?`clickable`:``}">
                         <div class="rail">
                             <div class="dot" style="${e.color?`--mateu-timeline-dot: ${e.color};`:``}">${e.icon??``}</div>
                             <div class="line"></div>
                         </div>
-                        <div role="button" tabindex="0" class="body" @click="${()=>this.clickItem(e)}" @keydown="${R(()=>this.clickItem(e))}">
+                        <div role="button" tabindex="0" class="body" @click="${()=>this.clickItem(e)}" @keydown="${L(()=>this.clickItem(e))}">
                             <div class="head">
                                 <span class="title">${e.title}</span>
-                                ${e.timestamp?T`<span class="time">${e.timestamp}</span>`:v}
+                                ${e.timestamp?w`<span class="time">${e.timestamp}</span>`:_}
                             </div>
-                            ${e.description?T`<div class="desc">${e.description}</div>`:v}
+                            ${e.description?w`<div class="desc">${e.description}</div>`:_}
                         </div>
                     </div>
                 `)}
             </div>
-        `}};k([y({type:Array})],Rr.prototype,`items`,void 0),Rr=k([g(`mateu-timeline`)],Rr);var zr=e=>T`
+        `}};O([v({type:Array})],zr.prototype,`items`,void 0),zr=O([h(`mateu-timeline`)],zr);var Br=e=>w`
         <mateu-timeline
                 .items="${e.metadata.items??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-timeline>
-    `,Br=class extends b{constructor(...e){super(...e),this.steps=[],this.vertical=!1}static{this.styles=h`
+    `,Vr=class extends y{constructor(...e){super(...e),this.steps=[],this.vertical=!1}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2603,26 +2603,26 @@ ${i}
             margin-top: 0;
             padding: 0;
         }
-    `}updated(){let e=this.steps.length;if(e===0)return;let t=this.steps.findIndex(e=>e.status===`current`),n=this.steps.every(e=>e.status===`done`),r=t>=0?t+1:n?e:0;this.dispatchEvent(new CustomEvent(`mateu-guided-progress`,{detail:{current:r,total:e,steps:this.steps.map(e=>({id:e.id,title:e.title,status:e.status??`upcoming`}))},bubbles:!0,composed:!0}))}render(){return T`
+    `}updated(){let e=this.steps.length;if(e===0)return;let t=this.steps.findIndex(e=>e.status===`current`),n=this.steps.every(e=>e.status===`done`),r=t>=0?t+1:n?e:0;this.dispatchEvent(new CustomEvent(`mateu-guided-progress`,{detail:{current:r,total:e,steps:this.steps.map(e=>({id:e.id,title:e.title,status:e.status??`upcoming`}))},bubbles:!0,composed:!0}))}render(){return w`
             <div class="steps">
-                ${this.steps.map((e,t)=>{let n=e.status??`upcoming`;return T`
+                ${this.steps.map((e,t)=>{let n=e.status??`upcoming`;return w`
                         <div class="step ${n}">
                             <div class="connector"></div>
                             <div class="dot">${n===`done`?`✓`:t+1}</div>
                             <div class="label">${e.title}</div>
-                            ${e.description?T`<div class="desc">${e.description}</div>`:v}
+                            ${e.description?w`<div class="desc">${e.description}</div>`:_}
                         </div>
                     `})}
             </div>
-        `}};k([y({type:Array})],Br.prototype,`steps`,void 0),k([y({type:Boolean,reflect:!0})],Br.prototype,`vertical`,void 0),Br=k([g(`mateu-progress-steps`)],Br);var Vr=e=>{let t=e.metadata;return T`
+        `}};O([v({type:Array})],Vr.prototype,`steps`,void 0),O([v({type:Boolean,reflect:!0})],Vr.prototype,`vertical`,void 0),Vr=O([h(`mateu-progress-steps`)],Vr);var Hr=e=>{let t=e.metadata;return w`
         <mateu-progress-steps
                 .steps="${t.steps??[]}"
                 ?vertical="${t.vertical??!1}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-progress-steps>
-    `},Hr=class extends b{constructor(...e){super(...e),this.spark=[]}static{this.styles=h`
+    `},Ur=class extends y{constructor(...e){super(...e),this.spark=[]}static{this.styles=m`
         :host {
             display: block;
         }
@@ -2677,36 +2677,36 @@ ${i}
             .tile { background: var(--lumo-contrast-5pct, #2a2a2a); }
         }
     
-        ${z}
-    `}sparkline(){let e=this.spark;if(!e||e.length<2)return v;let t=Math.min(...e),n=Math.max(...e)-t||1,r=80/(e.length-1),i=e.map((e,i)=>[2+i*r,2+26*(1-(e-t)/n)]),a=i.map(([e,t],n)=>`${n===0?`M`:`L`}${e.toFixed(1)} ${t.toFixed(1)}`).join(` `),o=`${a} L${i[i.length-1][0].toFixed(1)} 30 L${i[0][0].toFixed(1)} 30 Z`,s=this.trend===`down`?`var(--lumo-error-color, #e11d48)`:this.trend===`flat`?`var(--lumo-secondary-text-color, #888)`:`var(--lumo-success-color, #12b76a)`;return w`
+        ${R}
+    `}sparkline(){let e=this.spark;if(!e||e.length<2)return _;let t=Math.min(...e),n=Math.max(...e)-t||1,r=80/(e.length-1),i=e.map((e,i)=>[2+i*r,2+26*(1-(e-t)/n)]),a=i.map(([e,t],n)=>`${n===0?`M`:`L`}${e.toFixed(1)} ${t.toFixed(1)}`).join(` `),o=`${a} L${i[i.length-1][0].toFixed(1)} 30 L${i[0][0].toFixed(1)} 30 Z`,s=this.trend===`down`?`var(--lumo-error-color, #e11d48)`:this.trend===`flat`?`var(--lumo-secondary-text-color, #888)`:`var(--lumo-success-color, #12b76a)`;return C`
             <svg width="${84}" height="${30}" viewBox="0 0 ${84} ${30}">
                 <path d="${o}" fill="${s}" opacity="0.12"></path>
                 <path d="${a}" fill="none" stroke="${s}" stroke-width="1.6"
                       stroke-linejoin="round" stroke-linecap="round"></path>
             </svg>
-        `}dispatchAction(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId},bubbles:!0,composed:!0}))}render(){let e=this.trend??`up`;return T`
-            <div role="button" tabindex="0" class="tile ${this.actionId?`clickable`:``}" @click="${()=>this.dispatchAction()}" @keydown="${R(()=>this.dispatchAction())}">
-                ${this.label?T`<span class="label">${this.label}</span>`:v}
-                <span class="value">${this.value}${this.unit?T`<span class="unit">${this.unit}</span>`:v}</span>
+        `}dispatchAction(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId},bubbles:!0,composed:!0}))}render(){let e=this.trend??`up`;return w`
+            <div role="button" tabindex="0" class="tile ${this.actionId?`clickable`:``}" @click="${()=>this.dispatchAction()}" @keydown="${L(()=>this.dispatchAction())}">
+                ${this.label?w`<span class="label">${this.label}</span>`:_}
+                <span class="value">${this.value}${this.unit?w`<span class="unit">${this.unit}</span>`:_}</span>
                 <div class="foot">
-                    ${this.delta?T`<span class="delta ${e}">${e===`up`?`▲`:e===`down`?`▼`:`→`} ${this.delta}</span>`:T`<span></span>`}
+                    ${this.delta?w`<span class="delta ${e}">${e===`up`?`▲`:e===`down`?`▼`:`→`} ${this.delta}</span>`:w`<span></span>`}
                     ${this.sparkline()}
                 </div>
             </div>
-        `}};k([y()],Hr.prototype,`label`,void 0),k([y()],Hr.prototype,`value`,void 0),k([y()],Hr.prototype,`unit`,void 0),k([y()],Hr.prototype,`delta`,void 0),k([y()],Hr.prototype,`trend`,void 0),k([y({type:Array})],Hr.prototype,`spark`,void 0),k([y()],Hr.prototype,`actionId`,void 0),Hr=k([g(`mateu-stat`)],Hr);var Ur=e=>{let t=e.metadata;return T`
+        `}};O([v()],Ur.prototype,`label`,void 0),O([v()],Ur.prototype,`value`,void 0),O([v()],Ur.prototype,`unit`,void 0),O([v()],Ur.prototype,`delta`,void 0),O([v()],Ur.prototype,`trend`,void 0),O([v({type:Array})],Ur.prototype,`spark`,void 0),O([v()],Ur.prototype,`actionId`,void 0),Ur=O([h(`mateu-stat`)],Ur);var Wr=e=>{let t=e.metadata;return w`
         <mateu-stat
-                label="${t.label??v}"
-                value="${t.value??v}"
-                unit="${t.unit??v}"
-                delta="${t.delta??v}"
-                trend="${t.trend??v}"
-                actionId="${t.actionId??v}"
+                label="${t.label??_}"
+                value="${t.value??_}"
+                unit="${t.unit??_}"
+                delta="${t.delta??_}"
+                trend="${t.trend??_}"
+                actionId="${t.actionId??_}"
                 .spark="${t.spark??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-stat>
-    `},Wr=class extends b{constructor(...e){super(...e),this.events=[]}static{this.styles=h`
+    `},Gr=class extends y{constructor(...e){super(...e),this.events=[]}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2780,32 +2780,32 @@ ${i}
             .dow { background: var(--lumo-contrast-10pct, #333); }
         }
     
-        ${z}
-    `}clickEvent(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_clickedEvent:e}},bubbles:!0,composed:!0}))}render(){let e=this.month?new Date(this.month+`T00:00:00`):new Date,t=e.getFullYear(),n=e.getMonth(),r=new Date(t,n,1),i=(r.getDay()+6)%7,a=new Date(t,n+1,0).getDate(),o=new Date,s=e=>o.getFullYear()===t&&o.getMonth()===n&&o.getDate()===e,c={};for(let e of this.events){if(!e.date)continue;let r=new Date(e.date+`T00:00:00`);r.getFullYear()===t&&r.getMonth()===n&&(c[r.getDate()]??=[]).push(e)}let l=[`Mon`,`Tue`,`Wed`,`Thu`,`Fri`,`Sat`,`Sun`],u=[];for(let e=0;e<i;e++)u.push(T`<div class="cell blank"></div>`);for(let e=1;e<=a;e++)u.push(T`
+        ${R}
+    `}clickEvent(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_clickedEvent:e}},bubbles:!0,composed:!0}))}render(){let e=this.month?new Date(this.month+`T00:00:00`):new Date,t=e.getFullYear(),n=e.getMonth(),r=new Date(t,n,1),i=(r.getDay()+6)%7,a=new Date(t,n+1,0).getDate(),o=new Date,s=e=>o.getFullYear()===t&&o.getMonth()===n&&o.getDate()===e,c={};for(let e of this.events){if(!e.date)continue;let r=new Date(e.date+`T00:00:00`);r.getFullYear()===t&&r.getMonth()===n&&(c[r.getDate()]??=[]).push(e)}let l=[`Mon`,`Tue`,`Wed`,`Thu`,`Fri`,`Sat`,`Sun`],u=[];for(let e=0;e<i;e++)u.push(w`<div class="cell blank"></div>`);for(let e=1;e<=a;e++)u.push(w`
                 <div class="cell ${s(e)?`today`:``}">
                     <span class="num">${e}</span>
-                    ${(c[e]??[]).map(e=>T`
+                    ${(c[e]??[]).map(e=>w`
                         <span role="button" tabindex="0" class="chip ${e.actionId?`clickable`:``}"
                               style="${e.color?`--mateu-cal-accent: ${e.color};`:``}"
                               title="${e.title??``}"
-                              @click="${()=>this.clickEvent(e)}" @keydown="${R(()=>this.clickEvent(e))}">${e.title}</span>
+                              @click="${()=>this.clickEvent(e)}" @keydown="${L(()=>this.clickEvent(e))}">${e.title}</span>
                     `)}
                 </div>
-            `);return T`
+            `);return w`
             <div class="title">${r.toLocaleDateString(void 0,{month:`long`,year:`numeric`})}</div>
             <div class="grid">
-                ${l.map(e=>T`<div class="dow">${e}</div>`)}
+                ${l.map(e=>w`<div class="dow">${e}</div>`)}
                 ${u}
             </div>
-        `}};k([y()],Wr.prototype,`month`,void 0),k([y({type:Array})],Wr.prototype,`events`,void 0),Wr=k([g(`mateu-calendar`)],Wr);var Gr=e=>{let t=e.metadata;return T`
+        `}};O([v()],Gr.prototype,`month`,void 0),O([v({type:Array})],Gr.prototype,`events`,void 0),Gr=O([h(`mateu-calendar`)],Gr);var Kr=e=>{let t=e.metadata;return w`
         <mateu-calendar
-                month="${t.month??v}"
+                month="${t.month??_}"
                 .events="${t.events??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-calendar>
-    `},Kr=class extends b{constructor(...e){super(...e),this.plans=[]}static{this.styles=h`
+    `},qr=class extends y{constructor(...e){super(...e),this.plans=[]}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2898,33 +2898,33 @@ ${i}
         @media (prefers-color-scheme: dark) {
             .plan { background: var(--lumo-contrast-5pct, #2a2a2a); }
         }
-    `}cta(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))}render(){return T`
+    `}cta(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))}render(){return w`
             <div class="plans">
-                ${this.plans.map(e=>T`
+                ${this.plans.map(e=>w`
                     <div class="plan ${e.featured?`featured`:``}">
-                        ${e.featured?T`<span class="badge">Recommended</span>`:v}
+                        ${e.featured?w`<span class="badge">Recommended</span>`:_}
                         <span class="name">${e.name}</span>
                         <div>
                             <span class="price">${e.price}</span>
-                            ${e.period?T`<span class="period">${e.period}</span>`:v}
+                            ${e.period?w`<span class="period">${e.period}</span>`:_}
                         </div>
                         <ul>
-                            ${(e.features??[]).map(e=>T`<li>${e}</li>`)}
+                            ${(e.features??[]).map(e=>w`<li>${e}</li>`)}
                         </ul>
-                        ${e.ctaLabel?T`
+                        ${e.ctaLabel?w`
                             <button class="cta" @click="${()=>this.cta(e)}">${e.ctaLabel}</button>
-                        `:v}
+                        `:_}
                     </div>
                 `)}
             </div>
-        `}};k([y({type:Array})],Kr.prototype,`plans`,void 0),Kr=k([g(`mateu-pricing-table`)],Kr);var qr=e=>T`
+        `}};O([v({type:Array})],qr.prototype,`plans`,void 0),qr=O([h(`mateu-pricing-table`)],qr);var Jr=e=>w`
         <mateu-pricing-table
                 .plans="${e.metadata.plans??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-pricing-table>
-    `,Jr=class extends b{static{this.styles=h`
+    `,Yr=class extends y{static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -3020,26 +3020,26 @@ ${i}
             .node { background: var(--lumo-contrast-5pct, #2a2a2a); }
         }
     
-        ${z}
-    `}clickNode(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_clickedNode:e}},bubbles:!0,composed:!0}))}renderNode(e){let t=e.avatar,n=t&&(t.startsWith(`http`)||t.startsWith(`data:`));return T`
+        ${R}
+    `}clickNode(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_clickedNode:e}},bubbles:!0,composed:!0}))}renderNode(e){let t=e.avatar,n=t&&(t.startsWith(`http`)||t.startsWith(`data:`));return w`
             <li>
                 <div role="button" tabindex="0" class="node ${e.actionId?`clickable`:``}"
                      style="${e.color?`--mateu-org-accent: ${e.color};`:``}"
-                     @click="${()=>this.clickNode(e)}" @keydown="${R(()=>this.clickNode(e))}">
-                    ${t?T`<span class="avatar">${n?T`<img src="${t}" alt="">`:t}</span>`:v}
+                     @click="${()=>this.clickNode(e)}" @keydown="${L(()=>this.clickNode(e))}">
+                    ${t?w`<span class="avatar">${n?w`<img src="${t}" alt="">`:t}</span>`:_}
                     <span class="title">${e.title}</span>
-                    ${e.subtitle?T`<span class="subtitle">${e.subtitle}</span>`:v}
+                    ${e.subtitle?w`<span class="subtitle">${e.subtitle}</span>`:_}
                 </div>
-                ${e.children&&e.children.length?T`<ul>${e.children.map(e=>this.renderNode(e))}</ul>`:v}
+                ${e.children&&e.children.length?w`<ul>${e.children.map(e=>this.renderNode(e))}</ul>`:_}
             </li>
-        `}render(){return this.root?T`<div class="tree"><ul>${this.renderNode(this.root)}</ul></div>`:T``}};k([y({attribute:!1})],Jr.prototype,`root`,void 0),Jr=k([g(`mateu-org-chart`)],Jr);var Yr=e=>T`
+        `}render(){return this.root?w`<div class="tree"><ul>${this.renderNode(this.root)}</ul></div>`:w``}};O([v({attribute:!1})],Yr.prototype,`root`,void 0),Yr=O([h(`mateu-org-chart`)],Yr);var Xr=e=>w`
         <mateu-org-chart
                 .root="${e.metadata.root}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-org-chart>
-    `,Xr=1440*60*1e3,Zr=class extends b{constructor(...e){super(...e),this.cells=[]}static{this.styles=h`
+    `,Zr=1440*60*1e3,Qr=class extends y{constructor(...e){super(...e),this.cells=[]}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -3063,9 +3063,9 @@ ${i}
             margin-top: .15rem;
         }
         .legend .cell { width: 10px; height: 10px; }
-    `}color(e,t){if(e<=0||t<=0)return`var(--lumo-contrast-10pct, #ebedf0)`;let n=e/t;return`color-mix(in srgb, var(--lumo-primary-color, #1a73e8) ${Math.round((n>.75?1:n>.5?.75:n>.25?.5:.3)*100)}%, transparent)`}render(){let e=this.cells.filter(e=>!!e.date);if(!e.length)return T``;let t=e.map(e=>new Date(e.date+`T00:00:00`).getTime()),n=Math.min(...t),r=Math.max(...t),i=new Date(n);i.setDate(i.getDate()-(i.getDay()+6)%7);let a={};for(let t of e)a[t.date]=t;let o=Math.max(...e.map(e=>e.value??0),1),s=[];for(let e=i.getTime();e<=r;e+=Xr){let t=new Date(e),n=t.toISOString().slice(0,10),r=a[n],i=r?.value??0,c=(t.getDay()+6)%7+1,l=r?.label??`${n}: ${i}`;s.push(T`
+    `}color(e,t){if(e<=0||t<=0)return`var(--lumo-contrast-10pct, #ebedf0)`;let n=e/t;return`color-mix(in srgb, var(--lumo-primary-color, #1a73e8) ${Math.round((n>.75?1:n>.5?.75:n>.25?.5:.3)*100)}%, transparent)`}render(){let e=this.cells.filter(e=>!!e.date);if(!e.length)return w``;let t=e.map(e=>new Date(e.date+`T00:00:00`).getTime()),n=Math.min(...t),r=Math.max(...t),i=new Date(n);i.setDate(i.getDate()-(i.getDay()+6)%7);let a={};for(let t of e)a[t.date]=t;let o=Math.max(...e.map(e=>e.value??0),1),s=[];for(let e=i.getTime();e<=r;e+=Zr){let t=new Date(e),n=t.toISOString().slice(0,10),r=a[n],i=r?.value??0,c=(t.getDay()+6)%7+1,l=r?.label??`${n}: ${i}`;s.push(w`
                 <div class="cell" style="grid-row: ${c}; --cell: ${this.color(i,o)};" title="${l}"></div>
-            `)}return T`
+            `)}return w`
             <div class="wrap">
                 <div class="grid">${s}</div>
                 <div class="legend">
@@ -3078,14 +3078,14 @@ ${i}
                     <span>More</span>
                 </div>
             </div>
-        `}};k([y({type:Array})],Zr.prototype,`cells`,void 0),Zr=k([g(`mateu-heatmap`)],Zr);var Qr=e=>T`
+        `}};O([v({type:Array})],Qr.prototype,`cells`,void 0),Qr=O([h(`mateu-heatmap`)],Qr);var $r=e=>w`
         <mateu-heatmap
                 .cells="${e.metadata.cells??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-heatmap>
-    `,$r=class extends b{constructor(...e){super(...e),this.stages=[]}static{this.styles=h`
+    `,ei=class extends y{constructor(...e){super(...e),this.stages=[]}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .funnel { display: flex; flex-direction: column; gap: .35rem; }
         .stage { display: flex; flex-direction: column; align-items: center; gap: .1rem; }
@@ -3104,13 +3104,13 @@ ${i}
         .meta { display: flex; gap: .5rem; align-items: baseline; }
         .label { font-weight: 600; color: var(--lumo-body-text-color, #222); }
         .conv { color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-xs, .75rem); }
-    `}render(){let e=this.stages;if(!e.length)return T``;let t=e[0].value??0,n=Math.max(...e.map(e=>e.value??0),1);return T`
+    `}render(){let e=this.stages;if(!e.length)return w``;let t=e[0].value??0,n=Math.max(...e.map(e=>e.value??0),1);return w`
             <div class="funnel">
-                ${e.map((r,i)=>{let a=r.value??0,o=n>0?Math.max(6,a/n*100):6,s=i>0?e[i-1].value??0:t,c=i===0?t>0?`100%`:``:s>0?`${Math.round(a/s*100)}%`:`0%`;return T`
+                ${e.map((r,i)=>{let a=r.value??0,o=n>0?Math.max(6,a/n*100):6,s=i>0?e[i-1].value??0:t,c=i===0?t>0?`100%`:``:s>0?`${Math.round(a/s*100)}%`:`0%`;return w`
                         <div class="stage">
                             <div class="meta">
                                 <span class="label">${r.label}</span>
-                                ${i>0?T`<span class="conv">${c} of previous</span>`:v}
+                                ${i>0?w`<span class="conv">${c} of previous</span>`:_}
                             </div>
                             <div class="bar" style="width: ${o}%; ${r.color?`--bar: ${r.color};`:``}">
                                 ${a.toLocaleString()}
@@ -3118,38 +3118,38 @@ ${i}
                         </div>
                     `})}
             </div>
-        `}};k([y({type:Array})],$r.prototype,`stages`,void 0),$r=k([g(`mateu-funnel`)],$r);var ei=e=>T`
+        `}};O([v({type:Array})],ei.prototype,`stages`,void 0),ei=O([h(`mateu-funnel`)],ei);var ti=e=>w`
         <mateu-funnel
                 .stages="${e.metadata.stages??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-funnel>
-    `,ti=class extends b{constructor(...e){super(...e),this.values=[],this.labels=[],this.area=!1}static{this.styles=h`
+    `,ni=class extends y{constructor(...e){super(...e),this.values=[],this.labels=[],this.area=!1}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .title { font-weight: 600; margin-bottom: .35rem; color: var(--lumo-body-text-color, #222); }
         svg { display: block; width: 100%; height: auto; overflow: visible; }
         .labels { display: flex; justify-content: space-between; color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-xs, .72rem); margin-top: .2rem; }
-    `}render(){let e=this.values;if(!e||e.length<2)return T``;let t=Math.min(...e),n=Math.max(...e),r=n-t||1,i=584/(e.length-1),a=e.map((e,n)=>[8+n*i,8+144*(1-(e-t)/r)]),o=a.map(([e,t],n)=>`${n===0?`M`:`L`}${e.toFixed(1)} ${t.toFixed(1)}`).join(` `),s=`${o} L${a[a.length-1][0].toFixed(1)} 152 L${a[0][0].toFixed(1)} 152 Z`,c=this.color||`var(--lumo-primary-color, #1a73e8)`,l=e.indexOf(n),u=e.indexOf(t);return T`
-            ${this.heading?T`<div class="title">${this.heading}</div>`:v}
+    `}render(){let e=this.values;if(!e||e.length<2)return w``;let t=Math.min(...e),n=Math.max(...e),r=n-t||1,i=584/(e.length-1),a=e.map((e,n)=>[8+n*i,8+144*(1-(e-t)/r)]),o=a.map(([e,t],n)=>`${n===0?`M`:`L`}${e.toFixed(1)} ${t.toFixed(1)}`).join(` `),s=`${o} L${a[a.length-1][0].toFixed(1)} 152 L${a[0][0].toFixed(1)} 152 Z`,c=this.color||`var(--lumo-primary-color, #1a73e8)`,l=e.indexOf(n),u=e.indexOf(t);return w`
+            ${this.heading?w`<div class="title">${this.heading}</div>`:_}
             <svg viewBox="0 0 ${600} ${160}" preserveAspectRatio="none">
-                ${this.area?w`<path d="${s}" fill="${c}" opacity="0.12"></path>`:v}
+                ${this.area?C`<path d="${s}" fill="${c}" opacity="0.12"></path>`:_}
                 <path d="${o}" fill="none" stroke="${c}" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"></path>
-                ${a.map((t,n)=>n===l||n===u?w`<circle cx="${t[0]}" cy="${t[1]}" r="3.2" fill="${c}"><title>${this.labels[n]??``}: ${e[n]}</title></circle>`:w`<circle cx="${t[0]}" cy="${t[1]}" r="6" fill="transparent"><title>${this.labels[n]??``}: ${e[n]}</title></circle>`)}
+                ${a.map((t,n)=>n===l||n===u?C`<circle cx="${t[0]}" cy="${t[1]}" r="3.2" fill="${c}"><title>${this.labels[n]??``}: ${e[n]}</title></circle>`:C`<circle cx="${t[0]}" cy="${t[1]}" r="6" fill="transparent"><title>${this.labels[n]??``}: ${e[n]}</title></circle>`)}
             </svg>
-            ${this.labels&&this.labels.length?T`<div class="labels"><span>${this.labels[0]}</span><span>${this.labels[this.labels.length-1]}</span></div>`:v}
-        `}};k([y()],ti.prototype,`heading`,void 0),k([y({type:Array})],ti.prototype,`values`,void 0),k([y({type:Array})],ti.prototype,`labels`,void 0),k([y()],ti.prototype,`color`,void 0),k([y({type:Boolean})],ti.prototype,`area`,void 0),ti=k([g(`mateu-trend-chart`)],ti);var ni=e=>{let t=e.metadata;return T`
+            ${this.labels&&this.labels.length?w`<div class="labels"><span>${this.labels[0]}</span><span>${this.labels[this.labels.length-1]}</span></div>`:_}
+        `}};O([v()],ni.prototype,`heading`,void 0),O([v({type:Array})],ni.prototype,`values`,void 0),O([v({type:Array})],ni.prototype,`labels`,void 0),O([v()],ni.prototype,`color`,void 0),O([v({type:Boolean})],ni.prototype,`area`,void 0),ni=O([h(`mateu-trend-chart`)],ni);var ri=e=>{let t=e.metadata;return w`
         <mateu-trend-chart
-                heading="${t.title??v}"
-                color="${t.color??v}"
+                heading="${t.title??_}"
+                color="${t.color??_}"
                 ?area="${t.area??!1}"
                 .values="${t.values??[]}"
                 .labels="${t.labels??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-trend-chart>
-    `},ri=class extends b{constructor(...e){super(...e),this.features=[],this.columns=0}static{this.styles=h`
+    `},ii=class extends y{constructor(...e){super(...e),this.features=[],this.columns=0}static{this.styles=m`
         :host { display: block; width: 100%; }
         .grid {
             display: grid;
@@ -3179,26 +3179,26 @@ ${i}
             .card { background: var(--lumo-contrast-5pct, #2a2a2a); }
         }
     
-        ${z}
-    `}clickFeature(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))}render(){return T`
+        ${R}
+    `}clickFeature(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))}render(){return w`
             <div class="grid" style="grid-template-columns: ${this.columns&&this.columns>0?`repeat(${this.columns}, minmax(0, 1fr))`:`repeat(auto-fit, minmax(15rem, 1fr))`};">
-                ${this.features.map(e=>T`
-                    <div role="button" tabindex="0" class="card ${e.actionId?`clickable`:``}" @click="${()=>this.clickFeature(e)}" @keydown="${R(()=>this.clickFeature(e))}">
-                        ${e.icon?T`<span class="icon">${e.icon}</span>`:v}
+                ${this.features.map(e=>w`
+                    <div role="button" tabindex="0" class="card ${e.actionId?`clickable`:``}" @click="${()=>this.clickFeature(e)}" @keydown="${L(()=>this.clickFeature(e))}">
+                        ${e.icon?w`<span class="icon">${e.icon}</span>`:_}
                         <span class="title">${e.title}</span>
-                        ${e.description?T`<span class="desc">${e.description}</span>`:v}
+                        ${e.description?w`<span class="desc">${e.description}</span>`:_}
                     </div>
                 `)}
             </div>
-        `}};k([y({type:Array})],ri.prototype,`features`,void 0),k([y({type:Number})],ri.prototype,`columns`,void 0),ri=k([g(`mateu-feature-grid`)],ri);var ii=e=>{let t=e.metadata;return T`
+        `}};O([v({type:Array})],ii.prototype,`features`,void 0),O([v({type:Number})],ii.prototype,`columns`,void 0),ii=O([h(`mateu-feature-grid`)],ii);var ai=e=>{let t=e.metadata;return w`
         <mateu-feature-grid
                 .features="${t.features??[]}"
                 .columns="${t.columns??0}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-feature-grid>
-    `},ai=class extends b{constructor(...e){super(...e),this.items=[]}static{this.styles=h`
+    `},oi=class extends y{constructor(...e){super(...e),this.items=[]}static{this.styles=m`
         :host { display: block; width: 100%; }
         .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr)); gap: var(--lumo-space-m, 1rem); }
         .card {
@@ -3222,30 +3222,30 @@ ${i}
         .name { font-weight: 600; color: var(--lumo-body-text-color, #222); }
         .role { color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-xs, .75rem); }
         @media (prefers-color-scheme: dark) { .card { background: var(--lumo-contrast-5pct, #2a2a2a); } }
-    `}stars(e){let t=Math.max(0,Math.min(5,e||0));return`★`.repeat(t)+`☆`.repeat(5-t)}render(){return T`
+    `}stars(e){let t=Math.max(0,Math.min(5,e||0));return`★`.repeat(t)+`☆`.repeat(5-t)}render(){return w`
             <div class="grid">
-                ${this.items.map(e=>{let t=e.avatar&&(e.avatar.startsWith(`http`)||e.avatar.startsWith(`data:`));return T`
+                ${this.items.map(e=>{let t=e.avatar&&(e.avatar.startsWith(`http`)||e.avatar.startsWith(`data:`));return w`
                         <div class="card">
-                            ${e.rating?T`<div class="stars">${this.stars(e.rating)}</div>`:v}
+                            ${e.rating?w`<div class="stars">${this.stars(e.rating)}</div>`:_}
                             <div class="quote">${e.quote}</div>
                             <div class="author">
-                                ${e.avatar?T`<span class="avatar">${t?T`<img src="${e.avatar}" alt="">`:e.avatar}</span>`:v}
+                                ${e.avatar?w`<span class="avatar">${t?w`<img src="${e.avatar}" alt="">`:e.avatar}</span>`:_}
                                 <div>
                                     <div class="name">${e.author}</div>
-                                    ${e.role?T`<div class="role">${e.role}</div>`:v}
+                                    ${e.role?w`<div class="role">${e.role}</div>`:_}
                                 </div>
                             </div>
                         </div>
                     `})}
             </div>
-        `}};k([y({type:Array})],ai.prototype,`items`,void 0),ai=k([g(`mateu-testimonials`)],ai);var oi=e=>T`
+        `}};O([v({type:Array})],oi.prototype,`items`,void 0),oi=O([h(`mateu-testimonials`)],oi);var si=e=>w`
         <mateu-testimonials
                 .items="${e.metadata.items??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-testimonials>
-    `,si=class extends b{constructor(...e){super(...e),this.items=[],this.openSet=new Set,this.seeded=!1}static{this.styles=h`
+    `,ci=class extends y{constructor(...e){super(...e),this.items=[],this.openSet=new Set,this.seeded=!1}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-m, 1rem); }
         .list {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -3269,27 +3269,27 @@ ${i}
         }
         @media (prefers-color-scheme: dark) { .q { background: var(--lumo-contrast-5pct, #2a2a2a); } }
     
-        ${z}
-    `}seed(){this.seeded||(this.seeded=!0,this.items.forEach((e,t)=>{e.open&&this.openSet.add(t)}))}toggle(e){this.openSet.has(e)?this.openSet.delete(e):this.openSet.add(e),this.requestUpdate()}render(){return this.seed(),T`
+        ${R}
+    `}seed(){this.seeded||(this.seeded=!0,this.items.forEach((e,t)=>{e.open&&this.openSet.add(t)}))}toggle(e){this.openSet.has(e)?this.openSet.delete(e):this.openSet.add(e),this.requestUpdate()}render(){return this.seed(),w`
             <div class="list">
-                ${this.items.map((e,t)=>{let n=this.openSet.has(t);return T`
+                ${this.items.map((e,t)=>{let n=this.openSet.has(t);return w`
                         <div class="item ${n?`open`:``}">
-                            <div role="button" tabindex="0" aria-expanded="${n}" class="q" @click="${()=>this.toggle(t)}" @keydown="${R(()=>this.toggle(t))}">
+                            <div role="button" tabindex="0" aria-expanded="${n}" class="q" @click="${()=>this.toggle(t)}" @keydown="${L(()=>this.toggle(t))}">
                                 <span>${e.question}</span>
                                 <span class="chevron">›</span>
                             </div>
-                            ${n?T`<div class="a">${e.answer}</div>`:``}
+                            ${n?w`<div class="a">${e.answer}</div>`:``}
                         </div>
                     `})}
             </div>
-        `}};k([y({type:Array})],si.prototype,`items`,void 0),k([C()],si.prototype,`openSet`,void 0),si=k([g(`mateu-faq`)],si);var ci=e=>T`
+        `}};O([v({type:Array})],ci.prototype,`items`,void 0),O([S()],ci.prototype,`openSet`,void 0),ci=O([h(`mateu-faq`)],ci);var li=e=>w`
         <mateu-faq
                 .items="${e.metadata.items??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-faq>
-    `,li=class extends b{static{this.styles=h`
+    `,ui=class extends y{static{this.styles=m`
         :host { display: block; width: 100%; }
         .callout {
             display: flex; gap: 1rem; align-items: flex-start;
@@ -3309,28 +3309,28 @@ ${i}
             background: var(--accent, var(--lumo-primary-color, #1a73e8)); color: #fff;
         }
         .cta:hover { filter: brightness(.95); }
-    `}themeVars(){switch(this.theme){case`success`:return`--accent: var(--lumo-success-color, #12b76a); --bg: var(--lumo-success-color-10pct, rgba(18,183,106,.1));`;case`warning`:return`--accent: #f59e0b; --bg: rgba(245,158,11,.12);`;case`danger`:return`--accent: var(--lumo-error-color, #e11d48); --bg: var(--lumo-error-color-10pct, rgba(225,29,72,.1));`;default:return`--accent: var(--lumo-primary-color, #1a73e8); --bg: var(--lumo-primary-color-10pct, rgba(26,115,232,.1));`}}cta(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId},bubbles:!0,composed:!0}))}render(){return T`
+    `}themeVars(){switch(this.theme){case`success`:return`--accent: var(--lumo-success-color, #12b76a); --bg: var(--lumo-success-color-10pct, rgba(18,183,106,.1));`;case`warning`:return`--accent: #f59e0b; --bg: rgba(245,158,11,.12);`;case`danger`:return`--accent: var(--lumo-error-color, #e11d48); --bg: var(--lumo-error-color-10pct, rgba(225,29,72,.1));`;default:return`--accent: var(--lumo-primary-color, #1a73e8); --bg: var(--lumo-primary-color-10pct, rgba(26,115,232,.1));`}}cta(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId},bubbles:!0,composed:!0}))}render(){return w`
             <div class="callout" style="${this.themeVars()}">
-                ${this.icon?T`<span class="icon">${this.icon}</span>`:v}
+                ${this.icon?w`<span class="icon">${this.icon}</span>`:_}
                 <div class="body">
-                    ${this.heading?T`<span class="heading">${this.heading}</span>`:v}
-                    ${this.description?T`<span class="desc">${this.description}</span>`:v}
-                    ${this.ctaLabel?T`<button class="cta" @click="${()=>this.cta()}">${this.ctaLabel}</button>`:v}
+                    ${this.heading?w`<span class="heading">${this.heading}</span>`:_}
+                    ${this.description?w`<span class="desc">${this.description}</span>`:_}
+                    ${this.ctaLabel?w`<button class="cta" @click="${()=>this.cta()}">${this.ctaLabel}</button>`:_}
                 </div>
             </div>
-        `}};k([y()],li.prototype,`heading`,void 0),k([y()],li.prototype,`description`,void 0),k([y()],li.prototype,`icon`,void 0),k([y()],li.prototype,`ctaLabel`,void 0),k([y()],li.prototype,`actionId`,void 0),k([y()],li.prototype,`theme`,void 0),li=k([g(`mateu-callout-card`)],li);var ui=e=>{let t=e.metadata;return T`
+        `}};O([v()],ui.prototype,`heading`,void 0),O([v()],ui.prototype,`description`,void 0),O([v()],ui.prototype,`icon`,void 0),O([v()],ui.prototype,`ctaLabel`,void 0),O([v()],ui.prototype,`actionId`,void 0),O([v()],ui.prototype,`theme`,void 0),ui=O([h(`mateu-callout-card`)],ui);var di=e=>{let t=e.metadata;return w`
         <mateu-callout-card
-                heading="${t.title??v}"
-                description="${t.description??v}"
-                icon="${t.icon??v}"
-                ctaLabel="${t.ctaLabel??v}"
-                actionId="${t.actionId??v}"
-                theme="${t.theme??v}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                heading="${t.title??_}"
+                description="${t.description??_}"
+                icon="${t.icon??_}"
+                ctaLabel="${t.ctaLabel??_}"
+                actionId="${t.actionId??_}"
+                theme="${t.theme??_}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-callout-card>
-    `},di=class extends b{constructor(...e){super(...e),this.comments=[]}static{this.styles=h`
+    `},fi=class extends y{constructor(...e){super(...e),this.comments=[]}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .thread { display: flex; flex-direction: column; gap: 1rem; }
         .replies {
@@ -3350,26 +3350,26 @@ ${i}
         .author { font-weight: 600; color: var(--lumo-body-text-color, #222); }
         .time { color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-xs, .72rem); }
         .text { color: var(--lumo-body-text-color, #333); margin-top: .15rem; line-height: 1.5; }
-    `}renderComment(e){let t=e.avatar&&(e.avatar.startsWith(`http`)||e.avatar.startsWith(`data:`));return T`
+    `}renderComment(e){let t=e.avatar&&(e.avatar.startsWith(`http`)||e.avatar.startsWith(`data:`));return w`
             <div class="comment">
-                <span class="avatar">${e.avatar?t?T`<img src="${e.avatar}" alt="">`:e.avatar:e.author?.[0]??`?`}</span>
+                <span class="avatar">${e.avatar?t?w`<img src="${e.avatar}" alt="">`:e.avatar:e.author?.[0]??`?`}</span>
                 <div class="body">
                     <div class="head">
                         <span class="author">${e.author}</span>
-                        ${e.timestamp?T`<span class="time">${e.timestamp}</span>`:v}
+                        ${e.timestamp?w`<span class="time">${e.timestamp}</span>`:_}
                     </div>
                     <div class="text">${e.text}</div>
-                    ${e.replies&&e.replies.length?T`<div class="replies">${e.replies.map(e=>this.renderComment(e))}</div>`:v}
+                    ${e.replies&&e.replies.length?w`<div class="replies">${e.replies.map(e=>this.renderComment(e))}</div>`:_}
                 </div>
             </div>
-        `}render(){return T`<div class="thread">${this.comments.map(e=>this.renderComment(e))}</div>`}};k([y({type:Array})],di.prototype,`comments`,void 0),di=k([g(`mateu-comment-thread`)],di);var fi=e=>T`
+        `}render(){return w`<div class="thread">${this.comments.map(e=>this.renderComment(e))}</div>`}};O([v({type:Array})],fi.prototype,`comments`,void 0),fi=O([h(`mateu-comment-thread`)],fi);var pi=e=>w`
         <mateu-comment-thread
                 .comments="${e.metadata.comments??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-comment-thread>
-    `,pi={pdf:`📕`,image:`🖼️`,img:`🖼️`,doc:`📘`,docx:`📘`,word:`📘`,xls:`📗`,xlsx:`📗`,excel:`📗`,sheet:`📗`,zip:`🗜️`,archive:`🗜️`,video:`🎬`,audio:`🎵`,code:`💻`,csv:`📄`,txt:`📄`},mi=class extends b{constructor(...e){super(...e),this.files=[]}static{this.styles=h`
+    `,mi={pdf:`📕`,image:`🖼️`,img:`🖼️`,doc:`📘`,docx:`📘`,word:`📘`,xls:`📗`,xlsx:`📗`,excel:`📗`,sheet:`📗`,zip:`🗜️`,archive:`🗜️`,video:`🎬`,audio:`🎵`,code:`💻`,csv:`📄`,txt:`📄`},hi=class extends y{constructor(...e){super(...e),this.files=[]}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .list {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -3385,24 +3385,24 @@ ${i}
         .size { color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-xs, .75rem); flex: 0 0 auto; }
         .dl { color: var(--lumo-primary-color, #1a73e8); flex: 0 0 auto; }
     
-        ${z}
-    `}icon(e){return e&&pi[e.toLowerCase()]||`📄`}clickFile(e,t){e.url||e.actionId&&(t.preventDefault(),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_file:e}},bubbles:!0,composed:!0})))}render(){return T`
+        ${R}
+    `}icon(e){return e&&mi[e.toLowerCase()]||`📄`}clickFile(e,t){e.url||e.actionId&&(t.preventDefault(),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_file:e}},bubbles:!0,composed:!0})))}render(){return w`
             <div class="list">
-                ${this.files.map(e=>{let t=!!e.url||!!e.actionId,n=T`
+                ${this.files.map(e=>{let t=!!e.url||!!e.actionId,n=w`
                         <span class="icon">${this.icon(e.type)}</span>
                         <span class="name">${e.name}</span>
-                        ${e.size?T`<span class="size">${e.size}</span>`:v}
-                        ${e.url?T`<span class="dl">⬇</span>`:v}
-                    `;return e.url?T`<a class="file clickable" href="${e.url}" download target="_blank" rel="noopener">${n}</a>`:T`<div role="button" tabindex="0" class="file ${t?`clickable`:``}" @click="${t=>this.clickFile(e,t)}" @keydown="${R(t=>this.clickFile(e,t))}">${n}</div>`})}
+                        ${e.size?w`<span class="size">${e.size}</span>`:_}
+                        ${e.url?w`<span class="dl">⬇</span>`:_}
+                    `;return e.url?w`<a class="file clickable" href="${e.url}" download target="_blank" rel="noopener">${n}</a>`:w`<div role="button" tabindex="0" class="file ${t?`clickable`:``}" @click="${t=>this.clickFile(e,t)}" @keydown="${L(t=>this.clickFile(e,t))}">${n}</div>`})}
             </div>
-        `}};k([y({type:Array})],mi.prototype,`files`,void 0),mi=k([g(`mateu-file-list`)],mi);var hi=e=>T`
+        `}};O([v({type:Array})],hi.prototype,`files`,void 0),hi=O([h(`mateu-file-list`)],hi);var gi=e=>w`
         <mateu-file-list
                 .files="${e.metadata.files??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-file-list>
-    `,gi=class extends b{constructor(...e){super(...e),this.items=[],this.localDone=new Map}static{this.styles=h`
+    `,_i=class extends y{constructor(...e){super(...e),this.items=[],this.localDone=new Map}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .head { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: .5rem; }
         .title { font-weight: 700; color: var(--lumo-body-text-color, #222); }
@@ -3419,28 +3419,28 @@ ${i}
         .label { color: var(--lumo-body-text-color, #333); }
         .item.done .label { color: var(--lumo-secondary-text-color, #999); text-decoration: line-through; }
     
-        ${z}
-    `}isDone(e,t){return this.localDone.has(t)?!!this.localDone.get(t):!!e.done}toggle(e,t){let n=!this.isDone(e,t);this.localDone.set(t,n),this.requestUpdate(),e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_item:e,_done:n}},bubbles:!0,composed:!0}))}render(){let e=this.items.length,t=this.items.filter((e,t)=>this.isDone(e,t)).length,n=e>0?Math.round(t/e*100):0;return T`
+        ${R}
+    `}isDone(e,t){return this.localDone.has(t)?!!this.localDone.get(t):!!e.done}toggle(e,t){let n=!this.isDone(e,t);this.localDone.set(t,n),this.requestUpdate(),e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_item:e,_done:n}},bubbles:!0,composed:!0}))}render(){let e=this.items.length,t=this.items.filter((e,t)=>this.isDone(e,t)).length,n=e>0?Math.round(t/e*100):0;return w`
             <div class="head">
-                ${this.heading?T`<span class="title">${this.heading}</span>`:T`<span></span>`}
+                ${this.heading?w`<span class="title">${this.heading}</span>`:w`<span></span>`}
                 <span class="count">${t} / ${e}</span>
             </div>
             <div class="bar"><div class="fill" style="width: ${n}%;"></div></div>
-            ${this.items.map((e,t)=>{let n=this.isDone(e,t);return T`
-                    <div role="button" tabindex="0" class="item ${n?`done`:``}" @click="${()=>this.toggle(e,t)}" @keydown="${R(()=>this.toggle(e,t))}">
-                        <span class="box">${n?`✓`:v}</span>
+            ${this.items.map((e,t)=>{let n=this.isDone(e,t);return w`
+                    <div role="button" tabindex="0" class="item ${n?`done`:``}" @click="${()=>this.toggle(e,t)}" @keydown="${L(()=>this.toggle(e,t))}">
+                        <span class="box">${n?`✓`:_}</span>
                         <span class="label">${e.label}</span>
                     </div>
                 `})}
-        `}};k([y()],gi.prototype,`heading`,void 0),k([y({type:Array})],gi.prototype,`items`,void 0),k([C()],gi.prototype,`localDone`,void 0),gi=k([g(`mateu-checklist`)],gi);var _i=e=>{let t=e.metadata;return T`
+        `}};O([v()],_i.prototype,`heading`,void 0),O([v({type:Array})],_i.prototype,`items`,void 0),O([S()],_i.prototype,`localDone`,void 0),_i=O([h(`mateu-checklist`)],_i);var vi=e=>{let t=e.metadata;return w`
         <mateu-checklist
-                heading="${t.title??v}"
+                heading="${t.title??_}"
                 .items="${t.items??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-checklist>
-    `},vi=class extends b{static{this.styles=h`
+    `},yi=class extends y{static{this.styles=m`
         :host { display: block; width: 100%; }
         .card {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -3462,38 +3462,38 @@ ${i}
         .delta.down { color: var(--lumo-error-color, #e11d48); background: var(--lumo-error-color-10pct, rgba(225,29,72,.12)); }
         .delta.flat { color: var(--lumo-secondary-text-color, #888); background: var(--lumo-contrast-10pct, rgba(0,0,0,.06)); }
         @media (prefers-color-scheme: dark) { .card { background: var(--lumo-contrast-5pct, #2a2a2a); } }
-    `}render(){let e=this.trend??`flat`;return T`
+    `}render(){let e=this.trend??`flat`;return w`
             <div class="card">
-                ${this.heading?T`<div class="title">${this.heading}</div>`:v}
+                ${this.heading?w`<div class="title">${this.heading}</div>`:_}
                 <div class="row">
                     <div class="side">
-                        ${this.leftLabel?T`<div class="label">${this.leftLabel}</div>`:v}
+                        ${this.leftLabel?w`<div class="label">${this.leftLabel}</div>`:_}
                         <div class="value">${this.leftValue}</div>
                     </div>
                     <div class="mid">
                         <span class="arrow">${`→`}</span>
-                        ${this.delta?T`<span class="delta ${e}">${e===`up`?`▲`:e===`down`?`▼`:``} ${this.delta}</span>`:v}
+                        ${this.delta?w`<span class="delta ${e}">${e===`up`?`▲`:e===`down`?`▼`:``} ${this.delta}</span>`:_}
                     </div>
                     <div class="side">
-                        ${this.rightLabel?T`<div class="label">${this.rightLabel}</div>`:v}
+                        ${this.rightLabel?w`<div class="label">${this.rightLabel}</div>`:_}
                         <div class="value">${this.rightValue}</div>
                     </div>
                 </div>
             </div>
-        `}};k([y()],vi.prototype,`heading`,void 0),k([y()],vi.prototype,`leftLabel`,void 0),k([y()],vi.prototype,`leftValue`,void 0),k([y()],vi.prototype,`rightLabel`,void 0),k([y()],vi.prototype,`rightValue`,void 0),k([y()],vi.prototype,`delta`,void 0),k([y()],vi.prototype,`trend`,void 0),vi=k([g(`mateu-comparison-card`)],vi);var yi=e=>{let t=e.metadata;return T`
+        `}};O([v()],yi.prototype,`heading`,void 0),O([v()],yi.prototype,`leftLabel`,void 0),O([v()],yi.prototype,`leftValue`,void 0),O([v()],yi.prototype,`rightLabel`,void 0),O([v()],yi.prototype,`rightValue`,void 0),O([v()],yi.prototype,`delta`,void 0),O([v()],yi.prototype,`trend`,void 0),yi=O([h(`mateu-comparison-card`)],yi);var bi=e=>{let t=e.metadata;return w`
         <mateu-comparison-card
-                heading="${t.title??v}"
-                leftLabel="${t.leftLabel??v}"
-                leftValue="${t.leftValue??v}"
-                rightLabel="${t.rightLabel??v}"
-                rightValue="${t.rightValue??v}"
-                delta="${t.delta??v}"
-                trend="${t.trend??v}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                heading="${t.title??_}"
+                leftLabel="${t.leftLabel??_}"
+                leftValue="${t.leftValue??_}"
+                rightLabel="${t.rightLabel??_}"
+                rightValue="${t.rightValue??_}"
+                delta="${t.delta??_}"
+                trend="${t.trend??_}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-comparison-card>
-    `},bi=h`
+    `},xi=m`
     .chip {
         display: inline-flex;
         align-items: center;
@@ -3523,7 +3523,7 @@ ${i}
         color: var(--lumo-contrast-80pct, #333);
         background: var(--lumo-contrast-10pct, rgba(0, 0, 0, .08));
     }
-`,xi=new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}),Si=e=>xi.format(e),Ci=(e,t)=>{let n=e<0?`-`:``,r=Si(Math.abs(e));return t?`${n}${t} ${r}`:`${n}${r}`},wi=(e,t)=>t?`${Si(e)} ${t}`:Si(e),Ti=class extends b{constructor(...e){super(...e),this.title=``,this.badges=[],this.facts=[]}static{this.styles=[bi,h`
+`,Si=new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}),Ci=e=>Si.format(e),wi=(e,t)=>{let n=e<0?`-`:``,r=Ci(Math.abs(e));return t?`${n}${t} ${r}`:`${n}${r}`},Ti=(e,t)=>t?`${Ci(e)} ${t}`:Ci(e),Ei=class extends y{constructor(...e){super(...e),this.title=``,this.badges=[],this.facts=[]}static{this.styles=[xi,m`
         :host { display: block; width: 100%; }
         .card {
             display: flex;
@@ -3579,34 +3579,34 @@ ${i}
             color: var(--lumo-primary-text-color, #1a73e8);
         }
         .metric .caption { font-size: var(--lumo-font-size-xs, .75rem); color: var(--lumo-secondary-text-color, #888); }
-    `]}render(){let e=!!(this.metricLabel||this.metricValue||this.metricCaption);return T`
+    `]}render(){let e=!!(this.metricLabel||this.metricValue||this.metricCaption);return w`
             <div class="card">
                 <div class="main">
                     <div class="title-row">
                         <span class="title">${this.title}</span>
-                        ${this.badges.map(e=>T`<span class="chip ${e.color??``}">${e.label}</span>`)}
+                        ${this.badges.map(e=>w`<span class="chip ${e.color??``}">${e.label}</span>`)}
                     </div>
-                    ${this.subtitle?T`<span class="subtitle">${this.subtitle}</span>`:v}
-                    ${this.facts.length?T`
+                    ${this.subtitle?w`<span class="subtitle">${this.subtitle}</span>`:_}
+                    ${this.facts.length?w`
                         <div class="facts">
-                            ${this.facts.map(e=>T`
+                            ${this.facts.map(e=>w`
                                 <div class="fact">
                                     <span class="label">${e.label}</span>
                                     <span class="value">${e.value}</span>
                                 </div>
                             `)}
                         </div>
-                    `:v}
+                    `:_}
                 </div>
-                ${e?T`
+                ${e?w`
                     <div class="metric">
-                        ${this.metricLabel?T`<span class="label">${this.metricLabel}</span>`:v}
-                        ${this.metricValue?T`<span class="value">${this.metricValue}</span>`:v}
-                        ${this.metricCaption?T`<span class="caption">${this.metricCaption}</span>`:v}
+                        ${this.metricLabel?w`<span class="label">${this.metricLabel}</span>`:_}
+                        ${this.metricValue?w`<span class="value">${this.metricValue}</span>`:_}
+                        ${this.metricCaption?w`<span class="caption">${this.metricCaption}</span>`:_}
                     </div>
-                `:v}
+                `:_}
             </div>
-        `}};k([y()],Ti.prototype,`title`,void 0),k([y({type:Array})],Ti.prototype,`badges`,void 0),k([y()],Ti.prototype,`subtitle`,void 0),k([y({type:Array})],Ti.prototype,`facts`,void 0),k([y()],Ti.prototype,`metricLabel`,void 0),k([y()],Ti.prototype,`metricValue`,void 0),k([y()],Ti.prototype,`metricCaption`,void 0),Ti=k([g(`mateu-entity-header`)],Ti);var Ei=e=>{if(e.__hoistedToPageHeader)return T``;let t=e.metadata;return T`
+        `}};O([v()],Ei.prototype,`title`,void 0),O([v({type:Array})],Ei.prototype,`badges`,void 0),O([v()],Ei.prototype,`subtitle`,void 0),O([v({type:Array})],Ei.prototype,`facts`,void 0),O([v()],Ei.prototype,`metricLabel`,void 0),O([v()],Ei.prototype,`metricValue`,void 0),O([v()],Ei.prototype,`metricCaption`,void 0),Ei=O([h(`mateu-entity-header`)],Ei);var Di=e=>{if(e.__hoistedToPageHeader)return w``;let t=e.metadata;return w`
         <mateu-entity-header
                 .title="${t.title??``}"
                 .badges="${t.badges??[]}"
@@ -3615,11 +3615,11 @@ ${i}
                 .metricLabel="${t.metricLabel}"
                 .metricValue="${t.metricValue}"
                 .metricCaption="${t.metricCaption}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-entity-header>
-    `},Di=class extends b{constructor(...e){super(...e),this.value=0,this.max=0}static{this.styles=h`
+    `},Oi=class extends y{constructor(...e){super(...e),this.value=0,this.max=0}static{this.styles=m`
         :host { display: block; width: 100%; }
         .meter { display: flex; flex-direction: column; gap: .35rem; }
         .label {
@@ -3641,16 +3641,16 @@ ${i}
         .fill.warning { background: var(--lumo-warning-color, #f59e0b); }
         .fill.error { background: var(--lumo-error-color, #e11d48); }
         .caption { font-size: var(--lumo-font-size-xs, .75rem); color: var(--lumo-secondary-text-color, #888); }
-    `}fillColor(){return this.dangerAt!=null&&this.value>=this.dangerAt?`error`:this.warnAt!=null&&this.value>=this.warnAt?`warning`:this.warnAt!=null||this.dangerAt!=null?`success`:`primary`}render(){let e=this.max>0?Math.min(Math.max(this.value/this.max,0),1):0,t=Math.round(e*100);return T`
+    `}fillColor(){return this.dangerAt!=null&&this.value>=this.dangerAt?`error`:this.warnAt!=null&&this.value>=this.warnAt?`warning`:this.warnAt!=null||this.dangerAt!=null?`success`:`primary`}render(){let e=this.max>0?Math.min(Math.max(this.value/this.max,0),1):0,t=Math.round(e*100);return w`
             <div class="meter">
-                ${this.label?T`<span class="label">${this.label}</span>`:v}
-                <span class="value">${wi(this.value,this.unit)}</span>
+                ${this.label?w`<span class="label">${this.label}</span>`:_}
+                <span class="value">${Ti(this.value,this.unit)}</span>
                 <div class="track">
                     <div class="fill ${this.fillColor()}" style="width: ${t}%"></div>
                 </div>
                 <span class="caption">${this.caption?this.caption:`${t}%`}</span>
             </div>
-        `}};k([y()],Di.prototype,`label`,void 0),k([y({type:Number})],Di.prototype,`value`,void 0),k([y({type:Number})],Di.prototype,`max`,void 0),k([y()],Di.prototype,`unit`,void 0),k([y()],Di.prototype,`caption`,void 0),k([y({type:Number})],Di.prototype,`warnAt`,void 0),k([y({type:Number})],Di.prototype,`dangerAt`,void 0),Di=k([g(`mateu-meter`)],Di);var Oi=e=>{let t=e.metadata;return T`
+        `}};O([v()],Oi.prototype,`label`,void 0),O([v({type:Number})],Oi.prototype,`value`,void 0),O([v({type:Number})],Oi.prototype,`max`,void 0),O([v()],Oi.prototype,`unit`,void 0),O([v()],Oi.prototype,`caption`,void 0),O([v({type:Number})],Oi.prototype,`warnAt`,void 0),O([v({type:Number})],Oi.prototype,`dangerAt`,void 0),Oi=O([h(`mateu-meter`)],Oi);var ki=e=>{let t=e.metadata;return w`
         <mateu-meter
                 .label="${t.label}"
                 .value="${t.value??0}"
@@ -3659,11 +3659,11 @@ ${i}
                 .caption="${t.caption}"
                 .warnAt="${t.warnAt}"
                 .dangerAt="${t.dangerAt}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-meter>
-    `},ki=class extends b{constructor(...e){super(...e),this.total=0,this.done=0}static{this.styles=h`
+    `},Ai=class extends y{constructor(...e){super(...e),this.total=0,this.done=0}static{this.styles=m`
         :host { display: block; width: 100%; }
         .banner {
             display: flex; align-items: center; gap: .8rem; flex-wrap: wrap;
@@ -3706,30 +3706,30 @@ ${i}
             white-space: nowrap;
         }
         button:hover { filter: brightness(1.08); }
-    `}runAction(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{}},bubbles:!0,composed:!0}))}render(){let e=this.total>0&&this.done>=this.total,t=!e&&!!this.actionLabel&&!!this.actionId;return T`
+    `}runAction(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{}},bubbles:!0,composed:!0}))}render(){let e=this.total>0&&this.done>=this.total,t=!e&&!!this.actionLabel&&!!this.actionId;return w`
             <div class="banner ${e?`complete`:``}">
                 <span class="icon">👥</span>
-                ${this.label?T`<span class="label">${this.label}</span>`:v}
+                ${this.label?w`<span class="label">${this.label}</span>`:_}
                 <div class="pills">
-                    ${Array.from({length:this.total},(e,t)=>T`
+                    ${Array.from({length:this.total},(e,t)=>w`
                         <span class="pill ${t+1<=this.done?`filled`:``}">${t+1}/${this.total}</span>
                     `)}
                 </div>
                 <span class="spacer"></span>
-                ${t?T`<button @click="${()=>this.runAction()}">${this.actionLabel} →</button>`:v}
+                ${t?w`<button @click="${()=>this.runAction()}">${this.actionLabel} →</button>`:_}
             </div>
-        `}};k([y()],ki.prototype,`label`,void 0),k([y({type:Number})],ki.prototype,`total`,void 0),k([y({type:Number})],ki.prototype,`done`,void 0),k([y()],ki.prototype,`actionLabel`,void 0),k([y()],ki.prototype,`actionId`,void 0),ki=k([g(`mateu-task-progress`)],ki);var Ai=e=>{let t=e.metadata;return T`
+        `}};O([v()],Ai.prototype,`label`,void 0),O([v({type:Number})],Ai.prototype,`total`,void 0),O([v({type:Number})],Ai.prototype,`done`,void 0),O([v()],Ai.prototype,`actionLabel`,void 0),O([v()],Ai.prototype,`actionId`,void 0),Ai=O([h(`mateu-task-progress`)],Ai);var ji=e=>{let t=e.metadata;return w`
         <mateu-task-progress
                 .label="${t.label}"
                 .total="${t.total??0}"
                 .done="${t.done??0}"
                 .actionLabel="${t.actionLabel}"
                 .actionId="${t.actionId}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-task-progress>
-    `},ji=class extends b{constructor(...e){super(...e),this.items=[],this.compact=!1,this.frameless=!1,this.columns=0,this.itemHeadingLevel=3}static{this.styles=[bi,z,h`
+    `},Mi=class extends y{constructor(...e){super(...e),this.items=[],this.compact=!1,this.frameless=!1,this.columns=0,this.itemHeadingLevel=3}static{this.styles=[xi,R,m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .list {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -3831,60 +3831,60 @@ ${i}
             cursor: pointer; font-size: 1rem;
         }
         .icon-action:hover { background: var(--lumo-contrast-5pct, rgba(0,0,0,.04)); }
-    `]}runAction(e,t){t&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_item:e.id}},bubbles:!0,composed:!0}))}rowClicked(e){this.rowActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.rowActionId,parameters:{_item:e.id}},bubbles:!0,composed:!0}))}renderItemAction(e,t,n,r){return!t||!n?v:r?T`
+    `]}runAction(e,t){t&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_item:e.id}},bubbles:!0,composed:!0}))}rowClicked(e){this.rowActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.rowActionId,parameters:{_item:e.id}},bubbles:!0,composed:!0}))}renderItemAction(e,t,n,r){return!t||!n?_:r?w`
                 <button class="icon-action" title="${t}" aria-label="${t}"
                     @click="${t=>{t.stopPropagation(),this.runAction(e,n)}}">
-                    ${I(r)}
-                </button>`:T`
+                    ${F(r)}
+                </button>`:w`
             <button class="row-action" title="${t}"
-                @click="${t=>{t.stopPropagation(),this.runAction(e,n)}}">${t}</button>`}render(){let e=this.columns>1||this.items.some(e=>e.actionId||e.actionId2||e.actionId3||(e.lines?.length??0)>0),t=this.itemHeadingLevel===4?`h4`:`h3`;return e?T`
+                @click="${t=>{t.stopPropagation(),this.runAction(e,n)}}">${t}</button>`}render(){let e=this.columns>1||this.items.some(e=>e.actionId||e.actionId2||e.actionId3||(e.lines?.length??0)>0),t=this.itemHeadingLevel===4?`h4`:`h3`;return e?w`
                 <div class="list stacked ${this.compact?`compact`:``} ${this.columns>1?`grid`:``}"
                      style="${this.columns>1?`grid-template-columns: repeat(auto-fit, minmax(min(18rem, calc(100% / ${this.columns} - 1.5rem)), 1fr));`:``}">
-                    ${this.items.map(e=>T`
+                    ${this.items.map(e=>w`
                         <div role="button" tabindex="0" class="cell ${(e.lines?.length??0)>0?`with-lines`:``} ${this.rowActionId?`clickable`:``}"
-                             @click="${()=>this.rowClicked(e)}" @keydown="${R(()=>this.rowClicked(e))}">
+                             @click="${()=>this.rowClicked(e)}" @keydown="${L(()=>this.rowClicked(e))}">
                             <div class="cell-title-row">
-                                ${t===`h4`?T`<h4 class="cell-title">${e.title}</h4>`:T`<h3 class="cell-title">${e.title}</h3>`}
-                                ${e.status?T`<span class="chip ${e.statusColor??``}">${e.status}</span>`:v}
+                                ${t===`h4`?w`<h4 class="cell-title">${e.title}</h4>`:w`<h3 class="cell-title">${e.title}</h3>`}
+                                ${e.status?w`<span class="chip ${e.statusColor??``}">${e.status}</span>`:_}
                             </div>
-                            ${e.description?T`<span class="cell-description">${e.description}</span>`:v}
-                            ${(e.lines??[]).map(e=>T`<span class="cell-line">${e}</span>`)}
-                            ${e.actionId||e.actionId2||e.actionId3?T`
+                            ${e.description?w`<span class="cell-description">${e.description}</span>`:_}
+                            ${(e.lines??[]).map(e=>w`<span class="cell-line">${e}</span>`)}
+                            ${e.actionId||e.actionId2||e.actionId3?w`
                                 <div class="cell-actions">
                                     ${this.renderItemAction(e,e.actionLabel,e.actionId,e.actionIcon)}
                                     ${this.renderItemAction(e,e.actionLabel2,e.actionId2,e.actionIcon2)}
                                     ${this.renderItemAction(e,e.actionLabel3,e.actionId3,e.actionIcon3)}
-                                </div>`:v}
+                                </div>`:_}
                         </div>
                     `)}
                 </div>
-            `:T`
+            `:w`
             <div class="list ${this.compact?`compact`:``} ${this.frameless?`frameless`:``}">
-                ${this.items.map(e=>T`
+                ${this.items.map(e=>w`
                     <div role="button" tabindex="0" class="row ${this.rowActionId?`clickable`:``}"
-                         @click="${()=>this.rowClicked(e)}" @keydown="${R(()=>this.rowClicked(e))}">
-                        ${e.avatar?T`<span class="avatar">${e.avatar}</span>`:e.icon?T`<span class="icon">${e.icon}</span>`:v}
+                         @click="${()=>this.rowClicked(e)}" @keydown="${L(()=>this.rowClicked(e))}">
+                        ${e.avatar?w`<span class="avatar">${e.avatar}</span>`:e.icon?w`<span class="icon">${e.icon}</span>`:_}
                         <div class="body">
                             <span class="title">${e.title}</span>
-                            ${e.description?T`<span class="description">${e.description}</span>`:v}
+                            ${e.description?w`<span class="description">${e.description}</span>`:_}
                         </div>
-                        ${e.status?T`<span class="chip ${e.statusColor??``}">${e.status}</span>`:v}
+                        ${e.status?w`<span class="chip ${e.statusColor??``}">${e.status}</span>`:_}
                     </div>
                 `)}
             </div>
-        `}};k([y({type:Array})],ji.prototype,`items`,void 0),k([y({type:Boolean})],ji.prototype,`compact`,void 0),k([y({type:Boolean})],ji.prototype,`frameless`,void 0),k([y()],ji.prototype,`rowActionId`,void 0),k([y({type:Number})],ji.prototype,`columns`,void 0),k([y({type:Number})],ji.prototype,`itemHeadingLevel`,void 0),ji=k([g(`mateu-status-list`)],ji);var Mi=e=>{let t=e.metadata;return T`
+        `}};O([v({type:Array})],Mi.prototype,`items`,void 0),O([v({type:Boolean})],Mi.prototype,`compact`,void 0),O([v({type:Boolean})],Mi.prototype,`frameless`,void 0),O([v()],Mi.prototype,`rowActionId`,void 0),O([v({type:Number})],Mi.prototype,`columns`,void 0),O([v({type:Number})],Mi.prototype,`itemHeadingLevel`,void 0),Mi=O([h(`mateu-status-list`)],Mi);var Ni=e=>{let t=e.metadata;return w`
         <mateu-status-list
                 .items="${t.items??[]}"
                 ?compact="${t.compact??!1}"
                 ?frameless="${t.frameless??!1}"
                 columns="${t.columns??0}"
                 itemHeadingLevel="${t.itemHeadingLevel??3}"
-                rowActionId="${S(t.rowActionId??void 0)}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                rowActionId="${x(t.rowActionId??void 0)}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-status-list>
-    `},Ni=class extends b{constructor(...e){super(...e),this.items=[]}static{this.styles=h`
+    `},Pi=class extends y{constructor(...e){super(...e),this.items=[]}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         ul {
             margin: 0; padding-inline-start: 1.2rem;
@@ -3895,24 +3895,24 @@ ${i}
             line-height: normal;
         }
         li::marker { color: var(--lumo-secondary-text-color, #888); }
-    `}render(){return T`
+    `}render(){return w`
             <ul>
-                ${this.items.map(e=>T`<li>${e}</li>`)}
+                ${this.items.map(e=>w`<li>${e}</li>`)}
             </ul>
-        `}};k([y({type:Array})],Ni.prototype,`items`,void 0),Ni=k([g(`mateu-bulleted-list`)],Ni);var Pi=e=>T`
+        `}};O([v({type:Array})],Pi.prototype,`items`,void 0),Pi=O([h(`mateu-bulleted-list`)],Pi);var Fi=e=>w`
         <mateu-bulleted-list
                 .items="${e.metadata.items??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-bulleted-list>
-    `,Fi=e=>{let t=e.metadata.attributes?.[`data-colspan`];return T`
+    `,Ii=e=>{let t=e.metadata.attributes?.[`data-colspan`];return w`
         <hr style="border: none; border-top: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1)); width: 100%; margin: var(--lumo-space-s, .5rem) 0; ${e.style??``}"
-            class="${e.cssClasses??v}"
-            id="${S(e.id??void 0)}"
-            data-colspan="${S(t)}"
-            slot="${e.slot??v}"/>
-    `},Ii={info:`ℹ`,success:`✓`,warning:`!`,danger:`!`},V=class extends b{constructor(...e){super(...e),this.text=``,this.theme=`info`,this.noIcon=!1,this.slim=!1,this.fullWidth=!1,this.hasContent=!1,this.inlineContent=!1}static{this.styles=h`
+            class="${e.cssClasses??_}"
+            id="${x(e.id??void 0)}"
+            data-colspan="${x(t)}"
+            slot="${e.slot??_}"/>
+    `},Li={info:`ℹ`,success:`✓`,warning:`!`,danger:`!`},B=class extends y{constructor(...e){super(...e),this.text=``,this.theme=`info`,this.noIcon=!1,this.slim=!1,this.fullWidth=!1,this.hasContent=!1,this.inlineContent=!1}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .notice {
             display: flex;
@@ -3975,34 +3975,34 @@ ${i}
         .warning .icon { background: #c98a1e; }
         .danger  { background: #f6e0da; } .danger .text, .danger .status   { color: #a5502e; }
         .danger  .icon  { background: #b25b3d; }
-    `}runAction(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId},bubbles:!0,composed:!0}))}render(){let e=!!this.text&&!!this.text.trim();if(!e&&!this.hasContent)return T``;let t=[`info`,`success`,`warning`,`danger`].includes(this.theme)?this.theme:`info`;return T`
+    `}runAction(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId},bubbles:!0,composed:!0}))}render(){let e=!!this.text&&!!this.text.trim();if(!e&&!this.hasContent)return w``;let t=[`info`,`success`,`warning`,`danger`].includes(this.theme)?this.theme:`info`;return w`
             <div class="notice ${t} ${this.slim?`slim`:``}">
-                ${this.noIcon?v:T`<span class="icon ${this.icon?`custom`:``}">${this.icon||Ii[t]}</span>`}
+                ${this.noIcon?_:w`<span class="icon ${this.icon?`custom`:``}">${this.icon||Li[t]}</span>`}
                 <div class="body ${this.inlineContent?`inline`:``}">
-                    ${e?T`<span class="text">${this.text}</span>`:v}
-                    ${this.hasContent?T`<div class="content"><slot></slot></div>`:v}
+                    ${e?w`<span class="text">${this.text}</span>`:_}
+                    ${this.hasContent?w`<div class="content"><slot></slot></div>`:_}
                 </div>
-                ${this.actionLabel&&this.actionId?T`<button class="notice-action" @click="${()=>this.runAction()}">${this.actionLabel}</button>`:this.status?T`<span class="status">${this.status}</span>`:v}
+                ${this.actionLabel&&this.actionId?w`<button class="notice-action" @click="${()=>this.runAction()}">${this.actionLabel}</button>`:this.status?w`<span class="status">${this.status}</span>`:_}
             </div>
-        `}};k([y()],V.prototype,`text`,void 0),k([y()],V.prototype,`theme`,void 0),k([y()],V.prototype,`icon`,void 0),k([y({type:Boolean})],V.prototype,`noIcon`,void 0),k([y()],V.prototype,`actionLabel`,void 0),k([y()],V.prototype,`actionId`,void 0),k([y()],V.prototype,`status`,void 0),k([y({type:Boolean})],V.prototype,`slim`,void 0),k([y({type:Boolean})],V.prototype,`fullWidth`,void 0),k([y({type:Boolean})],V.prototype,`hasContent`,void 0),k([y({type:Boolean})],V.prototype,`inlineContent`,void 0),V=k([g(`mateu-notice`)],V);var Li=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=rt(s.text??``,r,i,a,o)??``,l=t.children??[];return T`
+        `}};O([v()],B.prototype,`text`,void 0),O([v()],B.prototype,`theme`,void 0),O([v()],B.prototype,`icon`,void 0),O([v({type:Boolean})],B.prototype,`noIcon`,void 0),O([v()],B.prototype,`actionLabel`,void 0),O([v()],B.prototype,`actionId`,void 0),O([v()],B.prototype,`status`,void 0),O([v({type:Boolean})],B.prototype,`slim`,void 0),O([v({type:Boolean})],B.prototype,`fullWidth`,void 0),O([v({type:Boolean})],B.prototype,`hasContent`,void 0),O([v({type:Boolean})],B.prototype,`inlineContent`,void 0),B=O([h(`mateu-notice`)],B);var Ri=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=it(s.text??``,r,i,a,o)??``,l=t.children??[];return w`
         <mateu-notice
                 text="${c}"
                 theme="${s.theme??`info`}"
-                icon="${S(s.icon??void 0)}"
+                icon="${x(s.icon??void 0)}"
                 ?noIcon="${s.noIcon??!1}"
-                actionLabel="${S(s.actionLabel??void 0)}"
-                actionId="${S(s.actionId??void 0)}"
-                status="${S(s.status??void 0)}"
+                actionLabel="${x(s.actionLabel??void 0)}"
+                actionId="${x(s.actionId??void 0)}"
+                status="${x(s.status??void 0)}"
                 ?slim="${s.slim??!1}"
                 ?fullWidth="${s.fullWidth??!1}"
                 ?inlineContent="${s.inlineContent??!1}"
                 ?hasContent="${l.length>0}"
-                data-colspan="${s.fullWidth?`99`:v}"
-                style="${t.style??v}"
-                class="${t.cssClasses??v}"
-                slot="${t.slot??v}"
-        >${l.map(t=>F(e,t,n,r,i,a,o))}</mateu-notice>
-    `},Ri=class extends b{constructor(...e){super(...e),this.groups=[]}static{this.styles=[bi,z,h`
+                data-colspan="${s.fullWidth?`99`:_}"
+                style="${t.style??_}"
+                class="${t.cssClasses??_}"
+                slot="${t.slot??_}"
+        >${l.map(t=>P(e,t,n,r,i,a,o))}</mateu-notice>
+    `},zi=class extends y{constructor(...e){super(...e),this.groups=[]}static{this.styles=[xi,R,m`
         :host { display: block; width: 100%; }
         .rail { display: flex; flex-direction: column; gap: var(--lumo-space-m, 1rem); }
         .group { display: flex; flex-direction: column; gap: .45rem; }
@@ -4043,37 +4043,37 @@ ${i}
             color: var(--lumo-secondary-text-color, #888);
             white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
         }
-    `]}willUpdate(e){e.has(`groups`)&&(this.selectedId=this.groups.flatMap(e=>e.items??[]).find(e=>e.selected)?.id)}itemAction(e,t,n){e.stopPropagation(),t&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_item:n}},bubbles:!0,composed:!0}))}select(e){this.selectedId=e,this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{_item:e}},bubbles:!0,composed:!0}))}render(){return T`
+    `]}willUpdate(e){e.has(`groups`)&&(this.selectedId=this.groups.flatMap(e=>e.items??[]).find(e=>e.selected)?.id)}itemAction(e,t,n){e.stopPropagation(),t&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_item:n}},bubbles:!0,composed:!0}))}select(e){this.selectedId=e,this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{_item:e}},bubbles:!0,composed:!0}))}render(){return w`
             <div class="rail">
-                ${this.groups.map(e=>T`
+                ${this.groups.map(e=>w`
                     <div class="group" role="listbox">
-                        ${e.label?T`<span class="group-label">${e.label}</span>`:v}
-                        ${(e.items??[]).map(e=>T`
+                        ${e.label?w`<span class="group-label">${e.label}</span>`:_}
+                        ${(e.items??[]).map(e=>w`
                             <div role="option" tabindex="0" aria-selected="${e.id===this.selectedId}" class="card ${e.id===this.selectedId?`selected`:``}"
-                                 @click="${()=>this.select(e.id)}" @keydown="${R(()=>this.select(e.id))}">
+                                 @click="${()=>this.select(e.id)}" @keydown="${L(()=>this.select(e.id))}">
                                 <span class="title">${e.title}</span>
                                 <div class="meta">
-                                    ${e.caption?T`<span class="caption">${e.caption}</span>`:v}
-                                    ${(e.badges??[]).map(e=>T`<span class="chip ${e.color??``}">${e.label}</span>`)}
+                                    ${e.caption?w`<span class="caption">${e.caption}</span>`:_}
+                                    ${(e.badges??[]).map(e=>w`<span class="chip ${e.color??``}">${e.label}</span>`)}
                                 </div>
-                                ${e.actionLabel&&e.actionId?T`
+                                ${e.actionLabel&&e.actionId?w`
                                     <button class="item-action"
                                             @click="${t=>this.itemAction(t,e.actionId,e.id)}">${e.actionLabel}</button>
-                                `:v}
+                                `:_}
                             </div>
                         `)}
                     </div>
                 `)}
             </div>
-        `}};k([y()],Ri.prototype,`actionId`,void 0),k([y({type:Array})],Ri.prototype,`groups`,void 0),k([C()],Ri.prototype,`selectedId`,void 0),Ri=k([g(`mateu-task-queue`)],Ri);var zi=e=>{let t=e.metadata;return T`
+        `}};O([v()],zi.prototype,`actionId`,void 0),O([v({type:Array})],zi.prototype,`groups`,void 0),O([S()],zi.prototype,`selectedId`,void 0),zi=O([h(`mateu-task-queue`)],zi);var Bi=e=>{let t=e.metadata;return w`
         <mateu-task-queue
                 .actionId="${t.actionId}"
                 .groups="${t.groups??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-task-queue>
-    `},Bi=class extends b{constructor(...e){super(...e),this.columns=0,this.items=[]}static{this.styles=[bi,z,h`
+    `},Vi=class extends y{constructor(...e){super(...e),this.columns=0,this.items=[]}static{this.styles=[xi,R,m`
         /* explicit line-height: inside a form field wrapper the inherited one is the 44px
            field height, which blows up every text row */
         :host { display: block; width: 100%; line-height: var(--lumo-line-height-m, 1.4); }
@@ -4124,30 +4124,30 @@ ${i}
         .note.warning { color: var(--lumo-warning-text-color, #b45309); }
         .note.error { color: var(--lumo-error-text-color, #c5221f); }
         .note.contrast { color: var(--lumo-contrast-80pct, #333); }
-    `]}willUpdate(e){e.has(`items`)&&(this.selectedId=this.items.find(e=>e.selected)?.id)}select(e){e.disabled||(this.selectedId=e.id,this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{_item:e.id}},bubbles:!0,composed:!0})))}render(){return T`
+    `]}willUpdate(e){e.has(`items`)&&(this.selectedId=this.items.find(e=>e.selected)?.id)}select(e){e.disabled||(this.selectedId=e.id,this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{_item:e.id}},bubbles:!0,composed:!0})))}render(){return w`
             <div class="grid" style="${this.columns>0?`grid-template-columns: repeat(${this.columns}, minmax(0, 1fr));`:`grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));`}">
-                ${this.items.map(e=>T`
+                ${this.items.map(e=>w`
                     <div role="button" tabindex="0" class="cell ${e.disabled?`disabled`:``} ${e.recommended?`recommended`:``} ${e.id===this.selectedId?`selected`:``}"
-                         @click="${()=>this.select(e)}" @keydown="${R(()=>this.select(e))}">
-                        ${e.recommended?T`<span class="tag">${this.recommendedLabel||`Recommended`}</span>`:v}
+                         @click="${()=>this.select(e)}" @keydown="${L(()=>this.select(e))}">
+                        ${e.recommended?w`<span class="tag">${this.recommendedLabel||`Recommended`}</span>`:_}
                         <span class="title">${e.title}</span>
-                        ${e.subtitle?T`<span class="subtitle">${e.subtitle}</span>`:v}
-                        ${e.statusLabel?T`<span class="chip ${e.statusColor??``}">${e.statusLabel}</span>`:v}
-                        ${e.note?T`<span class="note ${e.noteColor??``}"><span class="dot"></span>${e.note}</span>`:v}
+                        ${e.subtitle?w`<span class="subtitle">${e.subtitle}</span>`:_}
+                        ${e.statusLabel?w`<span class="chip ${e.statusColor??``}">${e.statusLabel}</span>`:_}
+                        ${e.note?w`<span class="note ${e.noteColor??``}"><span class="dot"></span>${e.note}</span>`:_}
                     </div>
                 `)}
             </div>
-        `}};k([y()],Bi.prototype,`actionId`,void 0),k([y({type:Number})],Bi.prototype,`columns`,void 0),k([y()],Bi.prototype,`recommendedLabel`,void 0),k([y({type:Array})],Bi.prototype,`items`,void 0),k([C()],Bi.prototype,`selectedId`,void 0),Bi=k([g(`mateu-resource-grid`)],Bi);var Vi=e=>{let t=e.metadata;return T`
+        `}};O([v()],Vi.prototype,`actionId`,void 0),O([v({type:Number})],Vi.prototype,`columns`,void 0),O([v()],Vi.prototype,`recommendedLabel`,void 0),O([v({type:Array})],Vi.prototype,`items`,void 0),O([S()],Vi.prototype,`selectedId`,void 0),Vi=O([h(`mateu-resource-grid`)],Vi);var Hi=e=>{let t=e.metadata;return w`
         <mateu-resource-grid
                 .actionId="${t.actionId}"
                 .columns="${t.columns??0}"
                 .recommendedLabel="${t.recommendedLabel}"
                 .items="${t.items??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-resource-grid>
-    `},H=class extends b{constructor(...e){super(...e),this.title=``,this.features=[],this.current=!1,this.added=!1}static{this.styles=h`
+    `},V=class extends y{constructor(...e){super(...e),this.title=``,this.features=[],this.current=!1,this.added=!1}static{this.styles=m`
         /* explicit line-height: inside a form field wrapper the inherited one is the 44px
            field height, which blows up every text row */
         :host { display: block; width: 100%; line-height: var(--lumo-line-height-m, 1.4); }
@@ -4212,30 +4212,30 @@ ${i}
         button:hover { filter: brightness(1.08); }
         button.added { background: var(--lumo-success-color, #2e7d32); }
         .price { font-weight: 700; white-space: nowrap; font-variant-numeric: tabular-nums; }
-    `}runAction(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{}},bubbles:!0,composed:!0}))}render(){return T`
+    `}runAction(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{}},bubbles:!0,composed:!0}))}render(){return w`
             <div class="card ${this.current?``:`offer`}">
-                ${this.image?T`<img class="image" src="${this.image}" alt="${this.title}">`:v}
-                ${this.tag&&this.image?T`<span class="tag">${this.tag}</span>`:v}
+                ${this.image?w`<img class="image" src="${this.image}" alt="${this.title}">`:_}
+                ${this.tag&&this.image?w`<span class="tag">${this.tag}</span>`:_}
                 <div class="body">
-                    ${this.tag&&!this.image?T`<span class="tag static">${this.tag}</span>`:v}
+                    ${this.tag&&!this.image?w`<span class="tag static">${this.tag}</span>`:_}
                     <span class="title">${this.title}</span>
-                    ${this.subtitle?T`<span class="subtitle">${this.subtitle}</span>`:v}
-                    ${this.features.length?T`
+                    ${this.subtitle?w`<span class="subtitle">${this.subtitle}</span>`:_}
+                    ${this.features.length?w`
                         <div class="features">
-                            ${this.features.map(e=>T`<span class="feature">${e}</span>`)}
+                            ${this.features.map(e=>w`<span class="feature">${e}</span>`)}
                         </div>
-                    `:v}
+                    `:_}
                 </div>
                 <div class="footer">
-                    ${this.current?this.currentLabel?T`<span class="current-label">${this.currentLabel}</span>`:v:this.actionLabel&&this.actionId?T`
+                    ${this.current?this.currentLabel?w`<span class="current-label">${this.currentLabel}</span>`:_:this.actionLabel&&this.actionId?w`
                             <button class="${this.added?`added`:``}" @click="${()=>this.runAction()}">
                                 <span>${this.added&&this.addedLabel||this.actionLabel}</span>
-                                ${this.priceLabel?T`<span class="price">${this.priceLabel}</span>`:v}
+                                ${this.priceLabel?w`<span class="price">${this.priceLabel}</span>`:_}
                             </button>
-                        `:v}
+                        `:_}
                 </div>
             </div>
-        `}};k([y()],H.prototype,`tag`,void 0),k([y()],H.prototype,`title`,void 0),k([y()],H.prototype,`subtitle`,void 0),k([y()],H.prototype,`image`,void 0),k([y({type:Array})],H.prototype,`features`,void 0),k([y()],H.prototype,`priceLabel`,void 0),k([y()],H.prototype,`actionLabel`,void 0),k([y()],H.prototype,`actionId`,void 0),k([y({type:Boolean})],H.prototype,`current`,void 0),k([y()],H.prototype,`currentLabel`,void 0),k([y({type:Boolean})],H.prototype,`added`,void 0),k([y()],H.prototype,`addedLabel`,void 0),H=k([g(`mateu-offer-card`)],H);var Hi=e=>{let t=e.metadata;return T`
+        `}};O([v()],V.prototype,`tag`,void 0),O([v()],V.prototype,`title`,void 0),O([v()],V.prototype,`subtitle`,void 0),O([v()],V.prototype,`image`,void 0),O([v({type:Array})],V.prototype,`features`,void 0),O([v()],V.prototype,`priceLabel`,void 0),O([v()],V.prototype,`actionLabel`,void 0),O([v()],V.prototype,`actionId`,void 0),O([v({type:Boolean})],V.prototype,`current`,void 0),O([v()],V.prototype,`currentLabel`,void 0),O([v({type:Boolean})],V.prototype,`added`,void 0),O([v()],V.prototype,`addedLabel`,void 0),V=O([h(`mateu-offer-card`)],V);var Ui=e=>{let t=e.metadata;return w`
         <mateu-offer-card
                 .tag="${t.tag}"
                 .title="${t.title??``}"
@@ -4249,11 +4249,11 @@ ${i}
                 .currentLabel="${t.currentLabel}"
                 .added="${t.added??!1}"
                 .addedLabel="${t.addedLabel}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-offer-card>
-    `},Ui=class extends b{constructor(...e){super(...e),this.items=[],this.added=new Set}static{this.styles=h`
+    `},Wi=class extends y{constructor(...e){super(...e),this.items=[],this.added=new Set}static{this.styles=m`
         :host { display: block; width: 100%; }
         .header { display: flex; align-items: baseline; justify-content: flex-end; gap: .4rem; margin-bottom: .6rem; }
         .total-label { font-size: var(--lumo-font-size-s, .875rem); color: var(--lumo-secondary-text-color, #888); }
@@ -4318,20 +4318,20 @@ ${i}
             background: var(--lumo-primary-color, #1a73e8);
             color: var(--lumo-primary-contrast-color, #fff);
         }
-    `}willUpdate(e){e.has(`items`)&&(this.added=new Set(this.items.filter(e=>e.added).map(e=>e.id)))}total(){return this.items.filter(e=>e.id!=null&&this.added.has(e.id)).reduce((e,t)=>e+(t.price??0),0)}toggle(e){if(e.id==null)return;let t=new Set(this.added),n=!t.has(e.id);n?t.add(e.id):t.delete(e.id),this.added=t,this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{_item:e.id,_added:n,_total:this.total()}},bubbles:!0,composed:!0}))}render(){return T`
+    `}willUpdate(e){e.has(`items`)&&(this.added=new Set(this.items.filter(e=>e.added).map(e=>e.id)))}total(){return this.items.filter(e=>e.id!=null&&this.added.has(e.id)).reduce((e,t)=>e+(t.price??0),0)}toggle(e){if(e.id==null)return;let t=new Set(this.added),n=!t.has(e.id);n?t.add(e.id):t.delete(e.id),this.added=t,this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{_item:e.id,_added:n,_total:this.total()}},bubbles:!0,composed:!0}))}render(){return w`
             <div class="header">
-                ${this.totalLabel?T`<span class="total-label">${this.totalLabel}:</span>`:v}
-                <span class="total">${Ci(this.total(),this.currency)}</span>
+                ${this.totalLabel?w`<span class="total-label">${this.totalLabel}:</span>`:_}
+                <span class="total">${wi(this.total(),this.currency)}</span>
             </div>
             <div class="grid">
-                ${this.items.map(e=>{let t=e.id!=null&&this.added.has(e.id);return T`
+                ${this.items.map(e=>{let t=e.id!=null&&this.added.has(e.id);return w`
                         <div class="card ${t?`added`:``}">
-                            ${e.icon?T`<span class="icon">${e.icon}</span>`:v}
+                            ${e.icon?w`<span class="icon">${e.icon}</span>`:_}
                             <span class="title">${e.title}</span>
-                            ${e.description?T`<span class="description">${e.description}</span>`:v}
-                            ${e.includedLabel?T`<span class="included">${e.includedLabel}</span>`:T`
-                                    ${e.price==null?v:T`
-                                        <span class="price">${Ci(e.price,this.currency)}${e.unit?` / ${e.unit}`:``}</span>
+                            ${e.description?w`<span class="description">${e.description}</span>`:_}
+                            ${e.includedLabel?w`<span class="included">${e.includedLabel}</span>`:w`
+                                    ${e.price==null?_:w`
+                                        <span class="price">${wi(e.price,this.currency)}${e.unit?` / ${e.unit}`:``}</span>
                                     `}
                                     <button class="toggle ${t?`on`:``}" @click="${()=>this.toggle(e)}"
                                             aria-pressed="${t}">${t?`✓`:`+`}</button>
@@ -4339,17 +4339,17 @@ ${i}
                         </div>
                     `})}
             </div>
-        `}};k([y()],Ui.prototype,`totalLabel`,void 0),k([y()],Ui.prototype,`currency`,void 0),k([y()],Ui.prototype,`actionId`,void 0),k([y({type:Array})],Ui.prototype,`items`,void 0),k([C()],Ui.prototype,`added`,void 0),Ui=k([g(`mateu-addon-picker`)],Ui);var Wi=e=>{let t=e.metadata;return T`
+        `}};O([v()],Wi.prototype,`totalLabel`,void 0),O([v()],Wi.prototype,`currency`,void 0),O([v()],Wi.prototype,`actionId`,void 0),O([v({type:Array})],Wi.prototype,`items`,void 0),O([S()],Wi.prototype,`added`,void 0),Wi=O([h(`mateu-addon-picker`)],Wi);var Gi=e=>{let t=e.metadata;return w`
         <mateu-addon-picker
                 .totalLabel="${t.totalLabel}"
                 .currency="${t.currency}"
                 .actionId="${t.actionId}"
                 .items="${t.items??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-addon-picker>
-    `},Gi=class extends b{constructor(...e){super(...e),this.lines=[]}static{this.styles=h`
+    `},Ki=class extends y{constructor(...e){super(...e),this.lines=[]}static{this.styles=m`
         :host {
             display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem);
             /* an ancestor (e.g. a form-layout row) may set an inherited line-height like 44px —
@@ -4386,29 +4386,29 @@ ${i}
             color: var(--lumo-body-text-color, #111);
             white-space: nowrap;
         }
-    `}computedTotal(){return this.total==null?this.lines.filter(e=>!e.included).reduce((e,t)=>e+(t.amount??0),0):this.total}render(){return T`
-            ${this.lines.map(e=>T`
+    `}computedTotal(){return this.total==null?this.lines.filter(e=>!e.included).reduce((e,t)=>e+(t.amount??0),0):this.total}render(){return w`
+            ${this.lines.map(e=>w`
                 <div class="row">
                     <span class="dot"></span>
                     <span class="concept">${e.concept}</span>
-                    ${e.included?T`<span class="included-label">${e.includedLabel||`Included`}</span>`:T`<span class="amount ${(e.amount??0)<0?`negative`:``}">${Ci(e.amount??0,this.currency)}</span>`}
+                    ${e.included?w`<span class="included-label">${e.includedLabel||`Included`}</span>`:w`<span class="amount ${(e.amount??0)<0?`negative`:``}">${wi(e.amount??0,this.currency)}</span>`}
                 </div>
             `)}
             <div class="total-row">
                 <span class="total-label">${this.totalLabel||`Total`}</span>
-                <span class="total">${Ci(this.computedTotal(),this.currency)}</span>
+                <span class="total">${wi(this.computedTotal(),this.currency)}</span>
             </div>
-        `}};k([y()],Gi.prototype,`currency`,void 0),k([y()],Gi.prototype,`totalLabel`,void 0),k([y({type:Array})],Gi.prototype,`lines`,void 0),k([y({type:Number})],Gi.prototype,`total`,void 0),Gi=k([g(`mateu-ledger`)],Gi);var Ki=e=>{let t=e.metadata;return T`
+        `}};O([v()],Ki.prototype,`currency`,void 0),O([v()],Ki.prototype,`totalLabel`,void 0),O([v({type:Array})],Ki.prototype,`lines`,void 0),O([v({type:Number})],Ki.prototype,`total`,void 0),Ki=O([h(`mateu-ledger`)],Ki);var qi=e=>{let t=e.metadata;return w`
         <mateu-ledger
                 .currency="${t.currency}"
                 .totalLabel="${t.totalLabel}"
                 .lines="${t.lines??[]}"
                 .total="${t.total}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-ledger>
-    `},qi=class extends b{constructor(...e){super(...e),this.methods=[]}static{this.styles=h`
+    `},Ji=class extends y{constructor(...e){super(...e),this.methods=[]}static{this.styles=m`
         :host { display: block; width: 100%; }
         .bar { display: flex; align-items: stretch; gap: .6rem; flex-wrap: wrap; }
         .methods { display: flex; gap: .4rem; flex-wrap: wrap; }
@@ -4453,24 +4453,24 @@ ${i}
             white-space: nowrap;
         }
         .confirm:hover { filter: brightness(1.08); }
-    `}willUpdate(e){e.has(`selected`)&&(this.selectedId=this.selected)}confirm(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{_method:this.selectedId}},bubbles:!0,composed:!0}))}pick(e){this.selectedId=e,this.methodActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.methodActionId,parameters:{_method:e}},bubbles:!0,composed:!0}))}render(){return T`
+    `}willUpdate(e){e.has(`selected`)&&(this.selectedId=this.selected)}confirm(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{_method:this.selectedId}},bubbles:!0,composed:!0}))}pick(e){this.selectedId=e,this.methodActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.methodActionId,parameters:{_method:e}},bubbles:!0,composed:!0}))}render(){return w`
             <div class="bar">
                 <div class="methods">
-                    ${this.methods.map(e=>T`
+                    ${this.methods.map(e=>w`
                         <button class="method ${e.id===this.selectedId?`selected`:``}"
                                 @click="${()=>this.pick(e.id)}">${e.label}</button>
                     `)}
                 </div>
-                ${this.contextLabel||this.contextValue?T`
+                ${this.contextLabel||this.contextValue?w`
                     <div class="context">
-                        ${this.contextLabel?T`<span class="label">${this.contextLabel}</span>`:v}
-                        ${this.contextValue?T`<span class="value">${this.contextValue}</span>`:v}
+                        ${this.contextLabel?w`<span class="label">${this.contextLabel}</span>`:_}
+                        ${this.contextValue?w`<span class="value">${this.contextValue}</span>`:_}
                     </div>
-                `:v}
+                `:_}
                 <span class="spacer"></span>
-                ${this.confirmLabel&&this.actionId?T`<button class="confirm" @click="${()=>this.confirm()}">${this.confirmLabel}</button>`:v}
+                ${this.confirmLabel&&this.actionId?w`<button class="confirm" @click="${()=>this.confirm()}">${this.confirmLabel}</button>`:_}
             </div>
-        `}};k([y()],qi.prototype,`actionId`,void 0),k([y()],qi.prototype,`methodActionId`,void 0),k([y({type:Array})],qi.prototype,`methods`,void 0),k([y()],qi.prototype,`selected`,void 0),k([y()],qi.prototype,`contextLabel`,void 0),k([y()],qi.prototype,`contextValue`,void 0),k([y()],qi.prototype,`confirmLabel`,void 0),k([C()],qi.prototype,`selectedId`,void 0),qi=k([g(`mateu-payment-picker`)],qi);var Ji=e=>{let t=e.metadata;return T`
+        `}};O([v()],Ji.prototype,`actionId`,void 0),O([v()],Ji.prototype,`methodActionId`,void 0),O([v({type:Array})],Ji.prototype,`methods`,void 0),O([v()],Ji.prototype,`selected`,void 0),O([v()],Ji.prototype,`contextLabel`,void 0),O([v()],Ji.prototype,`contextValue`,void 0),O([v()],Ji.prototype,`confirmLabel`,void 0),O([S()],Ji.prototype,`selectedId`,void 0),Ji=O([h(`mateu-payment-picker`)],Ji);var Yi=e=>{let t=e.metadata;return w`
         <mateu-payment-picker
                 .actionId="${t.actionId}"
                 .methodActionId="${t.methodActionId}"
@@ -4479,11 +4479,11 @@ ${i}
                 .contextLabel="${t.contextLabel}"
                 .contextValue="${t.contextValue}"
                 .confirmLabel="${t.confirmLabel}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-payment-picker>
-    `},Yi=class extends b{constructor(...e){super(...e),this.items=[]}static{this.styles=h`
+    `},Xi=class extends y{constructor(...e){super(...e),this.items=[]}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .list {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -4519,32 +4519,32 @@ ${i}
             cursor: pointer; white-space: nowrap; flex: 0 0 auto;
         }
         button:hover { background: var(--lumo-warning-color-10pct, rgba(245,158,11,.25)); filter: brightness(.97); }
-    `}runAction(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{}},bubbles:!0,composed:!0}))}render(){return T`
+    `}runAction(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{}},bubbles:!0,composed:!0}))}render(){return w`
             <div class="list">
-                ${this.items.map(e=>T`
+                ${this.items.map(e=>w`
                     <div class="row">
                         <span class="dot ${e.status??`ok`}"></span>
                         <div class="body">
                             <span class="name">${e.name}</span>
-                            ${e.systems?.length?T`<span class="systems">${e.systems.join(` · `)}</span>`:v}
+                            ${e.systems?.length?w`<span class="systems">${e.systems.join(` · `)}</span>`:_}
                         </div>
                         <div class="counters">
                             <span class="counter ok">✓ ${e.ok??0} OK</span>
-                            ${(e.warnings??0)>0?T`<span class="counter warning">⚠ ${e.warnings} warnings</span>`:v}
-                            ${(e.errors??0)>0?T`<span class="counter error">⛔ ${e.errors} errors</span>`:v}
+                            ${(e.warnings??0)>0?w`<span class="counter warning">⚠ ${e.warnings} warnings</span>`:_}
+                            ${(e.errors??0)>0?w`<span class="counter error">⛔ ${e.errors} errors</span>`:_}
                         </div>
-                        ${e.actionLabel&&e.actionId?T`<button @click="${()=>this.runAction(e)}">${e.actionLabel}</button>`:v}
+                        ${e.actionLabel&&e.actionId?w`<button @click="${()=>this.runAction(e)}">${e.actionLabel}</button>`:_}
                     </div>
                 `)}
             </div>
-        `}};k([y({type:Array})],Yi.prototype,`items`,void 0),Yi=k([g(`mateu-process-monitor`)],Yi);var Xi=e=>T`
+        `}};O([v({type:Array})],Xi.prototype,`items`,void 0),Xi=O([h(`mateu-process-monitor`)],Xi);var Zi=e=>w`
         <mateu-process-monitor
                 .items="${e.metadata.items??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-process-monitor>
-    `,Zi=(e,t)=>{let n=e.style;return e.id&&(n&&!n.endsWith(`;`)&&(n+=`;`),n??=``,t[e.id+`.hidden`]==1&&(n+=`display: none;`)),n},Qi=(e,t)=>{let n={...e.metadata};if(e.id&&n){if(n.type==j.Button){let r=n;t[e.id+`.disabled`]==1&&(r.disabled=!0)}if(n.type==j.FormField){let r=n;t[e.id+`.disabled`]==1&&(r.disabled=!0)}}return n},U=e=>t=>e(t.container,t.component,t.baseUrl,t.state,t.data,t.appState,t.appData),$i={[j.Bpmn]:({component:e})=>hr(e),[j.Workflow]:({component:e})=>_r(e),[j.FormEditor]:({component:e})=>vr(e),[j.Page]:U(pr),[j.Div]:U(or),[j.Directory]:({component:e,baseUrl:t,state:n,data:r})=>ir(e,t,n,r),[j.FormLayout]:U(Wt),[j.HorizontalLayout]:U(Xt),[j.VerticalLayout]:U(Zt),[j.SplitLayout]:U(Qt),[j.MasterDetailLayout]:U($t),[j.TabLayout]:U(en),[j.AccordionLayout]:U(tn),[j.BoardLayout]:U(sn),[j.BoardLayoutRow]:U(cn),[j.BoardLayoutItem]:U(ln),[j.Scroller]:U(rn),[j.FullWidth]:U(an),[j.Container]:U(on),[j.Form]:({container:e,component:t,baseUrl:n,state:r,data:i,appState:a,appData:o})=>{let s=t.metadata;return T`<mateu-form
+    `,Qi=(e,t)=>{let n=e.style;return e.id&&(n&&!n.endsWith(`;`)&&(n+=`;`),n??=``,t[e.id+`.hidden`]==1&&(n+=`display: none;`)),n},$i=(e,t)=>{let n={...e.metadata};if(e.id&&n){if(n.type==A.Button){let r=n;t[e.id+`.disabled`]==1&&(r.disabled=!0)}if(n.type==A.FormField){let r=n;t[e.id+`.disabled`]==1&&(r.disabled=!0)}}return n},H=e=>t=>e(t.container,t.component,t.baseUrl,t.state,t.data,t.appState,t.appData),ea={[A.Bpmn]:({component:e})=>gr(e),[A.Workflow]:({component:e})=>vr(e),[A.FormEditor]:({component:e})=>yr(e),[A.Page]:H(mr),[A.Div]:H(sr),[A.Directory]:({component:e,baseUrl:t,state:n,data:r})=>ar(e,t,n,r),[A.FormLayout]:H(Gt),[A.HorizontalLayout]:H(Zt),[A.VerticalLayout]:H(Qt),[A.SplitLayout]:H($t),[A.MasterDetailLayout]:H(en),[A.TabLayout]:H(tn),[A.AccordionLayout]:H(nn),[A.BoardLayout]:H(cn),[A.BoardLayoutRow]:H(ln),[A.BoardLayoutItem]:H(un),[A.Scroller]:H(an),[A.FullWidth]:H(on),[A.Container]:H(sn),[A.Form]:({container:e,component:t,baseUrl:n,state:r,data:i,appState:a,appData:o})=>{let s=t.metadata;return w`<mateu-form
             id="${t.id}"
         baseUrl="${n}"
             .component="${t}"
@@ -4555,14 +4555,14 @@ ${i}
             .appdata="${o}"
             style="${t.style}"
             class="${t.cssClasses}"
-            slot="${t.slot??v}"
+            slot="${t.slot??_}"
             >
-                ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
-            ${s?.buttons?.map(t=>T`
-               ${F(e,{id:t.actionId,metadata:t,type:A.ClientSide,slot:`buttons`},void 0,r,i,a,o)}
+                ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
+            ${s?.buttons?.map(t=>w`
+               ${P(e,{id:t.actionId,metadata:t,type:k.ClientSide,slot:`buttons`},void 0,r,i,a,o)}
 `)}
 
-            </mateu-form>`},[j.Table]:({component:e,state:t,data:n})=>pn(e,(e.id?n?.[e.id]:void 0)?.page?.content??mn(e,t)),[j.Crud]:U(mr),[j.App]:({container:e,component:t,baseUrl:n,state:r,data:i,appState:a,appData:o})=>T`
+            </mateu-form>`},[A.Table]:({component:e,state:t,data:n})=>mn(e,(e.id?n?.[e.id]:void 0)?.page?.content??hn(e,t)),[A.Crud]:H(hr),[A.App]:({container:e,component:t,baseUrl:n,state:r,data:i,appState:a,appData:o})=>w`
             <mateu-app
                         id="${t.id}"
                         baseUrl="${n}"
@@ -4574,26 +4574,26 @@ ${i}
                         .appState="${a}"
                         .appData="${o}"
             >
-             ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
-         </mateu-app>`,[j.Element]:({container:e,component:t})=>Tn(e,t.metadata,t),[j.FormField]:({component:e,state:t})=>dr(e,t),[j.Text]:({component:e,state:t,data:n,appState:r,appData:i})=>Dn(e,t,n,r,i),[j.Avatar]:({component:e,state:t,data:n})=>lt(e,t,n),[j.Chat]:({component:e,state:t,data:n})=>gr(e,t,n),[j.AvatarGroup]:({component:e})=>ut(e),[j.Badge]:({component:e,state:t,data:n})=>dt(e,t,n),[j.Breadcrumbs]:({component:e})=>nr(e),[j.Anchor]:({component:e})=>On(e),[j.Button]:({component:e,state:t,data:n})=>Fn(e,t,n),[j.Card]:U(Ln),[j.Chart]:({component:e})=>Rn(e),[j.Icon]:({component:e})=>zn(e),[j.ConfirmDialog]:U(Wn),[j.ContextMenu]:U(vn),[j.CookieConsent]:({component:e})=>Gn(e),[j.Details]:U(Kn),[j.Dialog]:({component:e,baseUrl:t,state:n,data:r,appState:i,appData:a})=>qn(e,t,n,r,i,a),[j.Drawer]:({component:e,baseUrl:t,state:n,data:r,appState:i,appData:a})=>Jn(e,t,n,r,i,a),[j.Image]:({component:e})=>tr(e),[j.Map]:({component:e})=>er(e),[j.Markdown]:({component:e})=>Xn(e),[j.MicroFrontend]:({component:e})=>Yn(e),[j.Notification]:({component:e})=>Zn(e),[j.ProgressBar]:({component:e,state:t})=>Qn(e,t),[j.Popover]:U($n),[j.CarouselLayout]:U(rr),[j.Tooltip]:U(xn),[j.MessageInput]:({component:e})=>bn(e),[j.MessageList]:({component:e})=>hn(e),[j.CustomField]:U(yn),[j.MenuBar]:({container:e,component:t,baseUrl:n,state:r,data:i})=>_n(e,t,n,r,i),[j.Grid]:({component:e,state:t})=>pn(e,mn(e,t)),[j.VirtualList]:U(un),[j.FormSection]:U(sr),[j.FormSubSection]:U(cr),[j.MetricCard]:({component:e})=>Cr(e),[j.Scoreboard]:U(wr),[j.DashboardPanel]:U(Tr),[j.DashboardLayout]:U(Er),[j.FoldoutLayout]:U(Or),[j.ContentLayout]:U(kr),[j.HeroSection]:U(Ar),[j.EmptyState]:({component:e})=>St(e),[j.Skeleton]:({component:e})=>Ct(e),[j.Gantt]:({component:e})=>Nr(e),[j.PlanningBoard]:({component:e})=>Fr(e),[j.Kanban]:({component:e})=>Lr(e),[j.Timeline]:({component:e})=>zr(e),[j.ProgressSteps]:({component:e})=>Vr(e),[j.Stat]:({component:e})=>Ur(e),[j.Calendar]:({component:e})=>Gr(e),[j.PricingTable]:({component:e})=>qr(e),[j.OrgChart]:({component:e})=>Yr(e),[j.Heatmap]:({component:e})=>Qr(e),[j.Funnel]:({component:e})=>ei(e),[j.TrendChart]:({component:e})=>ni(e),[j.FeatureGrid]:({component:e})=>ii(e),[j.Testimonials]:({component:e})=>oi(e),[j.Faq]:({component:e})=>ci(e),[j.CalloutCard]:({component:e})=>ui(e),[j.CommentThread]:({component:e})=>fi(e),[j.FileList]:({component:e})=>hi(e),[j.Checklist]:({component:e})=>_i(e),[j.ComparisonCard]:({component:e})=>yi(e),[j.EntityHeader]:({component:e})=>Ei(e),[j.Meter]:({component:e})=>Oi(e),[j.TaskProgress]:({component:e})=>Ai(e),[j.StatusList]:({component:e})=>Mi(e),[j.BulletedList]:({component:e})=>Pi(e),[j.Separator]:({component:e})=>Fi(e),[j.Notice]:U(Li),[j.TaskQueue]:({component:e})=>zi(e),[j.ResourceGrid]:({component:e})=>Vi(e),[j.OfferCard]:({component:e})=>Hi(e),[j.AddOnPicker]:({component:e})=>Wi(e),[j.Ledger]:({component:e})=>Ki(e),[j.PaymentPicker]:({component:e})=>Ji(e),[j.ProcessMonitor]:({component:e})=>Xi(e)},ea=(e,t,n,r,i,a,o,s)=>{if(!t?.metadata)return t==null?(console.warn(`No metadata for component`,t),T`<p>No metadata for component</p>`):ea(e,{id:E(),metadata:t,type:A.ClientSide},n,r,i,a,o,s);let c=t.metadata.type,l={...t,style:Zi(t,i),metadata:Qi(t,i)},u=$i[c];return u?u({container:e,component:l,baseUrl:n,state:r,data:i,appState:a,appData:o,labelAlreadyRendered:s}):T`<p ${l?.slot??v}>Unknown metadata type ${c} for component ${l?.id}</p>`},ta=function(e){return e.NONE=`NONE`,e.INFO=`INFO`,e.SUCCESS=`SUCCESS`,e.WARNING=`WARNING`,e.DANGER=`DANGER`,e}({}),na=(e,t,n)=>{let r=e[n.path];return r?T`<span theme="badge pill ${ra(r.type)}">${r.message}</span>`:T``},ra=e=>{switch(e){case ta.SUCCESS:return`success`;case ta.WARNING:return`warning`;case ta.DANGER:return`error`;case ta.NONE:return`contrast`}return``},W=class extends b{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.respondToVisibility=(e,t)=>{var n={root:document.documentElement};new IntersectionObserver(e=>{e.forEach(e=>{t(e.intersectionRatio>0)})},n).observe(e)},this.keepAsking=!1,this.askToUpper=()=>{let e=this.data[this.id]?.page,t=e?.content?.length/e?.pageSize;this.dispatchEvent(new CustomEvent(`fetch-more-elements`,{detail:{params:{page:t,pageSize:this.metadata?.pageSize},callback:()=>{this.keepAsking&&this.askToUpper()}},bubbles:!0,composed:!0}))},this.renderItem=e=>e.card?ea(this,e.card,this.baseUrl,this.state,this.data,this.appState,this.appData,!1):e.title?T`<div class="neutral-card">
-                ${e.image?T`<img class="card-media" src="${e.image}" alt="" />`:v}
+             ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
+         </mateu-app>`,[A.Element]:({container:e,component:t})=>En(e,t.metadata,t),[A.FormField]:({component:e,state:t})=>fr(e,t),[A.Text]:({component:e,state:t,data:n,appState:r,appData:i})=>On(e,t,n,r,i),[A.Avatar]:({component:e,state:t,data:n})=>ut(e,t,n),[A.Chat]:({component:e,state:t,data:n})=>_r(e,t,n),[A.AvatarGroup]:({component:e})=>dt(e),[A.Badge]:({component:e,state:t,data:n})=>ft(e,t,n),[A.Breadcrumbs]:({component:e})=>rr(e),[A.Anchor]:({component:e})=>kn(e),[A.Button]:({component:e,state:t,data:n})=>In(e,t,n),[A.Card]:H(Rn),[A.Chart]:({component:e})=>zn(e),[A.Icon]:({component:e})=>Bn(e),[A.ConfirmDialog]:H(Gn),[A.ContextMenu]:H(yn),[A.CookieConsent]:({component:e})=>Kn(e),[A.Details]:H(qn),[A.Dialog]:({component:e,baseUrl:t,state:n,data:r,appState:i,appData:a})=>Jn(e,t,n,r,i,a),[A.Drawer]:({component:e,baseUrl:t,state:n,data:r,appState:i,appData:a})=>Yn(e,t,n,r,i,a),[A.Image]:({component:e})=>nr(e),[A.Map]:({component:e})=>tr(e),[A.Markdown]:({component:e})=>Zn(e),[A.MicroFrontend]:({component:e})=>Xn(e),[A.Notification]:({component:e})=>Qn(e),[A.ProgressBar]:({component:e,state:t})=>$n(e,t),[A.Popover]:H(er),[A.CarouselLayout]:H(ir),[A.Tooltip]:H(Sn),[A.MessageInput]:({component:e})=>xn(e),[A.MessageList]:({component:e})=>gn(e),[A.CustomField]:H(bn),[A.MenuBar]:({container:e,component:t,baseUrl:n,state:r,data:i})=>vn(e,t,n,r,i),[A.Grid]:({component:e,state:t})=>mn(e,hn(e,t)),[A.VirtualList]:H(dn),[A.FormSection]:H(cr),[A.FormSubSection]:H(lr),[A.MetricCard]:({component:e})=>wr(e),[A.Scoreboard]:H(Tr),[A.DashboardPanel]:H(Er),[A.DashboardLayout]:H(Dr),[A.FoldoutLayout]:H(kr),[A.ContentLayout]:H(Ar),[A.HeroSection]:H(jr),[A.EmptyState]:({component:e})=>Ct(e),[A.Skeleton]:({component:e})=>wt(e),[A.Gantt]:({component:e})=>Pr(e),[A.PlanningBoard]:({component:e})=>Ir(e),[A.Kanban]:({component:e})=>Rr(e),[A.Timeline]:({component:e})=>Br(e),[A.ProgressSteps]:({component:e})=>Hr(e),[A.Stat]:({component:e})=>Wr(e),[A.Calendar]:({component:e})=>Kr(e),[A.PricingTable]:({component:e})=>Jr(e),[A.OrgChart]:({component:e})=>Xr(e),[A.Heatmap]:({component:e})=>$r(e),[A.Funnel]:({component:e})=>ti(e),[A.TrendChart]:({component:e})=>ri(e),[A.FeatureGrid]:({component:e})=>ai(e),[A.Testimonials]:({component:e})=>si(e),[A.Faq]:({component:e})=>li(e),[A.CalloutCard]:({component:e})=>di(e),[A.CommentThread]:({component:e})=>pi(e),[A.FileList]:({component:e})=>gi(e),[A.Checklist]:({component:e})=>vi(e),[A.ComparisonCard]:({component:e})=>bi(e),[A.EntityHeader]:({component:e})=>Di(e),[A.Meter]:({component:e})=>ki(e),[A.TaskProgress]:({component:e})=>ji(e),[A.StatusList]:({component:e})=>Ni(e),[A.BulletedList]:({component:e})=>Fi(e),[A.Separator]:({component:e})=>Ii(e),[A.Notice]:H(Ri),[A.TaskQueue]:({component:e})=>Bi(e),[A.ResourceGrid]:({component:e})=>Hi(e),[A.OfferCard]:({component:e})=>Ui(e),[A.AddOnPicker]:({component:e})=>Gi(e),[A.Ledger]:({component:e})=>qi(e),[A.PaymentPicker]:({component:e})=>Yi(e),[A.ProcessMonitor]:({component:e})=>Zi(e)},ta=(e,t,n,r,i,a,o,s)=>{if(!t?.metadata)return t==null?(console.warn(`No metadata for component`,t),w`<p>No metadata for component</p>`):ta(e,{id:T(),metadata:t,type:k.ClientSide},n,r,i,a,o,s);let c=t.metadata.type,l={...t,style:Qi(t,i),metadata:$i(t,i)},u=ea[c];return u?u({container:e,component:l,baseUrl:n,state:r,data:i,appState:a,appData:o,labelAlreadyRendered:s}):w`<p ${l?.slot??_}>Unknown metadata type ${c} for component ${l?.id}</p>`},na=function(e){return e.NONE=`NONE`,e.INFO=`INFO`,e.SUCCESS=`SUCCESS`,e.WARNING=`WARNING`,e.DANGER=`DANGER`,e}({}),ra=(e,t,n)=>{let r=e[n.path];return r?w`<span theme="badge pill ${ia(r.type)}">${r.message}</span>`:w``},ia=e=>{switch(e){case na.SUCCESS:return`success`;case na.WARNING:return`warning`;case na.DANGER:return`error`;case na.NONE:return`contrast`}return``},U=class extends y{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.respondToVisibility=(e,t)=>{var n={root:document.documentElement};new IntersectionObserver(e=>{e.forEach(e=>{t(e.intersectionRatio>0)})},n).observe(e)},this.keepAsking=!1,this.askToUpper=()=>{let e=this.data[this.id]?.page,t=e?.content?.length/e?.pageSize;this.dispatchEvent(new CustomEvent(`fetch-more-elements`,{detail:{params:{page:t,pageSize:this.metadata?.pageSize},callback:()=>{this.keepAsking&&this.askToUpper()}},bubbles:!0,composed:!0}))},this.renderItem=e=>e.card?ta(this,e.card,this.baseUrl,this.state,this.data,this.appState,this.appData,!1):e.title?w`<div class="neutral-card">
+                ${e.image?w`<img class="card-media" src="${e.image}" alt="" />`:_}
                 <div class="card-body">
                     <div class="card-head">
-                        ${e.title?T`<span class="card-title">${e.title}</span>`:v}
-                        ${e.status?T`<span theme="badge ${ra(e.status.type)}">${e.status.message}</span>`:v}
+                        ${e.title?w`<span class="card-title">${e.title}</span>`:_}
+                        ${e.status?w`<span theme="badge ${ia(e.status.type)}">${e.status.message}</span>`:_}
                     </div>
-                    ${e.subtitle?T`<div class="card-subtitle">${e.subtitle}</div>`:v}
-                    ${e.content?T`<div>${e.content}</div>`:v}
+                    ${e.subtitle?w`<div class="card-subtitle">${e.subtitle}</div>`:_}
+                    ${e.content?w`<div>${e.content}</div>`:_}
                 </div>
-        </div>`:T`${e}`,this.hasMore=!1,this.clickedOnCard=e=>{this.state[this.id+`_selected_items`]=[e],this.metadata?.onRowSelectionChangedActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.metadata?.onRowSelectionChangedActionId},bubbles:!0,composed:!0}))}}updated(e){super.updated(e);let t=this.data[this.id]?.page;this.hasMore=t?.content?.length<t?.totalElements}firstUpdated(e){super.firstUpdated(e),this.respondToVisibility(this.askForMore,e=>{this.keepAsking=e,e&&this.askToUpper()})}render(){return T`
+        </div>`:w`${e}`,this.hasMore=!1,this.clickedOnCard=e=>{this.state[this.id+`_selected_items`]=[e],this.metadata?.onRowSelectionChangedActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.metadata?.onRowSelectionChangedActionId},bubbles:!0,composed:!0}))}}updated(e){super.updated(e);let t=this.data[this.id]?.page;this.hasMore=t?.content?.length<t?.totalElements}firstUpdated(e){super.firstUpdated(e),this.respondToVisibility(this.askForMore,e=>{this.keepAsking=e,e&&this.askToUpper()})}render(){return w`
             <div class="card-container">
-                ${(this.data[this.id]?.page)?.content?.map(e=>T`<div role="button" tabindex="0" @click="${()=>this.clickedOnCard(e)}" @keydown="${R(()=>this.clickedOnCard(e))}" class="car-container">${this.renderItem(e)}</div>`)}
+                ${(this.data[this.id]?.page)?.content?.map(e=>w`<div role="button" tabindex="0" @click="${()=>this.clickedOnCard(e)}" @keydown="${L(()=>this.clickedOnCard(e))}" class="car-container">${this.renderItem(e)}</div>`)}
                 <div id="ask-for-more" style="display: ${this.hasMore?`flex`:`none`}; width: 100%; justify-content: center; padding: var(--lumo-space-m); color: var(--lumo-secondary-text-color); font-size: var(--lumo-font-size-s);">Loading more…</div>
             </div>
 
             <slot></slot>
-       `}static{this.styles=h`
-        ${de}
+       `}static{this.styles=m`
+        ${fe}
         
         .card-container {
             display: flex;
@@ -4617,147 +4617,147 @@ ${i}
         .neutral-card .card-title { font-weight: 600; }
         .neutral-card .card-subtitle { color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-s, .875rem); }
     
-        ${z}
-    `}};k([y()],W.prototype,`id`,void 0),k([y()],W.prototype,`metadata`,void 0),k([y()],W.prototype,`baseUrl`,void 0),k([y()],W.prototype,`state`,void 0),k([y()],W.prototype,`data`,void 0),k([y()],W.prototype,`appState`,void 0),k([y()],W.prototype,`appData`,void 0),k([y()],W.prototype,`emptyStateMessage`,void 0),k([C()],W.prototype,`keepAsking`,void 0),k([x(`#ask-for-more`)],W.prototype,`askForMore`,void 0),k([C()],W.prototype,`hasMore`,void 0),W=k([g(`mateu-card-list`)],W);var ia={show:e=>console.debug(`[mateu] no notifier registered, dropping toast:`,e.text)};function aa(e){ia=e}function oa(e,t){ia.show(e,t)}var sa=function(e){return e.none=`none`,e.success=`success`,e.error=`error`,e.warning=`warning`,e.contrast=`contrast`,e.normal=`normal`,e}({}),ca=function(e){return e.primary=`primary`,e.secondary=`secondary`,e.tertiary=`tertiary`,e.tertiaryInline=`tertiaryInline`,e}({});function la(e){if(e.weight!=null)return e.weight;let t=e.stereotype??``;if(t===`icon`)return 1;if(t===`image`)return 4;if(t===`html`||t===`richText`||t===`markdown`||t===`textarea`)return 5;if(t===`link`)return 2.5;if(t===`combobox`||t===`select`)return 2;let n=e.dataType??``;return n===`bool`?1:n===`status`||n===`integer`?1.5:n===`number`||n===`date`||n===`money`?2:n===`dateTime`||n===`dateRange`?2.5:3}function ua(e,t){if(e.length===0)return`table`;let n=e.reduce((e,t)=>e+la(t),0)/(t/76);if(n<=1.1)return`table`;if(n>1.6||e.length>10)return`masterDetail`;let r=e.filter(e=>e.identifier||(e.priority??2**53-1)<=2),i=r.reduce((e,t)=>e+la(t),0);return r.length>0&&i<=8?`list`:e.some(e=>e.stereotype===`image`||e.stereotype===`html`)||r.length===0&&e.length>=4&&e.length<=8?`cards`:`masterDetail`}function da(e){return e.filter(e=>e.identifier||(e.priority??2**53-1)<=2).sort((e,t)=>(e.priority??2**53-1)-(t.priority??2**53-1))}function fa(e){let t=da(e);return t.length>0?t:e.slice(0,3)}var pa={asc:`ascending`,desc:`descending`},G=class extends b{constructor(...e){super(...e),this.component=void 0,this.standalone=!1,this.state={},this.data={},this.appState={},this.appData={},this.showImportDialog=!1,this.availableWidthPx=1024,this.selectedItem=null,this._columnPrefsRevision=0,this._prefsRevisionApplied=-1,this.search=()=>{let e=this.component.metadata;this.state={...this.state,size:e.pageSize,page:0,crud_selected_items:[]},this._syncStateToUrl(e),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`search`,parameters:{crudId:this.id,_searchState:{...this.state}}},bubbles:!0,composed:!0}))},this.notify=e=>{oa({text:e,position:`bottomEnd`,variant:`error`,duration:3e3},this)},this.handleSearchRequested=e=>{this.state={...this.state,crud_selected_items:[]};let t=this.component.metadata;this._syncStateToUrl(t),!t.infiniteScrolling&&this.data?.[this.id]?.page&&(this.data[this.id].page.content=[]),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`search`,parameters:{crudId:this.id,_searchState:{...this.state}},callback:e},bubbles:!0,composed:!0}))},this.fetchMoreElements=e=>{let{params:t,callback:n}=e.detail;this.state={...this.state,size:t.pageSize,page:t.page},this.handleSearchRequested(n)},this.directionChanged=e=>{let t=e.detail.grid._sorters;this.state={...this.state,sort:t.map(e=>({fieldId:e.__data.path,direction:e.__data.direction?pa[e.__data.direction]:void 0}))},this.handleSearchRequested(void 0)},this._initializedForComponentId=void 0,this.evalLabel=e=>M(e,this.state,this.data),this.handleToolbarButtonClick=e=>{if(e===`import`){this.showImportDialog=!0;return}this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.handleImportUploadSuccess=e=>{let t=e.detail.xhr.responseText;this.showImportDialog=!1,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`process-import`,parameters:{fileId:t}},bubbles:!0,composed:!0}))}}get columnPrefsScope(){return window.location.pathname}get effectiveComponent(){let e=this.component,t=e?.metadata;if(!e||!t?.columns)return e;if(this._prefsSource===e&&this._prefsRevisionApplied===this._columnPrefsRevision)return this._prefsApplied;let n=It(this.columnPrefsScope),r=Bt(t.columns,n,e=>e.metadata??{});return this._prefsApplied=r===t.columns?e:{...e,metadata:{...t,columns:r}},this._prefsSource=e,this._prefsRevisionApplied=this._columnPrefsRevision,this._prefsApplied}get columnChooserEntries(){return(this.component?.metadata?.columns??[]).map(e=>{let t=e.metadata??{},n=t.id??e.id;return n?{id:n,label:t.label??n,protected:zt(t)}:void 0}).filter(e=>!!e)}renderColumnChooser(){let e=this.columnChooserEntries;return e.filter(e=>!e.protected).length===0?v:T`
+        ${R}
+    `}};O([v()],U.prototype,`id`,void 0),O([v()],U.prototype,`metadata`,void 0),O([v()],U.prototype,`baseUrl`,void 0),O([v()],U.prototype,`state`,void 0),O([v()],U.prototype,`data`,void 0),O([v()],U.prototype,`appState`,void 0),O([v()],U.prototype,`appData`,void 0),O([v()],U.prototype,`emptyStateMessage`,void 0),O([S()],U.prototype,`keepAsking`,void 0),O([b(`#ask-for-more`)],U.prototype,`askForMore`,void 0),O([S()],U.prototype,`hasMore`,void 0),U=O([h(`mateu-card-list`)],U);var aa={show:e=>console.debug(`[mateu] no notifier registered, dropping toast:`,e.text)};function oa(e){aa=e}function sa(e,t){aa.show(e,t)}var ca=function(e){return e.none=`none`,e.success=`success`,e.error=`error`,e.warning=`warning`,e.contrast=`contrast`,e.normal=`normal`,e}({}),la=function(e){return e.primary=`primary`,e.secondary=`secondary`,e.tertiary=`tertiary`,e.tertiaryInline=`tertiaryInline`,e}({});function ua(e){if(e.weight!=null)return e.weight;let t=e.stereotype??``;if(t===`icon`)return 1;if(t===`image`)return 4;if(t===`html`||t===`richText`||t===`markdown`||t===`textarea`)return 5;if(t===`link`)return 2.5;if(t===`combobox`||t===`select`)return 2;let n=e.dataType??``;return n===`bool`?1:n===`status`||n===`integer`?1.5:n===`number`||n===`date`||n===`money`?2:n===`dateTime`||n===`dateRange`?2.5:3}function da(e,t){if(e.length===0)return`table`;let n=e.reduce((e,t)=>e+ua(t),0)/(t/76);if(n<=1.1)return`table`;if(n>1.6||e.length>10)return`masterDetail`;let r=e.filter(e=>e.identifier||(e.priority??2**53-1)<=2),i=r.reduce((e,t)=>e+ua(t),0);return r.length>0&&i<=8?`list`:e.some(e=>e.stereotype===`image`||e.stereotype===`html`)||r.length===0&&e.length>=4&&e.length<=8?`cards`:`masterDetail`}function fa(e){return e.filter(e=>e.identifier||(e.priority??2**53-1)<=2).sort((e,t)=>(e.priority??2**53-1)-(t.priority??2**53-1))}function pa(e){let t=fa(e);return t.length>0?t:e.slice(0,3)}var ma={asc:`ascending`,desc:`descending`},W=class extends y{constructor(...e){super(...e),this.component=void 0,this.standalone=!1,this.state={},this.data={},this.appState={},this.appData={},this.showImportDialog=!1,this.availableWidthPx=1024,this.selectedItem=null,this._columnPrefsRevision=0,this._prefsRevisionApplied=-1,this.search=()=>{let e=this.component.metadata;this.state={...this.state,size:e.pageSize,page:0,crud_selected_items:[]},this._syncStateToUrl(e),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`search`,parameters:{crudId:this.id,_searchState:{...this.state}}},bubbles:!0,composed:!0}))},this.notify=e=>{sa({text:e,position:`bottomEnd`,variant:`error`,duration:3e3},this)},this.handleSearchRequested=e=>{this.state={...this.state,crud_selected_items:[]};let t=this.component.metadata;this._syncStateToUrl(t),!t.infiniteScrolling&&this.data?.[this.id]?.page&&(this.data[this.id].page.content=[]),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`search`,parameters:{crudId:this.id,_searchState:{...this.state}},callback:e},bubbles:!0,composed:!0}))},this.fetchMoreElements=e=>{let{params:t,callback:n}=e.detail;this.state={...this.state,size:t.pageSize,page:t.page},this.handleSearchRequested(n)},this.directionChanged=e=>{let t=e.detail.grid._sorters;this.state={...this.state,sort:t.map(e=>({fieldId:e.__data.path,direction:e.__data.direction?ma[e.__data.direction]:void 0}))},this.handleSearchRequested(void 0)},this._initializedForComponentId=void 0,this.evalLabel=e=>j(e,this.state,this.data),this.handleToolbarButtonClick=e=>{if(e===`import`){this.showImportDialog=!0;return}this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.handleImportUploadSuccess=e=>{let t=e.detail.xhr.responseText;this.showImportDialog=!1,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`process-import`,parameters:{fileId:t}},bubbles:!0,composed:!0}))}}get columnPrefsScope(){return window.location.pathname}get effectiveComponent(){let e=this.component,t=e?.metadata;if(!e||!t?.columns)return e;if(this._prefsSource===e&&this._prefsRevisionApplied===this._columnPrefsRevision)return this._prefsApplied;let n=Lt(this.columnPrefsScope),r=Vt(t.columns,n,e=>e.metadata??{});return this._prefsApplied=r===t.columns?e:{...e,metadata:{...t,columns:r}},this._prefsSource=e,this._prefsRevisionApplied=this._columnPrefsRevision,this._prefsApplied}get columnChooserEntries(){return(this.component?.metadata?.columns??[]).map(e=>{let t=e.metadata??{},n=t.id??e.id;return n?{id:n,label:t.label??n,protected:Bt(t)}:void 0}).filter(e=>!!e)}renderColumnChooser(){let e=this.columnChooserEntries;return e.filter(e=>!e.protected).length===0?_:w`
             <mateu-column-chooser
                 .columns="${e}"
                 .scope="${this.columnPrefsScope}"
                 @column-prefs-changed="${e=>{e.stopPropagation(),this._columnPrefsRevision++}}"
             ></mateu-column-chooser>
-        `}get cols(){return(this.effectiveComponent?.metadata)?.columns?.map(e=>e.metadata)??[]}get identifierFieldName(){let e=this.cols.find(e=>e.identifier);return e?e.id:this.cols.find(e=>e.id===`id`)?.id}get effectiveGridLayout(){let e=this.component?.metadata,t=e?.gridLayout??`auto`;return t===`auto`?e?.crudlType===`card`?`cards`:ua(this.cols,this.availableWidthPx):t}connectedCallback(){super.connectedCallback(),this.resizeObserver=new ResizeObserver(e=>{let t=e[0]?.contentRect.width;t&&Math.abs(t-this.availableWidthPx)>10&&(this.availableWidthPx=t)}),this.resizeObserver.observe(this)}disconnectedCallback(){super.disconnectedCallback(),this.resizeObserver?.disconnect()}_filterIds(e){return new Set([`searchText`,...(e.filters??[]).flatMap(e=>e.stereotype===`dateRange`||e.stereotype===`numberRange`?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId])])}_syncStateToUrl(e){let t=this._filterIds(e),n=new URLSearchParams(window.location.search);t.forEach(e=>n.delete(e)),n.delete(`page`),n.delete(`sort`),t.forEach(e=>{let t=this.state[e];t!=null&&t!==``&&n.set(e,String(t))});let r=this.state.page;r&&r>0&&n.set(`page`,String(r));let i=this.state.sort;if(i&&i.length>0){let e=i.filter(e=>e.fieldId&&e.direction).map(e=>`${e.fieldId}:${e.direction}`).join(`,`);e&&n.set(`sort`,e)}let a=n.toString(),o=a?`${window.location.pathname}?${a}`:window.location.pathname;window.location.pathname+window.location.search!==o&&history.replaceState(null,``,o)}_initStateFromUrl(e,t){let n=new URLSearchParams(window.location.search),r=this._filterIds(e),i={...t};n.forEach((e,t)=>{r.has(t)&&(i[t]=e)});let a=n.get(`page`);if(a!==null){let e=parseInt(a,10);!isNaN(e)&&e>0&&(i.page=e)}let o=n.get(`sort`);if(o){let e=o.split(`,`).map(e=>{let[t,n]=e.split(`:`);return t&&n?{fieldId:t,direction:n}:null}).filter(Boolean);e.length>0&&(i.sort=e)}return i}pageChanged(e){this.state={...this.state,page:e.detail.page},this.handleSearchRequested(void 0)}updated(e){if(super.updated(e),e.has(`component`)){let e=this.component?.id;if(e!==this._initializedForComponentId){this._initializedForComponentId=e;let t=this.component?.metadata,n=t.initialPage&&t.initialPage>0?t.initialPage:0;this.state=this._initStateFromUrl(t,{...this.state,size:t.pageSize,page:n,sort:[]}),(this.state.page!==n||this.state.sort?.length>0||[...this._filterIds(t)].some(e=>this.state[e]!=null))&&this.handleSearchRequested(void 0)}}}render(){let e=e=>{let t=[];return e.color&&e.color!==sa.normal&&t.push(e.color),e.buttonStyle&&t.push(e.buttonStyle===ca.tertiaryInline?`tertiary-inline`:e.buttonStyle),t.length?t.join(` `):void 0},t=e=>e===`back`||e===`backToList`||!!e&&e.startsWith(`cancel`),n=t=>P.get()?.renderToolbarButton?.(t,this.evalLabel(t.label),()=>this.handleToolbarButtonClick(t.actionId))||T`
+        `}get cols(){return(this.effectiveComponent?.metadata)?.columns?.map(e=>e.metadata)??[]}get identifierFieldName(){let e=this.cols.find(e=>e.identifier);return e?e.id:this.cols.find(e=>e.id===`id`)?.id}get effectiveGridLayout(){let e=this.component?.metadata,t=e?.gridLayout??`auto`;return t===`auto`?e?.crudlType===`card`?`cards`:da(this.cols,this.availableWidthPx):t}connectedCallback(){super.connectedCallback(),this.resizeObserver=new ResizeObserver(e=>{let t=e[0]?.contentRect.width;t&&Math.abs(t-this.availableWidthPx)>10&&(this.availableWidthPx=t)}),this.resizeObserver.observe(this)}disconnectedCallback(){super.disconnectedCallback(),this.resizeObserver?.disconnect()}_filterIds(e){return new Set([`searchText`,...(e.filters??[]).flatMap(e=>e.stereotype===`dateRange`||e.stereotype===`numberRange`?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId])])}_syncStateToUrl(e){let t=this._filterIds(e),n=new URLSearchParams(window.location.search);t.forEach(e=>n.delete(e)),n.delete(`page`),n.delete(`sort`),t.forEach(e=>{let t=this.state[e];t!=null&&t!==``&&n.set(e,String(t))});let r=this.state.page;r&&r>0&&n.set(`page`,String(r));let i=this.state.sort;if(i&&i.length>0){let e=i.filter(e=>e.fieldId&&e.direction).map(e=>`${e.fieldId}:${e.direction}`).join(`,`);e&&n.set(`sort`,e)}let a=n.toString(),o=a?`${window.location.pathname}?${a}`:window.location.pathname;window.location.pathname+window.location.search!==o&&history.replaceState(null,``,o)}_initStateFromUrl(e,t){let n=new URLSearchParams(window.location.search),r=this._filterIds(e),i={...t};n.forEach((e,t)=>{r.has(t)&&(i[t]=e)});let a=n.get(`page`);if(a!==null){let e=parseInt(a,10);!isNaN(e)&&e>0&&(i.page=e)}let o=n.get(`sort`);if(o){let e=o.split(`,`).map(e=>{let[t,n]=e.split(`:`);return t&&n?{fieldId:t,direction:n}:null}).filter(Boolean);e.length>0&&(i.sort=e)}return i}pageChanged(e){this.state={...this.state,page:e.detail.page},this.handleSearchRequested(void 0)}updated(e){if(super.updated(e),e.has(`component`)){let e=this.component?.id;if(e!==this._initializedForComponentId){this._initializedForComponentId=e;let t=this.component?.metadata,n=t.initialPage&&t.initialPage>0?t.initialPage:0;this.state=this._initStateFromUrl(t,{...this.state,size:t.pageSize,page:n,sort:[]}),(this.state.page!==n||this.state.sort?.length>0||[...this._filterIds(t)].some(e=>this.state[e]!=null))&&this.handleSearchRequested(void 0)}}}render(){let e=e=>{let t=[];return e.color&&e.color!==ca.normal&&t.push(e.color),e.buttonStyle&&t.push(e.buttonStyle===la.tertiaryInline?`tertiary-inline`:e.buttonStyle),t.length?t.join(` `):void 0},t=e=>e===`back`||e===`backToList`||!!e&&e.startsWith(`cancel`),n=t=>N.get()?.renderToolbarButton?.(t,this.evalLabel(t.label),()=>this.handleToolbarButtonClick(t.actionId))||w`
                 <button class="crud-btn"
                         data-action-id="${t.id}"
-                        theme="${e(t)||v}"
+                        theme="${e(t)||_}"
                         @click="${()=>this.handleToolbarButtonClick(t.actionId)}"
                 >${this.evalLabel(t.label)}</button>
-            `;if(!this.component)return T`no component`;let r=this.effectiveComponent,i=r.metadata;i.serverSideOrdering=!0;let a=(()=>{let e=this;for(;e;){let t=e;if(t.tagName===`MATEU-PAGE`)return(t.component?.metadata?.toolbar?.length??0)>0;e=t.parentElement??(t.getRootNode?.()instanceof ShadowRoot?t.getRootNode().host:null)}return!1})()?[]:i?.toolbar??[],o=a.filter(e=>t(e.actionId)),s=a.filter(e=>!t(e.actionId)),c=o.length>0&&s.length>0,l=!!i?.title||!!i?.subtitle||a.length>0,u=this.effectiveGridLayout,d=this.cols,f=da(d),p=this.data[this.id]?.page?.content??[],m=this.state[this.component?.id]?.emptyStateMessage,ee=(e,t)=>{let n=t[e.id];return n==null?T``:e.dataType===`status`?T`<span theme="badge pill ${ra(n.type)}">${n.message}</span>`:e.dataType===`bool`?T`${n?`✓`:`✗`}`:typeof n==`object`?T`${n.label??n.name??n.message??``}`:T`${n}`},te=()=>{let e=this.identifierFieldName,t=this.state._selectedId??this.appState?._splitDetailId,n=f.find(e=>e.identifier)??f[0],r=e=>e.dataType===`action`||e.dataType===`actionGroup`||e.dataType===`menu`||e.stereotype===`button`,i=f.filter(e=>e!==n&&!r(e)),a=d.filter(e=>r(e)),o=(e,t,n)=>{e.stopPropagation(),e.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_clickedRow:n}},bubbles:!0,composed:!0}))},s=e=>{let t=[];for(let n of a){let r=e[n.id];if(n.dataType===`action`){let i=r?.methodNameInCrud?r:e.action?.methodNameInCrud?e.action:{methodNameInCrud:n.id,label:n.label,icon:null,disabled:!1};t.push(T`
-                            <button class="crud-btn" theme="tertiary small" title="${i.label||v}"
+            `;if(!this.component)return w`no component`;let r=this.effectiveComponent,i=r.metadata;i.serverSideOrdering=!0;let a=(()=>{let e=this;for(;e;){let t=e;if(t.tagName===`MATEU-PAGE`)return(t.component?.metadata?.toolbar?.length??0)>0;e=t.parentElement??(t.getRootNode?.()instanceof ShadowRoot?t.getRootNode().host:null)}return!1})()?[]:i?.toolbar??[],o=a.filter(e=>t(e.actionId)),s=a.filter(e=>!t(e.actionId)),c=o.length>0&&s.length>0,l=!!i?.title||!!i?.subtitle||a.length>0,u=this.effectiveGridLayout,d=this.cols,f=fa(d),p=this.data[this.id]?.page?.content??[],ee=this.state[this.component?.id]?.emptyStateMessage,te=(e,t)=>{let n=t[e.id];return n==null?w``:e.dataType===`status`?w`<span theme="badge pill ${ia(n.type)}">${n.message}</span>`:e.dataType===`bool`?w`${n?`✓`:`✗`}`:typeof n==`object`?w`${n.label??n.name??n.message??``}`:w`${n}`},ne=()=>{let e=this.identifierFieldName,t=this.state._selectedId??this.appState?._splitDetailId,n=f.find(e=>e.identifier)??f[0],r=e=>e.dataType===`action`||e.dataType===`actionGroup`||e.dataType===`menu`||e.stereotype===`button`,i=f.filter(e=>e!==n&&!r(e)),a=d.filter(e=>r(e)),o=(e,t,n)=>{e.stopPropagation(),e.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_clickedRow:n}},bubbles:!0,composed:!0}))},s=e=>{let t=[];for(let n of a){let r=e[n.id];if(n.dataType===`action`){let i=r?.methodNameInCrud?r:e.action?.methodNameInCrud?e.action:{methodNameInCrud:n.id,label:n.label,icon:null,disabled:!1};t.push(w`
+                            <button class="crud-btn" theme="tertiary small" title="${i.label||_}"
                                 @click="${t=>o(t,`action-on-row-`+i.methodNameInCrud,e)}">
-                                ${i.icon?I(i.icon):v}
-                                ${i.label??v}
-                            </button>`)}else(n.dataType===`actionGroup`||n.dataType===`menu`)&&(r?.actions??[]).forEach(n=>t.push(T`
-                            <button class="crud-btn" theme="tertiary small" title="${n.label||v}"
+                                ${i.icon?F(i.icon):_}
+                                ${i.label??_}
+                            </button>`)}else(n.dataType===`actionGroup`||n.dataType===`menu`)&&(r?.actions??[]).forEach(n=>t.push(w`
+                            <button class="crud-btn" theme="tertiary small" title="${n.label||_}"
                                 @click="${t=>o(t,`action-on-row-`+n.methodNameInCrud,e)}">
-                                ${n.icon?I(n.icon):v}
-                                ${n.label??v}
-                            </button>`))}return t.length?T`
+                                ${n.icon?F(n.icon):_}
+                                ${n.label??_}
+                            </button>`))}return t.length?w`
                     <div style="display: flex; flex-wrap: wrap; gap: var(--lumo-space-xs); margin-top: var(--lumo-space-xs);">
                         ${t}
-                    </div>`:v};return T`
+                    </div>`:_};return w`
                 <div class="m-listbox" style="width: 100%;">
-                    ${p.length===0?T`<div class="m-item" disabled>${xt(m)}</div>`:v}
-                    ${p.map(r=>T`
+                    ${p.length===0?w`<div class="m-item" disabled>${St(ee)}</div>`:_}
+                    ${p.map(r=>w`
                         <div role="button" tabindex="0" class="m-item"
                             ?selected="${e&&t!==void 0&&String(r[e])===String(t)}"
-                            @click="${()=>{e&&r[e]!==void 0&&(this.state={...this.state,_selectedId:String(r[e])}),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`view`,parameters:r},bubbles:!0,composed:!0}))}}" @keydown="${R(()=>{e&&r[e]!==void 0&&(this.state={...this.state,_selectedId:String(r[e])}),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`view`,parameters:r},bubbles:!0,composed:!0}))})}"
+                            @click="${()=>{e&&r[e]!==void 0&&(this.state={...this.state,_selectedId:String(r[e])}),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`view`,parameters:r},bubbles:!0,composed:!0}))}}" @keydown="${L(()=>{e&&r[e]!==void 0&&(this.state={...this.state,_selectedId:String(r[e])}),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`view`,parameters:r},bubbles:!0,composed:!0}))})}"
                             style="cursor: pointer;"
                         >
                             <div style="font-weight: 600;">${n?r[n.id]??``:``}</div>
                             <div style="font-size: var(--lumo-font-size-s); color: var(--lumo-secondary-text-color); display: flex; flex-wrap: wrap; gap: var(--lumo-space-xs); align-items: center;">
-                                ${i.map(e=>T`<span>${e.label}: ${ee(e,r)}</span>`)}
+                                ${i.map(e=>w`<span>${e.label}: ${te(e,r)}</span>`)}
                             </div>
                             ${s(r)}
                         </div>
                     `)}
-                </div>`},ne=(e,t,n)=>{let r=this.identifierFieldName;r&&n[r]!==void 0&&(this.state={...this.state,_selectedId:String(n[r])}),e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:n},bubbles:!0,composed:!0}))},h=()=>{let e=this.identifierFieldName,t=this.state._selectedId??this.appState?._splitDetailId,n=e=>!!e.actionId,r=e=>e.dataType===`action`||e.dataType===`actionGroup`||e.dataType===`menu`||e.stereotype===`button`,i=[...d.slice(0,6),...d.slice(6).filter(e=>r(e)||e.dataType===`status`)],a=i.filter(e=>e.stereotype===`image`),o=i.find(e=>e.identifier)??i[0],s=i.find(e=>e.id===`select`&&e.dataType===`action`),c=!!s,l=i.filter(e=>e!==o&&!a.includes(e)&&!n(e)&&!r(e)),u=i.filter(e=>r(e)&&!(c&&e===s)),f=(e,t,n)=>{e.stopPropagation(),e.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_clickedRow:n}},bubbles:!0,composed:!0}))},te=e=>{let t=[];for(let n of u){let r=e[n.id];if(n.dataType===`action`){let i=r?.methodNameInCrud?r:e.action?.methodNameInCrud?e.action:{methodNameInCrud:n.id,label:n.label,icon:null,disabled:!1};t.push(T`
-                            <button class="crud-btn" theme="tertiary" title="${i.label||v}"
+                </div>`},re=(e,t,n)=>{let r=this.identifierFieldName;r&&n[r]!==void 0&&(this.state={...this.state,_selectedId:String(n[r])}),e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:n},bubbles:!0,composed:!0}))},m=()=>{let e=this.identifierFieldName,t=this.state._selectedId??this.appState?._splitDetailId,n=e=>!!e.actionId,r=e=>e.dataType===`action`||e.dataType===`actionGroup`||e.dataType===`menu`||e.stereotype===`button`,i=[...d.slice(0,6),...d.slice(6).filter(e=>r(e)||e.dataType===`status`)],a=i.filter(e=>e.stereotype===`image`),o=i.find(e=>e.identifier)??i[0],s=i.find(e=>e.id===`select`&&e.dataType===`action`),c=!!s,l=i.filter(e=>e!==o&&!a.includes(e)&&!n(e)&&!r(e)),u=i.filter(e=>r(e)&&!(c&&e===s)),f=(e,t,n)=>{e.stopPropagation(),e.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_clickedRow:n}},bubbles:!0,composed:!0}))},ne=e=>{let t=[];for(let n of u){let r=e[n.id];if(n.dataType===`action`){let i=r?.methodNameInCrud?r:e.action?.methodNameInCrud?e.action:{methodNameInCrud:n.id,label:n.label,icon:null,disabled:!1};t.push(w`
+                            <button class="crud-btn" theme="tertiary" title="${i.label||_}"
                                 @click="${t=>f(t,`action-on-row-`+i.methodNameInCrud,e)}">
-                                ${i.icon?I(i.icon):v}
-                                ${i.label??v}
-                            </button>`)}else(n.dataType===`actionGroup`||n.dataType===`menu`)&&(r?.actions??[]).forEach(n=>t.push(T`
-                            <button class="crud-btn" theme="tertiary" title="${n.label||v}"
+                                ${i.icon?F(i.icon):_}
+                                ${i.label??_}
+                            </button>`)}else(n.dataType===`actionGroup`||n.dataType===`menu`)&&(r?.actions??[]).forEach(n=>t.push(w`
+                            <button class="crud-btn" theme="tertiary" title="${n.label||_}"
                                 @click="${t=>f(t,`action-on-row-`+n.methodNameInCrud,e)}">
-                                ${n.icon?I(n.icon):v}
-                                ${n.label??v}
-                            </button>`))}return t.length?T`
+                                ${n.icon?F(n.icon):_}
+                                ${n.label??_}
+                            </button>`))}return t.length?w`
                     <div style="display: flex; flex-wrap: wrap; gap: var(--lumo-space-xs); padding-top: var(--lumo-space-s); border-top: 1px solid var(--lumo-contrast-10pct);">
                         ${t}
-                    </div>`:v};return T`
+                    </div>`:_};return w`
                 <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: var(--lumo-space-m); padding: var(--lumo-space-s) 0;">
-                    ${p.length===0?T`<div style="grid-column: 1 / -1;">${xt(m)}</div>`:v}
-                    ${p.map(n=>T`
+                    ${p.length===0?w`<div style="grid-column: 1 / -1;">${St(ee)}</div>`:_}
+                    ${p.map(n=>w`
                         <div role="button" tabindex="0" class="crud-card"
                             ?data-selected="${e&&t!==void 0&&String(n[e])===String(t)}"
                             style="cursor: pointer;"
-                            @click="${e=>c?f(e,`action-on-row-select`,n):ne(e.target,`view`,n)}" @keydown="${R(e=>c?f(e,`action-on-row-select`,n):ne(e.target,`view`,n))}"
+                            @click="${e=>c?f(e,`action-on-row-select`,n):re(e.target,`view`,n)}" @keydown="${L(e=>c?f(e,`action-on-row-select`,n):re(e.target,`view`,n))}"
                         >
-                            ${a.length?T`<img src="${n[a[0].id]??``}" alt="" style="width: 100%; max-height: 160px; object-fit: cover; border-radius: var(--lumo-border-radius-m, 8px);" />`:v}
-                            ${o?T`<div class="crud-card-title">${n[o.id]??``}</div>`:v}
+                            ${a.length?w`<img src="${n[a[0].id]??``}" alt="" style="width: 100%; max-height: 160px; object-fit: cover; border-radius: var(--lumo-border-radius-m, 8px);" />`:_}
+                            ${o?w`<div class="crud-card-title">${n[o.id]??``}</div>`:_}
                             <div style="display: flex; flex-direction: column; gap: var(--lumo-space-xs); padding: var(--lumo-space-s) 0;">
-                                ${l.map(e=>T`
+                                ${l.map(e=>w`
                                     <div style="display: flex; gap: var(--lumo-space-s); font-size: var(--lumo-font-size-s);">
                                         <span style="color: var(--lumo-secondary-text-color); min-width: 80px;">${e.label}</span>
-                                        <span>${ee(e,n)}</span>
+                                        <span>${te(e,n)}</span>
                                     </div>
                                 `)}
                             </div>
-                            ${te(n)}
+                            ${ne(n)}
                         </div>
                     `)}
-                </div>`},g=()=>{let e=fa(d),t=e.find(e=>e.identifier)??e[0],n=e.filter(e=>e!==t);return T`
+                </div>`},h=()=>{let e=pa(d),t=e.find(e=>e.identifier)??e[0],n=e.filter(e=>e!==t);return w`
                 <div style="display: flex; height: 100%; min-height: 400px; gap: 0;">
                     <div style="width: 260px; flex-shrink: 0; border-right: 1px solid var(--lumo-contrast-20pct); overflow-y: auto;">
                         <div class="m-listbox" style="width: 100%;">
-                            ${p.length===0?T`<div class="m-item" disabled>${xt(m)}</div>`:v}
-                            ${p.map(e=>T`
+                            ${p.length===0?w`<div class="m-item" disabled>${St(ee)}</div>`:_}
+                            ${p.map(e=>w`
                                 <div role="button" tabindex="0" class="m-item"
                                     ?selected="${this.selectedItem===e}"
-                                    @click="${()=>{this.selectedItem=e}}" @keydown="${R(()=>{this.selectedItem=e})}"
+                                    @click="${()=>{this.selectedItem=e}}" @keydown="${L(()=>{this.selectedItem=e})}"
                                     style="cursor: pointer;"
                                 >
                                     <div style="font-weight: 600;">${t?e[t.id]??``:``}</div>
                                     <div style="font-size: var(--lumo-font-size-s); color: var(--lumo-secondary-text-color); display: flex; flex-wrap: wrap; gap: var(--lumo-space-xs); align-items: center;">
-                                        ${n.map(t=>T`${ee(t,e)} `)}
+                                        ${n.map(t=>w`${te(t,e)} `)}
                                     </div>
                                 </div>
                             `)}
                         </div>
                     </div>
                     <div style="flex: 1; padding: var(--lumo-space-m); overflow-y: auto;">
-                        ${this.selectedItem?T`
+                        ${this.selectedItem?w`
                             <div class="m-formlayout">
-                                ${d.map(e=>T`
+                                ${d.map(e=>w`
                                     <label style="display: flex; flex-direction: column; gap: .1rem; font-size: var(--lumo-font-size-s, .875rem);">
                                         <span style="color: var(--lumo-secondary-text-color, #667);">${e.label}</span>
                                         <span>${String(this.selectedItem[e.id]??``)}</span>
                                     </label>
                                 `)}
                             </div>
-                        `:T`
+                        `:w`
                             <p style="color: var(--lumo-secondary-text-color);">Select a row to view details.</p>
                         `}
                     </div>
-                </div>`},_=()=>{let e=this.identifierFieldName,t=this.state._selectedId??this.appState?._splitDetailId,n=d[0],r=d.slice(1),i=!!n?.actionId,a=e=>(e??[]).map(e=>{let t=Array.isArray(e.children)?e.children:[];return t.length>0?{...e,children:a(t)}:{...e,children:void 0}}),o=a(p),s=(t,n,r)=>{t.stopPropagation(),e&&n[e]!==void 0&&(this.state={...this.state,_selectedId:String(n[e])}),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:r,parameters:n},bubbles:!0,composed:!0}))},c=(a,o)=>T`
+                </div>`},g=()=>{let e=this.identifierFieldName,t=this.state._selectedId??this.appState?._splitDetailId,n=d[0],r=d.slice(1),i=!!n?.actionId,a=e=>(e??[]).map(e=>{let t=Array.isArray(e.children)?e.children:[];return t.length>0?{...e,children:a(t)}:{...e,children:void 0}}),o=a(p),s=(t,n,r)=>{t.stopPropagation(),e&&n[e]!==void 0&&(this.state={...this.state,_selectedId:String(n[e])}),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:r,parameters:n},bubbles:!0,composed:!0}))},c=(a,o)=>w`
                 <tr class="${e&&t!==void 0&&String(a[e])===String(t)?`selected`:``}"
                     style="cursor: pointer;" @click="${e=>s(e,a,`view`)}">
-                    ${n?T`<td style="padding-left: ${o*1.2+.6}rem;">${a[n.id]??``}</td>`:v}
-                    ${r.map(e=>e.id===`select`?T`<td><button class="crud-btn small" @click="${e=>{e.stopPropagation(),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-select`,parameters:{_clickedRow:a}},bubbles:!0,composed:!0}))}}">Select</button></td>`:T`<td>${a[e.id]??``}</td>`)}
-                    ${i?T`<td style="text-align: end;">${a?.viewable===!1?v:T`<button class="crud-btn small" @click="${e=>s(e,a,`view`)}">View</button>`}</td>`:v}
+                    ${n?w`<td style="padding-left: ${o*1.2+.6}rem;">${a[n.id]??``}</td>`:_}
+                    ${r.map(e=>e.id===`select`?w`<td><button class="crud-btn small" @click="${e=>{e.stopPropagation(),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-select`,parameters:{_clickedRow:a}},bubbles:!0,composed:!0}))}}">Select</button></td>`:w`<td>${a[e.id]??``}</td>`)}
+                    ${i?w`<td style="text-align: end;">${a?.viewable===!1?_:w`<button class="crud-btn small" @click="${e=>s(e,a,`view`)}">View</button>`}</td>`:_}
                 </tr>
                 ${(a.children??[]).map(e=>c(e,o+1))}
-            `;return T`
+            `;return w`
                 <table class="crud-table">
                     <thead><tr>
-                        ${n?T`<th>${n.label??v}</th>`:v}
-                        ${r.map(e=>T`<th>${e.label??v}</th>`)}
-                        ${i?T`<th></th>`:v}
+                        ${n?w`<th>${n.label??_}</th>`:_}
+                        ${r.map(e=>w`<th>${e.label??_}</th>`)}
+                        ${i?w`<th></th>`:_}
                     </tr></thead>
                     <tbody>
-                        ${o.length===0?T`<tr><td colspan="99" style="padding: 1.5rem; text-align: center; color: var(--lumo-secondary-text-color, #888);">${xt(m)}</td></tr>`:v}
+                        ${o.length===0?w`<tr><td colspan="99" style="padding: 1.5rem; text-align: center; color: var(--lumo-secondary-text-color, #888);">${St(ee)}</td></tr>`:_}
                         ${o.map(e=>c(e,0))}
                     </tbody>
-                </table>`},re=P.get()?.rendersCrudLayouts?.()===!0,y=T`
-            ${i.infiniteScrolling?T`
+                </table>`},ie=N.get()?.rendersCrudLayouts?.()===!0,v=w`
+            ${i.infiniteScrolling?w`
                 <div>${this.data[this.id]?.page?.totalElements} items found.</div>
-            `:v}
-            ${!re&&u===`list`?te():!re&&u===`cards`?i.contentHeight?T`
+            `:_}
+            ${!ie&&u===`list`?ne():!ie&&u===`cards`?i.contentHeight?w`
                 <div class="m-scroll" style="width: 100%; height: ${i.contentHeight};">
-                    ${h()}
+                    ${m()}
                 </div>
-            `:h():!re&&u===`masterDetail`?g():!re&&u===`tree`?(()=>{let e=P.get();return e?.renderTreeComponent?e.renderTreeComponent(this,{rows:p,columns:d.map(e=>({id:e.id,label:e.label})),idField:this.identifierFieldName,navigable:!!d[0]?.actionId,selectedId:this.state._selectedId??this.appState?._splitDetailId}):_()})():P.get()?.renderTableComponent(this,r,this.baseUrl,this.state,this.data,this.appState,this.appData)}
+            `:m():!ie&&u===`masterDetail`?h():!ie&&u===`tree`?(()=>{let e=N.get();return e?.renderTreeComponent?e.renderTreeComponent(this,{rows:p,columns:d.map(e=>({id:e.id,label:e.label})),idField:this.identifierFieldName,navigable:!!d[0]?.actionId,selectedId:this.state._selectedId??this.appState?._splitDetailId}):g()})():N.get()?.renderTableComponent(this,r,this.baseUrl,this.state,this.data,this.appState,this.appData)}
             <slot></slot>
-        `,b=i.infiniteScrolling?v:P.get()?.renderPagination(this,this.component),x=this.showImportDialog?T`
-            <div role="button" tabindex="0" class="crud-modal-backdrop" @click="${e=>{e.target===e.currentTarget&&(this.showImportDialog=!1)}}" @keydown="${R(e=>{e.target===e.currentTarget&&(this.showImportDialog=!1)})}">
+        `,y=i.infiniteScrolling?_:N.get()?.renderPagination(this,this.component),b=this.showImportDialog?w`
+            <div role="button" tabindex="0" class="crud-modal-backdrop" @click="${e=>{e.target===e.currentTarget&&(this.showImportDialog=!1)}}" @keydown="${L(e=>{e.target===e.currentTarget&&(this.showImportDialog=!1)})}">
                 <div class="crud-modal">
                     <h3 style="margin: 0 0 .75rem;">Import</h3>
                     <input type="file" @change="${e=>{let t=e.target.files?.[0];if(t){let e=new FormData;e.append(`file`,t),fetch(`/upload`,{method:`POST`,body:e}).then(e=>e.json()).then(e=>this.handleImportUploadSuccess({detail:e})).catch(()=>this.notify(`Import failed`))}}}">
@@ -4766,8 +4766,8 @@ ${i}
                     </div>
                 </div>
             </div>
-        `:v;return this.standalone?T`
-                ${x}
+        `:_;return this.standalone?w`
+                ${b}
                 <div style="border: var(--mateu-section-border, none); background: var(--mateu-section-bg, transparent); overflow: hidden; max-height: calc(100dvh - 12rem); width: 100%; box-sizing: border-box; padding: var(--mateu-section-padding, 0); display: flex; flex-direction: column;">
                     <div style="flex-shrink: 0;">
                         <mateu-content-header
@@ -4780,40 +4780,40 @@ ${i}
                         ></mateu-content-header>
                     </div>
                     <div style="flex-shrink: 0; display: flex; align-items: center; gap: var(--lumo-space-s, 0.5rem);">
-                        <div style="flex: 1; min-width: 0;">${P.get()?.renderFilterBar(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData,!0)}</div>
+                        <div style="flex: 1; min-width: 0;">${N.get()?.renderFilterBar(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData,!0)}</div>
                         ${this.renderColumnChooser()}
                     </div>
-                    <div style="flex: 1; overflow-y: auto; min-height: 0;">${y}</div>
-                    <div style="flex-shrink: 0;">${b}</div>
+                    <div style="flex: 1; overflow-y: auto; min-height: 0;">${v}</div>
+                    <div style="flex-shrink: 0;">${y}</div>
                 </div>
-            `:T`
-            ${x}
-            ${l?T`
+            `:w`
+            ${b}
+            ${l?w`
                     <div style="display: flex; gap: var(--lumo-space-m, 1rem); width: 100%; align-items: flex-end; padding-bottom: var(--lumo-space-m, 1rem);">
                         <div style="flex: 1; min-width: 0;">
-                            ${i?.title?T`
+                            ${i?.title?w`
                                 <h2 style="margin: 0; font-size: var(--lumo-font-size-xxl); font-weight: 700; color: var(--lumo-header-text-color); overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">${this.evalLabel(i.title)}</h2>
-                            `:v}
-                            ${i?.subtitle?T`
+                            `:_}
+                            ${i?.subtitle?w`
                                 <span style="display: block; color: var(--lumo-secondary-text-color); font-size: var(--lumo-font-size-s); margin-top: var(--lumo-space-xs);">${this.evalLabel(i.subtitle)}</span>
-                            `:v}
+                            `:_}
                         </div>
                         ${o.map(e=>n(e))}
-                        ${c?T`<span class="toolbar-divider"></span>`:v}
+                        ${c?w`<span class="toolbar-divider"></span>`:_}
                         ${s.map(e=>n(e))}
                         <slot></slot>
                     </div>
-                `:v}
+                `:_}
             <div style="border: var(--mateu-section-border, none); background: var(--mateu-section-bg, transparent); overflow: hidden; max-height: calc(100dvh - 12rem); padding: var(--mateu-section-padding, 0); display: flex; flex-direction: column;">
                 <div style="flex-shrink: 0; display: flex; align-items: center; gap: var(--lumo-space-s, 0.5rem);">
-                    <div style="flex: 1; min-width: 0;">${P.get()?.renderFilterBar(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData)}</div>
+                    <div style="flex: 1; min-width: 0;">${N.get()?.renderFilterBar(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData)}</div>
                     ${this.renderColumnChooser()}
                 </div>
-                <div style="flex: 1; overflow-y: auto; min-height: 0;">${y}</div>
-                <div style="flex-shrink: 0;">${b}</div>
+                <div style="flex: 1; overflow-y: auto; min-height: 0;">${v}</div>
+                <div style="flex-shrink: 0;">${y}</div>
             </div>
-        `}createRenderRoot(){return P.mustUseShadowRoot()?super.createRenderRoot():this}static{this.styles=h`
-        ${de}
+        `}createRenderRoot(){return N.mustUseShadowRoot()?super.createRenderRoot():this}static{this.styles=m`
+        ${fe}
         /* DS-neutral crud widgets (replace vaadin-button/card/grid/list-box/form-layout/dialog). */
         .crud-btn {
             font: inherit; font-weight: 500;
@@ -4866,16 +4866,16 @@ ${i}
             outline-offset: -2px;
         }
     
-        ${z}
-    `}};k([y()],G.prototype,`component`,void 0),k([y()],G.prototype,`baseUrl`,void 0),k([y({type:Boolean})],G.prototype,`standalone`,void 0),k([y()],G.prototype,`state`,void 0),k([y()],G.prototype,`data`,void 0),k([y()],G.prototype,`appState`,void 0),k([y()],G.prototype,`appData`,void 0),k([C()],G.prototype,`showImportDialog`,void 0),k([C()],G.prototype,`availableWidthPx`,void 0),k([C()],G.prototype,`selectedItem`,void 0),k([C()],G.prototype,`_columnPrefsRevision`,void 0),G=k([g(`mateu-table-crud`)],G);var ma=function(e){return e.OnLoad=`OnLoad`,e.OnSuccess=`OnSuccess`,e.OnError=`OnError`,e.OnValueChange=`OnValueChange`,e.OnCustomEvent=`OnCustomEvent`,e.AutoSave=`AutoSave`,e}({}),ha=class extends $e{constructor(...e){super(...e),this.state={},this.data={},this.appData={},this.appState={},this.triggerOnLoad=()=>{let e=this.component;this.registerCustomEventListeners(),e.triggers?.filter(e=>e.type==ma.OnLoad).forEach(e=>{if((!e.condition||this._evalExpr(e.condition))&&!e.triggered){let n=e;n.triggered=!0;var t=n.times-1;n.timeoutMillis>0?this.scheduleOnload(n,t,this.id):this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.actionId},bubbles:!0,composed:!0}))}})},this.scheduleOnload=(e,t,n)=>{if(n!=this.component?.id)return;let r=this.callbackToken;setTimeout(()=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,callbackToken:r},bubbles:!0,composed:!0}))},e.timeoutMillis)},this._registeredCustomEventListeners=[],this.customEventManager=e=>{if(!(e instanceof CustomEvent))return;let t=e,n=(this.component.triggers??[]).filter(e=>e.type==ma.OnCustomEvent).filter(e=>e.eventName==t.type).filter(e=>e.source!==`COMPONENT`||t.detail?.__source===e.from);n.length!==0&&(n.some(e=>!e.source||e.source===`SELF`)&&(e.stopPropagation(),e.preventDefault()),n.forEach(e=>{(!e.condition||this._evalExpr(e.condition))&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:t.detail},bubbles:!0,composed:!0}))}))}}_interpolationExtra(){return{appState:this.appState??{},appData:this.appData??{},component:this.component}}_evalExpr(e){return at(e,this.state??{},this.data??{},this._interpolationExtra())}_evalTemplate(e){return ot(e,this.state??{},this.data??{},this._interpolationExtra())}isOverlayChild(e){let t=e?.metadata?.type;return t==j.Drawer||t==j.Dialog}removeSelfFromOwnerChildren(){let e=this.component;if(!e)return!1;let t=t=>{if(t===e)return!0;let n=t;return e.id!=null&&n?.id==e.id&&this.isOverlayChild(n)},n=this.parentNode;for(;n;){let e=n instanceof ShadowRoot?n.host:n,r=e.component?.children;if(Array.isArray(r)){let n=r.findIndex(t);if(n>=0)return r.splice(n,1),e.requestUpdate?.(),!0}n=n instanceof ShadowRoot?e:n.parentNode}return!1}applyFragment(e){if(this.id==e.targetComponentId){if(e.component)if(Ge.Add==e.action){if(this.component){let t=this.component.children??(this.component.children=[]),n=e.component.id?t.findIndex(t=>t.id==e.component.id&&this.isOverlayChild(t)):-1;n>=0?(t[n]=e.component,this.component={...this.component}):t.push(e.component)}}else{if(this.callbackToken=E(),e.component?.type==A.ServerSide)if(this.component){let t=this.component,n=e.component,r=t.serverSideType==n.serverSideType?(t.children??[]).filter(e=>this.isOverlayChild(e)):[];t.actions=n.actions,t.type=n.type,t.rules=n.rules,t.triggers=n.triggers,t.serverSideType=n.serverSideType,t.route=n.route,t.initialData=n.initialData,t.validations=n.validations,t.cssClasses=n.cssClasses,t.slot=n.slot,t.style=n.style,t.children=r.length?[...n.children??[],...r]:n.children,(t.serverSideType!=n.serverSideType||t.id!=n.id)&&setTimeout(()=>this.triggerOnLoad())}else this.component=e.component,setTimeout(()=>this.triggerOnLoad());else{let t=[e.component];this.component&&(this.component.children=t)}e.action!==Ge.ReplaceKeepData&&(this.state={},this.data={})}if(e.state&&(this.state={...this.state,...e.state}),e.data){for(let t in e.data){let n=e.data[t]?.page;n?.pageNumber>0&&this.data[t]&&this.data[t].page.content&&(n.content?n.content=[...this.data[t].page.content,...n.content]:n.content=[...this.data[t].page.content])}this.data={...this.data,...e.data}}this.registerCustomEventListeners();let t=P.getAfterRenderHook();t&&setTimeout(()=>t(this)),this.requestUpdate()}}registerCustomEventListeners(){this._registeredCustomEventListeners.forEach(({target:e,name:t})=>e.removeEventListener(t,this.customEventManager)),this._registeredCustomEventListeners=[],this.component?.triggers?.filter(e=>e.type==ma.OnCustomEvent).forEach(e=>{let t=e.source===`DOCUMENT`||e.source===`COMPONENT`?document:this;t.addEventListener(e.eventName,this.customEventManager),this._registeredCustomEventListeners.push({target:t,name:e.eventName})})}disconnectedCallback(){this._registeredCustomEventListeners.forEach(({target:e,name:t})=>e.removeEventListener(t,this.customEventManager)),this._registeredCustomEventListeners=[],super.disconnectedCallback()}connectedCallback(){super.connectedCallback(),this.component&&this.registerCustomEventListeners()}};k([y()],ha.prototype,`state`,void 0),k([y()],ha.prototype,`data`,void 0),k([y()],ha.prototype,`appData`,void 0),k([y()],ha.prototype,`appState`,void 0);var ga=`mateu-recent-routes`,_a=8;function va(){try{return JSON.parse(localStorage.getItem(ga)??`{}`)}catch{return{}}}function ya(e){try{localStorage.setItem(ga,JSON.stringify(e))}catch{}}function ba(e){return va()[e||`_`]??[]}function xa(e,t){if(!t?.route||!t.label)return;let n=e||`_`,r=va(),i=(r[n]??[]).filter(e=>e.route!==t.route);i.unshift({route:t.route,label:t.label}),r[n]=i.slice(0,_a),ya(r)}var K=class extends b{constructor(...e){super(...e),this.baseUrl=``,this.open=!1,this.queryText=``,this.dataHits=[],this.loading=!1,this.selectedIndex=0,this.fabOffset=0,this.keydownHandler=null}connectedCallback(){super.connectedCallback(),this.keydownHandler=e=>{(e.metaKey||e.ctrlKey)&&(e.key===`k`||e.key===`K`)?(e.preventDefault(),this.toggle()):e.key===`Escape`&&this.open&&this.close()},document.addEventListener(`keydown`,this.keydownHandler),this.setupFabObserver()}disconnectedCallback(){super.disconnectedCallback(),this.keydownHandler&&document.removeEventListener(`keydown`,this.keydownHandler),clearTimeout(this.searchTimer),this.fabObserver?.disconnect(),this.fabObserver=void 0}setupFabObserver(){let e=this.getRootNode(),t=e instanceof ShadowRoot?e:document.body;this.measureFabStack(),this.fabObserver?.disconnect(),this.fabObserver=new MutationObserver(()=>this.measureFabStack()),this.fabObserver.observe(t,{childList:!0,subtree:!0})}measureFabStack(){let e=(this.getRootNode().querySelectorAll?.(`.ai-fab, .app-fab, .page-fab`).length??0)*4;e!==this.fabOffset&&(this.fabOffset=e)}updated(e){e.has(`open`)&&this.open&&requestAnimationFrame(()=>this.inputEl?.focus())}toggle(){this.open?this.close():this.openCenter()}openCenter(){this.open=!0,this.queryText=``,this.dataHits=[],this.selectedIndex=0}close(){this.open=!1,this.queryText=``,this.dataHits=[],clearTimeout(this.searchTimer)}flattenMenu(e,t){let n=[];for(let r of e??[])if(!r.separator)if(r.submenus&&r.submenus.length>0){let e=t?`${t} › ${r.label}`:r.label;n.push(...this.flattenMenu(r.submenus,e))}else r.route!==void 0&&r.route!==null&&n.push({label:r.label,breadcrumb:t,route:r.route});return n}onInput(e){this.queryText=e,this.selectedIndex=0;let t=e.trim();if(clearTimeout(this.searchTimer),!t||!this.app?.globalSearchEnabled){this.dataHits=[],this.loading=!1;return}this.loading=!0,this.searchTimer=setTimeout(()=>this.fetchGlobalSearch(t),250)}async fetchGlobalSearch(e){let t=this.app;if(!t?.globalSearchEnabled){this.loading=!1;return}try{let n=(await We.runAction(this.baseUrl??``,t.rootRoute??``,``,`_globalsearch`,`command-center`,void 0,t.serverSideType,{},{searchText:e},this,!0))?.fragments?.map(e=>e.data).find(e=>e&&e._globalsearch);this.dataHits=n?._globalsearch??[]}catch{this.dataHits=[]}finally{this.loading=!1}}navigateTo(e,t){xa(this.app?.serverSideType??``,{route:e,label:t}),this.close();for(let t of[`route-changed`,`navigate-to-requested`])this.dispatchEvent(new CustomEvent(t,{detail:{route:e},bubbles:!0,composed:!0}))}askAi(){let e=this.queryText.trim();this.close(),this.dispatchEvent(new CustomEvent(`mateu-open-ai`,{detail:{query:e},bubbles:!0,composed:!0}))}visibleTargets(e){if(!this.queryText.trim()){let e=this.flattenMenu(this.app?.menu,``).map(e=>({route:e.route,label:e.label})),t=ba(this.app?.serverSideType??``);return[...e,...t]}return[...e.map(e=>({route:e.route,label:e.label})),...this.dataHits.map(e=>({route:e.route,label:e.label}))]}onKeydown(e,t){if(e.key===`ArrowDown`)e.preventDefault(),this.selectedIndex=Math.min(this.selectedIndex+1,t.length-1);else if(e.key===`ArrowUp`)e.preventDefault(),this.selectedIndex=Math.max(this.selectedIndex-1,0);else if(e.key===`Enter`){let e=t[this.selectedIndex];e&&this.navigateTo(e.route,e.label)}}render(){return T`
+        ${R}
+    `}};O([v()],W.prototype,`component`,void 0),O([v()],W.prototype,`baseUrl`,void 0),O([v({type:Boolean})],W.prototype,`standalone`,void 0),O([v()],W.prototype,`state`,void 0),O([v()],W.prototype,`data`,void 0),O([v()],W.prototype,`appState`,void 0),O([v()],W.prototype,`appData`,void 0),O([S()],W.prototype,`showImportDialog`,void 0),O([S()],W.prototype,`availableWidthPx`,void 0),O([S()],W.prototype,`selectedItem`,void 0),O([S()],W.prototype,`_columnPrefsRevision`,void 0),W=O([h(`mateu-table-crud`)],W);var ha=function(e){return e.OnLoad=`OnLoad`,e.OnSuccess=`OnSuccess`,e.OnError=`OnError`,e.OnValueChange=`OnValueChange`,e.OnCustomEvent=`OnCustomEvent`,e.AutoSave=`AutoSave`,e}({}),ga=class extends et{constructor(...e){super(...e),this.state={},this.data={},this.appData={},this.appState={},this.triggerOnLoad=()=>{let e=this.component;this.registerCustomEventListeners(),e.triggers?.filter(e=>e.type==ha.OnLoad).forEach(e=>{if((!e.condition||this._evalExpr(e.condition))&&!e.triggered){let n=e;n.triggered=!0;var t=n.times-1;n.timeoutMillis>0?this.scheduleOnload(n,t,this.id):this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.actionId},bubbles:!0,composed:!0}))}})},this.scheduleOnload=(e,t,n)=>{if(n!=this.component?.id)return;let r=this.callbackToken;setTimeout(()=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,callbackToken:r},bubbles:!0,composed:!0}))},e.timeoutMillis)},this._registeredCustomEventListeners=[],this.customEventManager=e=>{if(!(e instanceof CustomEvent))return;let t=e,n=(this.component.triggers??[]).filter(e=>e.type==ha.OnCustomEvent).filter(e=>e.eventName==t.type).filter(e=>e.source!==`COMPONENT`||t.detail?.__source===e.from);n.length!==0&&(n.some(e=>!e.source||e.source===`SELF`)&&(e.stopPropagation(),e.preventDefault()),n.forEach(e=>{(!e.condition||this._evalExpr(e.condition))&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:t.detail},bubbles:!0,composed:!0}))}))}}_interpolationExtra(){return{appState:this.appState??{},appData:this.appData??{},component:this.component}}_evalExpr(e){return ot(e,this.state??{},this.data??{},this._interpolationExtra())}_evalTemplate(e){return st(e,this.state??{},this.data??{},this._interpolationExtra())}isOverlayChild(e){let t=e?.metadata?.type;return t==A.Drawer||t==A.Dialog}removeSelfFromOwnerChildren(){let e=this.component;if(!e)return!1;let t=t=>{if(t===e)return!0;let n=t;return e.id!=null&&n?.id==e.id&&this.isOverlayChild(n)},n=this.parentNode;for(;n;){let e=n instanceof ShadowRoot?n.host:n,r=e.component?.children;if(Array.isArray(r)){let n=r.findIndex(t);if(n>=0)return r.splice(n,1),e.requestUpdate?.(),!0}n=n instanceof ShadowRoot?e:n.parentNode}return!1}applyFragment(e){if(this.id==e.targetComponentId){if(e.component)if(Ke.Add==e.action){if(this.component){let t=this.component.children??(this.component.children=[]),n=e.component.id?t.findIndex(t=>t.id==e.component.id&&this.isOverlayChild(t)):-1;n>=0?(t[n]=e.component,this.component={...this.component}):t.push(e.component)}}else{this.callbackToken=T();let t=!1;if(e.component?.type==k.ServerSide)if(this.component){let n=this.component,r=e.component;t=n.serverSideType==r.serverSideType;let i=t?(n.children??[]).filter(e=>this.isOverlayChild(e)):[];n.actions=r.actions,n.type=r.type,n.rules=r.rules,n.triggers=r.triggers,n.serverSideType=r.serverSideType,n.route=r.route,n.initialData=r.initialData,n.validations=r.validations,n.cssClasses=r.cssClasses,n.slot=r.slot,n.style=r.style,n.children=i.length?[...r.children??[],...i]:r.children,(n.serverSideType!=r.serverSideType||n.id!=r.id)&&setTimeout(()=>this.triggerOnLoad())}else this.component=e.component,setTimeout(()=>this.triggerOnLoad());else{let t=[e.component];this.component&&(this.component.children=t)}e.action!==Ke.ReplaceKeepData&&!t&&(this.state={},this.data={})}if(e.state&&(this.state={...this.state,...e.state}),e.data){for(let t in e.data){let n=e.data[t]?.page;n?.pageNumber>0&&this.data[t]&&this.data[t].page.content&&(n.content?n.content=[...this.data[t].page.content,...n.content]:n.content=[...this.data[t].page.content])}this.data={...this.data,...e.data}}this.registerCustomEventListeners();let t=N.getAfterRenderHook();t&&setTimeout(()=>t(this)),this.requestUpdate()}}registerCustomEventListeners(){this._registeredCustomEventListeners.forEach(({target:e,name:t})=>e.removeEventListener(t,this.customEventManager)),this._registeredCustomEventListeners=[],this.component?.triggers?.filter(e=>e.type==ha.OnCustomEvent).forEach(e=>{let t=e.source===`DOCUMENT`||e.source===`COMPONENT`?document:this;t.addEventListener(e.eventName,this.customEventManager),this._registeredCustomEventListeners.push({target:t,name:e.eventName})})}disconnectedCallback(){this._registeredCustomEventListeners.forEach(({target:e,name:t})=>e.removeEventListener(t,this.customEventManager)),this._registeredCustomEventListeners=[],super.disconnectedCallback()}connectedCallback(){super.connectedCallback(),this.component&&this.registerCustomEventListeners()}};O([v()],ga.prototype,`state`,void 0),O([v()],ga.prototype,`data`,void 0),O([v()],ga.prototype,`appData`,void 0),O([v()],ga.prototype,`appState`,void 0);var _a=`mateu-recent-routes`,va=8;function ya(){try{return JSON.parse(localStorage.getItem(_a)??`{}`)}catch{return{}}}function ba(e){try{localStorage.setItem(_a,JSON.stringify(e))}catch{}}function xa(e){return ya()[e||`_`]??[]}function Sa(e,t){if(!t?.route||!t.label)return;let n=e||`_`,r=ya(),i=(r[n]??[]).filter(e=>e.route!==t.route);i.unshift({route:t.route,label:t.label}),r[n]=i.slice(0,va),ba(r)}var G=class extends y{constructor(...e){super(...e),this.baseUrl=``,this.open=!1,this.queryText=``,this.dataHits=[],this.loading=!1,this.selectedIndex=0,this.fabOffset=0,this.keydownHandler=null}connectedCallback(){super.connectedCallback(),this.keydownHandler=e=>{(e.metaKey||e.ctrlKey)&&(e.key===`k`||e.key===`K`)?(e.preventDefault(),this.toggle()):e.key===`Escape`&&this.open&&this.close()},document.addEventListener(`keydown`,this.keydownHandler),this.setupFabObserver()}disconnectedCallback(){super.disconnectedCallback(),this.keydownHandler&&document.removeEventListener(`keydown`,this.keydownHandler),clearTimeout(this.searchTimer),this.fabObserver?.disconnect(),this.fabObserver=void 0}setupFabObserver(){let e=this.getRootNode(),t=e instanceof ShadowRoot?e:document.body;this.measureFabStack(),this.fabObserver?.disconnect(),this.fabObserver=new MutationObserver(()=>this.measureFabStack()),this.fabObserver.observe(t,{childList:!0,subtree:!0})}measureFabStack(){let e=(this.getRootNode().querySelectorAll?.(`.ai-fab, .app-fab, .page-fab`).length??0)*4;e!==this.fabOffset&&(this.fabOffset=e)}updated(e){e.has(`open`)&&this.open&&requestAnimationFrame(()=>this.inputEl?.focus())}toggle(){this.open?this.close():this.openCenter()}openCenter(){this.open=!0,this.queryText=``,this.dataHits=[],this.selectedIndex=0}close(){this.open=!1,this.queryText=``,this.dataHits=[],clearTimeout(this.searchTimer)}flattenMenu(e,t){let n=[];for(let r of e??[])if(!r.separator)if(r.submenus&&r.submenus.length>0){let e=t?`${t} › ${r.label}`:r.label;n.push(...this.flattenMenu(r.submenus,e))}else r.route!==void 0&&r.route!==null&&n.push({label:r.label,breadcrumb:t,route:r.route});return n}onInput(e){this.queryText=e,this.selectedIndex=0;let t=e.trim();if(clearTimeout(this.searchTimer),!t||!this.app?.globalSearchEnabled){this.dataHits=[],this.loading=!1;return}this.loading=!0,this.searchTimer=setTimeout(()=>this.fetchGlobalSearch(t),250)}async fetchGlobalSearch(e){let t=this.app;if(!t?.globalSearchEnabled){this.loading=!1;return}try{let n=(await Ge.runAction(this.baseUrl??``,t.rootRoute??``,``,`_globalsearch`,`command-center`,void 0,t.serverSideType,{},{searchText:e},this,!0))?.fragments?.map(e=>e.data).find(e=>e&&e._globalsearch);this.dataHits=n?._globalsearch??[]}catch{this.dataHits=[]}finally{this.loading=!1}}navigateTo(e,t){Sa(this.app?.serverSideType??``,{route:e,label:t}),this.close();for(let t of[`route-changed`,`navigate-to-requested`])this.dispatchEvent(new CustomEvent(t,{detail:{route:e},bubbles:!0,composed:!0}))}askAi(){let e=this.queryText.trim();this.close(),this.dispatchEvent(new CustomEvent(`mateu-open-ai`,{detail:{query:e},bubbles:!0,composed:!0}))}visibleTargets(e){if(!this.queryText.trim()){let e=this.flattenMenu(this.app?.menu,``).map(e=>({route:e.route,label:e.label})),t=xa(this.app?.serverSideType??``);return[...e,...t]}return[...e.map(e=>({route:e.route,label:e.label})),...this.dataHits.map(e=>({route:e.route,label:e.label}))]}onKeydown(e,t){if(e.key===`ArrowDown`)e.preventDefault(),this.selectedIndex=Math.min(this.selectedIndex+1,t.length-1);else if(e.key===`ArrowUp`)e.preventDefault(),this.selectedIndex=Math.max(this.selectedIndex-1,0);else if(e.key===`Enter`){let e=t[this.selectedIndex];e&&this.navigateTo(e.route,e.label)}}render(){return w`
             <button class="cc-fab" style="bottom: ${1.5+this.fabOffset}rem;"
                 @click=${()=>this.openCenter()} title="Buscar y navegar (⌘K)" aria-label="Command center">
                 ${this.fabIcon()}
             </button>
-            ${this.open?this.renderOverlay():v}
-        `}fabIcon(){return T`<svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            ${this.open?this.renderOverlay():_}
+        `}fabIcon(){return w`<svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="11" cy="11" r="7"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line>
-        </svg>`}renderOverlay(){let e=this.queryText.trim().toLowerCase(),t=e?this.flattenMenu(this.app?.menu,``).filter(t=>t.label.toLowerCase().includes(e)||t.breadcrumb.toLowerCase().includes(e)):[],n=this.visibleTargets(t);return T`
+        </svg>`}renderOverlay(){let e=this.queryText.trim().toLowerCase(),t=e?this.flattenMenu(this.app?.menu,``).filter(t=>t.label.toLowerCase().includes(e)||t.breadcrumb.toLowerCase().includes(e)):[],n=this.visibleTargets(t);return w`
             <div class="cc-backdrop" @click=${()=>this.close()}>
                 <div class="cc-panel" @click=${e=>e.stopPropagation()}>
                     <div class="cc-bar">
@@ -4885,7 +4885,7 @@ ${i}
                         <input class="cc-input" .value=${this.queryText} placeholder="Buscar pantallas, datos y acciones…"
                             @input=${e=>this.onInput(e.target.value)}
                             @keydown=${e=>this.onKeydown(e,n)}>
-                        ${this.queryText?T`<button class="cc-icon-btn" @click=${()=>this.onInput(``)} title="Limpiar">${this.clearIcon()}</button>`:v}
+                        ${this.queryText?w`<button class="cc-icon-btn" @click=${()=>this.onInput(``)} title="Limpiar">${this.clearIcon()}</button>`:_}
                     </div>
                     <div class="cc-body">
                         ${e?this.renderResults(t):this.renderDefault()}
@@ -4893,57 +4893,57 @@ ${i}
                 </div>
                 <button class="cc-close" @click=${()=>this.close()} title="Cerrar">${this.clearIcon()}</button>
             </div>
-        `}renderDefault(){let e=this.flattenMenu(this.app?.menu,``),t=ba(this.app?.serverSideType??``),n=-1;return T`
+        `}renderDefault(){let e=this.flattenMenu(this.app?.menu,``),t=xa(this.app?.serverSideType??``),n=-1;return w`
             <div class="cc-columns">
                 <div class="cc-col">
                     <div class="cc-section-title">Ir a</div>
                     <div class="cc-tiles">
-                        ${e.map(e=>{n++;let t=n;return T`
+                        ${e.map(e=>{n++;let t=n;return w`
                             <button class="cc-tile ${t===this.selectedIndex?`cc-sel`:``}"
                                 @click=${()=>this.navigateTo(e.route,e.label)}
                                 @mouseenter=${()=>{this.selectedIndex=t}}>
                                 <span class="cc-tile-label">${e.label}</span>
-                                ${e.breadcrumb?T`<span class="cc-sub">${e.breadcrumb}</span>`:v}
+                                ${e.breadcrumb?w`<span class="cc-sub">${e.breadcrumb}</span>`:_}
                             </button>`})}
-                        ${e.length===0?T`<div class="cc-empty">Sin opciones de menú.</div>`:v}
+                        ${e.length===0?w`<div class="cc-empty">Sin opciones de menú.</div>`:_}
                     </div>
                 </div>
-                ${t.length>0?T`
+                ${t.length>0?w`
                     <div class="cc-col cc-col--recent">
                         <div class="cc-section-title">Recientes</div>
-                        ${t.map(e=>{n++;let t=n;return T`
+                        ${t.map(e=>{n++;let t=n;return w`
                             <button class="cc-row ${t===this.selectedIndex?`cc-sel`:``}"
                                 @click=${()=>this.navigateTo(e.route,e.label)}
                                 @mouseenter=${()=>{this.selectedIndex=t}}>
                                 <span class="cc-tile-label">${e.label}</span>
                             </button>`})}
-                    </div>`:v}
+                    </div>`:_}
             </div>
-        `}renderResults(e){if(this.loading&&this.dataHits.length===0&&e.length===0)return T`<div class="cc-list">${[0,1,2,3].map(()=>T`<div class="cc-skeleton"></div>`)}</div>`;let t=e.length===0&&this.dataHits.length===0;return T`
+        `}renderResults(e){if(this.loading&&this.dataHits.length===0&&e.length===0)return w`<div class="cc-list">${[0,1,2,3].map(()=>w`<div class="cc-skeleton"></div>`)}</div>`;let t=e.length===0&&this.dataHits.length===0;return w`
             <div class="cc-list">
-                ${this.app?.sseUrl?T`
+                ${this.app?.sseUrl?w`
                     <button class="cc-row cc-ask-ai" @click=${()=>this.askAi()}>
                         ${this.aiIcon()}<span class="cc-tile-label">Preguntar a la IA: “${this.queryText.trim()}”</span>
-                    </button>`:v}
-                ${e.length>0?T`<div class="cc-section-title">Pantallas</div>`:v}
-                ${e.map((e,t)=>T`
+                    </button>`:_}
+                ${e.length>0?w`<div class="cc-section-title">Pantallas</div>`:_}
+                ${e.map((e,t)=>w`
                     <button class="cc-row ${t===this.selectedIndex?`cc-sel`:``}"
                         @click=${()=>this.navigateTo(e.route,e.label)}
                         @mouseenter=${()=>{this.selectedIndex=t}}>
                         <span class="cc-tile-label">${e.label}</span>
-                        ${e.breadcrumb?T`<span class="cc-sub">${e.breadcrumb}</span>`:v}
+                        ${e.breadcrumb?w`<span class="cc-sub">${e.breadcrumb}</span>`:_}
                     </button>`)}
                 ${this.renderDataHits(e.length)}
-                ${t?T`<div class="cc-empty">No encontramos coincidencias para “${this.queryText.trim()}”.</div>`:v}
+                ${t?w`<div class="cc-empty">No encontramos coincidencias para “${this.queryText.trim()}”.</div>`:_}
             </div>
-        `}renderDataHits(e){if(this.dataHits.length===0)return v;let t;return T`${this.dataHits.map((n,r)=>{let i=e+r,a=n.category&&n.category!==t;return t=n.category,T`
-                ${a?T`<div class="cc-section-title">${n.category}</div>`:v}
+        `}renderDataHits(e){if(this.dataHits.length===0)return _;let t;return w`${this.dataHits.map((n,r)=>{let i=e+r,a=n.category&&n.category!==t;return t=n.category,w`
+                ${a?w`<div class="cc-section-title">${n.category}</div>`:_}
                 <button class="cc-row ${i===this.selectedIndex?`cc-sel`:``}"
                     @click=${()=>this.navigateTo(n.route,n.label)}
                     @mouseenter=${()=>{this.selectedIndex=i}}>
                     <span class="cc-tile-label">${n.label}</span>
-                    ${n.description?T`<span class="cc-sub">${n.description}</span>`:v}
-                </button>`})}`}searchGlyph(){return T`<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="11" cy="11" r="7"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>`}backIcon(){return T`<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>`}clearIcon(){return T`<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>`}aiIcon(){return T`<svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><path d="M12 2l1.9 4.7L19 8.5l-4.1 2.3L12 15l-1.9-4.2L6 8.5l5.1-1.8z"></path></svg>`}static{this.styles=h`
+                    ${n.description?w`<span class="cc-sub">${n.description}</span>`:_}
+                </button>`})}`}searchGlyph(){return w`<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="11" cy="11" r="7"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>`}backIcon(){return w`<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>`}clearIcon(){return w`<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>`}aiIcon(){return w`<svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><path d="M12 2l1.9 4.7L19 8.5l-4.1 2.3L12 15l-1.9-4.2L6 8.5l5.1-1.8z"></path></svg>`}static{this.styles=m`
         :host { --cc-accent: var(--lumo-primary-color, #3b82f6); }
 
         .cc-fab {
@@ -5028,12 +5028,12 @@ ${i}
             display: flex; align-items: center; justify-content: center; cursor: pointer; z-index: 1110;
         }
         .cc-close:hover { background: rgba(0,0,0,0.75); }
-    `}};k([y({attribute:!1})],K.prototype,`app`,void 0),k([y()],K.prototype,`baseUrl`,void 0),k([C()],K.prototype,`open`,void 0),k([C()],K.prototype,`queryText`,void 0),k([C()],K.prototype,`dataHits`,void 0),k([C()],K.prototype,`loading`,void 0),k([C()],K.prototype,`selectedIndex`,void 0),k([C()],K.prototype,`fabOffset`,void 0),k([x(`.cc-input`)],K.prototype,`inputEl`,void 0),K=k([g(`mateu-command-center`)],K);var Sa=null;function Ca(e){let t=e.component?.metadata;t&&(t.commandCenterEnabled||t.chromeless)&&t.variant!==`MEDIATOR`?((!Sa||!Sa.isConnected)&&(Sa=document.createElement(`mateu-command-center`),e.renderRoot.appendChild(Sa)),Sa.app=t,Sa.baseUrl=e.baseUrl??``):Sa&&e.renderRoot.contains(Sa)&&(Sa.remove(),Sa=null)}var wa=class extends b{constructor(...e){super(...e),this.fetchStarted=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!0},this.fetchFinished=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!1},this.fetchFailed=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!1;let t=e.detail??{},n=t.failure??Pe(t.reason,{online:Be.isOnline()});if(n.kind===`cancelled`)return;let r=t.retry;oa({text:n.message,variant:`error`,duration:r?8e3:5e3,position:`bottomEnd`,...r?{actionLabel:`Retry`,onAction:r}:{}},this)}}connectedCallback(){super.connectedCallback(),this.addEventListener(`backend-called-event`,this.fetchStarted),this.addEventListener(`backend-succeeded-event`,this.fetchFinished),this.addEventListener(`backend-cancelled-event`,this.fetchFinished),this.addEventListener(`backend-failed-event`,this.fetchFailed)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`backend-called-event`,this.fetchStarted),this.removeEventListener(`backend-succeeded-event`,this.fetchFinished),this.removeEventListener(`backend-cancelled-event`,this.fetchFinished),this.removeEventListener(`backend-failed-event`,this.fetchFailed)}render(){return T`<div class="loader-container">
+    `}};O([v({attribute:!1})],G.prototype,`app`,void 0),O([v()],G.prototype,`baseUrl`,void 0),O([S()],G.prototype,`open`,void 0),O([S()],G.prototype,`queryText`,void 0),O([S()],G.prototype,`dataHits`,void 0),O([S()],G.prototype,`loading`,void 0),O([S()],G.prototype,`selectedIndex`,void 0),O([S()],G.prototype,`fabOffset`,void 0),O([b(`.cc-input`)],G.prototype,`inputEl`,void 0),G=O([h(`mateu-command-center`)],G);var Ca=null;function wa(e){let t=e.component?.metadata;t&&(t.commandCenterEnabled||t.chromeless)&&t.variant!==`MEDIATOR`?((!Ca||!Ca.isConnected)&&(Ca=document.createElement(`mateu-command-center`),e.renderRoot.appendChild(Ca)),Ca.app=t,Ca.baseUrl=e.baseUrl??``):Ca&&e.renderRoot.contains(Ca)&&(Ca.remove(),Ca=null)}var Ta=class extends y{constructor(...e){super(...e),this.fetchStarted=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!0},this.fetchFinished=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!1},this.fetchFailed=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!1;let t=e.detail??{},n=t.failure??Fe(t.reason,{online:Ve.isOnline()});if(n.kind===`cancelled`)return;let r=t.retry;sa({text:n.message,variant:`error`,duration:r?8e3:5e3,position:`bottomEnd`,...r?{actionLabel:`Retry`,onAction:r}:{}},this)}}connectedCallback(){super.connectedCallback(),this.addEventListener(`backend-called-event`,this.fetchStarted),this.addEventListener(`backend-succeeded-event`,this.fetchFinished),this.addEventListener(`backend-cancelled-event`,this.fetchFinished),this.addEventListener(`backend-failed-event`,this.fetchFailed)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`backend-called-event`,this.fetchStarted),this.removeEventListener(`backend-succeeded-event`,this.fetchFinished),this.removeEventListener(`backend-cancelled-event`,this.fetchFinished),this.removeEventListener(`backend-failed-event`,this.fetchFailed)}render(){return w`<div class="loader-container">
             <div style="display: flex; flex-direction: column;">
                 <slot></slot>
                 <div class="loader-frame ${this.loading?`delayed-show`:``}" style="${this.loading?`pointer-events: all;`:`display: none;`}"><div class="loader"></div></div>
             </div>
-        </div>`}static{this.styles=h`
+        </div>`}static{this.styles=m`
         :host {
         }
 
@@ -5096,11 +5096,11 @@ ${i}
             animation: l5 1s infinite;
         }
         @keyframes l5 {to{transform: rotate(.5turn)}}
-  `}};k([C()],wa.prototype,`loading`,void 0),wa=k([g(`mateu-api-caller`)],wa);var Ta=new class{constructor(){this._dirty=!1,this._installed=!1,this.message=`You have unsaved changes. Are you sure you want to leave this page?`,this._onDirty=()=>{this._dirty=!0},this._onClean=()=>{this._dirty=!1},this._onBeforeUnload=e=>{this._dirty&&(e.preventDefault(),e.returnValue=``)}}install(){this._installed||(this._installed=!0,document.addEventListener(`dirty`,this._onDirty),document.addEventListener(`clean`,this._onClean),window.addEventListener(`beforeunload`,this._onBeforeUnload))}get dirty(){return this._dirty}markDirty(){this._dirty=!0}markClean(){this._dirty=!1}confirmLeave(){if(!this._dirty)return!0;let e=window.confirm(this.message);return e&&(this._dirty=!1),e}},Ea,q=class extends ha{static{Ea=this}constructor(...e){super(...e),this.filter=``,this.instant=void 0,this.selectedConsumedRoute=void 0,this.selectedRoute=void 0,this.selectedUriPrefix=void 0,this.selectedBaseUrl=void 0,this.selectedServerSideType=void 0,this.selectedParams=void 0,this.tilesMenuOption=null,this.railOpenOption=null,this.commandPaletteOpen=!1,this.commandPaletteQuery=``,this.commandPaletteSelectedIndex=0,this.commandPaletteDataHits=[],this.openDataHit=e=>{Ta.confirmLeave()&&(this.commandPaletteOpen=!1,this.commandPaletteQuery=``,this.commandPaletteDataHits=[],this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:e.route},bubbles:!0,composed:!0})),this.dispatchEvent(new CustomEvent(`navigate-to-requested`,{detail:{route:e.route},bubbles:!0,composed:!0})))},this._commandPaletteHandler=null,this.pageCompact=!1,this._compactHandler=e=>{this.pageCompact=e.detail?.compact??!1},this._openAiHandler=()=>{this.chatOpen||this.showHideIa()},this.isDark=document.documentElement.getAttribute(`theme`)===`dark`,this.chatOpen=!1,this.toggleTheme=()=>{this.isDark=!this.isDark;let e=this.isDark?`dark`:`light`;document.documentElement.setAttribute(`theme`,e),localStorage.setItem(`mateu-theme`,e)},this.showHideIa=()=>{this.chat&&(this.chatOpen=!this.chatOpen,this.chat.slot=this.chatOpen?`detail`:`detail-hidden`)},this.runAction=e=>{let t=this.renderRoot.querySelector?.(`mateu-component`);t&&t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.getSelectedOption=e=>{if(e)for(let t=0;t<e.length;t++){let n=e[t];if(this.selectedRoute?this.isActiveOption(n):n.selected)return n;let r=this.getSelectedOption(n.submenus);if(r)return r}return null},this.itemSelected=e=>{let t=e.detail.value;this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix)},this.itemSelectedTiles=e=>{let t=e.detail.value._menuOption;t.submenus&&t.submenus.length>0?this.tilesMenuOption=t:(this.tilesMenuOption=null,this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix))},this.mapItemsForTiles=e=>e.map(e=>({text:e.label,consumedRoute:e.consumedRoute,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:e.selected,_menuOption:e})),this.flattenMenuForPalette=(e,t)=>{let n=[];for(let r of e)if(!r.separator)if(r.submenus&&r.submenus.length>0){let e=t?`${t} › ${r.label}`:r.label;n.push(...this.flattenMenuForPalette(r.submenus,e))}else n.push({label:r.label,breadcrumb:t,consumedRoute:r.consumedRoute,route:r.route,actionId:r.actionId,baseUrl:r.baseUrl,serverSideType:r.serverSideType,uriPrefix:r.uriPrefix});return n},this.handleCommandPaletteKeydown=(e,t)=>{let n=Math.min(t.length,10),r=n+Math.min(this.commandPaletteDataHits.length,8);if(e.key===`ArrowDown`)e.preventDefault(),this.commandPaletteSelectedIndex=Math.min(this.commandPaletteSelectedIndex+1,r-1);else if(e.key===`ArrowUp`)e.preventDefault(),this.commandPaletteSelectedIndex=Math.max(this.commandPaletteSelectedIndex-1,0);else if(e.key===`Enter`){if(this.commandPaletteSelectedIndex>=n){let e=this.commandPaletteDataHits[this.commandPaletteSelectedIndex-n];e&&this.openDataHit(e);return}let e=t[this.commandPaletteSelectedIndex];e&&(this.selectRoute(e.consumedRoute,e.route,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix),this.commandPaletteOpen=!1,this.commandPaletteQuery=``)}},this.renderCommandPalette=()=>{if(!this.commandPaletteOpen)return v;let e=this.component?.metadata;if(e?.commandCenterEnabled||!e?.menu)return v;let t=this.flattenMenuForPalette(e.menu,``),n=this.commandPaletteQuery.toLowerCase(),r=n?t.filter(e=>e.label.toLowerCase().includes(n)||e.breadcrumb.toLowerCase().includes(n)):t;return T`
+  `}};O([S()],Ta.prototype,`loading`,void 0),Ta=O([h(`mateu-api-caller`)],Ta);var Ea=new class{constructor(){this._dirty=!1,this._installed=!1,this.message=`You have unsaved changes. Are you sure you want to leave this page?`,this._onDirty=()=>{this._dirty=!0},this._onClean=()=>{this._dirty=!1},this._onBeforeUnload=e=>{this._dirty&&(e.preventDefault(),e.returnValue=``)}}install(){this._installed||(this._installed=!0,document.addEventListener(`dirty`,this._onDirty),document.addEventListener(`clean`,this._onClean),window.addEventListener(`beforeunload`,this._onBeforeUnload))}get dirty(){return this._dirty}markDirty(){this._dirty=!0}markClean(){this._dirty=!1}confirmLeave(){if(!this._dirty)return!0;let e=window.confirm(this.message);return e&&(this._dirty=!1),e}},Da,K=class extends ga{static{Da=this}constructor(...e){super(...e),this.filter=``,this.instant=void 0,this.selectedConsumedRoute=void 0,this.selectedRoute=void 0,this.selectedUriPrefix=void 0,this.selectedBaseUrl=void 0,this.selectedServerSideType=void 0,this.selectedParams=void 0,this.tilesMenuOption=null,this.railOpenOption=null,this.commandPaletteOpen=!1,this.commandPaletteQuery=``,this.commandPaletteSelectedIndex=0,this.commandPaletteDataHits=[],this.openDataHit=e=>{Ea.confirmLeave()&&(this.commandPaletteOpen=!1,this.commandPaletteQuery=``,this.commandPaletteDataHits=[],this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:e.route},bubbles:!0,composed:!0})),this.dispatchEvent(new CustomEvent(`navigate-to-requested`,{detail:{route:e.route},bubbles:!0,composed:!0})))},this._commandPaletteHandler=null,this.pageCompact=!1,this._compactHandler=e=>{this.pageCompact=e.detail?.compact??!1},this._openAiHandler=()=>{this.chatOpen||this.showHideIa()},this.isDark=document.documentElement.getAttribute(`theme`)===`dark`,this.chatOpen=!1,this.toggleTheme=()=>{this.isDark=!this.isDark;let e=this.isDark?`dark`:`light`;document.documentElement.setAttribute(`theme`,e),localStorage.setItem(`mateu-theme`,e)},this.showHideIa=()=>{this.chat&&(this.chatOpen=!this.chatOpen,this.chat.slot=this.chatOpen?`detail`:`detail-hidden`)},this.runAction=e=>{let t=this.renderRoot.querySelector?.(`mateu-component`);t&&t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.getSelectedOption=e=>{if(e)for(let t=0;t<e.length;t++){let n=e[t];if(this.selectedRoute?this.isActiveOption(n):n.selected)return n;let r=this.getSelectedOption(n.submenus);if(r)return r}return null},this.itemSelected=e=>{let t=e.detail.value;this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix)},this.itemSelectedTiles=e=>{let t=e.detail.value._menuOption;t.submenus&&t.submenus.length>0?this.tilesMenuOption=t:(this.tilesMenuOption=null,this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix))},this.mapItemsForTiles=e=>e.map(e=>({text:e.label,consumedRoute:e.consumedRoute,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:e.selected,_menuOption:e})),this.flattenMenuForPalette=(e,t)=>{let n=[];for(let r of e)if(!r.separator)if(r.submenus&&r.submenus.length>0){let e=t?`${t} › ${r.label}`:r.label;n.push(...this.flattenMenuForPalette(r.submenus,e))}else n.push({label:r.label,breadcrumb:t,consumedRoute:r.consumedRoute,route:r.route,actionId:r.actionId,baseUrl:r.baseUrl,serverSideType:r.serverSideType,uriPrefix:r.uriPrefix});return n},this.handleCommandPaletteKeydown=(e,t)=>{let n=Math.min(t.length,10),r=n+Math.min(this.commandPaletteDataHits.length,8);if(e.key===`ArrowDown`)e.preventDefault(),this.commandPaletteSelectedIndex=Math.min(this.commandPaletteSelectedIndex+1,r-1);else if(e.key===`ArrowUp`)e.preventDefault(),this.commandPaletteSelectedIndex=Math.max(this.commandPaletteSelectedIndex-1,0);else if(e.key===`Enter`){if(this.commandPaletteSelectedIndex>=n){let e=this.commandPaletteDataHits[this.commandPaletteSelectedIndex-n];e&&this.openDataHit(e);return}let e=t[this.commandPaletteSelectedIndex];e&&(this.selectRoute(e.consumedRoute,e.route,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix),this.commandPaletteOpen=!1,this.commandPaletteQuery=``)}},this.renderCommandPalette=()=>{if(!this.commandPaletteOpen)return _;let e=this.component?.metadata;if(e?.commandCenterEnabled||!e?.menu)return _;let t=this.flattenMenuForPalette(e.menu,``),n=this.commandPaletteQuery.toLowerCase(),r=n?t.filter(e=>e.label.toLowerCase().includes(n)||e.breadcrumb.toLowerCase().includes(n)):t;return w`
             <div class="cmd-backdrop" @click=${()=>{this.commandPaletteOpen=!1,this.commandPaletteQuery=``}}>
                 <div class="cmd-palette" @click=${e=>e.stopPropagation()}>
                     <div class="cmd-search-wrapper">
-                        ${I(`vaadin:search`,void 0,`cmd-search-icon`)}
+                        ${F(`vaadin:search`,void 0,`cmd-search-icon`)}
                         <input
                             class="cmd-input"
                             placeholder="Go to…"
@@ -5110,89 +5110,89 @@ ${i}
                         >
                     </div>
                     <div class="cmd-results">
-                        ${r.slice(0,10).map((e,t)=>T`
+                        ${r.slice(0,10).map((e,t)=>w`
                             <div class="cmd-result ${t===this.commandPaletteSelectedIndex?`cmd-result--selected`:``}"
                                 @click=${()=>{this.selectRoute(e.consumedRoute,e.route,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix),this.commandPaletteOpen=!1,this.commandPaletteQuery=``}}
                                 @mouseenter=${()=>{this.commandPaletteSelectedIndex=t}}
                             >
                                 <span class="cmd-result-label">${e.label}</span>
-                                ${e.breadcrumb?T`<span class="cmd-result-breadcrumb">${e.breadcrumb}</span>`:v}
+                                ${e.breadcrumb?w`<span class="cmd-result-breadcrumb">${e.breadcrumb}</span>`:_}
                             </div>
                         `)}
-                        ${n&&this.commandPaletteDataHits.length>0?T`
-                            ${this.commandPaletteDataHits.slice(0,8).map((e,t)=>{let n=Math.min(r.length,10)+t,i=this.commandPaletteDataHits[t-1];return T`
-                                    ${e.category&&e.category!==i?.category?T`
-                                        <div class="cmd-category">${e.category}</div>`:v}
+                        ${n&&this.commandPaletteDataHits.length>0?w`
+                            ${this.commandPaletteDataHits.slice(0,8).map((e,t)=>{let n=Math.min(r.length,10)+t,i=this.commandPaletteDataHits[t-1];return w`
+                                    ${e.category&&e.category!==i?.category?w`
+                                        <div class="cmd-category">${e.category}</div>`:_}
                                     <div class="cmd-result ${n===this.commandPaletteSelectedIndex?`cmd-result--selected`:``}"
                                          @click=${()=>this.openDataHit(e)}
                                          @mouseenter=${()=>{this.commandPaletteSelectedIndex=n}}
                                     >
                                         <span class="cmd-result-label">${e.label}</span>
-                                        ${e.description?T`<span class="cmd-result-breadcrumb">${e.description}</span>`:v}
-                                    </div>`})}`:v}
-                        ${r.length===0&&this.commandPaletteDataHits.length===0?T`<div class="cmd-empty">No results for "${this.commandPaletteQuery}"</div>`:v}
+                                        ${e.description?w`<span class="cmd-result-breadcrumb">${e.description}</span>`:_}
+                                    </div>`})}`:_}
+                        ${r.length===0&&this.commandPaletteDataHits.length===0?w`<div class="cmd-empty">No results for "${this.commandPaletteQuery}"</div>`:_}
                     </div>
                 </div>
             </div>
-        `},this.renderRail=e=>T`
+        `},this.renderRail=e=>w`
             <div class="nav-rail">
                 ${e.map(e=>this.renderRailItem(e))}
             </div>
-        `,this.renderRailItem=e=>T`
+        `,this.renderRailItem=e=>w`
             <div class="rail-item ${(e.submenus?.length>0?this.railOpenOption?.label===e.label:e.selected)?`rail-item--active`:``}"
                 @click=${()=>{e.submenus&&e.submenus.length>0?this.railOpenOption=this.railOpenOption?.label===e.label?null:e:(this.railOpenOption=null,this.selectRoute(e.consumedRoute,e.route,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix))}}
             >
-                ${e.icon?I(e.icon,void 0,`rail-icon`):T`<div class="rail-icon-placeholder">${e.label.charAt(0).toUpperCase()}</div>`}
+                ${e.icon?F(e.icon,void 0,`rail-icon`):w`<div class="rail-icon-placeholder">${e.label.charAt(0).toUpperCase()}</div>`}
                 <span class="rail-label">${e.label}</span>
             </div>
-        `,this.renderRailSubPanel=e=>T`
+        `,this.renderRailSubPanel=e=>w`
             <div class="rail-sub-panel">
                 <div class="rail-sub-title">${e.label}</div>
-                ${e.submenus.map(e=>T`
+                ${e.submenus.map(e=>w`
                     <div class="rail-sub-item ${e.selected?`rail-sub-item--active`:``}"
                         @click=${()=>{e.submenus&&e.submenus.length>0?this.railOpenOption=e:this.selectRoute(e.consumedRoute,e.route,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix)}}
                     >${e.label}</div>
                 `)}
             </div>
-        `,this.renderTilesHub=e=>T`
+        `,this.renderTilesHub=e=>w`
             <div style="padding: 2rem;">
                 <h2 style="margin-top: 0; margin-bottom: 1.5rem;">${e.label}</h2>
                 <div class="tiles-hub-grid">
-                    ${e.submenus.map(e=>T`
+                    ${e.submenus.map(e=>w`
                         <div class="nav-tile"
                             @click=${()=>{e.submenus&&e.submenus.length>0?this.tilesMenuOption=e:(this.tilesMenuOption=null,this.selectRoute(e.consumedRoute,e.route,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix))}}
                         >
-                            ${e.icon?I(e.icon,`font-size: 2rem; color: var(--lumo-primary-color); display: block; margin-bottom: 0.75rem;`):v}
+                            ${e.icon?F(e.icon,`font-size: 2rem; color: var(--lumo-primary-color); display: block; margin-bottom: 0.75rem;`):_}
                             <div class="nav-tile-title">${e.label}</div>
-                            ${e.description?T`<div class="nav-tile-desc">${e.description}</div>`:v}
+                            ${e.description?w`<div class="nav-tile-desc">${e.description}</div>`:_}
                         </div>
                     `)}
                 </div>
             </div>
-        `,this.goHome=()=>{Ta.confirmLeave()&&(window.history.pushState(null,``,`/`),window.dispatchEvent(new PopStateEvent(`popstate`,{state:null})))},this.selectRoute=(e,t,n,r,i,a)=>{Ta.confirmLeave()&&this._selectRoute(e,t,n,r,i,a)},this._selectRoute=(e,t,n,r,i,a)=>{{this.selectedConsumedRoute=e,this.selectedBaseUrl=r,this.selectedRoute=t,this.selectedServerSideType=i,this.selectedUriPrefix=a,this.instant=E(),this.state&&this.state._route!=null&&(this.state._route=void 0);let n=this.baseUrl??``;n.indexOf(`://`)<0&&(n.startsWith(`/`)||(n=`/`+n),n=window.location.origin+n),n.endsWith(`/`)&&(t??``).startsWith(`/`)&&(t=(t??``).substring(1));let o=new URL(n+t);if(e&&o.pathname.startsWith(e)){let t=o.pathname.substring(e.length);o=new URL(o.origin+(t||`/`))}if((window.location.pathname||o.pathname)&&window.location.pathname!=o.pathname){let e=o.pathname;o.search&&(e+=o.search),e&&!e.startsWith(`/`)&&(e=`/`+e),this.baseUrl&&e.startsWith(this.baseUrl)&&(e=e.substring(this.baseUrl.length));let t=e;this.selectedUriPrefix&&(t=t.startsWith(`/`)&&this.selectedUriPrefix.endsWith(`/`)?this.selectedUriPrefix+t.substring(1):!t.startsWith(`/`)&&!this.selectedUriPrefix.endsWith(`/`)?this.selectedUriPrefix+`/`+t:this.selectedUriPrefix+t),t==`/_page`&&(t=``),this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0}))}}},this.isActiveOption=e=>this.selectedRoute?!!e.route&&(this.selectedRoute==e.route||this.selectedRoute.startsWith(e.route+`/`)):!!e.selected,this.mapItems=(e,t)=>e.map(e=>{if(e.submenus&&e.submenus.length>0){let n=this.mapItems(e.submenus,t);return t&&e.label.toLowerCase().includes(t)&&(n=this.mapItems(e.submenus,``)),n&&n.length>0?{consumedRoute:e.consumedRoute,text:e.label,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:t||this.isActiveOption(e),children:n}:void 0}if(e.separator)return t?void 0:{component:`hr`};if(!t||e.label.toLowerCase().includes(t))return{consumedRoute:e.consumedRoute,text:e.label,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:t||this.isActiveOption(e)}}).filter(e=>e!=null),this.getSelectedIndex=e=>{if(!e)return NaN;let t=e=>{let t=(e??``).trim();return t.length>1&&t.endsWith(`/`)&&(t=t.slice(0,-1)),t},n=t(this.selectedRoute??window.location.pathname),r=NaN,i=-1;for(let a=0;a<e.length;a++){let o=t(e[a].route);o!==``&&(n===o||n.startsWith(o+`/`))&&o.length>i&&(i=o.length,r=a)}if(!Number.isNaN(r))return r;let a=this.getSelectedOption(e);return a?e.indexOf(a):NaN},this.renderOptionOnLeftMenu=e=>e.submenus&&e.submenus.length>0?T`
+        `,this.goHome=()=>{Ea.confirmLeave()&&(window.history.pushState(null,``,`/`),window.dispatchEvent(new PopStateEvent(`popstate`,{state:null})))},this.selectRoute=(e,t,n,r,i,a)=>{Ea.confirmLeave()&&this._selectRoute(e,t,n,r,i,a)},this._selectRoute=(e,t,n,r,i,a)=>{{this.selectedConsumedRoute=e,this.selectedBaseUrl=r,this.selectedRoute=t,this.selectedServerSideType=i,this.selectedUriPrefix=a,this.instant=T(),this.state&&this.state._route!=null&&(this.state._route=void 0);let n=this.baseUrl??``;n.indexOf(`://`)<0&&(n.startsWith(`/`)||(n=`/`+n),n=window.location.origin+n),n.endsWith(`/`)&&(t??``).startsWith(`/`)&&(t=(t??``).substring(1));let o=new URL(n+t);if(e&&o.pathname.startsWith(e)){let t=o.pathname.substring(e.length);o=new URL(o.origin+(t||`/`))}if((window.location.pathname||o.pathname)&&window.location.pathname!=o.pathname){let e=o.pathname;o.search&&(e+=o.search),e&&!e.startsWith(`/`)&&(e=`/`+e),this.baseUrl&&e.startsWith(this.baseUrl)&&(e=e.substring(this.baseUrl.length));let t=e;this.selectedUriPrefix&&(t=t.startsWith(`/`)&&this.selectedUriPrefix.endsWith(`/`)?this.selectedUriPrefix+t.substring(1):!t.startsWith(`/`)&&!this.selectedUriPrefix.endsWith(`/`)?this.selectedUriPrefix+`/`+t:this.selectedUriPrefix+t),t==`/_page`&&(t=``),this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0}))}}},this.isActiveOption=e=>this.selectedRoute?!!e.route&&(this.selectedRoute==e.route||this.selectedRoute.startsWith(e.route+`/`)):!!e.selected,this.mapItems=(e,t)=>e.map(e=>{if(e.submenus&&e.submenus.length>0){let n=this.mapItems(e.submenus,t);return t&&e.label.toLowerCase().includes(t)&&(n=this.mapItems(e.submenus,``)),n&&n.length>0?{consumedRoute:e.consumedRoute,text:e.label,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:t||this.isActiveOption(e),children:n}:void 0}if(e.separator)return t?void 0:{component:`hr`};if(!t||e.label.toLowerCase().includes(t))return{consumedRoute:e.consumedRoute,text:e.label,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:t||this.isActiveOption(e)}}).filter(e=>e!=null),this.getSelectedIndex=e=>{if(!e)return NaN;let t=e=>{let t=(e??``).trim();return t.length>1&&t.endsWith(`/`)&&(t=t.slice(0,-1)),t},n=t(this.selectedRoute??window.location.pathname),r=NaN,i=-1;for(let a=0;a<e.length;a++){let o=t(e[a].route);o!==``&&(n===o||n.startsWith(o+`/`))&&o.length>i&&(i=o.length,r=a)}if(!Number.isNaN(r))return r;let a=this.getSelectedOption(e);return a?e.indexOf(a):NaN},this.renderOptionOnLeftMenu=e=>e.submenus&&e.submenus.length>0?w`
                 <details open class="left-menu-group">
                     <summary>${e.label}</summary>
                     <div class="left-menu-children">
-                        ${e.submenus.map(e=>T`${this.renderOptionOnLeftMenu(e)}`)}
+                        ${e.submenus.map(e=>w`${this.renderOptionOnLeftMenu(e)}`)}
                     </div>
                 </details>
-`:T`<button class="left-menu-item"
+`:w`<button class="left-menu-item"
                 @click="${()=>this.selectRoute(e.consumedRoute,e.route,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix)}"
-        >${e.label}</button>`,this.navItemSelected=e=>{if(e.path==this.selectedRoute&&e.consumedRoute==this.selectedConsumedRoute&&e.baseUrl==this.selectedBaseUrl&&e.serverSideType==this.selectedServerSideType){let e=this.shadowRoot?.querySelector(`mateu-ux`);e&&e.setAttribute(`instant`,E())}else this.selectRoute(e.consumedRoute,e.path,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix);this.component.metadata.drawerClosed&&this.vaadinAppLayout&&(this.vaadinAppLayout.drawerOpened=!1)},this.renderSideNav=(e,t)=>e?T`
-            ${e.map(e=>{let t=e;return T`
+        >${e.label}</button>`,this.navItemSelected=e=>{if(e.path==this.selectedRoute&&e.consumedRoute==this.selectedConsumedRoute&&e.baseUrl==this.selectedBaseUrl&&e.serverSideType==this.selectedServerSideType){let e=this.shadowRoot?.querySelector(`mateu-ux`);e&&e.setAttribute(`instant`,T())}else this.selectRoute(e.consumedRoute,e.path,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix);this.component.metadata.drawerClosed&&this.vaadinAppLayout&&(this.vaadinAppLayout.drawerOpened=!1)},this.renderSideNav=(e,t)=>e?w`
+            ${e.map(e=>{let t=e;return w`
 
-                        ${t.component==`hr`?T`<hr/>`:T`
+                        ${t.component==`hr`?w`<hr/>`:w`
                                 <div class="side-nav-item ${t.selected?`side-nav-item--active`:``}">
                                     <button class="side-nav-link"
                                             @click="${()=>{t.route&&!t.children&&this.selectRoute(void 0,t.route,void 0,this.baseUrl,void 0,void 0)}}">
-                                        ${t.icon?I(`vaadin:dashboard`,`margin-right:.5rem;`):v}${t.text}
+                                        ${t.icon?F(`vaadin:dashboard`,`margin-right:.5rem;`):_}${t.text}
                                     </button>
-                                    ${t.children?T`<div class="side-nav-children">${this.renderSideNav(t.children,`children`)}</div>`:v}
+                                    ${t.children?w`<div class="side-nav-children">${this.renderSideNav(t.children,`children`)}</div>`:_}
                                 </div>
                         `}
 
-                            `})}`:v,this.updateRoute=e=>{e.preventDefault(),e.stopPropagation();var t=e.detail;this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix)}}createRenderRoot(){return P.mustUseShadowRoot()?super.createRenderRoot():(Ea.injectLightDomStyles(),this)}static{this.lightDomStylesInjected=!1}static injectLightDomStyles(){if(Ea.lightDomStylesInjected||typeof document>`u`||(Ea.lightDomStylesInjected=!0,document.getElementById(`mateu-app-light-styles`)))return;let e=Ea.styles,t=Array.isArray(e)?e.map(e=>e?.cssText??``).join(`
-`):e?.cssText??``;if(!t)return;let n=document.createElement(`style`);n.id=`mateu-app-light-styles`,n.textContent=t,document.head.appendChild(n)}fetchGlobalSearch(e){let t=this.component?.metadata;if(t?.globalSearchEnabled){if(clearTimeout(this._globalSearchTimer),!e){this.commandPaletteDataHits=[];return}this._globalSearchTimer=setTimeout(async()=>{try{let n=(await We.runAction(this.baseUrl??``,t.rootRoute??``,``,`_globalsearch`,`cmd-palette`,void 0,t.serverSideType,{},{searchText:e},this,!0))?.fragments?.map(e=>e.data).find(e=>e&&e._globalsearch);this.commandPaletteDataHits=n?._globalsearch??[]}catch{this.commandPaletteDataHits=[]}},250)}}connectedCallback(){super.connectedCallback(),this.isDark=document.documentElement.getAttribute(`theme`)===`dark`,this._commandPaletteHandler=e=>{this.component?.metadata?.commandCenterEnabled||((e.metaKey||e.ctrlKey)&&e.key===`k`&&(e.preventDefault(),this.commandPaletteOpen=!this.commandPaletteOpen,this.commandPaletteQuery=``,this.commandPaletteSelectedIndex=0),e.key===`Escape`&&this.commandPaletteOpen&&(this.commandPaletteOpen=!1,this.commandPaletteQuery=``))},document.addEventListener(`keydown`,this._commandPaletteHandler),Ta.install(),this.addEventListener(`compact-changed`,this._compactHandler),this.addEventListener(`mateu-open-ai`,this._openAiHandler)}disconnectedCallback(){super.disconnectedCallback(),this._commandPaletteHandler&&document.removeEventListener(`keydown`,this._commandPaletteHandler),this.removeEventListener(`compact-changed`,this._compactHandler),this.removeEventListener(`mateu-open-ai`,this._openAiHandler)}updated(e){if(super.updated(e),Ca(this),this.component){let t=this.component.metadata;if(t){let n=t;if(n.favicon){let e=document.querySelector(`link[rel~='icon']`);e||(e=document.createElement(`link`),e.rel=`icon`,document.head.appendChild(e)),e.href=n.favicon}e.has(`component`)&&(this.selectedRoute=n.homeRoute,this.selectedConsumedRoute=n.homeConsumedRoute,this.selectedServerSideType=n.homeServerSideType,this.selectedBaseUrl=n.homeBaseUrl,this.selectedUriPrefix=n.homeUriPrefix)}}e.has(`commandPaletteOpen`)&&this.commandPaletteOpen&&setTimeout(()=>{this.renderRoot.querySelector(`.cmd-input`)?.focus()},0)}render(){return P.get()?.renderAppComponent(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData)}static{this.styles=h`
+                            `})}`:_,this.updateRoute=e=>{e.preventDefault(),e.stopPropagation();var t=e.detail;this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix)}}createRenderRoot(){return N.mustUseShadowRoot()?super.createRenderRoot():(Da.injectLightDomStyles(),this)}static{this.lightDomStylesInjected=!1}static injectLightDomStyles(){if(Da.lightDomStylesInjected||typeof document>`u`||(Da.lightDomStylesInjected=!0,document.getElementById(`mateu-app-light-styles`)))return;let e=Da.styles,t=Array.isArray(e)?e.map(e=>e?.cssText??``).join(`
+`):e?.cssText??``;if(!t)return;let n=document.createElement(`style`);n.id=`mateu-app-light-styles`,n.textContent=t,document.head.appendChild(n)}fetchGlobalSearch(e){let t=this.component?.metadata;if(t?.globalSearchEnabled){if(clearTimeout(this._globalSearchTimer),!e){this.commandPaletteDataHits=[];return}this._globalSearchTimer=setTimeout(async()=>{try{let n=(await Ge.runAction(this.baseUrl??``,t.rootRoute??``,``,`_globalsearch`,`cmd-palette`,void 0,t.serverSideType,{},{searchText:e},this,!0))?.fragments?.map(e=>e.data).find(e=>e&&e._globalsearch);this.commandPaletteDataHits=n?._globalsearch??[]}catch{this.commandPaletteDataHits=[]}},250)}}connectedCallback(){super.connectedCallback(),this.isDark=document.documentElement.getAttribute(`theme`)===`dark`,this._commandPaletteHandler=e=>{this.component?.metadata?.commandCenterEnabled||((e.metaKey||e.ctrlKey)&&e.key===`k`&&(e.preventDefault(),this.commandPaletteOpen=!this.commandPaletteOpen,this.commandPaletteQuery=``,this.commandPaletteSelectedIndex=0),e.key===`Escape`&&this.commandPaletteOpen&&(this.commandPaletteOpen=!1,this.commandPaletteQuery=``))},document.addEventListener(`keydown`,this._commandPaletteHandler),Ea.install(),this.addEventListener(`compact-changed`,this._compactHandler),this.addEventListener(`mateu-open-ai`,this._openAiHandler)}disconnectedCallback(){super.disconnectedCallback(),this._commandPaletteHandler&&document.removeEventListener(`keydown`,this._commandPaletteHandler),this.removeEventListener(`compact-changed`,this._compactHandler),this.removeEventListener(`mateu-open-ai`,this._openAiHandler)}updated(e){if(super.updated(e),wa(this),this.component){let t=this.component.metadata;if(t){let n=t;if(n.favicon){let e=document.querySelector(`link[rel~='icon']`);e||(e=document.createElement(`link`),e.rel=`icon`,document.head.appendChild(e)),e.href=n.favicon}e.has(`component`)&&(this.selectedRoute=n.homeRoute,this.selectedConsumedRoute=n.homeConsumedRoute,this.selectedServerSideType=n.homeServerSideType,this.selectedBaseUrl=n.homeBaseUrl,this.selectedUriPrefix=n.homeUriPrefix)}}e.has(`commandPaletteOpen`)&&this.commandPaletteOpen&&setTimeout(()=>{this.renderRoot.querySelector(`.cmd-input`)?.focus()},0)}render(){return N.get()?.renderAppComponent(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData)}static{this.styles=m`
         /* DS-neutral app chrome (replaces vaadin-app-layout / menu-bar / tabs / side-nav). */
         .m-hl { display: flex; flex-direction: row; }
         .m-vl { display: flex; flex-direction: column; }
@@ -5542,14 +5542,14 @@ ${i}
             transform: scale(1.08);
         }
 
-  `}};k([C()],q.prototype,`filter`,void 0),k([C()],q.prototype,`instant`,void 0),k([C()],q.prototype,`selectedConsumedRoute`,void 0),k([C()],q.prototype,`selectedRoute`,void 0),k([C()],q.prototype,`selectedUriPrefix`,void 0),k([C()],q.prototype,`selectedBaseUrl`,void 0),k([C()],q.prototype,`selectedServerSideType`,void 0),k([C()],q.prototype,`selectedParams`,void 0),k([C()],q.prototype,`tilesMenuOption`,void 0),k([C()],q.prototype,`railOpenOption`,void 0),k([C()],q.prototype,`commandPaletteOpen`,void 0),k([C()],q.prototype,`commandPaletteQuery`,void 0),k([C()],q.prototype,`commandPaletteSelectedIndex`,void 0),k([C()],q.prototype,`commandPaletteDataHits`,void 0),k([C()],q.prototype,`pageCompact`,void 0),k([x(`mateu-chat`)],q.prototype,`chat`,void 0),k([C()],q.prototype,`isDark`,void 0),k([C()],q.prototype,`chatOpen`,void 0),k([x(`.mateu-app-layout`)],q.prototype,`vaadinAppLayout`,void 0),q=Ea=k([g(`mateu-app`)],q);var Da=class extends b{constructor(...e){super(...e),this.message=`This website uses cookies.`,this.dismiss=`Ok. Thanks :).`,this.learnMore=`Learn more`,this.learnMoreLink=`https://cookiesandyou.com/`,this.showLearnMore=!0,this.position=`top`,this.cookieName=`mateu-cookieconsent`}updated(e){super.updated(e)}connectedCallback(){super.connectedCallback(),this._css=document.createElement(`style`),this._css.innerText=`.cc-window{opacity:1;transition:opacity 1s ease}.cc-window.cc-invisible{opacity:0}.cc-animate.cc-revoke{transition:transform 1s ease}.cc-animate.cc-revoke.cc-top{transform:translateY(-2em)}.cc-animate.cc-revoke.cc-bottom{transform:translateY(2em)}.cc-animate.cc-revoke.cc-active.cc-bottom,.cc-animate.cc-revoke.cc-active.cc-top,.cc-revoke:hover{transform:translateY(0)}.cc-grower{max-height:0;overflow:hidden;transition:max-height 1s}.cc-link,.cc-revoke:hover{text-decoration:underline}.cc-revoke,.cc-window{position:fixed;overflow:hidden;box-sizing:border-box;font-family:Helvetica,Calibri,Arial,sans-serif;font-size:16px;line-height:1.5em;display:flex;flex-wrap:nowrap;z-index:9999}.cc-window.cc-static{position:static}.cc-window.cc-floating{padding:2em;max-width:24em;flex-direction:column}.cc-window.cc-banner{padding:1em 1.8em;width:100%;flex-direction:row}.cc-revoke{padding:.5em}.cc-header{font-size:18px;font-weight:700}.cc-btn,.cc-close,.cc-link,.cc-revoke{cursor:pointer}.cc-link{opacity:.8;display:inline-block;padding:.2em}.cc-link:hover{opacity:1}.cc-link:active,.cc-link:visited{color:initial}.cc-btn{display:block;padding:.4em .8em;font-size:.9em;font-weight:700;border-width:2px;border-style:solid;text-align:center;white-space:nowrap}.cc-banner .cc-btn:last-child{min-width:140px}.cc-highlight .cc-btn:first-child{background-color:transparent;border-color:transparent}.cc-highlight .cc-btn:first-child:focus,.cc-highlight .cc-btn:first-child:hover{background-color:transparent;text-decoration:underline}.cc-close{display:block;position:absolute;top:.5em;right:.5em;font-size:1.6em;opacity:.9;line-height:.75}.cc-close:focus,.cc-close:hover{opacity:1}.cc-revoke.cc-top{top:0;left:3em;border-bottom-left-radius:.5em;border-bottom-right-radius:.5em}.cc-revoke.cc-bottom{bottom:0;left:3em;border-top-left-radius:.5em;border-top-right-radius:.5em}.cc-revoke.cc-left{left:3em;right:unset}.cc-revoke.cc-right{right:3em;left:unset}.cc-top{top:1em}.cc-left{left:1em}.cc-right{right:1em}.cc-bottom{bottom:1em}.cc-floating>.cc-link{margin-bottom:1em}.cc-floating .cc-message{display:block;margin-bottom:1em}.cc-window.cc-floating .cc-compliance{flex:1 0 auto}.cc-window.cc-banner{align-items:center}.cc-banner.cc-top{left:0;right:0;top:0}.cc-banner.cc-bottom{left:0;right:0;bottom:0}.cc-banner .cc-message{flex:1}.cc-compliance{display:flex;align-items:center;align-content:space-between}.cc-compliance>.cc-btn{flex:1}.cc-btn+.cc-btn{margin-left:.5em}@media print{.cc-revoke,.cc-window{display:none}}@media screen and (max-width:900px){.cc-btn{white-space:normal}}@media screen and (max-width:414px) and (orientation:portrait),screen and (max-width:736px) and (orientation:landscape){.cc-window.cc-top{top:0}.cc-window.cc-bottom{bottom:0}.cc-window.cc-banner,.cc-window.cc-left,.cc-window.cc-right{left:0;right:0}.cc-window.cc-banner{flex-direction:column}.cc-window.cc-banner .cc-compliance{flex:1}.cc-window.cc-floating{max-width:none}.cc-window .cc-message{margin-bottom:1em}.cc-window.cc-banner{align-items:unset}}.cc-floating.cc-theme-classic{padding:1.2em;border-radius:5px}.cc-floating.cc-type-info.cc-theme-classic .cc-compliance{text-align:center;display:inline;flex:none}.cc-theme-classic .cc-btn{border-radius:5px}.cc-theme-classic .cc-btn:last-child{min-width:140px}.cc-floating.cc-type-info.cc-theme-classic .cc-btn{display:inline-block}.cc-theme-edgeless.cc-window{padding:0}.cc-floating.cc-theme-edgeless .cc-message{margin:2em 2em 1.5em}.cc-banner.cc-theme-edgeless .cc-btn{margin:0;padding:.8em 1.8em;height:100%}.cc-banner.cc-theme-edgeless .cc-message{margin-left:1em}.cc-floating.cc-theme-edgeless .cc-btn+.cc-btn{margin-left:0}`,document.head.appendChild(this._css),this.__updatePopup()}disconnectedCallback(){super.disconnectedCallback(),this.__closePopup(),this._css.isConnected&&this._css.remove()}__closePopup(){let e=this.popup;e&&e.parentNode?.removeChild(e)}_show(){let e=this.popup;e&&(e.classList.remove(`cc-invisible`),e.style.display=``)}__updatePopup(){this.__closePopup(),window.cookieconsent.initialise({palette:{popup:{background:`#000`},button:{background:`rgba(22, 118, 243, 0.95)`,hover:`rgba(22, 118, 243, 1)`}},showLink:this.showLearnMore,content:{message:this.message,dismiss:this.dismiss,link:this.learnMore,href:this.learnMoreLink},cookie:{name:this.cookieName},position:this.position,elements:{messagelink:`<span id="cookieconsent:desc" class="cc-message">${this.message} <a tabindex="0" class="cc-link" href="${this.learnMoreLink}" target="_blank" rel="noopener noreferrer nofollow">${this.learnMore}</a></span>`,dismiss:`<a tabindex="0" class="cc-btn cc-dismiss">${this.dismiss}</a>`}});let e=this.popup;if(e){e.setAttribute(`role`,`alert`);let t=e.querySelector(`a.cc-btn`);t?.addEventListener(`keydown`,e=>{let n=e.keyCode||e.which;(n===32||n===13)&&t.click()})}}render(){return T`
-       `}static{this.styles=h`
-  `}};k([y()],Da.prototype,`message`,void 0),k([y()],Da.prototype,`dismiss`,void 0),k([y()],Da.prototype,`learnMore`,void 0),k([y()],Da.prototype,`learnMoreLink`,void 0),k([y()],Da.prototype,`showLearnMore`,void 0),k([y()],Da.prototype,`position`,void 0),k([y()],Da.prototype,`cookieName`,void 0),k([C()],Da.prototype,`_css`,void 0),k([x(`[aria-label="cookieconsent"]`)],Da.prototype,`popup`,void 0),Da=k([g(`mateu-cookie-consent`)],Da);var Oa=class extends b{constructor(...e){super(...e),this.redispatchEvent=e=>{e instanceof CustomEvent&&(e.stopPropagation(),e.preventDefault(),this.target?.dispatchEvent(new CustomEvent(e.type,{detail:e.detail,bubbles:!0,composed:!0})))}}connectedCallback(){super.connectedCallback(),this.addEventListener(`value-changed`,this.redispatchEvent),this.addEventListener(`data-changed`,this.redispatchEvent),this.addEventListener(`action-requested`,this.redispatchEvent),this.addEventListener(`server-side-action-requested`,this.redispatchEvent),this.addEventListener(`route-changed`,this.redispatchEvent),this.addEventListener(`close-modal-requested`,this.redispatchEvent)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`value-changed`,this.redispatchEvent),this.removeEventListener(`data-changed`,this.redispatchEvent),this.removeEventListener(`action-requested`,this.redispatchEvent),this.removeEventListener(`server-side-action-requested`,this.redispatchEvent),this.removeEventListener(`route-changed`,this.redispatchEvent)}render(){return T`<slot></slot>`}static{this.styles=h`
+  `}};O([S()],K.prototype,`filter`,void 0),O([S()],K.prototype,`instant`,void 0),O([S()],K.prototype,`selectedConsumedRoute`,void 0),O([S()],K.prototype,`selectedRoute`,void 0),O([S()],K.prototype,`selectedUriPrefix`,void 0),O([S()],K.prototype,`selectedBaseUrl`,void 0),O([S()],K.prototype,`selectedServerSideType`,void 0),O([S()],K.prototype,`selectedParams`,void 0),O([S()],K.prototype,`tilesMenuOption`,void 0),O([S()],K.prototype,`railOpenOption`,void 0),O([S()],K.prototype,`commandPaletteOpen`,void 0),O([S()],K.prototype,`commandPaletteQuery`,void 0),O([S()],K.prototype,`commandPaletteSelectedIndex`,void 0),O([S()],K.prototype,`commandPaletteDataHits`,void 0),O([S()],K.prototype,`pageCompact`,void 0),O([b(`mateu-chat`)],K.prototype,`chat`,void 0),O([S()],K.prototype,`isDark`,void 0),O([S()],K.prototype,`chatOpen`,void 0),O([b(`.mateu-app-layout`)],K.prototype,`vaadinAppLayout`,void 0),K=Da=O([h(`mateu-app`)],K);var Oa=class extends y{constructor(...e){super(...e),this.message=`This website uses cookies.`,this.dismiss=`Ok. Thanks :).`,this.learnMore=`Learn more`,this.learnMoreLink=`https://cookiesandyou.com/`,this.showLearnMore=!0,this.position=`top`,this.cookieName=`mateu-cookieconsent`}updated(e){super.updated(e)}connectedCallback(){super.connectedCallback(),this._css=document.createElement(`style`),this._css.innerText=`.cc-window{opacity:1;transition:opacity 1s ease}.cc-window.cc-invisible{opacity:0}.cc-animate.cc-revoke{transition:transform 1s ease}.cc-animate.cc-revoke.cc-top{transform:translateY(-2em)}.cc-animate.cc-revoke.cc-bottom{transform:translateY(2em)}.cc-animate.cc-revoke.cc-active.cc-bottom,.cc-animate.cc-revoke.cc-active.cc-top,.cc-revoke:hover{transform:translateY(0)}.cc-grower{max-height:0;overflow:hidden;transition:max-height 1s}.cc-link,.cc-revoke:hover{text-decoration:underline}.cc-revoke,.cc-window{position:fixed;overflow:hidden;box-sizing:border-box;font-family:Helvetica,Calibri,Arial,sans-serif;font-size:16px;line-height:1.5em;display:flex;flex-wrap:nowrap;z-index:9999}.cc-window.cc-static{position:static}.cc-window.cc-floating{padding:2em;max-width:24em;flex-direction:column}.cc-window.cc-banner{padding:1em 1.8em;width:100%;flex-direction:row}.cc-revoke{padding:.5em}.cc-header{font-size:18px;font-weight:700}.cc-btn,.cc-close,.cc-link,.cc-revoke{cursor:pointer}.cc-link{opacity:.8;display:inline-block;padding:.2em}.cc-link:hover{opacity:1}.cc-link:active,.cc-link:visited{color:initial}.cc-btn{display:block;padding:.4em .8em;font-size:.9em;font-weight:700;border-width:2px;border-style:solid;text-align:center;white-space:nowrap}.cc-banner .cc-btn:last-child{min-width:140px}.cc-highlight .cc-btn:first-child{background-color:transparent;border-color:transparent}.cc-highlight .cc-btn:first-child:focus,.cc-highlight .cc-btn:first-child:hover{background-color:transparent;text-decoration:underline}.cc-close{display:block;position:absolute;top:.5em;right:.5em;font-size:1.6em;opacity:.9;line-height:.75}.cc-close:focus,.cc-close:hover{opacity:1}.cc-revoke.cc-top{top:0;left:3em;border-bottom-left-radius:.5em;border-bottom-right-radius:.5em}.cc-revoke.cc-bottom{bottom:0;left:3em;border-top-left-radius:.5em;border-top-right-radius:.5em}.cc-revoke.cc-left{left:3em;right:unset}.cc-revoke.cc-right{right:3em;left:unset}.cc-top{top:1em}.cc-left{left:1em}.cc-right{right:1em}.cc-bottom{bottom:1em}.cc-floating>.cc-link{margin-bottom:1em}.cc-floating .cc-message{display:block;margin-bottom:1em}.cc-window.cc-floating .cc-compliance{flex:1 0 auto}.cc-window.cc-banner{align-items:center}.cc-banner.cc-top{left:0;right:0;top:0}.cc-banner.cc-bottom{left:0;right:0;bottom:0}.cc-banner .cc-message{flex:1}.cc-compliance{display:flex;align-items:center;align-content:space-between}.cc-compliance>.cc-btn{flex:1}.cc-btn+.cc-btn{margin-left:.5em}@media print{.cc-revoke,.cc-window{display:none}}@media screen and (max-width:900px){.cc-btn{white-space:normal}}@media screen and (max-width:414px) and (orientation:portrait),screen and (max-width:736px) and (orientation:landscape){.cc-window.cc-top{top:0}.cc-window.cc-bottom{bottom:0}.cc-window.cc-banner,.cc-window.cc-left,.cc-window.cc-right{left:0;right:0}.cc-window.cc-banner{flex-direction:column}.cc-window.cc-banner .cc-compliance{flex:1}.cc-window.cc-floating{max-width:none}.cc-window .cc-message{margin-bottom:1em}.cc-window.cc-banner{align-items:unset}}.cc-floating.cc-theme-classic{padding:1.2em;border-radius:5px}.cc-floating.cc-type-info.cc-theme-classic .cc-compliance{text-align:center;display:inline;flex:none}.cc-theme-classic .cc-btn{border-radius:5px}.cc-theme-classic .cc-btn:last-child{min-width:140px}.cc-floating.cc-type-info.cc-theme-classic .cc-btn{display:inline-block}.cc-theme-edgeless.cc-window{padding:0}.cc-floating.cc-theme-edgeless .cc-message{margin:2em 2em 1.5em}.cc-banner.cc-theme-edgeless .cc-btn{margin:0;padding:.8em 1.8em;height:100%}.cc-banner.cc-theme-edgeless .cc-message{margin-left:1em}.cc-floating.cc-theme-edgeless .cc-btn+.cc-btn{margin-left:0}`,document.head.appendChild(this._css),this.__updatePopup()}disconnectedCallback(){super.disconnectedCallback(),this.__closePopup(),this._css.isConnected&&this._css.remove()}__closePopup(){let e=this.popup;e&&e.parentNode?.removeChild(e)}_show(){let e=this.popup;e&&(e.classList.remove(`cc-invisible`),e.style.display=``)}__updatePopup(){this.__closePopup(),window.cookieconsent.initialise({palette:{popup:{background:`#000`},button:{background:`rgba(22, 118, 243, 0.95)`,hover:`rgba(22, 118, 243, 1)`}},showLink:this.showLearnMore,content:{message:this.message,dismiss:this.dismiss,link:this.learnMore,href:this.learnMoreLink},cookie:{name:this.cookieName},position:this.position,elements:{messagelink:`<span id="cookieconsent:desc" class="cc-message">${this.message} <a tabindex="0" class="cc-link" href="${this.learnMoreLink}" target="_blank" rel="noopener noreferrer nofollow">${this.learnMore}</a></span>`,dismiss:`<a tabindex="0" class="cc-btn cc-dismiss">${this.dismiss}</a>`}});let e=this.popup;if(e){e.setAttribute(`role`,`alert`);let t=e.querySelector(`a.cc-btn`);t?.addEventListener(`keydown`,e=>{let n=e.keyCode||e.which;(n===32||n===13)&&t.click()})}}render(){return w`
+       `}static{this.styles=m`
+  `}};O([v()],Oa.prototype,`message`,void 0),O([v()],Oa.prototype,`dismiss`,void 0),O([v()],Oa.prototype,`learnMore`,void 0),O([v()],Oa.prototype,`learnMoreLink`,void 0),O([v()],Oa.prototype,`showLearnMore`,void 0),O([v()],Oa.prototype,`position`,void 0),O([v()],Oa.prototype,`cookieName`,void 0),O([S()],Oa.prototype,`_css`,void 0),O([b(`[aria-label="cookieconsent"]`)],Oa.prototype,`popup`,void 0),Oa=O([h(`mateu-cookie-consent`)],Oa);var ka=class extends y{constructor(...e){super(...e),this.redispatchEvent=e=>{e instanceof CustomEvent&&(e.stopPropagation(),e.preventDefault(),this.target?.dispatchEvent(new CustomEvent(e.type,{detail:e.detail,bubbles:!0,composed:!0})))}}connectedCallback(){super.connectedCallback(),this.addEventListener(`value-changed`,this.redispatchEvent),this.addEventListener(`data-changed`,this.redispatchEvent),this.addEventListener(`action-requested`,this.redispatchEvent),this.addEventListener(`server-side-action-requested`,this.redispatchEvent),this.addEventListener(`route-changed`,this.redispatchEvent),this.addEventListener(`close-modal-requested`,this.redispatchEvent)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`value-changed`,this.redispatchEvent),this.removeEventListener(`data-changed`,this.redispatchEvent),this.removeEventListener(`action-requested`,this.redispatchEvent),this.removeEventListener(`server-side-action-requested`,this.redispatchEvent),this.removeEventListener(`route-changed`,this.redispatchEvent)}render(){return w`<slot></slot>`}static{this.styles=m`
         :host {
             /* width: 100%; */
             display: inline-block;
         }
-  `}};k([y()],Oa.prototype,`target`,void 0),Oa=k([g(`mateu-event-interceptor`)],Oa);var ka=[`a[href]`,`button`,`input`,`select`,`textarea`,`[tabindex]`,`vaadin-button`,`vaadin-text-field`,`vaadin-combo-box`,`vaadin-select`,`vaadin-checkbox`,`vaadin-date-picker`,`ui5-button`,`oj-c-button`].join(`,`),Aa=e=>{let t=e;return t.hidden||t.hasAttribute(`disabled`)||t.getAttribute(`aria-hidden`)===`true`||t.getAttribute(`tabindex`)===`-1`?!1:!!(t.offsetParent||t.getClientRects().length)},ja=e=>{let t=[],n=e=>{e.querySelectorAll(`*`).forEach(e=>{e.matches(ka)&&Aa(e)&&t.push(e),e.shadowRoot&&n(e.shadowRoot),e instanceof HTMLSlotElement&&e.assignedElements().forEach(e=>{e.matches(ka)&&Aa(e)&&t.push(e),n(e)})})};return n(e),t.filter((e,n)=>t.indexOf(e)===n)},Ma=(e,t={})=>{let n=Na(),r=[],i=()=>{r=ja(e)},a=t=>{if(t.key!==`Tab`)return;if(i(),r.length===0){t.preventDefault(),e.focus();return}let n=r[0],a=r[r.length-1],o=Na();t.shiftKey&&(o===n||!o||!Pa(o,e))?(t.preventDefault(),a.focus()):!t.shiftKey&&o===a&&(t.preventDefault(),n.focus())};return e.addEventListener(`keydown`,a),requestAnimationFrame(()=>{i();let n=t.initialFocus?.()??r[0];n?n.focus():(e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus())}),{refresh:i,release(){e.removeEventListener(`keydown`,a);let t=Na();(!t||t===document.body||Pa(t,e))&&n?.focus?.()}}},Na=()=>{let e=document.activeElement;for(;e?.shadowRoot?.activeElement;)e=e.shadowRoot.activeElement;return e},Pa=(e,t)=>{let n=e;for(;n;){if(n===t)return!0;n=n.parentNode??n.host??null}return!1},Fa=class extends ha{constructor(...e){super(...e),this.opened=!0,this.close=()=>{this.opened=!1,this.releaseFocusTrap(),setTimeout(()=>{this.removeSelfFromOwnerChildren()||this.parentElement?.removeChild(this)},500)},this.onKeydown=e=>{e.key===`Escape`&&this.opened&&(e.stopPropagation(),this.close())}}connectedCallback(){super.connectedCallback(),this.addEventListener(`keydown`,this.onKeydown)}disconnectedCallback(){super.disconnectedCallback(),this.releaseFocusTrap()}releaseFocusTrap(){this.focusTrap?.release(),this.focusTrap=void 0}applyFragment(e){super.applyFragment(e);let t=e.state?._closeAfterMillis;t&&setTimeout(()=>this.close(),t)}updated(e){if(super.updated(e),e.has(`component`)&&this.component){let e=this.component.metadata;this.state=e.initialData}let t=this.renderRoot.querySelector(`[role="dialog"]`),n=this.component?.metadata?.modeless;this.opened&&t&&!this.focusTrap&&!n?this.focusTrap=Ma(t):this.focusTrap&&this.opened&&this.focusTrap.refresh()}render(){if(!this.opened)return T``;let e=this.component.metadata,t=rt(e.headerTitle,this.state,this.data,this.appState,this.appData),n=!!(t||e.header||e.closeButtonOnHeader),r=[e.width?`width:${e.width};`:`min-width:min(90vw,28rem);`,e.height?`height:${e.height};`:``,e.top?`margin-top:${e.top};`:``].join(``);return T`
+  `}};O([v()],ka.prototype,`target`,void 0),ka=O([h(`mateu-event-interceptor`)],ka);var Aa=[`a[href]`,`button`,`input`,`select`,`textarea`,`[tabindex]`,`vaadin-button`,`vaadin-text-field`,`vaadin-combo-box`,`vaadin-select`,`vaadin-checkbox`,`vaadin-date-picker`,`ui5-button`,`oj-c-button`].join(`,`),ja=e=>{let t=e;return t.hidden||t.hasAttribute(`disabled`)||t.getAttribute(`aria-hidden`)===`true`||t.getAttribute(`tabindex`)===`-1`?!1:!!(t.offsetParent||t.getClientRects().length)},Ma=e=>{let t=[],n=e=>{e.querySelectorAll(`*`).forEach(e=>{e.matches(Aa)&&ja(e)&&t.push(e),e.shadowRoot&&n(e.shadowRoot),e instanceof HTMLSlotElement&&e.assignedElements().forEach(e=>{e.matches(Aa)&&ja(e)&&t.push(e),n(e)})})};return n(e),t.filter((e,n)=>t.indexOf(e)===n)},Na=(e,t={})=>{let n=Pa(),r=[],i=()=>{r=Ma(e)},a=t=>{if(t.key!==`Tab`)return;if(i(),r.length===0){t.preventDefault(),e.focus();return}let n=r[0],a=r[r.length-1],o=Pa();t.shiftKey&&(o===n||!o||!Fa(o,e))?(t.preventDefault(),a.focus()):!t.shiftKey&&o===a&&(t.preventDefault(),n.focus())};return e.addEventListener(`keydown`,a),requestAnimationFrame(()=>{i();let n=t.initialFocus?.()??r[0];n?n.focus():(e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus())}),{refresh:i,release(){e.removeEventListener(`keydown`,a);let t=Pa();(!t||t===document.body||Fa(t,e))&&n?.focus?.()}}},Pa=()=>{let e=document.activeElement;for(;e?.shadowRoot?.activeElement;)e=e.shadowRoot.activeElement;return e},Fa=(e,t)=>{let n=e;for(;n;){if(n===t)return!0;n=n.parentNode??n.host??null}return!1},Ia=class extends ga{constructor(...e){super(...e),this.opened=!0,this.close=()=>{this.opened=!1,this.releaseFocusTrap(),setTimeout(()=>{this.removeSelfFromOwnerChildren()||this.parentElement?.removeChild(this)},500)},this.onKeydown=e=>{e.key===`Escape`&&this.opened&&(e.stopPropagation(),this.close())}}connectedCallback(){super.connectedCallback(),this.addEventListener(`keydown`,this.onKeydown)}disconnectedCallback(){super.disconnectedCallback(),this.releaseFocusTrap()}releaseFocusTrap(){this.focusTrap?.release(),this.focusTrap=void 0}applyFragment(e){super.applyFragment(e);let t=e.state?._closeAfterMillis;t&&setTimeout(()=>this.close(),t)}updated(e){if(super.updated(e),e.has(`component`)&&this.component){let e=this.component.metadata;this.state=e.initialData}let t=this.renderRoot.querySelector(`[role="dialog"]`),n=this.component?.metadata?.modeless;this.opened&&t&&!this.focusTrap&&!n?this.focusTrap=Na(t):this.focusTrap&&this.opened&&this.focusTrap.refresh()}render(){if(!this.opened)return w``;let e=this.component.metadata,t=it(e.headerTitle,this.state,this.data,this.appState,this.appData),n=!!(t||e.header||e.closeButtonOnHeader),r=[e.width?`width:${e.width};`:`min-width:min(90vw,28rem);`,e.height?`height:${e.height};`:``,e.top?`margin-top:${e.top};`:``].join(``);return w`
             <div class="backdrop ${e.modeless?`modeless`:``}"
                  @click="${t=>{!e.modeless&&t.target===t.currentTarget&&this.close()}}">
                 <div class="dialog ${e.noPadding?`no-padding`:``} ${this.component?.cssClasses??``}"
@@ -5557,29 +5557,29 @@ ${i}
                      aria-modal="${e.modeless?`false`:`true`}"
                      aria-label="${t||`Dialog`}"
                      style="${r} ${this.component?.style??``}">
-                    ${n?T`
+                    ${n?w`
                         <div class="dialog-header">
                             <mateu-event-interceptor .target="${this}" style="flex:1; min-width:0;">
-                                ${t?T`<span class="dialog-title">${t}</span>`:v}
-                                ${e.header?F(this,e.header,this.baseUrl,this.state,this.data,this.appState,this.appData):v}
+                                ${t?w`<span class="dialog-title">${t}</span>`:_}
+                                ${e.header?P(this,e.header,this.baseUrl,this.state,this.data,this.appState,this.appData):_}
                             </mateu-event-interceptor>
-                            ${e.closeButtonOnHeader?T`<button class="dialog-close" @click="${this.close}" aria-label="Close">✕</button>`:v}
-                        </div>`:v}
-                    ${e.content?T`
+                            ${e.closeButtonOnHeader?w`<button class="dialog-close" @click="${this.close}" aria-label="Close">✕</button>`:_}
+                        </div>`:_}
+                    ${e.content?w`
                         <div class="dialog-body">
                             <mateu-event-interceptor .target="${this}" style="--mateu-section-border: none; width:100%;">
-                                ${F(this,e.content,this.baseUrl,this.state,this.data,this.appState,this.appData)}
+                                ${P(this,e.content,this.baseUrl,this.state,this.data,this.appState,this.appData)}
                             </mateu-event-interceptor>
-                        </div>`:v}
-                    ${e.footer?T`
+                        </div>`:_}
+                    ${e.footer?w`
                         <div class="dialog-footer">
                             <mateu-event-interceptor .target="${this}" style="width:100%;">
-                                ${F(this,e.footer,this.baseUrl,this.state,this.data,this.appState,this.appData)}
+                                ${P(this,e.footer,this.baseUrl,this.state,this.data,this.appState,this.appData)}
                             </mateu-event-interceptor>
-                        </div>`:v}
+                        </div>`:_}
                 </div>
             </div>
-        `}static{this.styles=h`
+        `}static{this.styles=m`
         .backdrop {
             position: fixed; inset: 0; z-index: 1000;
             display: flex; align-items: center; justify-content: center;
@@ -5604,66 +5604,66 @@ ${i}
         .dialog-body { padding: .5rem 1.2rem; flex: 1; }
         .dialog.no-padding .dialog-body { padding: 0; }
         .dialog-footer { padding: .5rem 1.2rem 1rem; display: flex; justify-content: flex-end; gap: .5rem; }
-    `}};k([C()],Fa.prototype,`opened`,void 0),Fa=k([g(`mateu-dialog`)],Fa);var Ia,La=class extends ha{static{Ia=this}constructor(...e){super(...e),this.opened=!1,this.maximizeSteps=0,this.collapsed=!1,this.pagerMenuOpen=!1,this.onGuidedProgress=e=>{let t=e.detail;t&&t.total>0&&(this.guidedProgress=t)},this.close=()=>{this.opened=!1,this.releaseLayoutInset(),this.releaseFocusTrap(),setTimeout(()=>{this.removeSelfFromOwnerChildren()||this.parentElement?.removeChild(this)},300)},this._escListener=e=>{if(e.key!==`Escape`)return;let t=this.getRootNode().querySelectorAll(`mateu-drawer, mateu-dialog`);t[t.length-1]===this&&(e.stopPropagation(),this.close())}}jumpToStep(e){this.pagerMenuOpen=!1,e&&(this.renderRoot.querySelector(`.content mateu-component`)??this.renderRoot.querySelector(`mateu-component`))?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`goToStep`,parameters:{_stepId:e}},bubbles:!0,composed:!0}))}static{this.SIZE_LADDER=[`s`,`m`,`l`,`xl`]}static{this.SIZE_WIDTHS={s:`464px`,m:`648px`,l:`968px`,xl:`90vw`}}effectiveWidth(e){if(e.width)return e.width;if(!e.size)return;let t=Ia.SIZE_LADDER,n=Math.max(0,t.indexOf(e.size)),r=Math.min(t.length-1,n+this.maximizeSteps);return Ia.SIZE_WIDTHS[t[r]]}canMaximize(e){if(!e.maximizable)return!1;let t=Ia.SIZE_LADDER;return Math.max(0,t.indexOf(e.size??`m`))+this.maximizeSteps<t.length-1}firstUpdated(){requestAnimationFrame(()=>this.opened=!0),this.addEventListener(`mateu-guided-progress`,this.onGuidedProgress);let e=this.component?.metadata;e&&requestAnimationFrame(()=>this.applyLayoutInset(e))}releaseFocusTrap(){this.focusTrap?.release(),this.focusTrap=void 0}applyLayoutInset(e){if(!e.layout)return;let t=document.querySelector(`mateu-ui`);if(!t)return;let n=e.position??`end`,r=n===`bottom`?`var(--mateu-drawer-height, 50vh)`:this.effectiveWidth(e)??`648px`;this._insetProp=n===`start`?`paddingLeft`:n===`bottom`?`paddingBottom`:`paddingRight`,t.style.transition=`padding .25s ease`,t.style[this._insetProp]=r}releaseLayoutInset(){if(!this._insetProp)return;let e=document.querySelector(`mateu-ui`);e&&(e.style[this._insetProp]=``),this._insetProp=void 0}applyFragment(e){super.applyFragment(e);let t=e.state?._closeAfterMillis;t&&setTimeout(()=>this.close(),t)}updated(e){if(super.updated(e),e.has(`component`)&&this.component){let e=this.component.metadata;this.state=e.initialData}let t=this.component?.metadata,n=this.renderRoot.querySelector(`[role="dialog"]`);this.opened&&n&&!t?.modeless&&!t?.layout&&!this.focusTrap?this.focusTrap=Ma(n):this.focusTrap&&this.opened&&this.focusTrap.refresh()}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._escListener)}disconnectedCallback(){document.removeEventListener(`keydown`,this._escListener),this.releaseLayoutInset(),this.releaseFocusTrap(),super.disconnectedCallback()}render(){let e=this.component.metadata,t=e.position??`end`,n=rt(e.headerTitle,this.state,this.data,this.appState,this.appData),r=rt(e.subtitle,this.state,this.data,this.appState,this.appData),i=this.effectiveWidth(e),a=e.peerNav&&(e.peerNav.prevRoute||e.peerNav.nextRoute)?e.peerNav:void 0;return T`
-        ${e.modeless||e.layout?v:T`
+    `}};O([S()],Ia.prototype,`opened`,void 0),Ia=O([h(`mateu-dialog`)],Ia);var La,Ra=class extends ga{static{La=this}constructor(...e){super(...e),this.opened=!1,this.maximizeSteps=0,this.collapsed=!1,this.pagerMenuOpen=!1,this.onGuidedProgress=e=>{let t=e.detail;t&&t.total>0&&(this.guidedProgress=t)},this.close=()=>{this.opened=!1,this.releaseLayoutInset(),this.releaseFocusTrap(),setTimeout(()=>{this.removeSelfFromOwnerChildren()||this.parentElement?.removeChild(this)},300)},this._escListener=e=>{if(e.key!==`Escape`)return;let t=this.getRootNode().querySelectorAll(`mateu-drawer, mateu-dialog`);t[t.length-1]===this&&(e.stopPropagation(),this.close())}}jumpToStep(e){this.pagerMenuOpen=!1,e&&(this.renderRoot.querySelector(`.content mateu-component`)??this.renderRoot.querySelector(`mateu-component`))?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`goToStep`,parameters:{_stepId:e}},bubbles:!0,composed:!0}))}static{this.SIZE_LADDER=[`s`,`m`,`l`,`xl`]}static{this.SIZE_WIDTHS={s:`464px`,m:`648px`,l:`968px`,xl:`90vw`}}effectiveWidth(e){if(e.width)return e.width;if(!e.size)return;let t=La.SIZE_LADDER,n=Math.max(0,t.indexOf(e.size)),r=Math.min(t.length-1,n+this.maximizeSteps);return La.SIZE_WIDTHS[t[r]]}canMaximize(e){if(!e.maximizable)return!1;let t=La.SIZE_LADDER;return Math.max(0,t.indexOf(e.size??`m`))+this.maximizeSteps<t.length-1}firstUpdated(){requestAnimationFrame(()=>this.opened=!0),this.addEventListener(`mateu-guided-progress`,this.onGuidedProgress);let e=this.component?.metadata;e&&requestAnimationFrame(()=>this.applyLayoutInset(e))}releaseFocusTrap(){this.focusTrap?.release(),this.focusTrap=void 0}applyLayoutInset(e){if(!e.layout)return;let t=document.querySelector(`mateu-ui`);if(!t)return;let n=e.position??`end`,r=n===`bottom`?`var(--mateu-drawer-height, 50vh)`:this.effectiveWidth(e)??`648px`;this._insetProp=n===`start`?`paddingLeft`:n===`bottom`?`paddingBottom`:`paddingRight`,t.style.transition=`padding .25s ease`,t.style[this._insetProp]=r}releaseLayoutInset(){if(!this._insetProp)return;let e=document.querySelector(`mateu-ui`);e&&(e.style[this._insetProp]=``),this._insetProp=void 0}applyFragment(e){super.applyFragment(e);let t=e.state?._closeAfterMillis;t&&setTimeout(()=>this.close(),t)}updated(e){if(super.updated(e),e.has(`component`)&&this.component){let e=this.component.metadata;this.state=e.initialData}let t=this.component?.metadata,n=this.renderRoot.querySelector(`[role="dialog"]`);this.opened&&n&&!t?.modeless&&!t?.layout&&!this.focusTrap?this.focusTrap=Na(n):this.focusTrap&&this.opened&&this.focusTrap.refresh()}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._escListener)}disconnectedCallback(){document.removeEventListener(`keydown`,this._escListener),this.releaseLayoutInset(),this.releaseFocusTrap(),super.disconnectedCallback()}render(){let e=this.component.metadata,t=e.position??`end`,n=it(e.headerTitle,this.state,this.data,this.appState,this.appData),r=it(e.subtitle,this.state,this.data,this.appState,this.appData),i=this.effectiveWidth(e),a=e.peerNav&&(e.peerNav.prevRoute||e.peerNav.nextRoute)?e.peerNav:void 0;return w`
+        ${e.modeless||e.layout?_:w`
             <div class="backdrop ${this.opened?`open`:``}" @click="${this.close}"></div>
         `}
         <section
                 class="panel ${t} ${this.opened?`open`:``} ${this.collapsed?`collapsed`:``} ${this.component?.cssClasses??``}"
                 role="dialog"
                 aria-modal="${!e.modeless}"
-                aria-label="${n??v}"
+                aria-label="${n??_}"
                 style="${i&&t!==`bottom`?`width: ${i};`:``}${this.component?.style??``}"
         >
             <header>
-                ${n?T`<div class="titles"><h3>${n}</h3>${r?T`<span class="subtitle">${r}</span>`:v}</div>`:T`<span class="spacer"></span>`}
-                ${this.guidedProgress&&this.guidedProgress.total>1?T`
+                ${n?w`<div class="titles"><h3>${n}</h3>${r?w`<span class="subtitle">${r}</span>`:_}</div>`:w`<span class="spacer"></span>`}
+                ${this.guidedProgress&&this.guidedProgress.total>1?w`
                     <div class="guided-pager-wrap">
                         <button class="guided-pager" aria-haspopup="true" aria-expanded="${this.pagerMenuOpen}"
                                 aria-label="Step ${this.guidedProgress.current} of ${this.guidedProgress.total}"
                                 @click="${()=>this.pagerMenuOpen=!this.pagerMenuOpen}">${this.guidedProgress.current} | ${this.guidedProgress.total}<span class="caret">▾</span></button>
-                        ${this.pagerMenuOpen&&this.guidedProgress.steps?T`
+                        ${this.pagerMenuOpen&&this.guidedProgress.steps?w`
                             <div class="guided-pager-menu">
-                                ${this.guidedProgress.steps.map((e,t)=>T`
+                                ${this.guidedProgress.steps.map((e,t)=>w`
                                     <button class="guided-pager-item ${e.status}" ?disabled="${e.status!==`done`}"
                                             @click="${()=>this.jumpToStep(e.id)}"><span class="pager-dot">${e.status===`done`?`✓`:t+1}</span>${e.title??`Step ${t+1}`}</button>
                                 `)}
                             </div>
-                        `:v}
+                        `:_}
                     </div>
-                `:v}
-                ${e.header?T`
-                    <mateu-event-interceptor .target="${this}">${F(this,e.header,this.baseUrl,this.state,this.data,this.appState,this.appData)}</mateu-event-interceptor>
-                `:v}
-                ${a?T`
+                `:_}
+                ${e.header?w`
+                    <mateu-event-interceptor .target="${this}">${P(this,e.header,this.baseUrl,this.state,this.data,this.appState,this.appData)}</mateu-event-interceptor>
+                `:_}
+                ${a?w`
                     <button class="drawer-icon" aria-label="${a.prevLabel??`Previous`}" title="${a.prevLabel??`Previous`}"
                             ?disabled="${!a.prevRoute}" @click="${()=>{a.prevRoute&&(window.location.href=a.prevRoute)}}">‹</button>
                     <button class="drawer-icon" aria-label="${a.nextLabel??`Next`}" title="${a.nextLabel??`Next`}"
                             ?disabled="${!a.nextRoute}" @click="${()=>{a.nextRoute&&(window.location.href=a.nextRoute)}}">›</button>
-                `:v}
-                ${e.collapsible?T`
+                `:_}
+                ${e.collapsible?w`
                     <button class="drawer-icon" aria-label="${this.collapsed?`Expand`:`Collapse`}" title="${this.collapsed?`Expand`:`Collapse`}"
                             @click="${()=>this.collapsed=!this.collapsed}">${this.collapsed?`▴`:`▾`}</button>
-                `:v}
-                ${this.canMaximize(e)?T`
+                `:_}
+                ${this.canMaximize(e)?w`
                     <button class="drawer-icon" aria-label="Maximize" title="Maximize" @click="${()=>this.maximizeSteps++}">⤢</button>
-                `:v}
+                `:_}
                 <button class="drawer-close" aria-label="Close" @click="${this.close}">✕</button>
             </header>
-            ${this.collapsed?v:T`
+            ${this.collapsed?_:w`
             <div class="content ${e.noPadding?`no-padding`:``}">
-                ${e.content?T`
-                    <mateu-event-interceptor .target="${this}" style="--mateu-section-border: none; width: 100%;">${F(this,e.content,this.baseUrl,this.state,this.data,this.appState,this.appData)}</mateu-event-interceptor>
-                `:v}
+                ${e.content?w`
+                    <mateu-event-interceptor .target="${this}" style="--mateu-section-border: none; width: 100%;">${P(this,e.content,this.baseUrl,this.state,this.data,this.appState,this.appData)}</mateu-event-interceptor>
+                `:_}
             </div>
-            ${e.footer?T`
+            ${e.footer?w`
                 <footer>
-                    <mateu-event-interceptor .target="${this}" style="width: 100%;">${F(this,e.footer,this.baseUrl,this.state,this.data,this.appState,this.appData)}</mateu-event-interceptor>
+                    <mateu-event-interceptor .target="${this}" style="width: 100%;">${P(this,e.footer,this.baseUrl,this.state,this.data,this.appState,this.appData)}</mateu-event-interceptor>
                 </footer>
-            `:v}
+            `:_}
             `}
         </section>
-       `}static{this.styles=h`
+       `}static{this.styles=m`
         .drawer-close {
             border: none;
             background: transparent;
@@ -5882,19 +5882,19 @@ ${i}
             display: flex;
             justify-content: flex-end;
         }
-  `}};k([C()],La.prototype,`opened`,void 0),k([C()],La.prototype,`maximizeSteps`,void 0),k([C()],La.prototype,`collapsed`,void 0),k([C()],La.prototype,`guidedProgress`,void 0),k([C()],La.prototype,`pagerMenuOpen`,void 0),La=Ia=k([g(`mateu-drawer`)],La);function Ra(e){if(e.parentElement)return e.parentElement;let t=e.getRootNode();return t instanceof ShadowRoot?t.host:null}var J=class extends b{constructor(...e){super(...e),this.appState={},this.appData={},this.standalone=!1,this.actionBanners=[],this.dismissedStaticBannerIndices=new Set,this._tocEntries=[],this._activeToc=0,this._tocVisible=!1,this._tocRebuildScheduled=!1,this._headerH=0,this._onResize=()=>this._layoutStickyTops(),this._tocLocked=!1,this._unlockToc=e=>{if(e&&e.type===`keydown`){let t=e;if(t.ctrlKey&&t.altKey&&!t.shiftKey&&!t.metaKey&&/^(?:Digit|Numpad)[1-9]$/.test(t.code))return}this._tocLocked=!1},this._actionBannerTimers=[],this._staticBannerTimers=[],this._bannersHandler=e=>{let t=e.detail,n=t.banners??[],r=t.append??!1;r?this.actionBanners=[...this.actionBanners,...n]:(this._clearActionBannerTimers(),this.actionBanners=n);let i=r?this.actionBanners.length-n.length:0;n.forEach((e,t)=>{if(e.timeoutSeconds&&e.timeoutSeconds>0){let n=i+t;this._actionBannerTimers.push(setTimeout(()=>{this.actionBanners=this.actionBanners.filter((e,t)=>t!==n)},e.timeoutSeconds*1e3))}})},this._onTocKey=e=>{if(!this._tocVisible||!e.ctrlKey||!e.altKey||e.shiftKey||e.metaKey)return;let t=/^(?:Digit|Numpad)([1-9])$/.exec(e.code);if(!t)return;let n=parseInt(t[1],10)-1;n>=this._tocEntries.length||(e.preventDefault(),this._scrollToSection(n))},this._onScrollSpy=()=>{if(this._tocLocked)return;let e=this._sectionCards();if(!e.length)return;let t=this.shadowRoot?.querySelector(`mateu-content-header`),n=t?t.getBoundingClientRect().bottom:0;for(let t of e){if(!t.classList.contains(`mateu-section--sticky`))continue;let e=t.getBoundingClientRect();e.top<=n+12+2&&(n=Math.max(n,e.bottom))}let r=n+12+4,i=0;this._tocEntries.forEach((e,t)=>{e.el.getBoundingClientRect().top<=r&&(i=t)}),this._activeToc=i}}connectedCallback(){super.connectedCallback(),document.addEventListener(`page-banners-received`,this._bannersHandler),window.addEventListener(`resize`,this._onResize),document.addEventListener(`keydown`,this._onTocKey)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`page-banners-received`,this._bannersHandler),window.removeEventListener(`resize`,this._onResize),document.removeEventListener(`keydown`,this._onTocKey),this._clearAllTimers(),this._teardownScrollSpy()}updated(e){if(super.updated(e),e.has(`component`)&&e.get(`component`)!==void 0&&(this._clearAllTimers(),this.actionBanners=[],this.dismissedStaticBannerIndices=new Set),e.has(`component`)){let e=this.component?.metadata?.level??0;this.toggleAttribute(`data-nested`,e>0),this._scheduleStaticBannerTimeouts();let t=this.component?.metadata?.pageWidth===`edgeToEdge`;this.toggleAttribute(`data-edge`,t),this.dispatchEvent(new CustomEvent(`compact-changed`,{detail:{compact:!!this.component?.style?.includes(`--mateu-compact:1`)||t},bubbles:!0,composed:!0})),this._scheduleTocRebuild()}}_scheduleStaticBannerTimeouts(){this._staticBannerTimers.forEach(e=>clearTimeout(e)),this._staticBannerTimers=[],(this.component?.metadata?.banners??[]).forEach((e,t)=>{e.timeoutSeconds&&e.timeoutSeconds>0&&this._staticBannerTimers.push(setTimeout(()=>{this.dismissedStaticBannerIndices=new Set([...this.dismissedStaticBannerIndices,t])},e.timeoutSeconds*1e3))})}_clearActionBannerTimers(){this._actionBannerTimers.forEach(e=>clearTimeout(e)),this._actionBannerTimers=[]}_clearAllTimers(){this._clearActionBannerTimers(),this._staticBannerTimers.forEach(e=>clearTimeout(e)),this._staticBannerTimers=[]}_dismissActionBanner(e){this.actionBanners=this.actionBanners.filter((t,n)=>n!==e)}_dismissStaticBanner(e){this.dismissedStaticBannerIndices=new Set([...this.dismissedStaticBannerIndices,e])}bannerThemeClass(e){let t=e.theme?.toLowerCase()??`info`;return t===`none`?``:t}_evalBannerText(e){return M(e,this.state,this.data)}_renderBanner(e,t){let n=this._evalBannerText(e.title),r=this._evalBannerText(e.description);return T`
+  `}};O([S()],Ra.prototype,`opened`,void 0),O([S()],Ra.prototype,`maximizeSteps`,void 0),O([S()],Ra.prototype,`collapsed`,void 0),O([S()],Ra.prototype,`guidedProgress`,void 0),O([S()],Ra.prototype,`pagerMenuOpen`,void 0),Ra=La=O([h(`mateu-drawer`)],Ra);function za(e){if(e.parentElement)return e.parentElement;let t=e.getRootNode();return t instanceof ShadowRoot?t.host:null}var q=class extends y{constructor(...e){super(...e),this.appState={},this.appData={},this.standalone=!1,this.actionBanners=[],this.dismissedStaticBannerIndices=new Set,this._tocEntries=[],this._activeToc=0,this._tocVisible=!1,this._tocRebuildScheduled=!1,this._headerH=0,this._onResize=()=>this._layoutStickyTops(),this._tocLocked=!1,this._unlockToc=e=>{if(e&&e.type===`keydown`){let t=e;if(t.ctrlKey&&t.altKey&&!t.shiftKey&&!t.metaKey&&/^(?:Digit|Numpad)[1-9]$/.test(t.code))return}this._tocLocked=!1},this._actionBannerTimers=[],this._staticBannerTimers=[],this._bannersHandler=e=>{let t=e.detail,n=t.banners??[],r=t.append??!1;r?this.actionBanners=[...this.actionBanners,...n]:(this._clearActionBannerTimers(),this.actionBanners=n);let i=r?this.actionBanners.length-n.length:0;n.forEach((e,t)=>{if(e.timeoutSeconds&&e.timeoutSeconds>0){let n=i+t;this._actionBannerTimers.push(setTimeout(()=>{this.actionBanners=this.actionBanners.filter((e,t)=>t!==n)},e.timeoutSeconds*1e3))}})},this._onTocKey=e=>{if(!this._tocVisible||!e.ctrlKey||!e.altKey||e.shiftKey||e.metaKey)return;let t=/^(?:Digit|Numpad)([1-9])$/.exec(e.code);if(!t)return;let n=parseInt(t[1],10)-1;n>=this._tocEntries.length||(e.preventDefault(),this._scrollToSection(n))},this._onScrollSpy=()=>{if(this._tocLocked)return;let e=this._sectionCards();if(!e.length)return;let t=this.shadowRoot?.querySelector(`mateu-content-header`),n=t?t.getBoundingClientRect().bottom:0;for(let t of e){if(!t.classList.contains(`mateu-section--sticky`))continue;let e=t.getBoundingClientRect();e.top<=n+12+2&&(n=Math.max(n,e.bottom))}let r=n+12+4,i=0;this._tocEntries.forEach((e,t)=>{e.el.getBoundingClientRect().top<=r&&(i=t)}),this._activeToc=i}}connectedCallback(){super.connectedCallback(),document.addEventListener(`page-banners-received`,this._bannersHandler),window.addEventListener(`resize`,this._onResize),document.addEventListener(`keydown`,this._onTocKey)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`page-banners-received`,this._bannersHandler),window.removeEventListener(`resize`,this._onResize),document.removeEventListener(`keydown`,this._onTocKey),this._clearAllTimers(),this._teardownScrollSpy()}updated(e){if(super.updated(e),e.has(`component`)&&e.get(`component`)!==void 0&&(this._clearAllTimers(),this.actionBanners=[],this.dismissedStaticBannerIndices=new Set),e.has(`component`)){let e=this.component?.metadata?.level??0;this.toggleAttribute(`data-nested`,e>0),this._scheduleStaticBannerTimeouts();let t=this.component?.metadata?.pageWidth===`edgeToEdge`;this.toggleAttribute(`data-edge`,t),this.dispatchEvent(new CustomEvent(`compact-changed`,{detail:{compact:!!this.component?.style?.includes(`--mateu-compact:1`)||t},bubbles:!0,composed:!0})),this._scheduleTocRebuild()}}_scheduleStaticBannerTimeouts(){this._staticBannerTimers.forEach(e=>clearTimeout(e)),this._staticBannerTimers=[],(this.component?.metadata?.banners??[]).forEach((e,t)=>{e.timeoutSeconds&&e.timeoutSeconds>0&&this._staticBannerTimers.push(setTimeout(()=>{this.dismissedStaticBannerIndices=new Set([...this.dismissedStaticBannerIndices,t])},e.timeoutSeconds*1e3))})}_clearActionBannerTimers(){this._actionBannerTimers.forEach(e=>clearTimeout(e)),this._actionBannerTimers=[]}_clearAllTimers(){this._clearActionBannerTimers(),this._staticBannerTimers.forEach(e=>clearTimeout(e)),this._staticBannerTimers=[]}_dismissActionBanner(e){this.actionBanners=this.actionBanners.filter((t,n)=>n!==e)}_dismissStaticBanner(e){this.dismissedStaticBannerIndices=new Set([...this.dismissedStaticBannerIndices,e])}bannerThemeClass(e){let t=e.theme?.toLowerCase()??`info`;return t===`none`?``:t}_evalBannerText(e){return j(e,this.state,this.data)}_renderBanner(e,t){let n=this._evalBannerText(e.title),r=this._evalBannerText(e.description);return w`
             <div class="page-banner page-banner--${this.bannerThemeClass(e)}">
-                ${n||e.hasCloseButton?T`
+                ${n||e.hasCloseButton?w`
                     <div style="display: flex; align-items: center; justify-content: space-between; color: #1a1a1a; width: 100%;">
                         <span style="font-weight: 600;">${n??``}</span>
-                        ${e.hasCloseButton?T`
+                        ${e.hasCloseButton?w`
                             <button class="banner-close" @click=${t} title="Dismiss" aria-label="Dismiss">✕</button>
-                        `:v}
+                        `:_}
                     </div>
-                `:v}
-                ${r?T`<p>${r}</p>`:v}
+                `:_}
+                ${r?w`<p>${r}</p>`:_}
             </div>
-        `}_onSlotChange(){this._scheduleTocRebuild()}_scheduleTocRebuild(){this._tocRebuildScheduled||(this._tocRebuildScheduled=!0,requestAnimationFrame(()=>{this._tocRebuildScheduled=!1,this._rebuildToc()}))}_sectionCards(){return Array.from(this.querySelectorAll(`.mateu-section`))}_sectionTitle(e){return e.querySelector(`[slot="title"]`)?.textContent?.trim()||e.querySelector(`h1,h2,h3,h4,h5,h6`)?.textContent?.trim()||void 0}_rebuildToc(){let e=this._sectionCards(),t=e.map(e=>({title:this._sectionTitle(e),el:e})).filter(e=>!!e.title),n=this.component?.metadata?.toc,r=t.length>4&&e.every(e=>!e.closest(`vaadin-horizontal-layout`)),i=(n===!0||n!==!1&&r)&&t.length>0;this._tocEntries=t,this._tocVisible=i,this._activeToc>=t.length&&(this._activeToc=0),this._teardownScrollSpy(),i?requestAnimationFrame(()=>{this._layoutStickyTops(),this._setupScrollSpy()}):this._layoutStickyTops()}_layoutStickyTops(){let e=this.shadowRoot?.querySelector(`mateu-content-header`);this._headerH=this._tocVisible&&e?e.offsetHeight:0,this.style.setProperty(`--mateu-header-h`,this._headerH+`px`);let t=this._headerH+12;for(let e of this._sectionCards())e.classList.contains(`mateu-section--sticky`)&&(e.style.top=t+`px`,t+=e.offsetHeight+12)}_scrollContainer(){let e=Ra(this);for(;e;){let t=getComputedStyle(e).overflowY;if((t===`auto`||t===`scroll`)&&e.scrollHeight>e.clientHeight)return e;e=Ra(e)}return null}_setupScrollSpy(){this._tocEntries.length&&(this._spyTarget=this._scrollContainer()??window,this._spyTarget.addEventListener(`scroll`,this._onScrollSpy,{passive:!0}),window.addEventListener(`wheel`,this._unlockToc,{passive:!0}),window.addEventListener(`touchstart`,this._unlockToc,{passive:!0}),window.addEventListener(`keydown`,this._unlockToc),this._onScrollSpy())}_teardownScrollSpy(){this._spyTarget?.removeEventListener(`scroll`,this._onScrollSpy),window.removeEventListener(`wheel`,this._unlockToc),window.removeEventListener(`touchstart`,this._unlockToc),window.removeEventListener(`keydown`,this._unlockToc),this._spyTarget=void 0}_scrollToSection(e){let t=this._tocEntries[e];if(!t)return;this._activeToc=e,this._tocLocked=!0;let n=this._headerH+12;for(let e of this._sectionCards()){if(e===t.el)break;e.classList.contains(`mateu-section--sticky`)&&(n+=e.offsetHeight+12)}let r=this._scrollContainer(),i=r?r.getBoundingClientRect().top:0,a=t.el.getBoundingClientRect().top-i-n;(r??window).scrollBy({top:a,behavior:`smooth`})}_showHeaderBand(){let e=this.component?.metadata,t=!!(e?.title||e?.subtitle||e?.toolbar?.length),n=!!this.component?.children?.some(e=>e.metadata?.type===j.Crud);return t&&!n&&!this._hasWelcomeBanner()}_hasWelcomeBanner(){let e=t=>t?.metadata?.type===j.HeroSection||(t?.children??[]).some(e);return(this.component?.children??[]).some(e)}render(){let e=this.component?.metadata,t=[...(e?.banners??[]).map((e,t)=>({banner:e,index:t})).filter(({index:e})=>!this.dismissedStaticBannerIndices.has(e)).map(({banner:e,index:t})=>({banner:e,onDismiss:()=>this._dismissStaticBanner(t)})),...this.actionBanners.map((e,t)=>({banner:e,onDismiss:()=>this._dismissActionBanner(t)}))];return T`<div style="display: flex; flex-direction: column; width: 100%;">${T`
+        `}_onSlotChange(){this._scheduleTocRebuild()}_scheduleTocRebuild(){this._tocRebuildScheduled||(this._tocRebuildScheduled=!0,requestAnimationFrame(()=>{this._tocRebuildScheduled=!1,this._rebuildToc()}))}_sectionCards(){return Array.from(this.querySelectorAll(`.mateu-section`))}_sectionTitle(e){return e.querySelector(`[slot="title"]`)?.textContent?.trim()||e.querySelector(`h1,h2,h3,h4,h5,h6`)?.textContent?.trim()||void 0}_rebuildToc(){let e=this._sectionCards(),t=e.map(e=>({title:this._sectionTitle(e),el:e})).filter(e=>!!e.title),n=this.component?.metadata?.toc,r=t.length>4&&e.every(e=>!e.closest(`vaadin-horizontal-layout`)),i=(n===!0||n!==!1&&r)&&t.length>0;this._tocEntries=t,this._tocVisible=i,this._activeToc>=t.length&&(this._activeToc=0),this._teardownScrollSpy(),i?requestAnimationFrame(()=>{this._layoutStickyTops(),this._setupScrollSpy()}):this._layoutStickyTops()}_layoutStickyTops(){let e=this.shadowRoot?.querySelector(`mateu-content-header`);this._headerH=this._tocVisible&&e?e.offsetHeight:0,this.style.setProperty(`--mateu-header-h`,this._headerH+`px`);let t=this._headerH+12;for(let e of this._sectionCards())e.classList.contains(`mateu-section--sticky`)&&(e.style.top=t+`px`,t+=e.offsetHeight+12)}_scrollContainer(){let e=za(this);for(;e;){let t=getComputedStyle(e).overflowY;if((t===`auto`||t===`scroll`)&&e.scrollHeight>e.clientHeight)return e;e=za(e)}return null}_setupScrollSpy(){this._tocEntries.length&&(this._spyTarget=this._scrollContainer()??window,this._spyTarget.addEventListener(`scroll`,this._onScrollSpy,{passive:!0}),window.addEventListener(`wheel`,this._unlockToc,{passive:!0}),window.addEventListener(`touchstart`,this._unlockToc,{passive:!0}),window.addEventListener(`keydown`,this._unlockToc),this._onScrollSpy())}_teardownScrollSpy(){this._spyTarget?.removeEventListener(`scroll`,this._onScrollSpy),window.removeEventListener(`wheel`,this._unlockToc),window.removeEventListener(`touchstart`,this._unlockToc),window.removeEventListener(`keydown`,this._unlockToc),this._spyTarget=void 0}_scrollToSection(e){let t=this._tocEntries[e];if(!t)return;this._activeToc=e,this._tocLocked=!0;let n=this._headerH+12;for(let e of this._sectionCards()){if(e===t.el)break;e.classList.contains(`mateu-section--sticky`)&&(n+=e.offsetHeight+12)}let r=this._scrollContainer(),i=r?r.getBoundingClientRect().top:0,a=t.el.getBoundingClientRect().top-i-n;(r??window).scrollBy({top:a,behavior:`smooth`})}_showHeaderBand(){let e=this.component?.metadata,t=!!(e?.title||e?.subtitle||e?.toolbar?.length),n=!!this.component?.children?.some(e=>e.metadata?.type===A.Crud);return t&&!n&&!this._hasWelcomeBanner()}_hasWelcomeBanner(){let e=t=>t?.metadata?.type===A.HeroSection||(t?.children??[]).some(e);return(this.component?.children??[]).some(e)}render(){let e=this.component?.metadata,t=[...(e?.banners??[]).map((e,t)=>({banner:e,index:t})).filter(({index:e})=>!this.dismissedStaticBannerIndices.has(e)).map(({banner:e,index:t})=>({banner:e,onDismiss:()=>this._dismissStaticBanner(t)})),...this.actionBanners.map((e,t)=>({banner:e,onDismiss:()=>this._dismissActionBanner(t)}))];return w`<div style="display: flex; flex-direction: column; width: 100%;">${w`
             <div class="page-header-wrap">
                 <mateu-content-header
                     class="${this._tocVisible?`sticky-header`:``}"
@@ -5905,15 +5905,15 @@ ${i}
                     .appState="${this.appState}"
                     .appData="${this.appData}"
                 ></mateu-content-header>
-                ${this._showHeaderBand()?T`
+                ${this._showHeaderBand()?w`
                     <div class="page-header-band" aria-hidden="true"></div>
-                `:v}
+                `:_}
             </div>
-            ${t.length>0?T`
+            ${t.length>0?w`
                 <div class="page-banners">
                     ${t.map(({banner:e,onDismiss:t})=>this._renderBanner(e,t))}
                 </div>
-            `:v}
+            `:_}
             <div class="page-body ${this._tocVisible?`with-toc`:``}">
                 <div class="form-content">
                     <slot @slotchange=${this._onSlotChange}></slot>
@@ -5921,25 +5921,25 @@ ${i}
                         <slot name="buttons"></slot>
                     </div>
                 </div>
-                ${this._tocVisible?T`
+                ${this._tocVisible?w`
                     <aside class="page-toc">
                         <nav>
-                            ${this._tocEntries.map((e,t)=>T`
+                            ${this._tocEntries.map((e,t)=>w`
                                 <a class="page-toc__item ${t===this._activeToc?`is-active`:``}"
                                    @click=${()=>this._scrollToSection(t)}
                                    title=${t<9?`${e.title} (Ctrl+Alt+${t+1})`:e.title}>
                                     <span class="page-toc__label">${e.title}</span>
-                                    ${t<9?T`<span class="page-toc__key">${t+1}</span>`:v}
+                                    ${t<9?w`<span class="page-toc__key">${t+1}</span>`:_}
                                 </a>
                             `)}
                         </nav>
                     </aside>
-                `:v}
+                `:_}
             </div>
             <div class="form-footer">
-                ${e?.footer?.map(e=>F(this,e,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData))}
+                ${e?.footer?.map(e=>P(this,e,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData))}
             </div>
-        `}</div>`}static{this.styles=h`
+        `}</div>`}static{this.styles=m`
         /* Design-system hook: background behind the page header (the RDS "Header + Background"
            band) — transparent by default; the Redwood renderer paints it with the canvas color
            via a custom property, so the header reads as part of the canvas and the content slab
@@ -6138,7 +6138,7 @@ ${i}
             background: #fdf2f2;
             border-leftx: 4px solid var(--lumo-error-color);
         }
-    `}};k([y()],J.prototype,`component`,void 0),k([y()],J.prototype,`baseUrl`,void 0),k([y()],J.prototype,`state`,void 0),k([y()],J.prototype,`data`,void 0),k([y()],J.prototype,`appState`,void 0),k([y()],J.prototype,`appData`,void 0),k([y()],J.prototype,`value`,void 0),k([y({type:Boolean})],J.prototype,`standalone`,void 0),k([C()],J.prototype,`actionBanners`,void 0),k([C()],J.prototype,`dismissedStaticBannerIndices`,void 0),k([C()],J.prototype,`_tocEntries`,void 0),k([C()],J.prototype,`_activeToc`,void 0),k([C()],J.prototype,`_tocVisible`,void 0),J=k([g(`mateu-page`)],J);var za=h`
+    `}};O([v()],q.prototype,`component`,void 0),O([v()],q.prototype,`baseUrl`,void 0),O([v()],q.prototype,`state`,void 0),O([v()],q.prototype,`data`,void 0),O([v()],q.prototype,`appState`,void 0),O([v()],q.prototype,`appData`,void 0),O([v()],q.prototype,`value`,void 0),O([v({type:Boolean})],q.prototype,`standalone`,void 0),O([S()],q.prototype,`actionBanners`,void 0),O([S()],q.prototype,`dismissedStaticBannerIndices`,void 0),O([S()],q.prototype,`_tocEntries`,void 0),O([S()],q.prototype,`_activeToc`,void 0),O([S()],q.prototype,`_tocVisible`,void 0),q=O([h(`mateu-page`)],q);var Ba=m`
     .nbtn {
         display: inline-flex;
         align-items: center;
@@ -6167,47 +6167,47 @@ ${i}
     }
     .nbtn.primary:hover { background: var(--lumo-primary-color, #1676f3); filter: brightness(1.08); }
     .nbtn svg { width: 1em; height: 1em; flex-shrink: 0; }
-`,Ba=e=>w`
+`,Va=e=>C`
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-         stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${e}</svg>`,Va=Ba(w`
+         stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${e}</svg>`,Ha=Va(C`
     <circle cx="12" cy="12" r="3"></circle>
-    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path>`),Ha=Ba(w`
+    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path>`),Ua=Va(C`
     <line x1="12" y1="5" x2="12" y2="19"></line>
-    <line x1="5" y1="12" x2="19" y2="12"></line>`),Ua=Ba(w`
+    <line x1="5" y1="12" x2="19" y2="12"></line>`),Wa=Va(C`
     <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
     <polyline points="7 10 12 15 17 10"></polyline>
-    <line x1="12" y1="15" x2="12" y2="3"></line>`);Ba(w`
+    <line x1="12" y1="15" x2="12" y2="3"></line>`);Va(C`
     <rect x="9" y="2" width="6" height="5" rx="1"></rect>
     <rect x="2" y="17" width="6" height="5" rx="1"></rect>
     <rect x="16" y="17" width="6" height="5" rx="1"></rect>
-    <path d="M12 7v4M5 17v-3h14v3M12 11v3"></path>`);var Wa=Ba(w`
+    <path d="M12 7v4M5 17v-3h14v3M12 11v3"></path>`);var Ga=Va(C`
     <rect x="9" y="2" width="6" height="12" rx="3"></rect>
     <path d="M5 10v1a7 7 0 0 0 14 0v-1"></path>
-    <line x1="12" y1="18" x2="12" y2="22"></line>`),Ga=Ba(w`
+    <line x1="12" y1="18" x2="12" y2="22"></line>`),Ka=Va(C`
     <line x1="18" y1="6" x2="6" y2="18"></line>
-    <line x1="6" y1="6" x2="18" y2="18"></line>`),Ka=[`#e91e63`,`#1676f3`,`#10b981`,`#8b5cf6`,`#f59e0b`,`#ef4444`],qa=e=>Ka[Math.abs(e??0)%Ka.length],Ja=e=>(e??`?`).split(/\s+/).filter(e=>e).map(e=>e[0]).slice(0,2).join(``).toUpperCase()||`?`,Y=class extends b{constructor(...e){super(...e),this.localAgentUrl=`http://127.0.0.1:8776`,this.localAgentAlive=!1,this.menu=[],this.chatSessionId=E(),this.menuContextSent=!1,this.attachments=[],this.uploading=!1,this.expanded=!1,this.toggleExpanded=()=>{this.expanded=!this.expanded},this.items=[],this.listening=!1,this.recognitionAvailable=!1,this.loading=!1,this.elapsedSeconds=0,this.startListening=()=>{this.recognition&&(this.listening?(this.recognition.stop(),this.listening=!1):(this.recognition.start(),this.listening=!0))},this.onSpeechResult=e=>{if(this.recognition){let t=e,n=t.results[t.results[0].length-1][0].transcript;this.messageInputElement&&(this.messageInputElement.value=n,this.send(new CustomEvent(`submit`,{detail:{value:n},bubbles:!0,composed:!0})))}},this.probeLocalAgent=async()=>{if(this.localAgentUrl)try{let e=new AbortController,t=setTimeout(()=>e.abort(),1200),n=await fetch(this.localAgentUrl+`/health`,{signal:e.signal});clearTimeout(t),this.localAgentAlive=n.ok}catch{this.localAgentAlive=!1}},this.pickFiles=()=>this.fileInputElement?.click(),this.onFilesPicked=async e=>{let t=e.target,n=Array.from(t.files??[]);if(t.value=``,!(!n.length||!this.uploadUrl)){this.uploading=!0;try{let e=new FormData;e.append(`sessionId`,this.chatSessionId);for(let t of n)e.append(`files`,t,t.name);let t={},r=localStorage.getItem(`__mateu_auth_token`);r&&(t.Authorization=`Bearer `+r);let i=sessionStorage.getItem(`__mateu_sesion_id`);i&&(t[`X-Session-Id`]=i);let a=await fetch(this.uploadUrl,{method:`POST`,headers:t,body:e});if(!a.ok)throw Error(`Upload failed: ${a.status}`);let o=((await a.json()).files??[]).filter(e=>e&&e.path);this.attachments=[...this.attachments,...o]}catch(e){this.addMessage(`⚠️ No se pudieron subir los ficheros: ${e instanceof Error?e.message:e}`,`agent`)}finally{this.uploading=!1}}},this.removeAttachment=e=>{this.attachments=this.attachments.filter(t=>t.path!==e)},this.send=async e=>{this.messageInputElement?.setAttribute(`disabled`,`disabled`);let t=e.detail.value.trim(),n=this.localAgentAlive?this.localAgentUrl+`/mateu/agent/stream`:this.sseUrl,r=this.attachments;if(!t&&r.length===0||!n)return;let i=r.length?`${t}${t?`
+    <line x1="6" y1="6" x2="18" y2="18"></line>`),qa=[`#e91e63`,`#1676f3`,`#10b981`,`#8b5cf6`,`#f59e0b`,`#ef4444`],Ja=e=>qa[Math.abs(e??0)%qa.length],Ya=e=>(e??`?`).split(/\s+/).filter(e=>e).map(e=>e[0]).slice(0,2).join(``).toUpperCase()||`?`,J=class extends y{constructor(...e){super(...e),this.localAgentUrl=`http://127.0.0.1:8776`,this.localAgentAlive=!1,this.menu=[],this.chatSessionId=T(),this.menuContextSent=!1,this.attachments=[],this.uploading=!1,this.expanded=!1,this.toggleExpanded=()=>{this.expanded=!this.expanded},this.items=[],this.listening=!1,this.recognitionAvailable=!1,this.loading=!1,this.elapsedSeconds=0,this.startListening=()=>{this.recognition&&(this.listening?(this.recognition.stop(),this.listening=!1):(this.recognition.start(),this.listening=!0))},this.onSpeechResult=e=>{if(this.recognition){let t=e,n=t.results[t.results[0].length-1][0].transcript;this.messageInputElement&&(this.messageInputElement.value=n,this.send(new CustomEvent(`submit`,{detail:{value:n},bubbles:!0,composed:!0})))}},this.probeLocalAgent=async()=>{if(this.localAgentUrl)try{let e=new AbortController,t=setTimeout(()=>e.abort(),1200),n=await fetch(this.localAgentUrl+`/health`,{signal:e.signal});clearTimeout(t),this.localAgentAlive=n.ok}catch{this.localAgentAlive=!1}},this.pickFiles=()=>this.fileInputElement?.click(),this.onFilesPicked=async e=>{let t=e.target,n=Array.from(t.files??[]);if(t.value=``,!(!n.length||!this.uploadUrl)){this.uploading=!0;try{let e=new FormData;e.append(`sessionId`,this.chatSessionId);for(let t of n)e.append(`files`,t,t.name);let t={},r=localStorage.getItem(`__mateu_auth_token`);r&&(t.Authorization=`Bearer `+r);let i=sessionStorage.getItem(`__mateu_sesion_id`);i&&(t[`X-Session-Id`]=i);let a=await fetch(this.uploadUrl,{method:`POST`,headers:t,body:e});if(!a.ok)throw Error(`Upload failed: ${a.status}`);let o=((await a.json()).files??[]).filter(e=>e&&e.path);this.attachments=[...this.attachments,...o]}catch(e){this.addMessage(`⚠️ No se pudieron subir los ficheros: ${e instanceof Error?e.message:e}`,`agent`)}finally{this.uploading=!1}}},this.removeAttachment=e=>{this.attachments=this.attachments.filter(t=>t.path!==e)},this.send=async e=>{this.messageInputElement?.setAttribute(`disabled`,`disabled`);let t=e.detail.value.trim(),n=this.localAgentAlive?this.localAgentUrl+`/mateu/agent/stream`:this.sseUrl,r=this.attachments;if(!t&&r.length===0||!n)return;let i=r.length?`${t}${t?`
 
 `:``}📎 ${r.map(e=>e.name).join(`, `)}`:t;this.addMessage(i,`user`),this.attachments=[];let a=this.addMessage(``,`agent`);this.startLoading();let o=``;try{let e={Accept:`text/event-stream`,"Content-Type":`application/json`},i=localStorage.getItem(`__mateu_auth_token`);i&&(e.Authorization=`Bearer `+i);let s=sessionStorage.getItem(`__mateu_sesion_id`);s&&(e[`X-Session-Id`]=s);let c=this.contextProvider?.(),l=JSON.stringify({message:t,sessionId:this.chatSessionId,...r.length&&{attachments:r},...c!=null&&{context:c},...this.mcpUrl&&{mcpUrl:new URL(this.mcpUrl,window.location.origin).href},...!this.menuContextSent&&{menuContext:this.buildMenuContext(this.menu)}});this.menuContextSent=!0;let u=await fetch(n,{method:`POST`,headers:e,body:l});if(!u.ok){let e=await u.text();throw Error(`Servidor respondió ${u.status}: ${e}`)}let d=u.body?.getReader();if(!d)throw Error(`No se pudo obtener el reader del stream.`);let f=new TextDecoder,p=``;for(;;){let{done:e,value:t}=await d.read();if(e){if(p.trim().startsWith(`data:`)){let e=p.trim().slice(5).trim(),t=this.tryParseTokenUsage(e),n=!t&&this.tryParseCustomEvent(e);t?this.tokenUsage={...this.tokenUsage,...t}:n?n.event===`agent-error`?(o=`⚠️ `+(n.detail?.message??`Error desconocido del agente`),this.updateMessage(a,o)):this.dispatchEvent(new CustomEvent(n.event,{detail:n.detail,bubbles:!0,composed:!0})):(o+=e,this.updateMessage(a,o))}break}let n=f.decode(t,{stream:!0});p+=n;let r=p.split(`
 `);p=r.pop()||``;let i=!1;for(let e of r)if(e.trim().startsWith(`data:`)){let t=e.trim().slice(5).trim(),n=this.tryParseTokenUsage(t),r=!n&&this.tryParseCustomEvent(t);n?this.tokenUsage={...this.tokenUsage,...n}:r?r.event===`agent-error`?(o=`⚠️ `+(r.detail?.message??`Error desconocido del agente`),this.updateMessage(a,o)):this.dispatchEvent(new CustomEvent(r.event,{detail:r.detail,bubbles:!0,composed:!0})):(o+=t+`
-`,i=!0)}i&&this.updateMessage(a,o)}o||this.updateMessage(a,`⚠️ El agente no devolvió ninguna respuesta. Comprueba que el LLM está configurado correctamente (API key).`)}catch(e){console.error(`Error en el flujo SSE:`,e);let t=e?.message??String(e);(t===`Failed to fetch`||t===`network error`||t===`Load failed`)&&!o?this.updateMessage(a,`⚠️ No se recibió respuesta del agente. El servidor cerró la conexión sin enviar datos — comprueba que el LLM tiene la API key configurada y está disponible.`):this.updateMessage(a,`⚠️ Error: `+t)}finally{this.stopLoading(),setTimeout(()=>{this.messageInputElement&&(this.messageInputElement.value=``)},250),this.messageInputElement?.removeAttribute(`disabled`),this.messageInputElement?.focus()}},this.closeChat=()=>{this.dispatchEvent(new CustomEvent(`close-requested`,{bubbles:!0,composed:!0}))},this.submitFromInput=()=>{let e=this.messageInputElement?.value?.trim()??``;e&&this.send(new CustomEvent(`submit`,{detail:{value:e},bubbles:!0,composed:!0}))},this.onInputKeydown=e=>{e.key===`Enter`&&(e.preventDefault(),this.submitFromInput())}}connectedCallback(){super.connectedCallback(),this.probeLocalAgent();let e=window.SpeechRecognition||window.webkitSpeechRecognition;if(e){let t=new e;this.recognition=t,t.lang=`es-ES`,t.onend=()=>{setTimeout(()=>{if(this.listening&&this.recognition)try{this.recognition.start()}catch{}},250)},this.recognitionAvailable=!0,t.onresult=this.onSpeechResult,t.onerror=e=>{console.error(`Error de reconocimiento: `+e.error),this.listening&&this.recognition&&setTimeout(()=>{this.recognition.start()},250)}}}scrollBottom(){setTimeout(()=>{this.scrollContainer&&this.scrollContainer.scrollTo({top:this.scrollContainer.scrollHeight,behavior:`smooth`})},0)}addMessage(e,t){let n={text:e,time:new Date().toLocaleTimeString(),userName:t.includes(`agent`)?`Asistente`:`Tú`,userColorIndex:t.includes(`agent`)?2:1};return this.items=[...this.items,n],this.scrollBottom(),this.items.length-1}updateMessage(e,t){this.items=this.items.map((n,r)=>r===e?{...n,text:t}:n),this.scrollBottom()}tryParseCustomEvent(e){let t=e.trim();if(!t.startsWith(`{`))return null;try{let e=JSON.parse(t);if(typeof e.event==`string`)return{event:e.event,detail:e.detail??{}}}catch{}return null}tryParseTokenUsage(e){let t=e.trim();if(!t.startsWith(`{`))return null;try{let e=JSON.parse(t);if(`inputTokens`in e||`outputTokens`in e||`totalTokens`in e)return e}catch{}return null}buildMenuContext(e,t=[]){let n=[];for(let r of e){if(r.separator||r.remote)continue;let e=[...t,r.label];if(r.submenus&&r.submenus.length>0)n.push(...this.buildMenuContext(r.submenus,e));else{let t={path:e,navigation:{route:r.route,consumedRoute:r.consumedRoute,actionId:r.actionId??``,baseUrl:r.baseUrl,serverSideType:r.serverSideType,uriPrefix:r.uriPrefix}};r.description&&(t.description=r.description),n.push(t)}}return n}startLoading(){this.loading=!0,this.elapsedSeconds=0,this._elapsedTimer=setInterval(()=>{this.elapsedSeconds++},1e3)}stopLoading(){this.loading=!1,clearInterval(this._elapsedTimer),this._elapsedTimer=void 0}render(){return T`
+`,i=!0)}i&&this.updateMessage(a,o)}o||this.updateMessage(a,`⚠️ El agente no devolvió ninguna respuesta. Comprueba que el LLM está configurado correctamente (API key).`)}catch(e){console.error(`Error en el flujo SSE:`,e);let t=e?.message??String(e);(t===`Failed to fetch`||t===`network error`||t===`Load failed`)&&!o?this.updateMessage(a,`⚠️ No se recibió respuesta del agente. El servidor cerró la conexión sin enviar datos — comprueba que el LLM tiene la API key configurada y está disponible.`):this.updateMessage(a,`⚠️ Error: `+t)}finally{this.stopLoading(),setTimeout(()=>{this.messageInputElement&&(this.messageInputElement.value=``)},250),this.messageInputElement?.removeAttribute(`disabled`),this.messageInputElement?.focus()}},this.closeChat=()=>{this.dispatchEvent(new CustomEvent(`close-requested`,{bubbles:!0,composed:!0}))},this.submitFromInput=()=>{let e=this.messageInputElement?.value?.trim()??``;e&&this.send(new CustomEvent(`submit`,{detail:{value:e},bubbles:!0,composed:!0}))},this.onInputKeydown=e=>{e.key===`Enter`&&(e.preventDefault(),this.submitFromInput())}}connectedCallback(){super.connectedCallback(),this.probeLocalAgent();let e=window.SpeechRecognition||window.webkitSpeechRecognition;if(e){let t=new e;this.recognition=t,t.lang=`es-ES`,t.onend=()=>{setTimeout(()=>{if(this.listening&&this.recognition)try{this.recognition.start()}catch{}},250)},this.recognitionAvailable=!0,t.onresult=this.onSpeechResult,t.onerror=e=>{console.error(`Error de reconocimiento: `+e.error),this.listening&&this.recognition&&setTimeout(()=>{this.recognition.start()},250)}}}scrollBottom(){setTimeout(()=>{this.scrollContainer&&this.scrollContainer.scrollTo({top:this.scrollContainer.scrollHeight,behavior:`smooth`})},0)}addMessage(e,t){let n={text:e,time:new Date().toLocaleTimeString(),userName:t.includes(`agent`)?`Asistente`:`Tú`,userColorIndex:t.includes(`agent`)?2:1};return this.items=[...this.items,n],this.scrollBottom(),this.items.length-1}updateMessage(e,t){this.items=this.items.map((n,r)=>r===e?{...n,text:t}:n),this.scrollBottom()}tryParseCustomEvent(e){let t=e.trim();if(!t.startsWith(`{`))return null;try{let e=JSON.parse(t);if(typeof e.event==`string`)return{event:e.event,detail:e.detail??{}}}catch{}return null}tryParseTokenUsage(e){let t=e.trim();if(!t.startsWith(`{`))return null;try{let e=JSON.parse(t);if(`inputTokens`in e||`outputTokens`in e||`totalTokens`in e)return e}catch{}return null}buildMenuContext(e,t=[]){let n=[];for(let r of e){if(r.separator||r.remote)continue;let e=[...t,r.label];if(r.submenus&&r.submenus.length>0)n.push(...this.buildMenuContext(r.submenus,e));else{let t={path:e,navigation:{route:r.route,consumedRoute:r.consumedRoute,actionId:r.actionId??``,baseUrl:r.baseUrl,serverSideType:r.serverSideType,uriPrefix:r.uriPrefix}};r.description&&(t.description=r.description),n.push(t)}}return n}startLoading(){this.loading=!0,this.elapsedSeconds=0,this._elapsedTimer=setInterval(()=>{this.elapsedSeconds++},1e3)}stopLoading(){this.loading=!1,clearInterval(this._elapsedTimer),this._elapsedTimer=void 0}render(){return w`
             <div class="chat-container">
                 <div class="chat-header">
                     <span class="chat-title">AI Assistant</span>
-                    ${this.localAgentAlive?T`<span class="local-agent-badge" title="Hablando con tu CLI local (companion en ${this.localAgentUrl}) — sin api key">agente local</span>`:v}
+                    ${this.localAgentAlive?w`<span class="local-agent-badge" title="Hablando con tu CLI local (companion en ${this.localAgentUrl}) — sin api key">agente local</span>`:_}
                     <button class="chat-icon-btn" @click="${this.toggleExpanded}"
                             title="${this.expanded?`Contraer`:`Expandir a pantalla completa`}"
                             aria-label="${this.expanded?`Contraer el chat`:`Expandir el chat`}">
                         ${this.expanded?`⤡`:`⤢`}
                     </button>
                     <button class="chat-close" @click="${this.closeChat}" title="Cerrar">
-                        ${Ga}
+                        ${Ka}
                     </button>
                 </div>
                 <div class="scroll-container">
                     <div class="message-list" role="list">
-                        ${this.items.map(e=>T`
+                        ${this.items.map(e=>w`
                             <div class="message" role="listitem">
-                                <div class="avatar" style="background: ${qa(e.userColorIndex)};">${Ja(e.userName)}</div>
+                                <div class="avatar" style="background: ${Ja(e.userColorIndex)};">${Ya(e.userName)}</div>
                                 <div class="message-body">
                                     <div class="message-meta">
                                         <span class="message-name">${e.userName}</span>
@@ -6219,43 +6219,43 @@ ${i}
                         `)}
                     </div>
                 </div>
-                ${this.tokenUsage?T`
+                ${this.tokenUsage?w`
                     <div class="token-bar">
                         <span class="token-label">Tokens:</span>
-                        ${this.tokenUsage.inputTokens==null?v:T`<span class="token-chip">in&nbsp;<strong>${this.tokenUsage.inputTokens}</strong></span>`}
-                        ${this.tokenUsage.outputTokens==null?v:T`<span class="token-chip">out&nbsp;<strong>${this.tokenUsage.outputTokens}</strong></span>`}
-                        ${this.tokenUsage.totalTokens==null?v:T`<span class="token-chip">total&nbsp;<strong>${this.tokenUsage.totalTokens}</strong></span>`}
+                        ${this.tokenUsage.inputTokens==null?_:w`<span class="token-chip">in&nbsp;<strong>${this.tokenUsage.inputTokens}</strong></span>`}
+                        ${this.tokenUsage.outputTokens==null?_:w`<span class="token-chip">out&nbsp;<strong>${this.tokenUsage.outputTokens}</strong></span>`}
+                        ${this.tokenUsage.totalTokens==null?_:w`<span class="token-chip">total&nbsp;<strong>${this.tokenUsage.totalTokens}</strong></span>`}
                     </div>
-                `:v}
-                ${this.loading?T`
+                `:_}
+                ${this.loading?w`
                     <div class="loading-bar">
                         <span class="spinner"></span>
                         <span class="loading-text">Thinking… ${this.elapsedSeconds}s</span>
                     </div>
-                `:v}
-                ${this.attachments.length?T`
+                `:_}
+                ${this.attachments.length?w`
                     <div class="attachments">
-                        ${this.attachments.map(e=>T`
+                        ${this.attachments.map(e=>w`
                             <span class="attachment-chip" title="${e.path}">
                                 📎 ${e.name}
                                 <button class="attachment-remove" @click="${()=>this.removeAttachment(e.path)}" aria-label="Quitar ${e.name}">✕</button>
                             </span>`)}
                     </div>
-                `:v}
+                `:_}
                 <div class="input-bar">
-                    ${this.uploadUrl?T`
+                    ${this.uploadUrl?w`
                         <button class="mic-btn" title="Adjuntar ficheros"
                                 @click="${this.pickFiles}" ?disabled="${this.uploading}"
                                 aria-label="Adjuntar ficheros">${this.uploading?`…`:`📎`}</button>
                         <input class="file-input" type="file" multiple hidden
                                @change="${this.onFilesPicked}"/>
-                    `:v}
+                    `:_}
                     <button class="mic-btn"
                             title="Dictar"
                             style="color: ${this.listening?`red`:`var(--lumo-contrast-50pct, #767676)`};"
                             @click="${this.startListening}"
                             ?disabled="${!this.recognitionAvailable}"
-                    >${Wa}</button>
+                    >${Ga}</button>
                     <input class="msg-input"
                            placeholder="Message"
                            aria-label="Message"
@@ -6263,7 +6263,7 @@ ${i}
                     <button class="nbtn primary" ?disabled="${this.loading}" @click="${this.submitFromInput}">Send</button>
                 </div>
             </div>
-        `}static{this.styles=[za,h`
+        `}static{this.styles=[Ba,m`
         :host {
             display: block;
             height: 100%;
@@ -6588,14 +6588,14 @@ ${i}
         @keyframes spin {
             to { transform: rotate(360deg); }
         }
-    `]}};k([y({attribute:!1})],Y.prototype,`contextProvider`,void 0),k([y()],Y.prototype,`localAgentUrl`,void 0),k([y({attribute:!1})],Y.prototype,`mcpUrl`,void 0),k([C()],Y.prototype,`localAgentAlive`,void 0),k([y()],Y.prototype,`sseUrl`,void 0),k([y()],Y.prototype,`uploadUrl`,void 0),k([y({attribute:!1})],Y.prototype,`menu`,void 0),k([C()],Y.prototype,`attachments`,void 0),k([C()],Y.prototype,`uploading`,void 0),k([x(`.file-input`)],Y.prototype,`fileInputElement`,void 0),k([y({type:Boolean,reflect:!0})],Y.prototype,`expanded`,void 0),k([y()],Y.prototype,`items`,void 0),k([x(`.scroll-container`)],Y.prototype,`scrollContainer`,void 0),k([x(`.msg-input`)],Y.prototype,`messageInputElement`,void 0),k([C()],Y.prototype,`recognition`,void 0),k([C()],Y.prototype,`listening`,void 0),k([C()],Y.prototype,`recognitionAvailable`,void 0),k([C()],Y.prototype,`loading`,void 0),k([C()],Y.prototype,`elapsedSeconds`,void 0),k([C()],Y.prototype,`tokenUsage`,void 0),Y=k([g(`mateu-chat`)],Y);var Ya=class extends b{updated(e){super.updated(e),this.chart&&=(this.chart.destroy(),void 0),this.data&&this.createChart(this.data)}async createChart(e){let[{default:t}]=await Promise.all([D(()=>import(`./vendor-chartjs.js`).then(e=>e.n),__vite__mapDeps([3,1])),D(()=>import(`./vendor-chartjs.js`).then(e=>e.t),__vite__mapDeps([3,1]))]);if(e!==this.data)return;this.chart&&this.chart.destroy();let n={type:this.type,data:this.data,options:this.options};this.chart=new t(this.chartElement,n)}handleSlotChange(){}render(){return T`
+    `]}};O([v({attribute:!1})],J.prototype,`contextProvider`,void 0),O([v()],J.prototype,`localAgentUrl`,void 0),O([v({attribute:!1})],J.prototype,`mcpUrl`,void 0),O([S()],J.prototype,`localAgentAlive`,void 0),O([v()],J.prototype,`sseUrl`,void 0),O([v()],J.prototype,`uploadUrl`,void 0),O([v({attribute:!1})],J.prototype,`menu`,void 0),O([S()],J.prototype,`attachments`,void 0),O([S()],J.prototype,`uploading`,void 0),O([b(`.file-input`)],J.prototype,`fileInputElement`,void 0),O([v({type:Boolean,reflect:!0})],J.prototype,`expanded`,void 0),O([v()],J.prototype,`items`,void 0),O([b(`.scroll-container`)],J.prototype,`scrollContainer`,void 0),O([b(`.msg-input`)],J.prototype,`messageInputElement`,void 0),O([S()],J.prototype,`recognition`,void 0),O([S()],J.prototype,`listening`,void 0),O([S()],J.prototype,`recognitionAvailable`,void 0),O([S()],J.prototype,`loading`,void 0),O([S()],J.prototype,`elapsedSeconds`,void 0),O([S()],J.prototype,`tokenUsage`,void 0),J=O([h(`mateu-chat`)],J);var Xa=class extends y{updated(e){super.updated(e),this.chart&&=(this.chart.destroy(),void 0),this.data&&this.createChart(this.data)}async createChart(e){let[{default:t}]=await Promise.all([E(()=>import(`./vendor-chartjs.js`).then(e=>e.n),__vite__mapDeps([3,1])),E(()=>import(`./vendor-chartjs.js`).then(e=>e.t),__vite__mapDeps([3,1]))]);if(e!==this.data)return;this.chart&&this.chart.destroy();let n={type:this.type,data:this.data,options:this.options};this.chart=new t(this.chartElement,n)}handleSlotChange(){}render(){return w`
             <div class="container">
                 <canvas id="chart"></canvas>
             </div>
             <div style="display: none;">
                 <slot @slotchange=${this.handleSlotChange}></slot>
             </div>
-       `}static{this.styles=h`
+       `}static{this.styles=m`
     /* the host's inline height (Chart.style) must reach the canvas parent — chart.js
        measures .container to size the canvas when maintainAspectRatio is false */
     :host {
@@ -6605,7 +6605,7 @@ ${i}
         height: 100%;
         position: relative;
     }
-  `}};k([y()],Ya.prototype,`type`,void 0),k([y()],Ya.prototype,`data`,void 0),k([y()],Ya.prototype,`options`,void 0),k([x(`#chart`)],Ya.prototype,`chartElement`,void 0),Ya=k([g(`mateu-chart`)],Ya);var Xa=class extends b{updated(e){super.updated(e),this.chart&&=(this.chart.destroy(),void 0),this.xml&&this.createViewer(this.xml)}async createViewer(e){let{default:t}=await D(async()=>{let{default:e}=await import(`./vendor-diagrams.js`).then(e=>e.t);return{default:e}},__vite__mapDeps([4,1,2]));if(e!==this.xml)return;this.chart&&this.chart.destroy();let n={container:this.divElement};this.chart=new t(n),this.chart.importXML(e)}handleSlotChange(){}render(){return T`
+  `}};O([v()],Xa.prototype,`type`,void 0),O([v()],Xa.prototype,`data`,void 0),O([v()],Xa.prototype,`options`,void 0),O([b(`#chart`)],Xa.prototype,`chartElement`,void 0),Xa=O([h(`mateu-chart`)],Xa);var Za=class extends y{updated(e){super.updated(e),this.chart&&=(this.chart.destroy(),void 0),this.xml&&this.createViewer(this.xml)}async createViewer(e){let{default:t}=await E(async()=>{let{default:e}=await import(`./vendor-diagrams.js`).then(e=>e.t);return{default:e}},__vite__mapDeps([4,1,2]));if(e!==this.xml)return;this.chart&&this.chart.destroy();let n={container:this.divElement};this.chart=new t(n),this.chart.importXML(e)}handleSlotChange(){}render(){return w`
             <div class="container" style="width: 20rem; height: 15rem; overflow: auto;">
                 <!-- BPMN diagram container -->
                 <div id="canvas" style="width: 60rem; height: 30rem; zoom: 0.5;"></div>
@@ -6613,8 +6613,8 @@ ${i}
             <div style="display: none;">
                 <slot @slotchange=${this.handleSlotChange}></slot>
             </div>
-       `}static{this.styles=h`
-  `}};k([y()],Xa.prototype,`xml`,void 0),k([x(`#canvas`)],Xa.prototype,`divElement`,void 0),Xa=k([g(`mateu-bpmn`)],Xa);var Za=160,Qa=56,$a=220,eo=110,to=60,no={ACTION:`#3B82F6`,JOIN:`#8B5CF6`,FORK:`#F59E0B`,END:`#EF4444`,USER_TASK:`#10B981`,PROCESS:`#6366F1`},ro={ACTION:`▶`,JOIN:`⟨`,FORK:`⟩`,END:`◼`,USER_TASK:`👤`,PROCESS:`⚙`},io=[`ACTION`,`JOIN`,`FORK`,`END`,`USER_TASK`,`PROCESS`];function ao(){return`step-`+Math.random().toString(36).slice(2,8)}var oo=class extends b{constructor(...e){super(...e),this.value=`{"name":"New Workflow","steps":[]}`,this.wf={name:`New Workflow`,steps:[]},this.positions={},this.selectedId=null,this.showMeta=!1,this.draggingId=null,this.dragOffset={x:0,y:0},this.svgEl=null,this.onMouseMove=e=>{if(!this.draggingId||!this.svgEl)return;let t=this.toSvgPoint(e);this.positions={...this.positions,[this.draggingId]:{x:Math.max(0,t.x-this.dragOffset.x),y:Math.max(0,t.y-this.dragOffset.y)}}},this.onMouseUp=()=>{this.draggingId=null,window.removeEventListener(`mousemove`,this.onMouseMove),window.removeEventListener(`mouseup`,this.onMouseUp)}}updated(e){if(e.has(`value`)){try{this.wf=JSON.parse(this.value)}catch{}this.autoLayout()}}autoLayout(){let e=this.wf.steps??[],t={};e.forEach(e=>{t[e.id]=0});let n=!0;for(;n;)n=!1,e.forEach(e=>{if(e.preconditionStepId!=null&&t[e.preconditionStepId]!==void 0){let r=t[e.preconditionStepId]+1;r>t[e.id]&&(t[e.id]=r,n=!0)}});let r={};e.forEach(e=>{let n=t[e.id]??0;(r[n]??=[]).push(e.id)});let i={...this.positions},a=!1;Object.entries(r).forEach(([e,t])=>{let n=Number(e);t.forEach((e,t)=>{i[e]||(i[e]={x:to+n*$a,y:to+t*eo},a=!0)})}),a&&(this.positions=i)}emit(){let e=JSON.stringify(this.wf,null,2);this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e},bubbles:!0,composed:!0}))}updateWf(e){this.wf={...this.wf,...e},this.emit()}updateStep(e,t){this.wf={...this.wf,steps:this.wf.steps.map(n=>n.id===e?{...n,...t}:n)},this.emit()}addStep(){let e=ao(),t={id:e,type:`ACTION`,name:`New Step`};this.wf={...this.wf,steps:[...this.wf.steps??[],t]};let n=Object.values(this.positions).map(e=>e.y),r=n.length?Math.max(...n)+eo:to;this.positions={...this.positions,[e]:{x:to,y:r}},this.selectedId=e,this.emit()}deleteStep(e){this.wf={...this.wf,steps:this.wf.steps.filter(t=>t.id!==e).map(t=>t.preconditionStepId===e?{...t,preconditionStepId:void 0}:t)};let{[e]:t,...n}=this.positions;this.positions=n,this.selectedId===e&&(this.selectedId=null),this.emit()}onNodeMouseDown(e,t){e.preventDefault(),this.draggingId=t;let n=this.positions[t]??{x:0,y:0},r=this.toSvgPoint(e);this.dragOffset={x:r.x-n.x,y:r.y-n.y},this.svgEl=e.currentTarget.closest(`svg`),window.addEventListener(`mousemove`,this.onMouseMove),window.addEventListener(`mouseup`,this.onMouseUp)}toSvgPoint(e){if(!this.svgEl)return{x:0,y:0};let t=this.svgEl.getBoundingClientRect();return{x:e.clientX-t.left,y:e.clientY-t.top}}canvasSize(){let e=Object.values(this.positions),t=e.length?Math.max(...e.map(e=>e.x))+Za+to:600,n=e.length?Math.max(...e.map(e=>e.y))+Qa+to:400;return{w:Math.max(t,600),h:Math.max(n,400)}}render(){let{w:e,h:t}=this.canvasSize(),n=this.wf.steps??[];return T`
+       `}static{this.styles=m`
+  `}};O([v()],Za.prototype,`xml`,void 0),O([b(`#canvas`)],Za.prototype,`divElement`,void 0),Za=O([h(`mateu-bpmn`)],Za);var Qa=160,$a=56,eo=220,to=110,no=60,ro={ACTION:`#3B82F6`,JOIN:`#8B5CF6`,FORK:`#F59E0B`,END:`#EF4444`,USER_TASK:`#10B981`,PROCESS:`#6366F1`},io={ACTION:`▶`,JOIN:`⟨`,FORK:`⟩`,END:`◼`,USER_TASK:`👤`,PROCESS:`⚙`},ao=[`ACTION`,`JOIN`,`FORK`,`END`,`USER_TASK`,`PROCESS`];function oo(){return`step-`+Math.random().toString(36).slice(2,8)}var so=class extends y{constructor(...e){super(...e),this.value=`{"name":"New Workflow","steps":[]}`,this.wf={name:`New Workflow`,steps:[]},this.positions={},this.selectedId=null,this.showMeta=!1,this.draggingId=null,this.dragOffset={x:0,y:0},this.svgEl=null,this.onMouseMove=e=>{if(!this.draggingId||!this.svgEl)return;let t=this.toSvgPoint(e);this.positions={...this.positions,[this.draggingId]:{x:Math.max(0,t.x-this.dragOffset.x),y:Math.max(0,t.y-this.dragOffset.y)}}},this.onMouseUp=()=>{this.draggingId=null,window.removeEventListener(`mousemove`,this.onMouseMove),window.removeEventListener(`mouseup`,this.onMouseUp)}}updated(e){if(e.has(`value`)){try{this.wf=JSON.parse(this.value)}catch{}this.autoLayout()}}autoLayout(){let e=this.wf.steps??[],t={};e.forEach(e=>{t[e.id]=0});let n=!0;for(;n;)n=!1,e.forEach(e=>{if(e.preconditionStepId!=null&&t[e.preconditionStepId]!==void 0){let r=t[e.preconditionStepId]+1;r>t[e.id]&&(t[e.id]=r,n=!0)}});let r={};e.forEach(e=>{let n=t[e.id]??0;(r[n]??=[]).push(e.id)});let i={...this.positions},a=!1;Object.entries(r).forEach(([e,t])=>{let n=Number(e);t.forEach((e,t)=>{i[e]||(i[e]={x:no+n*eo,y:no+t*to},a=!0)})}),a&&(this.positions=i)}emit(){let e=JSON.stringify(this.wf,null,2);this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e},bubbles:!0,composed:!0}))}updateWf(e){this.wf={...this.wf,...e},this.emit()}updateStep(e,t){this.wf={...this.wf,steps:this.wf.steps.map(n=>n.id===e?{...n,...t}:n)},this.emit()}addStep(){let e=oo(),t={id:e,type:`ACTION`,name:`New Step`};this.wf={...this.wf,steps:[...this.wf.steps??[],t]};let n=Object.values(this.positions).map(e=>e.y),r=n.length?Math.max(...n)+to:no;this.positions={...this.positions,[e]:{x:no,y:r}},this.selectedId=e,this.emit()}deleteStep(e){this.wf={...this.wf,steps:this.wf.steps.filter(t=>t.id!==e).map(t=>t.preconditionStepId===e?{...t,preconditionStepId:void 0}:t)};let{[e]:t,...n}=this.positions;this.positions=n,this.selectedId===e&&(this.selectedId=null),this.emit()}onNodeMouseDown(e,t){e.preventDefault(),this.draggingId=t;let n=this.positions[t]??{x:0,y:0},r=this.toSvgPoint(e);this.dragOffset={x:r.x-n.x,y:r.y-n.y},this.svgEl=e.currentTarget.closest(`svg`),window.addEventListener(`mousemove`,this.onMouseMove),window.addEventListener(`mouseup`,this.onMouseUp)}toSvgPoint(e){if(!this.svgEl)return{x:0,y:0};let t=this.svgEl.getBoundingClientRect();return{x:e.clientX-t.left,y:e.clientY-t.top}}canvasSize(){let e=Object.values(this.positions),t=e.length?Math.max(...e.map(e=>e.x))+Qa+no:600,n=e.length?Math.max(...e.map(e=>e.y))+$a+no:400;return{w:Math.max(t,600),h:Math.max(n,400)}}render(){let{w:e,h:t}=this.canvasSize(),n=this.wf.steps??[];return w`
             <div class="root">
                 ${this.renderToolbar()}
                 ${this.showMeta?this.renderMeta():``}
@@ -6635,25 +6635,25 @@ ${i}
                     ${this.selectedId?this.renderPanel():``}
                 </div>
             </div>
-        `}renderToolbar(){let e=this.wf.status??`DRAFT`;return T`
+        `}renderToolbar(){let e=this.wf.status??`DRAFT`;return w`
             <div class="toolbar">
                 <span class="wf-name">${this.wf.name}</span>
                 <span class="badge badge-${e.toLowerCase()}">${e}</span>
                 <div style="flex:1"></div>
                 <button class="nbtn" @click="${()=>this.showMeta=!this.showMeta}">
-                    ${Va}
+                    ${Ha}
                     Settings
                 </button>
                 <button class="nbtn primary" @click="${()=>this.addStep()}">
-                    ${Ha}
+                    ${Ua}
                     Add Step
                 </button>
                 <button class="nbtn" @click="${()=>this.exportJson()}">
-                    ${Ua}
+                    ${Wa}
                     Export
                 </button>
             </div>
-        `}renderMeta(){let e=this.wf;return T`
+        `}renderMeta(){let e=this.wf;return w`
             <div class="meta-panel">
                 <div class="meta-grid">
                     <label>Name</label>
@@ -6662,13 +6662,13 @@ ${i}
                     <textarea class="inp" rows="2" @change="${e=>this.updateWf({description:e.target.value})}">${e.description??``}</textarea>
                     <label>Status</label>
                     <select class="inp" @change="${e=>this.updateWf({status:e.target.value})}">
-                        ${[`DRAFT`,`ACTIVE`,`DISABLED`,`ARCHIVED`].map(t=>T`
+                        ${[`DRAFT`,`ACTIVE`,`DISABLED`,`ARCHIVED`].map(t=>w`
                             <option value="${t}" ?selected="${e.status===t}">${t}</option>`)}
                     </select>
                     <label>Limit concurrent</label>
                     <input type="checkbox" ?checked="${e.limitConcurrentExecutions}"
                            @change="${e=>this.updateWf({limitConcurrentExecutions:e.target.checked})}"/>
-                    ${e.limitConcurrentExecutions?T`
+                    ${e.limitConcurrentExecutions?w`
                         <label>Max concurrent</label>
                         <input class="inp" type="number" min="0" .value="${String(e.maxConcurrentExecutions??0)}"
                                @change="${e=>this.updateWf({maxConcurrentExecutions:Number(e.target.value)})}"/>
@@ -6678,38 +6678,38 @@ ${i}
                     `:``}
                 </div>
             </div>
-        `}renderArrow(e){if(!e.preconditionStepId)return w``;let t=this.positions[e.preconditionStepId],n=this.positions[e.id];if(!t||!n)return w``;let r=t.x+Za,i=t.y+Qa/2,a=n.x,o=n.y+Qa/2,s=(r+a)/2;return w`
+        `}renderArrow(e){if(!e.preconditionStepId)return C``;let t=this.positions[e.preconditionStepId],n=this.positions[e.id];if(!t||!n)return C``;let r=t.x+Qa,i=t.y+$a/2,a=n.x,o=n.y+$a/2,s=(r+a)/2;return C`
             <path d="M${r},${i} C${s},${i} ${s},${o} ${a},${o}"
                   fill="none" stroke="#94a3b8" stroke-width="2"
                   marker-end="url(#arrow)"/>
-        `}renderNode(e){let t=this.positions[e.id]??{x:to,y:to},n=no[e.type]??`#64748b`,r=ro[e.type]??`•`,i=this.selectedId===e.id;return w`
+        `}renderNode(e){let t=this.positions[e.id]??{x:no,y:no},n=ro[e.type]??`#64748b`,r=io[e.type]??`•`,i=this.selectedId===e.id;return C`
             <g transform="translate(${t.x},${t.y})"
                style="cursor:grab"
                @mousedown="${t=>this.onNodeMouseDown(t,e.id)}"
                @click="${t=>{t.stopPropagation(),this.selectedId=e.id}}">
-                <rect width="${Za}" height="${Qa}" rx="8"
+                <rect width="${Qa}" height="${$a}" rx="8"
                       fill="white"
                       stroke="${i?n:`#e2e8f0`}"
                       stroke-width="${i?2.5:1.5}"
                       filter="url(#shadow)"/>
                 <!-- type badge -->
-                <rect x="0" y="0" width="32" height="${Qa}" rx="8" fill="${n}" clip-path="inset(0 -8px 0 0 round 8px)"/>
-                <rect x="24" y="0" width="8" height="${Qa}" fill="${n}"/>
+                <rect x="0" y="0" width="32" height="${$a}" rx="8" fill="${n}" clip-path="inset(0 -8px 0 0 round 8px)"/>
+                <rect x="24" y="0" width="8" height="${$a}" fill="${n}"/>
                 <text x="16" y="${33}" text-anchor="middle"
                       font-size="14" fill="white">${r}</text>
                 <!-- name -->
-                <text x="44" y="${Qa/2-6}" font-size="11" fill="#1e293b" font-weight="600">
+                <text x="44" y="${$a/2-6}" font-size="11" fill="#1e293b" font-weight="600">
                     ${e.name.length>16?e.name.slice(0,15)+`…`:e.name}
                 </text>
                 <text x="44" y="${36}" font-size="9" fill="#94a3b8">${e.id}</text>
                 <text x="44" y="${48}" font-size="9" fill="${n}">${e.type}</text>
             </g>
-        `}renderPanel(){let e=this.wf.steps.find(e=>e.id===this.selectedId);if(!e)return``;let t=this.wf.steps.filter(t=>t.id!==e.id),n=(e,t)=>T`
+        `}renderPanel(){let e=this.wf.steps.find(e=>e.id===this.selectedId);if(!e)return``;let t=this.wf.steps.filter(t=>t.id!==e.id),n=(e,t)=>w`
             <div class="field">
                 <label class="field-label">${e}</label>
                 ${t}
             </div>
-        `;return T`
+        `;return w`
             <div class="properties">
                 <div class="prop-header">
                     <span>Step Properties</span>
@@ -6718,21 +6718,21 @@ ${i}
                     <button class="close-btn" @click="${()=>this.selectedId=null}">✕</button>
                 </div>
                 <div class="prop-body">
-                    ${n(`ID`,T`<input class="inp" readonly .value="${e.id}"/>`)}
-                    ${n(`Name`,T`<input class="inp" .value="${e.name}"
+                    ${n(`ID`,w`<input class="inp" readonly .value="${e.id}"/>`)}
+                    ${n(`Name`,w`<input class="inp" .value="${e.name}"
                         @change="${t=>this.updateStep(e.id,{name:t.target.value})}"/>`)}
-                    ${n(`Type`,T`
+                    ${n(`Type`,w`
                         <select class="inp" @change="${t=>this.updateStep(e.id,{type:t.target.value})}">
-                            ${io.map(t=>T`<option value="${t}" ?selected="${e.type===t}">${t}</option>`)}
+                            ${ao.map(t=>w`<option value="${t}" ?selected="${e.type===t}">${t}</option>`)}
                         </select>`)}
-                    ${n(`Description`,T`<textarea class="inp" rows="2"
+                    ${n(`Description`,w`<textarea class="inp" rows="2"
                         @change="${t=>this.updateStep(e.id,{description:t.target.value})}">${e.description??``}</textarea>`)}
-                    ${n(`Precondition step`,T`
+                    ${n(`Precondition step`,w`
                         <select class="inp" @change="${t=>this.updateStep(e.id,{preconditionStepId:t.target.value||void 0})}">
                             <option value="">— none —</option>
-                            ${t.map(t=>T`<option value="${t.id}" ?selected="${e.preconditionStepId===t.id}">${t.name} (${t.id})</option>`)}
+                            ${t.map(t=>w`<option value="${t.id}" ?selected="${e.preconditionStepId===t.id}">${t.name} (${t.id})</option>`)}
                         </select>`)}
-                    ${n(`Precondition expression`,T`<input class="inp" placeholder="JEXL expression"
+                    ${n(`Precondition expression`,w`<input class="inp" placeholder="JEXL expression"
                         .value="${e.preconditionExpression??``}"
                         @change="${t=>this.updateStep(e.id,{preconditionExpression:t.target.value||void 0})}"/>`)}
                     <div class="field row">
@@ -6740,10 +6740,10 @@ ${i}
                         <input type="checkbox" ?checked="${e.parallel}"
                                @change="${t=>this.updateStep(e.id,{parallel:t.target.checked})}"/>
                     </div>
-                    ${n(`Timeout (ms)`,T`<input class="inp" type="number" min="0"
+                    ${n(`Timeout (ms)`,w`<input class="inp" type="number" min="0"
                         .value="${String(e.timeout??0)}"
                         @change="${t=>this.updateStep(e.id,{timeout:Number(t.target.value)})}"/>`)}
-                    ${n(`Retries`,T`<input class="inp" type="number" min="0"
+                    ${n(`Retries`,w`<input class="inp" type="number" min="0"
                         .value="${String(e.retries??0)}"
                         @change="${t=>this.updateStep(e.id,{retries:Number(t.target.value)})}"/>`)}
                     <div class="field row">
@@ -6751,24 +6751,24 @@ ${i}
                         <input type="checkbox" ?checked="${e.rollbackable}"
                                @change="${t=>this.updateStep(e.id,{rollbackable:t.target.checked})}"/>
                     </div>
-                    ${e.rollbackable?n(`Compensation step`,T`
+                    ${e.rollbackable?n(`Compensation step`,w`
                         <select class="inp" @change="${t=>this.updateStep(e.id,{compensationStepId:t.target.value||void 0})}">
                             <option value="">— none —</option>
-                            ${t.map(t=>T`<option value="${t.id}" ?selected="${e.compensationStepId===t.id}">${t.name} (${t.id})</option>`)}
+                            ${t.map(t=>w`<option value="${t.id}" ?selected="${e.compensationStepId===t.id}">${t.name} (${t.id})</option>`)}
                         </select>`):``}
 
-                    ${e.type===`ACTION`?n(`Topic`,T`<input class="inp" placeholder="kafka.topic.name"
+                    ${e.type===`ACTION`?n(`Topic`,w`<input class="inp" placeholder="kafka.topic.name"
                         .value="${e.topic??``}"
                         @change="${t=>this.updateStep(e.id,{topic:t.target.value||void 0})}"/>`):``}
-                    ${e.type===`USER_TASK`?n(`Form ID`,T`<input class="inp"
+                    ${e.type===`USER_TASK`?n(`Form ID`,w`<input class="inp"
                         .value="${e.formId??``}"
                         @change="${t=>this.updateStep(e.id,{formId:t.target.value||void 0})}"/>`):``}
-                    ${e.type===`PROCESS`?n(`Child workflow ID`,T`<input class="inp"
+                    ${e.type===`PROCESS`?n(`Child workflow ID`,w`<input class="inp"
                         .value="${e.childWorkflowDefinitionId??``}"
                         @change="${t=>this.updateStep(e.id,{childWorkflowDefinitionId:t.target.value||void 0})}"/>`):``}
                 </div>
             </div>
-        `}exportJson(){let e=JSON.stringify(this.wf,null,2),t=new Blob([e],{type:`application/json`}),n=URL.createObjectURL(t),r=document.createElement(`a`);r.href=n,r.download=(this.wf.name??`workflow`).replace(/\s+/g,`-`).toLowerCase()+`.json`,r.click(),URL.revokeObjectURL(n)}static{this.styles=[za,h`
+        `}exportJson(){let e=JSON.stringify(this.wf,null,2),t=new Blob([e],{type:`application/json`}),n=URL.createObjectURL(t),r=document.createElement(`a`);r.href=n,r.download=(this.wf.name??`workflow`).replace(/\s+/g,`-`).toLowerCase()+`.json`,r.click(),URL.revokeObjectURL(n)}static{this.styles=[Ba,m`
         :host { display: block; height: 100%; font-family: var(--lumo-font-family, sans-serif); }
 
         .root { display: flex; flex-direction: column; height: 100%; background: var(--lumo-base-color, #fff); }
@@ -6846,33 +6846,33 @@ ${i}
         .inp:focus { border-color: #3B82F6; }
         textarea.inp { resize: vertical; }
         input[readonly].inp { background: #f8fafc; color: #94a3b8; }
-    `]}};k([y()],oo.prototype,`value`,void 0),k([C()],oo.prototype,`wf`,void 0),k([C()],oo.prototype,`positions`,void 0),k([C()],oo.prototype,`selectedId`,void 0),k([C()],oo.prototype,`showMeta`,void 0),oo=k([g(`mateu-workflow`)],oo);var so=[`string`,`integer`,`number`,`bool`,`date`,`time`,`dateTime`,`dateRange`,`money`,`file`,`array`,`status`,`component`,`menu`,`range`,`action`,`actionGroup`],co=[`regular`,`radio`,`checkbox`,`textarea`,`toggle`,`combobox`,`select`,`email`,`password`,`richText`,`listBox`,`html`,`markdown`,`image`,`icon`,`link`,`money`,`grid`,`color`,`choice`,`popover`,`slider`,`button`,`stars`],lo={string:`#3B82F6`,integer:`#8B5CF6`,number:`#6366F1`,bool:`#10B981`,date:`#F59E0B`,time:`#F59E0B`,dateTime:`#F59E0B`,dateRange:`#F59E0B`,money:`#EF4444`,file:`#64748B`,array:`#0EA5E9`,status:`#EC4899`,component:`#14B8A6`,menu:`#94A3B8`,range:`#A855F7`,action:`#F97316`,actionGroup:`#FB923C`};function uo(){return`field-`+Math.random().toString(36).slice(2,8)}var fo=class extends b{constructor(...e){super(...e),this.value=`{"name":"New Form","fields":[]}`,this.form={name:`New Form`,fields:[]},this.selectedId=null,this.showMeta=!1,this.sortable=null,this.listEl=null}updated(e){if(e.has(`value`))try{this.form=JSON.parse(this.value)}catch{}this.attachSortable()}disconnectedCallback(){super.disconnectedCallback(),this.sortable?.destroy(),this.sortable=null}attachSortable(){let e=this.shadowRoot?.querySelector(`.field-list`);!e||e===this.listEl||(this.listEl=e,this.sortable?.destroy(),this.sortable=se.create(e,{animation:150,handle:`.drag-handle`,ghostClass:`sortable-ghost`,onEnd:e=>{let{oldIndex:t,newIndex:n}=e;if(t===void 0||n===void 0||t===n)return;let r=[...this.form.fields],[i]=r.splice(t,1);r.splice(n,0,i),this.form={...this.form,fields:r},this.emit()}}))}emit(){let e=JSON.stringify(this.form,null,2);this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e},bubbles:!0,composed:!0}))}updateForm(e){this.form={...this.form,...e},this.emit()}updateField(e,t){this.form={...this.form,fields:this.form.fields.map(n=>n.id===e?{...n,...t}:n)},this.emit()}addField(){let e=uo(),t={id:e,label:`New Field`,dataType:`string`};this.form={...this.form,fields:[...this.form.fields,t]},this.selectedId=e,this.emit()}deleteField(e){this.form={...this.form,fields:this.form.fields.filter(t=>t.id!==e)},this.selectedId===e&&(this.selectedId=null),this.emit()}duplicateField(e){let t=this.form.fields.find(t=>t.id===e);if(!t)return;let n={...t,id:uo(),label:t.label+` (copy)`},r=this.form.fields.findIndex(t=>t.id===e),i=[...this.form.fields];i.splice(r+1,0,n),this.form={...this.form,fields:i},this.selectedId=n.id,this.emit()}render(){return T`
+    `]}};O([v()],so.prototype,`value`,void 0),O([S()],so.prototype,`wf`,void 0),O([S()],so.prototype,`positions`,void 0),O([S()],so.prototype,`selectedId`,void 0),O([S()],so.prototype,`showMeta`,void 0),so=O([h(`mateu-workflow`)],so);var co=[`string`,`integer`,`number`,`bool`,`date`,`time`,`dateTime`,`dateRange`,`money`,`file`,`array`,`status`,`component`,`menu`,`range`,`action`,`actionGroup`],lo=[`regular`,`radio`,`checkbox`,`textarea`,`toggle`,`combobox`,`select`,`email`,`password`,`richText`,`listBox`,`html`,`markdown`,`image`,`icon`,`link`,`money`,`grid`,`color`,`choice`,`popover`,`slider`,`button`,`stars`],uo={string:`#3B82F6`,integer:`#8B5CF6`,number:`#6366F1`,bool:`#10B981`,date:`#F59E0B`,time:`#F59E0B`,dateTime:`#F59E0B`,dateRange:`#F59E0B`,money:`#EF4444`,file:`#64748B`,array:`#0EA5E9`,status:`#EC4899`,component:`#14B8A6`,menu:`#94A3B8`,range:`#A855F7`,action:`#F97316`,actionGroup:`#FB923C`};function fo(){return`field-`+Math.random().toString(36).slice(2,8)}var po=class extends y{constructor(...e){super(...e),this.value=`{"name":"New Form","fields":[]}`,this.form={name:`New Form`,fields:[]},this.selectedId=null,this.showMeta=!1,this.sortable=null,this.listEl=null}updated(e){if(e.has(`value`))try{this.form=JSON.parse(this.value)}catch{}this.attachSortable()}disconnectedCallback(){super.disconnectedCallback(),this.sortable?.destroy(),this.sortable=null}attachSortable(){let e=this.shadowRoot?.querySelector(`.field-list`);!e||e===this.listEl||(this.listEl=e,this.sortable?.destroy(),this.sortable=ce.create(e,{animation:150,handle:`.drag-handle`,ghostClass:`sortable-ghost`,onEnd:e=>{let{oldIndex:t,newIndex:n}=e;if(t===void 0||n===void 0||t===n)return;let r=[...this.form.fields],[i]=r.splice(t,1);r.splice(n,0,i),this.form={...this.form,fields:r},this.emit()}}))}emit(){let e=JSON.stringify(this.form,null,2);this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e},bubbles:!0,composed:!0}))}updateForm(e){this.form={...this.form,...e},this.emit()}updateField(e,t){this.form={...this.form,fields:this.form.fields.map(n=>n.id===e?{...n,...t}:n)},this.emit()}addField(){let e=fo(),t={id:e,label:`New Field`,dataType:`string`};this.form={...this.form,fields:[...this.form.fields,t]},this.selectedId=e,this.emit()}deleteField(e){this.form={...this.form,fields:this.form.fields.filter(t=>t.id!==e)},this.selectedId===e&&(this.selectedId=null),this.emit()}duplicateField(e){let t=this.form.fields.find(t=>t.id===e);if(!t)return;let n={...t,id:fo(),label:t.label+` (copy)`},r=this.form.fields.findIndex(t=>t.id===e),i=[...this.form.fields];i.splice(r+1,0,n),this.form={...this.form,fields:i},this.selectedId=n.id,this.emit()}render(){return w`
             <div class="root">
                 ${this.renderToolbar()}
-                ${this.showMeta?this.renderMeta():v}
+                ${this.showMeta?this.renderMeta():_}
                 <div class="workspace">
                     ${this.renderList()}
-                    ${this.selectedId?this.renderPanel():v}
+                    ${this.selectedId?this.renderPanel():_}
                 </div>
             </div>
-        `}renderToolbar(){return T`
+        `}renderToolbar(){return w`
             <div class="toolbar">
                 <span class="form-name">${this.form.name}</span>
                 <div style="flex:1"></div>
                 <button class="nbtn" @click="${()=>this.showMeta=!this.showMeta}">
-                    ${Va}
+                    ${Ha}
                     Settings
                 </button>
                 <button class="nbtn primary" @click="${()=>this.addField()}">
-                    ${Ha}
+                    ${Ua}
                     Add Field
                 </button>
                 <button class="nbtn" @click="${()=>this.exportJson()}">
-                    ${Ua}
+                    ${Wa}
                     Export
                 </button>
             </div>
-        `}renderMeta(){let e=this.form;return T`
+        `}renderMeta(){let e=this.form;return w`
             <div class="meta-panel">
                 <div class="meta-grid">
                     <label>Name</label>
@@ -6883,58 +6883,58 @@ ${i}
                               @change="${e=>this.updateForm({description:e.target.value})}">${e.description??``}</textarea>
                 </div>
             </div>
-        `}renderList(){let e=this.form.fields;return T`
+        `}renderList(){let e=this.form.fields;return w`
             <div class="list-wrap">
-                ${e.length===0?T`
+                ${e.length===0?w`
                     <div class="empty">
                         No fields yet. Click <strong>Add Field</strong> to start.
-                    </div>`:v}
+                    </div>`:_}
                 <div class="field-list">
                     ${e.map(e=>this.renderRow(e))}
                 </div>
             </div>
-        `}renderRow(e){let t=lo[e.dataType]??`#64748b`;return T`
+        `}renderRow(e){let t=uo[e.dataType]??`#64748b`;return w`
             <div role="button" tabindex="0" class="field-row ${this.selectedId===e.id?`selected`:``}"
                  data-id="${e.id}"
-                 @click="${()=>this.selectedId=this.selectedId===e.id?null:e.id}" @keydown="${R(()=>this.selectedId=this.selectedId===e.id?null:e.id)}">
+                 @click="${()=>this.selectedId=this.selectedId===e.id?null:e.id}" @keydown="${L(()=>this.selectedId=this.selectedId===e.id?null:e.id)}">
                 <span class="drag-handle" title="Drag to reorder">⠿</span>
                 <span class="type-badge" style="background:${t}">${e.dataType}</span>
                 <span class="field-label-text">${e.label}</span>
                 <span class="field-id-text">${e.id}</span>
-                ${e.required?T`<span class="required-badge">required</span>`:v}
-                ${e.stereotype&&e.stereotype!==`regular`?T`<span class="stereo-badge">${e.stereotype}</span>`:v}
+                ${e.required?w`<span class="required-badge">required</span>`:_}
+                ${e.stereotype&&e.stereotype!==`regular`?w`<span class="stereo-badge">${e.stereotype}</span>`:_}
                 <div style="flex:1"></div>
                 <button class="row-btn" title="Duplicate"
                         @click="${t=>{t.stopPropagation(),this.duplicateField(e.id)}}">⧉</button>
                 <button class="row-btn danger" title="Delete"
                         @click="${t=>{t.stopPropagation(),this.deleteField(e.id)}}">🗑</button>
             </div>
-        `}renderPanel(){let e=this.form.fields.find(e=>e.id===this.selectedId);if(!e)return v;let t=(e,t)=>T`
+        `}renderPanel(){let e=this.form.fields.find(e=>e.id===this.selectedId);if(!e)return _;let t=(e,t)=>w`
             <div class="prop-field">
                 <label class="prop-label">${e}</label>
                 ${t}
             </div>
-        `;return T`
+        `;return w`
             <div class="properties">
                 <div class="prop-header">
                     <span>Field Properties</span>
                     <button class="close-btn" @click="${()=>this.selectedId=null}">✕</button>
                 </div>
                 <div class="prop-body">
-                    ${t(`ID`,T`<input class="inp" readonly .value="${e.id}"/>`)}
-                    ${t(`Label`,T`
+                    ${t(`ID`,w`<input class="inp" readonly .value="${e.id}"/>`)}
+                    ${t(`Label`,w`
                         <input class="inp" .value="${e.label}"
                                @change="${t=>this.updateField(e.id,{label:t.target.value})}"/>`)}
-                    ${t(`Data type`,T`
+                    ${t(`Data type`,w`
                         <select class="inp"
                                 @change="${t=>this.updateField(e.id,{dataType:t.target.value})}">
-                            ${so.map(t=>T`
+                            ${co.map(t=>w`
                                 <option value="${t}" ?selected="${e.dataType===t}">${t}</option>`)}
                         </select>`)}
-                    ${t(`Stereotype`,T`
+                    ${t(`Stereotype`,w`
                         <select class="inp"
                                 @change="${t=>this.updateField(e.id,{stereotype:t.target.value||void 0})}">
-                            ${co.map(t=>T`
+                            ${lo.map(t=>w`
                                 <option value="${t}" ?selected="${(e.stereotype??`regular`)===t}">${t}</option>`)}
                         </select>`)}
                     <div class="prop-field row">
@@ -6942,12 +6942,12 @@ ${i}
                         <input type="checkbox" ?checked="${e.required}"
                                @change="${t=>this.updateField(e.id,{required:t.target.checked})}"/>
                     </div>
-                    ${t(`Description / hint`,T`
+                    ${t(`Description / hint`,w`
                         <textarea class="inp" rows="3"
                                   @change="${t=>this.updateField(e.id,{description:t.target.value||void 0})}">${e.description??``}</textarea>`)}
                 </div>
             </div>
-        `}exportJson(){let e=JSON.stringify(this.form,null,2),t=new Blob([e],{type:`application/json`}),n=URL.createObjectURL(t),r=document.createElement(`a`);r.href=n,r.download=(this.form.name??`form`).replace(/\s+/g,`-`).toLowerCase()+`.json`,r.click(),URL.revokeObjectURL(n)}static{this.styles=[za,z,h`
+        `}exportJson(){let e=JSON.stringify(this.form,null,2),t=new Blob([e],{type:`application/json`}),n=URL.createObjectURL(t),r=document.createElement(`a`);r.href=n,r.download=(this.form.name??`form`).replace(/\s+/g,`-`).toLowerCase()+`.json`,r.click(),URL.revokeObjectURL(n)}static{this.styles=[Ba,R,m`
         :host { display: block; height: 100%; font-family: var(--lumo-font-family, sans-serif); }
 
         .root { display: flex; flex-direction: column; height: 100%; background: var(--lumo-base-color, #fff); }
@@ -7062,12 +7062,12 @@ ${i}
         .inp:focus { border-color: #3B82F6; }
         textarea.inp { resize: vertical; }
         input[readonly].inp { background: #f8fafc; color: #94a3b8; }
-    `]}};k([y()],fo.prototype,`value`,void 0),k([C()],fo.prototype,`form`,void 0),k([C()],fo.prototype,`selectedId`,void 0),k([C()],fo.prototype,`showMeta`,void 0),fo=k([g(`mateu-form-editor`)],fo);var po=class extends b{constructor(...e){super(...e),this.appState={},this.appData={},this.open=!1,this.activeTab=`appstate`,this.hoveredTag=``,this.hoveredId=``,this.hoveredState=null,this.hoveredData=null,this.hoveredMeta=null,this._prevTarget=null,this._onMouseover=e=>{let t=e.target;for(;t&&!(t.tagName?.toLowerCase().startsWith(`mateu-`)&&t!==this);)t=t.parentElement;if(t===this||t===null){t===null&&this._prevTarget&&(this._prevTarget.style.outline=``,this._prevTarget.style.outlineOffset=``,this._prevTarget=null,this.hoveredTag=``,this.hoveredId=``,this.hoveredState=null,this.hoveredData=null,this.hoveredMeta=null);return}t!==this._prevTarget&&(this._prevTarget&&(this._prevTarget.style.outline=``,this._prevTarget.style.outlineOffset=``),this._prevTarget=t,t.style.outline=`2px solid #0070f3`,t.style.outlineOffset=`-2px`,this.hoveredTag=t.tagName.toLowerCase(),this.hoveredId=t.id||``,this.hoveredState=t.state,this.hoveredData=t.data,this.hoveredMeta=t.component?.metadata)}}connectedCallback(){super.connectedCallback(),document.addEventListener(`mouseover`,this._onMouseover,!0)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`mouseover`,this._onMouseover,!0),this._prevTarget&&=(this._prevTarget.style.outline=``,null)}_fmt(e){try{return JSON.stringify(e,null,2)??`null`}catch{return String(e)}}_renderTab(e,t){return T`
+    `]}};O([v()],po.prototype,`value`,void 0),O([S()],po.prototype,`form`,void 0),O([S()],po.prototype,`selectedId`,void 0),O([S()],po.prototype,`showMeta`,void 0),po=O([h(`mateu-form-editor`)],po);var mo=class extends y{constructor(...e){super(...e),this.appState={},this.appData={},this.open=!1,this.activeTab=`appstate`,this.hoveredTag=``,this.hoveredId=``,this.hoveredState=null,this.hoveredData=null,this.hoveredMeta=null,this._prevTarget=null,this._onMouseover=e=>{let t=e.target;for(;t&&!(t.tagName?.toLowerCase().startsWith(`mateu-`)&&t!==this);)t=t.parentElement;if(t===this||t===null){t===null&&this._prevTarget&&(this._prevTarget.style.outline=``,this._prevTarget.style.outlineOffset=``,this._prevTarget=null,this.hoveredTag=``,this.hoveredId=``,this.hoveredState=null,this.hoveredData=null,this.hoveredMeta=null);return}t!==this._prevTarget&&(this._prevTarget&&(this._prevTarget.style.outline=``,this._prevTarget.style.outlineOffset=``),this._prevTarget=t,t.style.outline=`2px solid #0070f3`,t.style.outlineOffset=`-2px`,this.hoveredTag=t.tagName.toLowerCase(),this.hoveredId=t.id||``,this.hoveredState=t.state,this.hoveredData=t.data,this.hoveredMeta=t.component?.metadata)}}connectedCallback(){super.connectedCallback(),document.addEventListener(`mouseover`,this._onMouseover,!0)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`mouseover`,this._onMouseover,!0),this._prevTarget&&=(this._prevTarget.style.outline=``,null)}_fmt(e){try{return JSON.stringify(e,null,2)??`null`}catch{return String(e)}}_renderTab(e,t){return w`
             <button class="tab ${this.activeTab===e?`tab--active`:``}"
                 @click=${()=>{this.activeTab=e}}>
                 ${t}
             </button>
-        `}render(){return this.open?T`
+        `}render(){return this.open?w`
                 <div class="panel">
                     <div class="panel-header">
                         <span class="panel-title">🐛 Mateu Debug</span>
@@ -7079,14 +7079,14 @@ ${i}
                         ${this._renderTab(`inspector`,`Inspector`)}
                     </div>
                     <div class="content">
-                        ${this.activeTab===`appstate`?T`
+                        ${this.activeTab===`appstate`?w`
                             <pre class="json">${this._fmt(this.appState)}</pre>
-                        `:v}
-                        ${this.activeTab===`appdata`?T`
+                        `:_}
+                        ${this.activeTab===`appdata`?w`
                             <pre class="json">${this._fmt(this.appData)}</pre>
-                        `:v}
-                        ${this.activeTab===`inspector`?T`
-                            ${this.hoveredTag?T`
+                        `:_}
+                        ${this.activeTab===`inspector`?w`
+                            ${this.hoveredTag?w`
                                 <div class="inspector-tag">&lt;${this.hoveredTag}${this.hoveredId?` id="${this.hoveredId}"`:``}&gt;</div>
                                 <div class="section-label">state</div>
                                 <pre class="json">${this._fmt(this.hoveredState)}</pre>
@@ -7094,15 +7094,15 @@ ${i}
                                 <pre class="json">${this._fmt(this.hoveredData)}</pre>
                                 <div class="section-label">metadata</div>
                                 <pre class="json">${this._fmt(this.hoveredMeta)}</pre>
-                            `:T`
+                            `:w`
                                 <div class="inspector-hint">Hover a mateu-* element to inspect it</div>
                             `}
-                        `:v}
+                        `:_}
                     </div>
                 </div>
-            `:T`
+            `:w`
             <button class="fab" @click=${()=>{this.open=!0}} title="Mateu Debug">🐛</button>
-        `}static{this.styles=h`
+        `}static{this.styles=m`
         :host {
             position: fixed;
             z-index: 9999;
@@ -7235,7 +7235,7 @@ ${i}
             border-bottom: 1px solid #2a2a3a;
         }
         .section-label:first-of-type { margin-top: 0; }
-    `}};k([y()],po.prototype,`appState`,void 0),k([y()],po.prototype,`appData`,void 0),k([C()],po.prototype,`open`,void 0),k([C()],po.prototype,`activeTab`,void 0),k([C()],po.prototype,`hoveredTag`,void 0),k([C()],po.prototype,`hoveredId`,void 0),k([C()],po.prototype,`hoveredState`,void 0),k([C()],po.prototype,`hoveredData`,void 0),k([C()],po.prototype,`hoveredMeta`,void 0),po=k([g(`mateu-debug-overlay`)],po);var mo=function(e){return e.SetAppDataValue=`SetAppDataValue`,e.SetAppStateValue=`SetAppStateValue`,e.SetDataValue=`SetDataValue`,e.RunAction=`RunAction`,e.RunJS=`RunJS`,e.SetAttributeValue=`SetAttributeValue`,e.SetStateValue=`SetStateValue`,e.SetCssClass=`SetCssClass`,e.SetStyle=`SetStyle`,e}({}),ho=function(e){return e.required=`required`,e.disabled=`disabled`,e.hidden=`hidden`,e.pattern=`pattern`,e.minValue=`minValue`,e.maxValue=`maxValue`,e.minLength=`minLength`,e.maxLength=`maxLength`,e.css=`css`,e.style=`style`,e.theme=`theme`,e.errorMessage=`errorMessage`,e.description=`description`,e.none=`none`,e}({}),go=function(e){return e.Continue=`Continue`,e.Stop=`Stop`,e}({}),_o=12e4,vo=(e,t)=>`${e??`_`}::${t}`,yo=new class{constructor(){this.started=new Map,this.listeners=new Set}begin(e,t=Date.now()){let n=this.started.get(e);return n!==void 0&&t-n<_o?!1:(this.started.set(e,t),this.emit(),!0)}end(e){this.started.delete(e)&&this.emit()}isPending(e,t=Date.now()){let n=this.started.get(e);return n!==void 0&&t-n<_o}snapshot(){return new Set(this.started.keys())}subscribe(e){return this.listeners.add(e),()=>this.listeners.delete(e)}reset(){this.started.clear(),this.emit()}emit(){let e=this.snapshot();this.listeners.forEach(t=>t(e))}},bo=`data-mateu-pending-styles`,xo=`
+    `}};O([v()],mo.prototype,`appState`,void 0),O([v()],mo.prototype,`appData`,void 0),O([S()],mo.prototype,`open`,void 0),O([S()],mo.prototype,`activeTab`,void 0),O([S()],mo.prototype,`hoveredTag`,void 0),O([S()],mo.prototype,`hoveredId`,void 0),O([S()],mo.prototype,`hoveredState`,void 0),O([S()],mo.prototype,`hoveredData`,void 0),O([S()],mo.prototype,`hoveredMeta`,void 0),mo=O([h(`mateu-debug-overlay`)],mo);var ho=function(e){return e.SetAppDataValue=`SetAppDataValue`,e.SetAppStateValue=`SetAppStateValue`,e.SetDataValue=`SetDataValue`,e.RunAction=`RunAction`,e.RunJS=`RunJS`,e.SetAttributeValue=`SetAttributeValue`,e.SetStateValue=`SetStateValue`,e.SetCssClass=`SetCssClass`,e.SetStyle=`SetStyle`,e}({}),go=function(e){return e.required=`required`,e.disabled=`disabled`,e.hidden=`hidden`,e.pattern=`pattern`,e.minValue=`minValue`,e.maxValue=`maxValue`,e.minLength=`minLength`,e.maxLength=`maxLength`,e.css=`css`,e.style=`style`,e.theme=`theme`,e.errorMessage=`errorMessage`,e.description=`description`,e.none=`none`,e}({}),_o=function(e){return e.Continue=`Continue`,e.Stop=`Stop`,e}({}),vo=12e4,yo=(e,t)=>`${e??`_`}::${t}`,bo=new class{constructor(){this.started=new Map,this.listeners=new Set}begin(e,t=Date.now()){let n=this.started.get(e);return n!==void 0&&t-n<vo?!1:(this.started.set(e,t),this.emit(),!0)}end(e){this.started.delete(e)&&this.emit()}isPending(e,t=Date.now()){let n=this.started.get(e);return n!==void 0&&t-n<vo}snapshot(){return new Set(this.started.keys())}subscribe(e){return this.listeners.add(e),()=>this.listeners.delete(e)}reset(){this.started.clear(),this.emit()}emit(){let e=this.snapshot();this.listeners.forEach(t=>t(e))}},xo=`data-mateu-pending-styles`,So=`
 [data-mateu-pending] {
     pointer-events: none;
     cursor: progress;
@@ -7249,9 +7249,9 @@ ${i}
     0%, 100% { opacity: .45; }
     50% { opacity: .85; }
 }
-`,So=new WeakSet,Co=e=>{if(So.has(e))return;So.add(e);let t=e;if(typeof CSSStyleSheet<`u`&&Array.isArray(t.adoptedStyleSheets))try{let e=new CSSStyleSheet;e.replaceSync(xo),t.adoptedStyleSheets=[...t.adoptedStyleSheets,e];return}catch{}let n=e instanceof Document?e.head:e;if(!n)return;let r=document.createElement(`style`);r.setAttribute(bo,``),r.textContent=xo,n.appendChild(r)},wo=e=>{let t=e.getRootNode();if(t instanceof ShadowRoot||t instanceof Document)return t},To=e=>{if(!e||e.hasAttribute(`data-mateu-pending`))return;let t=wo(e);t&&Co(t),e.setAttribute(`data-mateu-pending`,``),e.setAttribute(`aria-busy`,`true`)},Eo=e=>{e&&(e.removeAttribute(`data-mateu-pending`),e.removeAttribute(`aria-busy`))},Do=e=>{let t=(typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target;return t instanceof Element?t:void 0},Oo=[`button`,`a[href]`,`[role="button"]`,`[role="menuitem"]`,`input[type="button"]`,`input[type="submit"]`,`vaadin-button`,`vaadin-menu-bar-button`,`ui5-button`,`oj-c-button`,`oj-button`].join(`, `),ko=e=>{if(!(!e||typeof e.closest!=`function`))return e.closest(Oo)??void 0},Ao=null,jo=class extends ha{constructor(...e){super(...e),this.baseUrl=``,this.route=``,this.consumedRoute=``,this.formerState={},this.applyRules=()=>{let e=this.component.rules;if(e&&e.length>0){let t=this.state,n=this.data,r=this.appState,i=this.appData,a=this.component,o=e=>at(e,t,n,{appState:r,appData:i,component:a}),s=e=>it(e,t,n,r,i,{component:a}),c=[`state`,`data`,`appState`,`appData`,`component`],l=[t,n,r,i,a],u={...this.state},d={...this.data},f=!1,p=!1;for(let t=0;t<e.length;t++){let n=e[t];try{if(o(n.filter)){if(mo.SetStateValue==n.action||mo.SetDataValue==n.action){let e=mo.SetStateValue==n.action?u:d,t=n.fieldName.split(`,`);for(let r=0;r<t.length;r++){let i=t[r];if(!e[i]||e[i]!=n.value){let t=n.expression?s(n.expression):n.value,r=ho.none==n.fieldAttribute?i:i+`.`+n.fieldAttribute;t!=e[r]&&(e[r]=t,mo.SetStateValue==n.action&&(f=!0),mo.SetDataValue==n.action&&(p=!0))}}}if(mo.RunAction==n.action&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.actionId},bubbles:!0,composed:!0})),mo.RunJS==n.action&&Function(...c,n.value)(...l),mo.SetAttributeValue==n.action){let e=n.expression?o(n.expression):n.value;if(n.fieldAttribute==`disabled`){e?this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(n.fieldAttribute,`disabled`):this.shadowRoot?.getElementById(n.fieldName)?.removeAttribute(n.fieldAttribute);continue}this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(n.fieldAttribute,e)}if(mo.SetCssClass==n.action&&this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(`class`,n.value),mo.SetStyle==n.action&&this.shadowRoot?.getElementById(n.fieldName)?.style.setProperty(n.expression,n.value),go.Stop==n.result)break}}catch(e){console.error(`rule failed`,n,e)}}f&&(this.state=u),p&&(this.data=d),f&&this.checkValidations()}},this.skipValidation=(e,t)=>e&&t.fieldId&&!e.includes(t.fieldId)||!e&&t.fieldId&&t.fieldId.includes(`-`),this.checkValidations=e=>{let t=e?e.split(`,`):void 0,n=this.component.validations,r=!0,i=!1,a=this.data??{},o={...this.data??{},errors:{}};if(n){for(let e=0;e<n.length;e++){let r=n[e];if(this.skipValidation(t,r))continue;let i=(r.fieldId??`_component`).split(`,`);for(let e=0;e<i.length;e++){let t=i[e];o.errors[t]=[]}}for(let e=0;e<n.length;e++){let i=n[e];if(!this.skipValidation(t,i))try{let e=i.condition&&i.condition.includes("${")?this._evalTemplate(i.condition):this._evalExpr(i.condition);if(i.condition&&!e){r=!1;let e=(i.fieldId??`_component`).split(`,`);for(let t=0;t<e.length;t++){let n=e[t],r=o.errors[n];if(r||(o.errors[n]=[]),r=o.errors[n],!a[n]){let e=i.message;try{e=this._evalTemplate(i.message)}catch{}r.push(e)}}}}catch(e){console.error(`validation failed`,i,e)}}for(let e=0;e<n.length;e++){let r=n[e];if(this.skipValidation(t,r))continue;let s=(r.fieldId??`_component`).split(`,`);for(let e=0;e<s.length;e++){let t=s[e];if((a.errors||o.errors==``)&&[t].join(`,`)){i=!0;break}}}(a.errors||o.errors==``)&&[`_component`].join(`,`)&&(i=!0)}o._valid=r,o._valid!=a._valid&&(i=!0),i&&(this.data=o)},this._autoSaveTimers=new Map,this.onChange=()=>{this.applyRules()},this.closeModalRequestedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.closeModal()},this.resetFilters=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail,n={};t.fieldIds.forEach(e=>{n[e]=void 0}),n.searchText=void 0,this.state={...this.state,...n}}},this.dataChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail,n={};n[t.key]=t.value,e.type==`data-changed`&&(this.data={...this.data,...n})}},this.valueChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail;if(e.type==`value-changed`){let n={...this.state};n[t.fieldId]=t.value,this.state=n,(this.state[t.fieldId]||this.formerState[t.fieldId])&&this.state[t.fieldId]!=this.formerState[t.fieldId]&&this.component?.confirmOnNavigationIfDirty&&this.dispatchEvent(new CustomEvent(`dirty`,{detail:e.detail,bubbles:!0,composed:!0}));let r=this.component;r.triggers?.filter(e=>e.type==ma.OnValueChange).filter(e=>!e.propertyName||t.fieldId==e.propertyName).forEach(e=>{(!e.condition||this._evalExpr(e.condition))&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))}),r.triggers?.filter(e=>e.type==ma.AutoSave).forEach(e=>{let t=e.actionId,n=this._autoSaveTimers.get(t);n!==void 0&&clearTimeout(n),this._autoSaveTimers.set(t,setTimeout(()=>{this._autoSaveTimers.delete(t),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))},e.debounceMillis??800))})}}},this.actionRequestedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.manageActionRequestedEvent(e)},this.manageActionRequestedEvent=e=>{let t=e.detail,n=t?._originElement??Do(e);if(e.type==`action-requested`){e.preventDefault(),e.stopPropagation();let r=this.component,i=r.actions?.find(e=>e.id==t.actionId)??r.actions?.find(e=>e.id.endsWith(`*`)&&t.actionId.startsWith(e.id.replace(`*`,``)));if(i){if(i&&i.rowsSelectedRequired&&(!this.state.crud_selected_items||this.state.crud_selected_items.length==0)){this.notify(`You first need to select some rows`);return}if(i&&i.validationRequired){let e=Ao??this;if(Ao=null,e.checkValidations(i.fieldsToValidate),!e.data._valid){e.notifyValidationErrors();return}}Ao=null;let e={...t,initiatorComponentId:this.id};i&&i.confirmationRequired?this.callAfterConfirmation(i,()=>this.requestActionCallToServerOrBubble(e,r,i,n)):this.requestActionCallToServerOrBubble(e,r,i,n)}else{let r={...t.parameters};r.initiatorState||=this.state,Ao||=this,this.dispatchEvent(new CustomEvent(e.type,{detail:{...e.detail,_originElement:n,parameters:r},bubbles:!0,composed:!0}))}}},this.buildFieldLabelMap=()=>{let e={},t=n=>{if(n)for(let r of n){let n=r.metadata;if(n?.type===j.FormField){let t=n;t.fieldId&&t.label&&(e[t.fieldId]=t.label)}t(r.children)}};return t(this.component?.children),e},this.notifyValidationErrors=()=>{let e=this.data?.errors??{},t=this.buildFieldLabelMap(),n=[];if(Object.entries(e).forEach(([e,r])=>{if(!Array.isArray(r))return;let i=e===`_component`?void 0:t[e]??e;r.forEach(e=>{e&&!n.some(t=>t.label===i&&t.msg===e)&&n.push({label:i,msg:e})})}),n.length===0){this.notify(`There are validation errors`);return}oa({text:`There are validation errors
+`,Co=new WeakSet,wo=e=>{if(Co.has(e))return;Co.add(e);let t=e;if(typeof CSSStyleSheet<`u`&&Array.isArray(t.adoptedStyleSheets))try{let e=new CSSStyleSheet;e.replaceSync(So),t.adoptedStyleSheets=[...t.adoptedStyleSheets,e];return}catch{}let n=e instanceof Document?e.head:e;if(!n)return;let r=document.createElement(`style`);r.setAttribute(xo,``),r.textContent=So,n.appendChild(r)},To=e=>{let t=e.getRootNode();if(t instanceof ShadowRoot||t instanceof Document)return t},Eo=e=>{if(!e||e.hasAttribute(`data-mateu-pending`))return;let t=To(e);t&&wo(t),e.setAttribute(`data-mateu-pending`,``),e.setAttribute(`aria-busy`,`true`)},Do=e=>{e&&(e.removeAttribute(`data-mateu-pending`),e.removeAttribute(`aria-busy`))},Oo=e=>{let t=(typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target;return t instanceof Element?t:void 0},ko=[`button`,`a[href]`,`[role="button"]`,`[role="menuitem"]`,`input[type="button"]`,`input[type="submit"]`,`vaadin-button`,`vaadin-menu-bar-button`,`ui5-button`,`oj-c-button`,`oj-button`].join(`, `),Ao=e=>{if(!(!e||typeof e.closest!=`function`))return e.closest(ko)??void 0},jo=null,Mo=class extends ga{constructor(...e){super(...e),this.baseUrl=``,this.route=``,this.consumedRoute=``,this.formerState={},this.applyRules=()=>{let e=this.component.rules;if(e&&e.length>0){let t=this.state,n=this.data,r=this.appState,i=this.appData,a=this.component,o=e=>ot(e,t,n,{appState:r,appData:i,component:a}),s=e=>at(e,t,n,r,i,{component:a}),c=[`state`,`data`,`appState`,`appData`,`component`],l=[t,n,r,i,a],u={...this.state},d={...this.data},f=!1,p=!1;for(let t=0;t<e.length;t++){let n=e[t];try{if(o(n.filter)){if(ho.SetStateValue==n.action||ho.SetDataValue==n.action){let e=ho.SetStateValue==n.action?u:d,t=n.fieldName.split(`,`);for(let r=0;r<t.length;r++){let i=t[r];if(!e[i]||e[i]!=n.value){let t=n.expression?s(n.expression):n.value,r=go.none==n.fieldAttribute?i:i+`.`+n.fieldAttribute;t!=e[r]&&(e[r]=t,ho.SetStateValue==n.action&&(f=!0),ho.SetDataValue==n.action&&(p=!0))}}}if(ho.RunAction==n.action&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.actionId},bubbles:!0,composed:!0})),ho.RunJS==n.action&&Function(...c,n.value)(...l),ho.SetAttributeValue==n.action){let e=n.expression?o(n.expression):n.value;if(n.fieldAttribute==`disabled`){e?this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(n.fieldAttribute,`disabled`):this.shadowRoot?.getElementById(n.fieldName)?.removeAttribute(n.fieldAttribute);continue}this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(n.fieldAttribute,e)}if(ho.SetCssClass==n.action&&this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(`class`,n.value),ho.SetStyle==n.action&&this.shadowRoot?.getElementById(n.fieldName)?.style.setProperty(n.expression,n.value),_o.Stop==n.result)break}}catch(e){console.error(`rule failed`,n,e)}}f&&(this.state=u),p&&(this.data=d),f&&this.checkValidations()}},this.skipValidation=(e,t)=>e&&t.fieldId&&!e.includes(t.fieldId)||!e&&t.fieldId&&t.fieldId.includes(`-`),this.checkValidations=e=>{let t=e?e.split(`,`):void 0,n=this.component.validations,r=!0,i=!1,a=this.data??{},o={...this.data??{},errors:{}};if(n){for(let e=0;e<n.length;e++){let r=n[e];if(this.skipValidation(t,r))continue;let i=(r.fieldId??`_component`).split(`,`);for(let e=0;e<i.length;e++){let t=i[e];o.errors[t]=[]}}for(let e=0;e<n.length;e++){let i=n[e];if(!this.skipValidation(t,i))try{let e=i.condition&&i.condition.includes("${")?this._evalTemplate(i.condition):this._evalExpr(i.condition);if(i.condition&&!e){r=!1;let e=(i.fieldId??`_component`).split(`,`);for(let t=0;t<e.length;t++){let n=e[t],r=o.errors[n];if(r||(o.errors[n]=[]),r=o.errors[n],!a[n]){let e=i.message;try{e=this._evalTemplate(i.message)}catch{}r.push(e)}}}}catch(e){console.error(`validation failed`,i,e)}}for(let e=0;e<n.length;e++){let r=n[e];if(this.skipValidation(t,r))continue;let s=(r.fieldId??`_component`).split(`,`);for(let e=0;e<s.length;e++){let t=s[e];if((a.errors||o.errors==``)&&[t].join(`,`)){i=!0;break}}}(a.errors||o.errors==``)&&[`_component`].join(`,`)&&(i=!0)}o._valid=r,o._valid!=a._valid&&(i=!0),i&&(this.data=o)},this._autoSaveTimers=new Map,this.onChange=()=>{this.applyRules()},this.closeModalRequestedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.closeModal()},this.resetFilters=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail,n={};t.fieldIds.forEach(e=>{n[e]=void 0}),n.searchText=void 0,this.state={...this.state,...n}}},this.dataChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail,n={};n[t.key]=t.value,e.type==`data-changed`&&(this.data={...this.data,...n})}},this.valueChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail;if(e.type==`value-changed`){let n={...this.state};n[t.fieldId]=t.value,this.state=n,(this.state[t.fieldId]||this.formerState[t.fieldId])&&this.state[t.fieldId]!=this.formerState[t.fieldId]&&this.component?.confirmOnNavigationIfDirty&&this.dispatchEvent(new CustomEvent(`dirty`,{detail:e.detail,bubbles:!0,composed:!0}));let r=this.component;r.triggers?.filter(e=>e.type==ha.OnValueChange).filter(e=>!e.propertyName||t.fieldId==e.propertyName).forEach(e=>{(!e.condition||this._evalExpr(e.condition))&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))}),r.triggers?.filter(e=>e.type==ha.AutoSave).forEach(e=>{let t=e.actionId,n=this._autoSaveTimers.get(t);n!==void 0&&clearTimeout(n),this._autoSaveTimers.set(t,setTimeout(()=>{this._autoSaveTimers.delete(t),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))},e.debounceMillis??800))})}}},this.actionRequestedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.manageActionRequestedEvent(e)},this.manageActionRequestedEvent=e=>{let t=e.detail,n=t?._originElement??Oo(e);if(e.type==`action-requested`){e.preventDefault(),e.stopPropagation();let r=this.component,i=r.actions?.find(e=>e.id==t.actionId)??r.actions?.find(e=>e.id.endsWith(`*`)&&t.actionId.startsWith(e.id.replace(`*`,``)));if(i){if(i&&i.rowsSelectedRequired&&(!this.state.crud_selected_items||this.state.crud_selected_items.length==0)){this.notify(`You first need to select some rows`);return}if(i&&i.validationRequired){let e=jo??this;if(jo=null,e.checkValidations(i.fieldsToValidate),!e.data._valid){e.notifyValidationErrors();return}}jo=null;let e={...t,initiatorComponentId:this.id};i&&i.confirmationRequired?this.callAfterConfirmation(i,()=>this.requestActionCallToServerOrBubble(e,r,i,n)):this.requestActionCallToServerOrBubble(e,r,i,n)}else{let r={...t.parameters};r.initiatorState||=this.state,jo||=this,this.dispatchEvent(new CustomEvent(e.type,{detail:{...e.detail,_originElement:n,parameters:r},bubbles:!0,composed:!0}))}}},this.buildFieldLabelMap=()=>{let e={},t=n=>{if(n)for(let r of n){let n=r.metadata;if(n?.type===A.FormField){let t=n;t.fieldId&&t.label&&(e[t.fieldId]=t.label)}t(r.children)}};return t(this.component?.children),e},this.notifyValidationErrors=()=>{let e=this.data?.errors??{},t=this.buildFieldLabelMap(),n=[];if(Object.entries(e).forEach(([e,r])=>{if(!Array.isArray(r))return;let i=e===`_component`?void 0:t[e]??e;r.forEach(e=>{e&&!n.some(t=>t.label===i&&t.msg===e)&&n.push({label:i,msg:e})})}),n.length===0){this.notify(`There are validation errors`);return}sa({text:`There are validation errors
 `+n.map(({label:e,msg:t})=>e?`• ${e}: ${t}`:`• ${t}`).join(`
-`),variant:`error`,position:`bottomEnd`,duration:Math.max(3e3,1500+n.length*1e3)},this),this.focusFirstInvalidField()},this.notify=e=>{oa({text:e,variant:`error`,position:`bottomEnd`,duration:3e3},this)},this.callAfterConfirmation=(e,t)=>{let n=`One moment, please`,r=`Are you sure?`,i=`Yes`,a=`No`;e.confirmationTexts&&(n=e.confirmationTexts.title,r=e.confirmationTexts.message,i=e.confirmationTexts.confirmationText,a=e.confirmationTexts.denialText);let o=document.createElement(`div`);o.style.cssText=`position:fixed;inset:0;z-index:1100;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.35);padding:1rem;`;let s=document.createElement(`div`);s.style.cssText=`background:var(--lumo-base-color,#fff);color:var(--lumo-body-text-color,#1a1a1a);border-radius:var(--lumo-border-radius-l,12px);box-shadow:var(--lumo-box-shadow-xl,0 12px 40px rgba(0,0,0,.3));padding:1.2rem;max-width:min(90vw,26rem);`;let c=()=>{o.parentElement&&document.body.removeChild(o)},l=`font:inherit;font-weight:600;padding:.45rem 1rem;border-radius:var(--lumo-border-radius-m,6px);cursor:pointer;`;re(T`
+`),variant:`error`,position:`bottomEnd`,duration:Math.max(3e3,1500+n.length*1e3)},this),this.focusFirstInvalidField()},this.notify=e=>{sa({text:e,variant:`error`,position:`bottomEnd`,duration:3e3},this)},this.callAfterConfirmation=(e,t)=>{let n=`One moment, please`,r=`Are you sure?`,i=`Yes`,a=`No`;e.confirmationTexts&&(n=e.confirmationTexts.title,r=e.confirmationTexts.message,i=e.confirmationTexts.confirmationText,a=e.confirmationTexts.denialText);let o=document.createElement(`div`);o.style.cssText=`position:fixed;inset:0;z-index:1100;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.35);padding:1rem;`;let s=document.createElement(`div`);s.style.cssText=`background:var(--lumo-base-color,#fff);color:var(--lumo-body-text-color,#1a1a1a);border-radius:var(--lumo-border-radius-l,12px);box-shadow:var(--lumo-box-shadow-xl,0 12px 40px rgba(0,0,0,.3));padding:1.2rem;max-width:min(90vw,26rem);`;let c=()=>{o.parentElement&&document.body.removeChild(o)},l=`font:inherit;font-weight:600;padding:.45rem 1rem;border-radius:var(--lumo-border-radius-m,6px);cursor:pointer;`;ie(w`
             <h3 style="margin:0 0 .5rem;">${n}</h3>
             <div style="margin-bottom:1.2rem;">${r}</div>
             <div style="display:flex;justify-content:flex-end;gap:.5rem;">
@@ -7260,24 +7260,24 @@ ${i}
                 <button style="${l}border:none;background:var(--lumo-primary-color,#1676f3);color:var(--lumo-primary-contrast-color,#fff);"
                         @click="${()=>{c(),t()}}">${i}</button>
             </div>
-        `,s),o.appendChild(s),o.addEventListener(`click`,e=>{e.target===o&&c()}),document.body.appendChild(o)},this.requestActionCallToServerOrBubble=(e,t,n,r)=>{if(n&&n.bubble){let t={...e.parameters};t.initiatorState||=this.state,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{...e,_originElement:r,parameters:t},bubbles:!0,composed:!0}))}else this.requestActionCallToServer(e,t,n,r)},this.requestActionCallToServer=(e,t,n,r)=>{if(n&&n.href){window.location.href=n.href;return}if(n&&n.js)try{Function(`state`,`data`,`appState`,`appData`,`component`,n.js).call(this,this.state??{},this.data??{},this.appState??{},this.appData??{},this.component),this.state={...this.state},this.data={...this.data}}catch(e){console.error(`when evaluating `+n.js,e,this.component,this.state,this.data)}if(n&&n.customEvent&&this.dispatchEvent(new CustomEvent(n.customEvent.name,{detail:n.customEvent.detail,bubbles:!0,composed:!0})),!(n&&(n.js||n.customEvent))){if(e.actionId==`search`){let t=e.parameters?._searchState;t?this.state={...this.state,...t}:this.state.size||(this.state={...this.state,size:10,page:0,sort:[]})}if(!n?.background){if(!Le(e.actionId,n?.idempotent)&&!yo.begin(vo(this.id,e.actionId)))return;let t=ko(r);this._pendingOrigins.set(e.actionId,t),To(t)}this.dispatchEvent(new CustomEvent(`server-side-action-requested`,{detail:{route:this.route,consumedRoute:this.consumedRoute,componentState:{...this.state},parameters:e.parameters??{},actionId:e.actionId,serverSideType:t.serverSideType,serverSideComponentRoute:t.route,initiatorComponentId:e.initiatorComponentId??t.id,initiator:this,background:n?.background,sse:n?.sse,timeoutMillis:n?.timeoutMillis,idempotent:n?.idempotent,callback:e.callback,callbackonly:e.callbackonly,callbackToken:e.callbackToken??this.callbackToken},bubbles:!0,composed:!0}))}},this.handleBackendSucceeded=e=>{e.detail.actionId&&this.component.triggers?.filter(e=>e.type==ma.OnSuccess).filter(t=>e.detail.actionId==t.calledActionId).forEach(t=>{if(!t.condition||this._evalExpr(t.condition))if(e.preventDefault(),e.stopPropagation(),t.timeoutMillis>0){let e=this.callbackToken;setTimeout(()=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,callbackToken:e},bubbles:!0,composed:!0}))},t.timeoutMillis)}else this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))})},this.handleBackendFailed=e=>{e.detail.actionId&&this.component.triggers?.filter(e=>e.type==ma.OnError).filter(t=>e.detail.actionId==t.calledActionId).forEach(t=>{(!t.condition||this._evalExpr(t.condition))&&(e.preventDefault(),e.stopPropagation(),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0})))})},this._pendingOrigins=new Map,this._backendSettledListener=e=>{((typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target)===this&&this._releasePending(e.detail?.actionId)},this._keydownListener=e=>{if(this._handleTabShortcut(e))return;let t=this.component;if(t)for(let n of t.actions??[]){let t=n.shortcut||(n.runOnEnter?`enter`:null);if(t&&this._shortcutMatchesEvent(t,e)){e.preventDefault(),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.id},bubbles:!0,composed:!0}));return}}}}createRenderRoot(){return P.mustUseShadowRoot()?super.createRenderRoot():this}updated(e){super.updated(e),e.has(`state`)&&this.state&&JSON.stringify(this.state)!=JSON.stringify({})&&this.onChange(),e.has(`component`)&&(this.formerState={...this.state},this.component?.confirmOnNavigationIfDirty&&this.dispatchEvent(new CustomEvent(`clean`,{detail:{},bubbles:!0,composed:!0})),setTimeout(()=>this.triggerOnLoad()))}focusFirstInvalidField(){let e=t=>requestAnimationFrame(()=>{let n=this.findFirstInvalid(this.renderRoot);if(n){n.focus?.(),n.scrollIntoView?.({block:`center`,behavior:`smooth`});return}t>0&&e(t-1)});e(3)}findFirstInvalid(e){if(!e?.querySelectorAll)return null;for(let t of Array.from(e.querySelectorAll(`*`))){if(t.invalid===!0)return t;if(t.shadowRoot){let e=this.findFirstInvalid(t.shadowRoot);if(e)return e}}return null}_releasePending(e){(e===void 0?Array.from(this._pendingOrigins.keys()):[e]).forEach(e=>{yo.end(vo(this.id,e)),Eo(this._pendingOrigins.get(e)),this._pendingOrigins.delete(e)})}_shortcutMatchesEvent(e,t){return An(e,t)}_collectShortcutTabs(){let e=this.renderRoot;if(!e)return[];let t=Array.from(e.querySelectorAll(`vaadin-tab[data-shortcut]`));return e.querySelectorAll(`mateu-drawer, mateu-dialog`).forEach(e=>{let n=e.shadowRoot;n&&t.push(...Array.from(n.querySelectorAll(`vaadin-tab[data-shortcut]`)))}),t}_handleTabShortcut(e){let t=this._collectShortcutTabs();if(t.length===0)return!1;for(let n of Array.from(t)){let t=n.dataset.shortcut;if(!t||!this._shortcutMatchesEvent(t,e))continue;let r=n.closest(`vaadin-tabs`);if(!r)continue;let i=Array.from(r.querySelectorAll(`vaadin-tab`)).indexOf(n);if(!(i<0))return e.preventDefault(),r.selected=i,!0}return!1}connectedCallback(){super.connectedCallback(),this.addEventListener(`backend-call-succeeded`,this.handleBackendSucceeded),this.addEventListener(`backend-call-failed`,this.handleBackendFailed),this.addEventListener(`backend-succeeded-event`,this._backendSettledListener),this.addEventListener(`backend-failed-event`,this._backendSettledListener),this.addEventListener(`backend-cancelled-event`,this._backendSettledListener),document.addEventListener(`keydown`,this._keydownListener)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`backend-call-succeeded`,this.handleBackendSucceeded),this.removeEventListener(`backend-call-failed`,this.handleBackendFailed),this.removeEventListener(`backend-succeeded-event`,this._backendSettledListener),this.removeEventListener(`backend-failed-event`,this._backendSettledListener),this.removeEventListener(`backend-cancelled-event`,this._backendSettledListener),document.removeEventListener(`keydown`,this._keydownListener),this._releasePending()}render(){return T`<div>
+        `,s),o.appendChild(s),o.addEventListener(`click`,e=>{e.target===o&&c()}),document.body.appendChild(o)},this.requestActionCallToServerOrBubble=(e,t,n,r)=>{if(n&&n.bubble){let t={...e.parameters};t.initiatorState||=this.state,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{...e,_originElement:r,parameters:t},bubbles:!0,composed:!0}))}else this.requestActionCallToServer(e,t,n,r)},this.requestActionCallToServer=(e,t,n,r)=>{if(n&&n.href){window.location.href=n.href;return}if(n&&n.js)try{Function(`state`,`data`,`appState`,`appData`,`component`,n.js).call(this,this.state??{},this.data??{},this.appState??{},this.appData??{},this.component),this.state={...this.state},this.data={...this.data}}catch(e){console.error(`when evaluating `+n.js,e,this.component,this.state,this.data)}if(n&&n.customEvent&&this.dispatchEvent(new CustomEvent(n.customEvent.name,{detail:n.customEvent.detail,bubbles:!0,composed:!0})),!(n&&(n.js||n.customEvent))){if(e.actionId==`search`){let t=e.parameters?._searchState;t?this.state={...this.state,...t}:this.state.size||(this.state={...this.state,size:10,page:0,sort:[]})}if(!n?.background){if(!Re(e.actionId,n?.idempotent)&&!bo.begin(yo(this.id,e.actionId)))return;let t=Ao(r);this._pendingOrigins.set(e.actionId,t),Eo(t)}this.dispatchEvent(new CustomEvent(`server-side-action-requested`,{detail:{route:this.route,consumedRoute:this.consumedRoute,componentState:{...this.state},parameters:e.parameters??{},actionId:e.actionId,serverSideType:t.serverSideType,serverSideComponentRoute:t.route,initiatorComponentId:e.initiatorComponentId??t.id,initiator:this,background:n?.background,sse:n?.sse,timeoutMillis:n?.timeoutMillis,idempotent:n?.idempotent,callback:e.callback,callbackonly:e.callbackonly,callbackToken:e.callbackToken??this.callbackToken},bubbles:!0,composed:!0}))}},this.handleBackendSucceeded=e=>{e.detail.actionId&&this.component.triggers?.filter(e=>e.type==ha.OnSuccess).filter(t=>e.detail.actionId==t.calledActionId).forEach(t=>{if(!t.condition||this._evalExpr(t.condition))if(e.preventDefault(),e.stopPropagation(),t.timeoutMillis>0){let e=this.callbackToken;setTimeout(()=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,callbackToken:e},bubbles:!0,composed:!0}))},t.timeoutMillis)}else this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))})},this.handleBackendFailed=e=>{e.detail.actionId&&this.component.triggers?.filter(e=>e.type==ha.OnError).filter(t=>e.detail.actionId==t.calledActionId).forEach(t=>{(!t.condition||this._evalExpr(t.condition))&&(e.preventDefault(),e.stopPropagation(),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0})))})},this._pendingOrigins=new Map,this._backendSettledListener=e=>{((typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target)===this&&this._releasePending(e.detail?.actionId)},this._keydownListener=e=>{if(this._handleTabShortcut(e))return;let t=this.component;if(t)for(let n of t.actions??[]){let t=n.shortcut||(n.runOnEnter?`enter`:null);if(t&&this._shortcutMatchesEvent(t,e)){e.preventDefault(),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.id},bubbles:!0,composed:!0}));return}}}}createRenderRoot(){return N.mustUseShadowRoot()?super.createRenderRoot():this}updated(e){super.updated(e),e.has(`state`)&&this.state&&JSON.stringify(this.state)!=JSON.stringify({})&&this.onChange(),e.has(`component`)&&(this.formerState={...this.state},this.component?.confirmOnNavigationIfDirty&&this.dispatchEvent(new CustomEvent(`clean`,{detail:{},bubbles:!0,composed:!0})),setTimeout(()=>this.triggerOnLoad()))}focusFirstInvalidField(){let e=t=>requestAnimationFrame(()=>{let n=this.findFirstInvalid(this.renderRoot);if(n){n.focus?.(),n.scrollIntoView?.({block:`center`,behavior:`smooth`});return}t>0&&e(t-1)});e(3)}findFirstInvalid(e){if(!e?.querySelectorAll)return null;for(let t of Array.from(e.querySelectorAll(`*`))){if(t.invalid===!0)return t;if(t.shadowRoot){let e=this.findFirstInvalid(t.shadowRoot);if(e)return e}}return null}_releasePending(e){(e===void 0?Array.from(this._pendingOrigins.keys()):[e]).forEach(e=>{bo.end(yo(this.id,e)),Do(this._pendingOrigins.get(e)),this._pendingOrigins.delete(e)})}_shortcutMatchesEvent(e,t){return jn(e,t)}_collectShortcutTabs(){let e=this.renderRoot;if(!e)return[];let t=Array.from(e.querySelectorAll(`vaadin-tab[data-shortcut]`));return e.querySelectorAll(`mateu-drawer, mateu-dialog`).forEach(e=>{let n=e.shadowRoot;n&&t.push(...Array.from(n.querySelectorAll(`vaadin-tab[data-shortcut]`)))}),t}_handleTabShortcut(e){let t=this._collectShortcutTabs();if(t.length===0)return!1;for(let n of Array.from(t)){let t=n.dataset.shortcut;if(!t||!this._shortcutMatchesEvent(t,e))continue;let r=n.closest(`vaadin-tabs`);if(!r)continue;let i=Array.from(r.querySelectorAll(`vaadin-tab`)).indexOf(n);if(!(i<0))return e.preventDefault(),r.selected=i,!0}return!1}connectedCallback(){super.connectedCallback(),this.addEventListener(`backend-call-succeeded`,this.handleBackendSucceeded),this.addEventListener(`backend-call-failed`,this.handleBackendFailed),this.addEventListener(`backend-succeeded-event`,this._backendSettledListener),this.addEventListener(`backend-failed-event`,this._backendSettledListener),this.addEventListener(`backend-cancelled-event`,this._backendSettledListener),document.addEventListener(`keydown`,this._keydownListener)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`backend-call-succeeded`,this.handleBackendSucceeded),this.removeEventListener(`backend-call-failed`,this.handleBackendFailed),this.removeEventListener(`backend-succeeded-event`,this._backendSettledListener),this.removeEventListener(`backend-failed-event`,this._backendSettledListener),this.removeEventListener(`backend-cancelled-event`,this._backendSettledListener),document.removeEventListener(`keydown`,this._keydownListener),this._releasePending()}render(){return w`<div>
             <div>${this._render()}</div>
-            ${this.data&&this.data.errors&&this.data.errors._component&&this.data.errors._component.length>0?T`
-                <div><ul>${this.data.errors._component.map(e=>T`<li>${e}</li>`)}</ul></div>
-            `:v}</div>`}_render(){if(this.component?.type==A.ClientSide){let e=this.component;return e.metadata?.type==j.Page?pr(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!0):e.metadata?.type==j.Crud?mr(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!0):P.get()?.renderClientSideComponent(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!1)}return T`
+            ${this.data&&this.data.errors&&this.data.errors._component&&this.data.errors._component.length>0?w`
+                <div><ul>${this.data.errors._component.map(e=>w`<li>${e}</li>`)}</ul></div>
+            `:_}</div>`}_render(){if(this.component?.type==k.ClientSide){let e=this.component;return e.metadata?.type==A.Page?mr(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!0):e.metadata?.type==A.Crud?hr(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!0):N.get()?.renderClientSideComponent(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!1)}return w`
             <mateu-api-caller 
                     @value-changed="${this.valueChangedListener}"
                     @data-changed="${this.dataChangedListener}"
                     @close-modal-requested="${this.closeModalRequestedListener}"
                     @filter-reset-requested="${this.resetFilters}"
                     @action-requested="${this.actionRequestedListener}">
-            ${this.component?.children?.map(e=>{if(e.type==A.ClientSide){let t=e;if(t.metadata?.type==j.Page)return pr(this,t,this.baseUrl,this.state,this.data,this.appState,this.appData,!0);if(t.metadata?.type==j.Crud)return mr(this,t,this.baseUrl,this.state,this.data,this.appState,this.appData,!0)}return F(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData)})}
+            ${this.component?.children?.map(e=>{if(e.type==k.ClientSide){let t=e;if(t.metadata?.type==A.Page)return mr(this,t,this.baseUrl,this.state,this.data,this.appState,this.appData,!0);if(t.metadata?.type==A.Crud)return hr(this,t,this.baseUrl,this.state,this.data,this.appState,this.appData,!0)}return P(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData)})}
             </mateu-api-caller>
-        `}static{this.styles=h`
+        `}static{this.styles=m`
         :host {
         }
 
-        ${ie(de.cssText)}
+        ${ae(fe.cssText)}
         
         vaadin-card.image-on-right::part(media) {
             grid-column: 3;
@@ -7308,16 +7308,16 @@ ${i}
             padding-block: var(--lumo-space-xs);
             box-shadow: 0 1px 0 0 var(--lumo-contrast-10pct, rgba(0, 0, 0, 0.1));
         }
-  `}};k([y()],jo.prototype,`baseUrl`,void 0),k([y()],jo.prototype,`route`,void 0),k([y()],jo.prototype,`consumedRoute`,void 0),jo=k([g(`mateu-component`)],jo);var Mo=e=>{if(e)try{return JSON.parse(e)}catch{return{value:e}}else return{}},No=new class{async handle(e,t){return await e.runAction(t.baseUrl,t.route,t.consumedRoute,t.actionId,t.initiatorComponentId,t.appState,t.serverSideType,t.componentState,t.parameters,t.initiator,t.background,t.options)}},Po=new class{constructor(){this.handleUIIncrement=(e,t,n)=>{if(e?.fragments?.forEach(e=>{le.next({command:void 0,fragment:e,ui:void 0,error:void 0,callbackToken:n})}),e?.appState&&(O.value={...e.appState},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))),e?.appData){let n=e?.appData;ue.value={...e.appData,...n},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))}e?.messages?.forEach(e=>{oa({text:e.text,position:e.position,variant:e.variant,duration:e.duration,undoLabel:e.undoLabel,undoActionId:e.undoActionId,undoParameters:e.undoParameters},t)}),e?.banners&&e.banners.length>0&&document.dispatchEvent(new CustomEvent(`page-banners-received`,{detail:{banners:e.banners,append:e.appendBanners??!1},bubbles:!1,composed:!1})),e?.commands?.forEach(e=>{le.next({command:e,fragment:void 0,ui:void 0,error:void 0,callbackToken:n})})}}async runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,m,ee={}){let te=()=>{this.runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,m,ee)};try{let o=await No.handle(e,{baseUrl:t,route:n,consumedRoute:r,actionId:i,appState:O.value,initiatorComponentId:a,componentState:c,parameters:l,serverSideType:s,initiator:u,background:d,options:{...ee,retry:te}});f&&f(o),p||this.handleUIIncrement(o,u,m),o.messages&&o.messages.length==1&&o.messages[0].variant==`error`&&u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-succeeded`,{detail:{actionId:i,evevntId:E()},bubbles:!0,composed:!0}))}catch(e){console.warn(`Action request failed`,e),e?.__mateuReported||u.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:i,reason:this.serialize(e),retry:te}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))}}serialize(e){return e?.message?e:JSON.stringify(e)}},Fo=new class{constructor(){this.handleUIIncrement=(e,t,n)=>{if(e?.messages?.forEach(e=>{oa({text:e.text,position:e.position,variant:e.variant,duration:e.duration,undoLabel:e.undoLabel,undoActionId:e.undoActionId,undoParameters:e.undoParameters},t)}),e?.banners&&e.banners.length>0&&document.dispatchEvent(new CustomEvent(`page-banners-received`,{detail:{banners:e.banners,append:e.appendBanners??!1},bubbles:!1,composed:!1})),e?.commands?.forEach(e=>{le.next({command:e,fragment:void 0,ui:void 0,error:void 0,callbackToken:n})}),e?.fragments?.forEach(e=>{le.next({command:void 0,fragment:e,ui:void 0,error:void 0,callbackToken:n})}),e?.appState&&(O.value={...e.appState},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))),e?.appData){let n=e?.appData;ue.value={...e.appData,...n},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))}}}async runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,m,ee={}){let te=()=>{this.runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,m,ee)};if(n){n||=`_no_route`,n&&n.startsWith(`/`)&&(n=n.substring(1));let e={serverSideType:s,appState:O.value,componentState:c,parameters:l,initiatorComponentId:a,consumedRoute:r,route:`/`+n,actionId:i};d||u.dispatchEvent(new CustomEvent(`backend-called-event`,{bubbles:!0,composed:!0,detail:{}})),fetch(t+`/mateu/v3/sse/`+n,{method:`POST`,headers:{Accept:`text/event-stream`,"Content-Type":`application/json`},body:JSON.stringify(e)}).then(async e=>{let t=e.body?.pipeThrough(new TextDecoderStream).getReader();if(t){let e=``;for(;;){let{value:n,done:r}=await t.read();if(r)break;e+=n;let a=e.split(`
+  `}};O([v()],Mo.prototype,`baseUrl`,void 0),O([v()],Mo.prototype,`route`,void 0),O([v()],Mo.prototype,`consumedRoute`,void 0),Mo=O([h(`mateu-component`)],Mo);var No=e=>{if(e)try{return JSON.parse(e)}catch{return{value:e}}else return{}},Po=new class{async handle(e,t){return await e.runAction(t.baseUrl,t.route,t.consumedRoute,t.actionId,t.initiatorComponentId,t.appState,t.serverSideType,t.componentState,t.parameters,t.initiator,t.background,t.options)}},Fo=new class{constructor(){this.handleUIIncrement=(e,t,n)=>{if(e?.fragments?.forEach(e=>{ue.next({command:void 0,fragment:e,ui:void 0,error:void 0,callbackToken:n})}),e?.appState&&(D.value={...e.appState},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))),e?.appData){let n=e?.appData;de.value={...e.appData,...n},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))}e?.messages?.forEach(e=>{sa({text:e.text,position:e.position,variant:e.variant,duration:e.duration,undoLabel:e.undoLabel,undoActionId:e.undoActionId,undoParameters:e.undoParameters},t)}),e?.banners&&e.banners.length>0&&document.dispatchEvent(new CustomEvent(`page-banners-received`,{detail:{banners:e.banners,append:e.appendBanners??!1},bubbles:!1,composed:!1})),e?.commands?.forEach(e=>{ue.next({command:e,fragment:void 0,ui:void 0,error:void 0,callbackToken:n})})}}async runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,te={}){let ne=()=>{this.runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,te)};try{let o=await Po.handle(e,{baseUrl:t,route:n,consumedRoute:r,actionId:i,appState:D.value,initiatorComponentId:a,componentState:c,parameters:l,serverSideType:s,initiator:u,background:d,options:{...te,retry:ne}});f&&f(o),p||this.handleUIIncrement(o,u,ee),o.messages&&o.messages.length==1&&o.messages[0].variant==`error`&&u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-succeeded`,{detail:{actionId:i,evevntId:T()},bubbles:!0,composed:!0}))}catch(e){console.warn(`Action request failed`,e),e?.__mateuReported||u.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:i,reason:this.serialize(e),retry:ne}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))}}serialize(e){return e?.message?e:JSON.stringify(e)}},Io=new class{constructor(){this.handleUIIncrement=(e,t,n)=>{if(e?.messages?.forEach(e=>{sa({text:e.text,position:e.position,variant:e.variant,duration:e.duration,undoLabel:e.undoLabel,undoActionId:e.undoActionId,undoParameters:e.undoParameters},t)}),e?.banners&&e.banners.length>0&&document.dispatchEvent(new CustomEvent(`page-banners-received`,{detail:{banners:e.banners,append:e.appendBanners??!1},bubbles:!1,composed:!1})),e?.commands?.forEach(e=>{ue.next({command:e,fragment:void 0,ui:void 0,error:void 0,callbackToken:n})}),e?.fragments?.forEach(e=>{ue.next({command:void 0,fragment:e,ui:void 0,error:void 0,callbackToken:n})}),e?.appState&&(D.value={...e.appState},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))),e?.appData){let n=e?.appData;de.value={...e.appData,...n},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))}}}async runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,te={}){let ne=()=>{this.runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,te)};if(n){n||=`_no_route`,n&&n.startsWith(`/`)&&(n=n.substring(1));let e={serverSideType:s,appState:D.value,componentState:c,parameters:l,initiatorComponentId:a,consumedRoute:r,route:`/`+n,actionId:i};d||u.dispatchEvent(new CustomEvent(`backend-called-event`,{bubbles:!0,composed:!0,detail:{}})),fetch(t+`/mateu/v3/sse/`+n,{method:`POST`,headers:{Accept:`text/event-stream`,"Content-Type":`application/json`},body:JSON.stringify(e)}).then(async e=>{let t=e.body?.pipeThrough(new TextDecoderStream).getReader();if(t){let e=``;for(;;){let{value:n,done:r}=await t.read();if(r)break;e+=n;let a=e.split(`
 
-`);e=a.pop()??``;for(let e of a){let t=e.trim();if(t)if(t.startsWith(`data:`)){let e=JSON.parse(t.substring(5).trim());f&&f(e),p||this.handleUIIncrement(e,u,m),e.messages&&e.messages.length==1&&e.messages[0].variant==`error`&&u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))}else{let e=t;try{let n=JSON.parse(t);e=n.message,n._embedded?.errors?.length>0&&n._embedded.errors[0].message&&(e=n._embedded.errors[0].message)}catch{}throw Error(e)}}}}d||u.dispatchEvent(new CustomEvent(`backend-succeeded-event`,{bubbles:!0,composed:!0,detail:{actionId:i}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-succeeded`,{detail:{actionId:i},bubbles:!0,composed:!0}))}).catch(e=>{u.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:i,reason:this.serialize(e),retry:te}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))})}}serialize(e){return e?.message?e:JSON.stringify(e)}},Io={fixed:`fixed`,fullWidth:`full`,edgeToEdge:`edge`},Lo=new Set([j.Gantt,j.PlanningBoard,j.Kanban,j.Bpmn,j.Workflow,j.Map]),Ro={landing:`fixed`,form:`fixed`,process:`fixed`},zo=e=>e?Io[e]:void 0,Bo=e=>e.type==A.ClientSide?e.metadata:void 0,Vo=e=>{let t=Bo(e);if(t?.type==j.Page){let e=zo(t.pageWidth);if(e)return e}for(let t of e.children??[]){let e=Vo(t);if(e)return e}},Ho=e=>{let t=e.pageType;if(t)return t;let n=e=>{let t=Bo(e);if(t?.type==j.Page&&t.pageType)return t.pageType;for(let t of e.children??[]){let e=n(t);if(e)return e}};return n(e)},Uo=e=>{let t=Bo(e);if(t?.type!=j.Crud)return!1;let n=t;return n.compact?!0:(n.columns??[]).some(e=>e.metadata?.editable)},Wo=(e,t)=>t(e)||(e.children??[]).some(e=>Wo(e,t)),Go=e=>!!e&&Wo(e,e=>Bo(e)?.type==j.HeroSection),Ko=e=>Bo(e)?.type==j.App||(e.children??[]).some(e=>Bo(e)?.type==j.App),qo=(e,t)=>e?(zo(e.pageWidth)??Vo(e))||(t?.top&&Ko(e)?`edge`:Ro[Ho(e)??``]||(Wo(e,e=>{let t=Bo(e)?.type;return t!=null&&Lo.has(t)})?`edge`:Wo(e,Uo)?`full`:`fixed`)):`fixed`,Jo,X=class extends Qe{static{Jo=this}constructor(...e){super(...e),this.consumedRoute=``,this.serverSideType=void 0,this.uriPrefix=void 0,this.overrides=void 0,this.homeRoute=void 0,this.route=void 0,this.top=void 0,this.appState={},this.appData={},this.preventNavigation=!1,this.overridesParsed={},this.fragment=void 0,this.showSkeleton=!1,this.pendingRouteFocus=!1,this.hasRenderedContent=!1,this.loadLifecycleListener=e=>{if(((typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target)===this)if(clearTimeout(this.skeletonTimer),e.type===`backend-called-event`){if(this.fragment?.component)return;this.skeletonTimer=setTimeout(()=>{this.showSkeleton=!0},Jo.SKELETON_DELAY_MS)}else this.showSkeleton=!1},this.actionRequestedListener=e=>{e instanceof CustomEvent&&(e.preventDefault(),e.stopPropagation(),this.manageActionEvent(e))},this.historyPushed=e=>{e instanceof CustomEvent&&(e.preventDefault(),e.stopPropagation(),this.preventNavigation=!0,this.route=e.detail.route)},this.routeChangedListener=e=>{if(e instanceof CustomEvent){e.preventDefault(),e.stopPropagation();let t=e.detail.route;typeof t==`string`&&(t===``||t.startsWith(`/`))&&this.consumedRoute&&this.consumedRoute!==`_empty`&&this.consumedRoute.startsWith(`/`)&&!t.startsWith(this.consumedRoute)&&(t=this.consumedRoute+t),this.uriPrefix&&(t=t.startsWith(`/`)&&this.uriPrefix.endsWith(`/`)?this.uriPrefix+t.substring(1):!t.startsWith(`/`)&&!this.uriPrefix.endsWith(`/`)?this.uriPrefix+`/`+t:this.uriPrefix+t),this.dispatchEvent(new CustomEvent(`url-update-requested`,{detail:{route:t},bubbles:!0,composed:!0}))}},this.backendFailedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&e.detail.actionId==``&&(this.fragment={targetComponentId:this.id,data:{},state:{},component:{type:A.ClientSide,metadata:{type:j.Element,name:`div`,content:`Not found`},id:`fieldId`},action:Ge.Replace,containerId:void 0})},this.detail1=void 0,this.manageActionEvent=e=>{e.preventDefault(),e.stopPropagation(),this.detail1=e.detail;let t=this.detail1;if(e.type==`server-side-action-requested`){let e=Po;t.sse&&(e=Fo),e.runAction(We,this.baseUrl,t.route??``,t.consumedRoute,t.actionId,t.initiatorComponentId,this.getCustomisedAppState(),t.serverSideType,t.componentState,t.parameters,t.initiator,t.background,t.callback,t.callbackonly,t.callbackToken,{timeoutMillis:t.timeoutMillis,idempotent:t.idempotent})}},this.getCustomisedAppState=()=>{let e={...O.value};if(this.overrides){let t=Mo(this.overrides);e={...e,...t}}return e}}manageActionRequestedEvent(e){throw Error(`Method not implemented.`)}createRenderRoot(){return P.mustUseShadowRoot()?super.createRenderRoot():this}focusNewContent(){requestAnimationFrame(()=>{let e=this.renderRoot?.querySelector?.(`h1, h2, [role="heading"]`)??this;e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus?.({preventScroll:!0})})}static{this.SKELETON_DELAY_MS=400}connectedCallback(){super.connectedCallback(),this.overridesParsed=Mo(this.overrides),this.addEventListener(`server-side-action-requested`,this.actionRequestedListener),this.addEventListener(`backend-call-failed`,this.backendFailedListener),this.addEventListener(`history-pushed`,this.historyPushed),this.addEventListener(`route-changed`,this.routeChangedListener),this.addEventListener(`backend-called-event`,this.loadLifecycleListener),this.addEventListener(`backend-succeeded-event`,this.loadLifecycleListener),this.addEventListener(`backend-failed-event`,this.loadLifecycleListener),this.addEventListener(`backend-cancelled-event`,this.loadLifecycleListener)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`server-side-action-requested`,this.actionRequestedListener),this.removeEventListener(`backend-call-failed`,this.backendFailedListener),this.removeEventListener(`history-pushed`,this.historyPushed),this.removeEventListener(`route-changed`,this.routeChangedListener),this.removeEventListener(`backend-called-event`,this.loadLifecycleListener),this.removeEventListener(`backend-succeeded-event`,this.loadLifecycleListener),this.removeEventListener(`backend-failed-event`,this.loadLifecycleListener),this.removeEventListener(`backend-cancelled-event`,this.loadLifecycleListener),clearTimeout(this.skeletonTimer)}shouldUpdate(e){if(this.fragment?.component&&[...e.keys()].every(e=>e===`appState`||e===`appData`)){let t=this.renderRoot.querySelector(`mateu-component`);if(t)return e.has(`appState`)&&(t.appState=this.appState),e.has(`appData`)&&(t.appData=this.appData),!1}return!0}updated(e){(e.has(`id`)||e.has(`baseurl`)||e.has(`route`)||e.has(`consumedRoute`)||e.has(`instant`))&&(this.preventNavigation||(this.callbackToken=this.instant||E(),this.manageActionEvent(new CustomEvent(`server-side-action-requested`,{detail:{route:this.route,consumedRoute:this.consumedRoute,userData:void 0,actionId:``,serverSideType:this.serverSideType,initiatorComponentId:this.id,initiator:this,componentState:this.initialState,callbackToken:this.callbackToken},bubbles:!0,composed:!0})))),e.has(`route`)&&this.top&&(this.preventNavigation||(this.pendingRouteFocus=!0),this.preventNavigation||this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:this.route},bubbles:!0,composed:!0}))),this.preventNavigation&&=!1}applyFragment(e){if(!e.component&&this.fragment?.component){this.fragment={...this.fragment,state:{...this.fragment.state??{},...e.state??{}},data:{...this.fragment.data??{},...e.data??{}}};return}this.fragment=e,e.component&&(this.pendingRouteFocus&&this.hasRenderedContent&&this.focusNewContent(),this.pendingRouteFocus=!1,this.hasRenderedContent=!0),e.component&&(this.dataset.pageWidth=qo(e.component,{top:this.top}),this.dataset.pageType=Ho(e.component)??``,this.dataset.hasWelcomeBanner=String(Go(e.component)))}render(){return!this.fragment?.component&&this.showSkeleton?T`
+`);e=a.pop()??``;for(let e of a){let t=e.trim();if(t)if(t.startsWith(`data:`)){let e=JSON.parse(t.substring(5).trim());f&&f(e),p||this.handleUIIncrement(e,u,ee),e.messages&&e.messages.length==1&&e.messages[0].variant==`error`&&u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))}else{let e=t;try{let n=JSON.parse(t);e=n.message,n._embedded?.errors?.length>0&&n._embedded.errors[0].message&&(e=n._embedded.errors[0].message)}catch{}throw Error(e)}}}}d||u.dispatchEvent(new CustomEvent(`backend-succeeded-event`,{bubbles:!0,composed:!0,detail:{actionId:i}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-succeeded`,{detail:{actionId:i},bubbles:!0,composed:!0}))}).catch(e=>{u.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:i,reason:this.serialize(e),retry:ne}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))})}}serialize(e){return e?.message?e:JSON.stringify(e)}},Lo={fixed:`fixed`,fullWidth:`full`,edgeToEdge:`edge`},Ro=new Set([A.Gantt,A.PlanningBoard,A.Kanban,A.Bpmn,A.Workflow,A.Map]),zo={landing:`fixed`,form:`fixed`,process:`fixed`},Bo=e=>e?Lo[e]:void 0,Vo=e=>e.type==k.ClientSide?e.metadata:void 0,Ho=e=>{let t=Vo(e);if(t?.type==A.Page){let e=Bo(t.pageWidth);if(e)return e}for(let t of e.children??[]){let e=Ho(t);if(e)return e}},Uo=e=>{let t=e.pageType;if(t)return t;let n=e=>{let t=Vo(e);if(t?.type==A.Page&&t.pageType)return t.pageType;for(let t of e.children??[]){let e=n(t);if(e)return e}};return n(e)},Wo=e=>{let t=Vo(e);if(t?.type!=A.Crud)return!1;let n=t;return n.compact?!0:(n.columns??[]).some(e=>e.metadata?.editable)},Go=(e,t)=>t(e)||(e.children??[]).some(e=>Go(e,t)),Ko=e=>!!e&&Go(e,e=>Vo(e)?.type==A.HeroSection),qo=e=>Vo(e)?.type==A.App||(e.children??[]).some(e=>Vo(e)?.type==A.App),Jo=(e,t)=>e?(Bo(e.pageWidth)??Ho(e))||(t?.top&&qo(e)?`edge`:zo[Uo(e)??``]||(Go(e,e=>{let t=Vo(e)?.type;return t!=null&&Ro.has(t)})?`edge`:Go(e,Wo)?`full`:`fixed`)):`fixed`,Yo=`mateu-route-structure-cache`,Xo=1,Zo=50,Qo=(()=>{try{return localStorage.getItem(`mateu-route-structure-cache-off`)!==`1`}catch{return!0}})(),$o=()=>{try{return JSON.parse(localStorage.getItem(Yo)??`{}`)}catch{return{}}},es=e=>{try{localStorage.setItem(Yo,JSON.stringify(e))}catch{try{let t=Object.entries(e).sort((e,t)=>t[1].t-e[1].t).slice(0,Math.floor(Zo/2));localStorage.setItem(Yo,JSON.stringify(Object.fromEntries(t)))}catch{}}},ts=e=>{let t=e.initialState&&Object.keys(e.initialState).length?`#`+is(JSON.stringify(e.initialState)):``;return[e.baseUrl,e.consumedRoute??``,e.route??``,e.serverSideType??``].join(`|`)+t},ns=e=>{if(!Qo)return;let t=$o()[e];if(!(!t||t.v!==Xo))return{component:t.component,hash:t.hash}},rs=(e,t,n)=>{if(!Qo)return;let r=$o();r[e]={v:Xo,t:Date.now(),component:t,hash:n};let i=Object.keys(r);if(i.length>Zo){let e=i.sort((e,t)=>r[e].t-r[t].t).slice(0,i.length-Zo);for(let t of e)delete r[t]}es(r)},is=e=>{let t=2166136261;for(let n=0;n<e.length;n++)t^=e.charCodeAt(n),t=Math.imul(t,16777619);return(t>>>0).toString(36)},as=30,os=new Map,ss=!0,cs=e=>{if(ss)return os.get(e)},ls=(e,t)=>{if(ss&&(os.delete(e),os.set(e,t),os.size>as)){let e=os.keys().next().value;e!==void 0&&os.delete(e)}},us,Y=class extends $e{static{us=this}constructor(...e){super(...e),this.consumedRoute=``,this.serverSideType=void 0,this.uriPrefix=void 0,this.overrides=void 0,this.homeRoute=void 0,this.route=void 0,this.top=void 0,this.appState={},this.appData={},this.preventNavigation=!1,this.overridesParsed={},this.fragment=void 0,this.showSkeleton=!1,this.pendingRouteFocus=!1,this.hasRenderedContent=!1,this.loadLifecycleListener=e=>{if(((typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target)===this)if(clearTimeout(this.skeletonTimer),e.type===`backend-called-event`){if(this.fragment?.component)return;this.skeletonTimer=setTimeout(()=>{this.showSkeleton=!0},us.SKELETON_DELAY_MS)}else this.showSkeleton=!1},this.actionRequestedListener=e=>{e instanceof CustomEvent&&(e.preventDefault(),e.stopPropagation(),this.manageActionEvent(e))},this.historyPushed=e=>{e instanceof CustomEvent&&(e.preventDefault(),e.stopPropagation(),this.preventNavigation=!0,this.route=e.detail.route)},this.routeChangedListener=e=>{if(e instanceof CustomEvent){e.preventDefault(),e.stopPropagation();let t=e.detail.route;typeof t==`string`&&(t===``||t.startsWith(`/`))&&this.consumedRoute&&this.consumedRoute!==`_empty`&&this.consumedRoute.startsWith(`/`)&&!t.startsWith(this.consumedRoute)&&(t=this.consumedRoute+t),this.uriPrefix&&(t=t.startsWith(`/`)&&this.uriPrefix.endsWith(`/`)?this.uriPrefix+t.substring(1):!t.startsWith(`/`)&&!this.uriPrefix.endsWith(`/`)?this.uriPrefix+`/`+t:this.uriPrefix+t),this.dispatchEvent(new CustomEvent(`url-update-requested`,{detail:{route:t},bubbles:!0,composed:!0}))}},this.backendFailedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&e.detail.actionId==``&&(this.fragment={targetComponentId:this.id,data:{},state:{},component:{type:k.ClientSide,metadata:{type:A.Element,name:`div`,content:`Not found`},id:`fieldId`},action:Ke.Replace,containerId:void 0})},this.detail1=void 0,this.manageActionEvent=e=>{e.preventDefault(),e.stopPropagation(),this.detail1=e.detail;let t=this.detail1;if(e.type==`server-side-action-requested`){let e=Fo;t.sse&&(e=Io),e.runAction(Ge,this.baseUrl,t.route??``,t.consumedRoute,t.actionId,t.initiatorComponentId,this.getCustomisedAppState(),t.serverSideType,t.componentState,t.parameters,t.initiator,t.background,t.callback,t.callbackonly,t.callbackToken,{timeoutMillis:t.timeoutMillis,idempotent:t.idempotent,knownStructureHash:t.knownStructureHash})}},this.getCustomisedAppState=()=>{let e={...D.value};if(this.overrides){let t=No(this.overrides);e={...e,...t}}return e}}manageActionRequestedEvent(e){throw Error(`Method not implemented.`)}createRenderRoot(){return N.mustUseShadowRoot()?super.createRenderRoot():this}structureCacheKey(){return ts({baseUrl:this.baseUrl,consumedRoute:this.consumedRoute,route:this.route,serverSideType:this.serverSideType,initialState:this.initialState})}focusNewContent(){requestAnimationFrame(()=>{let e=this.renderRoot?.querySelector?.(`h1, h2, [role="heading"]`)??this;e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus?.({preventScroll:!0})})}static{this.SKELETON_DELAY_MS=400}connectedCallback(){super.connectedCallback(),this.overridesParsed=No(this.overrides),this.addEventListener(`server-side-action-requested`,this.actionRequestedListener),this.addEventListener(`backend-call-failed`,this.backendFailedListener),this.addEventListener(`history-pushed`,this.historyPushed),this.addEventListener(`route-changed`,this.routeChangedListener),this.addEventListener(`backend-called-event`,this.loadLifecycleListener),this.addEventListener(`backend-succeeded-event`,this.loadLifecycleListener),this.addEventListener(`backend-failed-event`,this.loadLifecycleListener),this.addEventListener(`backend-cancelled-event`,this.loadLifecycleListener)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`server-side-action-requested`,this.actionRequestedListener),this.removeEventListener(`backend-call-failed`,this.backendFailedListener),this.removeEventListener(`history-pushed`,this.historyPushed),this.removeEventListener(`route-changed`,this.routeChangedListener),this.removeEventListener(`backend-called-event`,this.loadLifecycleListener),this.removeEventListener(`backend-succeeded-event`,this.loadLifecycleListener),this.removeEventListener(`backend-failed-event`,this.loadLifecycleListener),this.removeEventListener(`backend-cancelled-event`,this.loadLifecycleListener),clearTimeout(this.skeletonTimer)}shouldUpdate(e){if(this.fragment?.component&&[...e.keys()].every(e=>e===`appState`||e===`appData`)){let t=this.renderRoot.querySelector(`mateu-component`);if(t)return e.has(`appState`)&&(t.appState=this.appState),e.has(`appData`)&&(t.appData=this.appData),!1}return!0}updated(e){if((e.has(`id`)||e.has(`baseurl`)||e.has(`route`)||e.has(`consumedRoute`)||e.has(`instant`))&&!this.preventNavigation){this.callbackToken=this.instant||T();let e=this.structureCacheKey(),t=e===this.lastAuthoritativeKey?void 0:cs(e);if(t)queueMicrotask(()=>this.applyFragment(t));else{if(e!==this.lastAuthoritativeKey){let t=ns(e);this.currentStructureHash=t?.hash,t&&(this.fragment={targetComponentId:this.id,component:t.component,state:{},data:{},action:Ke.Replace,containerId:void 0})}this.manageActionEvent(new CustomEvent(`server-side-action-requested`,{detail:{route:this.route,consumedRoute:this.consumedRoute,userData:void 0,actionId:``,serverSideType:this.serverSideType,initiatorComponentId:this.id,initiator:this,componentState:this.initialState,knownStructureHash:this.currentStructureHash,callbackToken:this.callbackToken},bubbles:!0,composed:!0}))}}e.has(`route`)&&this.top&&(this.preventNavigation||(this.pendingRouteFocus=!0),this.preventNavigation||this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:this.route},bubbles:!0,composed:!0}))),this.preventNavigation&&=!1}applyFragment(e){if(!e.component&&this.fragment?.component){this.fragment={...this.fragment,state:{...this.fragment.state??{},...e.state??{}},data:{...this.fragment.data??{},...e.data??{}}};return}if(this.fragment=e,e.component){if(e.action!==Ke.Add){let t=this.structureCacheKey(),n=e.component.structureHash;rs(t,e.component,n),this.lastAuthoritativeKey=t,this.currentStructureHash=n,e.component.staticView&&ls(t,e)}this.pendingRouteFocus&&this.hasRenderedContent&&this.focusNewContent(),this.pendingRouteFocus=!1,this.hasRenderedContent=!0}e.component&&(this.dataset.pageWidth=Jo(e.component,{top:this.top}),this.dataset.pageType=Uo(e.component)??``,this.dataset.hasWelcomeBanner=String(Ko(e.component)))}render(){return!this.fragment?.component&&this.showSkeleton?w`
                 <div class="route-skeleton" aria-busy="true" aria-live="polite">
                     <mateu-skeleton variant="text" count="1"></mateu-skeleton>
                     <mateu-skeleton variant="form" count="4"></mateu-skeleton>
                 </div>
-            `:T`
-           ${this.fragment?.component?F(this,this.fragment?.component,this.baseUrl,this.fragment?.state??{},this.fragment?.data??{},this.appState,this.appData):v}
-       `}static{this.styles=h`
+            `:w`
+           ${this.fragment?.component?P(this,this.fragment?.component,this.baseUrl,this.fragment?.state??{},this.fragment?.data??{},this.appState,this.appData):_}
+       `}static{this.styles=m`
         :host {
             display: block;
             min-height: 100%;
@@ -7350,10 +7350,10 @@ ${i}
             max-width: 16rem;
             margin-block-end: var(--lumo-space-l, 1.5rem);
         }
-  `}};k([y()],X.prototype,`consumedRoute`,void 0),k([y()],X.prototype,`serverSideType`,void 0),k([y()],X.prototype,`uriPrefix`,void 0),k([y()],X.prototype,`overrides`,void 0),k([y()],X.prototype,`homeRoute`,void 0),k([y()],X.prototype,`route`,void 0),k([y()],X.prototype,`top`,void 0),k([y()],X.prototype,`instant`,void 0),k([y()],X.prototype,`initialState`,void 0),k([y()],X.prototype,`appState`,void 0),k([y()],X.prototype,`appData`,void 0),k([C()],X.prototype,`fragment`,void 0),k([C()],X.prototype,`showSkeleton`,void 0),X=Jo=k([g(`mateu-ux`)],X);function Yo(e){let t=`var(--lumo-space-m, 1rem)`,n={left:`50%`,transform:`translateX(-50%)`};switch(e){case`topStart`:return{top:t,left:t};case`topCenter`:return{top:t,...n};case`topEnd`:return{top:t,right:t};case`topStretch`:return{top:t,left:t,right:t};case`middle`:return{top:`50%`,left:`50%`,transform:`translate(-50%, -50%)`};case`bottomStart`:return{bottom:t,left:t};case`bottomCenter`:return{bottom:t,...n};case`bottomStretch`:return{bottom:t,left:t,right:t};default:return{bottom:t,right:t}}}function Xo(e){switch(e){case`success`:return{bg:`var(--lumo-success-color, #2e7d32)`,fg:`#fff`};case`error`:return{bg:`var(--lumo-error-color, #c62828)`,fg:`#fff`};case`warning`:return{bg:`var(--lumo-warning-color, #f9a825)`,fg:`#1a1a1a`};case`contrast`:return{bg:`var(--lumo-contrast-90pct, #1a1a1a)`,fg:`#fff`};default:return{bg:`var(--lumo-base-color, #fff)`,fg:`var(--lumo-body-text-color, #1a1a1a)`}}}var Zo={show(e,t){let{bg:n,fg:r}=Xo(e.variant),i=Yo(e.position),a=document.createElement(`div`),o=e.variant===`error`;a.setAttribute(`role`,o?`alert`:`status`),a.setAttribute(`aria-live`,o?`assertive`:`polite`),a.setAttribute(`aria-atomic`,`true`),Object.assign(a.style,{position:`fixed`,zIndex:`2000`,display:`flex`,alignItems:`center`,gap:`0.75rem`,maxWidth:`min(90vw, 28rem)`,padding:`0.7rem 1rem`,borderRadius:`var(--lumo-border-radius-m, 8px)`,boxShadow:`var(--lumo-box-shadow-m, 0 4px 16px rgba(0,0,0,0.2))`,background:n,color:r,font:`inherit`,fontSize:`var(--lumo-font-size-s, 0.875rem)`,opacity:`0`,transition:`opacity 0.2s ease`,...i});let s=document.createElement(`span`);s.textContent=e.text,a.appendChild(s);let c=()=>{a.style.opacity=`0`,setTimeout(()=>a.remove(),200)},l=e.onAction?{label:e.actionLabel??`Retry`,run:e.onAction}:e.undoActionId?{label:e.undoLabel??`Undo`,run:()=>t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.undoActionId,parameters:e.undoParameters??{}},bubbles:!0,composed:!0}))}:void 0;if(l){let e=document.createElement(`button`);e.textContent=l.label,e.style.cssText=`margin-left: 0.25rem; background: none; border: 1px solid currentColor; border-radius: var(--lumo-border-radius-s, 4px); color: inherit; cursor: pointer; padding: 0.15rem 0.6rem; font: inherit; font-weight: 600;`,e.addEventListener(`click`,()=>{l.run(),c()}),a.appendChild(e)}document.body.appendChild(a),requestAnimationFrame(()=>{a.style.opacity=`1`});let u=e.duration??(l?1e4:5e3);u>0&&setTimeout(c,u)}};function Qo(){aa(Zo)}var $o=class extends b{constructor(...e){super(...e),this.online=!0,this.recovered=!1}connectedCallback(){super.connectedCallback(),this.online=Be.isOnline(),this.unsubscribe=Be.subscribe(e=>{let t=!this.online;this.online=e,e&&t&&(this.recovered=!0,clearTimeout(this.recoveredTimer),this.recoveredTimer=setTimeout(()=>{this.recovered=!1},4e3))})}disconnectedCallback(){super.disconnectedCallback(),this.unsubscribe?.(),clearTimeout(this.recoveredTimer),this.releaseSpace()}updated(){let e=this.renderRoot.querySelector(`.bar`);if(!e){this.releaseSpace();return}document.body.style.setProperty(`padding-block-start`,`${e.offsetHeight}px`)}releaseSpace(){typeof document<`u`&&document.body?.style.removeProperty(`padding-block-start`)}render(){if(this.online&&!this.recovered)return v;let e=!this.online;return T`<div class="bar ${e?`offline`:`back`}" role="status" aria-live="polite">
+  `}};O([v()],Y.prototype,`consumedRoute`,void 0),O([v()],Y.prototype,`serverSideType`,void 0),O([v()],Y.prototype,`uriPrefix`,void 0),O([v()],Y.prototype,`overrides`,void 0),O([v()],Y.prototype,`homeRoute`,void 0),O([v()],Y.prototype,`route`,void 0),O([v()],Y.prototype,`top`,void 0),O([v()],Y.prototype,`instant`,void 0),O([v()],Y.prototype,`initialState`,void 0),O([v()],Y.prototype,`appState`,void 0),O([v()],Y.prototype,`appData`,void 0),O([S()],Y.prototype,`fragment`,void 0),O([S()],Y.prototype,`showSkeleton`,void 0),Y=us=O([h(`mateu-ux`)],Y);function ds(e){let t=`var(--lumo-space-m, 1rem)`,n={left:`50%`,transform:`translateX(-50%)`};switch(e){case`topStart`:return{top:t,left:t};case`topCenter`:return{top:t,...n};case`topEnd`:return{top:t,right:t};case`topStretch`:return{top:t,left:t,right:t};case`middle`:return{top:`50%`,left:`50%`,transform:`translate(-50%, -50%)`};case`bottomStart`:return{bottom:t,left:t};case`bottomCenter`:return{bottom:t,...n};case`bottomStretch`:return{bottom:t,left:t,right:t};default:return{bottom:t,right:t}}}function fs(e){switch(e){case`success`:return{bg:`var(--lumo-success-color, #2e7d32)`,fg:`#fff`};case`error`:return{bg:`var(--lumo-error-color, #c62828)`,fg:`#fff`};case`warning`:return{bg:`var(--lumo-warning-color, #f9a825)`,fg:`#1a1a1a`};case`contrast`:return{bg:`var(--lumo-contrast-90pct, #1a1a1a)`,fg:`#fff`};default:return{bg:`var(--lumo-base-color, #fff)`,fg:`var(--lumo-body-text-color, #1a1a1a)`}}}var ps={show(e,t){let{bg:n,fg:r}=fs(e.variant),i=ds(e.position),a=document.createElement(`div`),o=e.variant===`error`;a.setAttribute(`role`,o?`alert`:`status`),a.setAttribute(`aria-live`,o?`assertive`:`polite`),a.setAttribute(`aria-atomic`,`true`),Object.assign(a.style,{position:`fixed`,zIndex:`2000`,display:`flex`,alignItems:`center`,gap:`0.75rem`,maxWidth:`min(90vw, 28rem)`,padding:`0.7rem 1rem`,borderRadius:`var(--lumo-border-radius-m, 8px)`,boxShadow:`var(--lumo-box-shadow-m, 0 4px 16px rgba(0,0,0,0.2))`,background:n,color:r,font:`inherit`,fontSize:`var(--lumo-font-size-s, 0.875rem)`,opacity:`0`,transition:`opacity 0.2s ease`,...i});let s=document.createElement(`span`);s.textContent=e.text,a.appendChild(s);let c=()=>{a.style.opacity=`0`,setTimeout(()=>a.remove(),200)},l=e.onAction?{label:e.actionLabel??`Retry`,run:e.onAction}:e.undoActionId?{label:e.undoLabel??`Undo`,run:()=>t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.undoActionId,parameters:e.undoParameters??{}},bubbles:!0,composed:!0}))}:void 0;if(l){let e=document.createElement(`button`);e.textContent=l.label,e.style.cssText=`margin-left: 0.25rem; background: none; border: 1px solid currentColor; border-radius: var(--lumo-border-radius-s, 4px); color: inherit; cursor: pointer; padding: 0.15rem 0.6rem; font: inherit; font-weight: 600;`,e.addEventListener(`click`,()=>{l.run(),c()}),a.appendChild(e)}document.body.appendChild(a),requestAnimationFrame(()=>{a.style.opacity=`1`});let u=e.duration??(l?1e4:5e3);u>0&&setTimeout(c,u)}};function ms(){oa(ps)}var hs=class extends y{constructor(...e){super(...e),this.online=!0,this.recovered=!1}connectedCallback(){super.connectedCallback(),this.online=Ve.isOnline(),this.unsubscribe=Ve.subscribe(e=>{let t=!this.online;this.online=e,e&&t&&(this.recovered=!0,clearTimeout(this.recoveredTimer),this.recoveredTimer=setTimeout(()=>{this.recovered=!1},4e3))})}disconnectedCallback(){super.disconnectedCallback(),this.unsubscribe?.(),clearTimeout(this.recoveredTimer),this.releaseSpace()}updated(){let e=this.renderRoot.querySelector(`.bar`);if(!e){this.releaseSpace();return}document.body.style.setProperty(`padding-block-start`,`${e.offsetHeight}px`)}releaseSpace(){typeof document<`u`&&document.body?.style.removeProperty(`padding-block-start`)}render(){if(this.online&&!this.recovered)return _;let e=!this.online;return w`<div class="bar ${e?`offline`:`back`}" role="status" aria-live="polite">
             <span class="dot"></span>
             <span>${e?`No connection — changes you make now will not be saved.`:`Connection restored.`}</span>
-        </div>`}static{this.styles=h`
+        </div>`}static{this.styles=m`
         :host {
             position: fixed;
             inset-block-start: 0;
@@ -7392,7 +7392,7 @@ ${i}
         @media (prefers-reduced-motion: reduce) {
             .bar, .bar.offline .dot { animation: none; }
         }
-    `}};k([C()],$o.prototype,`online`,void 0),k([C()],$o.prototype,`recovered`,void 0),$o=k([g(`mateu-connectivity-banner`)],$o);var es=null;function ts(){if(!(typeof document>`u`)&&!(es&&es.isConnected)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>ts(),{once:!0});return}es=document.createElement(`mateu-connectivity-banner`),document.body.appendChild(es)}}var ns,rs=class extends b{static{ns=this}constructor(...e){super(...e),this.skip=()=>{let e=this.findContent();e&&(e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus(),e.scrollIntoView({block:`start`}))}}static{this.TARGETS=[`.app-content`,`mateu-page`,`mateu-ux`,`mateu-component`]}findContent(){let e=new Set,t=n=>{if(e.has(n))return null;e.add(n);for(let e of ns.TARGETS){let t=n.querySelector?.(e);if(t&&t!==this)return t}for(let e of Array.from(n.querySelectorAll?.(`*`)??[]))if(e.shadowRoot){let n=t(e.shadowRoot);if(n)return n}return null};return t(document)}render(){return T`<button class="skip" @click="${this.skip}">Skip to content</button>`}static{this.styles=h`
+    `}};O([S()],hs.prototype,`online`,void 0),O([S()],hs.prototype,`recovered`,void 0),hs=O([h(`mateu-connectivity-banner`)],hs);var gs=null;function _s(){if(!(typeof document>`u`)&&!(gs&&gs.isConnected)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>_s(),{once:!0});return}gs=document.createElement(`mateu-connectivity-banner`),document.body.appendChild(gs)}}var vs,ys=class extends y{static{vs=this}constructor(...e){super(...e),this.skip=()=>{let e=this.findContent();e&&(e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus(),e.scrollIntoView({block:`start`}))}}static{this.TARGETS=[`.app-content`,`mateu-page`,`mateu-ux`,`mateu-component`]}findContent(){let e=new Set,t=n=>{if(e.has(n))return null;e.add(n);for(let e of vs.TARGETS){let t=n.querySelector?.(e);if(t&&t!==this)return t}for(let e of Array.from(n.querySelectorAll?.(`*`)??[]))if(e.shadowRoot){let n=t(e.shadowRoot);if(n)return n}return null};return t(document)}render(){return w`<button class="skip" @click="${this.skip}">Skip to content</button>`}static{this.styles=m`
         :host {
             position: fixed;
             inset-block-start: 0;
@@ -7425,7 +7425,7 @@ ${i}
             outline: 2px solid var(--lumo-body-text-color, #161513);
             outline-offset: 2px;
         }
-    `}};rs=ns=k([g(`mateu-skip-link`)],rs);var is=null;function as(){if(!(typeof document>`u`)&&!(is&&is.isConnected)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>as(),{once:!0});return}is=document.createElement(`mateu-skip-link`),document.body.insertBefore(is,document.body.firstChild)}}Qo(),ts(),Xe(),as();var os=class extends b{constructor(...e){super(...e),this.baseUrl=``,this.route=void 0,this.consumedRoute=`_empty`,this.config=void 0,this.top=`true`,this.pathPrefix=void 0,this.debug=!1,this._lastUrl=``,this.routeChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.top==`true`){let t=e.detail.route,n=this.baseUrl??``;!t||t.startsWith(`/`)?n=window.location.origin+(this.pathPrefix??``):(t=(this.pathPrefix??``)+t,n.indexOf(`://`)<0&&(n.startsWith(`/`)||(n=`/`+n),n=window.location.origin+n)),t.startsWith(this.pathPrefix+`/`)&&(t=t.substring(this.pathPrefix?.length)),n.endsWith(`/`)&&t.startsWith(`/`)&&(t=t.substring(1));let r=new URL(n+t);if((window.location.pathname||r.pathname)&&window.location.pathname!=r.pathname){let e=r.pathname;r.search&&(e+=r.search),e&&!e.startsWith(`/`)&&(e=`/`+e),window.history.pushState({},``,e),this._lastUrl=window.location.href}}},this.navigateToRequestedListener=e=>{if(e.preventDefault(),e.stopPropagation(),Ta.markClean(),e instanceof CustomEvent){let t=e.detail.route,n=this.renderRoot.querySelector(`mateu-ux`);n&&(n.setAttribute(`route`,t),n.setAttribute(`instant`,E()))}}}createRenderRoot(){return P.mustUseShadowRoot()?super.createRenderRoot():this}connectedCallback(){if(super.connectedCallback(),Ta.install(),this._lastUrl=window.location.href,window.onpopstate=e=>{if(!Ta.confirmLeave()){window.history.pushState({},``,this._lastUrl);return}let t=e.target;this.loadUrl(t)},this.top==`true`?this.loadUrl(window):this.route&&(this.consumedRoute=``),this.config)try{let e=JSON.parse(this.config);O.value={...O.value,...e}}catch{O.value={...O.value,config:this.config}}this.addEventListener(`url-update-requested`,this.routeChangedListener),this.addEventListener(`navigate-to-requested`,this.navigateToRequestedListener)}disconnectedCallback(){super.disconnectedCallback(),this.upstreamSubscription?.unsubscribe(),this.removeEventListener(`url-update-requested`,this.routeChangedListener),this.removeEventListener(`navigate-to-requested`,this.navigateToRequestedListener)}loadUrl(e){if(this.route=this.extractRouteFromUrl(e),this.setAttribute(`route`,this.route),this.instant=E(),this._lastUrl=e.location.href,e.location.search){let t=new URLSearchParams(e.location.search).get(`overrides`);if(t&&(this.config=t,this.config))try{let e=JSON.parse(this.config);O.value={...O.value,...e}}catch{O.value={...O.value,config:this.config}}}}extractRouteFromUrl(e){return this.addQueryParams(this.extractRouteWithoutParamsFromUrl(e),e.location)}extractRouteWithoutParamsFromUrl(e){let t=this.extractGrossRouteFromUrl(e);return this.pathPrefix&&t.startsWith(this.pathPrefix)?t.substring(this.pathPrefix.length):t==`/`?``:t}addQueryParams(e,t){return e+(t.search?``+t.search:``)}extractGrossRouteFromUrl(e){let t=e.location.pathname,n=this.baseUrl&&(this.baseUrl.startsWith(`http://`)||this.baseUrl.startsWith(`https://`))?this.baseUrl.substring(this.getContextPathStartingIndex(this.baseUrl)):this.baseUrl;return t.startsWith(n)?t.substring(n.length):t}getContextPathStartingIndex(e){return e.startsWith(`http:`)?e.indexOf(`/`,7):e.startsWith(`https:`)?e.indexOf(`/`,8):0}render(){return T`
+    `}};ys=vs=O([h(`mateu-skip-link`)],ys);var bs=null;function xs(){if(!(typeof document>`u`)&&!(bs&&bs.isConnected)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>xs(),{once:!0});return}bs=document.createElement(`mateu-skip-link`),document.body.insertBefore(bs,document.body.firstChild)}}ms(),_s(),Ze(),xs();var Ss=class extends y{constructor(...e){super(...e),this.baseUrl=``,this.route=void 0,this.consumedRoute=`_empty`,this.config=void 0,this.top=`true`,this.pathPrefix=void 0,this.debug=!1,this._lastUrl=``,this.routeChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.top==`true`){let t=e.detail.route,n=this.baseUrl??``;!t||t.startsWith(`/`)?n=window.location.origin+(this.pathPrefix??``):(t=(this.pathPrefix??``)+t,n.indexOf(`://`)<0&&(n.startsWith(`/`)||(n=`/`+n),n=window.location.origin+n)),t.startsWith(this.pathPrefix+`/`)&&(t=t.substring(this.pathPrefix?.length)),n.endsWith(`/`)&&t.startsWith(`/`)&&(t=t.substring(1));let r=new URL(n+t);if((window.location.pathname||r.pathname)&&window.location.pathname!=r.pathname){let e=r.pathname;r.search&&(e+=r.search),e&&!e.startsWith(`/`)&&(e=`/`+e),window.history.pushState({},``,e),this._lastUrl=window.location.href}}},this.navigateToRequestedListener=e=>{if(e.preventDefault(),e.stopPropagation(),Ea.markClean(),e instanceof CustomEvent){let t=e.detail.route,n=this.renderRoot.querySelector(`mateu-ux`);n&&(n.setAttribute(`route`,t),n.setAttribute(`instant`,T()))}}}createRenderRoot(){return N.mustUseShadowRoot()?super.createRenderRoot():this}connectedCallback(){if(super.connectedCallback(),Ea.install(),this._lastUrl=window.location.href,window.onpopstate=e=>{if(!Ea.confirmLeave()){window.history.pushState({},``,this._lastUrl);return}let t=e.target;this.loadUrl(t)},this.top==`true`?this.loadUrl(window):this.route&&(this.consumedRoute=``),this.config)try{let e=JSON.parse(this.config);D.value={...D.value,...e}}catch{D.value={...D.value,config:this.config}}this.addEventListener(`url-update-requested`,this.routeChangedListener),this.addEventListener(`navigate-to-requested`,this.navigateToRequestedListener)}disconnectedCallback(){super.disconnectedCallback(),this.upstreamSubscription?.unsubscribe(),this.removeEventListener(`url-update-requested`,this.routeChangedListener),this.removeEventListener(`navigate-to-requested`,this.navigateToRequestedListener)}loadUrl(e){if(this.route=this.extractRouteFromUrl(e),this.setAttribute(`route`,this.route),this.instant=T(),this._lastUrl=e.location.href,e.location.search){let t=new URLSearchParams(e.location.search).get(`overrides`);if(t&&(this.config=t,this.config))try{let e=JSON.parse(this.config);D.value={...D.value,...e}}catch{D.value={...D.value,config:this.config}}}}extractRouteFromUrl(e){return this.addQueryParams(this.extractRouteWithoutParamsFromUrl(e),e.location)}extractRouteWithoutParamsFromUrl(e){let t=this.extractGrossRouteFromUrl(e);return this.pathPrefix&&t.startsWith(this.pathPrefix)?t.substring(this.pathPrefix.length):t==`/`?``:t}addQueryParams(e,t){return e+(t.search?``+t.search:``)}extractGrossRouteFromUrl(e){let t=e.location.pathname,n=this.baseUrl&&(this.baseUrl.startsWith(`http://`)||this.baseUrl.startsWith(`https://`))?this.baseUrl.substring(this.getContextPathStartingIndex(this.baseUrl)):this.baseUrl;return t.startsWith(n)?t.substring(n.length):t}getContextPathStartingIndex(e){return e.startsWith(`http:`)?e.indexOf(`/`,7):e.startsWith(`https:`)?e.indexOf(`/`,8):0}render(){return w`
            <mateu-api-caller>
                 <mateu-ux id="_ux"
                           baseurl="${this.baseUrl}"
@@ -7435,43 +7435,43 @@ ${i}
                           top="${this.top}"
                           style="width: 100%;"
                           @app-data-updated="${()=>this.requestUpdate()}"
-                          .appData="${ue.value}"
-                          .appState="${O.value}"
+                          .appData="${de.value}"
+                          .appState="${D.value}"
                 ></mateu-ux>
            </mateu-api-caller>
-           ${this.debug?T`
+           ${this.debug?w`
                <mateu-debug-overlay
-                   .appState="${O.value}"
-                   .appData="${ue.value}"
+                   .appState="${D.value}"
+                   .appData="${de.value}"
                ></mateu-debug-overlay>
-           `:v}
-       `}static{this.styles=h`
+           `:_}
+       `}static{this.styles=m`
         :host {
             --lumo-clickable-cursor: pointer;
         }
-  `}};k([y()],os.prototype,`baseUrl`,void 0),k([y()],os.prototype,`route`,void 0),k([y()],os.prototype,`consumedRoute`,void 0),k([y()],os.prototype,`config`,void 0),k([y()],os.prototype,`top`,void 0),k([y()],os.prototype,`pathPrefix`,void 0),k([C()],os.prototype,`instant`,void 0),k([y({type:Boolean})],os.prototype,`debug`,void 0),os=k([g(`mateu-ui`)],os);var ss,cs=class extends b{static{ss=this}constructor(...e){super(...e),this.baseUrl=``,this.opened=!1,this.searchText=``}static{this.SEARCHABLE_THRESHOLD=7}connectedCallback(){super.connectedCallback(),Ee()}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick(),this.searchTimer&&clearTimeout(this.searchTimer)}currentValue(){return String(Se()[this.selector.fieldName]??``)}currentLabel(){let e=this.currentValue();if(!e)return`—`;let t=(this.searchedOptions??this.selector.options)?.find(t=>String(t.value)===e);if(t)return t.label;let n=Ce()[this.selector.fieldName];return n===void 0?e:String(n)}pick(e,t){we(this.selector.fieldName,e,t),window.location.reload()}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}openPanel(){this.opened||(this.opened=!0,this.searchText=``,this.searchedOptions=void 0,this.remoteSearch(),this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick),this.updateComplete.then(()=>this.renderRoot.querySelector(`input.picker-search`)?.focus()))}closePanel(){this.detachOutsideClick(),this.opened=!1}onSearchInput(e){this.searchText=e.target.value,this.searchTimer&&clearTimeout(this.searchTimer),this.searchTimer=setTimeout(()=>this.remoteSearch(),300)}async remoteSearch(){let e=this.app;if(e?.serverSideType)try{let t=await We.runAction(this.baseUrl??``,e.rootRoute??e.initialRoute??``,``,`_appcontext-search-${this.selector.fieldName}`,`appcontext-${this.selector.fieldName}`,void 0,e.serverSideType,{},{searchText:this.searchText},this,!0);for(let e of t?.fragments??[]){let t=e.data?.[`_appcontext_${this.selector.fieldName}`]?.content;if(Array.isArray(t)){this.searchedOptions=t.map(e=>({value:e.value,label:e.label??String(e.value)}));return}}}catch{}}visibleOptions(){let e=this.searchedOptions??this.selector.options??[],t=this.searchText.trim().toLowerCase();return t?e.filter(e=>e.label.toLowerCase().includes(t)):e}renderPanel(){let e=this.currentValue(),t=this.visibleOptions();return T`
+  `}};O([v()],Ss.prototype,`baseUrl`,void 0),O([v()],Ss.prototype,`route`,void 0),O([v()],Ss.prototype,`consumedRoute`,void 0),O([v()],Ss.prototype,`config`,void 0),O([v()],Ss.prototype,`top`,void 0),O([v()],Ss.prototype,`pathPrefix`,void 0),O([S()],Ss.prototype,`instant`,void 0),O([v({type:Boolean})],Ss.prototype,`debug`,void 0),Ss=O([h(`mateu-ui`)],Ss);var Cs,ws=class extends y{static{Cs=this}constructor(...e){super(...e),this.baseUrl=``,this.opened=!1,this.searchText=``}static{this.SEARCHABLE_THRESHOLD=7}connectedCallback(){super.connectedCallback(),De()}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick(),this.searchTimer&&clearTimeout(this.searchTimer)}currentValue(){return String(Ce()[this.selector.fieldName]??``)}currentLabel(){let e=this.currentValue();if(!e)return`—`;let t=(this.searchedOptions??this.selector.options)?.find(t=>String(t.value)===e);if(t)return t.label;let n=we()[this.selector.fieldName];return n===void 0?e:String(n)}pick(e,t){Te(this.selector.fieldName,e,t),window.location.reload()}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}openPanel(){this.opened||(this.opened=!0,this.searchText=``,this.searchedOptions=void 0,this.remoteSearch(),this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick),this.updateComplete.then(()=>this.renderRoot.querySelector(`input.picker-search`)?.focus()))}closePanel(){this.detachOutsideClick(),this.opened=!1}onSearchInput(e){this.searchText=e.target.value,this.searchTimer&&clearTimeout(this.searchTimer),this.searchTimer=setTimeout(()=>this.remoteSearch(),300)}async remoteSearch(){let e=this.app;if(e?.serverSideType)try{let t=await Ge.runAction(this.baseUrl??``,e.rootRoute??e.initialRoute??``,``,`_appcontext-search-${this.selector.fieldName}`,`appcontext-${this.selector.fieldName}`,void 0,e.serverSideType,{},{searchText:this.searchText},this,!0);for(let e of t?.fragments??[]){let t=e.data?.[`_appcontext_${this.selector.fieldName}`]?.content;if(Array.isArray(t)){this.searchedOptions=t.map(e=>({value:e.value,label:e.label??String(e.value)}));return}}}catch{}}visibleOptions(){let e=this.searchedOptions??this.selector.options??[],t=this.searchText.trim().toLowerCase();return t?e.filter(e=>e.label.toLowerCase().includes(t)):e}renderPanel(){let e=this.currentValue(),t=this.visibleOptions();return w`
             <div class="panel">
-                ${this.searchText!==``||t.length>ss.SEARCHABLE_THRESHOLD?T`
+                ${this.searchText!==``||t.length>Cs.SEARCHABLE_THRESHOLD?w`
                     <input class="picker-search" type="text" placeholder="Search"
                            .value="${this.searchText}"
                            @input="${this.onSearchInput}"
-                           @keydown="${e=>{e.key===`Escape`&&this.closePanel()}}"/>`:v}
+                           @keydown="${e=>{e.key===`Escape`&&this.closePanel()}}"/>`:_}
                 <div class="options">
-                    ${e?T`
-                        <div class="option option--clear" @click="${()=>this.pick(``)}">— (clear)</div>`:v}
-                    ${t.map(t=>T`
+                    ${e?w`
+                        <div class="option option--clear" @click="${()=>this.pick(``)}">— (clear)</div>`:_}
+                    ${t.map(t=>w`
                         <div class="option ${e===String(t.value)?`option--selected`:``}"
                              @click="${()=>this.pick(t.value,t.label)}">${t.label}</div>`)}
                 </div>
-            </div>`}render(){return this.selector?T`
+            </div>`}render(){return this.selector?w`
             <label class="root">
                 <span class="label">${this.selector.label}</span>
                 <button class="picker-button"
                         @click="${()=>this.opened?this.closePanel():this.openPanel()}">
                     ${this.currentLabel()} <span aria-hidden="true" class="caret">▾</span>
                 </button>
-                ${this.opened?this.renderPanel():v}
-            </label>`:T``}static{this.styles=h`
+                ${this.opened?this.renderPanel():_}
+            </label>`:w``}static{this.styles=m`
         :host {
             display: inline-flex;
             position: relative;
@@ -7543,30 +7543,30 @@ ${i}
         .option--clear {
             color: var(--lumo-secondary-text-color, rgba(0, 0, 0, 0.55));
         }
-    `}};k([y()],cs.prototype,`selector`,void 0),k([y()],cs.prototype,`app`,void 0),k([y()],cs.prototype,`baseUrl`,void 0),k([C()],cs.prototype,`opened`,void 0),k([C()],cs.prototype,`searchText`,void 0),k([C()],cs.prototype,`searchedOptions`,void 0),cs=ss=k([g(`mateu-app-context-picker`)],cs);var ls=class extends b{constructor(...e){super(...e),this.baseUrl=``,this.opened=!1,this.notifications=[],this.fetched=!1}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}updated(){!this.fetched&&this.app?.serverSideType&&(this.fetched=!0,this.refresh())}unreadCount(){return this.notifications.filter(e=>e.unread).length}async runNotificationsAction(e,t){let n=this.app;if(n?.serverSideType)try{let r=await We.runAction(this.baseUrl??``,n.rootRoute??n.initialRoute??``,``,e,`notification-bell`,void 0,n.serverSideType,{},t,this,!0);for(let e of r?.fragments??[]){let t=e.data?._notifications;if(Array.isArray(t)){this.notifications=t;return}}}catch{}}refresh(){return this.runNotificationsAction(`_notifications-list`,{})}markRead(e){return this.runNotificationsAction(`_notifications-read`,{ids:e})}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}openPanel(){this.opened||(this.opened=!0,this.refresh(),this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick))}closePanel(){this.detachOutsideClick(),this.opened=!1}async entryClicked(e){e.unread&&await this.markRead([e.id]);let t=e.route;if(t){if(!Ta.confirmLeave())return;this.closePanel(),this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0})),this.dispatchEvent(new CustomEvent(`navigate-to-requested`,{detail:{route:t},bubbles:!0,composed:!0}))}}renderEntry(e){return T`
+    `}};O([v()],ws.prototype,`selector`,void 0),O([v()],ws.prototype,`app`,void 0),O([v()],ws.prototype,`baseUrl`,void 0),O([S()],ws.prototype,`opened`,void 0),O([S()],ws.prototype,`searchText`,void 0),O([S()],ws.prototype,`searchedOptions`,void 0),ws=Cs=O([h(`mateu-app-context-picker`)],ws);var Ts=class extends y{constructor(...e){super(...e),this.baseUrl=``,this.opened=!1,this.notifications=[],this.fetched=!1}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}updated(){!this.fetched&&this.app?.serverSideType&&(this.fetched=!0,this.refresh())}unreadCount(){return this.notifications.filter(e=>e.unread).length}async runNotificationsAction(e,t){let n=this.app;if(n?.serverSideType)try{let r=await Ge.runAction(this.baseUrl??``,n.rootRoute??n.initialRoute??``,``,e,`notification-bell`,void 0,n.serverSideType,{},t,this,!0);for(let e of r?.fragments??[]){let t=e.data?._notifications;if(Array.isArray(t)){this.notifications=t;return}}}catch{}}refresh(){return this.runNotificationsAction(`_notifications-list`,{})}markRead(e){return this.runNotificationsAction(`_notifications-read`,{ids:e})}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}openPanel(){this.opened||(this.opened=!0,this.refresh(),this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick))}closePanel(){this.detachOutsideClick(),this.opened=!1}async entryClicked(e){e.unread&&await this.markRead([e.id]);let t=e.route;if(t){if(!Ea.confirmLeave())return;this.closePanel(),this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0})),this.dispatchEvent(new CustomEvent(`navigate-to-requested`,{detail:{route:t},bubbles:!0,composed:!0}))}}renderEntry(e){return w`
             <div role="button" tabindex="0" class="entry ${e.unread?`entry--unread`:``}"
-                 @click="${()=>this.entryClicked(e)}" @keydown="${R(()=>this.entryClicked(e))}">
+                 @click="${()=>this.entryClicked(e)}" @keydown="${L(()=>this.entryClicked(e))}">
                 <span class="unread-dot" aria-hidden="true"></span>
                 <div class="entry-body">
                     <div class="entry-top">
                         <span class="entry-title">${e.title}</span>
-                        ${e.when?T`<span class="entry-when">${e.when}</span>`:v}
+                        ${e.when?w`<span class="entry-when">${e.when}</span>`:_}
                     </div>
-                    ${e.text?T`<div class="entry-text">${e.text}</div>`:v}
+                    ${e.text?w`<div class="entry-text">${e.text}</div>`:_}
                 </div>
-            </div>`}renderPanel(){return T`
+            </div>`}renderPanel(){return w`
             <div class="panel">
                 <div class="entries">
-                    ${this.notifications.length===0?T`
-                        <div class="empty">No notifications</div>`:v}
+                    ${this.notifications.length===0?w`
+                        <div class="empty">No notifications</div>`:_}
                     ${this.notifications.map(e=>this.renderEntry(e))}
                 </div>
-                ${this.notifications.length>0?T`
+                ${this.notifications.length>0?w`
                     <div class="footer">
                         <button class="mark-all" ?disabled="${this.unreadCount()===0}"
                                 @click="${()=>this.markRead(`all`)}">Mark all read</button>
-                    </div>`:v}
-            </div>`}render(){let e=this.unreadCount();return T`
+                    </div>`:_}
+            </div>`}render(){let e=this.unreadCount();return w`
             <div class="root">
                 <button class="bell-button" title="Notifications" aria-label="Notifications"
                         @click="${()=>this.opened?this.closePanel():this.openPanel()}">
@@ -7576,10 +7576,10 @@ ${i}
                         <path d="M18 8a6 6 0 0 0-12 0c0 7-3 9-3 9h18s-3-2-3-9"></path>
                         <path d="M13.73 21a2 2 0 0 1-3.46 0"></path>
                     </svg>
-                    ${e>0?T`<span class="badge">${e>99?`99+`:e}</span>`:v}
+                    ${e>0?w`<span class="badge">${e>99?`99+`:e}</span>`:_}
                 </button>
-                ${this.opened?this.renderPanel():v}
-            </div>`}static{this.styles=h`
+                ${this.opened?this.renderPanel():_}
+            </div>`}static{this.styles=m`
         :host {
             display: inline-flex;
             position: relative;
@@ -7730,48 +7730,48 @@ ${i}
             cursor: default;
         }
     
-        ${z}
-    `}};k([y()],ls.prototype,`app`,void 0),k([y()],ls.prototype,`baseUrl`,void 0),k([C()],ls.prototype,`opened`,void 0),k([C()],ls.prototype,`notifications`,void 0),ls=k([g(`mateu-notification-bell`)],ls);var us=e=>{if(!e||!(`querySelectorAll`in e))return null;for(let t of e.querySelectorAll(`*`)){if(t.tagName?.toLowerCase()===`mateu-component`)return t;let e=us(t.shadowRoot);if(e)return e}return null},ds=async(e,t,n)=>{let r=us(t.renderRoot??t);await Fo.runAction(We,t.baseUrl??``,e.rootRoute||`_no_route`,``,n,r?.id??`app-header-action`,{},e.serverSideType??``,{},{},r??t,!0,void 0,!1,``)},fs=async(e,t,n)=>{try{await ds(e,t,n)}catch(e){oa({text:`La acción falló: `+e,position:`bottomStart`,duration:6e3,variant:`error`},t)}},ps=(e,t)=>{let n=e.contextSelectors??[],r=e.contextActions??[];return n.length===0&&r.length===0&&!e.notificationsEnabled?v:T`${e.notificationsEnabled?T`
-        <mateu-notification-bell .app="${e}" .baseUrl="${t.baseUrl??``}"></mateu-notification-bell>`:v}${n.map(n=>T`
-        <mateu-app-context-picker .selector="${n}" .app="${e}" .baseUrl="${t.baseUrl??``}"></mateu-app-context-picker>`)}${r.map(n=>(n.children?.length??0)>0?T`
+        ${R}
+    `}};O([v()],Ts.prototype,`app`,void 0),O([v()],Ts.prototype,`baseUrl`,void 0),O([S()],Ts.prototype,`opened`,void 0),O([S()],Ts.prototype,`notifications`,void 0),Ts=O([h(`mateu-notification-bell`)],Ts);var Es=e=>{if(!e||!(`querySelectorAll`in e))return null;for(let t of e.querySelectorAll(`*`)){if(t.tagName?.toLowerCase()===`mateu-component`)return t;let e=Es(t.shadowRoot);if(e)return e}return null},Ds=async(e,t,n)=>{let r=Es(t.renderRoot??t);await Io.runAction(Ge,t.baseUrl??``,e.rootRoute||`_no_route`,``,n,r?.id??`app-header-action`,{},e.serverSideType??``,{},{},r??t,!0,void 0,!1,``)},Os=async(e,t,n)=>{try{await Ds(e,t,n)}catch(e){sa({text:`La acción falló: `+e,position:`bottomStart`,duration:6e3,variant:`error`},t)}},ks=(e,t)=>{let n=e.contextSelectors??[],r=e.contextActions??[];return n.length===0&&r.length===0&&!e.notificationsEnabled?_:w`${e.notificationsEnabled?w`
+        <mateu-notification-bell .app="${e}" .baseUrl="${t.baseUrl??``}"></mateu-notification-bell>`:_}${n.map(n=>w`
+        <mateu-app-context-picker .selector="${n}" .app="${e}" .baseUrl="${t.baseUrl??``}"></mateu-app-context-picker>`)}${r.map(n=>(n.children?.length??0)>0?w`
         <details class="mateu-nav-group" style="margin-left: 0.5rem; flex-shrink: 0;">
             <summary class="app-header-action-btn">${n.label} ▾</summary>
             <div class="mateu-nav-panel" style="right: 0; left: auto;">
-                ${n.children.map(n=>T`
-                    <button class="mateu-nav-item" @click="${()=>n.actionId&&fs(e,t,n.actionId)}">${n.label}</button>`)}
+                ${n.children.map(n=>w`
+                    <button class="mateu-nav-item" @click="${()=>n.actionId&&Os(e,t,n.actionId)}">${n.label}</button>`)}
             </div>
-        </details>`:T`
+        </details>`:w`
         <button class="app-header-action-btn" style="margin-left: 0.5rem; flex-shrink: 0;"
-            @click="${()=>n.actionId&&fs(e,t,n.actionId)}" title="${n.label}">${n.icon?I(n.icon):v}${n.label}</button>`)}`},ms=(e,t)=>T`
+            @click="${()=>n.actionId&&Os(e,t,n.actionId)}" title="${n.label}">${n.icon?F(n.icon):_}${n.label}</button>`)}`},As=(e,t)=>w`
     <button class="mateu-nav-item ${e.selected?`mateu-nav-item--active`:``}"
             ?disabled="${e.disabled}"
-            @click="${()=>t(e)}">${e.text}</button>`,hs=(e,t,n=``)=>T`
+            @click="${()=>t(e)}">${e.text}</button>`,js=(e,t,n=``)=>w`
     <nav class="mateu-nav ${n}">
-        ${e.map(e=>(e.children?.length??0)>0?T`<details class="mateu-nav-group">
+        ${e.map(e=>(e.children?.length??0)>0?w`<details class="mateu-nav-group">
                        <summary class="mateu-nav-item">${e.text} ▾</summary>
                        <div class="mateu-nav-panel">
-                           ${e.children.map(e=>ms(e,t))}
+                           ${e.children.map(e=>As(e,t))}
                        </div>
-                   </details>`:ms(e,t))}
-    </nav>`,gs=(e,t)=>n=>t.call(e,{detail:{value:n}}),_s=(e,t)=>e.themeToggle?T`
+                   </details>`:As(e,t))}
+    </nav>`,Ms=(e,t)=>n=>t.call(e,{detail:{value:n}}),Ns=(e,t)=>e.themeToggle?w`
         <button class="app-chrome-icon-btn" @click="${t.toggleTheme}"
             title="${t.isDark?`Switch to light mode`:`Switch to dark mode`}"
             style="margin-left: 0.5rem; margin-right: 0.5rem; flex-shrink: 0;">
-            ${I(t.isDark?`vaadin:sun-o`:`vaadin:moon`,`color: var(--lumo-body-text-color);`)}
+            ${F(t.isDark?`vaadin:sun-o`:`vaadin:moon`,`color: var(--lumo-body-text-color);`)}
         </button>
-    `:v,vs=(e,t)=>{t.filter!=e.detail.value&&(t.filter=e.detail.value)},ys=(e,t,n)=>{let r=bs(e,t,n),i=Z(t,n);return r==`list`||r==i?`new`:r},bs=(e,t,n)=>{let r=e?._route;if(r!=null&&(r===``||r.startsWith(`/`))){let e=n.homeRoute??``,i=e.indexOf(`?`),a=i>=0?e.substring(i+1):``,o=Z(t,n)+r;return a?o+(o.indexOf(`?`)>=0?`&`:`?`)+a:o}return t.selectedRoute?t.selectedRoute:n.homeRoute},Z=(e,t)=>e.selectedRoute?e.selectedConsumedRoute??t.route:t.homeConsumedRoute,xs=(e,t)=>e.selectedRoute?e.selectedBaseUrl??e.baseUrl:t.homeBaseUrl,Ss=(e,t)=>e.selectedRoute?e.selectedServerSideType??t.serverSideType:t.homeServerSideType,Cs=(e,t)=>e.selectedRoute?e.selectedUriPrefix:t.homeUriPrefix,ws=(e,t,n,r,i,a,o)=>{if(t.chromeless)return T`
+    `:_,Ps=(e,t)=>{t.filter!=e.detail.value&&(t.filter=e.detail.value)},Fs=(e,t,n)=>{let r=Is(e,t,n),i=X(t,n);return r==`list`||r==i?`new`:r},Is=(e,t,n)=>{let r=e?._route;if(r!=null&&(r===``||r.startsWith(`/`))){let e=n.homeRoute??``,i=e.indexOf(`?`),a=i>=0?e.substring(i+1):``,o=X(t,n)+r;return a?o+(o.indexOf(`?`)>=0?`&`:`?`)+a:o}return t.selectedRoute?t.selectedRoute:n.homeRoute},X=(e,t)=>e.selectedRoute?e.selectedConsumedRoute??t.route:t.homeConsumedRoute,Ls=(e,t)=>e.selectedRoute?e.selectedBaseUrl??e.baseUrl:t.homeBaseUrl,Rs=(e,t)=>e.selectedRoute?e.selectedServerSideType??t.serverSideType:t.homeServerSideType,zs=(e,t)=>e.selectedRoute?e.selectedUriPrefix:t.homeUriPrefix,Bs=(e,t,n,r,i,a,o)=>{if(t.chromeless)return w`
             <div class="app chromeless">
                 <div role="main" class="${`app-content`+(e.pageCompact?` no-padding`:``)}" style="height: 100%;">
                     <div class="m-md">
                         <div class="m-scroll" style="height: 100%;">
                             <mateu-api-caller>
                                 <mateu-ux
-                                        route="${bs(r,e,t)}"
+                                        route="${Is(r,e,t)}"
                                         id="ux_${e.id}"
-                                        baseUrl="${xs(e,t)}"
-                                        consumedRoute="${Z(e,t)}"
-                                        serverSideType="${Ss(e,t)}"
-                                        uriPrefix="${Cs(e,t)}"
+                                        baseUrl="${Ls(e,t)}"
+                                        consumedRoute="${X(e,t)}"
+                                        serverSideType="${Rs(e,t)}"
+                                        uriPrefix="${zs(e,t)}"
                                         style="width: 100%;"
                                         .appState="${a}"
                                         .appData="${o}"
@@ -7780,25 +7780,25 @@ ${i}
                                 ></mateu-ux>
                             </mateu-api-caller>
                         </div>
-                        ${t.sseUrl?T`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:v}
+                        ${t.sseUrl?w`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:_}
                     </div>
                 </div>
                 <slot></slot>
             </div>
-        `;let s=e.mapItems(t.menu,e.filter?.toLowerCase()??``),c=Z(e,t),l=ys(r,e,t),u=l&&l!==`new`&&l.startsWith(c+`/`)?l.substring(c.length+1).split(`/`)[0]:void 0;return T`
-                    ${t.variant==Ke.MEDIATOR?T`
+        `;let s=e.mapItems(t.menu,e.filter?.toLowerCase()??``),c=X(e,t),l=Fs(r,e,t),u=l&&l!==`new`&&l.startsWith(c+`/`)?l.substring(c.length+1).split(`/`)[0]:void 0;return w`
+                    ${t.variant==qe.MEDIATOR?w`
 
-                        ${t.layout==`SPLIT`?T`
+                        ${t.layout==`SPLIT`?w`
                             <div class="m-md">
                                 <mateu-api-caller>
                                     <div style="display: block; width: calc(100% - 1rem);">
                                     <mateu-ux
-                                            route="${Z(e,t)}"
+                                            route="${X(e,t)}"
                                             id="ux_${e.id}"
-                                            baseUrl="${xs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Ss(e,t)}"
-                                            uriPrefix="${Cs(e,t)}"
+                                            baseUrl="${Ls(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Rs(e,t)}"
+                                            uriPrefix="${zs(e,t)}"
                                             style="width: 100%;"
                                             .appState="${{...a,_splitDetailId:u}}"
                                             .appData="${o}"
@@ -7810,12 +7810,12 @@ ${i}
                                 <mateu-api-caller slot="detail">
                                     <div style="padding-left: 1rem; width: calc(100% - 1rem);">
                                     <mateu-ux
-                                            route="${ys(r,e,t)}"
+                                            route="${Fs(r,e,t)}"
                                             id="ux_${e.id}_detail"
-                                            baseUrl="${xs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Ss(e,t)}"
-                                            uriPrefix="${Cs(e,t)}"
+                                            baseUrl="${Ls(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Rs(e,t)}"
+                                            uriPrefix="${zs(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -7826,15 +7826,15 @@ ${i}
                                 </mateu-api-caller>
 
                             </div>
-                        `:T`
+                        `:w`
                             <mateu-api-caller>
                                 <mateu-ux
-                                        route="${bs(r,e,t)}"
+                                        route="${Is(r,e,t)}"
                                         id="ux_${e.id}"
-                                        baseUrl="${xs(e,t)}"
-                                        consumedRoute="${Z(e,t)}"
-                                        serverSideType="${Ss(e,t)}"
-                                        uriPrefix="${Cs(e,t)}"
+                                        baseUrl="${Ls(e,t)}"
+                                        consumedRoute="${X(e,t)}"
+                                        serverSideType="${Rs(e,t)}"
+                                        uriPrefix="${zs(e,t)}"
                                         style="width: 100%;"
                                         .appState="${a}"
                                         .appData="${o}"
@@ -7845,28 +7845,28 @@ ${i}
                             </mateu-api-caller>
                         `}
                         
-`:v}
-            ${t.variant==Ke.HAMBURGUER_MENU?T`
+`:_}
+            ${t.variant==qe.HAMBURGUER_MENU?w`
                 <div class="mateu-app-layout m-app-layout ${t.drawerClosed?``:`drawer-open`} ${t?.cssClasses}" style="${t?.style}">
                     <header class="app-navbar">
                         <button class="drawer-toggle" title="Menu"
                                 @click="${e=>e.currentTarget.closest(`.m-app-layout`)?.classList.toggle(`drawer-open`)}">
-                            ${I(`vaadin:menu`)}
+                            ${F(`vaadin:menu`)}
                         </button>
                         <h2 style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; margin: 0 .5rem;">${t.title}</h2><p style="margin: 0;">${t.subtitle}</p>
                         <div class="m-hl" style="margin-left: auto; align-items: center;">
                             <slot name="widgets"></slot>
-                            ${ps(t,e)}${_s(t,e)}
+                            ${ks(t,e)}${Ns(t,e)}
                         </div>
                     </header>
                     <div class="app-body">
                         <aside class="app-drawer p-s" @navigation-requested="${e.updateRoute}">
-                            ${t.menu&&t.totalMenuOptions>10?T`
+                            ${t.menu&&t.totalMenuOptions>10?w`
                                 <div style="position: sticky; top: 0; z-index: 2; background: var(--lumo-base-color); padding: .25rem 0 .5rem;">
                                     <input class="drawer-search" placeholder="Search…" style="width: calc(100% - 20px); margin: 0 10px;"
-                                           @input="${t=>vs({detail:{value:t.target.value}},e)}">
+                                           @input="${t=>Ps({detail:{value:t.target.value}},e)}">
                                 </div>
-                                `:v}
+                                `:_}
                             <nav class="side-nav">
                                 ${e.renderSideNav(s,void 0)}
                             </nav>
@@ -7876,12 +7876,12 @@ ${i}
                                 <div class="m-scroll" style="height: 100%;">
                                     <mateu-api-caller>
                                         <mateu-ux
-                                                route="${bs(r,e,t)}"
+                                                route="${Is(r,e,t)}"
                                                 id="ux_${e.id}"
-                                                baseUrl="${xs(e,t)}"
-                                                consumedRoute="${Z(e,t)}"
-                                                serverSideType="${Ss(e,t)}"
-                                                uriPrefix="${Cs(e,t)}"
+                                                baseUrl="${Ls(e,t)}"
+                                                consumedRoute="${X(e,t)}"
+                                                serverSideType="${Rs(e,t)}"
+                                                uriPrefix="${zs(e,t)}"
                                                 style="width: 100%;"
                                                 .appState="${a}"
                                                 .appData="${o}"
@@ -7890,15 +7890,15 @@ ${i}
                                         ></mateu-ux>
                                     </mateu-api-caller>
                                 </div>
-                                ${t.sseUrl?T`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" class="" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:v}
+                                ${t.sseUrl?w`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" class="" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:_}
                             </div>
                         </div>
                     </div>
                 </div>
 
-            `:v}
+            `:_}
             
-            ${t.variant==Ke.MENU_ON_TOP?T`
+            ${t.variant==qe.MENU_ON_TOP?w`
                 <div class="m-vl" style="width: 100%; height: 100vh; overflow: hidden;">
                     <div class="m-hl"
                             style="width: 100%; height: 4rem; flex-shrink: 0; align-items: center; border-bottom: 1px solid var(--lumo-disabled-text-color); background-color: var(--lumo-base-color);"
@@ -7906,14 +7906,14 @@ ${i}
                             @navigation-requested="${e.updateRoute}">
                         <a href="javascript: void(0);" @click="${()=>e.goHome()}" style="text-decoration: none; color: inherit; flex-shrink: 0;">
                         <div class="m-hl" style="align-items: center;">
-                            ${t.logo?T`<img src="${t.logo}" alt="logo" height="28px" style="margin-left: 10px;">`:v}
-                            ${t.title?T`<h2 style="margin: 0 var(--lumo-space-l, 1.5rem) 0 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;">${t.title}</h2>`:v}
+                            ${t.logo?w`<img src="${t.logo}" alt="logo" height="28px" style="margin-left: 10px;">`:_}
+                            ${t.title?w`<h2 style="margin: 0 var(--lumo-space-l, 1.5rem) 0 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;">${t.title}</h2>`:_}
                         </div>
                         </a>
-                        ${(()=>{let t=gs(e,e.itemSelected);return P.get()?.renderTopNav?.(s,t,`menu-on-top`)??hs(s,t,`menu-on-top`)})()}
+                        ${(()=>{let t=Ms(e,e.itemSelected);return N.get()?.renderTopNav?.(s,t,`menu-on-top`)??js(s,t,`menu-on-top`)})()}
                         <div class="m-hl" style="margin-left: auto; flex-shrink: 0; align-items: center;">
                             <slot name="widgets"></slot>
-                            ${ps(t,e)}${_s(t,e)}
+                            ${ks(t,e)}${Ns(t,e)}
                         </div>
                     </div>
                     <div style="flex: 1; min-height: 0; overflow-y: auto; overflow-x: hidden; box-sizing: border-box; width: 100%;">
@@ -7921,12 +7921,12 @@ ${i}
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${bs(r,e,t)}"
+                                            route="${Is(r,e,t)}"
                                             id="ux_${e.id}"
-                                            baseUrl="${xs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Ss(e,t)}"
-                                            uriPrefix="${Cs(e,t)}"
+                                            baseUrl="${Ls(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Rs(e,t)}"
+                                            uriPrefix="${zs(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -7935,14 +7935,14 @@ ${i}
                                     ></mateu-ux>
                                 </mateu-api-caller>
                             </div>
-                            ${t.sseUrl?T`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" class="" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:v}
+                            ${t.sseUrl?w`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" class="" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:_}
                         </div>
                     </div>
                 </div>
 
-            `:v}
+            `:_}
 
-            ${t.variant==Ke.TILES?T`
+            ${t.variant==qe.TILES?w`
                 <div class="m-vl" style="width: 100%; height: 100vh; overflow: hidden;">
                     <div class="m-hl"
                             style="width: 100%; height: 4rem; flex-shrink: 0; align-items: center; border-bottom: 1px solid var(--lumo-disabled-text-color); background-color: var(--lumo-base-color);"
@@ -7950,28 +7950,28 @@ ${i}
                             @navigation-requested="${e.updateRoute}">
                         <a href="javascript: void(0);" @click="${()=>{e.goHome(),e.tilesMenuOption=null}}" style="text-decoration: none; color: inherit; flex-shrink: 0;">
                         <div class="m-hl" style="align-items: center;">
-                            ${t.logo?T`<img src="${t.logo}" alt="logo" height="28px" style="margin-left: 10px;">`:v}
-                            ${t.title?T`<h2 style="margin: 0 var(--lumo-space-l, 1.5rem) 0 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;">${t.title}</h2>`:v}
+                            ${t.logo?w`<img src="${t.logo}" alt="logo" height="28px" style="margin-left: 10px;">`:_}
+                            ${t.title?w`<h2 style="margin: 0 var(--lumo-space-l, 1.5rem) 0 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;">${t.title}</h2>`:_}
                         </div>
                         </a>
-                        ${hs(e.mapItemsForTiles(t.menu),gs(e,e.itemSelectedTiles),`menu-on-top`)}
+                        ${js(e.mapItemsForTiles(t.menu),Ms(e,e.itemSelectedTiles),`menu-on-top`)}
                         <div class="m-hl" style="margin-left: auto; flex-shrink: 0; align-items: center;">
                             <slot name="widgets"></slot>
-                            ${ps(t,e)}${_s(t,e)}
+                            ${ks(t,e)}${Ns(t,e)}
                         </div>
                     </div>
                     <div style="flex: 1; min-height: 0; overflow-y: auto; overflow-x: hidden; box-sizing: border-box; width: 100%;">
-                        ${e.tilesMenuOption?e.renderTilesHub(e.tilesMenuOption):T`
+                        ${e.tilesMenuOption?e.renderTilesHub(e.tilesMenuOption):w`
                         <div class="m-md">
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${bs(r,e,t)}"
+                                            route="${Is(r,e,t)}"
                                             id="ux_${e.id}"
-                                            baseUrl="${xs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Ss(e,t)}"
-                                            uriPrefix="${Cs(e,t)}"
+                                            baseUrl="${Ls(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Rs(e,t)}"
+                                            uriPrefix="${zs(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -7980,28 +7980,28 @@ ${i}
                                     ></mateu-ux>
                                 </mateu-api-caller>
                             </div>
-                            ${t.sseUrl?T`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" class="" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:v}
+                            ${t.sseUrl?w`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" class="" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:_}
                         </div>
                         `}
                     </div>
                 </div>
-            `:v}
+            `:_}
 
-            ${t.variant==Ke.RAIL?T`
+            ${t.variant==qe.RAIL?w`
                 <div style="display: flex; width: 100%; height: 100vh; overflow: hidden;">
                     ${e.renderRail(t.menu)}
-                    ${e.railOpenOption?e.renderRailSubPanel(e.railOpenOption):v}
+                    ${e.railOpenOption?e.renderRailSubPanel(e.railOpenOption):_}
                     <div style="flex: 1; overflow: hidden; padding: 2rem 2rem 0; height: 100vh; box-sizing: border-box; background-color: var(--lumo-contrast-10pct);">
                         <div class="m-md">
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${bs(r,e,t)}"
+                                            route="${Is(r,e,t)}"
                                             id="ux_${e.id}"
-                                            baseUrl="${xs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Ss(e,t)}"
-                                            uriPrefix="${Cs(e,t)}"
+                                            baseUrl="${Ls(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Rs(e,t)}"
+                                            uriPrefix="${zs(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -8010,20 +8010,20 @@ ${i}
                                     ></mateu-ux>
                                 </mateu-api-caller>
                             </div>
-                            ${t.sseUrl?T`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" class="" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:v}
+                            ${t.sseUrl?w`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" class="" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:_}
                         </div>
                     </div>
                 </div>
-            `:v}
+            `:_}
 
-            ${t.variant==Ke.MENU_ON_LEFT?T`
+            ${t.variant==qe.MENU_ON_LEFT?w`
 
                 <div class="m-hl">
                     <div class="m-scroll" style="width: 16em; border-right: 2px solid var(--lumo-contrast-5pct);">
                         <div class="m-vl"
                                 @navigation-requested="${e.updateRoute}">
                             ${t.menu.map(t=>e.renderOptionOnLeftMenu(t))}
-                            ${ps(t,e)}${_s(t,e)}
+                            ${ks(t,e)}${Ns(t,e)}
                         </div>
                     </div>
                     <div role="main" class="${`app-content`+(e.pageCompact?` no-padding`:``)}">
@@ -8031,12 +8031,12 @@ ${i}
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${bs(r,e,t)}"
+                                            route="${Is(r,e,t)}"
                                             id="ux_${e.id}"
-                                            baseUrl="${xs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Ss(e,t)}"
-                                            uriPrefix="${Cs(e,t)}"
+                                            baseUrl="${Ls(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Rs(e,t)}"
+                                            uriPrefix="${zs(e,t)}"
                                             style="width: 100%; padding: 1em;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -8045,15 +8045,15 @@ ${i}
                                     ></mateu-ux>
                                 </mateu-api-caller>
                             </div>
-                            ${t.sseUrl?T`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" class="" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:v}
+                            ${t.sseUrl?w`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" class="" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:_}
                         </div>
                     </div>
                 </div>
 
 
-            `:v}
+            `:_}
 
-            ${t.variant==Ke.TABS?T`
+            ${t.variant==qe.TABS?w`
                 <!--
                 
                 box-shadow: inset 0 -1px 0 0 var(--lumo-contrast-10pct);
@@ -8068,19 +8068,19 @@ ${i}
                                 @navigation-requested="${e.updateRoute}">
                             <a href="javascript: void(0);" @click="${()=>e.goHome()}" style="text-decoration: none; color: inherit; flex-shrink: 0;">
                             <div class="m-hl" style="align-items: center;">
-                                ${t.logo?T`<img src="${t.logo}" alt="logo" height="28px" style="margin-left: 10px;">`:v}
-                                ${t.title?T`<h2 style="margin: 0 var(--lumo-space-l, 1.5rem) 0 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;">${t.title}</h2>`:v}
+                                ${t.logo?w`<img src="${t.logo}" alt="logo" height="28px" style="margin-left: 10px;">`:_}
+                                ${t.title?w`<h2 style="margin: 0 var(--lumo-space-l, 1.5rem) 0 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;">${t.title}</h2>`:_}
                             </div>
                             </a>
                             <nav class="mateu-tabs ${e.component?.cssClasses??``}" style="flex-grow: 1; min-width: 0; margin-left: 1.5rem;">
-                                ${t.menu.map((n,r)=>T`
+                                ${t.menu.map((n,r)=>w`
                                 <button class="mateu-tab ${r===e.getSelectedIndex(t.menu)?`mateu-tab--active`:``}"
                                         @click="${()=>e.selectRoute(n.consumedRoute,n.route,n.actionId,n.baseUrl,n.serverSideType,n.uriPrefix)}"
                                 >${n.label}</button>`)}
                             </nav>
                             <div class="m-hl" style="flex-shrink: 0; align-items: center;">
                                 <slot name="widgets"></slot>
-                                ${ps(t,e)}${_s(t,e)}
+                                ${ks(t,e)}${Ns(t,e)}
                             </div>
                         </div>
                     </div>
@@ -8089,12 +8089,12 @@ ${i}
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${bs(r,e,t)}"
+                                            route="${Is(r,e,t)}"
                                             id="ux_${e.id}"
-                                            baseUrl="${xs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Ss(e,t)}"
-                                            uriPrefix="${Cs(e,t)}"
+                                            baseUrl="${Ls(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Rs(e,t)}"
+                                            uriPrefix="${zs(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -8103,28 +8103,28 @@ ${i}
                                     ></mateu-ux>
                                 </mateu-api-caller>
                             </div>
-                            ${t.sseUrl?T`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" class="" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:v}
+                            ${t.sseUrl?w`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" class="" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:_}
                         </div>
                     </div>
                 </div>
             
-            `:v}
+            `:_}
 
-            ${t.fabs?.map((n,r)=>T`
+            ${t.fabs?.map((n,r)=>w`
                 <button class="app-fab" style="bottom: ${(t.sseUrl?5.5:1.5)+r*4}rem; right: 1.5rem;"
                     @click="${()=>e.runAction(n.actionId)}"
                     title="${n.label}">
-                    ${I(n.icon)}
+                    ${F(n.icon)}
                 </button>
             `)}
-            ${t.sseUrl&&!e.chatOpen?T`
+            ${t.sseUrl&&!e.chatOpen?w`
                 <button class="ai-fab" @click="${e.showHideIa}" title="Asistente IA">
-                    ${I(`vaadin:comments-o`)}
+                    ${F(`vaadin:comments-o`)}
                 </button>
-            `:v}
+            `:_}
             ${e.renderCommandPalette()}
             <slot></slot>
-       `},Ts=(e,t)=>t!=null&&e!=null&&!e.has(t),Es=typeof HTMLElement<`u`?HTMLElement:class{},Ds=class extends Es{static get observedAttributes(){return[`type`,`renderer`]}connectedCallback(){this.render()}attributeChangedCallback(){this.render()}render(){let e=this.getAttribute(`type`)??`unknown`,t=this.getAttribute(`renderer`)??`unknown`;this.shadowRoot||this.attachShadow({mode:`open`}),this.shadowRoot.innerHTML=`
+       `},Vs=(e,t)=>t!=null&&e!=null&&!e.has(t),Hs=typeof HTMLElement<`u`?HTMLElement:class{},Us=class extends Hs{static get observedAttributes(){return[`type`,`renderer`]}connectedCallback(){this.render()}attributeChangedCallback(){this.render()}render(){let e=this.getAttribute(`type`)??`unknown`,t=this.getAttribute(`renderer`)??`unknown`;this.shadowRoot||this.attachShadow({mode:`open`}),this.shadowRoot.innerHTML=`
             <style>
                 :host { display: block; }
                 .mateu-unsupported {
@@ -8143,12 +8143,12 @@ ${i}
             <div class="mateu-unsupported" role="note">
                 ⚠ Component “${e}” is not supported by the “${t}” renderer yet.
             </div>
-        `}};typeof customElements<`u`&&!customElements.get(`mateu-unsupported`)&&customElements.define(`mateu-unsupported`,Ds);var Os=new Set,ks=(e,t,n)=>{let r=`${n}/${t}`;return Os.has(r)||(Os.add(r),console.warn(`[mateu] Component type "${t}" is not supported by the "${n}" renderer — rendering <mateu-unsupported> placeholder.`)),T`<mateu-unsupported
+        `}};typeof customElements<`u`&&!customElements.get(`mateu-unsupported`)&&customElements.define(`mateu-unsupported`,Us);var Ws=new Set,Gs=(e,t,n)=>{let r=`${n}/${t}`;return Ws.has(r)||(Ws.add(r),console.warn(`[mateu] Component type "${t}" is not supported by the "${n}" renderer — rendering <mateu-unsupported> placeholder.`)),w`<mateu-unsupported
             type="${t}"
             renderer="${n}"
-            data-component-id="${e?.id??v}"
-            slot="${e?.slot??v}"
-    ></mateu-unsupported>`},As=class{renderFilterBar(e,t,n,r,i,a,o,s){let c=t?.metadata;return T`
+            data-component-id="${e?.id??_}"
+            slot="${e?.slot??_}"
+    ></mateu-unsupported>`},Ks=class{renderFilterBar(e,t,n,r,i,a,o,s){let c=t?.metadata;return w`
             <mateu-filter-bar
                 .metadata="${c}"
                 @search-requested="${e.search}"
@@ -8160,9 +8160,9 @@ ${i}
                 .appData="${o}"
                 ?searchOnly="${s??!1}"
             >
-                ${c?.header?.map(t=>F(e,t,n,r,i,a,o))}
+                ${c?.header?.map(t=>P(e,t,n,r,i,a,o))}
             </mateu-filter-bar>
-        `}renderPagination(e,t){return T`
+        `}renderPagination(e,t){return w`
         <mateu-pagination
                 @page-changed="${e.pageChanged}"
                 @fetch-more-elements="${e.fetchMoreElements}"
@@ -8171,80 +8171,80 @@ ${i}
                 data-testid="pagination"
                 .pageNumber="${e.data[t?.id]?.page?.pageNumber??0}"
         ></mateu-pagination>
-        `}renderTableComponent(e,t,n,r,i,a,o){return pn(t,(e.data?.[e.id])?.page?.content??[],r[t?.id]?.emptyStateMessage)}rendererName(){return this.constructor?.name??`unknown`}supportedClientSideTypes(){}renderClientSideComponent(e,t,n,r,i,a,o,s){let c=t?.metadata?.type??t?.type,l=Object.values(j).includes(c)?c:void 0;return Ts(this.supportedClientSideTypes(),l)?ks(t,l,this.rendererName()):ea(e,t,n,r,i,a,o,s)}renderAppComponent(e,t,n,r,i,a,o){return ws(e,t?.metadata,n,r,i,a,o)}},js=(e,t,n,r,i,a,o)=>T`
+        `}renderTableComponent(e,t,n,r,i,a,o){return mn(t,(e.data?.[e.id])?.page?.content??[],r[t?.id]?.emptyStateMessage)}rendererName(){return this.constructor?.name??`unknown`}supportedClientSideTypes(){}renderClientSideComponent(e,t,n,r,i,a,o,s){let c=t?.metadata?.type??t?.type,l=Object.values(A).includes(c)?c:void 0;return Vs(this.supportedClientSideTypes(),l)?Gs(t,l,this.rendererName()):ta(e,t,n,r,i,a,o,s)}renderAppComponent(e,t,n,r,i,a,o){return Bs(e,t?.metadata,n,r,i,a,o)}},qs=(e,t,n,r,i,a,o)=>w`
         <vaadin-virtual-list
                 .items="${t.metadata.page.content}"
-                ${te(t=>T`${F(e,t,n,r,i,a,o)}`,[])}
+                ${ne(t=>w`${P(e,t,n,r,i,a,o)}`,[])}
                 style="${t.style}" class="${t.cssClasses}"
-                slot="${t.slot??v}"
+                slot="${t.slot??_}"
         ></vaadin-virtual-list>
-    `,Ms=e=>{let t=e.metadata;return T`
+    `,Js=e=>{let t=e.metadata;return w`
         <vaadin-notification
                 .opened="${!0}"
-                slot="${e.slot??v}"
+                slot="${e.slot??_}"
                 style="${e.style}"
                 class="${e.cssClasses}"
-                ${c(()=>T`
+                ${c(()=>w`
                     <vaadin-horizontal-layout theme="spacing" style="align-items: center;">
                         <h3>${t.title}</h3>
                         <div>${t.text}</div>
                     </vaadin-horizontal-layout>
                 `,[])}
         ></vaadin-notification>
-    `},Ns=(e,t={})=>{let n=e.metadata,r=n.valueKey?t[n.valueKey]:n.value;return T`
+    `},Ys=(e,t={})=>{let n=e.metadata,r=n.valueKey?t[n.valueKey]:n.value;return w`
         <div style="${e.style}">
         <vaadin-progress-bar
                 ?indeterminate="${n.indeterminate}"
-                min="${n.min&&n.min!=0?n.min:v}"
-                max="${n.max&&n.max!=0?n.max:v}"
-                value="${r??v}"
+                min="${n.min&&n.min!=0?n.min:_}"
+                max="${n.max&&n.max!=0?n.max:_}"
+                value="${r??_}"
                 style="${e.style}"
                 class="${e.cssClasses}"
-                slot="${e.slot??v}"
+                slot="${e.slot??_}"
         ></vaadin-progress-bar>
-        ${n.text?T`<span class="text-secondary text-xs" id="sublbl">
+        ${n.text?w`<span class="text-secondary text-xs" id="sublbl">
     ${n.text}
-  </span>`:v}
+  </span>`:_}
         </div>
-    `},Ps=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+    `},Xs=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <vaadin-details
                 ?opened="${s.opened}"
                 style="${t.style}"
                 class="${t.cssClasses}"
-                slot="${t.slot??v}"
+                slot="${t.slot??_}"
         >
             <vaadin-details-summary slot="summary">
-            ${F(e,s.summary,n,r,i,a,o)}
+            ${P(e,s.summary,n,r,i,a,o)}
             </vaadin-details-summary>
-            ${F(e,s.content,n,r,i,a,o)}
+            ${P(e,s.content,n,r,i,a,o)}
         </vaadin-details>
-            `},Fs=(e,t,n)=>{let r=e.metadata;return T`<vaadin-avatar
+            `},Zs=(e,t,n)=>{let r=e.metadata;return w`<vaadin-avatar
             img="${r.image}"
-            name="${N(r.name,t,n)}"
+            name="${M(r.name,t,n)}"
             abbr="${r.abbreviation}"
             style="${e.style}" class="${e.cssClasses}"
-            slot="${e.slot??v}"
-    ></vaadin-avatar>`},Is=e=>{let t=e.metadata;return T`<vaadin-avatar-group max-items-visible="${t.maxItemsVisible}"
+            slot="${e.slot??_}"
+    ></vaadin-avatar>`},Qs=e=>{let t=e.metadata;return w`<vaadin-avatar-group max-items-visible="${t.maxItemsVisible}"
                                      .items="${t.avatars}"
                                      style="${e.style}" class="${e.cssClasses}"
-                                     slot="${e.slot??v}">
-    </vaadin-avatar-group>`},Ls=(e,t,n,r,i,a,o)=>{let s=t.metadata;if(!s)return T``;let c=``;return s.variants?.map(e=>e==`stretchMedia`?`stretch-media`:e==`coverMedia`?`cover-media`:e).forEach(e=>c+=` `+e),c=c.trim(),T`
+                                     slot="${e.slot??_}">
+    </vaadin-avatar-group>`},$s=(e,t,n,r,i,a,o)=>{let s=t.metadata;if(!s)return w``;let c=``;return s.variants?.map(e=>e==`stretchMedia`?`stretch-media`:e==`coverMedia`?`cover-media`:e).forEach(e=>c+=` `+e),c=c.trim(),w`
         <vaadin-card
                 style="${t.style}"
                 class="${t.cssClasses}"
                 theme="${c}"
-                slot="${t.slot??v}"
+                slot="${t.slot??_}"
         >
-            ${s.media?pt(e,s.media,n,r,i,a,o,`media`,!1):v}
-            ${s.title?pt(e,s.title,n,r,i,a,o,`title`,!1):v}
-            ${s.subtitle?pt(e,s.subtitle,n,r,i,a,o,`subtitle`,!1):v}
-            ${s.header?pt(e,s.header,n,r,i,a,o,`header`,!1):v}
-            ${s.headerPrefix?pt(e,s.headerPrefix,n,r,i,a,o,`header-prefix`,!1):v}
-            ${s.headerSuffix?pt(e,s.headerSuffix,n,r,i,a,o,`header-suffix`,!1):v}
-            ${s.footer?pt(e,s.footer,n,r,i,a,o,`footer`,!1):v}
-            ${s.content?F(e,s.content,n,r,i,a,o,!1):v}
+            ${s.media?mt(e,s.media,n,r,i,a,o,`media`,!1):_}
+            ${s.title?mt(e,s.title,n,r,i,a,o,`title`,!1):_}
+            ${s.subtitle?mt(e,s.subtitle,n,r,i,a,o,`subtitle`,!1):_}
+            ${s.header?mt(e,s.header,n,r,i,a,o,`header`,!1):_}
+            ${s.headerPrefix?mt(e,s.headerPrefix,n,r,i,a,o,`header-prefix`,!1):_}
+            ${s.headerSuffix?mt(e,s.headerSuffix,n,r,i,a,o,`header-suffix`,!1):_}
+            ${s.footer?mt(e,s.footer,n,r,i,a,o,`footer`,!1):_}
+            ${s.content?P(e,s.content,n,r,i,a,o,!1):_}
         </vaadin-card>
-    `},Rs=e=>e>0&&e<640?`accordion`:`tabs`,zs=class extends b{constructor(...e){super(...e),this.tabLabels=[],this.mode=`tabs`,this.selected=0,this.selectedChangedListener=e=>{let t=e.detail?.value;typeof t==`number`&&t>=0&&(this.selected=t)}}connectedCallback(){super.connectedCallback(),this.resizeObserver=new ResizeObserver(e=>{for(let t of e)this.mode=Rs(t.contentRect.width)}),this.resizeObserver.observe(this)}disconnectedCallback(){super.disconnectedCallback(),this.resizeObserver?.disconnect(),this.resizeObserver=void 0,this.detachTabsListener()}detachTabsListener(){this.slottedTabs?.removeEventListener(`selected-changed`,this.selectedChangedListener),this.slottedTabs=void 0}tabsSlotChanged(e){this.detachTabsListener();let t=e.target.assignedElements().find(e=>`selected`in e);t&&(this.slottedTabs=t,t.addEventListener(`selected-changed`,this.selectedChangedListener),t.selected=this.selected)}select(e){this.selected=e,this.slottedTabs&&(this.slottedTabs.selected=e)}updated(){this.slottedTabs&&this.slottedTabs.selected!=this.selected&&(this.slottedTabs.selected=this.selected)}static{this.styles=h`
+    `},ec=e=>e>0&&e<640?`accordion`:`tabs`,tc=class extends y{constructor(...e){super(...e),this.tabLabels=[],this.mode=`tabs`,this.selected=0,this.selectedChangedListener=e=>{let t=e.detail?.value;typeof t==`number`&&t>=0&&(this.selected=t)}}connectedCallback(){super.connectedCallback(),this.resizeObserver=new ResizeObserver(e=>{for(let t of e)this.mode=ec(t.contentRect.width)}),this.resizeObserver.observe(this)}disconnectedCallback(){super.disconnectedCallback(),this.resizeObserver?.disconnect(),this.resizeObserver=void 0,this.detachTabsListener()}detachTabsListener(){this.slottedTabs?.removeEventListener(`selected-changed`,this.selectedChangedListener),this.slottedTabs=void 0}tabsSlotChanged(e){this.detachTabsListener();let t=e.target.assignedElements().find(e=>`selected`in e);t&&(this.slottedTabs=t,t.addEventListener(`selected-changed`,this.selectedChangedListener),t.selected=this.selected)}select(e){this.selected=e,this.slottedTabs&&(this.slottedTabs.selected=e)}updated(){this.slottedTabs&&this.slottedTabs.selected!=this.selected&&(this.slottedTabs.selected=this.selected)}static{this.styles=m`
         :host {
             display: block;
         }
@@ -8299,26 +8299,26 @@ ${i}
         .acc-body[hidden] {
             display: none;
         }
-    `}render(){return T`
+    `}render(){return w`
             <div class="strip" ?hidden="${this.mode!=`tabs`}">
                 <slot name="tabs" @slotchange="${this.tabsSlotChanged}"></slot>
             </div>
-            ${this.mode==`tabs`?T`
-                ${this.tabLabels.map((e,t)=>T`
+            ${this.mode==`tabs`?w`
+                ${this.tabLabels.map((e,t)=>w`
                     <div class="panel" ?hidden="${t!=this.selected}">
                         <slot name="panel-${t}"></slot>
                     </div>
                 `)}
-            `:T`
+            `:w`
                 <div class="accordion" part="accordion">
-                    ${this.tabLabels.map((e,t)=>T`
+                    ${this.tabLabels.map((e,t)=>w`
                         <div class="acc-item">
                             <button class="acc-header"
                                     aria-expanded="${t==this.selected}"
                                     aria-controls="acc-body-${t}"
                                     @click="${()=>this.select(t)}"
                             >
-                                <span>${e??v}</span>
+                                <span>${e??_}</span>
                                 <span class="chevron">⟩</span>
                             </button>
                             <div class="acc-body" id="acc-body-${t}" ?hidden="${t!=this.selected}">
@@ -8328,178 +8328,178 @@ ${i}
                     `)}
                 </div>
             `}
-        `}};k([y({type:Array})],zs.prototype,`tabLabels`,void 0),k([C()],zs.prototype,`mode`,void 0),k([C()],zs.prototype,`selected`,void 0),zs=k([g(`mateu-adaptive-tabs`)],zs);var Bs=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;c??=``,s.columnSpacing&&(c+=`--vaadin-form-layout-column-spacing: `+s.columnSpacing+`;`);let l=s.itemRowSpacing&&s.itemRowSpacing!==`0`?s.itemRowSpacing:`var(--lumo-space-m)`;return c+=`--vaadin-form-layout-row-spacing: `+l+`;`,s.itemLabelSpacing&&(c+=`--vaadin-form-layout-label-spacing: `+s.itemLabelSpacing+`;`),s.labelsAside&&(c+=`--vaadin-form-item-label-width: 10rem;`),s.fullWidth&&(c+=`width: 100%;`),T`
+        `}};O([v({type:Array})],tc.prototype,`tabLabels`,void 0),O([S()],tc.prototype,`mode`,void 0),O([S()],tc.prototype,`selected`,void 0),tc=O([h(`mateu-adaptive-tabs`)],tc);var nc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;c??=``,s.columnSpacing&&(c+=`--vaadin-form-layout-column-spacing: `+s.columnSpacing+`;`);let l=s.itemRowSpacing&&s.itemRowSpacing!==`0`?s.itemRowSpacing:`var(--lumo-space-m)`;return c+=`--vaadin-form-layout-row-spacing: `+l+`;`,s.itemLabelSpacing&&(c+=`--vaadin-form-layout-label-spacing: `+s.itemLabelSpacing+`;`),s.labelsAside&&(c+=`--vaadin-form-item-label-width: 10rem;`),s.fullWidth&&(c+=`width: 100%;`),w`
                <vaadin-form-layout 
-                       .responsiveSteps="${s.responsiveSteps||v}"  
-                       style="${c||v}" 
+                       .responsiveSteps="${s.responsiveSteps||_}"  
+                       style="${c||_}" 
                        class="${t.cssClasses}"
-                       max-columns="${s.maxColumns&&s.maxColumns>0?s.maxColumns:v}"
-                       auto-responsive="${s.autoResponsive||v}"
-                       column-width="${s.columnWidth||v}"
-                       expand-columns="${s.expandColumns||v}"
-                       expand-fields="${s.expandFields||!s.labelsAside||v}"
-                       labels-aside="${s.labelsAside||v}"
-                       slot="${t.slot||v}"
+                       max-columns="${s.maxColumns&&s.maxColumns>0?s.maxColumns:_}"
+                       auto-responsive="${s.autoResponsive||_}"
+                       column-width="${s.columnWidth||_}"
+                       expand-columns="${s.expandColumns||_}"
+                       expand-fields="${s.expandFields||!s.labelsAside||_}"
+                       labels-aside="${s.labelsAside||_}"
+                       slot="${t.slot||_}"
                >
-                   ${t.children?.map(t=>Vs(s,e,t,n,r,i,a,o))}
+                   ${t.children?.map(t=>rc(s,e,t,n,r,i,a,o))}
                </vaadin-form-layout>
-            `},Vs=(e,t,n,r,i,a,o,s)=>n.type==A.ClientSide&&n.metadata?.type==j.FormRow?Us(e,t,n,r,i,a,o,s):e.labelsAside?Hs(t,n,r,i,a,o,s):F(t,n,r,i,a,o,s),Hs=(e,t,n,r,i,a,o)=>{if(t.type==A.ClientSide&&t.metadata?.type==j.FormField&&t.metadata.label){let s=t.metadata,c=s.label?.includes("${")?e._evalTemplate(s.label):s.label;return T`
+            `},rc=(e,t,n,r,i,a,o,s)=>n.type==k.ClientSide&&n.metadata?.type==A.FormRow?ac(e,t,n,r,i,a,o,s):e.labelsAside?ic(t,n,r,i,a,o,s):P(t,n,r,i,a,o,s),ic=(e,t,n,r,i,a,o)=>{if(t.type==k.ClientSide&&t.metadata?.type==A.FormField&&t.metadata.label){let s=t.metadata,c=s.label?.includes("${")?e._evalTemplate(s.label):s.label;return w`
                        <vaadin-form-item data-colspan="${s.colspan}">
                            <label slot="label">${c}</label>
-                           ${F(e,t,n,r,i,a,o,!0)}
+                           ${P(e,t,n,r,i,a,o,!0)}
                        </vaadin-form-item>
-                   `}return F(e,t,n,r,i,a,o)},Us=(e,t,n,r,i,a,o,s)=>T`
+                   `}return P(e,t,n,r,i,a,o)},ac=(e,t,n,r,i,a,o,s)=>w`
         <vaadin-form-row>
-            ${n.children?.map(n=>Vs(e,t,n,r,i,a,o,s))}
+            ${n.children?.map(n=>rc(e,t,n,r,i,a,o,s))}
         </vaadin-form-row>
-            `,Ws=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=(s.padding?` padding`:``)+(s.spacing?` spacing`:``)+(s.spacingVariant?` spacing-`+s.spacingVariant:``)+(s.wrap?` wrap`:``),l=t.style;return s.fullWidth&&(l=l?`width: 100%;`+l:`width: 100%;`),s.justification&&(l=l?`justify-content: `+s.justification+`;`+l:`justify-content: `+s.justification+`;`),s.verticalAlignment&&(l=l?`align-items: `+s.verticalAlignment+`;`+l:`align-items: `+s.verticalAlignment+`;`),T`
+            `,oc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=(s.padding?` padding`:``)+(s.spacing?` spacing`:``)+(s.spacingVariant?` spacing-`+s.spacingVariant:``)+(s.wrap?` wrap`:``),l=t.style;return s.fullWidth&&(l=l?`width: 100%;`+l:`width: 100%;`),s.justification&&(l=l?`justify-content: `+s.justification+`;`+l:`justify-content: `+s.justification+`;`),s.verticalAlignment&&(l=l?`align-items: `+s.verticalAlignment+`;`+l:`align-items: `+s.verticalAlignment+`;`),w`
                <vaadin-horizontal-layout 
                        style="${l}" 
                        class="${t.cssClasses}"
                        theme="${c}"
-                       slot="${t.slot??v}"
+                       slot="${t.slot??_}"
                >
-                   ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+                   ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
                </vaadin-horizontal-layout>
-            `},Gs=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=(s.padding?` padding`:``)+(s.spacing?` spacing`:``)+(s.spacingVariant?` spacing-`+s.spacingVariant:``)+(s.wrap?` wrap`:``),l=t.style;return s.fullWidth&&(l=l?`width: 100%;`+l:`width: 100%;`),s.justification&&(l=l?`justify-content: `+s.justification+`;`+l:`justify-content: `+s.justification+`;`),s.horizontalAlignment&&(l=l?`align-items: `+s.horizontalAlignment+`;`+l:`align-items: `+s.horizontalAlignment+`;`),T`
+            `},sc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=(s.padding?` padding`:``)+(s.spacing?` spacing`:``)+(s.spacingVariant?` spacing-`+s.spacingVariant:``)+(s.wrap?` wrap`:``),l=t.style;return s.fullWidth&&(l=l?`width: 100%;`+l:`width: 100%;`),s.justification&&(l=l?`justify-content: `+s.justification+`;`+l:`justify-content: `+s.justification+`;`),s.horizontalAlignment&&(l=l?`align-items: `+s.horizontalAlignment+`;`+l:`align-items: `+s.horizontalAlignment+`;`),w`
         <vaadin-vertical-layout
                 style="${l}"
                 class="${t.cssClasses}"
                 theme="${c}"
-                slot="${t.slot??v}"
+                slot="${t.slot??_}"
         >
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </vaadin-vertical-layout>
-    `},Ks=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;return s.fullWidth&&(c=c?`width: 100%;`+c:`width: 100%;`),T`
+    `},cc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;return s.fullWidth&&(c=c?`width: 100%;`+c:`width: 100%;`),w`
                <vaadin-split-layout 
                        style="${c}" 
                        class="${t.cssClasses}"
-                       orientation="${s.orientation??v}"
-                       theme="${s.variant??v}"
-                       slot="${t.slot??v}"
+                       orientation="${s.orientation??_}"
+                       theme="${s.variant??_}"
+                       slot="${t.slot??_}"
                >
-                   <master-content>${F(e,t.children[0],n,r,i,a,o)}</master-content>
-                   <detail-content>${F(e,t.children[1],n,r,i,a,o)}</detail-content>
+                   <master-content>${P(e,t.children[0],n,r,i,a,o)}</master-content>
+                   <detail-content>${P(e,t.children[1],n,r,i,a,o)}</detail-content>
                </vaadin-split-layout>
-            `},qs=(e,t,n,r,i,a,o)=>{let s=t.children&&t.children.length>1?t.children[1]:null,c=i?.detailComponent??null,l=!!i?.hasDetail||!!s,u=c??s;return T`
+            `},lc=(e,t,n,r,i,a,o)=>{let s=t.children&&t.children.length>1?t.children[1]:null,c=i?.detailComponent??null,l=!!i?.hasDetail||!!s,u=c??s;return w`
                <vaadin-master-detail-layout ?has-detail="${l}"
                                             style="${t.style}"
                                             class="${t.cssClasses}"
-                                            slot="${t.slot??v}">
-                   <div>${F(e,t.children[0],n,r,i,a,o)}</div>
-                   ${l&&u?T`<div slot="detail">${F(e,u,n,r,i,a,o)}</div>`:T`<div slot="detail" style="display: flex; align-items: center; justify-content: center; height: 100%; color: var(--lumo-secondary-text-color); font-size: var(--lumo-font-size-s);">Select an item to view details</div>`}
+                                            slot="${t.slot??_}">
+                   <div>${P(e,t.children[0],n,r,i,a,o)}</div>
+                   ${l&&u?w`<div slot="detail">${P(e,u,n,r,i,a,o)}</div>`:w`<div slot="detail" style="display: flex; align-items: center; justify-content: center; height: 100%; color: var(--lumo-secondary-text-color); font-size: var(--lumo-font-size-s);">Select an item to view details</div>`}
                </vaadin-master-detail-layout>
-            `},Js=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;c??=``,s.fullWidth&&(c+=`width: 100%;`);let l=s.variant;l==`equalWidth`&&(l=`equal-width-tabs`);let u=Math.max(0,(t.children??[]).findIndex(e=>e.metadata.active)),d=e=>{e.target.selected=u};if(s.adaptable){let u=(t.children??[]).map(t=>{let n=t.metadata.label;return n?.includes("${")?e._evalTemplate(n):n});return T`
+            `},uc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;c??=``,s.fullWidth&&(c+=`width: 100%;`);let l=s.variant;l==`equalWidth`&&(l=`equal-width-tabs`);let u=Math.max(0,(t.children??[]).findIndex(e=>e.metadata.active)),d=e=>{e.target.selected=u};if(s.adaptable){let u=(t.children??[]).map(t=>{let n=t.metadata.label;return n?.includes("${")?e._evalTemplate(n):n});return w`
             <mateu-adaptive-tabs
                     .tabLabels="${u}"
                     style="${c}"
                     class="${t.cssClasses}"
-                    slot="${t.slot??v}"
+                    slot="${t.slot??_}"
             >
                 <vaadin-tabs slot="tabs"
-                             theme="${l??v}"
-                             orientation="${s.orientation??v}"
+                             theme="${l??_}"
+                             orientation="${s.orientation??_}"
                              @items-changed=${d}
                 >
-                    ${t.children?.map(e=>e).map((e,t)=>{let n=e.metadata.shortcut;return T`
+                    ${t.children?.map(e=>e).map((e,t)=>{let n=e.metadata.shortcut;return w`
                         <vaadin-tab id="${u[t]}"
                                     style="${e.style}"
                                     class="${e.cssClasses}"
-                                    data-shortcut="${n??v}"
+                                    data-shortcut="${n??_}"
                         >${u[t]}</vaadin-tab>`})}
                 </vaadin-tabs>
 
-                ${t.children?.map((t,s)=>T`
+                ${t.children?.map((t,s)=>w`
                     <div slot="panel-${s}" style="padding: var(--lumo-space-m) 0;">
-                        ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+                        ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
                     </div>`)}
             </mateu-adaptive-tabs>
-                `}return T`
+                `}return w`
         <vaadin-tabsheet
-                theme="${l??v}"
+                theme="${l??_}"
                 style="${c}"
-                slot="${t.slot??v}"
+                slot="${t.slot??_}"
         >
             <vaadin-tabs slot="tabs"
                          style="${c}"
                          class="${t.cssClasses}"
-                         orientation="${s.orientation??v}"
+                         orientation="${s.orientation??_}"
                          @items-changed=${d}
             >
-                ${t.children?.map(e=>e).map(t=>{let n=t.metadata.label,r=n?.includes("${")?e._evalTemplate(n):n,i=t.metadata.shortcut;return T`
+                ${t.children?.map(e=>e).map(t=>{let n=t.metadata.label,r=n?.includes("${")?e._evalTemplate(n):n,i=t.metadata.shortcut;return w`
                     <vaadin-tab id="${r}"
                                 style="${t.style}"
                                 class="${t.cssClasses}"
-                                data-shortcut="${i??v}"
+                                data-shortcut="${i??_}"
                     >${r}</vaadin-tab>`})}
             </vaadin-tabs>
 
-            ${t.children?.map(t=>Ys(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>dc(e,t,n,r,i,a,o))}
         </vaadin-tabsheet>
-            `},Ys=(e,t,n,r,i,a,o)=>{let s=t.metadata.label;return T`
+            `},dc=(e,t,n,r,i,a,o)=>{let s=t.metadata.label;return w`
         <div tab="${s?.includes("${")?e._evalTemplate(s):s}" style="padding: var(--lumo-space-m) 0;">
-                   ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+                   ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
                </div>
-            `},Xs=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;s.fullWidth&&(c=c?`width: 100%;`+c:`width: 100%;`);let l=0;if(t.children){for(let e=0;e<t.children.length;e++)if(t.children[e].metadata?.active){l=e;break}}return T`
+            `},fc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;s.fullWidth&&(c=c?`width: 100%;`+c:`width: 100%;`);let l=0;if(t.children){for(let e=0;e<t.children.length;e++)if(t.children[e].metadata?.active){l=e;break}}return w`
                <vaadin-accordion
                        style="${t.style}"
                        class="${t.cssClasses}"
                        opened="${l}"
-                       slot="${t.slot??v}"
+                       slot="${t.slot??_}"
                >
-                   ${t.children?.map(t=>Zs(e,t,n,r,i,a,o,s.variant))}
+                   ${t.children?.map(t=>pc(e,t,n,r,i,a,o,s.variant))}
                </vaadin-accordion>
-            `},Zs=(e,t,n,r,i,a,o,s)=>{let c=t.metadata,l=c.label?.includes("${")?e._evalTemplate(c.label):c.label;return T`
+            `},pc=(e,t,n,r,i,a,o,s)=>{let c=t.metadata,l=c.label?.includes("${")?e._evalTemplate(c.label):c.label;return w`
         <vaadin-accordion-panel style="${t.style}"
                                 class="${t.cssClasses}"
-                                theme="${s??v}"
+                                theme="${s??_}"
                                 ?opened="${c.active}"
                                 ?disabled="${c.disabled}">
             <vaadin-accordion-heading slot="summary">${l}</vaadin-accordion-heading>
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </vaadin-accordion-panel>
-            `},Qs=(e,t,n,r,i,a,o)=>T`
+            `},mc=(e,t,n,r,i,a,o)=>w`
                <vaadin-scroller style="${t.style}" 
                                 class="${t.cssClasses}"
-                                slot="${t.slot??v}">
-                   ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+                                slot="${t.slot??_}">
+                   ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
                </vaadin-scroller>
-            `,$s=(e,t,n,r,i,a,o)=>T`
+            `,hc=(e,t,n,r,i,a,o)=>w`
         <vaadin-board style="${t.style}" 
                       class="${t.cssClasses}"
-                      slot="${t.slot??v}">
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+                      slot="${t.slot??_}">
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </vaadin-board>
-            `,ec=(e,t,n,r,i,a,o)=>T`
+            `,gc=(e,t,n,r,i,a,o)=>w`
         <vaadin-board-row style="${t.style}" class="${t.cssClasses}">
-                   ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+                   ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
                </vaadin-board-row>
-            `,tc=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+            `,_c=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <div style="${t.style}" 
              class="${t.cssClasses}"
-             board-cols="${s.boardCols??v}"
+             board-cols="${s.boardCols??_}"
         >
-                   ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+                   ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
                </div>
-            `},nc=(e,t,n)=>T`
+            `},vc=(e,t,n)=>w`
     <vaadin-menu-bar
         .items=${e}
-        class="${n??v}"
+        class="${n??_}"
         @item-selected=${e=>t(e.detail.value)}>
-    </vaadin-menu-bar>`,rc=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
-        <vaadin-context-menu .items=${oc(e,s.menu,n,r,i,a,o)} 
+    </vaadin-menu-bar>`,yc=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+        <vaadin-context-menu .items=${Sc(e,s.menu,n,r,i,a,o)} 
                              style="${t.style}" 
                              class="${t.cssClasses}"
-                             open-on="${s.activateOnLeftClick?`click`:v}"
-                             slot="${t.slot??v}">
-            ${F(e,s.wrapped,n,r,i,a,o)}
+                             open-on="${s.activateOnLeftClick?`click`:_}"
+                             slot="${t.slot??_}">
+            ${P(e,s.wrapped,n,r,i,a,o)}
         </vaadin-context-menu>
-            `},ic=(e,t,n,r,i)=>{let a=t.metadata;return T`
-        <vaadin-menu-bar .items=${oc(e,a.options,n,r,i,O,ue)}
+            `},bc=(e,t,n,r,i)=>{let a=t.metadata;return w`
+        <vaadin-menu-bar .items=${Sc(e,a.options,n,r,i,D,de)}
                          style="${t.style}" class="${t.cssClasses}"
-                         slot="${t.slot??v}">
+                         slot="${t.slot??_}">
         </vaadin-menu-bar>
-            `},ac=(e,t,n,r,i,a,o)=>{let s=document.createElement(`vaadin-context-menu-item`);return re(F(e,t,n,r,i,a,o),s),s},oc=(e,t,n,r,i,a,o)=>t.map(t=>t.submenus?{text:t.component?void 0:t.label,route:t.path,checked:t.selected,disabled:t.disabled,className:t.className,component:t.component?ac(e,t.component,n,r,i,a,o):void 0,children:oc(e,t.submenus,n,r,i,a,o)}:t.separator?{component:`hr`}:{text:t.component?void 0:t.label,route:t.path,checked:t.selected,disabled:t.disabled,className:t.className,component:t.component?ac(e,t.component,n,r,i,a,o):void 0}),sc=class extends b{constructor(...e){super(...e),this.fieldId=``,this.signing=!1,this.hasStrokes=!1,this.drawing=!1,this.startStroke=e=>{let t=e.target;this.ensureCanvasSize(t),t.setPointerCapture(e.pointerId),this.drawing=!0;let n=t.getContext(`2d`);n.lineWidth=2,n.lineCap=`round`,n.lineJoin=`round`,n.strokeStyle=getComputedStyle(this).getPropertyValue(`--lumo-body-text-color`)||`#1a1a1a`;let[r,i]=this.pointerPosition(e);n.beginPath(),n.moveTo(r,i),e.preventDefault()},this.stroke=e=>{if(!this.drawing)return;let t=e.target.getContext(`2d`),[n,r]=this.pointerPosition(e);t.lineTo(n,r),t.stroke(),this.hasStrokes=!0,e.preventDefault()},this.endStroke=e=>{this.drawing=!1,e.target.releasePointerCapture(e.pointerId)}}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}canvas(){return this.renderRoot.querySelector(`canvas`)}pointerPosition(e){let t=e.target.getBoundingClientRect();return[e.clientX-t.left,e.clientY-t.top]}ensureCanvasSize(e){let t=e.getBoundingClientRect();(e.width!==Math.round(t.width)||e.height!==Math.round(t.height))&&(e.width=Math.round(t.width),e.height=Math.round(t.height))}clear(){let e=this.canvas();e&&e.getContext(`2d`).clearRect(0,0,e.width,e.height),this.hasStrokes=!1}accept(){let e=this.canvas();!e||!this.hasStrokes||(this.signing=!1,this.emit(e.toDataURL(`image/png`)))}renderPad(){return T`
+            `},xc=(e,t,n,r,i,a,o)=>{let s=document.createElement(`vaadin-context-menu-item`);return ie(P(e,t,n,r,i,a,o),s),s},Sc=(e,t,n,r,i,a,o)=>t.map(t=>t.submenus?{text:t.component?void 0:t.label,route:t.path,checked:t.selected,disabled:t.disabled,className:t.className,component:t.component?xc(e,t.component,n,r,i,a,o):void 0,children:Sc(e,t.submenus,n,r,i,a,o)}:t.separator?{component:`hr`}:{text:t.component?void 0:t.label,route:t.path,checked:t.selected,disabled:t.disabled,className:t.className,component:t.component?xc(e,t.component,n,r,i,a,o):void 0}),Cc=class extends y{constructor(...e){super(...e),this.fieldId=``,this.signing=!1,this.hasStrokes=!1,this.drawing=!1,this.startStroke=e=>{let t=e.target;this.ensureCanvasSize(t),t.setPointerCapture(e.pointerId),this.drawing=!0;let n=t.getContext(`2d`);n.lineWidth=2,n.lineCap=`round`,n.lineJoin=`round`,n.strokeStyle=getComputedStyle(this).getPropertyValue(`--lumo-body-text-color`)||`#1a1a1a`;let[r,i]=this.pointerPosition(e);n.beginPath(),n.moveTo(r,i),e.preventDefault()},this.stroke=e=>{if(!this.drawing)return;let t=e.target.getContext(`2d`),[n,r]=this.pointerPosition(e);t.lineTo(n,r),t.stroke(),this.hasStrokes=!0,e.preventDefault()},this.endStroke=e=>{this.drawing=!1,e.target.releasePointerCapture(e.pointerId)}}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}canvas(){return this.renderRoot.querySelector(`canvas`)}pointerPosition(e){let t=e.target.getBoundingClientRect();return[e.clientX-t.left,e.clientY-t.top]}ensureCanvasSize(e){let t=e.getBoundingClientRect();(e.width!==Math.round(t.width)||e.height!==Math.round(t.height))&&(e.width=Math.round(t.width),e.height=Math.round(t.height))}clear(){let e=this.canvas();e&&e.getContext(`2d`).clearRect(0,0,e.width,e.height),this.hasStrokes=!1}accept(){let e=this.canvas();!e||!this.hasStrokes||(this.signing=!1,this.emit(e.toDataURL(`image/png`)))}renderPad(){return w`
             <canvas class="pad"
                     @pointerdown="${this.startStroke}"
                     @pointermove="${this.stroke}"
@@ -8509,14 +8509,14 @@ ${i}
                 <button class="button" @click="${this.clear}">Clear</button>
                 <button class="button button--primary" ?disabled="${!this.hasStrokes}"
                         @click="${this.accept}">Accept</button>
-                ${this.value?T`
-                    <button class="button" @click="${()=>{this.signing=!1}}">Cancel</button>`:v}
-            </div>`}render(){let e=this.value!=null&&this.value!==``;return this.signing||!e?this.renderPad():T`
+                ${this.value?w`
+                    <button class="button" @click="${()=>{this.signing=!1}}">Cancel</button>`:_}
+            </div>`}render(){let e=this.value!=null&&this.value!==``;return this.signing||!e?this.renderPad():w`
             <img class="preview" src="${this.value}" alt="Signature"/>
             <div class="actions">
                 <button class="button" @click="${()=>{this.signing=!0,this.hasStrokes=!1,this.updateComplete.then(()=>this.clear())}}">Sign again</button>
                 <button class="button button--danger" @click="${()=>this.emit(``)}">Delete</button>
-            </div>`}static{this.styles=h`
+            </div>`}static{this.styles=m`
         :host {
             display: block;
             max-width: 420px;
@@ -8566,19 +8566,19 @@ ${i}
         .button--danger {
             color: var(--lumo-error-text-color, rgb(179, 49, 31));
         }
-    `}};k([y()],sc.prototype,`fieldId`,void 0),k([y()],sc.prototype,`value`,void 0),k([C()],sc.prototype,`signing`,void 0),k([C()],sc.prototype,`hasStrokes`,void 0),sc=k([g(`mateu-signature-pad`)],sc);var cc=class extends b{constructor(...e){super(...e),this.fieldId=``,this.options=[],this.leavesOnly=!1,this.opened=!1,this.expandedItems=[],this._normalized=[],this.dataProvider=(e,t)=>{let n=e.parentItem?e.parentItem.children??[]:this.normalized;t(n,n.length)}}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}get normalized(){return this._optsSource!==this.options&&(this._optsSource=this.options,this._normalized=this.normalizeOptions(this.options??[])),this._normalized}normalizeOptions(e){return e.map(e=>{let t=e.children&&e.children.length?this.normalizeOptions(e.children):void 0;return{...e,children:t}})}ancestorsOf(e,t){for(let n of t){if(String(n.value)===e)return[];let t=n.children?this.ancestorsOf(e,n.children):null;if(t!=null)return[n,...t]}return null}labelOf(e,t){for(let n of t){if(String(n.value)===e)return n.label;let t=n.children?this.labelOf(e,n.children):null;if(t!=null)return t}return null}open(){this.opened||(this.expandedItems=this.value==null?[]:this.ancestorsOf(String(this.value),this.normalized)??[],this.opened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.close()},document.addEventListener(`mousedown`,this.outsideClick))}close(){this.detachOutsideClick(),this.opened=!1}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}pick(e){this.close(),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e.value,fieldId:this.fieldId},bubbles:!0,composed:!0}))}clear(){this.close(),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:void 0,fieldId:this.fieldId},bubbles:!0,composed:!0}))}onActiveItemChanged(e){let t=e.detail.value;if(t){if((t.children?.length??0)>0&&this.leavesOnly){this.expandedItems=this.expandedItems.includes(t)?this.expandedItems.filter(e=>e!==t):[...this.expandedItems,t],e.target.activeItem=null;return}this.pick(t)}}render(){let e=this.value!=null&&this.value!==``?this.labelOf(String(this.value),this.normalized)??String(this.value):``;return T`
+    `}};O([v()],Cc.prototype,`fieldId`,void 0),O([v()],Cc.prototype,`value`,void 0),O([S()],Cc.prototype,`signing`,void 0),O([S()],Cc.prototype,`hasStrokes`,void 0),Cc=O([h(`mateu-signature-pad`)],Cc);var wc=class extends y{constructor(...e){super(...e),this.fieldId=``,this.options=[],this.leavesOnly=!1,this.opened=!1,this.expandedItems=[],this._normalized=[],this.dataProvider=(e,t)=>{let n=e.parentItem?e.parentItem.children??[]:this.normalized;t(n,n.length)}}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}get normalized(){return this._optsSource!==this.options&&(this._optsSource=this.options,this._normalized=this.normalizeOptions(this.options??[])),this._normalized}normalizeOptions(e){return e.map(e=>{let t=e.children&&e.children.length?this.normalizeOptions(e.children):void 0;return{...e,children:t}})}ancestorsOf(e,t){for(let n of t){if(String(n.value)===e)return[];let t=n.children?this.ancestorsOf(e,n.children):null;if(t!=null)return[n,...t]}return null}labelOf(e,t){for(let n of t){if(String(n.value)===e)return n.label;let t=n.children?this.labelOf(e,n.children):null;if(t!=null)return t}return null}open(){this.opened||(this.expandedItems=this.value==null?[]:this.ancestorsOf(String(this.value),this.normalized)??[],this.opened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.close()},document.addEventListener(`mousedown`,this.outsideClick))}close(){this.detachOutsideClick(),this.opened=!1}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}pick(e){this.close(),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e.value,fieldId:this.fieldId},bubbles:!0,composed:!0}))}clear(){this.close(),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:void 0,fieldId:this.fieldId},bubbles:!0,composed:!0}))}onActiveItemChanged(e){let t=e.detail.value;if(t){if((t.children?.length??0)>0&&this.leavesOnly){this.expandedItems=this.expandedItems.includes(t)?this.expandedItems.filter(e=>e!==t):[...this.expandedItems,t],e.target.activeItem=null;return}this.pick(t)}}render(){let e=this.value!=null&&this.value!==``?this.labelOf(String(this.value),this.normalized)??String(this.value):``;return w`
             <div class="root">
                 <vaadin-button class="control" theme="tertiary"
                                @click="${()=>this.opened?this.close():this.open()}">
                     <span class="${e?``:`placeholder`}">${e||`—`}</span>
                     <span class="chevron" slot="suffix" aria-hidden="true">▾</span>
                 </vaadin-button>
-                ${this.opened?T`
+                ${this.opened?w`
                     <div class="panel">
-                        ${this.value?T`
+                        ${this.value?w`
                             <div class="clear-row">
                                 <vaadin-button theme="tertiary small" @click="${this.clear}">— Clear</vaadin-button>
-                            </div>`:v}
+                            </div>`:_}
                         <vaadin-grid
                                 theme="compact no-border no-row-borders"
                                 all-rows-visible
@@ -8589,8 +8589,8 @@ ${i}
                                 @active-item-changed="${this.onActiveItemChanged}">
                             <vaadin-grid-tree-column path="label"></vaadin-grid-tree-column>
                         </vaadin-grid>
-                    </div>`:v}
-            </div>`}static{this.styles=h`
+                    </div>`:_}
+            </div>`}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -8637,29 +8637,29 @@ ${i}
             min-width: 16rem;
             max-height: 18rem;
         }
-    `}};k([y()],cc.prototype,`fieldId`,void 0),k([y()],cc.prototype,`value`,void 0),k([y()],cc.prototype,`options`,void 0),k([y({type:Boolean})],cc.prototype,`leavesOnly`,void 0),k([C()],cc.prototype,`opened`,void 0),k([C()],cc.prototype,`expandedItems`,void 0),cc=k([g(`mateu-vaadin-tree-select`)],cc);var lc=class extends b{constructor(...e){super(...e),this.fieldId=``,this.cameraOpen=!1,this.cameraError=!1,this.fileFallback=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>this.emit(r.result),r.readAsDataURL(n),t.value=``}}disconnectedCallback(){super.disconnectedCallback(),this.stopStream()}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}stopStream(){this.stream?.getTracks().forEach(e=>e.stop()),this.stream=void 0}async openCamera(){this.cameraError=!1;try{this.stream=await navigator.mediaDevices.getUserMedia({video:{facingMode:`environment`},audio:!1}),this.cameraOpen=!0,await this.updateComplete;let e=this.renderRoot.querySelector(`video`);e&&(e.srcObject=this.stream,await e.play())}catch{this.stopStream(),this.cameraOpen=!1,this.cameraError=!0}}closeCamera(){this.stopStream(),this.cameraOpen=!1}shoot(){let e=this.renderRoot.querySelector(`video`);if(!e||e.videoWidth===0)return;let t=document.createElement(`canvas`);t.width=e.videoWidth,t.height=e.videoHeight,t.getContext(`2d`).drawImage(e,0,0),this.closeCamera(),this.emit(t.toDataURL(`image/jpeg`,.9))}triggerFallback(){this.renderRoot.querySelector(`input[type=file]`)?.click()}render(){let e=this.value!=null&&this.value!==``;return T`
+    `}};O([v()],wc.prototype,`fieldId`,void 0),O([v()],wc.prototype,`value`,void 0),O([v()],wc.prototype,`options`,void 0),O([v({type:Boolean})],wc.prototype,`leavesOnly`,void 0),O([S()],wc.prototype,`opened`,void 0),O([S()],wc.prototype,`expandedItems`,void 0),wc=O([h(`mateu-vaadin-tree-select`)],wc);var Tc=class extends y{constructor(...e){super(...e),this.fieldId=``,this.cameraOpen=!1,this.cameraError=!1,this.fileFallback=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>this.emit(r.result),r.readAsDataURL(n),t.value=``}}disconnectedCallback(){super.disconnectedCallback(),this.stopStream()}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}stopStream(){this.stream?.getTracks().forEach(e=>e.stop()),this.stream=void 0}async openCamera(){this.cameraError=!1;try{this.stream=await navigator.mediaDevices.getUserMedia({video:{facingMode:`environment`},audio:!1}),this.cameraOpen=!0,await this.updateComplete;let e=this.renderRoot.querySelector(`video`);e&&(e.srcObject=this.stream,await e.play())}catch{this.stopStream(),this.cameraOpen=!1,this.cameraError=!0}}closeCamera(){this.stopStream(),this.cameraOpen=!1}shoot(){let e=this.renderRoot.querySelector(`video`);if(!e||e.videoWidth===0)return;let t=document.createElement(`canvas`);t.width=e.videoWidth,t.height=e.videoHeight,t.getContext(`2d`).drawImage(e,0,0),this.closeCamera(),this.emit(t.toDataURL(`image/jpeg`,.9))}triggerFallback(){this.renderRoot.querySelector(`input[type=file]`)?.click()}render(){let e=this.value!=null&&this.value!==``;return w`
             <input type="file" accept="image/*" capture="environment" style="display: none;"
                    @change="${this.fileFallback}">
-            ${this.cameraOpen?T`
+            ${this.cameraOpen?w`
                 <video class="viewfinder" playsinline muted></video>
                 <div class="actions">
                     <button class="button button--primary" @click="${this.shoot}">Capture</button>
                     <button class="button" @click="${this.closeCamera}">Cancel</button>
                 </div>
-            `:T`
-                ${e?T`<img class="preview" src="${this.value}" alt="Photo"/>`:T`<div class="placeholder" aria-hidden="true">📷</div>`}
+            `:w`
+                ${e?w`<img class="preview" src="${this.value}" alt="Photo"/>`:w`<div class="placeholder" aria-hidden="true">📷</div>`}
                 <div class="actions">
                     <button class="button button--primary" @click="${this.openCamera}">
                         ${e?`Retake`:`Take photo`}
                     </button>
-                    ${this.cameraError?T`
-                        <button class="button" @click="${this.triggerFallback}">Use file / native camera</button>`:v}
-                    ${e?T`
-                        <button class="button button--danger" @click="${()=>this.emit(``)}">Delete</button>`:v}
+                    ${this.cameraError?w`
+                        <button class="button" @click="${this.triggerFallback}">Use file / native camera</button>`:_}
+                    ${e?w`
+                        <button class="button button--danger" @click="${()=>this.emit(``)}">Delete</button>`:_}
                 </div>
-                ${this.cameraError?T`
-                    <div class="error-hint">Camera unavailable — the file picker opens the device camera on phones.</div>`:v}
-            `}`}static{this.styles=h`
+                ${this.cameraError?w`
+                    <div class="error-hint">Camera unavailable — the file picker opens the device camera on phones.</div>`:_}
+            `}`}static{this.styles=m`
         :host {
             display: block;
             max-width: 420px;
@@ -8715,17 +8715,17 @@ ${i}
             font-size: var(--lumo-font-size-xs, 0.75rem);
             color: var(--lumo-secondary-text-color, rgba(0, 0, 0, 0.6));
         }
-    `}};k([y()],lc.prototype,`fieldId`,void 0),k([y()],lc.prototype,`value`,void 0),k([C()],lc.prototype,`cameraOpen`,void 0),k([C()],lc.prototype,`cameraError`,void 0),lc=k([g(`mateu-camera-capture`)],lc);var uc,dc=(e,t)=>{if(!e)return;if(Array.isArray(e)){let n=e.find(e=>e.key==t);return n?.value==null?void 0:String(n.value)}let n=e[t];return n==null?void 0:String(n)},fc=class extends b{static{uc=this}constructor(...e){super(...e),this.fieldId=``,this.editable=!0,this.filePicked=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>{let e=r.result,t=e.indexOf(`,`),i=e.substring(0,t).replace(`;base64`,`;name=${encodeURIComponent(n.name)};base64`);this.emit(i+e.substring(t))},r.readAsDataURL(n),t.value=``}}static fileName(e){if(!e)return``;if(e.startsWith(`data:`)){let t=e.indexOf(`,`),n=e.substring(5,t<0?e.length:t).split(`;`).find(e=>e.startsWith(`name=`));if(n)try{return decodeURIComponent(n.substring(5))}catch{return n.substring(5)}return`Attached file`}return e.split(`/`).pop()||e}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}triggerPick(){this.renderRoot.querySelector(`input[type=file]`)?.click()}render(){let e=this.value!=null&&this.value!==``,t=uc.fileName(this.value),n=e&&this.value.startsWith(`data:`),r=e?T`<span class="file" title="${t}">📄 ${n?T`<a href="${this.value}" download="${t}">${t}</a>`:T`<a href="${this.value}" target="_blank">${t}</a>`}</span>`:v;return this.editable?T`
-            <input type="file" accept="${this.accept||v}" style="display: none;"
+    `}};O([v()],Tc.prototype,`fieldId`,void 0),O([v()],Tc.prototype,`value`,void 0),O([S()],Tc.prototype,`cameraOpen`,void 0),O([S()],Tc.prototype,`cameraError`,void 0),Tc=O([h(`mateu-camera-capture`)],Tc);var Ec,Dc=(e,t)=>{if(!e)return;if(Array.isArray(e)){let n=e.find(e=>e.key==t);return n?.value==null?void 0:String(n.value)}let n=e[t];return n==null?void 0:String(n)},Oc=class extends y{static{Ec=this}constructor(...e){super(...e),this.fieldId=``,this.editable=!0,this.filePicked=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>{let e=r.result,t=e.indexOf(`,`),i=e.substring(0,t).replace(`;base64`,`;name=${encodeURIComponent(n.name)};base64`);this.emit(i+e.substring(t))},r.readAsDataURL(n),t.value=``}}static fileName(e){if(!e)return``;if(e.startsWith(`data:`)){let t=e.indexOf(`,`),n=e.substring(5,t<0?e.length:t).split(`;`).find(e=>e.startsWith(`name=`));if(n)try{return decodeURIComponent(n.substring(5))}catch{return n.substring(5)}return`Attached file`}return e.split(`/`).pop()||e}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}triggerPick(){this.renderRoot.querySelector(`input[type=file]`)?.click()}render(){let e=this.value!=null&&this.value!==``,t=Ec.fileName(this.value),n=e&&this.value.startsWith(`data:`),r=e?w`<span class="file" title="${t}">📄 ${n?w`<a href="${this.value}" download="${t}">${t}</a>`:w`<a href="${this.value}" target="_blank">${t}</a>`}</span>`:_;return this.editable?w`
+            <input type="file" accept="${this.accept||_}" style="display: none;"
                    @change="${this.filePicked}">
             <div class="row">
                 ${r}
                 <button class="button" @click="${this.triggerPick}">
                     ${e?`Replace`:`Choose file`}
                 </button>
-                ${e?T`
-                    <button class="button button--danger" @click="${()=>this.emit(``)}">Remove</button>`:v}
-            </div>`:T`${e?r:T`<span class="empty">—</span>`}`}static{this.styles=h`
+                ${e?w`
+                    <button class="button button--danger" @click="${()=>this.emit(``)}">Remove</button>`:_}
+            </div>`:w`${e?r:w`<span class="empty">—</span>`}`}static{this.styles=m`
         :host {
             display: block;
         }
@@ -8763,114 +8763,114 @@ ${i}
         .button--danger {
             color: var(--lumo-error-text-color, rgb(179, 49, 31));
         }
-    `}};k([y()],fc.prototype,`fieldId`,void 0),k([y()],fc.prototype,`value`,void 0),k([y()],fc.prototype,`accept`,void 0),k([y({type:Boolean})],fc.prototype,`editable`,void 0),fc=uc=k([g(`mateu-file-upload`)],fc);var pc=e=>!!e&&typeof e==`object`&&`__mateuGroup`in e,mc=e=>String(e??``),hc=(e,t,n)=>{let r=e??[];if(!t||!n||n.length===0)return r;let i=[],a,o=!1;return r.forEach((e,s)=>{let c=mc(e?.[t]);if(!o||c!==a){let e=n.find(e=>mc(e.value)===c)??{value:c,count:r.filter(e=>mc(e?.[t])===c).length,aggregates:{}};i.push({__mateuGroup:e,__mateuGroupBy:t,_rowNumber:`__mateuGroup:${s}:${c}`}),o=!0,a=c}i.push(e)}),i},gc=(e,t)=>e==null?``:t.dataType===`money`||t.stereotype===`money`?new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e):t.aggregate===`count`?new Intl.NumberFormat(void 0,{maximumFractionDigits:0}).format(Math.round(e)):new Intl.NumberFormat(void 0,{maximumFractionDigits:2}).format(e),_c=(e,t)=>e&&t.includes(e)?e:t.find(e=>!!e),vc=(e,t,n)=>{let r=e.__mateuGroup;return t.id===n?`${r.value} (${r.count})`:t.aggregate?gc(r.aggregates?.[t.id],t):``},yc=(e,t,n)=>{let r=t?.aggregates;if(!r||!e.some(e=>e.aggregate))return;let i={};e.forEach(e=>{e.aggregate&&r[e.id]!=null&&(i[e.id]=gc(r[e.id],e))});let a=e[0];if(a&&i[a.id]===void 0){let e=t?.page?.totalElements;i[a.id]=n&&a.id===n&&e!=null?`Total (${e})`:`Total`}return i},bc=(e,t,n)=>I(e[n.path]?`vaadin:check`:`vaadin:minus`,`height: 16px; width: 16px; color: var(--lumo-body-text-color);`),xc=(e,t,n,r,i)=>{let a=e[n.path],o=a;return r==`money`&&a&&a.locale&&a.currency?o=new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(a.value):i==`money`&&(o=new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(a)),T`${o}`},Sc=(e,t,n)=>{e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:n},bubbles:!0,composed:!0}))},Cc=(e,t,n,r,i,a)=>{let o=n.xcolumn??a;if(o.text)return o.actionId?T`<a href="javascript: void(0);" @click="${t=>Sc(n,o,e)}">${o.text}</a>`:T`<a href="${e[n.path]}">${o.text}</a>`;if(r==`string`){if(o.actionId)return T`<a href="javascript: void(0);" @click="${t=>Sc(n,o,e)}">${e[n.path]}</a>`;let t=e[n.path];return T`<a href="${t}">${t}</a>`}let s=e[n.path];return T`<a href="${s.href}">${s.text}</a>`},wc=(e,t,n,r,i)=>{let a=e[n.path];return r==`string`?a.split(`,`).map(e=>I(e,`width: 16px;`)):a.split(`,`).map(e=>I(e.icon,`width: 16px;`))},Tc=(e,t,n,r,i)=>{let a=e[n.path];return T`${_(a)}`},Ec=(e,t,n,r,i,a)=>r==`string`?T`<img src="${e[n.path]}" style="${`max-height: 40px; `+(a.style??``)}">`:T`<img src="${e[n.path].src}" style="${a.style??``}">`,Dc=e=>{let t={_clickedRow:e.target.row};e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+e.detail.value.methodNameInCrud,parameters:t},bubbles:!0,composed:!0}))},Oc=e=>{let t={_clickedRow:e.target.row},n=e.target.action;e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+n.methodNameInCrud,parameters:t},bubbles:!0,composed:!0}))},kc=e=>{let t=document.createElement(`vaadin-context-menu-item`),n=document.createElement(`vaadin-icon`);return n.style.color=`var(--lumo-secondary-text-color)`,n.style.marginInlineEnd=`var(--lumo-space-s)`,n.style.padding=`var(--lumo-space-xs)`,n.setAttribute(`icon`,e.icon),t.appendChild(n),e.label&&t.appendChild(document.createTextNode(e.label)),t.disabled=e.disabled,t},Ac=(e,t,n)=>{let r=e[n.path]?.actions?.map(e=>e.icon?{component:kc(e),methodNameInCrud:e.methodNameInCrud}:{...e,text:e.label});return!r||r.length==0?T``:T`
+    `}};O([v()],Oc.prototype,`fieldId`,void 0),O([v()],Oc.prototype,`value`,void 0),O([v()],Oc.prototype,`accept`,void 0),O([v({type:Boolean})],Oc.prototype,`editable`,void 0),Oc=Ec=O([h(`mateu-file-upload`)],Oc);function kc(e,t){return t?t.split(`.`).reduce((e,t)=>typeof e==`object`&&e?e[t]:void 0,e):e}function Ac(e,t,n=`value`,r=`label`){let i=kc(e,t);return Array.isArray(i)?i.map(e=>{if(typeof e==`object`&&e){let t=kc(e,n),i=kc(e,r);return{value:t??i,label:String(i??t??``)}}return{value:e,label:String(e)}}):[]}async function jc(e,t=e=>e,n=fetch){let r=t(e.url)??e.url,i=(e.method||`GET`).toUpperCase(),a={};for(let[n,r]of Object.entries(e.headers??{}))a[n]=t(r)??r;let o={method:i,headers:a};i!==`GET`&&i!==`HEAD`&&e.body&&(o.body=t(e.body)??e.body);let s=await n(r,o);if(!s.ok)throw Error(`External options fetch failed: ${s.status}`);return Ac(await s.json(),e.itemsPath,e.valuePath,e.labelPath)}var Mc=e=>!!e&&typeof e==`object`&&`__mateuGroup`in e,Nc=e=>String(e??``),Pc=(e,t,n)=>{let r=e??[];if(!t||!n||n.length===0)return r;let i=[],a,o=!1;return r.forEach((e,s)=>{let c=Nc(e?.[t]);if(!o||c!==a){let e=n.find(e=>Nc(e.value)===c)??{value:c,count:r.filter(e=>Nc(e?.[t])===c).length,aggregates:{}};i.push({__mateuGroup:e,__mateuGroupBy:t,_rowNumber:`__mateuGroup:${s}:${c}`}),o=!0,a=c}i.push(e)}),i},Fc=(e,t)=>e==null?``:t.dataType===`money`||t.stereotype===`money`?new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e):t.aggregate===`count`?new Intl.NumberFormat(void 0,{maximumFractionDigits:0}).format(Math.round(e)):new Intl.NumberFormat(void 0,{maximumFractionDigits:2}).format(e),Ic=(e,t)=>e&&t.includes(e)?e:t.find(e=>!!e),Lc=(e,t,n)=>{let r=e.__mateuGroup;return t.id===n?`${r.value} (${r.count})`:t.aggregate?Fc(r.aggregates?.[t.id],t):``},Rc=(e,t,n)=>{let r=t?.aggregates;if(!r||!e.some(e=>e.aggregate))return;let i={};e.forEach(e=>{e.aggregate&&r[e.id]!=null&&(i[e.id]=Fc(r[e.id],e))});let a=e[0];if(a&&i[a.id]===void 0){let e=t?.page?.totalElements;i[a.id]=n&&a.id===n&&e!=null?`Total (${e})`:`Total`}return i},zc=(e,t,n)=>F(e[n.path]?`vaadin:check`:`vaadin:minus`,`height: 16px; width: 16px; color: var(--lumo-body-text-color);`),Bc=(e,t,n,r,i)=>{let a=e[n.path],o=a;return r==`money`&&a&&a.locale&&a.currency?o=new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(a.value):i==`money`&&(o=new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(a)),w`${o}`},Vc=(e,t,n)=>{e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:n},bubbles:!0,composed:!0}))},Hc=(e,t,n,r,i,a)=>{let o=n.xcolumn??a;if(o.text)return o.actionId?w`<a href="javascript: void(0);" @click="${t=>Vc(n,o,e)}">${o.text}</a>`:w`<a href="${e[n.path]}">${o.text}</a>`;if(r==`string`){if(o.actionId)return w`<a href="javascript: void(0);" @click="${t=>Vc(n,o,e)}">${e[n.path]}</a>`;let t=e[n.path];return w`<a href="${t}">${t}</a>`}let s=e[n.path];return w`<a href="${s.href}">${s.text}</a>`},Uc=(e,t,n,r,i)=>{let a=e[n.path];return r==`string`?a.split(`,`).map(e=>F(e,`width: 16px;`)):a.split(`,`).map(e=>F(e.icon,`width: 16px;`))},Wc=(e,t,n,r,i)=>{let a=e[n.path];return w`${g(a)}`},Gc=(e,t,n,r,i,a)=>r==`string`?w`<img src="${e[n.path]}" style="${`max-height: 40px; `+(a.style??``)}">`:w`<img src="${e[n.path].src}" style="${a.style??``}">`,Kc=e=>{let t={_clickedRow:e.target.row};e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+e.detail.value.methodNameInCrud,parameters:t},bubbles:!0,composed:!0}))},qc=e=>{let t={_clickedRow:e.target.row},n=e.target.action;e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+n.methodNameInCrud,parameters:t},bubbles:!0,composed:!0}))},Jc=e=>{let t=document.createElement(`vaadin-context-menu-item`),n=document.createElement(`vaadin-icon`);return n.style.color=`var(--lumo-secondary-text-color)`,n.style.marginInlineEnd=`var(--lumo-space-s)`,n.style.padding=`var(--lumo-space-xs)`,n.setAttribute(`icon`,e.icon),t.appendChild(n),e.label&&t.appendChild(document.createTextNode(e.label)),t.disabled=e.disabled,t},Yc=(e,t,n)=>{let r=e[n.path]?.actions?.map(e=>e.icon?{component:Jc(e),methodNameInCrud:e.methodNameInCrud}:{...e,text:e.label});return!r||r.length==0?w``:w`
                                      <vaadin-menu-bar
                                          .items=${[{text:`···`,children:r}]}
                                          theme="tertiary"
                                          .row="${e}"
                                          data-testid="menubar-${n.path}"
-                                         @item-selected="${Dc}"
+                                         @item-selected="${Kc}"
                                      ></vaadin-menu-bar>
-                                   `},jc=(e,t,n)=>{if(n.path==`select`)return T`
-         <vaadin-button theme="tertiary" title="Select" @click="${Oc}" .row="${e}" .action="${{actionId:n.path,icon:``,label:`Select`,disabled:!1,methodNameInCrud:`select`}}">
+                                   `},Xc=(e,t,n)=>{if(n.path==`select`)return w`
+         <vaadin-button theme="tertiary" title="Select" @click="${qc}" .row="${e}" .action="${{actionId:n.path,icon:``,label:`Select`,disabled:!1,methodNameInCrud:`select`}}">
              Select
          </vaadin-button>
-    `;let r=n.path&&e[n.path]?.methodNameInCrud?e[n.path]:e.action;return r?T`
-         <vaadin-button theme="tertiary${r.icon&&!r.label?` icon`:``}" title="${r.label||v}" @click="${Oc}" .row="${e}" .action="${r}">
-             ${r.icon?T`<vaadin-icon icon="${r.icon}"></vaadin-icon>`:v}
-             ${r.label?r.label:v}
+    `;let r=n.path&&e[n.path]?.methodNameInCrud?e[n.path]:e.action;return r?w`
+         <vaadin-button theme="tertiary${r.icon&&!r.label?` icon`:``}" title="${r.label||_}" @click="${qc}" .row="${e}" .action="${r}">
+             ${r.icon?w`<vaadin-icon icon="${r.icon}"></vaadin-icon>`:_}
+             ${r.label?r.label:_}
          </vaadin-button>
-    `:T``},Mc=(e,t,n)=>{e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:n},bubbles:!0,composed:!0}))},Nc=(e,t,n,r,i,a)=>{let o=n.xcolumn??a;if(o.actionId)return T`
-            <vaadin-button theme="tertiary" @click="${t=>Mc(n,o,e)}" .row="${e}">
+    `:w``},Zc=(e,t,n)=>{e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:n},bubbles:!0,composed:!0}))},Qc=(e,t,n,r,i,a)=>{let o=n.xcolumn??a;if(o.actionId)return w`
+            <vaadin-button theme="tertiary" @click="${t=>Zc(n,o,e)}" .row="${e}">
                 ${o.text||e[n.path]}
             </vaadin-button>
-        `;let s=e[n.path];return T`<a href="${s}">${o.text||s}</a>`},Pc=(e,t,n,r,i,a,o,s,c)=>{let l=e[n.path];return F(r,l,i,a,o,s,c)},Fc=new WeakMap,Ic=(e,t)=>Fc.get(e)?.[t],Lc=(e,t,n)=>{let r=Fc.get(e);r||(r={},Fc.set(e,r)),r[t]=n},Rc=e=>{if(e==null||e===``)return null;let t=Number(e);return Number.isNaN(t)?null:t},zc=(e,t,n,r)=>{let i=n?.field?.fieldId,a=a=>{if(e[t.id]===a||e[t.id]==null&&(a===``||a==null))return;if(e[t.id]=a,!i){n.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`update-row`,parameters:{_editedRow:{...e}}},bubbles:!0,composed:!0}));return}let o=(n?.state??r)[i];n.dispatchEvent(new CustomEvent(`value-changed`,{detail:{fieldId:i,value:Array.isArray(o)?[...o]:o},bubbles:!0,composed:!0}))},o=e[t.id],s=o==null?``:String(o);switch(t.editorType){case`boolean`:return T`<vaadin-checkbox ?checked=${!!o} @checked-changed=${e=>a(e.detail.value)}></vaadin-checkbox>`;case`integer`:return T`<vaadin-integer-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(Rc(e.target.value))}></vaadin-integer-field>`;case`number`:return T`<vaadin-number-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(Rc(e.target.value))}></vaadin-number-field>`;case`date`:return T`<vaadin-date-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-date-picker>`;case`time`:return T`<vaadin-time-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-time-picker>`;case`datetime`:return T`<vaadin-date-time-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-date-time-picker>`;case`select`:return T`<vaadin-combo-box
+        `;let s=e[n.path];return w`<a href="${s}">${o.text||s}</a>`},$c=(e,t,n,r,i,a,o,s,c)=>{let l=e[n.path];return P(r,l,i,a,o,s,c)},el=new WeakMap,tl=(e,t)=>el.get(e)?.[t],nl=(e,t,n)=>{let r=el.get(e);r||(r={},el.set(e,r)),r[t]=n},rl=e=>{if(e==null||e===``)return null;let t=Number(e);return Number.isNaN(t)?null:t},il=(e,t,n,r)=>{let i=n?.field?.fieldId,a=a=>{if(e[t.id]===a||e[t.id]==null&&(a===``||a==null))return;if(e[t.id]=a,!i){n.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`update-row`,parameters:{_editedRow:{...e}}},bubbles:!0,composed:!0}));return}let o=(n?.state??r)[i];n.dispatchEvent(new CustomEvent(`value-changed`,{detail:{fieldId:i,value:Array.isArray(o)?[...o]:o},bubbles:!0,composed:!0}))},o=e[t.id],s=o==null?``:String(o);switch(t.editorType){case`boolean`:return w`<vaadin-checkbox ?checked=${!!o} @checked-changed=${e=>a(e.detail.value)}></vaadin-checkbox>`;case`integer`:return w`<vaadin-integer-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(rl(e.target.value))}></vaadin-integer-field>`;case`number`:return w`<vaadin-number-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(rl(e.target.value))}></vaadin-number-field>`;case`date`:return w`<vaadin-date-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-date-picker>`;case`time`:return w`<vaadin-time-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-time-picker>`;case`datetime`:return w`<vaadin-date-time-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-date-time-picker>`;case`select`:return w`<vaadin-combo-box
                 theme="small" style="width:100%;"
                 .items=${(t.editorOptions??[]).map(e=>({label:e.label,value:String(e.value)}))}
                 item-label-path="label" item-value-path="value"
                 .value=${s}
-                @value-changed=${e=>a(e.detail.value)}></vaadin-combo-box>`;case`lookup`:{let r=n?.field?.fieldId,i=`search-${r}-${t.id}`,o=`${r}-${t.id}`;return T`<vaadin-combo-box
+                @value-changed=${e=>a(e.detail.value)}></vaadin-combo-box>`;case`lookup`:{let r=n?.field?.fieldId,i=`search-${r}-${t.id}`,o=`${r}-${t.id}`;return w`<vaadin-combo-box
                 theme="small" style="width:100%;"
                 item-label-path="label" item-id-path="value"
                 .dataProvider=${(e,t)=>{n.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:i,parameters:{searchText:e.filter,size:e.pageSize,page:e.page},callback:e=>{let n=e?.fragments?.[0]?.data?.[o];t(n?.content??[],n?.totalElements??0)},callbackonly:!0},bubbles:!0,composed:!0}))}}
-                .selectedItem=${(t.editorOptions??[]).find(e=>String(e.value)===s)??(s?{value:s,label:Ic(e,t.id)??s}:void 0)}
-                @selected-item-changed=${n=>{let r=n.detail.value,i=r?r.value:null;String(i??``)!==s&&(r&&Lc(e,t.id,r.label),a(i))}}></vaadin-combo-box>`}default:return T`<vaadin-text-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(e.target.value)}></vaadin-text-field>`}},Bc=e=>m(()=>T`<span title="${e}" style="white-space:normal;overflow-wrap:break-word;">${e}</span>`,[e]),Vc=e=>e===void 0?v:d(()=>T`<span style="font-weight: 600; white-space: nowrap;">${e}</span>`,[e]),Hc=e=>{e.preventDefault(),e.stopPropagation(),e.currentTarget?.dispatchEvent(new CustomEvent(`sort-direction-changed`,{detail:{grid:e.currentTarget.parentElement},bubbles:!0,composed:!0}))},Uc=(e,t,n,r,i,a,o,s)=>T`
-<vaadin-grid-column-group header="${M(e.label,r,i)}">
-    ${e.columns.map(e=>Gc(e.metadata,t,n,r,i,a,o,s?.[e.metadata?.id]))}
+                .selectedItem=${(t.editorOptions??[]).find(e=>String(e.value)===s)??(s?{value:s,label:tl(e,t.id)??s}:void 0)}
+                @selected-item-changed=${n=>{let r=n.detail.value,i=r?r.value:null;String(i??``)!==s&&(r&&nl(e,t.id,r.label),a(i))}}></vaadin-combo-box>`}default:return w`<vaadin-text-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(e.target.value)}></vaadin-text-field>`}},al=e=>ee(()=>w`<span title="${e}" style="white-space:normal;overflow-wrap:break-word;">${e}</span>`,[e]),ol=e=>e===void 0?_:d(()=>w`<span style="font-weight: 600; white-space: nowrap;">${e}</span>`,[e]),sl=e=>{e.preventDefault(),e.stopPropagation(),e.currentTarget?.dispatchEvent(new CustomEvent(`sort-direction-changed`,{detail:{grid:e.currentTarget.parentElement},bubbles:!0,composed:!0}))},cl=(e,t,n,r,i,a,o,s)=>w`
+<vaadin-grid-column-group header="${j(e.label,r,i)}">
+    ${e.columns.map(e=>ul(e.metadata,t,n,r,i,a,o,s?.[e.metadata?.id]))}
 </vaadin-grid-column-group>
-`,Wc=(e,t,n,r,i,a,o,s)=>j.GridGroupColumn==e.metadata?.type?Uc(e.metadata,t,n,r,i,a,o,s):Gc(e.metadata,t,n,r,i,a,o,s?.[e.metadata?.id]),Gc=(e,n,r,i,a,o,s,c)=>{let l=M(e.label,i,a);return e.sortable?T`
+`,ll=(e,t,n,r,i,a,o,s)=>A.GridGroupColumn==e.metadata?.type?cl(e.metadata,t,n,r,i,a,o,s):ul(e.metadata,t,n,r,i,a,o,s?.[e.metadata?.id]),ul=(e,n,r,i,a,o,s,c)=>{let l=j(e.label,i,a);return e.sortable?w`
                         <vaadin-grid-sort-column
                                 path="${e.id}"
-                                text-align="${e.align??v}"
+                                text-align="${e.align??_}"
                                 ?frozen="${e.frozen}"
                                 ?frozen-to-end="${e.frozenToEnd}"
                                 ?auto-width="${e.autoWidth}"
-                                flex-grow="${e.flexGrow??v}"
+                                flex-grow="${e.flexGrow??_}"
                                 ?resizable="${e.resizable}"
-                                width="${e.width??v}"
-                                @direction-changed="${Hc}"
+                                width="${e.width??_}"
+                                @direction-changed="${sl}"
                                 data-data-type="${e.dataType}"
                                 data-stereotype="${e.stereotype}"
-                                ${Bc(l)}
-                                ${Vc(c)}
-                                ${t((t,c,l)=>Kc(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
+                                ${al(l)}
+                                ${ol(c)}
+                                ${t((t,c,l)=>dl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
                         ></vaadin-grid-sort-column>
-                    `:e.filterable?T`
+                    `:e.filterable?w`
                         <vaadin-grid-filter-column
                                 path="${e.id}"
-                                text-align="${e.align??v}"
+                                text-align="${e.align??_}"
                                 ?frozen="${e.frozen}"
                                 ?frozen-to-end="${e.frozenToEnd}"
                                 ?auto-width="${e.autoWidth}"
-                                flex-grow="${e.flexGrow??v}"
+                                flex-grow="${e.flexGrow??_}"
                                 ?resizable="${e.resizable}"
-                                width="${e.width??v}"
+                                width="${e.width??_}"
                                 data-data-type="${e.dataType}"
                                 data-stereotype="${e.stereotype}"
-                                ${Bc(l)}
-                                ${Vc(c)}
-                                ${t((t,c,l)=>Kc(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
+                                ${al(l)}
+                                ${ol(c)}
+                                ${t((t,c,l)=>dl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
                         ></vaadin-grid-filter-column>
-                    `:T`
+                    `:w`
                         <vaadin-grid-column
                                 path="${e.id}"
-                                text-align="${e.align??v}"
+                                text-align="${e.align??_}"
                                 ?frozen="${e.frozen}"
                                 ?frozen-to-end="${e.frozenToEnd}"
                                 ?auto-width="${e.autoWidth}"
-                                flex-grow="${e.flexGrow??v}"
+                                flex-grow="${e.flexGrow??_}"
                                 ?resizable="${e.resizable}"
-                                width="${e.width??v}"
+                                width="${e.width??_}"
                                 data-data-type="${e.dataType}"
                                 data-stereotype="${e.stereotype}"
                                 .xcolumn="${e}"
-                                ${Bc(l)}
-                                ${Vc(c)}
-                                ${t((t,c,l)=>Kc(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
+                                ${al(l)}
+                                ${ol(c)}
+                                ${t((t,c,l)=>dl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
                         ></vaadin-grid-column>
-                    `},Kc=(e,t,n,r,i,a,o,s,c,l)=>{let u=n.dataset.dataType??``,d=n.dataset.stereotype??``;if(pc(e)){let t=i?.metadata,n=(t?.columns??[]).flatMap(e=>e?.metadata?.type===j.GridGroupColumn?(e.metadata.columns??[]).map(e=>e?.metadata?.id):[e?.metadata?.id]),a=vc(e,r,_c(e.__mateuGroupBy,n)),o=e.__mateuGroup.hiddenActions??[],s=r.id===n[n.length-1]?(t?.groupActions??[]).filter(e=>!o.includes(e.actionId??e.id)):[];return s.length?T`<span style="display: flex; align-items: center; justify-content: flex-end; gap: var(--lumo-space-s); overflow: hidden;">
-                ${a?T`<span style="font-weight: 600;">${a}</span>`:v}
-                ${s.map(t=>T`
+                    `},dl=(e,t,n,r,i,a,o,s,c,l)=>{let u=n.dataset.dataType??``,d=n.dataset.stereotype??``;if(Mc(e)){let t=i?.metadata,n=(t?.columns??[]).flatMap(e=>e?.metadata?.type===A.GridGroupColumn?(e.metadata.columns??[]).map(e=>e?.metadata?.id):[e?.metadata?.id]),a=Lc(e,r,Ic(e.__mateuGroupBy,n)),o=e.__mateuGroup.hiddenActions??[],s=r.id===n[n.length-1]?(t?.groupActions??[]).filter(e=>!o.includes(e.actionId??e.id)):[];return s.length?w`<span style="display: flex; align-items: center; justify-content: flex-end; gap: var(--lumo-space-s); overflow: hidden;">
+                ${a?w`<span style="font-weight: 600;">${a}</span>`:_}
+                ${s.map(t=>w`
                     <vaadin-button theme="tertiary small" style="flex-shrink: 0;"
                         @click="${n=>{n.stopPropagation(),n.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+(t.actionId??t.id),parameters:{_groupValue:e.__mateuGroup.value}},bubbles:!0,composed:!0}))}}">${t.label??t.caption??``}</vaadin-button>
                 `)}
-            </span>`:T`<span title="${a}" style="font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block;">${a}</span>`}if(r.editable)return zc(e,r,i,o);if(u==`status`)return na(e,t,n);if(u==`bool`)return bc(e,t,n);if(u==`money`||d==`money`)return xc(e,t,n,u,d);if(u==`link`||d==`link`)return Cc(e,t,n,u,d,r);if(u==`icon`||d==`icon`)return wc(e,t,n,u,d);if(d==`html`)return Tc(e,t,n,u,d);if(d==`image`)return Ec(e,t,n,u,d,r);if(u==`menu`)return Ac(e,t,n);if(u==`component`)return Pc(e,t,n,i,a,o,s,c,l);if(u==`action`)return jc(e,t,n);if(u==`actionGroup`)return Ac(e,t,n);if(d==`button`||r.actionId)return Nc(e,t,n,u,d,r);let f=e[n.path];return T`<span title="${f}" style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block;">${f}</span>`},qc=()=>{let e=document.activeElement;for(;e?.shadowRoot?.activeElement;)e=e.shadowRoot.activeElement;return e},Jc=(e,t)=>{let n=t;for(;n;){if(n===e)return!0;n=n.assignedSlot??n.parentNode??n.host??null}return!1},Yc=class extends $e{constructor(...e){super(...e),this.state={},this.data={},this.appState={},this.appData={},this.detailsOpenedItems=[],this.hoveredItem=null,this.onGridHoverMove=e=>{let t=e.currentTarget,n=t.getEventContext(e)?.item??null;n!==this.hoveredItem&&(this.hoveredItem=n,t.generateCellPartNames())},this.onGridHoverLeave=e=>{this.hoveredItem!==null&&(this.hoveredItem=null,e.currentTarget.generateCellPartNames())},this.hoverCellPartNameGenerator=(e,t)=>t?.item!=null&&t.item===this.hoveredItem?`hovered-cell`:``,this._onRowKey=e=>{let t=this.field?.rowSelectionShortcut;if(!t||!this.field?.onItemSelectionActionId||!this._isRowShortcutRelevant()||!kn(t,e))return;let n=/^(?:Digit|Numpad)([1-9])$/.exec(e.code);if(!n)return;let r=this.currentItems(),i=parseInt(n[1],10)-1;i>=r.length||(e.preventDefault(),this.selectRow(r[i]))},this.handleButtonClick=e=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))}}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._onRowKey)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`keydown`,this._onRowKey)}currentItems(){return this.field?.remoteCoordinates?this.data?.[this.id]?.content??[]:this.field?.fieldId&&this.state?this.state[this.field.fieldId]??[]:[]}selectRow(e){!e||!this.field?.onItemSelectionActionId||(this.selectedItems=[e],this.state[this.id+`_selected_items`]=[e],this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.field.onItemSelectionActionId,parameters:{_clickedRow:e}},bubbles:!0,composed:!0})))}_isRowShortcutRelevant(){if(this.offsetParent===null&&this.getClientRects().length===0)return!1;let e=qc();if(e&&e!==document.body&&!Jc(this,e)){let t=e.tagName?.toLowerCase()??``;if(e.isContentEditable||/^(input|textarea|select)$/.test(t)||t.startsWith(`vaadin-`)&&/(field|combo|picker|area|select)/.test(t))return!1}return!0}handleItemToggle(e){let{item:t,selected:n,shiftKey:r}=e.detail;if(this.rangeStartItem??=t,r){let e=[];this.field?.fieldId&&this.state&&this.state[this.field.fieldId]&&(e=this.state[this.field.fieldId]);let[r,i]=[this.rangeStartItem,t].map(t=>e.indexOf(t)).sort((e,t)=>e-t),a=e.slice(r,i+1),o=new Set(this.selectedItems);a.forEach(e=>{n?o.add(e):o.delete(e)}),this.selectedItems=[...o],this.state[this.id+`_selected_items`]=this.selectedItems}this.rangeStartItem=t}render(){let e=[];this.field?.fieldId&&this.state&&this.state[this.field.fieldId]&&(e=this.state[this.field.fieldId]);let t=this.state[this.field?.fieldId+`_show_detail`]||this.state._show_detail&&this.state._show_detail[this.field.fieldId];if(this.field?.remoteCoordinates){let t=this.field.remoteCoordinates;this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements?e=this.data[this.id].content:this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}if(Array.isArray(e)&&e.forEach((e,t)=>{e&&typeof e==`object`&&e._rowNumber===void 0&&(e._rowNumber=t)}),this.field?.inlineEditing)return this.renderMaster(e);if(this.field?.formPosition&&this.field?.formPosition.startsWith(`modal`)){let n=this;return T`
+            </span>`:w`<span title="${a}" style="font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block;">${a}</span>`}if(r.editable)return il(e,r,i,o);if(u==`status`)return ra(e,t,n);if(u==`bool`)return zc(e,t,n);if(u==`money`||d==`money`)return Bc(e,t,n,u,d);if(u==`link`||d==`link`)return Hc(e,t,n,u,d,r);if(u==`icon`||d==`icon`)return Uc(e,t,n,u,d);if(d==`html`)return Wc(e,t,n,u,d);if(d==`image`)return Gc(e,t,n,u,d,r);if(u==`menu`)return Yc(e,t,n);if(u==`component`)return $c(e,t,n,i,a,o,s,c,l);if(u==`action`)return Xc(e,t,n);if(u==`actionGroup`)return Yc(e,t,n);if(d==`button`||r.actionId)return Qc(e,t,n,u,d,r);let f=e[n.path];return w`<span title="${f}" style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block;">${f}</span>`},fl=()=>{let e=document.activeElement;for(;e?.shadowRoot?.activeElement;)e=e.shadowRoot.activeElement;return e},pl=(e,t)=>{let n=t;for(;n;){if(n===e)return!0;n=n.assignedSlot??n.parentNode??n.host??null}return!1},ml=class extends et{constructor(...e){super(...e),this.state={},this.data={},this.appState={},this.appData={},this.detailsOpenedItems=[],this.hoveredItem=null,this.onGridHoverMove=e=>{let t=e.currentTarget,n=t.getEventContext(e)?.item??null;n!==this.hoveredItem&&(this.hoveredItem=n,t.generateCellPartNames())},this.onGridHoverLeave=e=>{this.hoveredItem!==null&&(this.hoveredItem=null,e.currentTarget.generateCellPartNames())},this.hoverCellPartNameGenerator=(e,t)=>t?.item!=null&&t.item===this.hoveredItem?`hovered-cell`:``,this._onRowKey=e=>{let t=this.field?.rowSelectionShortcut;if(!t||!this.field?.onItemSelectionActionId||!this._isRowShortcutRelevant()||!An(t,e))return;let n=/^(?:Digit|Numpad)([1-9])$/.exec(e.code);if(!n)return;let r=this.currentItems(),i=parseInt(n[1],10)-1;i>=r.length||(e.preventDefault(),this.selectRow(r[i]))},this.handleButtonClick=e=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))}}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._onRowKey)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`keydown`,this._onRowKey)}currentItems(){return this.field?.remoteCoordinates?this.data?.[this.id]?.content??[]:this.field?.fieldId&&this.state?this.state[this.field.fieldId]??[]:[]}selectRow(e){!e||!this.field?.onItemSelectionActionId||(this.selectedItems=[e],this.state[this.id+`_selected_items`]=[e],this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.field.onItemSelectionActionId,parameters:{_clickedRow:e}},bubbles:!0,composed:!0})))}_isRowShortcutRelevant(){if(this.offsetParent===null&&this.getClientRects().length===0)return!1;let e=fl();if(e&&e!==document.body&&!pl(this,e)){let t=e.tagName?.toLowerCase()??``;if(e.isContentEditable||/^(input|textarea|select)$/.test(t)||t.startsWith(`vaadin-`)&&/(field|combo|picker|area|select)/.test(t))return!1}return!0}handleItemToggle(e){let{item:t,selected:n,shiftKey:r}=e.detail;if(this.rangeStartItem??=t,r){let e=[];this.field?.fieldId&&this.state&&this.state[this.field.fieldId]&&(e=this.state[this.field.fieldId]);let[r,i]=[this.rangeStartItem,t].map(t=>e.indexOf(t)).sort((e,t)=>e-t),a=e.slice(r,i+1),o=new Set(this.selectedItems);a.forEach(e=>{n?o.add(e):o.delete(e)}),this.selectedItems=[...o],this.state[this.id+`_selected_items`]=this.selectedItems}this.rangeStartItem=t}render(){let e=[];this.field?.fieldId&&this.state&&this.state[this.field.fieldId]&&(e=this.state[this.field.fieldId]);let t=this.state[this.field?.fieldId+`_show_detail`]||this.state._show_detail&&this.state._show_detail[this.field.fieldId];if(this.field?.remoteCoordinates){let t=this.field.remoteCoordinates;this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements?e=this.data[this.id].content:this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}if(Array.isArray(e)&&e.forEach((e,t)=>{e&&typeof e==`object`&&e._rowNumber===void 0&&(e._rowNumber=t)}),this.field?.inlineEditing)return this.renderMaster(e);if(this.field?.formPosition&&this.field?.formPosition.startsWith(`modal`)){let n=this;return w`
 
                 ${this.renderMaster(e)}
 
                 <vaadin-dialog
                         .opened="${t}"
                         @closed="${()=>{n.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.field?.fieldId+`_cancel`},bubbles:!0,composed:!0}))}}"
-                        ${s(()=>T`
+                        ${s(()=>w`
                             <mateu-event-interceptor .target="${n}">
                                 <div id="container" style="${this.field?.formStyle??`display: contents;`}">
                                     <mateu-component id="${this.field?.fieldId}-container"></mateu-component>
                                 </div>
                             </mateu-event-interceptor>
-                            `,[()=>E()])}
+                            `,[()=>T()])}
                 ></vaadin-dialog>
                 
-            `}else{let n=this.field?.formPosition==`left`||this.field?.formPosition==`right`?`horizontal`:`vertical`;return T`
+            `}else{let n=this.field?.formPosition==`left`||this.field?.formPosition==`right`?`horizontal`:`vertical`;return w`
             <vaadin-master-detail-layout
                     style="overflow: unset; width: 100%; ${t&&this.field?.minHeightWhenDetailVisible?`min-height: `+this.field?.minHeightWhenDetailVisible+`;`:``}"
                     orientation="${n}"
@@ -8884,14 +8884,14 @@ ${i}
                 </div>
                 
                 
-            </vaadin-master-detail-layout>`}}renderMaster(e){let r=this.selectedItems||[];return T`<vaadin-vertical-layout style="width: 100%;">
+            </vaadin-master-detail-layout>`}}renderMaster(e){let r=this.selectedItems||[];return w`<vaadin-vertical-layout style="width: 100%;">
             <!-- The field label is rendered by the surrounding mateu-field wrapper; rendering it
                  here too would duplicate it (e.g. "Guests / Guests"). -->
             <vaadin-grid
                     ?clickable="${!!this.field?.onItemSelectionActionId}"
-                    .cellPartNameGenerator="${S(this.field?.onItemSelectionActionId?this.hoverCellPartNameGenerator:void 0)}"
-                    @mousemove="${S(this.field?.onItemSelectionActionId?this.onGridHoverMove:void 0)}"
-                    @mouseleave="${S(this.field?.onItemSelectionActionId?this.onGridHoverLeave:void 0)}"
+                    .cellPartNameGenerator="${x(this.field?.onItemSelectionActionId?this.hoverCellPartNameGenerator:void 0)}"
+                    @mousemove="${x(this.field?.onItemSelectionActionId?this.onGridHoverMove:void 0)}"
+                    @mouseleave="${x(this.field?.onItemSelectionActionId?this.onGridHoverLeave:void 0)}"
                     style="${this.field?.onItemSelectionActionId?`cursor: pointer;`:``}${this.field?.style??``}"
                     class="${this.field?.cssClasses}"
                     .items="${e}"
@@ -8899,33 +8899,33 @@ ${i}
                     item-id-path="${this.field?.itemIdPath}"
                     @selected-items-changed="${e=>{this.selectedItems=e.detail.value,this.state[this.id+`_selected_items`]=this.selectedItems}}"
                     @item-toggle="${this.handleItemToggle}"
-                    @click="${S(this.field?.onItemSelectionActionId?e=>{let t=e.currentTarget.getEventContext(e)?.item;t&&this.selectRow(t)}:void 0)}"
-                    @active-item-changed="${S(this.field?.detailPath&&!this.field?.useButtonForDetail?e=>{if(this.field?.detailPath){let t=e.detail.value;t?this.detailsOpenedItems=[t]:this.detailsOpenedItems=[]}}:void 0)}"
+                    @click="${x(this.field?.onItemSelectionActionId?e=>{let t=e.currentTarget.getEventContext(e)?.item;t&&this.selectRow(t)}:void 0)}"
+                    @active-item-changed="${x(this.field?.detailPath&&!this.field?.useButtonForDetail?e=>{if(this.field?.detailPath){let t=e.detail.value;t?this.detailsOpenedItems=[t]:this.detailsOpenedItems=[]}}:void 0)}"
                     .detailsOpenedItems="${this.detailsOpenedItems}"
-                    ${S(this.field?.detailPath?n(e=>T`${F(this,e[this.field?.detailPath],this.baseUrl,this.state,this.data,this.appState,this.appData)}`):void 0)}
+                    ${x(this.field?.detailPath?n(e=>w`${P(this,e[this.field?.detailPath],this.baseUrl,this.state,this.data,this.appState,this.appData)}`):void 0)}
                     ?all-rows-visible=${e?.length<10}
             >
                 <span slot="empty-state">${this.field?.label?`No ${this.field.label.toLowerCase()} added yet.`:`No items added yet.`}</span>
-                ${this.field?.readOnly||this.field?.inlineEditing?v:T`
+                ${this.field?.readOnly||this.field?.inlineEditing?_:w`
                     <vaadin-grid-selection-column drag-select></vaadin-grid-selection-column>
                 `}
-                ${this.field?.columns?.map(e=>Wc(e,this,this.baseUrl,this.state,this.data,this.appState,this.appData))}
+                ${this.field?.columns?.map(e=>ll(e,this,this.baseUrl,this.state,this.data,this.appState,this.appData))}
 
-                ${this.field?.inlineEditing&&!this.field?.readOnly?T`
+                ${this.field?.inlineEditing&&!this.field?.readOnly?w`
                     <vaadin-grid-column width="3.5rem" flex-grow="0" frozen-to-end
-                            ${t(e=>T`
+                            ${t(e=>w`
                                 <vaadin-button theme="tertiary icon error" title="Remove row"
                                     @click="${()=>{this.state[this.id+`_selected_items`]=[e],this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.id+`_remove`},bubbles:!0,composed:!0}))}}">
                                     <vaadin-icon icon="vaadin:trash"></vaadin-icon>
                                 </vaadin-button>`,[])}
                     ></vaadin-grid-column>
-                `:v}
+                `:_}
 
-                ${this.field?.useButtonForDetail?T`
+                ${this.field?.useButtonForDetail?w`
                     <vaadin-grid-column
                             width="44px"
                             flex-grow="0"
-                            ${t((e,{detailsOpened:t})=>T`
+                            ${t((e,{detailsOpened:t})=>w`
               <vaadin-button
                 theme="tertiary icon"
                 title="${t?`Collapse`:`Expand`}"
@@ -8939,16 +8939,16 @@ ${i}
               </vaadin-button>
             `,[])}
                     ></vaadin-grid-column>
-                `:v}
+                `:_}
 
             </vaadin-grid>
-            ${this.field?.readOnly?v:this.field?.inlineEditing?T`
+            ${this.field?.readOnly?_:this.field?.inlineEditing?w`
                     <vaadin-horizontal-layout theme="spacing">
                         <!-- Inline mode: rows are removed with the per-row trash button, so the
                              toolbar only needs the "add" action. -->
                         <vaadin-button theme="tertiary icon" title="Add row" @click="${()=>this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.id+`_add`},bubbles:!0,composed:!0}))}"><vaadin-icon icon="vaadin:plus"></vaadin-icon></vaadin-button>
                     </vaadin-horizontal-layout>
-                `:T`
+                `:w`
                     <vaadin-horizontal-layout theme="spacing">
                         <vaadin-button theme="tertiary icon" @click="${()=>this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.id+`_add`},bubbles:!0,composed:!0}))}"><vaadin-icon icon="vaadin:plus"></vaadin-icon></vaadin-button>
                         <vaadin-button theme="tertiary icon error" @click="${()=>this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.id+`_remove`},bubbles:!0,composed:!0}))}"><vaadin-icon icon="vaadin:minus"></vaadin-icon></vaadin-button>
@@ -8956,8 +8956,8 @@ ${i}
                         <vaadin-button theme="tertiary icon" title="Move down" @click="${()=>this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.id+`_move-down`},bubbles:!0,composed:!0}))}"><vaadin-icon icon="vaadin:arrow-down"></vaadin-icon></vaadin-button>
                     </vaadin-horizontal-layout>
                 `}
-        </vaadin-vertical-layout>`}static{this.styles=h`
-        ${de}
+        </vaadin-vertical-layout>`}static{this.styles=m`
+        ${fe}
 
         /* Clickable grids (a row-selection action is wired) give visual feedback: the host sets a
            pointer cursor (inline, inherited by the slotted cell content), and the cells of the
@@ -8966,17 +8966,17 @@ ${i}
             background-color: var(--lumo-primary-color-10pct);
             cursor: pointer;
         }
-    `}};k([y()],Yc.prototype,`field`,void 0),k([y()],Yc.prototype,`state`,void 0),k([y()],Yc.prototype,`data`,void 0),k([y()],Yc.prototype,`appState`,void 0),k([y()],Yc.prototype,`appData`,void 0),k([y()],Yc.prototype,`selectedItems`,void 0),k([C()],Yc.prototype,`detailsOpenedItems`,void 0),Yc=k([g(`mateu-grid`)],Yc);var Xc=class extends b{constructor(...e){super(...e),this.getNewValue=e=>{if(this.field?.dataType==`array`){if(!this.value)return[e];let t=this.value;return t.indexOf(e)>=0?t.filter(t=>t!==e):[...t,e]}return e}}render(){let e=this.field?.options;if(this.field?.remoteCoordinates){let t=this.field.remoteCoordinates;this.data?.[this.field.fieldId]&&this.data[this.field.fieldId].content&&this.data[this.field.fieldId].totalElements?e=this.data[this.field.fieldId].content:this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}return T`
+    `}};O([v()],ml.prototype,`field`,void 0),O([v()],ml.prototype,`state`,void 0),O([v()],ml.prototype,`data`,void 0),O([v()],ml.prototype,`appState`,void 0),O([v()],ml.prototype,`appData`,void 0),O([v()],ml.prototype,`selectedItems`,void 0),O([S()],ml.prototype,`detailsOpenedItems`,void 0),ml=O([h(`mateu-grid`)],ml);var hl=class extends y{constructor(...e){super(...e),this.getNewValue=e=>{if(this.field?.dataType==`array`){if(!this.value)return[e];let t=this.value;return t.indexOf(e)>=0?t.filter(t=>t!==e):[...t,e]}return e}}render(){let e=this.field?.options;if(this.field?.remoteCoordinates){let t=this.field.remoteCoordinates;this.data?.[this.field.fieldId]&&this.data[this.field.fieldId].content&&this.data[this.field.fieldId].totalElements?e=this.data[this.field.fieldId].content:this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}return w`
         <div style="display: flex; gap: 1rem; padding: 1rem; flex-wrap: wrap; ${this.field?.attributes?.divStyle}">
-                                    ${e?.map(e=>T`
+                                    ${e?.map(e=>w`
                             <div role="button" tabindex="0" 
                                     class="choice ${this.value==e.value||Array.isArray(this.value)&&this.value.includes(e.value)?`selected`:``}"
-                                    @click="${()=>this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.getNewValue(e.value),fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}" @keydown="${R(()=>this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.getNewValue(e.value),fieldId:this.field?.fieldId},bubbles:!0,composed:!0})))}"
-                            >${e.description||e.image?T`
+                                    @click="${()=>this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.getNewValue(e.value),fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}" @keydown="${L(()=>this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.getNewValue(e.value),fieldId:this.field?.fieldId},bubbles:!0,composed:!0})))}"
+                            >${e.description||e.image?w`
                                 <div style="display: flex; align-items: center; gap: var(--lumo-space-m, 1rem);">
-                                    ${e.image?T`
+                                    ${e.image?w`
                                             <img src="${e.image}" alt="${e.label}" style="${e.imageStyle??`width: 2rem;`}" />
-                                        `:v}
+                                        `:_}
                                     <div style="display: flex; flex-direction: column;">
                                         <span> ${e.label} </span>
                                         <span
@@ -8990,7 +8990,7 @@ ${i}
                         `)}
                                 </div>
 
-       `}static{this.styles=h`
+       `}static{this.styles=m`
         .choice {
             min-width: 10rem;
             min-height: 5rem;
@@ -9013,8 +9013,8 @@ ${i}
             border: 1px solid var(--lumo-shade-20pct);
         }
   
-        ${z}
-    `}};k([y()],Xc.prototype,`field`,void 0),k([y()],Xc.prototype,`baseUrl`,void 0),k([y()],Xc.prototype,`state`,void 0),k([y()],Xc.prototype,`data`,void 0),k([y()],Xc.prototype,`value`,void 0),Xc=k([g(`mateu-choice`)],Xc);var Zc=class extends b{constructor(...e){super(...e),this.currencyChanged=e=>{this.value||={value:0,currency:`EUR`,locale:`es-ES`},this.value.currency=e.detail.value,this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:{...this.value},fieldId:this.fieldId}}))},this.valueChanged=e=>{this.value||={value:0,currency:`EUR`,locale:`es-ES`},e.detail.value&&(this.value.value=e.detail.value?parseFloat(e.detail.value):0,this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:{...this.value},fieldId:this.fieldId}})))}}render(){return T`
+        ${R}
+    `}};O([v()],hl.prototype,`field`,void 0),O([v()],hl.prototype,`baseUrl`,void 0),O([v()],hl.prototype,`state`,void 0),O([v()],hl.prototype,`data`,void 0),O([v()],hl.prototype,`value`,void 0),hl=O([h(`mateu-choice`)],hl);var gl=class extends y{constructor(...e){super(...e),this.currencyChanged=e=>{this.value||={value:0,currency:`EUR`,locale:`es-ES`},this.value.currency=e.detail.value,this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:{...this.value},fieldId:this.fieldId}}))},this.valueChanged=e=>{this.value||={value:0,currency:`EUR`,locale:`es-ES`},e.detail.value&&(this.value.value=e.detail.value?parseFloat(e.detail.value):0,this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:{...this.value},fieldId:this.fieldId}})))}}render(){return w`
             <vaadin-number-field
                     id="${this.fieldId}"
                     label="${this.label}"
@@ -9022,7 +9022,7 @@ ${i}
                     .value="${this.value?.value}"
                     .helperText="${this.helperText}"
                     ?autofocus="${this.autofocus}"
-                    ?required="${this.required||v}"
+                    ?required="${this.required||_}"
                     theme="align-right"
             ><div slot="prefix"><vaadin-select
                     item-label-path="label"
@@ -9033,11 +9033,11 @@ ${i}
                     style="max-width: 100px;"
                     theme="small"
             ></vaadin-select></div></vaadin-number-field>
-       `}static{this.styles=h`
-  `}};k([y()],Zc.prototype,`fieldId`,void 0),k([y()],Zc.prototype,`label`,void 0),k([y()],Zc.prototype,`state`,void 0),k([y()],Zc.prototype,`data`,void 0),k([y()],Zc.prototype,`value`,void 0),k([y()],Zc.prototype,`autoFocus`,void 0),k([y()],Zc.prototype,`required`,void 0),k([y()],Zc.prototype,`colspan`,void 0),k([y()],Zc.prototype,`helperText`,void 0),Zc=k([g(`mateu-money-field`)],Zc);var Qc=`vaadin:abacus.vaadin:absolute-position.vaadin:academy-cap.vaadin:accessibility.vaadin:accordion-menu.vaadin:add-dock.vaadin:adjust.vaadin:adobe-flash.vaadin:airplane.vaadin:alarm.vaadin:align-center.vaadin:align-justify.vaadin:align-left.vaadin:align-right.vaadin:alt-a.vaadin:alt.vaadin:ambulance.vaadin:anchor.vaadin:angle-double-down.vaadin:angle-double-left.vaadin:angle-double-right.vaadin:angle-double-up.vaadin:angle-down.vaadin:angle-left.vaadin:angle-right.vaadin:angle-up.vaadin:archive.vaadin:archives.vaadin:area-select.vaadin:arrow-backward.vaadin:arrow-circle-down-o.vaadin:arrow-circle-down.vaadin:arrow-circle-left-o.vaadin:arrow-circle-left.vaadin:arrow-circle-right-o.vaadin:arrow-circle-right.vaadin:arrow-circle-up-o.vaadin:arrow-circle-up.vaadin:arrow-down.vaadin:arrow-forward.vaadin:arrow-left.vaadin:arrow-long-down.vaadin:arrow-long-left.vaadin:arrow-right.vaadin:arrow-up.vaadin:arrows-cross.vaadin:arrows-long-h.vaadin:arrows-long-right.vaadin:arrows-long-up.vaadin:arrows-long-v.vaadin:arrows.vaadin:asterisk.vaadin:at.vaadin:automation.vaadin:backspace-a.vaadin:backspace.vaadin:backwards.vaadin:ban.vaadin:bar-chart-h.vaadin:bar-chart-v.vaadin:bar-chart.vaadin:barcode.vaadin:bed.vaadin:bell-o.vaadin:bell-slash-o.vaadin:bell-slash.vaadin:bell.vaadin:boat.vaadin:bold.vaadin:bolt.vaadin:bomb.vaadin:book-dollar.vaadin:book-percent.vaadin:book.vaadin:bookmark-o.vaadin:bookmark.vaadin:briefcase.vaadin:browser.vaadin:bug-o.vaadin:bug.vaadin:building-o.vaadin:building.vaadin:bullets.vaadin:bullseye.vaadin:bus.vaadin:buss.vaadin:button.vaadin:calc-book.vaadin:calc.vaadin:calendar-briefcase.vaadin:calendar-clock.vaadin:calendar-envelope.vaadin:calendar-o.vaadin:calendar-user.vaadin:calendar.vaadin:camera.vaadin:car.vaadin:caret-down.vaadin:caret-left.vaadin:caret-right.vaadin:caret-square-down-o.vaadin:caret-square-left-o.vaadin:caret-square-right-o.vaadin:caret-square-up-o.vaadin:caret-up.vaadin:cart-o.vaadin:cart.vaadin:cash.vaadin:chart-3d.vaadin:chart-grid.vaadin:chart-line.vaadin:chart-timeline.vaadin:chart.vaadin:chat.vaadin:check-circle-o.vaadin:check-circle.vaadin:check-square-o.vaadin:check-square.vaadin:check.vaadin:chevron-circle-down-o.vaadin:chevron-circle-down.vaadin:chevron-circle-left-o.vaadin:chevron-circle-left.vaadin:chevron-circle-right-o.vaadin:chevron-circle-right.vaadin:chevron-circle-up-o.vaadin:chevron-circle-up.vaadin:chevron-down-small.vaadin:chevron-down.vaadin:chevron-left-small.vaadin:chevron-left.vaadin:chevron-right-small.vaadin:chevron-right.vaadin:chevron-up-small.vaadin:chevron-up.vaadin:child.vaadin:circle-thin.vaadin:circle.vaadin:clipboard-check.vaadin:clipboard-cross.vaadin:clipboard-heart.vaadin:clipboard-pulse.vaadin:clipboard-text.vaadin:clipboard-user.vaadin:clipboard.vaadin:clock.vaadin:close-big.vaadin:close-circle-o.vaadin:close-circle.vaadin:close-small.vaadin:close.vaadin:cloud-download-o.vaadin:cloud-download.vaadin:cloud-o.vaadin:cloud-upload-o.vaadin:cloud-upload.vaadin:cloud.vaadin:cluster.vaadin:code.vaadin:coffee.vaadin:cog-o.vaadin:cog.vaadin:cogs.vaadin:coin-piles.vaadin:coins.vaadin:combobox.vaadin:comment-ellipsis-o.vaadin:comment-ellipsis.vaadin:comment-o.vaadin:comment.vaadin:comments-o.vaadin:comments.vaadin:compile.vaadin:compress-square.vaadin:compress.vaadin:connect-o.vaadin:connect.vaadin:controller.vaadin:copy-o.vaadin:copy.vaadin:copyright.vaadin:corner-lower-left.vaadin:corner-lower-right.vaadin:corner-upper-left.vaadin:corner-upper-right.vaadin:credit-card.vaadin:crop.vaadin:cross-cutlery.vaadin:crosshairs.vaadin:css.vaadin:ctrl-a.vaadin:ctrl.vaadin:cube.vaadin:cubes.vaadin:curly-brackets.vaadin:cursor-o.vaadin:cursor.vaadin:cutlery.vaadin:dashboard.vaadin:database.vaadin:date-input.vaadin:deindent.vaadin:del-a.vaadin:del.vaadin:dental-chair.vaadin:desktop.vaadin:diamond-o.vaadin:diamond.vaadin:diploma-scroll.vaadin:diploma.vaadin:disc.vaadin:doctor-briefcase.vaadin:doctor.vaadin:dollar.vaadin:dot-circle.vaadin:download-alt.vaadin:download.vaadin:drop.vaadin:edit.vaadin:eject.vaadin:elastic.vaadin:ellipsis-circle-o.vaadin:ellipsis-circle.vaadin:ellipsis-dots-h.vaadin:ellipsis-dots-v.vaadin:ellipsis-h.vaadin:ellipsis-v.vaadin:enter-arrow.vaadin:enter.vaadin:envelope-o.vaadin:envelope-open-o.vaadin:envelope-open.vaadin:envelope.vaadin:envelopes-o.vaadin:envelopes.vaadin:eraser.vaadin:esc-a.vaadin:esc.vaadin:euro.vaadin:exchange.vaadin:exclamation-circle-o.vaadin:exclamation-circle.vaadin:exclamation.vaadin:exit-o.vaadin:exit.vaadin:expand-full.vaadin:expand-square.vaadin:expand.vaadin:external-browser.vaadin:external-link.vaadin:eye-slash.vaadin:eye.vaadin:eyedropper.vaadin:facebook-square.vaadin:facebook.vaadin:factory.vaadin:family.vaadin:fast-backward.vaadin:fast-forward.vaadin:female.vaadin:file-add.vaadin:file-code.vaadin:file-font.vaadin:file-movie.vaadin:file-o.vaadin:file-picture.vaadin:file-presentation.vaadin:file-process.vaadin:file-refresh.vaadin:file-remove.vaadin:file-search.vaadin:file-sound.vaadin:file-start.vaadin:file-table.vaadin:file-text-o.vaadin:file-text.vaadin:file-tree-small.vaadin:file-tree-sub.vaadin:file-tree.vaadin:file-zip.vaadin:file.vaadin:fill.vaadin:film.vaadin:filter.vaadin:fire.vaadin:flag-checkered.vaadin:flag-o.vaadin:flag.vaadin:flash.vaadin:flask.vaadin:flight-landing.vaadin:flight-takeoff.vaadin:flip-h.vaadin:flip-v.vaadin:folder-add.vaadin:folder-o.vaadin:folder-open-o.vaadin:folder-open.vaadin:folder-remove.vaadin:folder-search.vaadin:folder.vaadin:font.vaadin:form.vaadin:forward.vaadin:frown-o.vaadin:funcion.vaadin:function.vaadin:funnel.vaadin:gamepad.vaadin:gavel.vaadin:gift.vaadin:glass.vaadin:glasses.vaadin:globe-wire.vaadin:globe.vaadin:golf.vaadin:google-plus-square.vaadin:google-plus.vaadin:grab.vaadin:grid-bevel.vaadin:grid-big-o.vaadin:grid-big.vaadin:grid-h.vaadin:grid-small-o.vaadin:grid-small.vaadin:grid-v.vaadin:grid.vaadin:group.vaadin:hammer.vaadin:hand.vaadin:handle-corner.vaadin:hands-up.vaadin:handshake.vaadin:harddrive-o.vaadin:harddrive.vaadin:hash.vaadin:header.vaadin:headphones.vaadin:headset.vaadin:health-card.vaadin:heart-o.vaadin:heart.vaadin:home-o.vaadin:home.vaadin:hospital.vaadin:hourglass-empty.vaadin:hourglass-end.vaadin:hourglass-start.vaadin:hourglass.vaadin:inbox.vaadin:indent.vaadin:info-circle-o.vaadin:info-circle.vaadin:info.vaadin:input.vaadin:insert.vaadin:institution.vaadin:invoice.vaadin:italic.vaadin:key-o.vaadin:key.vaadin:keyboard-o.vaadin:keyboard.vaadin:laptop.vaadin:layout.vaadin:level-down-bold.vaadin:level-down.vaadin:level-left-bold.vaadin:level-left.vaadin:level-right-bold.vaadin:level-right.vaadin:level-up-bold.vaadin:level-up.vaadin:lifebuoy.vaadin:lightbulb.vaadin:line-bar-chart.vaadin:line-chart.vaadin:line-h.vaadin:line-v.vaadin:lines-list.vaadin:lines.vaadin:link.vaadin:list-ol.vaadin:list-select.vaadin:list-ul.vaadin:list.vaadin:location-arrow-circle-o.vaadin:location-arrow-circle.vaadin:location-arrow.vaadin:lock.vaadin:magic.vaadin:magnet.vaadin:mailbox.vaadin:male.vaadin:map-marker.vaadin:margin-bottom.vaadin:margin-left.vaadin:margin-right.vaadin:margin-top.vaadin:margin.vaadin:medal.vaadin:megafone.vaadin:megaphone.vaadin:meh-o.vaadin:menu.vaadin:microphone.vaadin:minus-circle-o.vaadin:minus-circle.vaadin:minus-square-o.vaadin:minus.vaadin:mobile-browser.vaadin:mobile-retro.vaadin:mobile.vaadin:modal-list.vaadin:modal.vaadin:money-deposit.vaadin:money-exchange.vaadin:money-withdraw.vaadin:money.vaadin:moon-o.vaadin:moon.vaadin:morning.vaadin:movie.vaadin:music.vaadin:mute.vaadin:native-button.vaadin:newspaper.vaadin:notebook.vaadin:nurse.vaadin:office.vaadin:open-book.vaadin:option-a.vaadin:option.vaadin:options.vaadin:orientation.vaadin:out.vaadin:outbox.vaadin:package.vaadin:padding-bottom.vaadin:padding-left.vaadin:padding-right.vaadin:padding-top.vaadin:padding.vaadin:paint-roll.vaadin:paintbrush.vaadin:palete.vaadin:palette.vaadin:panel.vaadin:paperclip.vaadin:paperplane-o.vaadin:paperplane.vaadin:paragraph.vaadin:password.vaadin:paste.vaadin:pause.vaadin:pencil.vaadin:phone-landline.vaadin:phone.vaadin:picture.vaadin:pie-bar-chart.vaadin:pie-chart.vaadin:piggy-bank-coin.vaadin:piggy-bank.vaadin:pill.vaadin:pills.vaadin:pin-post.vaadin:pin.vaadin:play-circle-o.vaadin:play-circle.vaadin:play.vaadin:plug.vaadin:plus-circle-o.vaadin:plus-circle.vaadin:plus-minus.vaadin:plus-square-o.vaadin:plus.vaadin:pointer.vaadin:power-off.vaadin:presentation.vaadin:print.vaadin:progressbar.vaadin:puzzle-piece.vaadin:pyramid-chart.vaadin:qrcode.vaadin:question-circle-o.vaadin:question-circle.vaadin:question.vaadin:quote-left.vaadin:quote-right.vaadin:random.vaadin:raster-lower-left.vaadin:raster.vaadin:records.vaadin:recycle.vaadin:refresh.vaadin:reply-all.vaadin:reply.vaadin:resize-h.vaadin:resize-v.vaadin:retweet.vaadin:rhombus.vaadin:road-branch.vaadin:road-branches.vaadin:road-split.vaadin:road.vaadin:rocket.vaadin:rotate-left.vaadin:rotate-right.vaadin:rss-square.vaadin:rss.vaadin:safe-lock.vaadin:safe.vaadin:scale-unbalance.vaadin:scale.vaadin:scatter-chart.vaadin:scissors.vaadin:screwdriver.vaadin:search-minus.vaadin:search-plus.vaadin:search.vaadin:select.vaadin:server.vaadin:share-square.vaadin:share.vaadin:shield.vaadin:shift-arrow.vaadin:shift.vaadin:shop.vaadin:sign-in-alt.vaadin:sign-in.vaadin:sign-out-alt.vaadin:sign-out.vaadin:signal.vaadin:sitemap.vaadin:slider.vaadin:sliders.vaadin:smiley-o.vaadin:sort.vaadin:sound-disable.vaadin:spark-line.vaadin:specialist.vaadin:spinner-arc.vaadin:spinner-third.vaadin:spinner.vaadin:spline-area-chart.vaadin:spline-chart.vaadin:split-h.vaadin:split-v.vaadin:split.vaadin:spoon.vaadin:square-shadow.vaadin:star-half-left-o.vaadin:star-half-left.vaadin:star-half-right-o.vaadin:star-half-right.vaadin:star-o.vaadin:star.vaadin:start-cog.vaadin:step-backward.vaadin:step-forward.vaadin:stethoscope.vaadin:stock.vaadin:stop-cog.vaadin:stop.vaadin:stopwatch.vaadin:storage.vaadin:strikethrough.vaadin:subscript.vaadin:suitcase.vaadin:sun-down.vaadin:sun-o.vaadin:sun-rise.vaadin:superscript.vaadin:sword.vaadin:tab-a.vaadin:tab.vaadin:table.vaadin:tablet.vaadin:tabs.vaadin:tag.vaadin:tags.vaadin:tasks.vaadin:taxi.vaadin:teeth.vaadin:terminal.vaadin:text-height.vaadin:text-input.vaadin:text-label.vaadin:text-width.vaadin:thin-square.vaadin:thumbs-down-o.vaadin:thumbs-down.vaadin:thumbs-up-o.vaadin:thumbs-up.vaadin:ticket.vaadin:time-backward.vaadin:time-forward.vaadin:timer.vaadin:toolbox.vaadin:tools.vaadin:tooth.vaadin:touch.vaadin:train.vaadin:trash.vaadin:tree-table.vaadin:trendind-down.vaadin:trending-down.vaadin:trending-up.vaadin:trophy.vaadin:truck.vaadin:twin-col-select.vaadin:twitter-square.vaadin:twitter.vaadin:umbrella.vaadin:underline.vaadin:unlink.vaadin:unlock.vaadin:upload-alt.vaadin:upload.vaadin:user-card.vaadin:user-check.vaadin:user-clock.vaadin:user-heart.vaadin:user-star.vaadin:user.vaadin:users.vaadin:vaadin-h.vaadin:vaadin-v.vaadin:viewport.vaadin:vimeo-square.vaadin:vimeo.vaadin:volume-down.vaadin:volume-off.vaadin:volume-up.vaadin:volume.vaadin:wallet.vaadin:warning.vaadin:workplace.vaadin:wrench.vaadin:youtube-square.vaadin:youtube`.split(`.`),$c=null,el=()=>($c||=Promise.all([D(()=>import(`./vendor-ui5.js`).then(e=>e.n),__vite__mapDeps([5,1])),D(()=>import(`./vendor-ui5.js`).then(e=>e.t),__vite__mapDeps([5,1]))]),$c),Q=class extends b{constructor(...e){super(...e),this.ui5FieldComponentsReady=!1,this.component=void 0,this.field=void 0,this.baseUrl=void 0,this.state={},this.data={},this.appState={},this.appData={},this.colorPickerOpened=!1,this.colorPickerValue=void 0,this.comboData=[],this._comboFilter=``,this.rendered=!1,this.renderColorPicker=()=>{this.loadUi5FieldComponents();let e=this.field?.fieldId;return T`
+       `}static{this.styles=m`
+  `}};O([v()],gl.prototype,`fieldId`,void 0),O([v()],gl.prototype,`label`,void 0),O([v()],gl.prototype,`state`,void 0),O([v()],gl.prototype,`data`,void 0),O([v()],gl.prototype,`value`,void 0),O([v()],gl.prototype,`autoFocus`,void 0),O([v()],gl.prototype,`required`,void 0),O([v()],gl.prototype,`colspan`,void 0),O([v()],gl.prototype,`helperText`,void 0),gl=O([h(`mateu-money-field`)],gl);var _l=`vaadin:abacus.vaadin:absolute-position.vaadin:academy-cap.vaadin:accessibility.vaadin:accordion-menu.vaadin:add-dock.vaadin:adjust.vaadin:adobe-flash.vaadin:airplane.vaadin:alarm.vaadin:align-center.vaadin:align-justify.vaadin:align-left.vaadin:align-right.vaadin:alt-a.vaadin:alt.vaadin:ambulance.vaadin:anchor.vaadin:angle-double-down.vaadin:angle-double-left.vaadin:angle-double-right.vaadin:angle-double-up.vaadin:angle-down.vaadin:angle-left.vaadin:angle-right.vaadin:angle-up.vaadin:archive.vaadin:archives.vaadin:area-select.vaadin:arrow-backward.vaadin:arrow-circle-down-o.vaadin:arrow-circle-down.vaadin:arrow-circle-left-o.vaadin:arrow-circle-left.vaadin:arrow-circle-right-o.vaadin:arrow-circle-right.vaadin:arrow-circle-up-o.vaadin:arrow-circle-up.vaadin:arrow-down.vaadin:arrow-forward.vaadin:arrow-left.vaadin:arrow-long-down.vaadin:arrow-long-left.vaadin:arrow-right.vaadin:arrow-up.vaadin:arrows-cross.vaadin:arrows-long-h.vaadin:arrows-long-right.vaadin:arrows-long-up.vaadin:arrows-long-v.vaadin:arrows.vaadin:asterisk.vaadin:at.vaadin:automation.vaadin:backspace-a.vaadin:backspace.vaadin:backwards.vaadin:ban.vaadin:bar-chart-h.vaadin:bar-chart-v.vaadin:bar-chart.vaadin:barcode.vaadin:bed.vaadin:bell-o.vaadin:bell-slash-o.vaadin:bell-slash.vaadin:bell.vaadin:boat.vaadin:bold.vaadin:bolt.vaadin:bomb.vaadin:book-dollar.vaadin:book-percent.vaadin:book.vaadin:bookmark-o.vaadin:bookmark.vaadin:briefcase.vaadin:browser.vaadin:bug-o.vaadin:bug.vaadin:building-o.vaadin:building.vaadin:bullets.vaadin:bullseye.vaadin:bus.vaadin:buss.vaadin:button.vaadin:calc-book.vaadin:calc.vaadin:calendar-briefcase.vaadin:calendar-clock.vaadin:calendar-envelope.vaadin:calendar-o.vaadin:calendar-user.vaadin:calendar.vaadin:camera.vaadin:car.vaadin:caret-down.vaadin:caret-left.vaadin:caret-right.vaadin:caret-square-down-o.vaadin:caret-square-left-o.vaadin:caret-square-right-o.vaadin:caret-square-up-o.vaadin:caret-up.vaadin:cart-o.vaadin:cart.vaadin:cash.vaadin:chart-3d.vaadin:chart-grid.vaadin:chart-line.vaadin:chart-timeline.vaadin:chart.vaadin:chat.vaadin:check-circle-o.vaadin:check-circle.vaadin:check-square-o.vaadin:check-square.vaadin:check.vaadin:chevron-circle-down-o.vaadin:chevron-circle-down.vaadin:chevron-circle-left-o.vaadin:chevron-circle-left.vaadin:chevron-circle-right-o.vaadin:chevron-circle-right.vaadin:chevron-circle-up-o.vaadin:chevron-circle-up.vaadin:chevron-down-small.vaadin:chevron-down.vaadin:chevron-left-small.vaadin:chevron-left.vaadin:chevron-right-small.vaadin:chevron-right.vaadin:chevron-up-small.vaadin:chevron-up.vaadin:child.vaadin:circle-thin.vaadin:circle.vaadin:clipboard-check.vaadin:clipboard-cross.vaadin:clipboard-heart.vaadin:clipboard-pulse.vaadin:clipboard-text.vaadin:clipboard-user.vaadin:clipboard.vaadin:clock.vaadin:close-big.vaadin:close-circle-o.vaadin:close-circle.vaadin:close-small.vaadin:close.vaadin:cloud-download-o.vaadin:cloud-download.vaadin:cloud-o.vaadin:cloud-upload-o.vaadin:cloud-upload.vaadin:cloud.vaadin:cluster.vaadin:code.vaadin:coffee.vaadin:cog-o.vaadin:cog.vaadin:cogs.vaadin:coin-piles.vaadin:coins.vaadin:combobox.vaadin:comment-ellipsis-o.vaadin:comment-ellipsis.vaadin:comment-o.vaadin:comment.vaadin:comments-o.vaadin:comments.vaadin:compile.vaadin:compress-square.vaadin:compress.vaadin:connect-o.vaadin:connect.vaadin:controller.vaadin:copy-o.vaadin:copy.vaadin:copyright.vaadin:corner-lower-left.vaadin:corner-lower-right.vaadin:corner-upper-left.vaadin:corner-upper-right.vaadin:credit-card.vaadin:crop.vaadin:cross-cutlery.vaadin:crosshairs.vaadin:css.vaadin:ctrl-a.vaadin:ctrl.vaadin:cube.vaadin:cubes.vaadin:curly-brackets.vaadin:cursor-o.vaadin:cursor.vaadin:cutlery.vaadin:dashboard.vaadin:database.vaadin:date-input.vaadin:deindent.vaadin:del-a.vaadin:del.vaadin:dental-chair.vaadin:desktop.vaadin:diamond-o.vaadin:diamond.vaadin:diploma-scroll.vaadin:diploma.vaadin:disc.vaadin:doctor-briefcase.vaadin:doctor.vaadin:dollar.vaadin:dot-circle.vaadin:download-alt.vaadin:download.vaadin:drop.vaadin:edit.vaadin:eject.vaadin:elastic.vaadin:ellipsis-circle-o.vaadin:ellipsis-circle.vaadin:ellipsis-dots-h.vaadin:ellipsis-dots-v.vaadin:ellipsis-h.vaadin:ellipsis-v.vaadin:enter-arrow.vaadin:enter.vaadin:envelope-o.vaadin:envelope-open-o.vaadin:envelope-open.vaadin:envelope.vaadin:envelopes-o.vaadin:envelopes.vaadin:eraser.vaadin:esc-a.vaadin:esc.vaadin:euro.vaadin:exchange.vaadin:exclamation-circle-o.vaadin:exclamation-circle.vaadin:exclamation.vaadin:exit-o.vaadin:exit.vaadin:expand-full.vaadin:expand-square.vaadin:expand.vaadin:external-browser.vaadin:external-link.vaadin:eye-slash.vaadin:eye.vaadin:eyedropper.vaadin:facebook-square.vaadin:facebook.vaadin:factory.vaadin:family.vaadin:fast-backward.vaadin:fast-forward.vaadin:female.vaadin:file-add.vaadin:file-code.vaadin:file-font.vaadin:file-movie.vaadin:file-o.vaadin:file-picture.vaadin:file-presentation.vaadin:file-process.vaadin:file-refresh.vaadin:file-remove.vaadin:file-search.vaadin:file-sound.vaadin:file-start.vaadin:file-table.vaadin:file-text-o.vaadin:file-text.vaadin:file-tree-small.vaadin:file-tree-sub.vaadin:file-tree.vaadin:file-zip.vaadin:file.vaadin:fill.vaadin:film.vaadin:filter.vaadin:fire.vaadin:flag-checkered.vaadin:flag-o.vaadin:flag.vaadin:flash.vaadin:flask.vaadin:flight-landing.vaadin:flight-takeoff.vaadin:flip-h.vaadin:flip-v.vaadin:folder-add.vaadin:folder-o.vaadin:folder-open-o.vaadin:folder-open.vaadin:folder-remove.vaadin:folder-search.vaadin:folder.vaadin:font.vaadin:form.vaadin:forward.vaadin:frown-o.vaadin:funcion.vaadin:function.vaadin:funnel.vaadin:gamepad.vaadin:gavel.vaadin:gift.vaadin:glass.vaadin:glasses.vaadin:globe-wire.vaadin:globe.vaadin:golf.vaadin:google-plus-square.vaadin:google-plus.vaadin:grab.vaadin:grid-bevel.vaadin:grid-big-o.vaadin:grid-big.vaadin:grid-h.vaadin:grid-small-o.vaadin:grid-small.vaadin:grid-v.vaadin:grid.vaadin:group.vaadin:hammer.vaadin:hand.vaadin:handle-corner.vaadin:hands-up.vaadin:handshake.vaadin:harddrive-o.vaadin:harddrive.vaadin:hash.vaadin:header.vaadin:headphones.vaadin:headset.vaadin:health-card.vaadin:heart-o.vaadin:heart.vaadin:home-o.vaadin:home.vaadin:hospital.vaadin:hourglass-empty.vaadin:hourglass-end.vaadin:hourglass-start.vaadin:hourglass.vaadin:inbox.vaadin:indent.vaadin:info-circle-o.vaadin:info-circle.vaadin:info.vaadin:input.vaadin:insert.vaadin:institution.vaadin:invoice.vaadin:italic.vaadin:key-o.vaadin:key.vaadin:keyboard-o.vaadin:keyboard.vaadin:laptop.vaadin:layout.vaadin:level-down-bold.vaadin:level-down.vaadin:level-left-bold.vaadin:level-left.vaadin:level-right-bold.vaadin:level-right.vaadin:level-up-bold.vaadin:level-up.vaadin:lifebuoy.vaadin:lightbulb.vaadin:line-bar-chart.vaadin:line-chart.vaadin:line-h.vaadin:line-v.vaadin:lines-list.vaadin:lines.vaadin:link.vaadin:list-ol.vaadin:list-select.vaadin:list-ul.vaadin:list.vaadin:location-arrow-circle-o.vaadin:location-arrow-circle.vaadin:location-arrow.vaadin:lock.vaadin:magic.vaadin:magnet.vaadin:mailbox.vaadin:male.vaadin:map-marker.vaadin:margin-bottom.vaadin:margin-left.vaadin:margin-right.vaadin:margin-top.vaadin:margin.vaadin:medal.vaadin:megafone.vaadin:megaphone.vaadin:meh-o.vaadin:menu.vaadin:microphone.vaadin:minus-circle-o.vaadin:minus-circle.vaadin:minus-square-o.vaadin:minus.vaadin:mobile-browser.vaadin:mobile-retro.vaadin:mobile.vaadin:modal-list.vaadin:modal.vaadin:money-deposit.vaadin:money-exchange.vaadin:money-withdraw.vaadin:money.vaadin:moon-o.vaadin:moon.vaadin:morning.vaadin:movie.vaadin:music.vaadin:mute.vaadin:native-button.vaadin:newspaper.vaadin:notebook.vaadin:nurse.vaadin:office.vaadin:open-book.vaadin:option-a.vaadin:option.vaadin:options.vaadin:orientation.vaadin:out.vaadin:outbox.vaadin:package.vaadin:padding-bottom.vaadin:padding-left.vaadin:padding-right.vaadin:padding-top.vaadin:padding.vaadin:paint-roll.vaadin:paintbrush.vaadin:palete.vaadin:palette.vaadin:panel.vaadin:paperclip.vaadin:paperplane-o.vaadin:paperplane.vaadin:paragraph.vaadin:password.vaadin:paste.vaadin:pause.vaadin:pencil.vaadin:phone-landline.vaadin:phone.vaadin:picture.vaadin:pie-bar-chart.vaadin:pie-chart.vaadin:piggy-bank-coin.vaadin:piggy-bank.vaadin:pill.vaadin:pills.vaadin:pin-post.vaadin:pin.vaadin:play-circle-o.vaadin:play-circle.vaadin:play.vaadin:plug.vaadin:plus-circle-o.vaadin:plus-circle.vaadin:plus-minus.vaadin:plus-square-o.vaadin:plus.vaadin:pointer.vaadin:power-off.vaadin:presentation.vaadin:print.vaadin:progressbar.vaadin:puzzle-piece.vaadin:pyramid-chart.vaadin:qrcode.vaadin:question-circle-o.vaadin:question-circle.vaadin:question.vaadin:quote-left.vaadin:quote-right.vaadin:random.vaadin:raster-lower-left.vaadin:raster.vaadin:records.vaadin:recycle.vaadin:refresh.vaadin:reply-all.vaadin:reply.vaadin:resize-h.vaadin:resize-v.vaadin:retweet.vaadin:rhombus.vaadin:road-branch.vaadin:road-branches.vaadin:road-split.vaadin:road.vaadin:rocket.vaadin:rotate-left.vaadin:rotate-right.vaadin:rss-square.vaadin:rss.vaadin:safe-lock.vaadin:safe.vaadin:scale-unbalance.vaadin:scale.vaadin:scatter-chart.vaadin:scissors.vaadin:screwdriver.vaadin:search-minus.vaadin:search-plus.vaadin:search.vaadin:select.vaadin:server.vaadin:share-square.vaadin:share.vaadin:shield.vaadin:shift-arrow.vaadin:shift.vaadin:shop.vaadin:sign-in-alt.vaadin:sign-in.vaadin:sign-out-alt.vaadin:sign-out.vaadin:signal.vaadin:sitemap.vaadin:slider.vaadin:sliders.vaadin:smiley-o.vaadin:sort.vaadin:sound-disable.vaadin:spark-line.vaadin:specialist.vaadin:spinner-arc.vaadin:spinner-third.vaadin:spinner.vaadin:spline-area-chart.vaadin:spline-chart.vaadin:split-h.vaadin:split-v.vaadin:split.vaadin:spoon.vaadin:square-shadow.vaadin:star-half-left-o.vaadin:star-half-left.vaadin:star-half-right-o.vaadin:star-half-right.vaadin:star-o.vaadin:star.vaadin:start-cog.vaadin:step-backward.vaadin:step-forward.vaadin:stethoscope.vaadin:stock.vaadin:stop-cog.vaadin:stop.vaadin:stopwatch.vaadin:storage.vaadin:strikethrough.vaadin:subscript.vaadin:suitcase.vaadin:sun-down.vaadin:sun-o.vaadin:sun-rise.vaadin:superscript.vaadin:sword.vaadin:tab-a.vaadin:tab.vaadin:table.vaadin:tablet.vaadin:tabs.vaadin:tag.vaadin:tags.vaadin:tasks.vaadin:taxi.vaadin:teeth.vaadin:terminal.vaadin:text-height.vaadin:text-input.vaadin:text-label.vaadin:text-width.vaadin:thin-square.vaadin:thumbs-down-o.vaadin:thumbs-down.vaadin:thumbs-up-o.vaadin:thumbs-up.vaadin:ticket.vaadin:time-backward.vaadin:time-forward.vaadin:timer.vaadin:toolbox.vaadin:tools.vaadin:tooth.vaadin:touch.vaadin:train.vaadin:trash.vaadin:tree-table.vaadin:trendind-down.vaadin:trending-down.vaadin:trending-up.vaadin:trophy.vaadin:truck.vaadin:twin-col-select.vaadin:twitter-square.vaadin:twitter.vaadin:umbrella.vaadin:underline.vaadin:unlink.vaadin:unlock.vaadin:upload-alt.vaadin:upload.vaadin:user-card.vaadin:user-check.vaadin:user-clock.vaadin:user-heart.vaadin:user-star.vaadin:user.vaadin:users.vaadin:vaadin-h.vaadin:vaadin-v.vaadin:viewport.vaadin:vimeo-square.vaadin:vimeo.vaadin:volume-down.vaadin:volume-off.vaadin:volume-up.vaadin:volume.vaadin:wallet.vaadin:warning.vaadin:workplace.vaadin:wrench.vaadin:youtube-square.vaadin:youtube`.split(`.`),vl=null,yl=()=>(vl||=Promise.all([E(()=>import(`./vendor-ui5.js`).then(e=>e.n),__vite__mapDeps([5,1])),E(()=>import(`./vendor-ui5.js`).then(e=>e.t),__vite__mapDeps([5,1]))]),vl),Z=class extends y{constructor(...e){super(...e),this.ui5FieldComponentsReady=!1,this.component=void 0,this.field=void 0,this.baseUrl=void 0,this.state={},this.data={},this.appState={},this.appData={},this.colorPickerOpened=!1,this.colorPickerValue=void 0,this.comboData=[],this._comboFilter=``,this.rendered=!1,this.renderColorPicker=()=>{this.loadUi5FieldComponents();let e=this.field?.fieldId;return w`
             <ui5-color-picker value="${this.state&&e in this.state?this.state[e]:this.field?.initialValue}" @change="${e=>this.colorPickerValue=e.target.value}">Picker</ui5-color-picker>
-        `},this.saveColor=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.colorPickerValue,fieldId:this.field.fieldId},bubbles:!0,composed:!0})),this.colorPickerOpened=!1},this.renderColorPickerFooter=()=>T`<vaadin-button @click="${()=>this.colorPickerOpened=!1}">Cancel</vaadin-button>
-        <vaadin-button theme="primary" @click="${this.saveColor}">Save</vaadin-button>`,this.checked=e=>{let t=e.target;this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t.checked,fieldId:this.field.fieldId},bubbles:!0,composed:!0}))},this.convert=e=>this.field?.dataType==`integer`?parseInt(e):e,this.multiComboBoxValueChanged=e=>{if(this.rendered){let t=this.field?.fieldId,n=this.state&&t in this.state?this.state[t]:this.field?.initialValue,r;e.detail.value&&(r=e.detail.value.map(e=>e.value),r&&r.length>0&&(this.data[this.id]||(this.data[this.id]={}),this.data[this.id].content||(this.data[this.id].content=[]),this.data[this.id]&&this.data[this.id].content&&e.detail.value.forEach(e=>{this.data[this.id].content?.find(t=>e.value==t.value)||this.data[this.id].content.push(e)}))),this.compareArrays(r,n)||this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}},this.valueChanged=e=>{this.rendered&&e.detail.value!==void 0&&e.detail.value!=this.state[this.field.fieldId]&&this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.convert(e.detail.value),fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.selectedItems=e=>{if(e&&e.length>0)if(this.field?.remoteCoordinates){if(this.comboData&&this.comboData.length>0)return this.comboData?.filter(t=>e.indexOf(t.value)>=0);if(this.data[this.id]&&this.data[this.id].content&&this.data[this.id].content.length>0)return this.data[this.id].content.filter(t=>e.indexOf(t.value)>=0)}else return this.field?.options?.filter(t=>e.indexOf(t.value)>=0);return[]},this.selectedIndex=e=>{if(e)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content){let t=this.data[this.id].content.find(t=>t.value==e);if(t)return this.data[this.id].content.indexOf(t)}}else{let t=this.field?.options?.find(t=>t.value==e);if(t)return this.field?.options?.indexOf(t)}},this.selectedIndexes=e=>{if(e&&e.length>0)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content)return this.data[this.id].content.filter(t=>e.indexOf(t.value)>=0).map(e=>this.data[this.id].content.indexOf(e))}else return this.field?.options?.filter(t=>e.indexOf(t.value)>=0).map(e=>this.field?.options?.indexOf(e));return[]},this.compareArrays=(e,t)=>this.falsy(e)&&this.falsy(t)||e&&t&&e.length===t.length&&e.every((e,n)=>e===t[n]),this.falsy=e=>!e||e.length==0,this.listItemsSelected=e=>{let t=this.field?.fieldId,n=this.state&&t in this.state?this.state[t]:this.field?.initialValue,r;this.rendered&&(e.detail.value&&(this.field?.remoteCoordinates?this.data[this.id]&&this.data[this.id].content&&(r=e.detail.value.map(e=>this.data[this.id].content[e].value)):r=e.detail.value.map(e=>this.field.options[e].value)),this.compareArrays(r,n)||this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r,fieldId:this.field?.fieldId},bubbles:!0,composed:!0})))},this.listItemSelected=e=>{let t;if(e.detail.value||e.detail.value==0)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content){let n=this.data[this.id].content[e.detail.value];n&&(t=n.value)}}else{let n=this.field.options[e.detail.value];n&&(t=n.value)}this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.mapPosition=e=>{switch(e){case`topStretch`:return`top-stretch`;case`topStart`:return`top-start`;case`topCenter`:return`top-center`;case`topEnd`:return`top-end`;case`middle`:return`middle`;case`bottomStart`:return`bottom-start`;case`bottomEnd`:return`bottom-end`;case`bottomStretch`:return`bottom-stretch`;case`bottomCenter`:return`bottom-center`}return`bottom-end`},this.helperShownInControl=!1,this.lastAnnouncedError=``,this.controlOwnsValidity=!1,this.fileUploaded=e=>{let t=this.field?.fieldId??``,n=this.state[t];n.push({id:e.detail.xhr.responseText,name:e.detail.file.name}),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:n,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.fileChanged=e=>{let t=this.field?.fieldId??``,n=(e.detail.value??[]).filter(e=>e.id).map(e=>e.id),r=(this.state[t]??[]).map(e=>e.id);if(!this.compareArrays(r,n)){let t=(e.detail.value??[]).filter(e=>e.id).map(e=>({id:e.id,name:e.name}));this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}},this.triggerImageUpload=()=>{(this.renderRoot?.querySelector(`input[type="file"]`))?.click()},this.imageUpload=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r.result,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},r.readAsDataURL(n),t.value=``},this.imageDelete=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:``,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.iconComboboxRenderer=e=>T`
+        `},this.saveColor=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.colorPickerValue,fieldId:this.field.fieldId},bubbles:!0,composed:!0})),this.colorPickerOpened=!1},this.renderColorPickerFooter=()=>w`<vaadin-button @click="${()=>this.colorPickerOpened=!1}">Cancel</vaadin-button>
+        <vaadin-button theme="primary" @click="${this.saveColor}">Save</vaadin-button>`,this.checked=e=>{let t=e.target;this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t.checked,fieldId:this.field.fieldId},bubbles:!0,composed:!0}))},this.convert=e=>this.field?.dataType==`integer`?parseInt(e):e,this.multiComboBoxValueChanged=e=>{if(this.rendered){let t=this.field?.fieldId,n=this.state&&t in this.state?this.state[t]:this.field?.initialValue,r;e.detail.value&&(r=e.detail.value.map(e=>e.value),r&&r.length>0&&(this.data[this.id]||(this.data[this.id]={}),this.data[this.id].content||(this.data[this.id].content=[]),this.data[this.id]&&this.data[this.id].content&&e.detail.value.forEach(e=>{this.data[this.id].content?.find(t=>e.value==t.value)||this.data[this.id].content.push(e)}))),this.compareArrays(r,n)||this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}},this.valueChanged=e=>{this.rendered&&e.detail.value!==void 0&&e.detail.value!=this.state[this.field.fieldId]&&this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.convert(e.detail.value),fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.selectedItems=e=>{if(e&&e.length>0)if(this.field?.remoteCoordinates){if(this.comboData&&this.comboData.length>0)return this.comboData?.filter(t=>e.indexOf(t.value)>=0);if(this.data[this.id]&&this.data[this.id].content&&this.data[this.id].content.length>0)return this.data[this.id].content.filter(t=>e.indexOf(t.value)>=0)}else return this.field?.options?.filter(t=>e.indexOf(t.value)>=0);return[]},this.selectedIndex=e=>{if(e)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content){let t=this.data[this.id].content.find(t=>t.value==e);if(t)return this.data[this.id].content.indexOf(t)}}else{let t=this.field?.options?.find(t=>t.value==e);if(t)return this.field?.options?.indexOf(t)}},this.selectedIndexes=e=>{if(e&&e.length>0)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content)return this.data[this.id].content.filter(t=>e.indexOf(t.value)>=0).map(e=>this.data[this.id].content.indexOf(e))}else return this.field?.options?.filter(t=>e.indexOf(t.value)>=0).map(e=>this.field?.options?.indexOf(e));return[]},this.compareArrays=(e,t)=>this.falsy(e)&&this.falsy(t)||e&&t&&e.length===t.length&&e.every((e,n)=>e===t[n]),this.falsy=e=>!e||e.length==0,this.listItemsSelected=e=>{let t=this.field?.fieldId,n=this.state&&t in this.state?this.state[t]:this.field?.initialValue,r;this.rendered&&(e.detail.value&&(this.field?.remoteCoordinates?this.data[this.id]&&this.data[this.id].content&&(r=e.detail.value.map(e=>this.data[this.id].content[e].value)):r=e.detail.value.map(e=>this.field.options[e].value)),this.compareArrays(r,n)||this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r,fieldId:this.field?.fieldId},bubbles:!0,composed:!0})))},this.listItemSelected=e=>{let t;if(e.detail.value||e.detail.value==0)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content){let n=this.data[this.id].content[e.detail.value];n&&(t=n.value)}}else{let n=this.field.options[e.detail.value];n&&(t=n.value)}this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.mapPosition=e=>{switch(e){case`topStretch`:return`top-stretch`;case`topStart`:return`top-start`;case`topCenter`:return`top-center`;case`topEnd`:return`top-end`;case`middle`:return`middle`;case`bottomStart`:return`bottom-start`;case`bottomEnd`:return`bottom-end`;case`bottomStretch`:return`bottom-stretch`;case`bottomCenter`:return`bottom-center`}return`bottom-end`},this.helperShownInControl=!1,this.lastAnnouncedError=``,this.controlOwnsValidity=!1,this.fileUploaded=e=>{let t=this.field?.fieldId??``,n=this.state[t];n.push({id:e.detail.xhr.responseText,name:e.detail.file.name}),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:n,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.fileChanged=e=>{let t=this.field?.fieldId??``,n=(e.detail.value??[]).filter(e=>e.id).map(e=>e.id),r=(this.state[t]??[]).map(e=>e.id);if(!this.compareArrays(r,n)){let t=(e.detail.value??[]).filter(e=>e.id).map(e=>({id:e.id,name:e.name}));this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}},this.triggerImageUpload=()=>{(this.renderRoot?.querySelector(`input[type="file"]`))?.click()},this.imageUpload=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r.result,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},r.readAsDataURL(n),t.value=``},this.imageDelete=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:``,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.iconComboboxRenderer=e=>w`
   <div style="display: flex;">
       <vaadin-icon
               icon="${e}"
@@ -9050,12 +9050,12 @@ ${i}
       </div>
     </div>
   </div>
-`,this.comboRenderer=e=>T`
-        ${e.description||e.image||e.icon?T`
+`,this.comboRenderer=e=>w`
+        ${e.description||e.image||e.icon?w`
             <vaadin-horizontal-layout theme="spacing">
-                ${e.icon?T`<div><vaadin-icon icon="${e.icon}"></vaadin-icon></div>
-                                    `:v}
-                ${e.image?T`
+                ${e.icon?w`<div><vaadin-icon icon="${e.icon}"></vaadin-icon></div>
+                                    `:_}
+                ${e.image?w`
                     <div>
                     <img
                             style="width: var(--lumo-size-m); margin-right: var(--lumo-space-s);"
@@ -9063,75 +9063,75 @@ ${i}
                             alt="${e.label}"
                     />
                     </div>
-                                        `:v}
+                                        `:_}
                 <div>
                     ${e.label}
-                    ${e.description?T`
+                    ${e.description?w`
             <div style="font-size: var(--lumo-font-size-s); color: var(--lumo-secondary-text-color);">
                 ${e.description}
             </div>
-        `:v}
+        `:_}
                 </div>
 
             </vaadin-horizontal-layout>
                             `:e.label}
-`,this.filteredIcons=[],this.navLinkOffset=null,this.iconFilterChanged=e=>{this.filteredIcons=Qc.filter(t=>!e.detail.value||t.indexOf(e.detail.value)>=0)}}loadUi5FieldComponents(){this.ui5FieldComponentsReady||el().then(()=>{this.ui5FieldComponentsReady=!0})}remoteComboDataProvider(e){return(t,n)=>{let{filter:i,page:a,pageSize:o}=t,s=i??``;this._comboFilter=s,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{searchText:i,fieldId:this.field?.fieldId,size:o,page:a,sort:void 0},callback:e=>{if(s===this._comboFilter)if(e?.messages?.forEach(e=>{r.show(e.text,{position:e.position?this.mapPosition(e.position):void 0,theme:e.variant,duration:e.duration})}),!e.fragments||e.fragments.length==0)this.comboData=[],n([],0);else{let t=e.fragments[0].data?.[this.id];this.comboData=t?.content,n(t?.content,t?.totalElements)}},callbackonly:!0},bubbles:!0,composed:!0}))}}disconnectedCallback(){super.disconnectedCallback(),this.rendered=!1}renderNavLink(){let e=this.field?.link;if(!e?.href)return v;let t=M(e.href,this.state,this.data)??e.href,n=M(e.title,this.state,this.data)||t,r=e.icon||(t.startsWith(`http`)?`vaadin:external-link`:`vaadin:link`),i=this.navLinkOffset??`calc(var(--lumo-font-size-s) * 1.6 + (var(--lumo-size-m) - var(--lumo-icon-size-s)) / 2)`;return T`<a
+`,this.filteredIcons=[],this.navLinkOffset=null,this.iconFilterChanged=e=>{this.filteredIcons=_l.filter(t=>!e.detail.value||t.indexOf(e.detail.value)>=0)}}loadUi5FieldComponents(){this.ui5FieldComponentsReady||yl().then(()=>{this.ui5FieldComponentsReady=!0})}remoteComboDataProvider(e){return(t,n)=>{let{filter:i,page:a,pageSize:o}=t,s=i??``;this._comboFilter=s,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{searchText:i,fieldId:this.field?.fieldId,size:o,page:a,sort:void 0},callback:e=>{if(s===this._comboFilter)if(e?.messages?.forEach(e=>{r.show(e.text,{position:e.position?this.mapPosition(e.position):void 0,theme:e.variant,duration:e.duration})}),!e.fragments||e.fragments.length==0)this.comboData=[],n([],0);else{let t=e.fragments[0].data?.[this.id];this.comboData=t?.content,n(t?.content,t?.totalElements)}},callbackonly:!0},bubbles:!0,composed:!0}))}}disconnectedCallback(){super.disconnectedCallback(),this.rendered=!1}renderNavLink(){let e=this.field?.link;if(!e?.href)return _;let t=j(e.href,this.state,this.data)??e.href,n=j(e.title,this.state,this.data)||t,r=e.icon||(t.startsWith(`http`)?`vaadin:external-link`:`vaadin:link`),i=this.navLinkOffset??`calc(var(--lumo-font-size-s) * 1.6 + (var(--lumo-size-m) - var(--lumo-icon-size-s)) / 2)`;return w`<a
                 data-navlink
                 href="${t}"
                 title="${n}"
-                target="${S(e.target||void 0)}"
+                target="${x(e.target||void 0)}"
                 style="display: flex; align-items: center; color: var(--lumo-secondary-text-color); align-self: flex-start; margin-top: ${i};"
-        ><vaadin-icon icon="${r}" style="width: var(--lumo-icon-size-s); height: var(--lumo-icon-size-s);"></vaadin-icon></a>`}positionNavLink(){let e=this.renderRoot?.querySelector(`a[data-navlink]`);e&&setTimeout(()=>{let t=e.parentElement,n=t?.firstElementChild?.firstElementChild;if(!t||!n)return;let r=(n.shadowRoot?.querySelector(`[part="input-field"]`)??n).getBoundingClientRect();if(r.height===0)return;let i=Math.max(0,r.top+r.height/2-e.offsetHeight/2-t.getBoundingClientRect().top),a=`${Math.round(i)}px`;this.navLinkOffset!==a&&(this.navLinkOffset=a)})}helperText(){return this.helperShownInControl=!0,N(this.field?.description??``,this.state,this.data)??``}fieldErrors(){let e=this.field?.fieldId??``,t=this.data?.errors?.[e];return Array.isArray(t)?t.filter(e=>!!e):[]}validatableControl(){let e=this.renderRoot.querySelectorAll(`*`);for(let t of e)if(`invalid`in t&&`errorMessage`in t)return t;return null}applyValidationState(){let e=this.fieldErrors(),t=this.validatableControl();if(!t){this.lastAnnouncedError=e.join(`. `);return}let n=e.join(`. `);if(t.errorMessage=n,t.invalid=e.length>0,n&&n!==this.lastAnnouncedError){let e=(this.field?.label??``).toString().trim();Ze(e?`${e}: ${n}`:n,{politeness:`assertive`})}this.lastAnnouncedError=n}render(){this.rendered=!0;let e=this.renderNavLink();this.helperShownInControl=!1;let t=this.renderField(),n=this.field?.description&&!this.helperShownInControl?N(this.field.description,this.state,this.data):void 0,r=this.fieldErrors(),i=r.length>0&&!this.controlOwnsValidity;return T`<div style="display: block;">
-            <div style="${e===v?``:`display: flex; gap: var(--lumo-space-xs);`}"><div style="flex: 1; min-width: 0;">${t}</div>${e}</div>
-            ${n?T`
+        ><vaadin-icon icon="${r}" style="width: var(--lumo-icon-size-s); height: var(--lumo-icon-size-s);"></vaadin-icon></a>`}positionNavLink(){let e=this.renderRoot?.querySelector(`a[data-navlink]`);e&&setTimeout(()=>{let t=e.parentElement,n=t?.firstElementChild?.firstElementChild;if(!t||!n)return;let r=(n.shadowRoot?.querySelector(`[part="input-field"]`)??n).getBoundingClientRect();if(r.height===0)return;let i=Math.max(0,r.top+r.height/2-e.offsetHeight/2-t.getBoundingClientRect().top),a=`${Math.round(i)}px`;this.navLinkOffset!==a&&(this.navLinkOffset=a)})}helperText(){return this.helperShownInControl=!0,M(this.field?.description??``,this.state,this.data)??``}fieldErrors(){let e=this.field?.fieldId??``,t=this.data?.errors?.[e];return Array.isArray(t)?t.filter(e=>!!e):[]}validatableControl(){let e=this.renderRoot.querySelectorAll(`*`);for(let t of e)if(`invalid`in t&&`errorMessage`in t)return t;return null}applyValidationState(){let e=this.fieldErrors(),t=this.validatableControl();if(!t){this.lastAnnouncedError=e.join(`. `);return}let n=e.join(`. `);if(t.errorMessage=n,t.invalid=e.length>0,n&&n!==this.lastAnnouncedError){let e=(this.field?.label??``).toString().trim();Qe(e?`${e}: ${n}`:n,{politeness:`assertive`})}this.lastAnnouncedError=n}render(){this.rendered=!0;let e=this.renderNavLink();this.helperShownInControl=!1;let t=this.renderField(),n=this.field?.description&&!this.helperShownInControl?M(this.field.description,this.state,this.data):void 0,r=this.fieldErrors(),i=r.length>0&&!this.controlOwnsValidity;return w`<div style="display: block;">
+            <div style="${e===_?``:`display: flex; gap: var(--lumo-space-xs);`}"><div style="flex: 1; min-width: 0;">${t}</div>${e}</div>
+            ${n?w`
                 <div style="font-size: var(--lumo-font-size-xs); color: var(--lumo-secondary-text-color); margin-top: var(--lumo-space-xs);">${n}</div>
-            `:v}
-            ${i?T`
-                <div role="alert"><ul>${r.map(e=>T`<li>${e}</li>`)}</ul></div>
-            `:v}
-        </div>`}async firstUpdated(){this.filteredIcons=Qc}update(e){e.has(`component`)&&(this.rendered=!1),super.update(e)}updated(e){super.updated(e),this.positionNavLink(),this.applyValidationState(),this.controlOwnsValidity=!!this.validatableControl()}renderField(){let e=this.field?.fieldId??``,t=this.state&&e in this.state?this.state[e]:this.field?.initialValue,n=M(this.field?.label+``,this.state,this.data),r=this.labelAlreadyRendered||!n||n==`null`?v:n;return this.field?.propertyRow?this.renderPropertyRowField(e,t,r,n):this.field?.stereotype==`badge`?this.renderBadgeField(e,t,r,n):this.field?.stereotype==`plainText`?this.renderPlainTextField(e,t,r,n):this.field?.stereotype==`bulletedList`?this.renderBulletedListField(e,t,r,n):this.field?.readOnly&&this.field.stereotype!=`grid`&&this.field.dataType!=`status`&&this.field?.dataType!=`money`?this.renderReadOnlyField(e,t,r,n):this.field?.dataType==`file`?this.renderFileField(e,t,r,n):this.field?.dataType==`string`?this.renderStringField(e,t,r,n):this.field?.dataType==`number`?this.renderNumberField(e,t,r,n):this.field?.dataType==`integer`?this.renderIntegerField(e,t,r,n):this.field?.dataType==`bool`?this.renderBoolField(e,t,r,n):this.field?.dataType==`dateRange`?this.renderDateRangeField(e,t,r,n):this.field?.dataType==`date`?this.renderDateField(e,t,r,n):this.field?.dataType==`dateTime`?this.renderDateTimeField(e,t,r,n):this.field?.dataType==`time`?this.renderTimeField(e,t,r,n):this.field?.dataType==`array`?this.renderArrayField(e,t,r,n):this.field?.dataType==`money`?this.renderMoneyField(e,t,r,n):this.field?.dataType==`status`?this.renderStatusField(e,t,r,n):this.field?.dataType==`range`?this.renderRangeField(e,t,r,n):T`<p>Unknown field type ${this.field?.dataType} / ${this.field?.stereotype}</p>`}renderBadgeField(e,t,n,r){if(!this.field)return T``;let i=t===!0||t===`true`;return T`<vaadin-custom-field
+            `:_}
+            ${i?w`
+                <div role="alert"><ul>${r.map(e=>w`<li>${e}</li>`)}</ul></div>
+            `:_}
+        </div>`}async firstUpdated(){this.filteredIcons=_l}update(e){e.has(`component`)&&(this.rendered=!1),super.update(e)}updated(e){super.updated(e),this.positionNavLink(),this.applyValidationState(),this.controlOwnsValidity=!!this.validatableControl()}renderField(){let e=this.field?.fieldId??``,t=this.state&&e in this.state?this.state[e]:this.field?.initialValue,n=j(this.field?.label+``,this.state,this.data),r=this.labelAlreadyRendered||!n||n==`null`?_:n;return this.field?.propertyRow?this.renderPropertyRowField(e,t,r,n):this.field?.stereotype==`badge`?this.renderBadgeField(e,t,r,n):this.field?.stereotype==`plainText`?this.renderPlainTextField(e,t,r,n):this.field?.stereotype==`bulletedList`?this.renderBulletedListField(e,t,r,n):this.field?.readOnly&&this.field.stereotype!=`grid`&&this.field.dataType!=`status`&&this.field?.dataType!=`money`?this.renderReadOnlyField(e,t,r,n):this.field?.dataType==`file`?this.renderFileField(e,t,r,n):this.field?.dataType==`string`?this.renderStringField(e,t,r,n):this.field?.dataType==`number`?this.renderNumberField(e,t,r,n):this.field?.dataType==`integer`?this.renderIntegerField(e,t,r,n):this.field?.dataType==`bool`?this.renderBoolField(e,t,r,n):this.field?.dataType==`dateRange`?this.renderDateRangeField(e,t,r,n):this.field?.dataType==`date`?this.renderDateField(e,t,r,n):this.field?.dataType==`dateTime`?this.renderDateTimeField(e,t,r,n):this.field?.dataType==`time`?this.renderTimeField(e,t,r,n):this.field?.dataType==`array`?this.renderArrayField(e,t,r,n):this.field?.dataType==`money`?this.renderMoneyField(e,t,r,n):this.field?.dataType==`status`?this.renderStatusField(e,t,r,n):this.field?.dataType==`range`?this.renderRangeField(e,t,r,n):w`<p>Unknown field type ${this.field?.dataType} / ${this.field?.stereotype}</p>`}renderBadgeField(e,t,n,r){if(!this.field)return w``;let i=t===!0||t===`true`;return w`<vaadin-custom-field
                     id="${this.field.fieldId}"
                     .helperText="${this.helperText()}"
                     data-colspan="${this.field?.colspan}"
                     style="${this.field?.style}"
             ><span theme="badge ${i?`success`:``} pill" style="${i?``:`opacity: 0.4;`}">${r}</span>
-            </vaadin-custom-field>`}renderPropertyRowField(e,t,n,r){if(!this.field)return T``;let i=N(t,this.state,this.data),a=i&&typeof i==`object`&&`value`in i?i:null;i&&i.value&&(i=i.value);let o=this.field?.dataType==`bool`||i===!0||i===!1,s=this.field?.dataType==`money`,c=i!=null&&i!==``,l=c?String(i):`—`;if(s&&c){let e=typeof i==`number`?i:parseFloat(String(i));isNaN(e)||(l=a&&a.locale&&a.currency?new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(e):new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e))}let u=o?T`<vaadin-icon icon="${i===!0||i===`true`?`vaadin:check`:`vaadin:minus`}" style="height: 16px; width: 16px;"></vaadin-icon>`:T`<span style="font-weight: 500; text-align: right; word-break: break-word; margin-left: auto;${s?` font-variant-numeric: tabular-nums;`:``}">${l}</span>`,d=r&&r!=`null`;return T`<div
+            </vaadin-custom-field>`}renderPropertyRowField(e,t,n,r){if(!this.field)return w``;let i=M(t,this.state,this.data),a=i&&typeof i==`object`&&`value`in i?i:null;i&&i.value&&(i=i.value);let o=this.field?.dataType==`bool`||i===!0||i===!1,s=this.field?.dataType==`money`,c=i!=null&&i!==``,l=c?String(i):`—`;if(s&&c){let e=typeof i==`number`?i:parseFloat(String(i));isNaN(e)||(l=a&&a.locale&&a.currency?new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(e):new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e))}let u=o?w`<vaadin-icon icon="${i===!0||i===`true`?`vaadin:check`:`vaadin:minus`}" style="height: 16px; width: 16px;"></vaadin-icon>`:w`<span style="font-weight: 500; text-align: right; word-break: break-word; margin-left: auto;${s?` font-variant-numeric: tabular-nums;`:``}">${l}</span>`,d=r&&r!=`null`;return w`<div
                     id="${this.field.fieldId}"
                     data-colspan="${this.field?.colspan}"
                     style="display: flex; justify-content: space-between; align-items: baseline; gap: 1rem; width: 100%; padding: 0.4rem 0; border-bottom: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.08)); font-size: var(--lumo-font-size-s, .875rem); ${this.field?.style}"
-            >${d?T`<span style="color: var(--lumo-secondary-text-color, #888); white-space: nowrap;">${r}</span>`:v}${u}</div>`}renderBulletedListField(e,t,n,r){if(!this.field)return T``;let i=N(t,this.state,this.data),a=Array.isArray(i)?i.map(e=>String(e)):i!=null&&i!==``?[String(i)]:[];return T`<vaadin-custom-field
+            >${d?w`<span style="color: var(--lumo-secondary-text-color, #888); white-space: nowrap;">${r}</span>`:_}${u}</div>`}renderBulletedListField(e,t,n,r){if(!this.field)return w``;let i=M(t,this.state,this.data),a=Array.isArray(i)?i.map(e=>String(e)):i!=null&&i!==``?[String(i)]:[];return w`<vaadin-custom-field
                     id="${this.field.fieldId}"
                     label="${n}"
                     .helperText="${this.helperText()}"
                     data-colspan="${this.field?.colspan}"
                     style="${this.field?.style}"
             ><mateu-bulleted-list .items="${a}"></mateu-bulleted-list>
-            </vaadin-custom-field>`}renderPlainTextField(e,t,n,r){if(!this.field)return T``;let i=N(t,this.state,this.data),a=i&&typeof i==`object`&&`value`in i?i:null;i&&i.value&&(i=i.value);let o=this.field?.dataType==`bool`||i===!0||i===!1,s=this.field?.dataType==`money`,c=i!=null&&i!==``,l=c?String(i):`—`;if(s&&c){let e=typeof i==`number`?i:parseFloat(String(i));isNaN(e)||(l=a&&a.locale&&a.currency?new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(e):new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e))}let u=o?T`<vaadin-icon icon="${i===!0||i===`true`?`vaadin:check`:`vaadin:minus`}" style="height: 16px; width: 16px;"></vaadin-icon>`:this.field?.multiline?T`<span style="font-weight: 500; white-space: pre-wrap; word-break: break-word;">${l}</span>`:T`<span style="font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;${s?` font-variant-numeric: tabular-nums;`:``}">${l}</span>`;return T`<vaadin-custom-field
+            </vaadin-custom-field>`}renderPlainTextField(e,t,n,r){if(!this.field)return w``;let i=M(t,this.state,this.data),a=i&&typeof i==`object`&&`value`in i?i:null;i&&i.value&&(i=i.value);let o=this.field?.dataType==`bool`||i===!0||i===!1,s=this.field?.dataType==`money`,c=i!=null&&i!==``,l=c?String(i):`—`;if(s&&c){let e=typeof i==`number`?i:parseFloat(String(i));isNaN(e)||(l=a&&a.locale&&a.currency?new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(e):new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e))}let u=o?w`<vaadin-icon icon="${i===!0||i===`true`?`vaadin:check`:`vaadin:minus`}" style="height: 16px; width: 16px;"></vaadin-icon>`:this.field?.multiline?w`<span style="font-weight: 500; white-space: pre-wrap; word-break: break-word;">${l}</span>`:w`<span style="font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;${s?` font-variant-numeric: tabular-nums;`:``}">${l}</span>`;return w`<vaadin-custom-field
                     id="${this.field.fieldId}"
                     label="${n}"
                     data-colspan="${this.field?.colspan}"
                     style="${s?`text-align: right; `:``}${this.field?.style}"
-            >${u}</vaadin-custom-field>`}renderReadOnlyField(e,t,n,r){if(!this.field)return T``;let i=N(t,this.state,this.data)||this.data[e];if(i&&i.value&&(i=i.value),this.field.stereotype==`fileUpload`)return T`<vaadin-custom-field
+            >${u}</vaadin-custom-field>`}renderReadOnlyField(e,t,n,r){if(!this.field)return w``;let i=M(t,this.state,this.data)||this.data[e];if(i&&i.value&&(i=i.value),this.field.stereotype==`fileUpload`)return w`<vaadin-custom-field
                         id="${this.field.fieldId}"
                         label="${n}"
                         .helperText="${this.helperText()}"
                         data-colspan="${this.field.colspan}"
                 ><mateu-file-upload .fieldId="${this.field.fieldId}" .value="${i}" .editable="${!1}"></mateu-file-upload>
-                </vaadin-custom-field>`;if(this.field.stereotype==`image`||this.field.stereotype==`uploadableImage`||this.field.stereotype==`signature`||this.field.stereotype==`camera`)return T`<vaadin-custom-field
+                </vaadin-custom-field>`;if(this.field.stereotype==`image`||this.field.stereotype==`uploadableImage`||this.field.stereotype==`signature`||this.field.stereotype==`camera`)return w`<vaadin-custom-field
                         id="${this.field.fieldId}"
                         label="${n}"
-                        required="${this.field.required||v}"
+                        required="${this.field.required||_}"
                         .helperText="${this.helperText()}"
                         data-colspan="${this.field.colspan}"
                 ><img src="${i}" id="${this.field.fieldId}_img" style="${this.field.style}">
-                </vaadin-custom-field>`;if(this.field.dataType==`bool`)return T`<vaadin-custom-field
+                </vaadin-custom-field>`;if(this.field.dataType==`bool`)return w`<vaadin-custom-field
                         id="${this.field.fieldId}"
                         label="${n}"
-                        required="${this.field.required||v}"
+                        required="${this.field.required||_}"
                         .helperText="${this.helperText()}"
                         data-colspan="${this.field.colspan}"
                 ><vaadin-icon icon="${i?`vaadin:check`:`vaadin:minus`}" style="height: 20px;"></vaadin-icon>
-                </vaadin-custom-field>`;let a=i==null?``:String(i);return T`
+                </vaadin-custom-field>`;let a=i==null?``:String(i);return w`
                 <vaadin-text-field
                         id="${this.field.fieldId}"
                         label="${n}"
@@ -9140,14 +9140,14 @@ ${i}
                         style="${this.field.style}"
                         .helperText="${this.helperText()}"
                         data-colspan="${this.field.colspan}"
-                >${a.length>15?T`<vaadin-icon
+                >${a.length>15?w`<vaadin-icon
                         slot="suffix"
                         icon="vaadin:copy"
                         title="Copiar"
                         style="cursor: pointer; color: var(--lumo-secondary-text-color);"
                         @click="${()=>this.copyValue(a)}"
-                ></vaadin-icon>`:v}</vaadin-text-field>
-`}copyValue(e){navigator.clipboard.writeText(e).then(()=>r.show(`Copied`,{position:`bottom-end`,theme:`success`,duration:2e3})).catch(()=>{})}renderFileField(e,t,n,r){if(!this.field)return T``;let i=t?.map(e=>({id:e.id,name:e.name,type:``,uploadTarget:``,complete:!0}))??[];return T`
+                ></vaadin-icon>`:_}</vaadin-text-field>
+`}copyValue(e){navigator.clipboard.writeText(e).then(()=>r.show(`Copied`,{position:`bottom-end`,theme:`success`,duration:2e3})).catch(()=>{})}renderFileField(e,t,n,r){if(!this.field)return w``;let i=t?.map(e=>({id:e.id,name:e.name,type:``,uploadTarget:``,complete:!0}))??[];return w`
                 <vaadin-custom-field
                         label="${n}"
                         .helperText="${this.helperText()}"
@@ -9160,11 +9160,11 @@ ${i}
                             @files-changed="${this.fileChanged}"
                     ></vaadin-upload>
                 </vaadin-custom-field>
-            `}renderStringField(e,t,n,r){if(!this.field)return T``;if(this.field?.stereotype==`searchable`)return T`
+            `}renderStringField(e,t,n,r){if(!this.field)return w``;if(this.field?.stereotype==`searchable`)return w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
-                            required="${this.field.required||v}"
+                            required="${this.field.required||_}"
                             .helperText="${this.helperText()}"
                             data-colspan="${this.field.colspan}"
                     >
@@ -9174,7 +9174,21 @@ ${i}
                             <vaadin-button theme="icon" @click="${e=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`codesearch-`+this.field?.fieldId,parameters:{}},bubbles:!0,composed:!0}))}}"><vaadin-icon icon="lumo:search"></vaadin-icon></vaadin-button>
                         </vaadin-horizontal-layout>
                     </vaadin-custom-field>
-                `;if(this.field?.stereotype==`select`){if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates;this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements||this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}));let r=t;return t&&t.value&&(r=t.value),T`
+                `;if(this.field?.stereotype==`select`){if(this.field?.optionsSource){let e=this.field.optionsSource,r=j(e.url,this.state,this.data)??e.url;this.data[this.id]?.sourceSignature!==r&&(this.data[this.id]={content:this.data[this.id]?.content??[],sourceSignature:r},jc(e,e=>j(e,this.state,this.data)).then(e=>{this.data[this.id]={content:e,totalElements:e.length,sourceSignature:r},this.requestUpdate()}).catch(e=>console.warn(`mateu: external options fetch failed`,e)));let i=t;return t&&t.value&&(i=t.value),w`
+                    <vaadin-select
+                            id="${this.field.fieldId}"
+                            label="${n}"
+                            item-label-path="label"
+                            item-value-path="value"
+                            .items="${this.data[this.id]?.content??[]}"
+                            .helperText="${this.helperText()}"
+                            @value-changed="${this.valueChanged}"
+                            .value="${i}"
+                            ?autofocus="${this.field.wantsFocus}"
+                            required="${this.field.required||_}"
+                            data-colspan="${this.field.colspan}"
+                    ></vaadin-select>
+                    `}if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates;this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements||this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}));let r=t;return t&&t.value&&(r=t.value),w`
                     <vaadin-select
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9185,10 +9199,10 @@ ${i}
                             @value-changed="${this.valueChanged}"
                             .value="${r}"
                             ?autofocus="${this.field.wantsFocus}"
-                            required="${this.field.required||v}"
+                            required="${this.field.required||_}"
                             data-colspan="${this.field.colspan}"
                     ></vaadin-select>
-                    `}let e=t;return t&&t.value&&(e=t.value),T`
+                    `}let e=t;return t&&t.value&&(e=t.value),w`
                     <vaadin-select
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9199,21 +9213,21 @@ ${i}
                             @value-changed="${this.valueChanged}"
                             .value="${e}"
                             ?autofocus="${this.field.wantsFocus}"
-                            required="${this.field.required||v}"
+                            required="${this.field.required||_}"
                             data-colspan="${this.field.colspan}"
                     ></vaadin-select>
-                `}if(this.field?.stereotype==`markdown`)return T`
+                `}if(this.field?.stereotype==`markdown`)return w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
-                            required="${this.field.required||v}"
+                            required="${this.field.required||_}"
                             .helperText="${this.helperText()}"
                             data-colspan="${this.field.colspan}"
                     ><vaadin-markdown
                             .content="${t}"
                     ></vaadin-markdown>
                     </vaadin-custom-field>
-                `;if(this.field?.stereotype==`combobox`){if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates,r;this.data[this.id]&&this.data[this.id].content&&(r=this.data[this.id].content.find(e=>e.value==t)),!r&&this.comboData&&(r=this.comboData.find(e=>e.value==t)),!r&&t&&(r={value:t,label:this.data[this.id+`-label`]??t});let i=this.remoteComboDataProvider(e.action);return T`
+                `;if(this.field?.stereotype==`combobox`){if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates,r;this.data[this.id]&&this.data[this.id].content&&(r=this.data[this.id].content.find(e=>e.value==t)),!r&&this.comboData&&(r=this.comboData.find(e=>e.value==t)),!r&&t&&(r={value:t,label:this.data[this.id+`-label`]??t});let i=this.remoteComboDataProvider(e.action);return w`
                     <vaadin-combo-box
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9224,13 +9238,13 @@ ${i}
                             .helperText="${this.helperText()}"
                             @value-changed="${this.valueChanged}"
                             ?autofocus="${this.field.wantsFocus}"
-                            ?required="${this.field.required||v}"
+                            ?required="${this.field.required||_}"
                             data-colspan="${this.field.colspan}"
                             style="${this.field.style}"
                             @keyup="${e=>{if(e.key==`Backspace`){let t=e.currentTarget;t.inputElement.value||(t.value=``)}}}"
                             ${u(this.comboRenderer,[])}
                     ></vaadin-combo-box>
-                    `}return T`
+                    `}return w`
                     <vaadin-combo-box
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9241,12 +9255,12 @@ ${i}
                             @value-changed="${this.valueChanged}"
                             .value="${t}"
                             ?autofocus="${this.field.wantsFocus}"
-                            required="${this.field.required||v}"
+                            required="${this.field.required||_}"
                             data-colspan="${this.field.colspan}"
                             style="${this.field.style}"
                             ${u(this.comboRenderer,[])}
                     ></vaadin-combo-box>
-                    `}if(this.field?.stereotype==`listBox`){if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates;return this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements||this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0})),T`
+                    `}if(this.field?.stereotype==`listBox`){if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates;return this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements||this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0})),w`
                         <vaadin-custom-field
                                 label="${n}"
                                 .helperText="${this.helperText()}"
@@ -9254,19 +9268,19 @@ ${i}
                         >
                     <vaadin-list-box
                             id="${this.field.fieldId}"
-                            selected="${S(this.selectedIndex(t))}"
+                            selected="${x(this.selectedIndex(t))}"
                             @selected-changed="${this.listItemSelected}"
                             ?autofocus="${this.field.wantsFocus}"
                     >
-                        ${this.data[this.id]?.content?.map(e=>T`
-                            <vaadin-item>${e.description||e.image||e.icon?T`
+                        ${this.data[this.id]?.content?.map(e=>w`
+                            <vaadin-item>${e.description||e.image||e.icon?w`
                                 <vaadin-horizontal-layout style="align-items: center;" theme="spacing">
-                                    ${e.icon?T`
+                                    ${e.icon?w`
                                         <vaadin-icon icon="${e.icon}"></vaadin-icon>
-                                    `:v}
-                                    ${e.image?T`
+                                    `:_}
+                                    ${e.image?w`
                                             <img src="${e.image}" alt="${e.label}" style="width: 2rem;" />
-                                        `:v}
+                                        `:_}
                                     <vaadin-vertical-layout>
                                         <span> ${e.label} </span>
                                         <span
@@ -9280,7 +9294,7 @@ ${i}
                         `)}
                     </vaadin-list-box>
                         </vaadin-custom-field>
-                    `}return T`
+                    `}return w`
                     <vaadin-custom-field
                             label="${n}"
                             .helperText="${this.helperText()}"
@@ -9288,19 +9302,19 @@ ${i}
                     >
                     <vaadin-list-box
                             id="${this.field.fieldId}"
-                            selected="${S(this.selectedIndex(t))}"
+                            selected="${x(this.selectedIndex(t))}"
                             @selected-changed="${this.listItemSelected}"
                             ?autofocus="${this.field.wantsFocus}"
                     >
-                        ${this.field.options?.map(e=>T`
-                            <vaadin-item>${e.description||e.image||e.icon?T`
+                        ${this.field.options?.map(e=>w`
+                            <vaadin-item>${e.description||e.image||e.icon?w`
                                 <vaadin-horizontal-layout style="align-items: center;" theme="spacing">
-                                    ${e.icon?T`
+                                    ${e.icon?w`
                                         <vaadin-icon icon="${e.icon}"></vaadin-icon>
-                                    `:v}
-                                    ${e.image?T`
+                                    `:_}
+                                    ${e.image?w`
                                             <img src="${e.image}" alt="${e.label}" style="width: 2rem;" />
-                                        `:v}
+                                        `:_}
                                     <vaadin-vertical-layout>
                                         <span> ${e.label} </span>
                                         <span
@@ -9314,7 +9328,7 @@ ${i}
                         `)}
                     </vaadin-list-box>
                     </vaadin-custom-field>
-                `}if(this.field?.stereotype==`radio`){if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates;return this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements||this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0})),T`
+                `}if(this.field?.stereotype==`radio`){if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates;return this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements||this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0})),w`
                     <vaadin-radio-group
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9323,31 +9337,31 @@ ${i}
                             .helperText="${this.helperText()}"
                             theme="horizontal"
                             ?autofocus="${this.field.wantsFocus}"
-                            required="${this.field.required||v}"
+                            required="${this.field.required||_}"
                             data-colspan="${this.field.colspan}"
                     >
-                        ${this.data[this.id]?.content?.map(e=>T`
+                        ${this.data[this.id]?.content?.map(e=>w`
                             <vaadin-radio-button value="${e.value}" label="${e.label}" ?checked="${e&&t&&e.value===t}">
-                                ${e.description||e.image||e.icon?T`
+                                ${e.description||e.image||e.icon?w`
                                     <label slot="label">
                                         <vaadin-horizontal-layout theme="spacing">
-                                            ${e.icon?T`
+                                            ${e.icon?w`
                                                 <vaadin-icon icon="${e.icon}"></vaadin-icon>
-                                            `:v}
-                                            ${e.image?T`
+                                            `:_}
+                                            ${e.image?w`
                                                 <img src="${e.image}" alt="${e.label}" style="height: 1rem;" />
-                                            `:v}
+                                            `:_}
                                             <span>${e.label}</span>
                                         </vaadin-horizontal-layout>
-                                        ${e.description?T`
+                                        ${e.description?w`
                                             <div>${e.description}</div>
-                                        `:v}
+                                        `:_}
                                     </label>
-                                `:v}
+                                `:_}
                             </vaadin-radio-button>
                         `)}
 </vaadin-radio-group>
-                    `}return T`
+                    `}return w`
                     <vaadin-radio-group
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9355,34 +9369,34 @@ ${i}
                             .value="${t}"
                             .helperText="${this.helperText()}"
                             ?autofocus="${this.field.wantsFocus}"
-                            required="${this.field.required||v}"
+                            required="${this.field.required||_}"
                             data-colspan="${this.field.colspan}"
                     >
-                        ${this.field.options?.map(e=>T`
+                        ${this.field.options?.map(e=>w`
                             <vaadin-radio-button value="${e.value}" label="${e.label}">
-                                ${e.description||e.image||e.icon?T`
+                                ${e.description||e.image||e.icon?w`
                                     <label slot="label">
                                         <vaadin-horizontal-layout theme="spacing">
-                                            ${e.icon?T`
+                                            ${e.icon?w`
                                                 <vaadin-icon icon="${e.icon}"></vaadin-icon>
-                                            `:v}
-                                            ${e.image?T`
+                                            `:_}
+                                            ${e.image?w`
                                                 <img src="${e.image}" alt="${e.label}" style="height: 1rem;" />
-                                            `:v}
+                                            `:_}
                                             <span>${e.label}</span>
                                         </vaadin-horizontal-layout>
-                                        ${e.description?T`
+                                        ${e.description?w`
                                             <div>${e.description}</div>
-                                        `:v}
+                                        `:_}
                                     </label>
-                                `:v}
+                                `:_}
                             </vaadin-radio-button>
                         `)}
 </vaadin-radio-group>
-                    `}if(this.field.stereotype==`popover`)return T`<vaadin-custom-field
+                    `}if(this.field.stereotype==`popover`)return w`<vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
-                            required="${this.field.required||v}"
+                            required="${this.field.required||_}"
                             .helperText="${this.helperText()}"
                             data-colspan="${this.field.colspan}"
                     >
@@ -9399,7 +9413,7 @@ ${i}
                             accessible-name-ref="notifications-heading"
                             content-width="300px"
                             position="bottom"
-                            ${ee(()=>T`
+                            ${te(()=>w`
                                 <mateu-event-interceptor .target="${this}">
                                 <mateu-choice
                                         .field="${this.field}"
@@ -9409,12 +9423,12 @@ ${i}
                             `,[])}
                     ></vaadin-popover>
                     </vaadin-custom-field>
-                `;if(this.field?.stereotype==`choice`)return T`
+                `;if(this.field?.stereotype==`choice`)return w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
                             .helperText="${this.helperText()}"
-                            required="${this.field.required||v}"
+                            required="${this.field.required||_}"
                             data-colspan="${this.field.colspan}"
                     >
                         <mateu-choice
@@ -9427,7 +9441,7 @@ ${i}
                         ></mateu-choice>
                         
                     </vaadin-custom-field>
-                    `;if(this.field?.stereotype==`richText`)return T`
+                    `;if(this.field?.stereotype==`richText`)return w`
                     <vaadin-custom-field
                             label="${n}"
                             .helperText="${this.helperText()}"
@@ -9439,7 +9453,7 @@ ${i}
                             @value-changed="${this.valueChanged}"
                             ?autofocus="${this.field.wantsFocus}"
                     ></vaadin-rich-text-editor>
-                    </vaadin-custom-field>`;if(this.field?.stereotype==`textarea`)return T`
+                    </vaadin-custom-field>`;if(this.field?.stereotype==`textarea`)return w`
                     <vaadin-text-area
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9448,11 +9462,11 @@ ${i}
                             .helperText="${this.helperText()}"
                             @value-changed="${this.valueChanged}"
                             ?autofocus="${this.field.wantsFocus}"
-                            required="${this.field.required||v}"
+                            required="${this.field.required||_}"
                             data-colspan="${this.field.colspan}"
                             rows="4"
                             style="width: 100%;"
-                    ></vaadin-text-area>`;if(this.field?.stereotype==`email`)return T`
+                    ></vaadin-text-area>`;if(this.field?.stereotype==`email`)return w`
                     <vaadin-email-field
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9460,19 +9474,19 @@ ${i}
                             value="${t}"
                             .helperText="${this.helperText()}"
                             ?autofocus="${this.field.wantsFocus}"
-                            required="${this.field.required||v}"
+                            required="${this.field.required||_}"
                             data-colspan="${this.field.colspan}"
                     ></vaadin-email-field>
-                `;if(this.field?.stereotype==`link`)return this.field.readOnly?T`<vaadin-custom-field
+                `;if(this.field?.stereotype==`link`)return this.field.readOnly?w`<vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
                             .helperText="${this.helperText()}"
                             data-colspan="${this.field.colspan}"
-                    ><a href="${t}">${t}</a></vaadin-custom-field>`:T`
+                    ><a href="${t}">${t}</a></vaadin-custom-field>`:w`
                             <vaadin-text-field
                                     id="${this.field.fieldId}"
                                     label="${n}"
-                                    required="${this.field.required||v}"
+                                    required="${this.field.required||_}"
                                     @value-changed="${this.valueChanged}"
                                     value="${t}"
                                     .helperText="${this.helperText()}"
@@ -9484,14 +9498,14 @@ ${i}
                                              @click="${()=>window.open(t,`_blank`)?.focus()}"
                                 ></vaadin-icon>
                             </vaadin-text-field>
-                `;if(this.field?.stereotype==`icon`)return this.field.readOnly?T`<vaadin-icon
+                `;if(this.field?.stereotype==`icon`)return this.field.readOnly?w`<vaadin-icon
                                              icon="${t}"
                                              data-colspan="${this.field.colspan}"
-                    ></vaadin-icon>`:T`
+                    ></vaadin-icon>`:w`
                     <vaadin-combo-box
                                     id="${this.field.fieldId}"
                                     label="${n}"
-                                    required="${this.field.required||v}"
+                                    required="${this.field.required||_}"
                                     @value-changed="${this.valueChanged}"
                                     value="${t}"
                                     .helperText="${this.helperText()}"
@@ -9503,9 +9517,9 @@ ${i}
                             @filter-changed="${this.iconFilterChanged}"
                             ${u(this.iconComboboxRenderer,[])}
                     >
-                        ${t?T`<vaadin-icon slot="prefix" icon="${t}"></vaadin-icon>`:v}
+                        ${t?w`<vaadin-icon slot="prefix" icon="${t}"></vaadin-icon>`:_}
                     </vaadin-combo-box>
-                `;if(this.field?.stereotype==`password`)return T`
+                `;if(this.field?.stereotype==`password`)return w`
                     <vaadin-password-field
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9513,17 +9527,17 @@ ${i}
                             value="${t}"
                             .helperText="${this.helperText()}"
                             ?autofocus="${this.field.wantsFocus}"
-                            required="${this.field.required||v}"
+                            required="${this.field.required||_}"
                             data-colspan="${this.field.colspan}"
                     ></vaadin-password-field>
-                `;if(this.field?.stereotype==`html`)return T`
+                `;if(this.field?.stereotype==`html`)return w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
                             .helperText="${this.helperText()}"
                             data-colspan="${this.field.colspan}"
-                    ><div style="line-height: 20px; margin-top: 5px; margin-bottom: 24px;">${_(``+t)}</div></vaadin-custom-field>
-                `;if(this.field?.stereotype==`image`)return T`
+                    ><div style="line-height: 20px; margin-top: 5px; margin-bottom: 24px;">${g(``+t)}</div></vaadin-custom-field>
+                `;if(this.field?.stereotype==`image`)return w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9532,10 +9546,10 @@ ${i}
                     ><img
                             src="${t}"
                             style="${this.component?.style}" class="${this.component?.cssClasses}"></vaadin-custom-field>
-                `;if(this.field?.stereotype==`treeSelect`){let e=this.helperText();return T`
+                `;if(this.field?.stereotype==`treeSelect`){let e=this.helperText();return w`
                     <div class="tree-field" id="${this.field.fieldId}" data-colspan="${this.field.colspan}">
-                        ${n?T`
-                            <span class="tree-field__label">${n}${this.field.required?T`<span class="tree-field__required"> •</span>`:v}</span>`:v}
+                        ${n?w`
+                            <span class="tree-field__label">${n}${this.field.required?w`<span class="tree-field__required"> •</span>`:_}</span>`:_}
                         <mateu-vaadin-tree-select
                                 style="width: 100%;"
                                 .fieldId="${this.field.fieldId}"
@@ -9543,9 +9557,9 @@ ${i}
                                 .options="${this.field.options??[]}"
                                 .leavesOnly="${this.field.treeLeavesOnly??!1}"
                         ></mateu-vaadin-tree-select>
-                        ${e?T`<span class="tree-field__helper">${e}</span>`:v}
+                        ${e?w`<span class="tree-field__helper">${e}</span>`:_}
                     </div>
-                `}if(this.field?.stereotype==`signature`)return T`
+                `}if(this.field?.stereotype==`signature`)return w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9554,7 +9568,7 @@ ${i}
                     >
                         <mateu-signature-pad .fieldId="${this.field.fieldId}" .value="${t}"></mateu-signature-pad>
                     </vaadin-custom-field>
-                `;if(this.field?.stereotype==`camera`)return T`
+                `;if(this.field?.stereotype==`camera`)return w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9563,7 +9577,7 @@ ${i}
                     >
                         <mateu-camera-capture .fieldId="${this.field.fieldId}" .value="${t}"></mateu-camera-capture>
                     </vaadin-custom-field>
-                `;if(this.field?.stereotype==`fileUpload`){let e=dc(this.field.attributes,`accept`);return T`
+                `;if(this.field?.stereotype==`fileUpload`){let e=Dc(this.field.attributes,`accept`);return w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9572,7 +9586,7 @@ ${i}
                     >
                         <mateu-file-upload .fieldId="${this.field.fieldId}" .value="${t}" .accept="${e}"></mateu-file-upload>
                     </vaadin-custom-field>
-                `}if(this.field?.stereotype==`uploadableImage`){let e=t!=null&&t!==``;return T`
+                `}if(this.field?.stereotype==`uploadableImage`){let e=t!=null&&t!==``;return w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9580,10 +9594,10 @@ ${i}
                             data-colspan="${this.field.colspan}"
                     >
                         <vaadin-vertical-layout style="align-items: stretch; gap: var(--lumo-space-s); max-width: 320px;">
-                            ${e?T`<img
+                            ${e?w`<img
                                     src="${t}"
                                     style="max-width: 100%; max-height: 240px; object-fit: contain; border: 1px solid var(--lumo-contrast-20pct); border-radius: var(--lumo-border-radius-m); ${this.field.style??``}"
-                                    class="${this.component?.cssClasses}">`:T`<div style="height: 135px; display: flex; align-items: center; justify-content: center; border: 1px dashed var(--lumo-contrast-30pct); border-radius: var(--lumo-border-radius-m); color: var(--lumo-secondary-text-color);">
+                                    class="${this.component?.cssClasses}">`:w`<div style="height: 135px; display: flex; align-items: center; justify-content: center; border: 1px dashed var(--lumo-contrast-30pct); border-radius: var(--lumo-border-radius-m); color: var(--lumo-secondary-text-color);">
                                     <vaadin-icon icon="vaadin:picture" style="height: 2rem; width: 2rem;"></vaadin-icon>
                                 </div>`}
                             <input type="file" accept="image/*" style="display: none;" @change="${this.imageUpload}">
@@ -9592,21 +9606,21 @@ ${i}
                                     <vaadin-icon icon="vaadin:upload" slot="prefix"></vaadin-icon>
                                     ${e?`Replace`:`Upload`}
                                 </vaadin-button>
-                                ${e?T`<vaadin-button theme="error tertiary" @click="${this.imageDelete}">
+                                ${e?w`<vaadin-button theme="error tertiary" @click="${this.imageDelete}">
                                     <vaadin-icon icon="vaadin:trash" slot="prefix"></vaadin-icon>
                                     Delete
-                                </vaadin-button>`:v}
+                                </vaadin-button>`:_}
                             </vaadin-horizontal-layout>
                         </vaadin-vertical-layout>
                     </vaadin-custom-field>
-                `}return this.field?.stereotype==`color`?this.field.readOnly?T`
+                `}return this.field?.stereotype==`color`?this.field.readOnly?w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
                             .helperText="${this.helperText()}"
                             data-colspan="${this.field.colspan}"
                     ><span style="background-color: ${t}; display: block; height: 20px; width: 40px; margin-top: 5px; margin-bottom: 24px; border: 1px solid var(--lumo-secondary-text-color)"></vaadin-custom-field>
-                `:T`
+                `:w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9627,7 +9641,7 @@ ${i}
   ${s(this.renderColorPicker,[])}
   ${p(this.renderColorPickerFooter,[])}
 ></vaadin-dialog>
-                `:T`
+                `:w`
                 <vaadin-text-field
                         id="${this.field.fieldId}"
                         label="${n}"
@@ -9635,44 +9649,44 @@ ${i}
                         value="${t}"
                         .helperText="${this.helperText()}"
                         ?autofocus="${this.field.wantsFocus}"
-                        ?required="${this.field.required||v}"
+                        ?required="${this.field.required||_}"
                         ?disabled="${this.field.disabled}"
                         data-colspan="${this.field.colspan}"
                         style="${this.field.style}"
                 ></vaadin-text-field>
-`}renderNumberField(e,t,n,r){return this.field?T`<vaadin-number-field
+`}renderNumberField(e,t,n,r){return this.field?w`<vaadin-number-field
                         id="${this.field.fieldId}"
                         label="${n}"
                         @value-changed="${this.valueChanged}"
                         value="${t}"
                         .helperText="${this.helperText()}"
                         ?autofocus="${this.field.wantsFocus}"
-                        ?required="${this.field.required||v}"
+                        ?required="${this.field.required||_}"
                         data-colspan="${this.field.colspan}"
-                        step="${this.field.step||v}"
+                        step="${this.field.step||_}"
                         ?step-buttons-visible="${this.field.stepButtonsVisible}"
-                        min="${this.field.min==null?v:this.field.min}"
-                        max="${this.field.max==null?v:this.field.max}"
-            ></vaadin-number-field>`:T``}renderIntegerField(e,t,n,r){if(!this.field)return T``;if(this.field.stereotype==`stars`){let e=t;return isNaN(e)&&(e=0),T`<vaadin-custom-field
+                        min="${this.field.min==null?_:this.field.min}"
+                        max="${this.field.max==null?_:this.field.max}"
+            ></vaadin-number-field>`:w``}renderIntegerField(e,t,n,r){if(!this.field)return w``;if(this.field.stereotype==`stars`){let e=t;return isNaN(e)&&(e=0),w`<vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
                             .helperText="${this.helperText()}"
                             data-colspan="${this.field.colspan}"
-                    >${[1,2,3,4,5].map(t=>T`
+                    >${[1,2,3,4,5].map(t=>w`
                     <vaadin-icon 
                             icon="vaadin:star" 
                             style="cursor: pointer; color: var(${t<=e?`--lumo-warning-color`:`--lumo-shade-30pct`});"
                             @click="${()=>this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:this.field.fieldId},bubbles:!0,composed:!0}))}"
                     
                     ></vaadin-icon>
-                `)}</vaadin-custom-field>`}if(this.field.stereotype==`slider`){let e=t;return isNaN(e)&&(e=0),T`
+                `)}</vaadin-custom-field>`}if(this.field.stereotype==`slider`){let e=t;return isNaN(e)&&(e=0),w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
                             .helperText="${this.helperText()}"
                             data-colspan="${this.field.colspan}"
                     ><input type="range" @input="${e=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e.target.value,fieldId:this.field.fieldId},bubbles:!0,composed:!0}))}}" min="${this.field.sliderMin??0}" max="${this.field.sliderMax??10}" value="${e??0}"/></vaadin-custom-field>
-                `}return T`
+                `}return w`
                 <vaadin-integer-field
                         id="${this.field.fieldId}"
                         label="${n}"
@@ -9680,18 +9694,18 @@ ${i}
                         value="${t}"
                         .helperText="${this.helperText()}"
                         ?autofocus="${this.field.wantsFocus}"
-                        ?required="${this.field.required||v}"
+                        ?required="${this.field.required||_}"
                         data-colspan="${this.field.colspan}"
-                        step="${this.field.step||v}"
+                        step="${this.field.step||_}"
                         ?step-buttons-visible="${this.field.stepButtonsVisible}"
-                        min="${this.field.min==null?v:this.field.min}"
-                        max="${this.field.max==null?v:this.field.max}"
+                        min="${this.field.min==null?_:this.field.min}"
+                        max="${this.field.max==null?_:this.field.max}"
                 ></vaadin-integer-field>
-            `}renderBoolField(e,t,n,r){return this.field?this.field.stereotype==`toggle`?T`
+            `}renderBoolField(e,t,n,r){return this.field?this.field.stereotype==`toggle`?w`
                     <vaadin-custom-field
                             label="${n}"
                             .helperText="${this.helperText()}"
-                            ?required="${this.field.required||v}"
+                            ?required="${this.field.required||_}"
                             data-colspan="${this.field.colspan}"
                     >
                         <paper-toggle-button id="${this.field.fieldId}"
@@ -9700,60 +9714,60 @@ ${i}
                                              @change=${this.checked}>
                         </paper-toggle-button>
                     </vaadin-custom-field>
-                `:T`
+                `:w`
                 <vaadin-checkbox
                         id="${this.field.fieldId}"
                         label="${n}"
                         .helperText="${this.helperText()}"
-                        ?required="${this.field.required||v}"
+                        ?required="${this.field.required||_}"
                         data-colspan="${this.field.colspan}"
                         @change="${this.checked}"
                         value="${t}"
                         ?checked=${t}
                         ?autofocus="${this.field.wantsFocus}"
                 ></vaadin-checkbox>
-            `:T``}renderDateRangeField(e,t,n,r){if(!this.field)return T``;let i=t?t.from+`;`+t.to:void 0;return T`<vcf-date-range-picker
+            `:w``}renderDateRangeField(e,t,n,r){if(!this.field)return w``;let i=t?t.from+`;`+t.to:void 0;return w`<vcf-date-range-picker
                     id="${this.field.fieldId}"
                     label="${n}"
                     @value-changed="${e=>{e.detail.value&&(e.detail.value={from:e.detail.value.split(`;`)[0],to:e.detail.value.split(`;`)[1]}),this.valueChanged(e)}}"
                     value="${i}"
                     .helperText="${this.helperText()}"
                     ?autofocus="${this.field.wantsFocus}"
-                    ?required="${this.field.required||v}"
+                    ?required="${this.field.required||_}"
                     data-colspan="${this.field.colspan}"
-            ></vcf-date-range-picker>`}renderDateField(e,t,n,r){return this.field?T`<vaadin-date-picker
+            ></vcf-date-range-picker>`}renderDateField(e,t,n,r){return this.field?w`<vaadin-date-picker
                         id="${this.field.fieldId}"
                         label="${n}"
                         @value-changed="${this.valueChanged}"
                         value="${t}"
                         .helperText="${this.helperText()}"
                         ?autofocus="${this.field.wantsFocus}"
-                        ?required="${this.field.required||v}"
+                        ?required="${this.field.required||_}"
                         data-colspan="${this.field.colspan}"
-            ></vaadin-date-picker>`:T``}renderDateTimeField(e,t,n,r){return this.field?T`<vaadin-date-time-picker
+            ></vaadin-date-picker>`:w``}renderDateTimeField(e,t,n,r){return this.field?w`<vaadin-date-time-picker
                         id="${this.field.fieldId}"
                         label="${n}"
                         @value-changed="${this.valueChanged}"
                         value="${t}"
                         .helperText="${this.helperText()}"
                         ?autofocus="${this.field.wantsFocus}"
-                        ?required="${this.field.required||v}"
+                        ?required="${this.field.required||_}"
                         data-colspan="${this.field.colspan}"
-            ></vaadin-date-time-picker>`:T``}renderTimeField(e,t,n,r){return this.field?T`<vaadin-time-picker
+            ></vaadin-date-time-picker>`:w``}renderTimeField(e,t,n,r){return this.field?w`<vaadin-time-picker
                         id="${this.field.fieldId}"
                         label="${n}"
                         @value-changed="${this.valueChanged}"
                         value="${t}"
                         .helperText="${this.helperText()}"
                         ?autofocus="${this.field.wantsFocus}"
-                        ?required="${this.field.required||v}"
+                        ?required="${this.field.required||_}"
                         data-colspan="${this.field.colspan}"
-            ></vaadin-time-picker>`:T``}renderArrayField(e,t,n,r){if(!this.field)return T``;if(this.field?.stereotype==`choice`)return T`
+            ></vaadin-time-picker>`:w``}renderArrayField(e,t,n,r){if(!this.field)return w``;if(this.field?.stereotype==`choice`)return w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
                             .helperText="${this.helperText()}"
-                            required="${this.field.required||v}"
+                            required="${this.field.required||_}"
                             data-colspan="${this.field.colspan}"
                     >
                         <mateu-choice
@@ -9766,7 +9780,7 @@ ${i}
                         ></mateu-choice>
                         
                     </vaadin-custom-field>
-                    `;if(this.field?.stereotype==`grid`)return T`
+                    `;if(this.field?.stereotype==`grid`)return w`
                     <vaadin-custom-field
                             label="${n}"
                             .helperText="${this.helperText()}"
@@ -9783,24 +9797,24 @@ ${i}
                             data-colspan="${this.field.colspan}"
                     ></mateu-grid>
                     </vaadin-custom-field>
-`;if(this.field?.stereotype==`listBox`){if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates;return this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements||this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0})),T`
+`;if(this.field?.stereotype==`listBox`){if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates;return this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements||this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0})),w`
                         <vaadin-custom-field
                                 label="${n}"
                                 .helperText="${this.helperText()}"
                                 data-colspan="${this.field.colspan}"
                         >
                     <vaadin-list-box multiple
-                                     .selectedValues="${S(this.selectedIndexes(t))}"
+                                     .selectedValues="${x(this.selectedIndexes(t))}"
                                      @selected-values-changed="${this.listItemsSelected}"
                             id="${this.field.fieldId}"
                             ?autofocus="${this.field.wantsFocus}"
                     >
-                        ${this.data[this.id]?.content?.map(e=>T`
+                        ${this.data[this.id]?.content?.map(e=>w`
                             <vaadin-item>${e.label}</vaadin-item>
                         `)}
                     </vaadin-list-box>
                         </vaadin-custom-field>
-                    `}return T`
+                    `}return w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9808,17 +9822,17 @@ ${i}
                             data-colspan="${this.field.colspan}"
                     >
                     <vaadin-list-box multiple
-                                     .selectedValues="${S(this.selectedIndexes(t))}"
+                                     .selectedValues="${x(this.selectedIndexes(t))}"
                                      @selected-values-changed="${this.listItemsSelected}"
                                      ?autofocus="${this.field.wantsFocus}"
                                      data-colspan="${this.field.colspan}"
                     >
-                        ${this.field.options?.map(e=>T`
+                        ${this.field.options?.map(e=>w`
                             <vaadin-item>${e.label}</vaadin-item>
                         `)}
                     </vaadin-list-box>
                     </vaadin-custom-field>
-                `}if(this.field?.stereotype==`combobox`){if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates;return T`
+                `}if(this.field?.stereotype==`combobox`){if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates;return w`
                         <vaadin-multi-select-combo-box
                             label="${n}"
                             item-label-path="label"
@@ -9828,7 +9842,7 @@ ${i}
                             .helperText="${this.helperText()}"
                             .selectedItems="${this.selectedItems(t)}"
                             ?autofocus="${this.field.wantsFocus}"
-                            ?required="${this.field.required||v}"
+                            ?required="${this.field.required||_}"
                             @selected-items-changed="${this.multiComboBoxValueChanged}"
                             data-colspan="${this.field.colspan}"
                             style="${this.field.style}"
@@ -9836,7 +9850,7 @@ ${i}
                             auto-expand-vertically
                             xselected-items-on-top
                     ></vaadin-multi-select-combo-box>
-                    `}return T`
+                    `}return w`
                     <vaadin-multi-select-combo-box
                             label="${n}"
                             item-label-path="label"
@@ -9845,7 +9859,7 @@ ${i}
                             .helperText="${this.helperText()}"
                             .selectedItems="${this.selectedItems(t)}"
                             ?autofocus="${this.field.wantsFocus}"
-                            ?required="${this.field.required||v}"
+                            ?required="${this.field.required||_}"
                             @selected-items-changed="${this.multiComboBoxValueChanged}"
                             data-colspan="${this.field.colspan}"
                             style="${this.field.style}"
@@ -9853,7 +9867,7 @@ ${i}
                             auto-expand-vertically
                             xselected-items-on-top
                     ></vaadin-multi-select-combo-box>
-                    `}if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates;return this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements||this.rendered||setTimeout(()=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}),T`
+                    `}if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates;return this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements||this.rendered||setTimeout(()=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}),w`
                     <vaadin-checkbox-group
                         id="${this.field.fieldId}"
                         label="${n}"
@@ -9861,19 +9875,19 @@ ${i}
                         @value-changed="${this.valueChanged}"
                         .helperText="${this.helperText()}"
                         ?autofocus="${this.field.wantsFocus}"
-                        ?required="${this.field.required||v}"
+                        ?required="${this.field.required||_}"
                         data-colspan="${this.field.colspan}"
                         .value="${t}"
                         class="mateu-checkbox-group-${this.field.optionsColumns>1?`multi-column`:``}"
                 >
-                        ${this.data[this.id]?.content?.map(e=>T`
+                        ${this.data[this.id]?.content?.map(e=>w`
                             <vaadin-checkbox
                                     value="${e.value}"
                                     label="${e.label}"
                             ></vaadin-checkbox>
                         `)}
                 </vaadin-checkbox-group>
-                    `}return T`
+                    `}return w`
                 <vaadin-checkbox-group
                         id="${this.field.fieldId}"
                         label="${n}"
@@ -9881,43 +9895,43 @@ ${i}
                         theme="vertical"
                         .helperText="${this.helperText()}"
                         ?autofocus="${this.field.wantsFocus}"
-                        ?required="${this.field.required||v}"
+                        ?required="${this.field.required||_}"
                         data-colspan="${this.field.colspan}"
                         class="mateu-checkbox-group-${this.field.optionsColumns>1?`multi-column`:``}"
                         .value="${t}"
                 >
-                        ${this.field.options?.map(e=>T`
+                        ${this.field.options?.map(e=>w`
                         <vaadin-checkbox 
                                 value="${e.value}" 
                                 label="${e.label}"
                         ></vaadin-checkbox>
                         `)}
                 </vaadin-checkbox-group>
-            `}renderMoneyField(e,t,n,r){if(!this.field)return T``;if(this.field.readOnly){let e=t,r=e;return r=e&&e.locale&&e.currency?new Intl.NumberFormat(e.locale,{style:`currency`,currency:e.currency}).format(e.value):new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e),T`<vaadin-custom-field
+            `}renderMoneyField(e,t,n,r){if(!this.field)return w``;if(this.field.readOnly){let e=t,r=e;return r=e&&e.locale&&e.currency?new Intl.NumberFormat(e.locale,{style:`currency`,currency:e.currency}).format(e.value):new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e),w`<vaadin-custom-field
                         id="${this.field.fieldId}"
                         label="${n}"
                         .helperText="${this.helperText()}"
                         data-colspan="${this.field.colspan}"
-                ><div style="width: 186px; text-align: right;">${r}</div></vaadin-custom-field>`}return T`<mateu-money-field
+                ><div style="width: 186px; text-align: right;">${r}</div></vaadin-custom-field>`}return w`<mateu-money-field
                         id="${this.field.fieldId}"
                         label="${n}"
                         @value-changed="${this.valueChanged}"
                         .value="${t}"
                         .helperText="${this.helperText()}"
                         ?autofocus="${this.field.wantsFocus}"
-                        ?required="${this.field.required||v}"
+                        ?required="${this.field.required||_}"
                         data-colspan="${this.field.colspan}"
-            ></mateu-money-field>`}renderStatusField(e,t,n,r){if(!this.field)return T``;let i=t;return T`
+            ></mateu-money-field>`}renderStatusField(e,t,n,r){if(!this.field)return w``;let i=t;return w`
                 <vaadin-custom-field
                         id="${this.field.fieldId}"
                         label="${n}"
-                        required="${this.field.required||v}"
+                        required="${this.field.required||_}"
                         .helperText="${this.helperText()}"
                         data-colspan="${this.field.colspan}"
                 >
-                    ${i?T`<span theme="badge pill ${ra(i.type)}">${i.message}</span>`:T``}                    
+                    ${i?w`<span theme="badge pill ${ia(i.type)}">${i.message}</span>`:w``}                    
                 </vaadin-custom-field>
-            `}renderRangeField(e,t,n,r){if(!this.field)return T``;this.loadUi5FieldComponents();let i=t;return T`
+            `}renderRangeField(e,t,n,r){if(!this.field)return w``;this.loadUi5FieldComponents();let i=t;return w`
                 <vaadin-custom-field
                         id="${this.field.fieldId}"
                         label="${n}"
@@ -9926,12 +9940,12 @@ ${i}
                 ><ui5-range-slider start-value="${i?.from??0}" end-value="${i?.to??0}" 
                                    min="${this.field.sliderMin??0}" 
                                    max="${this.field.sliderMax??10}"
-                                   step="${this.field.step||v}"
+                                   step="${this.field.step||_}"
                                    @change="${e=>{let t=e.target;this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:{from:t.startValue,to:t.endValue},fieldId:this.field.fieldId},bubbles:!0,composed:!0}))}}"
                                    style="min-width: 10rem;"
                 ></ui5-range-slider></vaadin-custom-field>
-            `}static{this.styles=h`
-        ${de}
+            `}static{this.styles=m`
+        ${fe}
 
         /* Fields fill the whole column width by default. Date, checkbox, numeric and money inputs
            are the exception — they keep their natural (narrower) width so a date/amount doesn't
@@ -10013,7 +10027,7 @@ ${i}
             text-overflow: clip;
             height: auto;
         }
-  `}};k([C()],Q.prototype,`ui5FieldComponentsReady`,void 0),k([y()],Q.prototype,`component`,void 0),k([y()],Q.prototype,`field`,void 0),k([y()],Q.prototype,`baseUrl`,void 0),k([y()],Q.prototype,`state`,void 0),k([y()],Q.prototype,`data`,void 0),k([y()],Q.prototype,`appState`,void 0),k([y()],Q.prototype,`appData`,void 0),k([y()],Q.prototype,`labelAlreadyRendered`,void 0),k([C()],Q.prototype,`colorPickerOpened`,void 0),k([C()],Q.prototype,`colorPickerValue`,void 0),k([C()],Q.prototype,`controlOwnsValidity`,void 0),k([C()],Q.prototype,`filteredIcons`,void 0),k([C()],Q.prototype,`navLinkOffset`,void 0),Q=k([g(`mateu-field`)],Q);var tl=(e,t,n,r,i,a,o,s)=>{let c=t.metadata;return T`
+  `}};O([S()],Z.prototype,`ui5FieldComponentsReady`,void 0),O([v()],Z.prototype,`component`,void 0),O([v()],Z.prototype,`field`,void 0),O([v()],Z.prototype,`baseUrl`,void 0),O([v()],Z.prototype,`state`,void 0),O([v()],Z.prototype,`data`,void 0),O([v()],Z.prototype,`appState`,void 0),O([v()],Z.prototype,`appData`,void 0),O([v()],Z.prototype,`labelAlreadyRendered`,void 0),O([S()],Z.prototype,`colorPickerOpened`,void 0),O([S()],Z.prototype,`colorPickerValue`,void 0),O([S()],Z.prototype,`controlOwnsValidity`,void 0),O([S()],Z.prototype,`filteredIcons`,void 0),O([S()],Z.prototype,`navLinkOffset`,void 0),Z=O([h(`mateu-field`)],Z);var bl=(e,t,n,r,i,a,o,s)=>{let c=t.metadata;return w`
         <mateu-field
                 id="${t.id}"
                 .component="${t}"
@@ -10022,75 +10036,75 @@ ${i}
                 .data="${i}"
                 .appState="${a}"
                 .appdata="${o}"
-                style="${Zi(t,i)}" class="${t.cssClasses}"
-                slot="${t.slot??v}"
+                style="${Qi(t,i)}" class="${t.cssClasses}"
+                slot="${t.slot??_}"
                 data-colspan="${c.colspan}"
-                colspan="${(c.colspan??1)>1?c.colspan:v}"
+                colspan="${(c.colspan??1)>1?c.colspan:_}"
                 .labelAlreadyRendered="${s}"
         >
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o,s))}
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o,s))}
         </mateu-field>
-    `},nl=(e,n,r,i,a,o,s)=>{let c=n.metadata;if(c.tree)return T`
+    `},xl=(e,n,r,i,a,o,s)=>{let c=n.metadata;if(c.tree)return w`
         <vaadin-grid style="${n.style}" class="${n.cssClasses}"
                      .itemHasChildrenPath="${`children`}" .dataProvider="${async(e,t)=>{let n=e.parentItem?e.parentItem.children:c.page.content;t(n,n.length)}}"
-                     slot="${n.slot??v}"
+                     slot="${n.slot??_}"
                      all-rows-visible
         >
-            ${c.content.map((n,c)=>{let l=n.metadata;return c>0?T`
+            ${c.content.map((n,c)=>{let l=n.metadata;return c>0?w`
             <vaadin-grid-column path="${n.id}"
-                                header="${l?.label??v}"
+                                header="${l?.label??_}"
                                 ?auto-width="${l?.autoWidth}"
-                                flex-grow="${l?.flexGrow??v}"
-                                width="${l?.width??v}"
+                                flex-grow="${l?.flexGrow??_}"
+                                width="${l?.width??_}"
                                 .column="${n.metadata}"
-                                ${t((t,n,c)=>Kc(t,n,c,l,e,r,i,a,o,s),[])}></vaadin-grid-column>
-`:T`
+                                ${t((t,n,c)=>dl(t,n,c,l,e,r,i,a,o,s),[])}></vaadin-grid-column>
+`:w`
             <vaadin-grid-tree-column path="${n.id}"
-                                header="${l?.label??v}"
+                                header="${l?.label??_}"
                                 ?auto-width="${l?.autoWidth}"
-                                flex-grow="${l?.flexGrow??v}"
-                                width="${l?.width??v}"
+                                flex-grow="${l?.flexGrow??_}"
+                                width="${l?.width??_}"
             ></vaadin-grid-tree-column>
 `})}
-            <span slot="empty-state">${xt()}</span>
+            <span slot="empty-state">${St()}</span>
         </vaadin-grid>
-    `;let l=c.page?.content;return n.id&&i&&i[n.id]&&(l=i[n.id]),l||=[],T`
+    `;let l=c.page?.content;return n.id&&i&&i[n.id]&&(l=i[n.id]),l||=[],w`
         <vaadin-grid 
                 style="${n.style}" 
                 class="${n.cssClasses}" 
                 .items="${l}"
                 all-rows-visible
         >
-            ${c?.content?.map(t=>Wc(t,e,r,i,a,o,s))}
+            ${c?.content?.map(t=>ll(t,e,r,i,a,o,s))}
         </vaadin-grid>
-    `},$=class extends b{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.detailsOpenedItems=[],this.pagesRequested=[],this.emptyArray=e=>!e||e.length==0,this.dataProvider=(e,t)=>{let n=this.data[this.id]?.page;if(this.metadata?.infiniteScrolling&&e.page>0){let r=!1;n&&n.content&&(n.content.length>=(e.page+1)*e.pageSize||n.content.length==n.totalElements)&&(t(n.content.slice(e.page*e.pageSize,(e.page+1)*e.pageSize),n.totalElements),r=!0,this.grid&&this.grid.recalculateColumnWidths()),r||this.pagesRequested.find(t=>t==e.page)||(this.pagesRequested.push(e.page),this.dispatchEvent(new CustomEvent(`fetch-more-elements`,{detail:{params:e,callback:()=>{this.data[this.id]?.page?.content&&(t(this.data[this.id].page.content.slice(e.page*e.pageSize,(e.page+1)*e.pageSize),this.data[this.id].page.totalElements),this.grid&&this.grid.recalculateColumnWidths())}},bubbles:!0,composed:!0})))}else{let e=this.metadata?.infiniteScrolling?n?.totalElements:n?.content?.length??0;t(n?.content??[],e),this.grid&&this.grid.recalculateColumnWidths()}},this._onActionRequested=e=>{let t=e.detail,n=this.identifierFieldName;if(!n||!t.parameters||t.actionId?.startsWith(`action-on-row-`))return;let r=t.parameters[n];r!==void 0&&(this.state._selectedId=String(r),this._applyCellPartNameGenerator(),this.grid?.requestContentUpdate())},this.tooltipGenerator=e=>{let t=``,{column:n,item:r}=e,i=this.metadata?.columns?.find(e=>e.metadata.id==n?.path);if(i?.metadata){let e=(i?.metadata).tooltipPath;e&&n&&r&&(t=r[e])}return t}}get identifierFieldName(){let e=this.metadata?.columns?.find(e=>e.metadata?.identifier);if(e)return e.metadata?.id;if(this.metadata?.columns?.find(e=>e.metadata?.id===`id`))return`id`}_applyCellPartNameGenerator(){if(!this.grid)return;let e=this.identifierFieldName,t=this.state?._selectedId??this.appState?._splitDetailId,n=!!this.metadata?.groupBy;e&&t!==void 0||n?this.grid.cellPartNameGenerator=(n,r)=>{let i=r.item;return pc(i)?`mateu-group-row`:e&&t!==void 0&&String(i[e])===String(t)?`selected-row`:``}:this.grid.cellPartNameGenerator=null}connectedCallback(){super.connectedCallback(),this.addEventListener(`action-requested`,this._onActionRequested)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`action-requested`,this._onActionRequested)}updated(e){super.updated(e),this._applyCellPartNameGenerator(),this.grid?.clearCache(),this.grid?.requestContentUpdate(),this.grid?.recalculateColumnWidths(),this.pagesRequested=[]}render(){let e=this.data[this.id],r=e?.page,i=this.metadata?.groupBy,a=this.metadata?.infiniteScrolling?void 0:r?.content?hc(r.content,i,e?.groups):r?.content,o=yc((this.metadata?.columns??[]).flatMap(e=>e.metadata?.type===j.GridGroupColumn?(e.metadata.columns??[]).map(e=>e.metadata):[e.metadata]),e,i),s=``;return this.metadata?.wrapCellContent&&(s+=` wrap-cell-content`),this.metadata?.compact&&(s+=` compact`),this.metadata?.noBorder&&(s+=` no-border`),this.metadata?.noRowBorder&&(s+=` no-row-borders`),this.metadata?.columnBorders&&(s+=` column-borders`),this.metadata?.rowStripes&&(s+=` row-stripes`),T`
+    `},Q=class extends y{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.detailsOpenedItems=[],this.pagesRequested=[],this.emptyArray=e=>!e||e.length==0,this.dataProvider=(e,t)=>{let n=this.data[this.id]?.page;if(this.metadata?.infiniteScrolling&&e.page>0){let r=!1;n&&n.content&&(n.content.length>=(e.page+1)*e.pageSize||n.content.length==n.totalElements)&&(t(n.content.slice(e.page*e.pageSize,(e.page+1)*e.pageSize),n.totalElements),r=!0,this.grid&&this.grid.recalculateColumnWidths()),r||this.pagesRequested.find(t=>t==e.page)||(this.pagesRequested.push(e.page),this.dispatchEvent(new CustomEvent(`fetch-more-elements`,{detail:{params:e,callback:()=>{this.data[this.id]?.page?.content&&(t(this.data[this.id].page.content.slice(e.page*e.pageSize,(e.page+1)*e.pageSize),this.data[this.id].page.totalElements),this.grid&&this.grid.recalculateColumnWidths())}},bubbles:!0,composed:!0})))}else{let e=this.metadata?.infiniteScrolling?n?.totalElements:n?.content?.length??0;t(n?.content??[],e),this.grid&&this.grid.recalculateColumnWidths()}},this._onActionRequested=e=>{let t=e.detail,n=this.identifierFieldName;if(!n||!t.parameters||t.actionId?.startsWith(`action-on-row-`))return;let r=t.parameters[n];r!==void 0&&(this.state._selectedId=String(r),this._applyCellPartNameGenerator(),this.grid?.requestContentUpdate())},this.tooltipGenerator=e=>{let t=``,{column:n,item:r}=e,i=this.metadata?.columns?.find(e=>e.metadata.id==n?.path);if(i?.metadata){let e=(i?.metadata).tooltipPath;e&&n&&r&&(t=r[e])}return t}}get identifierFieldName(){let e=this.metadata?.columns?.find(e=>e.metadata?.identifier);if(e)return e.metadata?.id;if(this.metadata?.columns?.find(e=>e.metadata?.id===`id`))return`id`}_applyCellPartNameGenerator(){if(!this.grid)return;let e=this.identifierFieldName,t=this.state?._selectedId??this.appState?._splitDetailId,n=!!this.metadata?.groupBy;e&&t!==void 0||n?this.grid.cellPartNameGenerator=(n,r)=>{let i=r.item;return Mc(i)?`mateu-group-row`:e&&t!==void 0&&String(i[e])===String(t)?`selected-row`:``}:this.grid.cellPartNameGenerator=null}connectedCallback(){super.connectedCallback(),this.addEventListener(`action-requested`,this._onActionRequested)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`action-requested`,this._onActionRequested)}updated(e){super.updated(e),this._applyCellPartNameGenerator(),this.grid?.clearCache(),this.grid?.requestContentUpdate(),this.grid?.recalculateColumnWidths(),this.pagesRequested=[]}render(){let e=this.data[this.id],r=e?.page,i=this.metadata?.groupBy,a=this.metadata?.infiniteScrolling?void 0:r?.content?Pc(r.content,i,e?.groups):r?.content,o=Rc((this.metadata?.columns??[]).flatMap(e=>e.metadata?.type===A.GridGroupColumn?(e.metadata.columns??[]).map(e=>e.metadata):[e.metadata]),e,i),s=``;return this.metadata?.wrapCellContent&&(s+=` wrap-cell-content`),this.metadata?.compact&&(s+=` compact`),this.metadata?.noBorder&&(s+=` no-border`),this.metadata?.noRowBorder&&(s+=` no-row-borders`),this.metadata?.columnBorders&&(s+=` column-borders`),this.metadata?.rowStripes&&(s+=` row-stripes`),w`
             <vaadin-grid
                     .items="${a}"
                     item-id-path="_rowNumber"
                     .selectedItems="${this.state[this.id+`_selected_items`]||[]}"
                     ?data-clickable-rows="${this.metadata?.detailPath&&!this.metadata?.useButtonForDetail}"
                     ?all-rows-visible="${this.metadata?.allRowsVisible}"
-                    column-rendering="${this.metadata?.lazyColumnRendering?`lazy`:v}"
+                    column-rendering="${this.metadata?.lazyColumnRendering?`lazy`:_}"
                     ?column-reordering-allowed="${this.metadata?.columnReorderingAllowed}"
                     .dataProvider="${this.metadata?.infiniteScrolling?this.dataProvider:void 0}"
                     page-size="${this.metadata?.pageSize}"
                     multi-sort-on-shift-click
-                    @selected-items-changed="${e=>{let t=(e.detail.value??[]).filter(e=>!pc(e));this.emptyArray(this.state[this.id+`_selected_items`])&&this.emptyArray(t)||(this.state[this.id+`_selected_items`]=t,this.metadata?.onRowSelectionChangedActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.metadata?.onRowSelectionChangedActionId},bubbles:!0,composed:!0})))}}"
-                    @active-item-changed="${S(this.metadata?.detailPath&&!this.metadata?.useButtonForDetail?e=>{if(this.metadata?.detailPath){let t=e.detail.value;if(t&&pc(t))return;t?this.detailsOpenedItems=[t]:this.detailsOpenedItems=[]}}:void 0)}"
+                    @selected-items-changed="${e=>{let t=(e.detail.value??[]).filter(e=>!Mc(e));this.emptyArray(this.state[this.id+`_selected_items`])&&this.emptyArray(t)||(this.state[this.id+`_selected_items`]=t,this.metadata?.onRowSelectionChangedActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.metadata?.onRowSelectionChangedActionId},bubbles:!0,composed:!0})))}}"
+                    @active-item-changed="${x(this.metadata?.detailPath&&!this.metadata?.useButtonForDetail?e=>{if(this.metadata?.detailPath){let t=e.detail.value;if(t&&Mc(t))return;t?this.detailsOpenedItems=[t]:this.detailsOpenedItems=[]}}:void 0)}"
                     .detailsOpenedItems="${this.detailsOpenedItems}"
-                    ${S(this.metadata?.detailPath?n(e=>T`${F(this,e[this.metadata?.detailPath],this.baseUrl,this.state,this.data,this.appState,this.appData)}`):void 0)}
+                    ${x(this.metadata?.detailPath?n(e=>w`${P(this,e[this.metadata?.detailPath],this.baseUrl,this.state,this.data,this.appState,this.appData)}`):void 0)}
                     theme="${s}"
                     style="${this.metadata?.gridStyle}"
             >
-                ${this.metadata?.rowsSelectionEnabled?T`
+                ${this.metadata?.rowsSelectionEnabled?w`
                     <vaadin-grid-selection-column></vaadin-grid-selection-column>
-                `:v}
-                ${this.metadata?.columns?.map(e=>Wc(e,this,this.baseUrl,this.state,this.data,this.appState,this.appData,o))}
-                ${this.metadata?.useButtonForDetail?T`
+                `:_}
+                ${this.metadata?.columns?.map(e=>ll(e,this,this.baseUrl,this.state,this.data,this.appState,this.appData,o))}
+                ${this.metadata?.useButtonForDetail?w`
                     <vaadin-grid-column
                             width="44px"
                             flex-grow="0"
-                            ${t((e,{detailsOpened:t})=>T`
+                            ${t((e,{detailsOpened:t})=>w`
               <vaadin-button
                 theme="tertiary icon"
                 title="${t?`Collapse`:`Expand`}"
@@ -10104,13 +10118,13 @@ ${i}
               </vaadin-button>
             `,[])}
                     ></vaadin-grid-column>
-                `:v}
-                <span slot="empty-state">${xt(this.emptyStateMessage??this.metadata?.emptyStateMessage)}</span>
-                ${this.metadata?.columns?.find(e=>e.metadata.tooltipPath)?T`<vaadin-tooltip slot="tooltip" .generator="${this.tooltipGenerator}"></vaadin-tooltip>`:v}
+                `:_}
+                <span slot="empty-state">${St(this.emptyStateMessage??this.metadata?.emptyStateMessage)}</span>
+                ${this.metadata?.columns?.find(e=>e.metadata.tooltipPath)?w`<vaadin-tooltip slot="tooltip" .generator="${this.tooltipGenerator}"></vaadin-tooltip>`:_}
             </vaadin-grid>
             <slot></slot>
-       `}static{this.styles=h`
-        ${de}
+       `}static{this.styles=m`
+        ${fe}
         vaadin-grid[data-clickable-rows]::part(row) {
             cursor: pointer;
         }
@@ -10124,7 +10138,7 @@ ${i}
             background-color: var(--lumo-contrast-5pct, rgba(0, 0, 0, 0.04));
             font-weight: 600;
         }
-  `}};k([y()],$.prototype,`id`,void 0),k([y()],$.prototype,`metadata`,void 0),k([y()],$.prototype,`baseUrl`,void 0),k([y()],$.prototype,`state`,void 0),k([y()],$.prototype,`data`,void 0),k([y()],$.prototype,`appState`,void 0),k([y()],$.prototype,`appData`,void 0),k([y()],$.prototype,`emptyStateMessage`,void 0),k([C()],$.prototype,`detailsOpenedItems`,void 0),k([x(`vaadin-grid`)],$.prototype,`grid`,void 0),$=k([g(`mateu-table`)],$);var rl=(e,t,n,r,i,a,o)=>T`
+  `}};O([v()],Q.prototype,`id`,void 0),O([v()],Q.prototype,`metadata`,void 0),O([v()],Q.prototype,`baseUrl`,void 0),O([v()],Q.prototype,`state`,void 0),O([v()],Q.prototype,`data`,void 0),O([v()],Q.prototype,`appState`,void 0),O([v()],Q.prototype,`appData`,void 0),O([v()],Q.prototype,`emptyStateMessage`,void 0),O([S()],Q.prototype,`detailsOpenedItems`,void 0),O([b(`vaadin-grid`)],Q.prototype,`grid`,void 0),Q=O([h(`mateu-table`)],Q);var Sl=(e,t,n,r,i,a,o)=>w`
     <mateu-table
             id="${t.id}"
             baseUrl="${n}"
@@ -10134,10 +10148,10 @@ ${i}
             .appState="${a}"
             .appDate="${o}"
             style="${t.style}" class="${t.cssClasses}"
-            slot="${t.slot??v}"
+            slot="${t.slot??_}"
     >
-        ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
-    </mateu-table>`,il=(e,t,n,r,i,a)=>T`
+        ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
+    </mateu-table>`,Cl=(e,t,n,r,i,a)=>w`
     <mateu-table id="${e.id}"
                  .metadata="${t?.metadata}"
                  .data="${e.data}"
@@ -10148,8 +10162,8 @@ ${i}
                  @sort-direction-changed="${e.directionChanged}"
                  @fetch-more-elements="${e.fetchMoreElements}"
                  baseUrl="${n}"
-    ></mateu-table>`,al=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
-        <div id="show-notifications" slot="${t.slot??v}">${F(e,s.wrapped,n,r,i,a,o)}</div>
+    ></mateu-table>`,wl=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+        <div id="show-notifications" slot="${t.slot??_}">${P(e,s.wrapped,n,r,i,a,o)}</div>
         <vaadin-popover
                 for="show-notifications"
                 theme="arrow no-padding"
@@ -10157,17 +10171,17 @@ ${i}
                 accessible-name-ref="notifications-heading"
                 content-width="300px"
                 position="bottom"
-                ${ee(()=>T`${F(e,s.content,n,r,i,a,o)}`,[])}
+                ${te(()=>w`${P(e,s.content,n,r,i,a,o)}`,[])}
                 style="${t.style}" class="${t.cssClasses}"
         ></vaadin-popover>
-    `},ol=(e,t,n)=>{let r=e;return T`
+    `},Tl=(e,t,n)=>{let r=e;return w`
         <vaadin-button
                 data-action-id="${r.id}"
-                theme="${mt(e)||v}"
+                theme="${ht(e)||_}"
                 @click="${n}"
                 ?disabled="${r.disabled}"
-        >${r.iconOnLeft?T`<vaadin-icon icon="${r.iconOnLeft}"></vaadin-icon>`:v}${t}${r.iconOnRight?T`<vaadin-icon icon="${r.iconOnRight}"></vaadin-icon>`:v}</vaadin-button>
-    `},sl=e=>T`
+        >${r.iconOnLeft?w`<vaadin-icon icon="${r.iconOnLeft}"></vaadin-icon>`:_}${t}${r.iconOnRight?w`<vaadin-icon icon="${r.iconOnRight}"></vaadin-icon>`:_}</vaadin-button>
+    `},El=e=>w`
     <div style="display: flex; gap: var(--lumo-space-xs, .25rem); align-items: center;" class="peer-nav">
         <vaadin-button theme="tertiary icon" class="peer-nav-prev" title="${e.prevLabel??`Previous`}"
                 ?disabled="${!e.prevRoute}"
@@ -10179,30 +10193,30 @@ ${i}
                 @click="${()=>{e.nextRoute&&(window.location.href=e.nextRoute)}}">
             <vaadin-icon icon="vaadin:angle-right"></vaadin-icon>
         </vaadin-button>
-    </div>`,cl={"vaadin:wifi":`vaadin:connect`,"vaadin:pen":`vaadin:pencil`,"vaadin:automation":`vaadin:cogs`},ll=(e,t,n)=>T`<vaadin-icon icon="${cl[e]??e}" style="${t??v}" class="${n??v}"></vaadin-icon>`,ul=(e,t,n)=>{let r=e.metadata,i=M(r.label,t,n),a=``;return r.buttonStyle&&(a+=` `+r.buttonStyle),r.color&&r.color!==`none`&&r.color!==`normal`&&(a+=` `+r.color),r.size&&r.size!==`none`&&r.size!==`normal`&&(a+=` `+r.size),T`<vaadin-button
+    </div>`,Dl={"vaadin:wifi":`vaadin:connect`,"vaadin:pen":`vaadin:pencil`,"vaadin:automation":`vaadin:cogs`},Ol=(e,t,n)=>w`<vaadin-icon icon="${Dl[e]??e}" style="${t??_}" class="${n??_}"></vaadin-icon>`,kl=(e,t,n)=>{let r=e.metadata,i=j(r.label,t,n),a=``;return r.buttonStyle&&(a+=` `+r.buttonStyle),r.color&&r.color!==`none`&&r.color!==`normal`&&(a+=` `+r.color),r.size&&r.size!==`none`&&r.size!==`normal`&&(a+=` `+r.size),w`<vaadin-button
             id="${e.id}"
             data-action-id="${r.actionId}"
-            @click="${e=>Mn(e,r)}"
+            @click="${e=>Nn(e,r)}"
             style="${e.style}"
             class="${e.cssClasses}"
             theme="${a}"
             ?disabled="${r.disabled}"
-            title="${r.shortcut?`${i} (${jn(r.shortcut)})`:v}"
-            slot="${e.slot??v}"
-    >${r.iconOnLeft?T`<vaadin-icon icon="${r.iconOnLeft}"></vaadin-icon>`:v}${i}${r.iconOnRight?T`<vaadin-icon icon="${r.iconOnRight}"></vaadin-icon>`:v}</vaadin-button>`},dl=e=>{let t=e.metadata;return T`
+            title="${r.shortcut?`${i} (${Mn(r.shortcut)})`:_}"
+            slot="${e.slot??_}"
+    >${r.iconOnLeft?w`<vaadin-icon icon="${r.iconOnLeft}"></vaadin-icon>`:_}${i}${r.iconOnRight?w`<vaadin-icon icon="${r.iconOnRight}"></vaadin-icon>`:_}</vaadin-button>`},Al=e=>{let t=e.metadata;return w`
         <vaadin-message-input
                 style="${e.style}" class="${e.cssClasses}"
-                slot="${e.slot??v}"
+                slot="${e.slot??_}"
                 @submit="${e=>{let n=e.detail?.value??``;!t.actionId||!n.trim()||e.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:{message:n}},bubbles:!0,composed:!0}))}}"
         ></vaadin-message-input>
-    `},fl=e=>{let t=(e.metadata.items??[]).map(e=>({text:e.text,time:e.time,userName:e.userName,userImg:e.userImg,userAbbr:e.userAbbr,userColorIndex:e.userColorIndex}));return T`
+    `},jl=e=>{let t=(e.metadata.items??[]).map(e=>({text:e.text,time:e.time,userName:e.userName,userImg:e.userImg,userAbbr:e.userAbbr,userColorIndex:e.userColorIndex}));return w`
         <vaadin-message-list
                 markdown
                 style="${e.style}" class="${e.cssClasses}"
-                slot="${e.slot??v}"
+                slot="${e.slot??_}"
                 .items="${t}"
         ></vaadin-message-list>
-    `},pl=(e,t)=>{e&&e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},ml=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!1;if(s.openedCondition)try{c=it(s.openedCondition,r,i,a,o)}catch(e){console.error(`when evaluating `+s.openedCondition+` :`+e+`, where data is `+i+` and state is `+r)}return T`
+    `},Ml=(e,t)=>{e&&e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},Nl=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!1;if(s.openedCondition)try{c=at(s.openedCondition,r,i,a,o)}catch(e){console.error(`when evaluating `+s.openedCondition+` :`+e+`, where data is `+i+` and state is `+r)}return w`
         <vaadin-confirm-dialog
                 header="${s.header}"
                 ?cancel-button-visible="${s.canCancel}"
@@ -10210,15 +10224,15 @@ ${i}
                 reject-text="${s.rejectText}"
                 confirm-text="${s.confirmText}"
                 .opened="${c}"
-                @confirm="${e=>pl(e.currentTarget,s.confirmActionId)}"
-                @reject="${e=>pl(e.currentTarget,s.rejectActionId)}"
-                @cancel="${e=>pl(e.currentTarget,s.cancelActionId)}"
+                @confirm="${e=>Ml(e.currentTarget,s.confirmActionId)}"
+                @reject="${e=>Ml(e.currentTarget,s.rejectActionId)}"
+                @cancel="${e=>Ml(e.currentTarget,s.cancelActionId)}"
                 style="${t.style}" class="${t.cssClasses}"
-                slot="${t.slot??v}"
+                slot="${t.slot??_}"
         >
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </vaadin-confirm-dialog>
-    `},hl=class extends b{constructor(...e){super(...e),this.panels=[],this.headerTitle=``,this.badges=[],this.navigation=null,this.overviewEditActionId=``,this._raf=0,this._snapping=!1,this._less=!1,this._more=!1,this._onScroll=()=>{this._raf||=requestAnimationFrame(()=>{this._raf=0,this._syncPin()})},this._onScrollEnd=()=>{this._snapping||this._snapToNearest()},this._fit=()=>{let e=this.getBoundingClientRect().top;this.style.setProperty(`--mateu-foldout-fill`,`${Math.max(240,window.innerHeight-e)}px`),this._syncPin()},this._onKeydown=e=>{if(e.key!==`ArrowRight`&&e.key!==`ArrowLeft`||e.defaultPrevented||e.ctrlKey||e.metaKey||e.altKey||this._isEditingContext())return;let t=this._rail;!t||t.scrollWidth<=t.clientWidth||(e.preventDefault(),this._step(e.key===`ArrowRight`?1:-1))}}navAction(e){e&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{}},bubbles:!0,composed:!0}))}_stride(){let e=this.renderRoot.querySelectorAll(`.section`);return e.length>1?e[1].offsetLeft:this._rail?.clientWidth??0}_boundaries(){let e=this._rail;if(!e)return[];let t=e.scrollWidth-e.clientWidth,n=[...this.renderRoot.querySelectorAll(`.section`)].map(e=>Math.max(0,Math.min(e.offsetLeft,t)));return[...new Set(n)]}_snapToNearest(){let e=this._rail;if(!e)return;let t=this._boundaries();if(!t.length)return;let n=t.reduce((t,n)=>Math.abs(n-e.scrollLeft)<Math.abs(t-e.scrollLeft)?n:t);Math.abs(n-e.scrollLeft)<1||(this._snapping=!0,e.scrollTo({left:n,behavior:`smooth`}),window.setTimeout(()=>{this._snapping=!1},400))}_syncPin(){let e=this._rail,t=this._first;if(!e||!t)return;let n=this._stride(),r=Math.min(e.scrollLeft,n);t.style.transform=r?`translateX(${r}px)`:``,t.classList.toggle(`floating`,e.scrollLeft>0);let i=e.scrollWidth-e.clientWidth,a=i>32;this._less=a&&e.scrollLeft>2,this._more=a&&e.scrollLeft<i-2}_step(e){let t=this._rail;if(!t)return;let n=this._boundaries();if(!n.length)return;let r=n.reduce((e,r,i)=>Math.abs(r-t.scrollLeft)<Math.abs(n[e]-t.scrollLeft)?i:e,0),i=n[Math.max(0,Math.min(r+e,n.length-1))];this._snapping=!0,t.scrollTo({left:i,behavior:`smooth`}),window.setTimeout(()=>{this._snapping=!1},400)}_isEditingContext(){let e=document.activeElement;for(;e&&e.shadowRoot&&e.shadowRoot.activeElement;)e=e.shadowRoot.activeElement;if(!e)return!1;let t=e.tagName;return t===`INPUT`||t===`TEXTAREA`||t===`SELECT`||e.isContentEditable}_sectionFlex(e,t){if(!e.width)return v;let n=parseFloat(e.width)||1;return t===this.panels.length-1&&n<22?`flex: 22 1 var(--mateu-foldout-overview-width, 22rem);`:`flex: ${n} 1 ${e.width};`}firstUpdated(){this._fit(),this._resizeObserver=new ResizeObserver(()=>this._syncPin()),this._rail&&this._resizeObserver.observe(this._rail);for(let e of this.renderRoot.querySelectorAll(`.section`))this._resizeObserver.observe(e)}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._onKeydown),window.addEventListener(`resize`,this._fit)}disconnectedCallback(){document.removeEventListener(`keydown`,this._onKeydown),window.removeEventListener(`resize`,this._fit),this._resizeObserver?.disconnect(),this._resizeObserver=void 0,this._raf&&=(cancelAnimationFrame(this._raf),0),super.disconnectedCallback()}static{this.styles=h`
+    `},$=class extends y{constructor(...e){super(...e),this.panels=[],this.headerTitle=``,this.badges=[],this.navigation=null,this.overviewEditActionId=``,this._raf=0,this._snapping=!1,this._less=!1,this._more=!1,this._onScroll=()=>{this._raf||=requestAnimationFrame(()=>{this._raf=0,this._syncPin()})},this._onScrollEnd=()=>{this._snapping||this._snapToNearest()},this._fit=()=>{let e=this.getBoundingClientRect().top;this.style.setProperty(`--mateu-foldout-fill`,`${Math.max(240,window.innerHeight-e)}px`),this._syncPin()},this._onKeydown=e=>{if(e.key!==`ArrowRight`&&e.key!==`ArrowLeft`||e.defaultPrevented||e.ctrlKey||e.metaKey||e.altKey||this._isEditingContext())return;let t=this._rail;!t||t.scrollWidth<=t.clientWidth||(e.preventDefault(),this._step(e.key===`ArrowRight`?1:-1))}}navAction(e){e&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{}},bubbles:!0,composed:!0}))}_stride(){let e=this.renderRoot.querySelectorAll(`.section`);return e.length>1?e[1].offsetLeft:this._rail?.clientWidth??0}_boundaries(){let e=this._rail;if(!e)return[];let t=e.scrollWidth-e.clientWidth,n=[...this.renderRoot.querySelectorAll(`.section`)].map(e=>Math.max(0,Math.min(e.offsetLeft,t)));return[...new Set(n)]}_snapToNearest(){let e=this._rail;if(!e)return;let t=this._boundaries();if(!t.length)return;let n=t.reduce((t,n)=>Math.abs(n-e.scrollLeft)<Math.abs(t-e.scrollLeft)?n:t);Math.abs(n-e.scrollLeft)<1||(this._snapping=!0,e.scrollTo({left:n,behavior:`smooth`}),window.setTimeout(()=>{this._snapping=!1},400))}_syncPin(){let e=this._rail,t=this._first;if(!e||!t)return;let n=this._stride(),r=Math.min(e.scrollLeft,n);t.style.transform=r?`translateX(${r}px)`:``,t.classList.toggle(`floating`,e.scrollLeft>0);let i=e.scrollWidth-e.clientWidth,a=i>32;this._less=a&&e.scrollLeft>2,this._more=a&&e.scrollLeft<i-2}_step(e){let t=this._rail;if(!t)return;let n=this._boundaries();if(!n.length)return;let r=n.reduce((e,r,i)=>Math.abs(r-t.scrollLeft)<Math.abs(n[e]-t.scrollLeft)?i:e,0),i=n[Math.max(0,Math.min(r+e,n.length-1))];this._snapping=!0,t.scrollTo({left:i,behavior:`smooth`}),window.setTimeout(()=>{this._snapping=!1},400)}_isEditingContext(){let e=document.activeElement;for(;e&&e.shadowRoot&&e.shadowRoot.activeElement;)e=e.shadowRoot.activeElement;if(!e)return!1;let t=e.tagName;return t===`INPUT`||t===`TEXTAREA`||t===`SELECT`||e.isContentEditable}_sectionFlex(e,t){if(!e.width)return _;let n=parseFloat(e.width)||1;return t===this.panels.length-1&&n<22?`flex: 22 1 var(--mateu-foldout-overview-width, 22rem);`:`flex: ${n} 1 ${e.width};`}firstUpdated(){this._fit(),this._resizeObserver=new ResizeObserver(()=>this._syncPin()),this._rail&&this._resizeObserver.observe(this._rail);for(let e of this.renderRoot.querySelectorAll(`.section`))this._resizeObserver.observe(e)}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._onKeydown),window.addEventListener(`resize`,this._fit)}disconnectedCallback(){document.removeEventListener(`keydown`,this._onKeydown),window.removeEventListener(`resize`,this._fit),this._resizeObserver?.disconnect(),this._resizeObserver=void 0,this._raf&&=(cancelAnimationFrame(this._raf),0),super.disconnectedCallback()}static{this.styles=m`
         :host {
             position: relative;
             display: flex;
@@ -10402,66 +10416,66 @@ ${i}
             width: 1.35rem;
             height: 1.35rem;
         }
-    `}render(){let e=this.navigation,t=!!(this.overviewEditActionId||e&&(e.parentActionId||e.previousActionId||e.nextActionId)),n=!!(this.headerTitle||t||this.badges.length);return T`
+    `}render(){let e=this.navigation,t=!!(this.overviewEditActionId||e&&(e.parentActionId||e.previousActionId||e.nextActionId)),n=!!(this.headerTitle||t||this.badges.length);return w`
             <div class="rail" part="rail" tabindex="0"
                  @scroll="${this._onScroll}" @scrollend="${this._onScrollEnd}">
                 <section class="section section--first" part="section overview">
-                    ${n?T`
+                    ${n?w`
                         <header class="section-head" part="section-head">
                             <div class="section-head-row">
-                                ${this.headerTitle?T`<h2 class="section-title">${this.headerTitle}</h2>`:T`<span></span>`}
-                                ${t?T`
+                                ${this.headerTitle?w`<h2 class="section-title">${this.headerTitle}</h2>`:w`<span></span>`}
+                                ${t?w`
                                     <div class="section-toolbar" part="section-toolbar">
-                                        ${e?.parentActionId?T`
+                                        ${e?.parentActionId?w`
                                             <button class="tb-parent" title="${e.parentLabel??`Back`}"
                                                     @click="${()=>this.navAction(e.parentActionId)}">
                                                 <span>‹</span><span>${e.parentLabel??`Back`}</span>
                                             </button>
-                                        `:v}
-                                        ${e?.previousActionId?T`
+                                        `:_}
+                                        ${e?.previousActionId?w`
                                             <button class="tb-move" title="Previous"
                                                     @click="${()=>this.navAction(e.previousActionId)}">‹</button>
-                                        `:v}
-                                        ${e?.nextActionId?T`
+                                        `:_}
+                                        ${e?.nextActionId?w`
                                             <button class="tb-move" title="Next"
                                                     @click="${()=>this.navAction(e.nextActionId)}">›</button>
-                                        `:v}
-                                        ${this.overviewEditActionId?T`
+                                        `:_}
+                                        ${this.overviewEditActionId?w`
                                             <button class="tb-edit" title="Edit"
                                                     @click="${()=>this.navAction(this.overviewEditActionId)}">
                                                 <span>✎</span><span>Edit</span>
                                             </button>
-                                        `:v}
+                                        `:_}
                                     </div>
-                                `:v}
+                                `:_}
                             </div>
-                            ${this.badges.length?T`
+                            ${this.badges.length?w`
                                 <div class="section-badges">
-                                    ${this.badges.map(e=>T`<span class="section-badge">${e}</span>`)}
+                                    ${this.badges.map(e=>w`<span class="section-badge">${e}</span>`)}
                                 </div>
-                            `:v}
+                            `:_}
                         </header>
-                    `:v}
+                    `:_}
                     <div class="overview-body">
                         <slot name="overview"></slot>
                     </div>
                 </section>
-                ${this.panels.map((e,t)=>T`
+                ${this.panels.map((e,t)=>w`
                     <section class="section" part="section panel"
                              style="${this._sectionFlex(e,t)}">
-                        ${e.title||e.subtitle?T`
+                        ${e.title||e.subtitle?w`
                             <div class="panel-header">
-                                ${e.title?T`<h3>${e.title}${e.subtitle?T` <span class="subtitle" style="font-weight: 400;">· ${e.subtitle}</span>`:v}</h3>`:v}
-                                ${!e.title&&e.subtitle?T`<div class="subtitle">${e.subtitle}</div>`:v}
+                                ${e.title?w`<h3>${e.title}${e.subtitle?w` <span class="subtitle" style="font-weight: 400;">· ${e.subtitle}</span>`:_}</h3>`:_}
+                                ${!e.title&&e.subtitle?w`<div class="subtitle">${e.subtitle}</div>`:_}
                             </div>
-                        `:v}
+                        `:_}
                         <div class="panel-body">
                             <slot name="panel-${t}"></slot>
                         </div>
                     </section>
                 `)}
             </div>
-            ${this._less?T`
+            ${this._less?w`
                 <button class="scroll-nav left" part="scroll-nav-left" title="Scroll left"
                         aria-label="Scroll left" @click="${()=>this._step(-1)}">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
@@ -10469,8 +10483,8 @@ ${i}
                         <polyline points="15 6 9 12 15 18"></polyline>
                     </svg>
                 </button>
-            `:v}
-            ${this._more?T`
+            `:_}
+            ${this._more?w`
                 <button class="scroll-nav right" part="scroll-nav-right" title="Scroll right"
                         aria-label="Scroll right" @click="${()=>this._step(1)}">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
@@ -10478,8 +10492,8 @@ ${i}
                         <polyline points="9 6 15 12 9 18"></polyline>
                     </svg>
                 </button>
-            `:v}
-        `}};k([y({type:Array})],hl.prototype,`panels`,void 0),k([y({type:String})],hl.prototype,`headerTitle`,void 0),k([y({type:Array})],hl.prototype,`badges`,void 0),k([y({attribute:!1})],hl.prototype,`navigation`,void 0),k([y({type:String})],hl.prototype,`overviewEditActionId`,void 0),k([x(`.rail`)],hl.prototype,`_rail`,void 0),k([x(`.section--first`)],hl.prototype,`_first`,void 0),k([C()],hl.prototype,`_less`,void 0),k([C()],hl.prototype,`_more`,void 0),hl=k([g(`mateu-vaadin-foldout`)],hl);var gl=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+            `:_}
+        `}};O([v({type:Array})],$.prototype,`panels`,void 0),O([v({type:String})],$.prototype,`headerTitle`,void 0),O([v({type:Array})],$.prototype,`badges`,void 0),O([v({attribute:!1})],$.prototype,`navigation`,void 0),O([v({type:String})],$.prototype,`overviewEditActionId`,void 0),O([b(`.rail`)],$.prototype,`_rail`,void 0),O([b(`.section--first`)],$.prototype,`_first`,void 0),O([S()],$.prototype,`_less`,void 0),O([S()],$.prototype,`_more`,void 0),$=O([h(`mateu-vaadin-foldout`)],$);var Pl=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <mateu-vaadin-foldout
                 .panels="${s.panels??[]}"
                 .headerTitle="${s.headerTitle??``}"
@@ -10488,11 +10502,11 @@ ${i}
                 overviewEditActionId="${s.overviewEditActionId??``}"
                 style="${t.style}"
                 class="${t.cssClasses}"
-                slot="${t.slot??v}"
+                slot="${t.slot??_}"
         >
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </mateu-vaadin-foldout>
-    `},_l=class extends b{constructor(...e){super(...e),this.rows=[],this.columns=[],this.navigable=!1,this.expandedItems=[],this._normalized=[],this.dataProvider=(e,t)=>{let n=e.parentItem?e.parentItem.children??[]:this.normalized;t(n,n.length)}}get normalized(){return this._src!==this.rows&&(this._src=this.rows,this._normalized=this.normalizeRows(this.rows??[])),this._normalized}normalizeRows(e){return(e??[]).map(e=>{let t=Array.isArray(e.children)&&e.children.length?this.normalizeRows(e.children):void 0;return{...e,children:t}})}collectGroups(e,t=[]){return e.forEach(e=>{e.children&&e.children.length&&(t.push(e),this.collectGroups(e.children,t))}),t}willUpdate(){this._expandedSrc!==this.rows&&(this._expandedSrc=this.rows,this.expandedItems=this.collectGroups(this.normalized))}updated(e){e.has(`rows`)&&this._grid?.clearCache?.()}dispatch(e,t){this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:t},bubbles:!0,composed:!0}))}render(){let e=this.columns??[],n=e[0],r=e.slice(1);return T`
+    `},Fl=class extends y{constructor(...e){super(...e),this.rows=[],this.columns=[],this.navigable=!1,this.expandedItems=[],this._normalized=[],this.dataProvider=(e,t)=>{let n=e.parentItem?e.parentItem.children??[]:this.normalized;t(n,n.length)}}get normalized(){return this._src!==this.rows&&(this._src=this.rows,this._normalized=this.normalizeRows(this.rows??[])),this._normalized}normalizeRows(e){return(e??[]).map(e=>{let t=Array.isArray(e.children)&&e.children.length?this.normalizeRows(e.children):void 0;return{...e,children:t}})}collectGroups(e,t=[]){return e.forEach(e=>{e.children&&e.children.length&&(t.push(e),this.collectGroups(e.children,t))}),t}willUpdate(){this._expandedSrc!==this.rows&&(this._expandedSrc=this.rows,this.expandedItems=this.collectGroups(this.normalized))}updated(e){e.has(`rows`)&&this._grid?.clearCache?.()}dispatch(e,t){this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:t},bubbles:!0,composed:!0}))}render(){let e=this.columns??[],n=e[0],r=e.slice(1);return w`
             <vaadin-grid
                     theme="compact no-row-borders"
                     all-rows-visible
@@ -10500,20 +10514,20 @@ ${i}
                     .itemHasChildrenPath="${`children`}"
                     .expandedItems="${this.expandedItems}"
                     @expanded-items-changed="${e=>{this.expandedItems=e.detail.value}}">
-                ${n?T`
+                ${n?w`
                     <vaadin-grid-tree-column path="${n.id}" header="${n.label??``}"
                                              auto-width flex-grow="0"></vaadin-grid-tree-column>
-                `:v}
-                ${r.map(e=>e.id===`select`?T`<vaadin-grid-column header="${e.label??``}" auto-width flex-grow="0" text-align="end"
-                              ${t(e=>T`<vaadin-button theme="tertiary small"
-                                          @click="${()=>this.dispatch(`action-on-row-select`,{_clickedRow:e})}">Select</vaadin-button>`,[])}></vaadin-grid-column>`:T`<vaadin-grid-column path="${e.id}" header="${e.label??``}"></vaadin-grid-column>`)}
-                ${this.navigable?T`
+                `:_}
+                ${r.map(e=>e.id===`select`?w`<vaadin-grid-column header="${e.label??``}" auto-width flex-grow="0" text-align="end"
+                              ${t(e=>w`<vaadin-button theme="tertiary small"
+                                          @click="${()=>this.dispatch(`action-on-row-select`,{_clickedRow:e})}">Select</vaadin-button>`,[])}></vaadin-grid-column>`:w`<vaadin-grid-column path="${e.id}" header="${e.label??``}"></vaadin-grid-column>`)}
+                ${this.navigable?w`
                     <vaadin-grid-column auto-width flex-grow="0" text-align="end"
-                          ${t(e=>e?.viewable===!1?T``:T`<vaadin-button theme="tertiary small"
+                          ${t(e=>e?.viewable===!1?w``:w`<vaadin-button theme="tertiary small"
                                           @click="${()=>this.dispatch(`view`,e)}">View</vaadin-button>`,[])}></vaadin-grid-column>
-                `:v}
+                `:_}
             </vaadin-grid>
-        `}static{this.styles=h`
+        `}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -10522,11 +10536,11 @@ ${i}
             max-height: min(60vh, 32rem);
             min-width: 22rem;
         }
-    `}};k([y({attribute:!1})],_l.prototype,`rows`,void 0),k([y({attribute:!1})],_l.prototype,`columns`,void 0),k([y()],_l.prototype,`idField`,void 0),k([y({type:Boolean})],_l.prototype,`navigable`,void 0),k([y()],_l.prototype,`selectedId`,void 0),k([C()],_l.prototype,`expandedItems`,void 0),k([x(`vaadin-grid`)],_l.prototype,`_grid`,void 0),_l=k([g(`mateu-vaadin-tree`)],_l);var vl={[j.VirtualList]:(e,t,n,r,i,a,o)=>js(e,t,n,r,i,a,o),[j.Notification]:(e,t)=>Ms(t),[j.ProgressBar]:(e,t,n,r)=>Ns(t,r),[j.Details]:(e,t,n,r,i,a,o)=>Ps(e,t,n,r,i,a,o),[j.Avatar]:(e,t,n,r,i)=>Fs(t,r,i),[j.AvatarGroup]:(e,t)=>Is(t),[j.Card]:(e,t,n,r,i,a,o)=>Ls(e,t,n,r,i,a,o),[j.Button]:(e,t,n,r,i)=>ul(t,r,i),[j.MessageInput]:(e,t)=>dl(t),[j.MessageList]:(e,t)=>fl(t),[j.ConfirmDialog]:(e,t,n,r,i,a,o)=>ml(e,t,n,r,i,a,o),[j.FormLayout]:(e,t,n,r,i,a,o)=>Bs(e,t,n,r,i,a,o),[j.HorizontalLayout]:(e,t,n,r,i,a,o)=>Ws(e,t,n,r,i,a,o),[j.VerticalLayout]:(e,t,n,r,i,a,o)=>Gs(e,t,n,r,i,a,o),[j.SplitLayout]:(e,t,n,r,i,a,o)=>Ks(e,t,n,r,i,a,o),[j.MasterDetailLayout]:(e,t,n,r,i,a,o)=>qs(e,t,n,r,i,a,o),[j.TabLayout]:(e,t,n,r,i,a,o)=>Js(e,t,n,r,i,a,o),[j.AccordionLayout]:(e,t,n,r,i,a,o)=>Xs(e,t,n,r,i,a,o),[j.BoardLayout]:(e,t,n,r,i,a,o)=>$s(e,t,n,r,i,a,o),[j.BoardLayoutRow]:(e,t,n,r,i,a,o)=>ec(e,t,n,r,i,a,o),[j.BoardLayoutItem]:(e,t,n,r,i,a,o)=>tc(e,t,n,r,i,a,o),[j.Scroller]:(e,t,n,r,i,a,o)=>Qs(e,t,n,r,i,a,o),[j.MenuBar]:(e,t,n,r,i)=>ic(e,t,n,r,i),[j.ContextMenu]:(e,t,n,r,i,a,o)=>rc(e,t,n,r,i,a,o),[j.FormField]:(e,t,n,r,i,a,o,s)=>tl(e,t,n,r,i,a,o,s),[j.Grid]:(e,t,n,r,i,a,o)=>nl(e,t,n,r,i,a,o),[j.Table]:(e,t,n,r,i,a,o)=>rl(e,t,n,r,i,a,o),[j.Popover]:(e,t,n,r,i,a,o)=>al(e,t,n,r,i,a,o),[j.FoldoutLayout]:(e,t,n,r,i,a,o)=>gl(e,t,n,r,i,a,o)},yl=class extends As{rendererName(){return`vaadin`}renderClientSideComponent(e,t,n,r,i,a,o,s){let c=t?.metadata?.type,l=c?vl[c]:void 0;return l&&t?l(e,t,n,r,i,a,o,s):super.renderClientSideComponent(e,t,n,r,i,a,o,s)}renderTableComponent(e,t,n,r,i,a,o){return il(e,t,n,r,a,o)}renderTreeComponent(e,t){return T`
+    `}};O([v({attribute:!1})],Fl.prototype,`rows`,void 0),O([v({attribute:!1})],Fl.prototype,`columns`,void 0),O([v()],Fl.prototype,`idField`,void 0),O([v({type:Boolean})],Fl.prototype,`navigable`,void 0),O([v()],Fl.prototype,`selectedId`,void 0),O([S()],Fl.prototype,`expandedItems`,void 0),O([b(`vaadin-grid`)],Fl.prototype,`_grid`,void 0),Fl=O([h(`mateu-vaadin-tree`)],Fl);var Il={[A.VirtualList]:(e,t,n,r,i,a,o)=>qs(e,t,n,r,i,a,o),[A.Notification]:(e,t)=>Js(t),[A.ProgressBar]:(e,t,n,r)=>Ys(t,r),[A.Details]:(e,t,n,r,i,a,o)=>Xs(e,t,n,r,i,a,o),[A.Avatar]:(e,t,n,r,i)=>Zs(t,r,i),[A.AvatarGroup]:(e,t)=>Qs(t),[A.Card]:(e,t,n,r,i,a,o)=>$s(e,t,n,r,i,a,o),[A.Button]:(e,t,n,r,i)=>kl(t,r,i),[A.MessageInput]:(e,t)=>Al(t),[A.MessageList]:(e,t)=>jl(t),[A.ConfirmDialog]:(e,t,n,r,i,a,o)=>Nl(e,t,n,r,i,a,o),[A.FormLayout]:(e,t,n,r,i,a,o)=>nc(e,t,n,r,i,a,o),[A.HorizontalLayout]:(e,t,n,r,i,a,o)=>oc(e,t,n,r,i,a,o),[A.VerticalLayout]:(e,t,n,r,i,a,o)=>sc(e,t,n,r,i,a,o),[A.SplitLayout]:(e,t,n,r,i,a,o)=>cc(e,t,n,r,i,a,o),[A.MasterDetailLayout]:(e,t,n,r,i,a,o)=>lc(e,t,n,r,i,a,o),[A.TabLayout]:(e,t,n,r,i,a,o)=>uc(e,t,n,r,i,a,o),[A.AccordionLayout]:(e,t,n,r,i,a,o)=>fc(e,t,n,r,i,a,o),[A.BoardLayout]:(e,t,n,r,i,a,o)=>hc(e,t,n,r,i,a,o),[A.BoardLayoutRow]:(e,t,n,r,i,a,o)=>gc(e,t,n,r,i,a,o),[A.BoardLayoutItem]:(e,t,n,r,i,a,o)=>_c(e,t,n,r,i,a,o),[A.Scroller]:(e,t,n,r,i,a,o)=>mc(e,t,n,r,i,a,o),[A.MenuBar]:(e,t,n,r,i)=>bc(e,t,n,r,i),[A.ContextMenu]:(e,t,n,r,i,a,o)=>yc(e,t,n,r,i,a,o),[A.FormField]:(e,t,n,r,i,a,o,s)=>bl(e,t,n,r,i,a,o,s),[A.Grid]:(e,t,n,r,i,a,o)=>xl(e,t,n,r,i,a,o),[A.Table]:(e,t,n,r,i,a,o)=>Sl(e,t,n,r,i,a,o),[A.Popover]:(e,t,n,r,i,a,o)=>wl(e,t,n,r,i,a,o),[A.FoldoutLayout]:(e,t,n,r,i,a,o)=>Pl(e,t,n,r,i,a,o)},Ll=class extends Ks{rendererName(){return`vaadin`}renderClientSideComponent(e,t,n,r,i,a,o,s){let c=t?.metadata?.type,l=c?Il[c]:void 0;return l&&t?l(e,t,n,r,i,a,o,s):super.renderClientSideComponent(e,t,n,r,i,a,o,s)}renderTableComponent(e,t,n,r,i,a,o){return Cl(e,t,n,r,a,o)}renderTreeComponent(e,t){return w`
             <mateu-vaadin-tree
                     .rows="${t.rows}"
                     .columns="${t.columns}"
                     .idField="${t.idField}"
                     .navigable="${t.navigable}"
                     .selectedId="${t.selectedId}"
-            ></mateu-vaadin-tree>`}renderToolbarButton(e,t,n){return ol(e,t,n)}renderPeerNav(e){return sl(e)}renderIcon(e,t,n){return ll(e,t,n)}renderTopNav(e,t,n){return nc(e,t,n)}};function bl(e){switch(e){case`topStretch`:return`top-stretch`;case`topStart`:return`top-start`;case`topCenter`:return`top-center`;case`topEnd`:return`top-end`;case`middle`:return`middle`;case`bottomStart`:return`bottom-start`;case`bottomEnd`:return`bottom-end`;case`bottomStretch`:return`bottom-stretch`;case`bottomCenter`:return`bottom-center`}return`bottom-end`}function xl(e,t){if(e.onAction)return{label:e.actionLabel??`Retry`,run:e.onAction};if(e.undoActionId)return{label:e.undoLabel??`Undo`,run:()=>t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.undoActionId,parameters:e.undoParameters??{}},bubbles:!0,composed:!0}))}}function Sl(e,t){let n=new r;n.position=bl(e.position),n.duration=e.duration??1e4,e.variant&&n.setAttribute(`theme`,e.variant),n.renderer=r=>{if(r.firstElementChild)return;let i=document.createElement(`span`);i.textContent=e.text;let a=xl(e,t),o=document.createElement(`button`);o.textContent=a.label,o.style.cssText=`margin-left: 0.75rem; background: none; border: 1px solid currentColor; border-radius: var(--lumo-border-radius-s, 4px); color: inherit; cursor: pointer; padding: 0.15rem 0.6rem; font: inherit; font-weight: 600;`,o.addEventListener(`click`,()=>{a.run(),n.opened=!1}),r.append(i,o)},document.body.appendChild(n),n.opened=!0,n.addEventListener(`opened-changed`,e=>{e.detail.value||n.remove()})}P.set(new yl),aa({show(e,t){if(Ze(e.text,{politeness:e.variant===`error`?`assertive`:`polite`}),e.undoActionId||e.onAction){Sl(e,t);return}r.show(e.text,{position:e.position?bl(e.position):`bottom-end`,theme:e.variant,duration:e.duration})}});
+            ></mateu-vaadin-tree>`}renderToolbarButton(e,t,n){return Tl(e,t,n)}renderPeerNav(e){return El(e)}renderIcon(e,t,n){return Ol(e,t,n)}renderTopNav(e,t,n){return vc(e,t,n)}};function Rl(e){switch(e){case`topStretch`:return`top-stretch`;case`topStart`:return`top-start`;case`topCenter`:return`top-center`;case`topEnd`:return`top-end`;case`middle`:return`middle`;case`bottomStart`:return`bottom-start`;case`bottomEnd`:return`bottom-end`;case`bottomStretch`:return`bottom-stretch`;case`bottomCenter`:return`bottom-center`}return`bottom-end`}function zl(e,t){if(e.onAction)return{label:e.actionLabel??`Retry`,run:e.onAction};if(e.undoActionId)return{label:e.undoLabel??`Undo`,run:()=>t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.undoActionId,parameters:e.undoParameters??{}},bubbles:!0,composed:!0}))}}function Bl(e,t){let n=new r;n.position=Rl(e.position),n.duration=e.duration??1e4,e.variant&&n.setAttribute(`theme`,e.variant),n.renderer=r=>{if(r.firstElementChild)return;let i=document.createElement(`span`);i.textContent=e.text;let a=zl(e,t),o=document.createElement(`button`);o.textContent=a.label,o.style.cssText=`margin-left: 0.75rem; background: none; border: 1px solid currentColor; border-radius: var(--lumo-border-radius-s, 4px); color: inherit; cursor: pointer; padding: 0.15rem 0.6rem; font: inherit; font-weight: 600;`,o.addEventListener(`click`,()=>{a.run(),n.opened=!1}),r.append(i,o)},document.body.appendChild(n),n.opened=!0,n.addEventListener(`opened-changed`,e=>{e.detail.value||n.remove()})}N.set(new Ll),oa({show(e,t){if(Qe(e.text,{politeness:e.variant===`error`?`assertive`:`polite`}),e.undoActionId||e.onAction){Bl(e,t);return}r.show(e.text,{position:e.position?Rl(e.position):`bottom-end`,theme:e.variant,duration:e.duration})}});

--- a/backend/shared/uidl/src/main/java/io/mateu/uidl/annotations/RestOptions.java
+++ b/backend/shared/uidl/src/main/java/io/mateu/uidl/annotations/RestOptions.java
@@ -1,0 +1,59 @@
+package io.mateu.uidl.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Fills a field's select options from an arbitrary (non-Mateu) REST endpoint, fetched CLIENT-SIDE:
+ * the renderer calls {@link #url()} directly (no Mateu server mediating), navigates {@link
+ * #itemsPath()} to the array in the JSON response, and maps each item via {@link #valuePath()} /
+ * {@link #labelPath()} into the option value/label. The field renders as a select.
+ *
+ * <p>The first surface of the "decouple the UI from the Mateu backend" line — a Mateu form talking
+ * to any REST API. {@code url}/{@code headers}/{@code body} support {@code ${state.x}}
+ * interpolation, so the request can depend on other field values.
+ *
+ * <p>Example:
+ *
+ * <pre>{@code
+ * @RestOptions(
+ *     url = "https://restcountries.com/v3.1/all?fields=cca2,name",
+ *     itemsPath = "",           // the response root is already the array
+ *     valuePath = "cca2",
+ *     labelPath = "name.common")
+ * String country;
+ * }</pre>
+ *
+ * <p>ANNOTATION_TYPE so it composes as a meta-annotation (e.g. {@code @CountryPicker}), resolved
+ * via MetaAnnotations.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.ANNOTATION_TYPE})
+public @interface RestOptions {
+
+  /** The endpoint URL; supports {@code ${state.x}}/{@code ${data.y}} interpolation. */
+  String url();
+
+  /** The HTTP method (GET, POST, …). */
+  String method() default "GET";
+
+  /** Request headers as {@code "Name: Value"} strings (values interpolated). */
+  String[] headers() default {};
+
+  /** A request body template (interpolated) for non-GET methods. */
+  String body() default "";
+
+  /**
+   * A dot path to the array inside the JSON response (e.g. {@code data.items}); blank means the
+   * response root IS the array.
+   */
+  String itemsPath() default "";
+
+  /** A dot path within each item to the option value. */
+  String valuePath() default "value";
+
+  /** A dot path within each item to the option label. */
+  String labelPath() default "label";
+}

--- a/backend/shared/uidl/src/main/java/io/mateu/uidl/data/FormField.java
+++ b/backend/shared/uidl/src/main/java/io/mateu/uidl/data/FormField.java
@@ -18,6 +18,7 @@ public record FormField(
     String description,
     List<Option> options,
     RemoteCoordinates remoteCoordinates,
+    RestDataSource optionsSource,
     Object initialValue,
     String style,
     String cssClasses,

--- a/backend/shared/uidl/src/main/java/io/mateu/uidl/data/RestDataSource.java
+++ b/backend/shared/uidl/src/main/java/io/mateu/uidl/data/RestDataSource.java
@@ -1,0 +1,22 @@
+package io.mateu.uidl.data;
+
+import java.util.Map;
+import lombok.Builder;
+
+/**
+ * A descriptor for consuming an arbitrary (non-Mateu) REST endpoint CLIENT-SIDE — the renderer
+ * fetches the URL directly and shapes the JSON response into the surface's expected form (a
+ * select's options today; listing rows, form state and endpoint actions reuse the same descriptor).
+ *
+ * <p>{@code url}/{@code headers}/{@code body} support {@code ${state.x}} interpolation; {@code
+ * itemsPath} navigates to the response array; {@code valuePath}/{@code labelPath} map each item.
+ */
+@Builder
+public record RestDataSource(
+    String url,
+    String method,
+    Map<String, String> headers,
+    String body,
+    String itemsPath,
+    String valuePath,
+    String labelPath) {}

--- a/demo/sites/vaadin/assets/mateu-vaadin.js
+++ b/demo/sites/vaadin/assets/mateu-vaadin.js
@@ -1,19 +1,19 @@
 const __vite__mapDeps=(i,m=__vite__mapDeps,d=(m.f||(m.f=["assets/vendor-ol.js","assets/rolldown-runtime.js","assets/vendor.js","assets/vendor-chartjs.js","assets/vendor-diagrams.js","assets/vendor-ui5.js"])))=>i.map(i=>d[i]);
-import{_ as e,a as t,c as n,d as r,f as i,g as a,h as o,i as s,l as c,m as l,n as u,o as d,p as f,r as p,s as m,t as ee,u as te,v as ne}from"./vendor-vaadin.js";import{S as h,a as g,c as _,g as re,h as v,i as y,m as b,n as x,o as S,r as C,v as w,w as ie,y as T}from"./vendor-lit.js";import{c as ae,l as oe,o as se,s as E}from"./vendor.js";import{r as D}from"./vendor-ui5.js";(function(){let e=document.createElement(`link`).relList;if(e&&e.supports&&e.supports(`modulepreload`))return;for(let e of document.querySelectorAll(`link[rel="modulepreload"]`))n(e);new MutationObserver(e=>{for(let t of e)if(t.type===`childList`)for(let e of t.addedNodes)e.tagName===`LINK`&&e.rel===`modulepreload`&&n(e)}).observe(document,{childList:!0,subtree:!0});function t(e){let t={};return e.integrity&&(t.integrity=e.integrity),e.referrerPolicy&&(t.referrerPolicy=e.referrerPolicy),e.crossOrigin===`use-credentials`?t.credentials=`include`:e.crossOrigin===`anonymous`?t.credentials=`omit`:t.credentials=`same-origin`,t}function n(e){if(e.ep)return;e.ep=!0;let n=t(e);fetch(e.href,n)}})(),ne(`vaadin-card`,h`
+import{_ as e,a as t,c as n,d as r,f as i,g as a,h as o,i as s,l as c,m as l,n as u,o as d,p as f,r as p,s as ee,t as te,u as ne,v as re}from"./vendor-vaadin.js";import{S as m,a as h,c as g,g as ie,h as _,i as v,m as y,n as b,o as x,r as S,v as C,w as ae,y as w}from"./vendor-lit.js";import{c as oe,l as se,o as ce,s as T}from"./vendor.js";import{r as E}from"./vendor-ui5.js";(function(){let e=document.createElement(`link`).relList;if(e&&e.supports&&e.supports(`modulepreload`))return;for(let e of document.querySelectorAll(`link[rel="modulepreload"]`))n(e);new MutationObserver(e=>{for(let t of e)if(t.type===`childList`)for(let e of t.addedNodes)e.tagName===`LINK`&&e.rel===`modulepreload`&&n(e)}).observe(document,{childList:!0,subtree:!0});function t(e){let t={};return e.integrity&&(t.integrity=e.integrity),e.referrerPolicy&&(t.referrerPolicy=e.referrerPolicy),e.crossOrigin===`use-credentials`?t.credentials=`include`:e.crossOrigin===`anonymous`?t.credentials=`omit`:t.credentials=`same-origin`,t}function n(e){if(e.ep)return;e.ep=!0;let n=t(e);fetch(e.href,n)}})(),re(`vaadin-card`,m`
       :host(.mateu-section) {
         --vaadin-card-border-width: 0 !important;
         --vaadin-card-background: transparent !important;
         --vaadin-card-shadow: none !important;
         --vaadin-card-padding: 0 !important;
       }
-    `);var ce=document.createElement(`style`);ce.innerHTML=`
+    `);var le=document.createElement(`style`);le.innerHTML=`
 ${e.cssText}
 ${o.cssText}
 ${a.cssText}
 ${l.cssText}
 ${f}
 ${i}
-`,document.body.appendChild(ce);{let e=window.Vaadin;e&&((e.featureFlags??={}).masterDetailLayoutComponent=!0)}new class{constructor(){this.ui=void 0,this.loading=!1,this.config={},this.sharedData={},this.userData={},this.appData={},this.runtimeData={}}};var le=new oe,O={value:{}},ue={value:{}},de=h`
+`,document.body.appendChild(le);{let e=window.Vaadin;e&&((e.featureFlags??={}).masterDetailLayoutComponent=!0)}new class{constructor(){this.ui=void 0,this.loading=!1,this.config={},this.sharedData={},this.userData={},this.appData={},this.runtimeData={}}};var ue=new se,D={value:{}},de={value:{}},fe=m`
   [theme~='badge'] {
     display: inline-flex;
     align-items: center;
@@ -129,7 +129,7 @@ ${i}
   [theme~='badge'][theme~='pill'] {
     --lumo-border-radius-s: 1em;
   }
-`,fe={lon:0,lat:0},pe=e=>{if(!e)return;let t=e.split(`,`).map(e=>e.trim());if(t.length!==2)return;let n=Number(t[0]),r=Number(t[1]);if(!(t[0]===``||t[1]===``||!Number.isFinite(n)||!Number.isFinite(r)))return{lon:r,lat:n}},me=e=>{if(e==null||e.trim()===``)return 3;let t=Number(e);return Number.isFinite(t)?t:3};function k(e,t,n,r){var i=arguments.length,a=i<3?t:r===null?r=Object.getOwnPropertyDescriptor(t,n):r,o;if(typeof Reflect==`object`&&typeof Reflect.decorate==`function`)a=Reflect.decorate(e,t,n,r);else for(var s=e.length-1;s>=0;s--)(o=e[s])&&(a=(i<3?o(a):i>3?o(t,n,a):o(t,n))||a);return i>3&&a&&Object.defineProperty(t,n,a),a}var he=class extends b{constructor(...e){super(...e),this.renderSeq=0}updated(e){super.updated(e),this.createMap()}disconnectedCallback(){super.disconnectedCallback(),this.map?.setTarget(void 0),this.map=void 0}async createMap(){let e=++this.renderSeq,[{default:t},{default:n},{default:r},{default:i},{fromLonLat:a},{default:o}]=await Promise.all([D(()=>import(`./vendor-ol.js`).then(e=>e.i),__vite__mapDeps([0,1])),D(()=>import(`./vendor-ol.js`).then(e=>e.a),__vite__mapDeps([0,1])),D(()=>import(`./vendor-ol.js`).then(e=>e.r),__vite__mapDeps([0,1])),D(()=>import(`./vendor-ol.js`).then(e=>e.t),__vite__mapDeps([0,1])),D(()=>import(`./vendor-ol.js`).then(e=>e.o),__vite__mapDeps([0,1])),D(()=>import(`./vendor-ol.js`).then(e=>e.n),__vite__mapDeps([0,1]))]);if(e!==this.renderSeq||!this.isConnected)return;if(!this.shadowRoot.querySelector(`style[data-ol]`)){let e=document.createElement(`style`);e.setAttribute(`data-ol`,``),e.textContent=o,this.shadowRoot.appendChild(e)}this.map&&=(this.map.setTarget(void 0),void 0);let s=pe(this.position)??fe;this.map=new t({target:this.mapElement,layers:[new r({source:new i})],view:new n({center:a([s.lon,s.lat]),zoom:me(this.zoom)})})}render(){return T`<div id="map"></div>`}static{this.styles=h`
+`,pe={lon:0,lat:0},me=e=>{if(!e)return;let t=e.split(`,`).map(e=>e.trim());if(t.length!==2)return;let n=Number(t[0]),r=Number(t[1]);if(!(t[0]===``||t[1]===``||!Number.isFinite(n)||!Number.isFinite(r)))return{lon:r,lat:n}},he=e=>{if(e==null||e.trim()===``)return 3;let t=Number(e);return Number.isFinite(t)?t:3};function O(e,t,n,r){var i=arguments.length,a=i<3?t:r===null?r=Object.getOwnPropertyDescriptor(t,n):r,o;if(typeof Reflect==`object`&&typeof Reflect.decorate==`function`)a=Reflect.decorate(e,t,n,r);else for(var s=e.length-1;s>=0;s--)(o=e[s])&&(a=(i<3?o(a):i>3?o(t,n,a):o(t,n))||a);return i>3&&a&&Object.defineProperty(t,n,a),a}var ge=class extends y{constructor(...e){super(...e),this.renderSeq=0}updated(e){super.updated(e),this.createMap()}disconnectedCallback(){super.disconnectedCallback(),this.map?.setTarget(void 0),this.map=void 0}async createMap(){let e=++this.renderSeq,[{default:t},{default:n},{default:r},{default:i},{fromLonLat:a},{default:o}]=await Promise.all([E(()=>import(`./vendor-ol.js`).then(e=>e.i),__vite__mapDeps([0,1])),E(()=>import(`./vendor-ol.js`).then(e=>e.a),__vite__mapDeps([0,1])),E(()=>import(`./vendor-ol.js`).then(e=>e.r),__vite__mapDeps([0,1])),E(()=>import(`./vendor-ol.js`).then(e=>e.t),__vite__mapDeps([0,1])),E(()=>import(`./vendor-ol.js`).then(e=>e.o),__vite__mapDeps([0,1])),E(()=>import(`./vendor-ol.js`).then(e=>e.n),__vite__mapDeps([0,1]))]);if(e!==this.renderSeq||!this.isConnected)return;if(!this.shadowRoot.querySelector(`style[data-ol]`)){let e=document.createElement(`style`);e.setAttribute(`data-ol`,``),e.textContent=o,this.shadowRoot.appendChild(e)}this.map&&=(this.map.setTarget(void 0),void 0);let s=me(this.position)??pe;this.map=new t({target:this.mapElement,layers:[new r({source:new i})],view:new n({center:a([s.lon,s.lat]),zoom:he(this.zoom)})})}render(){return w`<div id="map"></div>`}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -139,23 +139,23 @@ ${i}
             width: 100%;
             height: 100%;
         }
-    `}};k([y()],he.prototype,`position`,void 0),k([y()],he.prototype,`zoom`,void 0),k([x(`#map`)],he.prototype,`mapElement`,void 0),he=k([g(`mateu-map`)],he);var ge=typeof HTMLElement<`u`?HTMLElement:class{},_e=class extends ge{static get observedAttributes(){return[`content`]}#e;#t=0;get content(){return this.#e}set content(e){this.#e=e,this.#n()}attributeChangedCallback(e,t,n){this.content=n??void 0}connectedCallback(){this.style.display=`block`,this.#n()}async#n(){if(!this.isConnected)return;let e=this.#e??``,t=++this.#t,[{marked:n},{default:r}]=await Promise.all([D(()=>import(`./vendor.js`).then(e=>e.n),__vite__mapDeps([2,1])),D(()=>import(`./vendor.js`).then(e=>e.a),__vite__mapDeps([2,1]))]);t===this.#t&&(this.innerHTML=r.sanitize(await n.parse(e),{USE_PROFILES:{html:!0,svg:!0,svgFilters:!0},CUSTOM_ELEMENT_HANDLING:{tagNameCheck:e=>!0}}))}};typeof customElements<`u`&&!customElements.get(`mateu-markdown`)&&customElements.define(`mateu-markdown`,_e);var A=function(e){return e.ServerSide=`ServerSide`,e.ClientSide=`ClientSide`,e}({}),j=function(e){return e.Page=`Page`,e.Div=`Div`,e.Element=`Element`,e.MicroFrontend=`MicroFrontend`,e.Form=`Form`,e.Crud=`Crud`,e.Result=`Result`,e.Card=`Card`,e.Directory=`Directory`,e.Stepper=`Stepper`,e.HorizontalLayout=`HorizontalLayout`,e.VerticalLayout=`VerticalLayout`,e.SplitLayout=`SplitLayout`,e.MasterDetailLayout=`MasterDetailLayout`,e.TabLayout=`TabLayout`,e.AccordionLayout=`AccordionLayout`,e.FormLayout=`FormLayout`,e.FormRow=`FormRow`,e.FormItem=`FormItem`,e.BoardLayout=`BoardLayout`,e.BoardLayoutRow=`BoardLayoutRow`,e.BoardLayoutItem=`BoardLayoutItem`,e.Scroller=`Scroller`,e.FullWidth=`FullWidth`,e.Container=`Container`,e.FormField=`FormField`,e.Table=`Table`,e.App=`App`,e.Text=`Text`,e.Avatar=`Avatar`,e.Chat=`Chat`,e.AvatarGroup=`AvatarGroup`,e.Badge=`Badge`,e.Breadcrumbs=`Breadcrumbs`,e.Anchor=`Anchor`,e.Button=`Button`,e.Chart=`Chart`,e.Icon=`Icon`,e.ConfirmDialog=`ConfirmDialog`,e.ContextMenu=`ContextMenu`,e.CookieConsent=`CookieConsent`,e.Details=`Details`,e.Dialog=`Dialog`,e.Drawer=`Drawer`,e.Image=`Image`,e.Map=`Map`,e.Markdown=`Markdown`,e.Notification=`Notification`,e.ProgressBar=`ProgressBar`,e.Popover=`Popover`,e.CarouselLayout=`CarouselLayout`,e.Tooltip=`Tooltip`,e.MessageInput=`MessageInput`,e.MessageList=`MessageList`,e.CustomField=`CustomField`,e.MenuBar=`MenuBar`,e.Grid=`Grid`,e.GridColumn=`GridColumn`,e.GridGroupColumn=`GridGroupColumn`,e.VirtualList=`VirtualList`,e.FormSection=`FormSection`,e.FormSubSection=`FormSubSection`,e.Bpmn=`Bpmn`,e.Workflow=`Workflow`,e.FormEditor=`FormEditor`,e.MetricCard=`MetricCard`,e.Scoreboard=`Scoreboard`,e.DashboardPanel=`DashboardPanel`,e.DashboardLayout=`DashboardLayout`,e.FoldoutLayout=`FoldoutLayout`,e.ContentLayout=`ContentLayout`,e.HeroSection=`HeroSection`,e.EmptyState=`EmptyState`,e.Skeleton=`Skeleton`,e.Gantt=`Gantt`,e.PlanningBoard=`PlanningBoard`,e.Kanban=`Kanban`,e.Timeline=`Timeline`,e.ProgressSteps=`ProgressSteps`,e.Stat=`Stat`,e.Calendar=`Calendar`,e.PricingTable=`PricingTable`,e.OrgChart=`OrgChart`,e.Heatmap=`Heatmap`,e.Funnel=`Funnel`,e.TrendChart=`TrendChart`,e.FeatureGrid=`FeatureGrid`,e.Testimonials=`Testimonials`,e.Faq=`Faq`,e.CalloutCard=`CalloutCard`,e.CommentThread=`CommentThread`,e.FileList=`FileList`,e.Checklist=`Checklist`,e.ComparisonCard=`ComparisonCard`,e.EntityHeader=`EntityHeader`,e.Meter=`Meter`,e.TaskProgress=`TaskProgress`,e.StatusList=`StatusList`,e.BulletedList=`BulletedList`,e.Separator=`Separator`,e.Notice=`Notice`,e.TaskQueue=`TaskQueue`,e.ResourceGrid=`ResourceGrid`,e.OfferCard=`OfferCard`,e.AddOnPicker=`AddOnPicker`,e.Ledger=`Ledger`,e.PaymentPicker=`PaymentPicker`,e.ProcessMonitor=`ProcessMonitor`,e}({}),ve=`mateu-app-context`,ye=`mateu-app-context-labels`,be=e=>{try{return JSON.parse(localStorage.getItem(e)??`{}`)}catch{return{}}},xe=(e,t)=>{try{localStorage.setItem(e,JSON.stringify(t))}catch{}},Se=()=>be(ve),Ce=()=>be(ye),we=(e,t,n)=>{let r=Se(),i=Ce();t==null||t===``?(delete r[e],delete i[e]):(r[e]=t,n!==void 0&&(i[e]=n)),xe(ve,r),xe(ye,i)},Te=!1,Ee=()=>{Te||(Te=!0,window.addEventListener(`storage`,e=>{e.key===ve&&e.newValue!==e.oldValue&&window.location.reload()}))},De,Oe=(e,t)=>new Promise((n,r)=>{let i=!1,a={retry:()=>{i||(i=!0,t().then(n,r))},giveUp:()=>{i||(i=!0,r(e))}};if(De){De(a);return}let o=new CustomEvent(`mateu-session-expired`,{detail:a,cancelable:!0,bubbles:!1});typeof document<`u`&&!document.dispatchEvent(o)||a.giveUp()}),ke=(e,t)=>e.includes(`json`)?!0:typeof t==`object`&&!!t,Ae=(e,t)=>{let n=e.finalUrl;if(!n)return;let r=t??(typeof window<`u`?window.location.href:void 0),i;try{i=new URL(e.requestedUrl,r).href}catch{return}if(i!==n&&!ke(e.contentType??``,e.data))return n},je=new class{constructor(){this.windowMs=4e3,this.threshold=12,this.events=[],this.reported=new Set}check(e,t=Date.now()){this.events.push({sig:e,t});let n=t-this.windowMs;this.events=this.events.filter(e=>e.t>=n);let r=0;for(let t of this.events)t.sig===e&&r++;if(r>=this.threshold){let t=!this.reported.has(e);return this.reported.add(e),{blocked:!0,firstTrip:t}}return this.reported.delete(e),{blocked:!1,firstTrip:!1}}reset(){this.events=[],this.reported.clear()}configure(e){e.windowMs!==void 0&&(this.windowMs=e.windowMs),e.threshold!==void 0&&(this.threshold=e.threshold)}},Me={offline:()=>`No connection. Your changes have not been sent — check your network and try again.`,timeout:()=>`The server is taking too long to answer. Your changes may not have been saved.`,server:e=>`The server could not complete the request${e?` (error ${e})`:``}. Please try again.`,unauthorized:()=>`Your session is no longer valid. Please sign in again.`,notFound:()=>`This is no longer available. It may have been moved or deleted.`,client:e=>`The request was rejected${e?` (error ${e})`:``}.`,cancelled:()=>``,unknown:()=>`Something went wrong. Please try again.`},Ne=new Set([`offline`,`timeout`,`server`]),Pe=(e,t={})=>{let n=e??{},r=n.response?.status,i=n.code,a=t.online??(typeof navigator<`u`&&typeof navigator.onLine==`boolean`?navigator.onLine:!0),o=e=>({kind:e,message:Me[e](r),retryable:Ne.has(e),status:r});return i===`ERR_CANCELED`?o(`cancelled`):i===`ECONNABORTED`||i===`ETIMEDOUT`||/timeout/i.test(n.message??``)?o(`timeout`):r===void 0?!a||i===`ERR_NETWORK`||/network error/i.test(n.message??``)?o(`offline`):o(`unknown`):o(r===401||r===403?`unauthorized`:r===404||r===410?`notFound`:r===408||r===429?`timeout`:r>=500?`server`:r>=400?`client`:`unknown`)},Fe=new Set([``,`__load__`,`search`,`_globalsearch`,`_notifications-list`]),Ie=[`_appcontext-search-`,`search-`],Le=(e,t)=>t===!0?!0:e==null?!1:Fe.has(e)?!0:Ie.some(t=>e.startsWith(t)),Re=(e,t=Math.random)=>{let n=300*3**Math.max(0,e-1);return Math.round(n*(.75+t()*.5))},ze=(e,t,n)=>!n.idempotent||t>2||!e.retryable?!1:e.kind===`timeout`||e.kind===`server`,Be=new class{constructor(){this.linkUp=!0,this.listeners=new Set,this.waiters=new Set,this.started=!1}start(){this.started||typeof window>`u`||(this.started=!0,this.linkUp=typeof navigator<`u`&&typeof navigator.onLine==`boolean`?navigator.onLine:!0,window.addEventListener(`online`,()=>{this.linkUp=!0,this.reachable=void 0,this.changed(),this.releaseWaiters()}),window.addEventListener(`offline`,()=>{this.linkUp=!1,this.changed()}))}isOnline(){return this.linkUp?this.reachable!==!1:!1}noteReachable(){let e=this.isOnline();this.reachable=!0,e||(this.changed(),this.releaseWaiters())}noteUnreachable(){let e=this.isOnline();this.reachable=!1,e&&this.changed()}subscribe(e){return this.listeners.add(e),()=>this.listeners.delete(e)}whenBack(e){return this.isOnline()?(e(),()=>{}):(this.waiters.add(e),()=>this.waiters.delete(e))}reset(){this.linkUp=!0,this.reachable=void 0,this.waiters.clear()}changed(){let e=this.isOnline();this.listeners.forEach(t=>t(e))}releaseWaiters(){let e=Array.from(this.waiters);this.waiters.clear(),e.forEach(e=>e())}};Be.start();var Ve=[],He=6e4,Ue=e=>new Promise(t=>setTimeout(t,e)),We=new class{constructor(){this.axiosInstance=ae.create({timeout:He}),this.axiosInstance.interceptors.request.use(e=>(this.addAuthToken(e),this.addSessionId(e),e)),this.axiosInstance.interceptors.response.use(e=>{let t=Ae({requestedUrl:this.axiosInstance.getUri(e.config),finalUrl:e.request?.responseURL,contentType:String(e.headers?.[`content-type`]??``),data:e.data});if(t)throw window.location.assign(t),Object.assign(Error(`session lost — redirecting to `+t),{code:`ERR_CANCELED`});return e},e=>{let t=e;if(t?.response?.status===401&&t.config&&!t.config.__mateuRetried){let n=t.config;return n.__mateuRetried=!0,Oe(e,()=>this.axiosInstance.request(n))}throw e})}addSessionId(e){let t=sessionStorage.getItem(`__mateu_sesion_id`);t||(t=E(),sessionStorage.setItem(`__mateu_sesion_id`,t)),e.headers[`X-Session-Id`]=t}addAuthToken(e){let t=localStorage.getItem(`__mateu_auth_token`);t&&(e.headers.Authorization=`Bearer `+t)}async wrap(e,t,n,r,i){return n||t.dispatchEvent(new CustomEvent(`backend-called-event`,{bubbles:!0,composed:!0,detail:{}})),e().then(e=>(t.dispatchEvent(new CustomEvent(`backend-succeeded-event`,{bubbles:!0,composed:!0,detail:{actionId:r}})),e)).catch(e=>{let n=Pe(e,{online:Be.isOnline()});throw n.kind==`cancelled`?t.dispatchEvent(new CustomEvent(`backend-cancelled-event`,{bubbles:!0,composed:!0,detail:{actionId:r}})):(e&&typeof e==`object`&&(e.__mateuReported=!0),t.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:r,reason:this.serialize(e),failure:n,retry:i}}))),e})}async sendWithRetry(e,t){let n=0;for(;;)try{let t=await e();return Be.noteReachable(),t}catch(e){let r=Pe(e,{online:Be.isOnline()});if(r.kind==`offline`&&Be.noteUnreachable(),n++,!ze(r,n,{idempotent:t}))throw e;await Ue(Re(n))}}serialize(e){return e?.message?e:JSON.stringify(e)}release(e){Ve=Ve.filter(t=>t!==e)}async get(e){let t=new AbortController;return Ve=[...Ve,t],this.axiosInstance.get(e,{signal:t.signal}).finally(()=>this.release(t))}async post(e,t,n){let r=new AbortController;return Ve=[...Ve,r],this.axiosInstance.post(e,t,{signal:r.signal,...n&&n>0?{timeout:n}:{}}).finally(()=>this.release(r))}async abortAll(){Ve.forEach(e=>e.abort()),Ve=[]}async runAction(e,t,n,r,i,a,o,s,c,l,u,d={}){t&&t.startsWith(`/`)&&(t=t.substring(1));let f=[e,t,n,o??``,r,i].join(``),p=je.check(f);if(p.blocked)return await this.abortAll(),p.firstTrip&&console.error(`[mateu] request loop detected — aborting repeated request`,f),{messages:p.firstTrip?[{title:``,text:`A repeating request was detected and stopped to protect the server. Reload the page or navigate elsewhere.`,position:`bottom-end`,variant:`error`,duration:6e3}]:[],commands:[],fragments:[],banners:[],appendBanners:!1,appData:void 0,appState:void 0};a={...Se(),...a};let m=e+`/mateu/v3/sync/`+(t&&t!=``?t:`_no_route`),ee={serverSideType:o,appState:a,componentState:s,parameters:c,initiatorComponentId:i,consumedRoute:n,route:t&&t!=``?`/`+t:``,actionId:r},te=Le(r,d.idempotent),ne=()=>this.post(m,ee,d.timeoutMillis).then(e=>e.data);return await this.wrap(()=>this.sendWithRetry(ne,te),l,u,r,d.retry)}},Ge=function(e){return e.Add=`Add`,e.Replace=`Replace`,e.ReplaceKeepData=`ReplaceKeepData`,e}({}),Ke=function(e){return e.HAMBURGUER_MENU=`HAMBURGUER_MENU`,e.MENU_ON_LEFT=`MENU_ON_LEFT`,e.MENU_ON_TOP=`MENU_ON_TOP`,e.TABS=`TABS`,e.TILES=`TILES`,e.RAIL=`RAIL`,e.AUTO=`AUTO`,e.MEDIATOR=`MEDIATOR`,e}({}),qe=new Map,Je=[`position:absolute`,`width:1px`,`height:1px`,`margin:-1px`,`padding:0`,`overflow:hidden`,`clip:rect(0 0 0 0)`,`clip-path:inset(50%)`,`white-space:nowrap`,`border:0`].join(`;`),Ye=e=>{if(typeof document>`u`||!document.body)return;let t=qe.get(e);return t?.isConnected?t:(t=document.createElement(`div`),t.setAttribute(`aria-live`,e),t.setAttribute(`aria-atomic`,`true`),t.setAttribute(`role`,e===`assertive`?`alert`:`status`),t.setAttribute(`data-mateu-live-region`,e),t.style.cssText=Je,document.body.appendChild(t),qe.set(e,t),t)},Xe=()=>{if(!(typeof document>`u`)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>Xe(),{once:!0});return}Ye(`polite`),Ye(`assertive`)}},Ze=(e,t={})=>{let n=(e??``).trim();if(!n)return;let r=Ye(t.politeness??`polite`);if(r){if(r.textContent===n){r.textContent=``,setTimeout(()=>{r.textContent=n},60);return}r.textContent=n}},Qe=class extends b{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.callbackToken=``,this.createElement=e=>{let t=e.data,n=document.createElement(t.name);for(let e in t.attributes)n.setAttribute(e,t.attributes[e]);for(let e in t.on)n.addEventListener(e,n=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.on[e],parameters:{event:n}},bubbles:!0,composed:!0}))});return n},this.closeModal=()=>{let e=(this.shadowRoot??this).querySelectorAll(`mateu-dialog, mateu-drawer`);if(e&&e.length>0){e[e.length-1].close();return}this.dispatchEvent(new CustomEvent(`close-modal-requested`,{bubbles:!0,composed:!0}))},this.changeFavicon=e=>{let t=document.querySelector(`link[rel="icon"]`);t===null?(t=document.createElement(`link`),t.setAttribute(`rel`,`icon`),t.setAttribute(`href`,e),document.head.appendChild(t)):t.setAttribute(`href`,e)}}connectedCallback(){super.connectedCallback(),this.upstreamSubscription=le.subscribe(e=>{if(e.command){let t=e.command;this.id==t.targetComponentId&&this.applyCommand(t)}if((!e.callbackToken||!this.callbackToken||e.callbackToken===this.callbackToken)&&e.fragment){let t=e.fragment;this.id==t.targetComponentId&&(this.applyFragment(t),this.completeMenu(t))}})}completeMenu(e){if(e.component&&e.component.type==A.ClientSide){let t=e.component,n=t.metadata;if(n?.type==j.App){let e=n,r=this.getRemoteMenus(e.menu);if(r.length>0){let n=r.map(e=>We.runAction(e.baseUrl,e.route,`_empty`,``,e.baseUrl+`#`+e.route,void 0,void 0,void 0,e.params,this,!0));Promise.all(n).then(n=>{e.menu=this.updateMenu(e.menu,n.map(e=>e.fragments).filter(e=>e).map(e=>e).flat()),e.variant=Ke.MENU_ON_TOP,le.next({fragment:{component:t,data:void 0,state:void 0,action:Ge.Replace,targetComponentId:this.id,containerId:void 0},callbackToken:this.callbackToken})})}}}}updateMenu(e,t){let n=[];return e.forEach(e=>{if(e.remote){let r=t.find(t=>t.targetComponentId==e.baseUrl+`#`+e.route);if(r&&r.component?.type==A.ClientSide){let t=r.component;if(t.metadata?.type==j.App){let r=t.metadata,i=e.serverSideType&&e.serverSideType!=``?e.serverSideType:r.serverSideType;this.changeBaseUrl(r.menu,e.baseUrl,i,e.route,r.route),n.push(...r.menu)}}}else n.push(e)}),n}changeBaseUrl(e,t,n,r,i){e.forEach(e=>{e.baseUrl||(e.submenus&&e.submenus.length>0?this.changeBaseUrl(e.submenus,t,n,r,i):(e.consumedRoute=i??``,e.baseUrl=t,e.serverSideType=n,e.uriPrefix=r))})}getRemoteMenus(e){let t=[];return e.forEach(e=>{e.remote&&t.push(e)}),t}disconnectedCallback(){super.disconnectedCallback(),this.upstreamSubscription?.unsubscribe()}applyCommand(e){if(e.type==`SetWindowTitle`&&(document.title=e.data,Ze(document.title)),e.type==`SetFavicon`&&this.changeFavicon(e.data),e.type==`DispatchEvent`&&this.dispatchNamedEvent(e.data),e.type==`NavigateTo`){let t=e.data;t&&(t.startsWith(`http:`)||t.startsWith(`https:`)?window.open(e.data,`_blank`):window.location.href=e.data)}if(e.type==`PushStateToHistory`){let t=e.data;t!==void 0&&this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0}))}if(e.type==`RunAction`){let t=e.data;if(t&&t.actionId)if(t.targetComponentId){let e={command:{type:`RunAction`,data:{actionId:t.actionId},targetComponentId:t.targetComponentId},fragment:void 0,ui:void 0,error:void 0,callbackToken:``};setTimeout(()=>le.next(e))}else this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:{}},bubbles:!0,composed:!0}))}if(e.type==`MarkAsDirty`&&this.dispatchEvent(new CustomEvent(`dirty`,{detail:{},bubbles:!0,composed:!0})),e.type==`MarkAsClean`&&this.dispatchEvent(new CustomEvent(`clean`,{detail:{},bubbles:!0,composed:!0})),e.type==`DownloadFile`){let t=e.data;if(t&&t.base64Content){let e=atob(t.base64Content),n=new Uint8Array(e.length);for(let t=0;t<e.length;t++)n[t]=e.charCodeAt(t);let r=new Blob([n],{type:t.mimeType}),i=URL.createObjectURL(r),a=document.createElement(`a`);a.href=i,a.download=t.filename??`export`,a.click(),URL.revokeObjectURL(i)}}if(e.type==`CloseModal`&&(this.closeModal(),this.dispatchNamedEvent(e.data)),e.type==`AddContentToHead`){let t=e.data;if(t&&t.name){if(t.attributes&&t.attributes.id&&document.getElementById(t.attributes.id))return;document.head.appendChild(this.createElement(e))}}if(e.type==`AddContentToBody`){let t=e.data;if(t&&t.name){if(t.attributes&&t.attributes.id&&document.getElementById(t.attributes.id))return;document.body.appendChild(this.createElement(e))}}}dispatchNamedEvent(e){if(e&&e.eventName){let t=this.component,n=t?.emitsName??t?.serverSideType,r=e.payload??e.detail;n&&r&&typeof r==`object`&&(r={...r,__source:n}),this.dispatchEvent(new CustomEvent(e.eventName,{detail:r,bubbles:!0,composed:!0}))}}};k([y()],Qe.prototype,`id`,void 0),k([y()],Qe.prototype,`baseUrl`,void 0);var $e=class extends Qe{applyFragment(e){}manageActionRequestedEvent(e){}};k([y()],$e.prototype,`component`,void 0);var et=(e,t)=>Function(...Object.keys(t),"return `"+e+"`")(...Object.values(t)),tt=(e,t,n)=>({state:e??{},data:t??{},...n});function M(e,t,n,r){if(!e?.includes("${"))return e;try{return et(e,tt(t,n,r))}catch(t){return console.warn(`Mateu: could not interpolate "${e}":`,t),e}}var nt=(e,t,n)=>{if(e&&e.indexOf("${")>=0)try{return et(e,tt(t,n))}catch(e){return e.message}return e},rt=(e,t,n,r,i)=>{if(!e)return e;let a=tt(t,n,{appState:r??{},appData:i??{}}),o=e;try{if(o=et(e,a),o.includes("${"))try{o=et(o,a)}catch(a){o=`when evaluating nested `+e+` :`+a+`, where data is `+n+` and state is `+t+` and app state is `+r+` and app data is `+i,console.error(a,o,t,n,r,i)}}catch(a){o=`when evaluating `+e+` :`+a+`, where data is `+n+` and state is `+t+` and app state is `+r+` and app data is `+i,console.error(a,o,t,n,r,i)}return o},it=(e,t,n,r,i,a)=>{let o=tt(t,n,{appState:r??{},appData:i??{},...a}),s=et(e,o);return Function(...Object.keys(o),`return (${s})`)(...Object.values(o))},at=(e,t,n,r)=>{let i=tt(t,n,r);return Function(...Object.keys(i),`return (${e})`)(...Object.values(i))},ot=(e,t,n,r)=>et(e,tt(t,n,r)),st=`display:inline-flex; align-items:center; justify-content:center; width:2rem; height:2rem; border-radius:50%; background:var(--lumo-contrast-10pct,#e0e0e0); color:var(--lumo-secondary-text-color,#555); font-size:.8rem; font-weight:600; overflow:hidden; flex:none;`,ct=(e,t)=>t||(typeof e==`string`&&e?e.trim().split(/\s+/).map(e=>e[0]).slice(0,2).join(``).toUpperCase():``),lt=(e,t,n)=>{let r=e.metadata,i=N(r.name,t,n);return T`<span style="${st}${e.style}" class="${e.cssClasses}"
-                      title="${i||v}" slot="${e.slot??v}">
-        ${r.image?T`<img src="${r.image}" alt="${i}" style="width:100%;height:100%;object-fit:cover;">`:ct(i,r.abbreviation)}
-    </span>`},N=(e,t,n)=>typeof e==`string`&&e.includes("${")?M(e,t,n):e,ut=e=>{let t=e.metadata,n=t.avatars??[],r=t.maxItemsVisible&&t.maxItemsVisible>0?t.maxItemsVisible:n.length,i=n.slice(0,r),a=n.length-i.length,o=`margin-left:-0.4rem; border:2px solid var(--lumo-base-color,#fff);`;return T`<span style="display:inline-flex; ${e.style}" class="${e.cssClasses}" slot="${e.slot??v}">
-        ${i.map(e=>T`<span style="${st}${o}" title="${e.name||v}">
-            ${e.img?T`<img src="${e.img}" style="width:100%;height:100%;object-fit:cover;">`:ct(e.name??``,e.abbr)}
+    `}};O([v()],ge.prototype,`position`,void 0),O([v()],ge.prototype,`zoom`,void 0),O([b(`#map`)],ge.prototype,`mapElement`,void 0),ge=O([h(`mateu-map`)],ge);var _e=typeof HTMLElement<`u`?HTMLElement:class{},ve=class extends _e{static get observedAttributes(){return[`content`]}#e;#t=0;get content(){return this.#e}set content(e){this.#e=e,this.#n()}attributeChangedCallback(e,t,n){this.content=n??void 0}connectedCallback(){this.style.display=`block`,this.#n()}async#n(){if(!this.isConnected)return;let e=this.#e??``,t=++this.#t,[{marked:n},{default:r}]=await Promise.all([E(()=>import(`./vendor.js`).then(e=>e.n),__vite__mapDeps([2,1])),E(()=>import(`./vendor.js`).then(e=>e.a),__vite__mapDeps([2,1]))]);t===this.#t&&(this.innerHTML=r.sanitize(await n.parse(e),{USE_PROFILES:{html:!0,svg:!0,svgFilters:!0},CUSTOM_ELEMENT_HANDLING:{tagNameCheck:e=>!0}}))}};typeof customElements<`u`&&!customElements.get(`mateu-markdown`)&&customElements.define(`mateu-markdown`,ve);var k=function(e){return e.ServerSide=`ServerSide`,e.ClientSide=`ClientSide`,e}({}),A=function(e){return e.Page=`Page`,e.Div=`Div`,e.Element=`Element`,e.MicroFrontend=`MicroFrontend`,e.Form=`Form`,e.Crud=`Crud`,e.Result=`Result`,e.Card=`Card`,e.Directory=`Directory`,e.Stepper=`Stepper`,e.HorizontalLayout=`HorizontalLayout`,e.VerticalLayout=`VerticalLayout`,e.SplitLayout=`SplitLayout`,e.MasterDetailLayout=`MasterDetailLayout`,e.TabLayout=`TabLayout`,e.AccordionLayout=`AccordionLayout`,e.FormLayout=`FormLayout`,e.FormRow=`FormRow`,e.FormItem=`FormItem`,e.BoardLayout=`BoardLayout`,e.BoardLayoutRow=`BoardLayoutRow`,e.BoardLayoutItem=`BoardLayoutItem`,e.Scroller=`Scroller`,e.FullWidth=`FullWidth`,e.Container=`Container`,e.FormField=`FormField`,e.Table=`Table`,e.App=`App`,e.Text=`Text`,e.Avatar=`Avatar`,e.Chat=`Chat`,e.AvatarGroup=`AvatarGroup`,e.Badge=`Badge`,e.Breadcrumbs=`Breadcrumbs`,e.Anchor=`Anchor`,e.Button=`Button`,e.Chart=`Chart`,e.Icon=`Icon`,e.ConfirmDialog=`ConfirmDialog`,e.ContextMenu=`ContextMenu`,e.CookieConsent=`CookieConsent`,e.Details=`Details`,e.Dialog=`Dialog`,e.Drawer=`Drawer`,e.Image=`Image`,e.Map=`Map`,e.Markdown=`Markdown`,e.Notification=`Notification`,e.ProgressBar=`ProgressBar`,e.Popover=`Popover`,e.CarouselLayout=`CarouselLayout`,e.Tooltip=`Tooltip`,e.MessageInput=`MessageInput`,e.MessageList=`MessageList`,e.CustomField=`CustomField`,e.MenuBar=`MenuBar`,e.Grid=`Grid`,e.GridColumn=`GridColumn`,e.GridGroupColumn=`GridGroupColumn`,e.VirtualList=`VirtualList`,e.FormSection=`FormSection`,e.FormSubSection=`FormSubSection`,e.Bpmn=`Bpmn`,e.Workflow=`Workflow`,e.FormEditor=`FormEditor`,e.MetricCard=`MetricCard`,e.Scoreboard=`Scoreboard`,e.DashboardPanel=`DashboardPanel`,e.DashboardLayout=`DashboardLayout`,e.FoldoutLayout=`FoldoutLayout`,e.ContentLayout=`ContentLayout`,e.HeroSection=`HeroSection`,e.EmptyState=`EmptyState`,e.Skeleton=`Skeleton`,e.Gantt=`Gantt`,e.PlanningBoard=`PlanningBoard`,e.Kanban=`Kanban`,e.Timeline=`Timeline`,e.ProgressSteps=`ProgressSteps`,e.Stat=`Stat`,e.Calendar=`Calendar`,e.PricingTable=`PricingTable`,e.OrgChart=`OrgChart`,e.Heatmap=`Heatmap`,e.Funnel=`Funnel`,e.TrendChart=`TrendChart`,e.FeatureGrid=`FeatureGrid`,e.Testimonials=`Testimonials`,e.Faq=`Faq`,e.CalloutCard=`CalloutCard`,e.CommentThread=`CommentThread`,e.FileList=`FileList`,e.Checklist=`Checklist`,e.ComparisonCard=`ComparisonCard`,e.EntityHeader=`EntityHeader`,e.Meter=`Meter`,e.TaskProgress=`TaskProgress`,e.StatusList=`StatusList`,e.BulletedList=`BulletedList`,e.Separator=`Separator`,e.Notice=`Notice`,e.TaskQueue=`TaskQueue`,e.ResourceGrid=`ResourceGrid`,e.OfferCard=`OfferCard`,e.AddOnPicker=`AddOnPicker`,e.Ledger=`Ledger`,e.PaymentPicker=`PaymentPicker`,e.ProcessMonitor=`ProcessMonitor`,e}({}),ye=`mateu-app-context`,be=`mateu-app-context-labels`,xe=e=>{try{return JSON.parse(localStorage.getItem(e)??`{}`)}catch{return{}}},Se=(e,t)=>{try{localStorage.setItem(e,JSON.stringify(t))}catch{}},Ce=()=>xe(ye),we=()=>xe(be),Te=(e,t,n)=>{let r=Ce(),i=we();t==null||t===``?(delete r[e],delete i[e]):(r[e]=t,n!==void 0&&(i[e]=n)),Se(ye,r),Se(be,i)},Ee=!1,De=()=>{Ee||(Ee=!0,window.addEventListener(`storage`,e=>{e.key===ye&&e.newValue!==e.oldValue&&window.location.reload()}))},Oe,ke=(e,t)=>new Promise((n,r)=>{let i=!1,a={retry:()=>{i||(i=!0,t().then(n,r))},giveUp:()=>{i||(i=!0,r(e))}};if(Oe){Oe(a);return}let o=new CustomEvent(`mateu-session-expired`,{detail:a,cancelable:!0,bubbles:!1});typeof document<`u`&&!document.dispatchEvent(o)||a.giveUp()}),Ae=(e,t)=>e.includes(`json`)?!0:typeof t==`object`&&!!t,je=(e,t)=>{let n=e.finalUrl;if(!n)return;let r=t??(typeof window<`u`?window.location.href:void 0),i;try{i=new URL(e.requestedUrl,r).href}catch{return}if(i!==n&&!Ae(e.contentType??``,e.data))return n},Me=new class{constructor(){this.windowMs=4e3,this.threshold=12,this.events=[],this.reported=new Set}check(e,t=Date.now()){this.events.push({sig:e,t});let n=t-this.windowMs;this.events=this.events.filter(e=>e.t>=n);let r=0;for(let t of this.events)t.sig===e&&r++;if(r>=this.threshold){let t=!this.reported.has(e);return this.reported.add(e),{blocked:!0,firstTrip:t}}return this.reported.delete(e),{blocked:!1,firstTrip:!1}}reset(){this.events=[],this.reported.clear()}configure(e){e.windowMs!==void 0&&(this.windowMs=e.windowMs),e.threshold!==void 0&&(this.threshold=e.threshold)}},Ne={offline:()=>`No connection. Your changes have not been sent — check your network and try again.`,timeout:()=>`The server is taking too long to answer. Your changes may not have been saved.`,server:e=>`The server could not complete the request${e?` (error ${e})`:``}. Please try again.`,unauthorized:()=>`Your session is no longer valid. Please sign in again.`,notFound:()=>`This is no longer available. It may have been moved or deleted.`,client:e=>`The request was rejected${e?` (error ${e})`:``}.`,cancelled:()=>``,unknown:()=>`Something went wrong. Please try again.`},Pe=new Set([`offline`,`timeout`,`server`]),Fe=(e,t={})=>{let n=e??{},r=n.response?.status,i=n.code,a=t.online??(typeof navigator<`u`&&typeof navigator.onLine==`boolean`?navigator.onLine:!0),o=e=>({kind:e,message:Ne[e](r),retryable:Pe.has(e),status:r});return i===`ERR_CANCELED`?o(`cancelled`):i===`ECONNABORTED`||i===`ETIMEDOUT`||/timeout/i.test(n.message??``)?o(`timeout`):r===void 0?!a||i===`ERR_NETWORK`||/network error/i.test(n.message??``)?o(`offline`):o(`unknown`):o(r===401||r===403?`unauthorized`:r===404||r===410?`notFound`:r===408||r===429?`timeout`:r>=500?`server`:r>=400?`client`:`unknown`)},Ie=new Set([``,`__load__`,`search`,`_globalsearch`,`_notifications-list`]),Le=[`_appcontext-search-`,`search-`],Re=(e,t)=>t===!0?!0:e==null?!1:Ie.has(e)?!0:Le.some(t=>e.startsWith(t)),ze=(e,t=Math.random)=>{let n=300*3**Math.max(0,e-1);return Math.round(n*(.75+t()*.5))},Be=(e,t,n)=>!n.idempotent||t>2||!e.retryable?!1:e.kind===`timeout`||e.kind===`server`,Ve=new class{constructor(){this.linkUp=!0,this.listeners=new Set,this.waiters=new Set,this.started=!1}start(){this.started||typeof window>`u`||(this.started=!0,this.linkUp=typeof navigator<`u`&&typeof navigator.onLine==`boolean`?navigator.onLine:!0,window.addEventListener(`online`,()=>{this.linkUp=!0,this.reachable=void 0,this.changed(),this.releaseWaiters()}),window.addEventListener(`offline`,()=>{this.linkUp=!1,this.changed()}))}isOnline(){return this.linkUp?this.reachable!==!1:!1}noteReachable(){let e=this.isOnline();this.reachable=!0,e||(this.changed(),this.releaseWaiters())}noteUnreachable(){let e=this.isOnline();this.reachable=!1,e&&this.changed()}subscribe(e){return this.listeners.add(e),()=>this.listeners.delete(e)}whenBack(e){return this.isOnline()?(e(),()=>{}):(this.waiters.add(e),()=>this.waiters.delete(e))}reset(){this.linkUp=!0,this.reachable=void 0,this.waiters.clear()}changed(){let e=this.isOnline();this.listeners.forEach(t=>t(e))}releaseWaiters(){let e=Array.from(this.waiters);this.waiters.clear(),e.forEach(e=>e())}};Ve.start();var He=[],Ue=6e4,We=e=>new Promise(t=>setTimeout(t,e)),Ge=new class{constructor(){this.axiosInstance=oe.create({timeout:Ue}),this.axiosInstance.interceptors.request.use(e=>(this.addAuthToken(e),this.addSessionId(e),e)),this.axiosInstance.interceptors.response.use(e=>{let t=je({requestedUrl:this.axiosInstance.getUri(e.config),finalUrl:e.request?.responseURL,contentType:String(e.headers?.[`content-type`]??``),data:e.data});if(t)throw window.location.assign(t),Object.assign(Error(`session lost — redirecting to `+t),{code:`ERR_CANCELED`});return e},e=>{let t=e;if(t?.response?.status===401&&t.config&&!t.config.__mateuRetried){let n=t.config;return n.__mateuRetried=!0,ke(e,()=>this.axiosInstance.request(n))}throw e})}addSessionId(e){let t=sessionStorage.getItem(`__mateu_sesion_id`);t||(t=T(),sessionStorage.setItem(`__mateu_sesion_id`,t)),e.headers[`X-Session-Id`]=t}addAuthToken(e){let t=localStorage.getItem(`__mateu_auth_token`);t&&(e.headers.Authorization=`Bearer `+t)}async wrap(e,t,n,r,i){return n||t.dispatchEvent(new CustomEvent(`backend-called-event`,{bubbles:!0,composed:!0,detail:{}})),e().then(e=>(t.dispatchEvent(new CustomEvent(`backend-succeeded-event`,{bubbles:!0,composed:!0,detail:{actionId:r}})),e)).catch(e=>{let n=Fe(e,{online:Ve.isOnline()});throw n.kind==`cancelled`?t.dispatchEvent(new CustomEvent(`backend-cancelled-event`,{bubbles:!0,composed:!0,detail:{actionId:r}})):(e&&typeof e==`object`&&(e.__mateuReported=!0),t.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:r,reason:this.serialize(e),failure:n,retry:i}}))),e})}async sendWithRetry(e,t){let n=0;for(;;)try{let t=await e();return Ve.noteReachable(),t}catch(e){let r=Fe(e,{online:Ve.isOnline()});if(r.kind==`offline`&&Ve.noteUnreachable(),n++,!Be(r,n,{idempotent:t}))throw e;await We(ze(n))}}serialize(e){return e?.message?e:JSON.stringify(e)}release(e){He=He.filter(t=>t!==e)}async get(e){let t=new AbortController;return He=[...He,t],this.axiosInstance.get(e,{signal:t.signal}).finally(()=>this.release(t))}async post(e,t,n){let r=new AbortController;return He=[...He,r],this.axiosInstance.post(e,t,{signal:r.signal,...n&&n>0?{timeout:n}:{}}).finally(()=>this.release(r))}async abortAll(){He.forEach(e=>e.abort()),He=[]}async runAction(e,t,n,r,i,a,o,s,c,l,u,d={}){t&&t.startsWith(`/`)&&(t=t.substring(1));let f=[e,t,n,o??``,r,i].join(``),p=Me.check(f);if(p.blocked)return await this.abortAll(),p.firstTrip&&console.error(`[mateu] request loop detected — aborting repeated request`,f),{messages:p.firstTrip?[{title:``,text:`A repeating request was detected and stopped to protect the server. Reload the page or navigate elsewhere.`,position:`bottom-end`,variant:`error`,duration:6e3}]:[],commands:[],fragments:[],banners:[],appendBanners:!1,appData:void 0,appState:void 0};a={...Ce(),...a};let ee=e+`/mateu/v3/sync/`+(t&&t!=``?t:`_no_route`),te={serverSideType:o,appState:a,componentState:s,parameters:c,initiatorComponentId:i,consumedRoute:n,route:t&&t!=``?`/`+t:``,actionId:r,knownStructureHash:d.knownStructureHash},ne=Re(r,d.idempotent),re=()=>this.post(ee,te,d.timeoutMillis).then(e=>e.data);return await this.wrap(()=>this.sendWithRetry(re,ne),l,u,r,d.retry)}},Ke=function(e){return e.Add=`Add`,e.Replace=`Replace`,e.ReplaceKeepData=`ReplaceKeepData`,e}({}),qe=function(e){return e.HAMBURGUER_MENU=`HAMBURGUER_MENU`,e.MENU_ON_LEFT=`MENU_ON_LEFT`,e.MENU_ON_TOP=`MENU_ON_TOP`,e.TABS=`TABS`,e.TILES=`TILES`,e.RAIL=`RAIL`,e.AUTO=`AUTO`,e.MEDIATOR=`MEDIATOR`,e}({}),Je=new Map,Ye=[`position:absolute`,`width:1px`,`height:1px`,`margin:-1px`,`padding:0`,`overflow:hidden`,`clip:rect(0 0 0 0)`,`clip-path:inset(50%)`,`white-space:nowrap`,`border:0`].join(`;`),Xe=e=>{if(typeof document>`u`||!document.body)return;let t=Je.get(e);return t?.isConnected?t:(t=document.createElement(`div`),t.setAttribute(`aria-live`,e),t.setAttribute(`aria-atomic`,`true`),t.setAttribute(`role`,e===`assertive`?`alert`:`status`),t.setAttribute(`data-mateu-live-region`,e),t.style.cssText=Ye,document.body.appendChild(t),Je.set(e,t),t)},Ze=()=>{if(!(typeof document>`u`)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>Ze(),{once:!0});return}Xe(`polite`),Xe(`assertive`)}},Qe=(e,t={})=>{let n=(e??``).trim();if(!n)return;let r=Xe(t.politeness??`polite`);if(r){if(r.textContent===n){r.textContent=``,setTimeout(()=>{r.textContent=n},60);return}r.textContent=n}},$e=class extends y{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.callbackToken=``,this.createElement=e=>{let t=e.data,n=document.createElement(t.name);for(let e in t.attributes)n.setAttribute(e,t.attributes[e]);for(let e in t.on)n.addEventListener(e,n=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.on[e],parameters:{event:n}},bubbles:!0,composed:!0}))});return n},this.closeModal=()=>{let e=(this.shadowRoot??this).querySelectorAll(`mateu-dialog, mateu-drawer`);if(e&&e.length>0){e[e.length-1].close();return}this.dispatchEvent(new CustomEvent(`close-modal-requested`,{bubbles:!0,composed:!0}))},this.changeFavicon=e=>{let t=document.querySelector(`link[rel="icon"]`);t===null?(t=document.createElement(`link`),t.setAttribute(`rel`,`icon`),t.setAttribute(`href`,e),document.head.appendChild(t)):t.setAttribute(`href`,e)}}connectedCallback(){super.connectedCallback(),this.upstreamSubscription=ue.subscribe(e=>{if(e.command){let t=e.command;this.id==t.targetComponentId&&this.applyCommand(t)}if((!e.callbackToken||!this.callbackToken||e.callbackToken===this.callbackToken)&&e.fragment){let t=e.fragment;this.id==t.targetComponentId&&(this.applyFragment(t),this.completeMenu(t))}})}completeMenu(e){if(e.component&&e.component.type==k.ClientSide){let t=e.component,n=t.metadata;if(n?.type==A.App){let e=n,r=this.getRemoteMenus(e.menu);if(r.length>0){let n=r.map(e=>Ge.runAction(e.baseUrl,e.route,`_empty`,``,e.baseUrl+`#`+e.route,void 0,void 0,void 0,e.params,this,!0));Promise.all(n).then(n=>{e.menu=this.updateMenu(e.menu,n.map(e=>e.fragments).filter(e=>e).map(e=>e).flat()),e.variant=qe.MENU_ON_TOP,ue.next({fragment:{component:t,data:void 0,state:void 0,action:Ke.Replace,targetComponentId:this.id,containerId:void 0},callbackToken:this.callbackToken})})}}}}updateMenu(e,t){let n=[];return e.forEach(e=>{if(e.remote){let r=t.find(t=>t.targetComponentId==e.baseUrl+`#`+e.route);if(r&&r.component?.type==k.ClientSide){let t=r.component;if(t.metadata?.type==A.App){let r=t.metadata,i=e.serverSideType&&e.serverSideType!=``?e.serverSideType:r.serverSideType;this.changeBaseUrl(r.menu,e.baseUrl,i,e.route,r.route),n.push(...r.menu)}}}else n.push(e)}),n}changeBaseUrl(e,t,n,r,i){e.forEach(e=>{e.baseUrl||(e.submenus&&e.submenus.length>0?this.changeBaseUrl(e.submenus,t,n,r,i):(e.consumedRoute=i??``,e.baseUrl=t,e.serverSideType=n,e.uriPrefix=r))})}getRemoteMenus(e){let t=[];return e.forEach(e=>{e.remote&&t.push(e)}),t}disconnectedCallback(){super.disconnectedCallback(),this.upstreamSubscription?.unsubscribe()}applyCommand(e){if(e.type==`SetWindowTitle`&&(document.title=e.data,Qe(document.title)),e.type==`SetFavicon`&&this.changeFavicon(e.data),e.type==`DispatchEvent`&&this.dispatchNamedEvent(e.data),e.type==`NavigateTo`){let t=e.data;t&&(t.startsWith(`http:`)||t.startsWith(`https:`)?window.open(e.data,`_blank`):window.location.href=e.data)}if(e.type==`PushStateToHistory`){let t=e.data;t!==void 0&&this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0}))}if(e.type==`RunAction`){let t=e.data;if(t&&t.actionId)if(t.targetComponentId){let e={command:{type:`RunAction`,data:{actionId:t.actionId},targetComponentId:t.targetComponentId},fragment:void 0,ui:void 0,error:void 0,callbackToken:``};setTimeout(()=>ue.next(e))}else this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:{}},bubbles:!0,composed:!0}))}if(e.type==`MarkAsDirty`&&this.dispatchEvent(new CustomEvent(`dirty`,{detail:{},bubbles:!0,composed:!0})),e.type==`MarkAsClean`&&this.dispatchEvent(new CustomEvent(`clean`,{detail:{},bubbles:!0,composed:!0})),e.type==`DownloadFile`){let t=e.data;if(t&&t.base64Content){let e=atob(t.base64Content),n=new Uint8Array(e.length);for(let t=0;t<e.length;t++)n[t]=e.charCodeAt(t);let r=new Blob([n],{type:t.mimeType}),i=URL.createObjectURL(r),a=document.createElement(`a`);a.href=i,a.download=t.filename??`export`,a.click(),URL.revokeObjectURL(i)}}if(e.type==`CloseModal`&&(this.closeModal(),this.dispatchNamedEvent(e.data)),e.type==`AddContentToHead`){let t=e.data;if(t&&t.name){if(t.attributes&&t.attributes.id&&document.getElementById(t.attributes.id))return;document.head.appendChild(this.createElement(e))}}if(e.type==`AddContentToBody`){let t=e.data;if(t&&t.name){if(t.attributes&&t.attributes.id&&document.getElementById(t.attributes.id))return;document.body.appendChild(this.createElement(e))}}}dispatchNamedEvent(e){if(e&&e.eventName){let t=this.component,n=t?.emitsName??t?.serverSideType,r=e.payload??e.detail;n&&r&&typeof r==`object`&&(r={...r,__source:n}),this.dispatchEvent(new CustomEvent(e.eventName,{detail:r,bubbles:!0,composed:!0}))}}};O([v()],$e.prototype,`id`,void 0),O([v()],$e.prototype,`baseUrl`,void 0);var et=class extends $e{applyFragment(e){}manageActionRequestedEvent(e){}};O([v()],et.prototype,`component`,void 0);var tt=(e,t)=>Function(...Object.keys(t),"return `"+e+"`")(...Object.values(t)),nt=(e,t,n)=>({state:e??{},data:t??{},...n});function j(e,t,n,r){if(!e?.includes("${"))return e;try{return tt(e,nt(t,n,r))}catch(t){return console.warn(`Mateu: could not interpolate "${e}":`,t),e}}var rt=(e,t,n)=>{if(e&&e.indexOf("${")>=0)try{return tt(e,nt(t,n))}catch(e){return e.message}return e},it=(e,t,n,r,i)=>{if(!e)return e;let a=nt(t,n,{appState:r??{},appData:i??{}}),o=e;try{if(o=tt(e,a),o.includes("${"))try{o=tt(o,a)}catch(a){o=`when evaluating nested `+e+` :`+a+`, where data is `+n+` and state is `+t+` and app state is `+r+` and app data is `+i,console.error(a,o,t,n,r,i)}}catch(a){o=`when evaluating `+e+` :`+a+`, where data is `+n+` and state is `+t+` and app state is `+r+` and app data is `+i,console.error(a,o,t,n,r,i)}return o},at=(e,t,n,r,i,a)=>{let o=nt(t,n,{appState:r??{},appData:i??{},...a}),s=tt(e,o);return Function(...Object.keys(o),`return (${s})`)(...Object.values(o))},ot=(e,t,n,r)=>{let i=nt(t,n,r);return Function(...Object.keys(i),`return (${e})`)(...Object.values(i))},st=(e,t,n,r)=>tt(e,nt(t,n,r)),ct=`display:inline-flex; align-items:center; justify-content:center; width:2rem; height:2rem; border-radius:50%; background:var(--lumo-contrast-10pct,#e0e0e0); color:var(--lumo-secondary-text-color,#555); font-size:.8rem; font-weight:600; overflow:hidden; flex:none;`,lt=(e,t)=>t||(typeof e==`string`&&e?e.trim().split(/\s+/).map(e=>e[0]).slice(0,2).join(``).toUpperCase():``),ut=(e,t,n)=>{let r=e.metadata,i=M(r.name,t,n);return w`<span style="${ct}${e.style}" class="${e.cssClasses}"
+                      title="${i||_}" slot="${e.slot??_}">
+        ${r.image?w`<img src="${r.image}" alt="${i}" style="width:100%;height:100%;object-fit:cover;">`:lt(i,r.abbreviation)}
+    </span>`},M=(e,t,n)=>typeof e==`string`&&e.includes("${")?j(e,t,n):e,dt=e=>{let t=e.metadata,n=t.avatars??[],r=t.maxItemsVisible&&t.maxItemsVisible>0?t.maxItemsVisible:n.length,i=n.slice(0,r),a=n.length-i.length,o=`margin-left:-0.4rem; border:2px solid var(--lumo-base-color,#fff);`;return w`<span style="display:inline-flex; ${e.style}" class="${e.cssClasses}" slot="${e.slot??_}">
+        ${i.map(e=>w`<span style="${ct}${o}" title="${e.name||_}">
+            ${e.img?w`<img src="${e.img}" style="width:100%;height:100%;object-fit:cover;">`:lt(e.name??``,e.abbr)}
         </span>`)}
-        ${a>0?T`<span style="${st}${o}">+${a}</span>`:v}
-    </span>`},dt=(e,t,n)=>{let r=e.metadata;return T`<span theme="badge ${r.color} ${r.pill?`pill`:``} ${r.small?`small`:``} ${r.primary?`primary`:``}"
+        ${a>0?w`<span style="${ct}${o}">+${a}</span>`:_}
+    </span>`},ft=(e,t,n)=>{let r=e.metadata;return w`<span theme="badge ${r.color} ${r.pill?`pill`:``} ${r.small?`small`:``} ${r.primary?`primary`:``}"
                       style="${e.style}" class="${e.cssClasses}"
-                      slot="${e.slot??v}">${N(r.text,t,n)}</span>`},ft=(e,t,n)=>{let r=N(e.text,t,n);if(!r)return v;let i=N(e.color,t,n);return i==`SUCCESS`&&(i=`success`),i==`ERROR`&&(i=`error`),i==`DANGER`&&(i=`error`),i==`WARNING`&&(i=`warning`),i==`INFO`&&(i=`info`),i==`PRIMARY`&&(i=`primary`),i==`SECONDARY`&&(i=`secondary`),i==`TERTIARY`&&(i=`tertiary`),i==`QUATERNARY`&&(i=`quaternary`),i==`LIGHT`&&(i=`light`),i==`DARK`&&(i=`dark`),T`<span theme="badge ${i} ${e.pill?`pill`:``} ${e.small?`small`:``} ${e.primary?`primary`:``}">${r}</span>`},P=new class{constructor(){this.afterRenderHook=void 0,this.useShadowRoot=!0,this.componentRenderer=void 0}set(e){if(this.componentRenderer=e,typeof window<`u`){let t=e.supportedClientSideTypes?.();window.__mateuRendererInfo={name:e.rendererName?.()??e.constructor?.name??`unknown`,supportedTypes:t?[...t].sort():null}}}get(){return this.componentRenderer}setUseShadowRoot(e){this.useShadowRoot=e}mustUseShadowRoot(){return this.useShadowRoot}setAfterRenderHook(e){this.afterRenderHook=e}getAfterRenderHook(){return this.afterRenderHook}},pt=(e,t,n,r,i,a,o,s,c)=>(t.slot=s,F(e,t,n,r,i,a,o,c)),F=(e,t,n,r,i,a,o,s)=>{if(!t)return T``;if(t.type==A.ClientSide)return P.get().renderClientSideComponent(e,t,n,r,i,a,o,s);let c=e.route,l=e.consumedRoute;return T`
+                      slot="${e.slot??_}">${M(r.text,t,n)}</span>`},pt=(e,t,n)=>{let r=M(e.text,t,n);if(!r)return _;let i=M(e.color,t,n);return i==`SUCCESS`&&(i=`success`),i==`ERROR`&&(i=`error`),i==`DANGER`&&(i=`error`),i==`WARNING`&&(i=`warning`),i==`INFO`&&(i=`info`),i==`PRIMARY`&&(i=`primary`),i==`SECONDARY`&&(i=`secondary`),i==`TERTIARY`&&(i=`tertiary`),i==`QUATERNARY`&&(i=`quaternary`),i==`LIGHT`&&(i=`light`),i==`DARK`&&(i=`dark`),w`<span theme="badge ${i} ${e.pill?`pill`:``} ${e.small?`small`:``} ${e.primary?`primary`:``}">${r}</span>`},N=new class{constructor(){this.afterRenderHook=void 0,this.useShadowRoot=!0,this.componentRenderer=void 0}set(e){if(this.componentRenderer=e,typeof window<`u`){let t=e.supportedClientSideTypes?.();window.__mateuRendererInfo={name:e.rendererName?.()??e.constructor?.name??`unknown`,supportedTypes:t?[...t].sort():null}}}get(){return this.componentRenderer}setUseShadowRoot(e){this.useShadowRoot=e}mustUseShadowRoot(){return this.useShadowRoot}setAfterRenderHook(e){this.afterRenderHook=e}getAfterRenderHook(){return this.afterRenderHook}},mt=(e,t,n,r,i,a,o,s,c)=>(t.slot=s,P(e,t,n,r,i,a,o,c)),P=(e,t,n,r,i,a,o,s)=>{if(!t)return w``;if(t.type==k.ClientSide)return N.get().renderClientSideComponent(e,t,n,r,i,a,o,s);let c=e.route,l=e.consumedRoute;return w`
         <mateu-component id="${t.id}"
                          .component="${t}"
                         route="${c}"
                          consumedRoute="${l}"
                          baseUrl="${n}"
-                         slot="${t.slot??v}"
+                         slot="${t.slot??_}"
                          style="${t.style}"
                          class="${t.cssClasses}"
                          .state="${{...t.initialData??{},...r}}"
@@ -163,29 +163,29 @@ ${i}
                          .appState="${a}"
                          .appData="${o}"
         >
-       </mateu-component>`},mt=e=>{let t=[];return e.color&&e.color!==`normal`&&e.color!==`none`&&t.push(e.color),e.buttonStyle&&t.push(e.buttonStyle===`tertiaryInline`?`tertiary-inline`:e.buttonStyle),e.size&&e.size!==`none`&&e.size!==`normal`&&t.push(e.size),t.length?t.join(` `):void 0},ht=e=>{let t=mt(e)??``,n=[];return t.includes(`primary`)&&n.push(`primary`),t.includes(`tertiary`)&&n.push(`tertiary`),(t.includes(`error`)||e.color===`error`)&&n.push(`danger`),n.join(` `)},gt=e=>e===`back`||e===`backToList`||!!e&&e.startsWith(`cancel`),_t=class extends b{constructor(...e){super(...e),this.appState={},this.appData={},this._overflowOpen=!1,this._onDocClick=e=>{e.composedPath().includes(this)||(this._overflowOpen=!1)},this.handleButtonClick=e=>{this._overflowOpen=!1,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.evalLabel=e=>M(e,this.state,this.data),this.renderBtn=e=>{if((this.data??{})[e.actionId+`.hidden`])return v;let t=this.evalLabel(e.label);return P.get()?.renderToolbarButton?.(e,t,()=>this.handleButtonClick(e.actionId))||T`
-        <button class="mtb ${ht(e)}"
+       </mateu-component>`},ht=e=>{let t=[];return e.color&&e.color!==`normal`&&e.color!==`none`&&t.push(e.color),e.buttonStyle&&t.push(e.buttonStyle===`tertiaryInline`?`tertiary-inline`:e.buttonStyle),e.size&&e.size!==`none`&&e.size!==`normal`&&t.push(e.size),t.length?t.join(` `):void 0},gt=e=>{let t=ht(e)??``,n=[];return t.includes(`primary`)&&n.push(`primary`),t.includes(`tertiary`)&&n.push(`tertiary`),(t.includes(`error`)||e.color===`error`)&&n.push(`danger`),n.join(` `)},_t=e=>e===`back`||e===`backToList`||!!e&&e.startsWith(`cancel`),vt=class extends y{constructor(...e){super(...e),this.appState={},this.appData={},this._overflowOpen=!1,this._onDocClick=e=>{e.composedPath().includes(this)||(this._overflowOpen=!1)},this.handleButtonClick=e=>{this._overflowOpen=!1,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.evalLabel=e=>j(e,this.state,this.data),this.renderBtn=e=>{if((this.data??{})[e.actionId+`.hidden`])return _;let t=this.evalLabel(e.label);return N.get()?.renderToolbarButton?.(e,t,()=>this.handleButtonClick(e.actionId))||w`
+        <button class="mtb ${gt(e)}"
                 data-action-id="${e.id}"
                 @click="${()=>this.handleButtonClick(e.actionId)}"
                 ?disabled="${e.disabled}"
         >${t}</button>
-    `},this.renderActions=e=>{let t=e.filter(e=>!(this.data??{})[e.actionId+`.hidden`]),n=t.filter(e=>e.buttonStyle===`primary`),r=t.filter(e=>e.buttonStyle!==`primary`);return r.length<2?T`${t.map(this.renderBtn)}`:T`
+    `},this.renderActions=e=>{let t=e.filter(e=>!(this.data??{})[e.actionId+`.hidden`]),n=t.filter(e=>e.buttonStyle===`primary`),r=t.filter(e=>e.buttonStyle!==`primary`);return r.length<2?w`${t.map(this.renderBtn)}`:w`
             ${n.map(this.renderBtn)}
             <div class="overflow-wrap">
                 <button class="mtb overflow-btn" title="Más acciones" aria-haspopup="true"
                         aria-expanded="${this._overflowOpen}"
                         @click="${e=>{e.stopPropagation(),this._overflowOpen=!this._overflowOpen}}">⋯</button>
-                ${this._overflowOpen?T`
+                ${this._overflowOpen?w`
                     <div class="overflow-menu">
-                        ${r.map(e=>T`
+                        ${r.map(e=>w`
                             <button class="overflow-item" ?disabled="${e.disabled}"
                                     data-action-id="${e.actionId}"
                                     @click="${()=>this.handleButtonClick(e.actionId)}">${this.evalLabel(e.label)}</button>
                         `)}
                     </div>
-                `:v}
+                `:_}
             </div>
-        `},this.renderPeerNav=e=>P.get()?.renderPeerNav?.(e)||T`
+        `},this.renderPeerNav=e=>N.get()?.renderPeerNav?.(e)||w`
             <div style="display: flex; gap: var(--lumo-space-xs, .25rem); align-items: center;" class="peer-nav">
                 <button class="mtb tertiary peer-nav-prev"
                         title="${e.prevLabel??`Previous`}"
@@ -196,71 +196,71 @@ ${i}
                         ?disabled="${!e.nextRoute}"
                         @click="${()=>{e.nextRoute&&(window.location.href=e.nextRoute)}}">›</button>
             </div>
-        `}connectedCallback(){super.connectedCallback(),document.addEventListener(`click`,this._onDocClick)}disconnectedCallback(){document.removeEventListener(`click`,this._onDocClick),super.disconnectedCallback()}render(){let e=this.metadata;if(!e)return T``;let t=e.peerNav&&(e.peerNav.prevRoute||e.peerNav.nextRoute)?e.peerNav:void 0,n=e.toolbar??[],r=n.filter(e=>gt(e.actionId)),i=n.filter(e=>!gt(e.actionId)),a=r.length>0&&i.length>0?T`<span class="toolbar-divider"></span>`:v,o=e.avatar||e.title||e.subtitle||e.kpis?.length>0||e.header?.length>0||n.length>0||!!t,s=e.level??0;return s>0?this.setAttribute(`data-nested`,``):this.removeAttribute(`data-nested`),T`
-            ${e.breadcrumbs&&e.breadcrumbs.length>0?T`
+        `}connectedCallback(){super.connectedCallback(),document.addEventListener(`click`,this._onDocClick)}disconnectedCallback(){document.removeEventListener(`click`,this._onDocClick),super.disconnectedCallback()}render(){let e=this.metadata;if(!e)return w``;let t=e.peerNav&&(e.peerNav.prevRoute||e.peerNav.nextRoute)?e.peerNav:void 0,n=e.toolbar??[],r=n.filter(e=>_t(e.actionId)),i=n.filter(e=>!_t(e.actionId)),a=r.length>0&&i.length>0?w`<span class="toolbar-divider"></span>`:_,o=e.avatar||e.title||e.subtitle||e.kpis?.length>0||e.header?.length>0||n.length>0||!!t,s=e.level??0;return s>0?this.setAttribute(`data-nested`,``):this.removeAttribute(`data-nested`),w`
+            ${e.breadcrumbs&&e.breadcrumbs.length>0?w`
                 <div style="display: flex; gap: var(--lumo-space-m, 1rem); width: 100%; align-items: center;" class="breadcrumbs-bar">
-                    ${e.breadcrumbs.map((e,t)=>T`
-                        ${t>0?T`<span>/</span>`:v}
-                        ${e.link?T`<button class="breadcrumb-link" @click="${()=>window.location.href=`${e.link}`}">${e.text}</button>`:T`<span>${e.text}</span>`}
+                    ${e.breadcrumbs.map((e,t)=>w`
+                        ${t>0?w`<span>/</span>`:_}
+                        ${e.link?w`<button class="breadcrumb-link" @click="${()=>window.location.href=`${e.link}`}">${e.text}</button>`:w`<span>${e.text}</span>`}
                     `)}
                 </div>
-            `:v}
-            ${e.noHeader?T`
+            `:_}
+            ${e.noHeader?w`
                 <div style="display: flex; gap: var(--lumo-space-m, 1rem); align-items: center;">
-                    ${e?.header?.map(e=>F(this,e,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData))}
-                    ${t?this.renderPeerNav(t):v}
+                    ${e?.header?.map(e=>P(this,e,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData))}
+                    ${t?this.renderPeerNav(t):_}
                     ${r.map(this.renderBtn)}
                     ${a}
                     ${this.renderActions(i)}
                 </div>
-            `:o?T`
+            `:o?w`
                 <div style="display: flex; gap: var(--lumo-space-m, 1rem); width: 100%; align-items: center; flex-wrap: wrap;" class="form-header">
-                    ${e.avatar?F(this,e.avatar,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData):v}
+                    ${e.avatar?P(this,e.avatar,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData):_}
                     <div style="flex: 1; min-width: min(22rem, 100%); overflow: hidden;">
-                        ${e?.title&&s==0?T`
+                        ${e?.title&&s==0?w`
                             <div style="display: flex; align-items: center; gap: var(--lumo-space-s, .5rem); min-width: 0;">
-                                <h2 style="margin: 0; margin-block-end: 0px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">${_(nt(e?.title,this.state??{},this.data??{}))}</h2>
-                                ${e.kpisBelow&&e.badges?.length?e.badges.map(e=>ft(e,this.state??{},this.data??{})):v}
-                            </div>`:v}
-                        ${e?.title&&s==1?T`<h3 style="margin: 0; margin-block-end: 0px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; width: 100%;">${_(nt(e?.title,this.state??{},this.data??{}))}</h3>`:v}
-                        ${e?.title&&s==2?T`<h4 style="margin: 0; margin-block-end: 0px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; width: 100%;">${_(nt(e?.title,this.state??{},this.data??{}))}</h4>`:v}
-                        ${e?.title&&s==3?T`<h5 style="margin: 0; margin-block-end: 0px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; width: 100%;">${_(nt(e?.title,this.state??{},this.data??{}))}</h5>`:v}
-                        ${e?.title&&s>3?T`<h6 style="margin: 0; margin-block-end: 0px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; width: 100%;">${_(nt(e?.title,this.state??{},this.data??{}))}</h6>`:v}
+                                <h2 style="margin: 0; margin-block-end: 0px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">${g(rt(e?.title,this.state??{},this.data??{}))}</h2>
+                                ${e.kpisBelow&&e.badges?.length?e.badges.map(e=>pt(e,this.state??{},this.data??{})):_}
+                            </div>`:_}
+                        ${e?.title&&s==1?w`<h3 style="margin: 0; margin-block-end: 0px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; width: 100%;">${g(rt(e?.title,this.state??{},this.data??{}))}</h3>`:_}
+                        ${e?.title&&s==2?w`<h4 style="margin: 0; margin-block-end: 0px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; width: 100%;">${g(rt(e?.title,this.state??{},this.data??{}))}</h4>`:_}
+                        ${e?.title&&s==3?w`<h5 style="margin: 0; margin-block-end: 0px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; width: 100%;">${g(rt(e?.title,this.state??{},this.data??{}))}</h5>`:_}
+                        ${e?.title&&s>3?w`<h6 style="margin: 0; margin-block-end: 0px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; width: 100%;">${g(rt(e?.title,this.state??{},this.data??{}))}</h6>`:_}
 
-                        ${e?.subtitle?T`<span style="display: inline-block; margin-block-end: 0.83em;">${_(nt(e?.subtitle,this.state??{},this.data??{}))}</span>`:v}
-                        ${e?.timestamp?T`<span class="page-timestamp" style="display: block; color: var(--lumo-secondary-text-color, #6b7280); font-size: var(--lumo-font-size-s, .875rem);">${_(nt(e.timestamp,this.state??{},this.data??{}))}</span>`:v}
+                        ${e?.subtitle?w`<span style="display: inline-block; margin-block-end: 0.83em;">${g(rt(e?.subtitle,this.state??{},this.data??{}))}</span>`:_}
+                        ${e?.timestamp?w`<span class="page-timestamp" style="display: block; color: var(--lumo-secondary-text-color, #6b7280); font-size: var(--lumo-font-size-s, .875rem);">${g(rt(e.timestamp,this.state??{},this.data??{}))}</span>`:_}
                     </div>
                     <div style="display: flex; gap: var(--lumo-space-m, 1rem); align-items: center;">
-                        ${e.kpisBelow?v:e?.kpis?.map(e=>T`
+                        ${e.kpisBelow?_:e?.kpis?.map(e=>w`
                             <div style="display: flex; flex-direction: column; align-items: center;">
                                 <div>${this.evalLabel(e.title)}</div>
-                                <div>${_(nt(e.text,this.state??{},this.data??{}))}</div>
+                                <div>${g(rt(e.text,this.state??{},this.data??{}))}</div>
                             </div>
                         `)}
-                        ${e?.header?.map(e=>F(this,e,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData))}
-                        ${t?this.renderPeerNav(t):v}
+                        ${e?.header?.map(e=>P(this,e,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData))}
+                        ${t?this.renderPeerNav(t):_}
                         ${r.map(this.renderBtn)}
                         ${a}
                         ${this.renderActions(i)}
                     </div>
                 </div>
-            `:v}
-            ${e.kpisBelow&&e?.kpis?.length?T`
+            `:_}
+            ${e.kpisBelow&&e?.kpis?.length?w`
                 <div class="kpi-row">
-                    ${e.kpis.map(e=>T`
+                    ${e.kpis.map(e=>w`
                         <div class="kpi-pair">
                             <span class="kpi-label">${this.evalLabel(e.title)}</span>
-                            <span class="kpi-value">${_(nt(e.text,this.state??{},this.data??{}))}</span>
+                            <span class="kpi-value">${g(rt(e.text,this.state??{},this.data??{}))}</span>
                         </div>
                     `)}
                 </div>
-            `:v}
-            ${e.badges&&e.badges.length>0&&!e.kpisBelow?T`
+            `:_}
+            ${e.badges&&e.badges.length>0&&!e.kpisBelow?w`
                 <div style="display: flex; gap: var(--lumo-space-s, .5rem); padding-bottom: var(--lumo-space-s, .5rem);">
-                    ${e.badges.map(e=>ft(e,this.state??{},this.data??{}))}
+                    ${e.badges.map(e=>pt(e,this.state??{},this.data??{}))}
                 </div>
-            `:v}
-        `}static{this.styles=h`
+            `:_}
+        `}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -372,8 +372,8 @@ ${i}
         .mtb.danger { color: var(--lumo-error-text-color, #c0392b); border-color: var(--lumo-error-color-50pct, rgba(192,57,43,.5)); }
         .mtb.danger.primary { background: var(--lumo-error-color, #c0392b); color: #fff; border-color: transparent; }
 
-        ${de}
-    `}};k([y()],_t.prototype,`metadata`,void 0),k([y()],_t.prototype,`baseUrl`,void 0),k([y()],_t.prototype,`state`,void 0),k([y()],_t.prototype,`data`,void 0),k([y()],_t.prototype,`appState`,void 0),k([y()],_t.prototype,`appData`,void 0),k([C()],_t.prototype,`_overflowOpen`,void 0),_t=k([g(`mateu-content-header`)],_t);var vt=class extends $e{constructor(...e){super(...e),this.state={},this.data={},this.appState={},this.appData={}}render(){let e=this.component?.metadata;return T`
+        ${fe}
+    `}};O([v()],vt.prototype,`metadata`,void 0),O([v()],vt.prototype,`baseUrl`,void 0),O([v()],vt.prototype,`state`,void 0),O([v()],vt.prototype,`data`,void 0),O([v()],vt.prototype,`appState`,void 0),O([v()],vt.prototype,`appData`,void 0),O([S()],vt.prototype,`_overflowOpen`,void 0),vt=O([h(`mateu-content-header`)],vt);var yt=class extends et{constructor(...e){super(...e),this.state={},this.data={},this.appState={},this.appData={}}render(){let e=this.component?.metadata;return w`
             <div class="mateu-vlayout ${this.component?.cssClasses??``}">
                 <mateu-content-header
                     .metadata="${e}"
@@ -390,7 +390,7 @@ ${i}
                     </div>
                 </div>
             </div>
-       `}static{this.styles=h`
+       `}static{this.styles=m`
         :host {
         }
 
@@ -419,7 +419,7 @@ ${i}
         .form-content {
             padding-bottom: 3rem;
         }
-    `}};k([y()],vt.prototype,`state`,void 0),k([y()],vt.prototype,`data`,void 0),k([y()],vt.prototype,`appState`,void 0),k([y()],vt.prototype,`appData`,void 0),vt=k([g(`mateu-form`)],vt);var yt=class extends b{constructor(...e){super(...e),this.variant=`text`,this.count=3}static{this.styles=h`
+    `}};O([v()],yt.prototype,`state`,void 0),O([v()],yt.prototype,`data`,void 0),O([v()],yt.prototype,`appState`,void 0),O([v()],yt.prototype,`appData`,void 0),yt=O([h(`mateu-form`)],yt);var bt=class extends y{constructor(...e){super(...e),this.variant=`text`,this.count=3}static{this.styles=m`
         :host {
             display: block;
             flex: 1 1 0;
@@ -448,37 +448,37 @@ ${i}
         .form-pair { display: flex; flex-direction: column; gap: .35em; margin: .9em 0; }
         .label { height: .8em; width: 30%; }
         .field { height: 2.25em; width: 100%; }
-    `}render(){let e=Array.from({length:Math.max(1,this.count)});return this.variant==`card`?T`${e.map(()=>T`<div class="bone card" style="margin: .5em 0;"></div>`)}`:this.variant==`grid`?T`${e.map(()=>T`<div class="bone row"></div>`)}`:this.variant==`form`?T`${e.map(()=>T`
+    `}render(){let e=Array.from({length:Math.max(1,this.count)});return this.variant==`card`?w`${e.map(()=>w`<div class="bone card" style="margin: .5em 0;"></div>`)}`:this.variant==`grid`?w`${e.map(()=>w`<div class="bone row"></div>`)}`:this.variant==`form`?w`${e.map(()=>w`
                 <div class="form-pair">
                     <div class="bone label"></div>
                     <div class="bone field"></div>
                 </div>
-            `)}`:T`${e.map(()=>T`<div class="bone line"></div>`)}`}};k([y()],yt.prototype,`variant`,void 0),k([y({type:Number})],yt.prototype,`count`,void 0),yt=k([g(`mateu-skeleton`)],yt);var bt=(e,t)=>{t&&e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},xt=(e,t,n,r,i,a)=>T`
+            `)}`:w`${e.map(()=>w`<div class="bone line"></div>`)}`}};O([v()],bt.prototype,`variant`,void 0),O([v({type:Number})],bt.prototype,`count`,void 0),bt=O([h(`mateu-skeleton`)],bt);var xt=(e,t)=>{t&&e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},St=(e,t,n,r,i,a)=>w`
         <div class="mateu-empty-state"
              style="display: flex; flex-direction: column; align-items: center; justify-content: center; gap: .35rem; padding: var(--lumo-space-l, 1.5rem); text-align: center; color: var(--lumo-secondary-text-color, #666);">
             <span style="font-size: 1.8rem; line-height: 1; opacity: .6;">${t??`🗂`}</span>
-            ${n?T`<span style="font-weight: 600; color: var(--lumo-body-text-color, #333);">${n}</span>`:v}
+            ${n?w`<span style="font-weight: 600; color: var(--lumo-body-text-color, #333);">${n}</span>`:_}
             <span style="font-size: var(--lumo-font-size-s, .875rem);">${r??e??`Nothing here yet.`}</span>
-            ${i&&a?T`
+            ${i&&a?w`
                 <button style="margin-top: .25rem; font: inherit; font-weight: 500; cursor: pointer; padding: .4rem .9rem; border: none; border-radius: var(--lumo-border-radius-m, 6px); background: transparent; color: var(--lumo-primary-text-color, #3b5bdb);"
-                        @click="${e=>bt(e,i)}">${a}</button>
-            `:v}
+                        @click="${e=>xt(e,i)}">${a}</button>
+            `:_}
         </div>
-    `,St=e=>{let t=e.metadata;return T`
-        <div style="${e.style??v}" class="${e.cssClasses??v}" slot="${e.slot??v}">
-            ${xt(void 0,t.icon,t.title,t.description,t.actionId,t.actionLabel)}
+    `,Ct=e=>{let t=e.metadata;return w`
+        <div style="${e.style??_}" class="${e.cssClasses??_}" slot="${e.slot??_}">
+            ${St(void 0,t.icon,t.title,t.description,t.actionId,t.actionLabel)}
         </div>
-    `},Ct=e=>{let t=e.metadata;return T`
+    `},wt=e=>{let t=e.metadata;return w`
         <mateu-skeleton
                 variant="${t.variant??`text`}"
                 count="${t.count&&t.count>0?t.count:3}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-skeleton>
-    `},I=(e,t,n,r)=>{if(!e)return T``;let i=P.get()?.renderIcon;if(i){let a=i.call(P.get(),e,t,n);return r?T`<span slot="${r}">${a}</span>`:a}return T`<span class="mateu-icon ${n??``}" data-icon="${e}" aria-hidden="true"
-                      style="display:inline-block; width:1em; height:1em; ${t??``}" slot="${r??v}"></span>`},wt=`mateu-saved-views`,Tt=()=>{try{return JSON.parse(localStorage.getItem(wt)??`{}`)}catch{return{}}},Et=e=>{try{localStorage.setItem(wt,JSON.stringify(e))}catch{}},Dt=e=>Tt()[e]??[],Ot=(e,t)=>{let n=t.name?.trim();if(!n||Object.keys(t.values??{}).length===0)return;let r=Tt(),i=(r[e]??[]).filter(e=>e.name!==n);i.push({...t,name:n}),r[e]=i,Et(r)},kt=(e,t)=>{let n=Tt(),r=(n[e]??[]).filter(e=>e.name!==t);r.length===0?delete n[e]:n[e]=r,Et(n)},At=(e,t)=>{let n=Tt();n[e]=(n[e]??[]).map(e=>({...e,isDefault:e.name===t&&!e.isDefault})),Et(n)},jt=e=>Dt(e).find(e=>e.isDefault),L=class extends b{constructor(...e){super(...e),this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.searchOnly=!1,this.panelOpened=!1,this.viewsOpened=!1,this.draftText=``,this.openPanel=()=>{this.panelOpened||this.filters.length===0||(this.panelOpened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick))},this.closePanel=()=>{this.detachOutsideClick(),this.panelOpened=!1,this.activeFilter=void 0},this.clearAllFilters=()=>{let e=this.filters.flatMap(e=>this.isRangeFilter(e)?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId]),t={searchText:void 0};e.forEach(e=>{t[e]=void 0}),this.state={...this.state,...t},this.dispatchEvent(new CustomEvent(`filter-reset-requested`,{detail:{fieldIds:e},bubbles:!0,composed:!0})),this.requestSearch()},this.keepFocus=e=>e.preventDefault()}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}get filters(){return this.metadata?.filters??[]}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}requestSearch(){this.closePanel(),this.dispatchEvent(new CustomEvent(`search-requested`,{detail:{},bubbles:!0,composed:!0}))}emitValueChanged(e,t){this.state={...this.state,[e]:t},this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:e},bubbles:!0,composed:!0}))}applyFilter(e,t){this.emitValueChanged(e,t),this.requestSearch()}removeChip(e){let t=this.filters.find(t=>t.fieldId===e);t&&this.isRangeFilter(t)?(this.emitValueChanged(`${e}_from`,void 0),this.emitValueChanged(`${e}_to`,void 0)):this.emitValueChanged(e,e===`searchText`?``:void 0),this.requestSearch()}commitText(e){this.emitValueChanged(`searchText`,e.value),this.draftText=``,e.value=``,this.requestSearch()}get viewsScope(){return window.location.pathname}allFilterKeys(){return[`searchText`,...this.filters.flatMap(e=>this.isRangeFilter(e)?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId])]}snapshotValues(){let e={};return this.state.searchText&&(e.searchText=this.state.searchText),this.filters.forEach(t=>{if(this.isSet(t))if(this.isRangeFilter(t)){let n=this.rangeBound(t,`from`),r=this.rangeBound(t,`to`);n&&(e[`${t.fieldId}_from`]=n),r&&(e[`${t.fieldId}_to`]=r)}else this.isMultiFilter(t)?e[t.fieldId]=this.multiValues(t):e[t.fieldId]=this.state[t.fieldId]}),e}applyView(e){let t=this.allFilterKeys(),n={};t.forEach(e=>{n[e]=void 0}),this.state={...this.state,...n},this.dispatchEvent(new CustomEvent(`filter-reset-requested`,{detail:{fieldIds:t},bubbles:!0,composed:!0})),Object.entries(e.values).forEach(([e,t])=>this.emitValueChanged(e,t)),this.viewsOpened=!1,this.detachOutsideClick(),this.requestSearch()}saveCurrentView(e){let t=e.value.trim();t&&(Ot(this.viewsScope,{name:t,values:this.snapshotValues()}),e.value=``,this.requestUpdate())}firstUpdated(){if(window.location.search)return;let e=jt(this.viewsScope);e&&setTimeout(()=>{this.state.searchText||this.filters.some(e=>this.isSet(e))||this.applyView(e)},0)}isBooleanFilter(e){return e.dataType===`boolean`||e.dataType===`bool`||e.stereotype===`checkbox`||e.stereotype===`toggle`}isNumericFilter(e){return[`integer`,`decimal`,`number`,`money`].includes(e.dataType??``)}isRangeFilter(e){return e.stereotype===`dateRange`||e.stereotype===`numberRange`}isMultiFilter(e){return e.stereotype===`multiSelect`}hasOptions(e){return(e.options?.length??0)>0}multiValues(e){let t=this.state[e.fieldId];return Array.isArray(t)?t.map(String):typeof t==`string`&&t!==``?t.split(`,`).map(e=>e.trim()).filter(e=>e):[]}rangeBound(e,t){let n=this.state[`${e.fieldId}_${t}`];return n==null?``:String(n)}isSet(e){if(this.isRangeFilter(e))return this.rangeBound(e,`from`)!==``||this.rangeBound(e,`to`)!==``;if(this.isMultiFilter(e))return this.multiValues(e).length>0;let t=this.state[e.fieldId];return t!=null&&t!==``&&!Number.isNaN(t)}getFilterDisplayValue(e,t){if(e.options?.length){let n=e.options.find(e=>e.value===String(t));if(n)return n.label??n.value}return typeof t==`boolean`?t?`Yes`:`No`:String(t)}conditionDisplay(e){if(this.isRangeFilter(e)){let t=this.rangeBound(e,`from`),n=this.rangeBound(e,`to`);return t&&n?`${t} – ${n}`:t?`≥ ${t}`:`≤ ${n}`}return this.isMultiFilter(e)?this.multiValues(e).map(t=>this.getFilterDisplayValue(e,t)).join(`, `):this.getFilterDisplayValue(e,this.state[e.fieldId])}labelOf(e){return M(e.label,this.state,this.data)||e.fieldId}panelRow(e,t,n=`panel-row`){return T`
-            <div class="${n}" @mousedown="${this.keepFocus}" @click="${t}">${e}</div>`}renderRangeWidget(e){let t=e.stereotype===`numberRange`?`number`:e.dataType===`dateTime`?`datetime-local`:e.dataType===`time`?`time`:`date`,n=t=>{let n=t.closest(`.panel-input-row`),r=n.querySelector(`input.range-from`).value,i=n.querySelector(`input.range-to`).value;this.emitValueChanged(`${e.fieldId}_from`,r===``?void 0:r),this.emitValueChanged(`${e.fieldId}_to`,i===``?void 0:i),this.requestSearch()},r=e=>{e.key===`Enter`&&n(e.target),e.key===`Escape`&&this.closePanel()};return T`
+    `},F=(e,t,n,r)=>{if(!e)return w``;let i=N.get()?.renderIcon;if(i){let a=i.call(N.get(),e,t,n);return r?w`<span slot="${r}">${a}</span>`:a}return w`<span class="mateu-icon ${n??``}" data-icon="${e}" aria-hidden="true"
+                      style="display:inline-block; width:1em; height:1em; ${t??``}" slot="${r??_}"></span>`},Tt=`mateu-saved-views`,Et=()=>{try{return JSON.parse(localStorage.getItem(Tt)??`{}`)}catch{return{}}},Dt=e=>{try{localStorage.setItem(Tt,JSON.stringify(e))}catch{}},Ot=e=>Et()[e]??[],kt=(e,t)=>{let n=t.name?.trim();if(!n||Object.keys(t.values??{}).length===0)return;let r=Et(),i=(r[e]??[]).filter(e=>e.name!==n);i.push({...t,name:n}),r[e]=i,Dt(r)},At=(e,t)=>{let n=Et(),r=(n[e]??[]).filter(e=>e.name!==t);r.length===0?delete n[e]:n[e]=r,Dt(n)},jt=(e,t)=>{let n=Et();n[e]=(n[e]??[]).map(e=>({...e,isDefault:e.name===t&&!e.isDefault})),Dt(n)},Mt=e=>Ot(e).find(e=>e.isDefault),I=class extends y{constructor(...e){super(...e),this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.searchOnly=!1,this.panelOpened=!1,this.viewsOpened=!1,this.draftText=``,this.openPanel=()=>{this.panelOpened||this.filters.length===0||(this.panelOpened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick))},this.closePanel=()=>{this.detachOutsideClick(),this.panelOpened=!1,this.activeFilter=void 0},this.clearAllFilters=()=>{let e=this.filters.flatMap(e=>this.isRangeFilter(e)?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId]),t={searchText:void 0};e.forEach(e=>{t[e]=void 0}),this.state={...this.state,...t},this.dispatchEvent(new CustomEvent(`filter-reset-requested`,{detail:{fieldIds:e},bubbles:!0,composed:!0})),this.requestSearch()},this.keepFocus=e=>e.preventDefault()}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}get filters(){return this.metadata?.filters??[]}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}requestSearch(){this.closePanel(),this.dispatchEvent(new CustomEvent(`search-requested`,{detail:{},bubbles:!0,composed:!0}))}emitValueChanged(e,t){this.state={...this.state,[e]:t},this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:e},bubbles:!0,composed:!0}))}applyFilter(e,t){this.emitValueChanged(e,t),this.requestSearch()}removeChip(e){let t=this.filters.find(t=>t.fieldId===e);t&&this.isRangeFilter(t)?(this.emitValueChanged(`${e}_from`,void 0),this.emitValueChanged(`${e}_to`,void 0)):this.emitValueChanged(e,e===`searchText`?``:void 0),this.requestSearch()}commitText(e){this.emitValueChanged(`searchText`,e.value),this.draftText=``,e.value=``,this.requestSearch()}get viewsScope(){return window.location.pathname}allFilterKeys(){return[`searchText`,...this.filters.flatMap(e=>this.isRangeFilter(e)?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId])]}snapshotValues(){let e={};return this.state.searchText&&(e.searchText=this.state.searchText),this.filters.forEach(t=>{if(this.isSet(t))if(this.isRangeFilter(t)){let n=this.rangeBound(t,`from`),r=this.rangeBound(t,`to`);n&&(e[`${t.fieldId}_from`]=n),r&&(e[`${t.fieldId}_to`]=r)}else this.isMultiFilter(t)?e[t.fieldId]=this.multiValues(t):e[t.fieldId]=this.state[t.fieldId]}),e}applyView(e){let t=this.allFilterKeys(),n={};t.forEach(e=>{n[e]=void 0}),this.state={...this.state,...n},this.dispatchEvent(new CustomEvent(`filter-reset-requested`,{detail:{fieldIds:t},bubbles:!0,composed:!0})),Object.entries(e.values).forEach(([e,t])=>this.emitValueChanged(e,t)),this.viewsOpened=!1,this.detachOutsideClick(),this.requestSearch()}saveCurrentView(e){let t=e.value.trim();t&&(kt(this.viewsScope,{name:t,values:this.snapshotValues()}),e.value=``,this.requestUpdate())}firstUpdated(){if(window.location.search)return;let e=Mt(this.viewsScope);e&&setTimeout(()=>{this.state.searchText||this.filters.some(e=>this.isSet(e))||this.applyView(e)},0)}isBooleanFilter(e){return e.dataType===`boolean`||e.dataType===`bool`||e.stereotype===`checkbox`||e.stereotype===`toggle`}isNumericFilter(e){return[`integer`,`decimal`,`number`,`money`].includes(e.dataType??``)}isRangeFilter(e){return e.stereotype===`dateRange`||e.stereotype===`numberRange`}isMultiFilter(e){return e.stereotype===`multiSelect`}hasOptions(e){return(e.options?.length??0)>0}multiValues(e){let t=this.state[e.fieldId];return Array.isArray(t)?t.map(String):typeof t==`string`&&t!==``?t.split(`,`).map(e=>e.trim()).filter(e=>e):[]}rangeBound(e,t){let n=this.state[`${e.fieldId}_${t}`];return n==null?``:String(n)}isSet(e){if(this.isRangeFilter(e))return this.rangeBound(e,`from`)!==``||this.rangeBound(e,`to`)!==``;if(this.isMultiFilter(e))return this.multiValues(e).length>0;let t=this.state[e.fieldId];return t!=null&&t!==``&&!Number.isNaN(t)}getFilterDisplayValue(e,t){if(e.options?.length){let n=e.options.find(e=>e.value===String(t));if(n)return n.label??n.value}return typeof t==`boolean`?t?`Yes`:`No`:String(t)}conditionDisplay(e){if(this.isRangeFilter(e)){let t=this.rangeBound(e,`from`),n=this.rangeBound(e,`to`);return t&&n?`${t} – ${n}`:t?`≥ ${t}`:`≤ ${n}`}return this.isMultiFilter(e)?this.multiValues(e).map(t=>this.getFilterDisplayValue(e,t)).join(`, `):this.getFilterDisplayValue(e,this.state[e.fieldId])}labelOf(e){return j(e.label,this.state,this.data)||e.fieldId}panelRow(e,t,n=`panel-row`){return w`
+            <div class="${n}" @mousedown="${this.keepFocus}" @click="${t}">${e}</div>`}renderRangeWidget(e){let t=e.stereotype===`numberRange`?`number`:e.dataType===`dateTime`?`datetime-local`:e.dataType===`time`?`time`:`date`,n=t=>{let n=t.closest(`.panel-input-row`),r=n.querySelector(`input.range-from`).value,i=n.querySelector(`input.range-to`).value;this.emitValueChanged(`${e.fieldId}_from`,r===``?void 0:r),this.emitValueChanged(`${e.fieldId}_to`,i===``?void 0:i),this.requestSearch()},r=e=>{e.key===`Enter`&&n(e.target),e.key===`Escape`&&this.closePanel()};return w`
             <div class="panel-input-row">
                 <input class="range-from" type="${t}" placeholder="From"
                        .value="${this.rangeBound(e,`from`)}"
@@ -492,13 +492,13 @@ ${i}
                 <button class="apply-button"
                         @mousedown="${this.keepFocus}"
                         @click="${e=>n(e.target)}">Apply</button>
-            </div>`}renderMultiWidget(e){let t=this.multiValues(e),n=n=>{let r=t.includes(n)?t.filter(e=>e!==n):[...t,n];this.emitValueChanged(e.fieldId,r.length>0?r:void 0),this.dispatchEvent(new CustomEvent(`search-requested`,{detail:{},bubbles:!0,composed:!0}))};return T`${(e.options??[]).map(e=>this.panelRow(T`
+            </div>`}renderMultiWidget(e){let t=this.multiValues(e),n=n=>{let r=t.includes(n)?t.filter(e=>e!==n):[...t,n];this.emitValueChanged(e.fieldId,r.length>0?r:void 0),this.dispatchEvent(new CustomEvent(`search-requested`,{detail:{},bubbles:!0,composed:!0}))};return w`${(e.options??[]).map(e=>this.panelRow(w`
             <span class="multi-check ${t.includes(e.value)?`multi-check--on`:``}"
                   aria-hidden="true">${t.includes(e.value)?`✓`:``}</span>
             ${e.label??e.value}
-        `,()=>n(e.value)))}`}renderActiveFilterWidget(e){if(this.isRangeFilter(e))return this.renderRangeWidget(e);if(this.isMultiFilter(e))return this.renderMultiWidget(e);if(this.hasOptions(e))return T`${e.options.map(t=>this.panelRow(t.label??t.value,()=>this.applyFilter(e.fieldId,t.value)))}`;if(this.isBooleanFilter(e))return T`
+        `,()=>n(e.value)))}`}renderActiveFilterWidget(e){if(this.isRangeFilter(e))return this.renderRangeWidget(e);if(this.isMultiFilter(e))return this.renderMultiWidget(e);if(this.hasOptions(e))return w`${e.options.map(t=>this.panelRow(t.label??t.value,()=>this.applyFilter(e.fieldId,t.value)))}`;if(this.isBooleanFilter(e))return w`
                 ${this.panelRow(`Yes`,()=>this.applyFilter(e.fieldId,!0))}
-                ${this.panelRow(`No`,()=>this.applyFilter(e.fieldId,!1))}`;let t=this.isNumericFilter(e),n=n=>{n.value!==``&&this.applyFilter(e.fieldId,t?Number(n.value):n.value)};return T`
+                ${this.panelRow(`No`,()=>this.applyFilter(e.fieldId,!1))}`;let t=this.isNumericFilter(e),n=n=>{n.value!==``&&this.applyFilter(e.fieldId,t?Number(n.value):n.value)};return w`
             <div class="panel-input-row">
                 <input type="${t?`number`:`text`}"
                        placeholder="${e.placeholder||this.labelOf(e)}"
@@ -507,29 +507,29 @@ ${i}
                 <button class="apply-button"
                         @mousedown="${this.keepFocus}"
                         @click="${e=>n(e.target.previousElementSibling)}">Apply</button>
-            </div>`}renderViewsPanel(){if(!this.viewsOpened)return v;let e=Dt(this.viewsScope),t=!!this.state.searchText||this.filters.some(e=>this.isSet(e));return T`
+            </div>`}renderViewsPanel(){if(!this.viewsOpened)return _;let e=Ot(this.viewsScope),t=!!this.state.searchText||this.filters.some(e=>this.isSet(e));return w`
             <div class="panel views-panel">
                 <div class="panel-caption">Saved views</div>
-                ${e.length===0?T`
-                    <div class="panel-row views-empty">No saved views yet</div>`:v}
-                ${e.map(e=>T`
+                ${e.length===0?w`
+                    <div class="panel-row views-empty">No saved views yet</div>`:_}
+                ${e.map(e=>w`
                     <div class="panel-row view-row" @mousedown="${this.keepFocus}">
                         <span class="view-name" @click="${()=>this.applyView(e)}">${e.name}</span>
                         <button class="view-star ${e.isDefault?`view-star--on`:``}"
                                 title="${e.isDefault?`Unset as default`:`Open this listing with this view`}"
-                                @click="${()=>{At(this.viewsScope,e.name),this.requestUpdate()}}">★</button>
+                                @click="${()=>{jt(this.viewsScope,e.name),this.requestUpdate()}}">★</button>
                         <button class="chip-remove" aria-label="Delete view ${e.name}"
-                                @click="${()=>{kt(this.viewsScope,e.name),this.requestUpdate()}}">✕</button>
+                                @click="${()=>{At(this.viewsScope,e.name),this.requestUpdate()}}">✕</button>
                     </div>`)}
-                ${t?T`
+                ${t?w`
                     <div class="panel-input-row" @mousedown="${e=>e.stopPropagation()}">
                         <input class="view-name-input" type="text" placeholder="Save current view as…"
                                @keydown="${e=>{e.key===`Enter`&&this.saveCurrentView(e.target),e.key===`Escape`&&(this.viewsOpened=!1)}}"/>
                         <button class="apply-button"
                                 @click="${e=>this.saveCurrentView(e.target.previousElementSibling)}">Save</button>
-                    </div>`:T`
+                    </div>`:w`
                     <div class="panel-row views-empty">Apply some filters to save a view</div>`}
-            </div>`}renderPanel(){if(!this.panelOpened||this.filters.length===0)return v;if(this.activeFilter){let e=this.activeFilter;return T`
+            </div>`}renderPanel(){if(!this.panelOpened||this.filters.length===0)return _;if(this.activeFilter){let e=this.activeFilter;return w`
                 <div class="panel">
                     <div class="panel-row panel-header"
                          @mousedown="${this.keepFocus}"
@@ -537,32 +537,32 @@ ${i}
                         <span aria-hidden="true">←</span> ${this.labelOf(e)}
                     </div>
                     ${this.renderActiveFilterWidget(e)}
-                </div>`}let e=!!this.state.searchText||this.filters.some(e=>this.isSet(e));return T`
+                </div>`}let e=!!this.state.searchText||this.filters.some(e=>this.isSet(e));return w`
             <div class="panel">
                 <div class="panel-caption">Filter by</div>
-                ${this.filters.map(e=>this.panelRow(T`
+                ${this.filters.map(e=>this.panelRow(w`
                     ${this.labelOf(e)}
-                    ${this.isSet(e)?T`<span class="current-value">${this.conditionDisplay(e)}</span>`:v}
+                    ${this.isSet(e)?w`<span class="current-value">${this.conditionDisplay(e)}</span>`:_}
                 `,()=>{this.activeFilter=e}))}
-                ${e?this.panelRow(`Clear filters`,this.clearAllFilters,`panel-row panel-footer`):v}
-            </div>`}render(){let e=[];return this.state.searchText&&e.push({fieldId:`searchText`,label:`Text`,display:String(this.state.searchText)}),this.filters.forEach(t=>{this.isSet(t)&&e.push({fieldId:t.fieldId,label:this.labelOf(t),display:this.conditionDisplay(t)})}),T`
+                ${e?this.panelRow(`Clear filters`,this.clearAllFilters,`panel-row panel-footer`):_}
+            </div>`}render(){let e=[];return this.state.searchText&&e.push({fieldId:`searchText`,label:`Text`,display:String(this.state.searchText)}),this.filters.forEach(t=>{this.isSet(t)&&e.push({fieldId:t.fieldId,label:this.labelOf(t),display:this.conditionDisplay(t)})}),w`
             <div class="smart-search">
                 <div class="bar"
                      @click="${e=>{e.currentTarget.querySelector(`input.free-text`)?.focus(),this.openPanel()}}">
                     <svg aria-hidden="true" class="magnifier" width="16" height="16" viewBox="0 0 24 24">
                         <path fill="currentColor" d="M15.5 14h-.79l-.28-.27a6.5 6.5 0 1 0-.7.7l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0A4.5 4.5 0 1 1 14 9.5 4.5 4.5 0 0 1 9.5 14z"/>
                     </svg>
-                    ${e.map(e=>T`
+                    ${e.map(e=>w`
                         <span theme="badge contrast pill" class="chip">
                             <span class="chip-label">${e.label}:</span> ${e.display}
                             <button class="chip-remove" aria-label="Remove filter ${e.label}"
                                     @mousedown="${this.keepFocus}"
                                     @click="${t=>{t.stopPropagation(),this.removeChip(e.fieldId)}}">✕</button>
                         </span>`)}
-                    ${this.metadata?.searchable===!1?v:T`
+                    ${this.metadata?.searchable===!1?_:w`
                         <input class="free-text" type="text" id="searchText"
                                placeholder="${e.length===0?`Search`:``}"
-                               autofocus="${this.metadata?.autoFocusOnSearchText?!0:v}"
+                               autofocus="${this.metadata?.autoFocusOnSearchText?!0:_}"
                                .value="${this.draftText??``}"
                                @input="${e=>{this.draftText=e.target.value,this.openPanel()}}"
                                @keydown="${e=>{e.key===`Enter`&&this.commitText(e.target),e.key===`Escape`&&this.closePanel()}}"/>
@@ -579,8 +579,8 @@ ${i}
                 ${this.renderViewsPanel()}
             </div>
             <slot></slot>
-        `}static{this.styles=h`
-        ${de}
+        `}static{this.styles=m`
+        ${fe}
         :host {
             width: 100%;
         }
@@ -776,7 +776,7 @@ ${i}
             padding: 0.35rem 0.75rem;
             cursor: pointer;
         }
-    `}};k([y()],L.prototype,`metadata`,void 0),k([y()],L.prototype,`baseUrl`,void 0),k([C()],L.prototype,`state`,void 0),k([C()],L.prototype,`data`,void 0),k([y()],L.prototype,`appState`,void 0),k([y()],L.prototype,`appData`,void 0),k([y({type:Boolean})],L.prototype,`searchOnly`,void 0),k([C()],L.prototype,`panelOpened`,void 0),k([C()],L.prototype,`viewsOpened`,void 0),k([C()],L.prototype,`activeFilter`,void 0),k([C()],L.prototype,`draftText`,void 0),L=k([g(`mateu-filter-bar`)],L);var Mt=`mateu-column-prefs`,Nt=()=>{try{let e=JSON.parse(localStorage.getItem(Mt)??`{}`);return e&&typeof e==`object`&&!Array.isArray(e)?e:{}}catch{return{}}},Pt=e=>{try{localStorage.setItem(Mt,JSON.stringify(e))}catch{}},Ft=e=>{if(!e||typeof e!=`object`)return;let t=e=>Array.isArray(e)?e.filter(e=>typeof e==`string`):[];return{hidden:t(e.hidden),order:t(e.order)}},It=e=>Ft(Nt()[e]),Lt=(e,t)=>{let n=Nt(),r=Ft(t);r.hidden.length===0&&r.order.length===0?delete n[e]:n[e]=r,Pt(n)},Rt=e=>{let t=Nt();delete t[e],Pt(t)},zt=e=>e?!!e.identifier||e.dataType===`action`||e.dataType===`actionGroup`||e.dataType===`menu`||e.id===`select`||e.id===`menu`:!1,Bt=(e,t,n=e=>e)=>{let r=Ft(t);if(!r||r.hidden.length===0&&r.order.length===0)return e;let i=e=>n(e)?.id??e.id,a=new Set(r.hidden),o=e.filter(e=>{let t=i(e);return!t||!a.has(t)||zt(n(e))});if(r.order.length===0)return o.length===e.length?e:o;let s=new Map;o.forEach(e=>{let t=i(e);t&&!s.has(t)&&s.set(t,e)});let c=[],l=new Set;return r.order.forEach(e=>{let t=s.get(e);t&&!l.has(t)&&(c.push(t),l.add(t))}),o.forEach(e=>{l.has(e)||(c.push(e),l.add(e))}),c.length===e.length&&c.every((t,n)=>t===e[n])?e:c},Vt=class extends b{constructor(...e){super(...e),this.columns=[],this.scope=``,this.panelOpened=!1,this.revision=0,this.togglePanel=()=>{if(this.panelOpened){this.closePanel();return}this.panelOpened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick)},this.closePanel=()=>{this.detachOutsideClick(),this.panelOpened=!1},this.reset=()=>{Rt(this.scope),this.revision++,this.dispatchEvent(new CustomEvent(`column-prefs-changed`,{bubbles:!0,composed:!0}))}}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}get prefs(){return It(this.scope)??{hidden:[],order:[]}}effectiveEntries(e){return Bt(this.columns,{hidden:[],order:e.order})}commit(e){Lt(this.scope,e),this.revision++,this.dispatchEvent(new CustomEvent(`column-prefs-changed`,{bubbles:!0,composed:!0}))}toggleVisibility(e){let t=this.prefs,n=t.hidden.includes(e)?t.hidden.filter(t=>t!==e):[...t.hidden,e];this.commit({...t,hidden:n})}move(e,t){let n=this.prefs,r=[...this.effectiveEntries(n)],i=r.findIndex(t=>t.id===e);if(i<0)return;let a=i+t;for(;a>=0&&a<r.length&&r[a].protected;)a+=t;if(a<0||a>=r.length)return;let o=r[i];r[i]=r[a],r[a]=o,this.commit({...n,order:r.map(e=>e.id)})}render(){this.revision;let e=this.prefs,t=this.effectiveEntries(e).filter(e=>!e.protected);if(t.length===0)return T``;let n=e.hidden.length>0||e.order.length>0;return T`
+    `}};O([v()],I.prototype,`metadata`,void 0),O([v()],I.prototype,`baseUrl`,void 0),O([S()],I.prototype,`state`,void 0),O([S()],I.prototype,`data`,void 0),O([v()],I.prototype,`appState`,void 0),O([v()],I.prototype,`appData`,void 0),O([v({type:Boolean})],I.prototype,`searchOnly`,void 0),O([S()],I.prototype,`panelOpened`,void 0),O([S()],I.prototype,`viewsOpened`,void 0),O([S()],I.prototype,`activeFilter`,void 0),O([S()],I.prototype,`draftText`,void 0),I=O([h(`mateu-filter-bar`)],I);var Nt=`mateu-column-prefs`,Pt=()=>{try{let e=JSON.parse(localStorage.getItem(Nt)??`{}`);return e&&typeof e==`object`&&!Array.isArray(e)?e:{}}catch{return{}}},Ft=e=>{try{localStorage.setItem(Nt,JSON.stringify(e))}catch{}},It=e=>{if(!e||typeof e!=`object`)return;let t=e=>Array.isArray(e)?e.filter(e=>typeof e==`string`):[];return{hidden:t(e.hidden),order:t(e.order)}},Lt=e=>It(Pt()[e]),Rt=(e,t)=>{let n=Pt(),r=It(t);r.hidden.length===0&&r.order.length===0?delete n[e]:n[e]=r,Ft(n)},zt=e=>{let t=Pt();delete t[e],Ft(t)},Bt=e=>e?!!e.identifier||e.dataType===`action`||e.dataType===`actionGroup`||e.dataType===`menu`||e.id===`select`||e.id===`menu`:!1,Vt=(e,t,n=e=>e)=>{let r=It(t);if(!r||r.hidden.length===0&&r.order.length===0)return e;let i=e=>n(e)?.id??e.id,a=new Set(r.hidden),o=e.filter(e=>{let t=i(e);return!t||!a.has(t)||Bt(n(e))});if(r.order.length===0)return o.length===e.length?e:o;let s=new Map;o.forEach(e=>{let t=i(e);t&&!s.has(t)&&s.set(t,e)});let c=[],l=new Set;return r.order.forEach(e=>{let t=s.get(e);t&&!l.has(t)&&(c.push(t),l.add(t))}),o.forEach(e=>{l.has(e)||(c.push(e),l.add(e))}),c.length===e.length&&c.every((t,n)=>t===e[n])?e:c},Ht=class extends y{constructor(...e){super(...e),this.columns=[],this.scope=``,this.panelOpened=!1,this.revision=0,this.togglePanel=()=>{if(this.panelOpened){this.closePanel();return}this.panelOpened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick)},this.closePanel=()=>{this.detachOutsideClick(),this.panelOpened=!1},this.reset=()=>{zt(this.scope),this.revision++,this.dispatchEvent(new CustomEvent(`column-prefs-changed`,{bubbles:!0,composed:!0}))}}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}get prefs(){return Lt(this.scope)??{hidden:[],order:[]}}effectiveEntries(e){return Vt(this.columns,{hidden:[],order:e.order})}commit(e){Rt(this.scope,e),this.revision++,this.dispatchEvent(new CustomEvent(`column-prefs-changed`,{bubbles:!0,composed:!0}))}toggleVisibility(e){let t=this.prefs,n=t.hidden.includes(e)?t.hidden.filter(t=>t!==e):[...t.hidden,e];this.commit({...t,hidden:n})}move(e,t){let n=this.prefs,r=[...this.effectiveEntries(n)],i=r.findIndex(t=>t.id===e);if(i<0)return;let a=i+t;for(;a>=0&&a<r.length&&r[a].protected;)a+=t;if(a<0||a>=r.length)return;let o=r[i];r[i]=r[a],r[a]=o,this.commit({...n,order:r.map(e=>e.id)})}render(){this.revision;let e=this.prefs,t=this.effectiveEntries(e).filter(e=>!e.protected);if(t.length===0)return w``;let n=e.hidden.length>0||e.order.length>0;return w`
             <div class="chooser">
                 <button
                     class="trigger ${n?`active`:``}"
@@ -793,10 +793,10 @@ ${i}
                         <rect x="11" y="2" width="4" height="12" rx="1" fill="currentColor" opacity="0.35"/>
                     </svg>
                 </button>
-                ${this.panelOpened?T`
+                ${this.panelOpened?w`
                     <div class="panel" role="menu">
                         <div class="panel-title">Columns</div>
-                        ${t.map((n,r)=>{let i=e.hidden.includes(n.id);return T`
+                        ${t.map((n,r)=>{let i=e.hidden.includes(n.id);return w`
                                 <div class="row" data-column-id="${n.id}">
                                     <label class="row-label">
                                         <input
@@ -818,9 +818,9 @@ ${i}
                             <button class="reset" type="button" ?disabled="${!n}" @click="${this.reset}">Reset</button>
                         </div>
                     </div>
-                `:v}
+                `:_}
             </div>
-        `}static{this.styles=h`
+        `}static{this.styles=m`
         :host {
             display: block;
             flex: none;
@@ -933,9 +933,9 @@ ${i}
             opacity: 0.4;
             cursor: default;
         }
-    `}};k([y()],Vt.prototype,`columns`,void 0),k([y()],Vt.prototype,`scope`,void 0),k([C()],Vt.prototype,`panelOpened`,void 0),k([C()],Vt.prototype,`revision`,void 0),Vt=k([g(`mateu-column-chooser`)],Vt);var Ht=class extends b{constructor(...e){super(...e),this.totalElements=0,this.pageSize=100,this.pageNumber=0,this.totalPages=0}updated(e){super.updated(e),(e.has(`totalElements`)||e.has(`pageSize`))&&(this.totalPages=Math.ceil(this.totalElements/this.pageSize))}dispatch(e){this.dispatchEvent(new CustomEvent(`page-changed`,{bubbles:!0,composed:!0,detail:{page:e}}))}render(){if(!this.totalElements)return v;let e=this.totalPages>1,t=this.pageNumber,n=t===0,r=t>=this.totalPages-1;return T`
+    `}};O([v()],Ht.prototype,`columns`,void 0),O([v()],Ht.prototype,`scope`,void 0),O([S()],Ht.prototype,`panelOpened`,void 0),O([S()],Ht.prototype,`revision`,void 0),Ht=O([h(`mateu-column-chooser`)],Ht);var Ut=class extends y{constructor(...e){super(...e),this.totalElements=0,this.pageSize=100,this.pageNumber=0,this.totalPages=0}updated(e){super.updated(e),(e.has(`totalElements`)||e.has(`pageSize`))&&(this.totalPages=Math.ceil(this.totalElements/this.pageSize))}dispatch(e){this.dispatchEvent(new CustomEvent(`page-changed`,{bubbles:!0,composed:!0,detail:{page:e}}))}render(){if(!this.totalElements)return _;let e=this.totalPages>1,t=this.pageNumber,n=t===0,r=t>=this.totalPages-1;return w`
             <div class="bar">
-                ${e?T`
+                ${e?w`
                     <button class="nav" title="First page" ?disabled="${n}"
                         @click="${()=>this.dispatch(0)}" data-testid="page-first">«</button>
                     <button class="nav" title="Previous page" ?disabled="${n}"
@@ -946,11 +946,11 @@ ${i}
                     <button class="nav" title="Last page" ?disabled="${r}"
                         @click="${()=>this.dispatch(this.totalPages-1)}" data-testid="page-last">»</button>
                     <span class="separator"></span>
-                `:v}
+                `:_}
                 <span class="total-count">${this.totalElements} item${this.totalElements===1?``:`s`}</span>
                 <slot></slot>
             </div>
-        `}static{this.styles=h`
+        `}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -997,301 +997,301 @@ ${i}
             align-self: center;
             margin: 0 4px;
         }
-    `}};k([y()],Ht.prototype,`totalElements`,void 0),k([y()],Ht.prototype,`pageSize`,void 0),k([y()],Ht.prototype,`pageNumber`,void 0),k([C()],Ht.prototype,`totalPages`,void 0),Ht=k([g(`mateu-pagination`)],Ht);var Ut=`var(--lumo-space-m, 1rem)`,Wt=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.columnWidth||`13rem`,l=`display: grid; grid-template-columns: ${s.maxColumns&&s.maxColumns>0?`repeat(${s.maxColumns}, minmax(0, 1fr))`:`repeat(auto-fill, minmax(min(100%, ${c}), 1fr))`}; gap: ${Ut} var(--lumo-space-l, 1.5rem); align-items: start;`;return s.labelsAside&&(l+=` --mateu-label-width: 10rem;`),s.fullWidth&&(l+=` width: 100%;`),l+=t.style??``,T`
-        <div style="${l}" class="${t.cssClasses}" slot="${t.slot||v}">
-            ${t.children?.map(t=>Gt(s,e,t,n,r,i,a,o))}
+    `}};O([v()],Ut.prototype,`totalElements`,void 0),O([v()],Ut.prototype,`pageSize`,void 0),O([v()],Ut.prototype,`pageNumber`,void 0),O([S()],Ut.prototype,`totalPages`,void 0),Ut=O([h(`mateu-pagination`)],Ut);var Wt=`var(--lumo-space-m, 1rem)`,Gt=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.columnWidth||`13rem`,l=`display: grid; grid-template-columns: ${s.maxColumns&&s.maxColumns>0?`repeat(${s.maxColumns}, minmax(0, 1fr))`:`repeat(auto-fill, minmax(min(100%, ${c}), 1fr))`}; gap: ${Wt} var(--lumo-space-l, 1.5rem); align-items: start;`;return s.labelsAside&&(l+=` --mateu-label-width: 10rem;`),s.fullWidth&&(l+=` width: 100%;`),l+=t.style??``,w`
+        <div style="${l}" class="${t.cssClasses}" slot="${t.slot||_}">
+            ${t.children?.map(t=>Kt(s,e,t,n,r,i,a,o))}
         </div>
-    `},Gt=(e,t,n,r,i,a,o,s)=>n.type==A.ClientSide&&n.metadata?.type==j.FormRow?Jt(e,t,n,r,i,a,o,s):T`<div style="grid-column: span ${Kt(n)}; min-width: 0;">${e.labelsAside?qt(t,n,r,i,a,o,s):F(t,n,r,i,a,o,s)}</div>`,Kt=e=>{if(e.type==A.ClientSide){let t=e.metadata;if(t?.type==j.FormField)return t.colspan||1}return 1},qt=(e,t,n,r,i,a,o)=>{if(t.type==A.ClientSide&&t.metadata?.type==j.FormField&&t.metadata.label){let s=t.metadata;return T`
-            <div style="display: flex; gap: ${Ut}; align-items: baseline;">
+    `},Kt=(e,t,n,r,i,a,o,s)=>n.type==k.ClientSide&&n.metadata?.type==A.FormRow?Yt(e,t,n,r,i,a,o,s):w`<div style="grid-column: span ${qt(n)}; min-width: 0;">${e.labelsAside?Jt(t,n,r,i,a,o,s):P(t,n,r,i,a,o,s)}</div>`,qt=e=>{if(e.type==k.ClientSide){let t=e.metadata;if(t?.type==A.FormField)return t.colspan||1}return 1},Jt=(e,t,n,r,i,a,o)=>{if(t.type==k.ClientSide&&t.metadata?.type==A.FormField&&t.metadata.label){let s=t.metadata;return w`
+            <div style="display: flex; gap: ${Wt}; align-items: baseline;">
                 <label style="flex: 0 0 var(--mateu-label-width, 10rem); color: var(--lumo-secondary-text-color, #667);">${s.label?.includes("${")?e._evalTemplate(s.label):s.label}</label>
-                <div style="flex: 1; min-width: 0;">${F(e,t,n,r,i,a,o,!0)}</div>
+                <div style="flex: 1; min-width: 0;">${P(e,t,n,r,i,a,o,!0)}</div>
             </div>
-        `}return F(e,t,n,r,i,a,o)},Jt=(e,t,n,r,i,a,o,s)=>T`
-        <div style="grid-column: 1 / -1; display: flex; gap: ${Ut}; flex-wrap: wrap;">
-            ${n.children?.map(c=>T`<div style="flex: 1 1 ${100/Math.max(1,n.children.length)}%; min-width: min(100%, 13rem);">${Gt(e,t,c,r,i,a,o,s)}</div>`)}
+        `}return P(e,t,n,r,i,a,o)},Yt=(e,t,n,r,i,a,o,s)=>w`
+        <div style="grid-column: 1 / -1; display: flex; gap: ${Wt}; flex-wrap: wrap;">
+            ${n.children?.map(c=>w`<div style="flex: 1 1 ${100/Math.max(1,n.children.length)}%; min-width: min(100%, 13rem);">${Kt(e,t,c,r,i,a,o,s)}</div>`)}
         </div>
-    `,Yt=(e,t,n,r,i,a,o,s)=>{let c=n.metadata,l=`display: flex; flex-direction: ${e};`;c.spacing&&(l+=` gap: ${Ut};`),c.padding&&(l+=` padding: var(--lumo-space-m, 1rem);`),c.wrap&&(l+=` flex-wrap: wrap;`),c.fullWidth&&(l+=` width: 100%;`),c.justification&&(l+=` justify-content: ${c.justification};`);let u=e===`row`?c.verticalAlignment:c.horizontalAlignment;return u&&(l+=` align-items: ${u};`),l+=n.style??``,T`
-        <div style="${l}" class="${n.cssClasses}" slot="${n.slot??v}">
-            ${n.children?.map(e=>F(t,e,r,i,a,o,s))}
+    `,Xt=(e,t,n,r,i,a,o,s)=>{let c=n.metadata,l=`display: flex; flex-direction: ${e};`;c.spacing&&(l+=` gap: ${Wt};`),c.padding&&(l+=` padding: var(--lumo-space-m, 1rem);`),c.wrap&&(l+=` flex-wrap: wrap;`),c.fullWidth&&(l+=` width: 100%;`),c.justification&&(l+=` justify-content: ${c.justification};`);let u=e===`row`?c.verticalAlignment:c.horizontalAlignment;return u&&(l+=` align-items: ${u};`),l+=n.style??``,w`
+        <div style="${l}" class="${n.cssClasses}" slot="${n.slot??_}">
+            ${n.children?.map(e=>P(t,e,r,i,a,o,s))}
         </div>
-    `},Xt=(e,t,n,r,i,a,o)=>Yt(`row`,e,t,n,r,i,a,o),Zt=(e,t,n,r,i,a,o)=>Yt(`column`,e,t,n,r,i,a,o),Qt=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=`display: flex; flex-direction: ${s.orientation===`vertical`?`column`:`row`}; gap: var(--lumo-space-s, 0.5rem);`;return s.fullWidth&&(c+=` width: 100%;`),c+=t.style??``,T`
-        <div style="${c}" class="${t.cssClasses}" slot="${t.slot??v}">
-            <div style="flex: 1; min-width: 0; min-height: 0;">${F(e,t.children[0],n,r,i,a,o)}</div>
-            <div style="flex: 1; min-width: 0; min-height: 0;">${F(e,t.children[1],n,r,i,a,o)}</div>
+    `},Zt=(e,t,n,r,i,a,o)=>Xt(`row`,e,t,n,r,i,a,o),Qt=(e,t,n,r,i,a,o)=>Xt(`column`,e,t,n,r,i,a,o),$t=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=`display: flex; flex-direction: ${s.orientation===`vertical`?`column`:`row`}; gap: var(--lumo-space-s, 0.5rem);`;return s.fullWidth&&(c+=` width: 100%;`),c+=t.style??``,w`
+        <div style="${c}" class="${t.cssClasses}" slot="${t.slot??_}">
+            <div style="flex: 1; min-width: 0; min-height: 0;">${P(e,t.children[0],n,r,i,a,o)}</div>
+            <div style="flex: 1; min-width: 0; min-height: 0;">${P(e,t.children[1],n,r,i,a,o)}</div>
         </div>
-    `},$t=(e,t,n,r,i,a,o)=>{let s=t.children&&t.children.length>1?t.children[1]:null,c=i?.detailComponent??null,l=!!i?.hasDetail||!!s,u=c??s;return T`
-        <div style="display: flex; gap: var(--lumo-space-m, 1rem); ${t.style??``}" class="${t.cssClasses}" slot="${t.slot??v}">
-            <div style="flex: 1; min-width: 0;">${F(e,t.children[0],n,r,i,a,o)}</div>
-            ${l&&u?T`<div style="flex: 1; min-width: 0;">${F(e,u,n,r,i,a,o)}</div>`:T`<div style="flex: 1; display: flex; align-items: center; justify-content: center; color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-s, .875rem);">Select an item to view details</div>`}
+    `},en=(e,t,n,r,i,a,o)=>{let s=t.children&&t.children.length>1?t.children[1]:null,c=i?.detailComponent??null,l=!!i?.hasDetail||!!s,u=c??s;return w`
+        <div style="display: flex; gap: var(--lumo-space-m, 1rem); ${t.style??``}" class="${t.cssClasses}" slot="${t.slot??_}">
+            <div style="flex: 1; min-width: 0;">${P(e,t.children[0],n,r,i,a,o)}</div>
+            ${l&&u?w`<div style="flex: 1; min-width: 0;">${P(e,u,n,r,i,a,o)}</div>`:w`<div style="flex: 1; display: flex; align-items: center; justify-content: center; color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-s, .875rem);">Select an item to view details</div>`}
         </div>
-    `},en=(e,t,n,r,i,a,o)=>{let s=t.style??``;t.metadata.fullWidth&&(s+=` width: 100%;`);let c=Math.max(0,(t.children??[]).findIndex(e=>e.metadata.active));return T`
-        <div style="${s}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${t.children?.map((t,s)=>{let l=t,u=l.metadata.label,d=u?.includes("${")?e._evalTemplate(u):u;return T`
+    `},tn=(e,t,n,r,i,a,o)=>{let s=t.style??``;t.metadata.fullWidth&&(s+=` width: 100%;`);let c=Math.max(0,(t.children??[]).findIndex(e=>e.metadata.active));return w`
+        <div style="${s}" class="${t.cssClasses}" slot="${t.slot??_}">
+            ${t.children?.map((t,s)=>{let l=t,u=l.metadata.label,d=u?.includes("${")?e._evalTemplate(u):u;return w`
                     <details ?open="${s===c}" style="border-bottom: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));">
                         <summary style="cursor: pointer; padding: var(--lumo-space-s, .5rem) 0; font-weight: 600;">${d}</summary>
                         <div style="padding: var(--lumo-space-m, 1rem) 0;">
-                            ${l.children?.map(t=>F(e,t,n,r,i,a,o))}
+                            ${l.children?.map(t=>P(e,t,n,r,i,a,o))}
                         </div>
                     </details>
                 `})}
         </div>
-    `},tn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style??``;return s.fullWidth&&(c+=` width: 100%;`),T`
-        <div style="${c}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${t.children?.map(t=>nn(e,t,n,r,i,a,o,s.variant))}
+    `},nn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style??``;return s.fullWidth&&(c+=` width: 100%;`),w`
+        <div style="${c}" class="${t.cssClasses}" slot="${t.slot??_}">
+            ${t.children?.map(t=>rn(e,t,n,r,i,a,o,s.variant))}
         </div>
-    `},nn=(e,t,n,r,i,a,o,s)=>{let c=t.metadata,l=c.label?.includes("${")?e._evalTemplate(c.label):c.label;return T`
+    `},rn=(e,t,n,r,i,a,o,s)=>{let c=t.metadata,l=c.label?.includes("${")?e._evalTemplate(c.label):c.label;return w`
         <details ?open="${c.active}" style="border-bottom: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1)); ${t.style??``}" class="${t.cssClasses}">
             <summary style="cursor: pointer; padding: var(--lumo-space-s, .5rem) 0; font-weight: 600; ${c.disabled?`pointer-events: none; opacity: .5;`:``}">${l}</summary>
             <div style="padding: var(--lumo-space-s, .5rem) 0;">
-                ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+                ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
             </div>
         </details>
-    `},rn=(e,t,n,r,i,a,o)=>T`
-        <div style="overflow: auto; ${t.style??``}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+    `},an=(e,t,n,r,i,a,o)=>w`
+        <div style="overflow: auto; ${t.style??``}" class="${t.cssClasses}" slot="${t.slot??_}">
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `,an=(e,t,n,r,i,a,o)=>T`
-        <div style="width: 100%; ${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+    `,on=(e,t,n,r,i,a,o)=>w`
+        <div style="width: 100%; ${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `,on=(e,t,n,r,i,a,o)=>T`
-        <div style="max-width: min(100%, 1200px); margin: auto; ${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+    `,sn=(e,t,n,r,i,a,o)=>w`
+        <div style="max-width: min(100%, 1200px); margin: auto; ${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `,sn=(e,t,n,r,i,a,o)=>T`
-        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr)); gap: ${Ut}; ${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+    `,cn=(e,t,n,r,i,a,o)=>w`
+        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr)); gap: ${Wt}; ${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `,cn=(e,t,n,r,i,a,o)=>T`
-        <div style="display: flex; gap: ${Ut}; flex-wrap: wrap; ${t.style}" class="${t.cssClasses}">
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+    `,ln=(e,t,n,r,i,a,o)=>w`
+        <div style="display: flex; gap: ${Wt}; flex-wrap: wrap; ${t.style}" class="${t.cssClasses}">
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `,ln=(e,t,n,r,i,a,o)=>T`
+    `,un=(e,t,n,r,i,a,o)=>w`
         <div style="flex: ${t.metadata.boardCols??1} 1 0; min-width: min(100%, 12rem); ${t.style}" class="${t.cssClasses}">
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `,un=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+    `,dn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <div
                 style="display: flex; flex-direction: column; overflow: auto; ${t.style}"
                 class="${t.cssClasses}"
-                slot="${t.slot??v}"
+                slot="${t.slot??_}"
         >
-            ${s.page.content.map(t=>F(e,t,n,r,i,a,o))}
+            ${s.page.content.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `},dn=e=>{let t=e.metadata;return(t?.content??t?.columns??[]).filter(e=>e&&e.metadata).map(e=>{let t=e.metadata;return{id:e.id??``,label:t?.label??e.id??``,autoWidth:t?.autoWidth,width:t?.width}})},fn=(e,t)=>{let n=e?.[t];return n==null?``:typeof n==`object`?n.text??n.label??n.value??``:String(n)},pn=(e,t,n)=>{let r=dn(e);return T`
-        <div style="overflow:auto; width:100%; ${e.style}" class="${e.cssClasses}" slot="${e.slot??v}">
+    `},fn=e=>{let t=e.metadata;return(t?.content??t?.columns??[]).filter(e=>e&&e.metadata).map(e=>{let t=e.metadata;return{id:e.id??``,label:t?.label??e.id??``,autoWidth:t?.autoWidth,width:t?.width}})},pn=(e,t)=>{let n=e?.[t];return n==null?``:typeof n==`object`?n.text??n.label??n.value??``:String(n)},mn=(e,t,n)=>{let r=fn(e);return w`
+        <div style="overflow:auto; width:100%; ${e.style}" class="${e.cssClasses}" slot="${e.slot??_}">
             <table style="border-collapse:collapse; width:100%; font-size: var(--lumo-font-size-s,.875rem);">
-                <thead><tr>${r.map(e=>T`<th style="${`text-align:left; padding:.45rem .6rem; border-bottom:2px solid var(--lumo-contrast-20pct,rgba(0,0,0,.2)); font-weight:600; white-space:nowrap; color: var(--lumo-secondary-text-color,#556);`}">${e.label}</th>`)}</tr></thead>
+                <thead><tr>${r.map(e=>w`<th style="${`text-align:left; padding:.45rem .6rem; border-bottom:2px solid var(--lumo-contrast-20pct,rgba(0,0,0,.2)); font-weight:600; white-space:nowrap; color: var(--lumo-secondary-text-color,#556);`}">${e.label}</th>`)}</tr></thead>
                 <tbody>
-                    ${(t??[]).length===0?T`<tr><td colspan="${Math.max(1,r.length)}" style="padding:1.5rem; text-align:center; color: var(--lumo-secondary-text-color,#888);">${n??`No data.`}</td></tr>`:t.map(e=>T`<tr>${r.map(t=>T`<td style="${`padding:.4rem .6rem; border-bottom:1px solid var(--lumo-contrast-10pct,rgba(0,0,0,.08)); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:24rem;`}" title="${fn(e,t.id)}">${fn(e,t.id)}</td>`)}</tr>`)}
+                    ${(t??[]).length===0?w`<tr><td colspan="${Math.max(1,r.length)}" style="padding:1.5rem; text-align:center; color: var(--lumo-secondary-text-color,#888);">${n??`No data.`}</td></tr>`:t.map(e=>w`<tr>${r.map(t=>w`<td style="${`padding:.4rem .6rem; border-bottom:1px solid var(--lumo-contrast-10pct,rgba(0,0,0,.08)); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:24rem;`}" title="${pn(e,t.id)}">${pn(e,t.id)}</td>`)}</tr>`)}
                 </tbody>
             </table>
         </div>
-    `},mn=(e,t)=>{let n=e.metadata;return e.id&&t&&t[e.id]?t[e.id]:n?.page?.content??[]},hn=e=>{let t=e.metadata.items??[];return T`
+    `},hn=(e,t)=>{let n=e.metadata;return e.id&&t&&t[e.id]?t[e.id]:n?.page?.content??[]},gn=e=>{let t=e.metadata.items??[];return w`
         <div class="mateu-message-list ${e.cssClasses??``}"
              style="display:flex; flex-direction:column; gap:.75rem; ${e.style??``}"
-             slot="${e.slot??v}">
-            ${t.map(e=>T`
+             slot="${e.slot??_}">
+            ${t.map(e=>w`
                 <div style="display:flex; gap:.6rem; align-items:flex-start;">
                     <span style="flex:0 0 auto; width:2rem; height:2rem; border-radius:50%; overflow:hidden; display:flex; align-items:center; justify-content:center; font-size:.8rem; background:var(--lumo-primary-color,#3b5bdb); color:var(--lumo-primary-contrast-color,#fff);">
-                        ${e.userImg?T`<img src="${e.userImg}" alt="" style="width:100%; height:100%; object-fit:cover;">`:e.userAbbr??(e.userName?e.userName.charAt(0):`?`)}
+                        ${e.userImg?w`<img src="${e.userImg}" alt="" style="width:100%; height:100%; object-fit:cover;">`:e.userAbbr??(e.userName?e.userName.charAt(0):`?`)}
                     </span>
                     <div style="min-width:0;">
                         <div style="display:flex; gap:.5rem; align-items:baseline;">
-                            ${e.userName?T`<span style="font-weight:600;">${e.userName}</span>`:v}
-                            ${e.time?T`<span style="font-size:var(--lumo-font-size-xs,.75rem); color:var(--lumo-secondary-text-color,#666);">${e.time}</span>`:v}
+                            ${e.userName?w`<span style="font-weight:600;">${e.userName}</span>`:_}
+                            ${e.time?w`<span style="font-size:var(--lumo-font-size-xs,.75rem); color:var(--lumo-secondary-text-color,#666);">${e.time}</span>`:_}
                         </div>
                         <div style="white-space:pre-wrap; overflow-wrap:anywhere;">${e.text}</div>
                     </div>
                 </div>
             `)}
         </div>
-    `},gn=(e,t,n,r,i,a,o)=>t.separator?T`<span style="align-self: stretch; width: 1px; background: var(--lumo-contrast-20pct, rgba(0,0,0,.2));"></span>`:t.submenus?T`
+    `},_n=(e,t,n,r,i,a,o)=>t.separator?w`<span style="align-self: stretch; width: 1px; background: var(--lumo-contrast-20pct, rgba(0,0,0,.2));"></span>`:t.submenus?w`
             <details style="position: relative;">
                 <summary style="cursor: pointer; list-style: none; padding: .35rem .7rem; border-radius: var(--lumo-border-radius-m, 6px);">
-                    ${t.component?F(e,t.component,n,r,i,a,o):t.label} ▾
+                    ${t.component?P(e,t.component,n,r,i,a,o):t.label} ▾
                 </summary>
                 <div style="display: flex; flex-direction: column; gap: .1rem; padding: .3rem; min-width: 10rem;
                             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1)); border-radius: var(--lumo-border-radius-m, 6px);
                             background: var(--lumo-base-color, #fff); box-shadow: var(--lumo-box-shadow-s, 0 2px 8px rgba(0,0,0,.15));">
-                    ${t.submenus.map(t=>gn(e,t,n,r,i,a,o))}
+                    ${t.submenus.map(t=>_n(e,t,n,r,i,a,o))}
                 </div>
             </details>
-        `:T`
+        `:w`
         <span class="${t.className??``}"
               style="cursor: ${t.disabled?`default`:`pointer`}; opacity: ${t.disabled?.5:1};
                      padding: .35rem .7rem; border-radius: var(--lumo-border-radius-m, 6px);
                      ${t.selected?`background: var(--lumo-primary-color-10pct, rgba(26,115,232,.12));`:``}">
-            ${t.component?F(e,t.component,n,r,i,a,o):t.label}
+            ${t.component?P(e,t.component,n,r,i,a,o):t.label}
         </span>
-    `,_n=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+    `,vn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <div style="display: flex; flex-wrap: wrap; gap: .25rem; align-items: center; ${t.style}"
-             class="${t.cssClasses}" slot="${t.slot??v}">
-            ${s.options?.map(t=>gn(e,t,n,r,i,a??{},o??{}))}
+             class="${t.cssClasses}" slot="${t.slot??_}">
+            ${s.options?.map(t=>_n(e,t,n,r,i,a??{},o??{}))}
         </div>
-    `},vn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
-        <div style="${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${F(e,s.wrapped,n,r,i,a,o)}
+    `},yn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+        <div style="${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
+            ${P(e,s.wrapped,n,r,i,a,o)}
         </div>
-    `},yn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.content?.metadata,l=c?.type==j.Notice&&c.fullWidth===!0;return T`
+    `},bn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.content?.metadata,l=c?.type==A.Notice&&c.fullWidth===!0;return w`
         <div style="display:flex; flex-direction:column; ${l?`width: 100%; `:``}${t.style}"
              class="${t.cssClasses}"
-             slot="${t.slot??v}"
-             data-colspan="${s.colspan||(l?99:v)}"
+             slot="${t.slot??_}"
+             data-colspan="${s.colspan||(l?99:_)}"
         >
-            ${s.label?T`<label style="font-size: var(--lumo-font-size-s,.875rem); color: var(--lumo-secondary-text-color,#667); margin-bottom:.15rem;">${s.label}</label>`:v}
-            ${F(e,s.content,n,r,i,a,o)}
+            ${s.label?w`<label style="font-size: var(--lumo-font-size-s,.875rem); color: var(--lumo-secondary-text-color,#667); margin-bottom:.15rem;">${s.label}</label>`:_}
+            ${P(e,s.content,n,r,i,a,o)}
         </div>
-            `},bn=e=>{let t=e.metadata,n=e=>{let n=e.closest(`.mateu-message-input`)?.querySelector(`input`),r=n?.value??``;!t.actionId||!r.trim()||(e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:{message:r}},bubbles:!0,composed:!0})),n&&(n.value=``))};return T`
+            `},xn=e=>{let t=e.metadata,n=e=>{let n=e.closest(`.mateu-message-input`)?.querySelector(`input`),r=n?.value??``;!t.actionId||!r.trim()||(e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:{message:r}},bubbles:!0,composed:!0})),n&&(n.value=``))};return w`
         <div class="mateu-message-input ${e.cssClasses??``}"
              style="display:flex; gap:.5rem; align-items:center; ${e.style??``}"
-             slot="${e.slot??v}">
+             slot="${e.slot??_}">
             <input type="text"
                    style="flex:1; min-width:0; font:inherit; padding:.5rem .75rem; border:1px solid var(--lumo-contrast-20pct,rgba(0,0,0,.16)); border-radius:var(--lumo-border-radius-m,6px); background:var(--lumo-base-color,#fff); color:var(--lumo-body-text-color,#161513);"
                    @keydown="${e=>{e.key===`Enter`&&!e.shiftKey&&(e.preventDefault(),n(e.currentTarget))}}">
             <button style="font:inherit; font-weight:500; cursor:pointer; padding:.5rem 1rem; border:none; border-radius:var(--lumo-border-radius-m,6px); background:var(--lumo-primary-color,#3b5bdb); color:var(--lumo-primary-contrast-color,#fff);"
                     @click="${e=>n(e.currentTarget)}">Send</button>
         </div>
-    `},xn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`<span title="${s.text}" style="${t.style}" class="${t.cssClasses}" slot="${t.slot??v}"
-        >${F(e,s.wrapped,n,r,i,a,o)}</span>`},Sn=e=>{if(e instanceof CustomEvent)return e.detail;let t={};for(let n in e){let r=e[n];[`number`,`string`,`boolean`].indexOf(typeof r)>=0&&(t[n]=e[n])}return t},Cn=(e,t,n)=>{for(let n in t.attributes)e.setAttribute(n,t.attributes[n]);n.style&&e.setAttribute(`style`,n.style),n.cssClasses&&e.setAttribute(`class`,n.cssClasses),n.slot&&e.setAttribute(`slot`,n.slot),t.content&&(t.html?e.innerHTML=t.content:e.append(t.content))},wn=e=>{let t=e.name,n=e.attributes?e.attributes.import:void 0;n&&t.includes(`-`)&&!customElements.get(t)&&D(()=>import(n),[])},Tn=(e,t,n)=>{wn(t);let r=t.name;return t.attributes&&t.attributes.id&&(r=`#`+t.attributes.id),setTimeout(()=>{let i=e.shadowRoot?.querySelector(`.element-container`)?.querySelector(r);if(i){for(;i.firstChild;)i.removeChild(i.lastChild);Cn(i,t,n)}else{let r=document.createElement(t.name);Cn(r,t,n);for(let n in t.on)r.addEventListener(n,r=>{let i=Sn(r);e.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.on[n],parameters:{event:i}},bubbles:!0,composed:!0}))});e.shadowRoot?.querySelector(`.element-container`)?.appendChild(r)}}),T`<div class="element-container"></div>`},En=function(e){return e.div=`div`,e.p=`p`,e.h1=`h1`,e.h2=`h2`,e.h3=`h3`,e.h4=`h4`,e.h5=`h5`,e.h6=`h6`,e.span=`span`,e}({}),Dn=(e,t,n,r,i)=>{let a=e.metadata,o=a.attributes?.[`data-colspan`],s=rt(a.text,t,n,r,i),c={xl:`var(--lumo-font-size-xl, 1.375rem)`,l:`var(--lumo-font-size-l, 1.125rem)`,s:`var(--lumo-font-size-s, .875rem)`,xs:`var(--lumo-font-size-xs, .8125rem)`},l=(a.size&&c[a.size]?`font-size: ${c[a.size]}; `:``)+(a.noMargins?`margin-block-start: 0; margin-block-end: 0; `:``);return En.h1==a.container?T`
+    `},Sn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`<span title="${s.text}" style="${t.style}" class="${t.cssClasses}" slot="${t.slot??_}"
+        >${P(e,s.wrapped,n,r,i,a,o)}</span>`},Cn=e=>{if(e instanceof CustomEvent)return e.detail;let t={};for(let n in e){let r=e[n];[`number`,`string`,`boolean`].indexOf(typeof r)>=0&&(t[n]=e[n])}return t},wn=(e,t,n)=>{for(let n in t.attributes)e.setAttribute(n,t.attributes[n]);n.style&&e.setAttribute(`style`,n.style),n.cssClasses&&e.setAttribute(`class`,n.cssClasses),n.slot&&e.setAttribute(`slot`,n.slot),t.content&&(t.html?e.innerHTML=t.content:e.append(t.content))},Tn=e=>{let t=e.name,n=e.attributes?e.attributes.import:void 0;n&&t.includes(`-`)&&!customElements.get(t)&&E(()=>import(n),[])},En=(e,t,n)=>{Tn(t);let r=t.name;return t.attributes&&t.attributes.id&&(r=`#`+t.attributes.id),setTimeout(()=>{let i=e.shadowRoot?.querySelector(`.element-container`)?.querySelector(r);if(i){for(;i.firstChild;)i.removeChild(i.lastChild);wn(i,t,n)}else{let r=document.createElement(t.name);wn(r,t,n);for(let n in t.on)r.addEventListener(n,r=>{let i=Cn(r);e.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.on[n],parameters:{event:i}},bubbles:!0,composed:!0}))});e.shadowRoot?.querySelector(`.element-container`)?.appendChild(r)}}),w`<div class="element-container"></div>`},Dn=function(e){return e.div=`div`,e.p=`p`,e.h1=`h1`,e.h2=`h2`,e.h3=`h3`,e.h4=`h4`,e.h5=`h5`,e.h6=`h6`,e.span=`span`,e}({}),On=(e,t,n,r,i)=>{let a=e.metadata,o=a.attributes?.[`data-colspan`],s=it(a.text,t,n,r,i),c={xl:`var(--lumo-font-size-xl, 1.375rem)`,l:`var(--lumo-font-size-l, 1.125rem)`,s:`var(--lumo-font-size-s, .875rem)`,xs:`var(--lumo-font-size-xs, .8125rem)`},l=(a.size&&c[a.size]?`font-size: ${c[a.size]}; `:``)+(a.noMargins?`margin-block-start: 0; margin-block-end: 0; `:``);return Dn.h1==a.container?w`
             <h1 style="${l}${e.style}" class="${e.cssClasses}"
-                id="${S(e.id)}"
-                data-colspan="${S(o)}"
-                slot="${e.slot??v}">
-                ${s??v}
+                id="${x(e.id)}"
+                data-colspan="${x(o)}"
+                slot="${e.slot??_}">
+                ${s??_}
             </h1>
-        `:En.h2==a.container?T`
+        `:Dn.h2==a.container?w`
             <h2 style="${l}${e.style}" class="${e.cssClasses}"
-                id="${S(e.id)}"
-                data-colspan="${S(o)}"
-                slot="${e.slot??v}">
-                ${s??v}
+                id="${x(e.id)}"
+                data-colspan="${x(o)}"
+                slot="${e.slot??_}">
+                ${s??_}
             </h2>
-        `:En.h3==a.container?T`
+        `:Dn.h3==a.container?w`
             <h3 style="${l}${e.style}" class="${e.cssClasses}"
-                id="${S(e.id)}"
-                data-colspan="${S(o)}"
-                slot="${e.slot??v}">
-                ${s??v}
+                id="${x(e.id)}"
+                data-colspan="${x(o)}"
+                slot="${e.slot??_}">
+                ${s??_}
             </h3>
-        `:En.h4==a.container?T`
+        `:Dn.h4==a.container?w`
             <h4 style="${l}${e.style}" class="${e.cssClasses}"
-                id="${S(e.id)}"
-                data-colspan="${S(o)}"
-                slot="${e.slot??v}">
-                ${s??v}
+                id="${x(e.id)}"
+                data-colspan="${x(o)}"
+                slot="${e.slot??_}">
+                ${s??_}
             </h4>
-        `:En.h5==a.container?T`
+        `:Dn.h5==a.container?w`
             <h5 style="${l}${e.style}" class="${e.cssClasses}"
-                id="${S(e.id)}"
-                data-colspan="${S(o)}"
-                slot="${e.slot??v}">
-                ${s??v}
+                id="${x(e.id)}"
+                data-colspan="${x(o)}"
+                slot="${e.slot??_}">
+                ${s??_}
             </h5>
-        `:En.h6==a.container?T`
+        `:Dn.h6==a.container?w`
             <h6 style="${l}${e.style}" class="${e.cssClasses}"
-                id="${S(e.id)}"
-                data-colspan="${S(o)}"
-                slot="${e.slot??v}">
-                ${s??v}
+                id="${x(e.id)}"
+                data-colspan="${x(o)}"
+                slot="${e.slot??_}">
+                ${s??_}
             </h6>
-        `:En.p==a.container?T`
+        `:Dn.p==a.container?w`
                <p style="${l}${e.style}" class="${e.cssClasses}"
-                  id="${S(e.id)}"
-                  data-colspan="${S(o)}"
-                  slot="${e.slot??v}">
-                   ${s??v}
+                  id="${x(e.id)}"
+                  data-colspan="${x(o)}"
+                  slot="${e.slot??_}">
+                   ${s??_}
                </p>
-            `:En.div==a.container?T`
+            `:Dn.div==a.container?w`
                <div style="${l}${e.style}" class="${e.cssClasses}"
-                    id="${S(e.id)}"
-                    data-colspan="${S(o)}"
-                    slot="${e.slot??v}">${s?_(s):v}</div>
-            `:En.span==a.container?T`
+                    id="${x(e.id)}"
+                    data-colspan="${x(o)}"
+                    slot="${e.slot??_}">${s?g(s):_}</div>
+            `:Dn.span==a.container?w`
                <span style="${l}${e.style}" class="${e.cssClasses}"
-                     id="${S(e.id)}"
-                     data-colspan="${S(o)}"
-                    slot="${e.slot??v}">${s??v}</span>
-            `:T`
+                     id="${x(e.id)}"
+                     data-colspan="${x(o)}"
+                    slot="${e.slot??_}">${s??_}</span>
+            `:w`
                <p
-                       id="${S(e.id)}"
-                       data-colspan="${S(o)}"
-                       slot="${e.slot??v}">
+                       id="${x(e.id)}"
+                       data-colspan="${x(o)}"
+                       slot="${e.slot??_}">
                    Unknown text container: ${a.container} 
                </p>
-            `},On=e=>{let t=e.metadata;return T`<a href="${t.url}" target="${t.target??v}"
-                   rel="${t.target===`_blank`?`noopener`:v}"
+            `},kn=e=>{let t=e.metadata;return w`<a href="${t.url}" target="${t.target??_}"
+                   rel="${t.target===`_blank`?`noopener`:_}"
                    style="${e.style}" class="${e.cssClasses}"
-                   slot="${e.slot??v}">${t.text}</a>`},kn=(e,t)=>{let n=e.toLowerCase().split(`+`);return t.ctrlKey===n.includes(`ctrl`)&&t.altKey===n.includes(`alt`)&&t.shiftKey===n.includes(`shift`)&&t.metaKey===n.includes(`meta`)},An=(e,t)=>{if(!kn(e,t))return!1;let n=e.toLowerCase().split(`+`),r=n[n.length-1];return!!(t.key.toLowerCase()===r||/^[a-z]$/.test(r)&&t.code===`Key`+r.toUpperCase()||/^[0-9]$/.test(r)&&(t.code===`Digit`+r||t.code===`Numpad`+r))},jn=e=>e?e.split(`+`).map(e=>e.length<=1?e.toUpperCase():e.charAt(0).toUpperCase()+e.slice(1)).join(`+`):void 0,Mn=(e,t)=>{let n=e.currentTarget.dataset.actionId;e.currentTarget?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:n,parameters:t.parameters},bubbles:!0,composed:!0}))},Nn=`display:inline-flex; align-items:center; justify-content:center; gap:.4em; box-sizing:border-box; font:inherit; font-weight:500; cursor:pointer; border-radius:var(--lumo-border-radius-m,6px); border:1px solid transparent; line-height:1; white-space:nowrap;`,Pn=e=>{let t=e.buttonStyle??``,n=e.color&&e.color!==`none`&&e.color!==`normal`?e.color:``,r=e.size,i=n===`success`?`var(--lumo-success-color,#1a7f37)`:n===`error`?`var(--lumo-error-color,#c5221f)`:n===`contrast`?`var(--lumo-contrast,#161513)`:`var(--lumo-primary-color,#3b5bdb)`,a=n===`success`?`var(--lumo-success-contrast-color,#fff)`:n===`error`?`var(--lumo-error-contrast-color,#fff)`:n===`contrast`?`var(--lumo-base-color,#fff)`:`var(--lumo-primary-contrast-color,#fff)`,o=n===`success`?`var(--lumo-success-text-color,#1a7f37)`:n===`error`?`var(--lumo-error-text-color,#c5221f)`:n===`contrast`?`var(--lumo-body-text-color,#161513)`:`var(--lumo-primary-text-color,#3b5bdb)`,s;return s=t===`primary`?`background:${i}; color:${a};`:t===`tertiary`||t===`tertiaryInline`?`background:transparent; color:${o};`:`background:var(--lumo-contrast-5pct,rgba(0,0,0,.04)); color:${o}; border-color:var(--lumo-contrast-20pct,rgba(0,0,0,.16));`,`${Nn}${s}${r===`small`?`padding:.25rem .6rem; font-size:var(--lumo-font-size-s,.875rem);`:r===`large`?`padding:.65rem 1.4rem; font-size:var(--lumo-font-size-l,1.125rem);`:`padding:.45rem 1rem; font-size:var(--lumo-font-size-m,1rem);`}`},Fn=(e,t,n)=>{let r=e.metadata,i=M(r.label,t,n);return T`<button
+                   slot="${e.slot??_}">${t.text}</a>`},An=(e,t)=>{let n=e.toLowerCase().split(`+`);return t.ctrlKey===n.includes(`ctrl`)&&t.altKey===n.includes(`alt`)&&t.shiftKey===n.includes(`shift`)&&t.metaKey===n.includes(`meta`)},jn=(e,t)=>{if(!An(e,t))return!1;let n=e.toLowerCase().split(`+`),r=n[n.length-1];return!!(t.key.toLowerCase()===r||/^[a-z]$/.test(r)&&t.code===`Key`+r.toUpperCase()||/^[0-9]$/.test(r)&&(t.code===`Digit`+r||t.code===`Numpad`+r))},Mn=e=>e?e.split(`+`).map(e=>e.length<=1?e.toUpperCase():e.charAt(0).toUpperCase()+e.slice(1)).join(`+`):void 0,Nn=(e,t)=>{let n=e.currentTarget.dataset.actionId;e.currentTarget?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:n,parameters:t.parameters},bubbles:!0,composed:!0}))},Pn=`display:inline-flex; align-items:center; justify-content:center; gap:.4em; box-sizing:border-box; font:inherit; font-weight:500; cursor:pointer; border-radius:var(--lumo-border-radius-m,6px); border:1px solid transparent; line-height:1; white-space:nowrap;`,Fn=e=>{let t=e.buttonStyle??``,n=e.color&&e.color!==`none`&&e.color!==`normal`?e.color:``,r=e.size,i=n===`success`?`var(--lumo-success-color,#1a7f37)`:n===`error`?`var(--lumo-error-color,#c5221f)`:n===`contrast`?`var(--lumo-contrast,#161513)`:`var(--lumo-primary-color,#3b5bdb)`,a=n===`success`?`var(--lumo-success-contrast-color,#fff)`:n===`error`?`var(--lumo-error-contrast-color,#fff)`:n===`contrast`?`var(--lumo-base-color,#fff)`:`var(--lumo-primary-contrast-color,#fff)`,o=n===`success`?`var(--lumo-success-text-color,#1a7f37)`:n===`error`?`var(--lumo-error-text-color,#c5221f)`:n===`contrast`?`var(--lumo-body-text-color,#161513)`:`var(--lumo-primary-text-color,#3b5bdb)`,s;return s=t===`primary`?`background:${i}; color:${a};`:t===`tertiary`||t===`tertiaryInline`?`background:transparent; color:${o};`:`background:var(--lumo-contrast-5pct,rgba(0,0,0,.04)); color:${o}; border-color:var(--lumo-contrast-20pct,rgba(0,0,0,.16));`,`${Pn}${s}${r===`small`?`padding:.25rem .6rem; font-size:var(--lumo-font-size-s,.875rem);`:r===`large`?`padding:.65rem 1.4rem; font-size:var(--lumo-font-size-l,1.125rem);`:`padding:.45rem 1rem; font-size:var(--lumo-font-size-m,1rem);`}`},In=(e,t,n)=>{let r=e.metadata,i=j(r.label,t,n);return w`<button
             id="${e.id}"
             data-action-id="${r.actionId}"
-            @click="${e=>Mn(e,r)}"
-            style="${Pn(r)}${e.style}"
+            @click="${e=>Nn(e,r)}"
+            style="${Fn(r)}${e.style}"
             class="${e.cssClasses}"
             ?disabled="${r.disabled}"
-            title="${r.shortcut?`${i} (${jn(r.shortcut)})`:v}"
-            slot="${e.slot??v}"
-    >${r.iconOnLeft?I(r.iconOnLeft):v}${i}${r.iconOnRight?I(r.iconOnRight):v}</button>`},In=`display:block; box-sizing:border-box; background:var(--lumo-base-color,#fff); border:1px solid var(--lumo-contrast-10pct,rgba(0,0,0,.1)); border-radius:var(--lumo-border-radius-l,12px); box-shadow:var(--lumo-box-shadow-xs,0 1px 3px rgba(0,0,0,.08)); overflow:hidden;`,Ln=(e,t,n,r,i,a,o)=>{let s=t.metadata;if(!s)return T``;let c=t=>t?F(e,t,n,r,i,a,o,!1):v,l=s.header||s.headerPrefix||s.headerSuffix||s.title||s.subtitle;return T`
-        <div style="${In}${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${s.media?c(s.media):v}
-            ${l?T`<div style="display:flex; align-items:flex-start; gap:.75rem; padding:1rem 1.25rem ${s.content||s.footer?`0`:`1rem`};">
-                ${s.headerPrefix?c(s.headerPrefix):v}
+            title="${r.shortcut?`${i} (${Mn(r.shortcut)})`:_}"
+            slot="${e.slot??_}"
+    >${r.iconOnLeft?F(r.iconOnLeft):_}${i}${r.iconOnRight?F(r.iconOnRight):_}</button>`},Ln=`display:block; box-sizing:border-box; background:var(--lumo-base-color,#fff); border:1px solid var(--lumo-contrast-10pct,rgba(0,0,0,.1)); border-radius:var(--lumo-border-radius-l,12px); box-shadow:var(--lumo-box-shadow-xs,0 1px 3px rgba(0,0,0,.08)); overflow:hidden;`,Rn=(e,t,n,r,i,a,o)=>{let s=t.metadata;if(!s)return w``;let c=t=>t?P(e,t,n,r,i,a,o,!1):_,l=s.header||s.headerPrefix||s.headerSuffix||s.title||s.subtitle;return w`
+        <div style="${Ln}${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
+            ${s.media?c(s.media):_}
+            ${l?w`<div style="display:flex; align-items:flex-start; gap:.75rem; padding:1rem 1.25rem ${s.content||s.footer?`0`:`1rem`};">
+                ${s.headerPrefix?c(s.headerPrefix):_}
                 <div style="flex:1; min-width:0;">
-                    ${s.header?c(s.header):v}
-                    ${s.title?T`<div style="font-weight:600; font-size:1.05rem; color:var(--lumo-body-text-color,#161513);">${c(s.title)}</div>`:v}
-                    ${s.subtitle?T`<div style="color:var(--lumo-secondary-text-color,#667);">${c(s.subtitle)}</div>`:v}
+                    ${s.header?c(s.header):_}
+                    ${s.title?w`<div style="font-weight:600; font-size:1.05rem; color:var(--lumo-body-text-color,#161513);">${c(s.title)}</div>`:_}
+                    ${s.subtitle?w`<div style="color:var(--lumo-secondary-text-color,#667);">${c(s.subtitle)}</div>`:_}
                 </div>
-                ${s.headerSuffix?c(s.headerSuffix):v}
-            </div>`:v}
-            ${s.content?T`<div style="padding:1rem 1.25rem;">${c(s.content)}</div>`:v}
-            ${s.footer?T`<div style="padding:0 1.25rem 1rem;">${c(s.footer)}</div>`:v}
+                ${s.headerSuffix?c(s.headerSuffix):_}
+            </div>`:_}
+            ${s.content?w`<div style="padding:1rem 1.25rem;">${c(s.content)}</div>`:_}
+            ${s.footer?w`<div style="padding:0 1.25rem 1rem;">${c(s.footer)}</div>`:_}
         </div>
-    `},Rn=e=>{let t=e.metadata;return T`
+    `},zn=e=>{let t=e.metadata;return w`
         <mateu-chart 
                 style="${e.style}" 
                 class="${e.cssClasses}"
-                slot="${e.slot??v}" 
+                slot="${e.slot??_}" 
                 type="${t.chartType}" 
                 .data="${t.chartData}" 
                 .options="${t.chartOptions}"
         >
         </mateu-chart>
-    `},zn=e=>{let t=e.metadata;return I(t.icon,e.style,e.cssClasses,e.slot)},Bn=(e,t)=>{e&&e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},Vn=`font:inherit; font-weight:500; cursor:pointer; padding:.45rem 1rem; border-radius:var(--lumo-border-radius-m,6px);`,Hn=`${Vn} background:var(--lumo-contrast-5pct,rgba(0,0,0,.04)); color:var(--lumo-body-text-color,#161513); border:1px solid var(--lumo-contrast-20pct,rgba(0,0,0,.16));`,Un=`${Vn} background:var(--lumo-primary-color,#3b5bdb); color:var(--lumo-primary-contrast-color,#fff); border:1px solid transparent;`,Wn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!1;if(s.openedCondition)try{c=it(s.openedCondition,r,i,a,o)}catch(e){console.error(`when evaluating `+s.openedCondition+` :`+e+`, where data is `+i+` and state is `+r)}return c?T`
+    `},Bn=e=>{let t=e.metadata;return F(t.icon,e.style,e.cssClasses,e.slot)},Vn=(e,t)=>{e&&e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},Hn=`font:inherit; font-weight:500; cursor:pointer; padding:.45rem 1rem; border-radius:var(--lumo-border-radius-m,6px);`,Un=`${Hn} background:var(--lumo-contrast-5pct,rgba(0,0,0,.04)); color:var(--lumo-body-text-color,#161513); border:1px solid var(--lumo-contrast-20pct,rgba(0,0,0,.16));`,Wn=`${Hn} background:var(--lumo-primary-color,#3b5bdb); color:var(--lumo-primary-contrast-color,#fff); border:1px solid transparent;`,Gn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!1;if(s.openedCondition)try{c=at(s.openedCondition,r,i,a,o)}catch(e){console.error(`when evaluating `+s.openedCondition+` :`+e+`, where data is `+i+` and state is `+r)}return c?w`
         <div class="mateu-confirm-dialog ${t.cssClasses??``}"
              style="position:fixed; inset:0; z-index:1000; display:flex; align-items:center; justify-content:center; background:rgba(0,0,0,.4); ${t.style??``}"
-             slot="${t.slot??v}">
+             slot="${t.slot??_}">
             <div style="background:var(--lumo-base-color,#fff); color:var(--lumo-body-text-color,#161513); border-radius:var(--lumo-border-radius-l,12px); box-shadow:var(--lumo-box-shadow-l,0 8px 24px rgba(0,0,0,.2)); width:100%; max-width:min(90vw,32rem); padding:1.5rem; box-sizing:border-box;">
-                ${s.header?T`<h3 style="margin:0 0 .75rem; font-size:1.15rem;">${s.header}</h3>`:v}
-                <div>${t.children?.map(t=>F(e,t,n,r,i,a,o))}</div>
+                ${s.header?w`<h3 style="margin:0 0 .75rem; font-size:1.15rem;">${s.header}</h3>`:_}
+                <div>${t.children?.map(t=>P(e,t,n,r,i,a,o))}</div>
                 <div style="display:flex; gap:.5rem; justify-content:flex-end; margin-top:1.25rem;">
-                    ${s.canCancel?T`<button style="${Hn}" @click="${e=>Bn(e.currentTarget,s.cancelActionId)}">${s.rejectText&&!s.canReject?s.rejectText:`Cancel`}</button>`:v}
-                    ${s.canReject?T`<button style="${Hn}" @click="${e=>Bn(e.currentTarget,s.rejectActionId)}">${s.rejectText||`No`}</button>`:v}
-                    <button style="${Un}" @click="${e=>Bn(e.currentTarget,s.confirmActionId)}">${s.confirmText||`OK`}</button>
+                    ${s.canCancel?w`<button style="${Un}" @click="${e=>Vn(e.currentTarget,s.cancelActionId)}">${s.rejectText&&!s.canReject?s.rejectText:`Cancel`}</button>`:_}
+                    ${s.canReject?w`<button style="${Un}" @click="${e=>Vn(e.currentTarget,s.rejectActionId)}">${s.rejectText||`No`}</button>`:_}
+                    <button style="${Wn}" @click="${e=>Vn(e.currentTarget,s.confirmActionId)}">${s.confirmText||`OK`}</button>
                 </div>
             </div>
         </div>
-    `:T``},Gn=e=>{let t=e.metadata,n;return t.position&&(n={Top:`top`,Bottom:`bottom`,TopLeft:`top-left`,TopRight:`top-right`,BottomLeft:`bottom-left`,BottomRight:`bottom-right`}[t.position]),T`
+    `:w``},Kn=e=>{let t=e.metadata,n;return t.position&&(n={Top:`top`,Bottom:`bottom`,TopLeft:`top-left`,TopRight:`top-right`,BottomLeft:`bottom-left`,BottomRight:`bottom-right`}[t.position]),w`
         <mateu-cookie-consent style="${e.style}" class="${e.cssClasses}"
-                               slot="${e.slot??v}"
-                               position="${n??v}"
-                               cookie-name="${t.cookieName??v}"
-                               .message="${t.message??v}"
-                               theme="${t.theme??v}"
-                               .learnMore="${t.learnMore??v}"
-                               .learnMoreLink="${t.learnMoreLink??v}"
-                               .dismiss="${t.dismiss??v}"
+                               slot="${e.slot??_}"
+                               position="${n??_}"
+                               cookie-name="${t.cookieName??_}"
+                               .message="${t.message??_}"
+                               theme="${t.theme??_}"
+                               .learnMore="${t.learnMore??_}"
+                               .learnMoreLink="${t.learnMoreLink??_}"
+                               .dismiss="${t.dismiss??_}"
         ></mateu-cookie-consent>
-    `},Kn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+    `},qn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <details
                 ?open="${s.opened}"
                 style="${t.style}"
                 class="${t.cssClasses}"
-                slot="${t.slot??v}"
+                slot="${t.slot??_}"
         >
-            <summary>${F(e,s.summary,n,r,i,a,o)}</summary>
-            ${F(e,s.content,n,r,i,a,o)}
+            <summary>${P(e,s.summary,n,r,i,a,o)}</summary>
+            ${P(e,s.content,n,r,i,a,o)}
         </details>
-            `},qn=(e,t,n,r,i,a)=>T`
+            `},Jn=(e,t,n,r,i,a)=>w`
         <mateu-dialog
                 id="${e.metadata.id}"
             .component="${e}"
@@ -1301,7 +1301,7 @@ ${i}
             .appState="${i}"
             .appdata="${a}"
         ></mateu-dialog>
-            `,Jn=(e,t,n,r,i,a)=>T`
+            `,Yn=(e,t,n,r,i,a)=>w`
         <mateu-drawer
                 id="${e.metadata.id}"
             .component="${e}"
@@ -1311,69 +1311,69 @@ ${i}
             .appState="${i}"
             .appdata="${a}"
         ></mateu-drawer>
-            `,Yn=e=>{let t=e.metadata;return T`
+            `,Xn=e=>{let t=e.metadata;return w`
         <mateu-api-caller>
         <mateu-ux baseUrl="${t.baseUrl}"  
                   route="${t.route}" 
                   consumedRoute="${t.consumedRoute}" 
-                  id="${E()}"
+                  id="${T()}"
                   serverSideType="${t.serverSideType}"
                   .appState="${t.appState}"
                   style="${e.style}" class="${e.cssClasses}"
-                  slot="${e.slot??v}"
+                  slot="${e.slot??_}"
         ></mateu-ux>
         </mateu-api-caller>
-            `},Xn=e=>T`
+            `},Zn=e=>w`
         <mateu-markdown .content=${e.metadata.markdown}
                         style="${e.style}" class="${e.cssClasses}"
-                        slot="${e.slot??v}"></mateu-markdown>
-            `,Zn=e=>{let t=e.metadata;return T`
+                        slot="${e.slot??_}"></mateu-markdown>
+            `,Qn=e=>{let t=e.metadata;return w`
         <div
             role="status"
-            slot="${e.slot??v}"
+            slot="${e.slot??_}"
             class="${e.cssClasses}"
             style="display: flex; align-items: center; gap: 0.6rem; padding: 0.6rem 0.9rem;
                    border-radius: var(--lumo-border-radius-m, 8px);
                    background: var(--lumo-contrast-5pct, rgba(0,0,0,0.05));
                    color: var(--lumo-body-text-color, #1a1a1a); ${e.style}"
         >
-            ${t.title?T`<strong>${t.title}</strong>`:v}
-            ${t.text?T`<span>${t.text}</span>`:v}
+            ${t.title?w`<strong>${t.title}</strong>`:_}
+            ${t.text?w`<span>${t.text}</span>`:_}
         </div>
-    `},Qn=(e,t={})=>{let n=e.metadata,r=n.valueKey?t[n.valueKey]:n.value,i=n.max&&n.max!=0?n.max:1,a=!n.indeterminate&&r!=null;return T`
-        <div style="${e.style}" class="${e.cssClasses}" slot="${e.slot??v}">
+    `},$n=(e,t={})=>{let n=e.metadata,r=n.valueKey?t[n.valueKey]:n.value,i=n.max&&n.max!=0?n.max:1,a=!n.indeterminate&&r!=null;return w`
+        <div style="${e.style}" class="${e.cssClasses}" slot="${e.slot??_}">
             <progress
                     style="width:100%;"
                     max="${i}"
-                    .value="${a?r:v}"
+                    .value="${a?r:_}"
             ></progress>
-            ${n.text?T`<span class="text-secondary text-xs" id="sublbl">
+            ${n.text?w`<span class="text-secondary text-xs" id="sublbl">
     ${n.text}
-  </span>`:v}
+  </span>`:_}
         </div>
-    `},$n=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
-        <details style="position: relative; ${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
-            <summary style="list-style: none; cursor: pointer;">${F(e,s.wrapped,n,r,i,a,o)}</summary>
+    `},er=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+        <details style="position: relative; ${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
+            <summary style="list-style: none; cursor: pointer;">${P(e,s.wrapped,n,r,i,a,o)}</summary>
             <div style="position: absolute; z-index: 100; min-width: 300px; margin-top: .25rem; padding: .6rem .8rem;
                         border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1)); border-radius: var(--lumo-border-radius-m, 8px);
                         background: var(--lumo-base-color, #fff); box-shadow: var(--lumo-box-shadow-m, 0 4px 16px rgba(0,0,0,.2));">
-                ${F(e,s.content,n,r,i,a,o)}
+                ${P(e,s.content,n,r,i,a,o)}
             </div>
         </details>
-    `},er=e=>{let t=e.metadata;return T`
+    `},tr=e=>{let t=e.metadata;return w`
         <mateu-map position="${t.position}" zoom="${t.zoom}"
                    style="${e.style}" class="${e.cssClasses}"
-                   slot="${e.slot??v}"></mateu-map>
-            `},tr=e=>T`
+                   slot="${e.slot??_}"></mateu-map>
+            `},nr=e=>w`
         <img src="${e.metadata.src}" style="${e.style}" class="${e.cssClasses}"
-             slot="${e.slot??v}">
-            `,nr=e=>{let t=e.metadata;return T`<div style="display:flex; align-items:center; gap:0.5rem;" slot="${e.slot??v}">
-        ${t.breadcrumbs.map(e=>T`
+             slot="${e.slot??_}">
+            `,rr=e=>{let t=e.metadata;return w`<div style="display:flex; align-items:center; gap:0.5rem;" slot="${e.slot??_}">
+        ${t.breadcrumbs.map(e=>w`
             <a href="${e.link}">${e.text}</a>
             <span>/</span>
         `)}
         <span style="${e.style}" class="${e.cssClasses}">${t.currentItemText}</span>
-    </div>`},rr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+    </div>`},ir=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <skeleton-carousel 
                 id="${t.id}"
                 ?dots = "${s.dots}" 
@@ -1382,77 +1382,77 @@ ${i}
                 style="${t.style}"
                 css="${t.cssClasses}"
         >
-            ${t.children?.map(t=>T`<div>${F(e,t,n,r,i,a,o)}</div>`)}
+            ${t.children?.map(t=>w`<div>${P(e,t,n,r,i,a,o)}</div>`)}
         </skeleton-carousel>
-    `},ir=(e,t,n,r)=>{let i=e.metadata;return T`
-        <div style="display: flex; gap: 3rem; ${e.style}" class="${e.cssClasses}" slot="${e.slot??v}">
-            ${i.menu.map(e=>ar(e))}
+    `},ar=(e,t,n,r)=>{let i=e.metadata;return w`
+        <div style="display: flex; gap: 3rem; ${e.style}" class="${e.cssClasses}" slot="${e.slot??_}">
+            ${i.menu.map(e=>or(e))}
         </div>
-            `},ar=e=>T`
-        ${e.submenus?T`
+            `},or=e=>w`
+        ${e.submenus?w`
                 <details open>
                     <summary>${e.label}</summary>
                     <div style="display:flex; flex-direction:column; gap:0.25rem; padding-left:0.5rem;">
-                        ${e.submenus.map(e=>ar(e))}
+                        ${e.submenus.map(e=>or(e))}
                     </div>
                 </details>
-            `:T`
+            `:w`
                 <a href="${e.path}">${e.label}</a>
         `}
-        `,or=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`<div
-                slot="${t.slot??v}"
+        `,sr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`<div
+                slot="${t.slot??_}"
                 style="${t.style}" class="${t.cssClasses}"
-        >${s.content?_(s.content):v}${t.children?.map(t=>F(e,t,n,r,i,a,o))}</div>
-    `},sr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.title?.includes("${")?e._evalTemplate(s.title):s.title;return T`<div
-                slot="${t.slot??v}"
+        >${s.content?g(s.content):_}${t.children?.map(t=>P(e,t,n,r,i,a,o))}</div>
+    `},cr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.title?.includes("${")?e._evalTemplate(s.title):s.title;return w`<div
+                slot="${t.slot??_}"
                 style="width: 100%; margin-bottom: var(--lumo-space-m); ${t.style}"
                 class="${t.cssClasses}"
         >
-        ${c?T`<div style="font-size: var(--lumo-font-size-l); font-weight: 600; color: var(--lumo-header-text-color); margin-bottom: var(--lumo-space-s);">${c}</div>`:v}
-        ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+        ${c?w`<div style="font-size: var(--lumo-font-size-l); font-weight: 600; color: var(--lumo-header-text-color); margin-bottom: var(--lumo-space-s);">${c}</div>`:_}
+        ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
     </div>
-    `},cr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.title?.includes("${")?e._evalTemplate(s.title):s.title;return T`
+    `},lr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.title?.includes("${")?e._evalTemplate(s.title):s.title;return w`
         <div
-                slot="${t.slot??v}"
+                slot="${t.slot??_}"
                 style="${t.style}" class="${t.cssClasses}"
         >
         <h4>${c}</h4>
-        ${t.children?.map(t=>F(e,t,n,r,i,a,o))}</div>
-    `},lr=(e,t,n)=>{n.dispatchEvent(new CustomEvent(`value-changed`,{detail:{fieldId:e,value:t},bubbles:!0,composed:!0}))},ur=e=>t=>{let n=t.target,r=n.type===`checkbox`?n.checked:n.value;lr(e.fieldId,r,n)},dr=(e,t)=>{let n=e.metadata,r=t?.[n.fieldId]??``,i=n,a=i.dataType,o=i.stereotype,s=!!i.readOnly,c=!!i.disabled,l=i.options,u=n.label?T`<label style="display:block; font-size: var(--lumo-font-size-s,.875rem); color: var(--lumo-secondary-text-color,#667); margin-bottom:.15rem;">${n.label}</label>`:v,d=`width:100%; box-sizing:border-box; padding:.4rem .6rem; border:1px solid var(--lumo-contrast-30pct,rgba(0,0,0,.3)); border-radius: var(--lumo-border-radius-m,6px); font:inherit; background: var(--lumo-base-color,#fff); color: var(--lumo-body-text-color,#1a1a1a);`,f;return f=s||o===`plainText`?T`<div style="padding:.4rem 0;">${String(r??``)}</div>`:a===`boolean`||o===`checkbox`||o===`badge`?T`<input type="checkbox" ?checked="${!!r}" ?disabled="${c}" @change="${ur(n)}">`:l&&l.length?T`
-            <select style="${d}" ?disabled="${c}" @change="${ur(n)}">
+        ${t.children?.map(t=>P(e,t,n,r,i,a,o))}</div>
+    `},ur=(e,t,n)=>{n.dispatchEvent(new CustomEvent(`value-changed`,{detail:{fieldId:e,value:t},bubbles:!0,composed:!0}))},dr=e=>t=>{let n=t.target,r=n.type===`checkbox`?n.checked:n.value;ur(e.fieldId,r,n)},fr=(e,t)=>{let n=e.metadata,r=t?.[n.fieldId]??``,i=n,a=i.dataType,o=i.stereotype,s=!!i.readOnly,c=!!i.disabled,l=i.options,u=n.label?w`<label style="display:block; font-size: var(--lumo-font-size-s,.875rem); color: var(--lumo-secondary-text-color,#667); margin-bottom:.15rem;">${n.label}</label>`:_,d=`width:100%; box-sizing:border-box; padding:.4rem .6rem; border:1px solid var(--lumo-contrast-30pct,rgba(0,0,0,.3)); border-radius: var(--lumo-border-radius-m,6px); font:inherit; background: var(--lumo-base-color,#fff); color: var(--lumo-body-text-color,#1a1a1a);`,f;return f=s||o===`plainText`?w`<div style="padding:.4rem 0;">${String(r??``)}</div>`:a===`boolean`||o===`checkbox`||o===`badge`?w`<input type="checkbox" ?checked="${!!r}" ?disabled="${c}" @change="${dr(n)}">`:l&&l.length?w`
+            <select style="${d}" ?disabled="${c}" @change="${dr(n)}">
                 <option value="">—</option>
-                ${l.map(e=>T`<option value="${e.value}" ?selected="${e.value===r}">${e.label}</option>`)}
-            </select>`:o===`textarea`||o===`richText`||o===`html`?T`<textarea style="${d}" rows="3" ?disabled="${c}" @input="${ur(n)}">${String(r??``)}</textarea>`:T`<input type="${a===`integer`||a===`number`||a===`double`||a===`money`?`number`:a===`date`?`date`:a===`datetime`?`datetime-local`:a===`time`?`time`:o===`password`?`password`:a===`email`?`email`:`text`}" style="${d}" .value="${String(r??``)}"
-                              placeholder="${i.placeholder??v}" ?disabled="${c}" @input="${ur(n)}">`,T`
-        <div style="${e.style}" class="${e.cssClasses}" slot="${e.slot??v}">
+                ${l.map(e=>w`<option value="${e.value}" ?selected="${e.value===r}">${e.label}</option>`)}
+            </select>`:o===`textarea`||o===`richText`||o===`html`?w`<textarea style="${d}" rows="3" ?disabled="${c}" @input="${dr(n)}">${String(r??``)}</textarea>`:w`<input type="${a===`integer`||a===`number`||a===`double`||a===`money`?`number`:a===`date`?`date`:a===`datetime`?`datetime-local`:a===`time`?`time`:o===`password`?`password`:a===`email`?`email`:`text`}" style="${d}" .value="${String(r??``)}"
+                              placeholder="${i.placeholder??_}" ?disabled="${c}" @input="${dr(n)}">`,w`
+        <div style="${e.style}" class="${e.cssClasses}" slot="${e.slot??_}">
             ${u}
             ${f}
         </div>
-    `},fr=e=>{let t=e.metadata;if((t?.level??0)>0)return e;let n=e=>{if(e?.metadata?.type===j.EntityHeader)return e;let t=e?.metadata?.content,r=[...e?.children??[],...Array.isArray(t)?t:t?[t]:[]];for(let e of r){let t=n(e);if(t)return t}},r;for(let t of e.children??[])if(r=n(t),r)break;if(!r)return e;let i=r.metadata;r.__hoistedToPageHeader=!0;let a=[...(i.facts??[]).filter(e=>e.label||e.value).map(e=>({title:e.label??``,text:e.value??``})),...i.metricLabel?[{title:i.metricLabel,text:i.metricValue??``}]:[]],o=(i.badges??[]).filter(e=>e.label).map(e=>({text:e.label,color:e.color})),s={...t,title:i.title||t.title,subtitle:i.subtitle??t.subtitle,kpis:[...t.kpis??[],...a],kpisBelow:!0,badges:[...t.badges??[],...o]};return{...e,metadata:s}},pr=(e,t,n,r,i,a,o,s)=>{let c=fr(t),l=c.metadata,u=l?.fabs??[];return T`<mateu-page
+    `},pr=e=>{let t=e.metadata;if((t?.level??0)>0)return e;let n=e=>{if(e?.metadata?.type===A.EntityHeader)return e;let t=e?.metadata?.content,r=[...e?.children??[],...Array.isArray(t)?t:t?[t]:[]];for(let e of r){let t=n(e);if(t)return t}},r;for(let t of e.children??[])if(r=n(t),r)break;if(!r)return e;let i=r.metadata;r.__hoistedToPageHeader=!0;let a=[...(i.facts??[]).filter(e=>e.label||e.value).map(e=>({title:e.label??``,text:e.value??``})),...i.metricLabel?[{title:i.metricLabel,text:i.metricValue??``}]:[]],o=(i.badges??[]).filter(e=>e.label).map(e=>({text:e.label,color:e.color})),s={...t,title:i.title||t.title,subtitle:i.subtitle??t.subtitle,kpis:[...t.kpis??[],...a],kpisBelow:!0,badges:[...t.badges??[],...o]};return{...e,metadata:s}},mr=(e,t,n,r,i,a,o,s)=>{let c=pr(t),l=c.metadata,u=l?.fabs??[];return w`<mateu-page
             .component="${c}"
             baseUrl="${n}"
             .state="${r}"
             .data="${i}"
             .appState="${a}"
             .appdata="${o}"
-            slot="${c.slot??v}"
+            slot="${c.slot??_}"
             style="${c.style}"
             class="${c.cssClasses}"
             ?standalone="${s??!1}"
     >
-        ${c.children?.map(t=>F(e,t,n,r,i,a,o))}
-        ${l?.buttons?.map(t=>T`
-                   ${F(e,{id:t.actionId,metadata:t,type:A.ClientSide,slot:`buttons`},void 0,r,i,a,o)}
+        ${c.children?.map(t=>P(e,t,n,r,i,a,o))}
+        ${l?.buttons?.map(t=>w`
+                   ${P(e,{id:t.actionId,metadata:t,type:k.ClientSide,slot:`buttons`},void 0,r,i,a,o)}
 `)}
-        ${u.map((t,n)=>T`
+        ${u.map((t,n)=>w`
             <button class="page-fab" style="position: fixed; bottom: ${1.5+n*4}rem; right: 5.5rem;"
                 @click="${()=>e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))}"
                 title="${t.label}">
-                ${I(t.icon)}
+                ${F(t.icon)}
             </button>
         `)}
 </mateu-page>
-    `},mr=(e,t,n,r,i,a,o,s)=>T`<mateu-table-crud
+    `},hr=(e,t,n,r,i,a,o,s)=>w`<mateu-table-crud
             id="${t.id}"
             baseUrl="${n}"
             .component="${t}"
@@ -1463,96 +1463,96 @@ ${i}
             .appdata="${o}"
             style="${t.style}"
             class="${t.cssClasses}"
-            slot="${t.slot??v}"
+            slot="${t.slot??_}"
             ?standalone="${s??!1}"
     >
-        ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
-    </mateu-table-crud>`,hr=e=>{let t=e.metadata;return T`
+        ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
+    </mateu-table-crud>`,gr=e=>{let t=e.metadata;return w`
         <mateu-bpmn
                 style="${e.style}"
                 class="${e.cssClasses}"
-                slot="${e.slot??v}"
+                slot="${e.slot??_}"
                 xml="${t.xml}"
         >
         </mateu-bpmn>
-    `},gr=(e,t,n)=>T`<mateu-chat sseUrl="${e.metadata.sseUrl}"
+    `},_r=(e,t,n)=>w`<mateu-chat sseUrl="${e.metadata.sseUrl}"
                             style="${e.style}" 
                             class="${e.cssClasses}" 
-                            slot="${e.slot??v}"></mateu-chat>`,_r=e=>{let t=e.metadata;return T`
+                            slot="${e.slot??_}"></mateu-chat>`,vr=e=>{let t=e.metadata;return w`
         <mateu-workflow
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
                 value="${t.value??`{"name":"New Workflow","steps":[]}`}"
         ></mateu-workflow>
-    `},vr=e=>{let t=e.metadata;return T`
+    `},yr=e=>{let t=e.metadata;return w`
         <mateu-form-editor
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
                 value="${t.value??`{"name":"New Form","fields":[]}`}"
         ></mateu-form-editor>
-    `},yr=`
+    `},br=`
     background: var(--lumo-base-color, #fff);
     border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.08));
     border-radius: var(--lumo-border-radius-l, 12px);
     padding: var(--lumo-space-m, 1rem);
     box-sizing: border-box;
-`,br=e=>e==`up`?`var(--lumo-success-text-color, #1a7f37)`:e==`down`?`var(--lumo-error-text-color, #c5221f)`:`var(--lumo-secondary-text-color, #666)`,xr=e=>e==`up`?`▲`:e==`down`?`▼`:``,Sr=(e,t)=>{t.actionId&&e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))},Cr=e=>{let t=e.metadata,n=!!t.actionId;return T`
+`,xr=e=>e==`up`?`var(--lumo-success-text-color, #1a7f37)`:e==`down`?`var(--lumo-error-text-color, #c5221f)`:`var(--lumo-secondary-text-color, #666)`,Sr=e=>e==`up`?`▲`:e==`down`?`▼`:``,Cr=(e,t)=>{t.actionId&&e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))},wr=e=>{let t=e.metadata,n=!!t.actionId;return w`
         <div class="mateu-metric-card ${e.cssClasses??``}"
-             style="${yr} display: flex; flex-direction: column; gap: .25rem; min-width: 11rem; flex: 1; ${n?`cursor: pointer;`:``} ${e.style??``}"
-             slot="${e.slot??v}"
-             role="${n?`button`:v}"
-             @click="${e=>Sr(e,t)}"
+             style="${br} display: flex; flex-direction: column; gap: .25rem; min-width: 11rem; flex: 1; ${n?`cursor: pointer;`:``} ${e.style??``}"
+             slot="${e.slot??_}"
+             role="${n?`button`:_}"
+             @click="${e=>Cr(e,t)}"
         >
             <div style="display: flex; align-items: center; justify-content: space-between; gap: .5rem;">
                 <span style="font-size: var(--lumo-font-size-s, .875rem); color: var(--lumo-secondary-text-color, #666);">${t.title}</span>
-                ${t.icon?I(t.icon,`color: var(--lumo-tertiary-text-color, #999); width: 1.1em; height: 1.1em;`):v}
+                ${t.icon?F(t.icon,`color: var(--lumo-tertiary-text-color, #999); width: 1.1em; height: 1.1em;`):_}
             </div>
             <div style="display: flex; align-items: baseline; gap: .35rem;">
                 <span style="font-size: var(--lumo-font-size-xxxl, 2rem); font-weight: 600; line-height: 1.1;">${t.value}</span>
-                ${t.unit?T`<span style="font-size: var(--lumo-font-size-m, 1rem); color: var(--lumo-secondary-text-color, #666);">${t.unit}</span>`:v}
+                ${t.unit?w`<span style="font-size: var(--lumo-font-size-m, 1rem); color: var(--lumo-secondary-text-color, #666);">${t.unit}</span>`:_}
             </div>
-            ${t.trend||t.trendLabel?T`
-                <span style="font-size: var(--lumo-font-size-s, .875rem); color: ${br(t.trend)};">
-                    ${xr(t.trend)} ${t.trendLabel??v}
+            ${t.trend||t.trendLabel?w`
+                <span style="font-size: var(--lumo-font-size-s, .875rem); color: ${xr(t.trend)};">
+                    ${Sr(t.trend)} ${t.trendLabel??_}
                 </span>
-            `:v}
-            ${t.description?T`<span style="font-size: var(--lumo-font-size-xs, .8rem); color: var(--lumo-tertiary-text-color, #999);">${t.description}</span>`:v}
+            `:_}
+            ${t.description?w`<span style="font-size: var(--lumo-font-size-xs, .8rem); color: var(--lumo-tertiary-text-color, #999);">${t.description}</span>`:_}
         </div>
-    `},wr=(e,t,n,r,i,a,o)=>T`
+    `},Tr=(e,t,n,r,i,a,o)=>w`
         <div class="mateu-scoreboard ${t.cssClasses??``}"
              style="display: flex; flex-wrap: wrap; gap: var(--lumo-space-m, 1rem); grid-column: 1 / -1; ${t.style??``}"
-             slot="${t.slot??v}"
+             slot="${t.slot??_}"
         >
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `,Tr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.colSpan&&s.colSpan>1?`grid-column: span ${s.colSpan};`:``,l=s.rowSpan&&s.rowSpan>1?`grid-row: span ${s.rowSpan};`:``,u=t.children??[];return u.length===1&&u[0].metadata?.type===`MetricCard`?T`
-            <div style="min-width: 0; ${c} ${l} ${t.style??``}" slot="${t.slot??v}">
-                ${F(e,u[0],n,r,i,a,o)}
-            </div>`:T`
+    `,Er=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.colSpan&&s.colSpan>1?`grid-column: span ${s.colSpan};`:``,l=s.rowSpan&&s.rowSpan>1?`grid-row: span ${s.rowSpan};`:``,u=t.children??[];return u.length===1&&u[0].metadata?.type===`MetricCard`?w`
+            <div style="min-width: 0; ${c} ${l} ${t.style??``}" slot="${t.slot??_}">
+                ${P(e,u[0],n,r,i,a,o)}
+            </div>`:w`
         <div class="mateu-dashboard-panel ${t.cssClasses??``}"
-             style="${yr} display: flex; flex-direction: column; gap: .5rem; min-width: 0; ${c} ${l} ${t.style??``}"
-             slot="${t.slot??v}"
+             style="${br} display: flex; flex-direction: column; gap: .5rem; min-width: 0; ${c} ${l} ${t.style??``}"
+             slot="${t.slot??_}"
         >
-            ${s.title?T`
+            ${s.title?w`
                 <div>
                     <h3 style="margin: 0; font-size: var(--lumo-font-size-l, 1.125rem);">${s.title}</h3>
-                    ${s.subtitle?T`<span style="font-size: var(--lumo-font-size-s, .875rem); color: var(--lumo-secondary-text-color, #666);">${s.subtitle}</span>`:v}
+                    ${s.subtitle?w`<span style="font-size: var(--lumo-font-size-s, .875rem); color: var(--lumo-secondary-text-color, #666);">${s.subtitle}</span>`:_}
                 </div>
-            `:v}
+            `:_}
             <div style="flex: 1; min-height: 0;">
-                ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+                ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
             </div>
         </div>
-    `},Er=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.columns&&s.columns>0?`repeat(${s.columns}, minmax(0, 1fr))`:`repeat(auto-fit, minmax(20rem, 1fr))`;return T`
+    `},Dr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.columns&&s.columns>0?`repeat(${s.columns}, minmax(0, 1fr))`:`repeat(auto-fit, minmax(20rem, 1fr))`;return w`
         <div class="mateu-dashboard ${t.cssClasses??``}"
              style="display: grid; grid-template-columns: ${c}; gap: var(--lumo-space-m, 1rem); align-items: stretch; ${t.style??``}"
-             slot="${t.slot??v}"
+             slot="${t.slot??_}"
         >
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `},Dr=class extends b{constructor(...e){super(...e),this.panels=[],this.headerTitle=``,this.badges=[],this.orientation=`vertical`,this.navigation=null,this.overviewEditActionId=``,this.openPanels=new Set,this.expandedPanel=null,this._onPopState=()=>{let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(e.startsWith(`expand=`)){let t=e.slice(7),n=this.panels.findIndex((e,n)=>this.panelAnchor(e,n)===t);this.expandedPanel=n>=0?n:null}else this.expandedPanel=null},this.initialized=!1}navAction(e){e&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{}},bubbles:!0,composed:!0}))}connectedCallback(){super.connectedCallback(),window.addEventListener(`popstate`,this._onPopState)}disconnectedCallback(){window.removeEventListener(`popstate`,this._onPopState),super.disconnectedCallback()}willUpdate(){if(!this.initialized&&this.panels.length){this.openPanels=new Set(this.panels.map((e,t)=>e.open?t:-1).filter(e=>e>=0));let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(e.startsWith(`expand=`)){let t=e.slice(7),n=this.panels.findIndex((e,n)=>this.panelAnchor(e,n)===t);n>=0&&(this.expandedPanel=n)}else if(e){let t=this.panels.findIndex((t,n)=>this.panelAnchor(t,n)===e);t>=0&&this.openPanels.add(t)}this.initialized=!0}}firstUpdated(){let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(!e)return;let t=this.renderRoot.querySelector(`[data-anchor="${CSS.escape(e)}"]`);t&&t.scrollIntoView({block:`nearest`})}panelAnchor(e,t){return(e.title??``).toLowerCase().replace(/[^a-z0-9]+/g,`-`).replace(/^-|-$/g,``)||`panel-${t}`}bookmarkPanel(e){let t=this.panelAnchor(this.panels[e],e);try{history.replaceState(history.state,``,`#`+t)}catch{}}clearBookmark(e){let t=this.panelAnchor(this.panels[e],e);if(decodeURIComponent((location.hash||``).replace(/^#/,``))===t)try{history.replaceState(history.state,``,location.pathname+location.search)}catch{}}expandPanel(e,t){t?.stopPropagation(),this.expandedPanel=e;let n=this.panelAnchor(this.panels[e],e);try{history.pushState(history.state,``,`#expand=`+n)}catch{}}collapsePanel(){try{history.back()}catch{this.expandedPanel=null}}toggle(e){let t=new Set(this.openPanels);t.has(e)?(t.delete(e),this.clearBookmark(e)):(t.add(e),this.bookmarkPanel(e)),this.openPanels=t}static{this.styles=h`
+    `},Or=class extends y{constructor(...e){super(...e),this.panels=[],this.headerTitle=``,this.badges=[],this.orientation=`vertical`,this.navigation=null,this.overviewEditActionId=``,this.openPanels=new Set,this.expandedPanel=null,this._onPopState=()=>{let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(e.startsWith(`expand=`)){let t=e.slice(7),n=this.panels.findIndex((e,n)=>this.panelAnchor(e,n)===t);this.expandedPanel=n>=0?n:null}else this.expandedPanel=null},this.initialized=!1}navAction(e){e&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{}},bubbles:!0,composed:!0}))}connectedCallback(){super.connectedCallback(),window.addEventListener(`popstate`,this._onPopState)}disconnectedCallback(){window.removeEventListener(`popstate`,this._onPopState),super.disconnectedCallback()}willUpdate(){if(!this.initialized&&this.panels.length){this.openPanels=new Set(this.panels.map((e,t)=>e.open?t:-1).filter(e=>e>=0));let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(e.startsWith(`expand=`)){let t=e.slice(7),n=this.panels.findIndex((e,n)=>this.panelAnchor(e,n)===t);n>=0&&(this.expandedPanel=n)}else if(e){let t=this.panels.findIndex((t,n)=>this.panelAnchor(t,n)===e);t>=0&&this.openPanels.add(t)}this.initialized=!0}}firstUpdated(){let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(!e)return;let t=this.renderRoot.querySelector(`[data-anchor="${CSS.escape(e)}"]`);t&&t.scrollIntoView({block:`nearest`})}panelAnchor(e,t){return(e.title??``).toLowerCase().replace(/[^a-z0-9]+/g,`-`).replace(/^-|-$/g,``)||`panel-${t}`}bookmarkPanel(e){let t=this.panelAnchor(this.panels[e],e);try{history.replaceState(history.state,``,`#`+t)}catch{}}clearBookmark(e){let t=this.panelAnchor(this.panels[e],e);if(decodeURIComponent((location.hash||``).replace(/^#/,``))===t)try{history.replaceState(history.state,``,location.pathname+location.search)}catch{}}expandPanel(e,t){t?.stopPropagation(),this.expandedPanel=e;let n=this.panelAnchor(this.panels[e],e);try{history.pushState(history.state,``,`#expand=`+n)}catch{}}collapsePanel(){try{history.back()}catch{this.expandedPanel=null}}toggle(e){let t=new Set(this.openPanels);t.has(e)?(t.delete(e),this.clearBookmark(e)):(t.add(e),this.bookmarkPanel(e)),this.openPanels=t}static{this.styles=m`
         :host {
             display: flex;
             flex-direction: column;
@@ -1851,7 +1851,7 @@ ${i}
             overflow: auto;
             padding: var(--mateu-foldout-panel-padding, var(--lumo-space-m, 1rem));
         }
-    `}render(){if(this.expandedPanel!=null&&this.panels[this.expandedPanel]){let e=this.panels[this.expandedPanel];return T`
+    `}render(){if(this.expandedPanel!=null&&this.panels[this.expandedPanel]){let e=this.panels[this.expandedPanel];return w`
                 <div class="expanded-view" part="expanded-view">
                     <div class="expanded-header">
                         <button class="nav-parent" title="Back"
@@ -1859,40 +1859,40 @@ ${i}
                             <span>‹</span><span>Back</span>
                         </button>
                         <span class="nav-title">${e.title}</span>
-                        ${e.subtitle?T`<span class="subtitle">${e.subtitle}</span>`:v}
+                        ${e.subtitle?w`<span class="subtitle">${e.subtitle}</span>`:_}
                     </div>
                     <div class="expanded-body">
                         <slot name="panel-${this.expandedPanel}"></slot>
                     </div>
                 </div>
-            `}let e=this.navigation;return T`
-            ${e?T`
+            `}let e=this.navigation;return w`
+            ${e?w`
                 <div class="nav-header" part="nav-header">
-                    ${e.parentActionId?T`
+                    ${e.parentActionId?w`
                         <button class="nav-parent" title="${e.parentLabel??`Back`}"
                                 @click="${()=>this.navAction(e.parentActionId)}">
                             <span>‹</span><span>${e.parentLabel??`Back`}</span>
                         </button>
-                    `:v}
-                    ${e.title?T`<span class="nav-title">${e.title}</span>`:v}
+                    `:_}
+                    ${e.title?w`<span class="nav-title">${e.title}</span>`:_}
                     <span class="nav-spacer"></span>
-                    ${e.previousActionId?T`
+                    ${e.previousActionId?w`
                         <button class="nav-move" title="Previous"
                                 @click="${()=>this.navAction(e.previousActionId)}">‹</button>
-                    `:v}
-                    ${e.nextActionId?T`
+                    `:_}
+                    ${e.nextActionId?w`
                         <button class="nav-move" title="Next"
                                 @click="${()=>this.navAction(e.nextActionId)}">›</button>
-                    `:v}
+                    `:_}
                 </div>
-            `:v}
-            ${this.headerTitle?T`
+            `:_}
+            ${this.headerTitle?w`
                 <div class="header-band" part="header-band">
                     <div class="header-content">
                         <h2 class="header-title">${this.headerTitle}</h2>
-                        ${this.badges.length?T`
+                        ${this.badges.length?w`
                             <div class="header-badges">
-                                ${this.badges.map(e=>T`<span class="header-badge">${e}</span>`)}
+                                ${this.badges.map(e=>w`<span class="header-badge">${e}</span>`)}
                             </div>
                         `:``}
                     </div>
@@ -1901,23 +1901,23 @@ ${i}
             `:``}
             <div class="columns" part="columns">
                 <div class="overview" part="overview">
-                    ${this.overviewEditActionId?T`
+                    ${this.overviewEditActionId?w`
                         <button class="overview-edit" title="Edit"
                                 @click="${()=>this.navAction(this.overviewEditActionId)}">
                             <span>✎</span><span>Edit</span>
                         </button>
-                    `:v}
+                    `:_}
                     <slot name="overview"></slot>
                 </div>
                 <div class="rail" part="rail">
-                    ${this.panels.map((e,t)=>this.openPanels.has(t)?T`
+                    ${this.panels.map((e,t)=>this.openPanels.has(t)?w`
                         <div class="panel" part="panel" data-anchor="${this.panelAnchor(e,t)}"
-                             style="${e.width?`flex-basis: ${e.width}; min-width: min(${e.width}, 100%);`:v}"
+                             style="${e.width?`flex-basis: ${e.width}; min-width: min(${e.width}, 100%);`:_}"
                              @click="${()=>this.bookmarkPanel(t)}">
                             <div class="panel-header">
                                 <div>
                                     <h3>${e.title}</h3>
-                                    ${e.subtitle?T`<div class="subtitle">${e.subtitle}</div>`:``}
+                                    ${e.subtitle?w`<div class="subtitle">${e.subtitle}</div>`:``}
                                 </div>
                                 <span class="panel-actions">
                                     <button class="panel-expand" title="Show all"
@@ -1929,7 +1929,7 @@ ${i}
                                 <slot name="panel-${t}"></slot>
                             </div>
                         </div>
-                    `:T`
+                    `:w`
                         <div class="strip" role="button" title="${e.title}"
                              data-anchor="${this.panelAnchor(e,t)}" @click="${()=>this.toggle(t)}">
                             <button class="fold" tabindex="-1">⟩</button>
@@ -1938,7 +1938,7 @@ ${i}
                     `)}
                 </div>
             </div>
-        `}};k([y({type:Array})],Dr.prototype,`panels`,void 0),k([y({type:String})],Dr.prototype,`headerTitle`,void 0),k([y({type:Array})],Dr.prototype,`badges`,void 0),k([y({type:String,reflect:!0})],Dr.prototype,`orientation`,void 0),k([y({attribute:!1})],Dr.prototype,`navigation`,void 0),k([y({type:String})],Dr.prototype,`overviewEditActionId`,void 0),k([C()],Dr.prototype,`openPanels`,void 0),k([C()],Dr.prototype,`expandedPanel`,void 0),Dr=k([g(`mateu-foldout`)],Dr);var Or=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+        `}};O([v({type:Array})],Or.prototype,`panels`,void 0),O([v({type:String})],Or.prototype,`headerTitle`,void 0),O([v({type:Array})],Or.prototype,`badges`,void 0),O([v({type:String,reflect:!0})],Or.prototype,`orientation`,void 0),O([v({attribute:!1})],Or.prototype,`navigation`,void 0),O([v({type:String})],Or.prototype,`overviewEditActionId`,void 0),O([S()],Or.prototype,`openPanels`,void 0),O([S()],Or.prototype,`expandedPanel`,void 0),Or=O([h(`mateu-foldout`)],Or);var kr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <mateu-foldout
                 .panels="${s.panels??[]}"
                 .headerTitle="${s.headerTitle??``}"
@@ -1948,45 +1948,45 @@ ${i}
                 orientation="${s.orientation??`vertical`}"
                 style="${t.style}"
                 class="${t.cssClasses}"
-                slot="${t.slot??v}"
+                slot="${t.slot??_}"
         >
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </mateu-foldout>
-    `},kr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.children??[],l=e=>c.filter(t=>(t.slot??``).startsWith(e)),u=l(`main-`),d=l(`aside-`),f=l(`footer-`),p=s.asideWidth&&s.asideWidth.trim()?s.asideWidth:`32%`,m=s.asidePosition===`start`,ee=s.asideSticky!==!1,te=t=>t.map(t=>F(e,t,n,r,i,a,o)),ne=T`
+    `},Ar=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.children??[],l=e=>c.filter(t=>(t.slot??``).startsWith(e)),u=l(`main-`),d=l(`aside-`),f=l(`footer-`),p=s.asideWidth&&s.asideWidth.trim()?s.asideWidth:`32%`,ee=s.asidePosition===`start`,te=s.asideSticky!==!1,ne=t=>t.map(t=>P(e,t,n,r,i,a,o)),re=w`
         <div class="mateu-content-main"
              style="flex: 1 1 0; min-width: min(20rem, 100%); box-sizing: border-box;">
-            ${te(u)}
-        </div>`,h=d.length?T`
+            ${ne(u)}
+        </div>`,m=d.length?w`
         <div class="mateu-content-aside"
-             style="flex: 0 1 calc(${p} - var(--lumo-space-m, 1rem)); min-width: min(18rem, 100%); box-sizing: border-box; ${ee?`position: sticky; top: 1rem; align-self: flex-start;`:``}">
-            ${te(d)}
-        </div>`:v;return T`
+             style="flex: 0 1 calc(${p} - var(--lumo-space-m, 1rem)); min-width: min(18rem, 100%); box-sizing: border-box; ${te?`position: sticky; top: 1rem; align-self: flex-start;`:``}">
+            ${ne(d)}
+        </div>`:_;return w`
         <div class="mateu-content-layout ${t.cssClasses??``}"
              style="${t.style??``}"
-             slot="${t.slot??v}">
+             slot="${t.slot??_}">
             <div style="display: flex; flex-wrap: wrap; gap: var(--lumo-space-m, 1rem); align-items: flex-start;">
-                ${m?[h,ne]:[ne,h]}
+                ${ee?[m,re]:[re,m]}
             </div>
-            ${f.length?T`
+            ${f.length?w`
                 <div class="mateu-content-footer"
                      style="flex-basis: 100%; margin-top: var(--lumo-space-m, 1rem);">
-                    ${te(f)}
-                </div>`:v}
+                    ${ne(f)}
+                </div>`:_}
         </div>
-    `},Ar=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!!s.image,l=c?`background-image: linear-gradient(rgba(0,0,0,.35), rgba(0,0,0,.35)), url('${s.image}'); background-size: cover; background-position: center; color: #fff;`:``,u=s.centered===!1?`flex-start`:`center`,d=s.centered===!1?`left`:`center`;return T`
+    `},jr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!!s.image,l=c?`background-image: linear-gradient(rgba(0,0,0,.35), rgba(0,0,0,.35)), url('${s.image}'); background-size: cover; background-position: center; color: #fff;`:``,u=s.centered===!1?`flex-start`:`center`,d=s.centered===!1?`left`:`center`;return w`
         <div class="mateu-hero ${t.cssClasses??``}"
              style="display: flex; flex-direction: column; align-items: ${u}; justify-content: center; gap: var(--lumo-space-m, 1rem); text-align: ${d}; padding: var(--lumo-space-xl, 2.5rem) var(--lumo-space-l, 1.5rem); border-radius: var(--lumo-border-radius-l, 12px); min-height: ${s.height??`12rem`}; box-sizing: border-box; ${l} ${t.style??``}"
-             slot="${t.slot??v}"
+             slot="${t.slot??_}"
         >
-            ${s.title?T`<h1 style="margin: 0; font-size: var(--lumo-font-size-xxxl, 2.5rem); line-height: 1.15;">${s.title}</h1>`:v}
-            ${s.subtitle?T`<p style="margin: 0; font-size: var(--lumo-font-size-l, 1.125rem); ${c?``:`color: var(--lumo-secondary-text-color, #666);`} max-width: 40rem;">${s.subtitle}</p>`:v}
-            ${t.children?.length?T`
+            ${s.title?w`<h1 style="margin: 0; font-size: var(--lumo-font-size-xxxl, 2.5rem); line-height: 1.15;">${s.title}</h1>`:_}
+            ${s.subtitle?w`<p style="margin: 0; font-size: var(--lumo-font-size-l, 1.125rem); ${c?``:`color: var(--lumo-secondary-text-color, #666);`} max-width: 40rem;">${s.subtitle}</p>`:_}
+            ${t.children?.length?w`
                 <div style="display: flex; gap: var(--lumo-space-s, .5rem); flex-wrap: wrap; justify-content: ${u}; width: 100%; max-width: 40rem;">
-                    ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+                    ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
                 </div>
-            `:v}
+            `:_}
         </div>
-    `},R=e=>t=>{if(t.key===`Enter`){e(t);return}(t.key===` `||t.key===`Spacebar`)&&(t.preventDefault(),e(t))},z=h`
+    `},L=e=>t=>{if(t.key===`Enter`){e(t);return}(t.key===` `||t.key===`Spacebar`)&&(t.preventDefault(),e(t))},R=m`
     [role="button"]:focus-visible,
     [role="option"]:focus-visible,
     [role="treeitem"]:focus-visible,
@@ -1997,7 +1997,7 @@ ${i}
         outline-offset: 2px;
         border-radius: var(--lumo-border-radius-s, 4px);
     }
-`,jr=1440*60*1e3,Mr=class extends b{constructor(...e){super(...e),this.tasks=[],this.onTaskSelectionActionId=``}selectTask(e){this.onTaskSelectionActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.onTaskSelectionActionId,parameters:{_clickedTaskId:e.id}},bubbles:!0,composed:!0}))}static{this.styles=h`
+`,Mr=1440*60*1e3,Nr=class extends y{constructor(...e){super(...e),this.tasks=[],this.onTaskSelectionActionId=``}selectTask(e){this.onTaskSelectionActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.onTaskSelectionActionId,parameters:{_clickedTaskId:e.id}},bubbles:!0,composed:!0}))}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2072,39 +2072,39 @@ ${i}
             opacity: .55;
         }
     
-        ${z}
-    `}range(){let e=this.tasks.flatMap(e=>[e.start,e.end]).filter(e=>!!e).map(e=>new Date(e+`T00:00:00`).getTime());return e.length?{min:Math.min(...e)-jr,max:Math.max(...e)+2*jr}:null}months(e,t){let n=[],r=new Date(e);for(r.setDate(1);r.getTime()<=t;){let i=Math.max(r.getTime(),e),a=new Date(r.getFullYear(),r.getMonth()+1,1),o=Math.min(a.getTime(),t);n.push({label:r.toLocaleDateString(void 0,{month:`short`,year:`2-digit`}),from:i,to:o}),r.setMonth(r.getMonth()+1)}return n}render(){let e=this.range();if(!e)return T``;let t=e.max-e.min,n=n=>(n-e.min)/t*100,r=Date.now();return T`
+        ${R}
+    `}range(){let e=this.tasks.flatMap(e=>[e.start,e.end]).filter(e=>!!e).map(e=>new Date(e+`T00:00:00`).getTime());return e.length?{min:Math.min(...e)-Mr,max:Math.max(...e)+2*Mr}:null}months(e,t){let n=[],r=new Date(e);for(r.setDate(1);r.getTime()<=t;){let i=Math.max(r.getTime(),e),a=new Date(r.getFullYear(),r.getMonth()+1,1),o=Math.min(a.getTime(),t);n.push({label:r.toLocaleDateString(void 0,{month:`short`,year:`2-digit`}),from:i,to:o}),r.setMonth(r.getMonth()+1)}return n}render(){let e=this.range();if(!e)return w``;let t=e.max-e.min,n=n=>(n-e.min)/t*100,r=Date.now();return w`
             <div class="frame">
                 <div class="head">Task</div>
                 <div class="head months">
-                    ${this.months(e.min,e.max).map(e=>T`
+                    ${this.months(e.min,e.max).map(e=>w`
                         <div class="month" style="width: ${(e.to-e.from)/t*100}%;">${e.label}</div>
                     `)}
                 </div>
-                ${this.tasks.map(i=>{let a=new Date(i.start+`T00:00:00`).getTime(),o=new Date(i.end+`T00:00:00`).getTime()+jr;return T`
+                ${this.tasks.map(i=>{let a=new Date(i.start+`T00:00:00`).getTime(),o=new Date(i.end+`T00:00:00`).getTime()+Mr;return w`
                         <div class="label" title="${i.title}">${i.title}</div>
                         <div class="lane">
-                            ${r>=e.min&&r<=e.max?T`<div class="today" style="left: ${n(r)}%;"></div>`:v}
+                            ${r>=e.min&&r<=e.max?w`<div class="today" style="left: ${n(r)}%;"></div>`:_}
                             <div role="button" tabindex="0"
                                  aria-label="${i.title}, ${i.start} to ${i.end}${i.progress?`, ${i.progress}% complete`:``}"
                                  class="bar ${this.onTaskSelectionActionId?`clickable`:``}"
                                  title="${i.title} · ${i.start} → ${i.end}${i.progress?` · ${i.progress}%`:``}"
-                                 @click="${()=>this.selectTask(i)}" @keydown="${R(()=>this.selectTask(i))}"
+                                 @click="${()=>this.selectTask(i)}" @keydown="${L(()=>this.selectTask(i))}"
                                  style="left: ${n(a)}%; width: ${(o-a)/t*100}%; ${i.color?`--mateu-gantt-fill: ${i.color};`:``}">
                                 <div class="fill" style="width: ${i.progress??0}%;"></div>
                             </div>
                         </div>
                     `})}
             </div>
-        `}};k([y({type:Array})],Mr.prototype,`tasks`,void 0),k([y()],Mr.prototype,`onTaskSelectionActionId`,void 0),Mr=k([g(`mateu-gantt`)],Mr);var Nr=e=>{let t=e.metadata;return T`
+        `}};O([v({type:Array})],Nr.prototype,`tasks`,void 0),O([v()],Nr.prototype,`onTaskSelectionActionId`,void 0),Nr=O([h(`mateu-gantt`)],Nr);var Pr=e=>{let t=e.metadata;return w`
         <mateu-gantt
                 .tasks="${t.tasks??[]}"
                 .onTaskSelectionActionId="${t.onTaskSelectionActionId??``}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-gantt>
-    `},B,Pr=class extends b{static{B=this}constructor(...e){super(...e),this.resources=[],this.blocks=[],this.drag=null,this.dragStartX=0,this.dragStartY=0,this.laneRects=[],this.onDragKeydown=e=>{e.key===`Escape`&&this.drag&&(e.stopPropagation(),this.endDrag())}}static{this.styles=h`
+    `},z,Fr=class extends y{static{z=this}constructor(...e){super(...e),this.resources=[],this.blocks=[],this.drag=null,this.dragStartX=0,this.dragStartY=0,this.laneRects=[],this.onDragKeydown=e=>{e.key===`Escape`&&this.drag&&(e.stopPropagation(),this.endDrag())}}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2246,10 +2246,10 @@ ${i}
             pointer-events: none;
             z-index: 2;
         }
-    `}static parse(e){return new Date(e+`T00:00:00`)}static iso(e){let t=e=>String(e).padStart(2,`0`);return`${e.getFullYear()}-${t(e.getMonth()+1)}-${t(e.getDate())}`}static addDays(e,t){return new Date(e.getFullYear(),e.getMonth(),e.getDate()+t)}static daysBetween(e,t){return Math.round((t.getTime()-e.getTime())/864e5)}window(){if(this.from&&this.to){let e=B.parse(this.from),t=B.daysBetween(e,B.parse(this.to))+1;return t>0?{from:e,days:t}:null}let e=this.blocks.flatMap(e=>[e.start,e.end]).filter(e=>!!e).map(e=>B.parse(e));if(!e.length)return null;let t=new Date(Math.min(...e.map(e=>e.getTime()))),n=new Date(Math.max(...e.map(e=>e.getTime())));return{from:t,days:B.daysBetween(t,n)+1}}onBlockPointerDown(e,t,n){if(!this.moveActionId&&!this.selectActionId||(e.preventDefault(),e.currentTarget.setPointerCapture(e.pointerId),this.dragStartX=e.clientX,this.dragStartY=e.clientY,!this.window()))return;let r=B.parse(t.start),i=B.parse(t.end),a=Math.max(1,B.daysBetween(r,i)+1);this.laneRects=[...this.renderRoot.querySelectorAll(`.lane[data-resource-id]`)].map(e=>({resourceId:e.dataset.resourceId,rect:e.getBoundingClientRect()}));let o=this.dayAt(t.resourceId,e.clientX)??n;this.drag={blockId:t.id,duration:a,grabOffsetDays:o-n,originResourceId:t.resourceId,originStartIdx:n,targetResourceId:t.resourceId,targetStartIdx:n,moved:!1},window.addEventListener(`keydown`,this.onDragKeydown)}dayAt(e,t){let n=this.laneRects.find(t=>t.resourceId===e),r=this.window();if(!n||!r||n.rect.width===0)return null;let i=Math.floor((t-n.rect.left)/n.rect.width*r.days);return Math.max(0,Math.min(r.days-1,i))}onBlockPointerMove(e){if(!this.drag||!this.drag.moved&&Math.abs(e.clientX-this.dragStartX)<4&&Math.abs(e.clientY-this.dragStartY)<4||!this.moveActionId)return;let t=this.window();if(!t)return;let n=this.laneRects.find(t=>e.clientY>=t.rect.top&&e.clientY<=t.rect.bottom)??this.laneRects.find(e=>e.resourceId===this.drag.targetResourceId);if(!n)return;let r=this.dayAt(n.resourceId,e.clientX);if(r==null)return;let i=Math.max(0,Math.min(t.days-this.drag.duration,r-this.drag.grabOffsetDays));this.drag={...this.drag,moved:!0,targetResourceId:n.resourceId,targetStartIdx:i}}onBlockPointerUp(e){let t=this.drag;if(this.endDrag(),!t)return;if(!t.moved){this.selectActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.selectActionId,parameters:{_blockId:e.id}},bubbles:!0,composed:!0}));return}if(!this.moveActionId||t.targetResourceId===t.originResourceId&&t.targetStartIdx===t.originStartIdx)return;let n=this.window();if(!n)return;let r=B.addDays(n.from,t.targetStartIdx),i=B.addDays(r,t.duration-1);this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.moveActionId,parameters:{_blockId:t.blockId,_resourceId:t.targetResourceId,_start:B.iso(r),_end:B.iso(i)}},bubbles:!0,composed:!0}))}endDrag(){this.drag=null,window.removeEventListener(`keydown`,this.onDragKeydown)}disconnectedCallback(){super.disconnectedCallback(),window.removeEventListener(`keydown`,this.onDragKeydown)}render(){let e=this.window();if(!e||!this.resources.length)return T``;let t=[...Array(e.days).keys()].map(t=>B.addDays(e.from,t)),n=new Date,r=B.daysBetween(e.from,new Date(n.getFullYear(),n.getMonth(),n.getDate())),i=r>=0&&r<e.days,a=[],o;return this.resources.forEach(n=>{n.group&&n.group!==o&&a.push(T`<div class="group">${n.group}</div>`),o=n.group,a.push(this.renderRow(n,e,t,i?r:null))}),T`
+    `}static parse(e){return new Date(e+`T00:00:00`)}static iso(e){let t=e=>String(e).padStart(2,`0`);return`${e.getFullYear()}-${t(e.getMonth()+1)}-${t(e.getDate())}`}static addDays(e,t){return new Date(e.getFullYear(),e.getMonth(),e.getDate()+t)}static daysBetween(e,t){return Math.round((t.getTime()-e.getTime())/864e5)}window(){if(this.from&&this.to){let e=z.parse(this.from),t=z.daysBetween(e,z.parse(this.to))+1;return t>0?{from:e,days:t}:null}let e=this.blocks.flatMap(e=>[e.start,e.end]).filter(e=>!!e).map(e=>z.parse(e));if(!e.length)return null;let t=new Date(Math.min(...e.map(e=>e.getTime()))),n=new Date(Math.max(...e.map(e=>e.getTime())));return{from:t,days:z.daysBetween(t,n)+1}}onBlockPointerDown(e,t,n){if(!this.moveActionId&&!this.selectActionId||(e.preventDefault(),e.currentTarget.setPointerCapture(e.pointerId),this.dragStartX=e.clientX,this.dragStartY=e.clientY,!this.window()))return;let r=z.parse(t.start),i=z.parse(t.end),a=Math.max(1,z.daysBetween(r,i)+1);this.laneRects=[...this.renderRoot.querySelectorAll(`.lane[data-resource-id]`)].map(e=>({resourceId:e.dataset.resourceId,rect:e.getBoundingClientRect()}));let o=this.dayAt(t.resourceId,e.clientX)??n;this.drag={blockId:t.id,duration:a,grabOffsetDays:o-n,originResourceId:t.resourceId,originStartIdx:n,targetResourceId:t.resourceId,targetStartIdx:n,moved:!1},window.addEventListener(`keydown`,this.onDragKeydown)}dayAt(e,t){let n=this.laneRects.find(t=>t.resourceId===e),r=this.window();if(!n||!r||n.rect.width===0)return null;let i=Math.floor((t-n.rect.left)/n.rect.width*r.days);return Math.max(0,Math.min(r.days-1,i))}onBlockPointerMove(e){if(!this.drag||!this.drag.moved&&Math.abs(e.clientX-this.dragStartX)<4&&Math.abs(e.clientY-this.dragStartY)<4||!this.moveActionId)return;let t=this.window();if(!t)return;let n=this.laneRects.find(t=>e.clientY>=t.rect.top&&e.clientY<=t.rect.bottom)??this.laneRects.find(e=>e.resourceId===this.drag.targetResourceId);if(!n)return;let r=this.dayAt(n.resourceId,e.clientX);if(r==null)return;let i=Math.max(0,Math.min(t.days-this.drag.duration,r-this.drag.grabOffsetDays));this.drag={...this.drag,moved:!0,targetResourceId:n.resourceId,targetStartIdx:i}}onBlockPointerUp(e){let t=this.drag;if(this.endDrag(),!t)return;if(!t.moved){this.selectActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.selectActionId,parameters:{_blockId:e.id}},bubbles:!0,composed:!0}));return}if(!this.moveActionId||t.targetResourceId===t.originResourceId&&t.targetStartIdx===t.originStartIdx)return;let n=this.window();if(!n)return;let r=z.addDays(n.from,t.targetStartIdx),i=z.addDays(r,t.duration-1);this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.moveActionId,parameters:{_blockId:t.blockId,_resourceId:t.targetResourceId,_start:z.iso(r),_end:z.iso(i)}},bubbles:!0,composed:!0}))}endDrag(){this.drag=null,window.removeEventListener(`keydown`,this.onDragKeydown)}disconnectedCallback(){super.disconnectedCallback(),window.removeEventListener(`keydown`,this.onDragKeydown)}render(){let e=this.window();if(!e||!this.resources.length)return w``;let t=[...Array(e.days).keys()].map(t=>z.addDays(e.from,t)),n=new Date,r=z.daysBetween(e.from,new Date(n.getFullYear(),n.getMonth(),n.getDate())),i=r>=0&&r<e.days,a=[],o;return this.resources.forEach(n=>{n.group&&n.group!==o&&a.push(w`<div class="group">${n.group}</div>`),o=n.group,a.push(this.renderRow(n,e,t,i?r:null))}),w`
             <div class="frame" style="grid-template-columns: minmax(8rem, 12rem) repeat(${e.days}, minmax(2.2rem, 1fr));">
                 <div class="corner">Resource</div>
-                ${t.map((e,t)=>T`
+                ${t.map((e,t)=>w`
                     <div class="day-head ${this.isWeekend(e)?`weekend`:``} ${t===r?`today`:``}">
                         <span class="dow">${e.toLocaleDateString(void 0,{weekday:`short`})}</span>
                         <span class="num">${e.getDate()}</span>
@@ -2257,14 +2257,14 @@ ${i}
                 `)}
                 ${a}
             </div>
-        `}isWeekend(e){return e.getDay()===0||e.getDay()===6}renderRow(e,t,n,r){let i=100/t.days,a=this.blocks.filter(t=>t.resourceId===e.id&&t.start&&t.end),o=this.drag?.moved&&this.drag.targetResourceId===e.id?this.drag:null;return T`
+        `}isWeekend(e){return e.getDay()===0||e.getDay()===6}renderRow(e,t,n,r){let i=100/t.days,a=this.blocks.filter(t=>t.resourceId===e.id&&t.start&&t.end),o=this.drag?.moved&&this.drag.targetResourceId===e.id?this.drag:null;return w`
             <div class="label" title="${e.label??``}">${e.label}</div>
             <div class="lane" data-resource-id="${e.id}">
                 <div class="cells">
-                    ${n.map(e=>T`<div class="cell ${this.isWeekend(e)?`weekend`:``}"></div>`)}
+                    ${n.map(e=>w`<div class="cell ${this.isWeekend(e)?`weekend`:``}"></div>`)}
                 </div>
-                ${r==null?v:T`<div class="today-line" style="left: ${(r+.5)*i}%;"></div>`}
-                ${a.map(e=>{let n=B.daysBetween(t.from,B.parse(e.start)),r=B.daysBetween(t.from,B.parse(e.end));if(r<0||n>=t.days)return v;let a=Math.max(0,n),o=Math.min(t.days-1,r),s=this.drag?.moved&&this.drag.blockId===e.id;return T`
+                ${r==null?_:w`<div class="today-line" style="left: ${(r+.5)*i}%;"></div>`}
+                ${a.map(e=>{let n=z.daysBetween(t.from,z.parse(e.start)),r=z.daysBetween(t.from,z.parse(e.end));if(r<0||n>=t.days)return _;let a=Math.max(0,n),o=Math.min(t.days-1,r),s=this.drag?.moved&&this.drag.blockId===e.id;return w`
                         <div class="block ${this.selectActionId?`clickable`:``} ${this.moveActionId?`draggable`:``} ${s?`dragging`:``}"
                              title="${e.label??``} · ${e.start} → ${e.end}${e.status?` · ${e.status}`:``}"
                              style="left: ${a*i}%; width: ${(o-a+1)*i}%; ${e.color?`--mateu-planning-block: ${e.color};`:``}"
@@ -2274,12 +2274,12 @@ ${i}
                              @pointercancel="${()=>this.endDrag()}"
                         >${e.label}</div>
                     `})}
-                ${o?T`
+                ${o?w`
                     <div class="ghost"
                          style="left: ${o.targetStartIdx*i}%; width: ${Math.min(o.duration,t.days-o.targetStartIdx)*i}%;"></div>
-                `:v}
+                `:_}
             </div>
-        `}};k([y({type:Array})],Pr.prototype,`resources`,void 0),k([y({type:Array})],Pr.prototype,`blocks`,void 0),k([y()],Pr.prototype,`from`,void 0),k([y()],Pr.prototype,`to`,void 0),k([y()],Pr.prototype,`moveActionId`,void 0),k([y()],Pr.prototype,`selectActionId`,void 0),k([C()],Pr.prototype,`drag`,void 0),Pr=B=k([g(`mateu-planning-board`)],Pr);var Fr=e=>{let t=e.metadata;return T`
+        `}};O([v({type:Array})],Fr.prototype,`resources`,void 0),O([v({type:Array})],Fr.prototype,`blocks`,void 0),O([v()],Fr.prototype,`from`,void 0),O([v()],Fr.prototype,`to`,void 0),O([v()],Fr.prototype,`moveActionId`,void 0),O([v()],Fr.prototype,`selectActionId`,void 0),O([S()],Fr.prototype,`drag`,void 0),Fr=z=O([h(`mateu-planning-board`)],Fr);var Ir=e=>{let t=e.metadata;return w`
         <mateu-planning-board
                 .resources="${t.resources??[]}"
                 .blocks="${t.blocks??[]}"
@@ -2287,11 +2287,11 @@ ${i}
                 .to="${t.to}"
                 .moveActionId="${t.moveActionId}"
                 .selectActionId="${t.selectActionId}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-planning-board>
-    `},Ir=class extends b{constructor(...e){super(...e),this.columns=[]}static{this.styles=h`
+    `},Lr=class extends y{constructor(...e){super(...e),this.columns=[]}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2374,35 +2374,35 @@ ${i}
             .card { background: var(--lumo-contrast-5pct, #2a2a2a); }
         }
     
-        ${z}
-    `}clickCard(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_clickedCard:e}},bubbles:!0,composed:!0}))}render(){return T`
+        ${R}
+    `}clickCard(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_clickedCard:e}},bubbles:!0,composed:!0}))}render(){return w`
             <div class="board">
-                ${this.columns.map(e=>T`
+                ${this.columns.map(e=>w`
                     <div class="column" style="${e.color?`--mateu-kanban-accent: ${e.color};`:``}">
                         <div class="column-head">
                             <span class="column-title" title="${e.title??``}">${e.title}</span>
                             <span class="count">${e.cards?.length??0}</span>
                         </div>
-                        ${(e.cards??[]).map(e=>T`
+                        ${(e.cards??[]).map(e=>w`
                             <div role="button" tabindex="0" class="card ${e.actionId?`clickable`:``}"
                                  style="${e.color?`--mateu-kanban-card-accent: ${e.color};`:``}"
-                                 @click="${()=>this.clickCard(e)}" @keydown="${R(()=>this.clickCard(e))}">
+                                 @click="${()=>this.clickCard(e)}" @keydown="${L(()=>this.clickCard(e))}">
                                 <span class="card-title">${e.title}</span>
-                                ${e.description?T`<span class="card-desc">${e.description}</span>`:v}
-                                ${e.badge?T`<span class="badge">${e.badge}</span>`:v}
+                                ${e.description?w`<span class="card-desc">${e.description}</span>`:_}
+                                ${e.badge?w`<span class="badge">${e.badge}</span>`:_}
                             </div>
                         `)}
                     </div>
                 `)}
             </div>
-        `}};k([y({type:Array})],Ir.prototype,`columns`,void 0),Ir=k([g(`mateu-kanban`)],Ir);var Lr=e=>T`
+        `}};O([v({type:Array})],Lr.prototype,`columns`,void 0),Lr=O([h(`mateu-kanban`)],Lr);var Rr=e=>w`
         <mateu-kanban
                 .columns="${e.metadata.columns??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-kanban>
-    `,Rr=class extends b{constructor(...e){super(...e),this.items=[]}static{this.styles=h`
+    `,zr=class extends y{constructor(...e){super(...e),this.items=[]}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2474,33 +2474,33 @@ ${i}
             margin-top: .15rem;
         }
     
-        ${z}
-    `}clickItem(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_clickedItem:e}},bubbles:!0,composed:!0}))}render(){return T`
+        ${R}
+    `}clickItem(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_clickedItem:e}},bubbles:!0,composed:!0}))}render(){return w`
             <div class="feed">
-                ${this.items.map(e=>T`
+                ${this.items.map(e=>w`
                     <div class="item ${e.actionId?`clickable`:``}">
                         <div class="rail">
                             <div class="dot" style="${e.color?`--mateu-timeline-dot: ${e.color};`:``}">${e.icon??``}</div>
                             <div class="line"></div>
                         </div>
-                        <div role="button" tabindex="0" class="body" @click="${()=>this.clickItem(e)}" @keydown="${R(()=>this.clickItem(e))}">
+                        <div role="button" tabindex="0" class="body" @click="${()=>this.clickItem(e)}" @keydown="${L(()=>this.clickItem(e))}">
                             <div class="head">
                                 <span class="title">${e.title}</span>
-                                ${e.timestamp?T`<span class="time">${e.timestamp}</span>`:v}
+                                ${e.timestamp?w`<span class="time">${e.timestamp}</span>`:_}
                             </div>
-                            ${e.description?T`<div class="desc">${e.description}</div>`:v}
+                            ${e.description?w`<div class="desc">${e.description}</div>`:_}
                         </div>
                     </div>
                 `)}
             </div>
-        `}};k([y({type:Array})],Rr.prototype,`items`,void 0),Rr=k([g(`mateu-timeline`)],Rr);var zr=e=>T`
+        `}};O([v({type:Array})],zr.prototype,`items`,void 0),zr=O([h(`mateu-timeline`)],zr);var Br=e=>w`
         <mateu-timeline
                 .items="${e.metadata.items??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-timeline>
-    `,Br=class extends b{constructor(...e){super(...e),this.steps=[],this.vertical=!1}static{this.styles=h`
+    `,Vr=class extends y{constructor(...e){super(...e),this.steps=[],this.vertical=!1}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2603,26 +2603,26 @@ ${i}
             margin-top: 0;
             padding: 0;
         }
-    `}updated(){let e=this.steps.length;if(e===0)return;let t=this.steps.findIndex(e=>e.status===`current`),n=this.steps.every(e=>e.status===`done`),r=t>=0?t+1:n?e:0;this.dispatchEvent(new CustomEvent(`mateu-guided-progress`,{detail:{current:r,total:e,steps:this.steps.map(e=>({id:e.id,title:e.title,status:e.status??`upcoming`}))},bubbles:!0,composed:!0}))}render(){return T`
+    `}updated(){let e=this.steps.length;if(e===0)return;let t=this.steps.findIndex(e=>e.status===`current`),n=this.steps.every(e=>e.status===`done`),r=t>=0?t+1:n?e:0;this.dispatchEvent(new CustomEvent(`mateu-guided-progress`,{detail:{current:r,total:e,steps:this.steps.map(e=>({id:e.id,title:e.title,status:e.status??`upcoming`}))},bubbles:!0,composed:!0}))}render(){return w`
             <div class="steps">
-                ${this.steps.map((e,t)=>{let n=e.status??`upcoming`;return T`
+                ${this.steps.map((e,t)=>{let n=e.status??`upcoming`;return w`
                         <div class="step ${n}">
                             <div class="connector"></div>
                             <div class="dot">${n===`done`?`✓`:t+1}</div>
                             <div class="label">${e.title}</div>
-                            ${e.description?T`<div class="desc">${e.description}</div>`:v}
+                            ${e.description?w`<div class="desc">${e.description}</div>`:_}
                         </div>
                     `})}
             </div>
-        `}};k([y({type:Array})],Br.prototype,`steps`,void 0),k([y({type:Boolean,reflect:!0})],Br.prototype,`vertical`,void 0),Br=k([g(`mateu-progress-steps`)],Br);var Vr=e=>{let t=e.metadata;return T`
+        `}};O([v({type:Array})],Vr.prototype,`steps`,void 0),O([v({type:Boolean,reflect:!0})],Vr.prototype,`vertical`,void 0),Vr=O([h(`mateu-progress-steps`)],Vr);var Hr=e=>{let t=e.metadata;return w`
         <mateu-progress-steps
                 .steps="${t.steps??[]}"
                 ?vertical="${t.vertical??!1}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-progress-steps>
-    `},Hr=class extends b{constructor(...e){super(...e),this.spark=[]}static{this.styles=h`
+    `},Ur=class extends y{constructor(...e){super(...e),this.spark=[]}static{this.styles=m`
         :host {
             display: block;
         }
@@ -2677,36 +2677,36 @@ ${i}
             .tile { background: var(--lumo-contrast-5pct, #2a2a2a); }
         }
     
-        ${z}
-    `}sparkline(){let e=this.spark;if(!e||e.length<2)return v;let t=Math.min(...e),n=Math.max(...e)-t||1,r=80/(e.length-1),i=e.map((e,i)=>[2+i*r,2+26*(1-(e-t)/n)]),a=i.map(([e,t],n)=>`${n===0?`M`:`L`}${e.toFixed(1)} ${t.toFixed(1)}`).join(` `),o=`${a} L${i[i.length-1][0].toFixed(1)} 30 L${i[0][0].toFixed(1)} 30 Z`,s=this.trend===`down`?`var(--lumo-error-color, #e11d48)`:this.trend===`flat`?`var(--lumo-secondary-text-color, #888)`:`var(--lumo-success-color, #12b76a)`;return w`
+        ${R}
+    `}sparkline(){let e=this.spark;if(!e||e.length<2)return _;let t=Math.min(...e),n=Math.max(...e)-t||1,r=80/(e.length-1),i=e.map((e,i)=>[2+i*r,2+26*(1-(e-t)/n)]),a=i.map(([e,t],n)=>`${n===0?`M`:`L`}${e.toFixed(1)} ${t.toFixed(1)}`).join(` `),o=`${a} L${i[i.length-1][0].toFixed(1)} 30 L${i[0][0].toFixed(1)} 30 Z`,s=this.trend===`down`?`var(--lumo-error-color, #e11d48)`:this.trend===`flat`?`var(--lumo-secondary-text-color, #888)`:`var(--lumo-success-color, #12b76a)`;return C`
             <svg width="${84}" height="${30}" viewBox="0 0 ${84} ${30}">
                 <path d="${o}" fill="${s}" opacity="0.12"></path>
                 <path d="${a}" fill="none" stroke="${s}" stroke-width="1.6"
                       stroke-linejoin="round" stroke-linecap="round"></path>
             </svg>
-        `}dispatchAction(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId},bubbles:!0,composed:!0}))}render(){let e=this.trend??`up`;return T`
-            <div role="button" tabindex="0" class="tile ${this.actionId?`clickable`:``}" @click="${()=>this.dispatchAction()}" @keydown="${R(()=>this.dispatchAction())}">
-                ${this.label?T`<span class="label">${this.label}</span>`:v}
-                <span class="value">${this.value}${this.unit?T`<span class="unit">${this.unit}</span>`:v}</span>
+        `}dispatchAction(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId},bubbles:!0,composed:!0}))}render(){let e=this.trend??`up`;return w`
+            <div role="button" tabindex="0" class="tile ${this.actionId?`clickable`:``}" @click="${()=>this.dispatchAction()}" @keydown="${L(()=>this.dispatchAction())}">
+                ${this.label?w`<span class="label">${this.label}</span>`:_}
+                <span class="value">${this.value}${this.unit?w`<span class="unit">${this.unit}</span>`:_}</span>
                 <div class="foot">
-                    ${this.delta?T`<span class="delta ${e}">${e===`up`?`▲`:e===`down`?`▼`:`→`} ${this.delta}</span>`:T`<span></span>`}
+                    ${this.delta?w`<span class="delta ${e}">${e===`up`?`▲`:e===`down`?`▼`:`→`} ${this.delta}</span>`:w`<span></span>`}
                     ${this.sparkline()}
                 </div>
             </div>
-        `}};k([y()],Hr.prototype,`label`,void 0),k([y()],Hr.prototype,`value`,void 0),k([y()],Hr.prototype,`unit`,void 0),k([y()],Hr.prototype,`delta`,void 0),k([y()],Hr.prototype,`trend`,void 0),k([y({type:Array})],Hr.prototype,`spark`,void 0),k([y()],Hr.prototype,`actionId`,void 0),Hr=k([g(`mateu-stat`)],Hr);var Ur=e=>{let t=e.metadata;return T`
+        `}};O([v()],Ur.prototype,`label`,void 0),O([v()],Ur.prototype,`value`,void 0),O([v()],Ur.prototype,`unit`,void 0),O([v()],Ur.prototype,`delta`,void 0),O([v()],Ur.prototype,`trend`,void 0),O([v({type:Array})],Ur.prototype,`spark`,void 0),O([v()],Ur.prototype,`actionId`,void 0),Ur=O([h(`mateu-stat`)],Ur);var Wr=e=>{let t=e.metadata;return w`
         <mateu-stat
-                label="${t.label??v}"
-                value="${t.value??v}"
-                unit="${t.unit??v}"
-                delta="${t.delta??v}"
-                trend="${t.trend??v}"
-                actionId="${t.actionId??v}"
+                label="${t.label??_}"
+                value="${t.value??_}"
+                unit="${t.unit??_}"
+                delta="${t.delta??_}"
+                trend="${t.trend??_}"
+                actionId="${t.actionId??_}"
                 .spark="${t.spark??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-stat>
-    `},Wr=class extends b{constructor(...e){super(...e),this.events=[]}static{this.styles=h`
+    `},Gr=class extends y{constructor(...e){super(...e),this.events=[]}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2780,32 +2780,32 @@ ${i}
             .dow { background: var(--lumo-contrast-10pct, #333); }
         }
     
-        ${z}
-    `}clickEvent(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_clickedEvent:e}},bubbles:!0,composed:!0}))}render(){let e=this.month?new Date(this.month+`T00:00:00`):new Date,t=e.getFullYear(),n=e.getMonth(),r=new Date(t,n,1),i=(r.getDay()+6)%7,a=new Date(t,n+1,0).getDate(),o=new Date,s=e=>o.getFullYear()===t&&o.getMonth()===n&&o.getDate()===e,c={};for(let e of this.events){if(!e.date)continue;let r=new Date(e.date+`T00:00:00`);r.getFullYear()===t&&r.getMonth()===n&&(c[r.getDate()]??=[]).push(e)}let l=[`Mon`,`Tue`,`Wed`,`Thu`,`Fri`,`Sat`,`Sun`],u=[];for(let e=0;e<i;e++)u.push(T`<div class="cell blank"></div>`);for(let e=1;e<=a;e++)u.push(T`
+        ${R}
+    `}clickEvent(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_clickedEvent:e}},bubbles:!0,composed:!0}))}render(){let e=this.month?new Date(this.month+`T00:00:00`):new Date,t=e.getFullYear(),n=e.getMonth(),r=new Date(t,n,1),i=(r.getDay()+6)%7,a=new Date(t,n+1,0).getDate(),o=new Date,s=e=>o.getFullYear()===t&&o.getMonth()===n&&o.getDate()===e,c={};for(let e of this.events){if(!e.date)continue;let r=new Date(e.date+`T00:00:00`);r.getFullYear()===t&&r.getMonth()===n&&(c[r.getDate()]??=[]).push(e)}let l=[`Mon`,`Tue`,`Wed`,`Thu`,`Fri`,`Sat`,`Sun`],u=[];for(let e=0;e<i;e++)u.push(w`<div class="cell blank"></div>`);for(let e=1;e<=a;e++)u.push(w`
                 <div class="cell ${s(e)?`today`:``}">
                     <span class="num">${e}</span>
-                    ${(c[e]??[]).map(e=>T`
+                    ${(c[e]??[]).map(e=>w`
                         <span role="button" tabindex="0" class="chip ${e.actionId?`clickable`:``}"
                               style="${e.color?`--mateu-cal-accent: ${e.color};`:``}"
                               title="${e.title??``}"
-                              @click="${()=>this.clickEvent(e)}" @keydown="${R(()=>this.clickEvent(e))}">${e.title}</span>
+                              @click="${()=>this.clickEvent(e)}" @keydown="${L(()=>this.clickEvent(e))}">${e.title}</span>
                     `)}
                 </div>
-            `);return T`
+            `);return w`
             <div class="title">${r.toLocaleDateString(void 0,{month:`long`,year:`numeric`})}</div>
             <div class="grid">
-                ${l.map(e=>T`<div class="dow">${e}</div>`)}
+                ${l.map(e=>w`<div class="dow">${e}</div>`)}
                 ${u}
             </div>
-        `}};k([y()],Wr.prototype,`month`,void 0),k([y({type:Array})],Wr.prototype,`events`,void 0),Wr=k([g(`mateu-calendar`)],Wr);var Gr=e=>{let t=e.metadata;return T`
+        `}};O([v()],Gr.prototype,`month`,void 0),O([v({type:Array})],Gr.prototype,`events`,void 0),Gr=O([h(`mateu-calendar`)],Gr);var Kr=e=>{let t=e.metadata;return w`
         <mateu-calendar
-                month="${t.month??v}"
+                month="${t.month??_}"
                 .events="${t.events??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-calendar>
-    `},Kr=class extends b{constructor(...e){super(...e),this.plans=[]}static{this.styles=h`
+    `},qr=class extends y{constructor(...e){super(...e),this.plans=[]}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2898,33 +2898,33 @@ ${i}
         @media (prefers-color-scheme: dark) {
             .plan { background: var(--lumo-contrast-5pct, #2a2a2a); }
         }
-    `}cta(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))}render(){return T`
+    `}cta(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))}render(){return w`
             <div class="plans">
-                ${this.plans.map(e=>T`
+                ${this.plans.map(e=>w`
                     <div class="plan ${e.featured?`featured`:``}">
-                        ${e.featured?T`<span class="badge">Recommended</span>`:v}
+                        ${e.featured?w`<span class="badge">Recommended</span>`:_}
                         <span class="name">${e.name}</span>
                         <div>
                             <span class="price">${e.price}</span>
-                            ${e.period?T`<span class="period">${e.period}</span>`:v}
+                            ${e.period?w`<span class="period">${e.period}</span>`:_}
                         </div>
                         <ul>
-                            ${(e.features??[]).map(e=>T`<li>${e}</li>`)}
+                            ${(e.features??[]).map(e=>w`<li>${e}</li>`)}
                         </ul>
-                        ${e.ctaLabel?T`
+                        ${e.ctaLabel?w`
                             <button class="cta" @click="${()=>this.cta(e)}">${e.ctaLabel}</button>
-                        `:v}
+                        `:_}
                     </div>
                 `)}
             </div>
-        `}};k([y({type:Array})],Kr.prototype,`plans`,void 0),Kr=k([g(`mateu-pricing-table`)],Kr);var qr=e=>T`
+        `}};O([v({type:Array})],qr.prototype,`plans`,void 0),qr=O([h(`mateu-pricing-table`)],qr);var Jr=e=>w`
         <mateu-pricing-table
                 .plans="${e.metadata.plans??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-pricing-table>
-    `,Jr=class extends b{static{this.styles=h`
+    `,Yr=class extends y{static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -3020,26 +3020,26 @@ ${i}
             .node { background: var(--lumo-contrast-5pct, #2a2a2a); }
         }
     
-        ${z}
-    `}clickNode(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_clickedNode:e}},bubbles:!0,composed:!0}))}renderNode(e){let t=e.avatar,n=t&&(t.startsWith(`http`)||t.startsWith(`data:`));return T`
+        ${R}
+    `}clickNode(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_clickedNode:e}},bubbles:!0,composed:!0}))}renderNode(e){let t=e.avatar,n=t&&(t.startsWith(`http`)||t.startsWith(`data:`));return w`
             <li>
                 <div role="button" tabindex="0" class="node ${e.actionId?`clickable`:``}"
                      style="${e.color?`--mateu-org-accent: ${e.color};`:``}"
-                     @click="${()=>this.clickNode(e)}" @keydown="${R(()=>this.clickNode(e))}">
-                    ${t?T`<span class="avatar">${n?T`<img src="${t}" alt="">`:t}</span>`:v}
+                     @click="${()=>this.clickNode(e)}" @keydown="${L(()=>this.clickNode(e))}">
+                    ${t?w`<span class="avatar">${n?w`<img src="${t}" alt="">`:t}</span>`:_}
                     <span class="title">${e.title}</span>
-                    ${e.subtitle?T`<span class="subtitle">${e.subtitle}</span>`:v}
+                    ${e.subtitle?w`<span class="subtitle">${e.subtitle}</span>`:_}
                 </div>
-                ${e.children&&e.children.length?T`<ul>${e.children.map(e=>this.renderNode(e))}</ul>`:v}
+                ${e.children&&e.children.length?w`<ul>${e.children.map(e=>this.renderNode(e))}</ul>`:_}
             </li>
-        `}render(){return this.root?T`<div class="tree"><ul>${this.renderNode(this.root)}</ul></div>`:T``}};k([y({attribute:!1})],Jr.prototype,`root`,void 0),Jr=k([g(`mateu-org-chart`)],Jr);var Yr=e=>T`
+        `}render(){return this.root?w`<div class="tree"><ul>${this.renderNode(this.root)}</ul></div>`:w``}};O([v({attribute:!1})],Yr.prototype,`root`,void 0),Yr=O([h(`mateu-org-chart`)],Yr);var Xr=e=>w`
         <mateu-org-chart
                 .root="${e.metadata.root}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-org-chart>
-    `,Xr=1440*60*1e3,Zr=class extends b{constructor(...e){super(...e),this.cells=[]}static{this.styles=h`
+    `,Zr=1440*60*1e3,Qr=class extends y{constructor(...e){super(...e),this.cells=[]}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -3063,9 +3063,9 @@ ${i}
             margin-top: .15rem;
         }
         .legend .cell { width: 10px; height: 10px; }
-    `}color(e,t){if(e<=0||t<=0)return`var(--lumo-contrast-10pct, #ebedf0)`;let n=e/t;return`color-mix(in srgb, var(--lumo-primary-color, #1a73e8) ${Math.round((n>.75?1:n>.5?.75:n>.25?.5:.3)*100)}%, transparent)`}render(){let e=this.cells.filter(e=>!!e.date);if(!e.length)return T``;let t=e.map(e=>new Date(e.date+`T00:00:00`).getTime()),n=Math.min(...t),r=Math.max(...t),i=new Date(n);i.setDate(i.getDate()-(i.getDay()+6)%7);let a={};for(let t of e)a[t.date]=t;let o=Math.max(...e.map(e=>e.value??0),1),s=[];for(let e=i.getTime();e<=r;e+=Xr){let t=new Date(e),n=t.toISOString().slice(0,10),r=a[n],i=r?.value??0,c=(t.getDay()+6)%7+1,l=r?.label??`${n}: ${i}`;s.push(T`
+    `}color(e,t){if(e<=0||t<=0)return`var(--lumo-contrast-10pct, #ebedf0)`;let n=e/t;return`color-mix(in srgb, var(--lumo-primary-color, #1a73e8) ${Math.round((n>.75?1:n>.5?.75:n>.25?.5:.3)*100)}%, transparent)`}render(){let e=this.cells.filter(e=>!!e.date);if(!e.length)return w``;let t=e.map(e=>new Date(e.date+`T00:00:00`).getTime()),n=Math.min(...t),r=Math.max(...t),i=new Date(n);i.setDate(i.getDate()-(i.getDay()+6)%7);let a={};for(let t of e)a[t.date]=t;let o=Math.max(...e.map(e=>e.value??0),1),s=[];for(let e=i.getTime();e<=r;e+=Zr){let t=new Date(e),n=t.toISOString().slice(0,10),r=a[n],i=r?.value??0,c=(t.getDay()+6)%7+1,l=r?.label??`${n}: ${i}`;s.push(w`
                 <div class="cell" style="grid-row: ${c}; --cell: ${this.color(i,o)};" title="${l}"></div>
-            `)}return T`
+            `)}return w`
             <div class="wrap">
                 <div class="grid">${s}</div>
                 <div class="legend">
@@ -3078,14 +3078,14 @@ ${i}
                     <span>More</span>
                 </div>
             </div>
-        `}};k([y({type:Array})],Zr.prototype,`cells`,void 0),Zr=k([g(`mateu-heatmap`)],Zr);var Qr=e=>T`
+        `}};O([v({type:Array})],Qr.prototype,`cells`,void 0),Qr=O([h(`mateu-heatmap`)],Qr);var $r=e=>w`
         <mateu-heatmap
                 .cells="${e.metadata.cells??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-heatmap>
-    `,$r=class extends b{constructor(...e){super(...e),this.stages=[]}static{this.styles=h`
+    `,ei=class extends y{constructor(...e){super(...e),this.stages=[]}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .funnel { display: flex; flex-direction: column; gap: .35rem; }
         .stage { display: flex; flex-direction: column; align-items: center; gap: .1rem; }
@@ -3104,13 +3104,13 @@ ${i}
         .meta { display: flex; gap: .5rem; align-items: baseline; }
         .label { font-weight: 600; color: var(--lumo-body-text-color, #222); }
         .conv { color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-xs, .75rem); }
-    `}render(){let e=this.stages;if(!e.length)return T``;let t=e[0].value??0,n=Math.max(...e.map(e=>e.value??0),1);return T`
+    `}render(){let e=this.stages;if(!e.length)return w``;let t=e[0].value??0,n=Math.max(...e.map(e=>e.value??0),1);return w`
             <div class="funnel">
-                ${e.map((r,i)=>{let a=r.value??0,o=n>0?Math.max(6,a/n*100):6,s=i>0?e[i-1].value??0:t,c=i===0?t>0?`100%`:``:s>0?`${Math.round(a/s*100)}%`:`0%`;return T`
+                ${e.map((r,i)=>{let a=r.value??0,o=n>0?Math.max(6,a/n*100):6,s=i>0?e[i-1].value??0:t,c=i===0?t>0?`100%`:``:s>0?`${Math.round(a/s*100)}%`:`0%`;return w`
                         <div class="stage">
                             <div class="meta">
                                 <span class="label">${r.label}</span>
-                                ${i>0?T`<span class="conv">${c} of previous</span>`:v}
+                                ${i>0?w`<span class="conv">${c} of previous</span>`:_}
                             </div>
                             <div class="bar" style="width: ${o}%; ${r.color?`--bar: ${r.color};`:``}">
                                 ${a.toLocaleString()}
@@ -3118,38 +3118,38 @@ ${i}
                         </div>
                     `})}
             </div>
-        `}};k([y({type:Array})],$r.prototype,`stages`,void 0),$r=k([g(`mateu-funnel`)],$r);var ei=e=>T`
+        `}};O([v({type:Array})],ei.prototype,`stages`,void 0),ei=O([h(`mateu-funnel`)],ei);var ti=e=>w`
         <mateu-funnel
                 .stages="${e.metadata.stages??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-funnel>
-    `,ti=class extends b{constructor(...e){super(...e),this.values=[],this.labels=[],this.area=!1}static{this.styles=h`
+    `,ni=class extends y{constructor(...e){super(...e),this.values=[],this.labels=[],this.area=!1}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .title { font-weight: 600; margin-bottom: .35rem; color: var(--lumo-body-text-color, #222); }
         svg { display: block; width: 100%; height: auto; overflow: visible; }
         .labels { display: flex; justify-content: space-between; color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-xs, .72rem); margin-top: .2rem; }
-    `}render(){let e=this.values;if(!e||e.length<2)return T``;let t=Math.min(...e),n=Math.max(...e),r=n-t||1,i=584/(e.length-1),a=e.map((e,n)=>[8+n*i,8+144*(1-(e-t)/r)]),o=a.map(([e,t],n)=>`${n===0?`M`:`L`}${e.toFixed(1)} ${t.toFixed(1)}`).join(` `),s=`${o} L${a[a.length-1][0].toFixed(1)} 152 L${a[0][0].toFixed(1)} 152 Z`,c=this.color||`var(--lumo-primary-color, #1a73e8)`,l=e.indexOf(n),u=e.indexOf(t);return T`
-            ${this.heading?T`<div class="title">${this.heading}</div>`:v}
+    `}render(){let e=this.values;if(!e||e.length<2)return w``;let t=Math.min(...e),n=Math.max(...e),r=n-t||1,i=584/(e.length-1),a=e.map((e,n)=>[8+n*i,8+144*(1-(e-t)/r)]),o=a.map(([e,t],n)=>`${n===0?`M`:`L`}${e.toFixed(1)} ${t.toFixed(1)}`).join(` `),s=`${o} L${a[a.length-1][0].toFixed(1)} 152 L${a[0][0].toFixed(1)} 152 Z`,c=this.color||`var(--lumo-primary-color, #1a73e8)`,l=e.indexOf(n),u=e.indexOf(t);return w`
+            ${this.heading?w`<div class="title">${this.heading}</div>`:_}
             <svg viewBox="0 0 ${600} ${160}" preserveAspectRatio="none">
-                ${this.area?w`<path d="${s}" fill="${c}" opacity="0.12"></path>`:v}
+                ${this.area?C`<path d="${s}" fill="${c}" opacity="0.12"></path>`:_}
                 <path d="${o}" fill="none" stroke="${c}" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"></path>
-                ${a.map((t,n)=>n===l||n===u?w`<circle cx="${t[0]}" cy="${t[1]}" r="3.2" fill="${c}"><title>${this.labels[n]??``}: ${e[n]}</title></circle>`:w`<circle cx="${t[0]}" cy="${t[1]}" r="6" fill="transparent"><title>${this.labels[n]??``}: ${e[n]}</title></circle>`)}
+                ${a.map((t,n)=>n===l||n===u?C`<circle cx="${t[0]}" cy="${t[1]}" r="3.2" fill="${c}"><title>${this.labels[n]??``}: ${e[n]}</title></circle>`:C`<circle cx="${t[0]}" cy="${t[1]}" r="6" fill="transparent"><title>${this.labels[n]??``}: ${e[n]}</title></circle>`)}
             </svg>
-            ${this.labels&&this.labels.length?T`<div class="labels"><span>${this.labels[0]}</span><span>${this.labels[this.labels.length-1]}</span></div>`:v}
-        `}};k([y()],ti.prototype,`heading`,void 0),k([y({type:Array})],ti.prototype,`values`,void 0),k([y({type:Array})],ti.prototype,`labels`,void 0),k([y()],ti.prototype,`color`,void 0),k([y({type:Boolean})],ti.prototype,`area`,void 0),ti=k([g(`mateu-trend-chart`)],ti);var ni=e=>{let t=e.metadata;return T`
+            ${this.labels&&this.labels.length?w`<div class="labels"><span>${this.labels[0]}</span><span>${this.labels[this.labels.length-1]}</span></div>`:_}
+        `}};O([v()],ni.prototype,`heading`,void 0),O([v({type:Array})],ni.prototype,`values`,void 0),O([v({type:Array})],ni.prototype,`labels`,void 0),O([v()],ni.prototype,`color`,void 0),O([v({type:Boolean})],ni.prototype,`area`,void 0),ni=O([h(`mateu-trend-chart`)],ni);var ri=e=>{let t=e.metadata;return w`
         <mateu-trend-chart
-                heading="${t.title??v}"
-                color="${t.color??v}"
+                heading="${t.title??_}"
+                color="${t.color??_}"
                 ?area="${t.area??!1}"
                 .values="${t.values??[]}"
                 .labels="${t.labels??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-trend-chart>
-    `},ri=class extends b{constructor(...e){super(...e),this.features=[],this.columns=0}static{this.styles=h`
+    `},ii=class extends y{constructor(...e){super(...e),this.features=[],this.columns=0}static{this.styles=m`
         :host { display: block; width: 100%; }
         .grid {
             display: grid;
@@ -3179,26 +3179,26 @@ ${i}
             .card { background: var(--lumo-contrast-5pct, #2a2a2a); }
         }
     
-        ${z}
-    `}clickFeature(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))}render(){return T`
+        ${R}
+    `}clickFeature(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))}render(){return w`
             <div class="grid" style="grid-template-columns: ${this.columns&&this.columns>0?`repeat(${this.columns}, minmax(0, 1fr))`:`repeat(auto-fit, minmax(15rem, 1fr))`};">
-                ${this.features.map(e=>T`
-                    <div role="button" tabindex="0" class="card ${e.actionId?`clickable`:``}" @click="${()=>this.clickFeature(e)}" @keydown="${R(()=>this.clickFeature(e))}">
-                        ${e.icon?T`<span class="icon">${e.icon}</span>`:v}
+                ${this.features.map(e=>w`
+                    <div role="button" tabindex="0" class="card ${e.actionId?`clickable`:``}" @click="${()=>this.clickFeature(e)}" @keydown="${L(()=>this.clickFeature(e))}">
+                        ${e.icon?w`<span class="icon">${e.icon}</span>`:_}
                         <span class="title">${e.title}</span>
-                        ${e.description?T`<span class="desc">${e.description}</span>`:v}
+                        ${e.description?w`<span class="desc">${e.description}</span>`:_}
                     </div>
                 `)}
             </div>
-        `}};k([y({type:Array})],ri.prototype,`features`,void 0),k([y({type:Number})],ri.prototype,`columns`,void 0),ri=k([g(`mateu-feature-grid`)],ri);var ii=e=>{let t=e.metadata;return T`
+        `}};O([v({type:Array})],ii.prototype,`features`,void 0),O([v({type:Number})],ii.prototype,`columns`,void 0),ii=O([h(`mateu-feature-grid`)],ii);var ai=e=>{let t=e.metadata;return w`
         <mateu-feature-grid
                 .features="${t.features??[]}"
                 .columns="${t.columns??0}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-feature-grid>
-    `},ai=class extends b{constructor(...e){super(...e),this.items=[]}static{this.styles=h`
+    `},oi=class extends y{constructor(...e){super(...e),this.items=[]}static{this.styles=m`
         :host { display: block; width: 100%; }
         .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr)); gap: var(--lumo-space-m, 1rem); }
         .card {
@@ -3222,30 +3222,30 @@ ${i}
         .name { font-weight: 600; color: var(--lumo-body-text-color, #222); }
         .role { color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-xs, .75rem); }
         @media (prefers-color-scheme: dark) { .card { background: var(--lumo-contrast-5pct, #2a2a2a); } }
-    `}stars(e){let t=Math.max(0,Math.min(5,e||0));return`★`.repeat(t)+`☆`.repeat(5-t)}render(){return T`
+    `}stars(e){let t=Math.max(0,Math.min(5,e||0));return`★`.repeat(t)+`☆`.repeat(5-t)}render(){return w`
             <div class="grid">
-                ${this.items.map(e=>{let t=e.avatar&&(e.avatar.startsWith(`http`)||e.avatar.startsWith(`data:`));return T`
+                ${this.items.map(e=>{let t=e.avatar&&(e.avatar.startsWith(`http`)||e.avatar.startsWith(`data:`));return w`
                         <div class="card">
-                            ${e.rating?T`<div class="stars">${this.stars(e.rating)}</div>`:v}
+                            ${e.rating?w`<div class="stars">${this.stars(e.rating)}</div>`:_}
                             <div class="quote">${e.quote}</div>
                             <div class="author">
-                                ${e.avatar?T`<span class="avatar">${t?T`<img src="${e.avatar}" alt="">`:e.avatar}</span>`:v}
+                                ${e.avatar?w`<span class="avatar">${t?w`<img src="${e.avatar}" alt="">`:e.avatar}</span>`:_}
                                 <div>
                                     <div class="name">${e.author}</div>
-                                    ${e.role?T`<div class="role">${e.role}</div>`:v}
+                                    ${e.role?w`<div class="role">${e.role}</div>`:_}
                                 </div>
                             </div>
                         </div>
                     `})}
             </div>
-        `}};k([y({type:Array})],ai.prototype,`items`,void 0),ai=k([g(`mateu-testimonials`)],ai);var oi=e=>T`
+        `}};O([v({type:Array})],oi.prototype,`items`,void 0),oi=O([h(`mateu-testimonials`)],oi);var si=e=>w`
         <mateu-testimonials
                 .items="${e.metadata.items??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-testimonials>
-    `,si=class extends b{constructor(...e){super(...e),this.items=[],this.openSet=new Set,this.seeded=!1}static{this.styles=h`
+    `,ci=class extends y{constructor(...e){super(...e),this.items=[],this.openSet=new Set,this.seeded=!1}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-m, 1rem); }
         .list {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -3269,27 +3269,27 @@ ${i}
         }
         @media (prefers-color-scheme: dark) { .q { background: var(--lumo-contrast-5pct, #2a2a2a); } }
     
-        ${z}
-    `}seed(){this.seeded||(this.seeded=!0,this.items.forEach((e,t)=>{e.open&&this.openSet.add(t)}))}toggle(e){this.openSet.has(e)?this.openSet.delete(e):this.openSet.add(e),this.requestUpdate()}render(){return this.seed(),T`
+        ${R}
+    `}seed(){this.seeded||(this.seeded=!0,this.items.forEach((e,t)=>{e.open&&this.openSet.add(t)}))}toggle(e){this.openSet.has(e)?this.openSet.delete(e):this.openSet.add(e),this.requestUpdate()}render(){return this.seed(),w`
             <div class="list">
-                ${this.items.map((e,t)=>{let n=this.openSet.has(t);return T`
+                ${this.items.map((e,t)=>{let n=this.openSet.has(t);return w`
                         <div class="item ${n?`open`:``}">
-                            <div role="button" tabindex="0" aria-expanded="${n}" class="q" @click="${()=>this.toggle(t)}" @keydown="${R(()=>this.toggle(t))}">
+                            <div role="button" tabindex="0" aria-expanded="${n}" class="q" @click="${()=>this.toggle(t)}" @keydown="${L(()=>this.toggle(t))}">
                                 <span>${e.question}</span>
                                 <span class="chevron">›</span>
                             </div>
-                            ${n?T`<div class="a">${e.answer}</div>`:``}
+                            ${n?w`<div class="a">${e.answer}</div>`:``}
                         </div>
                     `})}
             </div>
-        `}};k([y({type:Array})],si.prototype,`items`,void 0),k([C()],si.prototype,`openSet`,void 0),si=k([g(`mateu-faq`)],si);var ci=e=>T`
+        `}};O([v({type:Array})],ci.prototype,`items`,void 0),O([S()],ci.prototype,`openSet`,void 0),ci=O([h(`mateu-faq`)],ci);var li=e=>w`
         <mateu-faq
                 .items="${e.metadata.items??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-faq>
-    `,li=class extends b{static{this.styles=h`
+    `,ui=class extends y{static{this.styles=m`
         :host { display: block; width: 100%; }
         .callout {
             display: flex; gap: 1rem; align-items: flex-start;
@@ -3309,28 +3309,28 @@ ${i}
             background: var(--accent, var(--lumo-primary-color, #1a73e8)); color: #fff;
         }
         .cta:hover { filter: brightness(.95); }
-    `}themeVars(){switch(this.theme){case`success`:return`--accent: var(--lumo-success-color, #12b76a); --bg: var(--lumo-success-color-10pct, rgba(18,183,106,.1));`;case`warning`:return`--accent: #f59e0b; --bg: rgba(245,158,11,.12);`;case`danger`:return`--accent: var(--lumo-error-color, #e11d48); --bg: var(--lumo-error-color-10pct, rgba(225,29,72,.1));`;default:return`--accent: var(--lumo-primary-color, #1a73e8); --bg: var(--lumo-primary-color-10pct, rgba(26,115,232,.1));`}}cta(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId},bubbles:!0,composed:!0}))}render(){return T`
+    `}themeVars(){switch(this.theme){case`success`:return`--accent: var(--lumo-success-color, #12b76a); --bg: var(--lumo-success-color-10pct, rgba(18,183,106,.1));`;case`warning`:return`--accent: #f59e0b; --bg: rgba(245,158,11,.12);`;case`danger`:return`--accent: var(--lumo-error-color, #e11d48); --bg: var(--lumo-error-color-10pct, rgba(225,29,72,.1));`;default:return`--accent: var(--lumo-primary-color, #1a73e8); --bg: var(--lumo-primary-color-10pct, rgba(26,115,232,.1));`}}cta(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId},bubbles:!0,composed:!0}))}render(){return w`
             <div class="callout" style="${this.themeVars()}">
-                ${this.icon?T`<span class="icon">${this.icon}</span>`:v}
+                ${this.icon?w`<span class="icon">${this.icon}</span>`:_}
                 <div class="body">
-                    ${this.heading?T`<span class="heading">${this.heading}</span>`:v}
-                    ${this.description?T`<span class="desc">${this.description}</span>`:v}
-                    ${this.ctaLabel?T`<button class="cta" @click="${()=>this.cta()}">${this.ctaLabel}</button>`:v}
+                    ${this.heading?w`<span class="heading">${this.heading}</span>`:_}
+                    ${this.description?w`<span class="desc">${this.description}</span>`:_}
+                    ${this.ctaLabel?w`<button class="cta" @click="${()=>this.cta()}">${this.ctaLabel}</button>`:_}
                 </div>
             </div>
-        `}};k([y()],li.prototype,`heading`,void 0),k([y()],li.prototype,`description`,void 0),k([y()],li.prototype,`icon`,void 0),k([y()],li.prototype,`ctaLabel`,void 0),k([y()],li.prototype,`actionId`,void 0),k([y()],li.prototype,`theme`,void 0),li=k([g(`mateu-callout-card`)],li);var ui=e=>{let t=e.metadata;return T`
+        `}};O([v()],ui.prototype,`heading`,void 0),O([v()],ui.prototype,`description`,void 0),O([v()],ui.prototype,`icon`,void 0),O([v()],ui.prototype,`ctaLabel`,void 0),O([v()],ui.prototype,`actionId`,void 0),O([v()],ui.prototype,`theme`,void 0),ui=O([h(`mateu-callout-card`)],ui);var di=e=>{let t=e.metadata;return w`
         <mateu-callout-card
-                heading="${t.title??v}"
-                description="${t.description??v}"
-                icon="${t.icon??v}"
-                ctaLabel="${t.ctaLabel??v}"
-                actionId="${t.actionId??v}"
-                theme="${t.theme??v}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                heading="${t.title??_}"
+                description="${t.description??_}"
+                icon="${t.icon??_}"
+                ctaLabel="${t.ctaLabel??_}"
+                actionId="${t.actionId??_}"
+                theme="${t.theme??_}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-callout-card>
-    `},di=class extends b{constructor(...e){super(...e),this.comments=[]}static{this.styles=h`
+    `},fi=class extends y{constructor(...e){super(...e),this.comments=[]}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .thread { display: flex; flex-direction: column; gap: 1rem; }
         .replies {
@@ -3350,26 +3350,26 @@ ${i}
         .author { font-weight: 600; color: var(--lumo-body-text-color, #222); }
         .time { color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-xs, .72rem); }
         .text { color: var(--lumo-body-text-color, #333); margin-top: .15rem; line-height: 1.5; }
-    `}renderComment(e){let t=e.avatar&&(e.avatar.startsWith(`http`)||e.avatar.startsWith(`data:`));return T`
+    `}renderComment(e){let t=e.avatar&&(e.avatar.startsWith(`http`)||e.avatar.startsWith(`data:`));return w`
             <div class="comment">
-                <span class="avatar">${e.avatar?t?T`<img src="${e.avatar}" alt="">`:e.avatar:e.author?.[0]??`?`}</span>
+                <span class="avatar">${e.avatar?t?w`<img src="${e.avatar}" alt="">`:e.avatar:e.author?.[0]??`?`}</span>
                 <div class="body">
                     <div class="head">
                         <span class="author">${e.author}</span>
-                        ${e.timestamp?T`<span class="time">${e.timestamp}</span>`:v}
+                        ${e.timestamp?w`<span class="time">${e.timestamp}</span>`:_}
                     </div>
                     <div class="text">${e.text}</div>
-                    ${e.replies&&e.replies.length?T`<div class="replies">${e.replies.map(e=>this.renderComment(e))}</div>`:v}
+                    ${e.replies&&e.replies.length?w`<div class="replies">${e.replies.map(e=>this.renderComment(e))}</div>`:_}
                 </div>
             </div>
-        `}render(){return T`<div class="thread">${this.comments.map(e=>this.renderComment(e))}</div>`}};k([y({type:Array})],di.prototype,`comments`,void 0),di=k([g(`mateu-comment-thread`)],di);var fi=e=>T`
+        `}render(){return w`<div class="thread">${this.comments.map(e=>this.renderComment(e))}</div>`}};O([v({type:Array})],fi.prototype,`comments`,void 0),fi=O([h(`mateu-comment-thread`)],fi);var pi=e=>w`
         <mateu-comment-thread
                 .comments="${e.metadata.comments??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-comment-thread>
-    `,pi={pdf:`📕`,image:`🖼️`,img:`🖼️`,doc:`📘`,docx:`📘`,word:`📘`,xls:`📗`,xlsx:`📗`,excel:`📗`,sheet:`📗`,zip:`🗜️`,archive:`🗜️`,video:`🎬`,audio:`🎵`,code:`💻`,csv:`📄`,txt:`📄`},mi=class extends b{constructor(...e){super(...e),this.files=[]}static{this.styles=h`
+    `,mi={pdf:`📕`,image:`🖼️`,img:`🖼️`,doc:`📘`,docx:`📘`,word:`📘`,xls:`📗`,xlsx:`📗`,excel:`📗`,sheet:`📗`,zip:`🗜️`,archive:`🗜️`,video:`🎬`,audio:`🎵`,code:`💻`,csv:`📄`,txt:`📄`},hi=class extends y{constructor(...e){super(...e),this.files=[]}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .list {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -3385,24 +3385,24 @@ ${i}
         .size { color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-xs, .75rem); flex: 0 0 auto; }
         .dl { color: var(--lumo-primary-color, #1a73e8); flex: 0 0 auto; }
     
-        ${z}
-    `}icon(e){return e&&pi[e.toLowerCase()]||`📄`}clickFile(e,t){e.url||e.actionId&&(t.preventDefault(),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_file:e}},bubbles:!0,composed:!0})))}render(){return T`
+        ${R}
+    `}icon(e){return e&&mi[e.toLowerCase()]||`📄`}clickFile(e,t){e.url||e.actionId&&(t.preventDefault(),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_file:e}},bubbles:!0,composed:!0})))}render(){return w`
             <div class="list">
-                ${this.files.map(e=>{let t=!!e.url||!!e.actionId,n=T`
+                ${this.files.map(e=>{let t=!!e.url||!!e.actionId,n=w`
                         <span class="icon">${this.icon(e.type)}</span>
                         <span class="name">${e.name}</span>
-                        ${e.size?T`<span class="size">${e.size}</span>`:v}
-                        ${e.url?T`<span class="dl">⬇</span>`:v}
-                    `;return e.url?T`<a class="file clickable" href="${e.url}" download target="_blank" rel="noopener">${n}</a>`:T`<div role="button" tabindex="0" class="file ${t?`clickable`:``}" @click="${t=>this.clickFile(e,t)}" @keydown="${R(t=>this.clickFile(e,t))}">${n}</div>`})}
+                        ${e.size?w`<span class="size">${e.size}</span>`:_}
+                        ${e.url?w`<span class="dl">⬇</span>`:_}
+                    `;return e.url?w`<a class="file clickable" href="${e.url}" download target="_blank" rel="noopener">${n}</a>`:w`<div role="button" tabindex="0" class="file ${t?`clickable`:``}" @click="${t=>this.clickFile(e,t)}" @keydown="${L(t=>this.clickFile(e,t))}">${n}</div>`})}
             </div>
-        `}};k([y({type:Array})],mi.prototype,`files`,void 0),mi=k([g(`mateu-file-list`)],mi);var hi=e=>T`
+        `}};O([v({type:Array})],hi.prototype,`files`,void 0),hi=O([h(`mateu-file-list`)],hi);var gi=e=>w`
         <mateu-file-list
                 .files="${e.metadata.files??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-file-list>
-    `,gi=class extends b{constructor(...e){super(...e),this.items=[],this.localDone=new Map}static{this.styles=h`
+    `,_i=class extends y{constructor(...e){super(...e),this.items=[],this.localDone=new Map}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .head { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: .5rem; }
         .title { font-weight: 700; color: var(--lumo-body-text-color, #222); }
@@ -3419,28 +3419,28 @@ ${i}
         .label { color: var(--lumo-body-text-color, #333); }
         .item.done .label { color: var(--lumo-secondary-text-color, #999); text-decoration: line-through; }
     
-        ${z}
-    `}isDone(e,t){return this.localDone.has(t)?!!this.localDone.get(t):!!e.done}toggle(e,t){let n=!this.isDone(e,t);this.localDone.set(t,n),this.requestUpdate(),e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_item:e,_done:n}},bubbles:!0,composed:!0}))}render(){let e=this.items.length,t=this.items.filter((e,t)=>this.isDone(e,t)).length,n=e>0?Math.round(t/e*100):0;return T`
+        ${R}
+    `}isDone(e,t){return this.localDone.has(t)?!!this.localDone.get(t):!!e.done}toggle(e,t){let n=!this.isDone(e,t);this.localDone.set(t,n),this.requestUpdate(),e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_item:e,_done:n}},bubbles:!0,composed:!0}))}render(){let e=this.items.length,t=this.items.filter((e,t)=>this.isDone(e,t)).length,n=e>0?Math.round(t/e*100):0;return w`
             <div class="head">
-                ${this.heading?T`<span class="title">${this.heading}</span>`:T`<span></span>`}
+                ${this.heading?w`<span class="title">${this.heading}</span>`:w`<span></span>`}
                 <span class="count">${t} / ${e}</span>
             </div>
             <div class="bar"><div class="fill" style="width: ${n}%;"></div></div>
-            ${this.items.map((e,t)=>{let n=this.isDone(e,t);return T`
-                    <div role="button" tabindex="0" class="item ${n?`done`:``}" @click="${()=>this.toggle(e,t)}" @keydown="${R(()=>this.toggle(e,t))}">
-                        <span class="box">${n?`✓`:v}</span>
+            ${this.items.map((e,t)=>{let n=this.isDone(e,t);return w`
+                    <div role="button" tabindex="0" class="item ${n?`done`:``}" @click="${()=>this.toggle(e,t)}" @keydown="${L(()=>this.toggle(e,t))}">
+                        <span class="box">${n?`✓`:_}</span>
                         <span class="label">${e.label}</span>
                     </div>
                 `})}
-        `}};k([y()],gi.prototype,`heading`,void 0),k([y({type:Array})],gi.prototype,`items`,void 0),k([C()],gi.prototype,`localDone`,void 0),gi=k([g(`mateu-checklist`)],gi);var _i=e=>{let t=e.metadata;return T`
+        `}};O([v()],_i.prototype,`heading`,void 0),O([v({type:Array})],_i.prototype,`items`,void 0),O([S()],_i.prototype,`localDone`,void 0),_i=O([h(`mateu-checklist`)],_i);var vi=e=>{let t=e.metadata;return w`
         <mateu-checklist
-                heading="${t.title??v}"
+                heading="${t.title??_}"
                 .items="${t.items??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-checklist>
-    `},vi=class extends b{static{this.styles=h`
+    `},yi=class extends y{static{this.styles=m`
         :host { display: block; width: 100%; }
         .card {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -3462,38 +3462,38 @@ ${i}
         .delta.down { color: var(--lumo-error-color, #e11d48); background: var(--lumo-error-color-10pct, rgba(225,29,72,.12)); }
         .delta.flat { color: var(--lumo-secondary-text-color, #888); background: var(--lumo-contrast-10pct, rgba(0,0,0,.06)); }
         @media (prefers-color-scheme: dark) { .card { background: var(--lumo-contrast-5pct, #2a2a2a); } }
-    `}render(){let e=this.trend??`flat`;return T`
+    `}render(){let e=this.trend??`flat`;return w`
             <div class="card">
-                ${this.heading?T`<div class="title">${this.heading}</div>`:v}
+                ${this.heading?w`<div class="title">${this.heading}</div>`:_}
                 <div class="row">
                     <div class="side">
-                        ${this.leftLabel?T`<div class="label">${this.leftLabel}</div>`:v}
+                        ${this.leftLabel?w`<div class="label">${this.leftLabel}</div>`:_}
                         <div class="value">${this.leftValue}</div>
                     </div>
                     <div class="mid">
                         <span class="arrow">${`→`}</span>
-                        ${this.delta?T`<span class="delta ${e}">${e===`up`?`▲`:e===`down`?`▼`:``} ${this.delta}</span>`:v}
+                        ${this.delta?w`<span class="delta ${e}">${e===`up`?`▲`:e===`down`?`▼`:``} ${this.delta}</span>`:_}
                     </div>
                     <div class="side">
-                        ${this.rightLabel?T`<div class="label">${this.rightLabel}</div>`:v}
+                        ${this.rightLabel?w`<div class="label">${this.rightLabel}</div>`:_}
                         <div class="value">${this.rightValue}</div>
                     </div>
                 </div>
             </div>
-        `}};k([y()],vi.prototype,`heading`,void 0),k([y()],vi.prototype,`leftLabel`,void 0),k([y()],vi.prototype,`leftValue`,void 0),k([y()],vi.prototype,`rightLabel`,void 0),k([y()],vi.prototype,`rightValue`,void 0),k([y()],vi.prototype,`delta`,void 0),k([y()],vi.prototype,`trend`,void 0),vi=k([g(`mateu-comparison-card`)],vi);var yi=e=>{let t=e.metadata;return T`
+        `}};O([v()],yi.prototype,`heading`,void 0),O([v()],yi.prototype,`leftLabel`,void 0),O([v()],yi.prototype,`leftValue`,void 0),O([v()],yi.prototype,`rightLabel`,void 0),O([v()],yi.prototype,`rightValue`,void 0),O([v()],yi.prototype,`delta`,void 0),O([v()],yi.prototype,`trend`,void 0),yi=O([h(`mateu-comparison-card`)],yi);var bi=e=>{let t=e.metadata;return w`
         <mateu-comparison-card
-                heading="${t.title??v}"
-                leftLabel="${t.leftLabel??v}"
-                leftValue="${t.leftValue??v}"
-                rightLabel="${t.rightLabel??v}"
-                rightValue="${t.rightValue??v}"
-                delta="${t.delta??v}"
-                trend="${t.trend??v}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                heading="${t.title??_}"
+                leftLabel="${t.leftLabel??_}"
+                leftValue="${t.leftValue??_}"
+                rightLabel="${t.rightLabel??_}"
+                rightValue="${t.rightValue??_}"
+                delta="${t.delta??_}"
+                trend="${t.trend??_}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-comparison-card>
-    `},bi=h`
+    `},xi=m`
     .chip {
         display: inline-flex;
         align-items: center;
@@ -3523,7 +3523,7 @@ ${i}
         color: var(--lumo-contrast-80pct, #333);
         background: var(--lumo-contrast-10pct, rgba(0, 0, 0, .08));
     }
-`,xi=new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}),Si=e=>xi.format(e),Ci=(e,t)=>{let n=e<0?`-`:``,r=Si(Math.abs(e));return t?`${n}${t} ${r}`:`${n}${r}`},wi=(e,t)=>t?`${Si(e)} ${t}`:Si(e),Ti=class extends b{constructor(...e){super(...e),this.title=``,this.badges=[],this.facts=[]}static{this.styles=[bi,h`
+`,Si=new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}),Ci=e=>Si.format(e),wi=(e,t)=>{let n=e<0?`-`:``,r=Ci(Math.abs(e));return t?`${n}${t} ${r}`:`${n}${r}`},Ti=(e,t)=>t?`${Ci(e)} ${t}`:Ci(e),Ei=class extends y{constructor(...e){super(...e),this.title=``,this.badges=[],this.facts=[]}static{this.styles=[xi,m`
         :host { display: block; width: 100%; }
         .card {
             display: flex;
@@ -3579,34 +3579,34 @@ ${i}
             color: var(--lumo-primary-text-color, #1a73e8);
         }
         .metric .caption { font-size: var(--lumo-font-size-xs, .75rem); color: var(--lumo-secondary-text-color, #888); }
-    `]}render(){let e=!!(this.metricLabel||this.metricValue||this.metricCaption);return T`
+    `]}render(){let e=!!(this.metricLabel||this.metricValue||this.metricCaption);return w`
             <div class="card">
                 <div class="main">
                     <div class="title-row">
                         <span class="title">${this.title}</span>
-                        ${this.badges.map(e=>T`<span class="chip ${e.color??``}">${e.label}</span>`)}
+                        ${this.badges.map(e=>w`<span class="chip ${e.color??``}">${e.label}</span>`)}
                     </div>
-                    ${this.subtitle?T`<span class="subtitle">${this.subtitle}</span>`:v}
-                    ${this.facts.length?T`
+                    ${this.subtitle?w`<span class="subtitle">${this.subtitle}</span>`:_}
+                    ${this.facts.length?w`
                         <div class="facts">
-                            ${this.facts.map(e=>T`
+                            ${this.facts.map(e=>w`
                                 <div class="fact">
                                     <span class="label">${e.label}</span>
                                     <span class="value">${e.value}</span>
                                 </div>
                             `)}
                         </div>
-                    `:v}
+                    `:_}
                 </div>
-                ${e?T`
+                ${e?w`
                     <div class="metric">
-                        ${this.metricLabel?T`<span class="label">${this.metricLabel}</span>`:v}
-                        ${this.metricValue?T`<span class="value">${this.metricValue}</span>`:v}
-                        ${this.metricCaption?T`<span class="caption">${this.metricCaption}</span>`:v}
+                        ${this.metricLabel?w`<span class="label">${this.metricLabel}</span>`:_}
+                        ${this.metricValue?w`<span class="value">${this.metricValue}</span>`:_}
+                        ${this.metricCaption?w`<span class="caption">${this.metricCaption}</span>`:_}
                     </div>
-                `:v}
+                `:_}
             </div>
-        `}};k([y()],Ti.prototype,`title`,void 0),k([y({type:Array})],Ti.prototype,`badges`,void 0),k([y()],Ti.prototype,`subtitle`,void 0),k([y({type:Array})],Ti.prototype,`facts`,void 0),k([y()],Ti.prototype,`metricLabel`,void 0),k([y()],Ti.prototype,`metricValue`,void 0),k([y()],Ti.prototype,`metricCaption`,void 0),Ti=k([g(`mateu-entity-header`)],Ti);var Ei=e=>{if(e.__hoistedToPageHeader)return T``;let t=e.metadata;return T`
+        `}};O([v()],Ei.prototype,`title`,void 0),O([v({type:Array})],Ei.prototype,`badges`,void 0),O([v()],Ei.prototype,`subtitle`,void 0),O([v({type:Array})],Ei.prototype,`facts`,void 0),O([v()],Ei.prototype,`metricLabel`,void 0),O([v()],Ei.prototype,`metricValue`,void 0),O([v()],Ei.prototype,`metricCaption`,void 0),Ei=O([h(`mateu-entity-header`)],Ei);var Di=e=>{if(e.__hoistedToPageHeader)return w``;let t=e.metadata;return w`
         <mateu-entity-header
                 .title="${t.title??``}"
                 .badges="${t.badges??[]}"
@@ -3615,11 +3615,11 @@ ${i}
                 .metricLabel="${t.metricLabel}"
                 .metricValue="${t.metricValue}"
                 .metricCaption="${t.metricCaption}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-entity-header>
-    `},Di=class extends b{constructor(...e){super(...e),this.value=0,this.max=0}static{this.styles=h`
+    `},Oi=class extends y{constructor(...e){super(...e),this.value=0,this.max=0}static{this.styles=m`
         :host { display: block; width: 100%; }
         .meter { display: flex; flex-direction: column; gap: .35rem; }
         .label {
@@ -3641,16 +3641,16 @@ ${i}
         .fill.warning { background: var(--lumo-warning-color, #f59e0b); }
         .fill.error { background: var(--lumo-error-color, #e11d48); }
         .caption { font-size: var(--lumo-font-size-xs, .75rem); color: var(--lumo-secondary-text-color, #888); }
-    `}fillColor(){return this.dangerAt!=null&&this.value>=this.dangerAt?`error`:this.warnAt!=null&&this.value>=this.warnAt?`warning`:this.warnAt!=null||this.dangerAt!=null?`success`:`primary`}render(){let e=this.max>0?Math.min(Math.max(this.value/this.max,0),1):0,t=Math.round(e*100);return T`
+    `}fillColor(){return this.dangerAt!=null&&this.value>=this.dangerAt?`error`:this.warnAt!=null&&this.value>=this.warnAt?`warning`:this.warnAt!=null||this.dangerAt!=null?`success`:`primary`}render(){let e=this.max>0?Math.min(Math.max(this.value/this.max,0),1):0,t=Math.round(e*100);return w`
             <div class="meter">
-                ${this.label?T`<span class="label">${this.label}</span>`:v}
-                <span class="value">${wi(this.value,this.unit)}</span>
+                ${this.label?w`<span class="label">${this.label}</span>`:_}
+                <span class="value">${Ti(this.value,this.unit)}</span>
                 <div class="track">
                     <div class="fill ${this.fillColor()}" style="width: ${t}%"></div>
                 </div>
                 <span class="caption">${this.caption?this.caption:`${t}%`}</span>
             </div>
-        `}};k([y()],Di.prototype,`label`,void 0),k([y({type:Number})],Di.prototype,`value`,void 0),k([y({type:Number})],Di.prototype,`max`,void 0),k([y()],Di.prototype,`unit`,void 0),k([y()],Di.prototype,`caption`,void 0),k([y({type:Number})],Di.prototype,`warnAt`,void 0),k([y({type:Number})],Di.prototype,`dangerAt`,void 0),Di=k([g(`mateu-meter`)],Di);var Oi=e=>{let t=e.metadata;return T`
+        `}};O([v()],Oi.prototype,`label`,void 0),O([v({type:Number})],Oi.prototype,`value`,void 0),O([v({type:Number})],Oi.prototype,`max`,void 0),O([v()],Oi.prototype,`unit`,void 0),O([v()],Oi.prototype,`caption`,void 0),O([v({type:Number})],Oi.prototype,`warnAt`,void 0),O([v({type:Number})],Oi.prototype,`dangerAt`,void 0),Oi=O([h(`mateu-meter`)],Oi);var ki=e=>{let t=e.metadata;return w`
         <mateu-meter
                 .label="${t.label}"
                 .value="${t.value??0}"
@@ -3659,11 +3659,11 @@ ${i}
                 .caption="${t.caption}"
                 .warnAt="${t.warnAt}"
                 .dangerAt="${t.dangerAt}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-meter>
-    `},ki=class extends b{constructor(...e){super(...e),this.total=0,this.done=0}static{this.styles=h`
+    `},Ai=class extends y{constructor(...e){super(...e),this.total=0,this.done=0}static{this.styles=m`
         :host { display: block; width: 100%; }
         .banner {
             display: flex; align-items: center; gap: .8rem; flex-wrap: wrap;
@@ -3706,30 +3706,30 @@ ${i}
             white-space: nowrap;
         }
         button:hover { filter: brightness(1.08); }
-    `}runAction(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{}},bubbles:!0,composed:!0}))}render(){let e=this.total>0&&this.done>=this.total,t=!e&&!!this.actionLabel&&!!this.actionId;return T`
+    `}runAction(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{}},bubbles:!0,composed:!0}))}render(){let e=this.total>0&&this.done>=this.total,t=!e&&!!this.actionLabel&&!!this.actionId;return w`
             <div class="banner ${e?`complete`:``}">
                 <span class="icon">👥</span>
-                ${this.label?T`<span class="label">${this.label}</span>`:v}
+                ${this.label?w`<span class="label">${this.label}</span>`:_}
                 <div class="pills">
-                    ${Array.from({length:this.total},(e,t)=>T`
+                    ${Array.from({length:this.total},(e,t)=>w`
                         <span class="pill ${t+1<=this.done?`filled`:``}">${t+1}/${this.total}</span>
                     `)}
                 </div>
                 <span class="spacer"></span>
-                ${t?T`<button @click="${()=>this.runAction()}">${this.actionLabel} →</button>`:v}
+                ${t?w`<button @click="${()=>this.runAction()}">${this.actionLabel} →</button>`:_}
             </div>
-        `}};k([y()],ki.prototype,`label`,void 0),k([y({type:Number})],ki.prototype,`total`,void 0),k([y({type:Number})],ki.prototype,`done`,void 0),k([y()],ki.prototype,`actionLabel`,void 0),k([y()],ki.prototype,`actionId`,void 0),ki=k([g(`mateu-task-progress`)],ki);var Ai=e=>{let t=e.metadata;return T`
+        `}};O([v()],Ai.prototype,`label`,void 0),O([v({type:Number})],Ai.prototype,`total`,void 0),O([v({type:Number})],Ai.prototype,`done`,void 0),O([v()],Ai.prototype,`actionLabel`,void 0),O([v()],Ai.prototype,`actionId`,void 0),Ai=O([h(`mateu-task-progress`)],Ai);var ji=e=>{let t=e.metadata;return w`
         <mateu-task-progress
                 .label="${t.label}"
                 .total="${t.total??0}"
                 .done="${t.done??0}"
                 .actionLabel="${t.actionLabel}"
                 .actionId="${t.actionId}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-task-progress>
-    `},ji=class extends b{constructor(...e){super(...e),this.items=[],this.compact=!1,this.frameless=!1,this.columns=0,this.itemHeadingLevel=3}static{this.styles=[bi,z,h`
+    `},Mi=class extends y{constructor(...e){super(...e),this.items=[],this.compact=!1,this.frameless=!1,this.columns=0,this.itemHeadingLevel=3}static{this.styles=[xi,R,m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .list {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -3831,60 +3831,60 @@ ${i}
             cursor: pointer; font-size: 1rem;
         }
         .icon-action:hover { background: var(--lumo-contrast-5pct, rgba(0,0,0,.04)); }
-    `]}runAction(e,t){t&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_item:e.id}},bubbles:!0,composed:!0}))}rowClicked(e){this.rowActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.rowActionId,parameters:{_item:e.id}},bubbles:!0,composed:!0}))}renderItemAction(e,t,n,r){return!t||!n?v:r?T`
+    `]}runAction(e,t){t&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_item:e.id}},bubbles:!0,composed:!0}))}rowClicked(e){this.rowActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.rowActionId,parameters:{_item:e.id}},bubbles:!0,composed:!0}))}renderItemAction(e,t,n,r){return!t||!n?_:r?w`
                 <button class="icon-action" title="${t}" aria-label="${t}"
                     @click="${t=>{t.stopPropagation(),this.runAction(e,n)}}">
-                    ${I(r)}
-                </button>`:T`
+                    ${F(r)}
+                </button>`:w`
             <button class="row-action" title="${t}"
-                @click="${t=>{t.stopPropagation(),this.runAction(e,n)}}">${t}</button>`}render(){let e=this.columns>1||this.items.some(e=>e.actionId||e.actionId2||e.actionId3||(e.lines?.length??0)>0),t=this.itemHeadingLevel===4?`h4`:`h3`;return e?T`
+                @click="${t=>{t.stopPropagation(),this.runAction(e,n)}}">${t}</button>`}render(){let e=this.columns>1||this.items.some(e=>e.actionId||e.actionId2||e.actionId3||(e.lines?.length??0)>0),t=this.itemHeadingLevel===4?`h4`:`h3`;return e?w`
                 <div class="list stacked ${this.compact?`compact`:``} ${this.columns>1?`grid`:``}"
                      style="${this.columns>1?`grid-template-columns: repeat(auto-fit, minmax(min(18rem, calc(100% / ${this.columns} - 1.5rem)), 1fr));`:``}">
-                    ${this.items.map(e=>T`
+                    ${this.items.map(e=>w`
                         <div role="button" tabindex="0" class="cell ${(e.lines?.length??0)>0?`with-lines`:``} ${this.rowActionId?`clickable`:``}"
-                             @click="${()=>this.rowClicked(e)}" @keydown="${R(()=>this.rowClicked(e))}">
+                             @click="${()=>this.rowClicked(e)}" @keydown="${L(()=>this.rowClicked(e))}">
                             <div class="cell-title-row">
-                                ${t===`h4`?T`<h4 class="cell-title">${e.title}</h4>`:T`<h3 class="cell-title">${e.title}</h3>`}
-                                ${e.status?T`<span class="chip ${e.statusColor??``}">${e.status}</span>`:v}
+                                ${t===`h4`?w`<h4 class="cell-title">${e.title}</h4>`:w`<h3 class="cell-title">${e.title}</h3>`}
+                                ${e.status?w`<span class="chip ${e.statusColor??``}">${e.status}</span>`:_}
                             </div>
-                            ${e.description?T`<span class="cell-description">${e.description}</span>`:v}
-                            ${(e.lines??[]).map(e=>T`<span class="cell-line">${e}</span>`)}
-                            ${e.actionId||e.actionId2||e.actionId3?T`
+                            ${e.description?w`<span class="cell-description">${e.description}</span>`:_}
+                            ${(e.lines??[]).map(e=>w`<span class="cell-line">${e}</span>`)}
+                            ${e.actionId||e.actionId2||e.actionId3?w`
                                 <div class="cell-actions">
                                     ${this.renderItemAction(e,e.actionLabel,e.actionId,e.actionIcon)}
                                     ${this.renderItemAction(e,e.actionLabel2,e.actionId2,e.actionIcon2)}
                                     ${this.renderItemAction(e,e.actionLabel3,e.actionId3,e.actionIcon3)}
-                                </div>`:v}
+                                </div>`:_}
                         </div>
                     `)}
                 </div>
-            `:T`
+            `:w`
             <div class="list ${this.compact?`compact`:``} ${this.frameless?`frameless`:``}">
-                ${this.items.map(e=>T`
+                ${this.items.map(e=>w`
                     <div role="button" tabindex="0" class="row ${this.rowActionId?`clickable`:``}"
-                         @click="${()=>this.rowClicked(e)}" @keydown="${R(()=>this.rowClicked(e))}">
-                        ${e.avatar?T`<span class="avatar">${e.avatar}</span>`:e.icon?T`<span class="icon">${e.icon}</span>`:v}
+                         @click="${()=>this.rowClicked(e)}" @keydown="${L(()=>this.rowClicked(e))}">
+                        ${e.avatar?w`<span class="avatar">${e.avatar}</span>`:e.icon?w`<span class="icon">${e.icon}</span>`:_}
                         <div class="body">
                             <span class="title">${e.title}</span>
-                            ${e.description?T`<span class="description">${e.description}</span>`:v}
+                            ${e.description?w`<span class="description">${e.description}</span>`:_}
                         </div>
-                        ${e.status?T`<span class="chip ${e.statusColor??``}">${e.status}</span>`:v}
+                        ${e.status?w`<span class="chip ${e.statusColor??``}">${e.status}</span>`:_}
                     </div>
                 `)}
             </div>
-        `}};k([y({type:Array})],ji.prototype,`items`,void 0),k([y({type:Boolean})],ji.prototype,`compact`,void 0),k([y({type:Boolean})],ji.prototype,`frameless`,void 0),k([y()],ji.prototype,`rowActionId`,void 0),k([y({type:Number})],ji.prototype,`columns`,void 0),k([y({type:Number})],ji.prototype,`itemHeadingLevel`,void 0),ji=k([g(`mateu-status-list`)],ji);var Mi=e=>{let t=e.metadata;return T`
+        `}};O([v({type:Array})],Mi.prototype,`items`,void 0),O([v({type:Boolean})],Mi.prototype,`compact`,void 0),O([v({type:Boolean})],Mi.prototype,`frameless`,void 0),O([v()],Mi.prototype,`rowActionId`,void 0),O([v({type:Number})],Mi.prototype,`columns`,void 0),O([v({type:Number})],Mi.prototype,`itemHeadingLevel`,void 0),Mi=O([h(`mateu-status-list`)],Mi);var Ni=e=>{let t=e.metadata;return w`
         <mateu-status-list
                 .items="${t.items??[]}"
                 ?compact="${t.compact??!1}"
                 ?frameless="${t.frameless??!1}"
                 columns="${t.columns??0}"
                 itemHeadingLevel="${t.itemHeadingLevel??3}"
-                rowActionId="${S(t.rowActionId??void 0)}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                rowActionId="${x(t.rowActionId??void 0)}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-status-list>
-    `},Ni=class extends b{constructor(...e){super(...e),this.items=[]}static{this.styles=h`
+    `},Pi=class extends y{constructor(...e){super(...e),this.items=[]}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         ul {
             margin: 0; padding-inline-start: 1.2rem;
@@ -3895,24 +3895,24 @@ ${i}
             line-height: normal;
         }
         li::marker { color: var(--lumo-secondary-text-color, #888); }
-    `}render(){return T`
+    `}render(){return w`
             <ul>
-                ${this.items.map(e=>T`<li>${e}</li>`)}
+                ${this.items.map(e=>w`<li>${e}</li>`)}
             </ul>
-        `}};k([y({type:Array})],Ni.prototype,`items`,void 0),Ni=k([g(`mateu-bulleted-list`)],Ni);var Pi=e=>T`
+        `}};O([v({type:Array})],Pi.prototype,`items`,void 0),Pi=O([h(`mateu-bulleted-list`)],Pi);var Fi=e=>w`
         <mateu-bulleted-list
                 .items="${e.metadata.items??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-bulleted-list>
-    `,Fi=e=>{let t=e.metadata.attributes?.[`data-colspan`];return T`
+    `,Ii=e=>{let t=e.metadata.attributes?.[`data-colspan`];return w`
         <hr style="border: none; border-top: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1)); width: 100%; margin: var(--lumo-space-s, .5rem) 0; ${e.style??``}"
-            class="${e.cssClasses??v}"
-            id="${S(e.id??void 0)}"
-            data-colspan="${S(t)}"
-            slot="${e.slot??v}"/>
-    `},Ii={info:`ℹ`,success:`✓`,warning:`!`,danger:`!`},V=class extends b{constructor(...e){super(...e),this.text=``,this.theme=`info`,this.noIcon=!1,this.slim=!1,this.fullWidth=!1,this.hasContent=!1,this.inlineContent=!1}static{this.styles=h`
+            class="${e.cssClasses??_}"
+            id="${x(e.id??void 0)}"
+            data-colspan="${x(t)}"
+            slot="${e.slot??_}"/>
+    `},Li={info:`ℹ`,success:`✓`,warning:`!`,danger:`!`},B=class extends y{constructor(...e){super(...e),this.text=``,this.theme=`info`,this.noIcon=!1,this.slim=!1,this.fullWidth=!1,this.hasContent=!1,this.inlineContent=!1}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .notice {
             display: flex;
@@ -3975,34 +3975,34 @@ ${i}
         .warning .icon { background: #c98a1e; }
         .danger  { background: #f6e0da; } .danger .text, .danger .status   { color: #a5502e; }
         .danger  .icon  { background: #b25b3d; }
-    `}runAction(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId},bubbles:!0,composed:!0}))}render(){let e=!!this.text&&!!this.text.trim();if(!e&&!this.hasContent)return T``;let t=[`info`,`success`,`warning`,`danger`].includes(this.theme)?this.theme:`info`;return T`
+    `}runAction(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId},bubbles:!0,composed:!0}))}render(){let e=!!this.text&&!!this.text.trim();if(!e&&!this.hasContent)return w``;let t=[`info`,`success`,`warning`,`danger`].includes(this.theme)?this.theme:`info`;return w`
             <div class="notice ${t} ${this.slim?`slim`:``}">
-                ${this.noIcon?v:T`<span class="icon ${this.icon?`custom`:``}">${this.icon||Ii[t]}</span>`}
+                ${this.noIcon?_:w`<span class="icon ${this.icon?`custom`:``}">${this.icon||Li[t]}</span>`}
                 <div class="body ${this.inlineContent?`inline`:``}">
-                    ${e?T`<span class="text">${this.text}</span>`:v}
-                    ${this.hasContent?T`<div class="content"><slot></slot></div>`:v}
+                    ${e?w`<span class="text">${this.text}</span>`:_}
+                    ${this.hasContent?w`<div class="content"><slot></slot></div>`:_}
                 </div>
-                ${this.actionLabel&&this.actionId?T`<button class="notice-action" @click="${()=>this.runAction()}">${this.actionLabel}</button>`:this.status?T`<span class="status">${this.status}</span>`:v}
+                ${this.actionLabel&&this.actionId?w`<button class="notice-action" @click="${()=>this.runAction()}">${this.actionLabel}</button>`:this.status?w`<span class="status">${this.status}</span>`:_}
             </div>
-        `}};k([y()],V.prototype,`text`,void 0),k([y()],V.prototype,`theme`,void 0),k([y()],V.prototype,`icon`,void 0),k([y({type:Boolean})],V.prototype,`noIcon`,void 0),k([y()],V.prototype,`actionLabel`,void 0),k([y()],V.prototype,`actionId`,void 0),k([y()],V.prototype,`status`,void 0),k([y({type:Boolean})],V.prototype,`slim`,void 0),k([y({type:Boolean})],V.prototype,`fullWidth`,void 0),k([y({type:Boolean})],V.prototype,`hasContent`,void 0),k([y({type:Boolean})],V.prototype,`inlineContent`,void 0),V=k([g(`mateu-notice`)],V);var Li=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=rt(s.text??``,r,i,a,o)??``,l=t.children??[];return T`
+        `}};O([v()],B.prototype,`text`,void 0),O([v()],B.prototype,`theme`,void 0),O([v()],B.prototype,`icon`,void 0),O([v({type:Boolean})],B.prototype,`noIcon`,void 0),O([v()],B.prototype,`actionLabel`,void 0),O([v()],B.prototype,`actionId`,void 0),O([v()],B.prototype,`status`,void 0),O([v({type:Boolean})],B.prototype,`slim`,void 0),O([v({type:Boolean})],B.prototype,`fullWidth`,void 0),O([v({type:Boolean})],B.prototype,`hasContent`,void 0),O([v({type:Boolean})],B.prototype,`inlineContent`,void 0),B=O([h(`mateu-notice`)],B);var Ri=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=it(s.text??``,r,i,a,o)??``,l=t.children??[];return w`
         <mateu-notice
                 text="${c}"
                 theme="${s.theme??`info`}"
-                icon="${S(s.icon??void 0)}"
+                icon="${x(s.icon??void 0)}"
                 ?noIcon="${s.noIcon??!1}"
-                actionLabel="${S(s.actionLabel??void 0)}"
-                actionId="${S(s.actionId??void 0)}"
-                status="${S(s.status??void 0)}"
+                actionLabel="${x(s.actionLabel??void 0)}"
+                actionId="${x(s.actionId??void 0)}"
+                status="${x(s.status??void 0)}"
                 ?slim="${s.slim??!1}"
                 ?fullWidth="${s.fullWidth??!1}"
                 ?inlineContent="${s.inlineContent??!1}"
                 ?hasContent="${l.length>0}"
-                data-colspan="${s.fullWidth?`99`:v}"
-                style="${t.style??v}"
-                class="${t.cssClasses??v}"
-                slot="${t.slot??v}"
-        >${l.map(t=>F(e,t,n,r,i,a,o))}</mateu-notice>
-    `},Ri=class extends b{constructor(...e){super(...e),this.groups=[]}static{this.styles=[bi,z,h`
+                data-colspan="${s.fullWidth?`99`:_}"
+                style="${t.style??_}"
+                class="${t.cssClasses??_}"
+                slot="${t.slot??_}"
+        >${l.map(t=>P(e,t,n,r,i,a,o))}</mateu-notice>
+    `},zi=class extends y{constructor(...e){super(...e),this.groups=[]}static{this.styles=[xi,R,m`
         :host { display: block; width: 100%; }
         .rail { display: flex; flex-direction: column; gap: var(--lumo-space-m, 1rem); }
         .group { display: flex; flex-direction: column; gap: .45rem; }
@@ -4043,37 +4043,37 @@ ${i}
             color: var(--lumo-secondary-text-color, #888);
             white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
         }
-    `]}willUpdate(e){e.has(`groups`)&&(this.selectedId=this.groups.flatMap(e=>e.items??[]).find(e=>e.selected)?.id)}itemAction(e,t,n){e.stopPropagation(),t&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_item:n}},bubbles:!0,composed:!0}))}select(e){this.selectedId=e,this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{_item:e}},bubbles:!0,composed:!0}))}render(){return T`
+    `]}willUpdate(e){e.has(`groups`)&&(this.selectedId=this.groups.flatMap(e=>e.items??[]).find(e=>e.selected)?.id)}itemAction(e,t,n){e.stopPropagation(),t&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_item:n}},bubbles:!0,composed:!0}))}select(e){this.selectedId=e,this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{_item:e}},bubbles:!0,composed:!0}))}render(){return w`
             <div class="rail">
-                ${this.groups.map(e=>T`
+                ${this.groups.map(e=>w`
                     <div class="group" role="listbox">
-                        ${e.label?T`<span class="group-label">${e.label}</span>`:v}
-                        ${(e.items??[]).map(e=>T`
+                        ${e.label?w`<span class="group-label">${e.label}</span>`:_}
+                        ${(e.items??[]).map(e=>w`
                             <div role="option" tabindex="0" aria-selected="${e.id===this.selectedId}" class="card ${e.id===this.selectedId?`selected`:``}"
-                                 @click="${()=>this.select(e.id)}" @keydown="${R(()=>this.select(e.id))}">
+                                 @click="${()=>this.select(e.id)}" @keydown="${L(()=>this.select(e.id))}">
                                 <span class="title">${e.title}</span>
                                 <div class="meta">
-                                    ${e.caption?T`<span class="caption">${e.caption}</span>`:v}
-                                    ${(e.badges??[]).map(e=>T`<span class="chip ${e.color??``}">${e.label}</span>`)}
+                                    ${e.caption?w`<span class="caption">${e.caption}</span>`:_}
+                                    ${(e.badges??[]).map(e=>w`<span class="chip ${e.color??``}">${e.label}</span>`)}
                                 </div>
-                                ${e.actionLabel&&e.actionId?T`
+                                ${e.actionLabel&&e.actionId?w`
                                     <button class="item-action"
                                             @click="${t=>this.itemAction(t,e.actionId,e.id)}">${e.actionLabel}</button>
-                                `:v}
+                                `:_}
                             </div>
                         `)}
                     </div>
                 `)}
             </div>
-        `}};k([y()],Ri.prototype,`actionId`,void 0),k([y({type:Array})],Ri.prototype,`groups`,void 0),k([C()],Ri.prototype,`selectedId`,void 0),Ri=k([g(`mateu-task-queue`)],Ri);var zi=e=>{let t=e.metadata;return T`
+        `}};O([v()],zi.prototype,`actionId`,void 0),O([v({type:Array})],zi.prototype,`groups`,void 0),O([S()],zi.prototype,`selectedId`,void 0),zi=O([h(`mateu-task-queue`)],zi);var Bi=e=>{let t=e.metadata;return w`
         <mateu-task-queue
                 .actionId="${t.actionId}"
                 .groups="${t.groups??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-task-queue>
-    `},Bi=class extends b{constructor(...e){super(...e),this.columns=0,this.items=[]}static{this.styles=[bi,z,h`
+    `},Vi=class extends y{constructor(...e){super(...e),this.columns=0,this.items=[]}static{this.styles=[xi,R,m`
         /* explicit line-height: inside a form field wrapper the inherited one is the 44px
            field height, which blows up every text row */
         :host { display: block; width: 100%; line-height: var(--lumo-line-height-m, 1.4); }
@@ -4124,30 +4124,30 @@ ${i}
         .note.warning { color: var(--lumo-warning-text-color, #b45309); }
         .note.error { color: var(--lumo-error-text-color, #c5221f); }
         .note.contrast { color: var(--lumo-contrast-80pct, #333); }
-    `]}willUpdate(e){e.has(`items`)&&(this.selectedId=this.items.find(e=>e.selected)?.id)}select(e){e.disabled||(this.selectedId=e.id,this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{_item:e.id}},bubbles:!0,composed:!0})))}render(){return T`
+    `]}willUpdate(e){e.has(`items`)&&(this.selectedId=this.items.find(e=>e.selected)?.id)}select(e){e.disabled||(this.selectedId=e.id,this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{_item:e.id}},bubbles:!0,composed:!0})))}render(){return w`
             <div class="grid" style="${this.columns>0?`grid-template-columns: repeat(${this.columns}, minmax(0, 1fr));`:`grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));`}">
-                ${this.items.map(e=>T`
+                ${this.items.map(e=>w`
                     <div role="button" tabindex="0" class="cell ${e.disabled?`disabled`:``} ${e.recommended?`recommended`:``} ${e.id===this.selectedId?`selected`:``}"
-                         @click="${()=>this.select(e)}" @keydown="${R(()=>this.select(e))}">
-                        ${e.recommended?T`<span class="tag">${this.recommendedLabel||`Recommended`}</span>`:v}
+                         @click="${()=>this.select(e)}" @keydown="${L(()=>this.select(e))}">
+                        ${e.recommended?w`<span class="tag">${this.recommendedLabel||`Recommended`}</span>`:_}
                         <span class="title">${e.title}</span>
-                        ${e.subtitle?T`<span class="subtitle">${e.subtitle}</span>`:v}
-                        ${e.statusLabel?T`<span class="chip ${e.statusColor??``}">${e.statusLabel}</span>`:v}
-                        ${e.note?T`<span class="note ${e.noteColor??``}"><span class="dot"></span>${e.note}</span>`:v}
+                        ${e.subtitle?w`<span class="subtitle">${e.subtitle}</span>`:_}
+                        ${e.statusLabel?w`<span class="chip ${e.statusColor??``}">${e.statusLabel}</span>`:_}
+                        ${e.note?w`<span class="note ${e.noteColor??``}"><span class="dot"></span>${e.note}</span>`:_}
                     </div>
                 `)}
             </div>
-        `}};k([y()],Bi.prototype,`actionId`,void 0),k([y({type:Number})],Bi.prototype,`columns`,void 0),k([y()],Bi.prototype,`recommendedLabel`,void 0),k([y({type:Array})],Bi.prototype,`items`,void 0),k([C()],Bi.prototype,`selectedId`,void 0),Bi=k([g(`mateu-resource-grid`)],Bi);var Vi=e=>{let t=e.metadata;return T`
+        `}};O([v()],Vi.prototype,`actionId`,void 0),O([v({type:Number})],Vi.prototype,`columns`,void 0),O([v()],Vi.prototype,`recommendedLabel`,void 0),O([v({type:Array})],Vi.prototype,`items`,void 0),O([S()],Vi.prototype,`selectedId`,void 0),Vi=O([h(`mateu-resource-grid`)],Vi);var Hi=e=>{let t=e.metadata;return w`
         <mateu-resource-grid
                 .actionId="${t.actionId}"
                 .columns="${t.columns??0}"
                 .recommendedLabel="${t.recommendedLabel}"
                 .items="${t.items??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-resource-grid>
-    `},H=class extends b{constructor(...e){super(...e),this.title=``,this.features=[],this.current=!1,this.added=!1}static{this.styles=h`
+    `},V=class extends y{constructor(...e){super(...e),this.title=``,this.features=[],this.current=!1,this.added=!1}static{this.styles=m`
         /* explicit line-height: inside a form field wrapper the inherited one is the 44px
            field height, which blows up every text row */
         :host { display: block; width: 100%; line-height: var(--lumo-line-height-m, 1.4); }
@@ -4212,30 +4212,30 @@ ${i}
         button:hover { filter: brightness(1.08); }
         button.added { background: var(--lumo-success-color, #2e7d32); }
         .price { font-weight: 700; white-space: nowrap; font-variant-numeric: tabular-nums; }
-    `}runAction(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{}},bubbles:!0,composed:!0}))}render(){return T`
+    `}runAction(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{}},bubbles:!0,composed:!0}))}render(){return w`
             <div class="card ${this.current?``:`offer`}">
-                ${this.image?T`<img class="image" src="${this.image}" alt="${this.title}">`:v}
-                ${this.tag&&this.image?T`<span class="tag">${this.tag}</span>`:v}
+                ${this.image?w`<img class="image" src="${this.image}" alt="${this.title}">`:_}
+                ${this.tag&&this.image?w`<span class="tag">${this.tag}</span>`:_}
                 <div class="body">
-                    ${this.tag&&!this.image?T`<span class="tag static">${this.tag}</span>`:v}
+                    ${this.tag&&!this.image?w`<span class="tag static">${this.tag}</span>`:_}
                     <span class="title">${this.title}</span>
-                    ${this.subtitle?T`<span class="subtitle">${this.subtitle}</span>`:v}
-                    ${this.features.length?T`
+                    ${this.subtitle?w`<span class="subtitle">${this.subtitle}</span>`:_}
+                    ${this.features.length?w`
                         <div class="features">
-                            ${this.features.map(e=>T`<span class="feature">${e}</span>`)}
+                            ${this.features.map(e=>w`<span class="feature">${e}</span>`)}
                         </div>
-                    `:v}
+                    `:_}
                 </div>
                 <div class="footer">
-                    ${this.current?this.currentLabel?T`<span class="current-label">${this.currentLabel}</span>`:v:this.actionLabel&&this.actionId?T`
+                    ${this.current?this.currentLabel?w`<span class="current-label">${this.currentLabel}</span>`:_:this.actionLabel&&this.actionId?w`
                             <button class="${this.added?`added`:``}" @click="${()=>this.runAction()}">
                                 <span>${this.added&&this.addedLabel||this.actionLabel}</span>
-                                ${this.priceLabel?T`<span class="price">${this.priceLabel}</span>`:v}
+                                ${this.priceLabel?w`<span class="price">${this.priceLabel}</span>`:_}
                             </button>
-                        `:v}
+                        `:_}
                 </div>
             </div>
-        `}};k([y()],H.prototype,`tag`,void 0),k([y()],H.prototype,`title`,void 0),k([y()],H.prototype,`subtitle`,void 0),k([y()],H.prototype,`image`,void 0),k([y({type:Array})],H.prototype,`features`,void 0),k([y()],H.prototype,`priceLabel`,void 0),k([y()],H.prototype,`actionLabel`,void 0),k([y()],H.prototype,`actionId`,void 0),k([y({type:Boolean})],H.prototype,`current`,void 0),k([y()],H.prototype,`currentLabel`,void 0),k([y({type:Boolean})],H.prototype,`added`,void 0),k([y()],H.prototype,`addedLabel`,void 0),H=k([g(`mateu-offer-card`)],H);var Hi=e=>{let t=e.metadata;return T`
+        `}};O([v()],V.prototype,`tag`,void 0),O([v()],V.prototype,`title`,void 0),O([v()],V.prototype,`subtitle`,void 0),O([v()],V.prototype,`image`,void 0),O([v({type:Array})],V.prototype,`features`,void 0),O([v()],V.prototype,`priceLabel`,void 0),O([v()],V.prototype,`actionLabel`,void 0),O([v()],V.prototype,`actionId`,void 0),O([v({type:Boolean})],V.prototype,`current`,void 0),O([v()],V.prototype,`currentLabel`,void 0),O([v({type:Boolean})],V.prototype,`added`,void 0),O([v()],V.prototype,`addedLabel`,void 0),V=O([h(`mateu-offer-card`)],V);var Ui=e=>{let t=e.metadata;return w`
         <mateu-offer-card
                 .tag="${t.tag}"
                 .title="${t.title??``}"
@@ -4249,11 +4249,11 @@ ${i}
                 .currentLabel="${t.currentLabel}"
                 .added="${t.added??!1}"
                 .addedLabel="${t.addedLabel}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-offer-card>
-    `},Ui=class extends b{constructor(...e){super(...e),this.items=[],this.added=new Set}static{this.styles=h`
+    `},Wi=class extends y{constructor(...e){super(...e),this.items=[],this.added=new Set}static{this.styles=m`
         :host { display: block; width: 100%; }
         .header { display: flex; align-items: baseline; justify-content: flex-end; gap: .4rem; margin-bottom: .6rem; }
         .total-label { font-size: var(--lumo-font-size-s, .875rem); color: var(--lumo-secondary-text-color, #888); }
@@ -4318,20 +4318,20 @@ ${i}
             background: var(--lumo-primary-color, #1a73e8);
             color: var(--lumo-primary-contrast-color, #fff);
         }
-    `}willUpdate(e){e.has(`items`)&&(this.added=new Set(this.items.filter(e=>e.added).map(e=>e.id)))}total(){return this.items.filter(e=>e.id!=null&&this.added.has(e.id)).reduce((e,t)=>e+(t.price??0),0)}toggle(e){if(e.id==null)return;let t=new Set(this.added),n=!t.has(e.id);n?t.add(e.id):t.delete(e.id),this.added=t,this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{_item:e.id,_added:n,_total:this.total()}},bubbles:!0,composed:!0}))}render(){return T`
+    `}willUpdate(e){e.has(`items`)&&(this.added=new Set(this.items.filter(e=>e.added).map(e=>e.id)))}total(){return this.items.filter(e=>e.id!=null&&this.added.has(e.id)).reduce((e,t)=>e+(t.price??0),0)}toggle(e){if(e.id==null)return;let t=new Set(this.added),n=!t.has(e.id);n?t.add(e.id):t.delete(e.id),this.added=t,this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{_item:e.id,_added:n,_total:this.total()}},bubbles:!0,composed:!0}))}render(){return w`
             <div class="header">
-                ${this.totalLabel?T`<span class="total-label">${this.totalLabel}:</span>`:v}
-                <span class="total">${Ci(this.total(),this.currency)}</span>
+                ${this.totalLabel?w`<span class="total-label">${this.totalLabel}:</span>`:_}
+                <span class="total">${wi(this.total(),this.currency)}</span>
             </div>
             <div class="grid">
-                ${this.items.map(e=>{let t=e.id!=null&&this.added.has(e.id);return T`
+                ${this.items.map(e=>{let t=e.id!=null&&this.added.has(e.id);return w`
                         <div class="card ${t?`added`:``}">
-                            ${e.icon?T`<span class="icon">${e.icon}</span>`:v}
+                            ${e.icon?w`<span class="icon">${e.icon}</span>`:_}
                             <span class="title">${e.title}</span>
-                            ${e.description?T`<span class="description">${e.description}</span>`:v}
-                            ${e.includedLabel?T`<span class="included">${e.includedLabel}</span>`:T`
-                                    ${e.price==null?v:T`
-                                        <span class="price">${Ci(e.price,this.currency)}${e.unit?` / ${e.unit}`:``}</span>
+                            ${e.description?w`<span class="description">${e.description}</span>`:_}
+                            ${e.includedLabel?w`<span class="included">${e.includedLabel}</span>`:w`
+                                    ${e.price==null?_:w`
+                                        <span class="price">${wi(e.price,this.currency)}${e.unit?` / ${e.unit}`:``}</span>
                                     `}
                                     <button class="toggle ${t?`on`:``}" @click="${()=>this.toggle(e)}"
                                             aria-pressed="${t}">${t?`✓`:`+`}</button>
@@ -4339,17 +4339,17 @@ ${i}
                         </div>
                     `})}
             </div>
-        `}};k([y()],Ui.prototype,`totalLabel`,void 0),k([y()],Ui.prototype,`currency`,void 0),k([y()],Ui.prototype,`actionId`,void 0),k([y({type:Array})],Ui.prototype,`items`,void 0),k([C()],Ui.prototype,`added`,void 0),Ui=k([g(`mateu-addon-picker`)],Ui);var Wi=e=>{let t=e.metadata;return T`
+        `}};O([v()],Wi.prototype,`totalLabel`,void 0),O([v()],Wi.prototype,`currency`,void 0),O([v()],Wi.prototype,`actionId`,void 0),O([v({type:Array})],Wi.prototype,`items`,void 0),O([S()],Wi.prototype,`added`,void 0),Wi=O([h(`mateu-addon-picker`)],Wi);var Gi=e=>{let t=e.metadata;return w`
         <mateu-addon-picker
                 .totalLabel="${t.totalLabel}"
                 .currency="${t.currency}"
                 .actionId="${t.actionId}"
                 .items="${t.items??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-addon-picker>
-    `},Gi=class extends b{constructor(...e){super(...e),this.lines=[]}static{this.styles=h`
+    `},Ki=class extends y{constructor(...e){super(...e),this.lines=[]}static{this.styles=m`
         :host {
             display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem);
             /* an ancestor (e.g. a form-layout row) may set an inherited line-height like 44px —
@@ -4386,29 +4386,29 @@ ${i}
             color: var(--lumo-body-text-color, #111);
             white-space: nowrap;
         }
-    `}computedTotal(){return this.total==null?this.lines.filter(e=>!e.included).reduce((e,t)=>e+(t.amount??0),0):this.total}render(){return T`
-            ${this.lines.map(e=>T`
+    `}computedTotal(){return this.total==null?this.lines.filter(e=>!e.included).reduce((e,t)=>e+(t.amount??0),0):this.total}render(){return w`
+            ${this.lines.map(e=>w`
                 <div class="row">
                     <span class="dot"></span>
                     <span class="concept">${e.concept}</span>
-                    ${e.included?T`<span class="included-label">${e.includedLabel||`Included`}</span>`:T`<span class="amount ${(e.amount??0)<0?`negative`:``}">${Ci(e.amount??0,this.currency)}</span>`}
+                    ${e.included?w`<span class="included-label">${e.includedLabel||`Included`}</span>`:w`<span class="amount ${(e.amount??0)<0?`negative`:``}">${wi(e.amount??0,this.currency)}</span>`}
                 </div>
             `)}
             <div class="total-row">
                 <span class="total-label">${this.totalLabel||`Total`}</span>
-                <span class="total">${Ci(this.computedTotal(),this.currency)}</span>
+                <span class="total">${wi(this.computedTotal(),this.currency)}</span>
             </div>
-        `}};k([y()],Gi.prototype,`currency`,void 0),k([y()],Gi.prototype,`totalLabel`,void 0),k([y({type:Array})],Gi.prototype,`lines`,void 0),k([y({type:Number})],Gi.prototype,`total`,void 0),Gi=k([g(`mateu-ledger`)],Gi);var Ki=e=>{let t=e.metadata;return T`
+        `}};O([v()],Ki.prototype,`currency`,void 0),O([v()],Ki.prototype,`totalLabel`,void 0),O([v({type:Array})],Ki.prototype,`lines`,void 0),O([v({type:Number})],Ki.prototype,`total`,void 0),Ki=O([h(`mateu-ledger`)],Ki);var qi=e=>{let t=e.metadata;return w`
         <mateu-ledger
                 .currency="${t.currency}"
                 .totalLabel="${t.totalLabel}"
                 .lines="${t.lines??[]}"
                 .total="${t.total}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-ledger>
-    `},qi=class extends b{constructor(...e){super(...e),this.methods=[]}static{this.styles=h`
+    `},Ji=class extends y{constructor(...e){super(...e),this.methods=[]}static{this.styles=m`
         :host { display: block; width: 100%; }
         .bar { display: flex; align-items: stretch; gap: .6rem; flex-wrap: wrap; }
         .methods { display: flex; gap: .4rem; flex-wrap: wrap; }
@@ -4453,24 +4453,24 @@ ${i}
             white-space: nowrap;
         }
         .confirm:hover { filter: brightness(1.08); }
-    `}willUpdate(e){e.has(`selected`)&&(this.selectedId=this.selected)}confirm(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{_method:this.selectedId}},bubbles:!0,composed:!0}))}pick(e){this.selectedId=e,this.methodActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.methodActionId,parameters:{_method:e}},bubbles:!0,composed:!0}))}render(){return T`
+    `}willUpdate(e){e.has(`selected`)&&(this.selectedId=this.selected)}confirm(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{_method:this.selectedId}},bubbles:!0,composed:!0}))}pick(e){this.selectedId=e,this.methodActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.methodActionId,parameters:{_method:e}},bubbles:!0,composed:!0}))}render(){return w`
             <div class="bar">
                 <div class="methods">
-                    ${this.methods.map(e=>T`
+                    ${this.methods.map(e=>w`
                         <button class="method ${e.id===this.selectedId?`selected`:``}"
                                 @click="${()=>this.pick(e.id)}">${e.label}</button>
                     `)}
                 </div>
-                ${this.contextLabel||this.contextValue?T`
+                ${this.contextLabel||this.contextValue?w`
                     <div class="context">
-                        ${this.contextLabel?T`<span class="label">${this.contextLabel}</span>`:v}
-                        ${this.contextValue?T`<span class="value">${this.contextValue}</span>`:v}
+                        ${this.contextLabel?w`<span class="label">${this.contextLabel}</span>`:_}
+                        ${this.contextValue?w`<span class="value">${this.contextValue}</span>`:_}
                     </div>
-                `:v}
+                `:_}
                 <span class="spacer"></span>
-                ${this.confirmLabel&&this.actionId?T`<button class="confirm" @click="${()=>this.confirm()}">${this.confirmLabel}</button>`:v}
+                ${this.confirmLabel&&this.actionId?w`<button class="confirm" @click="${()=>this.confirm()}">${this.confirmLabel}</button>`:_}
             </div>
-        `}};k([y()],qi.prototype,`actionId`,void 0),k([y()],qi.prototype,`methodActionId`,void 0),k([y({type:Array})],qi.prototype,`methods`,void 0),k([y()],qi.prototype,`selected`,void 0),k([y()],qi.prototype,`contextLabel`,void 0),k([y()],qi.prototype,`contextValue`,void 0),k([y()],qi.prototype,`confirmLabel`,void 0),k([C()],qi.prototype,`selectedId`,void 0),qi=k([g(`mateu-payment-picker`)],qi);var Ji=e=>{let t=e.metadata;return T`
+        `}};O([v()],Ji.prototype,`actionId`,void 0),O([v()],Ji.prototype,`methodActionId`,void 0),O([v({type:Array})],Ji.prototype,`methods`,void 0),O([v()],Ji.prototype,`selected`,void 0),O([v()],Ji.prototype,`contextLabel`,void 0),O([v()],Ji.prototype,`contextValue`,void 0),O([v()],Ji.prototype,`confirmLabel`,void 0),O([S()],Ji.prototype,`selectedId`,void 0),Ji=O([h(`mateu-payment-picker`)],Ji);var Yi=e=>{let t=e.metadata;return w`
         <mateu-payment-picker
                 .actionId="${t.actionId}"
                 .methodActionId="${t.methodActionId}"
@@ -4479,11 +4479,11 @@ ${i}
                 .contextLabel="${t.contextLabel}"
                 .contextValue="${t.contextValue}"
                 .confirmLabel="${t.confirmLabel}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-payment-picker>
-    `},Yi=class extends b{constructor(...e){super(...e),this.items=[]}static{this.styles=h`
+    `},Xi=class extends y{constructor(...e){super(...e),this.items=[]}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .list {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -4519,32 +4519,32 @@ ${i}
             cursor: pointer; white-space: nowrap; flex: 0 0 auto;
         }
         button:hover { background: var(--lumo-warning-color-10pct, rgba(245,158,11,.25)); filter: brightness(.97); }
-    `}runAction(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{}},bubbles:!0,composed:!0}))}render(){return T`
+    `}runAction(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{}},bubbles:!0,composed:!0}))}render(){return w`
             <div class="list">
-                ${this.items.map(e=>T`
+                ${this.items.map(e=>w`
                     <div class="row">
                         <span class="dot ${e.status??`ok`}"></span>
                         <div class="body">
                             <span class="name">${e.name}</span>
-                            ${e.systems?.length?T`<span class="systems">${e.systems.join(` · `)}</span>`:v}
+                            ${e.systems?.length?w`<span class="systems">${e.systems.join(` · `)}</span>`:_}
                         </div>
                         <div class="counters">
                             <span class="counter ok">✓ ${e.ok??0} OK</span>
-                            ${(e.warnings??0)>0?T`<span class="counter warning">⚠ ${e.warnings} warnings</span>`:v}
-                            ${(e.errors??0)>0?T`<span class="counter error">⛔ ${e.errors} errors</span>`:v}
+                            ${(e.warnings??0)>0?w`<span class="counter warning">⚠ ${e.warnings} warnings</span>`:_}
+                            ${(e.errors??0)>0?w`<span class="counter error">⛔ ${e.errors} errors</span>`:_}
                         </div>
-                        ${e.actionLabel&&e.actionId?T`<button @click="${()=>this.runAction(e)}">${e.actionLabel}</button>`:v}
+                        ${e.actionLabel&&e.actionId?w`<button @click="${()=>this.runAction(e)}">${e.actionLabel}</button>`:_}
                     </div>
                 `)}
             </div>
-        `}};k([y({type:Array})],Yi.prototype,`items`,void 0),Yi=k([g(`mateu-process-monitor`)],Yi);var Xi=e=>T`
+        `}};O([v({type:Array})],Xi.prototype,`items`,void 0),Xi=O([h(`mateu-process-monitor`)],Xi);var Zi=e=>w`
         <mateu-process-monitor
                 .items="${e.metadata.items??[]}"
-                style="${e.style??v}"
-                class="${e.cssClasses??v}"
-                slot="${e.slot??v}"
+                style="${e.style??_}"
+                class="${e.cssClasses??_}"
+                slot="${e.slot??_}"
         ></mateu-process-monitor>
-    `,Zi=(e,t)=>{let n=e.style;return e.id&&(n&&!n.endsWith(`;`)&&(n+=`;`),n??=``,t[e.id+`.hidden`]==1&&(n+=`display: none;`)),n},Qi=(e,t)=>{let n={...e.metadata};if(e.id&&n){if(n.type==j.Button){let r=n;t[e.id+`.disabled`]==1&&(r.disabled=!0)}if(n.type==j.FormField){let r=n;t[e.id+`.disabled`]==1&&(r.disabled=!0)}}return n},U=e=>t=>e(t.container,t.component,t.baseUrl,t.state,t.data,t.appState,t.appData),$i={[j.Bpmn]:({component:e})=>hr(e),[j.Workflow]:({component:e})=>_r(e),[j.FormEditor]:({component:e})=>vr(e),[j.Page]:U(pr),[j.Div]:U(or),[j.Directory]:({component:e,baseUrl:t,state:n,data:r})=>ir(e,t,n,r),[j.FormLayout]:U(Wt),[j.HorizontalLayout]:U(Xt),[j.VerticalLayout]:U(Zt),[j.SplitLayout]:U(Qt),[j.MasterDetailLayout]:U($t),[j.TabLayout]:U(en),[j.AccordionLayout]:U(tn),[j.BoardLayout]:U(sn),[j.BoardLayoutRow]:U(cn),[j.BoardLayoutItem]:U(ln),[j.Scroller]:U(rn),[j.FullWidth]:U(an),[j.Container]:U(on),[j.Form]:({container:e,component:t,baseUrl:n,state:r,data:i,appState:a,appData:o})=>{let s=t.metadata;return T`<mateu-form
+    `,Qi=(e,t)=>{let n=e.style;return e.id&&(n&&!n.endsWith(`;`)&&(n+=`;`),n??=``,t[e.id+`.hidden`]==1&&(n+=`display: none;`)),n},$i=(e,t)=>{let n={...e.metadata};if(e.id&&n){if(n.type==A.Button){let r=n;t[e.id+`.disabled`]==1&&(r.disabled=!0)}if(n.type==A.FormField){let r=n;t[e.id+`.disabled`]==1&&(r.disabled=!0)}}return n},H=e=>t=>e(t.container,t.component,t.baseUrl,t.state,t.data,t.appState,t.appData),ea={[A.Bpmn]:({component:e})=>gr(e),[A.Workflow]:({component:e})=>vr(e),[A.FormEditor]:({component:e})=>yr(e),[A.Page]:H(mr),[A.Div]:H(sr),[A.Directory]:({component:e,baseUrl:t,state:n,data:r})=>ar(e,t,n,r),[A.FormLayout]:H(Gt),[A.HorizontalLayout]:H(Zt),[A.VerticalLayout]:H(Qt),[A.SplitLayout]:H($t),[A.MasterDetailLayout]:H(en),[A.TabLayout]:H(tn),[A.AccordionLayout]:H(nn),[A.BoardLayout]:H(cn),[A.BoardLayoutRow]:H(ln),[A.BoardLayoutItem]:H(un),[A.Scroller]:H(an),[A.FullWidth]:H(on),[A.Container]:H(sn),[A.Form]:({container:e,component:t,baseUrl:n,state:r,data:i,appState:a,appData:o})=>{let s=t.metadata;return w`<mateu-form
             id="${t.id}"
         baseUrl="${n}"
             .component="${t}"
@@ -4555,14 +4555,14 @@ ${i}
             .appdata="${o}"
             style="${t.style}"
             class="${t.cssClasses}"
-            slot="${t.slot??v}"
+            slot="${t.slot??_}"
             >
-                ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
-            ${s?.buttons?.map(t=>T`
-               ${F(e,{id:t.actionId,metadata:t,type:A.ClientSide,slot:`buttons`},void 0,r,i,a,o)}
+                ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
+            ${s?.buttons?.map(t=>w`
+               ${P(e,{id:t.actionId,metadata:t,type:k.ClientSide,slot:`buttons`},void 0,r,i,a,o)}
 `)}
 
-            </mateu-form>`},[j.Table]:({component:e,state:t,data:n})=>pn(e,(e.id?n?.[e.id]:void 0)?.page?.content??mn(e,t)),[j.Crud]:U(mr),[j.App]:({container:e,component:t,baseUrl:n,state:r,data:i,appState:a,appData:o})=>T`
+            </mateu-form>`},[A.Table]:({component:e,state:t,data:n})=>mn(e,(e.id?n?.[e.id]:void 0)?.page?.content??hn(e,t)),[A.Crud]:H(hr),[A.App]:({container:e,component:t,baseUrl:n,state:r,data:i,appState:a,appData:o})=>w`
             <mateu-app
                         id="${t.id}"
                         baseUrl="${n}"
@@ -4574,26 +4574,26 @@ ${i}
                         .appState="${a}"
                         .appData="${o}"
             >
-             ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
-         </mateu-app>`,[j.Element]:({container:e,component:t})=>Tn(e,t.metadata,t),[j.FormField]:({component:e,state:t})=>dr(e,t),[j.Text]:({component:e,state:t,data:n,appState:r,appData:i})=>Dn(e,t,n,r,i),[j.Avatar]:({component:e,state:t,data:n})=>lt(e,t,n),[j.Chat]:({component:e,state:t,data:n})=>gr(e,t,n),[j.AvatarGroup]:({component:e})=>ut(e),[j.Badge]:({component:e,state:t,data:n})=>dt(e,t,n),[j.Breadcrumbs]:({component:e})=>nr(e),[j.Anchor]:({component:e})=>On(e),[j.Button]:({component:e,state:t,data:n})=>Fn(e,t,n),[j.Card]:U(Ln),[j.Chart]:({component:e})=>Rn(e),[j.Icon]:({component:e})=>zn(e),[j.ConfirmDialog]:U(Wn),[j.ContextMenu]:U(vn),[j.CookieConsent]:({component:e})=>Gn(e),[j.Details]:U(Kn),[j.Dialog]:({component:e,baseUrl:t,state:n,data:r,appState:i,appData:a})=>qn(e,t,n,r,i,a),[j.Drawer]:({component:e,baseUrl:t,state:n,data:r,appState:i,appData:a})=>Jn(e,t,n,r,i,a),[j.Image]:({component:e})=>tr(e),[j.Map]:({component:e})=>er(e),[j.Markdown]:({component:e})=>Xn(e),[j.MicroFrontend]:({component:e})=>Yn(e),[j.Notification]:({component:e})=>Zn(e),[j.ProgressBar]:({component:e,state:t})=>Qn(e,t),[j.Popover]:U($n),[j.CarouselLayout]:U(rr),[j.Tooltip]:U(xn),[j.MessageInput]:({component:e})=>bn(e),[j.MessageList]:({component:e})=>hn(e),[j.CustomField]:U(yn),[j.MenuBar]:({container:e,component:t,baseUrl:n,state:r,data:i})=>_n(e,t,n,r,i),[j.Grid]:({component:e,state:t})=>pn(e,mn(e,t)),[j.VirtualList]:U(un),[j.FormSection]:U(sr),[j.FormSubSection]:U(cr),[j.MetricCard]:({component:e})=>Cr(e),[j.Scoreboard]:U(wr),[j.DashboardPanel]:U(Tr),[j.DashboardLayout]:U(Er),[j.FoldoutLayout]:U(Or),[j.ContentLayout]:U(kr),[j.HeroSection]:U(Ar),[j.EmptyState]:({component:e})=>St(e),[j.Skeleton]:({component:e})=>Ct(e),[j.Gantt]:({component:e})=>Nr(e),[j.PlanningBoard]:({component:e})=>Fr(e),[j.Kanban]:({component:e})=>Lr(e),[j.Timeline]:({component:e})=>zr(e),[j.ProgressSteps]:({component:e})=>Vr(e),[j.Stat]:({component:e})=>Ur(e),[j.Calendar]:({component:e})=>Gr(e),[j.PricingTable]:({component:e})=>qr(e),[j.OrgChart]:({component:e})=>Yr(e),[j.Heatmap]:({component:e})=>Qr(e),[j.Funnel]:({component:e})=>ei(e),[j.TrendChart]:({component:e})=>ni(e),[j.FeatureGrid]:({component:e})=>ii(e),[j.Testimonials]:({component:e})=>oi(e),[j.Faq]:({component:e})=>ci(e),[j.CalloutCard]:({component:e})=>ui(e),[j.CommentThread]:({component:e})=>fi(e),[j.FileList]:({component:e})=>hi(e),[j.Checklist]:({component:e})=>_i(e),[j.ComparisonCard]:({component:e})=>yi(e),[j.EntityHeader]:({component:e})=>Ei(e),[j.Meter]:({component:e})=>Oi(e),[j.TaskProgress]:({component:e})=>Ai(e),[j.StatusList]:({component:e})=>Mi(e),[j.BulletedList]:({component:e})=>Pi(e),[j.Separator]:({component:e})=>Fi(e),[j.Notice]:U(Li),[j.TaskQueue]:({component:e})=>zi(e),[j.ResourceGrid]:({component:e})=>Vi(e),[j.OfferCard]:({component:e})=>Hi(e),[j.AddOnPicker]:({component:e})=>Wi(e),[j.Ledger]:({component:e})=>Ki(e),[j.PaymentPicker]:({component:e})=>Ji(e),[j.ProcessMonitor]:({component:e})=>Xi(e)},ea=(e,t,n,r,i,a,o,s)=>{if(!t?.metadata)return t==null?(console.warn(`No metadata for component`,t),T`<p>No metadata for component</p>`):ea(e,{id:E(),metadata:t,type:A.ClientSide},n,r,i,a,o,s);let c=t.metadata.type,l={...t,style:Zi(t,i),metadata:Qi(t,i)},u=$i[c];return u?u({container:e,component:l,baseUrl:n,state:r,data:i,appState:a,appData:o,labelAlreadyRendered:s}):T`<p ${l?.slot??v}>Unknown metadata type ${c} for component ${l?.id}</p>`},ta=function(e){return e.NONE=`NONE`,e.INFO=`INFO`,e.SUCCESS=`SUCCESS`,e.WARNING=`WARNING`,e.DANGER=`DANGER`,e}({}),na=(e,t,n)=>{let r=e[n.path];return r?T`<span theme="badge pill ${ra(r.type)}">${r.message}</span>`:T``},ra=e=>{switch(e){case ta.SUCCESS:return`success`;case ta.WARNING:return`warning`;case ta.DANGER:return`error`;case ta.NONE:return`contrast`}return``},W=class extends b{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.respondToVisibility=(e,t)=>{var n={root:document.documentElement};new IntersectionObserver(e=>{e.forEach(e=>{t(e.intersectionRatio>0)})},n).observe(e)},this.keepAsking=!1,this.askToUpper=()=>{let e=this.data[this.id]?.page,t=e?.content?.length/e?.pageSize;this.dispatchEvent(new CustomEvent(`fetch-more-elements`,{detail:{params:{page:t,pageSize:this.metadata?.pageSize},callback:()=>{this.keepAsking&&this.askToUpper()}},bubbles:!0,composed:!0}))},this.renderItem=e=>e.card?ea(this,e.card,this.baseUrl,this.state,this.data,this.appState,this.appData,!1):e.title?T`<div class="neutral-card">
-                ${e.image?T`<img class="card-media" src="${e.image}" alt="" />`:v}
+             ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
+         </mateu-app>`,[A.Element]:({container:e,component:t})=>En(e,t.metadata,t),[A.FormField]:({component:e,state:t})=>fr(e,t),[A.Text]:({component:e,state:t,data:n,appState:r,appData:i})=>On(e,t,n,r,i),[A.Avatar]:({component:e,state:t,data:n})=>ut(e,t,n),[A.Chat]:({component:e,state:t,data:n})=>_r(e,t,n),[A.AvatarGroup]:({component:e})=>dt(e),[A.Badge]:({component:e,state:t,data:n})=>ft(e,t,n),[A.Breadcrumbs]:({component:e})=>rr(e),[A.Anchor]:({component:e})=>kn(e),[A.Button]:({component:e,state:t,data:n})=>In(e,t,n),[A.Card]:H(Rn),[A.Chart]:({component:e})=>zn(e),[A.Icon]:({component:e})=>Bn(e),[A.ConfirmDialog]:H(Gn),[A.ContextMenu]:H(yn),[A.CookieConsent]:({component:e})=>Kn(e),[A.Details]:H(qn),[A.Dialog]:({component:e,baseUrl:t,state:n,data:r,appState:i,appData:a})=>Jn(e,t,n,r,i,a),[A.Drawer]:({component:e,baseUrl:t,state:n,data:r,appState:i,appData:a})=>Yn(e,t,n,r,i,a),[A.Image]:({component:e})=>nr(e),[A.Map]:({component:e})=>tr(e),[A.Markdown]:({component:e})=>Zn(e),[A.MicroFrontend]:({component:e})=>Xn(e),[A.Notification]:({component:e})=>Qn(e),[A.ProgressBar]:({component:e,state:t})=>$n(e,t),[A.Popover]:H(er),[A.CarouselLayout]:H(ir),[A.Tooltip]:H(Sn),[A.MessageInput]:({component:e})=>xn(e),[A.MessageList]:({component:e})=>gn(e),[A.CustomField]:H(bn),[A.MenuBar]:({container:e,component:t,baseUrl:n,state:r,data:i})=>vn(e,t,n,r,i),[A.Grid]:({component:e,state:t})=>mn(e,hn(e,t)),[A.VirtualList]:H(dn),[A.FormSection]:H(cr),[A.FormSubSection]:H(lr),[A.MetricCard]:({component:e})=>wr(e),[A.Scoreboard]:H(Tr),[A.DashboardPanel]:H(Er),[A.DashboardLayout]:H(Dr),[A.FoldoutLayout]:H(kr),[A.ContentLayout]:H(Ar),[A.HeroSection]:H(jr),[A.EmptyState]:({component:e})=>Ct(e),[A.Skeleton]:({component:e})=>wt(e),[A.Gantt]:({component:e})=>Pr(e),[A.PlanningBoard]:({component:e})=>Ir(e),[A.Kanban]:({component:e})=>Rr(e),[A.Timeline]:({component:e})=>Br(e),[A.ProgressSteps]:({component:e})=>Hr(e),[A.Stat]:({component:e})=>Wr(e),[A.Calendar]:({component:e})=>Kr(e),[A.PricingTable]:({component:e})=>Jr(e),[A.OrgChart]:({component:e})=>Xr(e),[A.Heatmap]:({component:e})=>$r(e),[A.Funnel]:({component:e})=>ti(e),[A.TrendChart]:({component:e})=>ri(e),[A.FeatureGrid]:({component:e})=>ai(e),[A.Testimonials]:({component:e})=>si(e),[A.Faq]:({component:e})=>li(e),[A.CalloutCard]:({component:e})=>di(e),[A.CommentThread]:({component:e})=>pi(e),[A.FileList]:({component:e})=>gi(e),[A.Checklist]:({component:e})=>vi(e),[A.ComparisonCard]:({component:e})=>bi(e),[A.EntityHeader]:({component:e})=>Di(e),[A.Meter]:({component:e})=>ki(e),[A.TaskProgress]:({component:e})=>ji(e),[A.StatusList]:({component:e})=>Ni(e),[A.BulletedList]:({component:e})=>Fi(e),[A.Separator]:({component:e})=>Ii(e),[A.Notice]:H(Ri),[A.TaskQueue]:({component:e})=>Bi(e),[A.ResourceGrid]:({component:e})=>Hi(e),[A.OfferCard]:({component:e})=>Ui(e),[A.AddOnPicker]:({component:e})=>Gi(e),[A.Ledger]:({component:e})=>qi(e),[A.PaymentPicker]:({component:e})=>Yi(e),[A.ProcessMonitor]:({component:e})=>Zi(e)},ta=(e,t,n,r,i,a,o,s)=>{if(!t?.metadata)return t==null?(console.warn(`No metadata for component`,t),w`<p>No metadata for component</p>`):ta(e,{id:T(),metadata:t,type:k.ClientSide},n,r,i,a,o,s);let c=t.metadata.type,l={...t,style:Qi(t,i),metadata:$i(t,i)},u=ea[c];return u?u({container:e,component:l,baseUrl:n,state:r,data:i,appState:a,appData:o,labelAlreadyRendered:s}):w`<p ${l?.slot??_}>Unknown metadata type ${c} for component ${l?.id}</p>`},na=function(e){return e.NONE=`NONE`,e.INFO=`INFO`,e.SUCCESS=`SUCCESS`,e.WARNING=`WARNING`,e.DANGER=`DANGER`,e}({}),ra=(e,t,n)=>{let r=e[n.path];return r?w`<span theme="badge pill ${ia(r.type)}">${r.message}</span>`:w``},ia=e=>{switch(e){case na.SUCCESS:return`success`;case na.WARNING:return`warning`;case na.DANGER:return`error`;case na.NONE:return`contrast`}return``},U=class extends y{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.respondToVisibility=(e,t)=>{var n={root:document.documentElement};new IntersectionObserver(e=>{e.forEach(e=>{t(e.intersectionRatio>0)})},n).observe(e)},this.keepAsking=!1,this.askToUpper=()=>{let e=this.data[this.id]?.page,t=e?.content?.length/e?.pageSize;this.dispatchEvent(new CustomEvent(`fetch-more-elements`,{detail:{params:{page:t,pageSize:this.metadata?.pageSize},callback:()=>{this.keepAsking&&this.askToUpper()}},bubbles:!0,composed:!0}))},this.renderItem=e=>e.card?ta(this,e.card,this.baseUrl,this.state,this.data,this.appState,this.appData,!1):e.title?w`<div class="neutral-card">
+                ${e.image?w`<img class="card-media" src="${e.image}" alt="" />`:_}
                 <div class="card-body">
                     <div class="card-head">
-                        ${e.title?T`<span class="card-title">${e.title}</span>`:v}
-                        ${e.status?T`<span theme="badge ${ra(e.status.type)}">${e.status.message}</span>`:v}
+                        ${e.title?w`<span class="card-title">${e.title}</span>`:_}
+                        ${e.status?w`<span theme="badge ${ia(e.status.type)}">${e.status.message}</span>`:_}
                     </div>
-                    ${e.subtitle?T`<div class="card-subtitle">${e.subtitle}</div>`:v}
-                    ${e.content?T`<div>${e.content}</div>`:v}
+                    ${e.subtitle?w`<div class="card-subtitle">${e.subtitle}</div>`:_}
+                    ${e.content?w`<div>${e.content}</div>`:_}
                 </div>
-        </div>`:T`${e}`,this.hasMore=!1,this.clickedOnCard=e=>{this.state[this.id+`_selected_items`]=[e],this.metadata?.onRowSelectionChangedActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.metadata?.onRowSelectionChangedActionId},bubbles:!0,composed:!0}))}}updated(e){super.updated(e);let t=this.data[this.id]?.page;this.hasMore=t?.content?.length<t?.totalElements}firstUpdated(e){super.firstUpdated(e),this.respondToVisibility(this.askForMore,e=>{this.keepAsking=e,e&&this.askToUpper()})}render(){return T`
+        </div>`:w`${e}`,this.hasMore=!1,this.clickedOnCard=e=>{this.state[this.id+`_selected_items`]=[e],this.metadata?.onRowSelectionChangedActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.metadata?.onRowSelectionChangedActionId},bubbles:!0,composed:!0}))}}updated(e){super.updated(e);let t=this.data[this.id]?.page;this.hasMore=t?.content?.length<t?.totalElements}firstUpdated(e){super.firstUpdated(e),this.respondToVisibility(this.askForMore,e=>{this.keepAsking=e,e&&this.askToUpper()})}render(){return w`
             <div class="card-container">
-                ${(this.data[this.id]?.page)?.content?.map(e=>T`<div role="button" tabindex="0" @click="${()=>this.clickedOnCard(e)}" @keydown="${R(()=>this.clickedOnCard(e))}" class="car-container">${this.renderItem(e)}</div>`)}
+                ${(this.data[this.id]?.page)?.content?.map(e=>w`<div role="button" tabindex="0" @click="${()=>this.clickedOnCard(e)}" @keydown="${L(()=>this.clickedOnCard(e))}" class="car-container">${this.renderItem(e)}</div>`)}
                 <div id="ask-for-more" style="display: ${this.hasMore?`flex`:`none`}; width: 100%; justify-content: center; padding: var(--lumo-space-m); color: var(--lumo-secondary-text-color); font-size: var(--lumo-font-size-s);">Loading more…</div>
             </div>
 
             <slot></slot>
-       `}static{this.styles=h`
-        ${de}
+       `}static{this.styles=m`
+        ${fe}
         
         .card-container {
             display: flex;
@@ -4617,147 +4617,147 @@ ${i}
         .neutral-card .card-title { font-weight: 600; }
         .neutral-card .card-subtitle { color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-s, .875rem); }
     
-        ${z}
-    `}};k([y()],W.prototype,`id`,void 0),k([y()],W.prototype,`metadata`,void 0),k([y()],W.prototype,`baseUrl`,void 0),k([y()],W.prototype,`state`,void 0),k([y()],W.prototype,`data`,void 0),k([y()],W.prototype,`appState`,void 0),k([y()],W.prototype,`appData`,void 0),k([y()],W.prototype,`emptyStateMessage`,void 0),k([C()],W.prototype,`keepAsking`,void 0),k([x(`#ask-for-more`)],W.prototype,`askForMore`,void 0),k([C()],W.prototype,`hasMore`,void 0),W=k([g(`mateu-card-list`)],W);var ia={show:e=>console.debug(`[mateu] no notifier registered, dropping toast:`,e.text)};function aa(e){ia=e}function oa(e,t){ia.show(e,t)}var sa=function(e){return e.none=`none`,e.success=`success`,e.error=`error`,e.warning=`warning`,e.contrast=`contrast`,e.normal=`normal`,e}({}),ca=function(e){return e.primary=`primary`,e.secondary=`secondary`,e.tertiary=`tertiary`,e.tertiaryInline=`tertiaryInline`,e}({});function la(e){if(e.weight!=null)return e.weight;let t=e.stereotype??``;if(t===`icon`)return 1;if(t===`image`)return 4;if(t===`html`||t===`richText`||t===`markdown`||t===`textarea`)return 5;if(t===`link`)return 2.5;if(t===`combobox`||t===`select`)return 2;let n=e.dataType??``;return n===`bool`?1:n===`status`||n===`integer`?1.5:n===`number`||n===`date`||n===`money`?2:n===`dateTime`||n===`dateRange`?2.5:3}function ua(e,t){if(e.length===0)return`table`;let n=e.reduce((e,t)=>e+la(t),0)/(t/76);if(n<=1.1)return`table`;if(n>1.6||e.length>10)return`masterDetail`;let r=e.filter(e=>e.identifier||(e.priority??2**53-1)<=2),i=r.reduce((e,t)=>e+la(t),0);return r.length>0&&i<=8?`list`:e.some(e=>e.stereotype===`image`||e.stereotype===`html`)||r.length===0&&e.length>=4&&e.length<=8?`cards`:`masterDetail`}function da(e){return e.filter(e=>e.identifier||(e.priority??2**53-1)<=2).sort((e,t)=>(e.priority??2**53-1)-(t.priority??2**53-1))}function fa(e){let t=da(e);return t.length>0?t:e.slice(0,3)}var pa={asc:`ascending`,desc:`descending`},G=class extends b{constructor(...e){super(...e),this.component=void 0,this.standalone=!1,this.state={},this.data={},this.appState={},this.appData={},this.showImportDialog=!1,this.availableWidthPx=1024,this.selectedItem=null,this._columnPrefsRevision=0,this._prefsRevisionApplied=-1,this.search=()=>{let e=this.component.metadata;this.state={...this.state,size:e.pageSize,page:0,crud_selected_items:[]},this._syncStateToUrl(e),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`search`,parameters:{crudId:this.id,_searchState:{...this.state}}},bubbles:!0,composed:!0}))},this.notify=e=>{oa({text:e,position:`bottomEnd`,variant:`error`,duration:3e3},this)},this.handleSearchRequested=e=>{this.state={...this.state,crud_selected_items:[]};let t=this.component.metadata;this._syncStateToUrl(t),!t.infiniteScrolling&&this.data?.[this.id]?.page&&(this.data[this.id].page.content=[]),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`search`,parameters:{crudId:this.id,_searchState:{...this.state}},callback:e},bubbles:!0,composed:!0}))},this.fetchMoreElements=e=>{let{params:t,callback:n}=e.detail;this.state={...this.state,size:t.pageSize,page:t.page},this.handleSearchRequested(n)},this.directionChanged=e=>{let t=e.detail.grid._sorters;this.state={...this.state,sort:t.map(e=>({fieldId:e.__data.path,direction:e.__data.direction?pa[e.__data.direction]:void 0}))},this.handleSearchRequested(void 0)},this._initializedForComponentId=void 0,this.evalLabel=e=>M(e,this.state,this.data),this.handleToolbarButtonClick=e=>{if(e===`import`){this.showImportDialog=!0;return}this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.handleImportUploadSuccess=e=>{let t=e.detail.xhr.responseText;this.showImportDialog=!1,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`process-import`,parameters:{fileId:t}},bubbles:!0,composed:!0}))}}get columnPrefsScope(){return window.location.pathname}get effectiveComponent(){let e=this.component,t=e?.metadata;if(!e||!t?.columns)return e;if(this._prefsSource===e&&this._prefsRevisionApplied===this._columnPrefsRevision)return this._prefsApplied;let n=It(this.columnPrefsScope),r=Bt(t.columns,n,e=>e.metadata??{});return this._prefsApplied=r===t.columns?e:{...e,metadata:{...t,columns:r}},this._prefsSource=e,this._prefsRevisionApplied=this._columnPrefsRevision,this._prefsApplied}get columnChooserEntries(){return(this.component?.metadata?.columns??[]).map(e=>{let t=e.metadata??{},n=t.id??e.id;return n?{id:n,label:t.label??n,protected:zt(t)}:void 0}).filter(e=>!!e)}renderColumnChooser(){let e=this.columnChooserEntries;return e.filter(e=>!e.protected).length===0?v:T`
+        ${R}
+    `}};O([v()],U.prototype,`id`,void 0),O([v()],U.prototype,`metadata`,void 0),O([v()],U.prototype,`baseUrl`,void 0),O([v()],U.prototype,`state`,void 0),O([v()],U.prototype,`data`,void 0),O([v()],U.prototype,`appState`,void 0),O([v()],U.prototype,`appData`,void 0),O([v()],U.prototype,`emptyStateMessage`,void 0),O([S()],U.prototype,`keepAsking`,void 0),O([b(`#ask-for-more`)],U.prototype,`askForMore`,void 0),O([S()],U.prototype,`hasMore`,void 0),U=O([h(`mateu-card-list`)],U);var aa={show:e=>console.debug(`[mateu] no notifier registered, dropping toast:`,e.text)};function oa(e){aa=e}function sa(e,t){aa.show(e,t)}var ca=function(e){return e.none=`none`,e.success=`success`,e.error=`error`,e.warning=`warning`,e.contrast=`contrast`,e.normal=`normal`,e}({}),la=function(e){return e.primary=`primary`,e.secondary=`secondary`,e.tertiary=`tertiary`,e.tertiaryInline=`tertiaryInline`,e}({});function ua(e){if(e.weight!=null)return e.weight;let t=e.stereotype??``;if(t===`icon`)return 1;if(t===`image`)return 4;if(t===`html`||t===`richText`||t===`markdown`||t===`textarea`)return 5;if(t===`link`)return 2.5;if(t===`combobox`||t===`select`)return 2;let n=e.dataType??``;return n===`bool`?1:n===`status`||n===`integer`?1.5:n===`number`||n===`date`||n===`money`?2:n===`dateTime`||n===`dateRange`?2.5:3}function da(e,t){if(e.length===0)return`table`;let n=e.reduce((e,t)=>e+ua(t),0)/(t/76);if(n<=1.1)return`table`;if(n>1.6||e.length>10)return`masterDetail`;let r=e.filter(e=>e.identifier||(e.priority??2**53-1)<=2),i=r.reduce((e,t)=>e+ua(t),0);return r.length>0&&i<=8?`list`:e.some(e=>e.stereotype===`image`||e.stereotype===`html`)||r.length===0&&e.length>=4&&e.length<=8?`cards`:`masterDetail`}function fa(e){return e.filter(e=>e.identifier||(e.priority??2**53-1)<=2).sort((e,t)=>(e.priority??2**53-1)-(t.priority??2**53-1))}function pa(e){let t=fa(e);return t.length>0?t:e.slice(0,3)}var ma={asc:`ascending`,desc:`descending`},W=class extends y{constructor(...e){super(...e),this.component=void 0,this.standalone=!1,this.state={},this.data={},this.appState={},this.appData={},this.showImportDialog=!1,this.availableWidthPx=1024,this.selectedItem=null,this._columnPrefsRevision=0,this._prefsRevisionApplied=-1,this.search=()=>{let e=this.component.metadata;this.state={...this.state,size:e.pageSize,page:0,crud_selected_items:[]},this._syncStateToUrl(e),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`search`,parameters:{crudId:this.id,_searchState:{...this.state}}},bubbles:!0,composed:!0}))},this.notify=e=>{sa({text:e,position:`bottomEnd`,variant:`error`,duration:3e3},this)},this.handleSearchRequested=e=>{this.state={...this.state,crud_selected_items:[]};let t=this.component.metadata;this._syncStateToUrl(t),!t.infiniteScrolling&&this.data?.[this.id]?.page&&(this.data[this.id].page.content=[]),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`search`,parameters:{crudId:this.id,_searchState:{...this.state}},callback:e},bubbles:!0,composed:!0}))},this.fetchMoreElements=e=>{let{params:t,callback:n}=e.detail;this.state={...this.state,size:t.pageSize,page:t.page},this.handleSearchRequested(n)},this.directionChanged=e=>{let t=e.detail.grid._sorters;this.state={...this.state,sort:t.map(e=>({fieldId:e.__data.path,direction:e.__data.direction?ma[e.__data.direction]:void 0}))},this.handleSearchRequested(void 0)},this._initializedForComponentId=void 0,this.evalLabel=e=>j(e,this.state,this.data),this.handleToolbarButtonClick=e=>{if(e===`import`){this.showImportDialog=!0;return}this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.handleImportUploadSuccess=e=>{let t=e.detail.xhr.responseText;this.showImportDialog=!1,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`process-import`,parameters:{fileId:t}},bubbles:!0,composed:!0}))}}get columnPrefsScope(){return window.location.pathname}get effectiveComponent(){let e=this.component,t=e?.metadata;if(!e||!t?.columns)return e;if(this._prefsSource===e&&this._prefsRevisionApplied===this._columnPrefsRevision)return this._prefsApplied;let n=Lt(this.columnPrefsScope),r=Vt(t.columns,n,e=>e.metadata??{});return this._prefsApplied=r===t.columns?e:{...e,metadata:{...t,columns:r}},this._prefsSource=e,this._prefsRevisionApplied=this._columnPrefsRevision,this._prefsApplied}get columnChooserEntries(){return(this.component?.metadata?.columns??[]).map(e=>{let t=e.metadata??{},n=t.id??e.id;return n?{id:n,label:t.label??n,protected:Bt(t)}:void 0}).filter(e=>!!e)}renderColumnChooser(){let e=this.columnChooserEntries;return e.filter(e=>!e.protected).length===0?_:w`
             <mateu-column-chooser
                 .columns="${e}"
                 .scope="${this.columnPrefsScope}"
                 @column-prefs-changed="${e=>{e.stopPropagation(),this._columnPrefsRevision++}}"
             ></mateu-column-chooser>
-        `}get cols(){return(this.effectiveComponent?.metadata)?.columns?.map(e=>e.metadata)??[]}get identifierFieldName(){let e=this.cols.find(e=>e.identifier);return e?e.id:this.cols.find(e=>e.id===`id`)?.id}get effectiveGridLayout(){let e=this.component?.metadata,t=e?.gridLayout??`auto`;return t===`auto`?e?.crudlType===`card`?`cards`:ua(this.cols,this.availableWidthPx):t}connectedCallback(){super.connectedCallback(),this.resizeObserver=new ResizeObserver(e=>{let t=e[0]?.contentRect.width;t&&Math.abs(t-this.availableWidthPx)>10&&(this.availableWidthPx=t)}),this.resizeObserver.observe(this)}disconnectedCallback(){super.disconnectedCallback(),this.resizeObserver?.disconnect()}_filterIds(e){return new Set([`searchText`,...(e.filters??[]).flatMap(e=>e.stereotype===`dateRange`||e.stereotype===`numberRange`?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId])])}_syncStateToUrl(e){let t=this._filterIds(e),n=new URLSearchParams(window.location.search);t.forEach(e=>n.delete(e)),n.delete(`page`),n.delete(`sort`),t.forEach(e=>{let t=this.state[e];t!=null&&t!==``&&n.set(e,String(t))});let r=this.state.page;r&&r>0&&n.set(`page`,String(r));let i=this.state.sort;if(i&&i.length>0){let e=i.filter(e=>e.fieldId&&e.direction).map(e=>`${e.fieldId}:${e.direction}`).join(`,`);e&&n.set(`sort`,e)}let a=n.toString(),o=a?`${window.location.pathname}?${a}`:window.location.pathname;window.location.pathname+window.location.search!==o&&history.replaceState(null,``,o)}_initStateFromUrl(e,t){let n=new URLSearchParams(window.location.search),r=this._filterIds(e),i={...t};n.forEach((e,t)=>{r.has(t)&&(i[t]=e)});let a=n.get(`page`);if(a!==null){let e=parseInt(a,10);!isNaN(e)&&e>0&&(i.page=e)}let o=n.get(`sort`);if(o){let e=o.split(`,`).map(e=>{let[t,n]=e.split(`:`);return t&&n?{fieldId:t,direction:n}:null}).filter(Boolean);e.length>0&&(i.sort=e)}return i}pageChanged(e){this.state={...this.state,page:e.detail.page},this.handleSearchRequested(void 0)}updated(e){if(super.updated(e),e.has(`component`)){let e=this.component?.id;if(e!==this._initializedForComponentId){this._initializedForComponentId=e;let t=this.component?.metadata,n=t.initialPage&&t.initialPage>0?t.initialPage:0;this.state=this._initStateFromUrl(t,{...this.state,size:t.pageSize,page:n,sort:[]}),(this.state.page!==n||this.state.sort?.length>0||[...this._filterIds(t)].some(e=>this.state[e]!=null))&&this.handleSearchRequested(void 0)}}}render(){let e=e=>{let t=[];return e.color&&e.color!==sa.normal&&t.push(e.color),e.buttonStyle&&t.push(e.buttonStyle===ca.tertiaryInline?`tertiary-inline`:e.buttonStyle),t.length?t.join(` `):void 0},t=e=>e===`back`||e===`backToList`||!!e&&e.startsWith(`cancel`),n=t=>P.get()?.renderToolbarButton?.(t,this.evalLabel(t.label),()=>this.handleToolbarButtonClick(t.actionId))||T`
+        `}get cols(){return(this.effectiveComponent?.metadata)?.columns?.map(e=>e.metadata)??[]}get identifierFieldName(){let e=this.cols.find(e=>e.identifier);return e?e.id:this.cols.find(e=>e.id===`id`)?.id}get effectiveGridLayout(){let e=this.component?.metadata,t=e?.gridLayout??`auto`;return t===`auto`?e?.crudlType===`card`?`cards`:da(this.cols,this.availableWidthPx):t}connectedCallback(){super.connectedCallback(),this.resizeObserver=new ResizeObserver(e=>{let t=e[0]?.contentRect.width;t&&Math.abs(t-this.availableWidthPx)>10&&(this.availableWidthPx=t)}),this.resizeObserver.observe(this)}disconnectedCallback(){super.disconnectedCallback(),this.resizeObserver?.disconnect()}_filterIds(e){return new Set([`searchText`,...(e.filters??[]).flatMap(e=>e.stereotype===`dateRange`||e.stereotype===`numberRange`?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId])])}_syncStateToUrl(e){let t=this._filterIds(e),n=new URLSearchParams(window.location.search);t.forEach(e=>n.delete(e)),n.delete(`page`),n.delete(`sort`),t.forEach(e=>{let t=this.state[e];t!=null&&t!==``&&n.set(e,String(t))});let r=this.state.page;r&&r>0&&n.set(`page`,String(r));let i=this.state.sort;if(i&&i.length>0){let e=i.filter(e=>e.fieldId&&e.direction).map(e=>`${e.fieldId}:${e.direction}`).join(`,`);e&&n.set(`sort`,e)}let a=n.toString(),o=a?`${window.location.pathname}?${a}`:window.location.pathname;window.location.pathname+window.location.search!==o&&history.replaceState(null,``,o)}_initStateFromUrl(e,t){let n=new URLSearchParams(window.location.search),r=this._filterIds(e),i={...t};n.forEach((e,t)=>{r.has(t)&&(i[t]=e)});let a=n.get(`page`);if(a!==null){let e=parseInt(a,10);!isNaN(e)&&e>0&&(i.page=e)}let o=n.get(`sort`);if(o){let e=o.split(`,`).map(e=>{let[t,n]=e.split(`:`);return t&&n?{fieldId:t,direction:n}:null}).filter(Boolean);e.length>0&&(i.sort=e)}return i}pageChanged(e){this.state={...this.state,page:e.detail.page},this.handleSearchRequested(void 0)}updated(e){if(super.updated(e),e.has(`component`)){let e=this.component?.id;if(e!==this._initializedForComponentId){this._initializedForComponentId=e;let t=this.component?.metadata,n=t.initialPage&&t.initialPage>0?t.initialPage:0;this.state=this._initStateFromUrl(t,{...this.state,size:t.pageSize,page:n,sort:[]}),(this.state.page!==n||this.state.sort?.length>0||[...this._filterIds(t)].some(e=>this.state[e]!=null))&&this.handleSearchRequested(void 0)}}}render(){let e=e=>{let t=[];return e.color&&e.color!==ca.normal&&t.push(e.color),e.buttonStyle&&t.push(e.buttonStyle===la.tertiaryInline?`tertiary-inline`:e.buttonStyle),t.length?t.join(` `):void 0},t=e=>e===`back`||e===`backToList`||!!e&&e.startsWith(`cancel`),n=t=>N.get()?.renderToolbarButton?.(t,this.evalLabel(t.label),()=>this.handleToolbarButtonClick(t.actionId))||w`
                 <button class="crud-btn"
                         data-action-id="${t.id}"
-                        theme="${e(t)||v}"
+                        theme="${e(t)||_}"
                         @click="${()=>this.handleToolbarButtonClick(t.actionId)}"
                 >${this.evalLabel(t.label)}</button>
-            `;if(!this.component)return T`no component`;let r=this.effectiveComponent,i=r.metadata;i.serverSideOrdering=!0;let a=(()=>{let e=this;for(;e;){let t=e;if(t.tagName===`MATEU-PAGE`)return(t.component?.metadata?.toolbar?.length??0)>0;e=t.parentElement??(t.getRootNode?.()instanceof ShadowRoot?t.getRootNode().host:null)}return!1})()?[]:i?.toolbar??[],o=a.filter(e=>t(e.actionId)),s=a.filter(e=>!t(e.actionId)),c=o.length>0&&s.length>0,l=!!i?.title||!!i?.subtitle||a.length>0,u=this.effectiveGridLayout,d=this.cols,f=da(d),p=this.data[this.id]?.page?.content??[],m=this.state[this.component?.id]?.emptyStateMessage,ee=(e,t)=>{let n=t[e.id];return n==null?T``:e.dataType===`status`?T`<span theme="badge pill ${ra(n.type)}">${n.message}</span>`:e.dataType===`bool`?T`${n?`✓`:`✗`}`:typeof n==`object`?T`${n.label??n.name??n.message??``}`:T`${n}`},te=()=>{let e=this.identifierFieldName,t=this.state._selectedId??this.appState?._splitDetailId,n=f.find(e=>e.identifier)??f[0],r=e=>e.dataType===`action`||e.dataType===`actionGroup`||e.dataType===`menu`||e.stereotype===`button`,i=f.filter(e=>e!==n&&!r(e)),a=d.filter(e=>r(e)),o=(e,t,n)=>{e.stopPropagation(),e.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_clickedRow:n}},bubbles:!0,composed:!0}))},s=e=>{let t=[];for(let n of a){let r=e[n.id];if(n.dataType===`action`){let i=r?.methodNameInCrud?r:e.action?.methodNameInCrud?e.action:{methodNameInCrud:n.id,label:n.label,icon:null,disabled:!1};t.push(T`
-                            <button class="crud-btn" theme="tertiary small" title="${i.label||v}"
+            `;if(!this.component)return w`no component`;let r=this.effectiveComponent,i=r.metadata;i.serverSideOrdering=!0;let a=(()=>{let e=this;for(;e;){let t=e;if(t.tagName===`MATEU-PAGE`)return(t.component?.metadata?.toolbar?.length??0)>0;e=t.parentElement??(t.getRootNode?.()instanceof ShadowRoot?t.getRootNode().host:null)}return!1})()?[]:i?.toolbar??[],o=a.filter(e=>t(e.actionId)),s=a.filter(e=>!t(e.actionId)),c=o.length>0&&s.length>0,l=!!i?.title||!!i?.subtitle||a.length>0,u=this.effectiveGridLayout,d=this.cols,f=fa(d),p=this.data[this.id]?.page?.content??[],ee=this.state[this.component?.id]?.emptyStateMessage,te=(e,t)=>{let n=t[e.id];return n==null?w``:e.dataType===`status`?w`<span theme="badge pill ${ia(n.type)}">${n.message}</span>`:e.dataType===`bool`?w`${n?`✓`:`✗`}`:typeof n==`object`?w`${n.label??n.name??n.message??``}`:w`${n}`},ne=()=>{let e=this.identifierFieldName,t=this.state._selectedId??this.appState?._splitDetailId,n=f.find(e=>e.identifier)??f[0],r=e=>e.dataType===`action`||e.dataType===`actionGroup`||e.dataType===`menu`||e.stereotype===`button`,i=f.filter(e=>e!==n&&!r(e)),a=d.filter(e=>r(e)),o=(e,t,n)=>{e.stopPropagation(),e.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_clickedRow:n}},bubbles:!0,composed:!0}))},s=e=>{let t=[];for(let n of a){let r=e[n.id];if(n.dataType===`action`){let i=r?.methodNameInCrud?r:e.action?.methodNameInCrud?e.action:{methodNameInCrud:n.id,label:n.label,icon:null,disabled:!1};t.push(w`
+                            <button class="crud-btn" theme="tertiary small" title="${i.label||_}"
                                 @click="${t=>o(t,`action-on-row-`+i.methodNameInCrud,e)}">
-                                ${i.icon?I(i.icon):v}
-                                ${i.label??v}
-                            </button>`)}else(n.dataType===`actionGroup`||n.dataType===`menu`)&&(r?.actions??[]).forEach(n=>t.push(T`
-                            <button class="crud-btn" theme="tertiary small" title="${n.label||v}"
+                                ${i.icon?F(i.icon):_}
+                                ${i.label??_}
+                            </button>`)}else(n.dataType===`actionGroup`||n.dataType===`menu`)&&(r?.actions??[]).forEach(n=>t.push(w`
+                            <button class="crud-btn" theme="tertiary small" title="${n.label||_}"
                                 @click="${t=>o(t,`action-on-row-`+n.methodNameInCrud,e)}">
-                                ${n.icon?I(n.icon):v}
-                                ${n.label??v}
-                            </button>`))}return t.length?T`
+                                ${n.icon?F(n.icon):_}
+                                ${n.label??_}
+                            </button>`))}return t.length?w`
                     <div style="display: flex; flex-wrap: wrap; gap: var(--lumo-space-xs); margin-top: var(--lumo-space-xs);">
                         ${t}
-                    </div>`:v};return T`
+                    </div>`:_};return w`
                 <div class="m-listbox" style="width: 100%;">
-                    ${p.length===0?T`<div class="m-item" disabled>${xt(m)}</div>`:v}
-                    ${p.map(r=>T`
+                    ${p.length===0?w`<div class="m-item" disabled>${St(ee)}</div>`:_}
+                    ${p.map(r=>w`
                         <div role="button" tabindex="0" class="m-item"
                             ?selected="${e&&t!==void 0&&String(r[e])===String(t)}"
-                            @click="${()=>{e&&r[e]!==void 0&&(this.state={...this.state,_selectedId:String(r[e])}),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`view`,parameters:r},bubbles:!0,composed:!0}))}}" @keydown="${R(()=>{e&&r[e]!==void 0&&(this.state={...this.state,_selectedId:String(r[e])}),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`view`,parameters:r},bubbles:!0,composed:!0}))})}"
+                            @click="${()=>{e&&r[e]!==void 0&&(this.state={...this.state,_selectedId:String(r[e])}),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`view`,parameters:r},bubbles:!0,composed:!0}))}}" @keydown="${L(()=>{e&&r[e]!==void 0&&(this.state={...this.state,_selectedId:String(r[e])}),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`view`,parameters:r},bubbles:!0,composed:!0}))})}"
                             style="cursor: pointer;"
                         >
                             <div style="font-weight: 600;">${n?r[n.id]??``:``}</div>
                             <div style="font-size: var(--lumo-font-size-s); color: var(--lumo-secondary-text-color); display: flex; flex-wrap: wrap; gap: var(--lumo-space-xs); align-items: center;">
-                                ${i.map(e=>T`<span>${e.label}: ${ee(e,r)}</span>`)}
+                                ${i.map(e=>w`<span>${e.label}: ${te(e,r)}</span>`)}
                             </div>
                             ${s(r)}
                         </div>
                     `)}
-                </div>`},ne=(e,t,n)=>{let r=this.identifierFieldName;r&&n[r]!==void 0&&(this.state={...this.state,_selectedId:String(n[r])}),e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:n},bubbles:!0,composed:!0}))},h=()=>{let e=this.identifierFieldName,t=this.state._selectedId??this.appState?._splitDetailId,n=e=>!!e.actionId,r=e=>e.dataType===`action`||e.dataType===`actionGroup`||e.dataType===`menu`||e.stereotype===`button`,i=[...d.slice(0,6),...d.slice(6).filter(e=>r(e)||e.dataType===`status`)],a=i.filter(e=>e.stereotype===`image`),o=i.find(e=>e.identifier)??i[0],s=i.find(e=>e.id===`select`&&e.dataType===`action`),c=!!s,l=i.filter(e=>e!==o&&!a.includes(e)&&!n(e)&&!r(e)),u=i.filter(e=>r(e)&&!(c&&e===s)),f=(e,t,n)=>{e.stopPropagation(),e.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_clickedRow:n}},bubbles:!0,composed:!0}))},te=e=>{let t=[];for(let n of u){let r=e[n.id];if(n.dataType===`action`){let i=r?.methodNameInCrud?r:e.action?.methodNameInCrud?e.action:{methodNameInCrud:n.id,label:n.label,icon:null,disabled:!1};t.push(T`
-                            <button class="crud-btn" theme="tertiary" title="${i.label||v}"
+                </div>`},re=(e,t,n)=>{let r=this.identifierFieldName;r&&n[r]!==void 0&&(this.state={...this.state,_selectedId:String(n[r])}),e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:n},bubbles:!0,composed:!0}))},m=()=>{let e=this.identifierFieldName,t=this.state._selectedId??this.appState?._splitDetailId,n=e=>!!e.actionId,r=e=>e.dataType===`action`||e.dataType===`actionGroup`||e.dataType===`menu`||e.stereotype===`button`,i=[...d.slice(0,6),...d.slice(6).filter(e=>r(e)||e.dataType===`status`)],a=i.filter(e=>e.stereotype===`image`),o=i.find(e=>e.identifier)??i[0],s=i.find(e=>e.id===`select`&&e.dataType===`action`),c=!!s,l=i.filter(e=>e!==o&&!a.includes(e)&&!n(e)&&!r(e)),u=i.filter(e=>r(e)&&!(c&&e===s)),f=(e,t,n)=>{e.stopPropagation(),e.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_clickedRow:n}},bubbles:!0,composed:!0}))},ne=e=>{let t=[];for(let n of u){let r=e[n.id];if(n.dataType===`action`){let i=r?.methodNameInCrud?r:e.action?.methodNameInCrud?e.action:{methodNameInCrud:n.id,label:n.label,icon:null,disabled:!1};t.push(w`
+                            <button class="crud-btn" theme="tertiary" title="${i.label||_}"
                                 @click="${t=>f(t,`action-on-row-`+i.methodNameInCrud,e)}">
-                                ${i.icon?I(i.icon):v}
-                                ${i.label??v}
-                            </button>`)}else(n.dataType===`actionGroup`||n.dataType===`menu`)&&(r?.actions??[]).forEach(n=>t.push(T`
-                            <button class="crud-btn" theme="tertiary" title="${n.label||v}"
+                                ${i.icon?F(i.icon):_}
+                                ${i.label??_}
+                            </button>`)}else(n.dataType===`actionGroup`||n.dataType===`menu`)&&(r?.actions??[]).forEach(n=>t.push(w`
+                            <button class="crud-btn" theme="tertiary" title="${n.label||_}"
                                 @click="${t=>f(t,`action-on-row-`+n.methodNameInCrud,e)}">
-                                ${n.icon?I(n.icon):v}
-                                ${n.label??v}
-                            </button>`))}return t.length?T`
+                                ${n.icon?F(n.icon):_}
+                                ${n.label??_}
+                            </button>`))}return t.length?w`
                     <div style="display: flex; flex-wrap: wrap; gap: var(--lumo-space-xs); padding-top: var(--lumo-space-s); border-top: 1px solid var(--lumo-contrast-10pct);">
                         ${t}
-                    </div>`:v};return T`
+                    </div>`:_};return w`
                 <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: var(--lumo-space-m); padding: var(--lumo-space-s) 0;">
-                    ${p.length===0?T`<div style="grid-column: 1 / -1;">${xt(m)}</div>`:v}
-                    ${p.map(n=>T`
+                    ${p.length===0?w`<div style="grid-column: 1 / -1;">${St(ee)}</div>`:_}
+                    ${p.map(n=>w`
                         <div role="button" tabindex="0" class="crud-card"
                             ?data-selected="${e&&t!==void 0&&String(n[e])===String(t)}"
                             style="cursor: pointer;"
-                            @click="${e=>c?f(e,`action-on-row-select`,n):ne(e.target,`view`,n)}" @keydown="${R(e=>c?f(e,`action-on-row-select`,n):ne(e.target,`view`,n))}"
+                            @click="${e=>c?f(e,`action-on-row-select`,n):re(e.target,`view`,n)}" @keydown="${L(e=>c?f(e,`action-on-row-select`,n):re(e.target,`view`,n))}"
                         >
-                            ${a.length?T`<img src="${n[a[0].id]??``}" alt="" style="width: 100%; max-height: 160px; object-fit: cover; border-radius: var(--lumo-border-radius-m, 8px);" />`:v}
-                            ${o?T`<div class="crud-card-title">${n[o.id]??``}</div>`:v}
+                            ${a.length?w`<img src="${n[a[0].id]??``}" alt="" style="width: 100%; max-height: 160px; object-fit: cover; border-radius: var(--lumo-border-radius-m, 8px);" />`:_}
+                            ${o?w`<div class="crud-card-title">${n[o.id]??``}</div>`:_}
                             <div style="display: flex; flex-direction: column; gap: var(--lumo-space-xs); padding: var(--lumo-space-s) 0;">
-                                ${l.map(e=>T`
+                                ${l.map(e=>w`
                                     <div style="display: flex; gap: var(--lumo-space-s); font-size: var(--lumo-font-size-s);">
                                         <span style="color: var(--lumo-secondary-text-color); min-width: 80px;">${e.label}</span>
-                                        <span>${ee(e,n)}</span>
+                                        <span>${te(e,n)}</span>
                                     </div>
                                 `)}
                             </div>
-                            ${te(n)}
+                            ${ne(n)}
                         </div>
                     `)}
-                </div>`},g=()=>{let e=fa(d),t=e.find(e=>e.identifier)??e[0],n=e.filter(e=>e!==t);return T`
+                </div>`},h=()=>{let e=pa(d),t=e.find(e=>e.identifier)??e[0],n=e.filter(e=>e!==t);return w`
                 <div style="display: flex; height: 100%; min-height: 400px; gap: 0;">
                     <div style="width: 260px; flex-shrink: 0; border-right: 1px solid var(--lumo-contrast-20pct); overflow-y: auto;">
                         <div class="m-listbox" style="width: 100%;">
-                            ${p.length===0?T`<div class="m-item" disabled>${xt(m)}</div>`:v}
-                            ${p.map(e=>T`
+                            ${p.length===0?w`<div class="m-item" disabled>${St(ee)}</div>`:_}
+                            ${p.map(e=>w`
                                 <div role="button" tabindex="0" class="m-item"
                                     ?selected="${this.selectedItem===e}"
-                                    @click="${()=>{this.selectedItem=e}}" @keydown="${R(()=>{this.selectedItem=e})}"
+                                    @click="${()=>{this.selectedItem=e}}" @keydown="${L(()=>{this.selectedItem=e})}"
                                     style="cursor: pointer;"
                                 >
                                     <div style="font-weight: 600;">${t?e[t.id]??``:``}</div>
                                     <div style="font-size: var(--lumo-font-size-s); color: var(--lumo-secondary-text-color); display: flex; flex-wrap: wrap; gap: var(--lumo-space-xs); align-items: center;">
-                                        ${n.map(t=>T`${ee(t,e)} `)}
+                                        ${n.map(t=>w`${te(t,e)} `)}
                                     </div>
                                 </div>
                             `)}
                         </div>
                     </div>
                     <div style="flex: 1; padding: var(--lumo-space-m); overflow-y: auto;">
-                        ${this.selectedItem?T`
+                        ${this.selectedItem?w`
                             <div class="m-formlayout">
-                                ${d.map(e=>T`
+                                ${d.map(e=>w`
                                     <label style="display: flex; flex-direction: column; gap: .1rem; font-size: var(--lumo-font-size-s, .875rem);">
                                         <span style="color: var(--lumo-secondary-text-color, #667);">${e.label}</span>
                                         <span>${String(this.selectedItem[e.id]??``)}</span>
                                     </label>
                                 `)}
                             </div>
-                        `:T`
+                        `:w`
                             <p style="color: var(--lumo-secondary-text-color);">Select a row to view details.</p>
                         `}
                     </div>
-                </div>`},_=()=>{let e=this.identifierFieldName,t=this.state._selectedId??this.appState?._splitDetailId,n=d[0],r=d.slice(1),i=!!n?.actionId,a=e=>(e??[]).map(e=>{let t=Array.isArray(e.children)?e.children:[];return t.length>0?{...e,children:a(t)}:{...e,children:void 0}}),o=a(p),s=(t,n,r)=>{t.stopPropagation(),e&&n[e]!==void 0&&(this.state={...this.state,_selectedId:String(n[e])}),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:r,parameters:n},bubbles:!0,composed:!0}))},c=(a,o)=>T`
+                </div>`},g=()=>{let e=this.identifierFieldName,t=this.state._selectedId??this.appState?._splitDetailId,n=d[0],r=d.slice(1),i=!!n?.actionId,a=e=>(e??[]).map(e=>{let t=Array.isArray(e.children)?e.children:[];return t.length>0?{...e,children:a(t)}:{...e,children:void 0}}),o=a(p),s=(t,n,r)=>{t.stopPropagation(),e&&n[e]!==void 0&&(this.state={...this.state,_selectedId:String(n[e])}),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:r,parameters:n},bubbles:!0,composed:!0}))},c=(a,o)=>w`
                 <tr class="${e&&t!==void 0&&String(a[e])===String(t)?`selected`:``}"
                     style="cursor: pointer;" @click="${e=>s(e,a,`view`)}">
-                    ${n?T`<td style="padding-left: ${o*1.2+.6}rem;">${a[n.id]??``}</td>`:v}
-                    ${r.map(e=>e.id===`select`?T`<td><button class="crud-btn small" @click="${e=>{e.stopPropagation(),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-select`,parameters:{_clickedRow:a}},bubbles:!0,composed:!0}))}}">Select</button></td>`:T`<td>${a[e.id]??``}</td>`)}
-                    ${i?T`<td style="text-align: end;">${a?.viewable===!1?v:T`<button class="crud-btn small" @click="${e=>s(e,a,`view`)}">View</button>`}</td>`:v}
+                    ${n?w`<td style="padding-left: ${o*1.2+.6}rem;">${a[n.id]??``}</td>`:_}
+                    ${r.map(e=>e.id===`select`?w`<td><button class="crud-btn small" @click="${e=>{e.stopPropagation(),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-select`,parameters:{_clickedRow:a}},bubbles:!0,composed:!0}))}}">Select</button></td>`:w`<td>${a[e.id]??``}</td>`)}
+                    ${i?w`<td style="text-align: end;">${a?.viewable===!1?_:w`<button class="crud-btn small" @click="${e=>s(e,a,`view`)}">View</button>`}</td>`:_}
                 </tr>
                 ${(a.children??[]).map(e=>c(e,o+1))}
-            `;return T`
+            `;return w`
                 <table class="crud-table">
                     <thead><tr>
-                        ${n?T`<th>${n.label??v}</th>`:v}
-                        ${r.map(e=>T`<th>${e.label??v}</th>`)}
-                        ${i?T`<th></th>`:v}
+                        ${n?w`<th>${n.label??_}</th>`:_}
+                        ${r.map(e=>w`<th>${e.label??_}</th>`)}
+                        ${i?w`<th></th>`:_}
                     </tr></thead>
                     <tbody>
-                        ${o.length===0?T`<tr><td colspan="99" style="padding: 1.5rem; text-align: center; color: var(--lumo-secondary-text-color, #888);">${xt(m)}</td></tr>`:v}
+                        ${o.length===0?w`<tr><td colspan="99" style="padding: 1.5rem; text-align: center; color: var(--lumo-secondary-text-color, #888);">${St(ee)}</td></tr>`:_}
                         ${o.map(e=>c(e,0))}
                     </tbody>
-                </table>`},re=P.get()?.rendersCrudLayouts?.()===!0,y=T`
-            ${i.infiniteScrolling?T`
+                </table>`},ie=N.get()?.rendersCrudLayouts?.()===!0,v=w`
+            ${i.infiniteScrolling?w`
                 <div>${this.data[this.id]?.page?.totalElements} items found.</div>
-            `:v}
-            ${!re&&u===`list`?te():!re&&u===`cards`?i.contentHeight?T`
+            `:_}
+            ${!ie&&u===`list`?ne():!ie&&u===`cards`?i.contentHeight?w`
                 <div class="m-scroll" style="width: 100%; height: ${i.contentHeight};">
-                    ${h()}
+                    ${m()}
                 </div>
-            `:h():!re&&u===`masterDetail`?g():!re&&u===`tree`?(()=>{let e=P.get();return e?.renderTreeComponent?e.renderTreeComponent(this,{rows:p,columns:d.map(e=>({id:e.id,label:e.label})),idField:this.identifierFieldName,navigable:!!d[0]?.actionId,selectedId:this.state._selectedId??this.appState?._splitDetailId}):_()})():P.get()?.renderTableComponent(this,r,this.baseUrl,this.state,this.data,this.appState,this.appData)}
+            `:m():!ie&&u===`masterDetail`?h():!ie&&u===`tree`?(()=>{let e=N.get();return e?.renderTreeComponent?e.renderTreeComponent(this,{rows:p,columns:d.map(e=>({id:e.id,label:e.label})),idField:this.identifierFieldName,navigable:!!d[0]?.actionId,selectedId:this.state._selectedId??this.appState?._splitDetailId}):g()})():N.get()?.renderTableComponent(this,r,this.baseUrl,this.state,this.data,this.appState,this.appData)}
             <slot></slot>
-        `,b=i.infiniteScrolling?v:P.get()?.renderPagination(this,this.component),x=this.showImportDialog?T`
-            <div role="button" tabindex="0" class="crud-modal-backdrop" @click="${e=>{e.target===e.currentTarget&&(this.showImportDialog=!1)}}" @keydown="${R(e=>{e.target===e.currentTarget&&(this.showImportDialog=!1)})}">
+        `,y=i.infiniteScrolling?_:N.get()?.renderPagination(this,this.component),b=this.showImportDialog?w`
+            <div role="button" tabindex="0" class="crud-modal-backdrop" @click="${e=>{e.target===e.currentTarget&&(this.showImportDialog=!1)}}" @keydown="${L(e=>{e.target===e.currentTarget&&(this.showImportDialog=!1)})}">
                 <div class="crud-modal">
                     <h3 style="margin: 0 0 .75rem;">Import</h3>
                     <input type="file" @change="${e=>{let t=e.target.files?.[0];if(t){let e=new FormData;e.append(`file`,t),fetch(`/upload`,{method:`POST`,body:e}).then(e=>e.json()).then(e=>this.handleImportUploadSuccess({detail:e})).catch(()=>this.notify(`Import failed`))}}}">
@@ -4766,8 +4766,8 @@ ${i}
                     </div>
                 </div>
             </div>
-        `:v;return this.standalone?T`
-                ${x}
+        `:_;return this.standalone?w`
+                ${b}
                 <div style="border: var(--mateu-section-border, none); background: var(--mateu-section-bg, transparent); overflow: hidden; max-height: calc(100dvh - 12rem); width: 100%; box-sizing: border-box; padding: var(--mateu-section-padding, 0); display: flex; flex-direction: column;">
                     <div style="flex-shrink: 0;">
                         <mateu-content-header
@@ -4780,40 +4780,40 @@ ${i}
                         ></mateu-content-header>
                     </div>
                     <div style="flex-shrink: 0; display: flex; align-items: center; gap: var(--lumo-space-s, 0.5rem);">
-                        <div style="flex: 1; min-width: 0;">${P.get()?.renderFilterBar(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData,!0)}</div>
+                        <div style="flex: 1; min-width: 0;">${N.get()?.renderFilterBar(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData,!0)}</div>
                         ${this.renderColumnChooser()}
                     </div>
-                    <div style="flex: 1; overflow-y: auto; min-height: 0;">${y}</div>
-                    <div style="flex-shrink: 0;">${b}</div>
+                    <div style="flex: 1; overflow-y: auto; min-height: 0;">${v}</div>
+                    <div style="flex-shrink: 0;">${y}</div>
                 </div>
-            `:T`
-            ${x}
-            ${l?T`
+            `:w`
+            ${b}
+            ${l?w`
                     <div style="display: flex; gap: var(--lumo-space-m, 1rem); width: 100%; align-items: flex-end; padding-bottom: var(--lumo-space-m, 1rem);">
                         <div style="flex: 1; min-width: 0;">
-                            ${i?.title?T`
+                            ${i?.title?w`
                                 <h2 style="margin: 0; font-size: var(--lumo-font-size-xxl); font-weight: 700; color: var(--lumo-header-text-color); overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">${this.evalLabel(i.title)}</h2>
-                            `:v}
-                            ${i?.subtitle?T`
+                            `:_}
+                            ${i?.subtitle?w`
                                 <span style="display: block; color: var(--lumo-secondary-text-color); font-size: var(--lumo-font-size-s); margin-top: var(--lumo-space-xs);">${this.evalLabel(i.subtitle)}</span>
-                            `:v}
+                            `:_}
                         </div>
                         ${o.map(e=>n(e))}
-                        ${c?T`<span class="toolbar-divider"></span>`:v}
+                        ${c?w`<span class="toolbar-divider"></span>`:_}
                         ${s.map(e=>n(e))}
                         <slot></slot>
                     </div>
-                `:v}
+                `:_}
             <div style="border: var(--mateu-section-border, none); background: var(--mateu-section-bg, transparent); overflow: hidden; max-height: calc(100dvh - 12rem); padding: var(--mateu-section-padding, 0); display: flex; flex-direction: column;">
                 <div style="flex-shrink: 0; display: flex; align-items: center; gap: var(--lumo-space-s, 0.5rem);">
-                    <div style="flex: 1; min-width: 0;">${P.get()?.renderFilterBar(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData)}</div>
+                    <div style="flex: 1; min-width: 0;">${N.get()?.renderFilterBar(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData)}</div>
                     ${this.renderColumnChooser()}
                 </div>
-                <div style="flex: 1; overflow-y: auto; min-height: 0;">${y}</div>
-                <div style="flex-shrink: 0;">${b}</div>
+                <div style="flex: 1; overflow-y: auto; min-height: 0;">${v}</div>
+                <div style="flex-shrink: 0;">${y}</div>
             </div>
-        `}createRenderRoot(){return P.mustUseShadowRoot()?super.createRenderRoot():this}static{this.styles=h`
-        ${de}
+        `}createRenderRoot(){return N.mustUseShadowRoot()?super.createRenderRoot():this}static{this.styles=m`
+        ${fe}
         /* DS-neutral crud widgets (replace vaadin-button/card/grid/list-box/form-layout/dialog). */
         .crud-btn {
             font: inherit; font-weight: 500;
@@ -4866,16 +4866,16 @@ ${i}
             outline-offset: -2px;
         }
     
-        ${z}
-    `}};k([y()],G.prototype,`component`,void 0),k([y()],G.prototype,`baseUrl`,void 0),k([y({type:Boolean})],G.prototype,`standalone`,void 0),k([y()],G.prototype,`state`,void 0),k([y()],G.prototype,`data`,void 0),k([y()],G.prototype,`appState`,void 0),k([y()],G.prototype,`appData`,void 0),k([C()],G.prototype,`showImportDialog`,void 0),k([C()],G.prototype,`availableWidthPx`,void 0),k([C()],G.prototype,`selectedItem`,void 0),k([C()],G.prototype,`_columnPrefsRevision`,void 0),G=k([g(`mateu-table-crud`)],G);var ma=function(e){return e.OnLoad=`OnLoad`,e.OnSuccess=`OnSuccess`,e.OnError=`OnError`,e.OnValueChange=`OnValueChange`,e.OnCustomEvent=`OnCustomEvent`,e.AutoSave=`AutoSave`,e}({}),ha=class extends $e{constructor(...e){super(...e),this.state={},this.data={},this.appData={},this.appState={},this.triggerOnLoad=()=>{let e=this.component;this.registerCustomEventListeners(),e.triggers?.filter(e=>e.type==ma.OnLoad).forEach(e=>{if((!e.condition||this._evalExpr(e.condition))&&!e.triggered){let n=e;n.triggered=!0;var t=n.times-1;n.timeoutMillis>0?this.scheduleOnload(n,t,this.id):this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.actionId},bubbles:!0,composed:!0}))}})},this.scheduleOnload=(e,t,n)=>{if(n!=this.component?.id)return;let r=this.callbackToken;setTimeout(()=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,callbackToken:r},bubbles:!0,composed:!0}))},e.timeoutMillis)},this._registeredCustomEventListeners=[],this.customEventManager=e=>{if(!(e instanceof CustomEvent))return;let t=e,n=(this.component.triggers??[]).filter(e=>e.type==ma.OnCustomEvent).filter(e=>e.eventName==t.type).filter(e=>e.source!==`COMPONENT`||t.detail?.__source===e.from);n.length!==0&&(n.some(e=>!e.source||e.source===`SELF`)&&(e.stopPropagation(),e.preventDefault()),n.forEach(e=>{(!e.condition||this._evalExpr(e.condition))&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:t.detail},bubbles:!0,composed:!0}))}))}}_interpolationExtra(){return{appState:this.appState??{},appData:this.appData??{},component:this.component}}_evalExpr(e){return at(e,this.state??{},this.data??{},this._interpolationExtra())}_evalTemplate(e){return ot(e,this.state??{},this.data??{},this._interpolationExtra())}isOverlayChild(e){let t=e?.metadata?.type;return t==j.Drawer||t==j.Dialog}removeSelfFromOwnerChildren(){let e=this.component;if(!e)return!1;let t=t=>{if(t===e)return!0;let n=t;return e.id!=null&&n?.id==e.id&&this.isOverlayChild(n)},n=this.parentNode;for(;n;){let e=n instanceof ShadowRoot?n.host:n,r=e.component?.children;if(Array.isArray(r)){let n=r.findIndex(t);if(n>=0)return r.splice(n,1),e.requestUpdate?.(),!0}n=n instanceof ShadowRoot?e:n.parentNode}return!1}applyFragment(e){if(this.id==e.targetComponentId){if(e.component)if(Ge.Add==e.action){if(this.component){let t=this.component.children??(this.component.children=[]),n=e.component.id?t.findIndex(t=>t.id==e.component.id&&this.isOverlayChild(t)):-1;n>=0?(t[n]=e.component,this.component={...this.component}):t.push(e.component)}}else{if(this.callbackToken=E(),e.component?.type==A.ServerSide)if(this.component){let t=this.component,n=e.component,r=t.serverSideType==n.serverSideType?(t.children??[]).filter(e=>this.isOverlayChild(e)):[];t.actions=n.actions,t.type=n.type,t.rules=n.rules,t.triggers=n.triggers,t.serverSideType=n.serverSideType,t.route=n.route,t.initialData=n.initialData,t.validations=n.validations,t.cssClasses=n.cssClasses,t.slot=n.slot,t.style=n.style,t.children=r.length?[...n.children??[],...r]:n.children,(t.serverSideType!=n.serverSideType||t.id!=n.id)&&setTimeout(()=>this.triggerOnLoad())}else this.component=e.component,setTimeout(()=>this.triggerOnLoad());else{let t=[e.component];this.component&&(this.component.children=t)}e.action!==Ge.ReplaceKeepData&&(this.state={},this.data={})}if(e.state&&(this.state={...this.state,...e.state}),e.data){for(let t in e.data){let n=e.data[t]?.page;n?.pageNumber>0&&this.data[t]&&this.data[t].page.content&&(n.content?n.content=[...this.data[t].page.content,...n.content]:n.content=[...this.data[t].page.content])}this.data={...this.data,...e.data}}this.registerCustomEventListeners();let t=P.getAfterRenderHook();t&&setTimeout(()=>t(this)),this.requestUpdate()}}registerCustomEventListeners(){this._registeredCustomEventListeners.forEach(({target:e,name:t})=>e.removeEventListener(t,this.customEventManager)),this._registeredCustomEventListeners=[],this.component?.triggers?.filter(e=>e.type==ma.OnCustomEvent).forEach(e=>{let t=e.source===`DOCUMENT`||e.source===`COMPONENT`?document:this;t.addEventListener(e.eventName,this.customEventManager),this._registeredCustomEventListeners.push({target:t,name:e.eventName})})}disconnectedCallback(){this._registeredCustomEventListeners.forEach(({target:e,name:t})=>e.removeEventListener(t,this.customEventManager)),this._registeredCustomEventListeners=[],super.disconnectedCallback()}connectedCallback(){super.connectedCallback(),this.component&&this.registerCustomEventListeners()}};k([y()],ha.prototype,`state`,void 0),k([y()],ha.prototype,`data`,void 0),k([y()],ha.prototype,`appData`,void 0),k([y()],ha.prototype,`appState`,void 0);var ga=`mateu-recent-routes`,_a=8;function va(){try{return JSON.parse(localStorage.getItem(ga)??`{}`)}catch{return{}}}function ya(e){try{localStorage.setItem(ga,JSON.stringify(e))}catch{}}function ba(e){return va()[e||`_`]??[]}function xa(e,t){if(!t?.route||!t.label)return;let n=e||`_`,r=va(),i=(r[n]??[]).filter(e=>e.route!==t.route);i.unshift({route:t.route,label:t.label}),r[n]=i.slice(0,_a),ya(r)}var K=class extends b{constructor(...e){super(...e),this.baseUrl=``,this.open=!1,this.queryText=``,this.dataHits=[],this.loading=!1,this.selectedIndex=0,this.fabOffset=0,this.keydownHandler=null}connectedCallback(){super.connectedCallback(),this.keydownHandler=e=>{(e.metaKey||e.ctrlKey)&&(e.key===`k`||e.key===`K`)?(e.preventDefault(),this.toggle()):e.key===`Escape`&&this.open&&this.close()},document.addEventListener(`keydown`,this.keydownHandler),this.setupFabObserver()}disconnectedCallback(){super.disconnectedCallback(),this.keydownHandler&&document.removeEventListener(`keydown`,this.keydownHandler),clearTimeout(this.searchTimer),this.fabObserver?.disconnect(),this.fabObserver=void 0}setupFabObserver(){let e=this.getRootNode(),t=e instanceof ShadowRoot?e:document.body;this.measureFabStack(),this.fabObserver?.disconnect(),this.fabObserver=new MutationObserver(()=>this.measureFabStack()),this.fabObserver.observe(t,{childList:!0,subtree:!0})}measureFabStack(){let e=(this.getRootNode().querySelectorAll?.(`.ai-fab, .app-fab, .page-fab`).length??0)*4;e!==this.fabOffset&&(this.fabOffset=e)}updated(e){e.has(`open`)&&this.open&&requestAnimationFrame(()=>this.inputEl?.focus())}toggle(){this.open?this.close():this.openCenter()}openCenter(){this.open=!0,this.queryText=``,this.dataHits=[],this.selectedIndex=0}close(){this.open=!1,this.queryText=``,this.dataHits=[],clearTimeout(this.searchTimer)}flattenMenu(e,t){let n=[];for(let r of e??[])if(!r.separator)if(r.submenus&&r.submenus.length>0){let e=t?`${t} › ${r.label}`:r.label;n.push(...this.flattenMenu(r.submenus,e))}else r.route!==void 0&&r.route!==null&&n.push({label:r.label,breadcrumb:t,route:r.route});return n}onInput(e){this.queryText=e,this.selectedIndex=0;let t=e.trim();if(clearTimeout(this.searchTimer),!t||!this.app?.globalSearchEnabled){this.dataHits=[],this.loading=!1;return}this.loading=!0,this.searchTimer=setTimeout(()=>this.fetchGlobalSearch(t),250)}async fetchGlobalSearch(e){let t=this.app;if(!t?.globalSearchEnabled){this.loading=!1;return}try{let n=(await We.runAction(this.baseUrl??``,t.rootRoute??``,``,`_globalsearch`,`command-center`,void 0,t.serverSideType,{},{searchText:e},this,!0))?.fragments?.map(e=>e.data).find(e=>e&&e._globalsearch);this.dataHits=n?._globalsearch??[]}catch{this.dataHits=[]}finally{this.loading=!1}}navigateTo(e,t){xa(this.app?.serverSideType??``,{route:e,label:t}),this.close();for(let t of[`route-changed`,`navigate-to-requested`])this.dispatchEvent(new CustomEvent(t,{detail:{route:e},bubbles:!0,composed:!0}))}askAi(){let e=this.queryText.trim();this.close(),this.dispatchEvent(new CustomEvent(`mateu-open-ai`,{detail:{query:e},bubbles:!0,composed:!0}))}visibleTargets(e){if(!this.queryText.trim()){let e=this.flattenMenu(this.app?.menu,``).map(e=>({route:e.route,label:e.label})),t=ba(this.app?.serverSideType??``);return[...e,...t]}return[...e.map(e=>({route:e.route,label:e.label})),...this.dataHits.map(e=>({route:e.route,label:e.label}))]}onKeydown(e,t){if(e.key===`ArrowDown`)e.preventDefault(),this.selectedIndex=Math.min(this.selectedIndex+1,t.length-1);else if(e.key===`ArrowUp`)e.preventDefault(),this.selectedIndex=Math.max(this.selectedIndex-1,0);else if(e.key===`Enter`){let e=t[this.selectedIndex];e&&this.navigateTo(e.route,e.label)}}render(){return T`
+        ${R}
+    `}};O([v()],W.prototype,`component`,void 0),O([v()],W.prototype,`baseUrl`,void 0),O([v({type:Boolean})],W.prototype,`standalone`,void 0),O([v()],W.prototype,`state`,void 0),O([v()],W.prototype,`data`,void 0),O([v()],W.prototype,`appState`,void 0),O([v()],W.prototype,`appData`,void 0),O([S()],W.prototype,`showImportDialog`,void 0),O([S()],W.prototype,`availableWidthPx`,void 0),O([S()],W.prototype,`selectedItem`,void 0),O([S()],W.prototype,`_columnPrefsRevision`,void 0),W=O([h(`mateu-table-crud`)],W);var ha=function(e){return e.OnLoad=`OnLoad`,e.OnSuccess=`OnSuccess`,e.OnError=`OnError`,e.OnValueChange=`OnValueChange`,e.OnCustomEvent=`OnCustomEvent`,e.AutoSave=`AutoSave`,e}({}),ga=class extends et{constructor(...e){super(...e),this.state={},this.data={},this.appData={},this.appState={},this.triggerOnLoad=()=>{let e=this.component;this.registerCustomEventListeners(),e.triggers?.filter(e=>e.type==ha.OnLoad).forEach(e=>{if((!e.condition||this._evalExpr(e.condition))&&!e.triggered){let n=e;n.triggered=!0;var t=n.times-1;n.timeoutMillis>0?this.scheduleOnload(n,t,this.id):this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.actionId},bubbles:!0,composed:!0}))}})},this.scheduleOnload=(e,t,n)=>{if(n!=this.component?.id)return;let r=this.callbackToken;setTimeout(()=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,callbackToken:r},bubbles:!0,composed:!0}))},e.timeoutMillis)},this._registeredCustomEventListeners=[],this.customEventManager=e=>{if(!(e instanceof CustomEvent))return;let t=e,n=(this.component.triggers??[]).filter(e=>e.type==ha.OnCustomEvent).filter(e=>e.eventName==t.type).filter(e=>e.source!==`COMPONENT`||t.detail?.__source===e.from);n.length!==0&&(n.some(e=>!e.source||e.source===`SELF`)&&(e.stopPropagation(),e.preventDefault()),n.forEach(e=>{(!e.condition||this._evalExpr(e.condition))&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:t.detail},bubbles:!0,composed:!0}))}))}}_interpolationExtra(){return{appState:this.appState??{},appData:this.appData??{},component:this.component}}_evalExpr(e){return ot(e,this.state??{},this.data??{},this._interpolationExtra())}_evalTemplate(e){return st(e,this.state??{},this.data??{},this._interpolationExtra())}isOverlayChild(e){let t=e?.metadata?.type;return t==A.Drawer||t==A.Dialog}removeSelfFromOwnerChildren(){let e=this.component;if(!e)return!1;let t=t=>{if(t===e)return!0;let n=t;return e.id!=null&&n?.id==e.id&&this.isOverlayChild(n)},n=this.parentNode;for(;n;){let e=n instanceof ShadowRoot?n.host:n,r=e.component?.children;if(Array.isArray(r)){let n=r.findIndex(t);if(n>=0)return r.splice(n,1),e.requestUpdate?.(),!0}n=n instanceof ShadowRoot?e:n.parentNode}return!1}applyFragment(e){if(this.id==e.targetComponentId){if(e.component)if(Ke.Add==e.action){if(this.component){let t=this.component.children??(this.component.children=[]),n=e.component.id?t.findIndex(t=>t.id==e.component.id&&this.isOverlayChild(t)):-1;n>=0?(t[n]=e.component,this.component={...this.component}):t.push(e.component)}}else{this.callbackToken=T();let t=!1;if(e.component?.type==k.ServerSide)if(this.component){let n=this.component,r=e.component;t=n.serverSideType==r.serverSideType;let i=t?(n.children??[]).filter(e=>this.isOverlayChild(e)):[];n.actions=r.actions,n.type=r.type,n.rules=r.rules,n.triggers=r.triggers,n.serverSideType=r.serverSideType,n.route=r.route,n.initialData=r.initialData,n.validations=r.validations,n.cssClasses=r.cssClasses,n.slot=r.slot,n.style=r.style,n.children=i.length?[...r.children??[],...i]:r.children,(n.serverSideType!=r.serverSideType||n.id!=r.id)&&setTimeout(()=>this.triggerOnLoad())}else this.component=e.component,setTimeout(()=>this.triggerOnLoad());else{let t=[e.component];this.component&&(this.component.children=t)}e.action!==Ke.ReplaceKeepData&&!t&&(this.state={},this.data={})}if(e.state&&(this.state={...this.state,...e.state}),e.data){for(let t in e.data){let n=e.data[t]?.page;n?.pageNumber>0&&this.data[t]&&this.data[t].page.content&&(n.content?n.content=[...this.data[t].page.content,...n.content]:n.content=[...this.data[t].page.content])}this.data={...this.data,...e.data}}this.registerCustomEventListeners();let t=N.getAfterRenderHook();t&&setTimeout(()=>t(this)),this.requestUpdate()}}registerCustomEventListeners(){this._registeredCustomEventListeners.forEach(({target:e,name:t})=>e.removeEventListener(t,this.customEventManager)),this._registeredCustomEventListeners=[],this.component?.triggers?.filter(e=>e.type==ha.OnCustomEvent).forEach(e=>{let t=e.source===`DOCUMENT`||e.source===`COMPONENT`?document:this;t.addEventListener(e.eventName,this.customEventManager),this._registeredCustomEventListeners.push({target:t,name:e.eventName})})}disconnectedCallback(){this._registeredCustomEventListeners.forEach(({target:e,name:t})=>e.removeEventListener(t,this.customEventManager)),this._registeredCustomEventListeners=[],super.disconnectedCallback()}connectedCallback(){super.connectedCallback(),this.component&&this.registerCustomEventListeners()}};O([v()],ga.prototype,`state`,void 0),O([v()],ga.prototype,`data`,void 0),O([v()],ga.prototype,`appData`,void 0),O([v()],ga.prototype,`appState`,void 0);var _a=`mateu-recent-routes`,va=8;function ya(){try{return JSON.parse(localStorage.getItem(_a)??`{}`)}catch{return{}}}function ba(e){try{localStorage.setItem(_a,JSON.stringify(e))}catch{}}function xa(e){return ya()[e||`_`]??[]}function Sa(e,t){if(!t?.route||!t.label)return;let n=e||`_`,r=ya(),i=(r[n]??[]).filter(e=>e.route!==t.route);i.unshift({route:t.route,label:t.label}),r[n]=i.slice(0,va),ba(r)}var G=class extends y{constructor(...e){super(...e),this.baseUrl=``,this.open=!1,this.queryText=``,this.dataHits=[],this.loading=!1,this.selectedIndex=0,this.fabOffset=0,this.keydownHandler=null}connectedCallback(){super.connectedCallback(),this.keydownHandler=e=>{(e.metaKey||e.ctrlKey)&&(e.key===`k`||e.key===`K`)?(e.preventDefault(),this.toggle()):e.key===`Escape`&&this.open&&this.close()},document.addEventListener(`keydown`,this.keydownHandler),this.setupFabObserver()}disconnectedCallback(){super.disconnectedCallback(),this.keydownHandler&&document.removeEventListener(`keydown`,this.keydownHandler),clearTimeout(this.searchTimer),this.fabObserver?.disconnect(),this.fabObserver=void 0}setupFabObserver(){let e=this.getRootNode(),t=e instanceof ShadowRoot?e:document.body;this.measureFabStack(),this.fabObserver?.disconnect(),this.fabObserver=new MutationObserver(()=>this.measureFabStack()),this.fabObserver.observe(t,{childList:!0,subtree:!0})}measureFabStack(){let e=(this.getRootNode().querySelectorAll?.(`.ai-fab, .app-fab, .page-fab`).length??0)*4;e!==this.fabOffset&&(this.fabOffset=e)}updated(e){e.has(`open`)&&this.open&&requestAnimationFrame(()=>this.inputEl?.focus())}toggle(){this.open?this.close():this.openCenter()}openCenter(){this.open=!0,this.queryText=``,this.dataHits=[],this.selectedIndex=0}close(){this.open=!1,this.queryText=``,this.dataHits=[],clearTimeout(this.searchTimer)}flattenMenu(e,t){let n=[];for(let r of e??[])if(!r.separator)if(r.submenus&&r.submenus.length>0){let e=t?`${t} › ${r.label}`:r.label;n.push(...this.flattenMenu(r.submenus,e))}else r.route!==void 0&&r.route!==null&&n.push({label:r.label,breadcrumb:t,route:r.route});return n}onInput(e){this.queryText=e,this.selectedIndex=0;let t=e.trim();if(clearTimeout(this.searchTimer),!t||!this.app?.globalSearchEnabled){this.dataHits=[],this.loading=!1;return}this.loading=!0,this.searchTimer=setTimeout(()=>this.fetchGlobalSearch(t),250)}async fetchGlobalSearch(e){let t=this.app;if(!t?.globalSearchEnabled){this.loading=!1;return}try{let n=(await Ge.runAction(this.baseUrl??``,t.rootRoute??``,``,`_globalsearch`,`command-center`,void 0,t.serverSideType,{},{searchText:e},this,!0))?.fragments?.map(e=>e.data).find(e=>e&&e._globalsearch);this.dataHits=n?._globalsearch??[]}catch{this.dataHits=[]}finally{this.loading=!1}}navigateTo(e,t){Sa(this.app?.serverSideType??``,{route:e,label:t}),this.close();for(let t of[`route-changed`,`navigate-to-requested`])this.dispatchEvent(new CustomEvent(t,{detail:{route:e},bubbles:!0,composed:!0}))}askAi(){let e=this.queryText.trim();this.close(),this.dispatchEvent(new CustomEvent(`mateu-open-ai`,{detail:{query:e},bubbles:!0,composed:!0}))}visibleTargets(e){if(!this.queryText.trim()){let e=this.flattenMenu(this.app?.menu,``).map(e=>({route:e.route,label:e.label})),t=xa(this.app?.serverSideType??``);return[...e,...t]}return[...e.map(e=>({route:e.route,label:e.label})),...this.dataHits.map(e=>({route:e.route,label:e.label}))]}onKeydown(e,t){if(e.key===`ArrowDown`)e.preventDefault(),this.selectedIndex=Math.min(this.selectedIndex+1,t.length-1);else if(e.key===`ArrowUp`)e.preventDefault(),this.selectedIndex=Math.max(this.selectedIndex-1,0);else if(e.key===`Enter`){let e=t[this.selectedIndex];e&&this.navigateTo(e.route,e.label)}}render(){return w`
             <button class="cc-fab" style="bottom: ${1.5+this.fabOffset}rem;"
                 @click=${()=>this.openCenter()} title="Buscar y navegar (⌘K)" aria-label="Command center">
                 ${this.fabIcon()}
             </button>
-            ${this.open?this.renderOverlay():v}
-        `}fabIcon(){return T`<svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            ${this.open?this.renderOverlay():_}
+        `}fabIcon(){return w`<svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="11" cy="11" r="7"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line>
-        </svg>`}renderOverlay(){let e=this.queryText.trim().toLowerCase(),t=e?this.flattenMenu(this.app?.menu,``).filter(t=>t.label.toLowerCase().includes(e)||t.breadcrumb.toLowerCase().includes(e)):[],n=this.visibleTargets(t);return T`
+        </svg>`}renderOverlay(){let e=this.queryText.trim().toLowerCase(),t=e?this.flattenMenu(this.app?.menu,``).filter(t=>t.label.toLowerCase().includes(e)||t.breadcrumb.toLowerCase().includes(e)):[],n=this.visibleTargets(t);return w`
             <div class="cc-backdrop" @click=${()=>this.close()}>
                 <div class="cc-panel" @click=${e=>e.stopPropagation()}>
                     <div class="cc-bar">
@@ -4885,7 +4885,7 @@ ${i}
                         <input class="cc-input" .value=${this.queryText} placeholder="Buscar pantallas, datos y acciones…"
                             @input=${e=>this.onInput(e.target.value)}
                             @keydown=${e=>this.onKeydown(e,n)}>
-                        ${this.queryText?T`<button class="cc-icon-btn" @click=${()=>this.onInput(``)} title="Limpiar">${this.clearIcon()}</button>`:v}
+                        ${this.queryText?w`<button class="cc-icon-btn" @click=${()=>this.onInput(``)} title="Limpiar">${this.clearIcon()}</button>`:_}
                     </div>
                     <div class="cc-body">
                         ${e?this.renderResults(t):this.renderDefault()}
@@ -4893,57 +4893,57 @@ ${i}
                 </div>
                 <button class="cc-close" @click=${()=>this.close()} title="Cerrar">${this.clearIcon()}</button>
             </div>
-        `}renderDefault(){let e=this.flattenMenu(this.app?.menu,``),t=ba(this.app?.serverSideType??``),n=-1;return T`
+        `}renderDefault(){let e=this.flattenMenu(this.app?.menu,``),t=xa(this.app?.serverSideType??``),n=-1;return w`
             <div class="cc-columns">
                 <div class="cc-col">
                     <div class="cc-section-title">Ir a</div>
                     <div class="cc-tiles">
-                        ${e.map(e=>{n++;let t=n;return T`
+                        ${e.map(e=>{n++;let t=n;return w`
                             <button class="cc-tile ${t===this.selectedIndex?`cc-sel`:``}"
                                 @click=${()=>this.navigateTo(e.route,e.label)}
                                 @mouseenter=${()=>{this.selectedIndex=t}}>
                                 <span class="cc-tile-label">${e.label}</span>
-                                ${e.breadcrumb?T`<span class="cc-sub">${e.breadcrumb}</span>`:v}
+                                ${e.breadcrumb?w`<span class="cc-sub">${e.breadcrumb}</span>`:_}
                             </button>`})}
-                        ${e.length===0?T`<div class="cc-empty">Sin opciones de menú.</div>`:v}
+                        ${e.length===0?w`<div class="cc-empty">Sin opciones de menú.</div>`:_}
                     </div>
                 </div>
-                ${t.length>0?T`
+                ${t.length>0?w`
                     <div class="cc-col cc-col--recent">
                         <div class="cc-section-title">Recientes</div>
-                        ${t.map(e=>{n++;let t=n;return T`
+                        ${t.map(e=>{n++;let t=n;return w`
                             <button class="cc-row ${t===this.selectedIndex?`cc-sel`:``}"
                                 @click=${()=>this.navigateTo(e.route,e.label)}
                                 @mouseenter=${()=>{this.selectedIndex=t}}>
                                 <span class="cc-tile-label">${e.label}</span>
                             </button>`})}
-                    </div>`:v}
+                    </div>`:_}
             </div>
-        `}renderResults(e){if(this.loading&&this.dataHits.length===0&&e.length===0)return T`<div class="cc-list">${[0,1,2,3].map(()=>T`<div class="cc-skeleton"></div>`)}</div>`;let t=e.length===0&&this.dataHits.length===0;return T`
+        `}renderResults(e){if(this.loading&&this.dataHits.length===0&&e.length===0)return w`<div class="cc-list">${[0,1,2,3].map(()=>w`<div class="cc-skeleton"></div>`)}</div>`;let t=e.length===0&&this.dataHits.length===0;return w`
             <div class="cc-list">
-                ${this.app?.sseUrl?T`
+                ${this.app?.sseUrl?w`
                     <button class="cc-row cc-ask-ai" @click=${()=>this.askAi()}>
                         ${this.aiIcon()}<span class="cc-tile-label">Preguntar a la IA: “${this.queryText.trim()}”</span>
-                    </button>`:v}
-                ${e.length>0?T`<div class="cc-section-title">Pantallas</div>`:v}
-                ${e.map((e,t)=>T`
+                    </button>`:_}
+                ${e.length>0?w`<div class="cc-section-title">Pantallas</div>`:_}
+                ${e.map((e,t)=>w`
                     <button class="cc-row ${t===this.selectedIndex?`cc-sel`:``}"
                         @click=${()=>this.navigateTo(e.route,e.label)}
                         @mouseenter=${()=>{this.selectedIndex=t}}>
                         <span class="cc-tile-label">${e.label}</span>
-                        ${e.breadcrumb?T`<span class="cc-sub">${e.breadcrumb}</span>`:v}
+                        ${e.breadcrumb?w`<span class="cc-sub">${e.breadcrumb}</span>`:_}
                     </button>`)}
                 ${this.renderDataHits(e.length)}
-                ${t?T`<div class="cc-empty">No encontramos coincidencias para “${this.queryText.trim()}”.</div>`:v}
+                ${t?w`<div class="cc-empty">No encontramos coincidencias para “${this.queryText.trim()}”.</div>`:_}
             </div>
-        `}renderDataHits(e){if(this.dataHits.length===0)return v;let t;return T`${this.dataHits.map((n,r)=>{let i=e+r,a=n.category&&n.category!==t;return t=n.category,T`
-                ${a?T`<div class="cc-section-title">${n.category}</div>`:v}
+        `}renderDataHits(e){if(this.dataHits.length===0)return _;let t;return w`${this.dataHits.map((n,r)=>{let i=e+r,a=n.category&&n.category!==t;return t=n.category,w`
+                ${a?w`<div class="cc-section-title">${n.category}</div>`:_}
                 <button class="cc-row ${i===this.selectedIndex?`cc-sel`:``}"
                     @click=${()=>this.navigateTo(n.route,n.label)}
                     @mouseenter=${()=>{this.selectedIndex=i}}>
                     <span class="cc-tile-label">${n.label}</span>
-                    ${n.description?T`<span class="cc-sub">${n.description}</span>`:v}
-                </button>`})}`}searchGlyph(){return T`<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="11" cy="11" r="7"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>`}backIcon(){return T`<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>`}clearIcon(){return T`<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>`}aiIcon(){return T`<svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><path d="M12 2l1.9 4.7L19 8.5l-4.1 2.3L12 15l-1.9-4.2L6 8.5l5.1-1.8z"></path></svg>`}static{this.styles=h`
+                    ${n.description?w`<span class="cc-sub">${n.description}</span>`:_}
+                </button>`})}`}searchGlyph(){return w`<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="11" cy="11" r="7"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>`}backIcon(){return w`<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>`}clearIcon(){return w`<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>`}aiIcon(){return w`<svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><path d="M12 2l1.9 4.7L19 8.5l-4.1 2.3L12 15l-1.9-4.2L6 8.5l5.1-1.8z"></path></svg>`}static{this.styles=m`
         :host { --cc-accent: var(--lumo-primary-color, #3b82f6); }
 
         .cc-fab {
@@ -5028,12 +5028,12 @@ ${i}
             display: flex; align-items: center; justify-content: center; cursor: pointer; z-index: 1110;
         }
         .cc-close:hover { background: rgba(0,0,0,0.75); }
-    `}};k([y({attribute:!1})],K.prototype,`app`,void 0),k([y()],K.prototype,`baseUrl`,void 0),k([C()],K.prototype,`open`,void 0),k([C()],K.prototype,`queryText`,void 0),k([C()],K.prototype,`dataHits`,void 0),k([C()],K.prototype,`loading`,void 0),k([C()],K.prototype,`selectedIndex`,void 0),k([C()],K.prototype,`fabOffset`,void 0),k([x(`.cc-input`)],K.prototype,`inputEl`,void 0),K=k([g(`mateu-command-center`)],K);var Sa=null;function Ca(e){let t=e.component?.metadata;t&&(t.commandCenterEnabled||t.chromeless)&&t.variant!==`MEDIATOR`?((!Sa||!Sa.isConnected)&&(Sa=document.createElement(`mateu-command-center`),e.renderRoot.appendChild(Sa)),Sa.app=t,Sa.baseUrl=e.baseUrl??``):Sa&&e.renderRoot.contains(Sa)&&(Sa.remove(),Sa=null)}var wa=class extends b{constructor(...e){super(...e),this.fetchStarted=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!0},this.fetchFinished=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!1},this.fetchFailed=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!1;let t=e.detail??{},n=t.failure??Pe(t.reason,{online:Be.isOnline()});if(n.kind===`cancelled`)return;let r=t.retry;oa({text:n.message,variant:`error`,duration:r?8e3:5e3,position:`bottomEnd`,...r?{actionLabel:`Retry`,onAction:r}:{}},this)}}connectedCallback(){super.connectedCallback(),this.addEventListener(`backend-called-event`,this.fetchStarted),this.addEventListener(`backend-succeeded-event`,this.fetchFinished),this.addEventListener(`backend-cancelled-event`,this.fetchFinished),this.addEventListener(`backend-failed-event`,this.fetchFailed)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`backend-called-event`,this.fetchStarted),this.removeEventListener(`backend-succeeded-event`,this.fetchFinished),this.removeEventListener(`backend-cancelled-event`,this.fetchFinished),this.removeEventListener(`backend-failed-event`,this.fetchFailed)}render(){return T`<div class="loader-container">
+    `}};O([v({attribute:!1})],G.prototype,`app`,void 0),O([v()],G.prototype,`baseUrl`,void 0),O([S()],G.prototype,`open`,void 0),O([S()],G.prototype,`queryText`,void 0),O([S()],G.prototype,`dataHits`,void 0),O([S()],G.prototype,`loading`,void 0),O([S()],G.prototype,`selectedIndex`,void 0),O([S()],G.prototype,`fabOffset`,void 0),O([b(`.cc-input`)],G.prototype,`inputEl`,void 0),G=O([h(`mateu-command-center`)],G);var Ca=null;function wa(e){let t=e.component?.metadata;t&&(t.commandCenterEnabled||t.chromeless)&&t.variant!==`MEDIATOR`?((!Ca||!Ca.isConnected)&&(Ca=document.createElement(`mateu-command-center`),e.renderRoot.appendChild(Ca)),Ca.app=t,Ca.baseUrl=e.baseUrl??``):Ca&&e.renderRoot.contains(Ca)&&(Ca.remove(),Ca=null)}var Ta=class extends y{constructor(...e){super(...e),this.fetchStarted=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!0},this.fetchFinished=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!1},this.fetchFailed=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!1;let t=e.detail??{},n=t.failure??Fe(t.reason,{online:Ve.isOnline()});if(n.kind===`cancelled`)return;let r=t.retry;sa({text:n.message,variant:`error`,duration:r?8e3:5e3,position:`bottomEnd`,...r?{actionLabel:`Retry`,onAction:r}:{}},this)}}connectedCallback(){super.connectedCallback(),this.addEventListener(`backend-called-event`,this.fetchStarted),this.addEventListener(`backend-succeeded-event`,this.fetchFinished),this.addEventListener(`backend-cancelled-event`,this.fetchFinished),this.addEventListener(`backend-failed-event`,this.fetchFailed)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`backend-called-event`,this.fetchStarted),this.removeEventListener(`backend-succeeded-event`,this.fetchFinished),this.removeEventListener(`backend-cancelled-event`,this.fetchFinished),this.removeEventListener(`backend-failed-event`,this.fetchFailed)}render(){return w`<div class="loader-container">
             <div style="display: flex; flex-direction: column;">
                 <slot></slot>
                 <div class="loader-frame ${this.loading?`delayed-show`:``}" style="${this.loading?`pointer-events: all;`:`display: none;`}"><div class="loader"></div></div>
             </div>
-        </div>`}static{this.styles=h`
+        </div>`}static{this.styles=m`
         :host {
         }
 
@@ -5096,11 +5096,11 @@ ${i}
             animation: l5 1s infinite;
         }
         @keyframes l5 {to{transform: rotate(.5turn)}}
-  `}};k([C()],wa.prototype,`loading`,void 0),wa=k([g(`mateu-api-caller`)],wa);var Ta=new class{constructor(){this._dirty=!1,this._installed=!1,this.message=`You have unsaved changes. Are you sure you want to leave this page?`,this._onDirty=()=>{this._dirty=!0},this._onClean=()=>{this._dirty=!1},this._onBeforeUnload=e=>{this._dirty&&(e.preventDefault(),e.returnValue=``)}}install(){this._installed||(this._installed=!0,document.addEventListener(`dirty`,this._onDirty),document.addEventListener(`clean`,this._onClean),window.addEventListener(`beforeunload`,this._onBeforeUnload))}get dirty(){return this._dirty}markDirty(){this._dirty=!0}markClean(){this._dirty=!1}confirmLeave(){if(!this._dirty)return!0;let e=window.confirm(this.message);return e&&(this._dirty=!1),e}},Ea,q=class extends ha{static{Ea=this}constructor(...e){super(...e),this.filter=``,this.instant=void 0,this.selectedConsumedRoute=void 0,this.selectedRoute=void 0,this.selectedUriPrefix=void 0,this.selectedBaseUrl=void 0,this.selectedServerSideType=void 0,this.selectedParams=void 0,this.tilesMenuOption=null,this.railOpenOption=null,this.commandPaletteOpen=!1,this.commandPaletteQuery=``,this.commandPaletteSelectedIndex=0,this.commandPaletteDataHits=[],this.openDataHit=e=>{Ta.confirmLeave()&&(this.commandPaletteOpen=!1,this.commandPaletteQuery=``,this.commandPaletteDataHits=[],this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:e.route},bubbles:!0,composed:!0})),this.dispatchEvent(new CustomEvent(`navigate-to-requested`,{detail:{route:e.route},bubbles:!0,composed:!0})))},this._commandPaletteHandler=null,this.pageCompact=!1,this._compactHandler=e=>{this.pageCompact=e.detail?.compact??!1},this._openAiHandler=()=>{this.chatOpen||this.showHideIa()},this.isDark=document.documentElement.getAttribute(`theme`)===`dark`,this.chatOpen=!1,this.toggleTheme=()=>{this.isDark=!this.isDark;let e=this.isDark?`dark`:`light`;document.documentElement.setAttribute(`theme`,e),localStorage.setItem(`mateu-theme`,e)},this.showHideIa=()=>{this.chat&&(this.chatOpen=!this.chatOpen,this.chat.slot=this.chatOpen?`detail`:`detail-hidden`)},this.runAction=e=>{let t=this.renderRoot.querySelector?.(`mateu-component`);t&&t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.getSelectedOption=e=>{if(e)for(let t=0;t<e.length;t++){let n=e[t];if(this.selectedRoute?this.isActiveOption(n):n.selected)return n;let r=this.getSelectedOption(n.submenus);if(r)return r}return null},this.itemSelected=e=>{let t=e.detail.value;this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix)},this.itemSelectedTiles=e=>{let t=e.detail.value._menuOption;t.submenus&&t.submenus.length>0?this.tilesMenuOption=t:(this.tilesMenuOption=null,this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix))},this.mapItemsForTiles=e=>e.map(e=>({text:e.label,consumedRoute:e.consumedRoute,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:e.selected,_menuOption:e})),this.flattenMenuForPalette=(e,t)=>{let n=[];for(let r of e)if(!r.separator)if(r.submenus&&r.submenus.length>0){let e=t?`${t} › ${r.label}`:r.label;n.push(...this.flattenMenuForPalette(r.submenus,e))}else n.push({label:r.label,breadcrumb:t,consumedRoute:r.consumedRoute,route:r.route,actionId:r.actionId,baseUrl:r.baseUrl,serverSideType:r.serverSideType,uriPrefix:r.uriPrefix});return n},this.handleCommandPaletteKeydown=(e,t)=>{let n=Math.min(t.length,10),r=n+Math.min(this.commandPaletteDataHits.length,8);if(e.key===`ArrowDown`)e.preventDefault(),this.commandPaletteSelectedIndex=Math.min(this.commandPaletteSelectedIndex+1,r-1);else if(e.key===`ArrowUp`)e.preventDefault(),this.commandPaletteSelectedIndex=Math.max(this.commandPaletteSelectedIndex-1,0);else if(e.key===`Enter`){if(this.commandPaletteSelectedIndex>=n){let e=this.commandPaletteDataHits[this.commandPaletteSelectedIndex-n];e&&this.openDataHit(e);return}let e=t[this.commandPaletteSelectedIndex];e&&(this.selectRoute(e.consumedRoute,e.route,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix),this.commandPaletteOpen=!1,this.commandPaletteQuery=``)}},this.renderCommandPalette=()=>{if(!this.commandPaletteOpen)return v;let e=this.component?.metadata;if(e?.commandCenterEnabled||!e?.menu)return v;let t=this.flattenMenuForPalette(e.menu,``),n=this.commandPaletteQuery.toLowerCase(),r=n?t.filter(e=>e.label.toLowerCase().includes(n)||e.breadcrumb.toLowerCase().includes(n)):t;return T`
+  `}};O([S()],Ta.prototype,`loading`,void 0),Ta=O([h(`mateu-api-caller`)],Ta);var Ea=new class{constructor(){this._dirty=!1,this._installed=!1,this.message=`You have unsaved changes. Are you sure you want to leave this page?`,this._onDirty=()=>{this._dirty=!0},this._onClean=()=>{this._dirty=!1},this._onBeforeUnload=e=>{this._dirty&&(e.preventDefault(),e.returnValue=``)}}install(){this._installed||(this._installed=!0,document.addEventListener(`dirty`,this._onDirty),document.addEventListener(`clean`,this._onClean),window.addEventListener(`beforeunload`,this._onBeforeUnload))}get dirty(){return this._dirty}markDirty(){this._dirty=!0}markClean(){this._dirty=!1}confirmLeave(){if(!this._dirty)return!0;let e=window.confirm(this.message);return e&&(this._dirty=!1),e}},Da,K=class extends ga{static{Da=this}constructor(...e){super(...e),this.filter=``,this.instant=void 0,this.selectedConsumedRoute=void 0,this.selectedRoute=void 0,this.selectedUriPrefix=void 0,this.selectedBaseUrl=void 0,this.selectedServerSideType=void 0,this.selectedParams=void 0,this.tilesMenuOption=null,this.railOpenOption=null,this.commandPaletteOpen=!1,this.commandPaletteQuery=``,this.commandPaletteSelectedIndex=0,this.commandPaletteDataHits=[],this.openDataHit=e=>{Ea.confirmLeave()&&(this.commandPaletteOpen=!1,this.commandPaletteQuery=``,this.commandPaletteDataHits=[],this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:e.route},bubbles:!0,composed:!0})),this.dispatchEvent(new CustomEvent(`navigate-to-requested`,{detail:{route:e.route},bubbles:!0,composed:!0})))},this._commandPaletteHandler=null,this.pageCompact=!1,this._compactHandler=e=>{this.pageCompact=e.detail?.compact??!1},this._openAiHandler=()=>{this.chatOpen||this.showHideIa()},this.isDark=document.documentElement.getAttribute(`theme`)===`dark`,this.chatOpen=!1,this.toggleTheme=()=>{this.isDark=!this.isDark;let e=this.isDark?`dark`:`light`;document.documentElement.setAttribute(`theme`,e),localStorage.setItem(`mateu-theme`,e)},this.showHideIa=()=>{this.chat&&(this.chatOpen=!this.chatOpen,this.chat.slot=this.chatOpen?`detail`:`detail-hidden`)},this.runAction=e=>{let t=this.renderRoot.querySelector?.(`mateu-component`);t&&t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.getSelectedOption=e=>{if(e)for(let t=0;t<e.length;t++){let n=e[t];if(this.selectedRoute?this.isActiveOption(n):n.selected)return n;let r=this.getSelectedOption(n.submenus);if(r)return r}return null},this.itemSelected=e=>{let t=e.detail.value;this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix)},this.itemSelectedTiles=e=>{let t=e.detail.value._menuOption;t.submenus&&t.submenus.length>0?this.tilesMenuOption=t:(this.tilesMenuOption=null,this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix))},this.mapItemsForTiles=e=>e.map(e=>({text:e.label,consumedRoute:e.consumedRoute,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:e.selected,_menuOption:e})),this.flattenMenuForPalette=(e,t)=>{let n=[];for(let r of e)if(!r.separator)if(r.submenus&&r.submenus.length>0){let e=t?`${t} › ${r.label}`:r.label;n.push(...this.flattenMenuForPalette(r.submenus,e))}else n.push({label:r.label,breadcrumb:t,consumedRoute:r.consumedRoute,route:r.route,actionId:r.actionId,baseUrl:r.baseUrl,serverSideType:r.serverSideType,uriPrefix:r.uriPrefix});return n},this.handleCommandPaletteKeydown=(e,t)=>{let n=Math.min(t.length,10),r=n+Math.min(this.commandPaletteDataHits.length,8);if(e.key===`ArrowDown`)e.preventDefault(),this.commandPaletteSelectedIndex=Math.min(this.commandPaletteSelectedIndex+1,r-1);else if(e.key===`ArrowUp`)e.preventDefault(),this.commandPaletteSelectedIndex=Math.max(this.commandPaletteSelectedIndex-1,0);else if(e.key===`Enter`){if(this.commandPaletteSelectedIndex>=n){let e=this.commandPaletteDataHits[this.commandPaletteSelectedIndex-n];e&&this.openDataHit(e);return}let e=t[this.commandPaletteSelectedIndex];e&&(this.selectRoute(e.consumedRoute,e.route,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix),this.commandPaletteOpen=!1,this.commandPaletteQuery=``)}},this.renderCommandPalette=()=>{if(!this.commandPaletteOpen)return _;let e=this.component?.metadata;if(e?.commandCenterEnabled||!e?.menu)return _;let t=this.flattenMenuForPalette(e.menu,``),n=this.commandPaletteQuery.toLowerCase(),r=n?t.filter(e=>e.label.toLowerCase().includes(n)||e.breadcrumb.toLowerCase().includes(n)):t;return w`
             <div class="cmd-backdrop" @click=${()=>{this.commandPaletteOpen=!1,this.commandPaletteQuery=``}}>
                 <div class="cmd-palette" @click=${e=>e.stopPropagation()}>
                     <div class="cmd-search-wrapper">
-                        ${I(`vaadin:search`,void 0,`cmd-search-icon`)}
+                        ${F(`vaadin:search`,void 0,`cmd-search-icon`)}
                         <input
                             class="cmd-input"
                             placeholder="Go to…"
@@ -5110,89 +5110,89 @@ ${i}
                         >
                     </div>
                     <div class="cmd-results">
-                        ${r.slice(0,10).map((e,t)=>T`
+                        ${r.slice(0,10).map((e,t)=>w`
                             <div class="cmd-result ${t===this.commandPaletteSelectedIndex?`cmd-result--selected`:``}"
                                 @click=${()=>{this.selectRoute(e.consumedRoute,e.route,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix),this.commandPaletteOpen=!1,this.commandPaletteQuery=``}}
                                 @mouseenter=${()=>{this.commandPaletteSelectedIndex=t}}
                             >
                                 <span class="cmd-result-label">${e.label}</span>
-                                ${e.breadcrumb?T`<span class="cmd-result-breadcrumb">${e.breadcrumb}</span>`:v}
+                                ${e.breadcrumb?w`<span class="cmd-result-breadcrumb">${e.breadcrumb}</span>`:_}
                             </div>
                         `)}
-                        ${n&&this.commandPaletteDataHits.length>0?T`
-                            ${this.commandPaletteDataHits.slice(0,8).map((e,t)=>{let n=Math.min(r.length,10)+t,i=this.commandPaletteDataHits[t-1];return T`
-                                    ${e.category&&e.category!==i?.category?T`
-                                        <div class="cmd-category">${e.category}</div>`:v}
+                        ${n&&this.commandPaletteDataHits.length>0?w`
+                            ${this.commandPaletteDataHits.slice(0,8).map((e,t)=>{let n=Math.min(r.length,10)+t,i=this.commandPaletteDataHits[t-1];return w`
+                                    ${e.category&&e.category!==i?.category?w`
+                                        <div class="cmd-category">${e.category}</div>`:_}
                                     <div class="cmd-result ${n===this.commandPaletteSelectedIndex?`cmd-result--selected`:``}"
                                          @click=${()=>this.openDataHit(e)}
                                          @mouseenter=${()=>{this.commandPaletteSelectedIndex=n}}
                                     >
                                         <span class="cmd-result-label">${e.label}</span>
-                                        ${e.description?T`<span class="cmd-result-breadcrumb">${e.description}</span>`:v}
-                                    </div>`})}`:v}
-                        ${r.length===0&&this.commandPaletteDataHits.length===0?T`<div class="cmd-empty">No results for "${this.commandPaletteQuery}"</div>`:v}
+                                        ${e.description?w`<span class="cmd-result-breadcrumb">${e.description}</span>`:_}
+                                    </div>`})}`:_}
+                        ${r.length===0&&this.commandPaletteDataHits.length===0?w`<div class="cmd-empty">No results for "${this.commandPaletteQuery}"</div>`:_}
                     </div>
                 </div>
             </div>
-        `},this.renderRail=e=>T`
+        `},this.renderRail=e=>w`
             <div class="nav-rail">
                 ${e.map(e=>this.renderRailItem(e))}
             </div>
-        `,this.renderRailItem=e=>T`
+        `,this.renderRailItem=e=>w`
             <div class="rail-item ${(e.submenus?.length>0?this.railOpenOption?.label===e.label:e.selected)?`rail-item--active`:``}"
                 @click=${()=>{e.submenus&&e.submenus.length>0?this.railOpenOption=this.railOpenOption?.label===e.label?null:e:(this.railOpenOption=null,this.selectRoute(e.consumedRoute,e.route,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix))}}
             >
-                ${e.icon?I(e.icon,void 0,`rail-icon`):T`<div class="rail-icon-placeholder">${e.label.charAt(0).toUpperCase()}</div>`}
+                ${e.icon?F(e.icon,void 0,`rail-icon`):w`<div class="rail-icon-placeholder">${e.label.charAt(0).toUpperCase()}</div>`}
                 <span class="rail-label">${e.label}</span>
             </div>
-        `,this.renderRailSubPanel=e=>T`
+        `,this.renderRailSubPanel=e=>w`
             <div class="rail-sub-panel">
                 <div class="rail-sub-title">${e.label}</div>
-                ${e.submenus.map(e=>T`
+                ${e.submenus.map(e=>w`
                     <div class="rail-sub-item ${e.selected?`rail-sub-item--active`:``}"
                         @click=${()=>{e.submenus&&e.submenus.length>0?this.railOpenOption=e:this.selectRoute(e.consumedRoute,e.route,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix)}}
                     >${e.label}</div>
                 `)}
             </div>
-        `,this.renderTilesHub=e=>T`
+        `,this.renderTilesHub=e=>w`
             <div style="padding: 2rem;">
                 <h2 style="margin-top: 0; margin-bottom: 1.5rem;">${e.label}</h2>
                 <div class="tiles-hub-grid">
-                    ${e.submenus.map(e=>T`
+                    ${e.submenus.map(e=>w`
                         <div class="nav-tile"
                             @click=${()=>{e.submenus&&e.submenus.length>0?this.tilesMenuOption=e:(this.tilesMenuOption=null,this.selectRoute(e.consumedRoute,e.route,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix))}}
                         >
-                            ${e.icon?I(e.icon,`font-size: 2rem; color: var(--lumo-primary-color); display: block; margin-bottom: 0.75rem;`):v}
+                            ${e.icon?F(e.icon,`font-size: 2rem; color: var(--lumo-primary-color); display: block; margin-bottom: 0.75rem;`):_}
                             <div class="nav-tile-title">${e.label}</div>
-                            ${e.description?T`<div class="nav-tile-desc">${e.description}</div>`:v}
+                            ${e.description?w`<div class="nav-tile-desc">${e.description}</div>`:_}
                         </div>
                     `)}
                 </div>
             </div>
-        `,this.goHome=()=>{Ta.confirmLeave()&&(window.history.pushState(null,``,`/`),window.dispatchEvent(new PopStateEvent(`popstate`,{state:null})))},this.selectRoute=(e,t,n,r,i,a)=>{Ta.confirmLeave()&&this._selectRoute(e,t,n,r,i,a)},this._selectRoute=(e,t,n,r,i,a)=>{{this.selectedConsumedRoute=e,this.selectedBaseUrl=r,this.selectedRoute=t,this.selectedServerSideType=i,this.selectedUriPrefix=a,this.instant=E(),this.state&&this.state._route!=null&&(this.state._route=void 0);let n=this.baseUrl??``;n.indexOf(`://`)<0&&(n.startsWith(`/`)||(n=`/`+n),n=window.location.origin+n),n.endsWith(`/`)&&(t??``).startsWith(`/`)&&(t=(t??``).substring(1));let o=new URL(n+t);if(e&&o.pathname.startsWith(e)){let t=o.pathname.substring(e.length);o=new URL(o.origin+(t||`/`))}if((window.location.pathname||o.pathname)&&window.location.pathname!=o.pathname){let e=o.pathname;o.search&&(e+=o.search),e&&!e.startsWith(`/`)&&(e=`/`+e),this.baseUrl&&e.startsWith(this.baseUrl)&&(e=e.substring(this.baseUrl.length));let t=e;this.selectedUriPrefix&&(t=t.startsWith(`/`)&&this.selectedUriPrefix.endsWith(`/`)?this.selectedUriPrefix+t.substring(1):!t.startsWith(`/`)&&!this.selectedUriPrefix.endsWith(`/`)?this.selectedUriPrefix+`/`+t:this.selectedUriPrefix+t),t==`/_page`&&(t=``),this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0}))}}},this.isActiveOption=e=>this.selectedRoute?!!e.route&&(this.selectedRoute==e.route||this.selectedRoute.startsWith(e.route+`/`)):!!e.selected,this.mapItems=(e,t)=>e.map(e=>{if(e.submenus&&e.submenus.length>0){let n=this.mapItems(e.submenus,t);return t&&e.label.toLowerCase().includes(t)&&(n=this.mapItems(e.submenus,``)),n&&n.length>0?{consumedRoute:e.consumedRoute,text:e.label,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:t||this.isActiveOption(e),children:n}:void 0}if(e.separator)return t?void 0:{component:`hr`};if(!t||e.label.toLowerCase().includes(t))return{consumedRoute:e.consumedRoute,text:e.label,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:t||this.isActiveOption(e)}}).filter(e=>e!=null),this.getSelectedIndex=e=>{if(!e)return NaN;let t=e=>{let t=(e??``).trim();return t.length>1&&t.endsWith(`/`)&&(t=t.slice(0,-1)),t},n=t(this.selectedRoute??window.location.pathname),r=NaN,i=-1;for(let a=0;a<e.length;a++){let o=t(e[a].route);o!==``&&(n===o||n.startsWith(o+`/`))&&o.length>i&&(i=o.length,r=a)}if(!Number.isNaN(r))return r;let a=this.getSelectedOption(e);return a?e.indexOf(a):NaN},this.renderOptionOnLeftMenu=e=>e.submenus&&e.submenus.length>0?T`
+        `,this.goHome=()=>{Ea.confirmLeave()&&(window.history.pushState(null,``,`/`),window.dispatchEvent(new PopStateEvent(`popstate`,{state:null})))},this.selectRoute=(e,t,n,r,i,a)=>{Ea.confirmLeave()&&this._selectRoute(e,t,n,r,i,a)},this._selectRoute=(e,t,n,r,i,a)=>{{this.selectedConsumedRoute=e,this.selectedBaseUrl=r,this.selectedRoute=t,this.selectedServerSideType=i,this.selectedUriPrefix=a,this.instant=T(),this.state&&this.state._route!=null&&(this.state._route=void 0);let n=this.baseUrl??``;n.indexOf(`://`)<0&&(n.startsWith(`/`)||(n=`/`+n),n=window.location.origin+n),n.endsWith(`/`)&&(t??``).startsWith(`/`)&&(t=(t??``).substring(1));let o=new URL(n+t);if(e&&o.pathname.startsWith(e)){let t=o.pathname.substring(e.length);o=new URL(o.origin+(t||`/`))}if((window.location.pathname||o.pathname)&&window.location.pathname!=o.pathname){let e=o.pathname;o.search&&(e+=o.search),e&&!e.startsWith(`/`)&&(e=`/`+e),this.baseUrl&&e.startsWith(this.baseUrl)&&(e=e.substring(this.baseUrl.length));let t=e;this.selectedUriPrefix&&(t=t.startsWith(`/`)&&this.selectedUriPrefix.endsWith(`/`)?this.selectedUriPrefix+t.substring(1):!t.startsWith(`/`)&&!this.selectedUriPrefix.endsWith(`/`)?this.selectedUriPrefix+`/`+t:this.selectedUriPrefix+t),t==`/_page`&&(t=``),this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0}))}}},this.isActiveOption=e=>this.selectedRoute?!!e.route&&(this.selectedRoute==e.route||this.selectedRoute.startsWith(e.route+`/`)):!!e.selected,this.mapItems=(e,t)=>e.map(e=>{if(e.submenus&&e.submenus.length>0){let n=this.mapItems(e.submenus,t);return t&&e.label.toLowerCase().includes(t)&&(n=this.mapItems(e.submenus,``)),n&&n.length>0?{consumedRoute:e.consumedRoute,text:e.label,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:t||this.isActiveOption(e),children:n}:void 0}if(e.separator)return t?void 0:{component:`hr`};if(!t||e.label.toLowerCase().includes(t))return{consumedRoute:e.consumedRoute,text:e.label,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:t||this.isActiveOption(e)}}).filter(e=>e!=null),this.getSelectedIndex=e=>{if(!e)return NaN;let t=e=>{let t=(e??``).trim();return t.length>1&&t.endsWith(`/`)&&(t=t.slice(0,-1)),t},n=t(this.selectedRoute??window.location.pathname),r=NaN,i=-1;for(let a=0;a<e.length;a++){let o=t(e[a].route);o!==``&&(n===o||n.startsWith(o+`/`))&&o.length>i&&(i=o.length,r=a)}if(!Number.isNaN(r))return r;let a=this.getSelectedOption(e);return a?e.indexOf(a):NaN},this.renderOptionOnLeftMenu=e=>e.submenus&&e.submenus.length>0?w`
                 <details open class="left-menu-group">
                     <summary>${e.label}</summary>
                     <div class="left-menu-children">
-                        ${e.submenus.map(e=>T`${this.renderOptionOnLeftMenu(e)}`)}
+                        ${e.submenus.map(e=>w`${this.renderOptionOnLeftMenu(e)}`)}
                     </div>
                 </details>
-`:T`<button class="left-menu-item"
+`:w`<button class="left-menu-item"
                 @click="${()=>this.selectRoute(e.consumedRoute,e.route,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix)}"
-        >${e.label}</button>`,this.navItemSelected=e=>{if(e.path==this.selectedRoute&&e.consumedRoute==this.selectedConsumedRoute&&e.baseUrl==this.selectedBaseUrl&&e.serverSideType==this.selectedServerSideType){let e=this.shadowRoot?.querySelector(`mateu-ux`);e&&e.setAttribute(`instant`,E())}else this.selectRoute(e.consumedRoute,e.path,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix);this.component.metadata.drawerClosed&&this.vaadinAppLayout&&(this.vaadinAppLayout.drawerOpened=!1)},this.renderSideNav=(e,t)=>e?T`
-            ${e.map(e=>{let t=e;return T`
+        >${e.label}</button>`,this.navItemSelected=e=>{if(e.path==this.selectedRoute&&e.consumedRoute==this.selectedConsumedRoute&&e.baseUrl==this.selectedBaseUrl&&e.serverSideType==this.selectedServerSideType){let e=this.shadowRoot?.querySelector(`mateu-ux`);e&&e.setAttribute(`instant`,T())}else this.selectRoute(e.consumedRoute,e.path,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix);this.component.metadata.drawerClosed&&this.vaadinAppLayout&&(this.vaadinAppLayout.drawerOpened=!1)},this.renderSideNav=(e,t)=>e?w`
+            ${e.map(e=>{let t=e;return w`
 
-                        ${t.component==`hr`?T`<hr/>`:T`
+                        ${t.component==`hr`?w`<hr/>`:w`
                                 <div class="side-nav-item ${t.selected?`side-nav-item--active`:``}">
                                     <button class="side-nav-link"
                                             @click="${()=>{t.route&&!t.children&&this.selectRoute(void 0,t.route,void 0,this.baseUrl,void 0,void 0)}}">
-                                        ${t.icon?I(`vaadin:dashboard`,`margin-right:.5rem;`):v}${t.text}
+                                        ${t.icon?F(`vaadin:dashboard`,`margin-right:.5rem;`):_}${t.text}
                                     </button>
-                                    ${t.children?T`<div class="side-nav-children">${this.renderSideNav(t.children,`children`)}</div>`:v}
+                                    ${t.children?w`<div class="side-nav-children">${this.renderSideNav(t.children,`children`)}</div>`:_}
                                 </div>
                         `}
 
-                            `})}`:v,this.updateRoute=e=>{e.preventDefault(),e.stopPropagation();var t=e.detail;this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix)}}createRenderRoot(){return P.mustUseShadowRoot()?super.createRenderRoot():(Ea.injectLightDomStyles(),this)}static{this.lightDomStylesInjected=!1}static injectLightDomStyles(){if(Ea.lightDomStylesInjected||typeof document>`u`||(Ea.lightDomStylesInjected=!0,document.getElementById(`mateu-app-light-styles`)))return;let e=Ea.styles,t=Array.isArray(e)?e.map(e=>e?.cssText??``).join(`
-`):e?.cssText??``;if(!t)return;let n=document.createElement(`style`);n.id=`mateu-app-light-styles`,n.textContent=t,document.head.appendChild(n)}fetchGlobalSearch(e){let t=this.component?.metadata;if(t?.globalSearchEnabled){if(clearTimeout(this._globalSearchTimer),!e){this.commandPaletteDataHits=[];return}this._globalSearchTimer=setTimeout(async()=>{try{let n=(await We.runAction(this.baseUrl??``,t.rootRoute??``,``,`_globalsearch`,`cmd-palette`,void 0,t.serverSideType,{},{searchText:e},this,!0))?.fragments?.map(e=>e.data).find(e=>e&&e._globalsearch);this.commandPaletteDataHits=n?._globalsearch??[]}catch{this.commandPaletteDataHits=[]}},250)}}connectedCallback(){super.connectedCallback(),this.isDark=document.documentElement.getAttribute(`theme`)===`dark`,this._commandPaletteHandler=e=>{this.component?.metadata?.commandCenterEnabled||((e.metaKey||e.ctrlKey)&&e.key===`k`&&(e.preventDefault(),this.commandPaletteOpen=!this.commandPaletteOpen,this.commandPaletteQuery=``,this.commandPaletteSelectedIndex=0),e.key===`Escape`&&this.commandPaletteOpen&&(this.commandPaletteOpen=!1,this.commandPaletteQuery=``))},document.addEventListener(`keydown`,this._commandPaletteHandler),Ta.install(),this.addEventListener(`compact-changed`,this._compactHandler),this.addEventListener(`mateu-open-ai`,this._openAiHandler)}disconnectedCallback(){super.disconnectedCallback(),this._commandPaletteHandler&&document.removeEventListener(`keydown`,this._commandPaletteHandler),this.removeEventListener(`compact-changed`,this._compactHandler),this.removeEventListener(`mateu-open-ai`,this._openAiHandler)}updated(e){if(super.updated(e),Ca(this),this.component){let t=this.component.metadata;if(t){let n=t;if(n.favicon){let e=document.querySelector(`link[rel~='icon']`);e||(e=document.createElement(`link`),e.rel=`icon`,document.head.appendChild(e)),e.href=n.favicon}e.has(`component`)&&(this.selectedRoute=n.homeRoute,this.selectedConsumedRoute=n.homeConsumedRoute,this.selectedServerSideType=n.homeServerSideType,this.selectedBaseUrl=n.homeBaseUrl,this.selectedUriPrefix=n.homeUriPrefix)}}e.has(`commandPaletteOpen`)&&this.commandPaletteOpen&&setTimeout(()=>{this.renderRoot.querySelector(`.cmd-input`)?.focus()},0)}render(){return P.get()?.renderAppComponent(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData)}static{this.styles=h`
+                            `})}`:_,this.updateRoute=e=>{e.preventDefault(),e.stopPropagation();var t=e.detail;this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix)}}createRenderRoot(){return N.mustUseShadowRoot()?super.createRenderRoot():(Da.injectLightDomStyles(),this)}static{this.lightDomStylesInjected=!1}static injectLightDomStyles(){if(Da.lightDomStylesInjected||typeof document>`u`||(Da.lightDomStylesInjected=!0,document.getElementById(`mateu-app-light-styles`)))return;let e=Da.styles,t=Array.isArray(e)?e.map(e=>e?.cssText??``).join(`
+`):e?.cssText??``;if(!t)return;let n=document.createElement(`style`);n.id=`mateu-app-light-styles`,n.textContent=t,document.head.appendChild(n)}fetchGlobalSearch(e){let t=this.component?.metadata;if(t?.globalSearchEnabled){if(clearTimeout(this._globalSearchTimer),!e){this.commandPaletteDataHits=[];return}this._globalSearchTimer=setTimeout(async()=>{try{let n=(await Ge.runAction(this.baseUrl??``,t.rootRoute??``,``,`_globalsearch`,`cmd-palette`,void 0,t.serverSideType,{},{searchText:e},this,!0))?.fragments?.map(e=>e.data).find(e=>e&&e._globalsearch);this.commandPaletteDataHits=n?._globalsearch??[]}catch{this.commandPaletteDataHits=[]}},250)}}connectedCallback(){super.connectedCallback(),this.isDark=document.documentElement.getAttribute(`theme`)===`dark`,this._commandPaletteHandler=e=>{this.component?.metadata?.commandCenterEnabled||((e.metaKey||e.ctrlKey)&&e.key===`k`&&(e.preventDefault(),this.commandPaletteOpen=!this.commandPaletteOpen,this.commandPaletteQuery=``,this.commandPaletteSelectedIndex=0),e.key===`Escape`&&this.commandPaletteOpen&&(this.commandPaletteOpen=!1,this.commandPaletteQuery=``))},document.addEventListener(`keydown`,this._commandPaletteHandler),Ea.install(),this.addEventListener(`compact-changed`,this._compactHandler),this.addEventListener(`mateu-open-ai`,this._openAiHandler)}disconnectedCallback(){super.disconnectedCallback(),this._commandPaletteHandler&&document.removeEventListener(`keydown`,this._commandPaletteHandler),this.removeEventListener(`compact-changed`,this._compactHandler),this.removeEventListener(`mateu-open-ai`,this._openAiHandler)}updated(e){if(super.updated(e),wa(this),this.component){let t=this.component.metadata;if(t){let n=t;if(n.favicon){let e=document.querySelector(`link[rel~='icon']`);e||(e=document.createElement(`link`),e.rel=`icon`,document.head.appendChild(e)),e.href=n.favicon}e.has(`component`)&&(this.selectedRoute=n.homeRoute,this.selectedConsumedRoute=n.homeConsumedRoute,this.selectedServerSideType=n.homeServerSideType,this.selectedBaseUrl=n.homeBaseUrl,this.selectedUriPrefix=n.homeUriPrefix)}}e.has(`commandPaletteOpen`)&&this.commandPaletteOpen&&setTimeout(()=>{this.renderRoot.querySelector(`.cmd-input`)?.focus()},0)}render(){return N.get()?.renderAppComponent(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData)}static{this.styles=m`
         /* DS-neutral app chrome (replaces vaadin-app-layout / menu-bar / tabs / side-nav). */
         .m-hl { display: flex; flex-direction: row; }
         .m-vl { display: flex; flex-direction: column; }
@@ -5542,14 +5542,14 @@ ${i}
             transform: scale(1.08);
         }
 
-  `}};k([C()],q.prototype,`filter`,void 0),k([C()],q.prototype,`instant`,void 0),k([C()],q.prototype,`selectedConsumedRoute`,void 0),k([C()],q.prototype,`selectedRoute`,void 0),k([C()],q.prototype,`selectedUriPrefix`,void 0),k([C()],q.prototype,`selectedBaseUrl`,void 0),k([C()],q.prototype,`selectedServerSideType`,void 0),k([C()],q.prototype,`selectedParams`,void 0),k([C()],q.prototype,`tilesMenuOption`,void 0),k([C()],q.prototype,`railOpenOption`,void 0),k([C()],q.prototype,`commandPaletteOpen`,void 0),k([C()],q.prototype,`commandPaletteQuery`,void 0),k([C()],q.prototype,`commandPaletteSelectedIndex`,void 0),k([C()],q.prototype,`commandPaletteDataHits`,void 0),k([C()],q.prototype,`pageCompact`,void 0),k([x(`mateu-chat`)],q.prototype,`chat`,void 0),k([C()],q.prototype,`isDark`,void 0),k([C()],q.prototype,`chatOpen`,void 0),k([x(`.mateu-app-layout`)],q.prototype,`vaadinAppLayout`,void 0),q=Ea=k([g(`mateu-app`)],q);var Da=class extends b{constructor(...e){super(...e),this.message=`This website uses cookies.`,this.dismiss=`Ok. Thanks :).`,this.learnMore=`Learn more`,this.learnMoreLink=`https://cookiesandyou.com/`,this.showLearnMore=!0,this.position=`top`,this.cookieName=`mateu-cookieconsent`}updated(e){super.updated(e)}connectedCallback(){super.connectedCallback(),this._css=document.createElement(`style`),this._css.innerText=`.cc-window{opacity:1;transition:opacity 1s ease}.cc-window.cc-invisible{opacity:0}.cc-animate.cc-revoke{transition:transform 1s ease}.cc-animate.cc-revoke.cc-top{transform:translateY(-2em)}.cc-animate.cc-revoke.cc-bottom{transform:translateY(2em)}.cc-animate.cc-revoke.cc-active.cc-bottom,.cc-animate.cc-revoke.cc-active.cc-top,.cc-revoke:hover{transform:translateY(0)}.cc-grower{max-height:0;overflow:hidden;transition:max-height 1s}.cc-link,.cc-revoke:hover{text-decoration:underline}.cc-revoke,.cc-window{position:fixed;overflow:hidden;box-sizing:border-box;font-family:Helvetica,Calibri,Arial,sans-serif;font-size:16px;line-height:1.5em;display:flex;flex-wrap:nowrap;z-index:9999}.cc-window.cc-static{position:static}.cc-window.cc-floating{padding:2em;max-width:24em;flex-direction:column}.cc-window.cc-banner{padding:1em 1.8em;width:100%;flex-direction:row}.cc-revoke{padding:.5em}.cc-header{font-size:18px;font-weight:700}.cc-btn,.cc-close,.cc-link,.cc-revoke{cursor:pointer}.cc-link{opacity:.8;display:inline-block;padding:.2em}.cc-link:hover{opacity:1}.cc-link:active,.cc-link:visited{color:initial}.cc-btn{display:block;padding:.4em .8em;font-size:.9em;font-weight:700;border-width:2px;border-style:solid;text-align:center;white-space:nowrap}.cc-banner .cc-btn:last-child{min-width:140px}.cc-highlight .cc-btn:first-child{background-color:transparent;border-color:transparent}.cc-highlight .cc-btn:first-child:focus,.cc-highlight .cc-btn:first-child:hover{background-color:transparent;text-decoration:underline}.cc-close{display:block;position:absolute;top:.5em;right:.5em;font-size:1.6em;opacity:.9;line-height:.75}.cc-close:focus,.cc-close:hover{opacity:1}.cc-revoke.cc-top{top:0;left:3em;border-bottom-left-radius:.5em;border-bottom-right-radius:.5em}.cc-revoke.cc-bottom{bottom:0;left:3em;border-top-left-radius:.5em;border-top-right-radius:.5em}.cc-revoke.cc-left{left:3em;right:unset}.cc-revoke.cc-right{right:3em;left:unset}.cc-top{top:1em}.cc-left{left:1em}.cc-right{right:1em}.cc-bottom{bottom:1em}.cc-floating>.cc-link{margin-bottom:1em}.cc-floating .cc-message{display:block;margin-bottom:1em}.cc-window.cc-floating .cc-compliance{flex:1 0 auto}.cc-window.cc-banner{align-items:center}.cc-banner.cc-top{left:0;right:0;top:0}.cc-banner.cc-bottom{left:0;right:0;bottom:0}.cc-banner .cc-message{flex:1}.cc-compliance{display:flex;align-items:center;align-content:space-between}.cc-compliance>.cc-btn{flex:1}.cc-btn+.cc-btn{margin-left:.5em}@media print{.cc-revoke,.cc-window{display:none}}@media screen and (max-width:900px){.cc-btn{white-space:normal}}@media screen and (max-width:414px) and (orientation:portrait),screen and (max-width:736px) and (orientation:landscape){.cc-window.cc-top{top:0}.cc-window.cc-bottom{bottom:0}.cc-window.cc-banner,.cc-window.cc-left,.cc-window.cc-right{left:0;right:0}.cc-window.cc-banner{flex-direction:column}.cc-window.cc-banner .cc-compliance{flex:1}.cc-window.cc-floating{max-width:none}.cc-window .cc-message{margin-bottom:1em}.cc-window.cc-banner{align-items:unset}}.cc-floating.cc-theme-classic{padding:1.2em;border-radius:5px}.cc-floating.cc-type-info.cc-theme-classic .cc-compliance{text-align:center;display:inline;flex:none}.cc-theme-classic .cc-btn{border-radius:5px}.cc-theme-classic .cc-btn:last-child{min-width:140px}.cc-floating.cc-type-info.cc-theme-classic .cc-btn{display:inline-block}.cc-theme-edgeless.cc-window{padding:0}.cc-floating.cc-theme-edgeless .cc-message{margin:2em 2em 1.5em}.cc-banner.cc-theme-edgeless .cc-btn{margin:0;padding:.8em 1.8em;height:100%}.cc-banner.cc-theme-edgeless .cc-message{margin-left:1em}.cc-floating.cc-theme-edgeless .cc-btn+.cc-btn{margin-left:0}`,document.head.appendChild(this._css),this.__updatePopup()}disconnectedCallback(){super.disconnectedCallback(),this.__closePopup(),this._css.isConnected&&this._css.remove()}__closePopup(){let e=this.popup;e&&e.parentNode?.removeChild(e)}_show(){let e=this.popup;e&&(e.classList.remove(`cc-invisible`),e.style.display=``)}__updatePopup(){this.__closePopup(),window.cookieconsent.initialise({palette:{popup:{background:`#000`},button:{background:`rgba(22, 118, 243, 0.95)`,hover:`rgba(22, 118, 243, 1)`}},showLink:this.showLearnMore,content:{message:this.message,dismiss:this.dismiss,link:this.learnMore,href:this.learnMoreLink},cookie:{name:this.cookieName},position:this.position,elements:{messagelink:`<span id="cookieconsent:desc" class="cc-message">${this.message} <a tabindex="0" class="cc-link" href="${this.learnMoreLink}" target="_blank" rel="noopener noreferrer nofollow">${this.learnMore}</a></span>`,dismiss:`<a tabindex="0" class="cc-btn cc-dismiss">${this.dismiss}</a>`}});let e=this.popup;if(e){e.setAttribute(`role`,`alert`);let t=e.querySelector(`a.cc-btn`);t?.addEventListener(`keydown`,e=>{let n=e.keyCode||e.which;(n===32||n===13)&&t.click()})}}render(){return T`
-       `}static{this.styles=h`
-  `}};k([y()],Da.prototype,`message`,void 0),k([y()],Da.prototype,`dismiss`,void 0),k([y()],Da.prototype,`learnMore`,void 0),k([y()],Da.prototype,`learnMoreLink`,void 0),k([y()],Da.prototype,`showLearnMore`,void 0),k([y()],Da.prototype,`position`,void 0),k([y()],Da.prototype,`cookieName`,void 0),k([C()],Da.prototype,`_css`,void 0),k([x(`[aria-label="cookieconsent"]`)],Da.prototype,`popup`,void 0),Da=k([g(`mateu-cookie-consent`)],Da);var Oa=class extends b{constructor(...e){super(...e),this.redispatchEvent=e=>{e instanceof CustomEvent&&(e.stopPropagation(),e.preventDefault(),this.target?.dispatchEvent(new CustomEvent(e.type,{detail:e.detail,bubbles:!0,composed:!0})))}}connectedCallback(){super.connectedCallback(),this.addEventListener(`value-changed`,this.redispatchEvent),this.addEventListener(`data-changed`,this.redispatchEvent),this.addEventListener(`action-requested`,this.redispatchEvent),this.addEventListener(`server-side-action-requested`,this.redispatchEvent),this.addEventListener(`route-changed`,this.redispatchEvent),this.addEventListener(`close-modal-requested`,this.redispatchEvent)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`value-changed`,this.redispatchEvent),this.removeEventListener(`data-changed`,this.redispatchEvent),this.removeEventListener(`action-requested`,this.redispatchEvent),this.removeEventListener(`server-side-action-requested`,this.redispatchEvent),this.removeEventListener(`route-changed`,this.redispatchEvent)}render(){return T`<slot></slot>`}static{this.styles=h`
+  `}};O([S()],K.prototype,`filter`,void 0),O([S()],K.prototype,`instant`,void 0),O([S()],K.prototype,`selectedConsumedRoute`,void 0),O([S()],K.prototype,`selectedRoute`,void 0),O([S()],K.prototype,`selectedUriPrefix`,void 0),O([S()],K.prototype,`selectedBaseUrl`,void 0),O([S()],K.prototype,`selectedServerSideType`,void 0),O([S()],K.prototype,`selectedParams`,void 0),O([S()],K.prototype,`tilesMenuOption`,void 0),O([S()],K.prototype,`railOpenOption`,void 0),O([S()],K.prototype,`commandPaletteOpen`,void 0),O([S()],K.prototype,`commandPaletteQuery`,void 0),O([S()],K.prototype,`commandPaletteSelectedIndex`,void 0),O([S()],K.prototype,`commandPaletteDataHits`,void 0),O([S()],K.prototype,`pageCompact`,void 0),O([b(`mateu-chat`)],K.prototype,`chat`,void 0),O([S()],K.prototype,`isDark`,void 0),O([S()],K.prototype,`chatOpen`,void 0),O([b(`.mateu-app-layout`)],K.prototype,`vaadinAppLayout`,void 0),K=Da=O([h(`mateu-app`)],K);var Oa=class extends y{constructor(...e){super(...e),this.message=`This website uses cookies.`,this.dismiss=`Ok. Thanks :).`,this.learnMore=`Learn more`,this.learnMoreLink=`https://cookiesandyou.com/`,this.showLearnMore=!0,this.position=`top`,this.cookieName=`mateu-cookieconsent`}updated(e){super.updated(e)}connectedCallback(){super.connectedCallback(),this._css=document.createElement(`style`),this._css.innerText=`.cc-window{opacity:1;transition:opacity 1s ease}.cc-window.cc-invisible{opacity:0}.cc-animate.cc-revoke{transition:transform 1s ease}.cc-animate.cc-revoke.cc-top{transform:translateY(-2em)}.cc-animate.cc-revoke.cc-bottom{transform:translateY(2em)}.cc-animate.cc-revoke.cc-active.cc-bottom,.cc-animate.cc-revoke.cc-active.cc-top,.cc-revoke:hover{transform:translateY(0)}.cc-grower{max-height:0;overflow:hidden;transition:max-height 1s}.cc-link,.cc-revoke:hover{text-decoration:underline}.cc-revoke,.cc-window{position:fixed;overflow:hidden;box-sizing:border-box;font-family:Helvetica,Calibri,Arial,sans-serif;font-size:16px;line-height:1.5em;display:flex;flex-wrap:nowrap;z-index:9999}.cc-window.cc-static{position:static}.cc-window.cc-floating{padding:2em;max-width:24em;flex-direction:column}.cc-window.cc-banner{padding:1em 1.8em;width:100%;flex-direction:row}.cc-revoke{padding:.5em}.cc-header{font-size:18px;font-weight:700}.cc-btn,.cc-close,.cc-link,.cc-revoke{cursor:pointer}.cc-link{opacity:.8;display:inline-block;padding:.2em}.cc-link:hover{opacity:1}.cc-link:active,.cc-link:visited{color:initial}.cc-btn{display:block;padding:.4em .8em;font-size:.9em;font-weight:700;border-width:2px;border-style:solid;text-align:center;white-space:nowrap}.cc-banner .cc-btn:last-child{min-width:140px}.cc-highlight .cc-btn:first-child{background-color:transparent;border-color:transparent}.cc-highlight .cc-btn:first-child:focus,.cc-highlight .cc-btn:first-child:hover{background-color:transparent;text-decoration:underline}.cc-close{display:block;position:absolute;top:.5em;right:.5em;font-size:1.6em;opacity:.9;line-height:.75}.cc-close:focus,.cc-close:hover{opacity:1}.cc-revoke.cc-top{top:0;left:3em;border-bottom-left-radius:.5em;border-bottom-right-radius:.5em}.cc-revoke.cc-bottom{bottom:0;left:3em;border-top-left-radius:.5em;border-top-right-radius:.5em}.cc-revoke.cc-left{left:3em;right:unset}.cc-revoke.cc-right{right:3em;left:unset}.cc-top{top:1em}.cc-left{left:1em}.cc-right{right:1em}.cc-bottom{bottom:1em}.cc-floating>.cc-link{margin-bottom:1em}.cc-floating .cc-message{display:block;margin-bottom:1em}.cc-window.cc-floating .cc-compliance{flex:1 0 auto}.cc-window.cc-banner{align-items:center}.cc-banner.cc-top{left:0;right:0;top:0}.cc-banner.cc-bottom{left:0;right:0;bottom:0}.cc-banner .cc-message{flex:1}.cc-compliance{display:flex;align-items:center;align-content:space-between}.cc-compliance>.cc-btn{flex:1}.cc-btn+.cc-btn{margin-left:.5em}@media print{.cc-revoke,.cc-window{display:none}}@media screen and (max-width:900px){.cc-btn{white-space:normal}}@media screen and (max-width:414px) and (orientation:portrait),screen and (max-width:736px) and (orientation:landscape){.cc-window.cc-top{top:0}.cc-window.cc-bottom{bottom:0}.cc-window.cc-banner,.cc-window.cc-left,.cc-window.cc-right{left:0;right:0}.cc-window.cc-banner{flex-direction:column}.cc-window.cc-banner .cc-compliance{flex:1}.cc-window.cc-floating{max-width:none}.cc-window .cc-message{margin-bottom:1em}.cc-window.cc-banner{align-items:unset}}.cc-floating.cc-theme-classic{padding:1.2em;border-radius:5px}.cc-floating.cc-type-info.cc-theme-classic .cc-compliance{text-align:center;display:inline;flex:none}.cc-theme-classic .cc-btn{border-radius:5px}.cc-theme-classic .cc-btn:last-child{min-width:140px}.cc-floating.cc-type-info.cc-theme-classic .cc-btn{display:inline-block}.cc-theme-edgeless.cc-window{padding:0}.cc-floating.cc-theme-edgeless .cc-message{margin:2em 2em 1.5em}.cc-banner.cc-theme-edgeless .cc-btn{margin:0;padding:.8em 1.8em;height:100%}.cc-banner.cc-theme-edgeless .cc-message{margin-left:1em}.cc-floating.cc-theme-edgeless .cc-btn+.cc-btn{margin-left:0}`,document.head.appendChild(this._css),this.__updatePopup()}disconnectedCallback(){super.disconnectedCallback(),this.__closePopup(),this._css.isConnected&&this._css.remove()}__closePopup(){let e=this.popup;e&&e.parentNode?.removeChild(e)}_show(){let e=this.popup;e&&(e.classList.remove(`cc-invisible`),e.style.display=``)}__updatePopup(){this.__closePopup(),window.cookieconsent.initialise({palette:{popup:{background:`#000`},button:{background:`rgba(22, 118, 243, 0.95)`,hover:`rgba(22, 118, 243, 1)`}},showLink:this.showLearnMore,content:{message:this.message,dismiss:this.dismiss,link:this.learnMore,href:this.learnMoreLink},cookie:{name:this.cookieName},position:this.position,elements:{messagelink:`<span id="cookieconsent:desc" class="cc-message">${this.message} <a tabindex="0" class="cc-link" href="${this.learnMoreLink}" target="_blank" rel="noopener noreferrer nofollow">${this.learnMore}</a></span>`,dismiss:`<a tabindex="0" class="cc-btn cc-dismiss">${this.dismiss}</a>`}});let e=this.popup;if(e){e.setAttribute(`role`,`alert`);let t=e.querySelector(`a.cc-btn`);t?.addEventListener(`keydown`,e=>{let n=e.keyCode||e.which;(n===32||n===13)&&t.click()})}}render(){return w`
+       `}static{this.styles=m`
+  `}};O([v()],Oa.prototype,`message`,void 0),O([v()],Oa.prototype,`dismiss`,void 0),O([v()],Oa.prototype,`learnMore`,void 0),O([v()],Oa.prototype,`learnMoreLink`,void 0),O([v()],Oa.prototype,`showLearnMore`,void 0),O([v()],Oa.prototype,`position`,void 0),O([v()],Oa.prototype,`cookieName`,void 0),O([S()],Oa.prototype,`_css`,void 0),O([b(`[aria-label="cookieconsent"]`)],Oa.prototype,`popup`,void 0),Oa=O([h(`mateu-cookie-consent`)],Oa);var ka=class extends y{constructor(...e){super(...e),this.redispatchEvent=e=>{e instanceof CustomEvent&&(e.stopPropagation(),e.preventDefault(),this.target?.dispatchEvent(new CustomEvent(e.type,{detail:e.detail,bubbles:!0,composed:!0})))}}connectedCallback(){super.connectedCallback(),this.addEventListener(`value-changed`,this.redispatchEvent),this.addEventListener(`data-changed`,this.redispatchEvent),this.addEventListener(`action-requested`,this.redispatchEvent),this.addEventListener(`server-side-action-requested`,this.redispatchEvent),this.addEventListener(`route-changed`,this.redispatchEvent),this.addEventListener(`close-modal-requested`,this.redispatchEvent)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`value-changed`,this.redispatchEvent),this.removeEventListener(`data-changed`,this.redispatchEvent),this.removeEventListener(`action-requested`,this.redispatchEvent),this.removeEventListener(`server-side-action-requested`,this.redispatchEvent),this.removeEventListener(`route-changed`,this.redispatchEvent)}render(){return w`<slot></slot>`}static{this.styles=m`
         :host {
             /* width: 100%; */
             display: inline-block;
         }
-  `}};k([y()],Oa.prototype,`target`,void 0),Oa=k([g(`mateu-event-interceptor`)],Oa);var ka=[`a[href]`,`button`,`input`,`select`,`textarea`,`[tabindex]`,`vaadin-button`,`vaadin-text-field`,`vaadin-combo-box`,`vaadin-select`,`vaadin-checkbox`,`vaadin-date-picker`,`ui5-button`,`oj-c-button`].join(`,`),Aa=e=>{let t=e;return t.hidden||t.hasAttribute(`disabled`)||t.getAttribute(`aria-hidden`)===`true`||t.getAttribute(`tabindex`)===`-1`?!1:!!(t.offsetParent||t.getClientRects().length)},ja=e=>{let t=[],n=e=>{e.querySelectorAll(`*`).forEach(e=>{e.matches(ka)&&Aa(e)&&t.push(e),e.shadowRoot&&n(e.shadowRoot),e instanceof HTMLSlotElement&&e.assignedElements().forEach(e=>{e.matches(ka)&&Aa(e)&&t.push(e),n(e)})})};return n(e),t.filter((e,n)=>t.indexOf(e)===n)},Ma=(e,t={})=>{let n=Na(),r=[],i=()=>{r=ja(e)},a=t=>{if(t.key!==`Tab`)return;if(i(),r.length===0){t.preventDefault(),e.focus();return}let n=r[0],a=r[r.length-1],o=Na();t.shiftKey&&(o===n||!o||!Pa(o,e))?(t.preventDefault(),a.focus()):!t.shiftKey&&o===a&&(t.preventDefault(),n.focus())};return e.addEventListener(`keydown`,a),requestAnimationFrame(()=>{i();let n=t.initialFocus?.()??r[0];n?n.focus():(e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus())}),{refresh:i,release(){e.removeEventListener(`keydown`,a);let t=Na();(!t||t===document.body||Pa(t,e))&&n?.focus?.()}}},Na=()=>{let e=document.activeElement;for(;e?.shadowRoot?.activeElement;)e=e.shadowRoot.activeElement;return e},Pa=(e,t)=>{let n=e;for(;n;){if(n===t)return!0;n=n.parentNode??n.host??null}return!1},Fa=class extends ha{constructor(...e){super(...e),this.opened=!0,this.close=()=>{this.opened=!1,this.releaseFocusTrap(),setTimeout(()=>{this.removeSelfFromOwnerChildren()||this.parentElement?.removeChild(this)},500)},this.onKeydown=e=>{e.key===`Escape`&&this.opened&&(e.stopPropagation(),this.close())}}connectedCallback(){super.connectedCallback(),this.addEventListener(`keydown`,this.onKeydown)}disconnectedCallback(){super.disconnectedCallback(),this.releaseFocusTrap()}releaseFocusTrap(){this.focusTrap?.release(),this.focusTrap=void 0}applyFragment(e){super.applyFragment(e);let t=e.state?._closeAfterMillis;t&&setTimeout(()=>this.close(),t)}updated(e){if(super.updated(e),e.has(`component`)&&this.component){let e=this.component.metadata;this.state=e.initialData}let t=this.renderRoot.querySelector(`[role="dialog"]`),n=this.component?.metadata?.modeless;this.opened&&t&&!this.focusTrap&&!n?this.focusTrap=Ma(t):this.focusTrap&&this.opened&&this.focusTrap.refresh()}render(){if(!this.opened)return T``;let e=this.component.metadata,t=rt(e.headerTitle,this.state,this.data,this.appState,this.appData),n=!!(t||e.header||e.closeButtonOnHeader),r=[e.width?`width:${e.width};`:`min-width:min(90vw,28rem);`,e.height?`height:${e.height};`:``,e.top?`margin-top:${e.top};`:``].join(``);return T`
+  `}};O([v()],ka.prototype,`target`,void 0),ka=O([h(`mateu-event-interceptor`)],ka);var Aa=[`a[href]`,`button`,`input`,`select`,`textarea`,`[tabindex]`,`vaadin-button`,`vaadin-text-field`,`vaadin-combo-box`,`vaadin-select`,`vaadin-checkbox`,`vaadin-date-picker`,`ui5-button`,`oj-c-button`].join(`,`),ja=e=>{let t=e;return t.hidden||t.hasAttribute(`disabled`)||t.getAttribute(`aria-hidden`)===`true`||t.getAttribute(`tabindex`)===`-1`?!1:!!(t.offsetParent||t.getClientRects().length)},Ma=e=>{let t=[],n=e=>{e.querySelectorAll(`*`).forEach(e=>{e.matches(Aa)&&ja(e)&&t.push(e),e.shadowRoot&&n(e.shadowRoot),e instanceof HTMLSlotElement&&e.assignedElements().forEach(e=>{e.matches(Aa)&&ja(e)&&t.push(e),n(e)})})};return n(e),t.filter((e,n)=>t.indexOf(e)===n)},Na=(e,t={})=>{let n=Pa(),r=[],i=()=>{r=Ma(e)},a=t=>{if(t.key!==`Tab`)return;if(i(),r.length===0){t.preventDefault(),e.focus();return}let n=r[0],a=r[r.length-1],o=Pa();t.shiftKey&&(o===n||!o||!Fa(o,e))?(t.preventDefault(),a.focus()):!t.shiftKey&&o===a&&(t.preventDefault(),n.focus())};return e.addEventListener(`keydown`,a),requestAnimationFrame(()=>{i();let n=t.initialFocus?.()??r[0];n?n.focus():(e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus())}),{refresh:i,release(){e.removeEventListener(`keydown`,a);let t=Pa();(!t||t===document.body||Fa(t,e))&&n?.focus?.()}}},Pa=()=>{let e=document.activeElement;for(;e?.shadowRoot?.activeElement;)e=e.shadowRoot.activeElement;return e},Fa=(e,t)=>{let n=e;for(;n;){if(n===t)return!0;n=n.parentNode??n.host??null}return!1},Ia=class extends ga{constructor(...e){super(...e),this.opened=!0,this.close=()=>{this.opened=!1,this.releaseFocusTrap(),setTimeout(()=>{this.removeSelfFromOwnerChildren()||this.parentElement?.removeChild(this)},500)},this.onKeydown=e=>{e.key===`Escape`&&this.opened&&(e.stopPropagation(),this.close())}}connectedCallback(){super.connectedCallback(),this.addEventListener(`keydown`,this.onKeydown)}disconnectedCallback(){super.disconnectedCallback(),this.releaseFocusTrap()}releaseFocusTrap(){this.focusTrap?.release(),this.focusTrap=void 0}applyFragment(e){super.applyFragment(e);let t=e.state?._closeAfterMillis;t&&setTimeout(()=>this.close(),t)}updated(e){if(super.updated(e),e.has(`component`)&&this.component){let e=this.component.metadata;this.state=e.initialData}let t=this.renderRoot.querySelector(`[role="dialog"]`),n=this.component?.metadata?.modeless;this.opened&&t&&!this.focusTrap&&!n?this.focusTrap=Na(t):this.focusTrap&&this.opened&&this.focusTrap.refresh()}render(){if(!this.opened)return w``;let e=this.component.metadata,t=it(e.headerTitle,this.state,this.data,this.appState,this.appData),n=!!(t||e.header||e.closeButtonOnHeader),r=[e.width?`width:${e.width};`:`min-width:min(90vw,28rem);`,e.height?`height:${e.height};`:``,e.top?`margin-top:${e.top};`:``].join(``);return w`
             <div class="backdrop ${e.modeless?`modeless`:``}"
                  @click="${t=>{!e.modeless&&t.target===t.currentTarget&&this.close()}}">
                 <div class="dialog ${e.noPadding?`no-padding`:``} ${this.component?.cssClasses??``}"
@@ -5557,29 +5557,29 @@ ${i}
                      aria-modal="${e.modeless?`false`:`true`}"
                      aria-label="${t||`Dialog`}"
                      style="${r} ${this.component?.style??``}">
-                    ${n?T`
+                    ${n?w`
                         <div class="dialog-header">
                             <mateu-event-interceptor .target="${this}" style="flex:1; min-width:0;">
-                                ${t?T`<span class="dialog-title">${t}</span>`:v}
-                                ${e.header?F(this,e.header,this.baseUrl,this.state,this.data,this.appState,this.appData):v}
+                                ${t?w`<span class="dialog-title">${t}</span>`:_}
+                                ${e.header?P(this,e.header,this.baseUrl,this.state,this.data,this.appState,this.appData):_}
                             </mateu-event-interceptor>
-                            ${e.closeButtonOnHeader?T`<button class="dialog-close" @click="${this.close}" aria-label="Close">✕</button>`:v}
-                        </div>`:v}
-                    ${e.content?T`
+                            ${e.closeButtonOnHeader?w`<button class="dialog-close" @click="${this.close}" aria-label="Close">✕</button>`:_}
+                        </div>`:_}
+                    ${e.content?w`
                         <div class="dialog-body">
                             <mateu-event-interceptor .target="${this}" style="--mateu-section-border: none; width:100%;">
-                                ${F(this,e.content,this.baseUrl,this.state,this.data,this.appState,this.appData)}
+                                ${P(this,e.content,this.baseUrl,this.state,this.data,this.appState,this.appData)}
                             </mateu-event-interceptor>
-                        </div>`:v}
-                    ${e.footer?T`
+                        </div>`:_}
+                    ${e.footer?w`
                         <div class="dialog-footer">
                             <mateu-event-interceptor .target="${this}" style="width:100%;">
-                                ${F(this,e.footer,this.baseUrl,this.state,this.data,this.appState,this.appData)}
+                                ${P(this,e.footer,this.baseUrl,this.state,this.data,this.appState,this.appData)}
                             </mateu-event-interceptor>
-                        </div>`:v}
+                        </div>`:_}
                 </div>
             </div>
-        `}static{this.styles=h`
+        `}static{this.styles=m`
         .backdrop {
             position: fixed; inset: 0; z-index: 1000;
             display: flex; align-items: center; justify-content: center;
@@ -5604,66 +5604,66 @@ ${i}
         .dialog-body { padding: .5rem 1.2rem; flex: 1; }
         .dialog.no-padding .dialog-body { padding: 0; }
         .dialog-footer { padding: .5rem 1.2rem 1rem; display: flex; justify-content: flex-end; gap: .5rem; }
-    `}};k([C()],Fa.prototype,`opened`,void 0),Fa=k([g(`mateu-dialog`)],Fa);var Ia,La=class extends ha{static{Ia=this}constructor(...e){super(...e),this.opened=!1,this.maximizeSteps=0,this.collapsed=!1,this.pagerMenuOpen=!1,this.onGuidedProgress=e=>{let t=e.detail;t&&t.total>0&&(this.guidedProgress=t)},this.close=()=>{this.opened=!1,this.releaseLayoutInset(),this.releaseFocusTrap(),setTimeout(()=>{this.removeSelfFromOwnerChildren()||this.parentElement?.removeChild(this)},300)},this._escListener=e=>{if(e.key!==`Escape`)return;let t=this.getRootNode().querySelectorAll(`mateu-drawer, mateu-dialog`);t[t.length-1]===this&&(e.stopPropagation(),this.close())}}jumpToStep(e){this.pagerMenuOpen=!1,e&&(this.renderRoot.querySelector(`.content mateu-component`)??this.renderRoot.querySelector(`mateu-component`))?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`goToStep`,parameters:{_stepId:e}},bubbles:!0,composed:!0}))}static{this.SIZE_LADDER=[`s`,`m`,`l`,`xl`]}static{this.SIZE_WIDTHS={s:`464px`,m:`648px`,l:`968px`,xl:`90vw`}}effectiveWidth(e){if(e.width)return e.width;if(!e.size)return;let t=Ia.SIZE_LADDER,n=Math.max(0,t.indexOf(e.size)),r=Math.min(t.length-1,n+this.maximizeSteps);return Ia.SIZE_WIDTHS[t[r]]}canMaximize(e){if(!e.maximizable)return!1;let t=Ia.SIZE_LADDER;return Math.max(0,t.indexOf(e.size??`m`))+this.maximizeSteps<t.length-1}firstUpdated(){requestAnimationFrame(()=>this.opened=!0),this.addEventListener(`mateu-guided-progress`,this.onGuidedProgress);let e=this.component?.metadata;e&&requestAnimationFrame(()=>this.applyLayoutInset(e))}releaseFocusTrap(){this.focusTrap?.release(),this.focusTrap=void 0}applyLayoutInset(e){if(!e.layout)return;let t=document.querySelector(`mateu-ui`);if(!t)return;let n=e.position??`end`,r=n===`bottom`?`var(--mateu-drawer-height, 50vh)`:this.effectiveWidth(e)??`648px`;this._insetProp=n===`start`?`paddingLeft`:n===`bottom`?`paddingBottom`:`paddingRight`,t.style.transition=`padding .25s ease`,t.style[this._insetProp]=r}releaseLayoutInset(){if(!this._insetProp)return;let e=document.querySelector(`mateu-ui`);e&&(e.style[this._insetProp]=``),this._insetProp=void 0}applyFragment(e){super.applyFragment(e);let t=e.state?._closeAfterMillis;t&&setTimeout(()=>this.close(),t)}updated(e){if(super.updated(e),e.has(`component`)&&this.component){let e=this.component.metadata;this.state=e.initialData}let t=this.component?.metadata,n=this.renderRoot.querySelector(`[role="dialog"]`);this.opened&&n&&!t?.modeless&&!t?.layout&&!this.focusTrap?this.focusTrap=Ma(n):this.focusTrap&&this.opened&&this.focusTrap.refresh()}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._escListener)}disconnectedCallback(){document.removeEventListener(`keydown`,this._escListener),this.releaseLayoutInset(),this.releaseFocusTrap(),super.disconnectedCallback()}render(){let e=this.component.metadata,t=e.position??`end`,n=rt(e.headerTitle,this.state,this.data,this.appState,this.appData),r=rt(e.subtitle,this.state,this.data,this.appState,this.appData),i=this.effectiveWidth(e),a=e.peerNav&&(e.peerNav.prevRoute||e.peerNav.nextRoute)?e.peerNav:void 0;return T`
-        ${e.modeless||e.layout?v:T`
+    `}};O([S()],Ia.prototype,`opened`,void 0),Ia=O([h(`mateu-dialog`)],Ia);var La,Ra=class extends ga{static{La=this}constructor(...e){super(...e),this.opened=!1,this.maximizeSteps=0,this.collapsed=!1,this.pagerMenuOpen=!1,this.onGuidedProgress=e=>{let t=e.detail;t&&t.total>0&&(this.guidedProgress=t)},this.close=()=>{this.opened=!1,this.releaseLayoutInset(),this.releaseFocusTrap(),setTimeout(()=>{this.removeSelfFromOwnerChildren()||this.parentElement?.removeChild(this)},300)},this._escListener=e=>{if(e.key!==`Escape`)return;let t=this.getRootNode().querySelectorAll(`mateu-drawer, mateu-dialog`);t[t.length-1]===this&&(e.stopPropagation(),this.close())}}jumpToStep(e){this.pagerMenuOpen=!1,e&&(this.renderRoot.querySelector(`.content mateu-component`)??this.renderRoot.querySelector(`mateu-component`))?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`goToStep`,parameters:{_stepId:e}},bubbles:!0,composed:!0}))}static{this.SIZE_LADDER=[`s`,`m`,`l`,`xl`]}static{this.SIZE_WIDTHS={s:`464px`,m:`648px`,l:`968px`,xl:`90vw`}}effectiveWidth(e){if(e.width)return e.width;if(!e.size)return;let t=La.SIZE_LADDER,n=Math.max(0,t.indexOf(e.size)),r=Math.min(t.length-1,n+this.maximizeSteps);return La.SIZE_WIDTHS[t[r]]}canMaximize(e){if(!e.maximizable)return!1;let t=La.SIZE_LADDER;return Math.max(0,t.indexOf(e.size??`m`))+this.maximizeSteps<t.length-1}firstUpdated(){requestAnimationFrame(()=>this.opened=!0),this.addEventListener(`mateu-guided-progress`,this.onGuidedProgress);let e=this.component?.metadata;e&&requestAnimationFrame(()=>this.applyLayoutInset(e))}releaseFocusTrap(){this.focusTrap?.release(),this.focusTrap=void 0}applyLayoutInset(e){if(!e.layout)return;let t=document.querySelector(`mateu-ui`);if(!t)return;let n=e.position??`end`,r=n===`bottom`?`var(--mateu-drawer-height, 50vh)`:this.effectiveWidth(e)??`648px`;this._insetProp=n===`start`?`paddingLeft`:n===`bottom`?`paddingBottom`:`paddingRight`,t.style.transition=`padding .25s ease`,t.style[this._insetProp]=r}releaseLayoutInset(){if(!this._insetProp)return;let e=document.querySelector(`mateu-ui`);e&&(e.style[this._insetProp]=``),this._insetProp=void 0}applyFragment(e){super.applyFragment(e);let t=e.state?._closeAfterMillis;t&&setTimeout(()=>this.close(),t)}updated(e){if(super.updated(e),e.has(`component`)&&this.component){let e=this.component.metadata;this.state=e.initialData}let t=this.component?.metadata,n=this.renderRoot.querySelector(`[role="dialog"]`);this.opened&&n&&!t?.modeless&&!t?.layout&&!this.focusTrap?this.focusTrap=Na(n):this.focusTrap&&this.opened&&this.focusTrap.refresh()}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._escListener)}disconnectedCallback(){document.removeEventListener(`keydown`,this._escListener),this.releaseLayoutInset(),this.releaseFocusTrap(),super.disconnectedCallback()}render(){let e=this.component.metadata,t=e.position??`end`,n=it(e.headerTitle,this.state,this.data,this.appState,this.appData),r=it(e.subtitle,this.state,this.data,this.appState,this.appData),i=this.effectiveWidth(e),a=e.peerNav&&(e.peerNav.prevRoute||e.peerNav.nextRoute)?e.peerNav:void 0;return w`
+        ${e.modeless||e.layout?_:w`
             <div class="backdrop ${this.opened?`open`:``}" @click="${this.close}"></div>
         `}
         <section
                 class="panel ${t} ${this.opened?`open`:``} ${this.collapsed?`collapsed`:``} ${this.component?.cssClasses??``}"
                 role="dialog"
                 aria-modal="${!e.modeless}"
-                aria-label="${n??v}"
+                aria-label="${n??_}"
                 style="${i&&t!==`bottom`?`width: ${i};`:``}${this.component?.style??``}"
         >
             <header>
-                ${n?T`<div class="titles"><h3>${n}</h3>${r?T`<span class="subtitle">${r}</span>`:v}</div>`:T`<span class="spacer"></span>`}
-                ${this.guidedProgress&&this.guidedProgress.total>1?T`
+                ${n?w`<div class="titles"><h3>${n}</h3>${r?w`<span class="subtitle">${r}</span>`:_}</div>`:w`<span class="spacer"></span>`}
+                ${this.guidedProgress&&this.guidedProgress.total>1?w`
                     <div class="guided-pager-wrap">
                         <button class="guided-pager" aria-haspopup="true" aria-expanded="${this.pagerMenuOpen}"
                                 aria-label="Step ${this.guidedProgress.current} of ${this.guidedProgress.total}"
                                 @click="${()=>this.pagerMenuOpen=!this.pagerMenuOpen}">${this.guidedProgress.current} | ${this.guidedProgress.total}<span class="caret">▾</span></button>
-                        ${this.pagerMenuOpen&&this.guidedProgress.steps?T`
+                        ${this.pagerMenuOpen&&this.guidedProgress.steps?w`
                             <div class="guided-pager-menu">
-                                ${this.guidedProgress.steps.map((e,t)=>T`
+                                ${this.guidedProgress.steps.map((e,t)=>w`
                                     <button class="guided-pager-item ${e.status}" ?disabled="${e.status!==`done`}"
                                             @click="${()=>this.jumpToStep(e.id)}"><span class="pager-dot">${e.status===`done`?`✓`:t+1}</span>${e.title??`Step ${t+1}`}</button>
                                 `)}
                             </div>
-                        `:v}
+                        `:_}
                     </div>
-                `:v}
-                ${e.header?T`
-                    <mateu-event-interceptor .target="${this}">${F(this,e.header,this.baseUrl,this.state,this.data,this.appState,this.appData)}</mateu-event-interceptor>
-                `:v}
-                ${a?T`
+                `:_}
+                ${e.header?w`
+                    <mateu-event-interceptor .target="${this}">${P(this,e.header,this.baseUrl,this.state,this.data,this.appState,this.appData)}</mateu-event-interceptor>
+                `:_}
+                ${a?w`
                     <button class="drawer-icon" aria-label="${a.prevLabel??`Previous`}" title="${a.prevLabel??`Previous`}"
                             ?disabled="${!a.prevRoute}" @click="${()=>{a.prevRoute&&(window.location.href=a.prevRoute)}}">‹</button>
                     <button class="drawer-icon" aria-label="${a.nextLabel??`Next`}" title="${a.nextLabel??`Next`}"
                             ?disabled="${!a.nextRoute}" @click="${()=>{a.nextRoute&&(window.location.href=a.nextRoute)}}">›</button>
-                `:v}
-                ${e.collapsible?T`
+                `:_}
+                ${e.collapsible?w`
                     <button class="drawer-icon" aria-label="${this.collapsed?`Expand`:`Collapse`}" title="${this.collapsed?`Expand`:`Collapse`}"
                             @click="${()=>this.collapsed=!this.collapsed}">${this.collapsed?`▴`:`▾`}</button>
-                `:v}
-                ${this.canMaximize(e)?T`
+                `:_}
+                ${this.canMaximize(e)?w`
                     <button class="drawer-icon" aria-label="Maximize" title="Maximize" @click="${()=>this.maximizeSteps++}">⤢</button>
-                `:v}
+                `:_}
                 <button class="drawer-close" aria-label="Close" @click="${this.close}">✕</button>
             </header>
-            ${this.collapsed?v:T`
+            ${this.collapsed?_:w`
             <div class="content ${e.noPadding?`no-padding`:``}">
-                ${e.content?T`
-                    <mateu-event-interceptor .target="${this}" style="--mateu-section-border: none; width: 100%;">${F(this,e.content,this.baseUrl,this.state,this.data,this.appState,this.appData)}</mateu-event-interceptor>
-                `:v}
+                ${e.content?w`
+                    <mateu-event-interceptor .target="${this}" style="--mateu-section-border: none; width: 100%;">${P(this,e.content,this.baseUrl,this.state,this.data,this.appState,this.appData)}</mateu-event-interceptor>
+                `:_}
             </div>
-            ${e.footer?T`
+            ${e.footer?w`
                 <footer>
-                    <mateu-event-interceptor .target="${this}" style="width: 100%;">${F(this,e.footer,this.baseUrl,this.state,this.data,this.appState,this.appData)}</mateu-event-interceptor>
+                    <mateu-event-interceptor .target="${this}" style="width: 100%;">${P(this,e.footer,this.baseUrl,this.state,this.data,this.appState,this.appData)}</mateu-event-interceptor>
                 </footer>
-            `:v}
+            `:_}
             `}
         </section>
-       `}static{this.styles=h`
+       `}static{this.styles=m`
         .drawer-close {
             border: none;
             background: transparent;
@@ -5882,19 +5882,19 @@ ${i}
             display: flex;
             justify-content: flex-end;
         }
-  `}};k([C()],La.prototype,`opened`,void 0),k([C()],La.prototype,`maximizeSteps`,void 0),k([C()],La.prototype,`collapsed`,void 0),k([C()],La.prototype,`guidedProgress`,void 0),k([C()],La.prototype,`pagerMenuOpen`,void 0),La=Ia=k([g(`mateu-drawer`)],La);function Ra(e){if(e.parentElement)return e.parentElement;let t=e.getRootNode();return t instanceof ShadowRoot?t.host:null}var J=class extends b{constructor(...e){super(...e),this.appState={},this.appData={},this.standalone=!1,this.actionBanners=[],this.dismissedStaticBannerIndices=new Set,this._tocEntries=[],this._activeToc=0,this._tocVisible=!1,this._tocRebuildScheduled=!1,this._headerH=0,this._onResize=()=>this._layoutStickyTops(),this._tocLocked=!1,this._unlockToc=e=>{if(e&&e.type===`keydown`){let t=e;if(t.ctrlKey&&t.altKey&&!t.shiftKey&&!t.metaKey&&/^(?:Digit|Numpad)[1-9]$/.test(t.code))return}this._tocLocked=!1},this._actionBannerTimers=[],this._staticBannerTimers=[],this._bannersHandler=e=>{let t=e.detail,n=t.banners??[],r=t.append??!1;r?this.actionBanners=[...this.actionBanners,...n]:(this._clearActionBannerTimers(),this.actionBanners=n);let i=r?this.actionBanners.length-n.length:0;n.forEach((e,t)=>{if(e.timeoutSeconds&&e.timeoutSeconds>0){let n=i+t;this._actionBannerTimers.push(setTimeout(()=>{this.actionBanners=this.actionBanners.filter((e,t)=>t!==n)},e.timeoutSeconds*1e3))}})},this._onTocKey=e=>{if(!this._tocVisible||!e.ctrlKey||!e.altKey||e.shiftKey||e.metaKey)return;let t=/^(?:Digit|Numpad)([1-9])$/.exec(e.code);if(!t)return;let n=parseInt(t[1],10)-1;n>=this._tocEntries.length||(e.preventDefault(),this._scrollToSection(n))},this._onScrollSpy=()=>{if(this._tocLocked)return;let e=this._sectionCards();if(!e.length)return;let t=this.shadowRoot?.querySelector(`mateu-content-header`),n=t?t.getBoundingClientRect().bottom:0;for(let t of e){if(!t.classList.contains(`mateu-section--sticky`))continue;let e=t.getBoundingClientRect();e.top<=n+12+2&&(n=Math.max(n,e.bottom))}let r=n+12+4,i=0;this._tocEntries.forEach((e,t)=>{e.el.getBoundingClientRect().top<=r&&(i=t)}),this._activeToc=i}}connectedCallback(){super.connectedCallback(),document.addEventListener(`page-banners-received`,this._bannersHandler),window.addEventListener(`resize`,this._onResize),document.addEventListener(`keydown`,this._onTocKey)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`page-banners-received`,this._bannersHandler),window.removeEventListener(`resize`,this._onResize),document.removeEventListener(`keydown`,this._onTocKey),this._clearAllTimers(),this._teardownScrollSpy()}updated(e){if(super.updated(e),e.has(`component`)&&e.get(`component`)!==void 0&&(this._clearAllTimers(),this.actionBanners=[],this.dismissedStaticBannerIndices=new Set),e.has(`component`)){let e=this.component?.metadata?.level??0;this.toggleAttribute(`data-nested`,e>0),this._scheduleStaticBannerTimeouts();let t=this.component?.metadata?.pageWidth===`edgeToEdge`;this.toggleAttribute(`data-edge`,t),this.dispatchEvent(new CustomEvent(`compact-changed`,{detail:{compact:!!this.component?.style?.includes(`--mateu-compact:1`)||t},bubbles:!0,composed:!0})),this._scheduleTocRebuild()}}_scheduleStaticBannerTimeouts(){this._staticBannerTimers.forEach(e=>clearTimeout(e)),this._staticBannerTimers=[],(this.component?.metadata?.banners??[]).forEach((e,t)=>{e.timeoutSeconds&&e.timeoutSeconds>0&&this._staticBannerTimers.push(setTimeout(()=>{this.dismissedStaticBannerIndices=new Set([...this.dismissedStaticBannerIndices,t])},e.timeoutSeconds*1e3))})}_clearActionBannerTimers(){this._actionBannerTimers.forEach(e=>clearTimeout(e)),this._actionBannerTimers=[]}_clearAllTimers(){this._clearActionBannerTimers(),this._staticBannerTimers.forEach(e=>clearTimeout(e)),this._staticBannerTimers=[]}_dismissActionBanner(e){this.actionBanners=this.actionBanners.filter((t,n)=>n!==e)}_dismissStaticBanner(e){this.dismissedStaticBannerIndices=new Set([...this.dismissedStaticBannerIndices,e])}bannerThemeClass(e){let t=e.theme?.toLowerCase()??`info`;return t===`none`?``:t}_evalBannerText(e){return M(e,this.state,this.data)}_renderBanner(e,t){let n=this._evalBannerText(e.title),r=this._evalBannerText(e.description);return T`
+  `}};O([S()],Ra.prototype,`opened`,void 0),O([S()],Ra.prototype,`maximizeSteps`,void 0),O([S()],Ra.prototype,`collapsed`,void 0),O([S()],Ra.prototype,`guidedProgress`,void 0),O([S()],Ra.prototype,`pagerMenuOpen`,void 0),Ra=La=O([h(`mateu-drawer`)],Ra);function za(e){if(e.parentElement)return e.parentElement;let t=e.getRootNode();return t instanceof ShadowRoot?t.host:null}var q=class extends y{constructor(...e){super(...e),this.appState={},this.appData={},this.standalone=!1,this.actionBanners=[],this.dismissedStaticBannerIndices=new Set,this._tocEntries=[],this._activeToc=0,this._tocVisible=!1,this._tocRebuildScheduled=!1,this._headerH=0,this._onResize=()=>this._layoutStickyTops(),this._tocLocked=!1,this._unlockToc=e=>{if(e&&e.type===`keydown`){let t=e;if(t.ctrlKey&&t.altKey&&!t.shiftKey&&!t.metaKey&&/^(?:Digit|Numpad)[1-9]$/.test(t.code))return}this._tocLocked=!1},this._actionBannerTimers=[],this._staticBannerTimers=[],this._bannersHandler=e=>{let t=e.detail,n=t.banners??[],r=t.append??!1;r?this.actionBanners=[...this.actionBanners,...n]:(this._clearActionBannerTimers(),this.actionBanners=n);let i=r?this.actionBanners.length-n.length:0;n.forEach((e,t)=>{if(e.timeoutSeconds&&e.timeoutSeconds>0){let n=i+t;this._actionBannerTimers.push(setTimeout(()=>{this.actionBanners=this.actionBanners.filter((e,t)=>t!==n)},e.timeoutSeconds*1e3))}})},this._onTocKey=e=>{if(!this._tocVisible||!e.ctrlKey||!e.altKey||e.shiftKey||e.metaKey)return;let t=/^(?:Digit|Numpad)([1-9])$/.exec(e.code);if(!t)return;let n=parseInt(t[1],10)-1;n>=this._tocEntries.length||(e.preventDefault(),this._scrollToSection(n))},this._onScrollSpy=()=>{if(this._tocLocked)return;let e=this._sectionCards();if(!e.length)return;let t=this.shadowRoot?.querySelector(`mateu-content-header`),n=t?t.getBoundingClientRect().bottom:0;for(let t of e){if(!t.classList.contains(`mateu-section--sticky`))continue;let e=t.getBoundingClientRect();e.top<=n+12+2&&(n=Math.max(n,e.bottom))}let r=n+12+4,i=0;this._tocEntries.forEach((e,t)=>{e.el.getBoundingClientRect().top<=r&&(i=t)}),this._activeToc=i}}connectedCallback(){super.connectedCallback(),document.addEventListener(`page-banners-received`,this._bannersHandler),window.addEventListener(`resize`,this._onResize),document.addEventListener(`keydown`,this._onTocKey)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`page-banners-received`,this._bannersHandler),window.removeEventListener(`resize`,this._onResize),document.removeEventListener(`keydown`,this._onTocKey),this._clearAllTimers(),this._teardownScrollSpy()}updated(e){if(super.updated(e),e.has(`component`)&&e.get(`component`)!==void 0&&(this._clearAllTimers(),this.actionBanners=[],this.dismissedStaticBannerIndices=new Set),e.has(`component`)){let e=this.component?.metadata?.level??0;this.toggleAttribute(`data-nested`,e>0),this._scheduleStaticBannerTimeouts();let t=this.component?.metadata?.pageWidth===`edgeToEdge`;this.toggleAttribute(`data-edge`,t),this.dispatchEvent(new CustomEvent(`compact-changed`,{detail:{compact:!!this.component?.style?.includes(`--mateu-compact:1`)||t},bubbles:!0,composed:!0})),this._scheduleTocRebuild()}}_scheduleStaticBannerTimeouts(){this._staticBannerTimers.forEach(e=>clearTimeout(e)),this._staticBannerTimers=[],(this.component?.metadata?.banners??[]).forEach((e,t)=>{e.timeoutSeconds&&e.timeoutSeconds>0&&this._staticBannerTimers.push(setTimeout(()=>{this.dismissedStaticBannerIndices=new Set([...this.dismissedStaticBannerIndices,t])},e.timeoutSeconds*1e3))})}_clearActionBannerTimers(){this._actionBannerTimers.forEach(e=>clearTimeout(e)),this._actionBannerTimers=[]}_clearAllTimers(){this._clearActionBannerTimers(),this._staticBannerTimers.forEach(e=>clearTimeout(e)),this._staticBannerTimers=[]}_dismissActionBanner(e){this.actionBanners=this.actionBanners.filter((t,n)=>n!==e)}_dismissStaticBanner(e){this.dismissedStaticBannerIndices=new Set([...this.dismissedStaticBannerIndices,e])}bannerThemeClass(e){let t=e.theme?.toLowerCase()??`info`;return t===`none`?``:t}_evalBannerText(e){return j(e,this.state,this.data)}_renderBanner(e,t){let n=this._evalBannerText(e.title),r=this._evalBannerText(e.description);return w`
             <div class="page-banner page-banner--${this.bannerThemeClass(e)}">
-                ${n||e.hasCloseButton?T`
+                ${n||e.hasCloseButton?w`
                     <div style="display: flex; align-items: center; justify-content: space-between; color: #1a1a1a; width: 100%;">
                         <span style="font-weight: 600;">${n??``}</span>
-                        ${e.hasCloseButton?T`
+                        ${e.hasCloseButton?w`
                             <button class="banner-close" @click=${t} title="Dismiss" aria-label="Dismiss">✕</button>
-                        `:v}
+                        `:_}
                     </div>
-                `:v}
-                ${r?T`<p>${r}</p>`:v}
+                `:_}
+                ${r?w`<p>${r}</p>`:_}
             </div>
-        `}_onSlotChange(){this._scheduleTocRebuild()}_scheduleTocRebuild(){this._tocRebuildScheduled||(this._tocRebuildScheduled=!0,requestAnimationFrame(()=>{this._tocRebuildScheduled=!1,this._rebuildToc()}))}_sectionCards(){return Array.from(this.querySelectorAll(`.mateu-section`))}_sectionTitle(e){return e.querySelector(`[slot="title"]`)?.textContent?.trim()||e.querySelector(`h1,h2,h3,h4,h5,h6`)?.textContent?.trim()||void 0}_rebuildToc(){let e=this._sectionCards(),t=e.map(e=>({title:this._sectionTitle(e),el:e})).filter(e=>!!e.title),n=this.component?.metadata?.toc,r=t.length>4&&e.every(e=>!e.closest(`vaadin-horizontal-layout`)),i=(n===!0||n!==!1&&r)&&t.length>0;this._tocEntries=t,this._tocVisible=i,this._activeToc>=t.length&&(this._activeToc=0),this._teardownScrollSpy(),i?requestAnimationFrame(()=>{this._layoutStickyTops(),this._setupScrollSpy()}):this._layoutStickyTops()}_layoutStickyTops(){let e=this.shadowRoot?.querySelector(`mateu-content-header`);this._headerH=this._tocVisible&&e?e.offsetHeight:0,this.style.setProperty(`--mateu-header-h`,this._headerH+`px`);let t=this._headerH+12;for(let e of this._sectionCards())e.classList.contains(`mateu-section--sticky`)&&(e.style.top=t+`px`,t+=e.offsetHeight+12)}_scrollContainer(){let e=Ra(this);for(;e;){let t=getComputedStyle(e).overflowY;if((t===`auto`||t===`scroll`)&&e.scrollHeight>e.clientHeight)return e;e=Ra(e)}return null}_setupScrollSpy(){this._tocEntries.length&&(this._spyTarget=this._scrollContainer()??window,this._spyTarget.addEventListener(`scroll`,this._onScrollSpy,{passive:!0}),window.addEventListener(`wheel`,this._unlockToc,{passive:!0}),window.addEventListener(`touchstart`,this._unlockToc,{passive:!0}),window.addEventListener(`keydown`,this._unlockToc),this._onScrollSpy())}_teardownScrollSpy(){this._spyTarget?.removeEventListener(`scroll`,this._onScrollSpy),window.removeEventListener(`wheel`,this._unlockToc),window.removeEventListener(`touchstart`,this._unlockToc),window.removeEventListener(`keydown`,this._unlockToc),this._spyTarget=void 0}_scrollToSection(e){let t=this._tocEntries[e];if(!t)return;this._activeToc=e,this._tocLocked=!0;let n=this._headerH+12;for(let e of this._sectionCards()){if(e===t.el)break;e.classList.contains(`mateu-section--sticky`)&&(n+=e.offsetHeight+12)}let r=this._scrollContainer(),i=r?r.getBoundingClientRect().top:0,a=t.el.getBoundingClientRect().top-i-n;(r??window).scrollBy({top:a,behavior:`smooth`})}_showHeaderBand(){let e=this.component?.metadata,t=!!(e?.title||e?.subtitle||e?.toolbar?.length),n=!!this.component?.children?.some(e=>e.metadata?.type===j.Crud);return t&&!n&&!this._hasWelcomeBanner()}_hasWelcomeBanner(){let e=t=>t?.metadata?.type===j.HeroSection||(t?.children??[]).some(e);return(this.component?.children??[]).some(e)}render(){let e=this.component?.metadata,t=[...(e?.banners??[]).map((e,t)=>({banner:e,index:t})).filter(({index:e})=>!this.dismissedStaticBannerIndices.has(e)).map(({banner:e,index:t})=>({banner:e,onDismiss:()=>this._dismissStaticBanner(t)})),...this.actionBanners.map((e,t)=>({banner:e,onDismiss:()=>this._dismissActionBanner(t)}))];return T`<div style="display: flex; flex-direction: column; width: 100%;">${T`
+        `}_onSlotChange(){this._scheduleTocRebuild()}_scheduleTocRebuild(){this._tocRebuildScheduled||(this._tocRebuildScheduled=!0,requestAnimationFrame(()=>{this._tocRebuildScheduled=!1,this._rebuildToc()}))}_sectionCards(){return Array.from(this.querySelectorAll(`.mateu-section`))}_sectionTitle(e){return e.querySelector(`[slot="title"]`)?.textContent?.trim()||e.querySelector(`h1,h2,h3,h4,h5,h6`)?.textContent?.trim()||void 0}_rebuildToc(){let e=this._sectionCards(),t=e.map(e=>({title:this._sectionTitle(e),el:e})).filter(e=>!!e.title),n=this.component?.metadata?.toc,r=t.length>4&&e.every(e=>!e.closest(`vaadin-horizontal-layout`)),i=(n===!0||n!==!1&&r)&&t.length>0;this._tocEntries=t,this._tocVisible=i,this._activeToc>=t.length&&(this._activeToc=0),this._teardownScrollSpy(),i?requestAnimationFrame(()=>{this._layoutStickyTops(),this._setupScrollSpy()}):this._layoutStickyTops()}_layoutStickyTops(){let e=this.shadowRoot?.querySelector(`mateu-content-header`);this._headerH=this._tocVisible&&e?e.offsetHeight:0,this.style.setProperty(`--mateu-header-h`,this._headerH+`px`);let t=this._headerH+12;for(let e of this._sectionCards())e.classList.contains(`mateu-section--sticky`)&&(e.style.top=t+`px`,t+=e.offsetHeight+12)}_scrollContainer(){let e=za(this);for(;e;){let t=getComputedStyle(e).overflowY;if((t===`auto`||t===`scroll`)&&e.scrollHeight>e.clientHeight)return e;e=za(e)}return null}_setupScrollSpy(){this._tocEntries.length&&(this._spyTarget=this._scrollContainer()??window,this._spyTarget.addEventListener(`scroll`,this._onScrollSpy,{passive:!0}),window.addEventListener(`wheel`,this._unlockToc,{passive:!0}),window.addEventListener(`touchstart`,this._unlockToc,{passive:!0}),window.addEventListener(`keydown`,this._unlockToc),this._onScrollSpy())}_teardownScrollSpy(){this._spyTarget?.removeEventListener(`scroll`,this._onScrollSpy),window.removeEventListener(`wheel`,this._unlockToc),window.removeEventListener(`touchstart`,this._unlockToc),window.removeEventListener(`keydown`,this._unlockToc),this._spyTarget=void 0}_scrollToSection(e){let t=this._tocEntries[e];if(!t)return;this._activeToc=e,this._tocLocked=!0;let n=this._headerH+12;for(let e of this._sectionCards()){if(e===t.el)break;e.classList.contains(`mateu-section--sticky`)&&(n+=e.offsetHeight+12)}let r=this._scrollContainer(),i=r?r.getBoundingClientRect().top:0,a=t.el.getBoundingClientRect().top-i-n;(r??window).scrollBy({top:a,behavior:`smooth`})}_showHeaderBand(){let e=this.component?.metadata,t=!!(e?.title||e?.subtitle||e?.toolbar?.length),n=!!this.component?.children?.some(e=>e.metadata?.type===A.Crud);return t&&!n&&!this._hasWelcomeBanner()}_hasWelcomeBanner(){let e=t=>t?.metadata?.type===A.HeroSection||(t?.children??[]).some(e);return(this.component?.children??[]).some(e)}render(){let e=this.component?.metadata,t=[...(e?.banners??[]).map((e,t)=>({banner:e,index:t})).filter(({index:e})=>!this.dismissedStaticBannerIndices.has(e)).map(({banner:e,index:t})=>({banner:e,onDismiss:()=>this._dismissStaticBanner(t)})),...this.actionBanners.map((e,t)=>({banner:e,onDismiss:()=>this._dismissActionBanner(t)}))];return w`<div style="display: flex; flex-direction: column; width: 100%;">${w`
             <div class="page-header-wrap">
                 <mateu-content-header
                     class="${this._tocVisible?`sticky-header`:``}"
@@ -5905,15 +5905,15 @@ ${i}
                     .appState="${this.appState}"
                     .appData="${this.appData}"
                 ></mateu-content-header>
-                ${this._showHeaderBand()?T`
+                ${this._showHeaderBand()?w`
                     <div class="page-header-band" aria-hidden="true"></div>
-                `:v}
+                `:_}
             </div>
-            ${t.length>0?T`
+            ${t.length>0?w`
                 <div class="page-banners">
                     ${t.map(({banner:e,onDismiss:t})=>this._renderBanner(e,t))}
                 </div>
-            `:v}
+            `:_}
             <div class="page-body ${this._tocVisible?`with-toc`:``}">
                 <div class="form-content">
                     <slot @slotchange=${this._onSlotChange}></slot>
@@ -5921,25 +5921,25 @@ ${i}
                         <slot name="buttons"></slot>
                     </div>
                 </div>
-                ${this._tocVisible?T`
+                ${this._tocVisible?w`
                     <aside class="page-toc">
                         <nav>
-                            ${this._tocEntries.map((e,t)=>T`
+                            ${this._tocEntries.map((e,t)=>w`
                                 <a class="page-toc__item ${t===this._activeToc?`is-active`:``}"
                                    @click=${()=>this._scrollToSection(t)}
                                    title=${t<9?`${e.title} (Ctrl+Alt+${t+1})`:e.title}>
                                     <span class="page-toc__label">${e.title}</span>
-                                    ${t<9?T`<span class="page-toc__key">${t+1}</span>`:v}
+                                    ${t<9?w`<span class="page-toc__key">${t+1}</span>`:_}
                                 </a>
                             `)}
                         </nav>
                     </aside>
-                `:v}
+                `:_}
             </div>
             <div class="form-footer">
-                ${e?.footer?.map(e=>F(this,e,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData))}
+                ${e?.footer?.map(e=>P(this,e,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData))}
             </div>
-        `}</div>`}static{this.styles=h`
+        `}</div>`}static{this.styles=m`
         /* Design-system hook: background behind the page header (the RDS "Header + Background"
            band) — transparent by default; the Redwood renderer paints it with the canvas color
            via a custom property, so the header reads as part of the canvas and the content slab
@@ -6138,7 +6138,7 @@ ${i}
             background: #fdf2f2;
             border-leftx: 4px solid var(--lumo-error-color);
         }
-    `}};k([y()],J.prototype,`component`,void 0),k([y()],J.prototype,`baseUrl`,void 0),k([y()],J.prototype,`state`,void 0),k([y()],J.prototype,`data`,void 0),k([y()],J.prototype,`appState`,void 0),k([y()],J.prototype,`appData`,void 0),k([y()],J.prototype,`value`,void 0),k([y({type:Boolean})],J.prototype,`standalone`,void 0),k([C()],J.prototype,`actionBanners`,void 0),k([C()],J.prototype,`dismissedStaticBannerIndices`,void 0),k([C()],J.prototype,`_tocEntries`,void 0),k([C()],J.prototype,`_activeToc`,void 0),k([C()],J.prototype,`_tocVisible`,void 0),J=k([g(`mateu-page`)],J);var za=h`
+    `}};O([v()],q.prototype,`component`,void 0),O([v()],q.prototype,`baseUrl`,void 0),O([v()],q.prototype,`state`,void 0),O([v()],q.prototype,`data`,void 0),O([v()],q.prototype,`appState`,void 0),O([v()],q.prototype,`appData`,void 0),O([v()],q.prototype,`value`,void 0),O([v({type:Boolean})],q.prototype,`standalone`,void 0),O([S()],q.prototype,`actionBanners`,void 0),O([S()],q.prototype,`dismissedStaticBannerIndices`,void 0),O([S()],q.prototype,`_tocEntries`,void 0),O([S()],q.prototype,`_activeToc`,void 0),O([S()],q.prototype,`_tocVisible`,void 0),q=O([h(`mateu-page`)],q);var Ba=m`
     .nbtn {
         display: inline-flex;
         align-items: center;
@@ -6167,47 +6167,47 @@ ${i}
     }
     .nbtn.primary:hover { background: var(--lumo-primary-color, #1676f3); filter: brightness(1.08); }
     .nbtn svg { width: 1em; height: 1em; flex-shrink: 0; }
-`,Ba=e=>w`
+`,Va=e=>C`
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-         stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${e}</svg>`,Va=Ba(w`
+         stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${e}</svg>`,Ha=Va(C`
     <circle cx="12" cy="12" r="3"></circle>
-    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path>`),Ha=Ba(w`
+    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path>`),Ua=Va(C`
     <line x1="12" y1="5" x2="12" y2="19"></line>
-    <line x1="5" y1="12" x2="19" y2="12"></line>`),Ua=Ba(w`
+    <line x1="5" y1="12" x2="19" y2="12"></line>`),Wa=Va(C`
     <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
     <polyline points="7 10 12 15 17 10"></polyline>
-    <line x1="12" y1="15" x2="12" y2="3"></line>`);Ba(w`
+    <line x1="12" y1="15" x2="12" y2="3"></line>`);Va(C`
     <rect x="9" y="2" width="6" height="5" rx="1"></rect>
     <rect x="2" y="17" width="6" height="5" rx="1"></rect>
     <rect x="16" y="17" width="6" height="5" rx="1"></rect>
-    <path d="M12 7v4M5 17v-3h14v3M12 11v3"></path>`);var Wa=Ba(w`
+    <path d="M12 7v4M5 17v-3h14v3M12 11v3"></path>`);var Ga=Va(C`
     <rect x="9" y="2" width="6" height="12" rx="3"></rect>
     <path d="M5 10v1a7 7 0 0 0 14 0v-1"></path>
-    <line x1="12" y1="18" x2="12" y2="22"></line>`),Ga=Ba(w`
+    <line x1="12" y1="18" x2="12" y2="22"></line>`),Ka=Va(C`
     <line x1="18" y1="6" x2="6" y2="18"></line>
-    <line x1="6" y1="6" x2="18" y2="18"></line>`),Ka=[`#e91e63`,`#1676f3`,`#10b981`,`#8b5cf6`,`#f59e0b`,`#ef4444`],qa=e=>Ka[Math.abs(e??0)%Ka.length],Ja=e=>(e??`?`).split(/\s+/).filter(e=>e).map(e=>e[0]).slice(0,2).join(``).toUpperCase()||`?`,Y=class extends b{constructor(...e){super(...e),this.localAgentUrl=`http://127.0.0.1:8776`,this.localAgentAlive=!1,this.menu=[],this.chatSessionId=E(),this.menuContextSent=!1,this.attachments=[],this.uploading=!1,this.expanded=!1,this.toggleExpanded=()=>{this.expanded=!this.expanded},this.items=[],this.listening=!1,this.recognitionAvailable=!1,this.loading=!1,this.elapsedSeconds=0,this.startListening=()=>{this.recognition&&(this.listening?(this.recognition.stop(),this.listening=!1):(this.recognition.start(),this.listening=!0))},this.onSpeechResult=e=>{if(this.recognition){let t=e,n=t.results[t.results[0].length-1][0].transcript;this.messageInputElement&&(this.messageInputElement.value=n,this.send(new CustomEvent(`submit`,{detail:{value:n},bubbles:!0,composed:!0})))}},this.probeLocalAgent=async()=>{if(this.localAgentUrl)try{let e=new AbortController,t=setTimeout(()=>e.abort(),1200),n=await fetch(this.localAgentUrl+`/health`,{signal:e.signal});clearTimeout(t),this.localAgentAlive=n.ok}catch{this.localAgentAlive=!1}},this.pickFiles=()=>this.fileInputElement?.click(),this.onFilesPicked=async e=>{let t=e.target,n=Array.from(t.files??[]);if(t.value=``,!(!n.length||!this.uploadUrl)){this.uploading=!0;try{let e=new FormData;e.append(`sessionId`,this.chatSessionId);for(let t of n)e.append(`files`,t,t.name);let t={},r=localStorage.getItem(`__mateu_auth_token`);r&&(t.Authorization=`Bearer `+r);let i=sessionStorage.getItem(`__mateu_sesion_id`);i&&(t[`X-Session-Id`]=i);let a=await fetch(this.uploadUrl,{method:`POST`,headers:t,body:e});if(!a.ok)throw Error(`Upload failed: ${a.status}`);let o=((await a.json()).files??[]).filter(e=>e&&e.path);this.attachments=[...this.attachments,...o]}catch(e){this.addMessage(`⚠️ No se pudieron subir los ficheros: ${e instanceof Error?e.message:e}`,`agent`)}finally{this.uploading=!1}}},this.removeAttachment=e=>{this.attachments=this.attachments.filter(t=>t.path!==e)},this.send=async e=>{this.messageInputElement?.setAttribute(`disabled`,`disabled`);let t=e.detail.value.trim(),n=this.localAgentAlive?this.localAgentUrl+`/mateu/agent/stream`:this.sseUrl,r=this.attachments;if(!t&&r.length===0||!n)return;let i=r.length?`${t}${t?`
+    <line x1="6" y1="6" x2="18" y2="18"></line>`),qa=[`#e91e63`,`#1676f3`,`#10b981`,`#8b5cf6`,`#f59e0b`,`#ef4444`],Ja=e=>qa[Math.abs(e??0)%qa.length],Ya=e=>(e??`?`).split(/\s+/).filter(e=>e).map(e=>e[0]).slice(0,2).join(``).toUpperCase()||`?`,J=class extends y{constructor(...e){super(...e),this.localAgentUrl=`http://127.0.0.1:8776`,this.localAgentAlive=!1,this.menu=[],this.chatSessionId=T(),this.menuContextSent=!1,this.attachments=[],this.uploading=!1,this.expanded=!1,this.toggleExpanded=()=>{this.expanded=!this.expanded},this.items=[],this.listening=!1,this.recognitionAvailable=!1,this.loading=!1,this.elapsedSeconds=0,this.startListening=()=>{this.recognition&&(this.listening?(this.recognition.stop(),this.listening=!1):(this.recognition.start(),this.listening=!0))},this.onSpeechResult=e=>{if(this.recognition){let t=e,n=t.results[t.results[0].length-1][0].transcript;this.messageInputElement&&(this.messageInputElement.value=n,this.send(new CustomEvent(`submit`,{detail:{value:n},bubbles:!0,composed:!0})))}},this.probeLocalAgent=async()=>{if(this.localAgentUrl)try{let e=new AbortController,t=setTimeout(()=>e.abort(),1200),n=await fetch(this.localAgentUrl+`/health`,{signal:e.signal});clearTimeout(t),this.localAgentAlive=n.ok}catch{this.localAgentAlive=!1}},this.pickFiles=()=>this.fileInputElement?.click(),this.onFilesPicked=async e=>{let t=e.target,n=Array.from(t.files??[]);if(t.value=``,!(!n.length||!this.uploadUrl)){this.uploading=!0;try{let e=new FormData;e.append(`sessionId`,this.chatSessionId);for(let t of n)e.append(`files`,t,t.name);let t={},r=localStorage.getItem(`__mateu_auth_token`);r&&(t.Authorization=`Bearer `+r);let i=sessionStorage.getItem(`__mateu_sesion_id`);i&&(t[`X-Session-Id`]=i);let a=await fetch(this.uploadUrl,{method:`POST`,headers:t,body:e});if(!a.ok)throw Error(`Upload failed: ${a.status}`);let o=((await a.json()).files??[]).filter(e=>e&&e.path);this.attachments=[...this.attachments,...o]}catch(e){this.addMessage(`⚠️ No se pudieron subir los ficheros: ${e instanceof Error?e.message:e}`,`agent`)}finally{this.uploading=!1}}},this.removeAttachment=e=>{this.attachments=this.attachments.filter(t=>t.path!==e)},this.send=async e=>{this.messageInputElement?.setAttribute(`disabled`,`disabled`);let t=e.detail.value.trim(),n=this.localAgentAlive?this.localAgentUrl+`/mateu/agent/stream`:this.sseUrl,r=this.attachments;if(!t&&r.length===0||!n)return;let i=r.length?`${t}${t?`
 
 `:``}📎 ${r.map(e=>e.name).join(`, `)}`:t;this.addMessage(i,`user`),this.attachments=[];let a=this.addMessage(``,`agent`);this.startLoading();let o=``;try{let e={Accept:`text/event-stream`,"Content-Type":`application/json`},i=localStorage.getItem(`__mateu_auth_token`);i&&(e.Authorization=`Bearer `+i);let s=sessionStorage.getItem(`__mateu_sesion_id`);s&&(e[`X-Session-Id`]=s);let c=this.contextProvider?.(),l=JSON.stringify({message:t,sessionId:this.chatSessionId,...r.length&&{attachments:r},...c!=null&&{context:c},...this.mcpUrl&&{mcpUrl:new URL(this.mcpUrl,window.location.origin).href},...!this.menuContextSent&&{menuContext:this.buildMenuContext(this.menu)}});this.menuContextSent=!0;let u=await fetch(n,{method:`POST`,headers:e,body:l});if(!u.ok){let e=await u.text();throw Error(`Servidor respondió ${u.status}: ${e}`)}let d=u.body?.getReader();if(!d)throw Error(`No se pudo obtener el reader del stream.`);let f=new TextDecoder,p=``;for(;;){let{done:e,value:t}=await d.read();if(e){if(p.trim().startsWith(`data:`)){let e=p.trim().slice(5).trim(),t=this.tryParseTokenUsage(e),n=!t&&this.tryParseCustomEvent(e);t?this.tokenUsage={...this.tokenUsage,...t}:n?n.event===`agent-error`?(o=`⚠️ `+(n.detail?.message??`Error desconocido del agente`),this.updateMessage(a,o)):this.dispatchEvent(new CustomEvent(n.event,{detail:n.detail,bubbles:!0,composed:!0})):(o+=e,this.updateMessage(a,o))}break}let n=f.decode(t,{stream:!0});p+=n;let r=p.split(`
 `);p=r.pop()||``;let i=!1;for(let e of r)if(e.trim().startsWith(`data:`)){let t=e.trim().slice(5).trim(),n=this.tryParseTokenUsage(t),r=!n&&this.tryParseCustomEvent(t);n?this.tokenUsage={...this.tokenUsage,...n}:r?r.event===`agent-error`?(o=`⚠️ `+(r.detail?.message??`Error desconocido del agente`),this.updateMessage(a,o)):this.dispatchEvent(new CustomEvent(r.event,{detail:r.detail,bubbles:!0,composed:!0})):(o+=t+`
-`,i=!0)}i&&this.updateMessage(a,o)}o||this.updateMessage(a,`⚠️ El agente no devolvió ninguna respuesta. Comprueba que el LLM está configurado correctamente (API key).`)}catch(e){console.error(`Error en el flujo SSE:`,e);let t=e?.message??String(e);(t===`Failed to fetch`||t===`network error`||t===`Load failed`)&&!o?this.updateMessage(a,`⚠️ No se recibió respuesta del agente. El servidor cerró la conexión sin enviar datos — comprueba que el LLM tiene la API key configurada y está disponible.`):this.updateMessage(a,`⚠️ Error: `+t)}finally{this.stopLoading(),setTimeout(()=>{this.messageInputElement&&(this.messageInputElement.value=``)},250),this.messageInputElement?.removeAttribute(`disabled`),this.messageInputElement?.focus()}},this.closeChat=()=>{this.dispatchEvent(new CustomEvent(`close-requested`,{bubbles:!0,composed:!0}))},this.submitFromInput=()=>{let e=this.messageInputElement?.value?.trim()??``;e&&this.send(new CustomEvent(`submit`,{detail:{value:e},bubbles:!0,composed:!0}))},this.onInputKeydown=e=>{e.key===`Enter`&&(e.preventDefault(),this.submitFromInput())}}connectedCallback(){super.connectedCallback(),this.probeLocalAgent();let e=window.SpeechRecognition||window.webkitSpeechRecognition;if(e){let t=new e;this.recognition=t,t.lang=`es-ES`,t.onend=()=>{setTimeout(()=>{if(this.listening&&this.recognition)try{this.recognition.start()}catch{}},250)},this.recognitionAvailable=!0,t.onresult=this.onSpeechResult,t.onerror=e=>{console.error(`Error de reconocimiento: `+e.error),this.listening&&this.recognition&&setTimeout(()=>{this.recognition.start()},250)}}}scrollBottom(){setTimeout(()=>{this.scrollContainer&&this.scrollContainer.scrollTo({top:this.scrollContainer.scrollHeight,behavior:`smooth`})},0)}addMessage(e,t){let n={text:e,time:new Date().toLocaleTimeString(),userName:t.includes(`agent`)?`Asistente`:`Tú`,userColorIndex:t.includes(`agent`)?2:1};return this.items=[...this.items,n],this.scrollBottom(),this.items.length-1}updateMessage(e,t){this.items=this.items.map((n,r)=>r===e?{...n,text:t}:n),this.scrollBottom()}tryParseCustomEvent(e){let t=e.trim();if(!t.startsWith(`{`))return null;try{let e=JSON.parse(t);if(typeof e.event==`string`)return{event:e.event,detail:e.detail??{}}}catch{}return null}tryParseTokenUsage(e){let t=e.trim();if(!t.startsWith(`{`))return null;try{let e=JSON.parse(t);if(`inputTokens`in e||`outputTokens`in e||`totalTokens`in e)return e}catch{}return null}buildMenuContext(e,t=[]){let n=[];for(let r of e){if(r.separator||r.remote)continue;let e=[...t,r.label];if(r.submenus&&r.submenus.length>0)n.push(...this.buildMenuContext(r.submenus,e));else{let t={path:e,navigation:{route:r.route,consumedRoute:r.consumedRoute,actionId:r.actionId??``,baseUrl:r.baseUrl,serverSideType:r.serverSideType,uriPrefix:r.uriPrefix}};r.description&&(t.description=r.description),n.push(t)}}return n}startLoading(){this.loading=!0,this.elapsedSeconds=0,this._elapsedTimer=setInterval(()=>{this.elapsedSeconds++},1e3)}stopLoading(){this.loading=!1,clearInterval(this._elapsedTimer),this._elapsedTimer=void 0}render(){return T`
+`,i=!0)}i&&this.updateMessage(a,o)}o||this.updateMessage(a,`⚠️ El agente no devolvió ninguna respuesta. Comprueba que el LLM está configurado correctamente (API key).`)}catch(e){console.error(`Error en el flujo SSE:`,e);let t=e?.message??String(e);(t===`Failed to fetch`||t===`network error`||t===`Load failed`)&&!o?this.updateMessage(a,`⚠️ No se recibió respuesta del agente. El servidor cerró la conexión sin enviar datos — comprueba que el LLM tiene la API key configurada y está disponible.`):this.updateMessage(a,`⚠️ Error: `+t)}finally{this.stopLoading(),setTimeout(()=>{this.messageInputElement&&(this.messageInputElement.value=``)},250),this.messageInputElement?.removeAttribute(`disabled`),this.messageInputElement?.focus()}},this.closeChat=()=>{this.dispatchEvent(new CustomEvent(`close-requested`,{bubbles:!0,composed:!0}))},this.submitFromInput=()=>{let e=this.messageInputElement?.value?.trim()??``;e&&this.send(new CustomEvent(`submit`,{detail:{value:e},bubbles:!0,composed:!0}))},this.onInputKeydown=e=>{e.key===`Enter`&&(e.preventDefault(),this.submitFromInput())}}connectedCallback(){super.connectedCallback(),this.probeLocalAgent();let e=window.SpeechRecognition||window.webkitSpeechRecognition;if(e){let t=new e;this.recognition=t,t.lang=`es-ES`,t.onend=()=>{setTimeout(()=>{if(this.listening&&this.recognition)try{this.recognition.start()}catch{}},250)},this.recognitionAvailable=!0,t.onresult=this.onSpeechResult,t.onerror=e=>{console.error(`Error de reconocimiento: `+e.error),this.listening&&this.recognition&&setTimeout(()=>{this.recognition.start()},250)}}}scrollBottom(){setTimeout(()=>{this.scrollContainer&&this.scrollContainer.scrollTo({top:this.scrollContainer.scrollHeight,behavior:`smooth`})},0)}addMessage(e,t){let n={text:e,time:new Date().toLocaleTimeString(),userName:t.includes(`agent`)?`Asistente`:`Tú`,userColorIndex:t.includes(`agent`)?2:1};return this.items=[...this.items,n],this.scrollBottom(),this.items.length-1}updateMessage(e,t){this.items=this.items.map((n,r)=>r===e?{...n,text:t}:n),this.scrollBottom()}tryParseCustomEvent(e){let t=e.trim();if(!t.startsWith(`{`))return null;try{let e=JSON.parse(t);if(typeof e.event==`string`)return{event:e.event,detail:e.detail??{}}}catch{}return null}tryParseTokenUsage(e){let t=e.trim();if(!t.startsWith(`{`))return null;try{let e=JSON.parse(t);if(`inputTokens`in e||`outputTokens`in e||`totalTokens`in e)return e}catch{}return null}buildMenuContext(e,t=[]){let n=[];for(let r of e){if(r.separator||r.remote)continue;let e=[...t,r.label];if(r.submenus&&r.submenus.length>0)n.push(...this.buildMenuContext(r.submenus,e));else{let t={path:e,navigation:{route:r.route,consumedRoute:r.consumedRoute,actionId:r.actionId??``,baseUrl:r.baseUrl,serverSideType:r.serverSideType,uriPrefix:r.uriPrefix}};r.description&&(t.description=r.description),n.push(t)}}return n}startLoading(){this.loading=!0,this.elapsedSeconds=0,this._elapsedTimer=setInterval(()=>{this.elapsedSeconds++},1e3)}stopLoading(){this.loading=!1,clearInterval(this._elapsedTimer),this._elapsedTimer=void 0}render(){return w`
             <div class="chat-container">
                 <div class="chat-header">
                     <span class="chat-title">AI Assistant</span>
-                    ${this.localAgentAlive?T`<span class="local-agent-badge" title="Hablando con tu CLI local (companion en ${this.localAgentUrl}) — sin api key">agente local</span>`:v}
+                    ${this.localAgentAlive?w`<span class="local-agent-badge" title="Hablando con tu CLI local (companion en ${this.localAgentUrl}) — sin api key">agente local</span>`:_}
                     <button class="chat-icon-btn" @click="${this.toggleExpanded}"
                             title="${this.expanded?`Contraer`:`Expandir a pantalla completa`}"
                             aria-label="${this.expanded?`Contraer el chat`:`Expandir el chat`}">
                         ${this.expanded?`⤡`:`⤢`}
                     </button>
                     <button class="chat-close" @click="${this.closeChat}" title="Cerrar">
-                        ${Ga}
+                        ${Ka}
                     </button>
                 </div>
                 <div class="scroll-container">
                     <div class="message-list" role="list">
-                        ${this.items.map(e=>T`
+                        ${this.items.map(e=>w`
                             <div class="message" role="listitem">
-                                <div class="avatar" style="background: ${qa(e.userColorIndex)};">${Ja(e.userName)}</div>
+                                <div class="avatar" style="background: ${Ja(e.userColorIndex)};">${Ya(e.userName)}</div>
                                 <div class="message-body">
                                     <div class="message-meta">
                                         <span class="message-name">${e.userName}</span>
@@ -6219,43 +6219,43 @@ ${i}
                         `)}
                     </div>
                 </div>
-                ${this.tokenUsage?T`
+                ${this.tokenUsage?w`
                     <div class="token-bar">
                         <span class="token-label">Tokens:</span>
-                        ${this.tokenUsage.inputTokens==null?v:T`<span class="token-chip">in&nbsp;<strong>${this.tokenUsage.inputTokens}</strong></span>`}
-                        ${this.tokenUsage.outputTokens==null?v:T`<span class="token-chip">out&nbsp;<strong>${this.tokenUsage.outputTokens}</strong></span>`}
-                        ${this.tokenUsage.totalTokens==null?v:T`<span class="token-chip">total&nbsp;<strong>${this.tokenUsage.totalTokens}</strong></span>`}
+                        ${this.tokenUsage.inputTokens==null?_:w`<span class="token-chip">in&nbsp;<strong>${this.tokenUsage.inputTokens}</strong></span>`}
+                        ${this.tokenUsage.outputTokens==null?_:w`<span class="token-chip">out&nbsp;<strong>${this.tokenUsage.outputTokens}</strong></span>`}
+                        ${this.tokenUsage.totalTokens==null?_:w`<span class="token-chip">total&nbsp;<strong>${this.tokenUsage.totalTokens}</strong></span>`}
                     </div>
-                `:v}
-                ${this.loading?T`
+                `:_}
+                ${this.loading?w`
                     <div class="loading-bar">
                         <span class="spinner"></span>
                         <span class="loading-text">Thinking… ${this.elapsedSeconds}s</span>
                     </div>
-                `:v}
-                ${this.attachments.length?T`
+                `:_}
+                ${this.attachments.length?w`
                     <div class="attachments">
-                        ${this.attachments.map(e=>T`
+                        ${this.attachments.map(e=>w`
                             <span class="attachment-chip" title="${e.path}">
                                 📎 ${e.name}
                                 <button class="attachment-remove" @click="${()=>this.removeAttachment(e.path)}" aria-label="Quitar ${e.name}">✕</button>
                             </span>`)}
                     </div>
-                `:v}
+                `:_}
                 <div class="input-bar">
-                    ${this.uploadUrl?T`
+                    ${this.uploadUrl?w`
                         <button class="mic-btn" title="Adjuntar ficheros"
                                 @click="${this.pickFiles}" ?disabled="${this.uploading}"
                                 aria-label="Adjuntar ficheros">${this.uploading?`…`:`📎`}</button>
                         <input class="file-input" type="file" multiple hidden
                                @change="${this.onFilesPicked}"/>
-                    `:v}
+                    `:_}
                     <button class="mic-btn"
                             title="Dictar"
                             style="color: ${this.listening?`red`:`var(--lumo-contrast-50pct, #767676)`};"
                             @click="${this.startListening}"
                             ?disabled="${!this.recognitionAvailable}"
-                    >${Wa}</button>
+                    >${Ga}</button>
                     <input class="msg-input"
                            placeholder="Message"
                            aria-label="Message"
@@ -6263,7 +6263,7 @@ ${i}
                     <button class="nbtn primary" ?disabled="${this.loading}" @click="${this.submitFromInput}">Send</button>
                 </div>
             </div>
-        `}static{this.styles=[za,h`
+        `}static{this.styles=[Ba,m`
         :host {
             display: block;
             height: 100%;
@@ -6588,14 +6588,14 @@ ${i}
         @keyframes spin {
             to { transform: rotate(360deg); }
         }
-    `]}};k([y({attribute:!1})],Y.prototype,`contextProvider`,void 0),k([y()],Y.prototype,`localAgentUrl`,void 0),k([y({attribute:!1})],Y.prototype,`mcpUrl`,void 0),k([C()],Y.prototype,`localAgentAlive`,void 0),k([y()],Y.prototype,`sseUrl`,void 0),k([y()],Y.prototype,`uploadUrl`,void 0),k([y({attribute:!1})],Y.prototype,`menu`,void 0),k([C()],Y.prototype,`attachments`,void 0),k([C()],Y.prototype,`uploading`,void 0),k([x(`.file-input`)],Y.prototype,`fileInputElement`,void 0),k([y({type:Boolean,reflect:!0})],Y.prototype,`expanded`,void 0),k([y()],Y.prototype,`items`,void 0),k([x(`.scroll-container`)],Y.prototype,`scrollContainer`,void 0),k([x(`.msg-input`)],Y.prototype,`messageInputElement`,void 0),k([C()],Y.prototype,`recognition`,void 0),k([C()],Y.prototype,`listening`,void 0),k([C()],Y.prototype,`recognitionAvailable`,void 0),k([C()],Y.prototype,`loading`,void 0),k([C()],Y.prototype,`elapsedSeconds`,void 0),k([C()],Y.prototype,`tokenUsage`,void 0),Y=k([g(`mateu-chat`)],Y);var Ya=class extends b{updated(e){super.updated(e),this.chart&&=(this.chart.destroy(),void 0),this.data&&this.createChart(this.data)}async createChart(e){let[{default:t}]=await Promise.all([D(()=>import(`./vendor-chartjs.js`).then(e=>e.n),__vite__mapDeps([3,1])),D(()=>import(`./vendor-chartjs.js`).then(e=>e.t),__vite__mapDeps([3,1]))]);if(e!==this.data)return;this.chart&&this.chart.destroy();let n={type:this.type,data:this.data,options:this.options};this.chart=new t(this.chartElement,n)}handleSlotChange(){}render(){return T`
+    `]}};O([v({attribute:!1})],J.prototype,`contextProvider`,void 0),O([v()],J.prototype,`localAgentUrl`,void 0),O([v({attribute:!1})],J.prototype,`mcpUrl`,void 0),O([S()],J.prototype,`localAgentAlive`,void 0),O([v()],J.prototype,`sseUrl`,void 0),O([v()],J.prototype,`uploadUrl`,void 0),O([v({attribute:!1})],J.prototype,`menu`,void 0),O([S()],J.prototype,`attachments`,void 0),O([S()],J.prototype,`uploading`,void 0),O([b(`.file-input`)],J.prototype,`fileInputElement`,void 0),O([v({type:Boolean,reflect:!0})],J.prototype,`expanded`,void 0),O([v()],J.prototype,`items`,void 0),O([b(`.scroll-container`)],J.prototype,`scrollContainer`,void 0),O([b(`.msg-input`)],J.prototype,`messageInputElement`,void 0),O([S()],J.prototype,`recognition`,void 0),O([S()],J.prototype,`listening`,void 0),O([S()],J.prototype,`recognitionAvailable`,void 0),O([S()],J.prototype,`loading`,void 0),O([S()],J.prototype,`elapsedSeconds`,void 0),O([S()],J.prototype,`tokenUsage`,void 0),J=O([h(`mateu-chat`)],J);var Xa=class extends y{updated(e){super.updated(e),this.chart&&=(this.chart.destroy(),void 0),this.data&&this.createChart(this.data)}async createChart(e){let[{default:t}]=await Promise.all([E(()=>import(`./vendor-chartjs.js`).then(e=>e.n),__vite__mapDeps([3,1])),E(()=>import(`./vendor-chartjs.js`).then(e=>e.t),__vite__mapDeps([3,1]))]);if(e!==this.data)return;this.chart&&this.chart.destroy();let n={type:this.type,data:this.data,options:this.options};this.chart=new t(this.chartElement,n)}handleSlotChange(){}render(){return w`
             <div class="container">
                 <canvas id="chart"></canvas>
             </div>
             <div style="display: none;">
                 <slot @slotchange=${this.handleSlotChange}></slot>
             </div>
-       `}static{this.styles=h`
+       `}static{this.styles=m`
     /* the host's inline height (Chart.style) must reach the canvas parent — chart.js
        measures .container to size the canvas when maintainAspectRatio is false */
     :host {
@@ -6605,7 +6605,7 @@ ${i}
         height: 100%;
         position: relative;
     }
-  `}};k([y()],Ya.prototype,`type`,void 0),k([y()],Ya.prototype,`data`,void 0),k([y()],Ya.prototype,`options`,void 0),k([x(`#chart`)],Ya.prototype,`chartElement`,void 0),Ya=k([g(`mateu-chart`)],Ya);var Xa=class extends b{updated(e){super.updated(e),this.chart&&=(this.chart.destroy(),void 0),this.xml&&this.createViewer(this.xml)}async createViewer(e){let{default:t}=await D(async()=>{let{default:e}=await import(`./vendor-diagrams.js`).then(e=>e.t);return{default:e}},__vite__mapDeps([4,1,2]));if(e!==this.xml)return;this.chart&&this.chart.destroy();let n={container:this.divElement};this.chart=new t(n),this.chart.importXML(e)}handleSlotChange(){}render(){return T`
+  `}};O([v()],Xa.prototype,`type`,void 0),O([v()],Xa.prototype,`data`,void 0),O([v()],Xa.prototype,`options`,void 0),O([b(`#chart`)],Xa.prototype,`chartElement`,void 0),Xa=O([h(`mateu-chart`)],Xa);var Za=class extends y{updated(e){super.updated(e),this.chart&&=(this.chart.destroy(),void 0),this.xml&&this.createViewer(this.xml)}async createViewer(e){let{default:t}=await E(async()=>{let{default:e}=await import(`./vendor-diagrams.js`).then(e=>e.t);return{default:e}},__vite__mapDeps([4,1,2]));if(e!==this.xml)return;this.chart&&this.chart.destroy();let n={container:this.divElement};this.chart=new t(n),this.chart.importXML(e)}handleSlotChange(){}render(){return w`
             <div class="container" style="width: 20rem; height: 15rem; overflow: auto;">
                 <!-- BPMN diagram container -->
                 <div id="canvas" style="width: 60rem; height: 30rem; zoom: 0.5;"></div>
@@ -6613,8 +6613,8 @@ ${i}
             <div style="display: none;">
                 <slot @slotchange=${this.handleSlotChange}></slot>
             </div>
-       `}static{this.styles=h`
-  `}};k([y()],Xa.prototype,`xml`,void 0),k([x(`#canvas`)],Xa.prototype,`divElement`,void 0),Xa=k([g(`mateu-bpmn`)],Xa);var Za=160,Qa=56,$a=220,eo=110,to=60,no={ACTION:`#3B82F6`,JOIN:`#8B5CF6`,FORK:`#F59E0B`,END:`#EF4444`,USER_TASK:`#10B981`,PROCESS:`#6366F1`},ro={ACTION:`▶`,JOIN:`⟨`,FORK:`⟩`,END:`◼`,USER_TASK:`👤`,PROCESS:`⚙`},io=[`ACTION`,`JOIN`,`FORK`,`END`,`USER_TASK`,`PROCESS`];function ao(){return`step-`+Math.random().toString(36).slice(2,8)}var oo=class extends b{constructor(...e){super(...e),this.value=`{"name":"New Workflow","steps":[]}`,this.wf={name:`New Workflow`,steps:[]},this.positions={},this.selectedId=null,this.showMeta=!1,this.draggingId=null,this.dragOffset={x:0,y:0},this.svgEl=null,this.onMouseMove=e=>{if(!this.draggingId||!this.svgEl)return;let t=this.toSvgPoint(e);this.positions={...this.positions,[this.draggingId]:{x:Math.max(0,t.x-this.dragOffset.x),y:Math.max(0,t.y-this.dragOffset.y)}}},this.onMouseUp=()=>{this.draggingId=null,window.removeEventListener(`mousemove`,this.onMouseMove),window.removeEventListener(`mouseup`,this.onMouseUp)}}updated(e){if(e.has(`value`)){try{this.wf=JSON.parse(this.value)}catch{}this.autoLayout()}}autoLayout(){let e=this.wf.steps??[],t={};e.forEach(e=>{t[e.id]=0});let n=!0;for(;n;)n=!1,e.forEach(e=>{if(e.preconditionStepId!=null&&t[e.preconditionStepId]!==void 0){let r=t[e.preconditionStepId]+1;r>t[e.id]&&(t[e.id]=r,n=!0)}});let r={};e.forEach(e=>{let n=t[e.id]??0;(r[n]??=[]).push(e.id)});let i={...this.positions},a=!1;Object.entries(r).forEach(([e,t])=>{let n=Number(e);t.forEach((e,t)=>{i[e]||(i[e]={x:to+n*$a,y:to+t*eo},a=!0)})}),a&&(this.positions=i)}emit(){let e=JSON.stringify(this.wf,null,2);this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e},bubbles:!0,composed:!0}))}updateWf(e){this.wf={...this.wf,...e},this.emit()}updateStep(e,t){this.wf={...this.wf,steps:this.wf.steps.map(n=>n.id===e?{...n,...t}:n)},this.emit()}addStep(){let e=ao(),t={id:e,type:`ACTION`,name:`New Step`};this.wf={...this.wf,steps:[...this.wf.steps??[],t]};let n=Object.values(this.positions).map(e=>e.y),r=n.length?Math.max(...n)+eo:to;this.positions={...this.positions,[e]:{x:to,y:r}},this.selectedId=e,this.emit()}deleteStep(e){this.wf={...this.wf,steps:this.wf.steps.filter(t=>t.id!==e).map(t=>t.preconditionStepId===e?{...t,preconditionStepId:void 0}:t)};let{[e]:t,...n}=this.positions;this.positions=n,this.selectedId===e&&(this.selectedId=null),this.emit()}onNodeMouseDown(e,t){e.preventDefault(),this.draggingId=t;let n=this.positions[t]??{x:0,y:0},r=this.toSvgPoint(e);this.dragOffset={x:r.x-n.x,y:r.y-n.y},this.svgEl=e.currentTarget.closest(`svg`),window.addEventListener(`mousemove`,this.onMouseMove),window.addEventListener(`mouseup`,this.onMouseUp)}toSvgPoint(e){if(!this.svgEl)return{x:0,y:0};let t=this.svgEl.getBoundingClientRect();return{x:e.clientX-t.left,y:e.clientY-t.top}}canvasSize(){let e=Object.values(this.positions),t=e.length?Math.max(...e.map(e=>e.x))+Za+to:600,n=e.length?Math.max(...e.map(e=>e.y))+Qa+to:400;return{w:Math.max(t,600),h:Math.max(n,400)}}render(){let{w:e,h:t}=this.canvasSize(),n=this.wf.steps??[];return T`
+       `}static{this.styles=m`
+  `}};O([v()],Za.prototype,`xml`,void 0),O([b(`#canvas`)],Za.prototype,`divElement`,void 0),Za=O([h(`mateu-bpmn`)],Za);var Qa=160,$a=56,eo=220,to=110,no=60,ro={ACTION:`#3B82F6`,JOIN:`#8B5CF6`,FORK:`#F59E0B`,END:`#EF4444`,USER_TASK:`#10B981`,PROCESS:`#6366F1`},io={ACTION:`▶`,JOIN:`⟨`,FORK:`⟩`,END:`◼`,USER_TASK:`👤`,PROCESS:`⚙`},ao=[`ACTION`,`JOIN`,`FORK`,`END`,`USER_TASK`,`PROCESS`];function oo(){return`step-`+Math.random().toString(36).slice(2,8)}var so=class extends y{constructor(...e){super(...e),this.value=`{"name":"New Workflow","steps":[]}`,this.wf={name:`New Workflow`,steps:[]},this.positions={},this.selectedId=null,this.showMeta=!1,this.draggingId=null,this.dragOffset={x:0,y:0},this.svgEl=null,this.onMouseMove=e=>{if(!this.draggingId||!this.svgEl)return;let t=this.toSvgPoint(e);this.positions={...this.positions,[this.draggingId]:{x:Math.max(0,t.x-this.dragOffset.x),y:Math.max(0,t.y-this.dragOffset.y)}}},this.onMouseUp=()=>{this.draggingId=null,window.removeEventListener(`mousemove`,this.onMouseMove),window.removeEventListener(`mouseup`,this.onMouseUp)}}updated(e){if(e.has(`value`)){try{this.wf=JSON.parse(this.value)}catch{}this.autoLayout()}}autoLayout(){let e=this.wf.steps??[],t={};e.forEach(e=>{t[e.id]=0});let n=!0;for(;n;)n=!1,e.forEach(e=>{if(e.preconditionStepId!=null&&t[e.preconditionStepId]!==void 0){let r=t[e.preconditionStepId]+1;r>t[e.id]&&(t[e.id]=r,n=!0)}});let r={};e.forEach(e=>{let n=t[e.id]??0;(r[n]??=[]).push(e.id)});let i={...this.positions},a=!1;Object.entries(r).forEach(([e,t])=>{let n=Number(e);t.forEach((e,t)=>{i[e]||(i[e]={x:no+n*eo,y:no+t*to},a=!0)})}),a&&(this.positions=i)}emit(){let e=JSON.stringify(this.wf,null,2);this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e},bubbles:!0,composed:!0}))}updateWf(e){this.wf={...this.wf,...e},this.emit()}updateStep(e,t){this.wf={...this.wf,steps:this.wf.steps.map(n=>n.id===e?{...n,...t}:n)},this.emit()}addStep(){let e=oo(),t={id:e,type:`ACTION`,name:`New Step`};this.wf={...this.wf,steps:[...this.wf.steps??[],t]};let n=Object.values(this.positions).map(e=>e.y),r=n.length?Math.max(...n)+to:no;this.positions={...this.positions,[e]:{x:no,y:r}},this.selectedId=e,this.emit()}deleteStep(e){this.wf={...this.wf,steps:this.wf.steps.filter(t=>t.id!==e).map(t=>t.preconditionStepId===e?{...t,preconditionStepId:void 0}:t)};let{[e]:t,...n}=this.positions;this.positions=n,this.selectedId===e&&(this.selectedId=null),this.emit()}onNodeMouseDown(e,t){e.preventDefault(),this.draggingId=t;let n=this.positions[t]??{x:0,y:0},r=this.toSvgPoint(e);this.dragOffset={x:r.x-n.x,y:r.y-n.y},this.svgEl=e.currentTarget.closest(`svg`),window.addEventListener(`mousemove`,this.onMouseMove),window.addEventListener(`mouseup`,this.onMouseUp)}toSvgPoint(e){if(!this.svgEl)return{x:0,y:0};let t=this.svgEl.getBoundingClientRect();return{x:e.clientX-t.left,y:e.clientY-t.top}}canvasSize(){let e=Object.values(this.positions),t=e.length?Math.max(...e.map(e=>e.x))+Qa+no:600,n=e.length?Math.max(...e.map(e=>e.y))+$a+no:400;return{w:Math.max(t,600),h:Math.max(n,400)}}render(){let{w:e,h:t}=this.canvasSize(),n=this.wf.steps??[];return w`
             <div class="root">
                 ${this.renderToolbar()}
                 ${this.showMeta?this.renderMeta():``}
@@ -6635,25 +6635,25 @@ ${i}
                     ${this.selectedId?this.renderPanel():``}
                 </div>
             </div>
-        `}renderToolbar(){let e=this.wf.status??`DRAFT`;return T`
+        `}renderToolbar(){let e=this.wf.status??`DRAFT`;return w`
             <div class="toolbar">
                 <span class="wf-name">${this.wf.name}</span>
                 <span class="badge badge-${e.toLowerCase()}">${e}</span>
                 <div style="flex:1"></div>
                 <button class="nbtn" @click="${()=>this.showMeta=!this.showMeta}">
-                    ${Va}
+                    ${Ha}
                     Settings
                 </button>
                 <button class="nbtn primary" @click="${()=>this.addStep()}">
-                    ${Ha}
+                    ${Ua}
                     Add Step
                 </button>
                 <button class="nbtn" @click="${()=>this.exportJson()}">
-                    ${Ua}
+                    ${Wa}
                     Export
                 </button>
             </div>
-        `}renderMeta(){let e=this.wf;return T`
+        `}renderMeta(){let e=this.wf;return w`
             <div class="meta-panel">
                 <div class="meta-grid">
                     <label>Name</label>
@@ -6662,13 +6662,13 @@ ${i}
                     <textarea class="inp" rows="2" @change="${e=>this.updateWf({description:e.target.value})}">${e.description??``}</textarea>
                     <label>Status</label>
                     <select class="inp" @change="${e=>this.updateWf({status:e.target.value})}">
-                        ${[`DRAFT`,`ACTIVE`,`DISABLED`,`ARCHIVED`].map(t=>T`
+                        ${[`DRAFT`,`ACTIVE`,`DISABLED`,`ARCHIVED`].map(t=>w`
                             <option value="${t}" ?selected="${e.status===t}">${t}</option>`)}
                     </select>
                     <label>Limit concurrent</label>
                     <input type="checkbox" ?checked="${e.limitConcurrentExecutions}"
                            @change="${e=>this.updateWf({limitConcurrentExecutions:e.target.checked})}"/>
-                    ${e.limitConcurrentExecutions?T`
+                    ${e.limitConcurrentExecutions?w`
                         <label>Max concurrent</label>
                         <input class="inp" type="number" min="0" .value="${String(e.maxConcurrentExecutions??0)}"
                                @change="${e=>this.updateWf({maxConcurrentExecutions:Number(e.target.value)})}"/>
@@ -6678,38 +6678,38 @@ ${i}
                     `:``}
                 </div>
             </div>
-        `}renderArrow(e){if(!e.preconditionStepId)return w``;let t=this.positions[e.preconditionStepId],n=this.positions[e.id];if(!t||!n)return w``;let r=t.x+Za,i=t.y+Qa/2,a=n.x,o=n.y+Qa/2,s=(r+a)/2;return w`
+        `}renderArrow(e){if(!e.preconditionStepId)return C``;let t=this.positions[e.preconditionStepId],n=this.positions[e.id];if(!t||!n)return C``;let r=t.x+Qa,i=t.y+$a/2,a=n.x,o=n.y+$a/2,s=(r+a)/2;return C`
             <path d="M${r},${i} C${s},${i} ${s},${o} ${a},${o}"
                   fill="none" stroke="#94a3b8" stroke-width="2"
                   marker-end="url(#arrow)"/>
-        `}renderNode(e){let t=this.positions[e.id]??{x:to,y:to},n=no[e.type]??`#64748b`,r=ro[e.type]??`•`,i=this.selectedId===e.id;return w`
+        `}renderNode(e){let t=this.positions[e.id]??{x:no,y:no},n=ro[e.type]??`#64748b`,r=io[e.type]??`•`,i=this.selectedId===e.id;return C`
             <g transform="translate(${t.x},${t.y})"
                style="cursor:grab"
                @mousedown="${t=>this.onNodeMouseDown(t,e.id)}"
                @click="${t=>{t.stopPropagation(),this.selectedId=e.id}}">
-                <rect width="${Za}" height="${Qa}" rx="8"
+                <rect width="${Qa}" height="${$a}" rx="8"
                       fill="white"
                       stroke="${i?n:`#e2e8f0`}"
                       stroke-width="${i?2.5:1.5}"
                       filter="url(#shadow)"/>
                 <!-- type badge -->
-                <rect x="0" y="0" width="32" height="${Qa}" rx="8" fill="${n}" clip-path="inset(0 -8px 0 0 round 8px)"/>
-                <rect x="24" y="0" width="8" height="${Qa}" fill="${n}"/>
+                <rect x="0" y="0" width="32" height="${$a}" rx="8" fill="${n}" clip-path="inset(0 -8px 0 0 round 8px)"/>
+                <rect x="24" y="0" width="8" height="${$a}" fill="${n}"/>
                 <text x="16" y="${33}" text-anchor="middle"
                       font-size="14" fill="white">${r}</text>
                 <!-- name -->
-                <text x="44" y="${Qa/2-6}" font-size="11" fill="#1e293b" font-weight="600">
+                <text x="44" y="${$a/2-6}" font-size="11" fill="#1e293b" font-weight="600">
                     ${e.name.length>16?e.name.slice(0,15)+`…`:e.name}
                 </text>
                 <text x="44" y="${36}" font-size="9" fill="#94a3b8">${e.id}</text>
                 <text x="44" y="${48}" font-size="9" fill="${n}">${e.type}</text>
             </g>
-        `}renderPanel(){let e=this.wf.steps.find(e=>e.id===this.selectedId);if(!e)return``;let t=this.wf.steps.filter(t=>t.id!==e.id),n=(e,t)=>T`
+        `}renderPanel(){let e=this.wf.steps.find(e=>e.id===this.selectedId);if(!e)return``;let t=this.wf.steps.filter(t=>t.id!==e.id),n=(e,t)=>w`
             <div class="field">
                 <label class="field-label">${e}</label>
                 ${t}
             </div>
-        `;return T`
+        `;return w`
             <div class="properties">
                 <div class="prop-header">
                     <span>Step Properties</span>
@@ -6718,21 +6718,21 @@ ${i}
                     <button class="close-btn" @click="${()=>this.selectedId=null}">✕</button>
                 </div>
                 <div class="prop-body">
-                    ${n(`ID`,T`<input class="inp" readonly .value="${e.id}"/>`)}
-                    ${n(`Name`,T`<input class="inp" .value="${e.name}"
+                    ${n(`ID`,w`<input class="inp" readonly .value="${e.id}"/>`)}
+                    ${n(`Name`,w`<input class="inp" .value="${e.name}"
                         @change="${t=>this.updateStep(e.id,{name:t.target.value})}"/>`)}
-                    ${n(`Type`,T`
+                    ${n(`Type`,w`
                         <select class="inp" @change="${t=>this.updateStep(e.id,{type:t.target.value})}">
-                            ${io.map(t=>T`<option value="${t}" ?selected="${e.type===t}">${t}</option>`)}
+                            ${ao.map(t=>w`<option value="${t}" ?selected="${e.type===t}">${t}</option>`)}
                         </select>`)}
-                    ${n(`Description`,T`<textarea class="inp" rows="2"
+                    ${n(`Description`,w`<textarea class="inp" rows="2"
                         @change="${t=>this.updateStep(e.id,{description:t.target.value})}">${e.description??``}</textarea>`)}
-                    ${n(`Precondition step`,T`
+                    ${n(`Precondition step`,w`
                         <select class="inp" @change="${t=>this.updateStep(e.id,{preconditionStepId:t.target.value||void 0})}">
                             <option value="">— none —</option>
-                            ${t.map(t=>T`<option value="${t.id}" ?selected="${e.preconditionStepId===t.id}">${t.name} (${t.id})</option>`)}
+                            ${t.map(t=>w`<option value="${t.id}" ?selected="${e.preconditionStepId===t.id}">${t.name} (${t.id})</option>`)}
                         </select>`)}
-                    ${n(`Precondition expression`,T`<input class="inp" placeholder="JEXL expression"
+                    ${n(`Precondition expression`,w`<input class="inp" placeholder="JEXL expression"
                         .value="${e.preconditionExpression??``}"
                         @change="${t=>this.updateStep(e.id,{preconditionExpression:t.target.value||void 0})}"/>`)}
                     <div class="field row">
@@ -6740,10 +6740,10 @@ ${i}
                         <input type="checkbox" ?checked="${e.parallel}"
                                @change="${t=>this.updateStep(e.id,{parallel:t.target.checked})}"/>
                     </div>
-                    ${n(`Timeout (ms)`,T`<input class="inp" type="number" min="0"
+                    ${n(`Timeout (ms)`,w`<input class="inp" type="number" min="0"
                         .value="${String(e.timeout??0)}"
                         @change="${t=>this.updateStep(e.id,{timeout:Number(t.target.value)})}"/>`)}
-                    ${n(`Retries`,T`<input class="inp" type="number" min="0"
+                    ${n(`Retries`,w`<input class="inp" type="number" min="0"
                         .value="${String(e.retries??0)}"
                         @change="${t=>this.updateStep(e.id,{retries:Number(t.target.value)})}"/>`)}
                     <div class="field row">
@@ -6751,24 +6751,24 @@ ${i}
                         <input type="checkbox" ?checked="${e.rollbackable}"
                                @change="${t=>this.updateStep(e.id,{rollbackable:t.target.checked})}"/>
                     </div>
-                    ${e.rollbackable?n(`Compensation step`,T`
+                    ${e.rollbackable?n(`Compensation step`,w`
                         <select class="inp" @change="${t=>this.updateStep(e.id,{compensationStepId:t.target.value||void 0})}">
                             <option value="">— none —</option>
-                            ${t.map(t=>T`<option value="${t.id}" ?selected="${e.compensationStepId===t.id}">${t.name} (${t.id})</option>`)}
+                            ${t.map(t=>w`<option value="${t.id}" ?selected="${e.compensationStepId===t.id}">${t.name} (${t.id})</option>`)}
                         </select>`):``}
 
-                    ${e.type===`ACTION`?n(`Topic`,T`<input class="inp" placeholder="kafka.topic.name"
+                    ${e.type===`ACTION`?n(`Topic`,w`<input class="inp" placeholder="kafka.topic.name"
                         .value="${e.topic??``}"
                         @change="${t=>this.updateStep(e.id,{topic:t.target.value||void 0})}"/>`):``}
-                    ${e.type===`USER_TASK`?n(`Form ID`,T`<input class="inp"
+                    ${e.type===`USER_TASK`?n(`Form ID`,w`<input class="inp"
                         .value="${e.formId??``}"
                         @change="${t=>this.updateStep(e.id,{formId:t.target.value||void 0})}"/>`):``}
-                    ${e.type===`PROCESS`?n(`Child workflow ID`,T`<input class="inp"
+                    ${e.type===`PROCESS`?n(`Child workflow ID`,w`<input class="inp"
                         .value="${e.childWorkflowDefinitionId??``}"
                         @change="${t=>this.updateStep(e.id,{childWorkflowDefinitionId:t.target.value||void 0})}"/>`):``}
                 </div>
             </div>
-        `}exportJson(){let e=JSON.stringify(this.wf,null,2),t=new Blob([e],{type:`application/json`}),n=URL.createObjectURL(t),r=document.createElement(`a`);r.href=n,r.download=(this.wf.name??`workflow`).replace(/\s+/g,`-`).toLowerCase()+`.json`,r.click(),URL.revokeObjectURL(n)}static{this.styles=[za,h`
+        `}exportJson(){let e=JSON.stringify(this.wf,null,2),t=new Blob([e],{type:`application/json`}),n=URL.createObjectURL(t),r=document.createElement(`a`);r.href=n,r.download=(this.wf.name??`workflow`).replace(/\s+/g,`-`).toLowerCase()+`.json`,r.click(),URL.revokeObjectURL(n)}static{this.styles=[Ba,m`
         :host { display: block; height: 100%; font-family: var(--lumo-font-family, sans-serif); }
 
         .root { display: flex; flex-direction: column; height: 100%; background: var(--lumo-base-color, #fff); }
@@ -6846,33 +6846,33 @@ ${i}
         .inp:focus { border-color: #3B82F6; }
         textarea.inp { resize: vertical; }
         input[readonly].inp { background: #f8fafc; color: #94a3b8; }
-    `]}};k([y()],oo.prototype,`value`,void 0),k([C()],oo.prototype,`wf`,void 0),k([C()],oo.prototype,`positions`,void 0),k([C()],oo.prototype,`selectedId`,void 0),k([C()],oo.prototype,`showMeta`,void 0),oo=k([g(`mateu-workflow`)],oo);var so=[`string`,`integer`,`number`,`bool`,`date`,`time`,`dateTime`,`dateRange`,`money`,`file`,`array`,`status`,`component`,`menu`,`range`,`action`,`actionGroup`],co=[`regular`,`radio`,`checkbox`,`textarea`,`toggle`,`combobox`,`select`,`email`,`password`,`richText`,`listBox`,`html`,`markdown`,`image`,`icon`,`link`,`money`,`grid`,`color`,`choice`,`popover`,`slider`,`button`,`stars`],lo={string:`#3B82F6`,integer:`#8B5CF6`,number:`#6366F1`,bool:`#10B981`,date:`#F59E0B`,time:`#F59E0B`,dateTime:`#F59E0B`,dateRange:`#F59E0B`,money:`#EF4444`,file:`#64748B`,array:`#0EA5E9`,status:`#EC4899`,component:`#14B8A6`,menu:`#94A3B8`,range:`#A855F7`,action:`#F97316`,actionGroup:`#FB923C`};function uo(){return`field-`+Math.random().toString(36).slice(2,8)}var fo=class extends b{constructor(...e){super(...e),this.value=`{"name":"New Form","fields":[]}`,this.form={name:`New Form`,fields:[]},this.selectedId=null,this.showMeta=!1,this.sortable=null,this.listEl=null}updated(e){if(e.has(`value`))try{this.form=JSON.parse(this.value)}catch{}this.attachSortable()}disconnectedCallback(){super.disconnectedCallback(),this.sortable?.destroy(),this.sortable=null}attachSortable(){let e=this.shadowRoot?.querySelector(`.field-list`);!e||e===this.listEl||(this.listEl=e,this.sortable?.destroy(),this.sortable=se.create(e,{animation:150,handle:`.drag-handle`,ghostClass:`sortable-ghost`,onEnd:e=>{let{oldIndex:t,newIndex:n}=e;if(t===void 0||n===void 0||t===n)return;let r=[...this.form.fields],[i]=r.splice(t,1);r.splice(n,0,i),this.form={...this.form,fields:r},this.emit()}}))}emit(){let e=JSON.stringify(this.form,null,2);this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e},bubbles:!0,composed:!0}))}updateForm(e){this.form={...this.form,...e},this.emit()}updateField(e,t){this.form={...this.form,fields:this.form.fields.map(n=>n.id===e?{...n,...t}:n)},this.emit()}addField(){let e=uo(),t={id:e,label:`New Field`,dataType:`string`};this.form={...this.form,fields:[...this.form.fields,t]},this.selectedId=e,this.emit()}deleteField(e){this.form={...this.form,fields:this.form.fields.filter(t=>t.id!==e)},this.selectedId===e&&(this.selectedId=null),this.emit()}duplicateField(e){let t=this.form.fields.find(t=>t.id===e);if(!t)return;let n={...t,id:uo(),label:t.label+` (copy)`},r=this.form.fields.findIndex(t=>t.id===e),i=[...this.form.fields];i.splice(r+1,0,n),this.form={...this.form,fields:i},this.selectedId=n.id,this.emit()}render(){return T`
+    `]}};O([v()],so.prototype,`value`,void 0),O([S()],so.prototype,`wf`,void 0),O([S()],so.prototype,`positions`,void 0),O([S()],so.prototype,`selectedId`,void 0),O([S()],so.prototype,`showMeta`,void 0),so=O([h(`mateu-workflow`)],so);var co=[`string`,`integer`,`number`,`bool`,`date`,`time`,`dateTime`,`dateRange`,`money`,`file`,`array`,`status`,`component`,`menu`,`range`,`action`,`actionGroup`],lo=[`regular`,`radio`,`checkbox`,`textarea`,`toggle`,`combobox`,`select`,`email`,`password`,`richText`,`listBox`,`html`,`markdown`,`image`,`icon`,`link`,`money`,`grid`,`color`,`choice`,`popover`,`slider`,`button`,`stars`],uo={string:`#3B82F6`,integer:`#8B5CF6`,number:`#6366F1`,bool:`#10B981`,date:`#F59E0B`,time:`#F59E0B`,dateTime:`#F59E0B`,dateRange:`#F59E0B`,money:`#EF4444`,file:`#64748B`,array:`#0EA5E9`,status:`#EC4899`,component:`#14B8A6`,menu:`#94A3B8`,range:`#A855F7`,action:`#F97316`,actionGroup:`#FB923C`};function fo(){return`field-`+Math.random().toString(36).slice(2,8)}var po=class extends y{constructor(...e){super(...e),this.value=`{"name":"New Form","fields":[]}`,this.form={name:`New Form`,fields:[]},this.selectedId=null,this.showMeta=!1,this.sortable=null,this.listEl=null}updated(e){if(e.has(`value`))try{this.form=JSON.parse(this.value)}catch{}this.attachSortable()}disconnectedCallback(){super.disconnectedCallback(),this.sortable?.destroy(),this.sortable=null}attachSortable(){let e=this.shadowRoot?.querySelector(`.field-list`);!e||e===this.listEl||(this.listEl=e,this.sortable?.destroy(),this.sortable=ce.create(e,{animation:150,handle:`.drag-handle`,ghostClass:`sortable-ghost`,onEnd:e=>{let{oldIndex:t,newIndex:n}=e;if(t===void 0||n===void 0||t===n)return;let r=[...this.form.fields],[i]=r.splice(t,1);r.splice(n,0,i),this.form={...this.form,fields:r},this.emit()}}))}emit(){let e=JSON.stringify(this.form,null,2);this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e},bubbles:!0,composed:!0}))}updateForm(e){this.form={...this.form,...e},this.emit()}updateField(e,t){this.form={...this.form,fields:this.form.fields.map(n=>n.id===e?{...n,...t}:n)},this.emit()}addField(){let e=fo(),t={id:e,label:`New Field`,dataType:`string`};this.form={...this.form,fields:[...this.form.fields,t]},this.selectedId=e,this.emit()}deleteField(e){this.form={...this.form,fields:this.form.fields.filter(t=>t.id!==e)},this.selectedId===e&&(this.selectedId=null),this.emit()}duplicateField(e){let t=this.form.fields.find(t=>t.id===e);if(!t)return;let n={...t,id:fo(),label:t.label+` (copy)`},r=this.form.fields.findIndex(t=>t.id===e),i=[...this.form.fields];i.splice(r+1,0,n),this.form={...this.form,fields:i},this.selectedId=n.id,this.emit()}render(){return w`
             <div class="root">
                 ${this.renderToolbar()}
-                ${this.showMeta?this.renderMeta():v}
+                ${this.showMeta?this.renderMeta():_}
                 <div class="workspace">
                     ${this.renderList()}
-                    ${this.selectedId?this.renderPanel():v}
+                    ${this.selectedId?this.renderPanel():_}
                 </div>
             </div>
-        `}renderToolbar(){return T`
+        `}renderToolbar(){return w`
             <div class="toolbar">
                 <span class="form-name">${this.form.name}</span>
                 <div style="flex:1"></div>
                 <button class="nbtn" @click="${()=>this.showMeta=!this.showMeta}">
-                    ${Va}
+                    ${Ha}
                     Settings
                 </button>
                 <button class="nbtn primary" @click="${()=>this.addField()}">
-                    ${Ha}
+                    ${Ua}
                     Add Field
                 </button>
                 <button class="nbtn" @click="${()=>this.exportJson()}">
-                    ${Ua}
+                    ${Wa}
                     Export
                 </button>
             </div>
-        `}renderMeta(){let e=this.form;return T`
+        `}renderMeta(){let e=this.form;return w`
             <div class="meta-panel">
                 <div class="meta-grid">
                     <label>Name</label>
@@ -6883,58 +6883,58 @@ ${i}
                               @change="${e=>this.updateForm({description:e.target.value})}">${e.description??``}</textarea>
                 </div>
             </div>
-        `}renderList(){let e=this.form.fields;return T`
+        `}renderList(){let e=this.form.fields;return w`
             <div class="list-wrap">
-                ${e.length===0?T`
+                ${e.length===0?w`
                     <div class="empty">
                         No fields yet. Click <strong>Add Field</strong> to start.
-                    </div>`:v}
+                    </div>`:_}
                 <div class="field-list">
                     ${e.map(e=>this.renderRow(e))}
                 </div>
             </div>
-        `}renderRow(e){let t=lo[e.dataType]??`#64748b`;return T`
+        `}renderRow(e){let t=uo[e.dataType]??`#64748b`;return w`
             <div role="button" tabindex="0" class="field-row ${this.selectedId===e.id?`selected`:``}"
                  data-id="${e.id}"
-                 @click="${()=>this.selectedId=this.selectedId===e.id?null:e.id}" @keydown="${R(()=>this.selectedId=this.selectedId===e.id?null:e.id)}">
+                 @click="${()=>this.selectedId=this.selectedId===e.id?null:e.id}" @keydown="${L(()=>this.selectedId=this.selectedId===e.id?null:e.id)}">
                 <span class="drag-handle" title="Drag to reorder">⠿</span>
                 <span class="type-badge" style="background:${t}">${e.dataType}</span>
                 <span class="field-label-text">${e.label}</span>
                 <span class="field-id-text">${e.id}</span>
-                ${e.required?T`<span class="required-badge">required</span>`:v}
-                ${e.stereotype&&e.stereotype!==`regular`?T`<span class="stereo-badge">${e.stereotype}</span>`:v}
+                ${e.required?w`<span class="required-badge">required</span>`:_}
+                ${e.stereotype&&e.stereotype!==`regular`?w`<span class="stereo-badge">${e.stereotype}</span>`:_}
                 <div style="flex:1"></div>
                 <button class="row-btn" title="Duplicate"
                         @click="${t=>{t.stopPropagation(),this.duplicateField(e.id)}}">⧉</button>
                 <button class="row-btn danger" title="Delete"
                         @click="${t=>{t.stopPropagation(),this.deleteField(e.id)}}">🗑</button>
             </div>
-        `}renderPanel(){let e=this.form.fields.find(e=>e.id===this.selectedId);if(!e)return v;let t=(e,t)=>T`
+        `}renderPanel(){let e=this.form.fields.find(e=>e.id===this.selectedId);if(!e)return _;let t=(e,t)=>w`
             <div class="prop-field">
                 <label class="prop-label">${e}</label>
                 ${t}
             </div>
-        `;return T`
+        `;return w`
             <div class="properties">
                 <div class="prop-header">
                     <span>Field Properties</span>
                     <button class="close-btn" @click="${()=>this.selectedId=null}">✕</button>
                 </div>
                 <div class="prop-body">
-                    ${t(`ID`,T`<input class="inp" readonly .value="${e.id}"/>`)}
-                    ${t(`Label`,T`
+                    ${t(`ID`,w`<input class="inp" readonly .value="${e.id}"/>`)}
+                    ${t(`Label`,w`
                         <input class="inp" .value="${e.label}"
                                @change="${t=>this.updateField(e.id,{label:t.target.value})}"/>`)}
-                    ${t(`Data type`,T`
+                    ${t(`Data type`,w`
                         <select class="inp"
                                 @change="${t=>this.updateField(e.id,{dataType:t.target.value})}">
-                            ${so.map(t=>T`
+                            ${co.map(t=>w`
                                 <option value="${t}" ?selected="${e.dataType===t}">${t}</option>`)}
                         </select>`)}
-                    ${t(`Stereotype`,T`
+                    ${t(`Stereotype`,w`
                         <select class="inp"
                                 @change="${t=>this.updateField(e.id,{stereotype:t.target.value||void 0})}">
-                            ${co.map(t=>T`
+                            ${lo.map(t=>w`
                                 <option value="${t}" ?selected="${(e.stereotype??`regular`)===t}">${t}</option>`)}
                         </select>`)}
                     <div class="prop-field row">
@@ -6942,12 +6942,12 @@ ${i}
                         <input type="checkbox" ?checked="${e.required}"
                                @change="${t=>this.updateField(e.id,{required:t.target.checked})}"/>
                     </div>
-                    ${t(`Description / hint`,T`
+                    ${t(`Description / hint`,w`
                         <textarea class="inp" rows="3"
                                   @change="${t=>this.updateField(e.id,{description:t.target.value||void 0})}">${e.description??``}</textarea>`)}
                 </div>
             </div>
-        `}exportJson(){let e=JSON.stringify(this.form,null,2),t=new Blob([e],{type:`application/json`}),n=URL.createObjectURL(t),r=document.createElement(`a`);r.href=n,r.download=(this.form.name??`form`).replace(/\s+/g,`-`).toLowerCase()+`.json`,r.click(),URL.revokeObjectURL(n)}static{this.styles=[za,z,h`
+        `}exportJson(){let e=JSON.stringify(this.form,null,2),t=new Blob([e],{type:`application/json`}),n=URL.createObjectURL(t),r=document.createElement(`a`);r.href=n,r.download=(this.form.name??`form`).replace(/\s+/g,`-`).toLowerCase()+`.json`,r.click(),URL.revokeObjectURL(n)}static{this.styles=[Ba,R,m`
         :host { display: block; height: 100%; font-family: var(--lumo-font-family, sans-serif); }
 
         .root { display: flex; flex-direction: column; height: 100%; background: var(--lumo-base-color, #fff); }
@@ -7062,12 +7062,12 @@ ${i}
         .inp:focus { border-color: #3B82F6; }
         textarea.inp { resize: vertical; }
         input[readonly].inp { background: #f8fafc; color: #94a3b8; }
-    `]}};k([y()],fo.prototype,`value`,void 0),k([C()],fo.prototype,`form`,void 0),k([C()],fo.prototype,`selectedId`,void 0),k([C()],fo.prototype,`showMeta`,void 0),fo=k([g(`mateu-form-editor`)],fo);var po=class extends b{constructor(...e){super(...e),this.appState={},this.appData={},this.open=!1,this.activeTab=`appstate`,this.hoveredTag=``,this.hoveredId=``,this.hoveredState=null,this.hoveredData=null,this.hoveredMeta=null,this._prevTarget=null,this._onMouseover=e=>{let t=e.target;for(;t&&!(t.tagName?.toLowerCase().startsWith(`mateu-`)&&t!==this);)t=t.parentElement;if(t===this||t===null){t===null&&this._prevTarget&&(this._prevTarget.style.outline=``,this._prevTarget.style.outlineOffset=``,this._prevTarget=null,this.hoveredTag=``,this.hoveredId=``,this.hoveredState=null,this.hoveredData=null,this.hoveredMeta=null);return}t!==this._prevTarget&&(this._prevTarget&&(this._prevTarget.style.outline=``,this._prevTarget.style.outlineOffset=``),this._prevTarget=t,t.style.outline=`2px solid #0070f3`,t.style.outlineOffset=`-2px`,this.hoveredTag=t.tagName.toLowerCase(),this.hoveredId=t.id||``,this.hoveredState=t.state,this.hoveredData=t.data,this.hoveredMeta=t.component?.metadata)}}connectedCallback(){super.connectedCallback(),document.addEventListener(`mouseover`,this._onMouseover,!0)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`mouseover`,this._onMouseover,!0),this._prevTarget&&=(this._prevTarget.style.outline=``,null)}_fmt(e){try{return JSON.stringify(e,null,2)??`null`}catch{return String(e)}}_renderTab(e,t){return T`
+    `]}};O([v()],po.prototype,`value`,void 0),O([S()],po.prototype,`form`,void 0),O([S()],po.prototype,`selectedId`,void 0),O([S()],po.prototype,`showMeta`,void 0),po=O([h(`mateu-form-editor`)],po);var mo=class extends y{constructor(...e){super(...e),this.appState={},this.appData={},this.open=!1,this.activeTab=`appstate`,this.hoveredTag=``,this.hoveredId=``,this.hoveredState=null,this.hoveredData=null,this.hoveredMeta=null,this._prevTarget=null,this._onMouseover=e=>{let t=e.target;for(;t&&!(t.tagName?.toLowerCase().startsWith(`mateu-`)&&t!==this);)t=t.parentElement;if(t===this||t===null){t===null&&this._prevTarget&&(this._prevTarget.style.outline=``,this._prevTarget.style.outlineOffset=``,this._prevTarget=null,this.hoveredTag=``,this.hoveredId=``,this.hoveredState=null,this.hoveredData=null,this.hoveredMeta=null);return}t!==this._prevTarget&&(this._prevTarget&&(this._prevTarget.style.outline=``,this._prevTarget.style.outlineOffset=``),this._prevTarget=t,t.style.outline=`2px solid #0070f3`,t.style.outlineOffset=`-2px`,this.hoveredTag=t.tagName.toLowerCase(),this.hoveredId=t.id||``,this.hoveredState=t.state,this.hoveredData=t.data,this.hoveredMeta=t.component?.metadata)}}connectedCallback(){super.connectedCallback(),document.addEventListener(`mouseover`,this._onMouseover,!0)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`mouseover`,this._onMouseover,!0),this._prevTarget&&=(this._prevTarget.style.outline=``,null)}_fmt(e){try{return JSON.stringify(e,null,2)??`null`}catch{return String(e)}}_renderTab(e,t){return w`
             <button class="tab ${this.activeTab===e?`tab--active`:``}"
                 @click=${()=>{this.activeTab=e}}>
                 ${t}
             </button>
-        `}render(){return this.open?T`
+        `}render(){return this.open?w`
                 <div class="panel">
                     <div class="panel-header">
                         <span class="panel-title">🐛 Mateu Debug</span>
@@ -7079,14 +7079,14 @@ ${i}
                         ${this._renderTab(`inspector`,`Inspector`)}
                     </div>
                     <div class="content">
-                        ${this.activeTab===`appstate`?T`
+                        ${this.activeTab===`appstate`?w`
                             <pre class="json">${this._fmt(this.appState)}</pre>
-                        `:v}
-                        ${this.activeTab===`appdata`?T`
+                        `:_}
+                        ${this.activeTab===`appdata`?w`
                             <pre class="json">${this._fmt(this.appData)}</pre>
-                        `:v}
-                        ${this.activeTab===`inspector`?T`
-                            ${this.hoveredTag?T`
+                        `:_}
+                        ${this.activeTab===`inspector`?w`
+                            ${this.hoveredTag?w`
                                 <div class="inspector-tag">&lt;${this.hoveredTag}${this.hoveredId?` id="${this.hoveredId}"`:``}&gt;</div>
                                 <div class="section-label">state</div>
                                 <pre class="json">${this._fmt(this.hoveredState)}</pre>
@@ -7094,15 +7094,15 @@ ${i}
                                 <pre class="json">${this._fmt(this.hoveredData)}</pre>
                                 <div class="section-label">metadata</div>
                                 <pre class="json">${this._fmt(this.hoveredMeta)}</pre>
-                            `:T`
+                            `:w`
                                 <div class="inspector-hint">Hover a mateu-* element to inspect it</div>
                             `}
-                        `:v}
+                        `:_}
                     </div>
                 </div>
-            `:T`
+            `:w`
             <button class="fab" @click=${()=>{this.open=!0}} title="Mateu Debug">🐛</button>
-        `}static{this.styles=h`
+        `}static{this.styles=m`
         :host {
             position: fixed;
             z-index: 9999;
@@ -7235,7 +7235,7 @@ ${i}
             border-bottom: 1px solid #2a2a3a;
         }
         .section-label:first-of-type { margin-top: 0; }
-    `}};k([y()],po.prototype,`appState`,void 0),k([y()],po.prototype,`appData`,void 0),k([C()],po.prototype,`open`,void 0),k([C()],po.prototype,`activeTab`,void 0),k([C()],po.prototype,`hoveredTag`,void 0),k([C()],po.prototype,`hoveredId`,void 0),k([C()],po.prototype,`hoveredState`,void 0),k([C()],po.prototype,`hoveredData`,void 0),k([C()],po.prototype,`hoveredMeta`,void 0),po=k([g(`mateu-debug-overlay`)],po);var mo=function(e){return e.SetAppDataValue=`SetAppDataValue`,e.SetAppStateValue=`SetAppStateValue`,e.SetDataValue=`SetDataValue`,e.RunAction=`RunAction`,e.RunJS=`RunJS`,e.SetAttributeValue=`SetAttributeValue`,e.SetStateValue=`SetStateValue`,e.SetCssClass=`SetCssClass`,e.SetStyle=`SetStyle`,e}({}),ho=function(e){return e.required=`required`,e.disabled=`disabled`,e.hidden=`hidden`,e.pattern=`pattern`,e.minValue=`minValue`,e.maxValue=`maxValue`,e.minLength=`minLength`,e.maxLength=`maxLength`,e.css=`css`,e.style=`style`,e.theme=`theme`,e.errorMessage=`errorMessage`,e.description=`description`,e.none=`none`,e}({}),go=function(e){return e.Continue=`Continue`,e.Stop=`Stop`,e}({}),_o=12e4,vo=(e,t)=>`${e??`_`}::${t}`,yo=new class{constructor(){this.started=new Map,this.listeners=new Set}begin(e,t=Date.now()){let n=this.started.get(e);return n!==void 0&&t-n<_o?!1:(this.started.set(e,t),this.emit(),!0)}end(e){this.started.delete(e)&&this.emit()}isPending(e,t=Date.now()){let n=this.started.get(e);return n!==void 0&&t-n<_o}snapshot(){return new Set(this.started.keys())}subscribe(e){return this.listeners.add(e),()=>this.listeners.delete(e)}reset(){this.started.clear(),this.emit()}emit(){let e=this.snapshot();this.listeners.forEach(t=>t(e))}},bo=`data-mateu-pending-styles`,xo=`
+    `}};O([v()],mo.prototype,`appState`,void 0),O([v()],mo.prototype,`appData`,void 0),O([S()],mo.prototype,`open`,void 0),O([S()],mo.prototype,`activeTab`,void 0),O([S()],mo.prototype,`hoveredTag`,void 0),O([S()],mo.prototype,`hoveredId`,void 0),O([S()],mo.prototype,`hoveredState`,void 0),O([S()],mo.prototype,`hoveredData`,void 0),O([S()],mo.prototype,`hoveredMeta`,void 0),mo=O([h(`mateu-debug-overlay`)],mo);var ho=function(e){return e.SetAppDataValue=`SetAppDataValue`,e.SetAppStateValue=`SetAppStateValue`,e.SetDataValue=`SetDataValue`,e.RunAction=`RunAction`,e.RunJS=`RunJS`,e.SetAttributeValue=`SetAttributeValue`,e.SetStateValue=`SetStateValue`,e.SetCssClass=`SetCssClass`,e.SetStyle=`SetStyle`,e}({}),go=function(e){return e.required=`required`,e.disabled=`disabled`,e.hidden=`hidden`,e.pattern=`pattern`,e.minValue=`minValue`,e.maxValue=`maxValue`,e.minLength=`minLength`,e.maxLength=`maxLength`,e.css=`css`,e.style=`style`,e.theme=`theme`,e.errorMessage=`errorMessage`,e.description=`description`,e.none=`none`,e}({}),_o=function(e){return e.Continue=`Continue`,e.Stop=`Stop`,e}({}),vo=12e4,yo=(e,t)=>`${e??`_`}::${t}`,bo=new class{constructor(){this.started=new Map,this.listeners=new Set}begin(e,t=Date.now()){let n=this.started.get(e);return n!==void 0&&t-n<vo?!1:(this.started.set(e,t),this.emit(),!0)}end(e){this.started.delete(e)&&this.emit()}isPending(e,t=Date.now()){let n=this.started.get(e);return n!==void 0&&t-n<vo}snapshot(){return new Set(this.started.keys())}subscribe(e){return this.listeners.add(e),()=>this.listeners.delete(e)}reset(){this.started.clear(),this.emit()}emit(){let e=this.snapshot();this.listeners.forEach(t=>t(e))}},xo=`data-mateu-pending-styles`,So=`
 [data-mateu-pending] {
     pointer-events: none;
     cursor: progress;
@@ -7249,9 +7249,9 @@ ${i}
     0%, 100% { opacity: .45; }
     50% { opacity: .85; }
 }
-`,So=new WeakSet,Co=e=>{if(So.has(e))return;So.add(e);let t=e;if(typeof CSSStyleSheet<`u`&&Array.isArray(t.adoptedStyleSheets))try{let e=new CSSStyleSheet;e.replaceSync(xo),t.adoptedStyleSheets=[...t.adoptedStyleSheets,e];return}catch{}let n=e instanceof Document?e.head:e;if(!n)return;let r=document.createElement(`style`);r.setAttribute(bo,``),r.textContent=xo,n.appendChild(r)},wo=e=>{let t=e.getRootNode();if(t instanceof ShadowRoot||t instanceof Document)return t},To=e=>{if(!e||e.hasAttribute(`data-mateu-pending`))return;let t=wo(e);t&&Co(t),e.setAttribute(`data-mateu-pending`,``),e.setAttribute(`aria-busy`,`true`)},Eo=e=>{e&&(e.removeAttribute(`data-mateu-pending`),e.removeAttribute(`aria-busy`))},Do=e=>{let t=(typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target;return t instanceof Element?t:void 0},Oo=[`button`,`a[href]`,`[role="button"]`,`[role="menuitem"]`,`input[type="button"]`,`input[type="submit"]`,`vaadin-button`,`vaadin-menu-bar-button`,`ui5-button`,`oj-c-button`,`oj-button`].join(`, `),ko=e=>{if(!(!e||typeof e.closest!=`function`))return e.closest(Oo)??void 0},Ao=null,jo=class extends ha{constructor(...e){super(...e),this.baseUrl=``,this.route=``,this.consumedRoute=``,this.formerState={},this.applyRules=()=>{let e=this.component.rules;if(e&&e.length>0){let t=this.state,n=this.data,r=this.appState,i=this.appData,a=this.component,o=e=>at(e,t,n,{appState:r,appData:i,component:a}),s=e=>it(e,t,n,r,i,{component:a}),c=[`state`,`data`,`appState`,`appData`,`component`],l=[t,n,r,i,a],u={...this.state},d={...this.data},f=!1,p=!1;for(let t=0;t<e.length;t++){let n=e[t];try{if(o(n.filter)){if(mo.SetStateValue==n.action||mo.SetDataValue==n.action){let e=mo.SetStateValue==n.action?u:d,t=n.fieldName.split(`,`);for(let r=0;r<t.length;r++){let i=t[r];if(!e[i]||e[i]!=n.value){let t=n.expression?s(n.expression):n.value,r=ho.none==n.fieldAttribute?i:i+`.`+n.fieldAttribute;t!=e[r]&&(e[r]=t,mo.SetStateValue==n.action&&(f=!0),mo.SetDataValue==n.action&&(p=!0))}}}if(mo.RunAction==n.action&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.actionId},bubbles:!0,composed:!0})),mo.RunJS==n.action&&Function(...c,n.value)(...l),mo.SetAttributeValue==n.action){let e=n.expression?o(n.expression):n.value;if(n.fieldAttribute==`disabled`){e?this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(n.fieldAttribute,`disabled`):this.shadowRoot?.getElementById(n.fieldName)?.removeAttribute(n.fieldAttribute);continue}this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(n.fieldAttribute,e)}if(mo.SetCssClass==n.action&&this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(`class`,n.value),mo.SetStyle==n.action&&this.shadowRoot?.getElementById(n.fieldName)?.style.setProperty(n.expression,n.value),go.Stop==n.result)break}}catch(e){console.error(`rule failed`,n,e)}}f&&(this.state=u),p&&(this.data=d),f&&this.checkValidations()}},this.skipValidation=(e,t)=>e&&t.fieldId&&!e.includes(t.fieldId)||!e&&t.fieldId&&t.fieldId.includes(`-`),this.checkValidations=e=>{let t=e?e.split(`,`):void 0,n=this.component.validations,r=!0,i=!1,a=this.data??{},o={...this.data??{},errors:{}};if(n){for(let e=0;e<n.length;e++){let r=n[e];if(this.skipValidation(t,r))continue;let i=(r.fieldId??`_component`).split(`,`);for(let e=0;e<i.length;e++){let t=i[e];o.errors[t]=[]}}for(let e=0;e<n.length;e++){let i=n[e];if(!this.skipValidation(t,i))try{let e=i.condition&&i.condition.includes("${")?this._evalTemplate(i.condition):this._evalExpr(i.condition);if(i.condition&&!e){r=!1;let e=(i.fieldId??`_component`).split(`,`);for(let t=0;t<e.length;t++){let n=e[t],r=o.errors[n];if(r||(o.errors[n]=[]),r=o.errors[n],!a[n]){let e=i.message;try{e=this._evalTemplate(i.message)}catch{}r.push(e)}}}}catch(e){console.error(`validation failed`,i,e)}}for(let e=0;e<n.length;e++){let r=n[e];if(this.skipValidation(t,r))continue;let s=(r.fieldId??`_component`).split(`,`);for(let e=0;e<s.length;e++){let t=s[e];if((a.errors||o.errors==``)&&[t].join(`,`)){i=!0;break}}}(a.errors||o.errors==``)&&[`_component`].join(`,`)&&(i=!0)}o._valid=r,o._valid!=a._valid&&(i=!0),i&&(this.data=o)},this._autoSaveTimers=new Map,this.onChange=()=>{this.applyRules()},this.closeModalRequestedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.closeModal()},this.resetFilters=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail,n={};t.fieldIds.forEach(e=>{n[e]=void 0}),n.searchText=void 0,this.state={...this.state,...n}}},this.dataChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail,n={};n[t.key]=t.value,e.type==`data-changed`&&(this.data={...this.data,...n})}},this.valueChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail;if(e.type==`value-changed`){let n={...this.state};n[t.fieldId]=t.value,this.state=n,(this.state[t.fieldId]||this.formerState[t.fieldId])&&this.state[t.fieldId]!=this.formerState[t.fieldId]&&this.component?.confirmOnNavigationIfDirty&&this.dispatchEvent(new CustomEvent(`dirty`,{detail:e.detail,bubbles:!0,composed:!0}));let r=this.component;r.triggers?.filter(e=>e.type==ma.OnValueChange).filter(e=>!e.propertyName||t.fieldId==e.propertyName).forEach(e=>{(!e.condition||this._evalExpr(e.condition))&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))}),r.triggers?.filter(e=>e.type==ma.AutoSave).forEach(e=>{let t=e.actionId,n=this._autoSaveTimers.get(t);n!==void 0&&clearTimeout(n),this._autoSaveTimers.set(t,setTimeout(()=>{this._autoSaveTimers.delete(t),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))},e.debounceMillis??800))})}}},this.actionRequestedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.manageActionRequestedEvent(e)},this.manageActionRequestedEvent=e=>{let t=e.detail,n=t?._originElement??Do(e);if(e.type==`action-requested`){e.preventDefault(),e.stopPropagation();let r=this.component,i=r.actions?.find(e=>e.id==t.actionId)??r.actions?.find(e=>e.id.endsWith(`*`)&&t.actionId.startsWith(e.id.replace(`*`,``)));if(i){if(i&&i.rowsSelectedRequired&&(!this.state.crud_selected_items||this.state.crud_selected_items.length==0)){this.notify(`You first need to select some rows`);return}if(i&&i.validationRequired){let e=Ao??this;if(Ao=null,e.checkValidations(i.fieldsToValidate),!e.data._valid){e.notifyValidationErrors();return}}Ao=null;let e={...t,initiatorComponentId:this.id};i&&i.confirmationRequired?this.callAfterConfirmation(i,()=>this.requestActionCallToServerOrBubble(e,r,i,n)):this.requestActionCallToServerOrBubble(e,r,i,n)}else{let r={...t.parameters};r.initiatorState||=this.state,Ao||=this,this.dispatchEvent(new CustomEvent(e.type,{detail:{...e.detail,_originElement:n,parameters:r},bubbles:!0,composed:!0}))}}},this.buildFieldLabelMap=()=>{let e={},t=n=>{if(n)for(let r of n){let n=r.metadata;if(n?.type===j.FormField){let t=n;t.fieldId&&t.label&&(e[t.fieldId]=t.label)}t(r.children)}};return t(this.component?.children),e},this.notifyValidationErrors=()=>{let e=this.data?.errors??{},t=this.buildFieldLabelMap(),n=[];if(Object.entries(e).forEach(([e,r])=>{if(!Array.isArray(r))return;let i=e===`_component`?void 0:t[e]??e;r.forEach(e=>{e&&!n.some(t=>t.label===i&&t.msg===e)&&n.push({label:i,msg:e})})}),n.length===0){this.notify(`There are validation errors`);return}oa({text:`There are validation errors
+`,Co=new WeakSet,wo=e=>{if(Co.has(e))return;Co.add(e);let t=e;if(typeof CSSStyleSheet<`u`&&Array.isArray(t.adoptedStyleSheets))try{let e=new CSSStyleSheet;e.replaceSync(So),t.adoptedStyleSheets=[...t.adoptedStyleSheets,e];return}catch{}let n=e instanceof Document?e.head:e;if(!n)return;let r=document.createElement(`style`);r.setAttribute(xo,``),r.textContent=So,n.appendChild(r)},To=e=>{let t=e.getRootNode();if(t instanceof ShadowRoot||t instanceof Document)return t},Eo=e=>{if(!e||e.hasAttribute(`data-mateu-pending`))return;let t=To(e);t&&wo(t),e.setAttribute(`data-mateu-pending`,``),e.setAttribute(`aria-busy`,`true`)},Do=e=>{e&&(e.removeAttribute(`data-mateu-pending`),e.removeAttribute(`aria-busy`))},Oo=e=>{let t=(typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target;return t instanceof Element?t:void 0},ko=[`button`,`a[href]`,`[role="button"]`,`[role="menuitem"]`,`input[type="button"]`,`input[type="submit"]`,`vaadin-button`,`vaadin-menu-bar-button`,`ui5-button`,`oj-c-button`,`oj-button`].join(`, `),Ao=e=>{if(!(!e||typeof e.closest!=`function`))return e.closest(ko)??void 0},jo=null,Mo=class extends ga{constructor(...e){super(...e),this.baseUrl=``,this.route=``,this.consumedRoute=``,this.formerState={},this.applyRules=()=>{let e=this.component.rules;if(e&&e.length>0){let t=this.state,n=this.data,r=this.appState,i=this.appData,a=this.component,o=e=>ot(e,t,n,{appState:r,appData:i,component:a}),s=e=>at(e,t,n,r,i,{component:a}),c=[`state`,`data`,`appState`,`appData`,`component`],l=[t,n,r,i,a],u={...this.state},d={...this.data},f=!1,p=!1;for(let t=0;t<e.length;t++){let n=e[t];try{if(o(n.filter)){if(ho.SetStateValue==n.action||ho.SetDataValue==n.action){let e=ho.SetStateValue==n.action?u:d,t=n.fieldName.split(`,`);for(let r=0;r<t.length;r++){let i=t[r];if(!e[i]||e[i]!=n.value){let t=n.expression?s(n.expression):n.value,r=go.none==n.fieldAttribute?i:i+`.`+n.fieldAttribute;t!=e[r]&&(e[r]=t,ho.SetStateValue==n.action&&(f=!0),ho.SetDataValue==n.action&&(p=!0))}}}if(ho.RunAction==n.action&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.actionId},bubbles:!0,composed:!0})),ho.RunJS==n.action&&Function(...c,n.value)(...l),ho.SetAttributeValue==n.action){let e=n.expression?o(n.expression):n.value;if(n.fieldAttribute==`disabled`){e?this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(n.fieldAttribute,`disabled`):this.shadowRoot?.getElementById(n.fieldName)?.removeAttribute(n.fieldAttribute);continue}this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(n.fieldAttribute,e)}if(ho.SetCssClass==n.action&&this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(`class`,n.value),ho.SetStyle==n.action&&this.shadowRoot?.getElementById(n.fieldName)?.style.setProperty(n.expression,n.value),_o.Stop==n.result)break}}catch(e){console.error(`rule failed`,n,e)}}f&&(this.state=u),p&&(this.data=d),f&&this.checkValidations()}},this.skipValidation=(e,t)=>e&&t.fieldId&&!e.includes(t.fieldId)||!e&&t.fieldId&&t.fieldId.includes(`-`),this.checkValidations=e=>{let t=e?e.split(`,`):void 0,n=this.component.validations,r=!0,i=!1,a=this.data??{},o={...this.data??{},errors:{}};if(n){for(let e=0;e<n.length;e++){let r=n[e];if(this.skipValidation(t,r))continue;let i=(r.fieldId??`_component`).split(`,`);for(let e=0;e<i.length;e++){let t=i[e];o.errors[t]=[]}}for(let e=0;e<n.length;e++){let i=n[e];if(!this.skipValidation(t,i))try{let e=i.condition&&i.condition.includes("${")?this._evalTemplate(i.condition):this._evalExpr(i.condition);if(i.condition&&!e){r=!1;let e=(i.fieldId??`_component`).split(`,`);for(let t=0;t<e.length;t++){let n=e[t],r=o.errors[n];if(r||(o.errors[n]=[]),r=o.errors[n],!a[n]){let e=i.message;try{e=this._evalTemplate(i.message)}catch{}r.push(e)}}}}catch(e){console.error(`validation failed`,i,e)}}for(let e=0;e<n.length;e++){let r=n[e];if(this.skipValidation(t,r))continue;let s=(r.fieldId??`_component`).split(`,`);for(let e=0;e<s.length;e++){let t=s[e];if((a.errors||o.errors==``)&&[t].join(`,`)){i=!0;break}}}(a.errors||o.errors==``)&&[`_component`].join(`,`)&&(i=!0)}o._valid=r,o._valid!=a._valid&&(i=!0),i&&(this.data=o)},this._autoSaveTimers=new Map,this.onChange=()=>{this.applyRules()},this.closeModalRequestedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.closeModal()},this.resetFilters=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail,n={};t.fieldIds.forEach(e=>{n[e]=void 0}),n.searchText=void 0,this.state={...this.state,...n}}},this.dataChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail,n={};n[t.key]=t.value,e.type==`data-changed`&&(this.data={...this.data,...n})}},this.valueChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail;if(e.type==`value-changed`){let n={...this.state};n[t.fieldId]=t.value,this.state=n,(this.state[t.fieldId]||this.formerState[t.fieldId])&&this.state[t.fieldId]!=this.formerState[t.fieldId]&&this.component?.confirmOnNavigationIfDirty&&this.dispatchEvent(new CustomEvent(`dirty`,{detail:e.detail,bubbles:!0,composed:!0}));let r=this.component;r.triggers?.filter(e=>e.type==ha.OnValueChange).filter(e=>!e.propertyName||t.fieldId==e.propertyName).forEach(e=>{(!e.condition||this._evalExpr(e.condition))&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))}),r.triggers?.filter(e=>e.type==ha.AutoSave).forEach(e=>{let t=e.actionId,n=this._autoSaveTimers.get(t);n!==void 0&&clearTimeout(n),this._autoSaveTimers.set(t,setTimeout(()=>{this._autoSaveTimers.delete(t),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))},e.debounceMillis??800))})}}},this.actionRequestedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.manageActionRequestedEvent(e)},this.manageActionRequestedEvent=e=>{let t=e.detail,n=t?._originElement??Oo(e);if(e.type==`action-requested`){e.preventDefault(),e.stopPropagation();let r=this.component,i=r.actions?.find(e=>e.id==t.actionId)??r.actions?.find(e=>e.id.endsWith(`*`)&&t.actionId.startsWith(e.id.replace(`*`,``)));if(i){if(i&&i.rowsSelectedRequired&&(!this.state.crud_selected_items||this.state.crud_selected_items.length==0)){this.notify(`You first need to select some rows`);return}if(i&&i.validationRequired){let e=jo??this;if(jo=null,e.checkValidations(i.fieldsToValidate),!e.data._valid){e.notifyValidationErrors();return}}jo=null;let e={...t,initiatorComponentId:this.id};i&&i.confirmationRequired?this.callAfterConfirmation(i,()=>this.requestActionCallToServerOrBubble(e,r,i,n)):this.requestActionCallToServerOrBubble(e,r,i,n)}else{let r={...t.parameters};r.initiatorState||=this.state,jo||=this,this.dispatchEvent(new CustomEvent(e.type,{detail:{...e.detail,_originElement:n,parameters:r},bubbles:!0,composed:!0}))}}},this.buildFieldLabelMap=()=>{let e={},t=n=>{if(n)for(let r of n){let n=r.metadata;if(n?.type===A.FormField){let t=n;t.fieldId&&t.label&&(e[t.fieldId]=t.label)}t(r.children)}};return t(this.component?.children),e},this.notifyValidationErrors=()=>{let e=this.data?.errors??{},t=this.buildFieldLabelMap(),n=[];if(Object.entries(e).forEach(([e,r])=>{if(!Array.isArray(r))return;let i=e===`_component`?void 0:t[e]??e;r.forEach(e=>{e&&!n.some(t=>t.label===i&&t.msg===e)&&n.push({label:i,msg:e})})}),n.length===0){this.notify(`There are validation errors`);return}sa({text:`There are validation errors
 `+n.map(({label:e,msg:t})=>e?`• ${e}: ${t}`:`• ${t}`).join(`
-`),variant:`error`,position:`bottomEnd`,duration:Math.max(3e3,1500+n.length*1e3)},this),this.focusFirstInvalidField()},this.notify=e=>{oa({text:e,variant:`error`,position:`bottomEnd`,duration:3e3},this)},this.callAfterConfirmation=(e,t)=>{let n=`One moment, please`,r=`Are you sure?`,i=`Yes`,a=`No`;e.confirmationTexts&&(n=e.confirmationTexts.title,r=e.confirmationTexts.message,i=e.confirmationTexts.confirmationText,a=e.confirmationTexts.denialText);let o=document.createElement(`div`);o.style.cssText=`position:fixed;inset:0;z-index:1100;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.35);padding:1rem;`;let s=document.createElement(`div`);s.style.cssText=`background:var(--lumo-base-color,#fff);color:var(--lumo-body-text-color,#1a1a1a);border-radius:var(--lumo-border-radius-l,12px);box-shadow:var(--lumo-box-shadow-xl,0 12px 40px rgba(0,0,0,.3));padding:1.2rem;max-width:min(90vw,26rem);`;let c=()=>{o.parentElement&&document.body.removeChild(o)},l=`font:inherit;font-weight:600;padding:.45rem 1rem;border-radius:var(--lumo-border-radius-m,6px);cursor:pointer;`;re(T`
+`),variant:`error`,position:`bottomEnd`,duration:Math.max(3e3,1500+n.length*1e3)},this),this.focusFirstInvalidField()},this.notify=e=>{sa({text:e,variant:`error`,position:`bottomEnd`,duration:3e3},this)},this.callAfterConfirmation=(e,t)=>{let n=`One moment, please`,r=`Are you sure?`,i=`Yes`,a=`No`;e.confirmationTexts&&(n=e.confirmationTexts.title,r=e.confirmationTexts.message,i=e.confirmationTexts.confirmationText,a=e.confirmationTexts.denialText);let o=document.createElement(`div`);o.style.cssText=`position:fixed;inset:0;z-index:1100;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.35);padding:1rem;`;let s=document.createElement(`div`);s.style.cssText=`background:var(--lumo-base-color,#fff);color:var(--lumo-body-text-color,#1a1a1a);border-radius:var(--lumo-border-radius-l,12px);box-shadow:var(--lumo-box-shadow-xl,0 12px 40px rgba(0,0,0,.3));padding:1.2rem;max-width:min(90vw,26rem);`;let c=()=>{o.parentElement&&document.body.removeChild(o)},l=`font:inherit;font-weight:600;padding:.45rem 1rem;border-radius:var(--lumo-border-radius-m,6px);cursor:pointer;`;ie(w`
             <h3 style="margin:0 0 .5rem;">${n}</h3>
             <div style="margin-bottom:1.2rem;">${r}</div>
             <div style="display:flex;justify-content:flex-end;gap:.5rem;">
@@ -7260,24 +7260,24 @@ ${i}
                 <button style="${l}border:none;background:var(--lumo-primary-color,#1676f3);color:var(--lumo-primary-contrast-color,#fff);"
                         @click="${()=>{c(),t()}}">${i}</button>
             </div>
-        `,s),o.appendChild(s),o.addEventListener(`click`,e=>{e.target===o&&c()}),document.body.appendChild(o)},this.requestActionCallToServerOrBubble=(e,t,n,r)=>{if(n&&n.bubble){let t={...e.parameters};t.initiatorState||=this.state,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{...e,_originElement:r,parameters:t},bubbles:!0,composed:!0}))}else this.requestActionCallToServer(e,t,n,r)},this.requestActionCallToServer=(e,t,n,r)=>{if(n&&n.href){window.location.href=n.href;return}if(n&&n.js)try{Function(`state`,`data`,`appState`,`appData`,`component`,n.js).call(this,this.state??{},this.data??{},this.appState??{},this.appData??{},this.component),this.state={...this.state},this.data={...this.data}}catch(e){console.error(`when evaluating `+n.js,e,this.component,this.state,this.data)}if(n&&n.customEvent&&this.dispatchEvent(new CustomEvent(n.customEvent.name,{detail:n.customEvent.detail,bubbles:!0,composed:!0})),!(n&&(n.js||n.customEvent))){if(e.actionId==`search`){let t=e.parameters?._searchState;t?this.state={...this.state,...t}:this.state.size||(this.state={...this.state,size:10,page:0,sort:[]})}if(!n?.background){if(!Le(e.actionId,n?.idempotent)&&!yo.begin(vo(this.id,e.actionId)))return;let t=ko(r);this._pendingOrigins.set(e.actionId,t),To(t)}this.dispatchEvent(new CustomEvent(`server-side-action-requested`,{detail:{route:this.route,consumedRoute:this.consumedRoute,componentState:{...this.state},parameters:e.parameters??{},actionId:e.actionId,serverSideType:t.serverSideType,serverSideComponentRoute:t.route,initiatorComponentId:e.initiatorComponentId??t.id,initiator:this,background:n?.background,sse:n?.sse,timeoutMillis:n?.timeoutMillis,idempotent:n?.idempotent,callback:e.callback,callbackonly:e.callbackonly,callbackToken:e.callbackToken??this.callbackToken},bubbles:!0,composed:!0}))}},this.handleBackendSucceeded=e=>{e.detail.actionId&&this.component.triggers?.filter(e=>e.type==ma.OnSuccess).filter(t=>e.detail.actionId==t.calledActionId).forEach(t=>{if(!t.condition||this._evalExpr(t.condition))if(e.preventDefault(),e.stopPropagation(),t.timeoutMillis>0){let e=this.callbackToken;setTimeout(()=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,callbackToken:e},bubbles:!0,composed:!0}))},t.timeoutMillis)}else this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))})},this.handleBackendFailed=e=>{e.detail.actionId&&this.component.triggers?.filter(e=>e.type==ma.OnError).filter(t=>e.detail.actionId==t.calledActionId).forEach(t=>{(!t.condition||this._evalExpr(t.condition))&&(e.preventDefault(),e.stopPropagation(),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0})))})},this._pendingOrigins=new Map,this._backendSettledListener=e=>{((typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target)===this&&this._releasePending(e.detail?.actionId)},this._keydownListener=e=>{if(this._handleTabShortcut(e))return;let t=this.component;if(t)for(let n of t.actions??[]){let t=n.shortcut||(n.runOnEnter?`enter`:null);if(t&&this._shortcutMatchesEvent(t,e)){e.preventDefault(),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.id},bubbles:!0,composed:!0}));return}}}}createRenderRoot(){return P.mustUseShadowRoot()?super.createRenderRoot():this}updated(e){super.updated(e),e.has(`state`)&&this.state&&JSON.stringify(this.state)!=JSON.stringify({})&&this.onChange(),e.has(`component`)&&(this.formerState={...this.state},this.component?.confirmOnNavigationIfDirty&&this.dispatchEvent(new CustomEvent(`clean`,{detail:{},bubbles:!0,composed:!0})),setTimeout(()=>this.triggerOnLoad()))}focusFirstInvalidField(){let e=t=>requestAnimationFrame(()=>{let n=this.findFirstInvalid(this.renderRoot);if(n){n.focus?.(),n.scrollIntoView?.({block:`center`,behavior:`smooth`});return}t>0&&e(t-1)});e(3)}findFirstInvalid(e){if(!e?.querySelectorAll)return null;for(let t of Array.from(e.querySelectorAll(`*`))){if(t.invalid===!0)return t;if(t.shadowRoot){let e=this.findFirstInvalid(t.shadowRoot);if(e)return e}}return null}_releasePending(e){(e===void 0?Array.from(this._pendingOrigins.keys()):[e]).forEach(e=>{yo.end(vo(this.id,e)),Eo(this._pendingOrigins.get(e)),this._pendingOrigins.delete(e)})}_shortcutMatchesEvent(e,t){return An(e,t)}_collectShortcutTabs(){let e=this.renderRoot;if(!e)return[];let t=Array.from(e.querySelectorAll(`vaadin-tab[data-shortcut]`));return e.querySelectorAll(`mateu-drawer, mateu-dialog`).forEach(e=>{let n=e.shadowRoot;n&&t.push(...Array.from(n.querySelectorAll(`vaadin-tab[data-shortcut]`)))}),t}_handleTabShortcut(e){let t=this._collectShortcutTabs();if(t.length===0)return!1;for(let n of Array.from(t)){let t=n.dataset.shortcut;if(!t||!this._shortcutMatchesEvent(t,e))continue;let r=n.closest(`vaadin-tabs`);if(!r)continue;let i=Array.from(r.querySelectorAll(`vaadin-tab`)).indexOf(n);if(!(i<0))return e.preventDefault(),r.selected=i,!0}return!1}connectedCallback(){super.connectedCallback(),this.addEventListener(`backend-call-succeeded`,this.handleBackendSucceeded),this.addEventListener(`backend-call-failed`,this.handleBackendFailed),this.addEventListener(`backend-succeeded-event`,this._backendSettledListener),this.addEventListener(`backend-failed-event`,this._backendSettledListener),this.addEventListener(`backend-cancelled-event`,this._backendSettledListener),document.addEventListener(`keydown`,this._keydownListener)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`backend-call-succeeded`,this.handleBackendSucceeded),this.removeEventListener(`backend-call-failed`,this.handleBackendFailed),this.removeEventListener(`backend-succeeded-event`,this._backendSettledListener),this.removeEventListener(`backend-failed-event`,this._backendSettledListener),this.removeEventListener(`backend-cancelled-event`,this._backendSettledListener),document.removeEventListener(`keydown`,this._keydownListener),this._releasePending()}render(){return T`<div>
+        `,s),o.appendChild(s),o.addEventListener(`click`,e=>{e.target===o&&c()}),document.body.appendChild(o)},this.requestActionCallToServerOrBubble=(e,t,n,r)=>{if(n&&n.bubble){let t={...e.parameters};t.initiatorState||=this.state,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{...e,_originElement:r,parameters:t},bubbles:!0,composed:!0}))}else this.requestActionCallToServer(e,t,n,r)},this.requestActionCallToServer=(e,t,n,r)=>{if(n&&n.href){window.location.href=n.href;return}if(n&&n.js)try{Function(`state`,`data`,`appState`,`appData`,`component`,n.js).call(this,this.state??{},this.data??{},this.appState??{},this.appData??{},this.component),this.state={...this.state},this.data={...this.data}}catch(e){console.error(`when evaluating `+n.js,e,this.component,this.state,this.data)}if(n&&n.customEvent&&this.dispatchEvent(new CustomEvent(n.customEvent.name,{detail:n.customEvent.detail,bubbles:!0,composed:!0})),!(n&&(n.js||n.customEvent))){if(e.actionId==`search`){let t=e.parameters?._searchState;t?this.state={...this.state,...t}:this.state.size||(this.state={...this.state,size:10,page:0,sort:[]})}if(!n?.background){if(!Re(e.actionId,n?.idempotent)&&!bo.begin(yo(this.id,e.actionId)))return;let t=Ao(r);this._pendingOrigins.set(e.actionId,t),Eo(t)}this.dispatchEvent(new CustomEvent(`server-side-action-requested`,{detail:{route:this.route,consumedRoute:this.consumedRoute,componentState:{...this.state},parameters:e.parameters??{},actionId:e.actionId,serverSideType:t.serverSideType,serverSideComponentRoute:t.route,initiatorComponentId:e.initiatorComponentId??t.id,initiator:this,background:n?.background,sse:n?.sse,timeoutMillis:n?.timeoutMillis,idempotent:n?.idempotent,callback:e.callback,callbackonly:e.callbackonly,callbackToken:e.callbackToken??this.callbackToken},bubbles:!0,composed:!0}))}},this.handleBackendSucceeded=e=>{e.detail.actionId&&this.component.triggers?.filter(e=>e.type==ha.OnSuccess).filter(t=>e.detail.actionId==t.calledActionId).forEach(t=>{if(!t.condition||this._evalExpr(t.condition))if(e.preventDefault(),e.stopPropagation(),t.timeoutMillis>0){let e=this.callbackToken;setTimeout(()=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,callbackToken:e},bubbles:!0,composed:!0}))},t.timeoutMillis)}else this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))})},this.handleBackendFailed=e=>{e.detail.actionId&&this.component.triggers?.filter(e=>e.type==ha.OnError).filter(t=>e.detail.actionId==t.calledActionId).forEach(t=>{(!t.condition||this._evalExpr(t.condition))&&(e.preventDefault(),e.stopPropagation(),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0})))})},this._pendingOrigins=new Map,this._backendSettledListener=e=>{((typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target)===this&&this._releasePending(e.detail?.actionId)},this._keydownListener=e=>{if(this._handleTabShortcut(e))return;let t=this.component;if(t)for(let n of t.actions??[]){let t=n.shortcut||(n.runOnEnter?`enter`:null);if(t&&this._shortcutMatchesEvent(t,e)){e.preventDefault(),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.id},bubbles:!0,composed:!0}));return}}}}createRenderRoot(){return N.mustUseShadowRoot()?super.createRenderRoot():this}updated(e){super.updated(e),e.has(`state`)&&this.state&&JSON.stringify(this.state)!=JSON.stringify({})&&this.onChange(),e.has(`component`)&&(this.formerState={...this.state},this.component?.confirmOnNavigationIfDirty&&this.dispatchEvent(new CustomEvent(`clean`,{detail:{},bubbles:!0,composed:!0})),setTimeout(()=>this.triggerOnLoad()))}focusFirstInvalidField(){let e=t=>requestAnimationFrame(()=>{let n=this.findFirstInvalid(this.renderRoot);if(n){n.focus?.(),n.scrollIntoView?.({block:`center`,behavior:`smooth`});return}t>0&&e(t-1)});e(3)}findFirstInvalid(e){if(!e?.querySelectorAll)return null;for(let t of Array.from(e.querySelectorAll(`*`))){if(t.invalid===!0)return t;if(t.shadowRoot){let e=this.findFirstInvalid(t.shadowRoot);if(e)return e}}return null}_releasePending(e){(e===void 0?Array.from(this._pendingOrigins.keys()):[e]).forEach(e=>{bo.end(yo(this.id,e)),Do(this._pendingOrigins.get(e)),this._pendingOrigins.delete(e)})}_shortcutMatchesEvent(e,t){return jn(e,t)}_collectShortcutTabs(){let e=this.renderRoot;if(!e)return[];let t=Array.from(e.querySelectorAll(`vaadin-tab[data-shortcut]`));return e.querySelectorAll(`mateu-drawer, mateu-dialog`).forEach(e=>{let n=e.shadowRoot;n&&t.push(...Array.from(n.querySelectorAll(`vaadin-tab[data-shortcut]`)))}),t}_handleTabShortcut(e){let t=this._collectShortcutTabs();if(t.length===0)return!1;for(let n of Array.from(t)){let t=n.dataset.shortcut;if(!t||!this._shortcutMatchesEvent(t,e))continue;let r=n.closest(`vaadin-tabs`);if(!r)continue;let i=Array.from(r.querySelectorAll(`vaadin-tab`)).indexOf(n);if(!(i<0))return e.preventDefault(),r.selected=i,!0}return!1}connectedCallback(){super.connectedCallback(),this.addEventListener(`backend-call-succeeded`,this.handleBackendSucceeded),this.addEventListener(`backend-call-failed`,this.handleBackendFailed),this.addEventListener(`backend-succeeded-event`,this._backendSettledListener),this.addEventListener(`backend-failed-event`,this._backendSettledListener),this.addEventListener(`backend-cancelled-event`,this._backendSettledListener),document.addEventListener(`keydown`,this._keydownListener)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`backend-call-succeeded`,this.handleBackendSucceeded),this.removeEventListener(`backend-call-failed`,this.handleBackendFailed),this.removeEventListener(`backend-succeeded-event`,this._backendSettledListener),this.removeEventListener(`backend-failed-event`,this._backendSettledListener),this.removeEventListener(`backend-cancelled-event`,this._backendSettledListener),document.removeEventListener(`keydown`,this._keydownListener),this._releasePending()}render(){return w`<div>
             <div>${this._render()}</div>
-            ${this.data&&this.data.errors&&this.data.errors._component&&this.data.errors._component.length>0?T`
-                <div><ul>${this.data.errors._component.map(e=>T`<li>${e}</li>`)}</ul></div>
-            `:v}</div>`}_render(){if(this.component?.type==A.ClientSide){let e=this.component;return e.metadata?.type==j.Page?pr(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!0):e.metadata?.type==j.Crud?mr(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!0):P.get()?.renderClientSideComponent(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!1)}return T`
+            ${this.data&&this.data.errors&&this.data.errors._component&&this.data.errors._component.length>0?w`
+                <div><ul>${this.data.errors._component.map(e=>w`<li>${e}</li>`)}</ul></div>
+            `:_}</div>`}_render(){if(this.component?.type==k.ClientSide){let e=this.component;return e.metadata?.type==A.Page?mr(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!0):e.metadata?.type==A.Crud?hr(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!0):N.get()?.renderClientSideComponent(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!1)}return w`
             <mateu-api-caller 
                     @value-changed="${this.valueChangedListener}"
                     @data-changed="${this.dataChangedListener}"
                     @close-modal-requested="${this.closeModalRequestedListener}"
                     @filter-reset-requested="${this.resetFilters}"
                     @action-requested="${this.actionRequestedListener}">
-            ${this.component?.children?.map(e=>{if(e.type==A.ClientSide){let t=e;if(t.metadata?.type==j.Page)return pr(this,t,this.baseUrl,this.state,this.data,this.appState,this.appData,!0);if(t.metadata?.type==j.Crud)return mr(this,t,this.baseUrl,this.state,this.data,this.appState,this.appData,!0)}return F(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData)})}
+            ${this.component?.children?.map(e=>{if(e.type==k.ClientSide){let t=e;if(t.metadata?.type==A.Page)return mr(this,t,this.baseUrl,this.state,this.data,this.appState,this.appData,!0);if(t.metadata?.type==A.Crud)return hr(this,t,this.baseUrl,this.state,this.data,this.appState,this.appData,!0)}return P(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData)})}
             </mateu-api-caller>
-        `}static{this.styles=h`
+        `}static{this.styles=m`
         :host {
         }
 
-        ${ie(de.cssText)}
+        ${ae(fe.cssText)}
         
         vaadin-card.image-on-right::part(media) {
             grid-column: 3;
@@ -7308,16 +7308,16 @@ ${i}
             padding-block: var(--lumo-space-xs);
             box-shadow: 0 1px 0 0 var(--lumo-contrast-10pct, rgba(0, 0, 0, 0.1));
         }
-  `}};k([y()],jo.prototype,`baseUrl`,void 0),k([y()],jo.prototype,`route`,void 0),k([y()],jo.prototype,`consumedRoute`,void 0),jo=k([g(`mateu-component`)],jo);var Mo=e=>{if(e)try{return JSON.parse(e)}catch{return{value:e}}else return{}},No=new class{async handle(e,t){return await e.runAction(t.baseUrl,t.route,t.consumedRoute,t.actionId,t.initiatorComponentId,t.appState,t.serverSideType,t.componentState,t.parameters,t.initiator,t.background,t.options)}},Po=new class{constructor(){this.handleUIIncrement=(e,t,n)=>{if(e?.fragments?.forEach(e=>{le.next({command:void 0,fragment:e,ui:void 0,error:void 0,callbackToken:n})}),e?.appState&&(O.value={...e.appState},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))),e?.appData){let n=e?.appData;ue.value={...e.appData,...n},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))}e?.messages?.forEach(e=>{oa({text:e.text,position:e.position,variant:e.variant,duration:e.duration,undoLabel:e.undoLabel,undoActionId:e.undoActionId,undoParameters:e.undoParameters},t)}),e?.banners&&e.banners.length>0&&document.dispatchEvent(new CustomEvent(`page-banners-received`,{detail:{banners:e.banners,append:e.appendBanners??!1},bubbles:!1,composed:!1})),e?.commands?.forEach(e=>{le.next({command:e,fragment:void 0,ui:void 0,error:void 0,callbackToken:n})})}}async runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,m,ee={}){let te=()=>{this.runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,m,ee)};try{let o=await No.handle(e,{baseUrl:t,route:n,consumedRoute:r,actionId:i,appState:O.value,initiatorComponentId:a,componentState:c,parameters:l,serverSideType:s,initiator:u,background:d,options:{...ee,retry:te}});f&&f(o),p||this.handleUIIncrement(o,u,m),o.messages&&o.messages.length==1&&o.messages[0].variant==`error`&&u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-succeeded`,{detail:{actionId:i,evevntId:E()},bubbles:!0,composed:!0}))}catch(e){console.warn(`Action request failed`,e),e?.__mateuReported||u.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:i,reason:this.serialize(e),retry:te}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))}}serialize(e){return e?.message?e:JSON.stringify(e)}},Fo=new class{constructor(){this.handleUIIncrement=(e,t,n)=>{if(e?.messages?.forEach(e=>{oa({text:e.text,position:e.position,variant:e.variant,duration:e.duration,undoLabel:e.undoLabel,undoActionId:e.undoActionId,undoParameters:e.undoParameters},t)}),e?.banners&&e.banners.length>0&&document.dispatchEvent(new CustomEvent(`page-banners-received`,{detail:{banners:e.banners,append:e.appendBanners??!1},bubbles:!1,composed:!1})),e?.commands?.forEach(e=>{le.next({command:e,fragment:void 0,ui:void 0,error:void 0,callbackToken:n})}),e?.fragments?.forEach(e=>{le.next({command:void 0,fragment:e,ui:void 0,error:void 0,callbackToken:n})}),e?.appState&&(O.value={...e.appState},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))),e?.appData){let n=e?.appData;ue.value={...e.appData,...n},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))}}}async runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,m,ee={}){let te=()=>{this.runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,m,ee)};if(n){n||=`_no_route`,n&&n.startsWith(`/`)&&(n=n.substring(1));let e={serverSideType:s,appState:O.value,componentState:c,parameters:l,initiatorComponentId:a,consumedRoute:r,route:`/`+n,actionId:i};d||u.dispatchEvent(new CustomEvent(`backend-called-event`,{bubbles:!0,composed:!0,detail:{}})),fetch(t+`/mateu/v3/sse/`+n,{method:`POST`,headers:{Accept:`text/event-stream`,"Content-Type":`application/json`},body:JSON.stringify(e)}).then(async e=>{let t=e.body?.pipeThrough(new TextDecoderStream).getReader();if(t){let e=``;for(;;){let{value:n,done:r}=await t.read();if(r)break;e+=n;let a=e.split(`
+  `}};O([v()],Mo.prototype,`baseUrl`,void 0),O([v()],Mo.prototype,`route`,void 0),O([v()],Mo.prototype,`consumedRoute`,void 0),Mo=O([h(`mateu-component`)],Mo);var No=e=>{if(e)try{return JSON.parse(e)}catch{return{value:e}}else return{}},Po=new class{async handle(e,t){return await e.runAction(t.baseUrl,t.route,t.consumedRoute,t.actionId,t.initiatorComponentId,t.appState,t.serverSideType,t.componentState,t.parameters,t.initiator,t.background,t.options)}},Fo=new class{constructor(){this.handleUIIncrement=(e,t,n)=>{if(e?.fragments?.forEach(e=>{ue.next({command:void 0,fragment:e,ui:void 0,error:void 0,callbackToken:n})}),e?.appState&&(D.value={...e.appState},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))),e?.appData){let n=e?.appData;de.value={...e.appData,...n},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))}e?.messages?.forEach(e=>{sa({text:e.text,position:e.position,variant:e.variant,duration:e.duration,undoLabel:e.undoLabel,undoActionId:e.undoActionId,undoParameters:e.undoParameters},t)}),e?.banners&&e.banners.length>0&&document.dispatchEvent(new CustomEvent(`page-banners-received`,{detail:{banners:e.banners,append:e.appendBanners??!1},bubbles:!1,composed:!1})),e?.commands?.forEach(e=>{ue.next({command:e,fragment:void 0,ui:void 0,error:void 0,callbackToken:n})})}}async runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,te={}){let ne=()=>{this.runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,te)};try{let o=await Po.handle(e,{baseUrl:t,route:n,consumedRoute:r,actionId:i,appState:D.value,initiatorComponentId:a,componentState:c,parameters:l,serverSideType:s,initiator:u,background:d,options:{...te,retry:ne}});f&&f(o),p||this.handleUIIncrement(o,u,ee),o.messages&&o.messages.length==1&&o.messages[0].variant==`error`&&u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-succeeded`,{detail:{actionId:i,evevntId:T()},bubbles:!0,composed:!0}))}catch(e){console.warn(`Action request failed`,e),e?.__mateuReported||u.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:i,reason:this.serialize(e),retry:ne}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))}}serialize(e){return e?.message?e:JSON.stringify(e)}},Io=new class{constructor(){this.handleUIIncrement=(e,t,n)=>{if(e?.messages?.forEach(e=>{sa({text:e.text,position:e.position,variant:e.variant,duration:e.duration,undoLabel:e.undoLabel,undoActionId:e.undoActionId,undoParameters:e.undoParameters},t)}),e?.banners&&e.banners.length>0&&document.dispatchEvent(new CustomEvent(`page-banners-received`,{detail:{banners:e.banners,append:e.appendBanners??!1},bubbles:!1,composed:!1})),e?.commands?.forEach(e=>{ue.next({command:e,fragment:void 0,ui:void 0,error:void 0,callbackToken:n})}),e?.fragments?.forEach(e=>{ue.next({command:void 0,fragment:e,ui:void 0,error:void 0,callbackToken:n})}),e?.appState&&(D.value={...e.appState},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))),e?.appData){let n=e?.appData;de.value={...e.appData,...n},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))}}}async runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,te={}){let ne=()=>{this.runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,te)};if(n){n||=`_no_route`,n&&n.startsWith(`/`)&&(n=n.substring(1));let e={serverSideType:s,appState:D.value,componentState:c,parameters:l,initiatorComponentId:a,consumedRoute:r,route:`/`+n,actionId:i};d||u.dispatchEvent(new CustomEvent(`backend-called-event`,{bubbles:!0,composed:!0,detail:{}})),fetch(t+`/mateu/v3/sse/`+n,{method:`POST`,headers:{Accept:`text/event-stream`,"Content-Type":`application/json`},body:JSON.stringify(e)}).then(async e=>{let t=e.body?.pipeThrough(new TextDecoderStream).getReader();if(t){let e=``;for(;;){let{value:n,done:r}=await t.read();if(r)break;e+=n;let a=e.split(`
 
-`);e=a.pop()??``;for(let e of a){let t=e.trim();if(t)if(t.startsWith(`data:`)){let e=JSON.parse(t.substring(5).trim());f&&f(e),p||this.handleUIIncrement(e,u,m),e.messages&&e.messages.length==1&&e.messages[0].variant==`error`&&u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))}else{let e=t;try{let n=JSON.parse(t);e=n.message,n._embedded?.errors?.length>0&&n._embedded.errors[0].message&&(e=n._embedded.errors[0].message)}catch{}throw Error(e)}}}}d||u.dispatchEvent(new CustomEvent(`backend-succeeded-event`,{bubbles:!0,composed:!0,detail:{actionId:i}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-succeeded`,{detail:{actionId:i},bubbles:!0,composed:!0}))}).catch(e=>{u.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:i,reason:this.serialize(e),retry:te}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))})}}serialize(e){return e?.message?e:JSON.stringify(e)}},Io={fixed:`fixed`,fullWidth:`full`,edgeToEdge:`edge`},Lo=new Set([j.Gantt,j.PlanningBoard,j.Kanban,j.Bpmn,j.Workflow,j.Map]),Ro={landing:`fixed`,form:`fixed`,process:`fixed`},zo=e=>e?Io[e]:void 0,Bo=e=>e.type==A.ClientSide?e.metadata:void 0,Vo=e=>{let t=Bo(e);if(t?.type==j.Page){let e=zo(t.pageWidth);if(e)return e}for(let t of e.children??[]){let e=Vo(t);if(e)return e}},Ho=e=>{let t=e.pageType;if(t)return t;let n=e=>{let t=Bo(e);if(t?.type==j.Page&&t.pageType)return t.pageType;for(let t of e.children??[]){let e=n(t);if(e)return e}};return n(e)},Uo=e=>{let t=Bo(e);if(t?.type!=j.Crud)return!1;let n=t;return n.compact?!0:(n.columns??[]).some(e=>e.metadata?.editable)},Wo=(e,t)=>t(e)||(e.children??[]).some(e=>Wo(e,t)),Go=e=>!!e&&Wo(e,e=>Bo(e)?.type==j.HeroSection),Ko=e=>Bo(e)?.type==j.App||(e.children??[]).some(e=>Bo(e)?.type==j.App),qo=(e,t)=>e?(zo(e.pageWidth)??Vo(e))||(t?.top&&Ko(e)?`edge`:Ro[Ho(e)??``]||(Wo(e,e=>{let t=Bo(e)?.type;return t!=null&&Lo.has(t)})?`edge`:Wo(e,Uo)?`full`:`fixed`)):`fixed`,Jo,X=class extends Qe{static{Jo=this}constructor(...e){super(...e),this.consumedRoute=``,this.serverSideType=void 0,this.uriPrefix=void 0,this.overrides=void 0,this.homeRoute=void 0,this.route=void 0,this.top=void 0,this.appState={},this.appData={},this.preventNavigation=!1,this.overridesParsed={},this.fragment=void 0,this.showSkeleton=!1,this.pendingRouteFocus=!1,this.hasRenderedContent=!1,this.loadLifecycleListener=e=>{if(((typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target)===this)if(clearTimeout(this.skeletonTimer),e.type===`backend-called-event`){if(this.fragment?.component)return;this.skeletonTimer=setTimeout(()=>{this.showSkeleton=!0},Jo.SKELETON_DELAY_MS)}else this.showSkeleton=!1},this.actionRequestedListener=e=>{e instanceof CustomEvent&&(e.preventDefault(),e.stopPropagation(),this.manageActionEvent(e))},this.historyPushed=e=>{e instanceof CustomEvent&&(e.preventDefault(),e.stopPropagation(),this.preventNavigation=!0,this.route=e.detail.route)},this.routeChangedListener=e=>{if(e instanceof CustomEvent){e.preventDefault(),e.stopPropagation();let t=e.detail.route;typeof t==`string`&&(t===``||t.startsWith(`/`))&&this.consumedRoute&&this.consumedRoute!==`_empty`&&this.consumedRoute.startsWith(`/`)&&!t.startsWith(this.consumedRoute)&&(t=this.consumedRoute+t),this.uriPrefix&&(t=t.startsWith(`/`)&&this.uriPrefix.endsWith(`/`)?this.uriPrefix+t.substring(1):!t.startsWith(`/`)&&!this.uriPrefix.endsWith(`/`)?this.uriPrefix+`/`+t:this.uriPrefix+t),this.dispatchEvent(new CustomEvent(`url-update-requested`,{detail:{route:t},bubbles:!0,composed:!0}))}},this.backendFailedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&e.detail.actionId==``&&(this.fragment={targetComponentId:this.id,data:{},state:{},component:{type:A.ClientSide,metadata:{type:j.Element,name:`div`,content:`Not found`},id:`fieldId`},action:Ge.Replace,containerId:void 0})},this.detail1=void 0,this.manageActionEvent=e=>{e.preventDefault(),e.stopPropagation(),this.detail1=e.detail;let t=this.detail1;if(e.type==`server-side-action-requested`){let e=Po;t.sse&&(e=Fo),e.runAction(We,this.baseUrl,t.route??``,t.consumedRoute,t.actionId,t.initiatorComponentId,this.getCustomisedAppState(),t.serverSideType,t.componentState,t.parameters,t.initiator,t.background,t.callback,t.callbackonly,t.callbackToken,{timeoutMillis:t.timeoutMillis,idempotent:t.idempotent})}},this.getCustomisedAppState=()=>{let e={...O.value};if(this.overrides){let t=Mo(this.overrides);e={...e,...t}}return e}}manageActionRequestedEvent(e){throw Error(`Method not implemented.`)}createRenderRoot(){return P.mustUseShadowRoot()?super.createRenderRoot():this}focusNewContent(){requestAnimationFrame(()=>{let e=this.renderRoot?.querySelector?.(`h1, h2, [role="heading"]`)??this;e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus?.({preventScroll:!0})})}static{this.SKELETON_DELAY_MS=400}connectedCallback(){super.connectedCallback(),this.overridesParsed=Mo(this.overrides),this.addEventListener(`server-side-action-requested`,this.actionRequestedListener),this.addEventListener(`backend-call-failed`,this.backendFailedListener),this.addEventListener(`history-pushed`,this.historyPushed),this.addEventListener(`route-changed`,this.routeChangedListener),this.addEventListener(`backend-called-event`,this.loadLifecycleListener),this.addEventListener(`backend-succeeded-event`,this.loadLifecycleListener),this.addEventListener(`backend-failed-event`,this.loadLifecycleListener),this.addEventListener(`backend-cancelled-event`,this.loadLifecycleListener)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`server-side-action-requested`,this.actionRequestedListener),this.removeEventListener(`backend-call-failed`,this.backendFailedListener),this.removeEventListener(`history-pushed`,this.historyPushed),this.removeEventListener(`route-changed`,this.routeChangedListener),this.removeEventListener(`backend-called-event`,this.loadLifecycleListener),this.removeEventListener(`backend-succeeded-event`,this.loadLifecycleListener),this.removeEventListener(`backend-failed-event`,this.loadLifecycleListener),this.removeEventListener(`backend-cancelled-event`,this.loadLifecycleListener),clearTimeout(this.skeletonTimer)}shouldUpdate(e){if(this.fragment?.component&&[...e.keys()].every(e=>e===`appState`||e===`appData`)){let t=this.renderRoot.querySelector(`mateu-component`);if(t)return e.has(`appState`)&&(t.appState=this.appState),e.has(`appData`)&&(t.appData=this.appData),!1}return!0}updated(e){(e.has(`id`)||e.has(`baseurl`)||e.has(`route`)||e.has(`consumedRoute`)||e.has(`instant`))&&(this.preventNavigation||(this.callbackToken=this.instant||E(),this.manageActionEvent(new CustomEvent(`server-side-action-requested`,{detail:{route:this.route,consumedRoute:this.consumedRoute,userData:void 0,actionId:``,serverSideType:this.serverSideType,initiatorComponentId:this.id,initiator:this,componentState:this.initialState,callbackToken:this.callbackToken},bubbles:!0,composed:!0})))),e.has(`route`)&&this.top&&(this.preventNavigation||(this.pendingRouteFocus=!0),this.preventNavigation||this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:this.route},bubbles:!0,composed:!0}))),this.preventNavigation&&=!1}applyFragment(e){if(!e.component&&this.fragment?.component){this.fragment={...this.fragment,state:{...this.fragment.state??{},...e.state??{}},data:{...this.fragment.data??{},...e.data??{}}};return}this.fragment=e,e.component&&(this.pendingRouteFocus&&this.hasRenderedContent&&this.focusNewContent(),this.pendingRouteFocus=!1,this.hasRenderedContent=!0),e.component&&(this.dataset.pageWidth=qo(e.component,{top:this.top}),this.dataset.pageType=Ho(e.component)??``,this.dataset.hasWelcomeBanner=String(Go(e.component)))}render(){return!this.fragment?.component&&this.showSkeleton?T`
+`);e=a.pop()??``;for(let e of a){let t=e.trim();if(t)if(t.startsWith(`data:`)){let e=JSON.parse(t.substring(5).trim());f&&f(e),p||this.handleUIIncrement(e,u,ee),e.messages&&e.messages.length==1&&e.messages[0].variant==`error`&&u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))}else{let e=t;try{let n=JSON.parse(t);e=n.message,n._embedded?.errors?.length>0&&n._embedded.errors[0].message&&(e=n._embedded.errors[0].message)}catch{}throw Error(e)}}}}d||u.dispatchEvent(new CustomEvent(`backend-succeeded-event`,{bubbles:!0,composed:!0,detail:{actionId:i}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-succeeded`,{detail:{actionId:i},bubbles:!0,composed:!0}))}).catch(e=>{u.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:i,reason:this.serialize(e),retry:ne}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))})}}serialize(e){return e?.message?e:JSON.stringify(e)}},Lo={fixed:`fixed`,fullWidth:`full`,edgeToEdge:`edge`},Ro=new Set([A.Gantt,A.PlanningBoard,A.Kanban,A.Bpmn,A.Workflow,A.Map]),zo={landing:`fixed`,form:`fixed`,process:`fixed`},Bo=e=>e?Lo[e]:void 0,Vo=e=>e.type==k.ClientSide?e.metadata:void 0,Ho=e=>{let t=Vo(e);if(t?.type==A.Page){let e=Bo(t.pageWidth);if(e)return e}for(let t of e.children??[]){let e=Ho(t);if(e)return e}},Uo=e=>{let t=e.pageType;if(t)return t;let n=e=>{let t=Vo(e);if(t?.type==A.Page&&t.pageType)return t.pageType;for(let t of e.children??[]){let e=n(t);if(e)return e}};return n(e)},Wo=e=>{let t=Vo(e);if(t?.type!=A.Crud)return!1;let n=t;return n.compact?!0:(n.columns??[]).some(e=>e.metadata?.editable)},Go=(e,t)=>t(e)||(e.children??[]).some(e=>Go(e,t)),Ko=e=>!!e&&Go(e,e=>Vo(e)?.type==A.HeroSection),qo=e=>Vo(e)?.type==A.App||(e.children??[]).some(e=>Vo(e)?.type==A.App),Jo=(e,t)=>e?(Bo(e.pageWidth)??Ho(e))||(t?.top&&qo(e)?`edge`:zo[Uo(e)??``]||(Go(e,e=>{let t=Vo(e)?.type;return t!=null&&Ro.has(t)})?`edge`:Go(e,Wo)?`full`:`fixed`)):`fixed`,Yo=`mateu-route-structure-cache`,Xo=1,Zo=50,Qo=(()=>{try{return localStorage.getItem(`mateu-route-structure-cache-off`)!==`1`}catch{return!0}})(),$o=()=>{try{return JSON.parse(localStorage.getItem(Yo)??`{}`)}catch{return{}}},es=e=>{try{localStorage.setItem(Yo,JSON.stringify(e))}catch{try{let t=Object.entries(e).sort((e,t)=>t[1].t-e[1].t).slice(0,Math.floor(Zo/2));localStorage.setItem(Yo,JSON.stringify(Object.fromEntries(t)))}catch{}}},ts=e=>{let t=e.initialState&&Object.keys(e.initialState).length?`#`+is(JSON.stringify(e.initialState)):``;return[e.baseUrl,e.consumedRoute??``,e.route??``,e.serverSideType??``].join(`|`)+t},ns=e=>{if(!Qo)return;let t=$o()[e];if(!(!t||t.v!==Xo))return{component:t.component,hash:t.hash}},rs=(e,t,n)=>{if(!Qo)return;let r=$o();r[e]={v:Xo,t:Date.now(),component:t,hash:n};let i=Object.keys(r);if(i.length>Zo){let e=i.sort((e,t)=>r[e].t-r[t].t).slice(0,i.length-Zo);for(let t of e)delete r[t]}es(r)},is=e=>{let t=2166136261;for(let n=0;n<e.length;n++)t^=e.charCodeAt(n),t=Math.imul(t,16777619);return(t>>>0).toString(36)},as=30,os=new Map,ss=!0,cs=e=>{if(ss)return os.get(e)},ls=(e,t)=>{if(ss&&(os.delete(e),os.set(e,t),os.size>as)){let e=os.keys().next().value;e!==void 0&&os.delete(e)}},us,Y=class extends $e{static{us=this}constructor(...e){super(...e),this.consumedRoute=``,this.serverSideType=void 0,this.uriPrefix=void 0,this.overrides=void 0,this.homeRoute=void 0,this.route=void 0,this.top=void 0,this.appState={},this.appData={},this.preventNavigation=!1,this.overridesParsed={},this.fragment=void 0,this.showSkeleton=!1,this.pendingRouteFocus=!1,this.hasRenderedContent=!1,this.loadLifecycleListener=e=>{if(((typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target)===this)if(clearTimeout(this.skeletonTimer),e.type===`backend-called-event`){if(this.fragment?.component)return;this.skeletonTimer=setTimeout(()=>{this.showSkeleton=!0},us.SKELETON_DELAY_MS)}else this.showSkeleton=!1},this.actionRequestedListener=e=>{e instanceof CustomEvent&&(e.preventDefault(),e.stopPropagation(),this.manageActionEvent(e))},this.historyPushed=e=>{e instanceof CustomEvent&&(e.preventDefault(),e.stopPropagation(),this.preventNavigation=!0,this.route=e.detail.route)},this.routeChangedListener=e=>{if(e instanceof CustomEvent){e.preventDefault(),e.stopPropagation();let t=e.detail.route;typeof t==`string`&&(t===``||t.startsWith(`/`))&&this.consumedRoute&&this.consumedRoute!==`_empty`&&this.consumedRoute.startsWith(`/`)&&!t.startsWith(this.consumedRoute)&&(t=this.consumedRoute+t),this.uriPrefix&&(t=t.startsWith(`/`)&&this.uriPrefix.endsWith(`/`)?this.uriPrefix+t.substring(1):!t.startsWith(`/`)&&!this.uriPrefix.endsWith(`/`)?this.uriPrefix+`/`+t:this.uriPrefix+t),this.dispatchEvent(new CustomEvent(`url-update-requested`,{detail:{route:t},bubbles:!0,composed:!0}))}},this.backendFailedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&e.detail.actionId==``&&(this.fragment={targetComponentId:this.id,data:{},state:{},component:{type:k.ClientSide,metadata:{type:A.Element,name:`div`,content:`Not found`},id:`fieldId`},action:Ke.Replace,containerId:void 0})},this.detail1=void 0,this.manageActionEvent=e=>{e.preventDefault(),e.stopPropagation(),this.detail1=e.detail;let t=this.detail1;if(e.type==`server-side-action-requested`){let e=Fo;t.sse&&(e=Io),e.runAction(Ge,this.baseUrl,t.route??``,t.consumedRoute,t.actionId,t.initiatorComponentId,this.getCustomisedAppState(),t.serverSideType,t.componentState,t.parameters,t.initiator,t.background,t.callback,t.callbackonly,t.callbackToken,{timeoutMillis:t.timeoutMillis,idempotent:t.idempotent,knownStructureHash:t.knownStructureHash})}},this.getCustomisedAppState=()=>{let e={...D.value};if(this.overrides){let t=No(this.overrides);e={...e,...t}}return e}}manageActionRequestedEvent(e){throw Error(`Method not implemented.`)}createRenderRoot(){return N.mustUseShadowRoot()?super.createRenderRoot():this}structureCacheKey(){return ts({baseUrl:this.baseUrl,consumedRoute:this.consumedRoute,route:this.route,serverSideType:this.serverSideType,initialState:this.initialState})}focusNewContent(){requestAnimationFrame(()=>{let e=this.renderRoot?.querySelector?.(`h1, h2, [role="heading"]`)??this;e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus?.({preventScroll:!0})})}static{this.SKELETON_DELAY_MS=400}connectedCallback(){super.connectedCallback(),this.overridesParsed=No(this.overrides),this.addEventListener(`server-side-action-requested`,this.actionRequestedListener),this.addEventListener(`backend-call-failed`,this.backendFailedListener),this.addEventListener(`history-pushed`,this.historyPushed),this.addEventListener(`route-changed`,this.routeChangedListener),this.addEventListener(`backend-called-event`,this.loadLifecycleListener),this.addEventListener(`backend-succeeded-event`,this.loadLifecycleListener),this.addEventListener(`backend-failed-event`,this.loadLifecycleListener),this.addEventListener(`backend-cancelled-event`,this.loadLifecycleListener)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`server-side-action-requested`,this.actionRequestedListener),this.removeEventListener(`backend-call-failed`,this.backendFailedListener),this.removeEventListener(`history-pushed`,this.historyPushed),this.removeEventListener(`route-changed`,this.routeChangedListener),this.removeEventListener(`backend-called-event`,this.loadLifecycleListener),this.removeEventListener(`backend-succeeded-event`,this.loadLifecycleListener),this.removeEventListener(`backend-failed-event`,this.loadLifecycleListener),this.removeEventListener(`backend-cancelled-event`,this.loadLifecycleListener),clearTimeout(this.skeletonTimer)}shouldUpdate(e){if(this.fragment?.component&&[...e.keys()].every(e=>e===`appState`||e===`appData`)){let t=this.renderRoot.querySelector(`mateu-component`);if(t)return e.has(`appState`)&&(t.appState=this.appState),e.has(`appData`)&&(t.appData=this.appData),!1}return!0}updated(e){if((e.has(`id`)||e.has(`baseurl`)||e.has(`route`)||e.has(`consumedRoute`)||e.has(`instant`))&&!this.preventNavigation){this.callbackToken=this.instant||T();let e=this.structureCacheKey(),t=e===this.lastAuthoritativeKey?void 0:cs(e);if(t)queueMicrotask(()=>this.applyFragment(t));else{if(e!==this.lastAuthoritativeKey){let t=ns(e);this.currentStructureHash=t?.hash,t&&(this.fragment={targetComponentId:this.id,component:t.component,state:{},data:{},action:Ke.Replace,containerId:void 0})}this.manageActionEvent(new CustomEvent(`server-side-action-requested`,{detail:{route:this.route,consumedRoute:this.consumedRoute,userData:void 0,actionId:``,serverSideType:this.serverSideType,initiatorComponentId:this.id,initiator:this,componentState:this.initialState,knownStructureHash:this.currentStructureHash,callbackToken:this.callbackToken},bubbles:!0,composed:!0}))}}e.has(`route`)&&this.top&&(this.preventNavigation||(this.pendingRouteFocus=!0),this.preventNavigation||this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:this.route},bubbles:!0,composed:!0}))),this.preventNavigation&&=!1}applyFragment(e){if(!e.component&&this.fragment?.component){this.fragment={...this.fragment,state:{...this.fragment.state??{},...e.state??{}},data:{...this.fragment.data??{},...e.data??{}}};return}if(this.fragment=e,e.component){if(e.action!==Ke.Add){let t=this.structureCacheKey(),n=e.component.structureHash;rs(t,e.component,n),this.lastAuthoritativeKey=t,this.currentStructureHash=n,e.component.staticView&&ls(t,e)}this.pendingRouteFocus&&this.hasRenderedContent&&this.focusNewContent(),this.pendingRouteFocus=!1,this.hasRenderedContent=!0}e.component&&(this.dataset.pageWidth=Jo(e.component,{top:this.top}),this.dataset.pageType=Uo(e.component)??``,this.dataset.hasWelcomeBanner=String(Ko(e.component)))}render(){return!this.fragment?.component&&this.showSkeleton?w`
                 <div class="route-skeleton" aria-busy="true" aria-live="polite">
                     <mateu-skeleton variant="text" count="1"></mateu-skeleton>
                     <mateu-skeleton variant="form" count="4"></mateu-skeleton>
                 </div>
-            `:T`
-           ${this.fragment?.component?F(this,this.fragment?.component,this.baseUrl,this.fragment?.state??{},this.fragment?.data??{},this.appState,this.appData):v}
-       `}static{this.styles=h`
+            `:w`
+           ${this.fragment?.component?P(this,this.fragment?.component,this.baseUrl,this.fragment?.state??{},this.fragment?.data??{},this.appState,this.appData):_}
+       `}static{this.styles=m`
         :host {
             display: block;
             min-height: 100%;
@@ -7350,10 +7350,10 @@ ${i}
             max-width: 16rem;
             margin-block-end: var(--lumo-space-l, 1.5rem);
         }
-  `}};k([y()],X.prototype,`consumedRoute`,void 0),k([y()],X.prototype,`serverSideType`,void 0),k([y()],X.prototype,`uriPrefix`,void 0),k([y()],X.prototype,`overrides`,void 0),k([y()],X.prototype,`homeRoute`,void 0),k([y()],X.prototype,`route`,void 0),k([y()],X.prototype,`top`,void 0),k([y()],X.prototype,`instant`,void 0),k([y()],X.prototype,`initialState`,void 0),k([y()],X.prototype,`appState`,void 0),k([y()],X.prototype,`appData`,void 0),k([C()],X.prototype,`fragment`,void 0),k([C()],X.prototype,`showSkeleton`,void 0),X=Jo=k([g(`mateu-ux`)],X);function Yo(e){let t=`var(--lumo-space-m, 1rem)`,n={left:`50%`,transform:`translateX(-50%)`};switch(e){case`topStart`:return{top:t,left:t};case`topCenter`:return{top:t,...n};case`topEnd`:return{top:t,right:t};case`topStretch`:return{top:t,left:t,right:t};case`middle`:return{top:`50%`,left:`50%`,transform:`translate(-50%, -50%)`};case`bottomStart`:return{bottom:t,left:t};case`bottomCenter`:return{bottom:t,...n};case`bottomStretch`:return{bottom:t,left:t,right:t};default:return{bottom:t,right:t}}}function Xo(e){switch(e){case`success`:return{bg:`var(--lumo-success-color, #2e7d32)`,fg:`#fff`};case`error`:return{bg:`var(--lumo-error-color, #c62828)`,fg:`#fff`};case`warning`:return{bg:`var(--lumo-warning-color, #f9a825)`,fg:`#1a1a1a`};case`contrast`:return{bg:`var(--lumo-contrast-90pct, #1a1a1a)`,fg:`#fff`};default:return{bg:`var(--lumo-base-color, #fff)`,fg:`var(--lumo-body-text-color, #1a1a1a)`}}}var Zo={show(e,t){let{bg:n,fg:r}=Xo(e.variant),i=Yo(e.position),a=document.createElement(`div`),o=e.variant===`error`;a.setAttribute(`role`,o?`alert`:`status`),a.setAttribute(`aria-live`,o?`assertive`:`polite`),a.setAttribute(`aria-atomic`,`true`),Object.assign(a.style,{position:`fixed`,zIndex:`2000`,display:`flex`,alignItems:`center`,gap:`0.75rem`,maxWidth:`min(90vw, 28rem)`,padding:`0.7rem 1rem`,borderRadius:`var(--lumo-border-radius-m, 8px)`,boxShadow:`var(--lumo-box-shadow-m, 0 4px 16px rgba(0,0,0,0.2))`,background:n,color:r,font:`inherit`,fontSize:`var(--lumo-font-size-s, 0.875rem)`,opacity:`0`,transition:`opacity 0.2s ease`,...i});let s=document.createElement(`span`);s.textContent=e.text,a.appendChild(s);let c=()=>{a.style.opacity=`0`,setTimeout(()=>a.remove(),200)},l=e.onAction?{label:e.actionLabel??`Retry`,run:e.onAction}:e.undoActionId?{label:e.undoLabel??`Undo`,run:()=>t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.undoActionId,parameters:e.undoParameters??{}},bubbles:!0,composed:!0}))}:void 0;if(l){let e=document.createElement(`button`);e.textContent=l.label,e.style.cssText=`margin-left: 0.25rem; background: none; border: 1px solid currentColor; border-radius: var(--lumo-border-radius-s, 4px); color: inherit; cursor: pointer; padding: 0.15rem 0.6rem; font: inherit; font-weight: 600;`,e.addEventListener(`click`,()=>{l.run(),c()}),a.appendChild(e)}document.body.appendChild(a),requestAnimationFrame(()=>{a.style.opacity=`1`});let u=e.duration??(l?1e4:5e3);u>0&&setTimeout(c,u)}};function Qo(){aa(Zo)}var $o=class extends b{constructor(...e){super(...e),this.online=!0,this.recovered=!1}connectedCallback(){super.connectedCallback(),this.online=Be.isOnline(),this.unsubscribe=Be.subscribe(e=>{let t=!this.online;this.online=e,e&&t&&(this.recovered=!0,clearTimeout(this.recoveredTimer),this.recoveredTimer=setTimeout(()=>{this.recovered=!1},4e3))})}disconnectedCallback(){super.disconnectedCallback(),this.unsubscribe?.(),clearTimeout(this.recoveredTimer),this.releaseSpace()}updated(){let e=this.renderRoot.querySelector(`.bar`);if(!e){this.releaseSpace();return}document.body.style.setProperty(`padding-block-start`,`${e.offsetHeight}px`)}releaseSpace(){typeof document<`u`&&document.body?.style.removeProperty(`padding-block-start`)}render(){if(this.online&&!this.recovered)return v;let e=!this.online;return T`<div class="bar ${e?`offline`:`back`}" role="status" aria-live="polite">
+  `}};O([v()],Y.prototype,`consumedRoute`,void 0),O([v()],Y.prototype,`serverSideType`,void 0),O([v()],Y.prototype,`uriPrefix`,void 0),O([v()],Y.prototype,`overrides`,void 0),O([v()],Y.prototype,`homeRoute`,void 0),O([v()],Y.prototype,`route`,void 0),O([v()],Y.prototype,`top`,void 0),O([v()],Y.prototype,`instant`,void 0),O([v()],Y.prototype,`initialState`,void 0),O([v()],Y.prototype,`appState`,void 0),O([v()],Y.prototype,`appData`,void 0),O([S()],Y.prototype,`fragment`,void 0),O([S()],Y.prototype,`showSkeleton`,void 0),Y=us=O([h(`mateu-ux`)],Y);function ds(e){let t=`var(--lumo-space-m, 1rem)`,n={left:`50%`,transform:`translateX(-50%)`};switch(e){case`topStart`:return{top:t,left:t};case`topCenter`:return{top:t,...n};case`topEnd`:return{top:t,right:t};case`topStretch`:return{top:t,left:t,right:t};case`middle`:return{top:`50%`,left:`50%`,transform:`translate(-50%, -50%)`};case`bottomStart`:return{bottom:t,left:t};case`bottomCenter`:return{bottom:t,...n};case`bottomStretch`:return{bottom:t,left:t,right:t};default:return{bottom:t,right:t}}}function fs(e){switch(e){case`success`:return{bg:`var(--lumo-success-color, #2e7d32)`,fg:`#fff`};case`error`:return{bg:`var(--lumo-error-color, #c62828)`,fg:`#fff`};case`warning`:return{bg:`var(--lumo-warning-color, #f9a825)`,fg:`#1a1a1a`};case`contrast`:return{bg:`var(--lumo-contrast-90pct, #1a1a1a)`,fg:`#fff`};default:return{bg:`var(--lumo-base-color, #fff)`,fg:`var(--lumo-body-text-color, #1a1a1a)`}}}var ps={show(e,t){let{bg:n,fg:r}=fs(e.variant),i=ds(e.position),a=document.createElement(`div`),o=e.variant===`error`;a.setAttribute(`role`,o?`alert`:`status`),a.setAttribute(`aria-live`,o?`assertive`:`polite`),a.setAttribute(`aria-atomic`,`true`),Object.assign(a.style,{position:`fixed`,zIndex:`2000`,display:`flex`,alignItems:`center`,gap:`0.75rem`,maxWidth:`min(90vw, 28rem)`,padding:`0.7rem 1rem`,borderRadius:`var(--lumo-border-radius-m, 8px)`,boxShadow:`var(--lumo-box-shadow-m, 0 4px 16px rgba(0,0,0,0.2))`,background:n,color:r,font:`inherit`,fontSize:`var(--lumo-font-size-s, 0.875rem)`,opacity:`0`,transition:`opacity 0.2s ease`,...i});let s=document.createElement(`span`);s.textContent=e.text,a.appendChild(s);let c=()=>{a.style.opacity=`0`,setTimeout(()=>a.remove(),200)},l=e.onAction?{label:e.actionLabel??`Retry`,run:e.onAction}:e.undoActionId?{label:e.undoLabel??`Undo`,run:()=>t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.undoActionId,parameters:e.undoParameters??{}},bubbles:!0,composed:!0}))}:void 0;if(l){let e=document.createElement(`button`);e.textContent=l.label,e.style.cssText=`margin-left: 0.25rem; background: none; border: 1px solid currentColor; border-radius: var(--lumo-border-radius-s, 4px); color: inherit; cursor: pointer; padding: 0.15rem 0.6rem; font: inherit; font-weight: 600;`,e.addEventListener(`click`,()=>{l.run(),c()}),a.appendChild(e)}document.body.appendChild(a),requestAnimationFrame(()=>{a.style.opacity=`1`});let u=e.duration??(l?1e4:5e3);u>0&&setTimeout(c,u)}};function ms(){oa(ps)}var hs=class extends y{constructor(...e){super(...e),this.online=!0,this.recovered=!1}connectedCallback(){super.connectedCallback(),this.online=Ve.isOnline(),this.unsubscribe=Ve.subscribe(e=>{let t=!this.online;this.online=e,e&&t&&(this.recovered=!0,clearTimeout(this.recoveredTimer),this.recoveredTimer=setTimeout(()=>{this.recovered=!1},4e3))})}disconnectedCallback(){super.disconnectedCallback(),this.unsubscribe?.(),clearTimeout(this.recoveredTimer),this.releaseSpace()}updated(){let e=this.renderRoot.querySelector(`.bar`);if(!e){this.releaseSpace();return}document.body.style.setProperty(`padding-block-start`,`${e.offsetHeight}px`)}releaseSpace(){typeof document<`u`&&document.body?.style.removeProperty(`padding-block-start`)}render(){if(this.online&&!this.recovered)return _;let e=!this.online;return w`<div class="bar ${e?`offline`:`back`}" role="status" aria-live="polite">
             <span class="dot"></span>
             <span>${e?`No connection — changes you make now will not be saved.`:`Connection restored.`}</span>
-        </div>`}static{this.styles=h`
+        </div>`}static{this.styles=m`
         :host {
             position: fixed;
             inset-block-start: 0;
@@ -7392,7 +7392,7 @@ ${i}
         @media (prefers-reduced-motion: reduce) {
             .bar, .bar.offline .dot { animation: none; }
         }
-    `}};k([C()],$o.prototype,`online`,void 0),k([C()],$o.prototype,`recovered`,void 0),$o=k([g(`mateu-connectivity-banner`)],$o);var es=null;function ts(){if(!(typeof document>`u`)&&!(es&&es.isConnected)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>ts(),{once:!0});return}es=document.createElement(`mateu-connectivity-banner`),document.body.appendChild(es)}}var ns,rs=class extends b{static{ns=this}constructor(...e){super(...e),this.skip=()=>{let e=this.findContent();e&&(e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus(),e.scrollIntoView({block:`start`}))}}static{this.TARGETS=[`.app-content`,`mateu-page`,`mateu-ux`,`mateu-component`]}findContent(){let e=new Set,t=n=>{if(e.has(n))return null;e.add(n);for(let e of ns.TARGETS){let t=n.querySelector?.(e);if(t&&t!==this)return t}for(let e of Array.from(n.querySelectorAll?.(`*`)??[]))if(e.shadowRoot){let n=t(e.shadowRoot);if(n)return n}return null};return t(document)}render(){return T`<button class="skip" @click="${this.skip}">Skip to content</button>`}static{this.styles=h`
+    `}};O([S()],hs.prototype,`online`,void 0),O([S()],hs.prototype,`recovered`,void 0),hs=O([h(`mateu-connectivity-banner`)],hs);var gs=null;function _s(){if(!(typeof document>`u`)&&!(gs&&gs.isConnected)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>_s(),{once:!0});return}gs=document.createElement(`mateu-connectivity-banner`),document.body.appendChild(gs)}}var vs,ys=class extends y{static{vs=this}constructor(...e){super(...e),this.skip=()=>{let e=this.findContent();e&&(e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus(),e.scrollIntoView({block:`start`}))}}static{this.TARGETS=[`.app-content`,`mateu-page`,`mateu-ux`,`mateu-component`]}findContent(){let e=new Set,t=n=>{if(e.has(n))return null;e.add(n);for(let e of vs.TARGETS){let t=n.querySelector?.(e);if(t&&t!==this)return t}for(let e of Array.from(n.querySelectorAll?.(`*`)??[]))if(e.shadowRoot){let n=t(e.shadowRoot);if(n)return n}return null};return t(document)}render(){return w`<button class="skip" @click="${this.skip}">Skip to content</button>`}static{this.styles=m`
         :host {
             position: fixed;
             inset-block-start: 0;
@@ -7425,7 +7425,7 @@ ${i}
             outline: 2px solid var(--lumo-body-text-color, #161513);
             outline-offset: 2px;
         }
-    `}};rs=ns=k([g(`mateu-skip-link`)],rs);var is=null;function as(){if(!(typeof document>`u`)&&!(is&&is.isConnected)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>as(),{once:!0});return}is=document.createElement(`mateu-skip-link`),document.body.insertBefore(is,document.body.firstChild)}}Qo(),ts(),Xe(),as();var os=class extends b{constructor(...e){super(...e),this.baseUrl=``,this.route=void 0,this.consumedRoute=`_empty`,this.config=void 0,this.top=`true`,this.pathPrefix=void 0,this.debug=!1,this._lastUrl=``,this.routeChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.top==`true`){let t=e.detail.route,n=this.baseUrl??``;!t||t.startsWith(`/`)?n=window.location.origin+(this.pathPrefix??``):(t=(this.pathPrefix??``)+t,n.indexOf(`://`)<0&&(n.startsWith(`/`)||(n=`/`+n),n=window.location.origin+n)),t.startsWith(this.pathPrefix+`/`)&&(t=t.substring(this.pathPrefix?.length)),n.endsWith(`/`)&&t.startsWith(`/`)&&(t=t.substring(1));let r=new URL(n+t);if((window.location.pathname||r.pathname)&&window.location.pathname!=r.pathname){let e=r.pathname;r.search&&(e+=r.search),e&&!e.startsWith(`/`)&&(e=`/`+e),window.history.pushState({},``,e),this._lastUrl=window.location.href}}},this.navigateToRequestedListener=e=>{if(e.preventDefault(),e.stopPropagation(),Ta.markClean(),e instanceof CustomEvent){let t=e.detail.route,n=this.renderRoot.querySelector(`mateu-ux`);n&&(n.setAttribute(`route`,t),n.setAttribute(`instant`,E()))}}}createRenderRoot(){return P.mustUseShadowRoot()?super.createRenderRoot():this}connectedCallback(){if(super.connectedCallback(),Ta.install(),this._lastUrl=window.location.href,window.onpopstate=e=>{if(!Ta.confirmLeave()){window.history.pushState({},``,this._lastUrl);return}let t=e.target;this.loadUrl(t)},this.top==`true`?this.loadUrl(window):this.route&&(this.consumedRoute=``),this.config)try{let e=JSON.parse(this.config);O.value={...O.value,...e}}catch{O.value={...O.value,config:this.config}}this.addEventListener(`url-update-requested`,this.routeChangedListener),this.addEventListener(`navigate-to-requested`,this.navigateToRequestedListener)}disconnectedCallback(){super.disconnectedCallback(),this.upstreamSubscription?.unsubscribe(),this.removeEventListener(`url-update-requested`,this.routeChangedListener),this.removeEventListener(`navigate-to-requested`,this.navigateToRequestedListener)}loadUrl(e){if(this.route=this.extractRouteFromUrl(e),this.setAttribute(`route`,this.route),this.instant=E(),this._lastUrl=e.location.href,e.location.search){let t=new URLSearchParams(e.location.search).get(`overrides`);if(t&&(this.config=t,this.config))try{let e=JSON.parse(this.config);O.value={...O.value,...e}}catch{O.value={...O.value,config:this.config}}}}extractRouteFromUrl(e){return this.addQueryParams(this.extractRouteWithoutParamsFromUrl(e),e.location)}extractRouteWithoutParamsFromUrl(e){let t=this.extractGrossRouteFromUrl(e);return this.pathPrefix&&t.startsWith(this.pathPrefix)?t.substring(this.pathPrefix.length):t==`/`?``:t}addQueryParams(e,t){return e+(t.search?``+t.search:``)}extractGrossRouteFromUrl(e){let t=e.location.pathname,n=this.baseUrl&&(this.baseUrl.startsWith(`http://`)||this.baseUrl.startsWith(`https://`))?this.baseUrl.substring(this.getContextPathStartingIndex(this.baseUrl)):this.baseUrl;return t.startsWith(n)?t.substring(n.length):t}getContextPathStartingIndex(e){return e.startsWith(`http:`)?e.indexOf(`/`,7):e.startsWith(`https:`)?e.indexOf(`/`,8):0}render(){return T`
+    `}};ys=vs=O([h(`mateu-skip-link`)],ys);var bs=null;function xs(){if(!(typeof document>`u`)&&!(bs&&bs.isConnected)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>xs(),{once:!0});return}bs=document.createElement(`mateu-skip-link`),document.body.insertBefore(bs,document.body.firstChild)}}ms(),_s(),Ze(),xs();var Ss=class extends y{constructor(...e){super(...e),this.baseUrl=``,this.route=void 0,this.consumedRoute=`_empty`,this.config=void 0,this.top=`true`,this.pathPrefix=void 0,this.debug=!1,this._lastUrl=``,this.routeChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.top==`true`){let t=e.detail.route,n=this.baseUrl??``;!t||t.startsWith(`/`)?n=window.location.origin+(this.pathPrefix??``):(t=(this.pathPrefix??``)+t,n.indexOf(`://`)<0&&(n.startsWith(`/`)||(n=`/`+n),n=window.location.origin+n)),t.startsWith(this.pathPrefix+`/`)&&(t=t.substring(this.pathPrefix?.length)),n.endsWith(`/`)&&t.startsWith(`/`)&&(t=t.substring(1));let r=new URL(n+t);if((window.location.pathname||r.pathname)&&window.location.pathname!=r.pathname){let e=r.pathname;r.search&&(e+=r.search),e&&!e.startsWith(`/`)&&(e=`/`+e),window.history.pushState({},``,e),this._lastUrl=window.location.href}}},this.navigateToRequestedListener=e=>{if(e.preventDefault(),e.stopPropagation(),Ea.markClean(),e instanceof CustomEvent){let t=e.detail.route,n=this.renderRoot.querySelector(`mateu-ux`);n&&(n.setAttribute(`route`,t),n.setAttribute(`instant`,T()))}}}createRenderRoot(){return N.mustUseShadowRoot()?super.createRenderRoot():this}connectedCallback(){if(super.connectedCallback(),Ea.install(),this._lastUrl=window.location.href,window.onpopstate=e=>{if(!Ea.confirmLeave()){window.history.pushState({},``,this._lastUrl);return}let t=e.target;this.loadUrl(t)},this.top==`true`?this.loadUrl(window):this.route&&(this.consumedRoute=``),this.config)try{let e=JSON.parse(this.config);D.value={...D.value,...e}}catch{D.value={...D.value,config:this.config}}this.addEventListener(`url-update-requested`,this.routeChangedListener),this.addEventListener(`navigate-to-requested`,this.navigateToRequestedListener)}disconnectedCallback(){super.disconnectedCallback(),this.upstreamSubscription?.unsubscribe(),this.removeEventListener(`url-update-requested`,this.routeChangedListener),this.removeEventListener(`navigate-to-requested`,this.navigateToRequestedListener)}loadUrl(e){if(this.route=this.extractRouteFromUrl(e),this.setAttribute(`route`,this.route),this.instant=T(),this._lastUrl=e.location.href,e.location.search){let t=new URLSearchParams(e.location.search).get(`overrides`);if(t&&(this.config=t,this.config))try{let e=JSON.parse(this.config);D.value={...D.value,...e}}catch{D.value={...D.value,config:this.config}}}}extractRouteFromUrl(e){return this.addQueryParams(this.extractRouteWithoutParamsFromUrl(e),e.location)}extractRouteWithoutParamsFromUrl(e){let t=this.extractGrossRouteFromUrl(e);return this.pathPrefix&&t.startsWith(this.pathPrefix)?t.substring(this.pathPrefix.length):t==`/`?``:t}addQueryParams(e,t){return e+(t.search?``+t.search:``)}extractGrossRouteFromUrl(e){let t=e.location.pathname,n=this.baseUrl&&(this.baseUrl.startsWith(`http://`)||this.baseUrl.startsWith(`https://`))?this.baseUrl.substring(this.getContextPathStartingIndex(this.baseUrl)):this.baseUrl;return t.startsWith(n)?t.substring(n.length):t}getContextPathStartingIndex(e){return e.startsWith(`http:`)?e.indexOf(`/`,7):e.startsWith(`https:`)?e.indexOf(`/`,8):0}render(){return w`
            <mateu-api-caller>
                 <mateu-ux id="_ux"
                           baseurl="${this.baseUrl}"
@@ -7435,43 +7435,43 @@ ${i}
                           top="${this.top}"
                           style="width: 100%;"
                           @app-data-updated="${()=>this.requestUpdate()}"
-                          .appData="${ue.value}"
-                          .appState="${O.value}"
+                          .appData="${de.value}"
+                          .appState="${D.value}"
                 ></mateu-ux>
            </mateu-api-caller>
-           ${this.debug?T`
+           ${this.debug?w`
                <mateu-debug-overlay
-                   .appState="${O.value}"
-                   .appData="${ue.value}"
+                   .appState="${D.value}"
+                   .appData="${de.value}"
                ></mateu-debug-overlay>
-           `:v}
-       `}static{this.styles=h`
+           `:_}
+       `}static{this.styles=m`
         :host {
             --lumo-clickable-cursor: pointer;
         }
-  `}};k([y()],os.prototype,`baseUrl`,void 0),k([y()],os.prototype,`route`,void 0),k([y()],os.prototype,`consumedRoute`,void 0),k([y()],os.prototype,`config`,void 0),k([y()],os.prototype,`top`,void 0),k([y()],os.prototype,`pathPrefix`,void 0),k([C()],os.prototype,`instant`,void 0),k([y({type:Boolean})],os.prototype,`debug`,void 0),os=k([g(`mateu-ui`)],os);var ss,cs=class extends b{static{ss=this}constructor(...e){super(...e),this.baseUrl=``,this.opened=!1,this.searchText=``}static{this.SEARCHABLE_THRESHOLD=7}connectedCallback(){super.connectedCallback(),Ee()}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick(),this.searchTimer&&clearTimeout(this.searchTimer)}currentValue(){return String(Se()[this.selector.fieldName]??``)}currentLabel(){let e=this.currentValue();if(!e)return`—`;let t=(this.searchedOptions??this.selector.options)?.find(t=>String(t.value)===e);if(t)return t.label;let n=Ce()[this.selector.fieldName];return n===void 0?e:String(n)}pick(e,t){we(this.selector.fieldName,e,t),window.location.reload()}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}openPanel(){this.opened||(this.opened=!0,this.searchText=``,this.searchedOptions=void 0,this.remoteSearch(),this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick),this.updateComplete.then(()=>this.renderRoot.querySelector(`input.picker-search`)?.focus()))}closePanel(){this.detachOutsideClick(),this.opened=!1}onSearchInput(e){this.searchText=e.target.value,this.searchTimer&&clearTimeout(this.searchTimer),this.searchTimer=setTimeout(()=>this.remoteSearch(),300)}async remoteSearch(){let e=this.app;if(e?.serverSideType)try{let t=await We.runAction(this.baseUrl??``,e.rootRoute??e.initialRoute??``,``,`_appcontext-search-${this.selector.fieldName}`,`appcontext-${this.selector.fieldName}`,void 0,e.serverSideType,{},{searchText:this.searchText},this,!0);for(let e of t?.fragments??[]){let t=e.data?.[`_appcontext_${this.selector.fieldName}`]?.content;if(Array.isArray(t)){this.searchedOptions=t.map(e=>({value:e.value,label:e.label??String(e.value)}));return}}}catch{}}visibleOptions(){let e=this.searchedOptions??this.selector.options??[],t=this.searchText.trim().toLowerCase();return t?e.filter(e=>e.label.toLowerCase().includes(t)):e}renderPanel(){let e=this.currentValue(),t=this.visibleOptions();return T`
+  `}};O([v()],Ss.prototype,`baseUrl`,void 0),O([v()],Ss.prototype,`route`,void 0),O([v()],Ss.prototype,`consumedRoute`,void 0),O([v()],Ss.prototype,`config`,void 0),O([v()],Ss.prototype,`top`,void 0),O([v()],Ss.prototype,`pathPrefix`,void 0),O([S()],Ss.prototype,`instant`,void 0),O([v({type:Boolean})],Ss.prototype,`debug`,void 0),Ss=O([h(`mateu-ui`)],Ss);var Cs,ws=class extends y{static{Cs=this}constructor(...e){super(...e),this.baseUrl=``,this.opened=!1,this.searchText=``}static{this.SEARCHABLE_THRESHOLD=7}connectedCallback(){super.connectedCallback(),De()}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick(),this.searchTimer&&clearTimeout(this.searchTimer)}currentValue(){return String(Ce()[this.selector.fieldName]??``)}currentLabel(){let e=this.currentValue();if(!e)return`—`;let t=(this.searchedOptions??this.selector.options)?.find(t=>String(t.value)===e);if(t)return t.label;let n=we()[this.selector.fieldName];return n===void 0?e:String(n)}pick(e,t){Te(this.selector.fieldName,e,t),window.location.reload()}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}openPanel(){this.opened||(this.opened=!0,this.searchText=``,this.searchedOptions=void 0,this.remoteSearch(),this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick),this.updateComplete.then(()=>this.renderRoot.querySelector(`input.picker-search`)?.focus()))}closePanel(){this.detachOutsideClick(),this.opened=!1}onSearchInput(e){this.searchText=e.target.value,this.searchTimer&&clearTimeout(this.searchTimer),this.searchTimer=setTimeout(()=>this.remoteSearch(),300)}async remoteSearch(){let e=this.app;if(e?.serverSideType)try{let t=await Ge.runAction(this.baseUrl??``,e.rootRoute??e.initialRoute??``,``,`_appcontext-search-${this.selector.fieldName}`,`appcontext-${this.selector.fieldName}`,void 0,e.serverSideType,{},{searchText:this.searchText},this,!0);for(let e of t?.fragments??[]){let t=e.data?.[`_appcontext_${this.selector.fieldName}`]?.content;if(Array.isArray(t)){this.searchedOptions=t.map(e=>({value:e.value,label:e.label??String(e.value)}));return}}}catch{}}visibleOptions(){let e=this.searchedOptions??this.selector.options??[],t=this.searchText.trim().toLowerCase();return t?e.filter(e=>e.label.toLowerCase().includes(t)):e}renderPanel(){let e=this.currentValue(),t=this.visibleOptions();return w`
             <div class="panel">
-                ${this.searchText!==``||t.length>ss.SEARCHABLE_THRESHOLD?T`
+                ${this.searchText!==``||t.length>Cs.SEARCHABLE_THRESHOLD?w`
                     <input class="picker-search" type="text" placeholder="Search"
                            .value="${this.searchText}"
                            @input="${this.onSearchInput}"
-                           @keydown="${e=>{e.key===`Escape`&&this.closePanel()}}"/>`:v}
+                           @keydown="${e=>{e.key===`Escape`&&this.closePanel()}}"/>`:_}
                 <div class="options">
-                    ${e?T`
-                        <div class="option option--clear" @click="${()=>this.pick(``)}">— (clear)</div>`:v}
-                    ${t.map(t=>T`
+                    ${e?w`
+                        <div class="option option--clear" @click="${()=>this.pick(``)}">— (clear)</div>`:_}
+                    ${t.map(t=>w`
                         <div class="option ${e===String(t.value)?`option--selected`:``}"
                              @click="${()=>this.pick(t.value,t.label)}">${t.label}</div>`)}
                 </div>
-            </div>`}render(){return this.selector?T`
+            </div>`}render(){return this.selector?w`
             <label class="root">
                 <span class="label">${this.selector.label}</span>
                 <button class="picker-button"
                         @click="${()=>this.opened?this.closePanel():this.openPanel()}">
                     ${this.currentLabel()} <span aria-hidden="true" class="caret">▾</span>
                 </button>
-                ${this.opened?this.renderPanel():v}
-            </label>`:T``}static{this.styles=h`
+                ${this.opened?this.renderPanel():_}
+            </label>`:w``}static{this.styles=m`
         :host {
             display: inline-flex;
             position: relative;
@@ -7543,30 +7543,30 @@ ${i}
         .option--clear {
             color: var(--lumo-secondary-text-color, rgba(0, 0, 0, 0.55));
         }
-    `}};k([y()],cs.prototype,`selector`,void 0),k([y()],cs.prototype,`app`,void 0),k([y()],cs.prototype,`baseUrl`,void 0),k([C()],cs.prototype,`opened`,void 0),k([C()],cs.prototype,`searchText`,void 0),k([C()],cs.prototype,`searchedOptions`,void 0),cs=ss=k([g(`mateu-app-context-picker`)],cs);var ls=class extends b{constructor(...e){super(...e),this.baseUrl=``,this.opened=!1,this.notifications=[],this.fetched=!1}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}updated(){!this.fetched&&this.app?.serverSideType&&(this.fetched=!0,this.refresh())}unreadCount(){return this.notifications.filter(e=>e.unread).length}async runNotificationsAction(e,t){let n=this.app;if(n?.serverSideType)try{let r=await We.runAction(this.baseUrl??``,n.rootRoute??n.initialRoute??``,``,e,`notification-bell`,void 0,n.serverSideType,{},t,this,!0);for(let e of r?.fragments??[]){let t=e.data?._notifications;if(Array.isArray(t)){this.notifications=t;return}}}catch{}}refresh(){return this.runNotificationsAction(`_notifications-list`,{})}markRead(e){return this.runNotificationsAction(`_notifications-read`,{ids:e})}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}openPanel(){this.opened||(this.opened=!0,this.refresh(),this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick))}closePanel(){this.detachOutsideClick(),this.opened=!1}async entryClicked(e){e.unread&&await this.markRead([e.id]);let t=e.route;if(t){if(!Ta.confirmLeave())return;this.closePanel(),this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0})),this.dispatchEvent(new CustomEvent(`navigate-to-requested`,{detail:{route:t},bubbles:!0,composed:!0}))}}renderEntry(e){return T`
+    `}};O([v()],ws.prototype,`selector`,void 0),O([v()],ws.prototype,`app`,void 0),O([v()],ws.prototype,`baseUrl`,void 0),O([S()],ws.prototype,`opened`,void 0),O([S()],ws.prototype,`searchText`,void 0),O([S()],ws.prototype,`searchedOptions`,void 0),ws=Cs=O([h(`mateu-app-context-picker`)],ws);var Ts=class extends y{constructor(...e){super(...e),this.baseUrl=``,this.opened=!1,this.notifications=[],this.fetched=!1}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}updated(){!this.fetched&&this.app?.serverSideType&&(this.fetched=!0,this.refresh())}unreadCount(){return this.notifications.filter(e=>e.unread).length}async runNotificationsAction(e,t){let n=this.app;if(n?.serverSideType)try{let r=await Ge.runAction(this.baseUrl??``,n.rootRoute??n.initialRoute??``,``,e,`notification-bell`,void 0,n.serverSideType,{},t,this,!0);for(let e of r?.fragments??[]){let t=e.data?._notifications;if(Array.isArray(t)){this.notifications=t;return}}}catch{}}refresh(){return this.runNotificationsAction(`_notifications-list`,{})}markRead(e){return this.runNotificationsAction(`_notifications-read`,{ids:e})}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}openPanel(){this.opened||(this.opened=!0,this.refresh(),this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick))}closePanel(){this.detachOutsideClick(),this.opened=!1}async entryClicked(e){e.unread&&await this.markRead([e.id]);let t=e.route;if(t){if(!Ea.confirmLeave())return;this.closePanel(),this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0})),this.dispatchEvent(new CustomEvent(`navigate-to-requested`,{detail:{route:t},bubbles:!0,composed:!0}))}}renderEntry(e){return w`
             <div role="button" tabindex="0" class="entry ${e.unread?`entry--unread`:``}"
-                 @click="${()=>this.entryClicked(e)}" @keydown="${R(()=>this.entryClicked(e))}">
+                 @click="${()=>this.entryClicked(e)}" @keydown="${L(()=>this.entryClicked(e))}">
                 <span class="unread-dot" aria-hidden="true"></span>
                 <div class="entry-body">
                     <div class="entry-top">
                         <span class="entry-title">${e.title}</span>
-                        ${e.when?T`<span class="entry-when">${e.when}</span>`:v}
+                        ${e.when?w`<span class="entry-when">${e.when}</span>`:_}
                     </div>
-                    ${e.text?T`<div class="entry-text">${e.text}</div>`:v}
+                    ${e.text?w`<div class="entry-text">${e.text}</div>`:_}
                 </div>
-            </div>`}renderPanel(){return T`
+            </div>`}renderPanel(){return w`
             <div class="panel">
                 <div class="entries">
-                    ${this.notifications.length===0?T`
-                        <div class="empty">No notifications</div>`:v}
+                    ${this.notifications.length===0?w`
+                        <div class="empty">No notifications</div>`:_}
                     ${this.notifications.map(e=>this.renderEntry(e))}
                 </div>
-                ${this.notifications.length>0?T`
+                ${this.notifications.length>0?w`
                     <div class="footer">
                         <button class="mark-all" ?disabled="${this.unreadCount()===0}"
                                 @click="${()=>this.markRead(`all`)}">Mark all read</button>
-                    </div>`:v}
-            </div>`}render(){let e=this.unreadCount();return T`
+                    </div>`:_}
+            </div>`}render(){let e=this.unreadCount();return w`
             <div class="root">
                 <button class="bell-button" title="Notifications" aria-label="Notifications"
                         @click="${()=>this.opened?this.closePanel():this.openPanel()}">
@@ -7576,10 +7576,10 @@ ${i}
                         <path d="M18 8a6 6 0 0 0-12 0c0 7-3 9-3 9h18s-3-2-3-9"></path>
                         <path d="M13.73 21a2 2 0 0 1-3.46 0"></path>
                     </svg>
-                    ${e>0?T`<span class="badge">${e>99?`99+`:e}</span>`:v}
+                    ${e>0?w`<span class="badge">${e>99?`99+`:e}</span>`:_}
                 </button>
-                ${this.opened?this.renderPanel():v}
-            </div>`}static{this.styles=h`
+                ${this.opened?this.renderPanel():_}
+            </div>`}static{this.styles=m`
         :host {
             display: inline-flex;
             position: relative;
@@ -7730,48 +7730,48 @@ ${i}
             cursor: default;
         }
     
-        ${z}
-    `}};k([y()],ls.prototype,`app`,void 0),k([y()],ls.prototype,`baseUrl`,void 0),k([C()],ls.prototype,`opened`,void 0),k([C()],ls.prototype,`notifications`,void 0),ls=k([g(`mateu-notification-bell`)],ls);var us=e=>{if(!e||!(`querySelectorAll`in e))return null;for(let t of e.querySelectorAll(`*`)){if(t.tagName?.toLowerCase()===`mateu-component`)return t;let e=us(t.shadowRoot);if(e)return e}return null},ds=async(e,t,n)=>{let r=us(t.renderRoot??t);await Fo.runAction(We,t.baseUrl??``,e.rootRoute||`_no_route`,``,n,r?.id??`app-header-action`,{},e.serverSideType??``,{},{},r??t,!0,void 0,!1,``)},fs=async(e,t,n)=>{try{await ds(e,t,n)}catch(e){oa({text:`La acción falló: `+e,position:`bottomStart`,duration:6e3,variant:`error`},t)}},ps=(e,t)=>{let n=e.contextSelectors??[],r=e.contextActions??[];return n.length===0&&r.length===0&&!e.notificationsEnabled?v:T`${e.notificationsEnabled?T`
-        <mateu-notification-bell .app="${e}" .baseUrl="${t.baseUrl??``}"></mateu-notification-bell>`:v}${n.map(n=>T`
-        <mateu-app-context-picker .selector="${n}" .app="${e}" .baseUrl="${t.baseUrl??``}"></mateu-app-context-picker>`)}${r.map(n=>(n.children?.length??0)>0?T`
+        ${R}
+    `}};O([v()],Ts.prototype,`app`,void 0),O([v()],Ts.prototype,`baseUrl`,void 0),O([S()],Ts.prototype,`opened`,void 0),O([S()],Ts.prototype,`notifications`,void 0),Ts=O([h(`mateu-notification-bell`)],Ts);var Es=e=>{if(!e||!(`querySelectorAll`in e))return null;for(let t of e.querySelectorAll(`*`)){if(t.tagName?.toLowerCase()===`mateu-component`)return t;let e=Es(t.shadowRoot);if(e)return e}return null},Ds=async(e,t,n)=>{let r=Es(t.renderRoot??t);await Io.runAction(Ge,t.baseUrl??``,e.rootRoute||`_no_route`,``,n,r?.id??`app-header-action`,{},e.serverSideType??``,{},{},r??t,!0,void 0,!1,``)},Os=async(e,t,n)=>{try{await Ds(e,t,n)}catch(e){sa({text:`La acción falló: `+e,position:`bottomStart`,duration:6e3,variant:`error`},t)}},ks=(e,t)=>{let n=e.contextSelectors??[],r=e.contextActions??[];return n.length===0&&r.length===0&&!e.notificationsEnabled?_:w`${e.notificationsEnabled?w`
+        <mateu-notification-bell .app="${e}" .baseUrl="${t.baseUrl??``}"></mateu-notification-bell>`:_}${n.map(n=>w`
+        <mateu-app-context-picker .selector="${n}" .app="${e}" .baseUrl="${t.baseUrl??``}"></mateu-app-context-picker>`)}${r.map(n=>(n.children?.length??0)>0?w`
         <details class="mateu-nav-group" style="margin-left: 0.5rem; flex-shrink: 0;">
             <summary class="app-header-action-btn">${n.label} ▾</summary>
             <div class="mateu-nav-panel" style="right: 0; left: auto;">
-                ${n.children.map(n=>T`
-                    <button class="mateu-nav-item" @click="${()=>n.actionId&&fs(e,t,n.actionId)}">${n.label}</button>`)}
+                ${n.children.map(n=>w`
+                    <button class="mateu-nav-item" @click="${()=>n.actionId&&Os(e,t,n.actionId)}">${n.label}</button>`)}
             </div>
-        </details>`:T`
+        </details>`:w`
         <button class="app-header-action-btn" style="margin-left: 0.5rem; flex-shrink: 0;"
-            @click="${()=>n.actionId&&fs(e,t,n.actionId)}" title="${n.label}">${n.icon?I(n.icon):v}${n.label}</button>`)}`},ms=(e,t)=>T`
+            @click="${()=>n.actionId&&Os(e,t,n.actionId)}" title="${n.label}">${n.icon?F(n.icon):_}${n.label}</button>`)}`},As=(e,t)=>w`
     <button class="mateu-nav-item ${e.selected?`mateu-nav-item--active`:``}"
             ?disabled="${e.disabled}"
-            @click="${()=>t(e)}">${e.text}</button>`,hs=(e,t,n=``)=>T`
+            @click="${()=>t(e)}">${e.text}</button>`,js=(e,t,n=``)=>w`
     <nav class="mateu-nav ${n}">
-        ${e.map(e=>(e.children?.length??0)>0?T`<details class="mateu-nav-group">
+        ${e.map(e=>(e.children?.length??0)>0?w`<details class="mateu-nav-group">
                        <summary class="mateu-nav-item">${e.text} ▾</summary>
                        <div class="mateu-nav-panel">
-                           ${e.children.map(e=>ms(e,t))}
+                           ${e.children.map(e=>As(e,t))}
                        </div>
-                   </details>`:ms(e,t))}
-    </nav>`,gs=(e,t)=>n=>t.call(e,{detail:{value:n}}),_s=(e,t)=>e.themeToggle?T`
+                   </details>`:As(e,t))}
+    </nav>`,Ms=(e,t)=>n=>t.call(e,{detail:{value:n}}),Ns=(e,t)=>e.themeToggle?w`
         <button class="app-chrome-icon-btn" @click="${t.toggleTheme}"
             title="${t.isDark?`Switch to light mode`:`Switch to dark mode`}"
             style="margin-left: 0.5rem; margin-right: 0.5rem; flex-shrink: 0;">
-            ${I(t.isDark?`vaadin:sun-o`:`vaadin:moon`,`color: var(--lumo-body-text-color);`)}
+            ${F(t.isDark?`vaadin:sun-o`:`vaadin:moon`,`color: var(--lumo-body-text-color);`)}
         </button>
-    `:v,vs=(e,t)=>{t.filter!=e.detail.value&&(t.filter=e.detail.value)},ys=(e,t,n)=>{let r=bs(e,t,n),i=Z(t,n);return r==`list`||r==i?`new`:r},bs=(e,t,n)=>{let r=e?._route;if(r!=null&&(r===``||r.startsWith(`/`))){let e=n.homeRoute??``,i=e.indexOf(`?`),a=i>=0?e.substring(i+1):``,o=Z(t,n)+r;return a?o+(o.indexOf(`?`)>=0?`&`:`?`)+a:o}return t.selectedRoute?t.selectedRoute:n.homeRoute},Z=(e,t)=>e.selectedRoute?e.selectedConsumedRoute??t.route:t.homeConsumedRoute,xs=(e,t)=>e.selectedRoute?e.selectedBaseUrl??e.baseUrl:t.homeBaseUrl,Ss=(e,t)=>e.selectedRoute?e.selectedServerSideType??t.serverSideType:t.homeServerSideType,Cs=(e,t)=>e.selectedRoute?e.selectedUriPrefix:t.homeUriPrefix,ws=(e,t,n,r,i,a,o)=>{if(t.chromeless)return T`
+    `:_,Ps=(e,t)=>{t.filter!=e.detail.value&&(t.filter=e.detail.value)},Fs=(e,t,n)=>{let r=Is(e,t,n),i=X(t,n);return r==`list`||r==i?`new`:r},Is=(e,t,n)=>{let r=e?._route;if(r!=null&&(r===``||r.startsWith(`/`))){let e=n.homeRoute??``,i=e.indexOf(`?`),a=i>=0?e.substring(i+1):``,o=X(t,n)+r;return a?o+(o.indexOf(`?`)>=0?`&`:`?`)+a:o}return t.selectedRoute?t.selectedRoute:n.homeRoute},X=(e,t)=>e.selectedRoute?e.selectedConsumedRoute??t.route:t.homeConsumedRoute,Ls=(e,t)=>e.selectedRoute?e.selectedBaseUrl??e.baseUrl:t.homeBaseUrl,Rs=(e,t)=>e.selectedRoute?e.selectedServerSideType??t.serverSideType:t.homeServerSideType,zs=(e,t)=>e.selectedRoute?e.selectedUriPrefix:t.homeUriPrefix,Bs=(e,t,n,r,i,a,o)=>{if(t.chromeless)return w`
             <div class="app chromeless">
                 <div role="main" class="${`app-content`+(e.pageCompact?` no-padding`:``)}" style="height: 100%;">
                     <div class="m-md">
                         <div class="m-scroll" style="height: 100%;">
                             <mateu-api-caller>
                                 <mateu-ux
-                                        route="${bs(r,e,t)}"
+                                        route="${Is(r,e,t)}"
                                         id="ux_${e.id}"
-                                        baseUrl="${xs(e,t)}"
-                                        consumedRoute="${Z(e,t)}"
-                                        serverSideType="${Ss(e,t)}"
-                                        uriPrefix="${Cs(e,t)}"
+                                        baseUrl="${Ls(e,t)}"
+                                        consumedRoute="${X(e,t)}"
+                                        serverSideType="${Rs(e,t)}"
+                                        uriPrefix="${zs(e,t)}"
                                         style="width: 100%;"
                                         .appState="${a}"
                                         .appData="${o}"
@@ -7780,25 +7780,25 @@ ${i}
                                 ></mateu-ux>
                             </mateu-api-caller>
                         </div>
-                        ${t.sseUrl?T`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:v}
+                        ${t.sseUrl?w`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:_}
                     </div>
                 </div>
                 <slot></slot>
             </div>
-        `;let s=e.mapItems(t.menu,e.filter?.toLowerCase()??``),c=Z(e,t),l=ys(r,e,t),u=l&&l!==`new`&&l.startsWith(c+`/`)?l.substring(c.length+1).split(`/`)[0]:void 0;return T`
-                    ${t.variant==Ke.MEDIATOR?T`
+        `;let s=e.mapItems(t.menu,e.filter?.toLowerCase()??``),c=X(e,t),l=Fs(r,e,t),u=l&&l!==`new`&&l.startsWith(c+`/`)?l.substring(c.length+1).split(`/`)[0]:void 0;return w`
+                    ${t.variant==qe.MEDIATOR?w`
 
-                        ${t.layout==`SPLIT`?T`
+                        ${t.layout==`SPLIT`?w`
                             <div class="m-md">
                                 <mateu-api-caller>
                                     <div style="display: block; width: calc(100% - 1rem);">
                                     <mateu-ux
-                                            route="${Z(e,t)}"
+                                            route="${X(e,t)}"
                                             id="ux_${e.id}"
-                                            baseUrl="${xs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Ss(e,t)}"
-                                            uriPrefix="${Cs(e,t)}"
+                                            baseUrl="${Ls(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Rs(e,t)}"
+                                            uriPrefix="${zs(e,t)}"
                                             style="width: 100%;"
                                             .appState="${{...a,_splitDetailId:u}}"
                                             .appData="${o}"
@@ -7810,12 +7810,12 @@ ${i}
                                 <mateu-api-caller slot="detail">
                                     <div style="padding-left: 1rem; width: calc(100% - 1rem);">
                                     <mateu-ux
-                                            route="${ys(r,e,t)}"
+                                            route="${Fs(r,e,t)}"
                                             id="ux_${e.id}_detail"
-                                            baseUrl="${xs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Ss(e,t)}"
-                                            uriPrefix="${Cs(e,t)}"
+                                            baseUrl="${Ls(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Rs(e,t)}"
+                                            uriPrefix="${zs(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -7826,15 +7826,15 @@ ${i}
                                 </mateu-api-caller>
 
                             </div>
-                        `:T`
+                        `:w`
                             <mateu-api-caller>
                                 <mateu-ux
-                                        route="${bs(r,e,t)}"
+                                        route="${Is(r,e,t)}"
                                         id="ux_${e.id}"
-                                        baseUrl="${xs(e,t)}"
-                                        consumedRoute="${Z(e,t)}"
-                                        serverSideType="${Ss(e,t)}"
-                                        uriPrefix="${Cs(e,t)}"
+                                        baseUrl="${Ls(e,t)}"
+                                        consumedRoute="${X(e,t)}"
+                                        serverSideType="${Rs(e,t)}"
+                                        uriPrefix="${zs(e,t)}"
                                         style="width: 100%;"
                                         .appState="${a}"
                                         .appData="${o}"
@@ -7845,28 +7845,28 @@ ${i}
                             </mateu-api-caller>
                         `}
                         
-`:v}
-            ${t.variant==Ke.HAMBURGUER_MENU?T`
+`:_}
+            ${t.variant==qe.HAMBURGUER_MENU?w`
                 <div class="mateu-app-layout m-app-layout ${t.drawerClosed?``:`drawer-open`} ${t?.cssClasses}" style="${t?.style}">
                     <header class="app-navbar">
                         <button class="drawer-toggle" title="Menu"
                                 @click="${e=>e.currentTarget.closest(`.m-app-layout`)?.classList.toggle(`drawer-open`)}">
-                            ${I(`vaadin:menu`)}
+                            ${F(`vaadin:menu`)}
                         </button>
                         <h2 style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; margin: 0 .5rem;">${t.title}</h2><p style="margin: 0;">${t.subtitle}</p>
                         <div class="m-hl" style="margin-left: auto; align-items: center;">
                             <slot name="widgets"></slot>
-                            ${ps(t,e)}${_s(t,e)}
+                            ${ks(t,e)}${Ns(t,e)}
                         </div>
                     </header>
                     <div class="app-body">
                         <aside class="app-drawer p-s" @navigation-requested="${e.updateRoute}">
-                            ${t.menu&&t.totalMenuOptions>10?T`
+                            ${t.menu&&t.totalMenuOptions>10?w`
                                 <div style="position: sticky; top: 0; z-index: 2; background: var(--lumo-base-color); padding: .25rem 0 .5rem;">
                                     <input class="drawer-search" placeholder="Search…" style="width: calc(100% - 20px); margin: 0 10px;"
-                                           @input="${t=>vs({detail:{value:t.target.value}},e)}">
+                                           @input="${t=>Ps({detail:{value:t.target.value}},e)}">
                                 </div>
-                                `:v}
+                                `:_}
                             <nav class="side-nav">
                                 ${e.renderSideNav(s,void 0)}
                             </nav>
@@ -7876,12 +7876,12 @@ ${i}
                                 <div class="m-scroll" style="height: 100%;">
                                     <mateu-api-caller>
                                         <mateu-ux
-                                                route="${bs(r,e,t)}"
+                                                route="${Is(r,e,t)}"
                                                 id="ux_${e.id}"
-                                                baseUrl="${xs(e,t)}"
-                                                consumedRoute="${Z(e,t)}"
-                                                serverSideType="${Ss(e,t)}"
-                                                uriPrefix="${Cs(e,t)}"
+                                                baseUrl="${Ls(e,t)}"
+                                                consumedRoute="${X(e,t)}"
+                                                serverSideType="${Rs(e,t)}"
+                                                uriPrefix="${zs(e,t)}"
                                                 style="width: 100%;"
                                                 .appState="${a}"
                                                 .appData="${o}"
@@ -7890,15 +7890,15 @@ ${i}
                                         ></mateu-ux>
                                     </mateu-api-caller>
                                 </div>
-                                ${t.sseUrl?T`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" class="" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:v}
+                                ${t.sseUrl?w`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" class="" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:_}
                             </div>
                         </div>
                     </div>
                 </div>
 
-            `:v}
+            `:_}
             
-            ${t.variant==Ke.MENU_ON_TOP?T`
+            ${t.variant==qe.MENU_ON_TOP?w`
                 <div class="m-vl" style="width: 100%; height: 100vh; overflow: hidden;">
                     <div class="m-hl"
                             style="width: 100%; height: 4rem; flex-shrink: 0; align-items: center; border-bottom: 1px solid var(--lumo-disabled-text-color); background-color: var(--lumo-base-color);"
@@ -7906,14 +7906,14 @@ ${i}
                             @navigation-requested="${e.updateRoute}">
                         <a href="javascript: void(0);" @click="${()=>e.goHome()}" style="text-decoration: none; color: inherit; flex-shrink: 0;">
                         <div class="m-hl" style="align-items: center;">
-                            ${t.logo?T`<img src="${t.logo}" alt="logo" height="28px" style="margin-left: 10px;">`:v}
-                            ${t.title?T`<h2 style="margin: 0 var(--lumo-space-l, 1.5rem) 0 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;">${t.title}</h2>`:v}
+                            ${t.logo?w`<img src="${t.logo}" alt="logo" height="28px" style="margin-left: 10px;">`:_}
+                            ${t.title?w`<h2 style="margin: 0 var(--lumo-space-l, 1.5rem) 0 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;">${t.title}</h2>`:_}
                         </div>
                         </a>
-                        ${(()=>{let t=gs(e,e.itemSelected);return P.get()?.renderTopNav?.(s,t,`menu-on-top`)??hs(s,t,`menu-on-top`)})()}
+                        ${(()=>{let t=Ms(e,e.itemSelected);return N.get()?.renderTopNav?.(s,t,`menu-on-top`)??js(s,t,`menu-on-top`)})()}
                         <div class="m-hl" style="margin-left: auto; flex-shrink: 0; align-items: center;">
                             <slot name="widgets"></slot>
-                            ${ps(t,e)}${_s(t,e)}
+                            ${ks(t,e)}${Ns(t,e)}
                         </div>
                     </div>
                     <div style="flex: 1; min-height: 0; overflow-y: auto; overflow-x: hidden; box-sizing: border-box; width: 100%;">
@@ -7921,12 +7921,12 @@ ${i}
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${bs(r,e,t)}"
+                                            route="${Is(r,e,t)}"
                                             id="ux_${e.id}"
-                                            baseUrl="${xs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Ss(e,t)}"
-                                            uriPrefix="${Cs(e,t)}"
+                                            baseUrl="${Ls(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Rs(e,t)}"
+                                            uriPrefix="${zs(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -7935,14 +7935,14 @@ ${i}
                                     ></mateu-ux>
                                 </mateu-api-caller>
                             </div>
-                            ${t.sseUrl?T`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" class="" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:v}
+                            ${t.sseUrl?w`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" class="" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:_}
                         </div>
                     </div>
                 </div>
 
-            `:v}
+            `:_}
 
-            ${t.variant==Ke.TILES?T`
+            ${t.variant==qe.TILES?w`
                 <div class="m-vl" style="width: 100%; height: 100vh; overflow: hidden;">
                     <div class="m-hl"
                             style="width: 100%; height: 4rem; flex-shrink: 0; align-items: center; border-bottom: 1px solid var(--lumo-disabled-text-color); background-color: var(--lumo-base-color);"
@@ -7950,28 +7950,28 @@ ${i}
                             @navigation-requested="${e.updateRoute}">
                         <a href="javascript: void(0);" @click="${()=>{e.goHome(),e.tilesMenuOption=null}}" style="text-decoration: none; color: inherit; flex-shrink: 0;">
                         <div class="m-hl" style="align-items: center;">
-                            ${t.logo?T`<img src="${t.logo}" alt="logo" height="28px" style="margin-left: 10px;">`:v}
-                            ${t.title?T`<h2 style="margin: 0 var(--lumo-space-l, 1.5rem) 0 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;">${t.title}</h2>`:v}
+                            ${t.logo?w`<img src="${t.logo}" alt="logo" height="28px" style="margin-left: 10px;">`:_}
+                            ${t.title?w`<h2 style="margin: 0 var(--lumo-space-l, 1.5rem) 0 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;">${t.title}</h2>`:_}
                         </div>
                         </a>
-                        ${hs(e.mapItemsForTiles(t.menu),gs(e,e.itemSelectedTiles),`menu-on-top`)}
+                        ${js(e.mapItemsForTiles(t.menu),Ms(e,e.itemSelectedTiles),`menu-on-top`)}
                         <div class="m-hl" style="margin-left: auto; flex-shrink: 0; align-items: center;">
                             <slot name="widgets"></slot>
-                            ${ps(t,e)}${_s(t,e)}
+                            ${ks(t,e)}${Ns(t,e)}
                         </div>
                     </div>
                     <div style="flex: 1; min-height: 0; overflow-y: auto; overflow-x: hidden; box-sizing: border-box; width: 100%;">
-                        ${e.tilesMenuOption?e.renderTilesHub(e.tilesMenuOption):T`
+                        ${e.tilesMenuOption?e.renderTilesHub(e.tilesMenuOption):w`
                         <div class="m-md">
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${bs(r,e,t)}"
+                                            route="${Is(r,e,t)}"
                                             id="ux_${e.id}"
-                                            baseUrl="${xs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Ss(e,t)}"
-                                            uriPrefix="${Cs(e,t)}"
+                                            baseUrl="${Ls(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Rs(e,t)}"
+                                            uriPrefix="${zs(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -7980,28 +7980,28 @@ ${i}
                                     ></mateu-ux>
                                 </mateu-api-caller>
                             </div>
-                            ${t.sseUrl?T`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" class="" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:v}
+                            ${t.sseUrl?w`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" class="" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:_}
                         </div>
                         `}
                     </div>
                 </div>
-            `:v}
+            `:_}
 
-            ${t.variant==Ke.RAIL?T`
+            ${t.variant==qe.RAIL?w`
                 <div style="display: flex; width: 100%; height: 100vh; overflow: hidden;">
                     ${e.renderRail(t.menu)}
-                    ${e.railOpenOption?e.renderRailSubPanel(e.railOpenOption):v}
+                    ${e.railOpenOption?e.renderRailSubPanel(e.railOpenOption):_}
                     <div style="flex: 1; overflow: hidden; padding: 2rem 2rem 0; height: 100vh; box-sizing: border-box; background-color: var(--lumo-contrast-10pct);">
                         <div class="m-md">
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${bs(r,e,t)}"
+                                            route="${Is(r,e,t)}"
                                             id="ux_${e.id}"
-                                            baseUrl="${xs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Ss(e,t)}"
-                                            uriPrefix="${Cs(e,t)}"
+                                            baseUrl="${Ls(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Rs(e,t)}"
+                                            uriPrefix="${zs(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -8010,20 +8010,20 @@ ${i}
                                     ></mateu-ux>
                                 </mateu-api-caller>
                             </div>
-                            ${t.sseUrl?T`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" class="" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:v}
+                            ${t.sseUrl?w`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" class="" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:_}
                         </div>
                     </div>
                 </div>
-            `:v}
+            `:_}
 
-            ${t.variant==Ke.MENU_ON_LEFT?T`
+            ${t.variant==qe.MENU_ON_LEFT?w`
 
                 <div class="m-hl">
                     <div class="m-scroll" style="width: 16em; border-right: 2px solid var(--lumo-contrast-5pct);">
                         <div class="m-vl"
                                 @navigation-requested="${e.updateRoute}">
                             ${t.menu.map(t=>e.renderOptionOnLeftMenu(t))}
-                            ${ps(t,e)}${_s(t,e)}
+                            ${ks(t,e)}${Ns(t,e)}
                         </div>
                     </div>
                     <div role="main" class="${`app-content`+(e.pageCompact?` no-padding`:``)}">
@@ -8031,12 +8031,12 @@ ${i}
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${bs(r,e,t)}"
+                                            route="${Is(r,e,t)}"
                                             id="ux_${e.id}"
-                                            baseUrl="${xs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Ss(e,t)}"
-                                            uriPrefix="${Cs(e,t)}"
+                                            baseUrl="${Ls(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Rs(e,t)}"
+                                            uriPrefix="${zs(e,t)}"
                                             style="width: 100%; padding: 1em;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -8045,15 +8045,15 @@ ${i}
                                     ></mateu-ux>
                                 </mateu-api-caller>
                             </div>
-                            ${t.sseUrl?T`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" class="" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:v}
+                            ${t.sseUrl?w`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" class="" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:_}
                         </div>
                     </div>
                 </div>
 
 
-            `:v}
+            `:_}
 
-            ${t.variant==Ke.TABS?T`
+            ${t.variant==qe.TABS?w`
                 <!--
                 
                 box-shadow: inset 0 -1px 0 0 var(--lumo-contrast-10pct);
@@ -8068,19 +8068,19 @@ ${i}
                                 @navigation-requested="${e.updateRoute}">
                             <a href="javascript: void(0);" @click="${()=>e.goHome()}" style="text-decoration: none; color: inherit; flex-shrink: 0;">
                             <div class="m-hl" style="align-items: center;">
-                                ${t.logo?T`<img src="${t.logo}" alt="logo" height="28px" style="margin-left: 10px;">`:v}
-                                ${t.title?T`<h2 style="margin: 0 var(--lumo-space-l, 1.5rem) 0 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;">${t.title}</h2>`:v}
+                                ${t.logo?w`<img src="${t.logo}" alt="logo" height="28px" style="margin-left: 10px;">`:_}
+                                ${t.title?w`<h2 style="margin: 0 var(--lumo-space-l, 1.5rem) 0 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;">${t.title}</h2>`:_}
                             </div>
                             </a>
                             <nav class="mateu-tabs ${e.component?.cssClasses??``}" style="flex-grow: 1; min-width: 0; margin-left: 1.5rem;">
-                                ${t.menu.map((n,r)=>T`
+                                ${t.menu.map((n,r)=>w`
                                 <button class="mateu-tab ${r===e.getSelectedIndex(t.menu)?`mateu-tab--active`:``}"
                                         @click="${()=>e.selectRoute(n.consumedRoute,n.route,n.actionId,n.baseUrl,n.serverSideType,n.uriPrefix)}"
                                 >${n.label}</button>`)}
                             </nav>
                             <div class="m-hl" style="flex-shrink: 0; align-items: center;">
                                 <slot name="widgets"></slot>
-                                ${ps(t,e)}${_s(t,e)}
+                                ${ks(t,e)}${Ns(t,e)}
                             </div>
                         </div>
                     </div>
@@ -8089,12 +8089,12 @@ ${i}
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${bs(r,e,t)}"
+                                            route="${Is(r,e,t)}"
                                             id="ux_${e.id}"
-                                            baseUrl="${xs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Ss(e,t)}"
-                                            uriPrefix="${Cs(e,t)}"
+                                            baseUrl="${Ls(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Rs(e,t)}"
+                                            uriPrefix="${zs(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -8103,28 +8103,28 @@ ${i}
                                     ></mateu-ux>
                                 </mateu-api-caller>
                             </div>
-                            ${t.sseUrl?T`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" class="" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:v}
+                            ${t.sseUrl?w`<mateu-chat slot="${e.chatOpen?`detail`:`detail-hidden`}" sseurl="${t.sseUrl}" .mcpUrl="${t.mcpUrl}" .uploadUrl="${t.uploadUrl}" .menu="${t.menu}" .contextProvider="${()=>({url:window.location.pathname+window.location.search,screenTitle:document.title,appState:a,appData:o,componentState:e.state,componentData:e.data})}" style="border-left: 1px solid var(--lumo-contrast-10pct); padding-top: 0.5rem;" class="" @navigation-requested="${e.updateRoute}" @close-requested="${e.showHideIa}"></mateu-chat>`:_}
                         </div>
                     </div>
                 </div>
             
-            `:v}
+            `:_}
 
-            ${t.fabs?.map((n,r)=>T`
+            ${t.fabs?.map((n,r)=>w`
                 <button class="app-fab" style="bottom: ${(t.sseUrl?5.5:1.5)+r*4}rem; right: 1.5rem;"
                     @click="${()=>e.runAction(n.actionId)}"
                     title="${n.label}">
-                    ${I(n.icon)}
+                    ${F(n.icon)}
                 </button>
             `)}
-            ${t.sseUrl&&!e.chatOpen?T`
+            ${t.sseUrl&&!e.chatOpen?w`
                 <button class="ai-fab" @click="${e.showHideIa}" title="Asistente IA">
-                    ${I(`vaadin:comments-o`)}
+                    ${F(`vaadin:comments-o`)}
                 </button>
-            `:v}
+            `:_}
             ${e.renderCommandPalette()}
             <slot></slot>
-       `},Ts=(e,t)=>t!=null&&e!=null&&!e.has(t),Es=typeof HTMLElement<`u`?HTMLElement:class{},Ds=class extends Es{static get observedAttributes(){return[`type`,`renderer`]}connectedCallback(){this.render()}attributeChangedCallback(){this.render()}render(){let e=this.getAttribute(`type`)??`unknown`,t=this.getAttribute(`renderer`)??`unknown`;this.shadowRoot||this.attachShadow({mode:`open`}),this.shadowRoot.innerHTML=`
+       `},Vs=(e,t)=>t!=null&&e!=null&&!e.has(t),Hs=typeof HTMLElement<`u`?HTMLElement:class{},Us=class extends Hs{static get observedAttributes(){return[`type`,`renderer`]}connectedCallback(){this.render()}attributeChangedCallback(){this.render()}render(){let e=this.getAttribute(`type`)??`unknown`,t=this.getAttribute(`renderer`)??`unknown`;this.shadowRoot||this.attachShadow({mode:`open`}),this.shadowRoot.innerHTML=`
             <style>
                 :host { display: block; }
                 .mateu-unsupported {
@@ -8143,12 +8143,12 @@ ${i}
             <div class="mateu-unsupported" role="note">
                 ⚠ Component “${e}” is not supported by the “${t}” renderer yet.
             </div>
-        `}};typeof customElements<`u`&&!customElements.get(`mateu-unsupported`)&&customElements.define(`mateu-unsupported`,Ds);var Os=new Set,ks=(e,t,n)=>{let r=`${n}/${t}`;return Os.has(r)||(Os.add(r),console.warn(`[mateu] Component type "${t}" is not supported by the "${n}" renderer — rendering <mateu-unsupported> placeholder.`)),T`<mateu-unsupported
+        `}};typeof customElements<`u`&&!customElements.get(`mateu-unsupported`)&&customElements.define(`mateu-unsupported`,Us);var Ws=new Set,Gs=(e,t,n)=>{let r=`${n}/${t}`;return Ws.has(r)||(Ws.add(r),console.warn(`[mateu] Component type "${t}" is not supported by the "${n}" renderer — rendering <mateu-unsupported> placeholder.`)),w`<mateu-unsupported
             type="${t}"
             renderer="${n}"
-            data-component-id="${e?.id??v}"
-            slot="${e?.slot??v}"
-    ></mateu-unsupported>`},As=class{renderFilterBar(e,t,n,r,i,a,o,s){let c=t?.metadata;return T`
+            data-component-id="${e?.id??_}"
+            slot="${e?.slot??_}"
+    ></mateu-unsupported>`},Ks=class{renderFilterBar(e,t,n,r,i,a,o,s){let c=t?.metadata;return w`
             <mateu-filter-bar
                 .metadata="${c}"
                 @search-requested="${e.search}"
@@ -8160,9 +8160,9 @@ ${i}
                 .appData="${o}"
                 ?searchOnly="${s??!1}"
             >
-                ${c?.header?.map(t=>F(e,t,n,r,i,a,o))}
+                ${c?.header?.map(t=>P(e,t,n,r,i,a,o))}
             </mateu-filter-bar>
-        `}renderPagination(e,t){return T`
+        `}renderPagination(e,t){return w`
         <mateu-pagination
                 @page-changed="${e.pageChanged}"
                 @fetch-more-elements="${e.fetchMoreElements}"
@@ -8171,80 +8171,80 @@ ${i}
                 data-testid="pagination"
                 .pageNumber="${e.data[t?.id]?.page?.pageNumber??0}"
         ></mateu-pagination>
-        `}renderTableComponent(e,t,n,r,i,a,o){return pn(t,(e.data?.[e.id])?.page?.content??[],r[t?.id]?.emptyStateMessage)}rendererName(){return this.constructor?.name??`unknown`}supportedClientSideTypes(){}renderClientSideComponent(e,t,n,r,i,a,o,s){let c=t?.metadata?.type??t?.type,l=Object.values(j).includes(c)?c:void 0;return Ts(this.supportedClientSideTypes(),l)?ks(t,l,this.rendererName()):ea(e,t,n,r,i,a,o,s)}renderAppComponent(e,t,n,r,i,a,o){return ws(e,t?.metadata,n,r,i,a,o)}},js=(e,t,n,r,i,a,o)=>T`
+        `}renderTableComponent(e,t,n,r,i,a,o){return mn(t,(e.data?.[e.id])?.page?.content??[],r[t?.id]?.emptyStateMessage)}rendererName(){return this.constructor?.name??`unknown`}supportedClientSideTypes(){}renderClientSideComponent(e,t,n,r,i,a,o,s){let c=t?.metadata?.type??t?.type,l=Object.values(A).includes(c)?c:void 0;return Vs(this.supportedClientSideTypes(),l)?Gs(t,l,this.rendererName()):ta(e,t,n,r,i,a,o,s)}renderAppComponent(e,t,n,r,i,a,o){return Bs(e,t?.metadata,n,r,i,a,o)}},qs=(e,t,n,r,i,a,o)=>w`
         <vaadin-virtual-list
                 .items="${t.metadata.page.content}"
-                ${te(t=>T`${F(e,t,n,r,i,a,o)}`,[])}
+                ${ne(t=>w`${P(e,t,n,r,i,a,o)}`,[])}
                 style="${t.style}" class="${t.cssClasses}"
-                slot="${t.slot??v}"
+                slot="${t.slot??_}"
         ></vaadin-virtual-list>
-    `,Ms=e=>{let t=e.metadata;return T`
+    `,Js=e=>{let t=e.metadata;return w`
         <vaadin-notification
                 .opened="${!0}"
-                slot="${e.slot??v}"
+                slot="${e.slot??_}"
                 style="${e.style}"
                 class="${e.cssClasses}"
-                ${c(()=>T`
+                ${c(()=>w`
                     <vaadin-horizontal-layout theme="spacing" style="align-items: center;">
                         <h3>${t.title}</h3>
                         <div>${t.text}</div>
                     </vaadin-horizontal-layout>
                 `,[])}
         ></vaadin-notification>
-    `},Ns=(e,t={})=>{let n=e.metadata,r=n.valueKey?t[n.valueKey]:n.value;return T`
+    `},Ys=(e,t={})=>{let n=e.metadata,r=n.valueKey?t[n.valueKey]:n.value;return w`
         <div style="${e.style}">
         <vaadin-progress-bar
                 ?indeterminate="${n.indeterminate}"
-                min="${n.min&&n.min!=0?n.min:v}"
-                max="${n.max&&n.max!=0?n.max:v}"
-                value="${r??v}"
+                min="${n.min&&n.min!=0?n.min:_}"
+                max="${n.max&&n.max!=0?n.max:_}"
+                value="${r??_}"
                 style="${e.style}"
                 class="${e.cssClasses}"
-                slot="${e.slot??v}"
+                slot="${e.slot??_}"
         ></vaadin-progress-bar>
-        ${n.text?T`<span class="text-secondary text-xs" id="sublbl">
+        ${n.text?w`<span class="text-secondary text-xs" id="sublbl">
     ${n.text}
-  </span>`:v}
+  </span>`:_}
         </div>
-    `},Ps=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+    `},Xs=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <vaadin-details
                 ?opened="${s.opened}"
                 style="${t.style}"
                 class="${t.cssClasses}"
-                slot="${t.slot??v}"
+                slot="${t.slot??_}"
         >
             <vaadin-details-summary slot="summary">
-            ${F(e,s.summary,n,r,i,a,o)}
+            ${P(e,s.summary,n,r,i,a,o)}
             </vaadin-details-summary>
-            ${F(e,s.content,n,r,i,a,o)}
+            ${P(e,s.content,n,r,i,a,o)}
         </vaadin-details>
-            `},Fs=(e,t,n)=>{let r=e.metadata;return T`<vaadin-avatar
+            `},Zs=(e,t,n)=>{let r=e.metadata;return w`<vaadin-avatar
             img="${r.image}"
-            name="${N(r.name,t,n)}"
+            name="${M(r.name,t,n)}"
             abbr="${r.abbreviation}"
             style="${e.style}" class="${e.cssClasses}"
-            slot="${e.slot??v}"
-    ></vaadin-avatar>`},Is=e=>{let t=e.metadata;return T`<vaadin-avatar-group max-items-visible="${t.maxItemsVisible}"
+            slot="${e.slot??_}"
+    ></vaadin-avatar>`},Qs=e=>{let t=e.metadata;return w`<vaadin-avatar-group max-items-visible="${t.maxItemsVisible}"
                                      .items="${t.avatars}"
                                      style="${e.style}" class="${e.cssClasses}"
-                                     slot="${e.slot??v}">
-    </vaadin-avatar-group>`},Ls=(e,t,n,r,i,a,o)=>{let s=t.metadata;if(!s)return T``;let c=``;return s.variants?.map(e=>e==`stretchMedia`?`stretch-media`:e==`coverMedia`?`cover-media`:e).forEach(e=>c+=` `+e),c=c.trim(),T`
+                                     slot="${e.slot??_}">
+    </vaadin-avatar-group>`},$s=(e,t,n,r,i,a,o)=>{let s=t.metadata;if(!s)return w``;let c=``;return s.variants?.map(e=>e==`stretchMedia`?`stretch-media`:e==`coverMedia`?`cover-media`:e).forEach(e=>c+=` `+e),c=c.trim(),w`
         <vaadin-card
                 style="${t.style}"
                 class="${t.cssClasses}"
                 theme="${c}"
-                slot="${t.slot??v}"
+                slot="${t.slot??_}"
         >
-            ${s.media?pt(e,s.media,n,r,i,a,o,`media`,!1):v}
-            ${s.title?pt(e,s.title,n,r,i,a,o,`title`,!1):v}
-            ${s.subtitle?pt(e,s.subtitle,n,r,i,a,o,`subtitle`,!1):v}
-            ${s.header?pt(e,s.header,n,r,i,a,o,`header`,!1):v}
-            ${s.headerPrefix?pt(e,s.headerPrefix,n,r,i,a,o,`header-prefix`,!1):v}
-            ${s.headerSuffix?pt(e,s.headerSuffix,n,r,i,a,o,`header-suffix`,!1):v}
-            ${s.footer?pt(e,s.footer,n,r,i,a,o,`footer`,!1):v}
-            ${s.content?F(e,s.content,n,r,i,a,o,!1):v}
+            ${s.media?mt(e,s.media,n,r,i,a,o,`media`,!1):_}
+            ${s.title?mt(e,s.title,n,r,i,a,o,`title`,!1):_}
+            ${s.subtitle?mt(e,s.subtitle,n,r,i,a,o,`subtitle`,!1):_}
+            ${s.header?mt(e,s.header,n,r,i,a,o,`header`,!1):_}
+            ${s.headerPrefix?mt(e,s.headerPrefix,n,r,i,a,o,`header-prefix`,!1):_}
+            ${s.headerSuffix?mt(e,s.headerSuffix,n,r,i,a,o,`header-suffix`,!1):_}
+            ${s.footer?mt(e,s.footer,n,r,i,a,o,`footer`,!1):_}
+            ${s.content?P(e,s.content,n,r,i,a,o,!1):_}
         </vaadin-card>
-    `},Rs=e=>e>0&&e<640?`accordion`:`tabs`,zs=class extends b{constructor(...e){super(...e),this.tabLabels=[],this.mode=`tabs`,this.selected=0,this.selectedChangedListener=e=>{let t=e.detail?.value;typeof t==`number`&&t>=0&&(this.selected=t)}}connectedCallback(){super.connectedCallback(),this.resizeObserver=new ResizeObserver(e=>{for(let t of e)this.mode=Rs(t.contentRect.width)}),this.resizeObserver.observe(this)}disconnectedCallback(){super.disconnectedCallback(),this.resizeObserver?.disconnect(),this.resizeObserver=void 0,this.detachTabsListener()}detachTabsListener(){this.slottedTabs?.removeEventListener(`selected-changed`,this.selectedChangedListener),this.slottedTabs=void 0}tabsSlotChanged(e){this.detachTabsListener();let t=e.target.assignedElements().find(e=>`selected`in e);t&&(this.slottedTabs=t,t.addEventListener(`selected-changed`,this.selectedChangedListener),t.selected=this.selected)}select(e){this.selected=e,this.slottedTabs&&(this.slottedTabs.selected=e)}updated(){this.slottedTabs&&this.slottedTabs.selected!=this.selected&&(this.slottedTabs.selected=this.selected)}static{this.styles=h`
+    `},ec=e=>e>0&&e<640?`accordion`:`tabs`,tc=class extends y{constructor(...e){super(...e),this.tabLabels=[],this.mode=`tabs`,this.selected=0,this.selectedChangedListener=e=>{let t=e.detail?.value;typeof t==`number`&&t>=0&&(this.selected=t)}}connectedCallback(){super.connectedCallback(),this.resizeObserver=new ResizeObserver(e=>{for(let t of e)this.mode=ec(t.contentRect.width)}),this.resizeObserver.observe(this)}disconnectedCallback(){super.disconnectedCallback(),this.resizeObserver?.disconnect(),this.resizeObserver=void 0,this.detachTabsListener()}detachTabsListener(){this.slottedTabs?.removeEventListener(`selected-changed`,this.selectedChangedListener),this.slottedTabs=void 0}tabsSlotChanged(e){this.detachTabsListener();let t=e.target.assignedElements().find(e=>`selected`in e);t&&(this.slottedTabs=t,t.addEventListener(`selected-changed`,this.selectedChangedListener),t.selected=this.selected)}select(e){this.selected=e,this.slottedTabs&&(this.slottedTabs.selected=e)}updated(){this.slottedTabs&&this.slottedTabs.selected!=this.selected&&(this.slottedTabs.selected=this.selected)}static{this.styles=m`
         :host {
             display: block;
         }
@@ -8299,26 +8299,26 @@ ${i}
         .acc-body[hidden] {
             display: none;
         }
-    `}render(){return T`
+    `}render(){return w`
             <div class="strip" ?hidden="${this.mode!=`tabs`}">
                 <slot name="tabs" @slotchange="${this.tabsSlotChanged}"></slot>
             </div>
-            ${this.mode==`tabs`?T`
-                ${this.tabLabels.map((e,t)=>T`
+            ${this.mode==`tabs`?w`
+                ${this.tabLabels.map((e,t)=>w`
                     <div class="panel" ?hidden="${t!=this.selected}">
                         <slot name="panel-${t}"></slot>
                     </div>
                 `)}
-            `:T`
+            `:w`
                 <div class="accordion" part="accordion">
-                    ${this.tabLabels.map((e,t)=>T`
+                    ${this.tabLabels.map((e,t)=>w`
                         <div class="acc-item">
                             <button class="acc-header"
                                     aria-expanded="${t==this.selected}"
                                     aria-controls="acc-body-${t}"
                                     @click="${()=>this.select(t)}"
                             >
-                                <span>${e??v}</span>
+                                <span>${e??_}</span>
                                 <span class="chevron">⟩</span>
                             </button>
                             <div class="acc-body" id="acc-body-${t}" ?hidden="${t!=this.selected}">
@@ -8328,178 +8328,178 @@ ${i}
                     `)}
                 </div>
             `}
-        `}};k([y({type:Array})],zs.prototype,`tabLabels`,void 0),k([C()],zs.prototype,`mode`,void 0),k([C()],zs.prototype,`selected`,void 0),zs=k([g(`mateu-adaptive-tabs`)],zs);var Bs=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;c??=``,s.columnSpacing&&(c+=`--vaadin-form-layout-column-spacing: `+s.columnSpacing+`;`);let l=s.itemRowSpacing&&s.itemRowSpacing!==`0`?s.itemRowSpacing:`var(--lumo-space-m)`;return c+=`--vaadin-form-layout-row-spacing: `+l+`;`,s.itemLabelSpacing&&(c+=`--vaadin-form-layout-label-spacing: `+s.itemLabelSpacing+`;`),s.labelsAside&&(c+=`--vaadin-form-item-label-width: 10rem;`),s.fullWidth&&(c+=`width: 100%;`),T`
+        `}};O([v({type:Array})],tc.prototype,`tabLabels`,void 0),O([S()],tc.prototype,`mode`,void 0),O([S()],tc.prototype,`selected`,void 0),tc=O([h(`mateu-adaptive-tabs`)],tc);var nc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;c??=``,s.columnSpacing&&(c+=`--vaadin-form-layout-column-spacing: `+s.columnSpacing+`;`);let l=s.itemRowSpacing&&s.itemRowSpacing!==`0`?s.itemRowSpacing:`var(--lumo-space-m)`;return c+=`--vaadin-form-layout-row-spacing: `+l+`;`,s.itemLabelSpacing&&(c+=`--vaadin-form-layout-label-spacing: `+s.itemLabelSpacing+`;`),s.labelsAside&&(c+=`--vaadin-form-item-label-width: 10rem;`),s.fullWidth&&(c+=`width: 100%;`),w`
                <vaadin-form-layout 
-                       .responsiveSteps="${s.responsiveSteps||v}"  
-                       style="${c||v}" 
+                       .responsiveSteps="${s.responsiveSteps||_}"  
+                       style="${c||_}" 
                        class="${t.cssClasses}"
-                       max-columns="${s.maxColumns&&s.maxColumns>0?s.maxColumns:v}"
-                       auto-responsive="${s.autoResponsive||v}"
-                       column-width="${s.columnWidth||v}"
-                       expand-columns="${s.expandColumns||v}"
-                       expand-fields="${s.expandFields||!s.labelsAside||v}"
-                       labels-aside="${s.labelsAside||v}"
-                       slot="${t.slot||v}"
+                       max-columns="${s.maxColumns&&s.maxColumns>0?s.maxColumns:_}"
+                       auto-responsive="${s.autoResponsive||_}"
+                       column-width="${s.columnWidth||_}"
+                       expand-columns="${s.expandColumns||_}"
+                       expand-fields="${s.expandFields||!s.labelsAside||_}"
+                       labels-aside="${s.labelsAside||_}"
+                       slot="${t.slot||_}"
                >
-                   ${t.children?.map(t=>Vs(s,e,t,n,r,i,a,o))}
+                   ${t.children?.map(t=>rc(s,e,t,n,r,i,a,o))}
                </vaadin-form-layout>
-            `},Vs=(e,t,n,r,i,a,o,s)=>n.type==A.ClientSide&&n.metadata?.type==j.FormRow?Us(e,t,n,r,i,a,o,s):e.labelsAside?Hs(t,n,r,i,a,o,s):F(t,n,r,i,a,o,s),Hs=(e,t,n,r,i,a,o)=>{if(t.type==A.ClientSide&&t.metadata?.type==j.FormField&&t.metadata.label){let s=t.metadata,c=s.label?.includes("${")?e._evalTemplate(s.label):s.label;return T`
+            `},rc=(e,t,n,r,i,a,o,s)=>n.type==k.ClientSide&&n.metadata?.type==A.FormRow?ac(e,t,n,r,i,a,o,s):e.labelsAside?ic(t,n,r,i,a,o,s):P(t,n,r,i,a,o,s),ic=(e,t,n,r,i,a,o)=>{if(t.type==k.ClientSide&&t.metadata?.type==A.FormField&&t.metadata.label){let s=t.metadata,c=s.label?.includes("${")?e._evalTemplate(s.label):s.label;return w`
                        <vaadin-form-item data-colspan="${s.colspan}">
                            <label slot="label">${c}</label>
-                           ${F(e,t,n,r,i,a,o,!0)}
+                           ${P(e,t,n,r,i,a,o,!0)}
                        </vaadin-form-item>
-                   `}return F(e,t,n,r,i,a,o)},Us=(e,t,n,r,i,a,o,s)=>T`
+                   `}return P(e,t,n,r,i,a,o)},ac=(e,t,n,r,i,a,o,s)=>w`
         <vaadin-form-row>
-            ${n.children?.map(n=>Vs(e,t,n,r,i,a,o,s))}
+            ${n.children?.map(n=>rc(e,t,n,r,i,a,o,s))}
         </vaadin-form-row>
-            `,Ws=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=(s.padding?` padding`:``)+(s.spacing?` spacing`:``)+(s.spacingVariant?` spacing-`+s.spacingVariant:``)+(s.wrap?` wrap`:``),l=t.style;return s.fullWidth&&(l=l?`width: 100%;`+l:`width: 100%;`),s.justification&&(l=l?`justify-content: `+s.justification+`;`+l:`justify-content: `+s.justification+`;`),s.verticalAlignment&&(l=l?`align-items: `+s.verticalAlignment+`;`+l:`align-items: `+s.verticalAlignment+`;`),T`
+            `,oc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=(s.padding?` padding`:``)+(s.spacing?` spacing`:``)+(s.spacingVariant?` spacing-`+s.spacingVariant:``)+(s.wrap?` wrap`:``),l=t.style;return s.fullWidth&&(l=l?`width: 100%;`+l:`width: 100%;`),s.justification&&(l=l?`justify-content: `+s.justification+`;`+l:`justify-content: `+s.justification+`;`),s.verticalAlignment&&(l=l?`align-items: `+s.verticalAlignment+`;`+l:`align-items: `+s.verticalAlignment+`;`),w`
                <vaadin-horizontal-layout 
                        style="${l}" 
                        class="${t.cssClasses}"
                        theme="${c}"
-                       slot="${t.slot??v}"
+                       slot="${t.slot??_}"
                >
-                   ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+                   ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
                </vaadin-horizontal-layout>
-            `},Gs=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=(s.padding?` padding`:``)+(s.spacing?` spacing`:``)+(s.spacingVariant?` spacing-`+s.spacingVariant:``)+(s.wrap?` wrap`:``),l=t.style;return s.fullWidth&&(l=l?`width: 100%;`+l:`width: 100%;`),s.justification&&(l=l?`justify-content: `+s.justification+`;`+l:`justify-content: `+s.justification+`;`),s.horizontalAlignment&&(l=l?`align-items: `+s.horizontalAlignment+`;`+l:`align-items: `+s.horizontalAlignment+`;`),T`
+            `},sc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=(s.padding?` padding`:``)+(s.spacing?` spacing`:``)+(s.spacingVariant?` spacing-`+s.spacingVariant:``)+(s.wrap?` wrap`:``),l=t.style;return s.fullWidth&&(l=l?`width: 100%;`+l:`width: 100%;`),s.justification&&(l=l?`justify-content: `+s.justification+`;`+l:`justify-content: `+s.justification+`;`),s.horizontalAlignment&&(l=l?`align-items: `+s.horizontalAlignment+`;`+l:`align-items: `+s.horizontalAlignment+`;`),w`
         <vaadin-vertical-layout
                 style="${l}"
                 class="${t.cssClasses}"
                 theme="${c}"
-                slot="${t.slot??v}"
+                slot="${t.slot??_}"
         >
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </vaadin-vertical-layout>
-    `},Ks=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;return s.fullWidth&&(c=c?`width: 100%;`+c:`width: 100%;`),T`
+    `},cc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;return s.fullWidth&&(c=c?`width: 100%;`+c:`width: 100%;`),w`
                <vaadin-split-layout 
                        style="${c}" 
                        class="${t.cssClasses}"
-                       orientation="${s.orientation??v}"
-                       theme="${s.variant??v}"
-                       slot="${t.slot??v}"
+                       orientation="${s.orientation??_}"
+                       theme="${s.variant??_}"
+                       slot="${t.slot??_}"
                >
-                   <master-content>${F(e,t.children[0],n,r,i,a,o)}</master-content>
-                   <detail-content>${F(e,t.children[1],n,r,i,a,o)}</detail-content>
+                   <master-content>${P(e,t.children[0],n,r,i,a,o)}</master-content>
+                   <detail-content>${P(e,t.children[1],n,r,i,a,o)}</detail-content>
                </vaadin-split-layout>
-            `},qs=(e,t,n,r,i,a,o)=>{let s=t.children&&t.children.length>1?t.children[1]:null,c=i?.detailComponent??null,l=!!i?.hasDetail||!!s,u=c??s;return T`
+            `},lc=(e,t,n,r,i,a,o)=>{let s=t.children&&t.children.length>1?t.children[1]:null,c=i?.detailComponent??null,l=!!i?.hasDetail||!!s,u=c??s;return w`
                <vaadin-master-detail-layout ?has-detail="${l}"
                                             style="${t.style}"
                                             class="${t.cssClasses}"
-                                            slot="${t.slot??v}">
-                   <div>${F(e,t.children[0],n,r,i,a,o)}</div>
-                   ${l&&u?T`<div slot="detail">${F(e,u,n,r,i,a,o)}</div>`:T`<div slot="detail" style="display: flex; align-items: center; justify-content: center; height: 100%; color: var(--lumo-secondary-text-color); font-size: var(--lumo-font-size-s);">Select an item to view details</div>`}
+                                            slot="${t.slot??_}">
+                   <div>${P(e,t.children[0],n,r,i,a,o)}</div>
+                   ${l&&u?w`<div slot="detail">${P(e,u,n,r,i,a,o)}</div>`:w`<div slot="detail" style="display: flex; align-items: center; justify-content: center; height: 100%; color: var(--lumo-secondary-text-color); font-size: var(--lumo-font-size-s);">Select an item to view details</div>`}
                </vaadin-master-detail-layout>
-            `},Js=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;c??=``,s.fullWidth&&(c+=`width: 100%;`);let l=s.variant;l==`equalWidth`&&(l=`equal-width-tabs`);let u=Math.max(0,(t.children??[]).findIndex(e=>e.metadata.active)),d=e=>{e.target.selected=u};if(s.adaptable){let u=(t.children??[]).map(t=>{let n=t.metadata.label;return n?.includes("${")?e._evalTemplate(n):n});return T`
+            `},uc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;c??=``,s.fullWidth&&(c+=`width: 100%;`);let l=s.variant;l==`equalWidth`&&(l=`equal-width-tabs`);let u=Math.max(0,(t.children??[]).findIndex(e=>e.metadata.active)),d=e=>{e.target.selected=u};if(s.adaptable){let u=(t.children??[]).map(t=>{let n=t.metadata.label;return n?.includes("${")?e._evalTemplate(n):n});return w`
             <mateu-adaptive-tabs
                     .tabLabels="${u}"
                     style="${c}"
                     class="${t.cssClasses}"
-                    slot="${t.slot??v}"
+                    slot="${t.slot??_}"
             >
                 <vaadin-tabs slot="tabs"
-                             theme="${l??v}"
-                             orientation="${s.orientation??v}"
+                             theme="${l??_}"
+                             orientation="${s.orientation??_}"
                              @items-changed=${d}
                 >
-                    ${t.children?.map(e=>e).map((e,t)=>{let n=e.metadata.shortcut;return T`
+                    ${t.children?.map(e=>e).map((e,t)=>{let n=e.metadata.shortcut;return w`
                         <vaadin-tab id="${u[t]}"
                                     style="${e.style}"
                                     class="${e.cssClasses}"
-                                    data-shortcut="${n??v}"
+                                    data-shortcut="${n??_}"
                         >${u[t]}</vaadin-tab>`})}
                 </vaadin-tabs>
 
-                ${t.children?.map((t,s)=>T`
+                ${t.children?.map((t,s)=>w`
                     <div slot="panel-${s}" style="padding: var(--lumo-space-m) 0;">
-                        ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+                        ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
                     </div>`)}
             </mateu-adaptive-tabs>
-                `}return T`
+                `}return w`
         <vaadin-tabsheet
-                theme="${l??v}"
+                theme="${l??_}"
                 style="${c}"
-                slot="${t.slot??v}"
+                slot="${t.slot??_}"
         >
             <vaadin-tabs slot="tabs"
                          style="${c}"
                          class="${t.cssClasses}"
-                         orientation="${s.orientation??v}"
+                         orientation="${s.orientation??_}"
                          @items-changed=${d}
             >
-                ${t.children?.map(e=>e).map(t=>{let n=t.metadata.label,r=n?.includes("${")?e._evalTemplate(n):n,i=t.metadata.shortcut;return T`
+                ${t.children?.map(e=>e).map(t=>{let n=t.metadata.label,r=n?.includes("${")?e._evalTemplate(n):n,i=t.metadata.shortcut;return w`
                     <vaadin-tab id="${r}"
                                 style="${t.style}"
                                 class="${t.cssClasses}"
-                                data-shortcut="${i??v}"
+                                data-shortcut="${i??_}"
                     >${r}</vaadin-tab>`})}
             </vaadin-tabs>
 
-            ${t.children?.map(t=>Ys(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>dc(e,t,n,r,i,a,o))}
         </vaadin-tabsheet>
-            `},Ys=(e,t,n,r,i,a,o)=>{let s=t.metadata.label;return T`
+            `},dc=(e,t,n,r,i,a,o)=>{let s=t.metadata.label;return w`
         <div tab="${s?.includes("${")?e._evalTemplate(s):s}" style="padding: var(--lumo-space-m) 0;">
-                   ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+                   ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
                </div>
-            `},Xs=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;s.fullWidth&&(c=c?`width: 100%;`+c:`width: 100%;`);let l=0;if(t.children){for(let e=0;e<t.children.length;e++)if(t.children[e].metadata?.active){l=e;break}}return T`
+            `},fc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;s.fullWidth&&(c=c?`width: 100%;`+c:`width: 100%;`);let l=0;if(t.children){for(let e=0;e<t.children.length;e++)if(t.children[e].metadata?.active){l=e;break}}return w`
                <vaadin-accordion
                        style="${t.style}"
                        class="${t.cssClasses}"
                        opened="${l}"
-                       slot="${t.slot??v}"
+                       slot="${t.slot??_}"
                >
-                   ${t.children?.map(t=>Zs(e,t,n,r,i,a,o,s.variant))}
+                   ${t.children?.map(t=>pc(e,t,n,r,i,a,o,s.variant))}
                </vaadin-accordion>
-            `},Zs=(e,t,n,r,i,a,o,s)=>{let c=t.metadata,l=c.label?.includes("${")?e._evalTemplate(c.label):c.label;return T`
+            `},pc=(e,t,n,r,i,a,o,s)=>{let c=t.metadata,l=c.label?.includes("${")?e._evalTemplate(c.label):c.label;return w`
         <vaadin-accordion-panel style="${t.style}"
                                 class="${t.cssClasses}"
-                                theme="${s??v}"
+                                theme="${s??_}"
                                 ?opened="${c.active}"
                                 ?disabled="${c.disabled}">
             <vaadin-accordion-heading slot="summary">${l}</vaadin-accordion-heading>
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </vaadin-accordion-panel>
-            `},Qs=(e,t,n,r,i,a,o)=>T`
+            `},mc=(e,t,n,r,i,a,o)=>w`
                <vaadin-scroller style="${t.style}" 
                                 class="${t.cssClasses}"
-                                slot="${t.slot??v}">
-                   ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+                                slot="${t.slot??_}">
+                   ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
                </vaadin-scroller>
-            `,$s=(e,t,n,r,i,a,o)=>T`
+            `,hc=(e,t,n,r,i,a,o)=>w`
         <vaadin-board style="${t.style}" 
                       class="${t.cssClasses}"
-                      slot="${t.slot??v}">
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+                      slot="${t.slot??_}">
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </vaadin-board>
-            `,ec=(e,t,n,r,i,a,o)=>T`
+            `,gc=(e,t,n,r,i,a,o)=>w`
         <vaadin-board-row style="${t.style}" class="${t.cssClasses}">
-                   ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+                   ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
                </vaadin-board-row>
-            `,tc=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+            `,_c=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <div style="${t.style}" 
              class="${t.cssClasses}"
-             board-cols="${s.boardCols??v}"
+             board-cols="${s.boardCols??_}"
         >
-                   ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+                   ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
                </div>
-            `},nc=(e,t,n)=>T`
+            `},vc=(e,t,n)=>w`
     <vaadin-menu-bar
         .items=${e}
-        class="${n??v}"
+        class="${n??_}"
         @item-selected=${e=>t(e.detail.value)}>
-    </vaadin-menu-bar>`,rc=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
-        <vaadin-context-menu .items=${oc(e,s.menu,n,r,i,a,o)} 
+    </vaadin-menu-bar>`,yc=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+        <vaadin-context-menu .items=${Sc(e,s.menu,n,r,i,a,o)} 
                              style="${t.style}" 
                              class="${t.cssClasses}"
-                             open-on="${s.activateOnLeftClick?`click`:v}"
-                             slot="${t.slot??v}">
-            ${F(e,s.wrapped,n,r,i,a,o)}
+                             open-on="${s.activateOnLeftClick?`click`:_}"
+                             slot="${t.slot??_}">
+            ${P(e,s.wrapped,n,r,i,a,o)}
         </vaadin-context-menu>
-            `},ic=(e,t,n,r,i)=>{let a=t.metadata;return T`
-        <vaadin-menu-bar .items=${oc(e,a.options,n,r,i,O,ue)}
+            `},bc=(e,t,n,r,i)=>{let a=t.metadata;return w`
+        <vaadin-menu-bar .items=${Sc(e,a.options,n,r,i,D,de)}
                          style="${t.style}" class="${t.cssClasses}"
-                         slot="${t.slot??v}">
+                         slot="${t.slot??_}">
         </vaadin-menu-bar>
-            `},ac=(e,t,n,r,i,a,o)=>{let s=document.createElement(`vaadin-context-menu-item`);return re(F(e,t,n,r,i,a,o),s),s},oc=(e,t,n,r,i,a,o)=>t.map(t=>t.submenus?{text:t.component?void 0:t.label,route:t.path,checked:t.selected,disabled:t.disabled,className:t.className,component:t.component?ac(e,t.component,n,r,i,a,o):void 0,children:oc(e,t.submenus,n,r,i,a,o)}:t.separator?{component:`hr`}:{text:t.component?void 0:t.label,route:t.path,checked:t.selected,disabled:t.disabled,className:t.className,component:t.component?ac(e,t.component,n,r,i,a,o):void 0}),sc=class extends b{constructor(...e){super(...e),this.fieldId=``,this.signing=!1,this.hasStrokes=!1,this.drawing=!1,this.startStroke=e=>{let t=e.target;this.ensureCanvasSize(t),t.setPointerCapture(e.pointerId),this.drawing=!0;let n=t.getContext(`2d`);n.lineWidth=2,n.lineCap=`round`,n.lineJoin=`round`,n.strokeStyle=getComputedStyle(this).getPropertyValue(`--lumo-body-text-color`)||`#1a1a1a`;let[r,i]=this.pointerPosition(e);n.beginPath(),n.moveTo(r,i),e.preventDefault()},this.stroke=e=>{if(!this.drawing)return;let t=e.target.getContext(`2d`),[n,r]=this.pointerPosition(e);t.lineTo(n,r),t.stroke(),this.hasStrokes=!0,e.preventDefault()},this.endStroke=e=>{this.drawing=!1,e.target.releasePointerCapture(e.pointerId)}}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}canvas(){return this.renderRoot.querySelector(`canvas`)}pointerPosition(e){let t=e.target.getBoundingClientRect();return[e.clientX-t.left,e.clientY-t.top]}ensureCanvasSize(e){let t=e.getBoundingClientRect();(e.width!==Math.round(t.width)||e.height!==Math.round(t.height))&&(e.width=Math.round(t.width),e.height=Math.round(t.height))}clear(){let e=this.canvas();e&&e.getContext(`2d`).clearRect(0,0,e.width,e.height),this.hasStrokes=!1}accept(){let e=this.canvas();!e||!this.hasStrokes||(this.signing=!1,this.emit(e.toDataURL(`image/png`)))}renderPad(){return T`
+            `},xc=(e,t,n,r,i,a,o)=>{let s=document.createElement(`vaadin-context-menu-item`);return ie(P(e,t,n,r,i,a,o),s),s},Sc=(e,t,n,r,i,a,o)=>t.map(t=>t.submenus?{text:t.component?void 0:t.label,route:t.path,checked:t.selected,disabled:t.disabled,className:t.className,component:t.component?xc(e,t.component,n,r,i,a,o):void 0,children:Sc(e,t.submenus,n,r,i,a,o)}:t.separator?{component:`hr`}:{text:t.component?void 0:t.label,route:t.path,checked:t.selected,disabled:t.disabled,className:t.className,component:t.component?xc(e,t.component,n,r,i,a,o):void 0}),Cc=class extends y{constructor(...e){super(...e),this.fieldId=``,this.signing=!1,this.hasStrokes=!1,this.drawing=!1,this.startStroke=e=>{let t=e.target;this.ensureCanvasSize(t),t.setPointerCapture(e.pointerId),this.drawing=!0;let n=t.getContext(`2d`);n.lineWidth=2,n.lineCap=`round`,n.lineJoin=`round`,n.strokeStyle=getComputedStyle(this).getPropertyValue(`--lumo-body-text-color`)||`#1a1a1a`;let[r,i]=this.pointerPosition(e);n.beginPath(),n.moveTo(r,i),e.preventDefault()},this.stroke=e=>{if(!this.drawing)return;let t=e.target.getContext(`2d`),[n,r]=this.pointerPosition(e);t.lineTo(n,r),t.stroke(),this.hasStrokes=!0,e.preventDefault()},this.endStroke=e=>{this.drawing=!1,e.target.releasePointerCapture(e.pointerId)}}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}canvas(){return this.renderRoot.querySelector(`canvas`)}pointerPosition(e){let t=e.target.getBoundingClientRect();return[e.clientX-t.left,e.clientY-t.top]}ensureCanvasSize(e){let t=e.getBoundingClientRect();(e.width!==Math.round(t.width)||e.height!==Math.round(t.height))&&(e.width=Math.round(t.width),e.height=Math.round(t.height))}clear(){let e=this.canvas();e&&e.getContext(`2d`).clearRect(0,0,e.width,e.height),this.hasStrokes=!1}accept(){let e=this.canvas();!e||!this.hasStrokes||(this.signing=!1,this.emit(e.toDataURL(`image/png`)))}renderPad(){return w`
             <canvas class="pad"
                     @pointerdown="${this.startStroke}"
                     @pointermove="${this.stroke}"
@@ -8509,14 +8509,14 @@ ${i}
                 <button class="button" @click="${this.clear}">Clear</button>
                 <button class="button button--primary" ?disabled="${!this.hasStrokes}"
                         @click="${this.accept}">Accept</button>
-                ${this.value?T`
-                    <button class="button" @click="${()=>{this.signing=!1}}">Cancel</button>`:v}
-            </div>`}render(){let e=this.value!=null&&this.value!==``;return this.signing||!e?this.renderPad():T`
+                ${this.value?w`
+                    <button class="button" @click="${()=>{this.signing=!1}}">Cancel</button>`:_}
+            </div>`}render(){let e=this.value!=null&&this.value!==``;return this.signing||!e?this.renderPad():w`
             <img class="preview" src="${this.value}" alt="Signature"/>
             <div class="actions">
                 <button class="button" @click="${()=>{this.signing=!0,this.hasStrokes=!1,this.updateComplete.then(()=>this.clear())}}">Sign again</button>
                 <button class="button button--danger" @click="${()=>this.emit(``)}">Delete</button>
-            </div>`}static{this.styles=h`
+            </div>`}static{this.styles=m`
         :host {
             display: block;
             max-width: 420px;
@@ -8566,19 +8566,19 @@ ${i}
         .button--danger {
             color: var(--lumo-error-text-color, rgb(179, 49, 31));
         }
-    `}};k([y()],sc.prototype,`fieldId`,void 0),k([y()],sc.prototype,`value`,void 0),k([C()],sc.prototype,`signing`,void 0),k([C()],sc.prototype,`hasStrokes`,void 0),sc=k([g(`mateu-signature-pad`)],sc);var cc=class extends b{constructor(...e){super(...e),this.fieldId=``,this.options=[],this.leavesOnly=!1,this.opened=!1,this.expandedItems=[],this._normalized=[],this.dataProvider=(e,t)=>{let n=e.parentItem?e.parentItem.children??[]:this.normalized;t(n,n.length)}}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}get normalized(){return this._optsSource!==this.options&&(this._optsSource=this.options,this._normalized=this.normalizeOptions(this.options??[])),this._normalized}normalizeOptions(e){return e.map(e=>{let t=e.children&&e.children.length?this.normalizeOptions(e.children):void 0;return{...e,children:t}})}ancestorsOf(e,t){for(let n of t){if(String(n.value)===e)return[];let t=n.children?this.ancestorsOf(e,n.children):null;if(t!=null)return[n,...t]}return null}labelOf(e,t){for(let n of t){if(String(n.value)===e)return n.label;let t=n.children?this.labelOf(e,n.children):null;if(t!=null)return t}return null}open(){this.opened||(this.expandedItems=this.value==null?[]:this.ancestorsOf(String(this.value),this.normalized)??[],this.opened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.close()},document.addEventListener(`mousedown`,this.outsideClick))}close(){this.detachOutsideClick(),this.opened=!1}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}pick(e){this.close(),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e.value,fieldId:this.fieldId},bubbles:!0,composed:!0}))}clear(){this.close(),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:void 0,fieldId:this.fieldId},bubbles:!0,composed:!0}))}onActiveItemChanged(e){let t=e.detail.value;if(t){if((t.children?.length??0)>0&&this.leavesOnly){this.expandedItems=this.expandedItems.includes(t)?this.expandedItems.filter(e=>e!==t):[...this.expandedItems,t],e.target.activeItem=null;return}this.pick(t)}}render(){let e=this.value!=null&&this.value!==``?this.labelOf(String(this.value),this.normalized)??String(this.value):``;return T`
+    `}};O([v()],Cc.prototype,`fieldId`,void 0),O([v()],Cc.prototype,`value`,void 0),O([S()],Cc.prototype,`signing`,void 0),O([S()],Cc.prototype,`hasStrokes`,void 0),Cc=O([h(`mateu-signature-pad`)],Cc);var wc=class extends y{constructor(...e){super(...e),this.fieldId=``,this.options=[],this.leavesOnly=!1,this.opened=!1,this.expandedItems=[],this._normalized=[],this.dataProvider=(e,t)=>{let n=e.parentItem?e.parentItem.children??[]:this.normalized;t(n,n.length)}}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}get normalized(){return this._optsSource!==this.options&&(this._optsSource=this.options,this._normalized=this.normalizeOptions(this.options??[])),this._normalized}normalizeOptions(e){return e.map(e=>{let t=e.children&&e.children.length?this.normalizeOptions(e.children):void 0;return{...e,children:t}})}ancestorsOf(e,t){for(let n of t){if(String(n.value)===e)return[];let t=n.children?this.ancestorsOf(e,n.children):null;if(t!=null)return[n,...t]}return null}labelOf(e,t){for(let n of t){if(String(n.value)===e)return n.label;let t=n.children?this.labelOf(e,n.children):null;if(t!=null)return t}return null}open(){this.opened||(this.expandedItems=this.value==null?[]:this.ancestorsOf(String(this.value),this.normalized)??[],this.opened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.close()},document.addEventListener(`mousedown`,this.outsideClick))}close(){this.detachOutsideClick(),this.opened=!1}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}pick(e){this.close(),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e.value,fieldId:this.fieldId},bubbles:!0,composed:!0}))}clear(){this.close(),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:void 0,fieldId:this.fieldId},bubbles:!0,composed:!0}))}onActiveItemChanged(e){let t=e.detail.value;if(t){if((t.children?.length??0)>0&&this.leavesOnly){this.expandedItems=this.expandedItems.includes(t)?this.expandedItems.filter(e=>e!==t):[...this.expandedItems,t],e.target.activeItem=null;return}this.pick(t)}}render(){let e=this.value!=null&&this.value!==``?this.labelOf(String(this.value),this.normalized)??String(this.value):``;return w`
             <div class="root">
                 <vaadin-button class="control" theme="tertiary"
                                @click="${()=>this.opened?this.close():this.open()}">
                     <span class="${e?``:`placeholder`}">${e||`—`}</span>
                     <span class="chevron" slot="suffix" aria-hidden="true">▾</span>
                 </vaadin-button>
-                ${this.opened?T`
+                ${this.opened?w`
                     <div class="panel">
-                        ${this.value?T`
+                        ${this.value?w`
                             <div class="clear-row">
                                 <vaadin-button theme="tertiary small" @click="${this.clear}">— Clear</vaadin-button>
-                            </div>`:v}
+                            </div>`:_}
                         <vaadin-grid
                                 theme="compact no-border no-row-borders"
                                 all-rows-visible
@@ -8589,8 +8589,8 @@ ${i}
                                 @active-item-changed="${this.onActiveItemChanged}">
                             <vaadin-grid-tree-column path="label"></vaadin-grid-tree-column>
                         </vaadin-grid>
-                    </div>`:v}
-            </div>`}static{this.styles=h`
+                    </div>`:_}
+            </div>`}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -8637,29 +8637,29 @@ ${i}
             min-width: 16rem;
             max-height: 18rem;
         }
-    `}};k([y()],cc.prototype,`fieldId`,void 0),k([y()],cc.prototype,`value`,void 0),k([y()],cc.prototype,`options`,void 0),k([y({type:Boolean})],cc.prototype,`leavesOnly`,void 0),k([C()],cc.prototype,`opened`,void 0),k([C()],cc.prototype,`expandedItems`,void 0),cc=k([g(`mateu-vaadin-tree-select`)],cc);var lc=class extends b{constructor(...e){super(...e),this.fieldId=``,this.cameraOpen=!1,this.cameraError=!1,this.fileFallback=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>this.emit(r.result),r.readAsDataURL(n),t.value=``}}disconnectedCallback(){super.disconnectedCallback(),this.stopStream()}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}stopStream(){this.stream?.getTracks().forEach(e=>e.stop()),this.stream=void 0}async openCamera(){this.cameraError=!1;try{this.stream=await navigator.mediaDevices.getUserMedia({video:{facingMode:`environment`},audio:!1}),this.cameraOpen=!0,await this.updateComplete;let e=this.renderRoot.querySelector(`video`);e&&(e.srcObject=this.stream,await e.play())}catch{this.stopStream(),this.cameraOpen=!1,this.cameraError=!0}}closeCamera(){this.stopStream(),this.cameraOpen=!1}shoot(){let e=this.renderRoot.querySelector(`video`);if(!e||e.videoWidth===0)return;let t=document.createElement(`canvas`);t.width=e.videoWidth,t.height=e.videoHeight,t.getContext(`2d`).drawImage(e,0,0),this.closeCamera(),this.emit(t.toDataURL(`image/jpeg`,.9))}triggerFallback(){this.renderRoot.querySelector(`input[type=file]`)?.click()}render(){let e=this.value!=null&&this.value!==``;return T`
+    `}};O([v()],wc.prototype,`fieldId`,void 0),O([v()],wc.prototype,`value`,void 0),O([v()],wc.prototype,`options`,void 0),O([v({type:Boolean})],wc.prototype,`leavesOnly`,void 0),O([S()],wc.prototype,`opened`,void 0),O([S()],wc.prototype,`expandedItems`,void 0),wc=O([h(`mateu-vaadin-tree-select`)],wc);var Tc=class extends y{constructor(...e){super(...e),this.fieldId=``,this.cameraOpen=!1,this.cameraError=!1,this.fileFallback=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>this.emit(r.result),r.readAsDataURL(n),t.value=``}}disconnectedCallback(){super.disconnectedCallback(),this.stopStream()}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}stopStream(){this.stream?.getTracks().forEach(e=>e.stop()),this.stream=void 0}async openCamera(){this.cameraError=!1;try{this.stream=await navigator.mediaDevices.getUserMedia({video:{facingMode:`environment`},audio:!1}),this.cameraOpen=!0,await this.updateComplete;let e=this.renderRoot.querySelector(`video`);e&&(e.srcObject=this.stream,await e.play())}catch{this.stopStream(),this.cameraOpen=!1,this.cameraError=!0}}closeCamera(){this.stopStream(),this.cameraOpen=!1}shoot(){let e=this.renderRoot.querySelector(`video`);if(!e||e.videoWidth===0)return;let t=document.createElement(`canvas`);t.width=e.videoWidth,t.height=e.videoHeight,t.getContext(`2d`).drawImage(e,0,0),this.closeCamera(),this.emit(t.toDataURL(`image/jpeg`,.9))}triggerFallback(){this.renderRoot.querySelector(`input[type=file]`)?.click()}render(){let e=this.value!=null&&this.value!==``;return w`
             <input type="file" accept="image/*" capture="environment" style="display: none;"
                    @change="${this.fileFallback}">
-            ${this.cameraOpen?T`
+            ${this.cameraOpen?w`
                 <video class="viewfinder" playsinline muted></video>
                 <div class="actions">
                     <button class="button button--primary" @click="${this.shoot}">Capture</button>
                     <button class="button" @click="${this.closeCamera}">Cancel</button>
                 </div>
-            `:T`
-                ${e?T`<img class="preview" src="${this.value}" alt="Photo"/>`:T`<div class="placeholder" aria-hidden="true">📷</div>`}
+            `:w`
+                ${e?w`<img class="preview" src="${this.value}" alt="Photo"/>`:w`<div class="placeholder" aria-hidden="true">📷</div>`}
                 <div class="actions">
                     <button class="button button--primary" @click="${this.openCamera}">
                         ${e?`Retake`:`Take photo`}
                     </button>
-                    ${this.cameraError?T`
-                        <button class="button" @click="${this.triggerFallback}">Use file / native camera</button>`:v}
-                    ${e?T`
-                        <button class="button button--danger" @click="${()=>this.emit(``)}">Delete</button>`:v}
+                    ${this.cameraError?w`
+                        <button class="button" @click="${this.triggerFallback}">Use file / native camera</button>`:_}
+                    ${e?w`
+                        <button class="button button--danger" @click="${()=>this.emit(``)}">Delete</button>`:_}
                 </div>
-                ${this.cameraError?T`
-                    <div class="error-hint">Camera unavailable — the file picker opens the device camera on phones.</div>`:v}
-            `}`}static{this.styles=h`
+                ${this.cameraError?w`
+                    <div class="error-hint">Camera unavailable — the file picker opens the device camera on phones.</div>`:_}
+            `}`}static{this.styles=m`
         :host {
             display: block;
             max-width: 420px;
@@ -8715,17 +8715,17 @@ ${i}
             font-size: var(--lumo-font-size-xs, 0.75rem);
             color: var(--lumo-secondary-text-color, rgba(0, 0, 0, 0.6));
         }
-    `}};k([y()],lc.prototype,`fieldId`,void 0),k([y()],lc.prototype,`value`,void 0),k([C()],lc.prototype,`cameraOpen`,void 0),k([C()],lc.prototype,`cameraError`,void 0),lc=k([g(`mateu-camera-capture`)],lc);var uc,dc=(e,t)=>{if(!e)return;if(Array.isArray(e)){let n=e.find(e=>e.key==t);return n?.value==null?void 0:String(n.value)}let n=e[t];return n==null?void 0:String(n)},fc=class extends b{static{uc=this}constructor(...e){super(...e),this.fieldId=``,this.editable=!0,this.filePicked=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>{let e=r.result,t=e.indexOf(`,`),i=e.substring(0,t).replace(`;base64`,`;name=${encodeURIComponent(n.name)};base64`);this.emit(i+e.substring(t))},r.readAsDataURL(n),t.value=``}}static fileName(e){if(!e)return``;if(e.startsWith(`data:`)){let t=e.indexOf(`,`),n=e.substring(5,t<0?e.length:t).split(`;`).find(e=>e.startsWith(`name=`));if(n)try{return decodeURIComponent(n.substring(5))}catch{return n.substring(5)}return`Attached file`}return e.split(`/`).pop()||e}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}triggerPick(){this.renderRoot.querySelector(`input[type=file]`)?.click()}render(){let e=this.value!=null&&this.value!==``,t=uc.fileName(this.value),n=e&&this.value.startsWith(`data:`),r=e?T`<span class="file" title="${t}">📄 ${n?T`<a href="${this.value}" download="${t}">${t}</a>`:T`<a href="${this.value}" target="_blank">${t}</a>`}</span>`:v;return this.editable?T`
-            <input type="file" accept="${this.accept||v}" style="display: none;"
+    `}};O([v()],Tc.prototype,`fieldId`,void 0),O([v()],Tc.prototype,`value`,void 0),O([S()],Tc.prototype,`cameraOpen`,void 0),O([S()],Tc.prototype,`cameraError`,void 0),Tc=O([h(`mateu-camera-capture`)],Tc);var Ec,Dc=(e,t)=>{if(!e)return;if(Array.isArray(e)){let n=e.find(e=>e.key==t);return n?.value==null?void 0:String(n.value)}let n=e[t];return n==null?void 0:String(n)},Oc=class extends y{static{Ec=this}constructor(...e){super(...e),this.fieldId=``,this.editable=!0,this.filePicked=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>{let e=r.result,t=e.indexOf(`,`),i=e.substring(0,t).replace(`;base64`,`;name=${encodeURIComponent(n.name)};base64`);this.emit(i+e.substring(t))},r.readAsDataURL(n),t.value=``}}static fileName(e){if(!e)return``;if(e.startsWith(`data:`)){let t=e.indexOf(`,`),n=e.substring(5,t<0?e.length:t).split(`;`).find(e=>e.startsWith(`name=`));if(n)try{return decodeURIComponent(n.substring(5))}catch{return n.substring(5)}return`Attached file`}return e.split(`/`).pop()||e}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}triggerPick(){this.renderRoot.querySelector(`input[type=file]`)?.click()}render(){let e=this.value!=null&&this.value!==``,t=Ec.fileName(this.value),n=e&&this.value.startsWith(`data:`),r=e?w`<span class="file" title="${t}">📄 ${n?w`<a href="${this.value}" download="${t}">${t}</a>`:w`<a href="${this.value}" target="_blank">${t}</a>`}</span>`:_;return this.editable?w`
+            <input type="file" accept="${this.accept||_}" style="display: none;"
                    @change="${this.filePicked}">
             <div class="row">
                 ${r}
                 <button class="button" @click="${this.triggerPick}">
                     ${e?`Replace`:`Choose file`}
                 </button>
-                ${e?T`
-                    <button class="button button--danger" @click="${()=>this.emit(``)}">Remove</button>`:v}
-            </div>`:T`${e?r:T`<span class="empty">—</span>`}`}static{this.styles=h`
+                ${e?w`
+                    <button class="button button--danger" @click="${()=>this.emit(``)}">Remove</button>`:_}
+            </div>`:w`${e?r:w`<span class="empty">—</span>`}`}static{this.styles=m`
         :host {
             display: block;
         }
@@ -8763,114 +8763,114 @@ ${i}
         .button--danger {
             color: var(--lumo-error-text-color, rgb(179, 49, 31));
         }
-    `}};k([y()],fc.prototype,`fieldId`,void 0),k([y()],fc.prototype,`value`,void 0),k([y()],fc.prototype,`accept`,void 0),k([y({type:Boolean})],fc.prototype,`editable`,void 0),fc=uc=k([g(`mateu-file-upload`)],fc);var pc=e=>!!e&&typeof e==`object`&&`__mateuGroup`in e,mc=e=>String(e??``),hc=(e,t,n)=>{let r=e??[];if(!t||!n||n.length===0)return r;let i=[],a,o=!1;return r.forEach((e,s)=>{let c=mc(e?.[t]);if(!o||c!==a){let e=n.find(e=>mc(e.value)===c)??{value:c,count:r.filter(e=>mc(e?.[t])===c).length,aggregates:{}};i.push({__mateuGroup:e,__mateuGroupBy:t,_rowNumber:`__mateuGroup:${s}:${c}`}),o=!0,a=c}i.push(e)}),i},gc=(e,t)=>e==null?``:t.dataType===`money`||t.stereotype===`money`?new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e):t.aggregate===`count`?new Intl.NumberFormat(void 0,{maximumFractionDigits:0}).format(Math.round(e)):new Intl.NumberFormat(void 0,{maximumFractionDigits:2}).format(e),_c=(e,t)=>e&&t.includes(e)?e:t.find(e=>!!e),vc=(e,t,n)=>{let r=e.__mateuGroup;return t.id===n?`${r.value} (${r.count})`:t.aggregate?gc(r.aggregates?.[t.id],t):``},yc=(e,t,n)=>{let r=t?.aggregates;if(!r||!e.some(e=>e.aggregate))return;let i={};e.forEach(e=>{e.aggregate&&r[e.id]!=null&&(i[e.id]=gc(r[e.id],e))});let a=e[0];if(a&&i[a.id]===void 0){let e=t?.page?.totalElements;i[a.id]=n&&a.id===n&&e!=null?`Total (${e})`:`Total`}return i},bc=(e,t,n)=>I(e[n.path]?`vaadin:check`:`vaadin:minus`,`height: 16px; width: 16px; color: var(--lumo-body-text-color);`),xc=(e,t,n,r,i)=>{let a=e[n.path],o=a;return r==`money`&&a&&a.locale&&a.currency?o=new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(a.value):i==`money`&&(o=new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(a)),T`${o}`},Sc=(e,t,n)=>{e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:n},bubbles:!0,composed:!0}))},Cc=(e,t,n,r,i,a)=>{let o=n.xcolumn??a;if(o.text)return o.actionId?T`<a href="javascript: void(0);" @click="${t=>Sc(n,o,e)}">${o.text}</a>`:T`<a href="${e[n.path]}">${o.text}</a>`;if(r==`string`){if(o.actionId)return T`<a href="javascript: void(0);" @click="${t=>Sc(n,o,e)}">${e[n.path]}</a>`;let t=e[n.path];return T`<a href="${t}">${t}</a>`}let s=e[n.path];return T`<a href="${s.href}">${s.text}</a>`},wc=(e,t,n,r,i)=>{let a=e[n.path];return r==`string`?a.split(`,`).map(e=>I(e,`width: 16px;`)):a.split(`,`).map(e=>I(e.icon,`width: 16px;`))},Tc=(e,t,n,r,i)=>{let a=e[n.path];return T`${_(a)}`},Ec=(e,t,n,r,i,a)=>r==`string`?T`<img src="${e[n.path]}" style="${`max-height: 40px; `+(a.style??``)}">`:T`<img src="${e[n.path].src}" style="${a.style??``}">`,Dc=e=>{let t={_clickedRow:e.target.row};e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+e.detail.value.methodNameInCrud,parameters:t},bubbles:!0,composed:!0}))},Oc=e=>{let t={_clickedRow:e.target.row},n=e.target.action;e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+n.methodNameInCrud,parameters:t},bubbles:!0,composed:!0}))},kc=e=>{let t=document.createElement(`vaadin-context-menu-item`),n=document.createElement(`vaadin-icon`);return n.style.color=`var(--lumo-secondary-text-color)`,n.style.marginInlineEnd=`var(--lumo-space-s)`,n.style.padding=`var(--lumo-space-xs)`,n.setAttribute(`icon`,e.icon),t.appendChild(n),e.label&&t.appendChild(document.createTextNode(e.label)),t.disabled=e.disabled,t},Ac=(e,t,n)=>{let r=e[n.path]?.actions?.map(e=>e.icon?{component:kc(e),methodNameInCrud:e.methodNameInCrud}:{...e,text:e.label});return!r||r.length==0?T``:T`
+    `}};O([v()],Oc.prototype,`fieldId`,void 0),O([v()],Oc.prototype,`value`,void 0),O([v()],Oc.prototype,`accept`,void 0),O([v({type:Boolean})],Oc.prototype,`editable`,void 0),Oc=Ec=O([h(`mateu-file-upload`)],Oc);function kc(e,t){return t?t.split(`.`).reduce((e,t)=>typeof e==`object`&&e?e[t]:void 0,e):e}function Ac(e,t,n=`value`,r=`label`){let i=kc(e,t);return Array.isArray(i)?i.map(e=>{if(typeof e==`object`&&e){let t=kc(e,n),i=kc(e,r);return{value:t??i,label:String(i??t??``)}}return{value:e,label:String(e)}}):[]}async function jc(e,t=e=>e,n=fetch){let r=t(e.url)??e.url,i=(e.method||`GET`).toUpperCase(),a={};for(let[n,r]of Object.entries(e.headers??{}))a[n]=t(r)??r;let o={method:i,headers:a};i!==`GET`&&i!==`HEAD`&&e.body&&(o.body=t(e.body)??e.body);let s=await n(r,o);if(!s.ok)throw Error(`External options fetch failed: ${s.status}`);return Ac(await s.json(),e.itemsPath,e.valuePath,e.labelPath)}var Mc=e=>!!e&&typeof e==`object`&&`__mateuGroup`in e,Nc=e=>String(e??``),Pc=(e,t,n)=>{let r=e??[];if(!t||!n||n.length===0)return r;let i=[],a,o=!1;return r.forEach((e,s)=>{let c=Nc(e?.[t]);if(!o||c!==a){let e=n.find(e=>Nc(e.value)===c)??{value:c,count:r.filter(e=>Nc(e?.[t])===c).length,aggregates:{}};i.push({__mateuGroup:e,__mateuGroupBy:t,_rowNumber:`__mateuGroup:${s}:${c}`}),o=!0,a=c}i.push(e)}),i},Fc=(e,t)=>e==null?``:t.dataType===`money`||t.stereotype===`money`?new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e):t.aggregate===`count`?new Intl.NumberFormat(void 0,{maximumFractionDigits:0}).format(Math.round(e)):new Intl.NumberFormat(void 0,{maximumFractionDigits:2}).format(e),Ic=(e,t)=>e&&t.includes(e)?e:t.find(e=>!!e),Lc=(e,t,n)=>{let r=e.__mateuGroup;return t.id===n?`${r.value} (${r.count})`:t.aggregate?Fc(r.aggregates?.[t.id],t):``},Rc=(e,t,n)=>{let r=t?.aggregates;if(!r||!e.some(e=>e.aggregate))return;let i={};e.forEach(e=>{e.aggregate&&r[e.id]!=null&&(i[e.id]=Fc(r[e.id],e))});let a=e[0];if(a&&i[a.id]===void 0){let e=t?.page?.totalElements;i[a.id]=n&&a.id===n&&e!=null?`Total (${e})`:`Total`}return i},zc=(e,t,n)=>F(e[n.path]?`vaadin:check`:`vaadin:minus`,`height: 16px; width: 16px; color: var(--lumo-body-text-color);`),Bc=(e,t,n,r,i)=>{let a=e[n.path],o=a;return r==`money`&&a&&a.locale&&a.currency?o=new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(a.value):i==`money`&&(o=new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(a)),w`${o}`},Vc=(e,t,n)=>{e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:n},bubbles:!0,composed:!0}))},Hc=(e,t,n,r,i,a)=>{let o=n.xcolumn??a;if(o.text)return o.actionId?w`<a href="javascript: void(0);" @click="${t=>Vc(n,o,e)}">${o.text}</a>`:w`<a href="${e[n.path]}">${o.text}</a>`;if(r==`string`){if(o.actionId)return w`<a href="javascript: void(0);" @click="${t=>Vc(n,o,e)}">${e[n.path]}</a>`;let t=e[n.path];return w`<a href="${t}">${t}</a>`}let s=e[n.path];return w`<a href="${s.href}">${s.text}</a>`},Uc=(e,t,n,r,i)=>{let a=e[n.path];return r==`string`?a.split(`,`).map(e=>F(e,`width: 16px;`)):a.split(`,`).map(e=>F(e.icon,`width: 16px;`))},Wc=(e,t,n,r,i)=>{let a=e[n.path];return w`${g(a)}`},Gc=(e,t,n,r,i,a)=>r==`string`?w`<img src="${e[n.path]}" style="${`max-height: 40px; `+(a.style??``)}">`:w`<img src="${e[n.path].src}" style="${a.style??``}">`,Kc=e=>{let t={_clickedRow:e.target.row};e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+e.detail.value.methodNameInCrud,parameters:t},bubbles:!0,composed:!0}))},qc=e=>{let t={_clickedRow:e.target.row},n=e.target.action;e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+n.methodNameInCrud,parameters:t},bubbles:!0,composed:!0}))},Jc=e=>{let t=document.createElement(`vaadin-context-menu-item`),n=document.createElement(`vaadin-icon`);return n.style.color=`var(--lumo-secondary-text-color)`,n.style.marginInlineEnd=`var(--lumo-space-s)`,n.style.padding=`var(--lumo-space-xs)`,n.setAttribute(`icon`,e.icon),t.appendChild(n),e.label&&t.appendChild(document.createTextNode(e.label)),t.disabled=e.disabled,t},Yc=(e,t,n)=>{let r=e[n.path]?.actions?.map(e=>e.icon?{component:Jc(e),methodNameInCrud:e.methodNameInCrud}:{...e,text:e.label});return!r||r.length==0?w``:w`
                                      <vaadin-menu-bar
                                          .items=${[{text:`···`,children:r}]}
                                          theme="tertiary"
                                          .row="${e}"
                                          data-testid="menubar-${n.path}"
-                                         @item-selected="${Dc}"
+                                         @item-selected="${Kc}"
                                      ></vaadin-menu-bar>
-                                   `},jc=(e,t,n)=>{if(n.path==`select`)return T`
-         <vaadin-button theme="tertiary" title="Select" @click="${Oc}" .row="${e}" .action="${{actionId:n.path,icon:``,label:`Select`,disabled:!1,methodNameInCrud:`select`}}">
+                                   `},Xc=(e,t,n)=>{if(n.path==`select`)return w`
+         <vaadin-button theme="tertiary" title="Select" @click="${qc}" .row="${e}" .action="${{actionId:n.path,icon:``,label:`Select`,disabled:!1,methodNameInCrud:`select`}}">
              Select
          </vaadin-button>
-    `;let r=n.path&&e[n.path]?.methodNameInCrud?e[n.path]:e.action;return r?T`
-         <vaadin-button theme="tertiary${r.icon&&!r.label?` icon`:``}" title="${r.label||v}" @click="${Oc}" .row="${e}" .action="${r}">
-             ${r.icon?T`<vaadin-icon icon="${r.icon}"></vaadin-icon>`:v}
-             ${r.label?r.label:v}
+    `;let r=n.path&&e[n.path]?.methodNameInCrud?e[n.path]:e.action;return r?w`
+         <vaadin-button theme="tertiary${r.icon&&!r.label?` icon`:``}" title="${r.label||_}" @click="${qc}" .row="${e}" .action="${r}">
+             ${r.icon?w`<vaadin-icon icon="${r.icon}"></vaadin-icon>`:_}
+             ${r.label?r.label:_}
          </vaadin-button>
-    `:T``},Mc=(e,t,n)=>{e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:n},bubbles:!0,composed:!0}))},Nc=(e,t,n,r,i,a)=>{let o=n.xcolumn??a;if(o.actionId)return T`
-            <vaadin-button theme="tertiary" @click="${t=>Mc(n,o,e)}" .row="${e}">
+    `:w``},Zc=(e,t,n)=>{e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:n},bubbles:!0,composed:!0}))},Qc=(e,t,n,r,i,a)=>{let o=n.xcolumn??a;if(o.actionId)return w`
+            <vaadin-button theme="tertiary" @click="${t=>Zc(n,o,e)}" .row="${e}">
                 ${o.text||e[n.path]}
             </vaadin-button>
-        `;let s=e[n.path];return T`<a href="${s}">${o.text||s}</a>`},Pc=(e,t,n,r,i,a,o,s,c)=>{let l=e[n.path];return F(r,l,i,a,o,s,c)},Fc=new WeakMap,Ic=(e,t)=>Fc.get(e)?.[t],Lc=(e,t,n)=>{let r=Fc.get(e);r||(r={},Fc.set(e,r)),r[t]=n},Rc=e=>{if(e==null||e===``)return null;let t=Number(e);return Number.isNaN(t)?null:t},zc=(e,t,n,r)=>{let i=n?.field?.fieldId,a=a=>{if(e[t.id]===a||e[t.id]==null&&(a===``||a==null))return;if(e[t.id]=a,!i){n.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`update-row`,parameters:{_editedRow:{...e}}},bubbles:!0,composed:!0}));return}let o=(n?.state??r)[i];n.dispatchEvent(new CustomEvent(`value-changed`,{detail:{fieldId:i,value:Array.isArray(o)?[...o]:o},bubbles:!0,composed:!0}))},o=e[t.id],s=o==null?``:String(o);switch(t.editorType){case`boolean`:return T`<vaadin-checkbox ?checked=${!!o} @checked-changed=${e=>a(e.detail.value)}></vaadin-checkbox>`;case`integer`:return T`<vaadin-integer-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(Rc(e.target.value))}></vaadin-integer-field>`;case`number`:return T`<vaadin-number-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(Rc(e.target.value))}></vaadin-number-field>`;case`date`:return T`<vaadin-date-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-date-picker>`;case`time`:return T`<vaadin-time-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-time-picker>`;case`datetime`:return T`<vaadin-date-time-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-date-time-picker>`;case`select`:return T`<vaadin-combo-box
+        `;let s=e[n.path];return w`<a href="${s}">${o.text||s}</a>`},$c=(e,t,n,r,i,a,o,s,c)=>{let l=e[n.path];return P(r,l,i,a,o,s,c)},el=new WeakMap,tl=(e,t)=>el.get(e)?.[t],nl=(e,t,n)=>{let r=el.get(e);r||(r={},el.set(e,r)),r[t]=n},rl=e=>{if(e==null||e===``)return null;let t=Number(e);return Number.isNaN(t)?null:t},il=(e,t,n,r)=>{let i=n?.field?.fieldId,a=a=>{if(e[t.id]===a||e[t.id]==null&&(a===``||a==null))return;if(e[t.id]=a,!i){n.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`update-row`,parameters:{_editedRow:{...e}}},bubbles:!0,composed:!0}));return}let o=(n?.state??r)[i];n.dispatchEvent(new CustomEvent(`value-changed`,{detail:{fieldId:i,value:Array.isArray(o)?[...o]:o},bubbles:!0,composed:!0}))},o=e[t.id],s=o==null?``:String(o);switch(t.editorType){case`boolean`:return w`<vaadin-checkbox ?checked=${!!o} @checked-changed=${e=>a(e.detail.value)}></vaadin-checkbox>`;case`integer`:return w`<vaadin-integer-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(rl(e.target.value))}></vaadin-integer-field>`;case`number`:return w`<vaadin-number-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(rl(e.target.value))}></vaadin-number-field>`;case`date`:return w`<vaadin-date-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-date-picker>`;case`time`:return w`<vaadin-time-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-time-picker>`;case`datetime`:return w`<vaadin-date-time-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-date-time-picker>`;case`select`:return w`<vaadin-combo-box
                 theme="small" style="width:100%;"
                 .items=${(t.editorOptions??[]).map(e=>({label:e.label,value:String(e.value)}))}
                 item-label-path="label" item-value-path="value"
                 .value=${s}
-                @value-changed=${e=>a(e.detail.value)}></vaadin-combo-box>`;case`lookup`:{let r=n?.field?.fieldId,i=`search-${r}-${t.id}`,o=`${r}-${t.id}`;return T`<vaadin-combo-box
+                @value-changed=${e=>a(e.detail.value)}></vaadin-combo-box>`;case`lookup`:{let r=n?.field?.fieldId,i=`search-${r}-${t.id}`,o=`${r}-${t.id}`;return w`<vaadin-combo-box
                 theme="small" style="width:100%;"
                 item-label-path="label" item-id-path="value"
                 .dataProvider=${(e,t)=>{n.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:i,parameters:{searchText:e.filter,size:e.pageSize,page:e.page},callback:e=>{let n=e?.fragments?.[0]?.data?.[o];t(n?.content??[],n?.totalElements??0)},callbackonly:!0},bubbles:!0,composed:!0}))}}
-                .selectedItem=${(t.editorOptions??[]).find(e=>String(e.value)===s)??(s?{value:s,label:Ic(e,t.id)??s}:void 0)}
-                @selected-item-changed=${n=>{let r=n.detail.value,i=r?r.value:null;String(i??``)!==s&&(r&&Lc(e,t.id,r.label),a(i))}}></vaadin-combo-box>`}default:return T`<vaadin-text-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(e.target.value)}></vaadin-text-field>`}},Bc=e=>m(()=>T`<span title="${e}" style="white-space:normal;overflow-wrap:break-word;">${e}</span>`,[e]),Vc=e=>e===void 0?v:d(()=>T`<span style="font-weight: 600; white-space: nowrap;">${e}</span>`,[e]),Hc=e=>{e.preventDefault(),e.stopPropagation(),e.currentTarget?.dispatchEvent(new CustomEvent(`sort-direction-changed`,{detail:{grid:e.currentTarget.parentElement},bubbles:!0,composed:!0}))},Uc=(e,t,n,r,i,a,o,s)=>T`
-<vaadin-grid-column-group header="${M(e.label,r,i)}">
-    ${e.columns.map(e=>Gc(e.metadata,t,n,r,i,a,o,s?.[e.metadata?.id]))}
+                .selectedItem=${(t.editorOptions??[]).find(e=>String(e.value)===s)??(s?{value:s,label:tl(e,t.id)??s}:void 0)}
+                @selected-item-changed=${n=>{let r=n.detail.value,i=r?r.value:null;String(i??``)!==s&&(r&&nl(e,t.id,r.label),a(i))}}></vaadin-combo-box>`}default:return w`<vaadin-text-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(e.target.value)}></vaadin-text-field>`}},al=e=>ee(()=>w`<span title="${e}" style="white-space:normal;overflow-wrap:break-word;">${e}</span>`,[e]),ol=e=>e===void 0?_:d(()=>w`<span style="font-weight: 600; white-space: nowrap;">${e}</span>`,[e]),sl=e=>{e.preventDefault(),e.stopPropagation(),e.currentTarget?.dispatchEvent(new CustomEvent(`sort-direction-changed`,{detail:{grid:e.currentTarget.parentElement},bubbles:!0,composed:!0}))},cl=(e,t,n,r,i,a,o,s)=>w`
+<vaadin-grid-column-group header="${j(e.label,r,i)}">
+    ${e.columns.map(e=>ul(e.metadata,t,n,r,i,a,o,s?.[e.metadata?.id]))}
 </vaadin-grid-column-group>
-`,Wc=(e,t,n,r,i,a,o,s)=>j.GridGroupColumn==e.metadata?.type?Uc(e.metadata,t,n,r,i,a,o,s):Gc(e.metadata,t,n,r,i,a,o,s?.[e.metadata?.id]),Gc=(e,n,r,i,a,o,s,c)=>{let l=M(e.label,i,a);return e.sortable?T`
+`,ll=(e,t,n,r,i,a,o,s)=>A.GridGroupColumn==e.metadata?.type?cl(e.metadata,t,n,r,i,a,o,s):ul(e.metadata,t,n,r,i,a,o,s?.[e.metadata?.id]),ul=(e,n,r,i,a,o,s,c)=>{let l=j(e.label,i,a);return e.sortable?w`
                         <vaadin-grid-sort-column
                                 path="${e.id}"
-                                text-align="${e.align??v}"
+                                text-align="${e.align??_}"
                                 ?frozen="${e.frozen}"
                                 ?frozen-to-end="${e.frozenToEnd}"
                                 ?auto-width="${e.autoWidth}"
-                                flex-grow="${e.flexGrow??v}"
+                                flex-grow="${e.flexGrow??_}"
                                 ?resizable="${e.resizable}"
-                                width="${e.width??v}"
-                                @direction-changed="${Hc}"
+                                width="${e.width??_}"
+                                @direction-changed="${sl}"
                                 data-data-type="${e.dataType}"
                                 data-stereotype="${e.stereotype}"
-                                ${Bc(l)}
-                                ${Vc(c)}
-                                ${t((t,c,l)=>Kc(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
+                                ${al(l)}
+                                ${ol(c)}
+                                ${t((t,c,l)=>dl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
                         ></vaadin-grid-sort-column>
-                    `:e.filterable?T`
+                    `:e.filterable?w`
                         <vaadin-grid-filter-column
                                 path="${e.id}"
-                                text-align="${e.align??v}"
+                                text-align="${e.align??_}"
                                 ?frozen="${e.frozen}"
                                 ?frozen-to-end="${e.frozenToEnd}"
                                 ?auto-width="${e.autoWidth}"
-                                flex-grow="${e.flexGrow??v}"
+                                flex-grow="${e.flexGrow??_}"
                                 ?resizable="${e.resizable}"
-                                width="${e.width??v}"
+                                width="${e.width??_}"
                                 data-data-type="${e.dataType}"
                                 data-stereotype="${e.stereotype}"
-                                ${Bc(l)}
-                                ${Vc(c)}
-                                ${t((t,c,l)=>Kc(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
+                                ${al(l)}
+                                ${ol(c)}
+                                ${t((t,c,l)=>dl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
                         ></vaadin-grid-filter-column>
-                    `:T`
+                    `:w`
                         <vaadin-grid-column
                                 path="${e.id}"
-                                text-align="${e.align??v}"
+                                text-align="${e.align??_}"
                                 ?frozen="${e.frozen}"
                                 ?frozen-to-end="${e.frozenToEnd}"
                                 ?auto-width="${e.autoWidth}"
-                                flex-grow="${e.flexGrow??v}"
+                                flex-grow="${e.flexGrow??_}"
                                 ?resizable="${e.resizable}"
-                                width="${e.width??v}"
+                                width="${e.width??_}"
                                 data-data-type="${e.dataType}"
                                 data-stereotype="${e.stereotype}"
                                 .xcolumn="${e}"
-                                ${Bc(l)}
-                                ${Vc(c)}
-                                ${t((t,c,l)=>Kc(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
+                                ${al(l)}
+                                ${ol(c)}
+                                ${t((t,c,l)=>dl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
                         ></vaadin-grid-column>
-                    `},Kc=(e,t,n,r,i,a,o,s,c,l)=>{let u=n.dataset.dataType??``,d=n.dataset.stereotype??``;if(pc(e)){let t=i?.metadata,n=(t?.columns??[]).flatMap(e=>e?.metadata?.type===j.GridGroupColumn?(e.metadata.columns??[]).map(e=>e?.metadata?.id):[e?.metadata?.id]),a=vc(e,r,_c(e.__mateuGroupBy,n)),o=e.__mateuGroup.hiddenActions??[],s=r.id===n[n.length-1]?(t?.groupActions??[]).filter(e=>!o.includes(e.actionId??e.id)):[];return s.length?T`<span style="display: flex; align-items: center; justify-content: flex-end; gap: var(--lumo-space-s); overflow: hidden;">
-                ${a?T`<span style="font-weight: 600;">${a}</span>`:v}
-                ${s.map(t=>T`
+                    `},dl=(e,t,n,r,i,a,o,s,c,l)=>{let u=n.dataset.dataType??``,d=n.dataset.stereotype??``;if(Mc(e)){let t=i?.metadata,n=(t?.columns??[]).flatMap(e=>e?.metadata?.type===A.GridGroupColumn?(e.metadata.columns??[]).map(e=>e?.metadata?.id):[e?.metadata?.id]),a=Lc(e,r,Ic(e.__mateuGroupBy,n)),o=e.__mateuGroup.hiddenActions??[],s=r.id===n[n.length-1]?(t?.groupActions??[]).filter(e=>!o.includes(e.actionId??e.id)):[];return s.length?w`<span style="display: flex; align-items: center; justify-content: flex-end; gap: var(--lumo-space-s); overflow: hidden;">
+                ${a?w`<span style="font-weight: 600;">${a}</span>`:_}
+                ${s.map(t=>w`
                     <vaadin-button theme="tertiary small" style="flex-shrink: 0;"
                         @click="${n=>{n.stopPropagation(),n.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+(t.actionId??t.id),parameters:{_groupValue:e.__mateuGroup.value}},bubbles:!0,composed:!0}))}}">${t.label??t.caption??``}</vaadin-button>
                 `)}
-            </span>`:T`<span title="${a}" style="font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block;">${a}</span>`}if(r.editable)return zc(e,r,i,o);if(u==`status`)return na(e,t,n);if(u==`bool`)return bc(e,t,n);if(u==`money`||d==`money`)return xc(e,t,n,u,d);if(u==`link`||d==`link`)return Cc(e,t,n,u,d,r);if(u==`icon`||d==`icon`)return wc(e,t,n,u,d);if(d==`html`)return Tc(e,t,n,u,d);if(d==`image`)return Ec(e,t,n,u,d,r);if(u==`menu`)return Ac(e,t,n);if(u==`component`)return Pc(e,t,n,i,a,o,s,c,l);if(u==`action`)return jc(e,t,n);if(u==`actionGroup`)return Ac(e,t,n);if(d==`button`||r.actionId)return Nc(e,t,n,u,d,r);let f=e[n.path];return T`<span title="${f}" style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block;">${f}</span>`},qc=()=>{let e=document.activeElement;for(;e?.shadowRoot?.activeElement;)e=e.shadowRoot.activeElement;return e},Jc=(e,t)=>{let n=t;for(;n;){if(n===e)return!0;n=n.assignedSlot??n.parentNode??n.host??null}return!1},Yc=class extends $e{constructor(...e){super(...e),this.state={},this.data={},this.appState={},this.appData={},this.detailsOpenedItems=[],this.hoveredItem=null,this.onGridHoverMove=e=>{let t=e.currentTarget,n=t.getEventContext(e)?.item??null;n!==this.hoveredItem&&(this.hoveredItem=n,t.generateCellPartNames())},this.onGridHoverLeave=e=>{this.hoveredItem!==null&&(this.hoveredItem=null,e.currentTarget.generateCellPartNames())},this.hoverCellPartNameGenerator=(e,t)=>t?.item!=null&&t.item===this.hoveredItem?`hovered-cell`:``,this._onRowKey=e=>{let t=this.field?.rowSelectionShortcut;if(!t||!this.field?.onItemSelectionActionId||!this._isRowShortcutRelevant()||!kn(t,e))return;let n=/^(?:Digit|Numpad)([1-9])$/.exec(e.code);if(!n)return;let r=this.currentItems(),i=parseInt(n[1],10)-1;i>=r.length||(e.preventDefault(),this.selectRow(r[i]))},this.handleButtonClick=e=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))}}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._onRowKey)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`keydown`,this._onRowKey)}currentItems(){return this.field?.remoteCoordinates?this.data?.[this.id]?.content??[]:this.field?.fieldId&&this.state?this.state[this.field.fieldId]??[]:[]}selectRow(e){!e||!this.field?.onItemSelectionActionId||(this.selectedItems=[e],this.state[this.id+`_selected_items`]=[e],this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.field.onItemSelectionActionId,parameters:{_clickedRow:e}},bubbles:!0,composed:!0})))}_isRowShortcutRelevant(){if(this.offsetParent===null&&this.getClientRects().length===0)return!1;let e=qc();if(e&&e!==document.body&&!Jc(this,e)){let t=e.tagName?.toLowerCase()??``;if(e.isContentEditable||/^(input|textarea|select)$/.test(t)||t.startsWith(`vaadin-`)&&/(field|combo|picker|area|select)/.test(t))return!1}return!0}handleItemToggle(e){let{item:t,selected:n,shiftKey:r}=e.detail;if(this.rangeStartItem??=t,r){let e=[];this.field?.fieldId&&this.state&&this.state[this.field.fieldId]&&(e=this.state[this.field.fieldId]);let[r,i]=[this.rangeStartItem,t].map(t=>e.indexOf(t)).sort((e,t)=>e-t),a=e.slice(r,i+1),o=new Set(this.selectedItems);a.forEach(e=>{n?o.add(e):o.delete(e)}),this.selectedItems=[...o],this.state[this.id+`_selected_items`]=this.selectedItems}this.rangeStartItem=t}render(){let e=[];this.field?.fieldId&&this.state&&this.state[this.field.fieldId]&&(e=this.state[this.field.fieldId]);let t=this.state[this.field?.fieldId+`_show_detail`]||this.state._show_detail&&this.state._show_detail[this.field.fieldId];if(this.field?.remoteCoordinates){let t=this.field.remoteCoordinates;this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements?e=this.data[this.id].content:this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}if(Array.isArray(e)&&e.forEach((e,t)=>{e&&typeof e==`object`&&e._rowNumber===void 0&&(e._rowNumber=t)}),this.field?.inlineEditing)return this.renderMaster(e);if(this.field?.formPosition&&this.field?.formPosition.startsWith(`modal`)){let n=this;return T`
+            </span>`:w`<span title="${a}" style="font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block;">${a}</span>`}if(r.editable)return il(e,r,i,o);if(u==`status`)return ra(e,t,n);if(u==`bool`)return zc(e,t,n);if(u==`money`||d==`money`)return Bc(e,t,n,u,d);if(u==`link`||d==`link`)return Hc(e,t,n,u,d,r);if(u==`icon`||d==`icon`)return Uc(e,t,n,u,d);if(d==`html`)return Wc(e,t,n,u,d);if(d==`image`)return Gc(e,t,n,u,d,r);if(u==`menu`)return Yc(e,t,n);if(u==`component`)return $c(e,t,n,i,a,o,s,c,l);if(u==`action`)return Xc(e,t,n);if(u==`actionGroup`)return Yc(e,t,n);if(d==`button`||r.actionId)return Qc(e,t,n,u,d,r);let f=e[n.path];return w`<span title="${f}" style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block;">${f}</span>`},fl=()=>{let e=document.activeElement;for(;e?.shadowRoot?.activeElement;)e=e.shadowRoot.activeElement;return e},pl=(e,t)=>{let n=t;for(;n;){if(n===e)return!0;n=n.assignedSlot??n.parentNode??n.host??null}return!1},ml=class extends et{constructor(...e){super(...e),this.state={},this.data={},this.appState={},this.appData={},this.detailsOpenedItems=[],this.hoveredItem=null,this.onGridHoverMove=e=>{let t=e.currentTarget,n=t.getEventContext(e)?.item??null;n!==this.hoveredItem&&(this.hoveredItem=n,t.generateCellPartNames())},this.onGridHoverLeave=e=>{this.hoveredItem!==null&&(this.hoveredItem=null,e.currentTarget.generateCellPartNames())},this.hoverCellPartNameGenerator=(e,t)=>t?.item!=null&&t.item===this.hoveredItem?`hovered-cell`:``,this._onRowKey=e=>{let t=this.field?.rowSelectionShortcut;if(!t||!this.field?.onItemSelectionActionId||!this._isRowShortcutRelevant()||!An(t,e))return;let n=/^(?:Digit|Numpad)([1-9])$/.exec(e.code);if(!n)return;let r=this.currentItems(),i=parseInt(n[1],10)-1;i>=r.length||(e.preventDefault(),this.selectRow(r[i]))},this.handleButtonClick=e=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))}}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._onRowKey)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`keydown`,this._onRowKey)}currentItems(){return this.field?.remoteCoordinates?this.data?.[this.id]?.content??[]:this.field?.fieldId&&this.state?this.state[this.field.fieldId]??[]:[]}selectRow(e){!e||!this.field?.onItemSelectionActionId||(this.selectedItems=[e],this.state[this.id+`_selected_items`]=[e],this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.field.onItemSelectionActionId,parameters:{_clickedRow:e}},bubbles:!0,composed:!0})))}_isRowShortcutRelevant(){if(this.offsetParent===null&&this.getClientRects().length===0)return!1;let e=fl();if(e&&e!==document.body&&!pl(this,e)){let t=e.tagName?.toLowerCase()??``;if(e.isContentEditable||/^(input|textarea|select)$/.test(t)||t.startsWith(`vaadin-`)&&/(field|combo|picker|area|select)/.test(t))return!1}return!0}handleItemToggle(e){let{item:t,selected:n,shiftKey:r}=e.detail;if(this.rangeStartItem??=t,r){let e=[];this.field?.fieldId&&this.state&&this.state[this.field.fieldId]&&(e=this.state[this.field.fieldId]);let[r,i]=[this.rangeStartItem,t].map(t=>e.indexOf(t)).sort((e,t)=>e-t),a=e.slice(r,i+1),o=new Set(this.selectedItems);a.forEach(e=>{n?o.add(e):o.delete(e)}),this.selectedItems=[...o],this.state[this.id+`_selected_items`]=this.selectedItems}this.rangeStartItem=t}render(){let e=[];this.field?.fieldId&&this.state&&this.state[this.field.fieldId]&&(e=this.state[this.field.fieldId]);let t=this.state[this.field?.fieldId+`_show_detail`]||this.state._show_detail&&this.state._show_detail[this.field.fieldId];if(this.field?.remoteCoordinates){let t=this.field.remoteCoordinates;this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements?e=this.data[this.id].content:this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}if(Array.isArray(e)&&e.forEach((e,t)=>{e&&typeof e==`object`&&e._rowNumber===void 0&&(e._rowNumber=t)}),this.field?.inlineEditing)return this.renderMaster(e);if(this.field?.formPosition&&this.field?.formPosition.startsWith(`modal`)){let n=this;return w`
 
                 ${this.renderMaster(e)}
 
                 <vaadin-dialog
                         .opened="${t}"
                         @closed="${()=>{n.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.field?.fieldId+`_cancel`},bubbles:!0,composed:!0}))}}"
-                        ${s(()=>T`
+                        ${s(()=>w`
                             <mateu-event-interceptor .target="${n}">
                                 <div id="container" style="${this.field?.formStyle??`display: contents;`}">
                                     <mateu-component id="${this.field?.fieldId}-container"></mateu-component>
                                 </div>
                             </mateu-event-interceptor>
-                            `,[()=>E()])}
+                            `,[()=>T()])}
                 ></vaadin-dialog>
                 
-            `}else{let n=this.field?.formPosition==`left`||this.field?.formPosition==`right`?`horizontal`:`vertical`;return T`
+            `}else{let n=this.field?.formPosition==`left`||this.field?.formPosition==`right`?`horizontal`:`vertical`;return w`
             <vaadin-master-detail-layout
                     style="overflow: unset; width: 100%; ${t&&this.field?.minHeightWhenDetailVisible?`min-height: `+this.field?.minHeightWhenDetailVisible+`;`:``}"
                     orientation="${n}"
@@ -8884,14 +8884,14 @@ ${i}
                 </div>
                 
                 
-            </vaadin-master-detail-layout>`}}renderMaster(e){let r=this.selectedItems||[];return T`<vaadin-vertical-layout style="width: 100%;">
+            </vaadin-master-detail-layout>`}}renderMaster(e){let r=this.selectedItems||[];return w`<vaadin-vertical-layout style="width: 100%;">
             <!-- The field label is rendered by the surrounding mateu-field wrapper; rendering it
                  here too would duplicate it (e.g. "Guests / Guests"). -->
             <vaadin-grid
                     ?clickable="${!!this.field?.onItemSelectionActionId}"
-                    .cellPartNameGenerator="${S(this.field?.onItemSelectionActionId?this.hoverCellPartNameGenerator:void 0)}"
-                    @mousemove="${S(this.field?.onItemSelectionActionId?this.onGridHoverMove:void 0)}"
-                    @mouseleave="${S(this.field?.onItemSelectionActionId?this.onGridHoverLeave:void 0)}"
+                    .cellPartNameGenerator="${x(this.field?.onItemSelectionActionId?this.hoverCellPartNameGenerator:void 0)}"
+                    @mousemove="${x(this.field?.onItemSelectionActionId?this.onGridHoverMove:void 0)}"
+                    @mouseleave="${x(this.field?.onItemSelectionActionId?this.onGridHoverLeave:void 0)}"
                     style="${this.field?.onItemSelectionActionId?`cursor: pointer;`:``}${this.field?.style??``}"
                     class="${this.field?.cssClasses}"
                     .items="${e}"
@@ -8899,33 +8899,33 @@ ${i}
                     item-id-path="${this.field?.itemIdPath}"
                     @selected-items-changed="${e=>{this.selectedItems=e.detail.value,this.state[this.id+`_selected_items`]=this.selectedItems}}"
                     @item-toggle="${this.handleItemToggle}"
-                    @click="${S(this.field?.onItemSelectionActionId?e=>{let t=e.currentTarget.getEventContext(e)?.item;t&&this.selectRow(t)}:void 0)}"
-                    @active-item-changed="${S(this.field?.detailPath&&!this.field?.useButtonForDetail?e=>{if(this.field?.detailPath){let t=e.detail.value;t?this.detailsOpenedItems=[t]:this.detailsOpenedItems=[]}}:void 0)}"
+                    @click="${x(this.field?.onItemSelectionActionId?e=>{let t=e.currentTarget.getEventContext(e)?.item;t&&this.selectRow(t)}:void 0)}"
+                    @active-item-changed="${x(this.field?.detailPath&&!this.field?.useButtonForDetail?e=>{if(this.field?.detailPath){let t=e.detail.value;t?this.detailsOpenedItems=[t]:this.detailsOpenedItems=[]}}:void 0)}"
                     .detailsOpenedItems="${this.detailsOpenedItems}"
-                    ${S(this.field?.detailPath?n(e=>T`${F(this,e[this.field?.detailPath],this.baseUrl,this.state,this.data,this.appState,this.appData)}`):void 0)}
+                    ${x(this.field?.detailPath?n(e=>w`${P(this,e[this.field?.detailPath],this.baseUrl,this.state,this.data,this.appState,this.appData)}`):void 0)}
                     ?all-rows-visible=${e?.length<10}
             >
                 <span slot="empty-state">${this.field?.label?`No ${this.field.label.toLowerCase()} added yet.`:`No items added yet.`}</span>
-                ${this.field?.readOnly||this.field?.inlineEditing?v:T`
+                ${this.field?.readOnly||this.field?.inlineEditing?_:w`
                     <vaadin-grid-selection-column drag-select></vaadin-grid-selection-column>
                 `}
-                ${this.field?.columns?.map(e=>Wc(e,this,this.baseUrl,this.state,this.data,this.appState,this.appData))}
+                ${this.field?.columns?.map(e=>ll(e,this,this.baseUrl,this.state,this.data,this.appState,this.appData))}
 
-                ${this.field?.inlineEditing&&!this.field?.readOnly?T`
+                ${this.field?.inlineEditing&&!this.field?.readOnly?w`
                     <vaadin-grid-column width="3.5rem" flex-grow="0" frozen-to-end
-                            ${t(e=>T`
+                            ${t(e=>w`
                                 <vaadin-button theme="tertiary icon error" title="Remove row"
                                     @click="${()=>{this.state[this.id+`_selected_items`]=[e],this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.id+`_remove`},bubbles:!0,composed:!0}))}}">
                                     <vaadin-icon icon="vaadin:trash"></vaadin-icon>
                                 </vaadin-button>`,[])}
                     ></vaadin-grid-column>
-                `:v}
+                `:_}
 
-                ${this.field?.useButtonForDetail?T`
+                ${this.field?.useButtonForDetail?w`
                     <vaadin-grid-column
                             width="44px"
                             flex-grow="0"
-                            ${t((e,{detailsOpened:t})=>T`
+                            ${t((e,{detailsOpened:t})=>w`
               <vaadin-button
                 theme="tertiary icon"
                 title="${t?`Collapse`:`Expand`}"
@@ -8939,16 +8939,16 @@ ${i}
               </vaadin-button>
             `,[])}
                     ></vaadin-grid-column>
-                `:v}
+                `:_}
 
             </vaadin-grid>
-            ${this.field?.readOnly?v:this.field?.inlineEditing?T`
+            ${this.field?.readOnly?_:this.field?.inlineEditing?w`
                     <vaadin-horizontal-layout theme="spacing">
                         <!-- Inline mode: rows are removed with the per-row trash button, so the
                              toolbar only needs the "add" action. -->
                         <vaadin-button theme="tertiary icon" title="Add row" @click="${()=>this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.id+`_add`},bubbles:!0,composed:!0}))}"><vaadin-icon icon="vaadin:plus"></vaadin-icon></vaadin-button>
                     </vaadin-horizontal-layout>
-                `:T`
+                `:w`
                     <vaadin-horizontal-layout theme="spacing">
                         <vaadin-button theme="tertiary icon" @click="${()=>this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.id+`_add`},bubbles:!0,composed:!0}))}"><vaadin-icon icon="vaadin:plus"></vaadin-icon></vaadin-button>
                         <vaadin-button theme="tertiary icon error" @click="${()=>this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.id+`_remove`},bubbles:!0,composed:!0}))}"><vaadin-icon icon="vaadin:minus"></vaadin-icon></vaadin-button>
@@ -8956,8 +8956,8 @@ ${i}
                         <vaadin-button theme="tertiary icon" title="Move down" @click="${()=>this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.id+`_move-down`},bubbles:!0,composed:!0}))}"><vaadin-icon icon="vaadin:arrow-down"></vaadin-icon></vaadin-button>
                     </vaadin-horizontal-layout>
                 `}
-        </vaadin-vertical-layout>`}static{this.styles=h`
-        ${de}
+        </vaadin-vertical-layout>`}static{this.styles=m`
+        ${fe}
 
         /* Clickable grids (a row-selection action is wired) give visual feedback: the host sets a
            pointer cursor (inline, inherited by the slotted cell content), and the cells of the
@@ -8966,17 +8966,17 @@ ${i}
             background-color: var(--lumo-primary-color-10pct);
             cursor: pointer;
         }
-    `}};k([y()],Yc.prototype,`field`,void 0),k([y()],Yc.prototype,`state`,void 0),k([y()],Yc.prototype,`data`,void 0),k([y()],Yc.prototype,`appState`,void 0),k([y()],Yc.prototype,`appData`,void 0),k([y()],Yc.prototype,`selectedItems`,void 0),k([C()],Yc.prototype,`detailsOpenedItems`,void 0),Yc=k([g(`mateu-grid`)],Yc);var Xc=class extends b{constructor(...e){super(...e),this.getNewValue=e=>{if(this.field?.dataType==`array`){if(!this.value)return[e];let t=this.value;return t.indexOf(e)>=0?t.filter(t=>t!==e):[...t,e]}return e}}render(){let e=this.field?.options;if(this.field?.remoteCoordinates){let t=this.field.remoteCoordinates;this.data?.[this.field.fieldId]&&this.data[this.field.fieldId].content&&this.data[this.field.fieldId].totalElements?e=this.data[this.field.fieldId].content:this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}return T`
+    `}};O([v()],ml.prototype,`field`,void 0),O([v()],ml.prototype,`state`,void 0),O([v()],ml.prototype,`data`,void 0),O([v()],ml.prototype,`appState`,void 0),O([v()],ml.prototype,`appData`,void 0),O([v()],ml.prototype,`selectedItems`,void 0),O([S()],ml.prototype,`detailsOpenedItems`,void 0),ml=O([h(`mateu-grid`)],ml);var hl=class extends y{constructor(...e){super(...e),this.getNewValue=e=>{if(this.field?.dataType==`array`){if(!this.value)return[e];let t=this.value;return t.indexOf(e)>=0?t.filter(t=>t!==e):[...t,e]}return e}}render(){let e=this.field?.options;if(this.field?.remoteCoordinates){let t=this.field.remoteCoordinates;this.data?.[this.field.fieldId]&&this.data[this.field.fieldId].content&&this.data[this.field.fieldId].totalElements?e=this.data[this.field.fieldId].content:this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}return w`
         <div style="display: flex; gap: 1rem; padding: 1rem; flex-wrap: wrap; ${this.field?.attributes?.divStyle}">
-                                    ${e?.map(e=>T`
+                                    ${e?.map(e=>w`
                             <div role="button" tabindex="0" 
                                     class="choice ${this.value==e.value||Array.isArray(this.value)&&this.value.includes(e.value)?`selected`:``}"
-                                    @click="${()=>this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.getNewValue(e.value),fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}" @keydown="${R(()=>this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.getNewValue(e.value),fieldId:this.field?.fieldId},bubbles:!0,composed:!0})))}"
-                            >${e.description||e.image?T`
+                                    @click="${()=>this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.getNewValue(e.value),fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}" @keydown="${L(()=>this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.getNewValue(e.value),fieldId:this.field?.fieldId},bubbles:!0,composed:!0})))}"
+                            >${e.description||e.image?w`
                                 <div style="display: flex; align-items: center; gap: var(--lumo-space-m, 1rem);">
-                                    ${e.image?T`
+                                    ${e.image?w`
                                             <img src="${e.image}" alt="${e.label}" style="${e.imageStyle??`width: 2rem;`}" />
-                                        `:v}
+                                        `:_}
                                     <div style="display: flex; flex-direction: column;">
                                         <span> ${e.label} </span>
                                         <span
@@ -8990,7 +8990,7 @@ ${i}
                         `)}
                                 </div>
 
-       `}static{this.styles=h`
+       `}static{this.styles=m`
         .choice {
             min-width: 10rem;
             min-height: 5rem;
@@ -9013,8 +9013,8 @@ ${i}
             border: 1px solid var(--lumo-shade-20pct);
         }
   
-        ${z}
-    `}};k([y()],Xc.prototype,`field`,void 0),k([y()],Xc.prototype,`baseUrl`,void 0),k([y()],Xc.prototype,`state`,void 0),k([y()],Xc.prototype,`data`,void 0),k([y()],Xc.prototype,`value`,void 0),Xc=k([g(`mateu-choice`)],Xc);var Zc=class extends b{constructor(...e){super(...e),this.currencyChanged=e=>{this.value||={value:0,currency:`EUR`,locale:`es-ES`},this.value.currency=e.detail.value,this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:{...this.value},fieldId:this.fieldId}}))},this.valueChanged=e=>{this.value||={value:0,currency:`EUR`,locale:`es-ES`},e.detail.value&&(this.value.value=e.detail.value?parseFloat(e.detail.value):0,this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:{...this.value},fieldId:this.fieldId}})))}}render(){return T`
+        ${R}
+    `}};O([v()],hl.prototype,`field`,void 0),O([v()],hl.prototype,`baseUrl`,void 0),O([v()],hl.prototype,`state`,void 0),O([v()],hl.prototype,`data`,void 0),O([v()],hl.prototype,`value`,void 0),hl=O([h(`mateu-choice`)],hl);var gl=class extends y{constructor(...e){super(...e),this.currencyChanged=e=>{this.value||={value:0,currency:`EUR`,locale:`es-ES`},this.value.currency=e.detail.value,this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:{...this.value},fieldId:this.fieldId}}))},this.valueChanged=e=>{this.value||={value:0,currency:`EUR`,locale:`es-ES`},e.detail.value&&(this.value.value=e.detail.value?parseFloat(e.detail.value):0,this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:{...this.value},fieldId:this.fieldId}})))}}render(){return w`
             <vaadin-number-field
                     id="${this.fieldId}"
                     label="${this.label}"
@@ -9022,7 +9022,7 @@ ${i}
                     .value="${this.value?.value}"
                     .helperText="${this.helperText}"
                     ?autofocus="${this.autofocus}"
-                    ?required="${this.required||v}"
+                    ?required="${this.required||_}"
                     theme="align-right"
             ><div slot="prefix"><vaadin-select
                     item-label-path="label"
@@ -9033,11 +9033,11 @@ ${i}
                     style="max-width: 100px;"
                     theme="small"
             ></vaadin-select></div></vaadin-number-field>
-       `}static{this.styles=h`
-  `}};k([y()],Zc.prototype,`fieldId`,void 0),k([y()],Zc.prototype,`label`,void 0),k([y()],Zc.prototype,`state`,void 0),k([y()],Zc.prototype,`data`,void 0),k([y()],Zc.prototype,`value`,void 0),k([y()],Zc.prototype,`autoFocus`,void 0),k([y()],Zc.prototype,`required`,void 0),k([y()],Zc.prototype,`colspan`,void 0),k([y()],Zc.prototype,`helperText`,void 0),Zc=k([g(`mateu-money-field`)],Zc);var Qc=`vaadin:abacus.vaadin:absolute-position.vaadin:academy-cap.vaadin:accessibility.vaadin:accordion-menu.vaadin:add-dock.vaadin:adjust.vaadin:adobe-flash.vaadin:airplane.vaadin:alarm.vaadin:align-center.vaadin:align-justify.vaadin:align-left.vaadin:align-right.vaadin:alt-a.vaadin:alt.vaadin:ambulance.vaadin:anchor.vaadin:angle-double-down.vaadin:angle-double-left.vaadin:angle-double-right.vaadin:angle-double-up.vaadin:angle-down.vaadin:angle-left.vaadin:angle-right.vaadin:angle-up.vaadin:archive.vaadin:archives.vaadin:area-select.vaadin:arrow-backward.vaadin:arrow-circle-down-o.vaadin:arrow-circle-down.vaadin:arrow-circle-left-o.vaadin:arrow-circle-left.vaadin:arrow-circle-right-o.vaadin:arrow-circle-right.vaadin:arrow-circle-up-o.vaadin:arrow-circle-up.vaadin:arrow-down.vaadin:arrow-forward.vaadin:arrow-left.vaadin:arrow-long-down.vaadin:arrow-long-left.vaadin:arrow-right.vaadin:arrow-up.vaadin:arrows-cross.vaadin:arrows-long-h.vaadin:arrows-long-right.vaadin:arrows-long-up.vaadin:arrows-long-v.vaadin:arrows.vaadin:asterisk.vaadin:at.vaadin:automation.vaadin:backspace-a.vaadin:backspace.vaadin:backwards.vaadin:ban.vaadin:bar-chart-h.vaadin:bar-chart-v.vaadin:bar-chart.vaadin:barcode.vaadin:bed.vaadin:bell-o.vaadin:bell-slash-o.vaadin:bell-slash.vaadin:bell.vaadin:boat.vaadin:bold.vaadin:bolt.vaadin:bomb.vaadin:book-dollar.vaadin:book-percent.vaadin:book.vaadin:bookmark-o.vaadin:bookmark.vaadin:briefcase.vaadin:browser.vaadin:bug-o.vaadin:bug.vaadin:building-o.vaadin:building.vaadin:bullets.vaadin:bullseye.vaadin:bus.vaadin:buss.vaadin:button.vaadin:calc-book.vaadin:calc.vaadin:calendar-briefcase.vaadin:calendar-clock.vaadin:calendar-envelope.vaadin:calendar-o.vaadin:calendar-user.vaadin:calendar.vaadin:camera.vaadin:car.vaadin:caret-down.vaadin:caret-left.vaadin:caret-right.vaadin:caret-square-down-o.vaadin:caret-square-left-o.vaadin:caret-square-right-o.vaadin:caret-square-up-o.vaadin:caret-up.vaadin:cart-o.vaadin:cart.vaadin:cash.vaadin:chart-3d.vaadin:chart-grid.vaadin:chart-line.vaadin:chart-timeline.vaadin:chart.vaadin:chat.vaadin:check-circle-o.vaadin:check-circle.vaadin:check-square-o.vaadin:check-square.vaadin:check.vaadin:chevron-circle-down-o.vaadin:chevron-circle-down.vaadin:chevron-circle-left-o.vaadin:chevron-circle-left.vaadin:chevron-circle-right-o.vaadin:chevron-circle-right.vaadin:chevron-circle-up-o.vaadin:chevron-circle-up.vaadin:chevron-down-small.vaadin:chevron-down.vaadin:chevron-left-small.vaadin:chevron-left.vaadin:chevron-right-small.vaadin:chevron-right.vaadin:chevron-up-small.vaadin:chevron-up.vaadin:child.vaadin:circle-thin.vaadin:circle.vaadin:clipboard-check.vaadin:clipboard-cross.vaadin:clipboard-heart.vaadin:clipboard-pulse.vaadin:clipboard-text.vaadin:clipboard-user.vaadin:clipboard.vaadin:clock.vaadin:close-big.vaadin:close-circle-o.vaadin:close-circle.vaadin:close-small.vaadin:close.vaadin:cloud-download-o.vaadin:cloud-download.vaadin:cloud-o.vaadin:cloud-upload-o.vaadin:cloud-upload.vaadin:cloud.vaadin:cluster.vaadin:code.vaadin:coffee.vaadin:cog-o.vaadin:cog.vaadin:cogs.vaadin:coin-piles.vaadin:coins.vaadin:combobox.vaadin:comment-ellipsis-o.vaadin:comment-ellipsis.vaadin:comment-o.vaadin:comment.vaadin:comments-o.vaadin:comments.vaadin:compile.vaadin:compress-square.vaadin:compress.vaadin:connect-o.vaadin:connect.vaadin:controller.vaadin:copy-o.vaadin:copy.vaadin:copyright.vaadin:corner-lower-left.vaadin:corner-lower-right.vaadin:corner-upper-left.vaadin:corner-upper-right.vaadin:credit-card.vaadin:crop.vaadin:cross-cutlery.vaadin:crosshairs.vaadin:css.vaadin:ctrl-a.vaadin:ctrl.vaadin:cube.vaadin:cubes.vaadin:curly-brackets.vaadin:cursor-o.vaadin:cursor.vaadin:cutlery.vaadin:dashboard.vaadin:database.vaadin:date-input.vaadin:deindent.vaadin:del-a.vaadin:del.vaadin:dental-chair.vaadin:desktop.vaadin:diamond-o.vaadin:diamond.vaadin:diploma-scroll.vaadin:diploma.vaadin:disc.vaadin:doctor-briefcase.vaadin:doctor.vaadin:dollar.vaadin:dot-circle.vaadin:download-alt.vaadin:download.vaadin:drop.vaadin:edit.vaadin:eject.vaadin:elastic.vaadin:ellipsis-circle-o.vaadin:ellipsis-circle.vaadin:ellipsis-dots-h.vaadin:ellipsis-dots-v.vaadin:ellipsis-h.vaadin:ellipsis-v.vaadin:enter-arrow.vaadin:enter.vaadin:envelope-o.vaadin:envelope-open-o.vaadin:envelope-open.vaadin:envelope.vaadin:envelopes-o.vaadin:envelopes.vaadin:eraser.vaadin:esc-a.vaadin:esc.vaadin:euro.vaadin:exchange.vaadin:exclamation-circle-o.vaadin:exclamation-circle.vaadin:exclamation.vaadin:exit-o.vaadin:exit.vaadin:expand-full.vaadin:expand-square.vaadin:expand.vaadin:external-browser.vaadin:external-link.vaadin:eye-slash.vaadin:eye.vaadin:eyedropper.vaadin:facebook-square.vaadin:facebook.vaadin:factory.vaadin:family.vaadin:fast-backward.vaadin:fast-forward.vaadin:female.vaadin:file-add.vaadin:file-code.vaadin:file-font.vaadin:file-movie.vaadin:file-o.vaadin:file-picture.vaadin:file-presentation.vaadin:file-process.vaadin:file-refresh.vaadin:file-remove.vaadin:file-search.vaadin:file-sound.vaadin:file-start.vaadin:file-table.vaadin:file-text-o.vaadin:file-text.vaadin:file-tree-small.vaadin:file-tree-sub.vaadin:file-tree.vaadin:file-zip.vaadin:file.vaadin:fill.vaadin:film.vaadin:filter.vaadin:fire.vaadin:flag-checkered.vaadin:flag-o.vaadin:flag.vaadin:flash.vaadin:flask.vaadin:flight-landing.vaadin:flight-takeoff.vaadin:flip-h.vaadin:flip-v.vaadin:folder-add.vaadin:folder-o.vaadin:folder-open-o.vaadin:folder-open.vaadin:folder-remove.vaadin:folder-search.vaadin:folder.vaadin:font.vaadin:form.vaadin:forward.vaadin:frown-o.vaadin:funcion.vaadin:function.vaadin:funnel.vaadin:gamepad.vaadin:gavel.vaadin:gift.vaadin:glass.vaadin:glasses.vaadin:globe-wire.vaadin:globe.vaadin:golf.vaadin:google-plus-square.vaadin:google-plus.vaadin:grab.vaadin:grid-bevel.vaadin:grid-big-o.vaadin:grid-big.vaadin:grid-h.vaadin:grid-small-o.vaadin:grid-small.vaadin:grid-v.vaadin:grid.vaadin:group.vaadin:hammer.vaadin:hand.vaadin:handle-corner.vaadin:hands-up.vaadin:handshake.vaadin:harddrive-o.vaadin:harddrive.vaadin:hash.vaadin:header.vaadin:headphones.vaadin:headset.vaadin:health-card.vaadin:heart-o.vaadin:heart.vaadin:home-o.vaadin:home.vaadin:hospital.vaadin:hourglass-empty.vaadin:hourglass-end.vaadin:hourglass-start.vaadin:hourglass.vaadin:inbox.vaadin:indent.vaadin:info-circle-o.vaadin:info-circle.vaadin:info.vaadin:input.vaadin:insert.vaadin:institution.vaadin:invoice.vaadin:italic.vaadin:key-o.vaadin:key.vaadin:keyboard-o.vaadin:keyboard.vaadin:laptop.vaadin:layout.vaadin:level-down-bold.vaadin:level-down.vaadin:level-left-bold.vaadin:level-left.vaadin:level-right-bold.vaadin:level-right.vaadin:level-up-bold.vaadin:level-up.vaadin:lifebuoy.vaadin:lightbulb.vaadin:line-bar-chart.vaadin:line-chart.vaadin:line-h.vaadin:line-v.vaadin:lines-list.vaadin:lines.vaadin:link.vaadin:list-ol.vaadin:list-select.vaadin:list-ul.vaadin:list.vaadin:location-arrow-circle-o.vaadin:location-arrow-circle.vaadin:location-arrow.vaadin:lock.vaadin:magic.vaadin:magnet.vaadin:mailbox.vaadin:male.vaadin:map-marker.vaadin:margin-bottom.vaadin:margin-left.vaadin:margin-right.vaadin:margin-top.vaadin:margin.vaadin:medal.vaadin:megafone.vaadin:megaphone.vaadin:meh-o.vaadin:menu.vaadin:microphone.vaadin:minus-circle-o.vaadin:minus-circle.vaadin:minus-square-o.vaadin:minus.vaadin:mobile-browser.vaadin:mobile-retro.vaadin:mobile.vaadin:modal-list.vaadin:modal.vaadin:money-deposit.vaadin:money-exchange.vaadin:money-withdraw.vaadin:money.vaadin:moon-o.vaadin:moon.vaadin:morning.vaadin:movie.vaadin:music.vaadin:mute.vaadin:native-button.vaadin:newspaper.vaadin:notebook.vaadin:nurse.vaadin:office.vaadin:open-book.vaadin:option-a.vaadin:option.vaadin:options.vaadin:orientation.vaadin:out.vaadin:outbox.vaadin:package.vaadin:padding-bottom.vaadin:padding-left.vaadin:padding-right.vaadin:padding-top.vaadin:padding.vaadin:paint-roll.vaadin:paintbrush.vaadin:palete.vaadin:palette.vaadin:panel.vaadin:paperclip.vaadin:paperplane-o.vaadin:paperplane.vaadin:paragraph.vaadin:password.vaadin:paste.vaadin:pause.vaadin:pencil.vaadin:phone-landline.vaadin:phone.vaadin:picture.vaadin:pie-bar-chart.vaadin:pie-chart.vaadin:piggy-bank-coin.vaadin:piggy-bank.vaadin:pill.vaadin:pills.vaadin:pin-post.vaadin:pin.vaadin:play-circle-o.vaadin:play-circle.vaadin:play.vaadin:plug.vaadin:plus-circle-o.vaadin:plus-circle.vaadin:plus-minus.vaadin:plus-square-o.vaadin:plus.vaadin:pointer.vaadin:power-off.vaadin:presentation.vaadin:print.vaadin:progressbar.vaadin:puzzle-piece.vaadin:pyramid-chart.vaadin:qrcode.vaadin:question-circle-o.vaadin:question-circle.vaadin:question.vaadin:quote-left.vaadin:quote-right.vaadin:random.vaadin:raster-lower-left.vaadin:raster.vaadin:records.vaadin:recycle.vaadin:refresh.vaadin:reply-all.vaadin:reply.vaadin:resize-h.vaadin:resize-v.vaadin:retweet.vaadin:rhombus.vaadin:road-branch.vaadin:road-branches.vaadin:road-split.vaadin:road.vaadin:rocket.vaadin:rotate-left.vaadin:rotate-right.vaadin:rss-square.vaadin:rss.vaadin:safe-lock.vaadin:safe.vaadin:scale-unbalance.vaadin:scale.vaadin:scatter-chart.vaadin:scissors.vaadin:screwdriver.vaadin:search-minus.vaadin:search-plus.vaadin:search.vaadin:select.vaadin:server.vaadin:share-square.vaadin:share.vaadin:shield.vaadin:shift-arrow.vaadin:shift.vaadin:shop.vaadin:sign-in-alt.vaadin:sign-in.vaadin:sign-out-alt.vaadin:sign-out.vaadin:signal.vaadin:sitemap.vaadin:slider.vaadin:sliders.vaadin:smiley-o.vaadin:sort.vaadin:sound-disable.vaadin:spark-line.vaadin:specialist.vaadin:spinner-arc.vaadin:spinner-third.vaadin:spinner.vaadin:spline-area-chart.vaadin:spline-chart.vaadin:split-h.vaadin:split-v.vaadin:split.vaadin:spoon.vaadin:square-shadow.vaadin:star-half-left-o.vaadin:star-half-left.vaadin:star-half-right-o.vaadin:star-half-right.vaadin:star-o.vaadin:star.vaadin:start-cog.vaadin:step-backward.vaadin:step-forward.vaadin:stethoscope.vaadin:stock.vaadin:stop-cog.vaadin:stop.vaadin:stopwatch.vaadin:storage.vaadin:strikethrough.vaadin:subscript.vaadin:suitcase.vaadin:sun-down.vaadin:sun-o.vaadin:sun-rise.vaadin:superscript.vaadin:sword.vaadin:tab-a.vaadin:tab.vaadin:table.vaadin:tablet.vaadin:tabs.vaadin:tag.vaadin:tags.vaadin:tasks.vaadin:taxi.vaadin:teeth.vaadin:terminal.vaadin:text-height.vaadin:text-input.vaadin:text-label.vaadin:text-width.vaadin:thin-square.vaadin:thumbs-down-o.vaadin:thumbs-down.vaadin:thumbs-up-o.vaadin:thumbs-up.vaadin:ticket.vaadin:time-backward.vaadin:time-forward.vaadin:timer.vaadin:toolbox.vaadin:tools.vaadin:tooth.vaadin:touch.vaadin:train.vaadin:trash.vaadin:tree-table.vaadin:trendind-down.vaadin:trending-down.vaadin:trending-up.vaadin:trophy.vaadin:truck.vaadin:twin-col-select.vaadin:twitter-square.vaadin:twitter.vaadin:umbrella.vaadin:underline.vaadin:unlink.vaadin:unlock.vaadin:upload-alt.vaadin:upload.vaadin:user-card.vaadin:user-check.vaadin:user-clock.vaadin:user-heart.vaadin:user-star.vaadin:user.vaadin:users.vaadin:vaadin-h.vaadin:vaadin-v.vaadin:viewport.vaadin:vimeo-square.vaadin:vimeo.vaadin:volume-down.vaadin:volume-off.vaadin:volume-up.vaadin:volume.vaadin:wallet.vaadin:warning.vaadin:workplace.vaadin:wrench.vaadin:youtube-square.vaadin:youtube`.split(`.`),$c=null,el=()=>($c||=Promise.all([D(()=>import(`./vendor-ui5.js`).then(e=>e.n),__vite__mapDeps([5,1])),D(()=>import(`./vendor-ui5.js`).then(e=>e.t),__vite__mapDeps([5,1]))]),$c),Q=class extends b{constructor(...e){super(...e),this.ui5FieldComponentsReady=!1,this.component=void 0,this.field=void 0,this.baseUrl=void 0,this.state={},this.data={},this.appState={},this.appData={},this.colorPickerOpened=!1,this.colorPickerValue=void 0,this.comboData=[],this._comboFilter=``,this.rendered=!1,this.renderColorPicker=()=>{this.loadUi5FieldComponents();let e=this.field?.fieldId;return T`
+       `}static{this.styles=m`
+  `}};O([v()],gl.prototype,`fieldId`,void 0),O([v()],gl.prototype,`label`,void 0),O([v()],gl.prototype,`state`,void 0),O([v()],gl.prototype,`data`,void 0),O([v()],gl.prototype,`value`,void 0),O([v()],gl.prototype,`autoFocus`,void 0),O([v()],gl.prototype,`required`,void 0),O([v()],gl.prototype,`colspan`,void 0),O([v()],gl.prototype,`helperText`,void 0),gl=O([h(`mateu-money-field`)],gl);var _l=`vaadin:abacus.vaadin:absolute-position.vaadin:academy-cap.vaadin:accessibility.vaadin:accordion-menu.vaadin:add-dock.vaadin:adjust.vaadin:adobe-flash.vaadin:airplane.vaadin:alarm.vaadin:align-center.vaadin:align-justify.vaadin:align-left.vaadin:align-right.vaadin:alt-a.vaadin:alt.vaadin:ambulance.vaadin:anchor.vaadin:angle-double-down.vaadin:angle-double-left.vaadin:angle-double-right.vaadin:angle-double-up.vaadin:angle-down.vaadin:angle-left.vaadin:angle-right.vaadin:angle-up.vaadin:archive.vaadin:archives.vaadin:area-select.vaadin:arrow-backward.vaadin:arrow-circle-down-o.vaadin:arrow-circle-down.vaadin:arrow-circle-left-o.vaadin:arrow-circle-left.vaadin:arrow-circle-right-o.vaadin:arrow-circle-right.vaadin:arrow-circle-up-o.vaadin:arrow-circle-up.vaadin:arrow-down.vaadin:arrow-forward.vaadin:arrow-left.vaadin:arrow-long-down.vaadin:arrow-long-left.vaadin:arrow-right.vaadin:arrow-up.vaadin:arrows-cross.vaadin:arrows-long-h.vaadin:arrows-long-right.vaadin:arrows-long-up.vaadin:arrows-long-v.vaadin:arrows.vaadin:asterisk.vaadin:at.vaadin:automation.vaadin:backspace-a.vaadin:backspace.vaadin:backwards.vaadin:ban.vaadin:bar-chart-h.vaadin:bar-chart-v.vaadin:bar-chart.vaadin:barcode.vaadin:bed.vaadin:bell-o.vaadin:bell-slash-o.vaadin:bell-slash.vaadin:bell.vaadin:boat.vaadin:bold.vaadin:bolt.vaadin:bomb.vaadin:book-dollar.vaadin:book-percent.vaadin:book.vaadin:bookmark-o.vaadin:bookmark.vaadin:briefcase.vaadin:browser.vaadin:bug-o.vaadin:bug.vaadin:building-o.vaadin:building.vaadin:bullets.vaadin:bullseye.vaadin:bus.vaadin:buss.vaadin:button.vaadin:calc-book.vaadin:calc.vaadin:calendar-briefcase.vaadin:calendar-clock.vaadin:calendar-envelope.vaadin:calendar-o.vaadin:calendar-user.vaadin:calendar.vaadin:camera.vaadin:car.vaadin:caret-down.vaadin:caret-left.vaadin:caret-right.vaadin:caret-square-down-o.vaadin:caret-square-left-o.vaadin:caret-square-right-o.vaadin:caret-square-up-o.vaadin:caret-up.vaadin:cart-o.vaadin:cart.vaadin:cash.vaadin:chart-3d.vaadin:chart-grid.vaadin:chart-line.vaadin:chart-timeline.vaadin:chart.vaadin:chat.vaadin:check-circle-o.vaadin:check-circle.vaadin:check-square-o.vaadin:check-square.vaadin:check.vaadin:chevron-circle-down-o.vaadin:chevron-circle-down.vaadin:chevron-circle-left-o.vaadin:chevron-circle-left.vaadin:chevron-circle-right-o.vaadin:chevron-circle-right.vaadin:chevron-circle-up-o.vaadin:chevron-circle-up.vaadin:chevron-down-small.vaadin:chevron-down.vaadin:chevron-left-small.vaadin:chevron-left.vaadin:chevron-right-small.vaadin:chevron-right.vaadin:chevron-up-small.vaadin:chevron-up.vaadin:child.vaadin:circle-thin.vaadin:circle.vaadin:clipboard-check.vaadin:clipboard-cross.vaadin:clipboard-heart.vaadin:clipboard-pulse.vaadin:clipboard-text.vaadin:clipboard-user.vaadin:clipboard.vaadin:clock.vaadin:close-big.vaadin:close-circle-o.vaadin:close-circle.vaadin:close-small.vaadin:close.vaadin:cloud-download-o.vaadin:cloud-download.vaadin:cloud-o.vaadin:cloud-upload-o.vaadin:cloud-upload.vaadin:cloud.vaadin:cluster.vaadin:code.vaadin:coffee.vaadin:cog-o.vaadin:cog.vaadin:cogs.vaadin:coin-piles.vaadin:coins.vaadin:combobox.vaadin:comment-ellipsis-o.vaadin:comment-ellipsis.vaadin:comment-o.vaadin:comment.vaadin:comments-o.vaadin:comments.vaadin:compile.vaadin:compress-square.vaadin:compress.vaadin:connect-o.vaadin:connect.vaadin:controller.vaadin:copy-o.vaadin:copy.vaadin:copyright.vaadin:corner-lower-left.vaadin:corner-lower-right.vaadin:corner-upper-left.vaadin:corner-upper-right.vaadin:credit-card.vaadin:crop.vaadin:cross-cutlery.vaadin:crosshairs.vaadin:css.vaadin:ctrl-a.vaadin:ctrl.vaadin:cube.vaadin:cubes.vaadin:curly-brackets.vaadin:cursor-o.vaadin:cursor.vaadin:cutlery.vaadin:dashboard.vaadin:database.vaadin:date-input.vaadin:deindent.vaadin:del-a.vaadin:del.vaadin:dental-chair.vaadin:desktop.vaadin:diamond-o.vaadin:diamond.vaadin:diploma-scroll.vaadin:diploma.vaadin:disc.vaadin:doctor-briefcase.vaadin:doctor.vaadin:dollar.vaadin:dot-circle.vaadin:download-alt.vaadin:download.vaadin:drop.vaadin:edit.vaadin:eject.vaadin:elastic.vaadin:ellipsis-circle-o.vaadin:ellipsis-circle.vaadin:ellipsis-dots-h.vaadin:ellipsis-dots-v.vaadin:ellipsis-h.vaadin:ellipsis-v.vaadin:enter-arrow.vaadin:enter.vaadin:envelope-o.vaadin:envelope-open-o.vaadin:envelope-open.vaadin:envelope.vaadin:envelopes-o.vaadin:envelopes.vaadin:eraser.vaadin:esc-a.vaadin:esc.vaadin:euro.vaadin:exchange.vaadin:exclamation-circle-o.vaadin:exclamation-circle.vaadin:exclamation.vaadin:exit-o.vaadin:exit.vaadin:expand-full.vaadin:expand-square.vaadin:expand.vaadin:external-browser.vaadin:external-link.vaadin:eye-slash.vaadin:eye.vaadin:eyedropper.vaadin:facebook-square.vaadin:facebook.vaadin:factory.vaadin:family.vaadin:fast-backward.vaadin:fast-forward.vaadin:female.vaadin:file-add.vaadin:file-code.vaadin:file-font.vaadin:file-movie.vaadin:file-o.vaadin:file-picture.vaadin:file-presentation.vaadin:file-process.vaadin:file-refresh.vaadin:file-remove.vaadin:file-search.vaadin:file-sound.vaadin:file-start.vaadin:file-table.vaadin:file-text-o.vaadin:file-text.vaadin:file-tree-small.vaadin:file-tree-sub.vaadin:file-tree.vaadin:file-zip.vaadin:file.vaadin:fill.vaadin:film.vaadin:filter.vaadin:fire.vaadin:flag-checkered.vaadin:flag-o.vaadin:flag.vaadin:flash.vaadin:flask.vaadin:flight-landing.vaadin:flight-takeoff.vaadin:flip-h.vaadin:flip-v.vaadin:folder-add.vaadin:folder-o.vaadin:folder-open-o.vaadin:folder-open.vaadin:folder-remove.vaadin:folder-search.vaadin:folder.vaadin:font.vaadin:form.vaadin:forward.vaadin:frown-o.vaadin:funcion.vaadin:function.vaadin:funnel.vaadin:gamepad.vaadin:gavel.vaadin:gift.vaadin:glass.vaadin:glasses.vaadin:globe-wire.vaadin:globe.vaadin:golf.vaadin:google-plus-square.vaadin:google-plus.vaadin:grab.vaadin:grid-bevel.vaadin:grid-big-o.vaadin:grid-big.vaadin:grid-h.vaadin:grid-small-o.vaadin:grid-small.vaadin:grid-v.vaadin:grid.vaadin:group.vaadin:hammer.vaadin:hand.vaadin:handle-corner.vaadin:hands-up.vaadin:handshake.vaadin:harddrive-o.vaadin:harddrive.vaadin:hash.vaadin:header.vaadin:headphones.vaadin:headset.vaadin:health-card.vaadin:heart-o.vaadin:heart.vaadin:home-o.vaadin:home.vaadin:hospital.vaadin:hourglass-empty.vaadin:hourglass-end.vaadin:hourglass-start.vaadin:hourglass.vaadin:inbox.vaadin:indent.vaadin:info-circle-o.vaadin:info-circle.vaadin:info.vaadin:input.vaadin:insert.vaadin:institution.vaadin:invoice.vaadin:italic.vaadin:key-o.vaadin:key.vaadin:keyboard-o.vaadin:keyboard.vaadin:laptop.vaadin:layout.vaadin:level-down-bold.vaadin:level-down.vaadin:level-left-bold.vaadin:level-left.vaadin:level-right-bold.vaadin:level-right.vaadin:level-up-bold.vaadin:level-up.vaadin:lifebuoy.vaadin:lightbulb.vaadin:line-bar-chart.vaadin:line-chart.vaadin:line-h.vaadin:line-v.vaadin:lines-list.vaadin:lines.vaadin:link.vaadin:list-ol.vaadin:list-select.vaadin:list-ul.vaadin:list.vaadin:location-arrow-circle-o.vaadin:location-arrow-circle.vaadin:location-arrow.vaadin:lock.vaadin:magic.vaadin:magnet.vaadin:mailbox.vaadin:male.vaadin:map-marker.vaadin:margin-bottom.vaadin:margin-left.vaadin:margin-right.vaadin:margin-top.vaadin:margin.vaadin:medal.vaadin:megafone.vaadin:megaphone.vaadin:meh-o.vaadin:menu.vaadin:microphone.vaadin:minus-circle-o.vaadin:minus-circle.vaadin:minus-square-o.vaadin:minus.vaadin:mobile-browser.vaadin:mobile-retro.vaadin:mobile.vaadin:modal-list.vaadin:modal.vaadin:money-deposit.vaadin:money-exchange.vaadin:money-withdraw.vaadin:money.vaadin:moon-o.vaadin:moon.vaadin:morning.vaadin:movie.vaadin:music.vaadin:mute.vaadin:native-button.vaadin:newspaper.vaadin:notebook.vaadin:nurse.vaadin:office.vaadin:open-book.vaadin:option-a.vaadin:option.vaadin:options.vaadin:orientation.vaadin:out.vaadin:outbox.vaadin:package.vaadin:padding-bottom.vaadin:padding-left.vaadin:padding-right.vaadin:padding-top.vaadin:padding.vaadin:paint-roll.vaadin:paintbrush.vaadin:palete.vaadin:palette.vaadin:panel.vaadin:paperclip.vaadin:paperplane-o.vaadin:paperplane.vaadin:paragraph.vaadin:password.vaadin:paste.vaadin:pause.vaadin:pencil.vaadin:phone-landline.vaadin:phone.vaadin:picture.vaadin:pie-bar-chart.vaadin:pie-chart.vaadin:piggy-bank-coin.vaadin:piggy-bank.vaadin:pill.vaadin:pills.vaadin:pin-post.vaadin:pin.vaadin:play-circle-o.vaadin:play-circle.vaadin:play.vaadin:plug.vaadin:plus-circle-o.vaadin:plus-circle.vaadin:plus-minus.vaadin:plus-square-o.vaadin:plus.vaadin:pointer.vaadin:power-off.vaadin:presentation.vaadin:print.vaadin:progressbar.vaadin:puzzle-piece.vaadin:pyramid-chart.vaadin:qrcode.vaadin:question-circle-o.vaadin:question-circle.vaadin:question.vaadin:quote-left.vaadin:quote-right.vaadin:random.vaadin:raster-lower-left.vaadin:raster.vaadin:records.vaadin:recycle.vaadin:refresh.vaadin:reply-all.vaadin:reply.vaadin:resize-h.vaadin:resize-v.vaadin:retweet.vaadin:rhombus.vaadin:road-branch.vaadin:road-branches.vaadin:road-split.vaadin:road.vaadin:rocket.vaadin:rotate-left.vaadin:rotate-right.vaadin:rss-square.vaadin:rss.vaadin:safe-lock.vaadin:safe.vaadin:scale-unbalance.vaadin:scale.vaadin:scatter-chart.vaadin:scissors.vaadin:screwdriver.vaadin:search-minus.vaadin:search-plus.vaadin:search.vaadin:select.vaadin:server.vaadin:share-square.vaadin:share.vaadin:shield.vaadin:shift-arrow.vaadin:shift.vaadin:shop.vaadin:sign-in-alt.vaadin:sign-in.vaadin:sign-out-alt.vaadin:sign-out.vaadin:signal.vaadin:sitemap.vaadin:slider.vaadin:sliders.vaadin:smiley-o.vaadin:sort.vaadin:sound-disable.vaadin:spark-line.vaadin:specialist.vaadin:spinner-arc.vaadin:spinner-third.vaadin:spinner.vaadin:spline-area-chart.vaadin:spline-chart.vaadin:split-h.vaadin:split-v.vaadin:split.vaadin:spoon.vaadin:square-shadow.vaadin:star-half-left-o.vaadin:star-half-left.vaadin:star-half-right-o.vaadin:star-half-right.vaadin:star-o.vaadin:star.vaadin:start-cog.vaadin:step-backward.vaadin:step-forward.vaadin:stethoscope.vaadin:stock.vaadin:stop-cog.vaadin:stop.vaadin:stopwatch.vaadin:storage.vaadin:strikethrough.vaadin:subscript.vaadin:suitcase.vaadin:sun-down.vaadin:sun-o.vaadin:sun-rise.vaadin:superscript.vaadin:sword.vaadin:tab-a.vaadin:tab.vaadin:table.vaadin:tablet.vaadin:tabs.vaadin:tag.vaadin:tags.vaadin:tasks.vaadin:taxi.vaadin:teeth.vaadin:terminal.vaadin:text-height.vaadin:text-input.vaadin:text-label.vaadin:text-width.vaadin:thin-square.vaadin:thumbs-down-o.vaadin:thumbs-down.vaadin:thumbs-up-o.vaadin:thumbs-up.vaadin:ticket.vaadin:time-backward.vaadin:time-forward.vaadin:timer.vaadin:toolbox.vaadin:tools.vaadin:tooth.vaadin:touch.vaadin:train.vaadin:trash.vaadin:tree-table.vaadin:trendind-down.vaadin:trending-down.vaadin:trending-up.vaadin:trophy.vaadin:truck.vaadin:twin-col-select.vaadin:twitter-square.vaadin:twitter.vaadin:umbrella.vaadin:underline.vaadin:unlink.vaadin:unlock.vaadin:upload-alt.vaadin:upload.vaadin:user-card.vaadin:user-check.vaadin:user-clock.vaadin:user-heart.vaadin:user-star.vaadin:user.vaadin:users.vaadin:vaadin-h.vaadin:vaadin-v.vaadin:viewport.vaadin:vimeo-square.vaadin:vimeo.vaadin:volume-down.vaadin:volume-off.vaadin:volume-up.vaadin:volume.vaadin:wallet.vaadin:warning.vaadin:workplace.vaadin:wrench.vaadin:youtube-square.vaadin:youtube`.split(`.`),vl=null,yl=()=>(vl||=Promise.all([E(()=>import(`./vendor-ui5.js`).then(e=>e.n),__vite__mapDeps([5,1])),E(()=>import(`./vendor-ui5.js`).then(e=>e.t),__vite__mapDeps([5,1]))]),vl),Z=class extends y{constructor(...e){super(...e),this.ui5FieldComponentsReady=!1,this.component=void 0,this.field=void 0,this.baseUrl=void 0,this.state={},this.data={},this.appState={},this.appData={},this.colorPickerOpened=!1,this.colorPickerValue=void 0,this.comboData=[],this._comboFilter=``,this.rendered=!1,this.renderColorPicker=()=>{this.loadUi5FieldComponents();let e=this.field?.fieldId;return w`
             <ui5-color-picker value="${this.state&&e in this.state?this.state[e]:this.field?.initialValue}" @change="${e=>this.colorPickerValue=e.target.value}">Picker</ui5-color-picker>
-        `},this.saveColor=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.colorPickerValue,fieldId:this.field.fieldId},bubbles:!0,composed:!0})),this.colorPickerOpened=!1},this.renderColorPickerFooter=()=>T`<vaadin-button @click="${()=>this.colorPickerOpened=!1}">Cancel</vaadin-button>
-        <vaadin-button theme="primary" @click="${this.saveColor}">Save</vaadin-button>`,this.checked=e=>{let t=e.target;this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t.checked,fieldId:this.field.fieldId},bubbles:!0,composed:!0}))},this.convert=e=>this.field?.dataType==`integer`?parseInt(e):e,this.multiComboBoxValueChanged=e=>{if(this.rendered){let t=this.field?.fieldId,n=this.state&&t in this.state?this.state[t]:this.field?.initialValue,r;e.detail.value&&(r=e.detail.value.map(e=>e.value),r&&r.length>0&&(this.data[this.id]||(this.data[this.id]={}),this.data[this.id].content||(this.data[this.id].content=[]),this.data[this.id]&&this.data[this.id].content&&e.detail.value.forEach(e=>{this.data[this.id].content?.find(t=>e.value==t.value)||this.data[this.id].content.push(e)}))),this.compareArrays(r,n)||this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}},this.valueChanged=e=>{this.rendered&&e.detail.value!==void 0&&e.detail.value!=this.state[this.field.fieldId]&&this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.convert(e.detail.value),fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.selectedItems=e=>{if(e&&e.length>0)if(this.field?.remoteCoordinates){if(this.comboData&&this.comboData.length>0)return this.comboData?.filter(t=>e.indexOf(t.value)>=0);if(this.data[this.id]&&this.data[this.id].content&&this.data[this.id].content.length>0)return this.data[this.id].content.filter(t=>e.indexOf(t.value)>=0)}else return this.field?.options?.filter(t=>e.indexOf(t.value)>=0);return[]},this.selectedIndex=e=>{if(e)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content){let t=this.data[this.id].content.find(t=>t.value==e);if(t)return this.data[this.id].content.indexOf(t)}}else{let t=this.field?.options?.find(t=>t.value==e);if(t)return this.field?.options?.indexOf(t)}},this.selectedIndexes=e=>{if(e&&e.length>0)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content)return this.data[this.id].content.filter(t=>e.indexOf(t.value)>=0).map(e=>this.data[this.id].content.indexOf(e))}else return this.field?.options?.filter(t=>e.indexOf(t.value)>=0).map(e=>this.field?.options?.indexOf(e));return[]},this.compareArrays=(e,t)=>this.falsy(e)&&this.falsy(t)||e&&t&&e.length===t.length&&e.every((e,n)=>e===t[n]),this.falsy=e=>!e||e.length==0,this.listItemsSelected=e=>{let t=this.field?.fieldId,n=this.state&&t in this.state?this.state[t]:this.field?.initialValue,r;this.rendered&&(e.detail.value&&(this.field?.remoteCoordinates?this.data[this.id]&&this.data[this.id].content&&(r=e.detail.value.map(e=>this.data[this.id].content[e].value)):r=e.detail.value.map(e=>this.field.options[e].value)),this.compareArrays(r,n)||this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r,fieldId:this.field?.fieldId},bubbles:!0,composed:!0})))},this.listItemSelected=e=>{let t;if(e.detail.value||e.detail.value==0)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content){let n=this.data[this.id].content[e.detail.value];n&&(t=n.value)}}else{let n=this.field.options[e.detail.value];n&&(t=n.value)}this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.mapPosition=e=>{switch(e){case`topStretch`:return`top-stretch`;case`topStart`:return`top-start`;case`topCenter`:return`top-center`;case`topEnd`:return`top-end`;case`middle`:return`middle`;case`bottomStart`:return`bottom-start`;case`bottomEnd`:return`bottom-end`;case`bottomStretch`:return`bottom-stretch`;case`bottomCenter`:return`bottom-center`}return`bottom-end`},this.helperShownInControl=!1,this.lastAnnouncedError=``,this.controlOwnsValidity=!1,this.fileUploaded=e=>{let t=this.field?.fieldId??``,n=this.state[t];n.push({id:e.detail.xhr.responseText,name:e.detail.file.name}),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:n,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.fileChanged=e=>{let t=this.field?.fieldId??``,n=(e.detail.value??[]).filter(e=>e.id).map(e=>e.id),r=(this.state[t]??[]).map(e=>e.id);if(!this.compareArrays(r,n)){let t=(e.detail.value??[]).filter(e=>e.id).map(e=>({id:e.id,name:e.name}));this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}},this.triggerImageUpload=()=>{(this.renderRoot?.querySelector(`input[type="file"]`))?.click()},this.imageUpload=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r.result,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},r.readAsDataURL(n),t.value=``},this.imageDelete=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:``,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.iconComboboxRenderer=e=>T`
+        `},this.saveColor=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.colorPickerValue,fieldId:this.field.fieldId},bubbles:!0,composed:!0})),this.colorPickerOpened=!1},this.renderColorPickerFooter=()=>w`<vaadin-button @click="${()=>this.colorPickerOpened=!1}">Cancel</vaadin-button>
+        <vaadin-button theme="primary" @click="${this.saveColor}">Save</vaadin-button>`,this.checked=e=>{let t=e.target;this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t.checked,fieldId:this.field.fieldId},bubbles:!0,composed:!0}))},this.convert=e=>this.field?.dataType==`integer`?parseInt(e):e,this.multiComboBoxValueChanged=e=>{if(this.rendered){let t=this.field?.fieldId,n=this.state&&t in this.state?this.state[t]:this.field?.initialValue,r;e.detail.value&&(r=e.detail.value.map(e=>e.value),r&&r.length>0&&(this.data[this.id]||(this.data[this.id]={}),this.data[this.id].content||(this.data[this.id].content=[]),this.data[this.id]&&this.data[this.id].content&&e.detail.value.forEach(e=>{this.data[this.id].content?.find(t=>e.value==t.value)||this.data[this.id].content.push(e)}))),this.compareArrays(r,n)||this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}},this.valueChanged=e=>{this.rendered&&e.detail.value!==void 0&&e.detail.value!=this.state[this.field.fieldId]&&this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.convert(e.detail.value),fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.selectedItems=e=>{if(e&&e.length>0)if(this.field?.remoteCoordinates){if(this.comboData&&this.comboData.length>0)return this.comboData?.filter(t=>e.indexOf(t.value)>=0);if(this.data[this.id]&&this.data[this.id].content&&this.data[this.id].content.length>0)return this.data[this.id].content.filter(t=>e.indexOf(t.value)>=0)}else return this.field?.options?.filter(t=>e.indexOf(t.value)>=0);return[]},this.selectedIndex=e=>{if(e)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content){let t=this.data[this.id].content.find(t=>t.value==e);if(t)return this.data[this.id].content.indexOf(t)}}else{let t=this.field?.options?.find(t=>t.value==e);if(t)return this.field?.options?.indexOf(t)}},this.selectedIndexes=e=>{if(e&&e.length>0)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content)return this.data[this.id].content.filter(t=>e.indexOf(t.value)>=0).map(e=>this.data[this.id].content.indexOf(e))}else return this.field?.options?.filter(t=>e.indexOf(t.value)>=0).map(e=>this.field?.options?.indexOf(e));return[]},this.compareArrays=(e,t)=>this.falsy(e)&&this.falsy(t)||e&&t&&e.length===t.length&&e.every((e,n)=>e===t[n]),this.falsy=e=>!e||e.length==0,this.listItemsSelected=e=>{let t=this.field?.fieldId,n=this.state&&t in this.state?this.state[t]:this.field?.initialValue,r;this.rendered&&(e.detail.value&&(this.field?.remoteCoordinates?this.data[this.id]&&this.data[this.id].content&&(r=e.detail.value.map(e=>this.data[this.id].content[e].value)):r=e.detail.value.map(e=>this.field.options[e].value)),this.compareArrays(r,n)||this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r,fieldId:this.field?.fieldId},bubbles:!0,composed:!0})))},this.listItemSelected=e=>{let t;if(e.detail.value||e.detail.value==0)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content){let n=this.data[this.id].content[e.detail.value];n&&(t=n.value)}}else{let n=this.field.options[e.detail.value];n&&(t=n.value)}this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.mapPosition=e=>{switch(e){case`topStretch`:return`top-stretch`;case`topStart`:return`top-start`;case`topCenter`:return`top-center`;case`topEnd`:return`top-end`;case`middle`:return`middle`;case`bottomStart`:return`bottom-start`;case`bottomEnd`:return`bottom-end`;case`bottomStretch`:return`bottom-stretch`;case`bottomCenter`:return`bottom-center`}return`bottom-end`},this.helperShownInControl=!1,this.lastAnnouncedError=``,this.controlOwnsValidity=!1,this.fileUploaded=e=>{let t=this.field?.fieldId??``,n=this.state[t];n.push({id:e.detail.xhr.responseText,name:e.detail.file.name}),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:n,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.fileChanged=e=>{let t=this.field?.fieldId??``,n=(e.detail.value??[]).filter(e=>e.id).map(e=>e.id),r=(this.state[t]??[]).map(e=>e.id);if(!this.compareArrays(r,n)){let t=(e.detail.value??[]).filter(e=>e.id).map(e=>({id:e.id,name:e.name}));this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}},this.triggerImageUpload=()=>{(this.renderRoot?.querySelector(`input[type="file"]`))?.click()},this.imageUpload=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r.result,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},r.readAsDataURL(n),t.value=``},this.imageDelete=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:``,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.iconComboboxRenderer=e=>w`
   <div style="display: flex;">
       <vaadin-icon
               icon="${e}"
@@ -9050,12 +9050,12 @@ ${i}
       </div>
     </div>
   </div>
-`,this.comboRenderer=e=>T`
-        ${e.description||e.image||e.icon?T`
+`,this.comboRenderer=e=>w`
+        ${e.description||e.image||e.icon?w`
             <vaadin-horizontal-layout theme="spacing">
-                ${e.icon?T`<div><vaadin-icon icon="${e.icon}"></vaadin-icon></div>
-                                    `:v}
-                ${e.image?T`
+                ${e.icon?w`<div><vaadin-icon icon="${e.icon}"></vaadin-icon></div>
+                                    `:_}
+                ${e.image?w`
                     <div>
                     <img
                             style="width: var(--lumo-size-m); margin-right: var(--lumo-space-s);"
@@ -9063,75 +9063,75 @@ ${i}
                             alt="${e.label}"
                     />
                     </div>
-                                        `:v}
+                                        `:_}
                 <div>
                     ${e.label}
-                    ${e.description?T`
+                    ${e.description?w`
             <div style="font-size: var(--lumo-font-size-s); color: var(--lumo-secondary-text-color);">
                 ${e.description}
             </div>
-        `:v}
+        `:_}
                 </div>
 
             </vaadin-horizontal-layout>
                             `:e.label}
-`,this.filteredIcons=[],this.navLinkOffset=null,this.iconFilterChanged=e=>{this.filteredIcons=Qc.filter(t=>!e.detail.value||t.indexOf(e.detail.value)>=0)}}loadUi5FieldComponents(){this.ui5FieldComponentsReady||el().then(()=>{this.ui5FieldComponentsReady=!0})}remoteComboDataProvider(e){return(t,n)=>{let{filter:i,page:a,pageSize:o}=t,s=i??``;this._comboFilter=s,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{searchText:i,fieldId:this.field?.fieldId,size:o,page:a,sort:void 0},callback:e=>{if(s===this._comboFilter)if(e?.messages?.forEach(e=>{r.show(e.text,{position:e.position?this.mapPosition(e.position):void 0,theme:e.variant,duration:e.duration})}),!e.fragments||e.fragments.length==0)this.comboData=[],n([],0);else{let t=e.fragments[0].data?.[this.id];this.comboData=t?.content,n(t?.content,t?.totalElements)}},callbackonly:!0},bubbles:!0,composed:!0}))}}disconnectedCallback(){super.disconnectedCallback(),this.rendered=!1}renderNavLink(){let e=this.field?.link;if(!e?.href)return v;let t=M(e.href,this.state,this.data)??e.href,n=M(e.title,this.state,this.data)||t,r=e.icon||(t.startsWith(`http`)?`vaadin:external-link`:`vaadin:link`),i=this.navLinkOffset??`calc(var(--lumo-font-size-s) * 1.6 + (var(--lumo-size-m) - var(--lumo-icon-size-s)) / 2)`;return T`<a
+`,this.filteredIcons=[],this.navLinkOffset=null,this.iconFilterChanged=e=>{this.filteredIcons=_l.filter(t=>!e.detail.value||t.indexOf(e.detail.value)>=0)}}loadUi5FieldComponents(){this.ui5FieldComponentsReady||yl().then(()=>{this.ui5FieldComponentsReady=!0})}remoteComboDataProvider(e){return(t,n)=>{let{filter:i,page:a,pageSize:o}=t,s=i??``;this._comboFilter=s,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{searchText:i,fieldId:this.field?.fieldId,size:o,page:a,sort:void 0},callback:e=>{if(s===this._comboFilter)if(e?.messages?.forEach(e=>{r.show(e.text,{position:e.position?this.mapPosition(e.position):void 0,theme:e.variant,duration:e.duration})}),!e.fragments||e.fragments.length==0)this.comboData=[],n([],0);else{let t=e.fragments[0].data?.[this.id];this.comboData=t?.content,n(t?.content,t?.totalElements)}},callbackonly:!0},bubbles:!0,composed:!0}))}}disconnectedCallback(){super.disconnectedCallback(),this.rendered=!1}renderNavLink(){let e=this.field?.link;if(!e?.href)return _;let t=j(e.href,this.state,this.data)??e.href,n=j(e.title,this.state,this.data)||t,r=e.icon||(t.startsWith(`http`)?`vaadin:external-link`:`vaadin:link`),i=this.navLinkOffset??`calc(var(--lumo-font-size-s) * 1.6 + (var(--lumo-size-m) - var(--lumo-icon-size-s)) / 2)`;return w`<a
                 data-navlink
                 href="${t}"
                 title="${n}"
-                target="${S(e.target||void 0)}"
+                target="${x(e.target||void 0)}"
                 style="display: flex; align-items: center; color: var(--lumo-secondary-text-color); align-self: flex-start; margin-top: ${i};"
-        ><vaadin-icon icon="${r}" style="width: var(--lumo-icon-size-s); height: var(--lumo-icon-size-s);"></vaadin-icon></a>`}positionNavLink(){let e=this.renderRoot?.querySelector(`a[data-navlink]`);e&&setTimeout(()=>{let t=e.parentElement,n=t?.firstElementChild?.firstElementChild;if(!t||!n)return;let r=(n.shadowRoot?.querySelector(`[part="input-field"]`)??n).getBoundingClientRect();if(r.height===0)return;let i=Math.max(0,r.top+r.height/2-e.offsetHeight/2-t.getBoundingClientRect().top),a=`${Math.round(i)}px`;this.navLinkOffset!==a&&(this.navLinkOffset=a)})}helperText(){return this.helperShownInControl=!0,N(this.field?.description??``,this.state,this.data)??``}fieldErrors(){let e=this.field?.fieldId??``,t=this.data?.errors?.[e];return Array.isArray(t)?t.filter(e=>!!e):[]}validatableControl(){let e=this.renderRoot.querySelectorAll(`*`);for(let t of e)if(`invalid`in t&&`errorMessage`in t)return t;return null}applyValidationState(){let e=this.fieldErrors(),t=this.validatableControl();if(!t){this.lastAnnouncedError=e.join(`. `);return}let n=e.join(`. `);if(t.errorMessage=n,t.invalid=e.length>0,n&&n!==this.lastAnnouncedError){let e=(this.field?.label??``).toString().trim();Ze(e?`${e}: ${n}`:n,{politeness:`assertive`})}this.lastAnnouncedError=n}render(){this.rendered=!0;let e=this.renderNavLink();this.helperShownInControl=!1;let t=this.renderField(),n=this.field?.description&&!this.helperShownInControl?N(this.field.description,this.state,this.data):void 0,r=this.fieldErrors(),i=r.length>0&&!this.controlOwnsValidity;return T`<div style="display: block;">
-            <div style="${e===v?``:`display: flex; gap: var(--lumo-space-xs);`}"><div style="flex: 1; min-width: 0;">${t}</div>${e}</div>
-            ${n?T`
+        ><vaadin-icon icon="${r}" style="width: var(--lumo-icon-size-s); height: var(--lumo-icon-size-s);"></vaadin-icon></a>`}positionNavLink(){let e=this.renderRoot?.querySelector(`a[data-navlink]`);e&&setTimeout(()=>{let t=e.parentElement,n=t?.firstElementChild?.firstElementChild;if(!t||!n)return;let r=(n.shadowRoot?.querySelector(`[part="input-field"]`)??n).getBoundingClientRect();if(r.height===0)return;let i=Math.max(0,r.top+r.height/2-e.offsetHeight/2-t.getBoundingClientRect().top),a=`${Math.round(i)}px`;this.navLinkOffset!==a&&(this.navLinkOffset=a)})}helperText(){return this.helperShownInControl=!0,M(this.field?.description??``,this.state,this.data)??``}fieldErrors(){let e=this.field?.fieldId??``,t=this.data?.errors?.[e];return Array.isArray(t)?t.filter(e=>!!e):[]}validatableControl(){let e=this.renderRoot.querySelectorAll(`*`);for(let t of e)if(`invalid`in t&&`errorMessage`in t)return t;return null}applyValidationState(){let e=this.fieldErrors(),t=this.validatableControl();if(!t){this.lastAnnouncedError=e.join(`. `);return}let n=e.join(`. `);if(t.errorMessage=n,t.invalid=e.length>0,n&&n!==this.lastAnnouncedError){let e=(this.field?.label??``).toString().trim();Qe(e?`${e}: ${n}`:n,{politeness:`assertive`})}this.lastAnnouncedError=n}render(){this.rendered=!0;let e=this.renderNavLink();this.helperShownInControl=!1;let t=this.renderField(),n=this.field?.description&&!this.helperShownInControl?M(this.field.description,this.state,this.data):void 0,r=this.fieldErrors(),i=r.length>0&&!this.controlOwnsValidity;return w`<div style="display: block;">
+            <div style="${e===_?``:`display: flex; gap: var(--lumo-space-xs);`}"><div style="flex: 1; min-width: 0;">${t}</div>${e}</div>
+            ${n?w`
                 <div style="font-size: var(--lumo-font-size-xs); color: var(--lumo-secondary-text-color); margin-top: var(--lumo-space-xs);">${n}</div>
-            `:v}
-            ${i?T`
-                <div role="alert"><ul>${r.map(e=>T`<li>${e}</li>`)}</ul></div>
-            `:v}
-        </div>`}async firstUpdated(){this.filteredIcons=Qc}update(e){e.has(`component`)&&(this.rendered=!1),super.update(e)}updated(e){super.updated(e),this.positionNavLink(),this.applyValidationState(),this.controlOwnsValidity=!!this.validatableControl()}renderField(){let e=this.field?.fieldId??``,t=this.state&&e in this.state?this.state[e]:this.field?.initialValue,n=M(this.field?.label+``,this.state,this.data),r=this.labelAlreadyRendered||!n||n==`null`?v:n;return this.field?.propertyRow?this.renderPropertyRowField(e,t,r,n):this.field?.stereotype==`badge`?this.renderBadgeField(e,t,r,n):this.field?.stereotype==`plainText`?this.renderPlainTextField(e,t,r,n):this.field?.stereotype==`bulletedList`?this.renderBulletedListField(e,t,r,n):this.field?.readOnly&&this.field.stereotype!=`grid`&&this.field.dataType!=`status`&&this.field?.dataType!=`money`?this.renderReadOnlyField(e,t,r,n):this.field?.dataType==`file`?this.renderFileField(e,t,r,n):this.field?.dataType==`string`?this.renderStringField(e,t,r,n):this.field?.dataType==`number`?this.renderNumberField(e,t,r,n):this.field?.dataType==`integer`?this.renderIntegerField(e,t,r,n):this.field?.dataType==`bool`?this.renderBoolField(e,t,r,n):this.field?.dataType==`dateRange`?this.renderDateRangeField(e,t,r,n):this.field?.dataType==`date`?this.renderDateField(e,t,r,n):this.field?.dataType==`dateTime`?this.renderDateTimeField(e,t,r,n):this.field?.dataType==`time`?this.renderTimeField(e,t,r,n):this.field?.dataType==`array`?this.renderArrayField(e,t,r,n):this.field?.dataType==`money`?this.renderMoneyField(e,t,r,n):this.field?.dataType==`status`?this.renderStatusField(e,t,r,n):this.field?.dataType==`range`?this.renderRangeField(e,t,r,n):T`<p>Unknown field type ${this.field?.dataType} / ${this.field?.stereotype}</p>`}renderBadgeField(e,t,n,r){if(!this.field)return T``;let i=t===!0||t===`true`;return T`<vaadin-custom-field
+            `:_}
+            ${i?w`
+                <div role="alert"><ul>${r.map(e=>w`<li>${e}</li>`)}</ul></div>
+            `:_}
+        </div>`}async firstUpdated(){this.filteredIcons=_l}update(e){e.has(`component`)&&(this.rendered=!1),super.update(e)}updated(e){super.updated(e),this.positionNavLink(),this.applyValidationState(),this.controlOwnsValidity=!!this.validatableControl()}renderField(){let e=this.field?.fieldId??``,t=this.state&&e in this.state?this.state[e]:this.field?.initialValue,n=j(this.field?.label+``,this.state,this.data),r=this.labelAlreadyRendered||!n||n==`null`?_:n;return this.field?.propertyRow?this.renderPropertyRowField(e,t,r,n):this.field?.stereotype==`badge`?this.renderBadgeField(e,t,r,n):this.field?.stereotype==`plainText`?this.renderPlainTextField(e,t,r,n):this.field?.stereotype==`bulletedList`?this.renderBulletedListField(e,t,r,n):this.field?.readOnly&&this.field.stereotype!=`grid`&&this.field.dataType!=`status`&&this.field?.dataType!=`money`?this.renderReadOnlyField(e,t,r,n):this.field?.dataType==`file`?this.renderFileField(e,t,r,n):this.field?.dataType==`string`?this.renderStringField(e,t,r,n):this.field?.dataType==`number`?this.renderNumberField(e,t,r,n):this.field?.dataType==`integer`?this.renderIntegerField(e,t,r,n):this.field?.dataType==`bool`?this.renderBoolField(e,t,r,n):this.field?.dataType==`dateRange`?this.renderDateRangeField(e,t,r,n):this.field?.dataType==`date`?this.renderDateField(e,t,r,n):this.field?.dataType==`dateTime`?this.renderDateTimeField(e,t,r,n):this.field?.dataType==`time`?this.renderTimeField(e,t,r,n):this.field?.dataType==`array`?this.renderArrayField(e,t,r,n):this.field?.dataType==`money`?this.renderMoneyField(e,t,r,n):this.field?.dataType==`status`?this.renderStatusField(e,t,r,n):this.field?.dataType==`range`?this.renderRangeField(e,t,r,n):w`<p>Unknown field type ${this.field?.dataType} / ${this.field?.stereotype}</p>`}renderBadgeField(e,t,n,r){if(!this.field)return w``;let i=t===!0||t===`true`;return w`<vaadin-custom-field
                     id="${this.field.fieldId}"
                     .helperText="${this.helperText()}"
                     data-colspan="${this.field?.colspan}"
                     style="${this.field?.style}"
             ><span theme="badge ${i?`success`:``} pill" style="${i?``:`opacity: 0.4;`}">${r}</span>
-            </vaadin-custom-field>`}renderPropertyRowField(e,t,n,r){if(!this.field)return T``;let i=N(t,this.state,this.data),a=i&&typeof i==`object`&&`value`in i?i:null;i&&i.value&&(i=i.value);let o=this.field?.dataType==`bool`||i===!0||i===!1,s=this.field?.dataType==`money`,c=i!=null&&i!==``,l=c?String(i):`—`;if(s&&c){let e=typeof i==`number`?i:parseFloat(String(i));isNaN(e)||(l=a&&a.locale&&a.currency?new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(e):new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e))}let u=o?T`<vaadin-icon icon="${i===!0||i===`true`?`vaadin:check`:`vaadin:minus`}" style="height: 16px; width: 16px;"></vaadin-icon>`:T`<span style="font-weight: 500; text-align: right; word-break: break-word; margin-left: auto;${s?` font-variant-numeric: tabular-nums;`:``}">${l}</span>`,d=r&&r!=`null`;return T`<div
+            </vaadin-custom-field>`}renderPropertyRowField(e,t,n,r){if(!this.field)return w``;let i=M(t,this.state,this.data),a=i&&typeof i==`object`&&`value`in i?i:null;i&&i.value&&(i=i.value);let o=this.field?.dataType==`bool`||i===!0||i===!1,s=this.field?.dataType==`money`,c=i!=null&&i!==``,l=c?String(i):`—`;if(s&&c){let e=typeof i==`number`?i:parseFloat(String(i));isNaN(e)||(l=a&&a.locale&&a.currency?new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(e):new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e))}let u=o?w`<vaadin-icon icon="${i===!0||i===`true`?`vaadin:check`:`vaadin:minus`}" style="height: 16px; width: 16px;"></vaadin-icon>`:w`<span style="font-weight: 500; text-align: right; word-break: break-word; margin-left: auto;${s?` font-variant-numeric: tabular-nums;`:``}">${l}</span>`,d=r&&r!=`null`;return w`<div
                     id="${this.field.fieldId}"
                     data-colspan="${this.field?.colspan}"
                     style="display: flex; justify-content: space-between; align-items: baseline; gap: 1rem; width: 100%; padding: 0.4rem 0; border-bottom: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.08)); font-size: var(--lumo-font-size-s, .875rem); ${this.field?.style}"
-            >${d?T`<span style="color: var(--lumo-secondary-text-color, #888); white-space: nowrap;">${r}</span>`:v}${u}</div>`}renderBulletedListField(e,t,n,r){if(!this.field)return T``;let i=N(t,this.state,this.data),a=Array.isArray(i)?i.map(e=>String(e)):i!=null&&i!==``?[String(i)]:[];return T`<vaadin-custom-field
+            >${d?w`<span style="color: var(--lumo-secondary-text-color, #888); white-space: nowrap;">${r}</span>`:_}${u}</div>`}renderBulletedListField(e,t,n,r){if(!this.field)return w``;let i=M(t,this.state,this.data),a=Array.isArray(i)?i.map(e=>String(e)):i!=null&&i!==``?[String(i)]:[];return w`<vaadin-custom-field
                     id="${this.field.fieldId}"
                     label="${n}"
                     .helperText="${this.helperText()}"
                     data-colspan="${this.field?.colspan}"
                     style="${this.field?.style}"
             ><mateu-bulleted-list .items="${a}"></mateu-bulleted-list>
-            </vaadin-custom-field>`}renderPlainTextField(e,t,n,r){if(!this.field)return T``;let i=N(t,this.state,this.data),a=i&&typeof i==`object`&&`value`in i?i:null;i&&i.value&&(i=i.value);let o=this.field?.dataType==`bool`||i===!0||i===!1,s=this.field?.dataType==`money`,c=i!=null&&i!==``,l=c?String(i):`—`;if(s&&c){let e=typeof i==`number`?i:parseFloat(String(i));isNaN(e)||(l=a&&a.locale&&a.currency?new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(e):new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e))}let u=o?T`<vaadin-icon icon="${i===!0||i===`true`?`vaadin:check`:`vaadin:minus`}" style="height: 16px; width: 16px;"></vaadin-icon>`:this.field?.multiline?T`<span style="font-weight: 500; white-space: pre-wrap; word-break: break-word;">${l}</span>`:T`<span style="font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;${s?` font-variant-numeric: tabular-nums;`:``}">${l}</span>`;return T`<vaadin-custom-field
+            </vaadin-custom-field>`}renderPlainTextField(e,t,n,r){if(!this.field)return w``;let i=M(t,this.state,this.data),a=i&&typeof i==`object`&&`value`in i?i:null;i&&i.value&&(i=i.value);let o=this.field?.dataType==`bool`||i===!0||i===!1,s=this.field?.dataType==`money`,c=i!=null&&i!==``,l=c?String(i):`—`;if(s&&c){let e=typeof i==`number`?i:parseFloat(String(i));isNaN(e)||(l=a&&a.locale&&a.currency?new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(e):new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e))}let u=o?w`<vaadin-icon icon="${i===!0||i===`true`?`vaadin:check`:`vaadin:minus`}" style="height: 16px; width: 16px;"></vaadin-icon>`:this.field?.multiline?w`<span style="font-weight: 500; white-space: pre-wrap; word-break: break-word;">${l}</span>`:w`<span style="font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;${s?` font-variant-numeric: tabular-nums;`:``}">${l}</span>`;return w`<vaadin-custom-field
                     id="${this.field.fieldId}"
                     label="${n}"
                     data-colspan="${this.field?.colspan}"
                     style="${s?`text-align: right; `:``}${this.field?.style}"
-            >${u}</vaadin-custom-field>`}renderReadOnlyField(e,t,n,r){if(!this.field)return T``;let i=N(t,this.state,this.data)||this.data[e];if(i&&i.value&&(i=i.value),this.field.stereotype==`fileUpload`)return T`<vaadin-custom-field
+            >${u}</vaadin-custom-field>`}renderReadOnlyField(e,t,n,r){if(!this.field)return w``;let i=M(t,this.state,this.data)||this.data[e];if(i&&i.value&&(i=i.value),this.field.stereotype==`fileUpload`)return w`<vaadin-custom-field
                         id="${this.field.fieldId}"
                         label="${n}"
                         .helperText="${this.helperText()}"
                         data-colspan="${this.field.colspan}"
                 ><mateu-file-upload .fieldId="${this.field.fieldId}" .value="${i}" .editable="${!1}"></mateu-file-upload>
-                </vaadin-custom-field>`;if(this.field.stereotype==`image`||this.field.stereotype==`uploadableImage`||this.field.stereotype==`signature`||this.field.stereotype==`camera`)return T`<vaadin-custom-field
+                </vaadin-custom-field>`;if(this.field.stereotype==`image`||this.field.stereotype==`uploadableImage`||this.field.stereotype==`signature`||this.field.stereotype==`camera`)return w`<vaadin-custom-field
                         id="${this.field.fieldId}"
                         label="${n}"
-                        required="${this.field.required||v}"
+                        required="${this.field.required||_}"
                         .helperText="${this.helperText()}"
                         data-colspan="${this.field.colspan}"
                 ><img src="${i}" id="${this.field.fieldId}_img" style="${this.field.style}">
-                </vaadin-custom-field>`;if(this.field.dataType==`bool`)return T`<vaadin-custom-field
+                </vaadin-custom-field>`;if(this.field.dataType==`bool`)return w`<vaadin-custom-field
                         id="${this.field.fieldId}"
                         label="${n}"
-                        required="${this.field.required||v}"
+                        required="${this.field.required||_}"
                         .helperText="${this.helperText()}"
                         data-colspan="${this.field.colspan}"
                 ><vaadin-icon icon="${i?`vaadin:check`:`vaadin:minus`}" style="height: 20px;"></vaadin-icon>
-                </vaadin-custom-field>`;let a=i==null?``:String(i);return T`
+                </vaadin-custom-field>`;let a=i==null?``:String(i);return w`
                 <vaadin-text-field
                         id="${this.field.fieldId}"
                         label="${n}"
@@ -9140,14 +9140,14 @@ ${i}
                         style="${this.field.style}"
                         .helperText="${this.helperText()}"
                         data-colspan="${this.field.colspan}"
-                >${a.length>15?T`<vaadin-icon
+                >${a.length>15?w`<vaadin-icon
                         slot="suffix"
                         icon="vaadin:copy"
                         title="Copiar"
                         style="cursor: pointer; color: var(--lumo-secondary-text-color);"
                         @click="${()=>this.copyValue(a)}"
-                ></vaadin-icon>`:v}</vaadin-text-field>
-`}copyValue(e){navigator.clipboard.writeText(e).then(()=>r.show(`Copied`,{position:`bottom-end`,theme:`success`,duration:2e3})).catch(()=>{})}renderFileField(e,t,n,r){if(!this.field)return T``;let i=t?.map(e=>({id:e.id,name:e.name,type:``,uploadTarget:``,complete:!0}))??[];return T`
+                ></vaadin-icon>`:_}</vaadin-text-field>
+`}copyValue(e){navigator.clipboard.writeText(e).then(()=>r.show(`Copied`,{position:`bottom-end`,theme:`success`,duration:2e3})).catch(()=>{})}renderFileField(e,t,n,r){if(!this.field)return w``;let i=t?.map(e=>({id:e.id,name:e.name,type:``,uploadTarget:``,complete:!0}))??[];return w`
                 <vaadin-custom-field
                         label="${n}"
                         .helperText="${this.helperText()}"
@@ -9160,11 +9160,11 @@ ${i}
                             @files-changed="${this.fileChanged}"
                     ></vaadin-upload>
                 </vaadin-custom-field>
-            `}renderStringField(e,t,n,r){if(!this.field)return T``;if(this.field?.stereotype==`searchable`)return T`
+            `}renderStringField(e,t,n,r){if(!this.field)return w``;if(this.field?.stereotype==`searchable`)return w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
-                            required="${this.field.required||v}"
+                            required="${this.field.required||_}"
                             .helperText="${this.helperText()}"
                             data-colspan="${this.field.colspan}"
                     >
@@ -9174,7 +9174,21 @@ ${i}
                             <vaadin-button theme="icon" @click="${e=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`codesearch-`+this.field?.fieldId,parameters:{}},bubbles:!0,composed:!0}))}}"><vaadin-icon icon="lumo:search"></vaadin-icon></vaadin-button>
                         </vaadin-horizontal-layout>
                     </vaadin-custom-field>
-                `;if(this.field?.stereotype==`select`){if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates;this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements||this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}));let r=t;return t&&t.value&&(r=t.value),T`
+                `;if(this.field?.stereotype==`select`){if(this.field?.optionsSource){let e=this.field.optionsSource,r=j(e.url,this.state,this.data)??e.url;this.data[this.id]?.sourceSignature!==r&&(this.data[this.id]={content:this.data[this.id]?.content??[],sourceSignature:r},jc(e,e=>j(e,this.state,this.data)).then(e=>{this.data[this.id]={content:e,totalElements:e.length,sourceSignature:r},this.requestUpdate()}).catch(e=>console.warn(`mateu: external options fetch failed`,e)));let i=t;return t&&t.value&&(i=t.value),w`
+                    <vaadin-select
+                            id="${this.field.fieldId}"
+                            label="${n}"
+                            item-label-path="label"
+                            item-value-path="value"
+                            .items="${this.data[this.id]?.content??[]}"
+                            .helperText="${this.helperText()}"
+                            @value-changed="${this.valueChanged}"
+                            .value="${i}"
+                            ?autofocus="${this.field.wantsFocus}"
+                            required="${this.field.required||_}"
+                            data-colspan="${this.field.colspan}"
+                    ></vaadin-select>
+                    `}if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates;this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements||this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}));let r=t;return t&&t.value&&(r=t.value),w`
                     <vaadin-select
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9185,10 +9199,10 @@ ${i}
                             @value-changed="${this.valueChanged}"
                             .value="${r}"
                             ?autofocus="${this.field.wantsFocus}"
-                            required="${this.field.required||v}"
+                            required="${this.field.required||_}"
                             data-colspan="${this.field.colspan}"
                     ></vaadin-select>
-                    `}let e=t;return t&&t.value&&(e=t.value),T`
+                    `}let e=t;return t&&t.value&&(e=t.value),w`
                     <vaadin-select
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9199,21 +9213,21 @@ ${i}
                             @value-changed="${this.valueChanged}"
                             .value="${e}"
                             ?autofocus="${this.field.wantsFocus}"
-                            required="${this.field.required||v}"
+                            required="${this.field.required||_}"
                             data-colspan="${this.field.colspan}"
                     ></vaadin-select>
-                `}if(this.field?.stereotype==`markdown`)return T`
+                `}if(this.field?.stereotype==`markdown`)return w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
-                            required="${this.field.required||v}"
+                            required="${this.field.required||_}"
                             .helperText="${this.helperText()}"
                             data-colspan="${this.field.colspan}"
                     ><vaadin-markdown
                             .content="${t}"
                     ></vaadin-markdown>
                     </vaadin-custom-field>
-                `;if(this.field?.stereotype==`combobox`){if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates,r;this.data[this.id]&&this.data[this.id].content&&(r=this.data[this.id].content.find(e=>e.value==t)),!r&&this.comboData&&(r=this.comboData.find(e=>e.value==t)),!r&&t&&(r={value:t,label:this.data[this.id+`-label`]??t});let i=this.remoteComboDataProvider(e.action);return T`
+                `;if(this.field?.stereotype==`combobox`){if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates,r;this.data[this.id]&&this.data[this.id].content&&(r=this.data[this.id].content.find(e=>e.value==t)),!r&&this.comboData&&(r=this.comboData.find(e=>e.value==t)),!r&&t&&(r={value:t,label:this.data[this.id+`-label`]??t});let i=this.remoteComboDataProvider(e.action);return w`
                     <vaadin-combo-box
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9224,13 +9238,13 @@ ${i}
                             .helperText="${this.helperText()}"
                             @value-changed="${this.valueChanged}"
                             ?autofocus="${this.field.wantsFocus}"
-                            ?required="${this.field.required||v}"
+                            ?required="${this.field.required||_}"
                             data-colspan="${this.field.colspan}"
                             style="${this.field.style}"
                             @keyup="${e=>{if(e.key==`Backspace`){let t=e.currentTarget;t.inputElement.value||(t.value=``)}}}"
                             ${u(this.comboRenderer,[])}
                     ></vaadin-combo-box>
-                    `}return T`
+                    `}return w`
                     <vaadin-combo-box
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9241,12 +9255,12 @@ ${i}
                             @value-changed="${this.valueChanged}"
                             .value="${t}"
                             ?autofocus="${this.field.wantsFocus}"
-                            required="${this.field.required||v}"
+                            required="${this.field.required||_}"
                             data-colspan="${this.field.colspan}"
                             style="${this.field.style}"
                             ${u(this.comboRenderer,[])}
                     ></vaadin-combo-box>
-                    `}if(this.field?.stereotype==`listBox`){if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates;return this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements||this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0})),T`
+                    `}if(this.field?.stereotype==`listBox`){if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates;return this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements||this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0})),w`
                         <vaadin-custom-field
                                 label="${n}"
                                 .helperText="${this.helperText()}"
@@ -9254,19 +9268,19 @@ ${i}
                         >
                     <vaadin-list-box
                             id="${this.field.fieldId}"
-                            selected="${S(this.selectedIndex(t))}"
+                            selected="${x(this.selectedIndex(t))}"
                             @selected-changed="${this.listItemSelected}"
                             ?autofocus="${this.field.wantsFocus}"
                     >
-                        ${this.data[this.id]?.content?.map(e=>T`
-                            <vaadin-item>${e.description||e.image||e.icon?T`
+                        ${this.data[this.id]?.content?.map(e=>w`
+                            <vaadin-item>${e.description||e.image||e.icon?w`
                                 <vaadin-horizontal-layout style="align-items: center;" theme="spacing">
-                                    ${e.icon?T`
+                                    ${e.icon?w`
                                         <vaadin-icon icon="${e.icon}"></vaadin-icon>
-                                    `:v}
-                                    ${e.image?T`
+                                    `:_}
+                                    ${e.image?w`
                                             <img src="${e.image}" alt="${e.label}" style="width: 2rem;" />
-                                        `:v}
+                                        `:_}
                                     <vaadin-vertical-layout>
                                         <span> ${e.label} </span>
                                         <span
@@ -9280,7 +9294,7 @@ ${i}
                         `)}
                     </vaadin-list-box>
                         </vaadin-custom-field>
-                    `}return T`
+                    `}return w`
                     <vaadin-custom-field
                             label="${n}"
                             .helperText="${this.helperText()}"
@@ -9288,19 +9302,19 @@ ${i}
                     >
                     <vaadin-list-box
                             id="${this.field.fieldId}"
-                            selected="${S(this.selectedIndex(t))}"
+                            selected="${x(this.selectedIndex(t))}"
                             @selected-changed="${this.listItemSelected}"
                             ?autofocus="${this.field.wantsFocus}"
                     >
-                        ${this.field.options?.map(e=>T`
-                            <vaadin-item>${e.description||e.image||e.icon?T`
+                        ${this.field.options?.map(e=>w`
+                            <vaadin-item>${e.description||e.image||e.icon?w`
                                 <vaadin-horizontal-layout style="align-items: center;" theme="spacing">
-                                    ${e.icon?T`
+                                    ${e.icon?w`
                                         <vaadin-icon icon="${e.icon}"></vaadin-icon>
-                                    `:v}
-                                    ${e.image?T`
+                                    `:_}
+                                    ${e.image?w`
                                             <img src="${e.image}" alt="${e.label}" style="width: 2rem;" />
-                                        `:v}
+                                        `:_}
                                     <vaadin-vertical-layout>
                                         <span> ${e.label} </span>
                                         <span
@@ -9314,7 +9328,7 @@ ${i}
                         `)}
                     </vaadin-list-box>
                     </vaadin-custom-field>
-                `}if(this.field?.stereotype==`radio`){if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates;return this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements||this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0})),T`
+                `}if(this.field?.stereotype==`radio`){if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates;return this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements||this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0})),w`
                     <vaadin-radio-group
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9323,31 +9337,31 @@ ${i}
                             .helperText="${this.helperText()}"
                             theme="horizontal"
                             ?autofocus="${this.field.wantsFocus}"
-                            required="${this.field.required||v}"
+                            required="${this.field.required||_}"
                             data-colspan="${this.field.colspan}"
                     >
-                        ${this.data[this.id]?.content?.map(e=>T`
+                        ${this.data[this.id]?.content?.map(e=>w`
                             <vaadin-radio-button value="${e.value}" label="${e.label}" ?checked="${e&&t&&e.value===t}">
-                                ${e.description||e.image||e.icon?T`
+                                ${e.description||e.image||e.icon?w`
                                     <label slot="label">
                                         <vaadin-horizontal-layout theme="spacing">
-                                            ${e.icon?T`
+                                            ${e.icon?w`
                                                 <vaadin-icon icon="${e.icon}"></vaadin-icon>
-                                            `:v}
-                                            ${e.image?T`
+                                            `:_}
+                                            ${e.image?w`
                                                 <img src="${e.image}" alt="${e.label}" style="height: 1rem;" />
-                                            `:v}
+                                            `:_}
                                             <span>${e.label}</span>
                                         </vaadin-horizontal-layout>
-                                        ${e.description?T`
+                                        ${e.description?w`
                                             <div>${e.description}</div>
-                                        `:v}
+                                        `:_}
                                     </label>
-                                `:v}
+                                `:_}
                             </vaadin-radio-button>
                         `)}
 </vaadin-radio-group>
-                    `}return T`
+                    `}return w`
                     <vaadin-radio-group
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9355,34 +9369,34 @@ ${i}
                             .value="${t}"
                             .helperText="${this.helperText()}"
                             ?autofocus="${this.field.wantsFocus}"
-                            required="${this.field.required||v}"
+                            required="${this.field.required||_}"
                             data-colspan="${this.field.colspan}"
                     >
-                        ${this.field.options?.map(e=>T`
+                        ${this.field.options?.map(e=>w`
                             <vaadin-radio-button value="${e.value}" label="${e.label}">
-                                ${e.description||e.image||e.icon?T`
+                                ${e.description||e.image||e.icon?w`
                                     <label slot="label">
                                         <vaadin-horizontal-layout theme="spacing">
-                                            ${e.icon?T`
+                                            ${e.icon?w`
                                                 <vaadin-icon icon="${e.icon}"></vaadin-icon>
-                                            `:v}
-                                            ${e.image?T`
+                                            `:_}
+                                            ${e.image?w`
                                                 <img src="${e.image}" alt="${e.label}" style="height: 1rem;" />
-                                            `:v}
+                                            `:_}
                                             <span>${e.label}</span>
                                         </vaadin-horizontal-layout>
-                                        ${e.description?T`
+                                        ${e.description?w`
                                             <div>${e.description}</div>
-                                        `:v}
+                                        `:_}
                                     </label>
-                                `:v}
+                                `:_}
                             </vaadin-radio-button>
                         `)}
 </vaadin-radio-group>
-                    `}if(this.field.stereotype==`popover`)return T`<vaadin-custom-field
+                    `}if(this.field.stereotype==`popover`)return w`<vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
-                            required="${this.field.required||v}"
+                            required="${this.field.required||_}"
                             .helperText="${this.helperText()}"
                             data-colspan="${this.field.colspan}"
                     >
@@ -9399,7 +9413,7 @@ ${i}
                             accessible-name-ref="notifications-heading"
                             content-width="300px"
                             position="bottom"
-                            ${ee(()=>T`
+                            ${te(()=>w`
                                 <mateu-event-interceptor .target="${this}">
                                 <mateu-choice
                                         .field="${this.field}"
@@ -9409,12 +9423,12 @@ ${i}
                             `,[])}
                     ></vaadin-popover>
                     </vaadin-custom-field>
-                `;if(this.field?.stereotype==`choice`)return T`
+                `;if(this.field?.stereotype==`choice`)return w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
                             .helperText="${this.helperText()}"
-                            required="${this.field.required||v}"
+                            required="${this.field.required||_}"
                             data-colspan="${this.field.colspan}"
                     >
                         <mateu-choice
@@ -9427,7 +9441,7 @@ ${i}
                         ></mateu-choice>
                         
                     </vaadin-custom-field>
-                    `;if(this.field?.stereotype==`richText`)return T`
+                    `;if(this.field?.stereotype==`richText`)return w`
                     <vaadin-custom-field
                             label="${n}"
                             .helperText="${this.helperText()}"
@@ -9439,7 +9453,7 @@ ${i}
                             @value-changed="${this.valueChanged}"
                             ?autofocus="${this.field.wantsFocus}"
                     ></vaadin-rich-text-editor>
-                    </vaadin-custom-field>`;if(this.field?.stereotype==`textarea`)return T`
+                    </vaadin-custom-field>`;if(this.field?.stereotype==`textarea`)return w`
                     <vaadin-text-area
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9448,11 +9462,11 @@ ${i}
                             .helperText="${this.helperText()}"
                             @value-changed="${this.valueChanged}"
                             ?autofocus="${this.field.wantsFocus}"
-                            required="${this.field.required||v}"
+                            required="${this.field.required||_}"
                             data-colspan="${this.field.colspan}"
                             rows="4"
                             style="width: 100%;"
-                    ></vaadin-text-area>`;if(this.field?.stereotype==`email`)return T`
+                    ></vaadin-text-area>`;if(this.field?.stereotype==`email`)return w`
                     <vaadin-email-field
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9460,19 +9474,19 @@ ${i}
                             value="${t}"
                             .helperText="${this.helperText()}"
                             ?autofocus="${this.field.wantsFocus}"
-                            required="${this.field.required||v}"
+                            required="${this.field.required||_}"
                             data-colspan="${this.field.colspan}"
                     ></vaadin-email-field>
-                `;if(this.field?.stereotype==`link`)return this.field.readOnly?T`<vaadin-custom-field
+                `;if(this.field?.stereotype==`link`)return this.field.readOnly?w`<vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
                             .helperText="${this.helperText()}"
                             data-colspan="${this.field.colspan}"
-                    ><a href="${t}">${t}</a></vaadin-custom-field>`:T`
+                    ><a href="${t}">${t}</a></vaadin-custom-field>`:w`
                             <vaadin-text-field
                                     id="${this.field.fieldId}"
                                     label="${n}"
-                                    required="${this.field.required||v}"
+                                    required="${this.field.required||_}"
                                     @value-changed="${this.valueChanged}"
                                     value="${t}"
                                     .helperText="${this.helperText()}"
@@ -9484,14 +9498,14 @@ ${i}
                                              @click="${()=>window.open(t,`_blank`)?.focus()}"
                                 ></vaadin-icon>
                             </vaadin-text-field>
-                `;if(this.field?.stereotype==`icon`)return this.field.readOnly?T`<vaadin-icon
+                `;if(this.field?.stereotype==`icon`)return this.field.readOnly?w`<vaadin-icon
                                              icon="${t}"
                                              data-colspan="${this.field.colspan}"
-                    ></vaadin-icon>`:T`
+                    ></vaadin-icon>`:w`
                     <vaadin-combo-box
                                     id="${this.field.fieldId}"
                                     label="${n}"
-                                    required="${this.field.required||v}"
+                                    required="${this.field.required||_}"
                                     @value-changed="${this.valueChanged}"
                                     value="${t}"
                                     .helperText="${this.helperText()}"
@@ -9503,9 +9517,9 @@ ${i}
                             @filter-changed="${this.iconFilterChanged}"
                             ${u(this.iconComboboxRenderer,[])}
                     >
-                        ${t?T`<vaadin-icon slot="prefix" icon="${t}"></vaadin-icon>`:v}
+                        ${t?w`<vaadin-icon slot="prefix" icon="${t}"></vaadin-icon>`:_}
                     </vaadin-combo-box>
-                `;if(this.field?.stereotype==`password`)return T`
+                `;if(this.field?.stereotype==`password`)return w`
                     <vaadin-password-field
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9513,17 +9527,17 @@ ${i}
                             value="${t}"
                             .helperText="${this.helperText()}"
                             ?autofocus="${this.field.wantsFocus}"
-                            required="${this.field.required||v}"
+                            required="${this.field.required||_}"
                             data-colspan="${this.field.colspan}"
                     ></vaadin-password-field>
-                `;if(this.field?.stereotype==`html`)return T`
+                `;if(this.field?.stereotype==`html`)return w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
                             .helperText="${this.helperText()}"
                             data-colspan="${this.field.colspan}"
-                    ><div style="line-height: 20px; margin-top: 5px; margin-bottom: 24px;">${_(``+t)}</div></vaadin-custom-field>
-                `;if(this.field?.stereotype==`image`)return T`
+                    ><div style="line-height: 20px; margin-top: 5px; margin-bottom: 24px;">${g(``+t)}</div></vaadin-custom-field>
+                `;if(this.field?.stereotype==`image`)return w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9532,10 +9546,10 @@ ${i}
                     ><img
                             src="${t}"
                             style="${this.component?.style}" class="${this.component?.cssClasses}"></vaadin-custom-field>
-                `;if(this.field?.stereotype==`treeSelect`){let e=this.helperText();return T`
+                `;if(this.field?.stereotype==`treeSelect`){let e=this.helperText();return w`
                     <div class="tree-field" id="${this.field.fieldId}" data-colspan="${this.field.colspan}">
-                        ${n?T`
-                            <span class="tree-field__label">${n}${this.field.required?T`<span class="tree-field__required"> •</span>`:v}</span>`:v}
+                        ${n?w`
+                            <span class="tree-field__label">${n}${this.field.required?w`<span class="tree-field__required"> •</span>`:_}</span>`:_}
                         <mateu-vaadin-tree-select
                                 style="width: 100%;"
                                 .fieldId="${this.field.fieldId}"
@@ -9543,9 +9557,9 @@ ${i}
                                 .options="${this.field.options??[]}"
                                 .leavesOnly="${this.field.treeLeavesOnly??!1}"
                         ></mateu-vaadin-tree-select>
-                        ${e?T`<span class="tree-field__helper">${e}</span>`:v}
+                        ${e?w`<span class="tree-field__helper">${e}</span>`:_}
                     </div>
-                `}if(this.field?.stereotype==`signature`)return T`
+                `}if(this.field?.stereotype==`signature`)return w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9554,7 +9568,7 @@ ${i}
                     >
                         <mateu-signature-pad .fieldId="${this.field.fieldId}" .value="${t}"></mateu-signature-pad>
                     </vaadin-custom-field>
-                `;if(this.field?.stereotype==`camera`)return T`
+                `;if(this.field?.stereotype==`camera`)return w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9563,7 +9577,7 @@ ${i}
                     >
                         <mateu-camera-capture .fieldId="${this.field.fieldId}" .value="${t}"></mateu-camera-capture>
                     </vaadin-custom-field>
-                `;if(this.field?.stereotype==`fileUpload`){let e=dc(this.field.attributes,`accept`);return T`
+                `;if(this.field?.stereotype==`fileUpload`){let e=Dc(this.field.attributes,`accept`);return w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9572,7 +9586,7 @@ ${i}
                     >
                         <mateu-file-upload .fieldId="${this.field.fieldId}" .value="${t}" .accept="${e}"></mateu-file-upload>
                     </vaadin-custom-field>
-                `}if(this.field?.stereotype==`uploadableImage`){let e=t!=null&&t!==``;return T`
+                `}if(this.field?.stereotype==`uploadableImage`){let e=t!=null&&t!==``;return w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9580,10 +9594,10 @@ ${i}
                             data-colspan="${this.field.colspan}"
                     >
                         <vaadin-vertical-layout style="align-items: stretch; gap: var(--lumo-space-s); max-width: 320px;">
-                            ${e?T`<img
+                            ${e?w`<img
                                     src="${t}"
                                     style="max-width: 100%; max-height: 240px; object-fit: contain; border: 1px solid var(--lumo-contrast-20pct); border-radius: var(--lumo-border-radius-m); ${this.field.style??``}"
-                                    class="${this.component?.cssClasses}">`:T`<div style="height: 135px; display: flex; align-items: center; justify-content: center; border: 1px dashed var(--lumo-contrast-30pct); border-radius: var(--lumo-border-radius-m); color: var(--lumo-secondary-text-color);">
+                                    class="${this.component?.cssClasses}">`:w`<div style="height: 135px; display: flex; align-items: center; justify-content: center; border: 1px dashed var(--lumo-contrast-30pct); border-radius: var(--lumo-border-radius-m); color: var(--lumo-secondary-text-color);">
                                     <vaadin-icon icon="vaadin:picture" style="height: 2rem; width: 2rem;"></vaadin-icon>
                                 </div>`}
                             <input type="file" accept="image/*" style="display: none;" @change="${this.imageUpload}">
@@ -9592,21 +9606,21 @@ ${i}
                                     <vaadin-icon icon="vaadin:upload" slot="prefix"></vaadin-icon>
                                     ${e?`Replace`:`Upload`}
                                 </vaadin-button>
-                                ${e?T`<vaadin-button theme="error tertiary" @click="${this.imageDelete}">
+                                ${e?w`<vaadin-button theme="error tertiary" @click="${this.imageDelete}">
                                     <vaadin-icon icon="vaadin:trash" slot="prefix"></vaadin-icon>
                                     Delete
-                                </vaadin-button>`:v}
+                                </vaadin-button>`:_}
                             </vaadin-horizontal-layout>
                         </vaadin-vertical-layout>
                     </vaadin-custom-field>
-                `}return this.field?.stereotype==`color`?this.field.readOnly?T`
+                `}return this.field?.stereotype==`color`?this.field.readOnly?w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
                             .helperText="${this.helperText()}"
                             data-colspan="${this.field.colspan}"
                     ><span style="background-color: ${t}; display: block; height: 20px; width: 40px; margin-top: 5px; margin-bottom: 24px; border: 1px solid var(--lumo-secondary-text-color)"></vaadin-custom-field>
-                `:T`
+                `:w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9627,7 +9641,7 @@ ${i}
   ${s(this.renderColorPicker,[])}
   ${p(this.renderColorPickerFooter,[])}
 ></vaadin-dialog>
-                `:T`
+                `:w`
                 <vaadin-text-field
                         id="${this.field.fieldId}"
                         label="${n}"
@@ -9635,44 +9649,44 @@ ${i}
                         value="${t}"
                         .helperText="${this.helperText()}"
                         ?autofocus="${this.field.wantsFocus}"
-                        ?required="${this.field.required||v}"
+                        ?required="${this.field.required||_}"
                         ?disabled="${this.field.disabled}"
                         data-colspan="${this.field.colspan}"
                         style="${this.field.style}"
                 ></vaadin-text-field>
-`}renderNumberField(e,t,n,r){return this.field?T`<vaadin-number-field
+`}renderNumberField(e,t,n,r){return this.field?w`<vaadin-number-field
                         id="${this.field.fieldId}"
                         label="${n}"
                         @value-changed="${this.valueChanged}"
                         value="${t}"
                         .helperText="${this.helperText()}"
                         ?autofocus="${this.field.wantsFocus}"
-                        ?required="${this.field.required||v}"
+                        ?required="${this.field.required||_}"
                         data-colspan="${this.field.colspan}"
-                        step="${this.field.step||v}"
+                        step="${this.field.step||_}"
                         ?step-buttons-visible="${this.field.stepButtonsVisible}"
-                        min="${this.field.min==null?v:this.field.min}"
-                        max="${this.field.max==null?v:this.field.max}"
-            ></vaadin-number-field>`:T``}renderIntegerField(e,t,n,r){if(!this.field)return T``;if(this.field.stereotype==`stars`){let e=t;return isNaN(e)&&(e=0),T`<vaadin-custom-field
+                        min="${this.field.min==null?_:this.field.min}"
+                        max="${this.field.max==null?_:this.field.max}"
+            ></vaadin-number-field>`:w``}renderIntegerField(e,t,n,r){if(!this.field)return w``;if(this.field.stereotype==`stars`){let e=t;return isNaN(e)&&(e=0),w`<vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
                             .helperText="${this.helperText()}"
                             data-colspan="${this.field.colspan}"
-                    >${[1,2,3,4,5].map(t=>T`
+                    >${[1,2,3,4,5].map(t=>w`
                     <vaadin-icon 
                             icon="vaadin:star" 
                             style="cursor: pointer; color: var(${t<=e?`--lumo-warning-color`:`--lumo-shade-30pct`});"
                             @click="${()=>this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:this.field.fieldId},bubbles:!0,composed:!0}))}"
                     
                     ></vaadin-icon>
-                `)}</vaadin-custom-field>`}if(this.field.stereotype==`slider`){let e=t;return isNaN(e)&&(e=0),T`
+                `)}</vaadin-custom-field>`}if(this.field.stereotype==`slider`){let e=t;return isNaN(e)&&(e=0),w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
                             .helperText="${this.helperText()}"
                             data-colspan="${this.field.colspan}"
                     ><input type="range" @input="${e=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e.target.value,fieldId:this.field.fieldId},bubbles:!0,composed:!0}))}}" min="${this.field.sliderMin??0}" max="${this.field.sliderMax??10}" value="${e??0}"/></vaadin-custom-field>
-                `}return T`
+                `}return w`
                 <vaadin-integer-field
                         id="${this.field.fieldId}"
                         label="${n}"
@@ -9680,18 +9694,18 @@ ${i}
                         value="${t}"
                         .helperText="${this.helperText()}"
                         ?autofocus="${this.field.wantsFocus}"
-                        ?required="${this.field.required||v}"
+                        ?required="${this.field.required||_}"
                         data-colspan="${this.field.colspan}"
-                        step="${this.field.step||v}"
+                        step="${this.field.step||_}"
                         ?step-buttons-visible="${this.field.stepButtonsVisible}"
-                        min="${this.field.min==null?v:this.field.min}"
-                        max="${this.field.max==null?v:this.field.max}"
+                        min="${this.field.min==null?_:this.field.min}"
+                        max="${this.field.max==null?_:this.field.max}"
                 ></vaadin-integer-field>
-            `}renderBoolField(e,t,n,r){return this.field?this.field.stereotype==`toggle`?T`
+            `}renderBoolField(e,t,n,r){return this.field?this.field.stereotype==`toggle`?w`
                     <vaadin-custom-field
                             label="${n}"
                             .helperText="${this.helperText()}"
-                            ?required="${this.field.required||v}"
+                            ?required="${this.field.required||_}"
                             data-colspan="${this.field.colspan}"
                     >
                         <paper-toggle-button id="${this.field.fieldId}"
@@ -9700,60 +9714,60 @@ ${i}
                                              @change=${this.checked}>
                         </paper-toggle-button>
                     </vaadin-custom-field>
-                `:T`
+                `:w`
                 <vaadin-checkbox
                         id="${this.field.fieldId}"
                         label="${n}"
                         .helperText="${this.helperText()}"
-                        ?required="${this.field.required||v}"
+                        ?required="${this.field.required||_}"
                         data-colspan="${this.field.colspan}"
                         @change="${this.checked}"
                         value="${t}"
                         ?checked=${t}
                         ?autofocus="${this.field.wantsFocus}"
                 ></vaadin-checkbox>
-            `:T``}renderDateRangeField(e,t,n,r){if(!this.field)return T``;let i=t?t.from+`;`+t.to:void 0;return T`<vcf-date-range-picker
+            `:w``}renderDateRangeField(e,t,n,r){if(!this.field)return w``;let i=t?t.from+`;`+t.to:void 0;return w`<vcf-date-range-picker
                     id="${this.field.fieldId}"
                     label="${n}"
                     @value-changed="${e=>{e.detail.value&&(e.detail.value={from:e.detail.value.split(`;`)[0],to:e.detail.value.split(`;`)[1]}),this.valueChanged(e)}}"
                     value="${i}"
                     .helperText="${this.helperText()}"
                     ?autofocus="${this.field.wantsFocus}"
-                    ?required="${this.field.required||v}"
+                    ?required="${this.field.required||_}"
                     data-colspan="${this.field.colspan}"
-            ></vcf-date-range-picker>`}renderDateField(e,t,n,r){return this.field?T`<vaadin-date-picker
+            ></vcf-date-range-picker>`}renderDateField(e,t,n,r){return this.field?w`<vaadin-date-picker
                         id="${this.field.fieldId}"
                         label="${n}"
                         @value-changed="${this.valueChanged}"
                         value="${t}"
                         .helperText="${this.helperText()}"
                         ?autofocus="${this.field.wantsFocus}"
-                        ?required="${this.field.required||v}"
+                        ?required="${this.field.required||_}"
                         data-colspan="${this.field.colspan}"
-            ></vaadin-date-picker>`:T``}renderDateTimeField(e,t,n,r){return this.field?T`<vaadin-date-time-picker
+            ></vaadin-date-picker>`:w``}renderDateTimeField(e,t,n,r){return this.field?w`<vaadin-date-time-picker
                         id="${this.field.fieldId}"
                         label="${n}"
                         @value-changed="${this.valueChanged}"
                         value="${t}"
                         .helperText="${this.helperText()}"
                         ?autofocus="${this.field.wantsFocus}"
-                        ?required="${this.field.required||v}"
+                        ?required="${this.field.required||_}"
                         data-colspan="${this.field.colspan}"
-            ></vaadin-date-time-picker>`:T``}renderTimeField(e,t,n,r){return this.field?T`<vaadin-time-picker
+            ></vaadin-date-time-picker>`:w``}renderTimeField(e,t,n,r){return this.field?w`<vaadin-time-picker
                         id="${this.field.fieldId}"
                         label="${n}"
                         @value-changed="${this.valueChanged}"
                         value="${t}"
                         .helperText="${this.helperText()}"
                         ?autofocus="${this.field.wantsFocus}"
-                        ?required="${this.field.required||v}"
+                        ?required="${this.field.required||_}"
                         data-colspan="${this.field.colspan}"
-            ></vaadin-time-picker>`:T``}renderArrayField(e,t,n,r){if(!this.field)return T``;if(this.field?.stereotype==`choice`)return T`
+            ></vaadin-time-picker>`:w``}renderArrayField(e,t,n,r){if(!this.field)return w``;if(this.field?.stereotype==`choice`)return w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
                             .helperText="${this.helperText()}"
-                            required="${this.field.required||v}"
+                            required="${this.field.required||_}"
                             data-colspan="${this.field.colspan}"
                     >
                         <mateu-choice
@@ -9766,7 +9780,7 @@ ${i}
                         ></mateu-choice>
                         
                     </vaadin-custom-field>
-                    `;if(this.field?.stereotype==`grid`)return T`
+                    `;if(this.field?.stereotype==`grid`)return w`
                     <vaadin-custom-field
                             label="${n}"
                             .helperText="${this.helperText()}"
@@ -9783,24 +9797,24 @@ ${i}
                             data-colspan="${this.field.colspan}"
                     ></mateu-grid>
                     </vaadin-custom-field>
-`;if(this.field?.stereotype==`listBox`){if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates;return this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements||this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0})),T`
+`;if(this.field?.stereotype==`listBox`){if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates;return this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements||this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0})),w`
                         <vaadin-custom-field
                                 label="${n}"
                                 .helperText="${this.helperText()}"
                                 data-colspan="${this.field.colspan}"
                         >
                     <vaadin-list-box multiple
-                                     .selectedValues="${S(this.selectedIndexes(t))}"
+                                     .selectedValues="${x(this.selectedIndexes(t))}"
                                      @selected-values-changed="${this.listItemsSelected}"
                             id="${this.field.fieldId}"
                             ?autofocus="${this.field.wantsFocus}"
                     >
-                        ${this.data[this.id]?.content?.map(e=>T`
+                        ${this.data[this.id]?.content?.map(e=>w`
                             <vaadin-item>${e.label}</vaadin-item>
                         `)}
                     </vaadin-list-box>
                         </vaadin-custom-field>
-                    `}return T`
+                    `}return w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9808,17 +9822,17 @@ ${i}
                             data-colspan="${this.field.colspan}"
                     >
                     <vaadin-list-box multiple
-                                     .selectedValues="${S(this.selectedIndexes(t))}"
+                                     .selectedValues="${x(this.selectedIndexes(t))}"
                                      @selected-values-changed="${this.listItemsSelected}"
                                      ?autofocus="${this.field.wantsFocus}"
                                      data-colspan="${this.field.colspan}"
                     >
-                        ${this.field.options?.map(e=>T`
+                        ${this.field.options?.map(e=>w`
                             <vaadin-item>${e.label}</vaadin-item>
                         `)}
                     </vaadin-list-box>
                     </vaadin-custom-field>
-                `}if(this.field?.stereotype==`combobox`){if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates;return T`
+                `}if(this.field?.stereotype==`combobox`){if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates;return w`
                         <vaadin-multi-select-combo-box
                             label="${n}"
                             item-label-path="label"
@@ -9828,7 +9842,7 @@ ${i}
                             .helperText="${this.helperText()}"
                             .selectedItems="${this.selectedItems(t)}"
                             ?autofocus="${this.field.wantsFocus}"
-                            ?required="${this.field.required||v}"
+                            ?required="${this.field.required||_}"
                             @selected-items-changed="${this.multiComboBoxValueChanged}"
                             data-colspan="${this.field.colspan}"
                             style="${this.field.style}"
@@ -9836,7 +9850,7 @@ ${i}
                             auto-expand-vertically
                             xselected-items-on-top
                     ></vaadin-multi-select-combo-box>
-                    `}return T`
+                    `}return w`
                     <vaadin-multi-select-combo-box
                             label="${n}"
                             item-label-path="label"
@@ -9845,7 +9859,7 @@ ${i}
                             .helperText="${this.helperText()}"
                             .selectedItems="${this.selectedItems(t)}"
                             ?autofocus="${this.field.wantsFocus}"
-                            ?required="${this.field.required||v}"
+                            ?required="${this.field.required||_}"
                             @selected-items-changed="${this.multiComboBoxValueChanged}"
                             data-colspan="${this.field.colspan}"
                             style="${this.field.style}"
@@ -9853,7 +9867,7 @@ ${i}
                             auto-expand-vertically
                             xselected-items-on-top
                     ></vaadin-multi-select-combo-box>
-                    `}if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates;return this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements||this.rendered||setTimeout(()=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}),T`
+                    `}if(this.field?.remoteCoordinates){let e=this.field.remoteCoordinates;return this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements||this.rendered||setTimeout(()=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}),w`
                     <vaadin-checkbox-group
                         id="${this.field.fieldId}"
                         label="${n}"
@@ -9861,19 +9875,19 @@ ${i}
                         @value-changed="${this.valueChanged}"
                         .helperText="${this.helperText()}"
                         ?autofocus="${this.field.wantsFocus}"
-                        ?required="${this.field.required||v}"
+                        ?required="${this.field.required||_}"
                         data-colspan="${this.field.colspan}"
                         .value="${t}"
                         class="mateu-checkbox-group-${this.field.optionsColumns>1?`multi-column`:``}"
                 >
-                        ${this.data[this.id]?.content?.map(e=>T`
+                        ${this.data[this.id]?.content?.map(e=>w`
                             <vaadin-checkbox
                                     value="${e.value}"
                                     label="${e.label}"
                             ></vaadin-checkbox>
                         `)}
                 </vaadin-checkbox-group>
-                    `}return T`
+                    `}return w`
                 <vaadin-checkbox-group
                         id="${this.field.fieldId}"
                         label="${n}"
@@ -9881,43 +9895,43 @@ ${i}
                         theme="vertical"
                         .helperText="${this.helperText()}"
                         ?autofocus="${this.field.wantsFocus}"
-                        ?required="${this.field.required||v}"
+                        ?required="${this.field.required||_}"
                         data-colspan="${this.field.colspan}"
                         class="mateu-checkbox-group-${this.field.optionsColumns>1?`multi-column`:``}"
                         .value="${t}"
                 >
-                        ${this.field.options?.map(e=>T`
+                        ${this.field.options?.map(e=>w`
                         <vaadin-checkbox 
                                 value="${e.value}" 
                                 label="${e.label}"
                         ></vaadin-checkbox>
                         `)}
                 </vaadin-checkbox-group>
-            `}renderMoneyField(e,t,n,r){if(!this.field)return T``;if(this.field.readOnly){let e=t,r=e;return r=e&&e.locale&&e.currency?new Intl.NumberFormat(e.locale,{style:`currency`,currency:e.currency}).format(e.value):new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e),T`<vaadin-custom-field
+            `}renderMoneyField(e,t,n,r){if(!this.field)return w``;if(this.field.readOnly){let e=t,r=e;return r=e&&e.locale&&e.currency?new Intl.NumberFormat(e.locale,{style:`currency`,currency:e.currency}).format(e.value):new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e),w`<vaadin-custom-field
                         id="${this.field.fieldId}"
                         label="${n}"
                         .helperText="${this.helperText()}"
                         data-colspan="${this.field.colspan}"
-                ><div style="width: 186px; text-align: right;">${r}</div></vaadin-custom-field>`}return T`<mateu-money-field
+                ><div style="width: 186px; text-align: right;">${r}</div></vaadin-custom-field>`}return w`<mateu-money-field
                         id="${this.field.fieldId}"
                         label="${n}"
                         @value-changed="${this.valueChanged}"
                         .value="${t}"
                         .helperText="${this.helperText()}"
                         ?autofocus="${this.field.wantsFocus}"
-                        ?required="${this.field.required||v}"
+                        ?required="${this.field.required||_}"
                         data-colspan="${this.field.colspan}"
-            ></mateu-money-field>`}renderStatusField(e,t,n,r){if(!this.field)return T``;let i=t;return T`
+            ></mateu-money-field>`}renderStatusField(e,t,n,r){if(!this.field)return w``;let i=t;return w`
                 <vaadin-custom-field
                         id="${this.field.fieldId}"
                         label="${n}"
-                        required="${this.field.required||v}"
+                        required="${this.field.required||_}"
                         .helperText="${this.helperText()}"
                         data-colspan="${this.field.colspan}"
                 >
-                    ${i?T`<span theme="badge pill ${ra(i.type)}">${i.message}</span>`:T``}                    
+                    ${i?w`<span theme="badge pill ${ia(i.type)}">${i.message}</span>`:w``}                    
                 </vaadin-custom-field>
-            `}renderRangeField(e,t,n,r){if(!this.field)return T``;this.loadUi5FieldComponents();let i=t;return T`
+            `}renderRangeField(e,t,n,r){if(!this.field)return w``;this.loadUi5FieldComponents();let i=t;return w`
                 <vaadin-custom-field
                         id="${this.field.fieldId}"
                         label="${n}"
@@ -9926,12 +9940,12 @@ ${i}
                 ><ui5-range-slider start-value="${i?.from??0}" end-value="${i?.to??0}" 
                                    min="${this.field.sliderMin??0}" 
                                    max="${this.field.sliderMax??10}"
-                                   step="${this.field.step||v}"
+                                   step="${this.field.step||_}"
                                    @change="${e=>{let t=e.target;this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:{from:t.startValue,to:t.endValue},fieldId:this.field.fieldId},bubbles:!0,composed:!0}))}}"
                                    style="min-width: 10rem;"
                 ></ui5-range-slider></vaadin-custom-field>
-            `}static{this.styles=h`
-        ${de}
+            `}static{this.styles=m`
+        ${fe}
 
         /* Fields fill the whole column width by default. Date, checkbox, numeric and money inputs
            are the exception — they keep their natural (narrower) width so a date/amount doesn't
@@ -10013,7 +10027,7 @@ ${i}
             text-overflow: clip;
             height: auto;
         }
-  `}};k([C()],Q.prototype,`ui5FieldComponentsReady`,void 0),k([y()],Q.prototype,`component`,void 0),k([y()],Q.prototype,`field`,void 0),k([y()],Q.prototype,`baseUrl`,void 0),k([y()],Q.prototype,`state`,void 0),k([y()],Q.prototype,`data`,void 0),k([y()],Q.prototype,`appState`,void 0),k([y()],Q.prototype,`appData`,void 0),k([y()],Q.prototype,`labelAlreadyRendered`,void 0),k([C()],Q.prototype,`colorPickerOpened`,void 0),k([C()],Q.prototype,`colorPickerValue`,void 0),k([C()],Q.prototype,`controlOwnsValidity`,void 0),k([C()],Q.prototype,`filteredIcons`,void 0),k([C()],Q.prototype,`navLinkOffset`,void 0),Q=k([g(`mateu-field`)],Q);var tl=(e,t,n,r,i,a,o,s)=>{let c=t.metadata;return T`
+  `}};O([S()],Z.prototype,`ui5FieldComponentsReady`,void 0),O([v()],Z.prototype,`component`,void 0),O([v()],Z.prototype,`field`,void 0),O([v()],Z.prototype,`baseUrl`,void 0),O([v()],Z.prototype,`state`,void 0),O([v()],Z.prototype,`data`,void 0),O([v()],Z.prototype,`appState`,void 0),O([v()],Z.prototype,`appData`,void 0),O([v()],Z.prototype,`labelAlreadyRendered`,void 0),O([S()],Z.prototype,`colorPickerOpened`,void 0),O([S()],Z.prototype,`colorPickerValue`,void 0),O([S()],Z.prototype,`controlOwnsValidity`,void 0),O([S()],Z.prototype,`filteredIcons`,void 0),O([S()],Z.prototype,`navLinkOffset`,void 0),Z=O([h(`mateu-field`)],Z);var bl=(e,t,n,r,i,a,o,s)=>{let c=t.metadata;return w`
         <mateu-field
                 id="${t.id}"
                 .component="${t}"
@@ -10022,75 +10036,75 @@ ${i}
                 .data="${i}"
                 .appState="${a}"
                 .appdata="${o}"
-                style="${Zi(t,i)}" class="${t.cssClasses}"
-                slot="${t.slot??v}"
+                style="${Qi(t,i)}" class="${t.cssClasses}"
+                slot="${t.slot??_}"
                 data-colspan="${c.colspan}"
-                colspan="${(c.colspan??1)>1?c.colspan:v}"
+                colspan="${(c.colspan??1)>1?c.colspan:_}"
                 .labelAlreadyRendered="${s}"
         >
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o,s))}
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o,s))}
         </mateu-field>
-    `},nl=(e,n,r,i,a,o,s)=>{let c=n.metadata;if(c.tree)return T`
+    `},xl=(e,n,r,i,a,o,s)=>{let c=n.metadata;if(c.tree)return w`
         <vaadin-grid style="${n.style}" class="${n.cssClasses}"
                      .itemHasChildrenPath="${`children`}" .dataProvider="${async(e,t)=>{let n=e.parentItem?e.parentItem.children:c.page.content;t(n,n.length)}}"
-                     slot="${n.slot??v}"
+                     slot="${n.slot??_}"
                      all-rows-visible
         >
-            ${c.content.map((n,c)=>{let l=n.metadata;return c>0?T`
+            ${c.content.map((n,c)=>{let l=n.metadata;return c>0?w`
             <vaadin-grid-column path="${n.id}"
-                                header="${l?.label??v}"
+                                header="${l?.label??_}"
                                 ?auto-width="${l?.autoWidth}"
-                                flex-grow="${l?.flexGrow??v}"
-                                width="${l?.width??v}"
+                                flex-grow="${l?.flexGrow??_}"
+                                width="${l?.width??_}"
                                 .column="${n.metadata}"
-                                ${t((t,n,c)=>Kc(t,n,c,l,e,r,i,a,o,s),[])}></vaadin-grid-column>
-`:T`
+                                ${t((t,n,c)=>dl(t,n,c,l,e,r,i,a,o,s),[])}></vaadin-grid-column>
+`:w`
             <vaadin-grid-tree-column path="${n.id}"
-                                header="${l?.label??v}"
+                                header="${l?.label??_}"
                                 ?auto-width="${l?.autoWidth}"
-                                flex-grow="${l?.flexGrow??v}"
-                                width="${l?.width??v}"
+                                flex-grow="${l?.flexGrow??_}"
+                                width="${l?.width??_}"
             ></vaadin-grid-tree-column>
 `})}
-            <span slot="empty-state">${xt()}</span>
+            <span slot="empty-state">${St()}</span>
         </vaadin-grid>
-    `;let l=c.page?.content;return n.id&&i&&i[n.id]&&(l=i[n.id]),l||=[],T`
+    `;let l=c.page?.content;return n.id&&i&&i[n.id]&&(l=i[n.id]),l||=[],w`
         <vaadin-grid 
                 style="${n.style}" 
                 class="${n.cssClasses}" 
                 .items="${l}"
                 all-rows-visible
         >
-            ${c?.content?.map(t=>Wc(t,e,r,i,a,o,s))}
+            ${c?.content?.map(t=>ll(t,e,r,i,a,o,s))}
         </vaadin-grid>
-    `},$=class extends b{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.detailsOpenedItems=[],this.pagesRequested=[],this.emptyArray=e=>!e||e.length==0,this.dataProvider=(e,t)=>{let n=this.data[this.id]?.page;if(this.metadata?.infiniteScrolling&&e.page>0){let r=!1;n&&n.content&&(n.content.length>=(e.page+1)*e.pageSize||n.content.length==n.totalElements)&&(t(n.content.slice(e.page*e.pageSize,(e.page+1)*e.pageSize),n.totalElements),r=!0,this.grid&&this.grid.recalculateColumnWidths()),r||this.pagesRequested.find(t=>t==e.page)||(this.pagesRequested.push(e.page),this.dispatchEvent(new CustomEvent(`fetch-more-elements`,{detail:{params:e,callback:()=>{this.data[this.id]?.page?.content&&(t(this.data[this.id].page.content.slice(e.page*e.pageSize,(e.page+1)*e.pageSize),this.data[this.id].page.totalElements),this.grid&&this.grid.recalculateColumnWidths())}},bubbles:!0,composed:!0})))}else{let e=this.metadata?.infiniteScrolling?n?.totalElements:n?.content?.length??0;t(n?.content??[],e),this.grid&&this.grid.recalculateColumnWidths()}},this._onActionRequested=e=>{let t=e.detail,n=this.identifierFieldName;if(!n||!t.parameters||t.actionId?.startsWith(`action-on-row-`))return;let r=t.parameters[n];r!==void 0&&(this.state._selectedId=String(r),this._applyCellPartNameGenerator(),this.grid?.requestContentUpdate())},this.tooltipGenerator=e=>{let t=``,{column:n,item:r}=e,i=this.metadata?.columns?.find(e=>e.metadata.id==n?.path);if(i?.metadata){let e=(i?.metadata).tooltipPath;e&&n&&r&&(t=r[e])}return t}}get identifierFieldName(){let e=this.metadata?.columns?.find(e=>e.metadata?.identifier);if(e)return e.metadata?.id;if(this.metadata?.columns?.find(e=>e.metadata?.id===`id`))return`id`}_applyCellPartNameGenerator(){if(!this.grid)return;let e=this.identifierFieldName,t=this.state?._selectedId??this.appState?._splitDetailId,n=!!this.metadata?.groupBy;e&&t!==void 0||n?this.grid.cellPartNameGenerator=(n,r)=>{let i=r.item;return pc(i)?`mateu-group-row`:e&&t!==void 0&&String(i[e])===String(t)?`selected-row`:``}:this.grid.cellPartNameGenerator=null}connectedCallback(){super.connectedCallback(),this.addEventListener(`action-requested`,this._onActionRequested)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`action-requested`,this._onActionRequested)}updated(e){super.updated(e),this._applyCellPartNameGenerator(),this.grid?.clearCache(),this.grid?.requestContentUpdate(),this.grid?.recalculateColumnWidths(),this.pagesRequested=[]}render(){let e=this.data[this.id],r=e?.page,i=this.metadata?.groupBy,a=this.metadata?.infiniteScrolling?void 0:r?.content?hc(r.content,i,e?.groups):r?.content,o=yc((this.metadata?.columns??[]).flatMap(e=>e.metadata?.type===j.GridGroupColumn?(e.metadata.columns??[]).map(e=>e.metadata):[e.metadata]),e,i),s=``;return this.metadata?.wrapCellContent&&(s+=` wrap-cell-content`),this.metadata?.compact&&(s+=` compact`),this.metadata?.noBorder&&(s+=` no-border`),this.metadata?.noRowBorder&&(s+=` no-row-borders`),this.metadata?.columnBorders&&(s+=` column-borders`),this.metadata?.rowStripes&&(s+=` row-stripes`),T`
+    `},Q=class extends y{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.detailsOpenedItems=[],this.pagesRequested=[],this.emptyArray=e=>!e||e.length==0,this.dataProvider=(e,t)=>{let n=this.data[this.id]?.page;if(this.metadata?.infiniteScrolling&&e.page>0){let r=!1;n&&n.content&&(n.content.length>=(e.page+1)*e.pageSize||n.content.length==n.totalElements)&&(t(n.content.slice(e.page*e.pageSize,(e.page+1)*e.pageSize),n.totalElements),r=!0,this.grid&&this.grid.recalculateColumnWidths()),r||this.pagesRequested.find(t=>t==e.page)||(this.pagesRequested.push(e.page),this.dispatchEvent(new CustomEvent(`fetch-more-elements`,{detail:{params:e,callback:()=>{this.data[this.id]?.page?.content&&(t(this.data[this.id].page.content.slice(e.page*e.pageSize,(e.page+1)*e.pageSize),this.data[this.id].page.totalElements),this.grid&&this.grid.recalculateColumnWidths())}},bubbles:!0,composed:!0})))}else{let e=this.metadata?.infiniteScrolling?n?.totalElements:n?.content?.length??0;t(n?.content??[],e),this.grid&&this.grid.recalculateColumnWidths()}},this._onActionRequested=e=>{let t=e.detail,n=this.identifierFieldName;if(!n||!t.parameters||t.actionId?.startsWith(`action-on-row-`))return;let r=t.parameters[n];r!==void 0&&(this.state._selectedId=String(r),this._applyCellPartNameGenerator(),this.grid?.requestContentUpdate())},this.tooltipGenerator=e=>{let t=``,{column:n,item:r}=e,i=this.metadata?.columns?.find(e=>e.metadata.id==n?.path);if(i?.metadata){let e=(i?.metadata).tooltipPath;e&&n&&r&&(t=r[e])}return t}}get identifierFieldName(){let e=this.metadata?.columns?.find(e=>e.metadata?.identifier);if(e)return e.metadata?.id;if(this.metadata?.columns?.find(e=>e.metadata?.id===`id`))return`id`}_applyCellPartNameGenerator(){if(!this.grid)return;let e=this.identifierFieldName,t=this.state?._selectedId??this.appState?._splitDetailId,n=!!this.metadata?.groupBy;e&&t!==void 0||n?this.grid.cellPartNameGenerator=(n,r)=>{let i=r.item;return Mc(i)?`mateu-group-row`:e&&t!==void 0&&String(i[e])===String(t)?`selected-row`:``}:this.grid.cellPartNameGenerator=null}connectedCallback(){super.connectedCallback(),this.addEventListener(`action-requested`,this._onActionRequested)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`action-requested`,this._onActionRequested)}updated(e){super.updated(e),this._applyCellPartNameGenerator(),this.grid?.clearCache(),this.grid?.requestContentUpdate(),this.grid?.recalculateColumnWidths(),this.pagesRequested=[]}render(){let e=this.data[this.id],r=e?.page,i=this.metadata?.groupBy,a=this.metadata?.infiniteScrolling?void 0:r?.content?Pc(r.content,i,e?.groups):r?.content,o=Rc((this.metadata?.columns??[]).flatMap(e=>e.metadata?.type===A.GridGroupColumn?(e.metadata.columns??[]).map(e=>e.metadata):[e.metadata]),e,i),s=``;return this.metadata?.wrapCellContent&&(s+=` wrap-cell-content`),this.metadata?.compact&&(s+=` compact`),this.metadata?.noBorder&&(s+=` no-border`),this.metadata?.noRowBorder&&(s+=` no-row-borders`),this.metadata?.columnBorders&&(s+=` column-borders`),this.metadata?.rowStripes&&(s+=` row-stripes`),w`
             <vaadin-grid
                     .items="${a}"
                     item-id-path="_rowNumber"
                     .selectedItems="${this.state[this.id+`_selected_items`]||[]}"
                     ?data-clickable-rows="${this.metadata?.detailPath&&!this.metadata?.useButtonForDetail}"
                     ?all-rows-visible="${this.metadata?.allRowsVisible}"
-                    column-rendering="${this.metadata?.lazyColumnRendering?`lazy`:v}"
+                    column-rendering="${this.metadata?.lazyColumnRendering?`lazy`:_}"
                     ?column-reordering-allowed="${this.metadata?.columnReorderingAllowed}"
                     .dataProvider="${this.metadata?.infiniteScrolling?this.dataProvider:void 0}"
                     page-size="${this.metadata?.pageSize}"
                     multi-sort-on-shift-click
-                    @selected-items-changed="${e=>{let t=(e.detail.value??[]).filter(e=>!pc(e));this.emptyArray(this.state[this.id+`_selected_items`])&&this.emptyArray(t)||(this.state[this.id+`_selected_items`]=t,this.metadata?.onRowSelectionChangedActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.metadata?.onRowSelectionChangedActionId},bubbles:!0,composed:!0})))}}"
-                    @active-item-changed="${S(this.metadata?.detailPath&&!this.metadata?.useButtonForDetail?e=>{if(this.metadata?.detailPath){let t=e.detail.value;if(t&&pc(t))return;t?this.detailsOpenedItems=[t]:this.detailsOpenedItems=[]}}:void 0)}"
+                    @selected-items-changed="${e=>{let t=(e.detail.value??[]).filter(e=>!Mc(e));this.emptyArray(this.state[this.id+`_selected_items`])&&this.emptyArray(t)||(this.state[this.id+`_selected_items`]=t,this.metadata?.onRowSelectionChangedActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.metadata?.onRowSelectionChangedActionId},bubbles:!0,composed:!0})))}}"
+                    @active-item-changed="${x(this.metadata?.detailPath&&!this.metadata?.useButtonForDetail?e=>{if(this.metadata?.detailPath){let t=e.detail.value;if(t&&Mc(t))return;t?this.detailsOpenedItems=[t]:this.detailsOpenedItems=[]}}:void 0)}"
                     .detailsOpenedItems="${this.detailsOpenedItems}"
-                    ${S(this.metadata?.detailPath?n(e=>T`${F(this,e[this.metadata?.detailPath],this.baseUrl,this.state,this.data,this.appState,this.appData)}`):void 0)}
+                    ${x(this.metadata?.detailPath?n(e=>w`${P(this,e[this.metadata?.detailPath],this.baseUrl,this.state,this.data,this.appState,this.appData)}`):void 0)}
                     theme="${s}"
                     style="${this.metadata?.gridStyle}"
             >
-                ${this.metadata?.rowsSelectionEnabled?T`
+                ${this.metadata?.rowsSelectionEnabled?w`
                     <vaadin-grid-selection-column></vaadin-grid-selection-column>
-                `:v}
-                ${this.metadata?.columns?.map(e=>Wc(e,this,this.baseUrl,this.state,this.data,this.appState,this.appData,o))}
-                ${this.metadata?.useButtonForDetail?T`
+                `:_}
+                ${this.metadata?.columns?.map(e=>ll(e,this,this.baseUrl,this.state,this.data,this.appState,this.appData,o))}
+                ${this.metadata?.useButtonForDetail?w`
                     <vaadin-grid-column
                             width="44px"
                             flex-grow="0"
-                            ${t((e,{detailsOpened:t})=>T`
+                            ${t((e,{detailsOpened:t})=>w`
               <vaadin-button
                 theme="tertiary icon"
                 title="${t?`Collapse`:`Expand`}"
@@ -10104,13 +10118,13 @@ ${i}
               </vaadin-button>
             `,[])}
                     ></vaadin-grid-column>
-                `:v}
-                <span slot="empty-state">${xt(this.emptyStateMessage??this.metadata?.emptyStateMessage)}</span>
-                ${this.metadata?.columns?.find(e=>e.metadata.tooltipPath)?T`<vaadin-tooltip slot="tooltip" .generator="${this.tooltipGenerator}"></vaadin-tooltip>`:v}
+                `:_}
+                <span slot="empty-state">${St(this.emptyStateMessage??this.metadata?.emptyStateMessage)}</span>
+                ${this.metadata?.columns?.find(e=>e.metadata.tooltipPath)?w`<vaadin-tooltip slot="tooltip" .generator="${this.tooltipGenerator}"></vaadin-tooltip>`:_}
             </vaadin-grid>
             <slot></slot>
-       `}static{this.styles=h`
-        ${de}
+       `}static{this.styles=m`
+        ${fe}
         vaadin-grid[data-clickable-rows]::part(row) {
             cursor: pointer;
         }
@@ -10124,7 +10138,7 @@ ${i}
             background-color: var(--lumo-contrast-5pct, rgba(0, 0, 0, 0.04));
             font-weight: 600;
         }
-  `}};k([y()],$.prototype,`id`,void 0),k([y()],$.prototype,`metadata`,void 0),k([y()],$.prototype,`baseUrl`,void 0),k([y()],$.prototype,`state`,void 0),k([y()],$.prototype,`data`,void 0),k([y()],$.prototype,`appState`,void 0),k([y()],$.prototype,`appData`,void 0),k([y()],$.prototype,`emptyStateMessage`,void 0),k([C()],$.prototype,`detailsOpenedItems`,void 0),k([x(`vaadin-grid`)],$.prototype,`grid`,void 0),$=k([g(`mateu-table`)],$);var rl=(e,t,n,r,i,a,o)=>T`
+  `}};O([v()],Q.prototype,`id`,void 0),O([v()],Q.prototype,`metadata`,void 0),O([v()],Q.prototype,`baseUrl`,void 0),O([v()],Q.prototype,`state`,void 0),O([v()],Q.prototype,`data`,void 0),O([v()],Q.prototype,`appState`,void 0),O([v()],Q.prototype,`appData`,void 0),O([v()],Q.prototype,`emptyStateMessage`,void 0),O([S()],Q.prototype,`detailsOpenedItems`,void 0),O([b(`vaadin-grid`)],Q.prototype,`grid`,void 0),Q=O([h(`mateu-table`)],Q);var Sl=(e,t,n,r,i,a,o)=>w`
     <mateu-table
             id="${t.id}"
             baseUrl="${n}"
@@ -10134,10 +10148,10 @@ ${i}
             .appState="${a}"
             .appDate="${o}"
             style="${t.style}" class="${t.cssClasses}"
-            slot="${t.slot??v}"
+            slot="${t.slot??_}"
     >
-        ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
-    </mateu-table>`,il=(e,t,n,r,i,a)=>T`
+        ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
+    </mateu-table>`,Cl=(e,t,n,r,i,a)=>w`
     <mateu-table id="${e.id}"
                  .metadata="${t?.metadata}"
                  .data="${e.data}"
@@ -10148,8 +10162,8 @@ ${i}
                  @sort-direction-changed="${e.directionChanged}"
                  @fetch-more-elements="${e.fetchMoreElements}"
                  baseUrl="${n}"
-    ></mateu-table>`,al=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
-        <div id="show-notifications" slot="${t.slot??v}">${F(e,s.wrapped,n,r,i,a,o)}</div>
+    ></mateu-table>`,wl=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+        <div id="show-notifications" slot="${t.slot??_}">${P(e,s.wrapped,n,r,i,a,o)}</div>
         <vaadin-popover
                 for="show-notifications"
                 theme="arrow no-padding"
@@ -10157,17 +10171,17 @@ ${i}
                 accessible-name-ref="notifications-heading"
                 content-width="300px"
                 position="bottom"
-                ${ee(()=>T`${F(e,s.content,n,r,i,a,o)}`,[])}
+                ${te(()=>w`${P(e,s.content,n,r,i,a,o)}`,[])}
                 style="${t.style}" class="${t.cssClasses}"
         ></vaadin-popover>
-    `},ol=(e,t,n)=>{let r=e;return T`
+    `},Tl=(e,t,n)=>{let r=e;return w`
         <vaadin-button
                 data-action-id="${r.id}"
-                theme="${mt(e)||v}"
+                theme="${ht(e)||_}"
                 @click="${n}"
                 ?disabled="${r.disabled}"
-        >${r.iconOnLeft?T`<vaadin-icon icon="${r.iconOnLeft}"></vaadin-icon>`:v}${t}${r.iconOnRight?T`<vaadin-icon icon="${r.iconOnRight}"></vaadin-icon>`:v}</vaadin-button>
-    `},sl=e=>T`
+        >${r.iconOnLeft?w`<vaadin-icon icon="${r.iconOnLeft}"></vaadin-icon>`:_}${t}${r.iconOnRight?w`<vaadin-icon icon="${r.iconOnRight}"></vaadin-icon>`:_}</vaadin-button>
+    `},El=e=>w`
     <div style="display: flex; gap: var(--lumo-space-xs, .25rem); align-items: center;" class="peer-nav">
         <vaadin-button theme="tertiary icon" class="peer-nav-prev" title="${e.prevLabel??`Previous`}"
                 ?disabled="${!e.prevRoute}"
@@ -10179,30 +10193,30 @@ ${i}
                 @click="${()=>{e.nextRoute&&(window.location.href=e.nextRoute)}}">
             <vaadin-icon icon="vaadin:angle-right"></vaadin-icon>
         </vaadin-button>
-    </div>`,cl={"vaadin:wifi":`vaadin:connect`,"vaadin:pen":`vaadin:pencil`,"vaadin:automation":`vaadin:cogs`},ll=(e,t,n)=>T`<vaadin-icon icon="${cl[e]??e}" style="${t??v}" class="${n??v}"></vaadin-icon>`,ul=(e,t,n)=>{let r=e.metadata,i=M(r.label,t,n),a=``;return r.buttonStyle&&(a+=` `+r.buttonStyle),r.color&&r.color!==`none`&&r.color!==`normal`&&(a+=` `+r.color),r.size&&r.size!==`none`&&r.size!==`normal`&&(a+=` `+r.size),T`<vaadin-button
+    </div>`,Dl={"vaadin:wifi":`vaadin:connect`,"vaadin:pen":`vaadin:pencil`,"vaadin:automation":`vaadin:cogs`},Ol=(e,t,n)=>w`<vaadin-icon icon="${Dl[e]??e}" style="${t??_}" class="${n??_}"></vaadin-icon>`,kl=(e,t,n)=>{let r=e.metadata,i=j(r.label,t,n),a=``;return r.buttonStyle&&(a+=` `+r.buttonStyle),r.color&&r.color!==`none`&&r.color!==`normal`&&(a+=` `+r.color),r.size&&r.size!==`none`&&r.size!==`normal`&&(a+=` `+r.size),w`<vaadin-button
             id="${e.id}"
             data-action-id="${r.actionId}"
-            @click="${e=>Mn(e,r)}"
+            @click="${e=>Nn(e,r)}"
             style="${e.style}"
             class="${e.cssClasses}"
             theme="${a}"
             ?disabled="${r.disabled}"
-            title="${r.shortcut?`${i} (${jn(r.shortcut)})`:v}"
-            slot="${e.slot??v}"
-    >${r.iconOnLeft?T`<vaadin-icon icon="${r.iconOnLeft}"></vaadin-icon>`:v}${i}${r.iconOnRight?T`<vaadin-icon icon="${r.iconOnRight}"></vaadin-icon>`:v}</vaadin-button>`},dl=e=>{let t=e.metadata;return T`
+            title="${r.shortcut?`${i} (${Mn(r.shortcut)})`:_}"
+            slot="${e.slot??_}"
+    >${r.iconOnLeft?w`<vaadin-icon icon="${r.iconOnLeft}"></vaadin-icon>`:_}${i}${r.iconOnRight?w`<vaadin-icon icon="${r.iconOnRight}"></vaadin-icon>`:_}</vaadin-button>`},Al=e=>{let t=e.metadata;return w`
         <vaadin-message-input
                 style="${e.style}" class="${e.cssClasses}"
-                slot="${e.slot??v}"
+                slot="${e.slot??_}"
                 @submit="${e=>{let n=e.detail?.value??``;!t.actionId||!n.trim()||e.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:{message:n}},bubbles:!0,composed:!0}))}}"
         ></vaadin-message-input>
-    `},fl=e=>{let t=(e.metadata.items??[]).map(e=>({text:e.text,time:e.time,userName:e.userName,userImg:e.userImg,userAbbr:e.userAbbr,userColorIndex:e.userColorIndex}));return T`
+    `},jl=e=>{let t=(e.metadata.items??[]).map(e=>({text:e.text,time:e.time,userName:e.userName,userImg:e.userImg,userAbbr:e.userAbbr,userColorIndex:e.userColorIndex}));return w`
         <vaadin-message-list
                 markdown
                 style="${e.style}" class="${e.cssClasses}"
-                slot="${e.slot??v}"
+                slot="${e.slot??_}"
                 .items="${t}"
         ></vaadin-message-list>
-    `},pl=(e,t)=>{e&&e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},ml=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!1;if(s.openedCondition)try{c=it(s.openedCondition,r,i,a,o)}catch(e){console.error(`when evaluating `+s.openedCondition+` :`+e+`, where data is `+i+` and state is `+r)}return T`
+    `},Ml=(e,t)=>{e&&e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},Nl=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!1;if(s.openedCondition)try{c=at(s.openedCondition,r,i,a,o)}catch(e){console.error(`when evaluating `+s.openedCondition+` :`+e+`, where data is `+i+` and state is `+r)}return w`
         <vaadin-confirm-dialog
                 header="${s.header}"
                 ?cancel-button-visible="${s.canCancel}"
@@ -10210,15 +10224,15 @@ ${i}
                 reject-text="${s.rejectText}"
                 confirm-text="${s.confirmText}"
                 .opened="${c}"
-                @confirm="${e=>pl(e.currentTarget,s.confirmActionId)}"
-                @reject="${e=>pl(e.currentTarget,s.rejectActionId)}"
-                @cancel="${e=>pl(e.currentTarget,s.cancelActionId)}"
+                @confirm="${e=>Ml(e.currentTarget,s.confirmActionId)}"
+                @reject="${e=>Ml(e.currentTarget,s.rejectActionId)}"
+                @cancel="${e=>Ml(e.currentTarget,s.cancelActionId)}"
                 style="${t.style}" class="${t.cssClasses}"
-                slot="${t.slot??v}"
+                slot="${t.slot??_}"
         >
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </vaadin-confirm-dialog>
-    `},hl=class extends b{constructor(...e){super(...e),this.panels=[],this.headerTitle=``,this.badges=[],this.navigation=null,this.overviewEditActionId=``,this._raf=0,this._snapping=!1,this._less=!1,this._more=!1,this._onScroll=()=>{this._raf||=requestAnimationFrame(()=>{this._raf=0,this._syncPin()})},this._onScrollEnd=()=>{this._snapping||this._snapToNearest()},this._fit=()=>{let e=this.getBoundingClientRect().top;this.style.setProperty(`--mateu-foldout-fill`,`${Math.max(240,window.innerHeight-e)}px`),this._syncPin()},this._onKeydown=e=>{if(e.key!==`ArrowRight`&&e.key!==`ArrowLeft`||e.defaultPrevented||e.ctrlKey||e.metaKey||e.altKey||this._isEditingContext())return;let t=this._rail;!t||t.scrollWidth<=t.clientWidth||(e.preventDefault(),this._step(e.key===`ArrowRight`?1:-1))}}navAction(e){e&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{}},bubbles:!0,composed:!0}))}_stride(){let e=this.renderRoot.querySelectorAll(`.section`);return e.length>1?e[1].offsetLeft:this._rail?.clientWidth??0}_boundaries(){let e=this._rail;if(!e)return[];let t=e.scrollWidth-e.clientWidth,n=[...this.renderRoot.querySelectorAll(`.section`)].map(e=>Math.max(0,Math.min(e.offsetLeft,t)));return[...new Set(n)]}_snapToNearest(){let e=this._rail;if(!e)return;let t=this._boundaries();if(!t.length)return;let n=t.reduce((t,n)=>Math.abs(n-e.scrollLeft)<Math.abs(t-e.scrollLeft)?n:t);Math.abs(n-e.scrollLeft)<1||(this._snapping=!0,e.scrollTo({left:n,behavior:`smooth`}),window.setTimeout(()=>{this._snapping=!1},400))}_syncPin(){let e=this._rail,t=this._first;if(!e||!t)return;let n=this._stride(),r=Math.min(e.scrollLeft,n);t.style.transform=r?`translateX(${r}px)`:``,t.classList.toggle(`floating`,e.scrollLeft>0);let i=e.scrollWidth-e.clientWidth,a=i>32;this._less=a&&e.scrollLeft>2,this._more=a&&e.scrollLeft<i-2}_step(e){let t=this._rail;if(!t)return;let n=this._boundaries();if(!n.length)return;let r=n.reduce((e,r,i)=>Math.abs(r-t.scrollLeft)<Math.abs(n[e]-t.scrollLeft)?i:e,0),i=n[Math.max(0,Math.min(r+e,n.length-1))];this._snapping=!0,t.scrollTo({left:i,behavior:`smooth`}),window.setTimeout(()=>{this._snapping=!1},400)}_isEditingContext(){let e=document.activeElement;for(;e&&e.shadowRoot&&e.shadowRoot.activeElement;)e=e.shadowRoot.activeElement;if(!e)return!1;let t=e.tagName;return t===`INPUT`||t===`TEXTAREA`||t===`SELECT`||e.isContentEditable}_sectionFlex(e,t){if(!e.width)return v;let n=parseFloat(e.width)||1;return t===this.panels.length-1&&n<22?`flex: 22 1 var(--mateu-foldout-overview-width, 22rem);`:`flex: ${n} 1 ${e.width};`}firstUpdated(){this._fit(),this._resizeObserver=new ResizeObserver(()=>this._syncPin()),this._rail&&this._resizeObserver.observe(this._rail);for(let e of this.renderRoot.querySelectorAll(`.section`))this._resizeObserver.observe(e)}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._onKeydown),window.addEventListener(`resize`,this._fit)}disconnectedCallback(){document.removeEventListener(`keydown`,this._onKeydown),window.removeEventListener(`resize`,this._fit),this._resizeObserver?.disconnect(),this._resizeObserver=void 0,this._raf&&=(cancelAnimationFrame(this._raf),0),super.disconnectedCallback()}static{this.styles=h`
+    `},$=class extends y{constructor(...e){super(...e),this.panels=[],this.headerTitle=``,this.badges=[],this.navigation=null,this.overviewEditActionId=``,this._raf=0,this._snapping=!1,this._less=!1,this._more=!1,this._onScroll=()=>{this._raf||=requestAnimationFrame(()=>{this._raf=0,this._syncPin()})},this._onScrollEnd=()=>{this._snapping||this._snapToNearest()},this._fit=()=>{let e=this.getBoundingClientRect().top;this.style.setProperty(`--mateu-foldout-fill`,`${Math.max(240,window.innerHeight-e)}px`),this._syncPin()},this._onKeydown=e=>{if(e.key!==`ArrowRight`&&e.key!==`ArrowLeft`||e.defaultPrevented||e.ctrlKey||e.metaKey||e.altKey||this._isEditingContext())return;let t=this._rail;!t||t.scrollWidth<=t.clientWidth||(e.preventDefault(),this._step(e.key===`ArrowRight`?1:-1))}}navAction(e){e&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{}},bubbles:!0,composed:!0}))}_stride(){let e=this.renderRoot.querySelectorAll(`.section`);return e.length>1?e[1].offsetLeft:this._rail?.clientWidth??0}_boundaries(){let e=this._rail;if(!e)return[];let t=e.scrollWidth-e.clientWidth,n=[...this.renderRoot.querySelectorAll(`.section`)].map(e=>Math.max(0,Math.min(e.offsetLeft,t)));return[...new Set(n)]}_snapToNearest(){let e=this._rail;if(!e)return;let t=this._boundaries();if(!t.length)return;let n=t.reduce((t,n)=>Math.abs(n-e.scrollLeft)<Math.abs(t-e.scrollLeft)?n:t);Math.abs(n-e.scrollLeft)<1||(this._snapping=!0,e.scrollTo({left:n,behavior:`smooth`}),window.setTimeout(()=>{this._snapping=!1},400))}_syncPin(){let e=this._rail,t=this._first;if(!e||!t)return;let n=this._stride(),r=Math.min(e.scrollLeft,n);t.style.transform=r?`translateX(${r}px)`:``,t.classList.toggle(`floating`,e.scrollLeft>0);let i=e.scrollWidth-e.clientWidth,a=i>32;this._less=a&&e.scrollLeft>2,this._more=a&&e.scrollLeft<i-2}_step(e){let t=this._rail;if(!t)return;let n=this._boundaries();if(!n.length)return;let r=n.reduce((e,r,i)=>Math.abs(r-t.scrollLeft)<Math.abs(n[e]-t.scrollLeft)?i:e,0),i=n[Math.max(0,Math.min(r+e,n.length-1))];this._snapping=!0,t.scrollTo({left:i,behavior:`smooth`}),window.setTimeout(()=>{this._snapping=!1},400)}_isEditingContext(){let e=document.activeElement;for(;e&&e.shadowRoot&&e.shadowRoot.activeElement;)e=e.shadowRoot.activeElement;if(!e)return!1;let t=e.tagName;return t===`INPUT`||t===`TEXTAREA`||t===`SELECT`||e.isContentEditable}_sectionFlex(e,t){if(!e.width)return _;let n=parseFloat(e.width)||1;return t===this.panels.length-1&&n<22?`flex: 22 1 var(--mateu-foldout-overview-width, 22rem);`:`flex: ${n} 1 ${e.width};`}firstUpdated(){this._fit(),this._resizeObserver=new ResizeObserver(()=>this._syncPin()),this._rail&&this._resizeObserver.observe(this._rail);for(let e of this.renderRoot.querySelectorAll(`.section`))this._resizeObserver.observe(e)}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._onKeydown),window.addEventListener(`resize`,this._fit)}disconnectedCallback(){document.removeEventListener(`keydown`,this._onKeydown),window.removeEventListener(`resize`,this._fit),this._resizeObserver?.disconnect(),this._resizeObserver=void 0,this._raf&&=(cancelAnimationFrame(this._raf),0),super.disconnectedCallback()}static{this.styles=m`
         :host {
             position: relative;
             display: flex;
@@ -10402,66 +10416,66 @@ ${i}
             width: 1.35rem;
             height: 1.35rem;
         }
-    `}render(){let e=this.navigation,t=!!(this.overviewEditActionId||e&&(e.parentActionId||e.previousActionId||e.nextActionId)),n=!!(this.headerTitle||t||this.badges.length);return T`
+    `}render(){let e=this.navigation,t=!!(this.overviewEditActionId||e&&(e.parentActionId||e.previousActionId||e.nextActionId)),n=!!(this.headerTitle||t||this.badges.length);return w`
             <div class="rail" part="rail" tabindex="0"
                  @scroll="${this._onScroll}" @scrollend="${this._onScrollEnd}">
                 <section class="section section--first" part="section overview">
-                    ${n?T`
+                    ${n?w`
                         <header class="section-head" part="section-head">
                             <div class="section-head-row">
-                                ${this.headerTitle?T`<h2 class="section-title">${this.headerTitle}</h2>`:T`<span></span>`}
-                                ${t?T`
+                                ${this.headerTitle?w`<h2 class="section-title">${this.headerTitle}</h2>`:w`<span></span>`}
+                                ${t?w`
                                     <div class="section-toolbar" part="section-toolbar">
-                                        ${e?.parentActionId?T`
+                                        ${e?.parentActionId?w`
                                             <button class="tb-parent" title="${e.parentLabel??`Back`}"
                                                     @click="${()=>this.navAction(e.parentActionId)}">
                                                 <span>‹</span><span>${e.parentLabel??`Back`}</span>
                                             </button>
-                                        `:v}
-                                        ${e?.previousActionId?T`
+                                        `:_}
+                                        ${e?.previousActionId?w`
                                             <button class="tb-move" title="Previous"
                                                     @click="${()=>this.navAction(e.previousActionId)}">‹</button>
-                                        `:v}
-                                        ${e?.nextActionId?T`
+                                        `:_}
+                                        ${e?.nextActionId?w`
                                             <button class="tb-move" title="Next"
                                                     @click="${()=>this.navAction(e.nextActionId)}">›</button>
-                                        `:v}
-                                        ${this.overviewEditActionId?T`
+                                        `:_}
+                                        ${this.overviewEditActionId?w`
                                             <button class="tb-edit" title="Edit"
                                                     @click="${()=>this.navAction(this.overviewEditActionId)}">
                                                 <span>✎</span><span>Edit</span>
                                             </button>
-                                        `:v}
+                                        `:_}
                                     </div>
-                                `:v}
+                                `:_}
                             </div>
-                            ${this.badges.length?T`
+                            ${this.badges.length?w`
                                 <div class="section-badges">
-                                    ${this.badges.map(e=>T`<span class="section-badge">${e}</span>`)}
+                                    ${this.badges.map(e=>w`<span class="section-badge">${e}</span>`)}
                                 </div>
-                            `:v}
+                            `:_}
                         </header>
-                    `:v}
+                    `:_}
                     <div class="overview-body">
                         <slot name="overview"></slot>
                     </div>
                 </section>
-                ${this.panels.map((e,t)=>T`
+                ${this.panels.map((e,t)=>w`
                     <section class="section" part="section panel"
                              style="${this._sectionFlex(e,t)}">
-                        ${e.title||e.subtitle?T`
+                        ${e.title||e.subtitle?w`
                             <div class="panel-header">
-                                ${e.title?T`<h3>${e.title}${e.subtitle?T` <span class="subtitle" style="font-weight: 400;">· ${e.subtitle}</span>`:v}</h3>`:v}
-                                ${!e.title&&e.subtitle?T`<div class="subtitle">${e.subtitle}</div>`:v}
+                                ${e.title?w`<h3>${e.title}${e.subtitle?w` <span class="subtitle" style="font-weight: 400;">· ${e.subtitle}</span>`:_}</h3>`:_}
+                                ${!e.title&&e.subtitle?w`<div class="subtitle">${e.subtitle}</div>`:_}
                             </div>
-                        `:v}
+                        `:_}
                         <div class="panel-body">
                             <slot name="panel-${t}"></slot>
                         </div>
                     </section>
                 `)}
             </div>
-            ${this._less?T`
+            ${this._less?w`
                 <button class="scroll-nav left" part="scroll-nav-left" title="Scroll left"
                         aria-label="Scroll left" @click="${()=>this._step(-1)}">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
@@ -10469,8 +10483,8 @@ ${i}
                         <polyline points="15 6 9 12 15 18"></polyline>
                     </svg>
                 </button>
-            `:v}
-            ${this._more?T`
+            `:_}
+            ${this._more?w`
                 <button class="scroll-nav right" part="scroll-nav-right" title="Scroll right"
                         aria-label="Scroll right" @click="${()=>this._step(1)}">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
@@ -10478,8 +10492,8 @@ ${i}
                         <polyline points="9 6 15 12 9 18"></polyline>
                     </svg>
                 </button>
-            `:v}
-        `}};k([y({type:Array})],hl.prototype,`panels`,void 0),k([y({type:String})],hl.prototype,`headerTitle`,void 0),k([y({type:Array})],hl.prototype,`badges`,void 0),k([y({attribute:!1})],hl.prototype,`navigation`,void 0),k([y({type:String})],hl.prototype,`overviewEditActionId`,void 0),k([x(`.rail`)],hl.prototype,`_rail`,void 0),k([x(`.section--first`)],hl.prototype,`_first`,void 0),k([C()],hl.prototype,`_less`,void 0),k([C()],hl.prototype,`_more`,void 0),hl=k([g(`mateu-vaadin-foldout`)],hl);var gl=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+            `:_}
+        `}};O([v({type:Array})],$.prototype,`panels`,void 0),O([v({type:String})],$.prototype,`headerTitle`,void 0),O([v({type:Array})],$.prototype,`badges`,void 0),O([v({attribute:!1})],$.prototype,`navigation`,void 0),O([v({type:String})],$.prototype,`overviewEditActionId`,void 0),O([b(`.rail`)],$.prototype,`_rail`,void 0),O([b(`.section--first`)],$.prototype,`_first`,void 0),O([S()],$.prototype,`_less`,void 0),O([S()],$.prototype,`_more`,void 0),$=O([h(`mateu-vaadin-foldout`)],$);var Pl=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <mateu-vaadin-foldout
                 .panels="${s.panels??[]}"
                 .headerTitle="${s.headerTitle??``}"
@@ -10488,11 +10502,11 @@ ${i}
                 overviewEditActionId="${s.overviewEditActionId??``}"
                 style="${t.style}"
                 class="${t.cssClasses}"
-                slot="${t.slot??v}"
+                slot="${t.slot??_}"
         >
-            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </mateu-vaadin-foldout>
-    `},_l=class extends b{constructor(...e){super(...e),this.rows=[],this.columns=[],this.navigable=!1,this.expandedItems=[],this._normalized=[],this.dataProvider=(e,t)=>{let n=e.parentItem?e.parentItem.children??[]:this.normalized;t(n,n.length)}}get normalized(){return this._src!==this.rows&&(this._src=this.rows,this._normalized=this.normalizeRows(this.rows??[])),this._normalized}normalizeRows(e){return(e??[]).map(e=>{let t=Array.isArray(e.children)&&e.children.length?this.normalizeRows(e.children):void 0;return{...e,children:t}})}collectGroups(e,t=[]){return e.forEach(e=>{e.children&&e.children.length&&(t.push(e),this.collectGroups(e.children,t))}),t}willUpdate(){this._expandedSrc!==this.rows&&(this._expandedSrc=this.rows,this.expandedItems=this.collectGroups(this.normalized))}updated(e){e.has(`rows`)&&this._grid?.clearCache?.()}dispatch(e,t){this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:t},bubbles:!0,composed:!0}))}render(){let e=this.columns??[],n=e[0],r=e.slice(1);return T`
+    `},Fl=class extends y{constructor(...e){super(...e),this.rows=[],this.columns=[],this.navigable=!1,this.expandedItems=[],this._normalized=[],this.dataProvider=(e,t)=>{let n=e.parentItem?e.parentItem.children??[]:this.normalized;t(n,n.length)}}get normalized(){return this._src!==this.rows&&(this._src=this.rows,this._normalized=this.normalizeRows(this.rows??[])),this._normalized}normalizeRows(e){return(e??[]).map(e=>{let t=Array.isArray(e.children)&&e.children.length?this.normalizeRows(e.children):void 0;return{...e,children:t}})}collectGroups(e,t=[]){return e.forEach(e=>{e.children&&e.children.length&&(t.push(e),this.collectGroups(e.children,t))}),t}willUpdate(){this._expandedSrc!==this.rows&&(this._expandedSrc=this.rows,this.expandedItems=this.collectGroups(this.normalized))}updated(e){e.has(`rows`)&&this._grid?.clearCache?.()}dispatch(e,t){this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:t},bubbles:!0,composed:!0}))}render(){let e=this.columns??[],n=e[0],r=e.slice(1);return w`
             <vaadin-grid
                     theme="compact no-row-borders"
                     all-rows-visible
@@ -10500,20 +10514,20 @@ ${i}
                     .itemHasChildrenPath="${`children`}"
                     .expandedItems="${this.expandedItems}"
                     @expanded-items-changed="${e=>{this.expandedItems=e.detail.value}}">
-                ${n?T`
+                ${n?w`
                     <vaadin-grid-tree-column path="${n.id}" header="${n.label??``}"
                                              auto-width flex-grow="0"></vaadin-grid-tree-column>
-                `:v}
-                ${r.map(e=>e.id===`select`?T`<vaadin-grid-column header="${e.label??``}" auto-width flex-grow="0" text-align="end"
-                              ${t(e=>T`<vaadin-button theme="tertiary small"
-                                          @click="${()=>this.dispatch(`action-on-row-select`,{_clickedRow:e})}">Select</vaadin-button>`,[])}></vaadin-grid-column>`:T`<vaadin-grid-column path="${e.id}" header="${e.label??``}"></vaadin-grid-column>`)}
-                ${this.navigable?T`
+                `:_}
+                ${r.map(e=>e.id===`select`?w`<vaadin-grid-column header="${e.label??``}" auto-width flex-grow="0" text-align="end"
+                              ${t(e=>w`<vaadin-button theme="tertiary small"
+                                          @click="${()=>this.dispatch(`action-on-row-select`,{_clickedRow:e})}">Select</vaadin-button>`,[])}></vaadin-grid-column>`:w`<vaadin-grid-column path="${e.id}" header="${e.label??``}"></vaadin-grid-column>`)}
+                ${this.navigable?w`
                     <vaadin-grid-column auto-width flex-grow="0" text-align="end"
-                          ${t(e=>e?.viewable===!1?T``:T`<vaadin-button theme="tertiary small"
+                          ${t(e=>e?.viewable===!1?w``:w`<vaadin-button theme="tertiary small"
                                           @click="${()=>this.dispatch(`view`,e)}">View</vaadin-button>`,[])}></vaadin-grid-column>
-                `:v}
+                `:_}
             </vaadin-grid>
-        `}static{this.styles=h`
+        `}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -10522,11 +10536,11 @@ ${i}
             max-height: min(60vh, 32rem);
             min-width: 22rem;
         }
-    `}};k([y({attribute:!1})],_l.prototype,`rows`,void 0),k([y({attribute:!1})],_l.prototype,`columns`,void 0),k([y()],_l.prototype,`idField`,void 0),k([y({type:Boolean})],_l.prototype,`navigable`,void 0),k([y()],_l.prototype,`selectedId`,void 0),k([C()],_l.prototype,`expandedItems`,void 0),k([x(`vaadin-grid`)],_l.prototype,`_grid`,void 0),_l=k([g(`mateu-vaadin-tree`)],_l);var vl={[j.VirtualList]:(e,t,n,r,i,a,o)=>js(e,t,n,r,i,a,o),[j.Notification]:(e,t)=>Ms(t),[j.ProgressBar]:(e,t,n,r)=>Ns(t,r),[j.Details]:(e,t,n,r,i,a,o)=>Ps(e,t,n,r,i,a,o),[j.Avatar]:(e,t,n,r,i)=>Fs(t,r,i),[j.AvatarGroup]:(e,t)=>Is(t),[j.Card]:(e,t,n,r,i,a,o)=>Ls(e,t,n,r,i,a,o),[j.Button]:(e,t,n,r,i)=>ul(t,r,i),[j.MessageInput]:(e,t)=>dl(t),[j.MessageList]:(e,t)=>fl(t),[j.ConfirmDialog]:(e,t,n,r,i,a,o)=>ml(e,t,n,r,i,a,o),[j.FormLayout]:(e,t,n,r,i,a,o)=>Bs(e,t,n,r,i,a,o),[j.HorizontalLayout]:(e,t,n,r,i,a,o)=>Ws(e,t,n,r,i,a,o),[j.VerticalLayout]:(e,t,n,r,i,a,o)=>Gs(e,t,n,r,i,a,o),[j.SplitLayout]:(e,t,n,r,i,a,o)=>Ks(e,t,n,r,i,a,o),[j.MasterDetailLayout]:(e,t,n,r,i,a,o)=>qs(e,t,n,r,i,a,o),[j.TabLayout]:(e,t,n,r,i,a,o)=>Js(e,t,n,r,i,a,o),[j.AccordionLayout]:(e,t,n,r,i,a,o)=>Xs(e,t,n,r,i,a,o),[j.BoardLayout]:(e,t,n,r,i,a,o)=>$s(e,t,n,r,i,a,o),[j.BoardLayoutRow]:(e,t,n,r,i,a,o)=>ec(e,t,n,r,i,a,o),[j.BoardLayoutItem]:(e,t,n,r,i,a,o)=>tc(e,t,n,r,i,a,o),[j.Scroller]:(e,t,n,r,i,a,o)=>Qs(e,t,n,r,i,a,o),[j.MenuBar]:(e,t,n,r,i)=>ic(e,t,n,r,i),[j.ContextMenu]:(e,t,n,r,i,a,o)=>rc(e,t,n,r,i,a,o),[j.FormField]:(e,t,n,r,i,a,o,s)=>tl(e,t,n,r,i,a,o,s),[j.Grid]:(e,t,n,r,i,a,o)=>nl(e,t,n,r,i,a,o),[j.Table]:(e,t,n,r,i,a,o)=>rl(e,t,n,r,i,a,o),[j.Popover]:(e,t,n,r,i,a,o)=>al(e,t,n,r,i,a,o),[j.FoldoutLayout]:(e,t,n,r,i,a,o)=>gl(e,t,n,r,i,a,o)},yl=class extends As{rendererName(){return`vaadin`}renderClientSideComponent(e,t,n,r,i,a,o,s){let c=t?.metadata?.type,l=c?vl[c]:void 0;return l&&t?l(e,t,n,r,i,a,o,s):super.renderClientSideComponent(e,t,n,r,i,a,o,s)}renderTableComponent(e,t,n,r,i,a,o){return il(e,t,n,r,a,o)}renderTreeComponent(e,t){return T`
+    `}};O([v({attribute:!1})],Fl.prototype,`rows`,void 0),O([v({attribute:!1})],Fl.prototype,`columns`,void 0),O([v()],Fl.prototype,`idField`,void 0),O([v({type:Boolean})],Fl.prototype,`navigable`,void 0),O([v()],Fl.prototype,`selectedId`,void 0),O([S()],Fl.prototype,`expandedItems`,void 0),O([b(`vaadin-grid`)],Fl.prototype,`_grid`,void 0),Fl=O([h(`mateu-vaadin-tree`)],Fl);var Il={[A.VirtualList]:(e,t,n,r,i,a,o)=>qs(e,t,n,r,i,a,o),[A.Notification]:(e,t)=>Js(t),[A.ProgressBar]:(e,t,n,r)=>Ys(t,r),[A.Details]:(e,t,n,r,i,a,o)=>Xs(e,t,n,r,i,a,o),[A.Avatar]:(e,t,n,r,i)=>Zs(t,r,i),[A.AvatarGroup]:(e,t)=>Qs(t),[A.Card]:(e,t,n,r,i,a,o)=>$s(e,t,n,r,i,a,o),[A.Button]:(e,t,n,r,i)=>kl(t,r,i),[A.MessageInput]:(e,t)=>Al(t),[A.MessageList]:(e,t)=>jl(t),[A.ConfirmDialog]:(e,t,n,r,i,a,o)=>Nl(e,t,n,r,i,a,o),[A.FormLayout]:(e,t,n,r,i,a,o)=>nc(e,t,n,r,i,a,o),[A.HorizontalLayout]:(e,t,n,r,i,a,o)=>oc(e,t,n,r,i,a,o),[A.VerticalLayout]:(e,t,n,r,i,a,o)=>sc(e,t,n,r,i,a,o),[A.SplitLayout]:(e,t,n,r,i,a,o)=>cc(e,t,n,r,i,a,o),[A.MasterDetailLayout]:(e,t,n,r,i,a,o)=>lc(e,t,n,r,i,a,o),[A.TabLayout]:(e,t,n,r,i,a,o)=>uc(e,t,n,r,i,a,o),[A.AccordionLayout]:(e,t,n,r,i,a,o)=>fc(e,t,n,r,i,a,o),[A.BoardLayout]:(e,t,n,r,i,a,o)=>hc(e,t,n,r,i,a,o),[A.BoardLayoutRow]:(e,t,n,r,i,a,o)=>gc(e,t,n,r,i,a,o),[A.BoardLayoutItem]:(e,t,n,r,i,a,o)=>_c(e,t,n,r,i,a,o),[A.Scroller]:(e,t,n,r,i,a,o)=>mc(e,t,n,r,i,a,o),[A.MenuBar]:(e,t,n,r,i)=>bc(e,t,n,r,i),[A.ContextMenu]:(e,t,n,r,i,a,o)=>yc(e,t,n,r,i,a,o),[A.FormField]:(e,t,n,r,i,a,o,s)=>bl(e,t,n,r,i,a,o,s),[A.Grid]:(e,t,n,r,i,a,o)=>xl(e,t,n,r,i,a,o),[A.Table]:(e,t,n,r,i,a,o)=>Sl(e,t,n,r,i,a,o),[A.Popover]:(e,t,n,r,i,a,o)=>wl(e,t,n,r,i,a,o),[A.FoldoutLayout]:(e,t,n,r,i,a,o)=>Pl(e,t,n,r,i,a,o)},Ll=class extends Ks{rendererName(){return`vaadin`}renderClientSideComponent(e,t,n,r,i,a,o,s){let c=t?.metadata?.type,l=c?Il[c]:void 0;return l&&t?l(e,t,n,r,i,a,o,s):super.renderClientSideComponent(e,t,n,r,i,a,o,s)}renderTableComponent(e,t,n,r,i,a,o){return Cl(e,t,n,r,a,o)}renderTreeComponent(e,t){return w`
             <mateu-vaadin-tree
                     .rows="${t.rows}"
                     .columns="${t.columns}"
                     .idField="${t.idField}"
                     .navigable="${t.navigable}"
                     .selectedId="${t.selectedId}"
-            ></mateu-vaadin-tree>`}renderToolbarButton(e,t,n){return ol(e,t,n)}renderPeerNav(e){return sl(e)}renderIcon(e,t,n){return ll(e,t,n)}renderTopNav(e,t,n){return nc(e,t,n)}};function bl(e){switch(e){case`topStretch`:return`top-stretch`;case`topStart`:return`top-start`;case`topCenter`:return`top-center`;case`topEnd`:return`top-end`;case`middle`:return`middle`;case`bottomStart`:return`bottom-start`;case`bottomEnd`:return`bottom-end`;case`bottomStretch`:return`bottom-stretch`;case`bottomCenter`:return`bottom-center`}return`bottom-end`}function xl(e,t){if(e.onAction)return{label:e.actionLabel??`Retry`,run:e.onAction};if(e.undoActionId)return{label:e.undoLabel??`Undo`,run:()=>t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.undoActionId,parameters:e.undoParameters??{}},bubbles:!0,composed:!0}))}}function Sl(e,t){let n=new r;n.position=bl(e.position),n.duration=e.duration??1e4,e.variant&&n.setAttribute(`theme`,e.variant),n.renderer=r=>{if(r.firstElementChild)return;let i=document.createElement(`span`);i.textContent=e.text;let a=xl(e,t),o=document.createElement(`button`);o.textContent=a.label,o.style.cssText=`margin-left: 0.75rem; background: none; border: 1px solid currentColor; border-radius: var(--lumo-border-radius-s, 4px); color: inherit; cursor: pointer; padding: 0.15rem 0.6rem; font: inherit; font-weight: 600;`,o.addEventListener(`click`,()=>{a.run(),n.opened=!1}),r.append(i,o)},document.body.appendChild(n),n.opened=!0,n.addEventListener(`opened-changed`,e=>{e.detail.value||n.remove()})}P.set(new yl),aa({show(e,t){if(Ze(e.text,{politeness:e.variant===`error`?`assertive`:`polite`}),e.undoActionId||e.onAction){Sl(e,t);return}r.show(e.text,{position:e.position?bl(e.position):`bottom-end`,theme:e.variant,duration:e.duration})}});
+            ></mateu-vaadin-tree>`}renderToolbarButton(e,t,n){return Tl(e,t,n)}renderPeerNav(e){return El(e)}renderIcon(e,t,n){return Ol(e,t,n)}renderTopNav(e,t,n){return vc(e,t,n)}};function Rl(e){switch(e){case`topStretch`:return`top-stretch`;case`topStart`:return`top-start`;case`topCenter`:return`top-center`;case`topEnd`:return`top-end`;case`middle`:return`middle`;case`bottomStart`:return`bottom-start`;case`bottomEnd`:return`bottom-end`;case`bottomStretch`:return`bottom-stretch`;case`bottomCenter`:return`bottom-center`}return`bottom-end`}function zl(e,t){if(e.onAction)return{label:e.actionLabel??`Retry`,run:e.onAction};if(e.undoActionId)return{label:e.undoLabel??`Undo`,run:()=>t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.undoActionId,parameters:e.undoParameters??{}},bubbles:!0,composed:!0}))}}function Bl(e,t){let n=new r;n.position=Rl(e.position),n.duration=e.duration??1e4,e.variant&&n.setAttribute(`theme`,e.variant),n.renderer=r=>{if(r.firstElementChild)return;let i=document.createElement(`span`);i.textContent=e.text;let a=zl(e,t),o=document.createElement(`button`);o.textContent=a.label,o.style.cssText=`margin-left: 0.75rem; background: none; border: 1px solid currentColor; border-radius: var(--lumo-border-radius-s, 4px); color: inherit; cursor: pointer; padding: 0.15rem 0.6rem; font: inherit; font-weight: 600;`,o.addEventListener(`click`,()=>{a.run(),n.opened=!1}),r.append(i,o)},document.body.appendChild(n),n.opened=!0,n.addEventListener(`opened-changed`,e=>{e.detail.value||n.remove()})}N.set(new Ll),oa({show(e,t){if(Qe(e.text,{politeness:e.variant===`error`?`assertive`:`polite`}),e.undoActionId||e.onAction){Bl(e,t);return}r.show(e.text,{position:e.position?Rl(e.position):`bottom-end`,theme:e.variant,duration:e.duration})}});

--- a/doc/src/content/docs/java-ui-definition/annotations/rest-options.md
+++ b/doc/src/content/docs/java-ui-definition/annotations/rest-options.md
@@ -1,0 +1,66 @@
+---
+title: "@RestOptions — external REST options"
+description: "Fill a select's options from an arbitrary, non-Mateu REST endpoint fetched client-side."
+---
+
+`@RestOptions` fills a field's select options from an **arbitrary (non-Mateu) REST endpoint**,
+fetched **client-side**: the renderer calls the URL directly — no Mateu server mediating — navigates
+to the array in the JSON response, and maps each item into an option. The field renders as a select.
+
+It is the first surface of decoupling the Mateu UI from the Mateu backend: a Mateu form talking to
+any REST API.
+
+**Target:** `FIELD` (and `ANNOTATION_TYPE`, so it composes as a [semantic annotation](./semantic-annotations)).
+
+## Example
+
+```java
+@UI("/rest-options")
+public class RestOptionsForm {
+
+  @RestOptions(
+      url = "https://restcountries.com/v3.1/all?fields=cca2,name",
+      itemsPath = "",            // the response root is already the array
+      valuePath = "cca2",
+      labelPath = "name.common") // dot paths navigate nested JSON
+  String country;
+}
+```
+
+## Attributes
+
+| Attribute    | Default   | Meaning |
+|--------------|-----------|---------|
+| `url`        | —         | The endpoint URL. Supports `${state.x}` interpolation, so the request can depend on other field values. |
+| `method`     | `GET`     | The HTTP method. |
+| `headers`    | `{}`      | Request headers as `"Name: Value"` strings (values interpolated) — e.g. an `Authorization` bearer token. |
+| `body`       | `""`      | A request body template (interpolated) for non-`GET` methods. |
+| `itemsPath`  | `""`      | A dot path to the array inside the response (`data.countries`); blank means the response root **is** the array. |
+| `valuePath`  | `value`   | A dot path within each item to the option value. |
+| `labelPath`  | `label`   | A dot path within each item to the option label. |
+
+A primitive array element becomes its own value and label; a missing `valuePath`/`labelPath` falls
+back to the other side, so half-specified mappings still render.
+
+## How it works
+
+`@RestOptions` travels on the wire as `FormFieldDto.optionsSource` (a `RestDataSource` descriptor:
+`url`, `method`, `headers`, `body`, `itemsPath`, `valuePath`, `labelPath`). The renderer interpolates
+the url/headers/body against the live field state, `fetch`es the endpoint, and shapes the JSON into
+the select's options — a pure client-side call, so the endpoint must be reachable from the browser
+(CORS-friendly for cross-origin APIs; same-origin needs nothing).
+
+## Interpolation and dependent options
+
+Because `url`/`headers`/`body` support `${state.x}`, a select can depend on another field. The
+options refetch whenever the interpolated url changes:
+
+```java
+@RestOptions(url = "/api/cities?country=${state.country}", valuePath = "id", labelPath = "name")
+String city;
+```
+
+:::note
+This is the **options** surface. Consuming external endpoints for listing rows, form data and
+button actions reuses the same `RestDataSource` descriptor and is on the roadmap.
+:::

--- a/e2e/sut/apps/mvc-app1/src/main/resources/static/rest-options-demo.json
+++ b/e2e/sut/apps/mvc-app1/src/main/resources/static/rest-options-demo.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "countries": [
+      { "code": "ES", "name": { "common": "Spain" } },
+      { "code": "FR", "name": { "common": "France" } },
+      { "code": "DE", "name": { "common": "Germany" } },
+      { "code": "IT", "name": { "common": "Italy" } },
+      { "code": "PT", "name": { "common": "Portugal" } }
+    ]
+  }
+}

--- a/e2e/sut/modules/sample1/src/main/java/io/mateu/sample1/RestOptionsForm.java
+++ b/e2e/sut/modules/sample1/src/main/java/io/mateu/sample1/RestOptionsForm.java
@@ -1,0 +1,31 @@
+package io.mateu.sample1;
+
+import io.mateu.uidl.annotations.*;
+import io.mateu.uidl.data.Message;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * A select whose options come from an arbitrary REST endpoint, fetched CLIENT-SIDE — the first
+ * surface of consuming non-Mateu endpoints. The JSON is served same-origin by the app
+ * (static/rest-options-demo.json); {@code itemsPath} navigates to the array, {@code valuePath}/
+ * {@code labelPath} map each item (the label lives at a nested path to exercise dot navigation).
+ */
+@UI("/rest-options")
+@Title("REST Options Form")
+@Getter
+@Setter
+public class RestOptionsForm {
+
+    @RestOptions(
+            url = "/rest-options-demo.json",
+            itemsPath = "data.countries",
+            valuePath = "code",
+            labelPath = "name.common")
+    String country;
+
+    @Button
+    public Message submit() {
+        return new Message("Selected country: " + country);
+    }
+}

--- a/frontend/web/monorepo/apps/vaadin/src/fields/mateu-field.ts
+++ b/frontend/web/monorepo/apps/vaadin/src/fields/mateu-field.ts
@@ -7,6 +7,7 @@ import { fieldAttribute } from '@components/mateu-file-upload.ts';
 import '@components/mateu-bulleted-list.ts';
 import {css, html, LitElement, nothing, PropertyValues, TemplateResult} from "lit";
 import { interpolate } from '@components/interpolation'
+import { fetchExternalOptions } from '@mateu/ui/infra/http/externalOptions'
 import '@vaadin/horizontal-layout'
 import '@vaadin/vertical-layout'
 import '@vaadin/form-layout'
@@ -964,6 +965,41 @@ export class MateuField extends LitElement {
                 `
             }
             if (this.field?.stereotype == 'select') {
+                if (this.field?.optionsSource) {
+                    // Options from an arbitrary REST endpoint, fetched CLIENT-SIDE (no Mateu server
+                    // mediating). Refetch only when the interpolated url changes (a state-dependent
+                    // source), keyed by a signature so re-renders don't loop.
+                    const src = this.field.optionsSource
+                    const signature = interpolate(src.url, this.state, this.data) ?? src.url
+                    if (this.data[this.id]?.sourceSignature !== signature) {
+                        this.data[this.id] = { content: this.data[this.id]?.content ?? [], sourceSignature: signature }
+                        fetchExternalOptions(src, (t) => interpolate(t, this.state, this.data))
+                            .then((opts) => {
+                                this.data[this.id] = { content: opts, totalElements: opts.length, sourceSignature: signature }
+                                this.requestUpdate()
+                            })
+                            .catch((e) => console.warn('mateu: external options fetch failed', e))
+                    }
+                    let realValue = value
+                    if (value && value.value) {
+                        realValue = value.value
+                    }
+                    return html`
+                    <vaadin-select
+                            id="${this.field.fieldId}"
+                            label="${label}"
+                            item-label-path="label"
+                            item-value-path="value"
+                            .items="${this.data[this.id]?.content ?? []}"
+                            .helperText="${this.helperText()}"
+                            @value-changed="${this.valueChanged}"
+                            .value="${realValue}"
+                            ?autofocus="${this.field.wantsFocus}"
+                            required="${this.field.required || nothing}"
+                            data-colspan="${this.field.colspan}"
+                    ></vaadin-select>
+                    `
+                }
                 if (this.field?.remoteCoordinates) {
                     const coords = this.field.remoteCoordinates;
                     const filter = ''

--- a/frontend/web/monorepo/libs/mateu/src/mateu/shared/apiClients/dtos/componentmetadata/FormField.ts
+++ b/frontend/web/monorepo/libs/mateu/src/mateu/shared/apiClients/dtos/componentmetadata/FormField.ts
@@ -4,6 +4,7 @@ import Option from "@mateu/shared/apiClients/dtos/componentmetadata/Option";
 import ComponentMetadata from "@mateu/shared/apiClients/dtos/ComponentMetadata";
 import ClientSideComponent from "@mateu/shared/apiClients/dtos/ClientSideComponent.ts";
 import RemoteCoordinates from "@mateu/shared/apiClients/dtos/componentmetadata/RemoteCoordinates.ts";
+import RestDataSource from "@mateu/shared/apiClients/dtos/componentmetadata/RestDataSource.ts";
 import NavLink from "@mateu/shared/apiClients/dtos/componentmetadata/NavLink.ts";
 
 export default interface FormField extends ComponentMetadata {
@@ -25,6 +26,7 @@ export default interface FormField extends ComponentMetadata {
     initialValue?: unknown
     options?: Option[] | undefined
     remoteCoordinates: RemoteCoordinates | undefined
+    optionsSource?: RestDataSource | undefined
     charLimit?: string
     required: boolean
     disabled: boolean

--- a/frontend/web/monorepo/libs/mateu/src/mateu/shared/apiClients/dtos/componentmetadata/RestDataSource.ts
+++ b/frontend/web/monorepo/libs/mateu/src/mateu/shared/apiClients/dtos/componentmetadata/RestDataSource.ts
@@ -1,0 +1,15 @@
+/**
+ * Descriptor for consuming an arbitrary (non-Mateu) REST endpoint CLIENT-SIDE: the renderer fetches
+ * the URL directly and shapes the JSON response into the surface's expected form (a select's options
+ * today). `url`/`headers`/`body` support `${state.x}` interpolation; `itemsPath` navigates to the
+ * response array; `valuePath`/`labelPath` map each item.
+ */
+export default interface RestDataSource {
+    url: string
+    method?: string | undefined
+    headers?: Record<string, string> | undefined
+    body?: string | undefined
+    itemsPath?: string | undefined
+    valuePath?: string | undefined
+    labelPath?: string | undefined
+}

--- a/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/http/externalOptions.test.ts
+++ b/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/http/externalOptions.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import { getByPath, mapItemsToOptions, fetchExternalOptions } from './externalOptions'
+import type RestDataSource from '@mateu/shared/apiClients/dtos/componentmetadata/RestDataSource.ts'
+
+describe('getByPath', () => {
+    it('returns the object itself for an empty path', () => {
+        expect(getByPath({ a: 1 }, '')).toEqual({ a: 1 })
+        expect(getByPath({ a: 1 }, undefined)).toEqual({ a: 1 })
+    })
+    it('navigates a dot path', () => {
+        expect(getByPath({ name: { common: 'Spain' } }, 'name.common')).toBe('Spain')
+    })
+    it('is undefined for a missing key', () => {
+        expect(getByPath({ a: 1 }, 'b.c')).toBeUndefined()
+    })
+})
+
+describe('mapItemsToOptions', () => {
+    it('maps objects by value/label paths', () => {
+        const json = { data: { items: [{ cca2: 'ES', name: { common: 'Spain' } }] } }
+        expect(mapItemsToOptions(json, 'data.items', 'cca2', 'name.common')).toEqual([
+            { value: 'ES', label: 'Spain' },
+        ])
+    })
+    it('treats the root as the array when itemsPath is blank', () => {
+        const json = [{ id: 1, title: 'One' }]
+        expect(mapItemsToOptions(json, '', 'id', 'title')).toEqual([{ value: 1, label: 'One' }])
+    })
+    it('maps a primitive array to value=label', () => {
+        expect(mapItemsToOptions(['a', 'b'], '')).toEqual([
+            { value: 'a', label: 'a' },
+            { value: 'b', label: 'b' },
+        ])
+    })
+    it('falls back value↔label when one side is missing', () => {
+        expect(mapItemsToOptions([{ name: 'X' }], '', 'missing', 'name')).toEqual([
+            { value: 'X', label: 'X' },
+        ])
+    })
+    it('returns [] when the path is not an array', () => {
+        expect(mapItemsToOptions({ nope: true }, 'data.items')).toEqual([])
+    })
+})
+
+describe('fetchExternalOptions', () => {
+    const ok = (body: unknown): typeof fetch =>
+        (async () => ({ ok: true, status: 200, json: async () => body })) as unknown as typeof fetch
+
+    it('interpolates the url and maps the response', async () => {
+        let calledUrl = ''
+        const source: RestDataSource = { url: 'https://x/${state.q}', itemsPath: '', valuePath: 'v', labelPath: 'l' }
+        const fetchImpl = (async (u: string) => {
+            calledUrl = u
+            return { ok: true, status: 200, json: async () => [{ v: 1, l: 'one' }] }
+        }) as unknown as typeof fetch
+        const opts = await fetchExternalOptions(source, (t) => t?.replace('${state.q}', 'ES'), fetchImpl)
+        expect(calledUrl).toBe('https://x/ES')
+        expect(opts).toEqual([{ value: 1, label: 'one' }])
+    })
+
+    it('throws on a non-2xx response', async () => {
+        const fetchImpl = (async () => ({ ok: false, status: 503, json: async () => ({}) })) as unknown as typeof fetch
+        await expect(fetchExternalOptions({ url: 'https://x' }, (t) => t, fetchImpl)).rejects.toThrow(/503/)
+    })
+
+    it('sends a body for POST', async () => {
+        let sentBody: unknown
+        const source: RestDataSource = { url: 'https://x', method: 'POST', body: '{"q":1}' }
+        const fetchImpl = (async (_u: string, init: RequestInit) => {
+            sentBody = init.body
+            return { ok: true, status: 200, json: async () => [] }
+        }) as unknown as typeof fetch
+        await fetchExternalOptions(source, (t) => t, fetchImpl)
+        expect(sentBody).toBe('{"q":1}')
+        void ok
+    })
+})

--- a/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/http/externalOptions.ts
+++ b/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/http/externalOptions.ts
@@ -1,0 +1,68 @@
+import type RestDataSource from '@mateu/shared/apiClients/dtos/componentmetadata/RestDataSource.ts'
+
+/**
+ * Client-side consumption of an arbitrary (non-Mateu) REST endpoint for a field's select options —
+ * the first surface of the "decouple the UI from the Mateu backend" line. The renderer fetches the
+ * endpoint directly (no Mateu server mediating), navigates to the response array and maps each item
+ * into an option. Pure helpers (`getByPath`/`mapItemsToOptions`) are vitest-tested; `fetch` is
+ * injectable so `fetchExternalOptions` is too.
+ */
+
+export interface FetchedOption {
+    value: unknown
+    label: string
+}
+
+/** Navigate a dot path (`data.items`, `name.common`) into a JSON value; an empty path is identity. */
+export function getByPath(obj: unknown, path?: string): unknown {
+    if (!path) return obj
+    return path.split('.').reduce<unknown>(
+        (acc, key) => (acc != null && typeof acc === 'object' ? (acc as Record<string, unknown>)[key] : undefined),
+        obj,
+    )
+}
+
+/**
+ * Shape a JSON response into options: navigate `itemsPath` to the array, then read `valuePath`/
+ * `labelPath` from each item. A primitive array element becomes its own value and label; a missing
+ * value falls back to the label (and vice-versa) so half-specified mappings still render.
+ */
+export function mapItemsToOptions(
+    json: unknown,
+    itemsPath?: string,
+    valuePath: string = 'value',
+    labelPath: string = 'label',
+): FetchedOption[] {
+    const arr = getByPath(json, itemsPath)
+    if (!Array.isArray(arr)) return []
+    return arr.map((item) => {
+        if (item != null && typeof item === 'object') {
+            const value = getByPath(item, valuePath)
+            const label = getByPath(item, labelPath)
+            return { value: value ?? label, label: String(label ?? value ?? '') }
+        }
+        return { value: item, label: String(item) }
+    })
+}
+
+/**
+ * Fetch a field's options from its {@link RestDataSource}. `resolve` interpolates `${state.x}`
+ * templates in the url/headers/body against the current field context (pass the shared
+ * `interpolate`); it defaults to identity for tests. Throws on a non-2xx response.
+ */
+export async function fetchExternalOptions(
+    source: RestDataSource,
+    resolve: (tpl: string | undefined) => string | undefined = (t) => t,
+    fetchImpl: typeof fetch = fetch,
+): Promise<FetchedOption[]> {
+    const url = resolve(source.url) ?? source.url
+    const method = (source.method || 'GET').toUpperCase()
+    const headers: Record<string, string> = {}
+    for (const [k, v] of Object.entries(source.headers ?? {})) headers[k] = resolve(v) ?? v
+    const init: RequestInit = { method, headers }
+    if (method !== 'GET' && method !== 'HEAD' && source.body) init.body = resolve(source.body) ?? source.body
+    const res = await fetchImpl(url, init)
+    if (!res.ok) throw new Error(`External options fetch failed: ${res.status}`)
+    const json = await res.json()
+    return mapItemsToOptions(json, source.itemsPath, source.valuePath, source.labelPath)
+}


### PR DESCRIPTION
The **first surface** of consuming non-Mateu REST endpoints — decouple the Mateu UI from the Mateu backend by letting a field's select options come from **any** REST API, fetched **client-side** (no Mateu server mediating). Fetch mode = client-direct, as decided.

## Usage
```java
@RestOptions(
    url = "https://restcountries.com/v3.1/all?fields=cca2,name",
    itemsPath = "",            // response root is the array
    valuePath = "cca2",
    labelPath = "name.common") // dot paths for nested JSON
String country;
```
The field renders as a select; the renderer fetches the URL directly, navigates `itemsPath` to the array and maps each item via `valuePath`/`labelPath`. `url`/`headers`/`body` support `${state.x}` interpolation, so a select can depend on another field (refetches when the interpolated url changes).

## Wire + mapping
- New `RestDataSourceDto` (`url`, `method`, `headers`, `body`, `itemsPath`, `valuePath`, `labelPath`) on `FormFieldDto.optionsSource`; mirrored by fluent `uidl.data.RestDataSource`.
- `FieldTypeMapper`: `@RestOptions` → stereotype `select`. `FieldMetadataExtractor` builds the descriptor; `FieldMapper` maps it to the DTO.
- The descriptor is intentionally **general** so the next surfaces (listing rows, form data, endpoint actions) reuse it.

## Frontend (shared → every renderer)
- `libs/mateu/ui/infra/http/externalOptions.ts`: pure `getByPath`/`mapItemsToOptions` + `fetchExternalOptions` (injectable `fetch`).
- `mateu-field.ts` select branch fetches on first render (and when the interpolated url changes), populating the `vaadin-select`.

## Verified
- **core** `RestOptionsSyncTest`: `@RestOptions` → select + full descriptor on `optionsSource`.
- **vitest** `externalOptions.test.ts` (11): path navigation, item mapping (incl. primitives + half-specified fallbacks), fetch + interpolation + non-2xx.
- **browser** (`mvc-app1` `/rest-options`): client-side fetch of a same-origin JSON, select populated with all 5 options including the nested `name.common` label path.

Docs: `java-ui-definition/annotations/rest-options.md`.

Scope note: this is the options surface (client-direct). Listing rows, form data and endpoint actions reuse `RestDataSource` and are the next increments. .NET/Python port is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)