### PR TITLE
Port @RestData to .NET and Python — external-endpoints line complete

### DIFF
--- a/backend/dotnet/src/Mateu.Core/ReflectionMapper.cs
+++ b/backend/dotnet/src/Mateu.Core/ReflectionMapper.cs
@@ -339,6 +339,14 @@ public sealed class ReflectionMapper(ITranslator? translator = null, Func<Identi
                 }];
             }
         }
+        // [RestData]: fetch the screen's initial data client-side on load — a synthetic __restdata__
+        // action carrying the REST descriptor plus an OnLoad trigger that fires it (reuses the
+        // [RestAction] fetch+merge path; silent load, so no success message).
+        if (RestDataOf(type) is { } restData)
+        {
+            actions.Add(new ActionDto("__restdata__", ValidationRequired: false) { RestAction = restData });
+            triggers = [.. triggers, new TriggerDto("OnLoad", "__restdata__")];
+        }
         return new ServerSideComponentDto(
             Guid.NewGuid().ToString(), type.FullName!, route,
             [page], initialData, actions, triggers, null, null, null)
@@ -1468,6 +1476,21 @@ public sealed class ReflectionMapper(ITranslator? translator = null, Func<Identi
         return new RestActionDto(source,
             a.SuccessMessage.Length > 0 ? a.SuccessMessage : null,
             a.ResultPath.Length > 0 ? a.ResultPath : null);
+    }
+
+    /// <summary>The client-side REST descriptor for a [RestData] screen (silent load; blank
+    /// ResultPath merges the whole response — getByPath with an empty path is identity); null
+    /// when the class carries no [RestData].</summary>
+    private static RestActionDto? RestDataOf(Type type)
+    {
+        if (type.Find<RestDataAttribute>() is not { } a) return null;
+        var source = new RestDataSourceDto(a.Url)
+        {
+            Method = a.Method,
+            Headers = ParseHeaders(a.Headers),
+            Body = a.Body,
+        };
+        return new RestActionDto(source, null, a.ResultPath);
     }
 
     /// <summary>Parses "Name: Value" header strings into a map.</summary>

--- a/backend/dotnet/src/Mateu.Uidl/Attributes.cs
+++ b/backend/dotnet/src/Mateu.Uidl/Attributes.cs
@@ -156,6 +156,27 @@ public sealed class RestActionAttribute(string url) : Attribute
     public string ResultPath { get; init; } = "";
 }
 
+/// <summary>Loads a screen's initial data from an arbitrary (non-Mateu) REST endpoint, fetched
+/// CLIENT-SIDE on entry: when the view mounts the renderer calls <see cref="Url"/> directly and
+/// merges the object at <see cref="ResultPath"/> in the JSON response into the form state, so the
+/// fields arrive populated. Reuses the [RestAction] machinery (a synthetic __restdata__ action +
+/// an OnLoad trigger). Url/Headers/Body support <c>${state.x}</c> interpolation. (C# analogue of
+/// Java's @RestData.)</summary>
+[AttributeUsage(AttributeTargets.Class)]
+public sealed class RestDataAttribute(string url) : Attribute
+{
+    public string Url { get; } = url;
+    public string Method { get; init; } = "GET";
+
+    /// <summary>Request headers as "Name: Value" strings (values interpolated).</summary>
+    public string[] Headers { get; init; } = [];
+    public string Body { get; init; } = "";
+
+    /// <summary>A dot path to the object in the response to merge into the form state; blank merges
+    /// the whole response object.</summary>
+    public string ResultPath { get; init; } = "";
+}
+
 /// <summary>An overridden display label for a field or method.</summary>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Class)]
 public sealed class LabelAttribute(string value) : Attribute

--- a/backend/dotnet/test/Mateu.Tests/SyncHandlerTests.cs
+++ b/backend/dotnet/test/Mateu.Tests/SyncHandlerTests.cs
@@ -61,6 +61,16 @@ public class RestActionForm
     public void Lookup() { }
 }
 
+// A screen whose initial data is fetched client-side from a REST endpoint on entry.
+[UI("rest-data"), Title("Rest data"),
+ RestData("https://api.example.com/me?token=${state.token}",
+     Headers = ["Authorization: Bearer x"], ResultPath = "profile")]
+public class RestDataForm
+{
+    public string? Name { get; set; }
+    public string? Email { get; set; }
+}
+
 // A fully-static screen: the client caches its whole response and skips the round-trip on return.
 [UI("static-view"), Title("About"), StaticView]
 public class StaticViewForm
