### PR TITLE
Port @RestListing to .NET and Python (external REST listing rows)

### DIFF
--- a/backend/dotnet/src/Mateu.Core/ReflectionMapper.cs
+++ b/backend/dotnet/src/Mateu.Core/ReflectionMapper.cs
@@ -818,6 +818,8 @@ public sealed class ReflectionMapper(ITranslator? translator = null, Func<Identi
             Filters = MapListingFilters(filters),
             GridLayout = gridLayout,
             GroupBy = GroupByOf(row),
+            // [RestListing]: rows fetched client-side from an arbitrary REST endpoint.
+            RowsSource = RestListingOf(viewType),
         }, "crud", []);
         var pageChildren = new List<ComponentDto>();
         if (smartSearch?.PageSubtitle() is { } subtitle)
@@ -1422,21 +1424,42 @@ public sealed class ReflectionMapper(ITranslator? translator = null, Func<Identi
     private static RestDataSourceDto? RestOptionsOf(PropertyInfo p)
     {
         if (p.Find<RestOptionsAttribute>() is not { } a) return null;
-        var headers = new Dictionary<string, string>();
-        foreach (var h in a.Headers)
-        {
-            var i = h.IndexOf(':');
-            if (i > 0) headers[h[..i].Trim()] = h[(i + 1)..].Trim();
-        }
         return new RestDataSourceDto(a.Url)
         {
             Method = a.Method,
-            Headers = headers,
+            Headers = ParseHeaders(a.Headers),
             Body = a.Body,
             ItemsPath = a.ItemsPath,
             ValuePath = a.ValuePath,
             LabelPath = a.LabelPath,
         };
+    }
+
+    /// <summary>The client-side external rows descriptor when the listing class carries
+    /// [RestListing] (columns come from the row type; each item is keyed by column id); null
+    /// otherwise.</summary>
+    private static RestDataSourceDto? RestListingOf(Type type)
+    {
+        if (type.Find<RestListingAttribute>() is not { } a) return null;
+        return new RestDataSourceDto(a.Url)
+        {
+            Method = a.Method,
+            Headers = ParseHeaders(a.Headers),
+            Body = a.Body,
+            ItemsPath = a.ItemsPath,
+        };
+    }
+
+    /// <summary>Parses "Name: Value" header strings into a map.</summary>
+    private static Dictionary<string, string> ParseHeaders(string[] headers)
+    {
+        var map = new Dictionary<string, string>();
+        foreach (var h in headers)
+        {
+            var i = h.IndexOf(':');
+            if (i > 0) map[h[..i].Trim()] = h[(i + 1)..].Trim();
+        }
+        return map;
     }
 
     /// <summary>The stereotype a field renders with, including its plain-text context — the weight

--- a/backend/dotnet/src/Mateu.Dtos/Wire.cs
+++ b/backend/dotnet/src/Mateu.Dtos/Wire.cs
@@ -711,6 +711,11 @@ public record CrudMetadataDto(
     /// <summary>Row selection checkboxes on the listing (a deletable/bulk-capable listing needs
     /// them; a bare listing shows none — mirrors CrudlDto.rowsSelectionEnabled).</summary>
     public bool RowsSelectionEnabled { get; init; }
+
+    /// <summary>Rows fetched CLIENT-SIDE from an arbitrary (non-Mateu) REST endpoint
+    /// ([RestListing]); the renderer maps each JSON item into a row keyed by column id instead of
+    /// dispatching the server search. Null on server-backed listings (mirrors CrudlDto.rowsSource).</summary>
+    public RestDataSourceDto? RowsSource { get; init; }
 }
 
 public record GridColumnDto(GridColumnMetaDto Metadata);

--- a/backend/dotnet/src/Mateu.Uidl/FieldAndPageFeatures.cs
+++ b/backend/dotnet/src/Mateu.Uidl/FieldAndPageFeatures.cs
@@ -69,6 +69,26 @@ public sealed class RestOptionsAttribute(string url) : Attribute
     public string LabelPath { get; init; } = "label";
 }
 
+/// <summary>Fills a listing's ROWS from an arbitrary (non-Mateu) REST endpoint, fetched
+/// CLIENT-SIDE: the renderer calls <see cref="Url"/> directly, navigates <see cref="ItemsPath"/>
+/// to the array in the JSON response and maps each item into a row by reading each COLUMN by its
+/// field name. Put it on a class implementing <c>IListing&lt;TRow&gt;</c>; its columns come from the
+/// TRow type as usual and its Fetch is never called. Url/Headers/Body support <c>${state.x}</c>
+/// interpolation. (C# analogue of Java's @RestListing.)</summary>
+[AttributeUsage(AttributeTargets.Class)]
+public sealed class RestListingAttribute(string url) : Attribute
+{
+    public string Url { get; } = url;
+    public string Method { get; init; } = "GET";
+
+    /// <summary>Request headers as "Name: Value" strings (values interpolated).</summary>
+    public string[] Headers { get; init; } = [];
+    public string Body { get; init; } = "";
+
+    /// <summary>A dot path to the array inside the response; blank means the root IS the array.</summary>
+    public string ItemsPath { get; init; } = "";
+}
+
 /// <summary>A reference field picked through a full selector DIALOG instead of a combo: clicking
 /// the field fires <c>codesearch-&lt;fieldId&gt;</c>, which opens the given selector — a Listing
 /// implementing ISelector — in a modal; selecting a row writes its (id, label) back into the

