### PR TITLE
Port @RestOptions to .NET and Python (external REST select options)

### DIFF
--- a/backend/dotnet/src/Mateu.Core/ReflectionMapper.cs
+++ b/backend/dotnet/src/Mateu.Core/ReflectionMapper.cs
@@ -1361,6 +1361,8 @@ public sealed class ReflectionMapper(ITranslator? translator = null, Func<Identi
             RemoteCoordinates = p.Find<LookupAttribute>() != null
                 ? new RemoteCoordinatesDto("search-" + fieldId)
                 : null,
+            // [RestOptions]: options fetched client-side from an arbitrary REST endpoint.
+            OptionsSource = RestOptionsOf(p),
             // [FileUpload(Accept = ".csv")]: the file input's accept filter travels in the
             // field's generic attributes list — no dedicated wire field (Java parity).
             Attributes = p.Find<FileUploadAttribute>() is { Accept.Length: > 0 } fileUpload
@@ -1402,6 +1404,8 @@ public sealed class ReflectionMapper(ITranslator? translator = null, Func<Identi
         if (p.Find<TreeSelectAttribute>() != null) return "treeSelect";
         if (p.Find<PasswordAttribute>() != null) return "password";
         if (p.Find<MoneyAttribute>() != null) return plainText ? "plainText" : "money";
+        // [RestOptions]: options fetched client-side from an arbitrary REST endpoint → a select.
+        if (p.Find<RestOptionsAttribute>() != null) return "select";
         if (p.Find<LookupAttribute>() != null) return "combobox";
         if (p.Find<SearchableAttribute>() != null) return "searchable";
         if (plainText) return "plainText";
@@ -1411,6 +1415,28 @@ public sealed class ReflectionMapper(ITranslator? translator = null, Func<Identi
                 : "select";
         if (multiline) return "textarea";
         return "regular";
+    }
+
+    /// <summary>The client-side external options descriptor when the property carries [RestOptions]
+    /// (headers parsed from "Name: Value" strings); null otherwise.</summary>
+    private static RestDataSourceDto? RestOptionsOf(PropertyInfo p)
+    {
+        if (p.Find<RestOptionsAttribute>() is not { } a) return null;
+        var headers = new Dictionary<string, string>();
+        foreach (var h in a.Headers)
+        {
+            var i = h.IndexOf(':');
+            if (i > 0) headers[h[..i].Trim()] = h[(i + 1)..].Trim();
+        }
+        return new RestDataSourceDto(a.Url)
+        {
+            Method = a.Method,
+            Headers = headers,
+            Body = a.Body,
+            ItemsPath = a.ItemsPath,
+            ValuePath = a.ValuePath,
+            LabelPath = a.LabelPath,
+        };
     }
 
     /// <summary>The stereotype a field renders with, including its plain-text context — the weight

--- a/backend/dotnet/src/Mateu.Dtos/Wire.cs
+++ b/backend/dotnet/src/Mateu.Dtos/Wire.cs
@@ -925,6 +925,11 @@ public record FormFieldMetadataDto(string FieldId, string DataType, string Label
     /// non-lookup fields.</summary>
     public RemoteCoordinatesDto? RemoteCoordinates { get; init; }
 
+    /// <summary>Options fetched CLIENT-SIDE from an arbitrary (non-Mateu) REST endpoint
+    /// ([RestOptions]); the renderer calls the URL directly and maps the JSON into the select's
+    /// options. Null on fields without an external source.</summary>
+    public RestDataSourceDto? OptionsSource { get; init; }
+
     /// <summary>Grid (list-of-rows) fields: one GridColumn per row-type property. Null on
     /// non-grid fields.</summary>
     public IReadOnlyList<GridColumnDto>? Columns { get; init; }
@@ -955,6 +960,20 @@ public record RemoteCoordinatesDto(string Action)
     public string? BaseUrl { get; init; }
     public string? Route { get; init; }
     public Dictionary<string, object?>? Params { get; init; }
+}
+
+/// <summary>Descriptor for consuming an arbitrary (non-Mateu) REST endpoint CLIENT-SIDE (mirrors
+/// io.mateu.dtos.RestDataSourceDto): the renderer fetches the URL directly, navigates ItemsPath to
+/// the response array and maps each item via ValuePath/LabelPath. Url/Headers/Body support
+/// ${state.x} interpolation.</summary>
+public record RestDataSourceDto(string Url)
+{
+    public string? Method { get; init; }
+    public Dictionary<string, string>? Headers { get; init; }
+    public string? Body { get; init; }
+    public string? ItemsPath { get; init; }
+    public string? ValuePath { get; init; }
+    public string? LabelPath { get; init; }
 }
 
 /// <summary>A drawer overlay (mirrors io.mateu.dtos.DrawerDto): a panel sliding in from a

--- a/backend/dotnet/src/Mateu.Uidl/FieldAndPageFeatures.cs
+++ b/backend/dotnet/src/Mateu.Uidl/FieldAndPageFeatures.cs
@@ -48,6 +48,27 @@ public sealed class UseRadioButtonsAttribute : Attribute;
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Class)]
 public sealed class LookupAttribute : Attribute;
 
