### PR TITLE
Server-proxy mode + SecretsProvider (auth/CORS hardening, Java backend)

### DIFF
--- a/backend/shared/core/src/main/java/io/mateu/core/application/runaction/RestSourceResolver.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/runaction/RestSourceResolver.java
@@ -1,0 +1,117 @@
+package io.mateu.core.application.runaction;
+
+import io.mateu.core.infra.reflection.MetaAnnotations;
+import io.mateu.uidl.annotations.RestAction;
+import io.mateu.uidl.annotations.RestData;
+import io.mateu.uidl.annotations.RestListing;
+import io.mateu.uidl.annotations.RestOptions;
+import io.mateu.uidl.data.RestDataSource;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Resolves the DECLARED {@link RestDataSource} of a view for a proxy fetch — from the annotation on
+ * the field ({@code @RestOptions}), the class ({@code @RestListing}/{@code @RestData}) or the
+ * method ({@code @RestAction}), never from a client-supplied url (so the proxy can't be turned into
+ * an open SSRF/secret-exfiltration relay). Used by {@code __restfetch__}.
+ */
+final class RestSourceResolver {
+
+  private RestSourceResolver() {}
+
+  static RestDataSource resolve(Object instance, String kind, String id) {
+    var cls = instance.getClass();
+    switch (kind == null ? "" : kind) {
+      case "options" -> {
+        var field = fieldByName(cls, id);
+        var a = field == null ? null : MetaAnnotations.find(field, RestOptions.class);
+        return a == null
+            ? null
+            : RestDataSource.builder()
+                .url(a.url())
+                .method(a.method())
+                .headers(parseHeaders(a.headers()))
+                .body(a.body())
+                .itemsPath(a.itemsPath())
+                .valuePath(a.valuePath())
+                .labelPath(a.labelPath())
+                .proxy(a.proxy())
+                .build();
+      }
+      case "rows" -> {
+        var a = MetaAnnotations.find(cls, RestListing.class);
+        return a == null
+            ? null
+            : RestDataSource.builder()
+                .url(a.url())
+                .method(a.method())
+                .headers(parseHeaders(a.headers()))
+                .body(a.body())
+                .itemsPath(a.itemsPath())
+                .proxy(a.proxy())
+                .build();
+      }
+      case "action" -> {
+        var method = methodByName(cls, id);
+        var a = method == null ? null : MetaAnnotations.find(method, RestAction.class);
+        return a == null
+            ? null
+            : RestDataSource.builder()
+                .url(a.url())
+                .method(a.method())
+                .headers(parseHeaders(a.headers()))
+                .body(a.body())
+                .proxy(a.proxy())
+                .build();
+      }
+      case "data" -> {
+        var a = MetaAnnotations.find(cls, RestData.class);
+        return a == null
+            ? null
+            : RestDataSource.builder()
+                .url(a.url())
+                .method(a.method())
+                .headers(parseHeaders(a.headers()))
+                .body(a.body())
+                .proxy(a.proxy())
+                .build();
+      }
+      default -> {
+        return null;
+      }
+    }
+  }
+
+  private static Map<String, String> parseHeaders(String[] headers) {
+    var map = new LinkedHashMap<String, String>();
+    for (String h : headers) {
+      int i = h.indexOf(':');
+      if (i > 0) {
+        map.put(h.substring(0, i).trim(), h.substring(i + 1).trim());
+      }
+    }
+    return map;
+  }
+
+  private static Field fieldByName(Class<?> cls, String name) {
+    for (var c = cls; c != null && c != Object.class; c = c.getSuperclass()) {
+      for (var f : c.getDeclaredFields()) {
+        if (f.getName().equals(name)) {
+          return f;
+        }
+      }
+    }
+    return null;
+  }
+
+  private static Method methodByName(Class<?> cls, String name) {
+    for (var m : cls.getMethods()) {
+      if (m.getName().equals(name)) {
+        return m;
+      }
+    }
+    return null;
+  }
+}