--- a/backend/dotnet/test/Mateu.Tests/SyncHandlerTests.cs
+++ b/backend/dotnet/test/Mateu.Tests/SyncHandlerTests.cs
@@ -28,6 +28,25 @@ public class RestOptsForm
     public string Country { get; set; } = "";
 }
 
+// A listing whose rows come from an arbitrary REST endpoint, fetched client-side. Columns come
+// from the Row type; Search() is never called.
+[UI("rest-list"), Title("Rest listing"),
+ RestListing("https://api.example.com/countries?q=${state.searchText}",
+     Headers = ["Authorization: Bearer x"], ItemsPath = "data.countries")]
+public class RestList : Listing<RestList.Filters, RestList.Row>
+{
+    public class Filters { }
+
+    public class Row
+    {
+        public string? Code { get; set; }
+        public string? Name { get; set; }
+        public long Population { get; set; }
+    }
+
+    public override ListingData<Row> Search(SearchRequest request) => ListingData.From<Row>([]);
+}
+
 // A fully-static screen: the client caches its whole response and skips the round-trip on return.
 [UI("static-view"), Title("About"), StaticView]
 public class StaticViewForm
@@ -1791,6 +1810,21 @@ public class SyncHandlerTests
         Assert.Contains("\"valuePath\":\"code\"", json);
         Assert.Contains("\"labelPath\":\"name.common\"", json);
         Assert.Contains("\"Authorization\":\"Bearer x\"", json); // header parsed from "Name: Value"
+    }
+
+    [Fact]
+    public void RestListing_carries_the_endpoint_descriptor_and_columns_from_the_row_type()
+    {
+        var inc = Handler().Handle(new RunActionRqDto { Route = "rest-list", ConsumedRoute = "rest-list" });
+        var json = Render(inc);
+
+        Assert.Contains("\"rowsSource\":{", json);
+        Assert.Contains("\"url\":\"https://api.example.com/countries?q=${state.searchText}\"", json);
+        Assert.Contains("\"itemsPath\":\"data.countries\"", json);
+        Assert.Contains("\"Authorization\":\"Bearer x\"", json);
+        // columns come from the Row type (the frontend keys each JSON item by column id)
+        Assert.Contains("\"id\":\"code\"", json);
+        Assert.Contains("\"id\":\"population\"", json);
     }
 
     [Fact]

--- a/backend/python/mateu_core/mapper.py
+++ b/backend/python/mateu_core/mapper.py
@@ -1940,7 +1940,9 @@ class ReflectionMapper:
                          rows_selection_enabled=deletable,
                          filters=self.listing_filters(filters_type) if filters_type is not None else [],
                          grid_layout=cls().grid_layout(),
-                         group_by=self.group_by_of(row_type) if row_type is not None else None),
+                         group_by=self.group_by_of(row_type) if row_type is not None else None,
+                         # @rest_listing: rows fetched client-side from an arbitrary REST endpoint.
+                         rows_source=self._rest_listing(cls)),
             "crud",
             [],
         )
@@ -2577,6 +2579,24 @@ class ReflectionMapper:
             items_path=a.items_path,
             value_path=a.value_path,
             label_path=a.label_path,
+        )
+
+    @staticmethod
+    def _rest_listing(cls) -> "RestDataSource | None":
+        """The client-side external rows descriptor when the listing class carries
+        ``@rest_listing`` (columns come from the Row type; each item is keyed by column id); None
+        otherwise."""
+        spec = getattr(cls, "__mateu_rest_listing__", None)
+        if spec is None:
+            return None
+        url, method, header_strings, body, items_path = spec
+        headers: dict[str, str] = {}
+        for h in header_strings:
+            name, sep, value = h.partition(":")
+            if sep:
+                headers[name.strip()] = value.strip()
+        return RestDataSource(
+            url=url, method=method, headers=headers, body=body, items_path=items_path
         )
 
     def link_of(self, f, instance) -> NavLinkRecord | None:

--- a/backend/python/mateu_dtos/__init__.py
+++ b/backend/python/mateu_dtos/__init__.py
@@ -250,6 +250,10 @@ class CrudMetadata(Wire):
     #: Row selection checkboxes on (a Deletable listing / a full crud); mirrors
     #: CrudlDto.rowsSelectionEnabled.
     rows_selection_enabled: bool = False