@@ -1852,6 +1862,20 @@ public class SyncHandlerTests
         Assert.Contains("\"resultPath\":\"address\"", json);
         Assert.Contains("\"url\":\"https://api.example.com/zip/${state.zip}\"", json);
         Assert.Contains("\"Authorization\":\"Bearer x\"", json);
+    }
+
+    [Fact]
+    public void RestData_advertises_an_onload_action_carrying_the_endpoint_descriptor()
+    {
+        var inc = Handler().Handle(new RunActionRqDto { Route = "rest-data", ConsumedRoute = "rest-data" });
+        var json = Render(inc);
+
+        Assert.Contains("\"id\":\"__restdata__\"", json);
+        Assert.Contains("\"restAction\":{", json);
+        Assert.Contains("\"resultPath\":\"profile\"", json);
+        Assert.Contains("\"url\":\"https://api.example.com/me?token=${state.token}\"", json);
+        // an OnLoad trigger fires it on entry
+        Assert.Contains("\"type\":\"OnLoad\",\"actionId\":\"__restdata__\"", json);
     }
 
     [Fact]

--- a/backend/python/mateu_core/mapper.py
+++ b/backend/python/mateu_core/mapper.py
@@ -581,6 +581,15 @@ class ReflectionMapper:
             if on_row is not None and all(a.id != camel_case(on_row.value) for a in actions):
                 actions.append(Action(id=camel_case(on_row.value), validation_required=False))
 
+        # @rest_data: fetch the screen's initial data client-side on load — a synthetic
+        # __restdata__ action carrying the REST descriptor (fired by the OnLoad trigger added
+        # below), reusing the @rest_action fetch+merge path.
+        rest_data_desc = self._rest_data(cls)
+        if rest_data_desc is not None:
+            actions.append(
+                Action(id="__restdata__", validation_required=False, rest_action=rest_data_desc)
+            )
+
         # A YAML page's layout (bound to this instance as its ModelView) renders as the page
         # content exactly like an archetype's fluent tree — its FormField ids bind to the
         # instance's state (seeded into initialData below), its Button actionIds (collected below)
@@ -635,6 +644,9 @@ class ReflectionMapper:
             style="--mateu-compact:1" if compact else None,
         )
         triggers, emits = self.events_of(cls)
+        # @rest_data: fire the synthetic __restdata__ action on load (the action is advertised above).
+        if rest_data_desc is not None:
+            triggers = list(triggers) + [Trigger(type="OnLoad", action_id="__restdata__")]
         initial_data: dict = {}
         if tree is not None:
             # Tree-supplier views (archetypes): scalar attributes are the view's state — seed
@@ -2623,6 +2635,26 @@ class ReflectionMapper:
             source=RestDataSource(url=url, method=method, headers=headers, body=body),
             success_message=success_message or None,
             result_path=result_path or None,
+        )
+
+    @staticmethod
+    def _rest_data(cls) -> "RestAction | None":
+        """The client-side REST descriptor for a ``@rest_data`` screen (silent load; blank
+        result_path merges the whole response — getByPath with an empty path is identity on the
+        frontend); None when the class carries no ``@rest_data``."""
+        spec = getattr(cls, "__mateu_rest_data__", None)
+        if spec is None:
+            return None
+        url, method, header_strings, body, result_path = spec
+        headers: dict[str, str] = {}
+        for h in header_strings:
+            name, sep, value = h.partition(":")
+            if sep:
+                headers[name.strip()] = value.strip()
+        return RestAction(
+            source=RestDataSource(url=url, method=method, headers=headers, body=body),
+            success_message=None,
+            result_path=result_path,
         )
 
     def link_of(self, f, instance) -> NavLinkRecord | None:

