### PR TITLE
feat(rest): port proxy mode to .NET and Python

### DIFF
--- a/backend/dotnet/src/Mateu.Core/ReflectionMapper.cs
+++ b/backend/dotnet/src/Mateu.Core/ReflectionMapper.cs
@@ -347,6 +347,11 @@ public sealed class ReflectionMapper(ITranslator? translator = null, Func<Identi
             actions.Add(new ActionDto("__restdata__", ValidationRequired: false) { RestAction = restData });
             triggers = [.. triggers, new TriggerDto("OnLoad", "__restdata__")];
         }
+        // Proxy mode ([RestOptions]/[RestListing]/[RestAction]/[RestData] with Proxy=true): advertise
+        // the reserved __restfetch__ action so the renderer can route the fetch through the server
+        // (which resolves the DECLARED source, injects ${secret.X} and fetches server-side).
+        if (HasProxySource(type))
+            actions.Add(new ActionDto("__restfetch__"));
         return new ServerSideComponentDto(
             Guid.NewGuid().ToString(), type.FullName!, route,
             [page], initialData, actions, triggers, null, null, null)
@@ -1444,6 +1449,7 @@ public sealed class ReflectionMapper(ITranslator? translator = null, Func<Identi
             ItemsPath = a.ItemsPath,
             ValuePath = a.ValuePath,
             LabelPath = a.LabelPath,
+            Proxy = a.Proxy,
         };
     }
 
@@ -1459,6 +1465,7 @@ public sealed class ReflectionMapper(ITranslator? translator = null, Func<Identi
             Headers = ParseHeaders(a.Headers),
             Body = a.Body,
             ItemsPath = a.ItemsPath,
+            Proxy = a.Proxy,
         };
     }
 
@@ -1472,6 +1479,7 @@ public sealed class ReflectionMapper(ITranslator? translator = null, Func<Identi
             Method = a.Method,
             Headers = ParseHeaders(a.Headers),
             Body = a.Body,
+            Proxy = a.Proxy,
         };
         return new RestActionDto(source,
             a.SuccessMessage.Length > 0 ? a.SuccessMessage : null,
@@ -1489,9 +1497,36 @@ public sealed class ReflectionMapper(ITranslator? translator = null, Func<Identi
             Method = a.Method,
             Headers = ParseHeaders(a.Headers),
             Body = a.Body,
+            Proxy = a.Proxy,
         };
         return new RestActionDto(source, null, a.ResultPath);
     }
+
+    /// <summary>True when the view declares at least one proxy-mode REST source (Proxy=true on a
+    /// property [RestOptions], a method [RestAction], or the class [RestListing]/[RestData]). Gates
+    /// advertising the __restfetch__ action so only proxy views carry it.</summary>
+    internal static bool HasProxySource(Type type)
+    {
+        if (type.Find<RestListingAttribute>() is { Proxy: true }) return true;
+        if (type.Find<RestDataAttribute>() is { Proxy: true }) return true;
+        if (type.GetProperties().Any(p => p.Find<RestOptionsAttribute>() is { Proxy: true })) return true;
+        return type.GetMethods().Any(m => m.Find<RestActionAttribute>() is { Proxy: true });
+    }
+
+    /// <summary>Resolves the DECLARED source of a view for a proxy fetch — from the property
+    /// ([RestOptions]), the class ([RestListing]/[RestData]) or the method ([RestAction]), never
+    /// from a client-supplied url (so the proxy can't be turned into an open relay). Used by the
+    /// __restfetch__ reserved action.</summary>
+    internal static RestDataSourceDto? ResolveRestSource(Type type, string? kind, string? id) => kind switch
+    {
+        "options" => type.GetProperties().FirstOrDefault(p => p.Name == id || Naming.CamelCase(p.Name) == id) is { } p
+            ? RestOptionsOf(p) : null,
+        "rows" => RestListingOf(type),
+        "action" => type.GetMethods().FirstOrDefault(m => m.Name == id || Naming.CamelCase(m.Name) == id) is { } m
+            ? RestActionOf(m)?.Source : null,
+        "data" => RestDataOf(type)?.Source,
+        _ => null,
+    };
 
     /// <summary>Parses "Name: Value" header strings into a map.</summary>
     private static Dictionary<string, string> ParseHeaders(string[] headers)