+    #: Rows fetched CLIENT-SIDE from an arbitrary (non-Mateu) REST endpoint (@rest_listing): the
+    #: renderer maps each JSON item into a row keyed by column id instead of dispatching the server
+    #: search. None on server-backed listings (mirrors CrudlDto.rowsSource).
+    rows_source: "RestDataSource | None" = None
 
 
 class ProgressBarMetadata(Wire):

--- a/backend/python/mateu_uidl/__init__.py
+++ b/backend/python/mateu_uidl/__init__.py
@@ -746,6 +746,27 @@ def page_template(page_type: PageType) -> Callable[[type], type]:
     return deco
 
 
+def rest_listing(
+    url: str,
+    method: str = "GET",
+    headers: tuple[str, ...] = (),
+    body: str = "",
+    items_path: str = "",
+) -> Callable[[type], type]:
+    """Class-level: fills a listing's ROWS from an arbitrary (non-Mateu) REST endpoint, fetched
+    CLIENT-SIDE. The renderer calls ``url`` directly, navigates ``items_path`` to the array in the
+    JSON response and maps each item into a row by reading each COLUMN by its field name. Put it on
+    a class implementing ``Listing[Row]``; its columns come from the Row type as usual and its
+    ``search`` is never called. ``url``/``headers``/``body`` support ``${state.x}`` interpolation
+    (including ``${searchText}``/``${page}``/``${size}``). Python analogue of Java's @RestListing."""
+
+    def deco(cls: type) -> type:
+        cls.__mateu_rest_listing__ = (url, method, headers, body, items_path)
+        return cls
+
+    return deco
+
+
 def welcome_banner(title: str = "", subtitle: str = "", image: str = "") -> Callable[[type], type]:
     """Class-level: prepends the Redwood "Welcome Banner" element to the page content — a
     centered HeroSection (id "welcome-banner") with the given title (empty → the page title),
@@ -1512,7 +1533,7 @@ __all__ = [
     "ai", "remote_menu", "ui", "title", "subtitle", "app", "auto_layout", "read_only", "compact",
     "static_view",
     "confirm_on_navigation_if_dirty", "inline_editing", "toc", "zones", "folded_layout", "form_layout", "LabelsAsideMode", "wizard_progress", "page_width", "page_template",
-    "plain_text", "emits", "subscribe_to", "secured", "welcome_banner",
+    "plain_text", "emits", "subscribe_to", "secured", "welcome_banner", "rest_listing",
     "button", "menu_item", "kpi", "fab", "banner", "shortcut", "list_toolbar_button",
     "Crud", "HeroSearch", "Listing", "SearchRequest", "ListingData", "Filterable", "Navigable", "Editable", "Creatable", "Deletable", "SmartSearchPage", "DateRange", "NumberRange", "Pageable", "PageResult", "SortSpec", "Searchable", "SelectedItem", "Selector", "Wizard", "Translator",
     "ComponentTreeSupplier", "Dashboard", "DataManagement", "Foldout", "GanttPage", "ItemOverview", "Welcome", "TodoList",

--- a/backend/python/tests/test_sync_handler.py
+++ b/backend/python/tests/test_sync_handler.py
@@ -99,6 +99,7 @@ from mateu_uidl import (  # noqa: E402
     audience,
     disabled_unless,
     remote_menu,
+    rest_listing,
 )
 from mateu_uidl.components import MicroFrontend  # noqa: E402
 
@@ -1692,6 +1693,37 @@ def test_rest_options_field_is_a_select_carrying_the_endpoint_descriptor():
     assert '"valuePath": "code"' in j
     assert '"labelPath": "name.common"' in j
     assert '"Authorization": "Bearer x"' in j  # header parsed from "Name: Value"
+
+
+class RestCountryRow:
+    code: str = ""
+    name: str = ""
+    population: int = 0
+
+
+@ui("rest-list")
+@title("Rest listing")
+@rest_listing(
+    url="https://api.example.com/countries?q=${state.searchText}",
+    headers=("Authorization: Bearer x",),
+    items_path="data.countries",
+)
+class RestListingView(Listing[RestCountryRow]):
+    def search(self, request, http=None):
+        return []
+
+
+def test_rest_listing_carries_the_endpoint_descriptor_and_columns_from_the_row_type():
+    inc = handler().handle(RunActionRq(route="rest-list", consumed_route="rest-list"))
+    j = render(inc)
+
+    assert '"rowsSource": {' in j
+    assert '"url": "https://api.example.com/countries?q=${state.searchText}"' in j
+    assert '"itemsPath": "data.countries"' in j
+    assert '"Authorization": "Bearer x"' in j
+    # columns come from the Row type (the frontend keys each JSON item by column id)
+    assert '"id": "code"' in j
+    assert '"id": "population"' in j
 
 
 def test_lookup_search_filters_and_pages_the_suppliers_options():

--- a/doc/src/content/docs/java-ui-definition/annotations/rest-listing.md
+++ b/doc/src/content/docs/java-ui-definition/annotations/rest-listing.md
@@ -62,5 +62,30 @@ needs nothing). The listing is read-only.
 :::note
 Rows and [options](./rest-options) are the shipped surfaces of consuming external endpoints. Form/
 screen data load and endpoint button actions reuse the same `RestDataSource` descriptor and are on
-the roadmap. This surface is currently Java-only; the .NET/Python port is a follow-up.
+the roadmap.
 :::
+
+## Other backends
+
+Mateu.NET and the Python backend emit the same `rowsSource` descriptor:
+
+```csharp
+// .NET
+[UI("rest-countries"),
+ RestListing("/countries.json", ItemsPath = "data.countries")]
+public class RestCountries : Listing<RestCountries.Filters, RestCountries.Row>
+{
+    public class Filters { }
+    public class Row { public string? Code { get; set; } public string? Name { get; set; } }
+    public override ListingData<Row> Search(SearchRequest r) => ListingData.From<Row>([]);
+}
+```
+
+```python
+# Python
+@ui("rest-countries")
+@rest_listing(url="/countries.json", items_path="data.countries")
+class RestCountries(Listing[Row]):
+    def search(self, request, http=None):
+        return []
+```

--- a/doc/src/content/docs/reference/parity.md
+++ b/doc/src/content/docs/reference/parity.md
@@ -48,7 +48,7 @@ for the surface below (verified by golden-JSON tests in `backend/dotnet/test` an
 | Lookup fields (`@Lookup` remote combobox + `search-<field>` action) | ✅ | ✅ | ✅ |
 | — `@Searchable` full selector dialogs (`Selector` + `codesearch`) | ✅ | ✅ | ✅ |
 | External REST options (`@RestOptions`/`[RestOptions]`/`RestOptions()` → select; options fetched client-side from an arbitrary endpoint via `FormField.optionsSource`) | ✅ | ✅ | ✅ |
-| External REST listing rows (`@RestListing` on a `Listing<Row>` → rows fetched client-side from an arbitrary endpoint via `Crudl.rowsSource`; columns from the Row type) | ✅ | — | — |
+| External REST listing rows (`@RestListing`/`[RestListing]`/`@rest_listing` on a listing → rows fetched client-side from an arbitrary endpoint via `Crudl.rowsSource`; columns from the Row type) | ✅ | ✅ | ✅ |
 | Editable grids / inline CRUD editing (`@InlineEditing` + update-row) | ✅ | ✅ | ✅ |
 | Bulk list actions (`@ListToolbarButton` + typed selection) | ✅ | ✅ | ✅ |
 | Listing aggregates & grouping (`@Aggregate`/`@GroupBy` + summaries) | ✅ | ✅ | ✅ |


### PR DESCRIPTION
Ports the listing surface of consuming non-Mateu endpoints ([#336](https://github.com/miguelperezcolom/mateu/pull/336)) to Mateu.NET and the Python backend: a listing whose rows are fetched **client-side** from an arbitrary REST endpoint. Backend-only — the shared frontend already consumes `rowsSource` from any backend.

## .NET
```csharp
[UI("rest-countries"), RestListing("/countries.json", ItemsPath = "data.countries")]
public class RestCountries : Listing<RestCountries.Filters, RestCountries.Row>
{
    public class Filters { }
    public class Row { public string? Code { get; set; } public string? Name { get; set; } }
    public override ListingData<Row> Search(SearchRequest r) => ListingData.From<Row>([]);
}
```
`[RestListing]` → `CrudMetadataDto.RowsSource` (reuses `RestDataSourceDto`). Mapped in `ReflectionMapper.MapListing` via `RestListingOf` (headers via the shared `ParseHeaders`).

## Python
```python
@ui("rest-countries")
@rest_listing(url="/countries.json", items_path="data.countries")
class RestCountries(Listing[Row]):
    def search(self, request, http=None): return []
```
`@rest_listing` class decorator → `CrudMetadata.rows_source` (reuses `RestDataSource`). Mapped in `mapper.map_listing` via `_rest_listing`; exported in `__all__`.

Columns come from the Row type as usual; the descriptor carries only `url`/`method`/`headers`/`body`/`itemsPath` (the frontend keys each JSON item by column id). Mirrors the Java `@RestListing` exactly.

## Tests
- .NET: `RestListing_carries_the_endpoint_descriptor_and_columns_from_the_row_type` — 243/243
- Python: `test_rest_listing_carries_the_endpoint_descriptor_and_columns_from_the_row_type` — 242
- Parity row flipped to all-green + port examples in the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)