--- a/backend/shared/core/src/main/java/io/mateu/core/application/runaction/RunActionUseCase.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/runaction/RunActionUseCase.java
@@ -4,6 +4,7 @@ import io.mateu.core.application.contract.ModelViewContractExtractor;
 import io.mateu.core.domain.act.ActionRunnerProvider;
 import io.mateu.core.domain.out.UiIncrementMapperProvider;
 import io.mateu.core.infra.StructureHashPostProcessor;
+import io.mateu.core.infra.TemplateInterpolator;
 import io.mateu.dtos.ModelViewContractDto;
 import io.mateu.dtos.ServerSideComponentDto;
 import io.mateu.dtos.UIIncrementDto;
@@ -90,6 +91,9 @@ public class RunActionUseCase {
     }
     if (PREVIEW_ACTION.equals(command.actionId())) {
       return handlePreview(command);
+    }
+    if (RESTFETCH_ACTION.equals(command.actionId())) {
+      return handleRestFetch(command);
     }
     return (Mono.just(command)
             .flatMap(ignored -> actionInstanceCreator.createInstance(command))
@@ -190,6 +194,113 @@ public class RunActionUseCase {
           .flux();
     }
     return mapToUiIncrement(component, command).flux();
+  }
+
+  // ── Server-side proxy fetch ────────────────────────────────────────────────
+  // PROXY mode of the external-REST features (@RestOptions/@RestListing/@RestAction/@RestData): the
+  // browser posts this reserved action with the source's id/kind instead of fetching the endpoint
+  // itself, and the SERVER does the fetch — resolving CORS (browser↔Mateu is same-origin) and
+  // injecting ${secret.X} auth server-side (never on the client). The declared RestDataSource is
+  // resolved from the annotation (RestSourceResolver), never from a client-supplied url. The raw
+  // JSON body rides back on appData._restfetch; the renderer maps it exactly as in direct mode.
+  public static final String RESTFETCH_ACTION = "__restfetch__";
+  public static final String RESTFETCH_KEY = "_restfetch";
+
+  private static final java.net.http.HttpClient REST_HTTP =
+      java.net.http.HttpClient.newBuilder()
+          .connectTimeout(java.time.Duration.ofSeconds(10))
+          .build();
+  private static final com.fasterxml.jackson.databind.ObjectMapper REST_MAPPER =
+      new com.fasterxml.jackson.databind.ObjectMapper();
+
+  private Flux<UIIncrementDto> handleRestFetch(RunActionCommand command) {
+    return Mono.just(command)
+        .flatMap(ignored -> actionInstanceCreator.createInstance(command))
+        .map(
+            instance ->
+                io.mateu.core.infra.declarative.orchestrators.crud.CapabilityCrud.bridgeIfNeeded(
+                    instance))
+        .flatMap(instance -> routeIfNeeded(command, instance))
+        .map(instance -> toRestFetchResponse(instance, command))
+        .flux();
+  }
+
+  private UIIncrementDto toRestFetchResponse(Object instance, RunActionCommand command) {
+    var rq = command.httpRequest() != null ? command.httpRequest().runActionRq() : null;
+    var params =
+        rq != null && rq.parameters() != null
+            ? rq.parameters()
+            : java.util.Map.<String, Object>of();
+    var kind = String.valueOf(params.getOrDefault("_sourceKind", ""));
+    var id = String.valueOf(params.getOrDefault("_sourceId", ""));
+    var source = RestSourceResolver.resolve(instance, kind, id);
+    if (source == null) {
+      return UIIncrementDto.builder()
+          .appData(java.util.Map.of(RESTFETCH_KEY, java.util.Map.of()))
+          .build();
+    }
+    var state =
+        command.componentState() != null
+            ? command.componentState()
+            : java.util.Map.<String, Object>of();
+    java.util.function.Function<String, String> secrets = this::resolveSecret;
+    var url = TemplateInterpolator.interpolate(source.url(), state, secrets);
+    var method =
+        source.method() == null || source.method().isBlank()
+            ? "GET"
+            : source.method().toUpperCase();
+    Object json;
+    try {
+      var builder =
+          java.net.http.HttpRequest.newBuilder()
+              .uri(java.net.URI.create(url))
+              .timeout(java.time.Duration.ofSeconds(60))
+              .header("Accept", "application/json");
+      if (source.headers() != null) {
+        for (var e : source.headers().entrySet()) {
+          builder.header(
+              e.getKey(), TemplateInterpolator.interpolate(e.getValue(), state, secrets));
+        }
+      }
+      if (!"GET".equals(method)
+          && !"HEAD".equals(method)
+          && source.body() != null
+          && !source.body().isBlank()) {
+        builder.method(
+            method,
+            java.net.http.HttpRequest.BodyPublishers.ofString(
+                TemplateInterpolator.interpolate(source.body(), state, secrets)));
+      } else {
+        builder.method(method, java.net.http.HttpRequest.BodyPublishers.noBody());
+      }
+      var response =
+          REST_HTTP.send(builder.build(), java.net.http.HttpResponse.BodyHandlers.ofString());
+      if (response.statusCode() >= 400) {
+        throw new RuntimeException("HTTP " + response.statusCode());
+      }
+      json = REST_MAPPER.readValue(response.body(), Object.class);
+    } catch (Exception e) {
+      log.warn("proxy rest fetch failed: {}", e.getMessage());
+      json = java.util.Map.of();
+    }
+    return UIIncrementDto.builder().appData(java.util.Map.of(RESTFETCH_KEY, json)).build();
+  }
+
+  /** A {@code ${secret.X}} value: the first non-null SecretsProvider bean, else the environment. */
+  private String resolveSecret(String key) {
+    try {
+      for (var p :
+          io.mateu.uidl.di.MateuBeanProvider.getBeans(
+              io.mateu.uidl.interfaces.SecretsProvider.class)) {
+        var v = p.getSecret(key);
+        if (v != null) {
+          return v;
+        }
+      }
+    } catch (Exception ignored) {
+      // no provider registered (e.g. tests) — fall through to the environment
+    }
+    return System.getenv(key);
   }
 
   private String extractTitle(Throwable e) {

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/out/componentmapper/FieldMetadataExtractor.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/out/componentmapper/FieldMetadataExtractor.java
@@ -214,6 +214,7 @@ public class FieldMetadataExtractor {
         .itemsPath(a.itemsPath())
         .valuePath(a.valuePath())
         .labelPath(a.labelPath())
+        .proxy(a.proxy())
         .build();
   }
 

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/out/componentmapper/PageListingBuilder.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/out/componentmapper/PageListingBuilder.java
@@ -177,6 +177,7 @@ public class PageListingBuilder {
         .headers(headers)
         .body(a.body())
         .itemsPath(a.itemsPath())
+        .proxy(a.proxy())
         .build();
   }
 

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/mappers/ActionDtoMapper.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/mappers/ActionDtoMapper.java
@@ -86,7 +86,8 @@ final class ActionDtoMapper {
                 s.body(),
                 s.itemsPath(),
                 s.valuePath(),
-                s.labelPath());
+                s.labelPath(),
+                s.proxy());
     return new io.mateu.dtos.RestActionDto(
         sourceDto, restAction.successMessage(), restAction.resultPath());
   }

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/mappers/CrudlMapper.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/mappers/CrudlMapper.java
@@ -164,6 +164,7 @@ public class CrudlMapper {
         source.body(),
         source.itemsPath(),
         source.valuePath(),
-        source.labelPath());
+        source.labelPath(),
+        source.proxy());
   }
 }

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/mappers/FieldActionCollector.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/mappers/FieldActionCollector.java
@@ -173,6 +173,7 @@ final class FieldActionCollector {
             .method(a.method())
             .headers(headers)
             .body(a.body())
+            .proxy(a.proxy())
             .build();
     return new io.mateu.uidl.data.RestAction(
         source,

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/mappers/FieldMapper.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/mappers/FieldMapper.java
@@ -108,7 +108,8 @@ public class FieldMapper {
         source.body(),
         source.itemsPath(),
         source.valuePath(),
-        source.labelPath());
+        source.labelPath(),
+        source.proxy());
   }
 
   private static RemoteCoordinatesDto mapRemoteCoordinates(RemoteCoordinates remoteCoordinates) {

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/mappers/RestDataSupport.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/mappers/RestDataSupport.java
@@ -34,6 +34,7 @@ final class RestDataSupport {
             .method(a.method())
             .headers(headers)
             .body(a.body())
+            .proxy(a.proxy())
             .build();
     // resultPath stays as declared: blank means "merge the whole response object" (getByPath with
     // an empty path is identity on the frontend), a path narrows to that sub-object.

--- a/backend/shared/core/src/main/java/io/mateu/core/infra/TemplateInterpolator.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/infra/TemplateInterpolator.java
@@ -1,0 +1,44 @@
+package io.mateu.core.infra;
+
+import java.util.Map;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Server-side {@code ${...}} interpolation for the PROXY mode of the external-REST features — the
+ * backend counterpart of the frontend's client-side interpolate. Resolves {@code ${state.field}}
+ * from the component state and {@code ${secret.KEY}} from a {@link
+ * io.mateu.uidl.interfaces.SecretsProvider} (so auth secrets are injected on the server, never on
+ * the client). An unresolvable placeholder becomes the empty string; a template without {@code ${}
+ * } is returned untouched.
+ */
+public final class TemplateInterpolator {
+
+  private static final Pattern PLACEHOLDER = Pattern.compile("\\$\\{([^}]+)}");
+
+  private TemplateInterpolator() {}
+
+  public static String interpolate(
+      String template, Map<String, Object> state, Function<String, String> secrets) {
+    if (template == null || !template.contains("${")) {
+      return template == null ? "" : template;
+    }
+    var matcher = PLACEHOLDER.matcher(template);
+    var sb = new StringBuilder();
+    while (matcher.find()) {
+      var expr = matcher.group(1).trim();
+      String value = "";
+      if (expr.startsWith("state.")) {
+        var v = state != null ? state.get(expr.substring("state.".length())) : null;
+        value = v == null ? "" : String.valueOf(v);
+      } else if (expr.startsWith("secret.")) {
+        var v = secrets != null ? secrets.apply(expr.substring("secret.".length())) : null;
+        value = v == null ? "" : v;
+      }
+      matcher.appendReplacement(sb, Matcher.quoteReplacement(value));
+    }
+    matcher.appendTail(sb);
+    return sb.toString();
+  }
+}

--- a/backend/shared/core/src/test/java/io/mateu/core/application/RestProxySyncTest.java
+++ b/backend/shared/core/src/test/java/io/mateu/core/application/RestProxySyncTest.java
@@ -1,0 +1,61 @@
+package io.mateu.core.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.mateu.core.testutil.TestMateu;
+import io.mateu.uidl.annotations.RestOptions;
+import io.mateu.uidl.annotations.Title;
+import io.mateu.uidl.annotations.UI;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Proxy mode: a @RestOptions(proxy=true) field carries proxy=true on its optionsSource so the
+ * renderer routes the fetch through the Mateu server (the __restfetch__ action) instead of fetching
+ * the endpoint directly — the CORS/auth-hardening flag. A plain @RestOptions stays proxy=false.
+ */
+class RestProxySyncTest {
+
+  @SuppressWarnings("unused")
+  @UI("/restproxy")
+  @Title("Rest proxy")
+  public static class ProxyForm {
+    @RestOptions(url = "https://api.example.com/x?t=${secret.TOKEN}", proxy = true)
+    String viaServer;
+
+    @RestOptions(url = "https://public.example.com/x")
+    String direct;
+  }
+
+  static TestMateu mateu;
+
+  @BeforeAll
+  static void boot() {
+    mateu = TestMateu.withUis(ProxyForm.class);
+  }
+
+  @AfterAll
+  static void shutdown() {
+    mateu.close();
+  }
+
+  @Test
+  void proxyFlagTravelsOnTheOptionsSource() {
+    var increment = mateu.sync("/restproxy");
+    var fields = new java.util.ArrayList<io.mateu.dtos.FormFieldDto>();
+    FieldKindsSyncTest.walk(
+        increment.fragments().get(0).component(), io.mateu.dtos.FormFieldDto.class, fields);
+
+    var viaServer =
+        fields.stream().filter(f -> "viaServer".equals(f.fieldId())).findFirst().orElseThrow();
+    assertThat(viaServer.optionsSource()).isNotNull();
+    assertThat(viaServer.optionsSource().proxy()).isTrue();
+    // the raw ${secret.X} template rides on the wire, but never its resolved value
+    assertThat(viaServer.optionsSource().url()).contains("${secret.TOKEN}");
+
+    var direct =
+        fields.stream().filter(f -> "direct".equals(f.fieldId())).findFirst().orElseThrow();
+    assertThat(direct.optionsSource().proxy()).isFalse();
+  }
+}

--- a/backend/shared/core/src/test/java/io/mateu/core/infra/TemplateInterpolatorTest.java
+++ b/backend/shared/core/src/test/java/io/mateu/core/infra/TemplateInterpolatorTest.java
@@ -1,0 +1,31 @@
+package io.mateu.core.infra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class TemplateInterpolatorTest {
+
+  @Test
+  void resolvesStateAndSecretPlaceholdersAndLeavesTheRestBlank() {
+    var state = Map.<String, Object>of("zip", "28001");
+    java.util.function.Function<String, String> secrets =
+        k -> "API_TOKEN".equals(k) ? "s3cr3t" : null;
+
+    assertThat(TemplateInterpolator.interpolate("/x/${state.zip}", state, secrets))
+        .isEqualTo("/x/28001");
+    assertThat(TemplateInterpolator.interpolate("Bearer ${secret.API_TOKEN}", state, secrets))
+        .isEqualTo("Bearer s3cr3t");
+    // a state key that is absent and an unknown secret both collapse to empty
+    assertThat(TemplateInterpolator.interpolate("${state.missing}-${secret.NOPE}", state, secrets))
+        .isEqualTo("-");
+  }
+
+  @Test
+  void aTemplateWithoutPlaceholdersIsReturnedUntouchedAndNullBecomesEmpty() {
+    assertThat(TemplateInterpolator.interpolate("https://api/x", Map.of(), k -> null))
+        .isEqualTo("https://api/x");
+    assertThat(TemplateInterpolator.interpolate(null, Map.of(), k -> null)).isEmpty();
+  }
+}

--- a/backend/shared/dtos/src/main/java/io/mateu/dtos/RestDataSourceDto.java
+++ b/backend/shared/dtos/src/main/java/io/mateu/dtos/RestDataSourceDto.java
@@ -27,4 +27,5 @@ public record RestDataSourceDto(
     String body,
     String itemsPath,
     String valuePath,
-    String labelPath) {}
+    String labelPath,
+    boolean proxy) {}

--- a/backend/shared/uidl/src/main/java/io/mateu/uidl/annotations/RestAction.java
+++ b/backend/shared/uidl/src/main/java/io/mateu/uidl/annotations/RestAction.java
@@ -55,4 +55,10 @@ public @interface RestAction {
    * (fire-and-toast).
    */
   String resultPath() default "";
+
+  /**
+   * Fetch through the Mateu SERVER (proxy mode) instead of directly from the browser: no CORS, and
+   * {@code ${secret.X}} auth is injected server-side from a {@code SecretsProvider}. Default false.
+   */
+  boolean proxy() default false;
 }

--- a/backend/shared/uidl/src/main/java/io/mateu/uidl/annotations/RestData.java
+++ b/backend/shared/uidl/src/main/java/io/mateu/uidl/annotations/RestData.java
@@ -55,4 +55,10 @@ public @interface RestData {
    * whole response object.
    */
   String resultPath() default "";
+
+  /**
+   * Fetch through the Mateu SERVER (proxy mode) instead of directly from the browser: no CORS, and
+   * {@code ${secret.X}} auth is injected server-side from a {@code SecretsProvider}. Default false.
+   */
+  boolean proxy() default false;
 }

--- a/backend/shared/uidl/src/main/java/io/mateu/uidl/annotations/RestListing.java
+++ b/backend/shared/uidl/src/main/java/io/mateu/uidl/annotations/RestListing.java
@@ -58,4 +58,10 @@ public @interface RestListing {
    * response root IS the array.
    */
   String itemsPath() default "";
+
+  /**
+   * Fetch through the Mateu SERVER (proxy mode) instead of directly from the browser: no CORS, and
+   * {@code ${secret.X}} auth is injected server-side from a {@code SecretsProvider}. Default false.
+   */
+  boolean proxy() default false;
 }

--- a/backend/shared/uidl/src/main/java/io/mateu/uidl/annotations/RestOptions.java
+++ b/backend/shared/uidl/src/main/java/io/mateu/uidl/annotations/RestOptions.java
@@ -56,4 +56,12 @@ public @interface RestOptions {
 
   /** A dot path within each item to the option label. */
   String labelPath() default "label";
+
+  /**
+   * Fetch through the Mateu SERVER (proxy mode) instead of directly from the browser: the server
+   * calls the endpoint (server-to-server, so no CORS) and can inject {@code ${secret.X}} auth into
+   * headers/url from a {@code SecretsProvider}, keeping secrets off the client. Default false
+   * (client-direct).
+   */
+  boolean proxy() default false;
 }

--- a/backend/shared/uidl/src/main/java/io/mateu/uidl/data/RestDataSource.java
+++ b/backend/shared/uidl/src/main/java/io/mateu/uidl/data/RestDataSource.java
@@ -19,4 +19,9 @@ public record RestDataSource(
     String body,
     String itemsPath,
     String valuePath,
-    String labelPath) {}
+    String labelPath,
+    /**
+     * When true the fetch goes through the Mateu server (proxy mode) — it resolves CORS and keeps
+     * auth secrets server-side; false (default) = the renderer fetches the endpoint directly.
+     */
+    boolean proxy) {}