--- a/backend/dotnet/src/Mateu.Core/SyncHandler.cs
+++ b/backend/dotnet/src/Mateu.Core/SyncHandler.cs
@@ -2,14 +2,18 @@ using System.ComponentModel.DataAnnotations;
 using System.Reflection;
 using System.Security.Cryptography;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using Mateu.Dtos;
 using Mateu.Uidl;
 
 namespace Mateu.Core;
 
 /// <summary>Handles a single POST /mateu/v3/sync/{route} call → a UIIncrement.</summary>
-public sealed class SyncHandler(MateuRegistry registry, ITranslator? translator = null, Func<Identity?>? identity = null)
+public sealed class SyncHandler(MateuRegistry registry, ITranslator? translator = null, Func<Identity?>? identity = null,
+    Func<string, string?>? secrets = null)
 {
+    private static readonly HttpClient RestHttp = new() { Timeout = TimeSpan.FromSeconds(60) };
+
     private readonly ReflectionMapper _mapper = new(translator, identity);
     private readonly YamlSpecLoader _yaml = new();
 
@@ -36,6 +40,13 @@ public sealed class SyncHandler(MateuRegistry registry, ITranslator? translator 
                               ?? new Text("Invalid YAML");
             return FragmentResponse("Preview", ComponentMapper.Map(previewTree), rq);
         }
+
+        // 0d. Proxy-mode external fetch: a proxy source's renderer POSTs __restfetch__ with
+        // _sourceKind/_sourceId + component state; resolve the DECLARED source (never a client url),
+        // inject ${secret.X} and fetch server-side, returning the raw JSON on appData._restfetch
+        // (mirrors Java's __restfetch__ reserved action).
+        if (rq.ActionId == "__restfetch__")
+            return RestFetchResponse(rq);
 
         // 1. App shell at the root route.
         if (string.IsNullOrEmpty(rq.ActionId)
@@ -1178,6 +1189,65 @@ public sealed class SyncHandler(MateuRegistry registry, ITranslator? translator 
 
     private static object? GetState(Dictionary<string, object?>? state, string key)
         => state is not null && state.TryGetValue(key, out var v) ? v : null;
+
+    /// <summary>The __restfetch__ reserved action: resolve the DECLARED source of the routed view by
+    /// _sourceKind/_sourceId, interpolate ${state.x}/${secret.X}, fetch server-side and return the
+    /// raw JSON on appData._restfetch (an empty object on any failure — the renderer maps it as in
+    /// direct mode).</summary>
+    private UIIncrementDto RestFetchResponse(RunActionRqDto rq)
+    {
+        object? json = new Dictionary<string, object?>();
+        if (registry.Resolve(rq.ServerSideType, rq.Route) is { } type)
+        {
+            var kind = StateString(GetState(rq.Parameters, "_sourceKind"));
+            var id = StateString(GetState(rq.Parameters, "_sourceId"));
+            if (ReflectionMapper.ResolveRestSource(type, kind, id) is { } source)
+                json = FetchProxy(source, rq.ComponentState) ?? new Dictionary<string, object?>();
+        }
+        return new UIIncrementDto([], [], [], [], false,
+            new Dictionary<string, object?> { ["_restfetch"] = json }, null);
+    }
+
+    /// <summary>Fetch a resolved source server-side (url/headers/body interpolated); null on any
+    /// non-2xx or transport error.</summary>
+    private object? FetchProxy(RestDataSourceDto source, Dictionary<string, object?> state)
+    {
+        try
+        {
+            var url = Interpolate(source.Url, state, ResolveSecret);
+            var method = string.IsNullOrWhiteSpace(source.Method) ? "GET" : source.Method!.ToUpperInvariant();
+            using var req = new HttpRequestMessage(new HttpMethod(method), url);
+            if (source.Headers is not null)
+                foreach (var (k, v) in source.Headers)
+                    req.Headers.TryAddWithoutValidation(k, Interpolate(v, state, ResolveSecret));
+            if (method is not "GET" and not "HEAD" && !string.IsNullOrWhiteSpace(source.Body))
+                req.Content = new StringContent(Interpolate(source.Body, state, ResolveSecret) ?? "");
+            using var resp = RestHttp.Send(req);
+            if ((int)resp.StatusCode >= 400) return null;
+            using var reader = new StreamReader(resp.Content.ReadAsStream());
+            return JsonSerializer.Deserialize<JsonElement>(reader.ReadToEnd());
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>Resolve a secret: the injected provider first, then the same-named env var.</summary>
+    private string? ResolveSecret(string key) => secrets?.Invoke(key) ?? Environment.GetEnvironmentVariable(key);
+
+    /// <summary>Interpolate ${state.x}/${secret.X} placeholders (unknown → empty).</summary>
+    private static string Interpolate(string? template, Dictionary<string, object?> state, Func<string, string?> secrets)
+    {
+        if (string.IsNullOrEmpty(template)) return template ?? "";
+        return Regex.Replace(template, @"\$\{([^}]+)\}", m =>
+        {
+            var expr = m.Groups[1].Value.Trim();
+            if (expr.StartsWith("state.")) return StateString(GetState(state, expr[6..])) ?? "";
+            if (expr.StartsWith("secret.")) return secrets(expr[7..]) ?? "";
+            return "";
+        });
+    }
 
     /// <summary>The id inside the calendar's <c>_clickedEvent</c> action parameter — a map
     /// {id, title, date, color} the frontend sends with every "openCalendarEvent" dispatch

--- a/backend/dotnet/src/Mateu.Dtos/Wire.cs
+++ b/backend/dotnet/src/Mateu.Dtos/Wire.cs
@@ -990,6 +990,11 @@ public record RestDataSourceDto(string Url)
     public string? ItemsPath { get; init; }
     public string? ValuePath { get; init; }
     public string? LabelPath { get; init; }
+
+    /// <summary>Fetch through the Mateu SERVER (proxy mode) instead of directly from the browser:
+    /// no CORS, and ${secret.X} auth is injected server-side. The renderer dispatches the reserved
+    /// __restfetch__ action instead of a direct fetch. Default false (client-direct).</summary>
+    public bool Proxy { get; init; }
 }
 
 /// <summary>A drawer overlay (mirrors io.mateu.dtos.DrawerDto): a panel sliding in from a

--- a/backend/dotnet/src/Mateu.Uidl/Attributes.cs
+++ b/backend/dotnet/src/Mateu.Uidl/Attributes.cs
@@ -154,6 +154,10 @@ public sealed class RestActionAttribute(string url) : Attribute
     /// <summary>A dot path to the object in the response to merge into the form state; blank merges
     /// nothing (fire-and-toast).</summary>
     public string ResultPath { get; init; } = "";
+
+    /// <summary>Fetch through the Mateu SERVER (proxy mode): no CORS, and ${secret.X} auth is
+    /// injected server-side from a secrets provider. Default false (client-direct).</summary>
+    public bool Proxy { get; init; }
 }
 
 /// <summary>Loads a screen's initial data from an arbitrary (non-Mateu) REST endpoint, fetched
@@ -175,6 +179,10 @@ public sealed class RestDataAttribute(string url) : Attribute
     /// <summary>A dot path to the object in the response to merge into the form state; blank merges
     /// the whole response object.</summary>
     public string ResultPath { get; init; } = "";
+
+    /// <summary>Fetch through the Mateu SERVER (proxy mode): no CORS, and ${secret.X} auth is
+    /// injected server-side from a secrets provider. Default false (client-direct).</summary>
+    public bool Proxy { get; init; }
 }
 
 /// <summary>An overridden display label for a field or method.</summary>

--- a/backend/dotnet/src/Mateu.Uidl/FieldAndPageFeatures.cs
+++ b/backend/dotnet/src/Mateu.Uidl/FieldAndPageFeatures.cs
@@ -67,6 +67,10 @@ public sealed class RestOptionsAttribute(string url) : Attribute
     public string ItemsPath { get; init; } = "";
     public string ValuePath { get; init; } = "value";
     public string LabelPath { get; init; } = "label";
+
+    /// <summary>Fetch through the Mateu SERVER (proxy mode): no CORS, and ${secret.X} auth is
+    /// injected server-side from a secrets provider. Default false (client-direct).</summary>
+    public bool Proxy { get; init; }
 }
 
 /// <summary>Fills a listing's ROWS from an arbitrary (non-Mateu) REST endpoint, fetched
@@ -87,6 +91,10 @@ public sealed class RestListingAttribute(string url) : Attribute
 
     /// <summary>A dot path to the array inside the response; blank means the root IS the array.</summary>
     public string ItemsPath { get; init; } = "";
+
+    /// <summary>Fetch through the Mateu SERVER (proxy mode): no CORS, and ${secret.X} auth is
+    /// injected server-side from a secrets provider. Default false (client-direct).</summary>
+    public bool Proxy { get; init; }
 }
 
 /// <summary>A reference field picked through a full selector DIALOG instead of a combo: clicking

