### PR TITLE
@RestData / @RestAction client-side handling in React Native + IntelliJ

### DIFF
--- a/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/api/MateuApiClient.kt
+++ b/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/api/MateuApiClient.kt
@@ -83,6 +83,26 @@ class MateuApiClient(
         return mapper.readTree(responseBody)
     }
 
+    /**
+     * Fetch an arbitrary (non-Mateu) REST endpoint — the client-side leg of @RestAction/@RestData.
+     * No Mateu session headers; returns the parsed JSON body. Throws on a non-2xx response.
+     */
+    fun fetchExternal(url: String, method: String, headers: Map<String, String>, body: String?): JsonNode {
+        val builder = HttpRequest.newBuilder()
+            .uri(URI.create(url))
+            .timeout(Duration.ofSeconds(60))
+            .header("Accept", "application/json")
+        headers.forEach { (k, v) -> builder.header(k, v) }
+        val publisher =
+            if (method == "GET" || method == "HEAD") HttpRequest.BodyPublishers.noBody()
+            else HttpRequest.BodyPublishers.ofString(body ?: "")
+        if (method != "GET" && method != "HEAD" && !body.isNullOrBlank()) builder.header("Content-Type", "application/json")
+        val request = builder.method(method, publisher).build()
+        val response = http.send(request, HttpResponse.BodyHandlers.ofString())
+        if (response.statusCode() >= 400) throw RuntimeException("HTTP ${response.statusCode()}")
+        return mapper.readTree(response.body())
+    }
+
     fun initialLoad(route: String?, appState: Map<String, Any?>): JsonNode =
         runAction(route, "_empty", "", null, "ux_main", emptyMap(), appState, emptyMap())
 

--- a/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/debug/RenderProbe.kt
+++ b/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/debug/RenderProbe.kt
@@ -139,5 +139,11 @@ private fun bootstrap() {
         val laf = Class.forName("com.intellij.ide.ui.laf.darcula.DarculaLaf")
             .getDeclaredConstructor().newInstance() as javax.swing.LookAndFeel
         UIManager.setLookAndFeel(laf)
-    }.onFailure { System.err.println("[probe] Darcula failed (${it.message}), default L&F") }
+    }.onFailure {
+        // The system L&F (Aqua on macOS) is not module-accessible under newer JDKs, leaving no
+        // ComponentUI and a blank render — fall back to the cross-platform (Metal) L&F so the probe
+        // still paints on any environment.
+        System.err.println("[probe] Darcula failed (${it.message}), cross-platform L&F")
+        runCatching { UIManager.setLookAndFeel(UIManager.getCrossPlatformLookAndFeelClassName()) }
+    }
 }

--- a/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/state/AppContext.kt
+++ b/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/state/AppContext.kt
@@ -244,6 +244,10 @@ class AppContext(val session: AppSession) {
     private var currentActionBubble: MutableMap<String, Boolean> = HashMap()
     private var currentActionRowsSelectedRequired: MutableMap<String, Boolean> = HashMap()
 
+    /** @RestAction/@RestData: actions whose descriptor makes the client fetch an external REST
+     *  endpoint instead of dispatching to the Mateu server (keyed by action id). */
+    private var currentActionRestData: MutableMap<String, JsonNode> = HashMap()
+
     /** A wire `parameters` object node → a plain map (empty when absent / not an object). */
     @Suppress("UNCHECKED_CAST")
     fun jsonToParams(node: JsonNode?): Map<String, Any?> =
@@ -460,6 +464,14 @@ class AppContext(val session: AppSession) {
             }
         }
 
