### PR TITLE
feat(rest): proxy mode in the native renderers (RN + IntelliJ)

### DIFF
--- a/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/state/AppContext.kt
+++ b/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/state/AppContext.kt
@@ -468,7 +468,7 @@ class AppContext(val session: AppSession) {
         // to the Mateu server — fetch + merge the response into the state + notify (fires on click
         // for a @RestAction button, and on mount for @RestData via its OnLoad __restdata__ action).
         currentActionRestData[actionId]?.let { rest ->
-            handleRestAction(rest)
+            handleRestAction(rest, actionId)
             return
         }
 
@@ -497,21 +497,30 @@ class AppContext(val session: AppSession) {
      * state (so bound fields refresh) and show a success notification; an error shows a failure one.
      * No server round-trip — the plugin analogue of the web's mateu-component.handleRestAction.
      */
-    private fun handleRestAction(rest: JsonNode) {
+    private fun handleRestAction(rest: JsonNode, actionId: String? = null) {
         val source = rest.path("source")
         val ctx = mapOf<String, Any?>("state" to currentComponentState, "appState" to appState)
         background(
             work = {
-                val url = Expressions.interpolate(source.text("url"), ctx)
-                val method = source.text("method").ifBlank { "GET" }.uppercase()
-                val headers = LinkedHashMap<String, String>()
-                source.path("headers").fields().forEach { (k, v) ->
-                    headers[k] = Expressions.interpolate(v.asText(""), ctx)
+                if (source.path("proxy").asBoolean(false)) {
+                    // Proxy mode: route through the Mateu server (no CORS, secrets injected
+                    // server-side) via the reserved __restfetch__ action. The __restdata__
+                    // (screen-load) id resolves the class @RestData source; any other id is a
+                    // @RestAction method — hence the source kind.
+                    val kind = if (actionId == "__restdata__") "data" else "action"
+                    fetchViaProxy(kind, actionId.orEmpty())
+                } else {
+                    val url = Expressions.interpolate(source.text("url"), ctx)
+                    val method = source.text("method").ifBlank { "GET" }.uppercase()
+                    val headers = LinkedHashMap<String, String>()
+                    source.path("headers").fields().forEach { (k, v) ->
+                        headers[k] = Expressions.interpolate(v.asText(""), ctx)
+                    }
+                    val body = source.get("body")?.asText("").orEmpty().let {
+                        if (it.isBlank()) null else Expressions.interpolate(it, ctx)
+                    }
+                    apiClient.fetchExternal(url, method, headers, body)
                 }
-                val body = source.get("body")?.asText("").orEmpty().let {
-                    if (it.isBlank()) null else Expressions.interpolate(it, ctx)
-                }
-                apiClient.fetchExternal(url, method, headers, body)
             },
             onOk = { json ->
                 // resultPath: a string (possibly empty = whole response) merges into the state;
@@ -532,6 +541,22 @@ class AppContext(val session: AppSession) {
                 else showMessage("Request failed", "error")
             },
         )
+    }
+
+    /**
+     * Proxy-mode external fetch: route a DECLARED REST source through the Mateu server via the
+     * reserved __restfetch__ action (the server resolves the source, injects `${'$'}{secret.X}` and
+     * fetches server-side — no CORS, secrets off the client). Returns the raw JSON the server
+     * fetched (appData._restfetch). Runs on the CALLER's thread (options/rows/action already fetch
+     * on a background worker), so no extra threading here.
+     */
+    fun fetchViaProxy(sourceKind: String, sourceId: String): JsonNode {
+        val increment = apiClient.runAction(
+            currentRoute, currentConsumedRoute, "__restfetch__", currentServerSideType,
+            currentComponentId, currentComponentState, appState,
+            mapOf("_sourceKind" to sourceKind, "_sourceId" to sourceId),
+        )
+        return increment.path("appData").path("_restfetch")
     }
 
     /** Navigate a dot path (`profile`, `data.address`) into a JSON value; an empty path is identity. */

--- a/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/ui/CrudRenderer.kt
+++ b/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/ui/CrudRenderer.kt
@@ -346,9 +346,13 @@ fun renderCrud(r: ComponentRenderer, component: JsonNode, metadata: JsonNode, st
             .filter { it.isNotBlank() }
         val exprCtx = mapOf<String, Any?>("state" to ctx.currentComponentState, "appState" to ctx.appState)
         val mapper = ctx.session.mapper
+        val crudId = component.text("id", "crud")
         ctx.session.executor.submit {
             try {
-                val json = RestFetch.fetch(ctx.apiClient, rowsSource, exprCtx)
+                // Proxy mode: route through the Mateu server via __restfetch__ (no CORS, secrets
+                // server-side); direct fetch otherwise. Both resolve to the same JSON.
+                val json = if (rowsSource.path("proxy").asBoolean(false)) ctx.fetchViaProxy("rows", crudId)
+                           else RestFetch.fetch(ctx.apiClient, rowsSource, exprCtx)
                 val arr = RestFetch.valueAtPath(json, rowsSource.text("itemsPath"))
                 val content = mapper.createArrayNode()
                 if (arr != null && arr.isArray) for (item in arr) {

--- a/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/ui/FormFieldRenderer.kt
+++ b/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/ui/FormFieldRenderer.kt
@@ -704,7 +704,10 @@ private fun restOptionsCombo(ctx: AppContext, fieldId: String, source: JsonNode,
     val exprCtx = mapOf<String, Any?>("state" to ctx.currentComponentState, "appState" to ctx.appState)
     ctx.session.executor.submit {
         val opts = try {
-            val json = RestFetch.fetch(ctx.apiClient, source, exprCtx)
+            // Proxy mode: route through the Mateu server via __restfetch__ (no CORS, secrets
+            // server-side); direct fetch otherwise. Both resolve to the same JSON.
+            val json = if (source.path("proxy").asBoolean(false)) ctx.fetchViaProxy("options", fieldId)
+                       else RestFetch.fetch(ctx.apiClient, source, exprCtx)
             val arr = RestFetch.valueAtPath(json, source.text("itemsPath"))
             val valuePath = source.text("valuePath").ifBlank { "value" }
             val labelPath = source.text("labelPath").ifBlank { "label" }

--- a/frontend/app/react-native/src/core/MateuViewController.ts
+++ b/frontend/app/react-native/src/core/MateuViewController.ts
@@ -191,7 +191,7 @@ export class MateuViewController {
     // @RestAction button, and on mount for @RestData via its OnLoad trigger's __restdata__ action).
     const rest = this.actionRestData[actionId];
     if (rest) {
-      await this.handleRestAction(rest);
+      await this.handleRestAction(rest, actionId);
       return;
     }
 
@@ -222,7 +222,7 @@ export class MateuViewController {
    * (so bound fields refresh) and show a success toast; an error shows a failure toast. No server
    * round-trip — the RN analogue of the web's mateu-component.handleRestAction.
    */
-  private async handleRestAction(rest: Json): Promise<void> {
+  private async handleRestAction(rest: Json, actionId?: string): Promise<void> {
     const ctx = {
       state: this.currentComponentState,
       data: this.view.data,
@@ -233,15 +233,24 @@ export class MateuViewController {
     const source = (rest['source'] as Json) ?? {};
     const resolve = (t: unknown): string => interpolate(str(t), ctx);
     try {
-      const url = resolve(source['url']);
-      const method = (str(source['method']) || 'GET').toUpperCase();
-      const headers: Record<string, string> = {};
-      for (const [k, v] of Object.entries((source['headers'] as Json) ?? {})) headers[k] = resolve(v);
-      const init: RequestInit = { method, headers };
-      if (method !== 'GET' && method !== 'HEAD' && source['body']) init.body = resolve(source['body']);
-      const res = await fetch(url, init);
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const json = await res.json();
+      let json: unknown;
+      if (source['proxy']) {
+        // Proxy mode: route through the Mateu server (no CORS, secrets injected server-side) via
+        // the reserved __restfetch__ action. The __restdata__ (screen-load) id resolves the class
+        // @RestData source; any other id is a @RestAction method — hence the source kind.
+        const kind = actionId === '__restdata__' ? 'data' : 'action';
+        json = await this.fetchViaProxy(kind, actionId ?? '');
+      } else {
+        const url = resolve(source['url']);
+        const method = (str(source['method']) || 'GET').toUpperCase();
+        const headers: Record<string, string> = {};
+        for (const [k, v] of Object.entries((source['headers'] as Json) ?? {})) headers[k] = resolve(v);
+        const init: RequestInit = { method, headers };
+        if (method !== 'GET' && method !== 'HEAD' && source['body']) init.body = resolve(source['body']);
+        const res = await fetch(url, init);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        json = await res.json();
+      }
       // resultPath: a string (possibly empty = whole response) merges into the state; null/absent
       // (a @RestAction fire-and-toast) merges nothing.
       const resultPath = rest['resultPath'];
@@ -262,6 +271,31 @@ export class MateuViewController {
     } catch (e) {
       if (this.silentErrors) console.log('[Mateu] rest action failed:', errorText(e));
       else this.session.notify(null, 'Request failed', 'error');
+    }
+  }
+
+  /**
+   * Proxy-mode external fetch: route a DECLARED REST source through the Mateu server via the
+   * reserved __restfetch__ action (the server resolves the source, injects ${secret.X} and fetches
+   * server-side — no CORS, secrets off the client). Returns the raw JSON the server fetched
+   * (appData._restfetch), or {} on failure. Shared by the options/rows/action/data proxy paths.
+   */
+  async fetchViaProxy(sourceKind: string, sourceId: string): Promise<unknown> {
+    try {
+      const increment = (await this.session.api.runAction({
+        route: this.currentRoute,
+        consumedRoute: this.currentConsumedRoute,
+        actionId: '__restfetch__',
+        serverSideType: this.currentServerSideType || null,
+        initiatorComponentId: this.currentComponentId,
+        componentState: this.currentComponentState,
+        appState: this.session.appState,
+        parameters: { _sourceKind: sourceKind, _sourceId: sourceId },
+      })) as Json;
+      return (increment?.['appData'] as Json)?.['_restfetch'] ?? {};
+    } catch (e) {
+      console.log('[Mateu] proxy rest fetch failed:', errorText(e));
+      return {};
     }
   }
 

--- a/frontend/app/react-native/src/renderer/CrudRenderer.tsx
+++ b/frontend/app/react-native/src/renderer/CrudRenderer.tsx
@@ -144,7 +144,7 @@ export function CrudRenderer({ component, metadata, state, data }: Props) {
   // `search` action. Declarative listings get no server OnLoad trigger, so self-fetch on mount (and
   // when the interpolated url changes); free-text search filters the fetched rows in memory.
   const rowsSource = metadata['rowsSource'] as
-    | { url: string; method?: string; headers?: Record<string, string>; body?: string; itemsPath?: string }
+    | { url: string; method?: string; headers?: Record<string, string>; body?: string; itemsPath?: string; proxy?: boolean }
     | undefined;
   const columnIds = columns.map((c) => c.metadata?.id ?? c.id ?? c.fieldId).filter(Boolean) as string[];
   const restResolve = (t: unknown): string => interpolate(String(t ?? ''), { state, appState: controller.session.appState });
@@ -153,7 +153,12 @@ export function CrudRenderer({ component, metadata, state, data }: Props) {
   useEffect(() => {
     if (!rowsSource) return;
     let cancelled = false;
-    fetchExternalJson(rowsSource, restResolve)
+    // Proxy mode: route through the Mateu server via __restfetch__ (no CORS, secrets server-side);
+    // direct fetch otherwise. Both resolve to the same JSON → mapItemsToRows.
+    const jsonPromise = rowsSource.proxy
+      ? controller.fetchViaProxy('rows', String(component['id'] ?? 'crud'))
+      : fetchExternalJson(rowsSource, restResolve);
+    jsonPromise
       .then((json) => {
         if (cancelled) return;
         const rows = mapItemsToRows(json, rowsSource.itemsPath, columnIds) as Record<string, unknown>[];

--- a/frontend/app/react-native/src/renderer/FormFieldRenderer.tsx
+++ b/frontend/app/react-native/src/renderer/FormFieldRenderer.tsx
@@ -68,6 +68,8 @@ interface FieldMeta {
     itemsPath?: string;
     valuePath?: string;
     labelPath?: string;
+    /** Fetch through the Mateu server (no CORS, secrets server-side) instead of directly. */
+    proxy?: boolean;
   };
   /** Grid fields: ClientSide GridColumn nodes. */
   columns?: { metadata?: GridColumnMeta }[];
@@ -326,6 +328,7 @@ export function FormFieldRenderer({ metadata, state, onStateChange, error }: Pro
       return (
         <RestOptionsField
           source={metadata.optionsSource}
+          fieldId={fieldId}
           state={state}
           appState={controller.session.appState}
           value={stringValue}
@@ -619,20 +622,27 @@ export function GridRowForm({ columns, row, isNew, onSave, onDelete, onCancel }:
 
 // @RestOptions: a select whose options are fetched CLIENT-SIDE from an arbitrary REST endpoint on
 // mount (and refetched when the interpolated url changes — a state-dependent source).
-function RestOptionsField({ source, state, appState, value, editable, onChange }: {
+function RestOptionsField({ source, fieldId, state, appState, value, editable, onChange }: {
   source: NonNullable<FieldMeta['optionsSource']>;
+  fieldId: string;
   state: Record<string, unknown>;
   appState: Record<string, unknown>;
   value: string;
   editable: boolean;
   onChange: (v: string) => void;
 }) {
+  const controller = useViewController();
   const [options, setOptions] = useState<FetchedOption[]>([]);
   const resolve = (t: unknown): string => interpolate(String(t ?? ''), { state, appState });
   const url = resolve(source.url);
   useEffect(() => {
     let cancelled = false;
-    fetchExternalJson(source, resolve)
+    // Proxy mode: route through the Mateu server via __restfetch__ (no CORS, secrets server-side);
+    // direct fetch otherwise. Both resolve to the same JSON → mapItemsToOptions.
+    const jsonPromise = source.proxy
+      ? controller.fetchViaProxy('options', fieldId)
+      : fetchExternalJson(source, resolve);
+    jsonPromise
       .then((json) => { if (!cancelled) setOptions(mapItemsToOptions(json, source.itemsPath, source.valuePath, source.labelPath)); })
       .catch((e) => console.warn('mateu: external options fetch failed', e));
     return () => { cancelled = true; };


### PR DESCRIPTION
Increment 4 of the external-endpoints auth/CORS hardening. Both native renderers now route a proxy-mode REST source through the Mateu server via the reserved `__restfetch__` action instead of a direct fetch — the native analogue of the web wiring (#345/#346) and the .NET/Python ports (#347).

Both renderers gain a `fetchViaProxy(sourceKind, sourceId)` that POSTs `__restfetch__` with the component state and returns the server's `appData._restfetch`, then map it exactly as in direct mode. All four surfaces:

### React Native (`MateuViewController.fetchViaProxy`)
- **options** — `RestOptionsField` (gains `fieldId`, uses `useViewController()`)
- **rows** — `CrudRenderer` rows effect
- **action + data** — `handleRestAction` takes the action id → `_sourceKind` `'data'` for `__restdata__`, else `'action'`
- direct fetch kept for `proxy=false`

### IntelliJ (`AppContext.fetchViaProxy`)
- **options** — `restOptionsCombo` (on the background executor)
- **rows** — `CrudRenderer` rows fetch
- **action + data** — `handleRestAction`

### Verification (jsonplaceholder + `DEMO_TOKEN` env secret)
- **IntelliJ** `renderProbe`: combo filled with 10 real users (`Leanne Graham`, …) via one `__restfetch__` round-trip.
- **RN** (expo web + Playwright): select options populated, **one** `__restfetch__` POST, secret value **absent** from the wire.

(Temp SUT route + local expo probe affordances were not committed. RN's route-only boot hits a pre-existing framework `resolveAsApp` lombok runtime bug on this SUT build — reproduced on a committed non-proxy route — so verification passed serverSideType via a local, reverted probe patch.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)