--- a/backend/dotnet/test/Mateu.Tests/SyncHandlerTests.cs
+++ b/backend/dotnet/test/Mateu.Tests/SyncHandlerTests.cs
@@ -71,6 +71,26 @@ public class RestDataForm
     public string? Email { get; set; }
 }
 
+// Proxy mode: a [RestOptions(Proxy=true)] field routes the fetch through the Mateu server (the
+// __restfetch__ action) instead of fetching the endpoint directly — the CORS/auth-hardening flag.
+[UI("rest-proxy"), Title("Rest proxy")]
+public class RestProxyForm
+{
+    [RestOptions("https://api.example.com/x?t=${secret.TOKEN}", Proxy = true)]
+    public string ViaServer { get; set; } = "";
+
+    [RestOptions("https://public.example.com/x")]
+    public string Direct { get; set; } = "";
+}
+
+// A view with only a plain [RestOptions] (no proxy) — must NOT advertise __restfetch__.
+[UI("rest-direct"), Title("Rest direct")]
+public class RestDirectForm
+{
+    [RestOptions("https://public.example.com/x")]
+    public string Direct { get; set; } = "";
+}
+
 // A fully-static screen: the client caches its whole response and skips the round-trip on return.
 [UI("static-view"), Title("About"), StaticView]
 public class StaticViewForm
