### PR TITLE
@RestData — load a screen's data from a REST endpoint (client-side)

### DIFF
--- a/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/mappers/ActionMapper.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/mappers/ActionMapper.java
@@ -89,6 +89,20 @@ public class ActionMapper {
 
     actions.addAll(fieldActions);
 
+    // @RestData: a synthetic action carrying the client-side REST descriptor, fired on load by the
+    // OnLoad trigger TriggerMapper adds — so the screen's initial data is fetched client-side and
+    // merged into the form state (reuses the @RestAction fetch+merge machinery).
+    var restData =
+        MetaAnnotations.find(serverSideObject.getClass(), io.mateu.uidl.annotations.RestData.class);
+    if (restData != null) {
+      actions.add(
+          Action.builder()
+              .id(RestDataSupport.RESTDATA_ACTION_ID)
+              .validationRequired(false)
+              .restAction(RestDataSupport.restActionOf(restData))
+              .build());
+    }
+
     return actions;
   }
 

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/mappers/RestDataSupport.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/mappers/RestDataSupport.java
@@ -1,0 +1,42 @@
+package io.mateu.core.domain.out.fragmentmapper.mappers;
+
+import io.mateu.uidl.annotations.RestData;
+import io.mateu.uidl.data.RestAction;
+import io.mateu.uidl.data.RestDataSource;
+import java.util.LinkedHashMap;
+
+/**
+ * Shared bits of the {@code @RestData} screen-data surface: it advertises a synthetic {@code
+ * __restdata__} action carrying the client-side REST descriptor ({@link ActionMapper}) plus an
+ * {@code OnLoad} trigger that fires it ({@link TriggerMapper}), so the initial data is fetched
+ * client-side and merged into the form state — reusing the {@code @RestAction} fetch+merge path.
+ */
+final class RestDataSupport {
+
+  static final String RESTDATA_ACTION_ID = "__restdata__";
+
+  private RestDataSupport() {}
+
+  /**
+   * The client-side REST descriptor for a {@code @RestData} screen (silent load, so no message).
+   */
+  static RestAction restActionOf(RestData a) {
+    var headers = new LinkedHashMap<String, String>();
+    for (String h : a.headers()) {
+      int i = h.indexOf(':');
+      if (i > 0) {
+        headers.put(h.substring(0, i).trim(), h.substring(i + 1).trim());
+      }
+    }
+    var source =
+        RestDataSource.builder()
+            .url(a.url())
+            .method(a.method())
+            .headers(headers)
+            .body(a.body())
+            .build();
+    // resultPath stays as declared: blank means "merge the whole response object" (getByPath with
+    // an empty path is identity on the frontend), a path narrows to that sub-object.
+    return new RestAction(source, null, a.resultPath());
+  }
+}

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/mappers/TriggerMapper.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/mappers/TriggerMapper.java
@@ -79,6 +79,12 @@ public class TriggerMapper {
     if (autoSave != null) {
       triggers.add(new AutoSaveTrigger(autoSave.action(), autoSave.debounceMillis()));
     }
+    // @RestData: fire the synthetic __restdata__ action on load, so the screen's initial data is
+    // fetched client-side and merged into the form state (ActionMapper advertises the action).
+    if (MetaAnnotations.isPresent(
+        serverSideObject.getClass(), io.mateu.uidl.annotations.RestData.class)) {
+      triggers.add(new OnLoadTrigger(RestDataSupport.RESTDATA_ACTION_ID));
+    }
     triggers.addAll(supplied);
     return triggers;
   }

