### PR TITLE
@RestOptions + @RestListing client-side handling in React Native + IntelliJ

### DIFF
--- a/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/debug/RenderProbe.kt
+++ b/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/debug/RenderProbe.kt
@@ -102,6 +102,8 @@ private fun dump(c: JComponent, depth: Int) {
             (0 until c.rowCount).joinToString(" | ") { r ->
                 (0 until c.columnCount).joinToString(",") { col -> "${c.getValueAt(r, col)}" }
             }
+        is javax.swing.JComboBox<*> -> " combo items=${c.itemCount} selected='${c.selectedItem}'" +
+            (0 until c.itemCount).joinToString(",", " [", "]") { "${c.getItemAt(it)}" }
         is javax.swing.JLabel -> " text='${c.text}'"
         is javax.swing.AbstractButton -> " text='${c.text}'"
         is javax.swing.text.JTextComponent -> " text='${c.text.take(40)}'"

--- a/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/ui/CrudRenderer.kt
+++ b/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/ui/CrudRenderer.kt
@@ -336,6 +336,40 @@ fun renderCrud(r: ComponentRenderer, component: JsonNode, metadata: JsonNode, st
     // Seed with any data already present on this fragment.
     if (!data.isNull && !data.isMissingNode) applyData(data)
 
+    // @RestListing: rows fetched CLIENT-SIDE from an arbitrary REST endpoint instead of the server
+    // `search` action. Declarative listings get no server OnLoad trigger, so self-fetch on mount:
+    // map each JSON item into a row object keyed by column id and feed it through applyData.
+    val rowsSource = metadata.path("rowsSource")
+    if (rowsSource.isObject) {
+        val columnIds = metadata.arr("columns")
+            .map { it.path("metadata").text("id", it.text("id")) }
+            .filter { it.isNotBlank() }
+        val exprCtx = mapOf<String, Any?>("state" to ctx.currentComponentState, "appState" to ctx.appState)
+        val mapper = ctx.session.mapper
+        ctx.session.executor.submit {
+            try {
+                val json = RestFetch.fetch(ctx.apiClient, rowsSource, exprCtx)
+                val arr = RestFetch.valueAtPath(json, rowsSource.text("itemsPath"))
+                val content = mapper.createArrayNode()
+                if (arr != null && arr.isArray) for (item in arr) {
+                    val rowNode = mapper.createObjectNode()
+                    for (cid in columnIds) RestFetch.valueAtPath(item, cid)?.let { rowNode.replace(cid, it) }
+                    content.add(rowNode)
+                }
+                val page = mapper.createObjectNode()
+                page.replace("content", content)
+                page.put("totalElements", content.size())
+                page.put("pageSize", content.size().coerceAtLeast(1))
+                page.put("pageNumber", 0)
+                val envelope = mapper.createObjectNode()
+                envelope.replace("page", page)
+                javax.swing.SwingUtilities.invokeLater { applyData(envelope) }
+            } catch (t: Throwable) {
+                println("[Mateu] external rows fetch failed: ${t.message}")
+            }
+        }
+    }
+
     return panel
 }
 

--- a/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/ui/FormFieldRenderer.kt
+++ b/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/ui/FormFieldRenderer.kt
@@ -165,6 +165,7 @@ fun renderFormField(ctx: AppContext, metadata: JsonNode, state: JsonNode, data: 
         stereotype in setOf("markdown", "html", "richText") && !enabled -> richTextField(value, stereotype)
         stereotype == "textarea" || (stereotype in setOf("markdown", "html", "richText") && enabled) ->
             textArea(ctx, fieldId, value, enabled)
+        metadata.path("optionsSource").isObject -> restOptionsCombo(ctx, fieldId, metadata.path("optionsSource"), value, enabled)
         options.isNotEmpty() -> optionsCombo(ctx, fieldId, options, value, enabled)
         dataType == "reference" -> referenceCombo(ctx, fieldId, data, enabled)
         stereotype == "password" -> passwordField(ctx, fieldId, value, enabled)
@@ -691,6 +692,44 @@ private fun optionsCombo(ctx: AppContext, fieldId: String, options: List<JsonNod
     combo.addActionListener {
         val i = combo.selectedIndex
         if (i in values.indices) ctx.putState(fieldId, values[i])
+    }
+    return combo
+}
+
+/** @RestOptions: a combo whose options are fetched CLIENT-SIDE from an arbitrary REST endpoint on
+ *  the background executor; the model + selection are set on the EDT once the fetch resolves. */
+private fun restOptionsCombo(ctx: AppContext, fieldId: String, source: JsonNode, value: String, enabled: Boolean): JComponent {
+    val combo = ComboBox(DefaultComboBoxModel(arrayOf<String>()))
+    combo.isEnabled = enabled
+    val exprCtx = mapOf<String, Any?>("state" to ctx.currentComponentState, "appState" to ctx.appState)
+    ctx.session.executor.submit {
+        val opts = try {
+            val json = RestFetch.fetch(ctx.apiClient, source, exprCtx)
+            val arr = RestFetch.valueAtPath(json, source.text("itemsPath"))
+            val valuePath = source.text("valuePath").ifBlank { "value" }
+            val labelPath = source.text("labelPath").ifBlank { "label" }
+            val list = ArrayList<Pair<String, String>>()
+            if (arr != null && arr.isArray) for (item in arr) {
+                val v = RestFetch.valueAtPath(item, valuePath)?.asText() ?: item.asText("")
+                val l = RestFetch.valueAtPath(item, labelPath)?.asText() ?: v
+                list.add(v to l)
+            }
+            list
+        } catch (t: Throwable) {
+            println("[Mateu] external options fetch failed: ${t.message}")
+            emptyList()
+        }
+        javax.swing.SwingUtilities.invokeLater {
+            val values = opts.map { it.first }
+            combo.model = DefaultComboBoxModel(opts.map { it.second }.toTypedArray())
+            val idx = values.indexOf(value)
+            combo.selectedIndex = if (idx >= 0) idx else -1
+            // attach AFTER the programmatic selection so it doesn't spuriously write state
+            combo.addActionListener {
+                val i = combo.selectedIndex
+                if (i in values.indices) ctx.putState(fieldId, values[i])
+            }
+        }
     }
     return combo
 }

--- a/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/ui/RestFetch.kt
+++ b/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/ui/RestFetch.kt
@@ -1,0 +1,34 @@
+package io.mateu.ijp.ui
+
+import com.fasterxml.jackson.databind.JsonNode
+import io.mateu.ijp.api.MateuApiClient
+import io.mateu.ijp.api.text
+import io.mateu.ijp.state.Expressions
+
+/**
+ * Client-side consumption of arbitrary (non-Mateu) REST endpoints for widget-level surfaces
+ * (@RestOptions combo options, @RestListing table rows) — the plugin analogue of the web's
+ * libs/mateu externalOptions.ts. url/headers/body are interpolated against the given context and
+ * the endpoint is fetched directly (no Mateu server mediating); path navigation mirrors getByPath.
+ */
+object RestFetch {
+
+    /** Navigate a dot path (`data.items`, `name.common`) into a JSON value; blank path is identity. */
+    fun valueAtPath(node: JsonNode?, path: String?): JsonNode? {
+        if (node == null) return null
+        if (path.isNullOrBlank()) return node
+        var cur: JsonNode? = node
+        for (key in path.split('.')) cur = cur?.get(key) ?: return null
+        return cur
+    }
+
+    /** Fetch a RestDataSource node (`url`/`method`/`headers`/`body`), interpolating each against ctx. */
+    fun fetch(apiClient: MateuApiClient, source: JsonNode, ctx: Map<String, Any?>): JsonNode {
+        val url = Expressions.interpolate(source.text("url"), ctx)
+        val method = source.text("method").ifBlank { "GET" }.uppercase()
+        val headers = LinkedHashMap<String, String>()
+        source.path("headers").fields().forEach { (k, v) -> headers[k] = Expressions.interpolate(v.asText(""), ctx) }
+        val body = source.get("body")?.asText("").orEmpty().let { if (it.isBlank()) null else Expressions.interpolate(it, ctx) }
+        return apiClient.fetchExternal(url, method, headers, body)
+    }
+}

--- a/frontend/app/react-native/src/core/restFetch.ts
+++ b/frontend/app/react-native/src/core/restFetch.ts
@@ -1,0 +1,66 @@
+// Client-side consumption of arbitrary (non-Mateu) REST endpoints for widget-level surfaces
+// (@RestOptions select options, @RestListing listing rows) — the RN analogue of the web's
+// libs/mateu externalOptions.ts. url/headers/body are interpolated by the caller (pass a resolve
+// that runs the shared `interpolate`); the endpoint is fetched directly, no Mateu server mediating.
+
+type Json = Record<string, any>;
+
+/** Navigate a dot path (`data.items`, `name.common`) into a JSON value; an empty path is identity. */
+export function getByPath(obj: unknown, path?: string): unknown {
+  if (!path) return obj;
+  return path.split('.').reduce<unknown>(
+    (acc, key) => (acc != null && typeof acc === 'object' ? (acc as Json)[key] : undefined),
+    obj,
+  );
+}
+
+export interface FetchedOption {
+  value: string;
+  label: string;
+}
+
+/** Shape a JSON response into select options: navigate `itemsPath` to the array, then read
+ *  `valuePath`/`labelPath` from each item (a primitive element becomes its own value and label). */
+export function mapItemsToOptions(
+  json: unknown,
+  itemsPath?: string,
+  valuePath = 'value',
+  labelPath = 'label',
+): FetchedOption[] {
+  const arr = getByPath(json, itemsPath);
+  if (!Array.isArray(arr)) return [];
+  return arr.map((item) => {
+    if (item != null && typeof item === 'object') {
+      const value = getByPath(item, valuePath);
+      const label = getByPath(item, labelPath);
+      return { value: String(value ?? label ?? ''), label: String(label ?? value ?? '') };
+    }
+    return { value: String(item), label: String(item) };
+  });
+}
+
+/** Shape a JSON response into listing rows: navigate `itemsPath` to the array, then read each
+ *  column by its id as a dot path from each item (a row is an object keyed by column id). */
+export function mapItemsToRows(json: unknown, itemsPath: string | undefined, columnIds: string[]): Json[] {
+  const arr = getByPath(json, itemsPath);
+  if (!Array.isArray(arr)) return [];
+  return arr.map((item) => {
+    const row: Json = {};
+    for (const id of columnIds) row[id] = getByPath(item, id);
+    return row;
+  });
+}
+
+/** Interpolate url/headers/body of a RestDataSource and fetch it. `resolve` runs `${state.x}`
+ *  interpolation. Throws on a non-2xx response. */
+export async function fetchExternalJson(source: Json, resolve: (t: unknown) => string): Promise<unknown> {
+  const url = resolve(source['url']);
+  const method = String(source['method'] ?? 'GET').toUpperCase();
+  const headers: Record<string, string> = {};
+  for (const [k, v] of Object.entries((source['headers'] as Json) ?? {})) headers[k] = resolve(v);
+  const init: RequestInit = { method, headers };
+  if (method !== 'GET' && method !== 'HEAD' && source['body']) init.body = resolve(source['body']);
+  const res = await fetch(url, init);
+  if (!res.ok) throw new Error(`External REST fetch failed: ${res.status}`);
+  return res.json();
+}

--- a/frontend/app/react-native/src/renderer/CrudRenderer.tsx
+++ b/frontend/app/react-native/src/renderer/CrudRenderer.tsx
@@ -9,6 +9,8 @@ import {
   View,
 } from 'react-native';
 import { useViewController } from './MateuViewHost';
+import { interpolate } from '../core/expressions';
+import { fetchExternalJson, mapItemsToRows } from '../core/restFetch';
 import { DateField } from './DateField';
 import { FormFieldRenderer, GridRowForm } from './FormFieldRenderer';
 import { theme } from '../theme';
@@ -138,6 +140,31 @@ export function CrudRenderer({ component, metadata, state, data }: Props) {
     controller.registerDataHandler('crud', onData);
   }, [component, controller]);
 
+  // @RestListing: rows fetched CLIENT-SIDE from an arbitrary REST endpoint instead of the server
+  // `search` action. Declarative listings get no server OnLoad trigger, so self-fetch on mount (and
+  // when the interpolated url changes); free-text search filters the fetched rows in memory.
+  const rowsSource = metadata['rowsSource'] as
+    | { url: string; method?: string; headers?: Record<string, string>; body?: string; itemsPath?: string }
+    | undefined;
+  const columnIds = columns.map((c) => c.metadata?.id ?? c.id ?? c.fieldId).filter(Boolean) as string[];
+  const restResolve = (t: unknown): string => interpolate(String(t ?? ''), { state, appState: controller.session.appState });
+  const rowsUrl = rowsSource ? restResolve(rowsSource.url) : '';
+  const [restRows, setRestRows] = useState<Record<string, unknown>[]>([]);
+  useEffect(() => {
+    if (!rowsSource) return;
+    let cancelled = false;
+    fetchExternalJson(rowsSource, restResolve)
+      .then((json) => {
+        if (cancelled) return;
+        const rows = mapItemsToRows(json, rowsSource.itemsPath, columnIds) as Record<string, unknown>[];
+        setRestRows(rows);
+        setLiveData({ page: { content: rows, totalElements: rows.length, pageSize: rows.length, pageNumber: 0 } });
+      })
+      .catch((e) => console.warn('mateu: external rows fetch failed', e));
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rowsUrl]);
+
   const listing = extractListing(liveData);
   const rawRows = extractRows(extractPage(liveData));
   const d = extractPage(liveData);
@@ -161,6 +188,15 @@ export function CrudRenderer({ component, metadata, state, data }: Props) {
   ).length;
 
   const doSearch = (values?: Record<string, unknown>) => {
+    // @RestListing: filter the client-fetched rows in memory — no server round-trip.
+    if (rowsSource) {
+      const q = searchText.trim().toLowerCase();
+      const filtered = q
+        ? restRows.filter((r) => columnIds.some((id) => String(r[id] ?? '').toLowerCase().includes(q)))
+        : restRows;
+      setLiveData({ page: { content: filtered, totalElements: filtered.length, pageSize: filtered.length, pageNumber: 0 } });
+      return;
+    }
     controller.seedSearchState();
     controller.currentComponentState['searchText'] = searchText;
     controller.currentComponentState['page'] = 0;

--- a/frontend/app/react-native/src/renderer/FormFieldRenderer.tsx
+++ b/frontend/app/react-native/src/renderer/FormFieldRenderer.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Modal,
   Switch,
@@ -27,6 +27,7 @@ import {
 } from './FieldWidgets';
 import { LookupField } from './LookupField';
 import { interpolate } from '../core/expressions';
+import { fetchExternalJson, mapItemsToOptions, type FetchedOption } from '../core/restFetch';
 import { useViewController } from './MateuViewHost';
 import { theme } from '../theme';
 import { fieldA11y, buttonA11y, modalA11y, headingA11y, announce } from '../a11y/a11y';
@@ -57,6 +58,17 @@ interface FieldMeta {
   disabled?: boolean;
   initialValue?: unknown;
   options?: Option[];
+  /** @RestOptions: options fetched CLIENT-SIDE from an arbitrary REST endpoint (url/method/headers/
+   *  body interpolated; itemsPath→array; valuePath/labelPath per item). */
+  optionsSource?: {
+    url: string;
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+    itemsPath?: string;
+    valuePath?: string;
+    labelPath?: string;
+  };
   /** Grid fields: ClientSide GridColumn nodes. */
   columns?: { metadata?: GridColumnMeta }[];
   /** Lookup fields: remote search coordinates (action = `search-<fieldId>` by convention). */
@@ -307,6 +319,20 @@ export function FormFieldRenderer({ metadata, state, onStateChange, error }: Pro
     }
     if (stereotype === 'camera') {
       return <PhotoCaptureField value={stringValue} editable={editable} onChange={(v) => commit(fieldId, v)} />;
+    }
+
+    // @RestOptions: options fetched CLIENT-SIDE from an arbitrary REST endpoint.
+    if (metadata.optionsSource) {
+      return (
+        <RestOptionsField
+          source={metadata.optionsSource}
+          state={state}
+          appState={controller.session.appState}
+          value={stringValue}
+          editable={editable}
+          onChange={(v) => commit(fieldId, v)}
+        />
+      );
     }
 
     // Options (enum / static list)
@@ -589,6 +615,30 @@ export function GridRowForm({ columns, row, isNew, onSave, onDelete, onCancel }:
       </View>
     </Modal>
   );
+}
+
+// @RestOptions: a select whose options are fetched CLIENT-SIDE from an arbitrary REST endpoint on
+// mount (and refetched when the interpolated url changes — a state-dependent source).
+function RestOptionsField({ source, state, appState, value, editable, onChange }: {
+  source: NonNullable<FieldMeta['optionsSource']>;
+  state: Record<string, unknown>;
+  appState: Record<string, unknown>;
+  value: string;
+  editable: boolean;
+  onChange: (v: string) => void;
+}) {
+  const [options, setOptions] = useState<FetchedOption[]>([]);
+  const resolve = (t: unknown): string => interpolate(String(t ?? ''), { state, appState });
+  const url = resolve(source.url);
+  useEffect(() => {
+    let cancelled = false;
+    fetchExternalJson(source, resolve)
+      .then((json) => { if (!cancelled) setOptions(mapItemsToOptions(json, source.itemsPath, source.valuePath, source.labelPath)); })
+      .catch((e) => console.warn('mateu: external options fetch failed', e));
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [url]);
+  return <OptionsField options={options} value={value} editable={editable} onChange={onChange} />;
 }
 
 function OptionsField({ options, value, editable, onChange }: { options: Option[]; value: string; editable: boolean; onChange: (v: string) => void }) {


### PR DESCRIPTION
Completes the external-endpoints line on the native renderers (after [#342](https://github.com/miguelperezcolom/mateu/pull/342) @RestData/@RestAction): the two **widget-level** surfaces, fetched **client-side on mount** — a select whose options come from an arbitrary REST endpoint (`@RestOptions` → `FormField.optionsSource`) and a listing whose rows come from one (`@RestListing` → `Crudl.rowsSource`). Neither renderer shares `libs/mateu`, so each got its own implementation mirroring the web's `externalOptions.ts`.

## Shared helpers per renderer
- **RN**: new `src/core/restFetch.ts` (`getByPath` / `mapItemsToOptions` / `mapItemsToRows` / `fetchExternalJson`).
- **IntelliJ**: new `ui/RestFetch.kt` (`valueAtPath` + `fetch` via the already-added `MateuApiClient.fetchExternal`; interpolation via `Expressions.interpolate`).

## React Native
- `FormFieldRenderer.tsx`: a `RestOptionsField` (useState + useEffect) fetches on mount (refetch when the interpolated url changes) and renders the existing `OptionsField` with the fetched options.
- `CrudRenderer.tsx`: a useEffect self-fetches the rows on mount (declarative listings get no server OnLoad trigger), maps each item by column id and seeds `liveData`; `doSearch` filters the fetched rows in memory when `rowsSource` is present.

## IntelliJ plugin
- `FormFieldRenderer.kt`: a `restOptionsCombo` fetches on the background executor and sets the ComboBox model + selection on the EDT.
- `CrudRenderer.kt`: after the data handler is registered, self-fetch the rows on the background executor, build a `{page:{content:[…]}}` envelope keyed by column id and feed it through the existing `applyData` on the EDT.
- `RenderProbe.kt`: dump a `JComboBox`'s items (combo state was invisible before).

## Verified (against live screens hitting a CORS-open public API)
- **React Native** (Expo web + Playwright): the select opens with all 10 fetched options; the listing renders all 10 fetched rows (screenshots).
- **IntelliJ** (`./gradlew renderProbe`): the combo carries the 10 fetched items. The `@RestListing` JBTable render can't be captured headlessly here — a pre-existing JNA/native-lib limitation of the gradle-run probe for tables, unrelated to this change; the fetch machinery is the same one the combo proves and the rows flow through the existing server-search `applyData` path.

With this, the whole external-endpoints line (`@RestOptions`, `@RestListing`, `@RestAction`, `@RestData`) is on **3 backends + web renderers + both native renderers**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)