@@ -1876,6 +1896,26 @@ public class SyncHandlerTests
         Assert.Contains("\"url\":\"https://api.example.com/me?token=${state.token}\"", json);
         // an OnLoad trigger fires it on entry
         Assert.Contains("\"type\":\"OnLoad\",\"actionId\":\"__restdata__\"", json);
+    }
+
+    [Fact]
+    public void Proxy_flag_travels_on_the_options_source_and_the_view_advertises_restfetch()
+    {
+        var json = Render(Handler().Handle(new RunActionRqDto { Route = "rest-proxy", ConsumedRoute = "rest-proxy" }));
+
+        // proxy=true on the proxied field's source; the ${secret.X} template rides on the wire...
+        Assert.Contains("\"url\":\"https://api.example.com/x?t=${secret.TOKEN}\",\"method\":\"GET\"", json);
+        Assert.Contains("\"proxy\":true", json);
+        Assert.Contains("\"proxy\":false", json); // ...and the plain field stays direct
+        // a proxy source makes the view advertise the reserved __restfetch__ action
+        Assert.Contains("\"id\":\"__restfetch__\"", json);
+    }
+
+    [Fact]
+    public void Direct_only_view_does_not_advertise_restfetch()
+    {
+        var json = Render(Handler().Handle(new RunActionRqDto { Route = "rest-direct", ConsumedRoute = "rest-direct" }));
+        Assert.DoesNotContain("__restfetch__", json);
     }
 
     [Fact]

--- a/backend/python/mateu_core/mapper.py
+++ b/backend/python/mateu_core/mapper.py
@@ -673,6 +673,11 @@ class ReflectionMapper:
                         "debounceMillis": getattr(cls, "__mateu_refresh_debounce__", 400),
                     }
                 ]
+        # Proxy mode (RestOptions/rest_listing/rest_action/rest_data with proxy=True): advertise the
+        # reserved __restfetch__ action so the renderer can route the fetch through the server (which
+        # resolves the DECLARED source, injects ${secret.X} and fetches server-side).
+        if self._has_proxy_source(cls):
+            actions = list(actions) + [Action(id="__restfetch__")]
         return ServerSideComponent(
             id=_id(),
             server_side_type=type_name(cls),
@@ -2597,6 +2602,7 @@ class ReflectionMapper:
             items_path=a.items_path,
             value_path=a.value_path,
             label_path=a.label_path,
+            proxy=a.proxy,
         )
 
     @staticmethod
@@ -2607,14 +2613,14 @@ class ReflectionMapper:
         spec = getattr(cls, "__mateu_rest_listing__", None)
         if spec is None:
             return None
-        url, method, header_strings, body, items_path = spec
+        url, method, header_strings, body, items_path, proxy = spec
         headers: dict[str, str] = {}
         for h in header_strings:
             name, sep, value = h.partition(":")
             if sep:
                 headers[name.strip()] = value.strip()
         return RestDataSource(
-            url=url, method=method, headers=headers, body=body, items_path=items_path
+            url=url, method=method, headers=headers, body=body, items_path=items_path, proxy=proxy
         )
 
     @staticmethod