+/// <summary>Fills a field's select options from an arbitrary (non-Mateu) REST endpoint, fetched
+/// CLIENT-SIDE: the renderer calls <see cref="Url"/> directly (no Mateu server mediating),
+/// navigates <see cref="ItemsPath"/> to the array in the JSON response and maps each item via
+/// <see cref="ValuePath"/>/<see cref="LabelPath"/>. The field renders as a select. Url/Headers/Body
+/// support <c>${state.x}</c> interpolation. (C# analogue of Java's @RestOptions.)</summary>
+[AttributeUsage(AttributeTargets.Property)]
+public sealed class RestOptionsAttribute(string url) : Attribute
+{
+    public string Url { get; } = url;
+    public string Method { get; init; } = "GET";
+
+    /// <summary>Request headers as "Name: Value" strings (values interpolated).</summary>
+    public string[] Headers { get; init; } = [];
+    public string Body { get; init; } = "";
+
+    /// <summary>A dot path to the array inside the response; blank means the root IS the array.</summary>
+    public string ItemsPath { get; init; } = "";
+    public string ValuePath { get; init; } = "value";
+    public string LabelPath { get; init; } = "label";
+}
+
 /// <summary>A reference field picked through a full selector DIALOG instead of a combo: clicking
 /// the field fires <c>codesearch-&lt;fieldId&gt;</c>, which opens the given selector — a Listing
 /// implementing ISelector — in a modal; selecting a row writes its (id, label) back into the

--- a/backend/dotnet/test/Mateu.Tests/SyncHandlerTests.cs
+++ b/backend/dotnet/test/Mateu.Tests/SyncHandlerTests.cs
@@ -18,6 +18,16 @@ public class SimpleForm
     [Button] public string GoHome() => "/things";
 }
 
+// A select whose options come from an arbitrary REST endpoint, fetched client-side.
+[UI("rest-opts"), Title("Rest options")]
+public class RestOptsForm
+{
+    [RestOptions("https://api.example.com/countries",
+        Headers = ["Authorization: Bearer x"],
+        ItemsPath = "data.countries", ValuePath = "code", LabelPath = "name.common")]
+    public string Country { get; set; } = "";
+}
+
 // A fully-static screen: the client caches its whole response and skips the round-trip on return.
 [UI("static-view"), Title("About"), StaticView]
 public class StaticViewForm
@@ -1766,6 +1776,21 @@ public class SyncHandlerTests
 
         Assert.Contains("\"stereotype\":\"combobox\"", json);
         Assert.Contains("\"remoteCoordinates\":{\"action\":\"search-supplier\"", json);
+    }
+
+    [Fact]
+    public void RestOptions_field_is_a_select_carrying_the_endpoint_descriptor()
+    {
+        var inc = Handler().Handle(new RunActionRqDto { Route = "rest-opts", ConsumedRoute = "rest-opts" });
+        var json = Render(inc);
+
+        Assert.Contains("\"stereotype\":\"select\"", json);
+        Assert.Contains("\"optionsSource\":{", json);
+        Assert.Contains("\"url\":\"https://api.example.com/countries\"", json);
+        Assert.Contains("\"itemsPath\":\"data.countries\"", json);
+        Assert.Contains("\"valuePath\":\"code\"", json);
+        Assert.Contains("\"labelPath\":\"name.common\"", json);
+        Assert.Contains("\"Authorization\":\"Bearer x\"", json); // header parsed from "Name: Value"
     }
 
     [Fact]