+        // @RestAction/@RestData: call the external REST endpoint CLIENT-SIDE instead of dispatching
+        // to the Mateu server — fetch + merge the response into the state + notify (fires on click
+        // for a @RestAction button, and on mount for @RestData via its OnLoad __restdata__ action).
+        currentActionRestData[actionId]?.let { rest ->
+            handleRestAction(rest)
+            return
+        }
+
         val serverSideType = resolveActionTarget(actionId)
         background(
             work = {
@@ -479,12 +491,66 @@ class AppContext(val session: AppSession) {
         )
     }
 
+    /**
+     * Runs a @RestAction/@RestData descriptor: fetch the external endpoint CLIENT-SIDE (url/headers/
+     * body interpolated from the live state), then merge the object at resultPath into the form
+     * state (so bound fields refresh) and show a success notification; an error shows a failure one.
+     * No server round-trip — the plugin analogue of the web's mateu-component.handleRestAction.
+     */
+    private fun handleRestAction(rest: JsonNode) {
+        val source = rest.path("source")
+        val ctx = mapOf<String, Any?>("state" to currentComponentState, "appState" to appState)
+        background(
+            work = {
+                val url = Expressions.interpolate(source.text("url"), ctx)
+                val method = source.text("method").ifBlank { "GET" }.uppercase()
+                val headers = LinkedHashMap<String, String>()
+                source.path("headers").fields().forEach { (k, v) ->
+                    headers[k] = Expressions.interpolate(v.asText(""), ctx)
+                }
+                val body = source.get("body")?.asText("").orEmpty().let {
+                    if (it.isBlank()) null else Expressions.interpolate(it, ctx)
+                }
+                apiClient.fetchExternal(url, method, headers, body)
+            },
+            onOk = { json ->
+                // resultPath: a string (possibly empty = whole response) merges into the state;
+                // null/absent (a @RestAction fire-and-toast) merges nothing.
+                val resultPath = rest.get("resultPath")
+                if (resultPath != null && resultPath.isTextual) {
+                    val merged = valueAtPath(json, resultPath.asText())
+                    if (merged != null && merged.isObject) {
+                        merged.fields().forEach { (k, v) -> currentComponentState[k] = v }
+                        rerenderCurrentForm()
+                    }
+                }
+                val message = Expressions.interpolate(rest.get("successMessage")?.asText("").orEmpty(), ctx)
+                if (message.isNotBlank()) showMessage(message, "success")
+            },
+            onErr = {
+                if (silentErrors) println("[Mateu] rest action failed: ${it.message}")
+                else showMessage("Request failed", "error")
+            },
+        )
+    }
+
+    /** Navigate a dot path (`profile`, `data.address`) into a JSON value; an empty path is identity. */
+    private fun valueAtPath(node: JsonNode, path: String): JsonNode? {
+        if (path.isBlank()) return node
+        var cur: JsonNode? = node
+        for (key in path.split('.')) {
+            cur = cur?.get(key) ?: return null
+        }
+        return cur
+    }
+
     // ── action bubbling / validation (framework-neutral, ported verbatim) ─────────────
     fun captureComponentContext(sscNode: JsonNode, serverSideType: String) {
         val actions = ArrayList<String>()
         val validationFlags = HashMap<String, Boolean>()
         val bubbleFlags = HashMap<String, Boolean>()
         val rowsSelectedFlags = HashMap<String, Boolean>()
+        val restData = HashMap<String, JsonNode>()
         val actionNodes = sscNode.path("actions")
         if (actionNodes.isArray) {
             for (a in actionNodes) {
@@ -494,6 +560,8 @@ class AppContext(val session: AppSession) {
                     validationFlags[id] = a.bool("validationRequired")
                     bubbleFlags[id] = a.bool("bubble")
                     rowsSelectedFlags[id] = a.bool("rowsSelectedRequired")
+                    val rest = a.path("restAction")
+                    if (rest.isObject) restData[id] = rest
                 }
             }
         }
@@ -501,6 +569,7 @@ class AppContext(val session: AppSession) {
         currentActionValidationRequired = validationFlags
         currentActionBubble = bubbleFlags
         currentActionRowsSelectedRequired = rowsSelectedFlags
+        currentActionRestData = restData
         currentComponentValidations = sscNode.path("validations")
         currentRules = sscNode.path("rules").takeIf { it.isArray && it.size() > 0 }
         fieldAttributes.clear()

--- a/frontend/app/react-native/App.tsx
+++ b/frontend/app/react-native/App.tsx
@@ -23,6 +23,9 @@ import { MateuViewHost } from './src/renderer/MateuViewHost';
 // Overridable so a dev (or a probe) can point the app at a different backend without editing
 // this file — e.g. EXPO_PUBLIC_MATEU_BACKEND_PORT=8080 for the e2e SUT.
 const MATEU_BACKEND_PORT = Number(process.env.EXPO_PUBLIC_MATEU_BACKEND_PORT) || 8594;
+// Boot directly at a specific route instead of the backend's home — a probe/test affordance
+// (e.g. EXPO_PUBLIC_MATEU_ROUTE=/rest-data). Empty = the home route.
+const MATEU_ROUTE = process.env.EXPO_PUBLIC_MATEU_ROUTE || '';
 const devHost = Constants.expoConfig?.hostUri?.split(':')[0];
 const DEV_CONFIG = {
   baseUrl: `http://${Platform.OS === 'web' || !devHost ? 'localhost' : devHost}:${MATEU_BACKEND_PORT}`,
@@ -159,7 +162,7 @@ function MateuRoot() {
 
   useEffect(() => {
     api
-      .initialLoad('', appState)
+      .initialLoad(MATEU_ROUTE, appState)
       .then((result) => {
         // The backend returns a UIIncrementDto: pick the App fragment (or the first one).
         const res = result as Record<string, unknown>;
@@ -206,7 +209,7 @@ function MateuRoot() {
   }
 
   // No app shell: the root route IS a single view — host it directly.
-  return <MateuViewHost session={session} target={{ label: '', route: '', consumedRoute: '_empty', serverSideType: '' }} />;
+  return <MateuViewHost session={session} target={{ label: '', route: MATEU_ROUTE, consumedRoute: '_empty', serverSideType: '' }} />;
 }
 
 /** Blocking screen shown when the registry demands a newer renderer. "Update now" first tries

--- a/frontend/app/react-native/src/core/MateuViewController.ts
+++ b/frontend/app/react-native/src/core/MateuViewController.ts
@@ -1,4 +1,4 @@
-import { evaluateExpression } from './expressions';
+import { evaluateExpression, interpolate } from './expressions';
 import { MateuSession, NavTarget } from './MateuSession';
 import { announce } from '../a11y/a11y';
 
@@ -57,6 +57,9 @@ export class MateuViewController {
   private actionValidationRequired: Record<string, boolean> = {};
   private actionRowsSelectedRequired: Record<string, boolean> = {};
   private actionBubble: Record<string, boolean> = {};
+  /** @RestAction/@RestData: actions whose descriptor makes the client fetch an external REST
+   *  endpoint instead of dispatching to the Mateu server (keyed by action id). */
+  private actionRestData: Record<string, Json> = {};
   private currentValidations: Json[] = [];
   /** Client-side rules of the current component (RuleMapper wire shape). */
   private currentRules: Json[] = [];
@@ -183,6 +186,15 @@ export class MateuViewController {
       }
     }
 
+    // @RestAction/@RestData: call the external REST endpoint CLIENT-SIDE instead of dispatching to
+    // the Mateu server — fetch + merge the response into the state + toast (fires on click for a
+    // @RestAction button, and on mount for @RestData via its OnLoad trigger's __restdata__ action).
+    const rest = this.actionRestData[actionId];
+    if (rest) {
+      await this.handleRestAction(rest);
+      return;
+    }
+
     try {
       const increment = await this.session.api.runAction({
         route: this.currentRoute,
@@ -203,6 +215,55 @@ export class MateuViewController {
 
   /** Host hook: asked before a discarding action throws away unsaved changes. */
   confirmDiscard: () => Promise<boolean> = async () => true;
+
+  /**
+   * Runs a @RestAction/@RestData descriptor: fetch the external endpoint CLIENT-SIDE (url/headers/
+   * body interpolated from the live state), then merge the object at resultPath into the form state
+   * (so bound fields refresh) and show a success toast; an error shows a failure toast. No server
+   * round-trip — the RN analogue of the web's mateu-component.handleRestAction.
+   */
+  private async handleRestAction(rest: Json): Promise<void> {
+    const ctx = {
+      state: this.currentComponentState,
+      data: this.view.data,
+      appState: this.session.appState,
+      appData: {},
+      component: this.view.component,
+    };
+    const source = (rest['source'] as Json) ?? {};
+    const resolve = (t: unknown): string => interpolate(str(t), ctx);
+    try {
+      const url = resolve(source['url']);
+      const method = (str(source['method']) || 'GET').toUpperCase();
+      const headers: Record<string, string> = {};
+      for (const [k, v] of Object.entries((source['headers'] as Json) ?? {})) headers[k] = resolve(v);
+      const init: RequestInit = { method, headers };
+      if (method !== 'GET' && method !== 'HEAD' && source['body']) init.body = resolve(source['body']);
+      const res = await fetch(url, init);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const json = await res.json();
+      // resultPath: a string (possibly empty = whole response) merges into the state; null/absent
+      // (a @RestAction fire-and-toast) merges nothing.
+      const resultPath = rest['resultPath'];
+      if (typeof resultPath === 'string') {
+        const merged = getByPath(json, resultPath);
+        if (merged && typeof merged === 'object') {
+          Object.assign(this.currentComponentState, merged as Json);
+          this.publish({
+            ...this.view,
+            state: { ...this.currentComponentState },
+            loading: false,
+            version: this.view.version + 1,
+          });
+        }
+      }
+      const message = interpolate(str(rest['successMessage']), ctx);
+      if (message) this.session.notify(null, message, 'info', { duration: 3000 });
+    } catch (e) {
+      if (this.silentErrors) console.log('[Mateu] rest action failed:', errorText(e));
+      else this.session.notify(null, 'Request failed', 'error');
+    }
+  }
 
   // ── field state ─────────────────────────────────────────────────────────────────────
 
@@ -235,6 +296,7 @@ export class MateuViewController {
     const validationFlags: Record<string, boolean> = {};
     const rowsSelectedFlags: Record<string, boolean> = {};
     const bubbleFlags: Record<string, boolean> = {};
+    const restData: Record<string, Json> = {};
     for (const a of asArray(sscNode['actions'])) {
       const id = str(a['id']);
       if (!id) continue;
@@ -242,11 +304,13 @@ export class MateuViewController {
       validationFlags[id] = a['validationRequired'] === true;
       rowsSelectedFlags[id] = a['rowsSelectedRequired'] === true;
       bubbleFlags[id] = a['bubble'] === true;
+      if (a['restAction'] && typeof a['restAction'] === 'object') restData[id] = a['restAction'] as Json;
     }
     this.currentComponentActions = actions;
     this.actionValidationRequired = validationFlags;
     this.actionRowsSelectedRequired = rowsSelectedFlags;
     this.actionBubble = bubbleFlags;
+    this.actionRestData = restData;
     this.currentValidations = asArray(sscNode['validations']);
     this.currentRules = asArray(sscNode['rules']);
     this.fieldAttributes = {};
@@ -745,6 +809,15 @@ function asArray(value: unknown): Json[] {
 
 function str(value: unknown): string {
   return value === null || value === undefined ? '' : String(value);
+}
+
+/** Navigate a dot path (`profile`, `data.address`) into a JSON value; an empty path is identity. */
+function getByPath(obj: unknown, path: string): unknown {
+  if (!path) return obj;
+  return path.split('.').reduce<unknown>(
+    (acc, key) => (acc != null && typeof acc === 'object' ? (acc as Json)[key] : undefined),
+    obj,
+  );
 }
 
 function trimSlashes(s: string): string {


### PR DESCRIPTION
The native renderers (React Native, IntelliJ plugin) are standalone clients that speak the same `/mateu/v3/sync` wire but do NOT share `libs/mateu`, so the client-side REST machinery had to be ported to each. This adds handling of an action's `restAction` descriptor — fetch an arbitrary REST endpoint **client-side**, merge the response at `resultPath` into the form state, toast — which, with the already-existing OnLoad-trigger firing, delivers **@RestData** (the `__restdata__` action fired on mount) and **@RestAction** (fired on a button click) on both.

## React Native (`MateuViewController.ts`)
- `captureComponentContext` caches each action's `restAction` by id; `runAction` branches to `handleRestAction` before the server call.
- `handleRestAction` interpolates url/headers/body against the live state, fetches, merges `getByPath(json, resultPath)` into `currentComponentState` + republishes, and notifies.
- `App.tsx` gains an `EXPO_PUBLIC_MATEU_ROUTE` boot override (a probe affordance, like the existing port override) + a `consumedRoute` fix for the direct-route boot.

## IntelliJ plugin (`AppContext.kt` / `MateuApiClient.kt`)
- `captureComponentContext` caches `restAction` nodes; `runAction` branches to `handleRestAction`.
- `handleRestAction` fetches on the background executor (new `MateuApiClient.fetchExternal`, plain `java.net.http` — no CORS), merges the `resultPath` object into `currentComponentState` + `rerenderCurrentForm` on the EDT, and notifies.
- `RenderProbe`: fall back to the cross-platform L&F when Darcula/system L&F isn't accessible (newer JDKs can't reach `com.apple.laf.AquaLookAndFeel`), so the headless probe still paints.

## Verified end-to-end (against a live `@RestData` screen hitting a CORS-open public API)
- **React Native**: Expo web + Playwright — the screen loads, fires OnLoad, fetches the endpoint and fills the Name/Email fields (screenshot).
- **IntelliJ**: `./gradlew renderProbe` on the captured increment — OnLoad fires, the real fetch runs, and the JBTextFields render `Leanne Graham` / `Sincere@april.biz` (component tree + PNG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)