--- a/backend/shared/core/src/test/java/io/mateu/core/application/RestDataSyncTest.java
+++ b/backend/shared/core/src/test/java/io/mateu/core/application/RestDataSyncTest.java
@@ -1,0 +1,70 @@
+package io.mateu.core.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.mateu.core.testutil.TestMateu;
+import io.mateu.dtos.OnLoadTriggerDto;
+import io.mateu.dtos.ServerSideComponentDto;
+import io.mateu.uidl.annotations.RestData;
+import io.mateu.uidl.annotations.Title;
+import io.mateu.uidl.annotations.UI;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Screen data load: a @RestData view advertises a synthetic __restdata__ action carrying the
+ * client-side REST descriptor plus an OnLoad trigger that fires it, so the initial data is fetched
+ * client-side and merged into the form state — reusing the @RestAction fetch+merge machinery.
+ */
+class RestDataSyncTest {
+
+  @SuppressWarnings("unused")
+  @UI("/restdata")
+  @Title("Rest data")
+  @RestData(
+      url = "https://api.example.com/me?token=${state.token}",
+      headers = {"Authorization: Bearer x"},
+      resultPath = "profile")
+  public static class RestDataForm {
+    String name;
+    String email;
+  }
+
+  static TestMateu mateu;
+
+  @BeforeAll
+  static void boot() {
+    mateu = TestMateu.withUis(RestDataForm.class);
+  }
+
+  @AfterAll
+  static void shutdown() {
+    mateu.close();
+  }
+
+  @Test
+  void restDataAdvertisesAnOnLoadActionCarryingTheEndpointDescriptor() {
+    var increment = mateu.sync("/restdata");
+    var component = (ServerSideComponentDto) increment.fragments().get(0).component();
+
+    // the synthetic action carries the client-side REST descriptor
+    var action =
+        component.actions().stream()
+            .filter(a -> "__restdata__".equals(a.id()))
+            .findFirst()
+            .orElseThrow();
+    var rest = action.restAction();
+    assertThat(rest).isNotNull();
+    assertThat(rest.resultPath()).isEqualTo("profile");
+    assertThat(rest.successMessage()).isNull(); // silent load
+    assertThat(rest.source().url()).isEqualTo("https://api.example.com/me?token=${state.token}");
+    assertThat(rest.source().headers()).containsEntry("Authorization", "Bearer x");
+
+    // an OnLoad trigger fires it on entry
+    assertThat(component.triggers())
+        .filteredOn(t -> t instanceof OnLoadTriggerDto)
+        .extracting(t -> ((OnLoadTriggerDto) t).actionId())
+        .contains("__restdata__");
+  }
+}

