### PR TITLE
Port @RestAction to .NET and Python (client-side REST button action)

### DIFF
--- a/backend/dotnet/src/Mateu.Core/ReflectionMapper.cs
+++ b/backend/dotnet/src/Mateu.Core/ReflectionMapper.cs
@@ -238,12 +238,16 @@ public sealed class ReflectionMapper(ITranslator? translator = null, Func<Identi
 
         var title = T(type.Find<TitleAttribute>()?.Value ?? Naming.Humanize(type.Name));
 
-        var buttons = type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+        var buttonMethods = type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
             .Where(m => m.Find<ButtonAttribute>() != null && ForCurrentAudience(m))
-            .Select(MapButton).ToList();
+            .ToList();
+        var buttons = buttonMethods.Select(MapButton).ToList();
         var fabs = Fabs(type);
-        // Both [Button] and [Fab] methods are server-side actions the renderer can invoke.
-        var actions = buttons.Select(b => WithActionOptions(new ActionDto(b.ActionId), type, b.ActionId))
+        // Both [Button] and [Fab] methods are server-side actions the renderer can invoke; a
+        // [RestAction] button carries the client-side REST descriptor on its action.
+        var actions = buttonMethods.Select(m =>
+                WithActionOptions(new ActionDto(Naming.CamelCase(m.Name)) { RestAction = RestActionOf(m) },
+                    type, Naming.CamelCase(m.Name)))
             .Concat(fabs.Select(f => WithActionOptions(new ActionDto(f.ActionId), type, f.ActionId))).ToList();
         // [OnRowSelected] grid actions must be advertised or the renderer drops the row click.
         actions.AddRange(EditableProperties(type)
@@ -1448,6 +1452,22 @@ public sealed class ReflectionMapper(ITranslator? translator = null, Func<Identi
             Body = a.Body,
             ItemsPath = a.ItemsPath,
         };
+    }
+
+    /// <summary>The client-side REST descriptor when a button method carries [RestAction]; null
+    /// otherwise — the button then dispatches to the Mateu server as usual.</summary>
+    private static RestActionDto? RestActionOf(MethodInfo m)
+    {
+        if (m.Find<RestActionAttribute>() is not { } a) return null;
+        var source = new RestDataSourceDto(a.Url)
+        {
+            Method = a.Method,
+            Headers = ParseHeaders(a.Headers),
+            Body = a.Body,
+        };
+        return new RestActionDto(source,
+            a.SuccessMessage.Length > 0 ? a.SuccessMessage : null,
+            a.ResultPath.Length > 0 ? a.ResultPath : null);
     }
 
     /// <summary>Parses "Name: Value" header strings into a map.</summary>

--- a/backend/dotnet/src/Mateu.Dtos/Wire.cs
+++ b/backend/dotnet/src/Mateu.Dtos/Wire.cs
@@ -151,7 +151,18 @@ public record ActionDto(
     /// naturally idempotent writes: after a timeout the client cannot know whether the server
     /// processed the request.</summary>
     public bool Idempotent { get; init; }
+
+    /// <summary>Makes this action call an arbitrary (non-Mateu) REST endpoint CLIENT-SIDE instead of
+    /// dispatching to the Mateu server ([RestAction]); null for normal actions (mirrors
+    /// io.mateu.dtos.ActionDto.restAction).</summary>
+    public RestActionDto? RestAction { get; init; }
 }
+
+/// <summary>Descriptor for a button that calls an arbitrary (non-Mateu) REST endpoint CLIENT-SIDE
+/// (mirrors io.mateu.dtos.RestActionDto): the renderer fetches <c>Source</c> directly, shows
+/// <c>SuccessMessage</c> as a toast on a 2xx response and — when <c>ResultPath</c> is set — merges
+/// the object at that path in the JSON response into the form state.</summary>
+public record RestActionDto(RestDataSourceDto Source, string? SuccessMessage, string? ResultPath);
 
 /// <summary>A trigger that fires <c>ActionId</c> when a named custom event is received.</summary>
 public record CustomTriggerDto(string Event, string ActionId)

--- a/backend/dotnet/src/Mateu.Uidl/Attributes.cs
+++ b/backend/dotnet/src/Mateu.Uidl/Attributes.cs
@@ -131,6 +131,31 @@ public sealed class ActionOptionsAttribute : Attribute
     public bool Idempotent { get; init; }
 }
 