--- a/backend/python/mateu_core/mapper.py
+++ b/backend/python/mateu_core/mapper.py
@@ -120,6 +120,7 @@ from mateu_dtos import (
     ProgressStepsMetadata,
     StepRecord,
     RemoteCoordinates,
+    RestDataSource,
     RuleRecord,
     ScoreboardMetadata,
     ServerSideComponent,
@@ -164,6 +165,7 @@ from mateu_uidl import (
     LinkTo,
     Listing,
     Lookup,
+    RestOptions,
     Money,
     Multiline,
     NotificationsSupplier,
@@ -2543,6 +2545,8 @@ class ReflectionMapper:
             remote_coordinates=(
                 RemoteCoordinates(action=f"search-{field_id}") if f.has(Lookup) else None
             ),
+            # RestOptions(): options fetched client-side from an arbitrary REST endpoint.
+            options_source=self._rest_options(f),
             # FileUpload(accept=".csv"): the file input's accept filter travels in the field's
             # generic attributes list — no dedicated wire field (Java parity).
             attributes=(
@@ -2552,6 +2556,28 @@ class ReflectionMapper:
             ),
         )
         return self.client(meta, field_id, [])
+
+    @staticmethod
+    def _rest_options(f) -> "RestDataSource | None":
+        """The client-side external options descriptor when the field carries ``RestOptions()``
+        (headers parsed from "Name: Value" strings); None otherwise."""
+        if not f.has(RestOptions):
+            return None
+        a = f.marker(RestOptions)
+        headers: dict[str, str] = {}
+        for h in a.headers:
+            name, sep, value = h.partition(":")
+            if sep:
+                headers[name.strip()] = value.strip()
+        return RestDataSource(
+            url=a.url,
+            method=a.method,
+            headers=headers,
+            body=a.body,
+            items_path=a.items_path,
+            value_path=a.value_path,
+            label_path=a.label_path,
+        )
 
     def link_of(self, f, instance) -> NavLinkRecord | None:
         """The field's nav link: a :class:`LinkSupplier` on the view wins; when it returns ``None``
@@ -2612,6 +2638,9 @@ class ReflectionMapper:
             return "password"
         if f.has(Money):
             return "plainText" if plain else "money"
+        # RestOptions(): options fetched client-side from an arbitrary REST endpoint → a select.
+        if f.has(RestOptions):
+            return "select"
         if f.has(Lookup):
             return "combobox"
         if f.has(Searchable):

--- a/backend/python/mateu_dtos/__init__.py
+++ b/backend/python/mateu_dtos/__init__.py
@@ -166,6 +166,10 @@ class FormFieldMetadata(Wire):
     #: Where a lookup (remote combo) field searches its options: the renderer fires ``action``
     #: with {searchText, page, size} and expects a page of options back. None on other fields.
     remote_coordinates: "RemoteCoordinates | None" = None
+    #: Options fetched CLIENT-SIDE from an arbitrary (non-Mateu) REST endpoint (``RestOptions()``):
+    #: the renderer calls the URL directly and maps the JSON into the select's options. None on
+    #: fields without an external source.
+    options_source: "RestDataSource | None" = None
     #: Grid (list-of-rows) fields: one GridColumn per row-type field. None on non-grid fields.
     columns: "list[GridColumn] | None" = None
     #: Grid fields: the row-identity path ("_rowNumber" — rows are identified by position).
@@ -195,6 +199,21 @@ class RemoteCoordinates(Wire):
     base_url: str | None = None
     route: str | None = None
     params: dict[str, Any] | None = None
+
+
+class RestDataSource(Wire):
+    """Descriptor for consuming an arbitrary (non-Mateu) REST endpoint CLIENT-SIDE (mirrors
+    ``io.mateu.dtos.RestDataSourceDto``): the renderer fetches ``url`` directly, navigates
+    ``items_path`` to the response array and maps each item via ``value_path``/``label_path``.
+    ``url``/``headers``/``body`` support ``${state.x}`` interpolation."""
+
+    url: str
+    method: str | None = None
+    headers: dict[str, str] | None = None
+    body: str | None = None
+    items_path: str | None = None
+    value_path: str | None = None
+    label_path: str | None = None
 
 
 class NavLinkRecord(Wire):

--- a/backend/python/mateu_uidl/__init__.py
+++ b/backend/python/mateu_uidl/__init__.py
@@ -177,6 +177,23 @@ class FileUpload:
 
 
 @dataclass(frozen=True)
+class RestOptions:
+    """Fills a field's select options from an arbitrary (non-Mateu) REST endpoint, fetched
+    CLIENT-SIDE: the renderer calls ``url`` directly (no Mateu server mediating), navigates
+    ``items_path`` to the array in the JSON response and maps each item via
+    ``value_path``/``label_path``. The field renders as a select. ``url``/``headers``/``body``
+    support ``${state.x}`` interpolation. Python analogue of Java's @RestOptions."""
+
+    url: str = ""
+    method: str = "GET"
+    headers: tuple[str, ...] = ()  #: "Name: Value" strings (values interpolated)
+    body: str = ""
+    items_path: str = ""  #: dot path to the response array; blank means the root IS the array
+    value_path: str = "value"
+    label_path: str = "label"
+
+
+@dataclass(frozen=True)
 class RangeFilter:
     """On a numeric field of a Crud entity: the listing filter becomes a min-max RANGE widget
     (the bounds travel as <field>_from/<field>_to state keys) instead of an equality input.
@@ -1491,7 +1508,7 @@ class Welcome(ComponentTreeSupplier):
 __all__ = [
     "Message", "MessageVariant", "BannerTheme", "PageBanner", "PageWidth", "PageType",
     "Required", "Label", "Section", "Tab", "Stereotype", "Multiline", "Password",
-    "Money", "PlainText", "ReadOnly", "Version", "Lookup", "Hidden", "Disabled", "OnRowSelected", "InlineEditing", "EyesOnly", "ReadOnlyUnless", "DisabledUnless", "Identity", "disabled_unless", "Audience", "audience", "LookupLabelSupplier", "Rule", "RuleSupplier", "AppHeaderAction", "AppActionsSupplier", "PeerNav", "PeerNavigationSupplier", "AppNotification", "NotificationsSupplier", "BulletedList", "SeparatorBefore", "Signature", "PhotoCapture", "FileUpload", "RangeFilter", "Aggregate", "AggregateFunction", "GroupBy", "TreeSelect", "UseRadioButtons", "HeaderBadge", "Timestamp", "Step", "Panel",
+    "Money", "PlainText", "ReadOnly", "Version", "Lookup", "RestOptions", "Hidden", "Disabled", "OnRowSelected", "InlineEditing", "EyesOnly", "ReadOnlyUnless", "DisabledUnless", "Identity", "disabled_unless", "Audience", "audience", "LookupLabelSupplier", "Rule", "RuleSupplier", "AppHeaderAction", "AppActionsSupplier", "PeerNav", "PeerNavigationSupplier", "AppNotification", "NotificationsSupplier", "BulletedList", "SeparatorBefore", "Signature", "PhotoCapture", "FileUpload", "RangeFilter", "Aggregate", "AggregateFunction", "GroupBy", "TreeSelect", "UseRadioButtons", "HeaderBadge", "Timestamp", "Step", "Panel",
     "ai", "remote_menu", "ui", "title", "subtitle", "app", "auto_layout", "read_only", "compact",
     "static_view",
     "confirm_on_navigation_if_dirty", "inline_editing", "toc", "zones", "folded_layout", "form_layout", "LabelsAsideMode", "wizard_progress", "page_width", "page_template",

--- a/backend/python/tests/test_sync_handler.py
+++ b/backend/python/tests/test_sync_handler.py
@@ -47,6 +47,7 @@ from mateu_uidl import (  # noqa: E402
     LinkTo,
     Lookup,
     Message,
+    RestOptions,
     Money,
     Multiline,
     NavLink,
@@ -1663,6 +1664,34 @@ def test_lookup_field_renders_a_remote_combobox_on_the_wire():
 
     assert '"stereotype": "combobox"' in j
     assert '"remoteCoordinates": {"action": "search-supplier"' in j
+
+
+@ui("rest-opts")
+@title("Rest options")
+class RestOptsForm:
+    country: Annotated[
+        str,
+        RestOptions(
+            url="https://api.example.com/countries",
+            headers=("Authorization: Bearer x",),
+            items_path="data.countries",
+            value_path="code",
+            label_path="name.common",
+        ),
+    ] = ""
+
+
+def test_rest_options_field_is_a_select_carrying_the_endpoint_descriptor():
+    inc = handler().handle(RunActionRq(route="rest-opts", consumed_route="rest-opts"))
+    j = render(inc)
+
+    assert '"stereotype": "select"' in j
+    assert '"optionsSource": {' in j
+    assert '"url": "https://api.example.com/countries"' in j
+    assert '"itemsPath": "data.countries"' in j
+    assert '"valuePath": "code"' in j
+    assert '"labelPath": "name.common"' in j
+    assert '"Authorization": "Bearer x"' in j  # header parsed from "Name: Value"
 
 
 def test_lookup_search_filters_and_pages_the_suppliers_options():

--- a/doc/src/content/docs/java-ui-definition/annotations/rest-options.md
+++ b/doc/src/content/docs/java-ui-definition/annotations/rest-options.md
@@ -64,3 +64,22 @@ String city;
 This is the **options** surface. Consuming external endpoints for listing rows, form data and
 button actions reuses the same `RestDataSource` descriptor and is on the roadmap.
 :::
+
+## Other backends
+
+Mateu.NET and the Python backend emit the same `optionsSource` descriptor, so any renderer fetches
+the endpoint the same way:
+
+```csharp
+// .NET
+[RestOptions("https://api.example.com/countries",
+    ItemsPath = "data.countries", ValuePath = "code", LabelPath = "name.common")]
+public string Country { get; set; } = "";
+```
+
+```python
+# Python
+country: Annotated[str, RestOptions(
+    url="https://api.example.com/countries",
+    items_path="data.countries", value_path="code", label_path="name.common")] = ""
+```

--- a/doc/src/content/docs/reference/parity.md
+++ b/doc/src/content/docs/reference/parity.md
@@ -47,6 +47,7 @@ for the surface below (verified by golden-JSON tests in `backend/dotnet/test` an
 | Tree lookup selectors (`GridLayout.tree` + `Selector`) | ✅ | ✅ | ✅ |
 | Lookup fields (`@Lookup` remote combobox + `search-<field>` action) | ✅ | ✅ | ✅ |
 | — `@Searchable` full selector dialogs (`Selector` + `codesearch`) | ✅ | ✅ | ✅ |
+| External REST options (`@RestOptions`/`[RestOptions]`/`RestOptions()` → select; options fetched client-side from an arbitrary endpoint via `FormField.optionsSource`) | ✅ | ✅ | ✅ |
 | Editable grids / inline CRUD editing (`@InlineEditing` + update-row) | ✅ | ✅ | ✅ |
 | Bulk list actions (`@ListToolbarButton` + typed selection) | ✅ | ✅ | ✅ |
 | Listing aggregates & grouping (`@Aggregate`/`@GroupBy` + summaries) | ✅ | ✅ | ✅ |


### PR DESCRIPTION
Ports the first external-endpoints surface ([#334](https://github.com/miguelperezcolom/mateu/pull/334)) to Mateu.NET and the Python backend: a field whose select options are fetched **client-side** from an arbitrary (non-Mateu) REST endpoint. Backend-only — the shared frontend already consumes `optionsSource` from any backend.

## .NET
```csharp
[RestOptions("https://api.example.com/countries",
    ItemsPath = "data.countries", ValuePath = "code", LabelPath = "name.common")]
public string Country { get; set; } = "";
```
`[RestOptions]` → stereotype `select` + `FormFieldMetadataDto.OptionsSource` (new `RestDataSourceDto`). Mapped in `ReflectionMapper` (`StereotypeOf` + `RestOptionsOf`; headers parsed from `"Name: Value"`).

## Python
```python
country: Annotated[str, RestOptions(
    url="https://api.example.com/countries",
    items_path="data.countries", value_path="code", label_path="name.common")] = ""
```
`RestOptions(...)` marker → stereotype `select` + `FormFieldMetadata.options_source` (new `RestDataSource`). Mapped in `mapper.py` (`stereotype_of` + `_rest_options`); exported in `__all__`.

Both mirror the Java descriptor exactly (`url`/`method`/`headers`/`body`/`itemsPath`/`valuePath`/`labelPath`), so the same `optionsSource` wire drives the renderer's client-side fetch regardless of backend.

## Tests
- .NET: `RestOptions_field_is_a_select_carrying_the_endpoint_descriptor` — 242/242
- Python: `test_rest_options_field_is_a_select_carrying_the_endpoint_descriptor` — 241
- Parity row + port examples added to the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)