--- a/backend/shared/uidl/src/main/java/io/mateu/uidl/interfaces/SecretsProvider.java
+++ b/backend/shared/uidl/src/main/java/io/mateu/uidl/interfaces/SecretsProvider.java
@@ -1,0 +1,22 @@
+package io.mateu.uidl.interfaces;
+
+/**
+ * Supplies secret values referenced as {@code ${secret.KEY}} in a
+ * {@code @RestOptions}/{@code @RestListing}/{@code @RestAction}/{@code @RestData} url/headers/body
+ * when the source is fetched in PROXY mode (server-side). Because the interpolation happens on the
+ * Mateu server, the secret never reaches the browser — the auth-hardening counterpart of the
+ * CORS-hardening proxy mode.
+ *
+ * <p>Register an implementation as a bean (e.g. a Spring {@code @Service}); it is discovered via
+ * the platform bean provider. With no implementation registered, Mateu falls back to reading an
+ * environment variable of the same name. Return {@code null} for an unknown key (Mateu then tries
+ * the next provider, and finally the environment).
+ */
+public interface SecretsProvider {
+
+  /**
+   * The secret for {@code key} (e.g. {@code API_TOKEN} for {@code ${secret.API_TOKEN}}); null if
+   * unknown.
+   */
+  String getSecret(String key);
+}