+/// <summary>Makes a button call an arbitrary (non-Mateu) REST endpoint CLIENT-SIDE instead of
+/// dispatching to the Mateu server: the renderer calls <see cref="Url"/> directly with the
+/// interpolated <see cref="Body"/>, then applies the response — shows <see cref="SuccessMessage"/>
+/// as a toast and, when <see cref="ResultPath"/> is set, merges the object at that path in the JSON
+/// response into the form state (so bound fields refresh). Put it on a method that is ALSO a
+/// [Button]/[Toolbar]. Url/Headers/Body support <c>${state.x}</c> interpolation. (C# analogue of
+/// Java's @RestAction.)</summary>
+[AttributeUsage(AttributeTargets.Method)]
+public sealed class RestActionAttribute(string url) : Attribute
+{
+    public string Url { get; } = url;
+    public string Method { get; init; } = "POST";
+
+    /// <summary>Request headers as "Name: Value" strings (values interpolated).</summary>
+    public string[] Headers { get; init; } = [];
+    public string Body { get; init; } = "";
+
+    /// <summary>A toast shown on a 2xx response (interpolated); blank shows none.</summary>
+    public string SuccessMessage { get; init; } = "";
+
+    /// <summary>A dot path to the object in the response to merge into the form state; blank merges
+    /// nothing (fire-and-toast).</summary>
+    public string ResultPath { get; init; } = "";
+}
+
 /// <summary>An overridden display label for a field or method.</summary>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Class)]
 public sealed class LabelAttribute(string value) : Attribute

--- a/backend/dotnet/test/Mateu.Tests/SyncHandlerTests.cs
+++ b/backend/dotnet/test/Mateu.Tests/SyncHandlerTests.cs
@@ -47,6 +47,20 @@ public class RestList : Listing<RestList.Filters, RestList.Row>
     public override ListingData<Row> Search(SearchRequest request) => ListingData.From<Row>([]);
 }
 
+// A button that calls a REST endpoint client-side (fetch + toast + merge into the form state).
+[UI("rest-action"), Title("Rest action")]
+public class RestActionForm
+{
+    public string? Zip { get; set; } = "28001";
+    public string? Street { get; set; }
+    public string? City { get; set; }
+
+    [Button, Label("Look up address")]
+    [RestAction("https://api.example.com/zip/${state.zip}", Method = "GET",
+        Headers = ["Authorization: Bearer x"], ResultPath = "address", SuccessMessage = "Address found")]
+    public void Lookup() { }
+}
+
 // A fully-static screen: the client caches its whole response and skips the round-trip on return.
 [UI("static-view"), Title("About"), StaticView]
 public class StaticViewForm
@@ -795,18 +809,18 @@ public class SyncHandlerTests
         Assert.Contains(
             "{\"id\":\"quickLookup\",\"validationRequired\":true,\"confirmationRequired\":false,"
             + "\"rowsSelectedRequired\":false,\"bubble\":false,"
-            + "\"timeoutMillis\":5000,\"idempotent\":false}", json);
+            + "\"timeoutMillis\":5000,\"idempotent\":false,\"restAction\":null}", json);
         Assert.Contains(
             "{\"id\":\"recalculateTotals\",\"validationRequired\":true,\"confirmationRequired\":false,"
             + "\"rowsSelectedRequired\":false,\"bubble\":false,"
-            + "\"timeoutMillis\":120000,\"idempotent\":true}", json);
+            + "\"timeoutMillis\":120000,\"idempotent\":true,\"restAction\":null}", json);
         // Safe defaults when nothing is declared: the client's own timeout applies, and the action
         // is never re-sent on its own — after a timeout the client cannot know whether the server
         // already applied it.
         Assert.Contains(
             "{\"id\":\"save\",\"validationRequired\":true,\"confirmationRequired\":false,"
             + "\"rowsSelectedRequired\":false,\"bubble\":false,"
-            + "\"timeoutMillis\":0,\"idempotent\":false}", json);
+            + "\"timeoutMillis\":0,\"idempotent\":false,\"restAction\":null}", json);
     }
 
     // ── Structure ETag / template-ref (phase b of the client structure cache) ──────