@@ -2625,14 +2631,14 @@ class ReflectionMapper:
         spec = getattr(fn, "__mateu_rest_action__", None)
         if spec is None:
             return None
-        url, method, header_strings, body, success_message, result_path = spec
+        url, method, header_strings, body, success_message, result_path, proxy = spec
         headers: dict[str, str] = {}
         for h in header_strings:
             name, sep, value = h.partition(":")
             if sep:
                 headers[name.strip()] = value.strip()
         return RestAction(
-            source=RestDataSource(url=url, method=method, headers=headers, body=body),
+            source=RestDataSource(url=url, method=method, headers=headers, body=body, proxy=proxy),
             success_message=success_message or None,
             result_path=result_path or None,
         )
@@ -2645,17 +2651,64 @@ class ReflectionMapper:
         spec = getattr(cls, "__mateu_rest_data__", None)
         if spec is None:
             return None
-        url, method, header_strings, body, result_path = spec
+        url, method, header_strings, body, result_path, proxy = spec
         headers: dict[str, str] = {}
         for h in header_strings:
             name, sep, value = h.partition(":")
             if sep:
                 headers[name.strip()] = value.strip()
         return RestAction(
-            source=RestDataSource(url=url, method=method, headers=headers, body=body),
+            source=RestDataSource(url=url, method=method, headers=headers, body=body, proxy=proxy),
             success_message=None,
             result_path=result_path,
         )