--- a/doc/src/content/docs/java-ui-definition/annotations/rest-options.md
+++ b/doc/src/content/docs/java-ui-definition/annotations/rest-options.md
@@ -65,6 +65,46 @@ This is the **options** surface. Consuming external endpoints for listing rows, 
 button actions reuses the same `RestDataSource` descriptor and is on the roadmap.
 :::
 
+## Server-proxy mode (`proxy = true`) — CORS & auth hardening
+
+By default the **browser** fetches the endpoint directly, so the endpoint must be CORS-friendly and
+any auth token would have to live in the client. Set `proxy = true` (available on all four
+annotations — `@RestOptions`, `@RestListing`, `@RestAction`, `@RestData`) to route the fetch through
+the **Mateu server** instead:
+
+```java
+@RestOptions(
+    proxy = true,
+    url = "https://api.example.com/countries",
+    headers = "Authorization: Bearer ${secret.COUNTRIES_TOKEN}",
+    valuePath = "cca2", labelPath = "name.common")
+String country;
+```
+
+- **CORS is solved** — the browser only talks to Mateu (same-origin); the server talks to the
+  external API server-to-server, where CORS does not apply.
+- **Secrets stay server-side** — `${secret.KEY}` placeholders in the url/headers/body are resolved
+  on the server by a `SecretsProvider` (see below), so the token **never reaches the browser**. Only
+  the placeholder (`${secret.COUNTRIES_TOKEN}`) travels on the wire, never its value.
+
+The server resolves the endpoint from the **declared** annotation (by field/action/class), never
+from a url supplied by the client, so the proxy can't be turned into an open relay. `${state.x}`
+interpolation works the same as in direct mode (resolved from the component state).
+
+### Supplying secrets — `SecretsProvider`
+
+Implement `io.mateu.uidl.interfaces.SecretsProvider` and register it as a bean:
+
+```java
+@Service
+public class VaultSecrets implements SecretsProvider {
+  public String getSecret(String key) { return vault.read(key); }  // null if unknown
+}
+```
+
+With no `SecretsProvider` registered, Mateu falls back to reading an **environment variable** of the
+same name (`${secret.COUNTRIES_TOKEN}` → `System.getenv("COUNTRIES_TOKEN")`).
+
 ## Other backends
 
 Mateu.NET and the Python backend emit the same `optionsSource` descriptor, so any renderer fetches