@@ -1828,6 +1842,19 @@ public class SyncHandlerTests
     }
 
     [Fact]
+    public void RestAction_button_advertises_the_endpoint_descriptor_on_its_action()
+    {
+        var inc = Handler().Handle(new RunActionRqDto { Route = "rest-action", ConsumedRoute = "rest-action" });
+        var json = Render(inc);
+
+        Assert.Contains("\"restAction\":{", json);
+        Assert.Contains("\"successMessage\":\"Address found\"", json);
+        Assert.Contains("\"resultPath\":\"address\"", json);
+        Assert.Contains("\"url\":\"https://api.example.com/zip/${state.zip}\"", json);
+        Assert.Contains("\"Authorization\":\"Bearer x\"", json);
+    }
+
+    [Fact]
     public void Lookup_search_filters_and_pages_the_suppliers_options()
     {
         var rq = new RunActionRqDto
@@ -1890,11 +1917,11 @@ public class SyncHandlerTests
         Assert.Contains(
             "{\"id\":\"action-on-row-deactivate\",\"validationRequired\":false,"
             + "\"confirmationRequired\":false,\"rowsSelectedRequired\":true,\"bubble\":true,"
-            + "\"timeoutMillis\":0,\"idempotent\":false}", json);
+            + "\"timeoutMillis\":0,\"idempotent\":false,\"restAction\":null}", json);
         Assert.Contains(
             "{\"id\":\"action-on-row-restockAll\",\"validationRequired\":false,"
             + "\"confirmationRequired\":true,\"rowsSelectedRequired\":false,\"bubble\":true,"
-            + "\"timeoutMillis\":0,\"idempotent\":false}", json);
+            + "\"timeoutMillis\":0,\"idempotent\":false,\"restAction\":null}", json);
     }
 
     [Fact]