+
+    @staticmethod
+    def _has_proxy_source(cls) -> bool:
+        """True when the view declares at least one proxy-mode REST source (proxy=True on a field
+        ``RestOptions()``, a method ``@rest_action``, or the class ``@rest_listing``/``@rest_data``).
+        Gates advertising the ``__restfetch__`` action so only proxy views carry it."""
+        listing = getattr(cls, "__mateu_rest_listing__", None)
+        if listing is not None and listing[5]:
+            return True
+        data = getattr(cls, "__mateu_rest_data__", None)
+        if data is not None and data[5]:
+            return True
+        for f in view_fields(cls):
+            if f.has(RestOptions) and f.marker(RestOptions).proxy:
+                return True
+        for klass in cls.__mro__:
+            for m in vars(klass).values():
+                spec = getattr(m, "__mateu_rest_action__", None)
+                if spec is not None and spec[6]:
+                    return True
+        return False
+
+    def resolve_rest_source(self, cls, kind, id) -> "RestDataSource | None":
+        """Resolve the DECLARED source of a view for a proxy fetch — from the field
+        (``RestOptions``), the class (``@rest_listing``/``@rest_data``) or the method
+        (``@rest_action``), never from a client-supplied url (so the proxy can't be turned into an
+        open relay). Used by the ``__restfetch__`` reserved action."""
+        if kind == "options":
+            for f in view_fields(cls):
+                if camel_case(f.name) == id and f.has(RestOptions):
+                    return self._rest_options(f)
+            return None
+        if kind == "rows":
+            return self._rest_listing(cls)
+        if kind == "action":
+            for klass in cls.__mro__:
+                for name, m in vars(klass).items():
+                    if (name == id or camel_case(name) == id) and getattr(
+                        m, "__mateu_rest_action__", None
+                    ) is not None:
+                        r = self._rest_action(m)
+                        return r.source if r else None
+            return None
+        if kind == "data":
+            r = self._rest_data(cls)
+            return r.source if r is not None else None
+        return None
 
     def link_of(self, f, instance) -> NavLinkRecord | None:
         """The field's nav link: a :class:`LinkSupplier` on the view wins; when it returns ``None``

--- a/backend/python/mateu_core/sync_handler.py
+++ b/backend/python/mateu_core/sync_handler.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 import hashlib
 import inspect
 import json
+import os
+import re
+import urllib.error
+import urllib.request
 from datetime import date, datetime
 from decimal import Decimal
 from enum import Enum
@@ -126,9 +130,11 @@ SAVED_IN_DRAWER_EVENT = "mateu-crud:saved-in-drawer"
 
 
 class SyncHandler:
-    def __init__(self, registry: MateuRegistry, translator=None, identity_provider=None):
+    def __init__(self, registry: MateuRegistry, translator=None, identity_provider=None, secrets_provider=None):
         self.registry = registry
         self.mapper = ReflectionMapper(translator, identity_provider)
+        #: resolves ${secret.X} for proxy mode; None → same-named env var fallback.
+        self._secrets = secrets_provider
         self.yaml_specs = YamlSpecLoader()
 
     def handle(self, rq: RunActionRq, request_base_url: str | None = None) -> UIIncrement:
@@ -149,6 +155,13 @@ class SyncHandler:
         # Java's __preview__ reserved action / YamlUidlLoader.parseText).
         if rq.action_id == "__preview__" and rq.parameters.get("_yaml"):
             return self._preview_response(rq.parameters["_yaml"], rq)
+
+        # 0d. Proxy-mode external fetch: a proxy source's renderer POSTs __restfetch__ with
+        # _sourceKind/_sourceId + component state; resolve the DECLARED source (never a client url),
+        # inject ${secret.X} and fetch server-side, returning the raw JSON on app_data._restfetch
+        # (mirrors Java's __restfetch__ reserved action).
+        if rq.action_id == "__restfetch__":
+            return self._rest_fetch_response(rq)
 
         # 1. App shell at the root route.
         if not rq.action_id:
@@ -1440,6 +1453,65 @@ class SyncHandler:
 
         tree = build_from_yaml(yaml_text) or fluent.Text(text="Invalid YAML")
         return self.fragment_response("Preview", self.mapper.map_component(tree), rq)
+
+    # ── Proxy-mode external fetch (__restfetch__) ───────────────────────────────
+    def _rest_fetch_response(self, rq: RunActionRq) -> UIIncrement:
+        """Resolve the DECLARED source of the routed view by _sourceKind/_sourceId, interpolate
+        ${state.x}/${secret.X}, fetch server-side and return the raw JSON on app_data._restfetch
+        (an empty object on any failure — the renderer maps it as in direct mode)."""
+        json_obj: Any = {}
+        cls = self.registry.resolve(rq.server_side_type, rq.route)
+        if cls is not None:
+            kind = rq.parameters.get("_sourceKind")
+            source_id = rq.parameters.get("_sourceId")
+            source = self.mapper.resolve_rest_source(cls, kind, source_id)
+            if source is not None:
+                json_obj = self._fetch_proxy(source, rq.component_state)
+        return UIIncrement(app_data={"_restfetch": json_obj})
+
+    def _fetch_proxy(self, source, state: dict) -> Any:
+        """Fetch a resolved source server-side (url/headers/body interpolated); an empty object on
+        any non-2xx or transport error."""
+        try:
+            url = self._interpolate(source.url, state)
+            method = (source.method or "GET").upper()
+            data = None
+            if method not in ("GET", "HEAD") and source.body:
+                data = self._interpolate(source.body, state).encode()
+            req = urllib.request.Request(url, data=data, method=method)
+            req.add_header("Accept", "application/json")
+            for name, value in (source.headers or {}).items():
+                req.add_header(name, self._interpolate(value, state))
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                if resp.status >= 400:
+                    return {}
+                return json.loads(resp.read().decode())
+        except (urllib.error.URLError, ValueError, OSError):
+            return {}
+
+    def _resolve_secret(self, key: str) -> str | None:
+        """Resolve a secret: the injected provider first, then the same-named env var."""
+        if self._secrets is not None:
+            value = self._secrets(key)
+            if value is not None:
+                return value
+        return os.environ.get(key)
+
+    def _interpolate(self, template: str | None, state: dict) -> str:
+        """Interpolate ${state.x}/${secret.X} placeholders (unknown → empty)."""
+        if not template:
+            return template or ""
+
+        def repl(m: re.Match) -> str:
+            expr = m.group(1).strip()
+            if expr.startswith("state."):
+                v = state.get(expr[6:])
+                return "" if v is None else str(v)
+            if expr.startswith("secret."):
+                return self._resolve_secret(expr[7:]) or ""
+            return ""
+
+        return re.sub(r"\$\{([^}]+)\}", repl, template)
 
     # ── ModelView contract ─────────────────────────────────────────────────────
     def _contract_response(self, cls, rq: RunActionRq) -> UIIncrement:

--- a/backend/python/mateu_dtos/__init__.py
+++ b/backend/python/mateu_dtos/__init__.py
@@ -214,6 +214,8 @@ class RestDataSource(Wire):
     items_path: str | None = None
     value_path: str | None = None
     label_path: str | None = None
+    #: fetch through the Mateu server (no CORS, ${secret.X} injected server-side); default False
+    proxy: bool = False
 
 
 class NavLinkRecord(Wire):

--- a/backend/python/mateu_uidl/__init__.py
+++ b/backend/python/mateu_uidl/__init__.py
@@ -191,6 +191,7 @@ class RestOptions:
     items_path: str = ""  #: dot path to the response array; blank means the root IS the array
     value_path: str = "value"
     label_path: str = "label"
+    proxy: bool = False  #: fetch through the Mateu server (no CORS, ${secret.X} injected server-side)
 
 
 @dataclass(frozen=True)
@@ -752,6 +753,7 @@ def rest_listing(
     headers: tuple[str, ...] = (),
     body: str = "",
     items_path: str = "",
+    proxy: bool = False,
 ) -> Callable[[type], type]:
     """Class-level: fills a listing's ROWS from an arbitrary (non-Mateu) REST endpoint, fetched
     CLIENT-SIDE. The renderer calls ``url`` directly, navigates ``items_path`` to the array in the