### PR DESCRIPTION
The external-REST features (`@RestOptions`/`@RestListing`/`@RestAction`/`@RestData`) fetch **client-side**, which the browser blocks cross-origin (CORS) and would force auth tokens into the client state. This adds the **server-side hardening**: an opt-in `proxy = true` per source that routes the fetch through the Mateu server, plus a `SecretsProvider` so auth stays server-side.

## What
```java
@RestOptions(
    proxy = true,
    url = "https://api.example.com/countries",
    headers = "Authorization: Bearer ${secret.COUNTRIES_TOKEN}",
    valuePath = "cca2", labelPath = "name.common")
String country;
```
- **CORS solved** — the browser only talks to Mateu (same-origin); the server talks to the external API server-to-server.
- **Secrets stay server-side** — `${secret.KEY}` is resolved on the server by a `SecretsProvider`, so the token **never reaches the browser** (only the placeholder rides the wire).
- **No open relay** — the server resolves the endpoint from the **declared** annotation (by route/serverSideType/sourceId), never a client-supplied url.

## Pieces
- Wire: `proxy` on `RestDataSource` + `RestDataSourceDto` + a `proxy()` attribute on all four annotations; carried through the 4 source builders + 3 dto mappers.
- `SecretsProvider` (`uidl.interfaces`): resolves `${secret.KEY}`; discovered via the platform bean provider, falling back to an env var of the same name.
- `__restfetch__` reserved action (`RunActionUseCase`, like `__contract__`/`__preview__`): resolves the declared source (`RestSourceResolver`), interpolates url/headers/body against state + `${secret.X}` (`TemplateInterpolator`), fetches server-to-server (`java.net.http`), returns the raw JSON on `appData._restfetch`.

## Verified
- **curl** of `__restfetch__` against a `@RestOptions(proxy)` route hitting postman-echo with `DEMO_TOKEN` set: the server injected `${secret.DEMO_TOKEN}` into the url arg **and** an Authorization-style header, interpolated `${state.q}`, and the resolved secret value **never appeared in the component wire** (only the `${secret.…}` placeholder).
- **Tests**: `RestProxySyncTest` (proxy flag on the wire), `TemplateInterpolatorTest`; full core build green (JaCoCo gate + all tests).
- **Docs**: `rest-options.md` (proxy mode + SecretsProvider).

## Scope
This is the **backend** of the hardening. Follow-up increments: the web/native renderer proxy wiring (post `__restfetch__` + map `appData._restfetch`), the .NET/Python ports, and the client-side secure token provider (the "both modes" other half).

🤖 Generated with [Claude Code](https://claude.com/claude-code)