--- a/backend/python/mateu_uidl/__init__.py
+++ b/backend/python/mateu_uidl/__init__.py
@@ -790,6 +790,27 @@ def rest_action(
     return deco
 
 
+def rest_data(
+    url: str,
+    method: str = "GET",
+    headers: tuple[str, ...] = (),
+    body: str = "",
+    result_path: str = "",
+) -> Callable[[type], type]:
+    """Class-level: loads a screen's initial data from an arbitrary (non-Mateu) REST endpoint,
+    fetched CLIENT-SIDE on entry. When the view mounts the renderer calls ``url`` directly and
+    merges the object at ``result_path`` in the JSON response into the form state, so the fields
+    arrive populated. Reuses the @rest_action machinery (a synthetic ``__restdata__`` action + an
+    OnLoad trigger). ``url``/``headers``/``body`` support ``${state.x}`` interpolation. Python
+    analogue of Java's @RestData."""
+
+    def deco(cls: type) -> type:
+        cls.__mateu_rest_data__ = (url, method, headers, body, result_path)
+        return cls
+
+    return deco
+
+
 def welcome_banner(title: str = "", subtitle: str = "", image: str = "") -> Callable[[type], type]:
     """Class-level: prepends the Redwood "Welcome Banner" element to the page content — a
     centered HeroSection (id "welcome-banner") with the given title (empty → the page title),
@@ -1556,7 +1577,7 @@ __all__ = [
     "ai", "remote_menu", "ui", "title", "subtitle", "app", "auto_layout", "read_only", "compact",
     "static_view",
     "confirm_on_navigation_if_dirty", "inline_editing", "toc", "zones", "folded_layout", "form_layout", "LabelsAsideMode", "wizard_progress", "page_width", "page_template",
-    "plain_text", "emits", "subscribe_to", "secured", "welcome_banner", "rest_listing", "rest_action",
+    "plain_text", "emits", "subscribe_to", "secured", "welcome_banner", "rest_listing", "rest_action", "rest_data",
     "button", "menu_item", "kpi", "fab", "banner", "shortcut", "list_toolbar_button",
     "Crud", "HeroSearch", "Listing", "SearchRequest", "ListingData", "Filterable", "Navigable", "Editable", "Creatable", "Deletable", "SmartSearchPage", "DateRange", "NumberRange", "Pageable", "PageResult", "SortSpec", "Searchable", "SelectedItem", "Selector", "Wizard", "Translator",
     "ComponentTreeSupplier", "Dashboard", "DataManagement", "Foldout", "GanttPage", "ItemOverview", "Welcome", "TodoList",

--- a/backend/python/tests/test_sync_handler.py
+++ b/backend/python/tests/test_sync_handler.py
@@ -100,6 +100,7 @@ from mateu_uidl import (  # noqa: E402
     disabled_unless,
     remote_menu,
     rest_action,
+    rest_data,
     rest_listing,
 )
 from mateu_uidl.components import MicroFrontend  # noqa: E402
@@ -1755,6 +1756,30 @@ def test_rest_action_button_advertises_the_endpoint_descriptor_on_its_action():
     assert '"resultPath": "address"' in j
     assert '"url": "https://api.example.com/zip/${state.zip}"' in j
     assert '"Authorization": "Bearer x"' in j
+
+
+@ui("rest-data")
+@title("Rest data")
+@rest_data(
+    url="https://api.example.com/me?token=${state.token}",
+    headers=("Authorization: Bearer x",),
+    result_path="profile",
+)
+class RestDataForm:
+    name: str = ""
+    email: str = ""
+
+
+def test_rest_data_advertises_an_onload_action_carrying_the_endpoint_descriptor():
+    inc = handler().handle(RunActionRq(route="rest-data", consumed_route="rest-data"))
+    j = render(inc)
+
+    assert '"id": "__restdata__"' in j
+    assert '"restAction": {' in j
+    assert '"resultPath": "profile"' in j
+    assert '"url": "https://api.example.com/me?token=${state.token}"' in j
+    # an OnLoad trigger fires it on entry
+    assert '"type": "OnLoad", "actionId": "__restdata__"' in j
 
 
 def test_lookup_search_filters_and_pages_the_suppliers_options():

--- a/doc/src/content/docs/java-ui-definition/annotations/rest-data.md
+++ b/doc/src/content/docs/java-ui-definition/annotations/rest-data.md
@@ -50,3 +50,22 @@ reachable from the browser (CORS-friendly for cross-origin APIs).
 
 `url` interpolation lets the request depend on a route parameter seeded into the state (e.g.
 `url = "https://api.example.com/users/${state.id}"`).
+
+## Other backends
+
+Mateu.NET and the Python backend emit the same synthetic `__restdata__` action + OnLoad trigger:
+
+```csharp
+// .NET
+[UI("profile"), RestData("https://api.example.com/me", ResultPath = "profile")]
+public class Profile { public string? Name { get; set; } public string? Email { get; set; } }
+```
+
+```python
+# Python
+@ui("profile")
+@rest_data(url="https://api.example.com/me", result_path="profile")
+class Profile:
+    name: str = ""
+    email: str = ""
+```

--- a/doc/src/content/docs/reference/parity.md
+++ b/doc/src/content/docs/reference/parity.md
@@ -50,7 +50,7 @@ for the surface below (verified by golden-JSON tests in `backend/dotnet/test` an
 | External REST options (`@RestOptions`/`[RestOptions]`/`RestOptions()` → select; options fetched client-side from an arbitrary endpoint via `FormField.optionsSource`) | ✅ | ✅ | ✅ |
 | External REST listing rows (`@RestListing`/`[RestListing]`/`@rest_listing` on a listing → rows fetched client-side from an arbitrary endpoint via `Crudl.rowsSource`; columns from the Row type) | ✅ | ✅ | ✅ |
 | External REST button action (`@RestAction`/`[RestAction]`/`@rest_action` on a button → calls an arbitrary endpoint client-side via `Action.restAction`; response toast + merge into form state) | ✅ | ✅ | ✅ |
-| External REST screen data (`@RestData` on a view → initial data fetched client-side on load and merged into the form state; reuses the `restAction` machinery via a synthetic `__restdata__` action + OnLoad trigger) | ✅ | — | — |
+| External REST screen data (`@RestData`/`[RestData]`/`@rest_data` on a view → initial data fetched client-side on load and merged into the form state; reuses the `restAction` machinery via a synthetic `__restdata__` action + OnLoad trigger) | ✅ | ✅ | ✅ |
 | Editable grids / inline CRUD editing (`@InlineEditing` + update-row) | ✅ | ✅ | ✅ |
 | Bulk list actions (`@ListToolbarButton` + typed selection) | ✅ | ✅ | ✅ |
 | Listing aggregates & grouping (`@Aggregate`/`@GroupBy` + summaries) | ✅ | ✅ | ✅ |


### PR DESCRIPTION
Ports the **screen-data surface** (the last of the four external-endpoint surfaces) to Mateu.NET and the Python backend: a view whose initial data is fetched **client-side** on entry and merged into the form state. Backend-only, and reuses the already-ported `@RestAction` machinery — **no new wire types**.

## .NET
```csharp
[UI("profile"), RestData("https://api.example.com/me", ResultPath = "profile")]
public class Profile { public string? Name { get; set; } public string? Email { get; set; } }
```
`[RestData]` → `MapView` adds a synthetic `__restdata__` `ActionDto` carrying the `RestActionDto` (via `RestDataOf`) plus a `TriggerDto("OnLoad", "__restdata__")` that fires it on mount.

## Python
```python
@ui("profile")
@rest_data(url="https://api.example.com/me", result_path="profile")
class Profile:
    name: str = ""
    email: str = ""
```
`@rest_data` → `map_view` appends the `__restdata__` `Action` (`rest_action` via `_rest_data`) + a `Trigger(type="OnLoad", action_id="__restdata__")`; exported in `__all__`.

Silent load (no success message); blank `result_path` merges the whole response. The existing shared frontend OnLoad-trigger + `handleRestAction` path does the fetch+merge — **zero frontend changes**, exactly like the Java implementation.

## Tests
- .NET: `RestData_advertises_an_onload_action_carrying_the_endpoint_descriptor` — 245/245
- Python: `test_rest_data_advertises_an_onload_action_carrying_the_endpoint_descriptor` — 244
- Parity row flipped to all-green + port examples in the docs.

## Line complete
The external-endpoints line is now at **full parity across all three backends**:

| Surface | Java | .NET | Python |
|---|---|---|---|
| Select options (`@RestOptions`) | ✅ | ✅ | ✅ |
| Listing rows (`@RestListing`) | ✅ | ✅ | ✅ |
| Button action (`@RestAction`) | ✅ | ✅ | ✅ |
| Screen data (`@RestData`) | ✅ | ✅ | ✅ |

All client-side (client-direct fetch), all reusing the `RestDataSource` descriptor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)