@@ -761,7 +763,7 @@ def rest_listing(
     (including ``${searchText}``/``${page}``/``${size}``). Python analogue of Java's @RestListing."""
 
     def deco(cls: type) -> type:
-        cls.__mateu_rest_listing__ = (url, method, headers, body, items_path)
+        cls.__mateu_rest_listing__ = (url, method, headers, body, items_path, proxy)
         return cls
 
     return deco
@@ -774,6 +776,7 @@ def rest_action(
     body: str = "",
     success_message: str = "",
     result_path: str = "",
+    proxy: bool = False,
 ) -> Callable[[Callable], Callable]:
     """Method-level: makes a button call an arbitrary (non-Mateu) REST endpoint CLIENT-SIDE instead
     of dispatching to the Mateu server. On click the renderer calls ``url`` directly with the
@@ -784,7 +787,7 @@ def rest_action(
     @RestAction."""
 
     def deco(fn: Callable) -> Callable:
-        fn.__mateu_rest_action__ = (url, method, headers, body, success_message, result_path)
+        fn.__mateu_rest_action__ = (url, method, headers, body, success_message, result_path, proxy)
         return fn
 
     return deco
@@ -796,6 +799,7 @@ def rest_data(
     headers: tuple[str, ...] = (),
     body: str = "",
     result_path: str = "",
+    proxy: bool = False,
 ) -> Callable[[type], type]:
     """Class-level: loads a screen's initial data from an arbitrary (non-Mateu) REST endpoint,
     fetched CLIENT-SIDE on entry. When the view mounts the renderer calls ``url`` directly and
@@ -805,7 +809,7 @@ def rest_data(
     analogue of Java's @RestData."""
 
     def deco(cls: type) -> type:
-        cls.__mateu_rest_data__ = (url, method, headers, body, result_path)
+        cls.__mateu_rest_data__ = (url, method, headers, body, result_path, proxy)
         return cls
 
     return deco

--- a/backend/python/tests/test_sync_handler.py
+++ b/backend/python/tests/test_sync_handler.py
@@ -1782,6 +1782,39 @@ def test_rest_data_advertises_an_onload_action_carrying_the_endpoint_descriptor(
     assert '"type": "OnLoad", "actionId": "__restdata__"' in j
 
 
+# Proxy mode: a RestOptions(proxy=True) field routes the fetch through the Mateu server (the
+# __restfetch__ action) instead of fetching directly — the CORS/auth-hardening flag.
+@ui("rest-proxy")
+@title("Rest proxy")
+class RestProxyForm:
+    via_server: Annotated[
+        str, RestOptions(url="https://api.example.com/x?t=${secret.TOKEN}", proxy=True)
+    ] = ""
+    direct: Annotated[str, RestOptions(url="https://public.example.com/x")] = ""
+
+
+@ui("rest-direct")
+@title("Rest direct")
+class RestDirectForm:
+    direct: Annotated[str, RestOptions(url="https://public.example.com/x")] = ""
+
+
+def test_proxy_flag_travels_on_the_options_source_and_the_view_advertises_restfetch():
+    j = render(handler().handle(RunActionRq(route="rest-proxy", consumed_route="rest-proxy")))
+
+    # the ${secret.X} template rides on the wire, proxy=true on the proxied field...
+    assert '"url": "https://api.example.com/x?t=${secret.TOKEN}"' in j
+    assert '"proxy": true' in j
+    assert '"proxy": false' in j  # ...and the plain field stays direct
+    # a proxy source makes the view advertise the reserved __restfetch__ action
+    assert '"id": "__restfetch__"' in j
+
+
+def test_direct_only_view_does_not_advertise_restfetch():
+    j = render(handler().handle(RunActionRq(route="rest-direct", consumed_route="rest-direct")))
+    assert "__restfetch__" not in j
+
+
 def test_lookup_search_filters_and_pages_the_suppliers_options():
     inc = handler().handle(
         RunActionRq(

--- a/doc/src/content/docs/java-ui-definition/annotations/rest-options.md
+++ b/doc/src/content/docs/java-ui-definition/annotations/rest-options.md
@@ -123,3 +123,5 @@ country: Annotated[str, RestOptions(
     url="https://api.example.com/countries",
     items_path="data.countries", value_path="code", label_path="name.common")] = ""
 ```
+
+**Proxy mode ports.** `proxy` is available on all four annotations in every backend — `[RestOptions(Proxy = true)]` / `RestOptions(proxy=True)`, likewise for listing/action/data. The server resolves the declared source, injects `${secret.X}` and fetches server-side (`__restfetch__`). Supply secrets in .NET via the `SyncHandler`'s `secrets` delegate (`Func<string, string?>`) and in Python via the `SyncHandler(secrets_provider=…)` argument; both fall back to a same-named environment variable when no provider is registered.

--- a/doc/src/content/docs/reference/parity.md
+++ b/doc/src/content/docs/reference/parity.md
@@ -51,6 +51,7 @@ for the surface below (verified by golden-JSON tests in `backend/dotnet/test` an
 | External REST listing rows (`@RestListing`/`[RestListing]`/`@rest_listing` on a listing → rows fetched client-side from an arbitrary endpoint via `Crudl.rowsSource`; columns from the Row type) | ✅ | ✅ | ✅ |
 | External REST button action (`@RestAction`/`[RestAction]`/`@rest_action` on a button → calls an arbitrary endpoint client-side via `Action.restAction`; response toast + merge into form state) | ✅ | ✅ | ✅ |
 | External REST screen data (`@RestData`/`[RestData]`/`@rest_data` on a view → initial data fetched client-side on load and merged into the form state; reuses the `restAction` machinery via a synthetic `__restdata__` action + OnLoad trigger) | ✅ | ✅ | ✅ |
+| — Proxy mode (`proxy = true` on any of the four → the fetch is routed through the Mateu server via the reserved `__restfetch__` action: no CORS, and `${secret.X}` auth injected server-side from a secrets provider / env var; the server resolves the DECLARED source only) | ✅ | ✅ | ✅ |
 | Editable grids / inline CRUD editing (`@InlineEditing` + update-row) | ✅ | ✅ | ✅ |
 | Bulk list actions (`@ListToolbarButton` + typed selection) | ✅ | ✅ | ✅ |
 | Listing aggregates & grouping (`@Aggregate`/`@GroupBy` + summaries) | ✅ | ✅ | ✅ |


### PR DESCRIPTION
Increment 3 of the external-endpoints auth/CORS hardening. Java landed in #344 (backend) + #345/#346 (web wiring); this brings the `proxy` flag + the reserved `__restfetch__` server fetch to both ports, so a .NET/Python app renders proxied REST sources through the same browser path (the frontend is backend-agnostic).

### .NET
- `Proxy` on `RestDataSourceDto` (Wire) + all four attributes (`RestOptions`/`RestListing`/`RestAction`/`RestData`); the four mapper builders carry it.
- `ReflectionMapper.HasProxySource` advertises `__restfetch__` **only** for a view with a proxy source; `ResolveRestSource` resolves the DECLARED source by `kind`+`id` (never a client url → no SSRF/exfil).
- `SyncHandler` handles `__restfetch__`: interpolate `${state.x}`/`${secret.X}`, fetch server-side (`HttpClient.Send`), return `appData._restfetch`. New `secrets` delegate ctor param (`Func<string,string?>`), env-var fallback.

### Python
- `proxy` on the `RestOptions` marker + `rest_listing`/`rest_action`/`rest_data` decorators + `RestDataSource` model; the four builders carry it.
- `mapper._has_proxy_source` advertises `__restfetch__`; `resolve_rest_source` resolves the declared source.
- `sync_handler` handles `__restfetch__` (**urllib**, stdlib — no new dependency): interpolate, fetch, return `app_data._restfetch`. New `secrets_provider` ctor arg, env-var fallback.

### Tests
- .NET +2 (proxy flag on the options source + `__restfetch__` advertised; a direct-only view does NOT advertise it). Full suite **247 green**.
- Python +2 (same). Full suite **246 green**.
- `parity.md` gains a proxy-mode row (✅✅✅); `rest-options.md` documents the port secrets hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)