--- a/backend/python/mateu_core/mapper.py
+++ b/backend/python/mateu_core/mapper.py
@@ -120,6 +120,7 @@ from mateu_dtos import (
     ProgressStepsMetadata,
     StepRecord,
     RemoteCoordinates,
+    RestAction,
     RestDataSource,
     RuleRecord,
     ScoreboardMetadata,
@@ -560,14 +561,19 @@ class ReflectionMapper:
             return self.map_listing(cls, route)
 
         title = self.T(getattr(cls, "__mateu_title__", humanize(cls.__name__)))
-        buttons = [
-            self.map_button(n, f)
+        button_methods = [
+            (n, f)
             for n, f in methods_with(cls, "__mateu_button__")
             if for_current_audience(getattr(f, "__mateu_audience__", None))
         ]
+        buttons = [self.map_button(n, f) for n, f in button_methods]
         fabs = self.fabs(cls)
+        # A @rest_action button carries the client-side REST descriptor on its action.
         actions = [
-            with_action_options(Action(id=b.action_id), cls, b.action_id) for b in buttons
+            with_action_options(
+                Action(id=b.action_id, rest_action=self._rest_action(f)), cls, b.action_id
+            )
+            for (n, f), b in zip(button_methods, buttons)
         ] + [with_action_options(Action(id=f.action_id), cls, f.action_id) for f in fabs]
         # OnRowSelected() grid actions must be advertised or the renderer drops the row click.
         for f in view_fields(cls):
@@ -2597,6 +2603,26 @@ class ReflectionMapper:
                 headers[name.strip()] = value.strip()
         return RestDataSource(
             url=url, method=method, headers=headers, body=body, items_path=items_path
+        )
+
+    @staticmethod
+    def _rest_action(fn) -> "RestAction | None":
+        """The client-side REST descriptor when a button method carries ``@rest_action`` (headers
+        parsed from "Name: Value" strings); None otherwise — the button then dispatches to the Mateu
+        server as usual."""
+        spec = getattr(fn, "__mateu_rest_action__", None)
+        if spec is None:
+            return None
+        url, method, header_strings, body, success_message, result_path = spec
+        headers: dict[str, str] = {}
+        for h in header_strings:
+            name, sep, value = h.partition(":")
+            if sep:
+                headers[name.strip()] = value.strip()
+        return RestAction(
+            source=RestDataSource(url=url, method=method, headers=headers, body=body),
+            success_message=success_message or None,
+            result_path=result_path or None,
         )
 
     def link_of(self, f, instance) -> NavLinkRecord | None:

--- a/backend/python/mateu_dtos/__init__.py
+++ b/backend/python/mateu_dtos/__init__.py
@@ -1382,6 +1382,21 @@ class Action(Wire):
     # retry it by itself after a transient failure. Only for reads or naturally idempotent
     # writes: after a timeout the client cannot know whether the server processed the request.
     idempotent: bool = False
+    #: Makes this action call an arbitrary (non-Mateu) REST endpoint CLIENT-SIDE instead of
+    #: dispatching to the Mateu server (@rest_action); None for normal actions (mirrors
+    #: io.mateu.dtos.ActionDto.restAction).
+    rest_action: "RestAction | None" = None
+
+
+class RestAction(Wire):
+    """Descriptor for a button that calls an arbitrary (non-Mateu) REST endpoint CLIENT-SIDE
+    (mirrors ``io.mateu.dtos.RestActionDto``): the renderer fetches ``source`` directly, shows
+    ``success_message`` as a toast on a 2xx response and — when ``result_path`` is set — merges the
+    object at that path in the JSON response into the form state."""
+
+    source: "RestDataSource"
+    success_message: str | None = None
+    result_path: str | None = None
 
 
 class Trigger(Wire):

--- a/backend/python/mateu_uidl/__init__.py
+++ b/backend/python/mateu_uidl/__init__.py
@@ -767,6 +767,29 @@ def rest_listing(
     return deco
 
 
+def rest_action(
+    url: str,
+    method: str = "POST",
+    headers: tuple[str, ...] = (),
+    body: str = "",
+    success_message: str = "",
+    result_path: str = "",
+) -> Callable[[Callable], Callable]:
+    """Method-level: makes a button call an arbitrary (non-Mateu) REST endpoint CLIENT-SIDE instead
+    of dispatching to the Mateu server. On click the renderer calls ``url`` directly with the
+    interpolated ``body``, then applies the response — shows ``success_message`` as a toast and,
+    when ``result_path`` is set, merges the object at that path in the JSON response into the form
+    state (so bound fields refresh). Put it on a method that is ALSO a ``@button``/``@toolbar``;
+    ``url``/``headers``/``body`` support ``${state.x}`` interpolation. Python analogue of Java's
+    @RestAction."""
+
+    def deco(fn: Callable) -> Callable:
+        fn.__mateu_rest_action__ = (url, method, headers, body, success_message, result_path)
+        return fn
+
+    return deco
+
+
 def welcome_banner(title: str = "", subtitle: str = "", image: str = "") -> Callable[[type], type]:
     """Class-level: prepends the Redwood "Welcome Banner" element to the page content — a
     centered HeroSection (id "welcome-banner") with the given title (empty → the page title),
@@ -1533,7 +1556,7 @@ __all__ = [
     "ai", "remote_menu", "ui", "title", "subtitle", "app", "auto_layout", "read_only", "compact",
     "static_view",
     "confirm_on_navigation_if_dirty", "inline_editing", "toc", "zones", "folded_layout", "form_layout", "LabelsAsideMode", "wizard_progress", "page_width", "page_template",
-    "plain_text", "emits", "subscribe_to", "secured", "welcome_banner", "rest_listing",
+    "plain_text", "emits", "subscribe_to", "secured", "welcome_banner", "rest_listing", "rest_action",
     "button", "menu_item", "kpi", "fab", "banner", "shortcut", "list_toolbar_button",
     "Crud", "HeroSearch", "Listing", "SearchRequest", "ListingData", "Filterable", "Navigable", "Editable", "Creatable", "Deletable", "SmartSearchPage", "DateRange", "NumberRange", "Pageable", "PageResult", "SortSpec", "Searchable", "SelectedItem", "Selector", "Wizard", "Translator",
     "ComponentTreeSupplier", "Dashboard", "DataManagement", "Foldout", "GanttPage", "ItemOverview", "Welcome", "TodoList",

--- a/backend/python/tests/test_sync_handler.py
+++ b/backend/python/tests/test_sync_handler.py
@@ -99,6 +99,7 @@ from mateu_uidl import (  # noqa: E402
     audience,
     disabled_unless,
     remote_menu,
+    rest_action,
     rest_listing,
 )
 from mateu_uidl.components import MicroFrontend  # noqa: E402
@@ -1726,6 +1727,36 @@ def test_rest_listing_carries_the_endpoint_descriptor_and_columns_from_the_row_t
     assert '"id": "population"' in j
 
 
+@ui("rest-action")
+@title("Rest action")
+class RestActionForm:
+    zip: str = "28001"
+    street: str = ""
+    city: str = ""
+
+    @button()
+    @rest_action(
+        url="https://api.example.com/zip/${state.zip}",
+        method="GET",
+        headers=("Authorization: Bearer x",),
+        result_path="address",
+        success_message="Address found",
+    )
+    def lookup(self):
+        pass
+
+
+def test_rest_action_button_advertises_the_endpoint_descriptor_on_its_action():
+    inc = handler().handle(RunActionRq(route="rest-action", consumed_route="rest-action"))
+    j = render(inc)
+
+    assert '"restAction": {' in j
+    assert '"successMessage": "Address found"' in j
+    assert '"resultPath": "address"' in j
+    assert '"url": "https://api.example.com/zip/${state.zip}"' in j
+    assert '"Authorization": "Bearer x"' in j
+
+
 def test_lookup_search_filters_and_pages_the_suppliers_options():
     inc = handler().handle(
         RunActionRq(
@@ -1781,12 +1812,12 @@ def test_list_toolbar_button_emits_toolbar_button_and_selection_flagged_action()
     assert (
         '{"id": "action-on-row-deactivate", "validationRequired": false, '
         '"confirmationRequired": false, "rowsSelectedRequired": true, "bubble": true, '
-        '"timeoutMillis": 0, "idempotent": false}'
+        '"timeoutMillis": 0, "idempotent": false, "restAction": null}'
     ) in j
     assert (
         '{"id": "action-on-row-restockAll", "validationRequired": false, '
         '"confirmationRequired": true, "rowsSelectedRequired": false, "bubble": true, '
-        '"timeoutMillis": 0, "idempotent": false}'
+        '"timeoutMillis": 0, "idempotent": false, "restAction": null}'
     ) in j
 
 

--- a/backend/python/tests/test_ux_components.py
+++ b/backend/python/tests/test_ux_components.py
@@ -913,6 +913,7 @@ def test_dashboard_archetype_emits_scoreboard_panels_and_gantt():
         # action is never re-sent on its own.
         "timeoutMillis": 0,
         "idempotent": False,
+        "restAction": None,
     } in component["actions"]
     inc = handler().handle(
         RunActionRq(action_id="openRevenue", server_side_type=type_name(SalesDashboard))

--- a/doc/src/content/docs/java-ui-definition/annotations/rest-action.md
+++ b/doc/src/content/docs/java-ui-definition/annotations/rest-action.md
@@ -61,5 +61,22 @@ endpoint must be reachable from the browser (CORS-friendly for cross-origin APIs
 
 ## Other backends
 
-Mateu.NET and the Python backend emit the same `restAction` descriptor. *(Port pending — see the
-parity table.)*
+Mateu.NET and the Python backend emit the same `restAction` descriptor:
+
+```csharp
+// .NET
+[Button, Label("Look up address")]
+[RestAction("https://api.example.com/zip/${state.zip}", Method = "GET",
+    ResultPath = "address", SuccessMessage = "Address found")]
+public void Lookup() { }
+```
+
+```python
+# Python
+@button()
+@rest_action(
+    url="https://api.example.com/zip/${state.zip}", method="GET",
+    result_path="address", success_message="Address found")
+def lookup(self):
+    ...
+```

--- a/doc/src/content/docs/reference/parity.md
+++ b/doc/src/content/docs/reference/parity.md
@@ -49,7 +49,7 @@ for the surface below (verified by golden-JSON tests in `backend/dotnet/test` an
 | — `@Searchable` full selector dialogs (`Selector` + `codesearch`) | ✅ | ✅ | ✅ |
 | External REST options (`@RestOptions`/`[RestOptions]`/`RestOptions()` → select; options fetched client-side from an arbitrary endpoint via `FormField.optionsSource`) | ✅ | ✅ | ✅ |
 | External REST listing rows (`@RestListing`/`[RestListing]`/`@rest_listing` on a listing → rows fetched client-side from an arbitrary endpoint via `Crudl.rowsSource`; columns from the Row type) | ✅ | ✅ | ✅ |
-| External REST button action (`@RestAction` on a `@Button` → calls an arbitrary endpoint client-side via `Action.restAction`; response toast + merge into form state) | ✅ | — | — |
+| External REST button action (`@RestAction`/`[RestAction]`/`@rest_action` on a button → calls an arbitrary endpoint client-side via `Action.restAction`; response toast + merge into form state) | ✅ | ✅ | ✅ |
 | Editable grids / inline CRUD editing (`@InlineEditing` + update-row) | ✅ | ✅ | ✅ |
 | Bulk list actions (`@ListToolbarButton` + typed selection) | ✅ | ✅ | ✅ |
 | Listing aggregates & grouping (`@Aggregate`/`@GroupBy` + summaries) | ✅ | ✅ | ✅ |


### PR DESCRIPTION
Ports the action surface of consuming non-Mateu endpoints ([#338](https://github.com/miguelperezcolom/mateu/pull/338)) to Mateu.NET and the Python backend: a button that calls an arbitrary REST endpoint **client-side** (fetch + toast + merge into the form state). Backend-only — the shared frontend already consumes `action.restAction`.

## .NET
```csharp
[Button, Label("Look up address")]
[RestAction("https://api.example.com/zip/${state.zip}", Method = "GET",
    ResultPath = "address", SuccessMessage = "Address found")]
public void Lookup() { }
```
`[RestAction]` → `ActionDto.RestAction` (new `RestActionDto` = `RestDataSourceDto` + `SuccessMessage` + `ResultPath`). `MapView` now iterates the button **methods** (not the mapped DTOs) so `RestActionOf(method)` can attach the descriptor.

## Python
```python
@button()
@rest_action(url="https://api.example.com/zip/${state.zip}", method="GET",
    result_path="address", success_message="Address found")
def lookup(self): ...
```
`@rest_action` method decorator → `Action.rest_action` (new `RestAction` wire model). `map_view` zips the button methods with their mapped buttons so `_rest_action(fn)` can attach the descriptor; exported in `__all__`.

Both mirror the Java descriptor exactly. Golden action-JSON assertions updated in both ports for the new trailing `restAction` field (serialized as `null` on normal actions — `IgnoreCondition.Never` / `by_alias`, matching Java).

## Tests
- .NET: `RestAction_button_advertises_the_endpoint_descriptor_on_its_action` — 244/244
- Python: `test_rest_action_button_advertises_the_endpoint_descriptor_on_its_action` — 243
- Parity row flipped to all-green + port examples in the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)