--- a/backend/shared/uidl/src/main/java/io/mateu/uidl/annotations/RestData.java
+++ b/backend/shared/uidl/src/main/java/io/mateu/uidl/annotations/RestData.java
@@ -1,0 +1,58 @@
+package io.mateu.uidl.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Loads a screen's initial data from an arbitrary (non-Mateu) REST endpoint, fetched CLIENT-SIDE on
+ * entry: when the view mounts the renderer calls {@link #url()} directly (no Mateu server
+ * mediating), then merges the object at {@link #resultPath()} in the JSON response into the form
+ * state, so the fields arrive populated.
+ *
+ * <p>The screen-data surface of the "decouple the UI from the Mateu backend" line — after
+ * {@code @RestOptions} (select options), {@code @RestListing} (listing rows) and
+ * {@code @RestAction} (button calls). It is exactly {@code @RestAction}'s merge, triggered on load
+ * instead of on click: the view advertises a synthetic {@code __restdata__} action carrying the
+ * descriptor plus an {@code OnLoad} trigger that fires it — so it reuses the same client-side
+ * fetch+merge machinery.
+ *
+ * <p>{@code url}/{@code headers}/{@code body} support {@code ${state.x}} interpolation (against the
+ * fields' initial values), so the request can depend on a route parameter seeded into the state.
+ *
+ * <p>Example — a profile screen whose fields come from a REST API:
+ *
+ * <pre>{@code
+ * @UI("/profile")
+ * @RestData(url = "https://api.example.com/me", resultPath = "profile")
+ * public class Profile {
+ *   String name;
+ *   String email;
+ * }
+ * }</pre>
+ *
+ * <p>ANNOTATION_TYPE so it composes as a meta-annotation, resolved via MetaAnnotations.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+public @interface RestData {
+
+  /** The endpoint URL; supports {@code ${state.x}} interpolation. */
+  String url();
+
+  /** The HTTP method (GET, POST, …). */
+  String method() default "GET";
+
+  /** Request headers as {@code "Name: Value"} strings (values interpolated). */
+  String[] headers() default {};
+
+  /** A request body template (interpolated) for non-GET methods. */
+  String body() default "";
+
+  /**
+   * A dot path to the object in the JSON response to merge into the form state; blank merges the
+   * whole response object.
+   */
+  String resultPath() default "";
+}

--- a/doc/src/content/docs/java-ui-definition/annotations/rest-data.md
+++ b/doc/src/content/docs/java-ui-definition/annotations/rest-data.md
@@ -1,0 +1,52 @@
+---
+title: "@RestData — load a screen's data from a REST endpoint"
+description: "A screen whose initial field values are fetched client-side from an arbitrary, non-Mateu REST endpoint on entry."
+---
+
+`@RestData` loads a screen's **initial data** from an **arbitrary (non-Mateu) REST endpoint**,
+fetched **client-side on entry**: when the view mounts the renderer calls the URL directly — no Mateu
+server mediating — then merges the object at `resultPath` in the JSON response into the **form
+state**, so the fields arrive populated.
+
+It is the screen-data surface of decoupling the Mateu UI from the Mateu backend — after
+[`@RestOptions`](./rest-options) (select options), [`@RestListing`](./rest-listing) (listing rows)
+and [`@RestAction`](./rest-action) (button calls). It is exactly `@RestAction`'s merge, triggered
+**on load** instead of on click.
+
+**Target:** `TYPE` (and `ANNOTATION_TYPE`, so it composes as a [semantic annotation](./semantic-annotations)).
+
+## Example
+
+```java
+@UI("/profile")
+@RestData(url = "https://api.example.com/me", resultPath = "profile")
+public class Profile {
+  String name;
+  String email;
+}
+```
+
+Given a response `{ "profile": { "name": "Ada Lovelace", "email": "ada@example.com" } }`, opening
+`/profile` fills the **Name** and **Email** fields — no button, no server round-trip.
+
+## Attributes
+
+| Attribute    | Default | Meaning |
+|--------------|---------|---------|
+| `url`        | —       | The endpoint URL. Supports `${state.x}` interpolation (against the fields' initial values). |
+| `method`     | `GET`   | The HTTP method. |
+| `headers`    | `{}`    | Request headers as `"Name: Value"` strings (values interpolated). |
+| `body`       | `""`    | A request body template (interpolated) for non-`GET` methods. |
+| `resultPath` | `""`    | A dot path to the object in the response to merge into the form state; blank merges the whole response object. |
+
+## How it works
+
+`@RestData` reuses the `@RestAction` machinery: the view advertises a synthetic `__restdata__` action
+carrying the `RestDataSource` descriptor plus an `OnLoad` trigger that fires it. When the view mounts,
+the trigger runs the action client-side — interpolating the url/headers/body against the state,
+`fetch`ing the endpoint and merging `resultPath` into the form state. No new wire types; every
+renderer that already runs OnLoad triggers and `@RestAction` gets it for free. The endpoint must be
+reachable from the browser (CORS-friendly for cross-origin APIs).
+
+`url` interpolation lets the request depend on a route parameter seeded into the state (e.g.
+`url = "https://api.example.com/users/${state.id}"`).

--- a/doc/src/content/docs/reference/parity.md
+++ b/doc/src/content/docs/reference/parity.md
@@ -50,6 +50,7 @@ for the surface below (verified by golden-JSON tests in `backend/dotnet/test` an
 | External REST options (`@RestOptions`/`[RestOptions]`/`RestOptions()` → select; options fetched client-side from an arbitrary endpoint via `FormField.optionsSource`) | ✅ | ✅ | ✅ |
 | External REST listing rows (`@RestListing`/`[RestListing]`/`@rest_listing` on a listing → rows fetched client-side from an arbitrary endpoint via `Crudl.rowsSource`; columns from the Row type) | ✅ | ✅ | ✅ |
 | External REST button action (`@RestAction`/`[RestAction]`/`@rest_action` on a button → calls an arbitrary endpoint client-side via `Action.restAction`; response toast + merge into form state) | ✅ | ✅ | ✅ |
+| External REST screen data (`@RestData` on a view → initial data fetched client-side on load and merged into the form state; reuses the `restAction` machinery via a synthetic `__restdata__` action + OnLoad trigger) | ✅ | — | — |
 | Editable grids / inline CRUD editing (`@InlineEditing` + update-row) | ✅ | ✅ | ✅ |
 | Bulk list actions (`@ListToolbarButton` + typed selection) | ✅ | ✅ | ✅ |
 | Listing aggregates & grouping (`@Aggregate`/`@GroupBy` + summaries) | ✅ | ✅ | ✅ |

--- a/e2e/sut/apps/mvc-app1/src/main/resources/static/rest-data-demo.json
+++ b/e2e/sut/apps/mvc-app1/src/main/resources/static/rest-data-demo.json
@@ -1,0 +1,6 @@
+{
+  "profile": {
+    "name": "Ada Lovelace",
+    "email": "ada@example.com"
+  }
+}

--- a/e2e/sut/modules/sample1/src/main/java/io/mateu/sample1/RestDataForm.java
+++ b/e2e/sut/modules/sample1/src/main/java/io/mateu/sample1/RestDataForm.java
@@ -1,0 +1,24 @@
+package io.mateu.sample1;
+
+import io.mateu.uidl.annotations.RestData;
+import io.mateu.uidl.annotations.Title;
+import io.mateu.uidl.annotations.UI;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * A screen whose initial data is fetched CLIENT-SIDE from a REST endpoint on entry. On load the
+ * renderer fetches a same-origin JSON ({@code static/rest-data-demo.json} =
+ * {@code {"profile": {"name": ..., "email": ...}}}); {@code resultPath="profile"} merges
+ * {@code {name, email}} into the form state, so the fields arrive populated — no server round-trip.
+ */
+@UI("/rest-data")
+@Title("REST Data Form")
+@RestData(url = "/rest-data-demo.json", resultPath = "profile")
+@Getter
+@Setter
+public class RestDataForm {
+
+  String name;
+  String email;
+}


### PR DESCRIPTION
The **fourth and final surface** of consuming non-Mateu REST endpoints (after [#334](https://github.com/miguelperezcolom/mateu/pull/334) options, [#336](https://github.com/miguelperezcolom/mateu/pull/336) rows, [#338](https://github.com/miguelperezcolom/mateu/pull/338) actions): a view whose **initial data** is fetched **client-side** from an arbitrary REST endpoint on entry, then merged into the form state so the fields arrive populated.

## Usage
```java
@UI("/profile")
@RestData(url = "https://api.example.com/me", resultPath = "profile")
public class Profile {
  String name;
  String email;
}
```
Given `{ "profile": { "name": "Ada Lovelace", "email": "ada@example.com" } }`, opening `/profile` fills Name/Email — no button, no server round-trip.

## Design — zero new wire, zero frontend
It reuses the `@RestAction` machinery entirely: the view advertises a synthetic `__restdata__` action carrying the `RestAction` descriptor (`ActionMapper`) plus an `OnLoad` trigger that fires it (`TriggerMapper`). On mount the existing OnLoad trigger runs the action, which the frontend already handles client-side (`handleRestAction`: interpolate + fetch + merge `getByPath(response, resultPath)` into the form state). Silent load (no toast); blank `resultPath` merges the whole response. Shared bits in `RestDataSupport`.

## Verified
- **core** `RestDataSyncTest`: `@RestData` → `__restdata__` action with the `restAction` descriptor + an OnLoad trigger firing it. Full core build green (JaCoCo gate + all tests).
- **browser** (`mvc-app1` `/rest-data`): opening the screen fetches a same-origin JSON **on load** (no interaction) and fills the Name/Email fields from `resultPath="profile"`.

Docs: `java-ui-definition/annotations/rest-data.md` + parity row (Java; .NET/Python port pending).

This completes the four external-endpoint surfaces: **options, listing rows, button actions, screen data** — all client-side, all reusing the `RestDataSource` descriptor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)