### PR TITLE
feat(rest): client-side secure auth provider (direct fetch path)

### DIFF
--- a/backend/shared/frontend/vaadin-lit/src/main/resources/META-INF/resources/assets/mateu-vaadin.js
+++ b/backend/shared/frontend/vaadin-lit/src/main/resources/META-INF/resources/assets/mateu-vaadin.js
@@ -933,7 +933,7 @@ ${i}
             opacity: 0.4;
             cursor: default;
         }
-    `}};O([v()],Ht.prototype,`columns`,void 0),O([v()],Ht.prototype,`scope`,void 0),O([S()],Ht.prototype,`panelOpened`,void 0),O([S()],Ht.prototype,`revision`,void 0),Ht=O([h(`mateu-column-chooser`)],Ht);function Ut(e,t){return t?t.split(`.`).reduce((e,t)=>typeof e==`object`&&e?e[t]:void 0,e):e}function Wt(e,t,n=`value`,r=`label`){let i=Ut(e,t);return Array.isArray(i)?i.map(e=>{if(typeof e==`object`&&e){let t=Ut(e,n),i=Ut(e,r);return{value:t??i,label:String(i??t??``)}}return{value:e,label:String(e)}}):[]}function Gt(e,t,n){let r=Ut(e,t);return Array.isArray(r)?r.map(e=>{let t={};for(let r of n)t[r]=Ut(e,r);return t}):[]}async function Kt(e,t=e=>e,n=fetch){let r=t(e.url)??e.url,i=(e.method||`GET`).toUpperCase(),a={};for(let[n,r]of Object.entries(e.headers??{}))a[n]=t(r)??r;let o={method:i,headers:a};i!==`GET`&&i!==`HEAD`&&e.body&&(o.body=t(e.body)??e.body);let s=await n(r,o);if(!s.ok)throw Error(`External REST fetch failed: ${s.status}`);return s.json()}async function qt(e,t=e=>e,n=fetch){return Wt(await Kt(e,t,n),e.itemsPath,e.valuePath,e.labelPath)}async function Jt(e,t,n=e=>e,r=fetch){return Gt(await Kt(e,n,r),e.itemsPath,t)}var Yt=class extends y{constructor(...e){super(...e),this.totalElements=0,this.pageSize=100,this.pageNumber=0,this.totalPages=0}updated(e){super.updated(e),(e.has(`totalElements`)||e.has(`pageSize`))&&(this.totalPages=Math.ceil(this.totalElements/this.pageSize))}dispatch(e){this.dispatchEvent(new CustomEvent(`page-changed`,{bubbles:!0,composed:!0,detail:{page:e}}))}render(){if(!this.totalElements)return _;let e=this.totalPages>1,t=this.pageNumber,n=t===0,r=t>=this.totalPages-1;return w`
+    `}};O([v()],Ht.prototype,`columns`,void 0),O([v()],Ht.prototype,`scope`,void 0),O([S()],Ht.prototype,`panelOpened`,void 0),O([S()],Ht.prototype,`revision`,void 0),Ht=O([h(`mateu-column-chooser`)],Ht);var Ut;async function Wt(e){if(!Ut)return{};try{return await Ut(e)??{}}catch(e){return console.warn(`mateu: external auth provider failed`,e),{}}}function Gt(e,t){return t?t.split(`.`).reduce((e,t)=>typeof e==`object`&&e?e[t]:void 0,e):e}function Kt(e,t,n=`value`,r=`label`){let i=Gt(e,t);return Array.isArray(i)?i.map(e=>{if(typeof e==`object`&&e){let t=Gt(e,n),i=Gt(e,r);return{value:t??i,label:String(i??t??``)}}return{value:e,label:String(e)}}):[]}function qt(e,t,n){let r=Gt(e,t);return Array.isArray(r)?r.map(e=>{let t={};for(let r of n)t[r]=Gt(e,r);return t}):[]}async function Jt(e,t=e=>e,n=fetch){let r=t(e.url)??e.url,i=(e.method||`GET`).toUpperCase(),a={};for(let[n,r]of Object.entries(e.headers??{}))a[n]=t(r)??r;Object.assign(a,await Wt({url:r,method:i}));let o={method:i,headers:a};i!==`GET`&&i!==`HEAD`&&e.body&&(o.body=t(e.body)??e.body);let s=await n(r,o);if(!s.ok)throw Error(`External REST fetch failed: ${s.status}`);return s.json()}async function Yt(e,t=e=>e,n=fetch){return Kt(await Jt(e,t,n),e.itemsPath,e.valuePath,e.labelPath)}async function Xt(e,t,n=e=>e,r=fetch){return qt(await Jt(e,n,r),e.itemsPath,t)}var Zt=class extends y{constructor(...e){super(...e),this.totalElements=0,this.pageSize=100,this.pageNumber=0,this.totalPages=0}updated(e){super.updated(e),(e.has(`totalElements`)||e.has(`pageSize`))&&(this.totalPages=Math.ceil(this.totalElements/this.pageSize))}dispatch(e){this.dispatchEvent(new CustomEvent(`page-changed`,{bubbles:!0,composed:!0,detail:{page:e}}))}render(){if(!this.totalElements)return _;let e=this.totalPages>1,t=this.pageNumber,n=t===0,r=t>=this.totalPages-1;return w`
             <div class="bar">
                 ${e?w`
                     <button class="nav" title="First page" ?disabled="${n}"
@@ -997,34 +997,34 @@ ${i}
             align-self: center;
             margin: 0 4px;
         }
-    `}};O([v()],Yt.prototype,`totalElements`,void 0),O([v()],Yt.prototype,`pageSize`,void 0),O([v()],Yt.prototype,`pageNumber`,void 0),O([S()],Yt.prototype,`totalPages`,void 0),Yt=O([h(`mateu-pagination`)],Yt);var Xt=`var(--lumo-space-m, 1rem)`,Zt=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.columnWidth||`13rem`,l=`display: grid; grid-template-columns: ${s.maxColumns&&s.maxColumns>0?`repeat(${s.maxColumns}, minmax(0, 1fr))`:`repeat(auto-fill, minmax(min(100%, ${c}), 1fr))`}; gap: ${Xt} var(--lumo-space-l, 1.5rem); align-items: start;`;return s.labelsAside&&(l+=` --mateu-label-width: 10rem;`),s.fullWidth&&(l+=` width: 100%;`),l+=t.style??``,w`
+    `}};O([v()],Zt.prototype,`totalElements`,void 0),O([v()],Zt.prototype,`pageSize`,void 0),O([v()],Zt.prototype,`pageNumber`,void 0),O([S()],Zt.prototype,`totalPages`,void 0),Zt=O([h(`mateu-pagination`)],Zt);var Qt=`var(--lumo-space-m, 1rem)`,$t=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.columnWidth||`13rem`,l=`display: grid; grid-template-columns: ${s.maxColumns&&s.maxColumns>0?`repeat(${s.maxColumns}, minmax(0, 1fr))`:`repeat(auto-fill, minmax(min(100%, ${c}), 1fr))`}; gap: ${Qt} var(--lumo-space-l, 1.5rem); align-items: start;`;return s.labelsAside&&(l+=` --mateu-label-width: 10rem;`),s.fullWidth&&(l+=` width: 100%;`),l+=t.style??``,w`
         <div style="${l}" class="${t.cssClasses}" slot="${t.slot||_}">
-            ${t.children?.map(t=>Qt(s,e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>en(s,e,t,n,r,i,a,o))}
         </div>
-    `},Qt=(e,t,n,r,i,a,o,s)=>n.type==k.ClientSide&&n.metadata?.type==A.FormRow?tn(e,t,n,r,i,a,o,s):w`<div style="grid-column: span ${$t(n)}; min-width: 0;">${e.labelsAside?en(t,n,r,i,a,o,s):P(t,n,r,i,a,o,s)}</div>`,$t=e=>{if(e.type==k.ClientSide){let t=e.metadata;if(t?.type==A.FormField)return t.colspan||1}return 1},en=(e,t,n,r,i,a,o)=>{if(t.type==k.ClientSide&&t.metadata?.type==A.FormField&&t.metadata.label){let s=t.metadata;return w`
-            <div style="display: flex; gap: ${Xt}; align-items: baseline;">
+    `},en=(e,t,n,r,i,a,o,s)=>n.type==k.ClientSide&&n.metadata?.type==A.FormRow?rn(e,t,n,r,i,a,o,s):w`<div style="grid-column: span ${tn(n)}; min-width: 0;">${e.labelsAside?nn(t,n,r,i,a,o,s):P(t,n,r,i,a,o,s)}</div>`,tn=e=>{if(e.type==k.ClientSide){let t=e.metadata;if(t?.type==A.FormField)return t.colspan||1}return 1},nn=(e,t,n,r,i,a,o)=>{if(t.type==k.ClientSide&&t.metadata?.type==A.FormField&&t.metadata.label){let s=t.metadata;return w`
+            <div style="display: flex; gap: ${Qt}; align-items: baseline;">
                 <label style="flex: 0 0 var(--mateu-label-width, 10rem); color: var(--lumo-secondary-text-color, #667);">${s.label?.includes("${")?e._evalTemplate(s.label):s.label}</label>
                 <div style="flex: 1; min-width: 0;">${P(e,t,n,r,i,a,o,!0)}</div>
             </div>
-        `}return P(e,t,n,r,i,a,o)},tn=(e,t,n,r,i,a,o,s)=>w`
-        <div style="grid-column: 1 / -1; display: flex; gap: ${Xt}; flex-wrap: wrap;">
-            ${n.children?.map(c=>w`<div style="flex: 1 1 ${100/Math.max(1,n.children.length)}%; min-width: min(100%, 13rem);">${Qt(e,t,c,r,i,a,o,s)}</div>`)}
+        `}return P(e,t,n,r,i,a,o)},rn=(e,t,n,r,i,a,o,s)=>w`
+        <div style="grid-column: 1 / -1; display: flex; gap: ${Qt}; flex-wrap: wrap;">
+            ${n.children?.map(c=>w`<div style="flex: 1 1 ${100/Math.max(1,n.children.length)}%; min-width: min(100%, 13rem);">${en(e,t,c,r,i,a,o,s)}</div>`)}
         </div>
-    `,nn=(e,t,n,r,i,a,o,s)=>{let c=n.metadata,l=`display: flex; flex-direction: ${e};`;c.spacing&&(l+=` gap: ${Xt};`),c.padding&&(l+=` padding: var(--lumo-space-m, 1rem);`),c.wrap&&(l+=` flex-wrap: wrap;`),c.fullWidth&&(l+=` width: 100%;`),c.justification&&(l+=` justify-content: ${c.justification};`);let u=e===`row`?c.verticalAlignment:c.horizontalAlignment;return u&&(l+=` align-items: ${u};`),l+=n.style??``,w`
+    `,an=(e,t,n,r,i,a,o,s)=>{let c=n.metadata,l=`display: flex; flex-direction: ${e};`;c.spacing&&(l+=` gap: ${Qt};`),c.padding&&(l+=` padding: var(--lumo-space-m, 1rem);`),c.wrap&&(l+=` flex-wrap: wrap;`),c.fullWidth&&(l+=` width: 100%;`),c.justification&&(l+=` justify-content: ${c.justification};`);let u=e===`row`?c.verticalAlignment:c.horizontalAlignment;return u&&(l+=` align-items: ${u};`),l+=n.style??``,w`
         <div style="${l}" class="${n.cssClasses}" slot="${n.slot??_}">
             ${n.children?.map(e=>P(t,e,r,i,a,o,s))}
         </div>
-    `},rn=(e,t,n,r,i,a,o)=>nn(`row`,e,t,n,r,i,a,o),an=(e,t,n,r,i,a,o)=>nn(`column`,e,t,n,r,i,a,o),on=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=`display: flex; flex-direction: ${s.orientation===`vertical`?`column`:`row`}; gap: var(--lumo-space-s, 0.5rem);`;return s.fullWidth&&(c+=` width: 100%;`),c+=t.style??``,w`
+    `},on=(e,t,n,r,i,a,o)=>an(`row`,e,t,n,r,i,a,o),sn=(e,t,n,r,i,a,o)=>an(`column`,e,t,n,r,i,a,o),cn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=`display: flex; flex-direction: ${s.orientation===`vertical`?`column`:`row`}; gap: var(--lumo-space-s, 0.5rem);`;return s.fullWidth&&(c+=` width: 100%;`),c+=t.style??``,w`
         <div style="${c}" class="${t.cssClasses}" slot="${t.slot??_}">
             <div style="flex: 1; min-width: 0; min-height: 0;">${P(e,t.children[0],n,r,i,a,o)}</div>
             <div style="flex: 1; min-width: 0; min-height: 0;">${P(e,t.children[1],n,r,i,a,o)}</div>
         </div>
-    `},sn=(e,t,n,r,i,a,o)=>{let s=t.children&&t.children.length>1?t.children[1]:null,c=i?.detailComponent??null,l=!!i?.hasDetail||!!s,u=c??s;return w`
+    `},ln=(e,t,n,r,i,a,o)=>{let s=t.children&&t.children.length>1?t.children[1]:null,c=i?.detailComponent??null,l=!!i?.hasDetail||!!s,u=c??s;return w`
         <div style="display: flex; gap: var(--lumo-space-m, 1rem); ${t.style??``}" class="${t.cssClasses}" slot="${t.slot??_}">
             <div style="flex: 1; min-width: 0;">${P(e,t.children[0],n,r,i,a,o)}</div>
             ${l&&u?w`<div style="flex: 1; min-width: 0;">${P(e,u,n,r,i,a,o)}</div>`:w`<div style="flex: 1; display: flex; align-items: center; justify-content: center; color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-s, .875rem);">Select an item to view details</div>`}
         </div>
-    `},cn=(e,t,n,r,i,a,o)=>{let s=t.style??``;t.metadata.fullWidth&&(s+=` width: 100%;`);let c=Math.max(0,(t.children??[]).findIndex(e=>e.metadata.active));return w`
+    `},un=(e,t,n,r,i,a,o)=>{let s=t.style??``;t.metadata.fullWidth&&(s+=` width: 100%;`);let c=Math.max(0,(t.children??[]).findIndex(e=>e.metadata.active));return w`
         <div style="${s}" class="${t.cssClasses}" slot="${t.slot??_}">
             ${t.children?.map((t,s)=>{let l=t,u=l.metadata.label,d=u?.includes("${")?e._evalTemplate(u):u;return w`
                     <details ?open="${s===c}" style="border-bottom: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));">
@@ -1035,42 +1035,42 @@ ${i}
                     </details>
                 `})}
         </div>
-    `},ln=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style??``;return s.fullWidth&&(c+=` width: 100%;`),w`
+    `},dn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style??``;return s.fullWidth&&(c+=` width: 100%;`),w`
         <div style="${c}" class="${t.cssClasses}" slot="${t.slot??_}">
-            ${t.children?.map(t=>un(e,t,n,r,i,a,o,s.variant))}
+            ${t.children?.map(t=>fn(e,t,n,r,i,a,o,s.variant))}
         </div>
-    `},un=(e,t,n,r,i,a,o,s)=>{let c=t.metadata,l=c.label?.includes("${")?e._evalTemplate(c.label):c.label;return w`
+    `},fn=(e,t,n,r,i,a,o,s)=>{let c=t.metadata,l=c.label?.includes("${")?e._evalTemplate(c.label):c.label;return w`
         <details ?open="${c.active}" style="border-bottom: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1)); ${t.style??``}" class="${t.cssClasses}">
             <summary style="cursor: pointer; padding: var(--lumo-space-s, .5rem) 0; font-weight: 600; ${c.disabled?`pointer-events: none; opacity: .5;`:``}">${l}</summary>
             <div style="padding: var(--lumo-space-s, .5rem) 0;">
                 ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
             </div>
         </details>
-    `},dn=(e,t,n,r,i,a,o)=>w`
+    `},pn=(e,t,n,r,i,a,o)=>w`
         <div style="overflow: auto; ${t.style??``}" class="${t.cssClasses}" slot="${t.slot??_}">
             ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `,fn=(e,t,n,r,i,a,o)=>w`
+    `,mn=(e,t,n,r,i,a,o)=>w`
         <div style="width: 100%; ${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
             ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `,pn=(e,t,n,r,i,a,o)=>w`
+    `,hn=(e,t,n,r,i,a,o)=>w`
         <div style="max-width: min(100%, 1200px); margin: auto; ${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
             ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `,mn=(e,t,n,r,i,a,o)=>w`
-        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr)); gap: ${Xt}; ${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
-            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
-        </div>
-    `,hn=(e,t,n,r,i,a,o)=>w`
-        <div style="display: flex; gap: ${Xt}; flex-wrap: wrap; ${t.style}" class="${t.cssClasses}">
-            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
-        </div>
     `,gn=(e,t,n,r,i,a,o)=>w`
+        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr)); gap: ${Qt}; ${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
+        </div>
+    `,_n=(e,t,n,r,i,a,o)=>w`
+        <div style="display: flex; gap: ${Qt}; flex-wrap: wrap; ${t.style}" class="${t.cssClasses}">
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
+        </div>
+    `,vn=(e,t,n,r,i,a,o)=>w`
         <div style="flex: ${t.metadata.boardCols??1} 1 0; min-width: min(100%, 12rem); ${t.style}" class="${t.cssClasses}">
             ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `,_n=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+    `,yn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <div
                 style="display: flex; flex-direction: column; overflow: auto; ${t.style}"
                 class="${t.cssClasses}"
@@ -1078,16 +1078,16 @@ ${i}
         >
             ${s.page.content.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `},vn=e=>{let t=e.metadata;return(t?.content??t?.columns??[]).filter(e=>e&&e.metadata).map(e=>{let t=e.metadata;return{id:e.id??``,label:t?.label??e.id??``,autoWidth:t?.autoWidth,width:t?.width}})},yn=(e,t)=>{let n=e?.[t];return n==null?``:typeof n==`object`?n.text??n.label??n.value??``:String(n)},bn=(e,t,n)=>{let r=vn(e);return w`
+    `},bn=e=>{let t=e.metadata;return(t?.content??t?.columns??[]).filter(e=>e&&e.metadata).map(e=>{let t=e.metadata;return{id:e.id??``,label:t?.label??e.id??``,autoWidth:t?.autoWidth,width:t?.width}})},xn=(e,t)=>{let n=e?.[t];return n==null?``:typeof n==`object`?n.text??n.label??n.value??``:String(n)},Sn=(e,t,n)=>{let r=bn(e);return w`
         <div style="overflow:auto; width:100%; ${e.style}" class="${e.cssClasses}" slot="${e.slot??_}">
             <table style="border-collapse:collapse; width:100%; font-size: var(--lumo-font-size-s,.875rem);">
                 <thead><tr>${r.map(e=>w`<th style="${`text-align:left; padding:.45rem .6rem; border-bottom:2px solid var(--lumo-contrast-20pct,rgba(0,0,0,.2)); font-weight:600; white-space:nowrap; color: var(--lumo-secondary-text-color,#556);`}">${e.label}</th>`)}</tr></thead>
                 <tbody>
-                    ${(t??[]).length===0?w`<tr><td colspan="${Math.max(1,r.length)}" style="padding:1.5rem; text-align:center; color: var(--lumo-secondary-text-color,#888);">${n??`No data.`}</td></tr>`:t.map(e=>w`<tr>${r.map(t=>w`<td style="${`padding:.4rem .6rem; border-bottom:1px solid var(--lumo-contrast-10pct,rgba(0,0,0,.08)); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:24rem;`}" title="${yn(e,t.id)}">${yn(e,t.id)}</td>`)}</tr>`)}
+                    ${(t??[]).length===0?w`<tr><td colspan="${Math.max(1,r.length)}" style="padding:1.5rem; text-align:center; color: var(--lumo-secondary-text-color,#888);">${n??`No data.`}</td></tr>`:t.map(e=>w`<tr>${r.map(t=>w`<td style="${`padding:.4rem .6rem; border-bottom:1px solid var(--lumo-contrast-10pct,rgba(0,0,0,.08)); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:24rem;`}" title="${xn(e,t.id)}">${xn(e,t.id)}</td>`)}</tr>`)}
                 </tbody>
             </table>
         </div>
-    `},xn=(e,t)=>{let n=e.metadata;return e.id&&t&&t[e.id]?t[e.id]:n?.page?.content??[]},Sn=e=>{let t=e.metadata.items??[];return w`
+    `},Cn=(e,t)=>{let n=e.metadata;return e.id&&t&&t[e.id]?t[e.id]:n?.page?.content??[]},wn=e=>{let t=e.metadata.items??[];return w`
         <div class="mateu-message-list ${e.cssClasses??``}"
              style="display:flex; flex-direction:column; gap:.75rem; ${e.style??``}"
              slot="${e.slot??_}">
@@ -1106,7 +1106,7 @@ ${i}
                 </div>
             `)}
         </div>
-    `},Cn=(e,t,n,r,i,a,o)=>t.separator?w`<span style="align-self: stretch; width: 1px; background: var(--lumo-contrast-20pct, rgba(0,0,0,.2));"></span>`:t.submenus?w`
+    `},Tn=(e,t,n,r,i,a,o)=>t.separator?w`<span style="align-self: stretch; width: 1px; background: var(--lumo-contrast-20pct, rgba(0,0,0,.2));"></span>`:t.submenus?w`
             <details style="position: relative;">
                 <summary style="cursor: pointer; list-style: none; padding: .35rem .7rem; border-radius: var(--lumo-border-radius-m, 6px);">
                     ${t.component?P(e,t.component,n,r,i,a,o):t.label} ▾
@@ -1114,7 +1114,7 @@ ${i}
                 <div style="display: flex; flex-direction: column; gap: .1rem; padding: .3rem; min-width: 10rem;
                             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1)); border-radius: var(--lumo-border-radius-m, 6px);
                             background: var(--lumo-base-color, #fff); box-shadow: var(--lumo-box-shadow-s, 0 2px 8px rgba(0,0,0,.15));">
-                    ${t.submenus.map(t=>Cn(e,t,n,r,i,a,o))}
+                    ${t.submenus.map(t=>Tn(e,t,n,r,i,a,o))}
                 </div>
             </details>
         `:w`
@@ -1124,16 +1124,16 @@ ${i}
                      ${t.selected?`background: var(--lumo-primary-color-10pct, rgba(26,115,232,.12));`:``}">
             ${t.component?P(e,t.component,n,r,i,a,o):t.label}
         </span>
-    `,wn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+    `,En=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <div style="display: flex; flex-wrap: wrap; gap: .25rem; align-items: center; ${t.style}"
              class="${t.cssClasses}" slot="${t.slot??_}">
-            ${s.options?.map(t=>Cn(e,t,n,r,i,a??{},o??{}))}
+            ${s.options?.map(t=>Tn(e,t,n,r,i,a??{},o??{}))}
         </div>
-    `},Tn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+    `},Dn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <div style="${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
             ${P(e,s.wrapped,n,r,i,a,o)}
         </div>
-    `},En=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.content?.metadata,l=c?.type==A.Notice&&c.fullWidth===!0;return w`
+    `},On=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.content?.metadata,l=c?.type==A.Notice&&c.fullWidth===!0;return w`
         <div style="display:flex; flex-direction:column; ${l?`width: 100%; `:``}${t.style}"
              class="${t.cssClasses}"
              slot="${t.slot??_}"
@@ -1142,7 +1142,7 @@ ${i}
             ${s.label?w`<label style="font-size: var(--lumo-font-size-s,.875rem); color: var(--lumo-secondary-text-color,#667); margin-bottom:.15rem;">${s.label}</label>`:_}
             ${P(e,s.content,n,r,i,a,o)}
         </div>
-            `},Dn=e=>{let t=e.metadata,n=e=>{let n=e.closest(`.mateu-message-input`)?.querySelector(`input`),r=n?.value??``;!t.actionId||!r.trim()||(e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:{message:r}},bubbles:!0,composed:!0})),n&&(n.value=``))};return w`
+            `},kn=e=>{let t=e.metadata,n=e=>{let n=e.closest(`.mateu-message-input`)?.querySelector(`input`),r=n?.value??``;!t.actionId||!r.trim()||(e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:{message:r}},bubbles:!0,composed:!0})),n&&(n.value=``))};return w`
         <div class="mateu-message-input ${e.cssClasses??``}"
              style="display:flex; gap:.5rem; align-items:center; ${e.style??``}"
              slot="${e.slot??_}">
@@ -1152,62 +1152,62 @@ ${i}
             <button style="font:inherit; font-weight:500; cursor:pointer; padding:.5rem 1rem; border:none; border-radius:var(--lumo-border-radius-m,6px); background:var(--lumo-primary-color,#3b5bdb); color:var(--lumo-primary-contrast-color,#fff);"
                     @click="${e=>n(e.currentTarget)}">Send</button>
         </div>
-    `},On=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`<span title="${s.text}" style="${t.style}" class="${t.cssClasses}" slot="${t.slot??_}"
-        >${P(e,s.wrapped,n,r,i,a,o)}</span>`},kn=e=>{if(e instanceof CustomEvent)return e.detail;let t={};for(let n in e){let r=e[n];[`number`,`string`,`boolean`].indexOf(typeof r)>=0&&(t[n]=e[n])}return t},An=(e,t,n)=>{for(let n in t.attributes)e.setAttribute(n,t.attributes[n]);n.style&&e.setAttribute(`style`,n.style),n.cssClasses&&e.setAttribute(`class`,n.cssClasses),n.slot&&e.setAttribute(`slot`,n.slot),t.content&&(t.html?e.innerHTML=t.content:e.append(t.content))},jn=e=>{let t=e.name,n=e.attributes?e.attributes.import:void 0;n&&t.includes(`-`)&&!customElements.get(t)&&E(()=>import(n),[])},Mn=(e,t,n)=>{jn(t);let r=t.name;return t.attributes&&t.attributes.id&&(r=`#`+t.attributes.id),setTimeout(()=>{let i=e.shadowRoot?.querySelector(`.element-container`)?.querySelector(r);if(i){for(;i.firstChild;)i.removeChild(i.lastChild);An(i,t,n)}else{let r=document.createElement(t.name);An(r,t,n);for(let n in t.on)r.addEventListener(n,r=>{let i=kn(r);e.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.on[n],parameters:{event:i}},bubbles:!0,composed:!0}))});e.shadowRoot?.querySelector(`.element-container`)?.appendChild(r)}}),w`<div class="element-container"></div>`},Nn=function(e){return e.div=`div`,e.p=`p`,e.h1=`h1`,e.h2=`h2`,e.h3=`h3`,e.h4=`h4`,e.h5=`h5`,e.h6=`h6`,e.span=`span`,e}({}),Pn=(e,t,n,r,i)=>{let a=e.metadata,o=a.attributes?.[`data-colspan`],s=it(a.text,t,n,r,i),c={xl:`var(--lumo-font-size-xl, 1.375rem)`,l:`var(--lumo-font-size-l, 1.125rem)`,s:`var(--lumo-font-size-s, .875rem)`,xs:`var(--lumo-font-size-xs, .8125rem)`},l=(a.size&&c[a.size]?`font-size: ${c[a.size]}; `:``)+(a.noMargins?`margin-block-start: 0; margin-block-end: 0; `:``);return Nn.h1==a.container?w`
+    `},An=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`<span title="${s.text}" style="${t.style}" class="${t.cssClasses}" slot="${t.slot??_}"
+        >${P(e,s.wrapped,n,r,i,a,o)}</span>`},jn=e=>{if(e instanceof CustomEvent)return e.detail;let t={};for(let n in e){let r=e[n];[`number`,`string`,`boolean`].indexOf(typeof r)>=0&&(t[n]=e[n])}return t},Mn=(e,t,n)=>{for(let n in t.attributes)e.setAttribute(n,t.attributes[n]);n.style&&e.setAttribute(`style`,n.style),n.cssClasses&&e.setAttribute(`class`,n.cssClasses),n.slot&&e.setAttribute(`slot`,n.slot),t.content&&(t.html?e.innerHTML=t.content:e.append(t.content))},Nn=e=>{let t=e.name,n=e.attributes?e.attributes.import:void 0;n&&t.includes(`-`)&&!customElements.get(t)&&E(()=>import(n),[])},Pn=(e,t,n)=>{Nn(t);let r=t.name;return t.attributes&&t.attributes.id&&(r=`#`+t.attributes.id),setTimeout(()=>{let i=e.shadowRoot?.querySelector(`.element-container`)?.querySelector(r);if(i){for(;i.firstChild;)i.removeChild(i.lastChild);Mn(i,t,n)}else{let r=document.createElement(t.name);Mn(r,t,n);for(let n in t.on)r.addEventListener(n,r=>{let i=jn(r);e.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.on[n],parameters:{event:i}},bubbles:!0,composed:!0}))});e.shadowRoot?.querySelector(`.element-container`)?.appendChild(r)}}),w`<div class="element-container"></div>`},Fn=function(e){return e.div=`div`,e.p=`p`,e.h1=`h1`,e.h2=`h2`,e.h3=`h3`,e.h4=`h4`,e.h5=`h5`,e.h6=`h6`,e.span=`span`,e}({}),In=(e,t,n,r,i)=>{let a=e.metadata,o=a.attributes?.[`data-colspan`],s=it(a.text,t,n,r,i),c={xl:`var(--lumo-font-size-xl, 1.375rem)`,l:`var(--lumo-font-size-l, 1.125rem)`,s:`var(--lumo-font-size-s, .875rem)`,xs:`var(--lumo-font-size-xs, .8125rem)`},l=(a.size&&c[a.size]?`font-size: ${c[a.size]}; `:``)+(a.noMargins?`margin-block-start: 0; margin-block-end: 0; `:``);return Fn.h1==a.container?w`
             <h1 style="${l}${e.style}" class="${e.cssClasses}"
                 id="${x(e.id)}"
                 data-colspan="${x(o)}"
                 slot="${e.slot??_}">
                 ${s??_}
             </h1>
-        `:Nn.h2==a.container?w`
+        `:Fn.h2==a.container?w`
             <h2 style="${l}${e.style}" class="${e.cssClasses}"
                 id="${x(e.id)}"
                 data-colspan="${x(o)}"
                 slot="${e.slot??_}">
                 ${s??_}
             </h2>
-        `:Nn.h3==a.container?w`
+        `:Fn.h3==a.container?w`
             <h3 style="${l}${e.style}" class="${e.cssClasses}"
                 id="${x(e.id)}"
                 data-colspan="${x(o)}"
                 slot="${e.slot??_}">
                 ${s??_}
             </h3>
-        `:Nn.h4==a.container?w`
+        `:Fn.h4==a.container?w`
             <h4 style="${l}${e.style}" class="${e.cssClasses}"
                 id="${x(e.id)}"
                 data-colspan="${x(o)}"
                 slot="${e.slot??_}">
                 ${s??_}
             </h4>
-        `:Nn.h5==a.container?w`
+        `:Fn.h5==a.container?w`
             <h5 style="${l}${e.style}" class="${e.cssClasses}"
                 id="${x(e.id)}"
                 data-colspan="${x(o)}"
                 slot="${e.slot??_}">
                 ${s??_}
             </h5>
-        `:Nn.h6==a.container?w`
+        `:Fn.h6==a.container?w`
             <h6 style="${l}${e.style}" class="${e.cssClasses}"
                 id="${x(e.id)}"
                 data-colspan="${x(o)}"
                 slot="${e.slot??_}">
                 ${s??_}
             </h6>
-        `:Nn.p==a.container?w`
+        `:Fn.p==a.container?w`
                <p style="${l}${e.style}" class="${e.cssClasses}"
                   id="${x(e.id)}"
                   data-colspan="${x(o)}"
                   slot="${e.slot??_}">
                    ${s??_}
                </p>
-            `:Nn.div==a.container?w`
+            `:Fn.div==a.container?w`
                <div style="${l}${e.style}" class="${e.cssClasses}"
                     id="${x(e.id)}"
                     data-colspan="${x(o)}"
                     slot="${e.slot??_}">${s?g(s):_}</div>
-            `:Nn.span==a.container?w`
+            `:Fn.span==a.container?w`
                <span style="${l}${e.style}" class="${e.cssClasses}"
                      id="${x(e.id)}"
                      data-colspan="${x(o)}"
@@ -1219,20 +1219,20 @@ ${i}
                        slot="${e.slot??_}">
                    Unknown text container: ${a.container} 
                </p>
-            `},Fn=e=>{let t=e.metadata;return w`<a href="${t.url}" target="${t.target??_}"
+            `},Ln=e=>{let t=e.metadata;return w`<a href="${t.url}" target="${t.target??_}"
                    rel="${t.target===`_blank`?`noopener`:_}"
                    style="${e.style}" class="${e.cssClasses}"
-                   slot="${e.slot??_}">${t.text}</a>`},In=(e,t)=>{let n=e.toLowerCase().split(`+`);return t.ctrlKey===n.includes(`ctrl`)&&t.altKey===n.includes(`alt`)&&t.shiftKey===n.includes(`shift`)&&t.metaKey===n.includes(`meta`)},Ln=(e,t)=>{if(!In(e,t))return!1;let n=e.toLowerCase().split(`+`),r=n[n.length-1];return!!(t.key.toLowerCase()===r||/^[a-z]$/.test(r)&&t.code===`Key`+r.toUpperCase()||/^[0-9]$/.test(r)&&(t.code===`Digit`+r||t.code===`Numpad`+r))},Rn=e=>e?e.split(`+`).map(e=>e.length<=1?e.toUpperCase():e.charAt(0).toUpperCase()+e.slice(1)).join(`+`):void 0,zn=(e,t)=>{let n=e.currentTarget.dataset.actionId;e.currentTarget?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:n,parameters:t.parameters},bubbles:!0,composed:!0}))},Bn=`display:inline-flex; align-items:center; justify-content:center; gap:.4em; box-sizing:border-box; font:inherit; font-weight:500; cursor:pointer; border-radius:var(--lumo-border-radius-m,6px); border:1px solid transparent; line-height:1; white-space:nowrap;`,Vn=e=>{let t=e.buttonStyle??``,n=e.color&&e.color!==`none`&&e.color!==`normal`?e.color:``,r=e.size,i=n===`success`?`var(--lumo-success-color,#1a7f37)`:n===`error`?`var(--lumo-error-color,#c5221f)`:n===`contrast`?`var(--lumo-contrast,#161513)`:`var(--lumo-primary-color,#3b5bdb)`,a=n===`success`?`var(--lumo-success-contrast-color,#fff)`:n===`error`?`var(--lumo-error-contrast-color,#fff)`:n===`contrast`?`var(--lumo-base-color,#fff)`:`var(--lumo-primary-contrast-color,#fff)`,o=n===`success`?`var(--lumo-success-text-color,#1a7f37)`:n===`error`?`var(--lumo-error-text-color,#c5221f)`:n===`contrast`?`var(--lumo-body-text-color,#161513)`:`var(--lumo-primary-text-color,#3b5bdb)`,s;return s=t===`primary`?`background:${i}; color:${a};`:t===`tertiary`||t===`tertiaryInline`?`background:transparent; color:${o};`:`background:var(--lumo-contrast-5pct,rgba(0,0,0,.04)); color:${o}; border-color:var(--lumo-contrast-20pct,rgba(0,0,0,.16));`,`${Bn}${s}${r===`small`?`padding:.25rem .6rem; font-size:var(--lumo-font-size-s,.875rem);`:r===`large`?`padding:.65rem 1.4rem; font-size:var(--lumo-font-size-l,1.125rem);`:`padding:.45rem 1rem; font-size:var(--lumo-font-size-m,1rem);`}`},Hn=(e,t,n)=>{let r=e.metadata,i=j(r.label,t,n);return w`<button
+                   slot="${e.slot??_}">${t.text}</a>`},Rn=(e,t)=>{let n=e.toLowerCase().split(`+`);return t.ctrlKey===n.includes(`ctrl`)&&t.altKey===n.includes(`alt`)&&t.shiftKey===n.includes(`shift`)&&t.metaKey===n.includes(`meta`)},zn=(e,t)=>{if(!Rn(e,t))return!1;let n=e.toLowerCase().split(`+`),r=n[n.length-1];return!!(t.key.toLowerCase()===r||/^[a-z]$/.test(r)&&t.code===`Key`+r.toUpperCase()||/^[0-9]$/.test(r)&&(t.code===`Digit`+r||t.code===`Numpad`+r))},Bn=e=>e?e.split(`+`).map(e=>e.length<=1?e.toUpperCase():e.charAt(0).toUpperCase()+e.slice(1)).join(`+`):void 0,Vn=(e,t)=>{let n=e.currentTarget.dataset.actionId;e.currentTarget?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:n,parameters:t.parameters},bubbles:!0,composed:!0}))},Hn=`display:inline-flex; align-items:center; justify-content:center; gap:.4em; box-sizing:border-box; font:inherit; font-weight:500; cursor:pointer; border-radius:var(--lumo-border-radius-m,6px); border:1px solid transparent; line-height:1; white-space:nowrap;`,Un=e=>{let t=e.buttonStyle??``,n=e.color&&e.color!==`none`&&e.color!==`normal`?e.color:``,r=e.size,i=n===`success`?`var(--lumo-success-color,#1a7f37)`:n===`error`?`var(--lumo-error-color,#c5221f)`:n===`contrast`?`var(--lumo-contrast,#161513)`:`var(--lumo-primary-color,#3b5bdb)`,a=n===`success`?`var(--lumo-success-contrast-color,#fff)`:n===`error`?`var(--lumo-error-contrast-color,#fff)`:n===`contrast`?`var(--lumo-base-color,#fff)`:`var(--lumo-primary-contrast-color,#fff)`,o=n===`success`?`var(--lumo-success-text-color,#1a7f37)`:n===`error`?`var(--lumo-error-text-color,#c5221f)`:n===`contrast`?`var(--lumo-body-text-color,#161513)`:`var(--lumo-primary-text-color,#3b5bdb)`,s;return s=t===`primary`?`background:${i}; color:${a};`:t===`tertiary`||t===`tertiaryInline`?`background:transparent; color:${o};`:`background:var(--lumo-contrast-5pct,rgba(0,0,0,.04)); color:${o}; border-color:var(--lumo-contrast-20pct,rgba(0,0,0,.16));`,`${Hn}${s}${r===`small`?`padding:.25rem .6rem; font-size:var(--lumo-font-size-s,.875rem);`:r===`large`?`padding:.65rem 1.4rem; font-size:var(--lumo-font-size-l,1.125rem);`:`padding:.45rem 1rem; font-size:var(--lumo-font-size-m,1rem);`}`},Wn=(e,t,n)=>{let r=e.metadata,i=j(r.label,t,n);return w`<button
             id="${e.id}"
             data-action-id="${r.actionId}"
-            @click="${e=>zn(e,r)}"
-            style="${Vn(r)}${e.style}"
+            @click="${e=>Vn(e,r)}"
+            style="${Un(r)}${e.style}"
             class="${e.cssClasses}"
             ?disabled="${r.disabled}"
-            title="${r.shortcut?`${i} (${Rn(r.shortcut)})`:_}"
+            title="${r.shortcut?`${i} (${Bn(r.shortcut)})`:_}"
             slot="${e.slot??_}"
-    >${r.iconOnLeft?F(r.iconOnLeft):_}${i}${r.iconOnRight?F(r.iconOnRight):_}</button>`},Un=`display:block; box-sizing:border-box; background:var(--lumo-base-color,#fff); border:1px solid var(--lumo-contrast-10pct,rgba(0,0,0,.1)); border-radius:var(--lumo-border-radius-l,12px); box-shadow:var(--lumo-box-shadow-xs,0 1px 3px rgba(0,0,0,.08)); overflow:hidden;`,Wn=(e,t,n,r,i,a,o)=>{let s=t.metadata;if(!s)return w``;let c=t=>t?P(e,t,n,r,i,a,o,!1):_,l=s.header||s.headerPrefix||s.headerSuffix||s.title||s.subtitle;return w`
-        <div style="${Un}${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
+    >${r.iconOnLeft?F(r.iconOnLeft):_}${i}${r.iconOnRight?F(r.iconOnRight):_}</button>`},Gn=`display:block; box-sizing:border-box; background:var(--lumo-base-color,#fff); border:1px solid var(--lumo-contrast-10pct,rgba(0,0,0,.1)); border-radius:var(--lumo-border-radius-l,12px); box-shadow:var(--lumo-box-shadow-xs,0 1px 3px rgba(0,0,0,.08)); overflow:hidden;`,Kn=(e,t,n,r,i,a,o)=>{let s=t.metadata;if(!s)return w``;let c=t=>t?P(e,t,n,r,i,a,o,!1):_,l=s.header||s.headerPrefix||s.headerSuffix||s.title||s.subtitle;return w`
+        <div style="${Gn}${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
             ${s.media?c(s.media):_}
             ${l?w`<div style="display:flex; align-items:flex-start; gap:.75rem; padding:1rem 1.25rem ${s.content||s.footer?`0`:`1rem`};">
                 ${s.headerPrefix?c(s.headerPrefix):_}
@@ -1246,7 +1246,7 @@ ${i}
             ${s.content?w`<div style="padding:1rem 1.25rem;">${c(s.content)}</div>`:_}
             ${s.footer?w`<div style="padding:0 1.25rem 1rem;">${c(s.footer)}</div>`:_}
         </div>
-    `},Gn=e=>{let t=e.metadata;return w`
+    `},qn=e=>{let t=e.metadata;return w`
         <mateu-chart 
                 style="${e.style}" 
                 class="${e.cssClasses}"
@@ -1256,7 +1256,7 @@ ${i}
                 .options="${t.chartOptions}"
         >
         </mateu-chart>
-    `},Kn=e=>{let t=e.metadata;return F(t.icon,e.style,e.cssClasses,e.slot)},qn=(e,t)=>{e&&e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},Jn=`font:inherit; font-weight:500; cursor:pointer; padding:.45rem 1rem; border-radius:var(--lumo-border-radius-m,6px);`,Yn=`${Jn} background:var(--lumo-contrast-5pct,rgba(0,0,0,.04)); color:var(--lumo-body-text-color,#161513); border:1px solid var(--lumo-contrast-20pct,rgba(0,0,0,.16));`,Xn=`${Jn} background:var(--lumo-primary-color,#3b5bdb); color:var(--lumo-primary-contrast-color,#fff); border:1px solid transparent;`,Zn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!1;if(s.openedCondition)try{c=at(s.openedCondition,r,i,a,o)}catch(e){console.error(`when evaluating `+s.openedCondition+` :`+e+`, where data is `+i+` and state is `+r)}return c?w`
+    `},Jn=e=>{let t=e.metadata;return F(t.icon,e.style,e.cssClasses,e.slot)},Yn=(e,t)=>{e&&e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},Xn=`font:inherit; font-weight:500; cursor:pointer; padding:.45rem 1rem; border-radius:var(--lumo-border-radius-m,6px);`,Zn=`${Xn} background:var(--lumo-contrast-5pct,rgba(0,0,0,.04)); color:var(--lumo-body-text-color,#161513); border:1px solid var(--lumo-contrast-20pct,rgba(0,0,0,.16));`,Qn=`${Xn} background:var(--lumo-primary-color,#3b5bdb); color:var(--lumo-primary-contrast-color,#fff); border:1px solid transparent;`,$n=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!1;if(s.openedCondition)try{c=at(s.openedCondition,r,i,a,o)}catch(e){console.error(`when evaluating `+s.openedCondition+` :`+e+`, where data is `+i+` and state is `+r)}return c?w`
         <div class="mateu-confirm-dialog ${t.cssClasses??``}"
              style="position:fixed; inset:0; z-index:1000; display:flex; align-items:center; justify-content:center; background:rgba(0,0,0,.4); ${t.style??``}"
              slot="${t.slot??_}">
@@ -1264,13 +1264,13 @@ ${i}
                 ${s.header?w`<h3 style="margin:0 0 .75rem; font-size:1.15rem;">${s.header}</h3>`:_}
                 <div>${t.children?.map(t=>P(e,t,n,r,i,a,o))}</div>
                 <div style="display:flex; gap:.5rem; justify-content:flex-end; margin-top:1.25rem;">
-                    ${s.canCancel?w`<button style="${Yn}" @click="${e=>qn(e.currentTarget,s.cancelActionId)}">${s.rejectText&&!s.canReject?s.rejectText:`Cancel`}</button>`:_}
-                    ${s.canReject?w`<button style="${Yn}" @click="${e=>qn(e.currentTarget,s.rejectActionId)}">${s.rejectText||`No`}</button>`:_}
-                    <button style="${Xn}" @click="${e=>qn(e.currentTarget,s.confirmActionId)}">${s.confirmText||`OK`}</button>
+                    ${s.canCancel?w`<button style="${Zn}" @click="${e=>Yn(e.currentTarget,s.cancelActionId)}">${s.rejectText&&!s.canReject?s.rejectText:`Cancel`}</button>`:_}
+                    ${s.canReject?w`<button style="${Zn}" @click="${e=>Yn(e.currentTarget,s.rejectActionId)}">${s.rejectText||`No`}</button>`:_}
+                    <button style="${Qn}" @click="${e=>Yn(e.currentTarget,s.confirmActionId)}">${s.confirmText||`OK`}</button>
                 </div>
             </div>
         </div>
-    `:w``},Qn=e=>{let t=e.metadata,n;return t.position&&(n={Top:`top`,Bottom:`bottom`,TopLeft:`top-left`,TopRight:`top-right`,BottomLeft:`bottom-left`,BottomRight:`bottom-right`}[t.position]),w`
+    `:w``},er=e=>{let t=e.metadata,n;return t.position&&(n={Top:`top`,Bottom:`bottom`,TopLeft:`top-left`,TopRight:`top-right`,BottomLeft:`bottom-left`,BottomRight:`bottom-right`}[t.position]),w`
         <mateu-cookie-consent style="${e.style}" class="${e.cssClasses}"
                                slot="${e.slot??_}"
                                position="${n??_}"
@@ -1281,7 +1281,7 @@ ${i}
                                .learnMoreLink="${t.learnMoreLink??_}"
                                .dismiss="${t.dismiss??_}"
         ></mateu-cookie-consent>
-    `},$n=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+    `},tr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <details
                 ?open="${s.opened}"
                 style="${t.style}"
@@ -1291,7 +1291,7 @@ ${i}
             <summary>${P(e,s.summary,n,r,i,a,o)}</summary>
             ${P(e,s.content,n,r,i,a,o)}
         </details>
-            `},er=(e,t,n,r,i,a)=>w`
+            `},nr=(e,t,n,r,i,a)=>w`
         <mateu-dialog
                 id="${e.metadata.id}"
             .component="${e}"
@@ -1301,7 +1301,7 @@ ${i}
             .appState="${i}"
             .appdata="${a}"
         ></mateu-dialog>
-            `,tr=(e,t,n,r,i,a)=>w`
+            `,rr=(e,t,n,r,i,a)=>w`
         <mateu-drawer
                 id="${e.metadata.id}"
             .component="${e}"
@@ -1311,7 +1311,7 @@ ${i}
             .appState="${i}"
             .appdata="${a}"
         ></mateu-drawer>
-            `,nr=e=>{let t=e.metadata;return w`
+            `,ir=e=>{let t=e.metadata;return w`
         <mateu-api-caller>
         <mateu-ux baseUrl="${t.baseUrl}"  
                   route="${t.route}" 
@@ -1323,11 +1323,11 @@ ${i}
                   slot="${e.slot??_}"
         ></mateu-ux>
         </mateu-api-caller>
-            `},rr=e=>w`
+            `},ar=e=>w`
         <mateu-markdown .content=${e.metadata.markdown}
                         style="${e.style}" class="${e.cssClasses}"
                         slot="${e.slot??_}"></mateu-markdown>
-            `,ir=e=>{let t=e.metadata;return w`
+            `,or=e=>{let t=e.metadata;return w`
         <div
             role="status"
             slot="${e.slot??_}"
@@ -1340,7 +1340,7 @@ ${i}
             ${t.title?w`<strong>${t.title}</strong>`:_}
             ${t.text?w`<span>${t.text}</span>`:_}
         </div>
-    `},ar=(e,t={})=>{let n=e.metadata,r=n.valueKey?t[n.valueKey]:n.value,i=n.max&&n.max!=0?n.max:1,a=!n.indeterminate&&r!=null;return w`
+    `},sr=(e,t={})=>{let n=e.metadata,r=n.valueKey?t[n.valueKey]:n.value,i=n.max&&n.max!=0?n.max:1,a=!n.indeterminate&&r!=null;return w`
         <div style="${e.style}" class="${e.cssClasses}" slot="${e.slot??_}">
             <progress
                     style="width:100%;"
@@ -1351,7 +1351,7 @@ ${i}
     ${n.text}
   </span>`:_}
         </div>
-    `},or=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+    `},cr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <details style="position: relative; ${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
             <summary style="list-style: none; cursor: pointer;">${P(e,s.wrapped,n,r,i,a,o)}</summary>
             <div style="position: absolute; z-index: 100; min-width: 300px; margin-top: .25rem; padding: .6rem .8rem;
@@ -1360,20 +1360,20 @@ ${i}
                 ${P(e,s.content,n,r,i,a,o)}
             </div>
         </details>
-    `},sr=e=>{let t=e.metadata;return w`
+    `},lr=e=>{let t=e.metadata;return w`
         <mateu-map position="${t.position}" zoom="${t.zoom}"
                    style="${e.style}" class="${e.cssClasses}"
                    slot="${e.slot??_}"></mateu-map>
-            `},cr=e=>w`
+            `},ur=e=>w`
         <img src="${e.metadata.src}" style="${e.style}" class="${e.cssClasses}"
              slot="${e.slot??_}">
-            `,lr=e=>{let t=e.metadata;return w`<div style="display:flex; align-items:center; gap:0.5rem;" slot="${e.slot??_}">
+            `,dr=e=>{let t=e.metadata;return w`<div style="display:flex; align-items:center; gap:0.5rem;" slot="${e.slot??_}">
         ${t.breadcrumbs.map(e=>w`
             <a href="${e.link}">${e.text}</a>
             <span>/</span>
         `)}
         <span style="${e.style}" class="${e.cssClasses}">${t.currentItemText}</span>
-    </div>`},ur=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+    </div>`},fr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <skeleton-carousel 
                 id="${t.id}"
                 ?dots = "${s.dots}" 
@@ -1384,26 +1384,26 @@ ${i}
         >
             ${t.children?.map(t=>w`<div>${P(e,t,n,r,i,a,o)}</div>`)}
         </skeleton-carousel>
-    `},dr=(e,t,n,r)=>{let i=e.metadata;return w`
+    `},pr=(e,t,n,r)=>{let i=e.metadata;return w`
         <div style="display: flex; gap: 3rem; ${e.style}" class="${e.cssClasses}" slot="${e.slot??_}">
-            ${i.menu.map(e=>fr(e))}
+            ${i.menu.map(e=>mr(e))}
         </div>
-            `},fr=e=>w`
+            `},mr=e=>w`
         ${e.submenus?w`
                 <details open>
                     <summary>${e.label}</summary>
                     <div style="display:flex; flex-direction:column; gap:0.25rem; padding-left:0.5rem;">
-                        ${e.submenus.map(e=>fr(e))}
+                        ${e.submenus.map(e=>mr(e))}
                     </div>
                 </details>
             `:w`
                 <a href="${e.path}">${e.label}</a>
         `}
-        `,pr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`<div
+        `,hr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`<div
                 slot="${t.slot??_}"
                 style="${t.style}" class="${t.cssClasses}"
         >${s.content?g(s.content):_}${t.children?.map(t=>P(e,t,n,r,i,a,o))}</div>
-    `},mr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.title?.includes("${")?e._evalTemplate(s.title):s.title;return w`<div
+    `},gr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.title?.includes("${")?e._evalTemplate(s.title):s.title;return w`<div
                 slot="${t.slot??_}"
                 style="width: 100%; margin-bottom: var(--lumo-space-m); ${t.style}"
                 class="${t.cssClasses}"
@@ -1411,24 +1411,24 @@ ${i}
         ${c?w`<div style="font-size: var(--lumo-font-size-l); font-weight: 600; color: var(--lumo-header-text-color); margin-bottom: var(--lumo-space-s);">${c}</div>`:_}
         ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
     </div>
-    `},hr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.title?.includes("${")?e._evalTemplate(s.title):s.title;return w`
+    `},_r=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.title?.includes("${")?e._evalTemplate(s.title):s.title;return w`
         <div
                 slot="${t.slot??_}"
                 style="${t.style}" class="${t.cssClasses}"
         >
         <h4>${c}</h4>
         ${t.children?.map(t=>P(e,t,n,r,i,a,o))}</div>
-    `},gr=(e,t,n)=>{n.dispatchEvent(new CustomEvent(`value-changed`,{detail:{fieldId:e,value:t},bubbles:!0,composed:!0}))},_r=e=>t=>{let n=t.target,r=n.type===`checkbox`?n.checked:n.value;gr(e.fieldId,r,n)},vr=(e,t)=>{let n=e.metadata,r=t?.[n.fieldId]??``,i=n,a=i.dataType,o=i.stereotype,s=!!i.readOnly,c=!!i.disabled,l=i.options,u=n.label?w`<label style="display:block; font-size: var(--lumo-font-size-s,.875rem); color: var(--lumo-secondary-text-color,#667); margin-bottom:.15rem;">${n.label}</label>`:_,d=`width:100%; box-sizing:border-box; padding:.4rem .6rem; border:1px solid var(--lumo-contrast-30pct,rgba(0,0,0,.3)); border-radius: var(--lumo-border-radius-m,6px); font:inherit; background: var(--lumo-base-color,#fff); color: var(--lumo-body-text-color,#1a1a1a);`,f;return f=s||o===`plainText`?w`<div style="padding:.4rem 0;">${String(r??``)}</div>`:a===`boolean`||o===`checkbox`||o===`badge`?w`<input type="checkbox" ?checked="${!!r}" ?disabled="${c}" @change="${_r(n)}">`:l&&l.length?w`
-            <select style="${d}" ?disabled="${c}" @change="${_r(n)}">
+    `},vr=(e,t,n)=>{n.dispatchEvent(new CustomEvent(`value-changed`,{detail:{fieldId:e,value:t},bubbles:!0,composed:!0}))},yr=e=>t=>{let n=t.target,r=n.type===`checkbox`?n.checked:n.value;vr(e.fieldId,r,n)},br=(e,t)=>{let n=e.metadata,r=t?.[n.fieldId]??``,i=n,a=i.dataType,o=i.stereotype,s=!!i.readOnly,c=!!i.disabled,l=i.options,u=n.label?w`<label style="display:block; font-size: var(--lumo-font-size-s,.875rem); color: var(--lumo-secondary-text-color,#667); margin-bottom:.15rem;">${n.label}</label>`:_,d=`width:100%; box-sizing:border-box; padding:.4rem .6rem; border:1px solid var(--lumo-contrast-30pct,rgba(0,0,0,.3)); border-radius: var(--lumo-border-radius-m,6px); font:inherit; background: var(--lumo-base-color,#fff); color: var(--lumo-body-text-color,#1a1a1a);`,f;return f=s||o===`plainText`?w`<div style="padding:.4rem 0;">${String(r??``)}</div>`:a===`boolean`||o===`checkbox`||o===`badge`?w`<input type="checkbox" ?checked="${!!r}" ?disabled="${c}" @change="${yr(n)}">`:l&&l.length?w`
+            <select style="${d}" ?disabled="${c}" @change="${yr(n)}">
                 <option value="">—</option>
                 ${l.map(e=>w`<option value="${e.value}" ?selected="${e.value===r}">${e.label}</option>`)}
-            </select>`:o===`textarea`||o===`richText`||o===`html`?w`<textarea style="${d}" rows="3" ?disabled="${c}" @input="${_r(n)}">${String(r??``)}</textarea>`:w`<input type="${a===`integer`||a===`number`||a===`double`||a===`money`?`number`:a===`date`?`date`:a===`datetime`?`datetime-local`:a===`time`?`time`:o===`password`?`password`:a===`email`?`email`:`text`}" style="${d}" .value="${String(r??``)}"
-                              placeholder="${i.placeholder??_}" ?disabled="${c}" @input="${_r(n)}">`,w`
+            </select>`:o===`textarea`||o===`richText`||o===`html`?w`<textarea style="${d}" rows="3" ?disabled="${c}" @input="${yr(n)}">${String(r??``)}</textarea>`:w`<input type="${a===`integer`||a===`number`||a===`double`||a===`money`?`number`:a===`date`?`date`:a===`datetime`?`datetime-local`:a===`time`?`time`:o===`password`?`password`:a===`email`?`email`:`text`}" style="${d}" .value="${String(r??``)}"
+                              placeholder="${i.placeholder??_}" ?disabled="${c}" @input="${yr(n)}">`,w`
         <div style="${e.style}" class="${e.cssClasses}" slot="${e.slot??_}">
             ${u}
             ${f}
         </div>
-    `},yr=e=>{let t=e.metadata;if((t?.level??0)>0)return e;let n=e=>{if(e?.metadata?.type===A.EntityHeader)return e;let t=e?.metadata?.content,r=[...e?.children??[],...Array.isArray(t)?t:t?[t]:[]];for(let e of r){let t=n(e);if(t)return t}},r;for(let t of e.children??[])if(r=n(t),r)break;if(!r)return e;let i=r.metadata;r.__hoistedToPageHeader=!0;let a=[...(i.facts??[]).filter(e=>e.label||e.value).map(e=>({title:e.label??``,text:e.value??``})),...i.metricLabel?[{title:i.metricLabel,text:i.metricValue??``}]:[]],o=(i.badges??[]).filter(e=>e.label).map(e=>({text:e.label,color:e.color})),s={...t,title:i.title||t.title,subtitle:i.subtitle??t.subtitle,kpis:[...t.kpis??[],...a],kpisBelow:!0,badges:[...t.badges??[],...o]};return{...e,metadata:s}},br=(e,t,n,r,i,a,o,s)=>{let c=yr(t),l=c.metadata,u=l?.fabs??[];return w`<mateu-page
+    `},xr=e=>{let t=e.metadata;if((t?.level??0)>0)return e;let n=e=>{if(e?.metadata?.type===A.EntityHeader)return e;let t=e?.metadata?.content,r=[...e?.children??[],...Array.isArray(t)?t:t?[t]:[]];for(let e of r){let t=n(e);if(t)return t}},r;for(let t of e.children??[])if(r=n(t),r)break;if(!r)return e;let i=r.metadata;r.__hoistedToPageHeader=!0;let a=[...(i.facts??[]).filter(e=>e.label||e.value).map(e=>({title:e.label??``,text:e.value??``})),...i.metricLabel?[{title:i.metricLabel,text:i.metricValue??``}]:[]],o=(i.badges??[]).filter(e=>e.label).map(e=>({text:e.label,color:e.color})),s={...t,title:i.title||t.title,subtitle:i.subtitle??t.subtitle,kpis:[...t.kpis??[],...a],kpisBelow:!0,badges:[...t.badges??[],...o]};return{...e,metadata:s}},Sr=(e,t,n,r,i,a,o,s)=>{let c=xr(t),l=c.metadata,u=l?.fabs??[];return w`<mateu-page
             .component="${c}"
             baseUrl="${n}"
             .state="${r}"
@@ -1452,7 +1452,7 @@ ${i}
             </button>
         `)}
 </mateu-page>
-    `},xr=(e,t,n,r,i,a,o,s)=>w`<mateu-table-crud
+    `},Cr=(e,t,n,r,i,a,o,s)=>w`<mateu-table-crud
             id="${t.id}"
             baseUrl="${n}"
             .component="${t}"
@@ -1467,7 +1467,7 @@ ${i}
             ?standalone="${s??!1}"
     >
         ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
-    </mateu-table-crud>`,Sr=e=>{let t=e.metadata;return w`
+    </mateu-table-crud>`,wr=e=>{let t=e.metadata;return w`
         <mateu-bpmn
                 style="${e.style}"
                 class="${e.cssClasses}"
@@ -1475,35 +1475,35 @@ ${i}
                 xml="${t.xml}"
         >
         </mateu-bpmn>
-    `},Cr=(e,t,n)=>w`<mateu-chat sseUrl="${e.metadata.sseUrl}"
+    `},Tr=(e,t,n)=>w`<mateu-chat sseUrl="${e.metadata.sseUrl}"
                             style="${e.style}" 
                             class="${e.cssClasses}" 
-                            slot="${e.slot??_}"></mateu-chat>`,wr=e=>{let t=e.metadata;return w`
+                            slot="${e.slot??_}"></mateu-chat>`,Er=e=>{let t=e.metadata;return w`
         <mateu-workflow
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
                 value="${t.value??`{"name":"New Workflow","steps":[]}`}"
         ></mateu-workflow>
-    `},Tr=e=>{let t=e.metadata;return w`
+    `},Dr=e=>{let t=e.metadata;return w`
         <mateu-form-editor
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
                 value="${t.value??`{"name":"New Form","fields":[]}`}"
         ></mateu-form-editor>
-    `},Er=`
+    `},Or=`
     background: var(--lumo-base-color, #fff);
     border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.08));
     border-radius: var(--lumo-border-radius-l, 12px);
     padding: var(--lumo-space-m, 1rem);
     box-sizing: border-box;
-`,Dr=e=>e==`up`?`var(--lumo-success-text-color, #1a7f37)`:e==`down`?`var(--lumo-error-text-color, #c5221f)`:`var(--lumo-secondary-text-color, #666)`,Or=e=>e==`up`?`▲`:e==`down`?`▼`:``,kr=(e,t)=>{t.actionId&&e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))},Ar=e=>{let t=e.metadata,n=!!t.actionId;return w`
+`,kr=e=>e==`up`?`var(--lumo-success-text-color, #1a7f37)`:e==`down`?`var(--lumo-error-text-color, #c5221f)`:`var(--lumo-secondary-text-color, #666)`,Ar=e=>e==`up`?`▲`:e==`down`?`▼`:``,jr=(e,t)=>{t.actionId&&e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))},Mr=e=>{let t=e.metadata,n=!!t.actionId;return w`
         <div class="mateu-metric-card ${e.cssClasses??``}"
-             style="${Er} display: flex; flex-direction: column; gap: .25rem; min-width: 11rem; flex: 1; ${n?`cursor: pointer;`:``} ${e.style??``}"
+             style="${Or} display: flex; flex-direction: column; gap: .25rem; min-width: 11rem; flex: 1; ${n?`cursor: pointer;`:``} ${e.style??``}"
              slot="${e.slot??_}"
              role="${n?`button`:_}"
-             @click="${e=>kr(e,t)}"
+             @click="${e=>jr(e,t)}"
         >
             <div style="display: flex; align-items: center; justify-content: space-between; gap: .5rem;">
                 <span style="font-size: var(--lumo-font-size-s, .875rem); color: var(--lumo-secondary-text-color, #666);">${t.title}</span>
@@ -1514,25 +1514,25 @@ ${i}
                 ${t.unit?w`<span style="font-size: var(--lumo-font-size-m, 1rem); color: var(--lumo-secondary-text-color, #666);">${t.unit}</span>`:_}
             </div>
             ${t.trend||t.trendLabel?w`
-                <span style="font-size: var(--lumo-font-size-s, .875rem); color: ${Dr(t.trend)};">
-                    ${Or(t.trend)} ${t.trendLabel??_}
+                <span style="font-size: var(--lumo-font-size-s, .875rem); color: ${kr(t.trend)};">
+                    ${Ar(t.trend)} ${t.trendLabel??_}
                 </span>
             `:_}
             ${t.description?w`<span style="font-size: var(--lumo-font-size-xs, .8rem); color: var(--lumo-tertiary-text-color, #999);">${t.description}</span>`:_}
         </div>
-    `},jr=(e,t,n,r,i,a,o)=>w`
+    `},Nr=(e,t,n,r,i,a,o)=>w`
         <div class="mateu-scoreboard ${t.cssClasses??``}"
              style="display: flex; flex-wrap: wrap; gap: var(--lumo-space-m, 1rem); grid-column: 1 / -1; ${t.style??``}"
              slot="${t.slot??_}"
         >
             ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `,Mr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.colSpan&&s.colSpan>1?`grid-column: span ${s.colSpan};`:``,l=s.rowSpan&&s.rowSpan>1?`grid-row: span ${s.rowSpan};`:``,u=t.children??[];return u.length===1&&u[0].metadata?.type===`MetricCard`?w`
+    `,Pr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.colSpan&&s.colSpan>1?`grid-column: span ${s.colSpan};`:``,l=s.rowSpan&&s.rowSpan>1?`grid-row: span ${s.rowSpan};`:``,u=t.children??[];return u.length===1&&u[0].metadata?.type===`MetricCard`?w`
             <div style="min-width: 0; ${c} ${l} ${t.style??``}" slot="${t.slot??_}">
                 ${P(e,u[0],n,r,i,a,o)}
             </div>`:w`
         <div class="mateu-dashboard-panel ${t.cssClasses??``}"
-             style="${Er} display: flex; flex-direction: column; gap: .5rem; min-width: 0; ${c} ${l} ${t.style??``}"
+             style="${Or} display: flex; flex-direction: column; gap: .5rem; min-width: 0; ${c} ${l} ${t.style??``}"
              slot="${t.slot??_}"
         >
             ${s.title?w`
@@ -1545,14 +1545,14 @@ ${i}
                 ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
             </div>
         </div>
-    `},Nr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.columns&&s.columns>0?`repeat(${s.columns}, minmax(0, 1fr))`:`repeat(auto-fit, minmax(20rem, 1fr))`;return w`
+    `},Fr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.columns&&s.columns>0?`repeat(${s.columns}, minmax(0, 1fr))`:`repeat(auto-fit, minmax(20rem, 1fr))`;return w`
         <div class="mateu-dashboard ${t.cssClasses??``}"
              style="display: grid; grid-template-columns: ${c}; gap: var(--lumo-space-m, 1rem); align-items: stretch; ${t.style??``}"
              slot="${t.slot??_}"
         >
             ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `},Pr=class extends y{constructor(...e){super(...e),this.panels=[],this.headerTitle=``,this.badges=[],this.orientation=`vertical`,this.navigation=null,this.overviewEditActionId=``,this.openPanels=new Set,this.expandedPanel=null,this._onPopState=()=>{let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(e.startsWith(`expand=`)){let t=e.slice(7),n=this.panels.findIndex((e,n)=>this.panelAnchor(e,n)===t);this.expandedPanel=n>=0?n:null}else this.expandedPanel=null},this.initialized=!1}navAction(e){e&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{}},bubbles:!0,composed:!0}))}connectedCallback(){super.connectedCallback(),window.addEventListener(`popstate`,this._onPopState)}disconnectedCallback(){window.removeEventListener(`popstate`,this._onPopState),super.disconnectedCallback()}willUpdate(){if(!this.initialized&&this.panels.length){this.openPanels=new Set(this.panels.map((e,t)=>e.open?t:-1).filter(e=>e>=0));let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(e.startsWith(`expand=`)){let t=e.slice(7),n=this.panels.findIndex((e,n)=>this.panelAnchor(e,n)===t);n>=0&&(this.expandedPanel=n)}else if(e){let t=this.panels.findIndex((t,n)=>this.panelAnchor(t,n)===e);t>=0&&this.openPanels.add(t)}this.initialized=!0}}firstUpdated(){let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(!e)return;let t=this.renderRoot.querySelector(`[data-anchor="${CSS.escape(e)}"]`);t&&t.scrollIntoView({block:`nearest`})}panelAnchor(e,t){return(e.title??``).toLowerCase().replace(/[^a-z0-9]+/g,`-`).replace(/^-|-$/g,``)||`panel-${t}`}bookmarkPanel(e){let t=this.panelAnchor(this.panels[e],e);try{history.replaceState(history.state,``,`#`+t)}catch{}}clearBookmark(e){let t=this.panelAnchor(this.panels[e],e);if(decodeURIComponent((location.hash||``).replace(/^#/,``))===t)try{history.replaceState(history.state,``,location.pathname+location.search)}catch{}}expandPanel(e,t){t?.stopPropagation(),this.expandedPanel=e;let n=this.panelAnchor(this.panels[e],e);try{history.pushState(history.state,``,`#expand=`+n)}catch{}}collapsePanel(){try{history.back()}catch{this.expandedPanel=null}}toggle(e){let t=new Set(this.openPanels);t.has(e)?(t.delete(e),this.clearBookmark(e)):(t.add(e),this.bookmarkPanel(e)),this.openPanels=t}static{this.styles=m`
+    `},Ir=class extends y{constructor(...e){super(...e),this.panels=[],this.headerTitle=``,this.badges=[],this.orientation=`vertical`,this.navigation=null,this.overviewEditActionId=``,this.openPanels=new Set,this.expandedPanel=null,this._onPopState=()=>{let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(e.startsWith(`expand=`)){let t=e.slice(7),n=this.panels.findIndex((e,n)=>this.panelAnchor(e,n)===t);this.expandedPanel=n>=0?n:null}else this.expandedPanel=null},this.initialized=!1}navAction(e){e&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{}},bubbles:!0,composed:!0}))}connectedCallback(){super.connectedCallback(),window.addEventListener(`popstate`,this._onPopState)}disconnectedCallback(){window.removeEventListener(`popstate`,this._onPopState),super.disconnectedCallback()}willUpdate(){if(!this.initialized&&this.panels.length){this.openPanels=new Set(this.panels.map((e,t)=>e.open?t:-1).filter(e=>e>=0));let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(e.startsWith(`expand=`)){let t=e.slice(7),n=this.panels.findIndex((e,n)=>this.panelAnchor(e,n)===t);n>=0&&(this.expandedPanel=n)}else if(e){let t=this.panels.findIndex((t,n)=>this.panelAnchor(t,n)===e);t>=0&&this.openPanels.add(t)}this.initialized=!0}}firstUpdated(){let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(!e)return;let t=this.renderRoot.querySelector(`[data-anchor="${CSS.escape(e)}"]`);t&&t.scrollIntoView({block:`nearest`})}panelAnchor(e,t){return(e.title??``).toLowerCase().replace(/[^a-z0-9]+/g,`-`).replace(/^-|-$/g,``)||`panel-${t}`}bookmarkPanel(e){let t=this.panelAnchor(this.panels[e],e);try{history.replaceState(history.state,``,`#`+t)}catch{}}clearBookmark(e){let t=this.panelAnchor(this.panels[e],e);if(decodeURIComponent((location.hash||``).replace(/^#/,``))===t)try{history.replaceState(history.state,``,location.pathname+location.search)}catch{}}expandPanel(e,t){t?.stopPropagation(),this.expandedPanel=e;let n=this.panelAnchor(this.panels[e],e);try{history.pushState(history.state,``,`#expand=`+n)}catch{}}collapsePanel(){try{history.back()}catch{this.expandedPanel=null}}toggle(e){let t=new Set(this.openPanels);t.has(e)?(t.delete(e),this.clearBookmark(e)):(t.add(e),this.bookmarkPanel(e)),this.openPanels=t}static{this.styles=m`
         :host {
             display: flex;
             flex-direction: column;
@@ -1938,7 +1938,7 @@ ${i}
                     `)}
                 </div>
             </div>
-        `}};O([v({type:Array})],Pr.prototype,`panels`,void 0),O([v({type:String})],Pr.prototype,`headerTitle`,void 0),O([v({type:Array})],Pr.prototype,`badges`,void 0),O([v({type:String,reflect:!0})],Pr.prototype,`orientation`,void 0),O([v({attribute:!1})],Pr.prototype,`navigation`,void 0),O([v({type:String})],Pr.prototype,`overviewEditActionId`,void 0),O([S()],Pr.prototype,`openPanels`,void 0),O([S()],Pr.prototype,`expandedPanel`,void 0),Pr=O([h(`mateu-foldout`)],Pr);var Fr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+        `}};O([v({type:Array})],Ir.prototype,`panels`,void 0),O([v({type:String})],Ir.prototype,`headerTitle`,void 0),O([v({type:Array})],Ir.prototype,`badges`,void 0),O([v({type:String,reflect:!0})],Ir.prototype,`orientation`,void 0),O([v({attribute:!1})],Ir.prototype,`navigation`,void 0),O([v({type:String})],Ir.prototype,`overviewEditActionId`,void 0),O([S()],Ir.prototype,`openPanels`,void 0),O([S()],Ir.prototype,`expandedPanel`,void 0),Ir=O([h(`mateu-foldout`)],Ir);var Lr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <mateu-foldout
                 .panels="${s.panels??[]}"
                 .headerTitle="${s.headerTitle??``}"
@@ -1952,7 +1952,7 @@ ${i}
         >
             ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </mateu-foldout>
-    `},Ir=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.children??[],l=e=>c.filter(t=>(t.slot??``).startsWith(e)),u=l(`main-`),d=l(`aside-`),f=l(`footer-`),p=s.asideWidth&&s.asideWidth.trim()?s.asideWidth:`32%`,ee=s.asidePosition===`start`,te=s.asideSticky!==!1,ne=t=>t.map(t=>P(e,t,n,r,i,a,o)),re=w`
+    `},Rr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.children??[],l=e=>c.filter(t=>(t.slot??``).startsWith(e)),u=l(`main-`),d=l(`aside-`),f=l(`footer-`),p=s.asideWidth&&s.asideWidth.trim()?s.asideWidth:`32%`,ee=s.asidePosition===`start`,te=s.asideSticky!==!1,ne=t=>t.map(t=>P(e,t,n,r,i,a,o)),re=w`
         <div class="mateu-content-main"
              style="flex: 1 1 0; min-width: min(20rem, 100%); box-sizing: border-box;">
             ${ne(u)}
@@ -1973,7 +1973,7 @@ ${i}
                     ${ne(f)}
                 </div>`:_}
         </div>
-    `},Lr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!!s.image,l=c?`background-image: linear-gradient(rgba(0,0,0,.35), rgba(0,0,0,.35)), url('${s.image}'); background-size: cover; background-position: center; color: #fff;`:``,u=s.centered===!1?`flex-start`:`center`,d=s.centered===!1?`left`:`center`;return w`
+    `},zr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!!s.image,l=c?`background-image: linear-gradient(rgba(0,0,0,.35), rgba(0,0,0,.35)), url('${s.image}'); background-size: cover; background-position: center; color: #fff;`:``,u=s.centered===!1?`flex-start`:`center`,d=s.centered===!1?`left`:`center`;return w`
         <div class="mateu-hero ${t.cssClasses??``}"
              style="display: flex; flex-direction: column; align-items: ${u}; justify-content: center; gap: var(--lumo-space-m, 1rem); text-align: ${d}; padding: var(--lumo-space-xl, 2.5rem) var(--lumo-space-l, 1.5rem); border-radius: var(--lumo-border-radius-l, 12px); min-height: ${s.height??`12rem`}; box-sizing: border-box; ${l} ${t.style??``}"
              slot="${t.slot??_}"
@@ -1997,7 +1997,7 @@ ${i}
         outline-offset: 2px;
         border-radius: var(--lumo-border-radius-s, 4px);
     }
-`,Rr=1440*60*1e3,zr=class extends y{constructor(...e){super(...e),this.tasks=[],this.onTaskSelectionActionId=``}selectTask(e){this.onTaskSelectionActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.onTaskSelectionActionId,parameters:{_clickedTaskId:e.id}},bubbles:!0,composed:!0}))}static{this.styles=m`
+`,Br=1440*60*1e3,Vr=class extends y{constructor(...e){super(...e),this.tasks=[],this.onTaskSelectionActionId=``}selectTask(e){this.onTaskSelectionActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.onTaskSelectionActionId,parameters:{_clickedTaskId:e.id}},bubbles:!0,composed:!0}))}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2073,7 +2073,7 @@ ${i}
         }
     
         ${R}
-    `}range(){let e=this.tasks.flatMap(e=>[e.start,e.end]).filter(e=>!!e).map(e=>new Date(e+`T00:00:00`).getTime());return e.length?{min:Math.min(...e)-Rr,max:Math.max(...e)+2*Rr}:null}months(e,t){let n=[],r=new Date(e);for(r.setDate(1);r.getTime()<=t;){let i=Math.max(r.getTime(),e),a=new Date(r.getFullYear(),r.getMonth()+1,1),o=Math.min(a.getTime(),t);n.push({label:r.toLocaleDateString(void 0,{month:`short`,year:`2-digit`}),from:i,to:o}),r.setMonth(r.getMonth()+1)}return n}render(){let e=this.range();if(!e)return w``;let t=e.max-e.min,n=n=>(n-e.min)/t*100,r=Date.now();return w`
+    `}range(){let e=this.tasks.flatMap(e=>[e.start,e.end]).filter(e=>!!e).map(e=>new Date(e+`T00:00:00`).getTime());return e.length?{min:Math.min(...e)-Br,max:Math.max(...e)+2*Br}:null}months(e,t){let n=[],r=new Date(e);for(r.setDate(1);r.getTime()<=t;){let i=Math.max(r.getTime(),e),a=new Date(r.getFullYear(),r.getMonth()+1,1),o=Math.min(a.getTime(),t);n.push({label:r.toLocaleDateString(void 0,{month:`short`,year:`2-digit`}),from:i,to:o}),r.setMonth(r.getMonth()+1)}return n}render(){let e=this.range();if(!e)return w``;let t=e.max-e.min,n=n=>(n-e.min)/t*100,r=Date.now();return w`
             <div class="frame">
                 <div class="head">Task</div>
                 <div class="head months">
@@ -2081,7 +2081,7 @@ ${i}
                         <div class="month" style="width: ${(e.to-e.from)/t*100}%;">${e.label}</div>
                     `)}
                 </div>
-                ${this.tasks.map(i=>{let a=new Date(i.start+`T00:00:00`).getTime(),o=new Date(i.end+`T00:00:00`).getTime()+Rr;return w`
+                ${this.tasks.map(i=>{let a=new Date(i.start+`T00:00:00`).getTime(),o=new Date(i.end+`T00:00:00`).getTime()+Br;return w`
                         <div class="label" title="${i.title}">${i.title}</div>
                         <div class="lane">
                             ${r>=e.min&&r<=e.max?w`<div class="today" style="left: ${n(r)}%;"></div>`:_}
@@ -2096,7 +2096,7 @@ ${i}
                         </div>
                     `})}
             </div>
-        `}};O([v({type:Array})],zr.prototype,`tasks`,void 0),O([v()],zr.prototype,`onTaskSelectionActionId`,void 0),zr=O([h(`mateu-gantt`)],zr);var Br=e=>{let t=e.metadata;return w`
+        `}};O([v({type:Array})],Vr.prototype,`tasks`,void 0),O([v()],Vr.prototype,`onTaskSelectionActionId`,void 0),Vr=O([h(`mateu-gantt`)],Vr);var Hr=e=>{let t=e.metadata;return w`
         <mateu-gantt
                 .tasks="${t.tasks??[]}"
                 .onTaskSelectionActionId="${t.onTaskSelectionActionId??``}"
@@ -2104,7 +2104,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-gantt>
-    `},z,Vr=class extends y{static{z=this}constructor(...e){super(...e),this.resources=[],this.blocks=[],this.drag=null,this.dragStartX=0,this.dragStartY=0,this.laneRects=[],this.onDragKeydown=e=>{e.key===`Escape`&&this.drag&&(e.stopPropagation(),this.endDrag())}}static{this.styles=m`
+    `},z,Ur=class extends y{static{z=this}constructor(...e){super(...e),this.resources=[],this.blocks=[],this.drag=null,this.dragStartX=0,this.dragStartY=0,this.laneRects=[],this.onDragKeydown=e=>{e.key===`Escape`&&this.drag&&(e.stopPropagation(),this.endDrag())}}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2279,7 +2279,7 @@ ${i}
                          style="left: ${o.targetStartIdx*i}%; width: ${Math.min(o.duration,t.days-o.targetStartIdx)*i}%;"></div>
                 `:_}
             </div>
-        `}};O([v({type:Array})],Vr.prototype,`resources`,void 0),O([v({type:Array})],Vr.prototype,`blocks`,void 0),O([v()],Vr.prototype,`from`,void 0),O([v()],Vr.prototype,`to`,void 0),O([v()],Vr.prototype,`moveActionId`,void 0),O([v()],Vr.prototype,`selectActionId`,void 0),O([S()],Vr.prototype,`drag`,void 0),Vr=z=O([h(`mateu-planning-board`)],Vr);var Hr=e=>{let t=e.metadata;return w`
+        `}};O([v({type:Array})],Ur.prototype,`resources`,void 0),O([v({type:Array})],Ur.prototype,`blocks`,void 0),O([v()],Ur.prototype,`from`,void 0),O([v()],Ur.prototype,`to`,void 0),O([v()],Ur.prototype,`moveActionId`,void 0),O([v()],Ur.prototype,`selectActionId`,void 0),O([S()],Ur.prototype,`drag`,void 0),Ur=z=O([h(`mateu-planning-board`)],Ur);var Wr=e=>{let t=e.metadata;return w`
         <mateu-planning-board
                 .resources="${t.resources??[]}"
                 .blocks="${t.blocks??[]}"
@@ -2291,7 +2291,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-planning-board>
-    `},Ur=class extends y{constructor(...e){super(...e),this.columns=[]}static{this.styles=m`
+    `},Gr=class extends y{constructor(...e){super(...e),this.columns=[]}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2395,14 +2395,14 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};O([v({type:Array})],Ur.prototype,`columns`,void 0),Ur=O([h(`mateu-kanban`)],Ur);var Wr=e=>w`
+        `}};O([v({type:Array})],Gr.prototype,`columns`,void 0),Gr=O([h(`mateu-kanban`)],Gr);var Kr=e=>w`
         <mateu-kanban
                 .columns="${e.metadata.columns??[]}"
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-kanban>
-    `,Gr=class extends y{constructor(...e){super(...e),this.items=[]}static{this.styles=m`
+    `,qr=class extends y{constructor(...e){super(...e),this.items=[]}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2493,14 +2493,14 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};O([v({type:Array})],Gr.prototype,`items`,void 0),Gr=O([h(`mateu-timeline`)],Gr);var Kr=e=>w`
+        `}};O([v({type:Array})],qr.prototype,`items`,void 0),qr=O([h(`mateu-timeline`)],qr);var Jr=e=>w`
         <mateu-timeline
                 .items="${e.metadata.items??[]}"
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-timeline>
-    `,qr=class extends y{constructor(...e){super(...e),this.steps=[],this.vertical=!1}static{this.styles=m`
+    `,Yr=class extends y{constructor(...e){super(...e),this.steps=[],this.vertical=!1}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2614,7 +2614,7 @@ ${i}
                         </div>
                     `})}
             </div>
-        `}};O([v({type:Array})],qr.prototype,`steps`,void 0),O([v({type:Boolean,reflect:!0})],qr.prototype,`vertical`,void 0),qr=O([h(`mateu-progress-steps`)],qr);var Jr=e=>{let t=e.metadata;return w`
+        `}};O([v({type:Array})],Yr.prototype,`steps`,void 0),O([v({type:Boolean,reflect:!0})],Yr.prototype,`vertical`,void 0),Yr=O([h(`mateu-progress-steps`)],Yr);var Xr=e=>{let t=e.metadata;return w`
         <mateu-progress-steps
                 .steps="${t.steps??[]}"
                 ?vertical="${t.vertical??!1}"
@@ -2622,7 +2622,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-progress-steps>
-    `},Yr=class extends y{constructor(...e){super(...e),this.spark=[]}static{this.styles=m`
+    `},Zr=class extends y{constructor(...e){super(...e),this.spark=[]}static{this.styles=m`
         :host {
             display: block;
         }
@@ -2693,7 +2693,7 @@ ${i}
                     ${this.sparkline()}
                 </div>
             </div>
-        `}};O([v()],Yr.prototype,`label`,void 0),O([v()],Yr.prototype,`value`,void 0),O([v()],Yr.prototype,`unit`,void 0),O([v()],Yr.prototype,`delta`,void 0),O([v()],Yr.prototype,`trend`,void 0),O([v({type:Array})],Yr.prototype,`spark`,void 0),O([v()],Yr.prototype,`actionId`,void 0),Yr=O([h(`mateu-stat`)],Yr);var Xr=e=>{let t=e.metadata;return w`
+        `}};O([v()],Zr.prototype,`label`,void 0),O([v()],Zr.prototype,`value`,void 0),O([v()],Zr.prototype,`unit`,void 0),O([v()],Zr.prototype,`delta`,void 0),O([v()],Zr.prototype,`trend`,void 0),O([v({type:Array})],Zr.prototype,`spark`,void 0),O([v()],Zr.prototype,`actionId`,void 0),Zr=O([h(`mateu-stat`)],Zr);var Qr=e=>{let t=e.metadata;return w`
         <mateu-stat
                 label="${t.label??_}"
                 value="${t.value??_}"
@@ -2706,7 +2706,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-stat>
-    `},Zr=class extends y{constructor(...e){super(...e),this.events=[]}static{this.styles=m`
+    `},$r=class extends y{constructor(...e){super(...e),this.events=[]}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2797,7 +2797,7 @@ ${i}
                 ${l.map(e=>w`<div class="dow">${e}</div>`)}
                 ${u}
             </div>
-        `}};O([v()],Zr.prototype,`month`,void 0),O([v({type:Array})],Zr.prototype,`events`,void 0),Zr=O([h(`mateu-calendar`)],Zr);var Qr=e=>{let t=e.metadata;return w`
+        `}};O([v()],$r.prototype,`month`,void 0),O([v({type:Array})],$r.prototype,`events`,void 0),$r=O([h(`mateu-calendar`)],$r);var ei=e=>{let t=e.metadata;return w`
         <mateu-calendar
                 month="${t.month??_}"
                 .events="${t.events??[]}"
@@ -2805,7 +2805,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-calendar>
-    `},$r=class extends y{constructor(...e){super(...e),this.plans=[]}static{this.styles=m`
+    `},ti=class extends y{constructor(...e){super(...e),this.plans=[]}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2917,14 +2917,14 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};O([v({type:Array})],$r.prototype,`plans`,void 0),$r=O([h(`mateu-pricing-table`)],$r);var ei=e=>w`
+        `}};O([v({type:Array})],ti.prototype,`plans`,void 0),ti=O([h(`mateu-pricing-table`)],ti);var ni=e=>w`
         <mateu-pricing-table
                 .plans="${e.metadata.plans??[]}"
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-pricing-table>
-    `,ti=class extends y{static{this.styles=m`
+    `,ri=class extends y{static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -3032,14 +3032,14 @@ ${i}
                 </div>
                 ${e.children&&e.children.length?w`<ul>${e.children.map(e=>this.renderNode(e))}</ul>`:_}
             </li>
-        `}render(){return this.root?w`<div class="tree"><ul>${this.renderNode(this.root)}</ul></div>`:w``}};O([v({attribute:!1})],ti.prototype,`root`,void 0),ti=O([h(`mateu-org-chart`)],ti);var ni=e=>w`
+        `}render(){return this.root?w`<div class="tree"><ul>${this.renderNode(this.root)}</ul></div>`:w``}};O([v({attribute:!1})],ri.prototype,`root`,void 0),ri=O([h(`mateu-org-chart`)],ri);var ii=e=>w`
         <mateu-org-chart
                 .root="${e.metadata.root}"
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-org-chart>
-    `,ri=1440*60*1e3,ii=class extends y{constructor(...e){super(...e),this.cells=[]}static{this.styles=m`
+    `,ai=1440*60*1e3,oi=class extends y{constructor(...e){super(...e),this.cells=[]}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -3063,7 +3063,7 @@ ${i}
             margin-top: .15rem;
         }
         .legend .cell { width: 10px; height: 10px; }
-    `}color(e,t){if(e<=0||t<=0)return`var(--lumo-contrast-10pct, #ebedf0)`;let n=e/t;return`color-mix(in srgb, var(--lumo-primary-color, #1a73e8) ${Math.round((n>.75?1:n>.5?.75:n>.25?.5:.3)*100)}%, transparent)`}render(){let e=this.cells.filter(e=>!!e.date);if(!e.length)return w``;let t=e.map(e=>new Date(e.date+`T00:00:00`).getTime()),n=Math.min(...t),r=Math.max(...t),i=new Date(n);i.setDate(i.getDate()-(i.getDay()+6)%7);let a={};for(let t of e)a[t.date]=t;let o=Math.max(...e.map(e=>e.value??0),1),s=[];for(let e=i.getTime();e<=r;e+=ri){let t=new Date(e),n=t.toISOString().slice(0,10),r=a[n],i=r?.value??0,c=(t.getDay()+6)%7+1,l=r?.label??`${n}: ${i}`;s.push(w`
+    `}color(e,t){if(e<=0||t<=0)return`var(--lumo-contrast-10pct, #ebedf0)`;let n=e/t;return`color-mix(in srgb, var(--lumo-primary-color, #1a73e8) ${Math.round((n>.75?1:n>.5?.75:n>.25?.5:.3)*100)}%, transparent)`}render(){let e=this.cells.filter(e=>!!e.date);if(!e.length)return w``;let t=e.map(e=>new Date(e.date+`T00:00:00`).getTime()),n=Math.min(...t),r=Math.max(...t),i=new Date(n);i.setDate(i.getDate()-(i.getDay()+6)%7);let a={};for(let t of e)a[t.date]=t;let o=Math.max(...e.map(e=>e.value??0),1),s=[];for(let e=i.getTime();e<=r;e+=ai){let t=new Date(e),n=t.toISOString().slice(0,10),r=a[n],i=r?.value??0,c=(t.getDay()+6)%7+1,l=r?.label??`${n}: ${i}`;s.push(w`
                 <div class="cell" style="grid-row: ${c}; --cell: ${this.color(i,o)};" title="${l}"></div>
             `)}return w`
             <div class="wrap">
@@ -3078,14 +3078,14 @@ ${i}
                     <span>More</span>
                 </div>
             </div>
-        `}};O([v({type:Array})],ii.prototype,`cells`,void 0),ii=O([h(`mateu-heatmap`)],ii);var ai=e=>w`
+        `}};O([v({type:Array})],oi.prototype,`cells`,void 0),oi=O([h(`mateu-heatmap`)],oi);var si=e=>w`
         <mateu-heatmap
                 .cells="${e.metadata.cells??[]}"
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-heatmap>
-    `,oi=class extends y{constructor(...e){super(...e),this.stages=[]}static{this.styles=m`
+    `,ci=class extends y{constructor(...e){super(...e),this.stages=[]}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .funnel { display: flex; flex-direction: column; gap: .35rem; }
         .stage { display: flex; flex-direction: column; align-items: center; gap: .1rem; }
@@ -3118,14 +3118,14 @@ ${i}
                         </div>
                     `})}
             </div>
-        `}};O([v({type:Array})],oi.prototype,`stages`,void 0),oi=O([h(`mateu-funnel`)],oi);var si=e=>w`
+        `}};O([v({type:Array})],ci.prototype,`stages`,void 0),ci=O([h(`mateu-funnel`)],ci);var li=e=>w`
         <mateu-funnel
                 .stages="${e.metadata.stages??[]}"
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-funnel>
-    `,ci=class extends y{constructor(...e){super(...e),this.values=[],this.labels=[],this.area=!1}static{this.styles=m`
+    `,ui=class extends y{constructor(...e){super(...e),this.values=[],this.labels=[],this.area=!1}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .title { font-weight: 600; margin-bottom: .35rem; color: var(--lumo-body-text-color, #222); }
         svg { display: block; width: 100%; height: auto; overflow: visible; }
@@ -3138,7 +3138,7 @@ ${i}
                 ${a.map((t,n)=>n===l||n===u?C`<circle cx="${t[0]}" cy="${t[1]}" r="3.2" fill="${c}"><title>${this.labels[n]??``}: ${e[n]}</title></circle>`:C`<circle cx="${t[0]}" cy="${t[1]}" r="6" fill="transparent"><title>${this.labels[n]??``}: ${e[n]}</title></circle>`)}
             </svg>
             ${this.labels&&this.labels.length?w`<div class="labels"><span>${this.labels[0]}</span><span>${this.labels[this.labels.length-1]}</span></div>`:_}
-        `}};O([v()],ci.prototype,`heading`,void 0),O([v({type:Array})],ci.prototype,`values`,void 0),O([v({type:Array})],ci.prototype,`labels`,void 0),O([v()],ci.prototype,`color`,void 0),O([v({type:Boolean})],ci.prototype,`area`,void 0),ci=O([h(`mateu-trend-chart`)],ci);var li=e=>{let t=e.metadata;return w`
+        `}};O([v()],ui.prototype,`heading`,void 0),O([v({type:Array})],ui.prototype,`values`,void 0),O([v({type:Array})],ui.prototype,`labels`,void 0),O([v()],ui.prototype,`color`,void 0),O([v({type:Boolean})],ui.prototype,`area`,void 0),ui=O([h(`mateu-trend-chart`)],ui);var di=e=>{let t=e.metadata;return w`
         <mateu-trend-chart
                 heading="${t.title??_}"
                 color="${t.color??_}"
@@ -3149,7 +3149,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-trend-chart>
-    `},ui=class extends y{constructor(...e){super(...e),this.features=[],this.columns=0}static{this.styles=m`
+    `},fi=class extends y{constructor(...e){super(...e),this.features=[],this.columns=0}static{this.styles=m`
         :host { display: block; width: 100%; }
         .grid {
             display: grid;
@@ -3190,7 +3190,7 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};O([v({type:Array})],ui.prototype,`features`,void 0),O([v({type:Number})],ui.prototype,`columns`,void 0),ui=O([h(`mateu-feature-grid`)],ui);var di=e=>{let t=e.metadata;return w`
+        `}};O([v({type:Array})],fi.prototype,`features`,void 0),O([v({type:Number})],fi.prototype,`columns`,void 0),fi=O([h(`mateu-feature-grid`)],fi);var pi=e=>{let t=e.metadata;return w`
         <mateu-feature-grid
                 .features="${t.features??[]}"
                 .columns="${t.columns??0}"
@@ -3198,7 +3198,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-feature-grid>
-    `},fi=class extends y{constructor(...e){super(...e),this.items=[]}static{this.styles=m`
+    `},mi=class extends y{constructor(...e){super(...e),this.items=[]}static{this.styles=m`
         :host { display: block; width: 100%; }
         .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr)); gap: var(--lumo-space-m, 1rem); }
         .card {
@@ -3238,14 +3238,14 @@ ${i}
                         </div>
                     `})}
             </div>
-        `}};O([v({type:Array})],fi.prototype,`items`,void 0),fi=O([h(`mateu-testimonials`)],fi);var pi=e=>w`
+        `}};O([v({type:Array})],mi.prototype,`items`,void 0),mi=O([h(`mateu-testimonials`)],mi);var hi=e=>w`
         <mateu-testimonials
                 .items="${e.metadata.items??[]}"
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-testimonials>
-    `,mi=class extends y{constructor(...e){super(...e),this.items=[],this.openSet=new Set,this.seeded=!1}static{this.styles=m`
+    `,gi=class extends y{constructor(...e){super(...e),this.items=[],this.openSet=new Set,this.seeded=!1}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-m, 1rem); }
         .list {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -3282,14 +3282,14 @@ ${i}
                         </div>
                     `})}
             </div>
-        `}};O([v({type:Array})],mi.prototype,`items`,void 0),O([S()],mi.prototype,`openSet`,void 0),mi=O([h(`mateu-faq`)],mi);var hi=e=>w`
+        `}};O([v({type:Array})],gi.prototype,`items`,void 0),O([S()],gi.prototype,`openSet`,void 0),gi=O([h(`mateu-faq`)],gi);var _i=e=>w`
         <mateu-faq
                 .items="${e.metadata.items??[]}"
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-faq>
-    `,gi=class extends y{static{this.styles=m`
+    `,vi=class extends y{static{this.styles=m`
         :host { display: block; width: 100%; }
         .callout {
             display: flex; gap: 1rem; align-items: flex-start;
@@ -3318,7 +3318,7 @@ ${i}
                     ${this.ctaLabel?w`<button class="cta" @click="${()=>this.cta()}">${this.ctaLabel}</button>`:_}
                 </div>
             </div>
-        `}};O([v()],gi.prototype,`heading`,void 0),O([v()],gi.prototype,`description`,void 0),O([v()],gi.prototype,`icon`,void 0),O([v()],gi.prototype,`ctaLabel`,void 0),O([v()],gi.prototype,`actionId`,void 0),O([v()],gi.prototype,`theme`,void 0),gi=O([h(`mateu-callout-card`)],gi);var _i=e=>{let t=e.metadata;return w`
+        `}};O([v()],vi.prototype,`heading`,void 0),O([v()],vi.prototype,`description`,void 0),O([v()],vi.prototype,`icon`,void 0),O([v()],vi.prototype,`ctaLabel`,void 0),O([v()],vi.prototype,`actionId`,void 0),O([v()],vi.prototype,`theme`,void 0),vi=O([h(`mateu-callout-card`)],vi);var yi=e=>{let t=e.metadata;return w`
         <mateu-callout-card
                 heading="${t.title??_}"
                 description="${t.description??_}"
@@ -3330,7 +3330,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-callout-card>
-    `},vi=class extends y{constructor(...e){super(...e),this.comments=[]}static{this.styles=m`
+    `},bi=class extends y{constructor(...e){super(...e),this.comments=[]}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .thread { display: flex; flex-direction: column; gap: 1rem; }
         .replies {
@@ -3362,14 +3362,14 @@ ${i}
                     ${e.replies&&e.replies.length?w`<div class="replies">${e.replies.map(e=>this.renderComment(e))}</div>`:_}
                 </div>
             </div>
-        `}render(){return w`<div class="thread">${this.comments.map(e=>this.renderComment(e))}</div>`}};O([v({type:Array})],vi.prototype,`comments`,void 0),vi=O([h(`mateu-comment-thread`)],vi);var yi=e=>w`
+        `}render(){return w`<div class="thread">${this.comments.map(e=>this.renderComment(e))}</div>`}};O([v({type:Array})],bi.prototype,`comments`,void 0),bi=O([h(`mateu-comment-thread`)],bi);var xi=e=>w`
         <mateu-comment-thread
                 .comments="${e.metadata.comments??[]}"
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-comment-thread>
-    `,bi={pdf:`📕`,image:`🖼️`,img:`🖼️`,doc:`📘`,docx:`📘`,word:`📘`,xls:`📗`,xlsx:`📗`,excel:`📗`,sheet:`📗`,zip:`🗜️`,archive:`🗜️`,video:`🎬`,audio:`🎵`,code:`💻`,csv:`📄`,txt:`📄`},xi=class extends y{constructor(...e){super(...e),this.files=[]}static{this.styles=m`
+    `,Si={pdf:`📕`,image:`🖼️`,img:`🖼️`,doc:`📘`,docx:`📘`,word:`📘`,xls:`📗`,xlsx:`📗`,excel:`📗`,sheet:`📗`,zip:`🗜️`,archive:`🗜️`,video:`🎬`,audio:`🎵`,code:`💻`,csv:`📄`,txt:`📄`},Ci=class extends y{constructor(...e){super(...e),this.files=[]}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .list {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -3386,7 +3386,7 @@ ${i}
         .dl { color: var(--lumo-primary-color, #1a73e8); flex: 0 0 auto; }
     
         ${R}
-    `}icon(e){return e&&bi[e.toLowerCase()]||`📄`}clickFile(e,t){e.url||e.actionId&&(t.preventDefault(),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_file:e}},bubbles:!0,composed:!0})))}render(){return w`
+    `}icon(e){return e&&Si[e.toLowerCase()]||`📄`}clickFile(e,t){e.url||e.actionId&&(t.preventDefault(),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_file:e}},bubbles:!0,composed:!0})))}render(){return w`
             <div class="list">
                 ${this.files.map(e=>{let t=!!e.url||!!e.actionId,n=w`
                         <span class="icon">${this.icon(e.type)}</span>
@@ -3395,14 +3395,14 @@ ${i}
                         ${e.url?w`<span class="dl">⬇</span>`:_}
                     `;return e.url?w`<a class="file clickable" href="${e.url}" download target="_blank" rel="noopener">${n}</a>`:w`<div role="button" tabindex="0" class="file ${t?`clickable`:``}" @click="${t=>this.clickFile(e,t)}" @keydown="${L(t=>this.clickFile(e,t))}">${n}</div>`})}
             </div>
-        `}};O([v({type:Array})],xi.prototype,`files`,void 0),xi=O([h(`mateu-file-list`)],xi);var Si=e=>w`
+        `}};O([v({type:Array})],Ci.prototype,`files`,void 0),Ci=O([h(`mateu-file-list`)],Ci);var wi=e=>w`
         <mateu-file-list
                 .files="${e.metadata.files??[]}"
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-file-list>
-    `,Ci=class extends y{constructor(...e){super(...e),this.items=[],this.localDone=new Map}static{this.styles=m`
+    `,Ti=class extends y{constructor(...e){super(...e),this.items=[],this.localDone=new Map}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .head { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: .5rem; }
         .title { font-weight: 700; color: var(--lumo-body-text-color, #222); }
@@ -3432,7 +3432,7 @@ ${i}
                         <span class="label">${e.label}</span>
                     </div>
                 `})}
-        `}};O([v()],Ci.prototype,`heading`,void 0),O([v({type:Array})],Ci.prototype,`items`,void 0),O([S()],Ci.prototype,`localDone`,void 0),Ci=O([h(`mateu-checklist`)],Ci);var wi=e=>{let t=e.metadata;return w`
+        `}};O([v()],Ti.prototype,`heading`,void 0),O([v({type:Array})],Ti.prototype,`items`,void 0),O([S()],Ti.prototype,`localDone`,void 0),Ti=O([h(`mateu-checklist`)],Ti);var Ei=e=>{let t=e.metadata;return w`
         <mateu-checklist
                 heading="${t.title??_}"
                 .items="${t.items??[]}"
@@ -3440,7 +3440,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-checklist>
-    `},Ti=class extends y{static{this.styles=m`
+    `},Di=class extends y{static{this.styles=m`
         :host { display: block; width: 100%; }
         .card {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -3480,7 +3480,7 @@ ${i}
                     </div>
                 </div>
             </div>
-        `}};O([v()],Ti.prototype,`heading`,void 0),O([v()],Ti.prototype,`leftLabel`,void 0),O([v()],Ti.prototype,`leftValue`,void 0),O([v()],Ti.prototype,`rightLabel`,void 0),O([v()],Ti.prototype,`rightValue`,void 0),O([v()],Ti.prototype,`delta`,void 0),O([v()],Ti.prototype,`trend`,void 0),Ti=O([h(`mateu-comparison-card`)],Ti);var Ei=e=>{let t=e.metadata;return w`
+        `}};O([v()],Di.prototype,`heading`,void 0),O([v()],Di.prototype,`leftLabel`,void 0),O([v()],Di.prototype,`leftValue`,void 0),O([v()],Di.prototype,`rightLabel`,void 0),O([v()],Di.prototype,`rightValue`,void 0),O([v()],Di.prototype,`delta`,void 0),O([v()],Di.prototype,`trend`,void 0),Di=O([h(`mateu-comparison-card`)],Di);var Oi=e=>{let t=e.metadata;return w`
         <mateu-comparison-card
                 heading="${t.title??_}"
                 leftLabel="${t.leftLabel??_}"
@@ -3493,7 +3493,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-comparison-card>
-    `},Di=m`
+    `},ki=m`
     .chip {
         display: inline-flex;
         align-items: center;
@@ -3523,7 +3523,7 @@ ${i}
         color: var(--lumo-contrast-80pct, #333);
         background: var(--lumo-contrast-10pct, rgba(0, 0, 0, .08));
     }
-`,Oi=new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}),ki=e=>Oi.format(e),Ai=(e,t)=>{let n=e<0?`-`:``,r=ki(Math.abs(e));return t?`${n}${t} ${r}`:`${n}${r}`},ji=(e,t)=>t?`${ki(e)} ${t}`:ki(e),Mi=class extends y{constructor(...e){super(...e),this.title=``,this.badges=[],this.facts=[]}static{this.styles=[Di,m`
+`,Ai=new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}),ji=e=>Ai.format(e),Mi=(e,t)=>{let n=e<0?`-`:``,r=ji(Math.abs(e));return t?`${n}${t} ${r}`:`${n}${r}`},Ni=(e,t)=>t?`${ji(e)} ${t}`:ji(e),Pi=class extends y{constructor(...e){super(...e),this.title=``,this.badges=[],this.facts=[]}static{this.styles=[ki,m`
         :host { display: block; width: 100%; }
         .card {
             display: flex;
@@ -3606,7 +3606,7 @@ ${i}
                     </div>
                 `:_}
             </div>
-        `}};O([v()],Mi.prototype,`title`,void 0),O([v({type:Array})],Mi.prototype,`badges`,void 0),O([v()],Mi.prototype,`subtitle`,void 0),O([v({type:Array})],Mi.prototype,`facts`,void 0),O([v()],Mi.prototype,`metricLabel`,void 0),O([v()],Mi.prototype,`metricValue`,void 0),O([v()],Mi.prototype,`metricCaption`,void 0),Mi=O([h(`mateu-entity-header`)],Mi);var Ni=e=>{if(e.__hoistedToPageHeader)return w``;let t=e.metadata;return w`
+        `}};O([v()],Pi.prototype,`title`,void 0),O([v({type:Array})],Pi.prototype,`badges`,void 0),O([v()],Pi.prototype,`subtitle`,void 0),O([v({type:Array})],Pi.prototype,`facts`,void 0),O([v()],Pi.prototype,`metricLabel`,void 0),O([v()],Pi.prototype,`metricValue`,void 0),O([v()],Pi.prototype,`metricCaption`,void 0),Pi=O([h(`mateu-entity-header`)],Pi);var Fi=e=>{if(e.__hoistedToPageHeader)return w``;let t=e.metadata;return w`
         <mateu-entity-header
                 .title="${t.title??``}"
                 .badges="${t.badges??[]}"
@@ -3619,7 +3619,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-entity-header>
-    `},Pi=class extends y{constructor(...e){super(...e),this.value=0,this.max=0}static{this.styles=m`
+    `},Ii=class extends y{constructor(...e){super(...e),this.value=0,this.max=0}static{this.styles=m`
         :host { display: block; width: 100%; }
         .meter { display: flex; flex-direction: column; gap: .35rem; }
         .label {
@@ -3644,13 +3644,13 @@ ${i}
     `}fillColor(){return this.dangerAt!=null&&this.value>=this.dangerAt?`error`:this.warnAt!=null&&this.value>=this.warnAt?`warning`:this.warnAt!=null||this.dangerAt!=null?`success`:`primary`}render(){let e=this.max>0?Math.min(Math.max(this.value/this.max,0),1):0,t=Math.round(e*100);return w`
             <div class="meter">
                 ${this.label?w`<span class="label">${this.label}</span>`:_}
-                <span class="value">${ji(this.value,this.unit)}</span>
+                <span class="value">${Ni(this.value,this.unit)}</span>
                 <div class="track">
                     <div class="fill ${this.fillColor()}" style="width: ${t}%"></div>
                 </div>
                 <span class="caption">${this.caption?this.caption:`${t}%`}</span>
             </div>
-        `}};O([v()],Pi.prototype,`label`,void 0),O([v({type:Number})],Pi.prototype,`value`,void 0),O([v({type:Number})],Pi.prototype,`max`,void 0),O([v()],Pi.prototype,`unit`,void 0),O([v()],Pi.prototype,`caption`,void 0),O([v({type:Number})],Pi.prototype,`warnAt`,void 0),O([v({type:Number})],Pi.prototype,`dangerAt`,void 0),Pi=O([h(`mateu-meter`)],Pi);var Fi=e=>{let t=e.metadata;return w`
+        `}};O([v()],Ii.prototype,`label`,void 0),O([v({type:Number})],Ii.prototype,`value`,void 0),O([v({type:Number})],Ii.prototype,`max`,void 0),O([v()],Ii.prototype,`unit`,void 0),O([v()],Ii.prototype,`caption`,void 0),O([v({type:Number})],Ii.prototype,`warnAt`,void 0),O([v({type:Number})],Ii.prototype,`dangerAt`,void 0),Ii=O([h(`mateu-meter`)],Ii);var Li=e=>{let t=e.metadata;return w`
         <mateu-meter
                 .label="${t.label}"
                 .value="${t.value??0}"
@@ -3663,7 +3663,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-meter>
-    `},Ii=class extends y{constructor(...e){super(...e),this.total=0,this.done=0}static{this.styles=m`
+    `},Ri=class extends y{constructor(...e){super(...e),this.total=0,this.done=0}static{this.styles=m`
         :host { display: block; width: 100%; }
         .banner {
             display: flex; align-items: center; gap: .8rem; flex-wrap: wrap;
@@ -3718,7 +3718,7 @@ ${i}
                 <span class="spacer"></span>
                 ${t?w`<button @click="${()=>this.runAction()}">${this.actionLabel} →</button>`:_}
             </div>
-        `}};O([v()],Ii.prototype,`label`,void 0),O([v({type:Number})],Ii.prototype,`total`,void 0),O([v({type:Number})],Ii.prototype,`done`,void 0),O([v()],Ii.prototype,`actionLabel`,void 0),O([v()],Ii.prototype,`actionId`,void 0),Ii=O([h(`mateu-task-progress`)],Ii);var Li=e=>{let t=e.metadata;return w`
+        `}};O([v()],Ri.prototype,`label`,void 0),O([v({type:Number})],Ri.prototype,`total`,void 0),O([v({type:Number})],Ri.prototype,`done`,void 0),O([v()],Ri.prototype,`actionLabel`,void 0),O([v()],Ri.prototype,`actionId`,void 0),Ri=O([h(`mateu-task-progress`)],Ri);var zi=e=>{let t=e.metadata;return w`
         <mateu-task-progress
                 .label="${t.label}"
                 .total="${t.total??0}"
@@ -3729,7 +3729,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-task-progress>
-    `},Ri=class extends y{constructor(...e){super(...e),this.items=[],this.compact=!1,this.frameless=!1,this.columns=0,this.itemHeadingLevel=3}static{this.styles=[Di,R,m`
+    `},Bi=class extends y{constructor(...e){super(...e),this.items=[],this.compact=!1,this.frameless=!1,this.columns=0,this.itemHeadingLevel=3}static{this.styles=[ki,R,m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .list {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -3872,7 +3872,7 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};O([v({type:Array})],Ri.prototype,`items`,void 0),O([v({type:Boolean})],Ri.prototype,`compact`,void 0),O([v({type:Boolean})],Ri.prototype,`frameless`,void 0),O([v()],Ri.prototype,`rowActionId`,void 0),O([v({type:Number})],Ri.prototype,`columns`,void 0),O([v({type:Number})],Ri.prototype,`itemHeadingLevel`,void 0),Ri=O([h(`mateu-status-list`)],Ri);var zi=e=>{let t=e.metadata;return w`
+        `}};O([v({type:Array})],Bi.prototype,`items`,void 0),O([v({type:Boolean})],Bi.prototype,`compact`,void 0),O([v({type:Boolean})],Bi.prototype,`frameless`,void 0),O([v()],Bi.prototype,`rowActionId`,void 0),O([v({type:Number})],Bi.prototype,`columns`,void 0),O([v({type:Number})],Bi.prototype,`itemHeadingLevel`,void 0),Bi=O([h(`mateu-status-list`)],Bi);var Vi=e=>{let t=e.metadata;return w`
         <mateu-status-list
                 .items="${t.items??[]}"
                 ?compact="${t.compact??!1}"
@@ -3884,7 +3884,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-status-list>
-    `},Bi=class extends y{constructor(...e){super(...e),this.items=[]}static{this.styles=m`
+    `},Hi=class extends y{constructor(...e){super(...e),this.items=[]}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         ul {
             margin: 0; padding-inline-start: 1.2rem;
@@ -3899,20 +3899,20 @@ ${i}
             <ul>
                 ${this.items.map(e=>w`<li>${e}</li>`)}
             </ul>
-        `}};O([v({type:Array})],Bi.prototype,`items`,void 0),Bi=O([h(`mateu-bulleted-list`)],Bi);var Vi=e=>w`
+        `}};O([v({type:Array})],Hi.prototype,`items`,void 0),Hi=O([h(`mateu-bulleted-list`)],Hi);var Ui=e=>w`
         <mateu-bulleted-list
                 .items="${e.metadata.items??[]}"
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-bulleted-list>
-    `,Hi=e=>{let t=e.metadata.attributes?.[`data-colspan`];return w`
+    `,Wi=e=>{let t=e.metadata.attributes?.[`data-colspan`];return w`
         <hr style="border: none; border-top: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1)); width: 100%; margin: var(--lumo-space-s, .5rem) 0; ${e.style??``}"
             class="${e.cssClasses??_}"
             id="${x(e.id??void 0)}"
             data-colspan="${x(t)}"
             slot="${e.slot??_}"/>
-    `},Ui={info:`ℹ`,success:`✓`,warning:`!`,danger:`!`},B=class extends y{constructor(...e){super(...e),this.text=``,this.theme=`info`,this.noIcon=!1,this.slim=!1,this.fullWidth=!1,this.hasContent=!1,this.inlineContent=!1}static{this.styles=m`
+    `},Gi={info:`ℹ`,success:`✓`,warning:`!`,danger:`!`},B=class extends y{constructor(...e){super(...e),this.text=``,this.theme=`info`,this.noIcon=!1,this.slim=!1,this.fullWidth=!1,this.hasContent=!1,this.inlineContent=!1}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .notice {
             display: flex;
@@ -3977,14 +3977,14 @@ ${i}
         .danger  .icon  { background: #b25b3d; }
     `}runAction(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId},bubbles:!0,composed:!0}))}render(){let e=!!this.text&&!!this.text.trim();if(!e&&!this.hasContent)return w``;let t=[`info`,`success`,`warning`,`danger`].includes(this.theme)?this.theme:`info`;return w`
             <div class="notice ${t} ${this.slim?`slim`:``}">
-                ${this.noIcon?_:w`<span class="icon ${this.icon?`custom`:``}">${this.icon||Ui[t]}</span>`}
+                ${this.noIcon?_:w`<span class="icon ${this.icon?`custom`:``}">${this.icon||Gi[t]}</span>`}
                 <div class="body ${this.inlineContent?`inline`:``}">
                     ${e?w`<span class="text">${this.text}</span>`:_}
                     ${this.hasContent?w`<div class="content"><slot></slot></div>`:_}
                 </div>
                 ${this.actionLabel&&this.actionId?w`<button class="notice-action" @click="${()=>this.runAction()}">${this.actionLabel}</button>`:this.status?w`<span class="status">${this.status}</span>`:_}
             </div>
-        `}};O([v()],B.prototype,`text`,void 0),O([v()],B.prototype,`theme`,void 0),O([v()],B.prototype,`icon`,void 0),O([v({type:Boolean})],B.prototype,`noIcon`,void 0),O([v()],B.prototype,`actionLabel`,void 0),O([v()],B.prototype,`actionId`,void 0),O([v()],B.prototype,`status`,void 0),O([v({type:Boolean})],B.prototype,`slim`,void 0),O([v({type:Boolean})],B.prototype,`fullWidth`,void 0),O([v({type:Boolean})],B.prototype,`hasContent`,void 0),O([v({type:Boolean})],B.prototype,`inlineContent`,void 0),B=O([h(`mateu-notice`)],B);var Wi=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=it(s.text??``,r,i,a,o)??``,l=t.children??[];return w`
+        `}};O([v()],B.prototype,`text`,void 0),O([v()],B.prototype,`theme`,void 0),O([v()],B.prototype,`icon`,void 0),O([v({type:Boolean})],B.prototype,`noIcon`,void 0),O([v()],B.prototype,`actionLabel`,void 0),O([v()],B.prototype,`actionId`,void 0),O([v()],B.prototype,`status`,void 0),O([v({type:Boolean})],B.prototype,`slim`,void 0),O([v({type:Boolean})],B.prototype,`fullWidth`,void 0),O([v({type:Boolean})],B.prototype,`hasContent`,void 0),O([v({type:Boolean})],B.prototype,`inlineContent`,void 0),B=O([h(`mateu-notice`)],B);var Ki=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=it(s.text??``,r,i,a,o)??``,l=t.children??[];return w`
         <mateu-notice
                 text="${c}"
                 theme="${s.theme??`info`}"
@@ -4002,7 +4002,7 @@ ${i}
                 class="${t.cssClasses??_}"
                 slot="${t.slot??_}"
         >${l.map(t=>P(e,t,n,r,i,a,o))}</mateu-notice>
-    `},Gi=class extends y{constructor(...e){super(...e),this.groups=[]}static{this.styles=[Di,R,m`
+    `},qi=class extends y{constructor(...e){super(...e),this.groups=[]}static{this.styles=[ki,R,m`
         :host { display: block; width: 100%; }
         .rail { display: flex; flex-direction: column; gap: var(--lumo-space-m, 1rem); }
         .group { display: flex; flex-direction: column; gap: .45rem; }
@@ -4065,7 +4065,7 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};O([v()],Gi.prototype,`actionId`,void 0),O([v({type:Array})],Gi.prototype,`groups`,void 0),O([S()],Gi.prototype,`selectedId`,void 0),Gi=O([h(`mateu-task-queue`)],Gi);var Ki=e=>{let t=e.metadata;return w`
+        `}};O([v()],qi.prototype,`actionId`,void 0),O([v({type:Array})],qi.prototype,`groups`,void 0),O([S()],qi.prototype,`selectedId`,void 0),qi=O([h(`mateu-task-queue`)],qi);var Ji=e=>{let t=e.metadata;return w`
         <mateu-task-queue
                 .actionId="${t.actionId}"
                 .groups="${t.groups??[]}"
@@ -4073,7 +4073,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-task-queue>
-    `},qi=class extends y{constructor(...e){super(...e),this.columns=0,this.items=[]}static{this.styles=[Di,R,m`
+    `},Yi=class extends y{constructor(...e){super(...e),this.columns=0,this.items=[]}static{this.styles=[ki,R,m`
         /* explicit line-height: inside a form field wrapper the inherited one is the 44px
            field height, which blows up every text row */
         :host { display: block; width: 100%; line-height: var(--lumo-line-height-m, 1.4); }
@@ -4137,7 +4137,7 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};O([v()],qi.prototype,`actionId`,void 0),O([v({type:Number})],qi.prototype,`columns`,void 0),O([v()],qi.prototype,`recommendedLabel`,void 0),O([v({type:Array})],qi.prototype,`items`,void 0),O([S()],qi.prototype,`selectedId`,void 0),qi=O([h(`mateu-resource-grid`)],qi);var Ji=e=>{let t=e.metadata;return w`
+        `}};O([v()],Yi.prototype,`actionId`,void 0),O([v({type:Number})],Yi.prototype,`columns`,void 0),O([v()],Yi.prototype,`recommendedLabel`,void 0),O([v({type:Array})],Yi.prototype,`items`,void 0),O([S()],Yi.prototype,`selectedId`,void 0),Yi=O([h(`mateu-resource-grid`)],Yi);var Xi=e=>{let t=e.metadata;return w`
         <mateu-resource-grid
                 .actionId="${t.actionId}"
                 .columns="${t.columns??0}"
@@ -4235,7 +4235,7 @@ ${i}
                         `:_}
                 </div>
             </div>
-        `}};O([v()],V.prototype,`tag`,void 0),O([v()],V.prototype,`title`,void 0),O([v()],V.prototype,`subtitle`,void 0),O([v()],V.prototype,`image`,void 0),O([v({type:Array})],V.prototype,`features`,void 0),O([v()],V.prototype,`priceLabel`,void 0),O([v()],V.prototype,`actionLabel`,void 0),O([v()],V.prototype,`actionId`,void 0),O([v({type:Boolean})],V.prototype,`current`,void 0),O([v()],V.prototype,`currentLabel`,void 0),O([v({type:Boolean})],V.prototype,`added`,void 0),O([v()],V.prototype,`addedLabel`,void 0),V=O([h(`mateu-offer-card`)],V);var Yi=e=>{let t=e.metadata;return w`
+        `}};O([v()],V.prototype,`tag`,void 0),O([v()],V.prototype,`title`,void 0),O([v()],V.prototype,`subtitle`,void 0),O([v()],V.prototype,`image`,void 0),O([v({type:Array})],V.prototype,`features`,void 0),O([v()],V.prototype,`priceLabel`,void 0),O([v()],V.prototype,`actionLabel`,void 0),O([v()],V.prototype,`actionId`,void 0),O([v({type:Boolean})],V.prototype,`current`,void 0),O([v()],V.prototype,`currentLabel`,void 0),O([v({type:Boolean})],V.prototype,`added`,void 0),O([v()],V.prototype,`addedLabel`,void 0),V=O([h(`mateu-offer-card`)],V);var Zi=e=>{let t=e.metadata;return w`
         <mateu-offer-card
                 .tag="${t.tag}"
                 .title="${t.title??``}"
@@ -4253,7 +4253,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-offer-card>
-    `},Xi=class extends y{constructor(...e){super(...e),this.items=[],this.added=new Set}static{this.styles=m`
+    `},Qi=class extends y{constructor(...e){super(...e),this.items=[],this.added=new Set}static{this.styles=m`
         :host { display: block; width: 100%; }
         .header { display: flex; align-items: baseline; justify-content: flex-end; gap: .4rem; margin-bottom: .6rem; }
         .total-label { font-size: var(--lumo-font-size-s, .875rem); color: var(--lumo-secondary-text-color, #888); }
@@ -4321,7 +4321,7 @@ ${i}
     `}willUpdate(e){e.has(`items`)&&(this.added=new Set(this.items.filter(e=>e.added).map(e=>e.id)))}total(){return this.items.filter(e=>e.id!=null&&this.added.has(e.id)).reduce((e,t)=>e+(t.price??0),0)}toggle(e){if(e.id==null)return;let t=new Set(this.added),n=!t.has(e.id);n?t.add(e.id):t.delete(e.id),this.added=t,this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{_item:e.id,_added:n,_total:this.total()}},bubbles:!0,composed:!0}))}render(){return w`
             <div class="header">
                 ${this.totalLabel?w`<span class="total-label">${this.totalLabel}:</span>`:_}
-                <span class="total">${Ai(this.total(),this.currency)}</span>
+                <span class="total">${Mi(this.total(),this.currency)}</span>
             </div>
             <div class="grid">
                 ${this.items.map(e=>{let t=e.id!=null&&this.added.has(e.id);return w`
@@ -4331,7 +4331,7 @@ ${i}
                             ${e.description?w`<span class="description">${e.description}</span>`:_}
                             ${e.includedLabel?w`<span class="included">${e.includedLabel}</span>`:w`
                                     ${e.price==null?_:w`
-                                        <span class="price">${Ai(e.price,this.currency)}${e.unit?` / ${e.unit}`:``}</span>
+                                        <span class="price">${Mi(e.price,this.currency)}${e.unit?` / ${e.unit}`:``}</span>
                                     `}
                                     <button class="toggle ${t?`on`:``}" @click="${()=>this.toggle(e)}"
                                             aria-pressed="${t}">${t?`✓`:`+`}</button>
@@ -4339,7 +4339,7 @@ ${i}
                         </div>
                     `})}
             </div>
-        `}};O([v()],Xi.prototype,`totalLabel`,void 0),O([v()],Xi.prototype,`currency`,void 0),O([v()],Xi.prototype,`actionId`,void 0),O([v({type:Array})],Xi.prototype,`items`,void 0),O([S()],Xi.prototype,`added`,void 0),Xi=O([h(`mateu-addon-picker`)],Xi);var Zi=e=>{let t=e.metadata;return w`
+        `}};O([v()],Qi.prototype,`totalLabel`,void 0),O([v()],Qi.prototype,`currency`,void 0),O([v()],Qi.prototype,`actionId`,void 0),O([v({type:Array})],Qi.prototype,`items`,void 0),O([S()],Qi.prototype,`added`,void 0),Qi=O([h(`mateu-addon-picker`)],Qi);var $i=e=>{let t=e.metadata;return w`
         <mateu-addon-picker
                 .totalLabel="${t.totalLabel}"
                 .currency="${t.currency}"
@@ -4349,7 +4349,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-addon-picker>
-    `},Qi=class extends y{constructor(...e){super(...e),this.lines=[]}static{this.styles=m`
+    `},ea=class extends y{constructor(...e){super(...e),this.lines=[]}static{this.styles=m`
         :host {
             display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem);
             /* an ancestor (e.g. a form-layout row) may set an inherited line-height like 44px —
@@ -4391,14 +4391,14 @@ ${i}
                 <div class="row">
                     <span class="dot"></span>
                     <span class="concept">${e.concept}</span>
-                    ${e.included?w`<span class="included-label">${e.includedLabel||`Included`}</span>`:w`<span class="amount ${(e.amount??0)<0?`negative`:``}">${Ai(e.amount??0,this.currency)}</span>`}
+                    ${e.included?w`<span class="included-label">${e.includedLabel||`Included`}</span>`:w`<span class="amount ${(e.amount??0)<0?`negative`:``}">${Mi(e.amount??0,this.currency)}</span>`}
                 </div>
             `)}
             <div class="total-row">
                 <span class="total-label">${this.totalLabel||`Total`}</span>
-                <span class="total">${Ai(this.computedTotal(),this.currency)}</span>
+                <span class="total">${Mi(this.computedTotal(),this.currency)}</span>
             </div>
-        `}};O([v()],Qi.prototype,`currency`,void 0),O([v()],Qi.prototype,`totalLabel`,void 0),O([v({type:Array})],Qi.prototype,`lines`,void 0),O([v({type:Number})],Qi.prototype,`total`,void 0),Qi=O([h(`mateu-ledger`)],Qi);var $i=e=>{let t=e.metadata;return w`
+        `}};O([v()],ea.prototype,`currency`,void 0),O([v()],ea.prototype,`totalLabel`,void 0),O([v({type:Array})],ea.prototype,`lines`,void 0),O([v({type:Number})],ea.prototype,`total`,void 0),ea=O([h(`mateu-ledger`)],ea);var ta=e=>{let t=e.metadata;return w`
         <mateu-ledger
                 .currency="${t.currency}"
                 .totalLabel="${t.totalLabel}"
@@ -4408,7 +4408,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-ledger>
-    `},ea=class extends y{constructor(...e){super(...e),this.methods=[]}static{this.styles=m`
+    `},na=class extends y{constructor(...e){super(...e),this.methods=[]}static{this.styles=m`
         :host { display: block; width: 100%; }
         .bar { display: flex; align-items: stretch; gap: .6rem; flex-wrap: wrap; }
         .methods { display: flex; gap: .4rem; flex-wrap: wrap; }
@@ -4470,7 +4470,7 @@ ${i}
                 <span class="spacer"></span>
                 ${this.confirmLabel&&this.actionId?w`<button class="confirm" @click="${()=>this.confirm()}">${this.confirmLabel}</button>`:_}
             </div>
-        `}};O([v()],ea.prototype,`actionId`,void 0),O([v()],ea.prototype,`methodActionId`,void 0),O([v({type:Array})],ea.prototype,`methods`,void 0),O([v()],ea.prototype,`selected`,void 0),O([v()],ea.prototype,`contextLabel`,void 0),O([v()],ea.prototype,`contextValue`,void 0),O([v()],ea.prototype,`confirmLabel`,void 0),O([S()],ea.prototype,`selectedId`,void 0),ea=O([h(`mateu-payment-picker`)],ea);var ta=e=>{let t=e.metadata;return w`
+        `}};O([v()],na.prototype,`actionId`,void 0),O([v()],na.prototype,`methodActionId`,void 0),O([v({type:Array})],na.prototype,`methods`,void 0),O([v()],na.prototype,`selected`,void 0),O([v()],na.prototype,`contextLabel`,void 0),O([v()],na.prototype,`contextValue`,void 0),O([v()],na.prototype,`confirmLabel`,void 0),O([S()],na.prototype,`selectedId`,void 0),na=O([h(`mateu-payment-picker`)],na);var ra=e=>{let t=e.metadata;return w`
         <mateu-payment-picker
                 .actionId="${t.actionId}"
                 .methodActionId="${t.methodActionId}"
@@ -4483,7 +4483,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-payment-picker>
-    `},na=class extends y{constructor(...e){super(...e),this.items=[]}static{this.styles=m`
+    `},ia=class extends y{constructor(...e){super(...e),this.items=[]}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .list {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -4537,14 +4537,14 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};O([v({type:Array})],na.prototype,`items`,void 0),na=O([h(`mateu-process-monitor`)],na);var ra=e=>w`
+        `}};O([v({type:Array})],ia.prototype,`items`,void 0),ia=O([h(`mateu-process-monitor`)],ia);var aa=e=>w`
         <mateu-process-monitor
                 .items="${e.metadata.items??[]}"
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-process-monitor>
-    `,ia=(e,t)=>{let n=e.style;return e.id&&(n&&!n.endsWith(`;`)&&(n+=`;`),n??=``,t[e.id+`.hidden`]==1&&(n+=`display: none;`)),n},aa=(e,t)=>{let n={...e.metadata};if(e.id&&n){if(n.type==A.Button){let r=n;t[e.id+`.disabled`]==1&&(r.disabled=!0)}if(n.type==A.FormField){let r=n;t[e.id+`.disabled`]==1&&(r.disabled=!0)}}return n},H=e=>t=>e(t.container,t.component,t.baseUrl,t.state,t.data,t.appState,t.appData),oa={[A.Bpmn]:({component:e})=>Sr(e),[A.Workflow]:({component:e})=>wr(e),[A.FormEditor]:({component:e})=>Tr(e),[A.Page]:H(br),[A.Div]:H(pr),[A.Directory]:({component:e,baseUrl:t,state:n,data:r})=>dr(e,t,n,r),[A.FormLayout]:H(Zt),[A.HorizontalLayout]:H(rn),[A.VerticalLayout]:H(an),[A.SplitLayout]:H(on),[A.MasterDetailLayout]:H(sn),[A.TabLayout]:H(cn),[A.AccordionLayout]:H(ln),[A.BoardLayout]:H(mn),[A.BoardLayoutRow]:H(hn),[A.BoardLayoutItem]:H(gn),[A.Scroller]:H(dn),[A.FullWidth]:H(fn),[A.Container]:H(pn),[A.Form]:({container:e,component:t,baseUrl:n,state:r,data:i,appState:a,appData:o})=>{let s=t.metadata;return w`<mateu-form
+    `,oa=(e,t)=>{let n=e.style;return e.id&&(n&&!n.endsWith(`;`)&&(n+=`;`),n??=``,t[e.id+`.hidden`]==1&&(n+=`display: none;`)),n},sa=(e,t)=>{let n={...e.metadata};if(e.id&&n){if(n.type==A.Button){let r=n;t[e.id+`.disabled`]==1&&(r.disabled=!0)}if(n.type==A.FormField){let r=n;t[e.id+`.disabled`]==1&&(r.disabled=!0)}}return n},H=e=>t=>e(t.container,t.component,t.baseUrl,t.state,t.data,t.appState,t.appData),ca={[A.Bpmn]:({component:e})=>wr(e),[A.Workflow]:({component:e})=>Er(e),[A.FormEditor]:({component:e})=>Dr(e),[A.Page]:H(Sr),[A.Div]:H(hr),[A.Directory]:({component:e,baseUrl:t,state:n,data:r})=>pr(e,t,n,r),[A.FormLayout]:H($t),[A.HorizontalLayout]:H(on),[A.VerticalLayout]:H(sn),[A.SplitLayout]:H(cn),[A.MasterDetailLayout]:H(ln),[A.TabLayout]:H(un),[A.AccordionLayout]:H(dn),[A.BoardLayout]:H(gn),[A.BoardLayoutRow]:H(_n),[A.BoardLayoutItem]:H(vn),[A.Scroller]:H(pn),[A.FullWidth]:H(mn),[A.Container]:H(hn),[A.Form]:({container:e,component:t,baseUrl:n,state:r,data:i,appState:a,appData:o})=>{let s=t.metadata;return w`<mateu-form
             id="${t.id}"
         baseUrl="${n}"
             .component="${t}"
@@ -4562,7 +4562,7 @@ ${i}
                ${P(e,{id:t.actionId,metadata:t,type:k.ClientSide,slot:`buttons`},void 0,r,i,a,o)}
 `)}
 
-            </mateu-form>`},[A.Table]:({component:e,state:t,data:n})=>bn(e,(e.id?n?.[e.id]:void 0)?.page?.content??xn(e,t)),[A.Crud]:H(xr),[A.App]:({container:e,component:t,baseUrl:n,state:r,data:i,appState:a,appData:o})=>w`
+            </mateu-form>`},[A.Table]:({component:e,state:t,data:n})=>Sn(e,(e.id?n?.[e.id]:void 0)?.page?.content??Cn(e,t)),[A.Crud]:H(Cr),[A.App]:({container:e,component:t,baseUrl:n,state:r,data:i,appState:a,appData:o})=>w`
             <mateu-app
                         id="${t.id}"
                         baseUrl="${n}"
@@ -4575,12 +4575,12 @@ ${i}
                         .appData="${o}"
             >
              ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
-         </mateu-app>`,[A.Element]:({container:e,component:t})=>Mn(e,t.metadata,t),[A.FormField]:({component:e,state:t})=>vr(e,t),[A.Text]:({component:e,state:t,data:n,appState:r,appData:i})=>Pn(e,t,n,r,i),[A.Avatar]:({component:e,state:t,data:n})=>ut(e,t,n),[A.Chat]:({component:e,state:t,data:n})=>Cr(e,t,n),[A.AvatarGroup]:({component:e})=>dt(e),[A.Badge]:({component:e,state:t,data:n})=>ft(e,t,n),[A.Breadcrumbs]:({component:e})=>lr(e),[A.Anchor]:({component:e})=>Fn(e),[A.Button]:({component:e,state:t,data:n})=>Hn(e,t,n),[A.Card]:H(Wn),[A.Chart]:({component:e})=>Gn(e),[A.Icon]:({component:e})=>Kn(e),[A.ConfirmDialog]:H(Zn),[A.ContextMenu]:H(Tn),[A.CookieConsent]:({component:e})=>Qn(e),[A.Details]:H($n),[A.Dialog]:({component:e,baseUrl:t,state:n,data:r,appState:i,appData:a})=>er(e,t,n,r,i,a),[A.Drawer]:({component:e,baseUrl:t,state:n,data:r,appState:i,appData:a})=>tr(e,t,n,r,i,a),[A.Image]:({component:e})=>cr(e),[A.Map]:({component:e})=>sr(e),[A.Markdown]:({component:e})=>rr(e),[A.MicroFrontend]:({component:e})=>nr(e),[A.Notification]:({component:e})=>ir(e),[A.ProgressBar]:({component:e,state:t})=>ar(e,t),[A.Popover]:H(or),[A.CarouselLayout]:H(ur),[A.Tooltip]:H(On),[A.MessageInput]:({component:e})=>Dn(e),[A.MessageList]:({component:e})=>Sn(e),[A.CustomField]:H(En),[A.MenuBar]:({container:e,component:t,baseUrl:n,state:r,data:i})=>wn(e,t,n,r,i),[A.Grid]:({component:e,state:t})=>bn(e,xn(e,t)),[A.VirtualList]:H(_n),[A.FormSection]:H(mr),[A.FormSubSection]:H(hr),[A.MetricCard]:({component:e})=>Ar(e),[A.Scoreboard]:H(jr),[A.DashboardPanel]:H(Mr),[A.DashboardLayout]:H(Nr),[A.FoldoutLayout]:H(Fr),[A.ContentLayout]:H(Ir),[A.HeroSection]:H(Lr),[A.EmptyState]:({component:e})=>Ct(e),[A.Skeleton]:({component:e})=>wt(e),[A.Gantt]:({component:e})=>Br(e),[A.PlanningBoard]:({component:e})=>Hr(e),[A.Kanban]:({component:e})=>Wr(e),[A.Timeline]:({component:e})=>Kr(e),[A.ProgressSteps]:({component:e})=>Jr(e),[A.Stat]:({component:e})=>Xr(e),[A.Calendar]:({component:e})=>Qr(e),[A.PricingTable]:({component:e})=>ei(e),[A.OrgChart]:({component:e})=>ni(e),[A.Heatmap]:({component:e})=>ai(e),[A.Funnel]:({component:e})=>si(e),[A.TrendChart]:({component:e})=>li(e),[A.FeatureGrid]:({component:e})=>di(e),[A.Testimonials]:({component:e})=>pi(e),[A.Faq]:({component:e})=>hi(e),[A.CalloutCard]:({component:e})=>_i(e),[A.CommentThread]:({component:e})=>yi(e),[A.FileList]:({component:e})=>Si(e),[A.Checklist]:({component:e})=>wi(e),[A.ComparisonCard]:({component:e})=>Ei(e),[A.EntityHeader]:({component:e})=>Ni(e),[A.Meter]:({component:e})=>Fi(e),[A.TaskProgress]:({component:e})=>Li(e),[A.StatusList]:({component:e})=>zi(e),[A.BulletedList]:({component:e})=>Vi(e),[A.Separator]:({component:e})=>Hi(e),[A.Notice]:H(Wi),[A.TaskQueue]:({component:e})=>Ki(e),[A.ResourceGrid]:({component:e})=>Ji(e),[A.OfferCard]:({component:e})=>Yi(e),[A.AddOnPicker]:({component:e})=>Zi(e),[A.Ledger]:({component:e})=>$i(e),[A.PaymentPicker]:({component:e})=>ta(e),[A.ProcessMonitor]:({component:e})=>ra(e)},sa=(e,t,n,r,i,a,o,s)=>{if(!t?.metadata)return t==null?(console.warn(`No metadata for component`,t),w`<p>No metadata for component</p>`):sa(e,{id:T(),metadata:t,type:k.ClientSide},n,r,i,a,o,s);let c=t.metadata.type,l={...t,style:ia(t,i),metadata:aa(t,i)},u=oa[c];return u?u({container:e,component:l,baseUrl:n,state:r,data:i,appState:a,appData:o,labelAlreadyRendered:s}):w`<p ${l?.slot??_}>Unknown metadata type ${c} for component ${l?.id}</p>`},ca=function(e){return e.NONE=`NONE`,e.INFO=`INFO`,e.SUCCESS=`SUCCESS`,e.WARNING=`WARNING`,e.DANGER=`DANGER`,e}({}),la=(e,t,n)=>{let r=e[n.path];return r?w`<span theme="badge pill ${ua(r.type)}">${r.message}</span>`:w``},ua=e=>{switch(e){case ca.SUCCESS:return`success`;case ca.WARNING:return`warning`;case ca.DANGER:return`error`;case ca.NONE:return`contrast`}return``},U=class extends y{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.respondToVisibility=(e,t)=>{var n={root:document.documentElement};new IntersectionObserver(e=>{e.forEach(e=>{t(e.intersectionRatio>0)})},n).observe(e)},this.keepAsking=!1,this.askToUpper=()=>{let e=this.data[this.id]?.page,t=e?.content?.length/e?.pageSize;this.dispatchEvent(new CustomEvent(`fetch-more-elements`,{detail:{params:{page:t,pageSize:this.metadata?.pageSize},callback:()=>{this.keepAsking&&this.askToUpper()}},bubbles:!0,composed:!0}))},this.renderItem=e=>e.card?sa(this,e.card,this.baseUrl,this.state,this.data,this.appState,this.appData,!1):e.title?w`<div class="neutral-card">
+         </mateu-app>`,[A.Element]:({container:e,component:t})=>Pn(e,t.metadata,t),[A.FormField]:({component:e,state:t})=>br(e,t),[A.Text]:({component:e,state:t,data:n,appState:r,appData:i})=>In(e,t,n,r,i),[A.Avatar]:({component:e,state:t,data:n})=>ut(e,t,n),[A.Chat]:({component:e,state:t,data:n})=>Tr(e,t,n),[A.AvatarGroup]:({component:e})=>dt(e),[A.Badge]:({component:e,state:t,data:n})=>ft(e,t,n),[A.Breadcrumbs]:({component:e})=>dr(e),[A.Anchor]:({component:e})=>Ln(e),[A.Button]:({component:e,state:t,data:n})=>Wn(e,t,n),[A.Card]:H(Kn),[A.Chart]:({component:e})=>qn(e),[A.Icon]:({component:e})=>Jn(e),[A.ConfirmDialog]:H($n),[A.ContextMenu]:H(Dn),[A.CookieConsent]:({component:e})=>er(e),[A.Details]:H(tr),[A.Dialog]:({component:e,baseUrl:t,state:n,data:r,appState:i,appData:a})=>nr(e,t,n,r,i,a),[A.Drawer]:({component:e,baseUrl:t,state:n,data:r,appState:i,appData:a})=>rr(e,t,n,r,i,a),[A.Image]:({component:e})=>ur(e),[A.Map]:({component:e})=>lr(e),[A.Markdown]:({component:e})=>ar(e),[A.MicroFrontend]:({component:e})=>ir(e),[A.Notification]:({component:e})=>or(e),[A.ProgressBar]:({component:e,state:t})=>sr(e,t),[A.Popover]:H(cr),[A.CarouselLayout]:H(fr),[A.Tooltip]:H(An),[A.MessageInput]:({component:e})=>kn(e),[A.MessageList]:({component:e})=>wn(e),[A.CustomField]:H(On),[A.MenuBar]:({container:e,component:t,baseUrl:n,state:r,data:i})=>En(e,t,n,r,i),[A.Grid]:({component:e,state:t})=>Sn(e,Cn(e,t)),[A.VirtualList]:H(yn),[A.FormSection]:H(gr),[A.FormSubSection]:H(_r),[A.MetricCard]:({component:e})=>Mr(e),[A.Scoreboard]:H(Nr),[A.DashboardPanel]:H(Pr),[A.DashboardLayout]:H(Fr),[A.FoldoutLayout]:H(Lr),[A.ContentLayout]:H(Rr),[A.HeroSection]:H(zr),[A.EmptyState]:({component:e})=>Ct(e),[A.Skeleton]:({component:e})=>wt(e),[A.Gantt]:({component:e})=>Hr(e),[A.PlanningBoard]:({component:e})=>Wr(e),[A.Kanban]:({component:e})=>Kr(e),[A.Timeline]:({component:e})=>Jr(e),[A.ProgressSteps]:({component:e})=>Xr(e),[A.Stat]:({component:e})=>Qr(e),[A.Calendar]:({component:e})=>ei(e),[A.PricingTable]:({component:e})=>ni(e),[A.OrgChart]:({component:e})=>ii(e),[A.Heatmap]:({component:e})=>si(e),[A.Funnel]:({component:e})=>li(e),[A.TrendChart]:({component:e})=>di(e),[A.FeatureGrid]:({component:e})=>pi(e),[A.Testimonials]:({component:e})=>hi(e),[A.Faq]:({component:e})=>_i(e),[A.CalloutCard]:({component:e})=>yi(e),[A.CommentThread]:({component:e})=>xi(e),[A.FileList]:({component:e})=>wi(e),[A.Checklist]:({component:e})=>Ei(e),[A.ComparisonCard]:({component:e})=>Oi(e),[A.EntityHeader]:({component:e})=>Fi(e),[A.Meter]:({component:e})=>Li(e),[A.TaskProgress]:({component:e})=>zi(e),[A.StatusList]:({component:e})=>Vi(e),[A.BulletedList]:({component:e})=>Ui(e),[A.Separator]:({component:e})=>Wi(e),[A.Notice]:H(Ki),[A.TaskQueue]:({component:e})=>Ji(e),[A.ResourceGrid]:({component:e})=>Xi(e),[A.OfferCard]:({component:e})=>Zi(e),[A.AddOnPicker]:({component:e})=>$i(e),[A.Ledger]:({component:e})=>ta(e),[A.PaymentPicker]:({component:e})=>ra(e),[A.ProcessMonitor]:({component:e})=>aa(e)},la=(e,t,n,r,i,a,o,s)=>{if(!t?.metadata)return t==null?(console.warn(`No metadata for component`,t),w`<p>No metadata for component</p>`):la(e,{id:T(),metadata:t,type:k.ClientSide},n,r,i,a,o,s);let c=t.metadata.type,l={...t,style:oa(t,i),metadata:sa(t,i)},u=ca[c];return u?u({container:e,component:l,baseUrl:n,state:r,data:i,appState:a,appData:o,labelAlreadyRendered:s}):w`<p ${l?.slot??_}>Unknown metadata type ${c} for component ${l?.id}</p>`},ua=function(e){return e.NONE=`NONE`,e.INFO=`INFO`,e.SUCCESS=`SUCCESS`,e.WARNING=`WARNING`,e.DANGER=`DANGER`,e}({}),da=(e,t,n)=>{let r=e[n.path];return r?w`<span theme="badge pill ${fa(r.type)}">${r.message}</span>`:w``},fa=e=>{switch(e){case ua.SUCCESS:return`success`;case ua.WARNING:return`warning`;case ua.DANGER:return`error`;case ua.NONE:return`contrast`}return``},U=class extends y{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.respondToVisibility=(e,t)=>{var n={root:document.documentElement};new IntersectionObserver(e=>{e.forEach(e=>{t(e.intersectionRatio>0)})},n).observe(e)},this.keepAsking=!1,this.askToUpper=()=>{let e=this.data[this.id]?.page,t=e?.content?.length/e?.pageSize;this.dispatchEvent(new CustomEvent(`fetch-more-elements`,{detail:{params:{page:t,pageSize:this.metadata?.pageSize},callback:()=>{this.keepAsking&&this.askToUpper()}},bubbles:!0,composed:!0}))},this.renderItem=e=>e.card?la(this,e.card,this.baseUrl,this.state,this.data,this.appState,this.appData,!1):e.title?w`<div class="neutral-card">
                 ${e.image?w`<img class="card-media" src="${e.image}" alt="" />`:_}
                 <div class="card-body">
                     <div class="card-head">
                         ${e.title?w`<span class="card-title">${e.title}</span>`:_}
-                        ${e.status?w`<span theme="badge ${ua(e.status.type)}">${e.status.message}</span>`:_}
+                        ${e.status?w`<span theme="badge ${fa(e.status.type)}">${e.status.message}</span>`:_}
                     </div>
                     ${e.subtitle?w`<div class="card-subtitle">${e.subtitle}</div>`:_}
                     ${e.content?w`<div>${e.content}</div>`:_}
@@ -4618,19 +4618,19 @@ ${i}
         .neutral-card .card-subtitle { color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-s, .875rem); }
     
         ${R}
-    `}};O([v()],U.prototype,`id`,void 0),O([v()],U.prototype,`metadata`,void 0),O([v()],U.prototype,`baseUrl`,void 0),O([v()],U.prototype,`state`,void 0),O([v()],U.prototype,`data`,void 0),O([v()],U.prototype,`appState`,void 0),O([v()],U.prototype,`appData`,void 0),O([v()],U.prototype,`emptyStateMessage`,void 0),O([S()],U.prototype,`keepAsking`,void 0),O([b(`#ask-for-more`)],U.prototype,`askForMore`,void 0),O([S()],U.prototype,`hasMore`,void 0),U=O([h(`mateu-card-list`)],U);var da={show:e=>console.debug(`[mateu] no notifier registered, dropping toast:`,e.text)};function fa(e){da=e}function pa(e,t){da.show(e,t)}var ma=function(e){return e.none=`none`,e.success=`success`,e.error=`error`,e.warning=`warning`,e.contrast=`contrast`,e.normal=`normal`,e}({}),ha=function(e){return e.primary=`primary`,e.secondary=`secondary`,e.tertiary=`tertiary`,e.tertiaryInline=`tertiaryInline`,e}({});function ga(e){if(e.weight!=null)return e.weight;let t=e.stereotype??``;if(t===`icon`)return 1;if(t===`image`)return 4;if(t===`html`||t===`richText`||t===`markdown`||t===`textarea`)return 5;if(t===`link`)return 2.5;if(t===`combobox`||t===`select`)return 2;let n=e.dataType??``;return n===`bool`?1:n===`status`||n===`integer`?1.5:n===`number`||n===`date`||n===`money`?2:n===`dateTime`||n===`dateRange`?2.5:3}function _a(e,t){if(e.length===0)return`table`;let n=e.reduce((e,t)=>e+ga(t),0)/(t/76);if(n<=1.1)return`table`;if(n>1.6||e.length>10)return`masterDetail`;let r=e.filter(e=>e.identifier||(e.priority??2**53-1)<=2),i=r.reduce((e,t)=>e+ga(t),0);return r.length>0&&i<=8?`list`:e.some(e=>e.stereotype===`image`||e.stereotype===`html`)||r.length===0&&e.length>=4&&e.length<=8?`cards`:`masterDetail`}function va(e){return e.filter(e=>e.identifier||(e.priority??2**53-1)<=2).sort((e,t)=>(e.priority??2**53-1)-(t.priority??2**53-1))}function ya(e){let t=va(e);return t.length>0?t:e.slice(0,3)}var ba={asc:`ascending`,desc:`descending`},W=class extends y{constructor(...e){super(...e),this.component=void 0,this.standalone=!1,this.state={},this.data={},this.appState={},this.appData={},this.showImportDialog=!1,this.availableWidthPx=1024,this.selectedItem=null,this._columnPrefsRevision=0,this._prefsRevisionApplied=-1,this.search=()=>{let e=this.component.metadata;this.state={...this.state,size:e.pageSize,page:0,crud_selected_items:[]},this._syncStateToUrl(e),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`search`,parameters:{crudId:this.id,_searchState:{...this.state}}},bubbles:!0,composed:!0}))},this.notify=e=>{pa({text:e,position:`bottomEnd`,variant:`error`,duration:3e3},this)},this.handleSearchRequested=e=>{this.state={...this.state,crud_selected_items:[]};let t=this.component.metadata;if(this._syncStateToUrl(t),t.rowsSource){this._fetchRowsFromRest(t,e);return}!t.infiniteScrolling&&this.data?.[this.id]?.page&&(this.data[this.id].page.content=[]),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`search`,parameters:{crudId:this.id,_searchState:{...this.state}},callback:e},bubbles:!0,composed:!0}))},this._fetchRowsFromRest=(e,t)=>{let n=this.cols.map(e=>e.id).filter(Boolean),r=e.rowsSource;(r.proxy?new Promise(e=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`__restfetch__`,parameters:{_sourceKind:`rows`,_sourceId:this.id},callback:t=>e(Gt(t?.appData?._restfetch,r.itemsPath,n)),callbackonly:!0},bubbles:!0,composed:!0}))}):Jt(r,n,e=>j(e,this.state,this.data))).then(r=>{let i=String(this.state?.searchText??``).trim().toLowerCase(),a=i?r.filter(e=>n.some(t=>String(e[t]??``).toLowerCase().includes(i))):r,o=e.pageSize&&e.pageSize>0?e.pageSize:a.length||1,s=Number(this.state?.page??0),c=a.slice(s*o,s*o+o);this.data={...this.data,[this.id]:{page:{totalElements:a.length,pageSize:o,pageNumber:s,content:c}}},this.requestUpdate(),t?.()}).catch(e=>{console.warn(`mateu: external rows fetch failed`,e),t?.()})},this.fetchMoreElements=e=>{let{params:t,callback:n}=e.detail;this.state={...this.state,size:t.pageSize,page:t.page},this.handleSearchRequested(n)},this.directionChanged=e=>{let t=e.detail.grid._sorters;this.state={...this.state,sort:t.map(e=>({fieldId:e.__data.path,direction:e.__data.direction?ba[e.__data.direction]:void 0}))},this.handleSearchRequested(void 0)},this._initializedForComponentId=void 0,this.evalLabel=e=>j(e,this.state,this.data),this.handleToolbarButtonClick=e=>{if(e===`import`){this.showImportDialog=!0;return}this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.handleImportUploadSuccess=e=>{let t=e.detail.xhr.responseText;this.showImportDialog=!1,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`process-import`,parameters:{fileId:t}},bubbles:!0,composed:!0}))}}get columnPrefsScope(){return window.location.pathname}get effectiveComponent(){let e=this.component,t=e?.metadata;if(!e||!t?.columns)return e;if(this._prefsSource===e&&this._prefsRevisionApplied===this._columnPrefsRevision)return this._prefsApplied;let n=Lt(this.columnPrefsScope),r=Vt(t.columns,n,e=>e.metadata??{});return this._prefsApplied=r===t.columns?e:{...e,metadata:{...t,columns:r}},this._prefsSource=e,this._prefsRevisionApplied=this._columnPrefsRevision,this._prefsApplied}get columnChooserEntries(){return(this.component?.metadata?.columns??[]).map(e=>{let t=e.metadata??{},n=t.id??e.id;return n?{id:n,label:t.label??n,protected:Bt(t)}:void 0}).filter(e=>!!e)}renderColumnChooser(){let e=this.columnChooserEntries;return e.filter(e=>!e.protected).length===0?_:w`
+    `}};O([v()],U.prototype,`id`,void 0),O([v()],U.prototype,`metadata`,void 0),O([v()],U.prototype,`baseUrl`,void 0),O([v()],U.prototype,`state`,void 0),O([v()],U.prototype,`data`,void 0),O([v()],U.prototype,`appState`,void 0),O([v()],U.prototype,`appData`,void 0),O([v()],U.prototype,`emptyStateMessage`,void 0),O([S()],U.prototype,`keepAsking`,void 0),O([b(`#ask-for-more`)],U.prototype,`askForMore`,void 0),O([S()],U.prototype,`hasMore`,void 0),U=O([h(`mateu-card-list`)],U);var pa={show:e=>console.debug(`[mateu] no notifier registered, dropping toast:`,e.text)};function ma(e){pa=e}function ha(e,t){pa.show(e,t)}var ga=function(e){return e.none=`none`,e.success=`success`,e.error=`error`,e.warning=`warning`,e.contrast=`contrast`,e.normal=`normal`,e}({}),_a=function(e){return e.primary=`primary`,e.secondary=`secondary`,e.tertiary=`tertiary`,e.tertiaryInline=`tertiaryInline`,e}({});function va(e){if(e.weight!=null)return e.weight;let t=e.stereotype??``;if(t===`icon`)return 1;if(t===`image`)return 4;if(t===`html`||t===`richText`||t===`markdown`||t===`textarea`)return 5;if(t===`link`)return 2.5;if(t===`combobox`||t===`select`)return 2;let n=e.dataType??``;return n===`bool`?1:n===`status`||n===`integer`?1.5:n===`number`||n===`date`||n===`money`?2:n===`dateTime`||n===`dateRange`?2.5:3}function ya(e,t){if(e.length===0)return`table`;let n=e.reduce((e,t)=>e+va(t),0)/(t/76);if(n<=1.1)return`table`;if(n>1.6||e.length>10)return`masterDetail`;let r=e.filter(e=>e.identifier||(e.priority??2**53-1)<=2),i=r.reduce((e,t)=>e+va(t),0);return r.length>0&&i<=8?`list`:e.some(e=>e.stereotype===`image`||e.stereotype===`html`)||r.length===0&&e.length>=4&&e.length<=8?`cards`:`masterDetail`}function ba(e){return e.filter(e=>e.identifier||(e.priority??2**53-1)<=2).sort((e,t)=>(e.priority??2**53-1)-(t.priority??2**53-1))}function xa(e){let t=ba(e);return t.length>0?t:e.slice(0,3)}var Sa={asc:`ascending`,desc:`descending`},W=class extends y{constructor(...e){super(...e),this.component=void 0,this.standalone=!1,this.state={},this.data={},this.appState={},this.appData={},this.showImportDialog=!1,this.availableWidthPx=1024,this.selectedItem=null,this._columnPrefsRevision=0,this._prefsRevisionApplied=-1,this.search=()=>{let e=this.component.metadata;this.state={...this.state,size:e.pageSize,page:0,crud_selected_items:[]},this._syncStateToUrl(e),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`search`,parameters:{crudId:this.id,_searchState:{...this.state}}},bubbles:!0,composed:!0}))},this.notify=e=>{ha({text:e,position:`bottomEnd`,variant:`error`,duration:3e3},this)},this.handleSearchRequested=e=>{this.state={...this.state,crud_selected_items:[]};let t=this.component.metadata;if(this._syncStateToUrl(t),t.rowsSource){this._fetchRowsFromRest(t,e);return}!t.infiniteScrolling&&this.data?.[this.id]?.page&&(this.data[this.id].page.content=[]),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`search`,parameters:{crudId:this.id,_searchState:{...this.state}},callback:e},bubbles:!0,composed:!0}))},this._fetchRowsFromRest=(e,t)=>{let n=this.cols.map(e=>e.id).filter(Boolean),r=e.rowsSource;(r.proxy?new Promise(e=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`__restfetch__`,parameters:{_sourceKind:`rows`,_sourceId:this.id},callback:t=>e(qt(t?.appData?._restfetch,r.itemsPath,n)),callbackonly:!0},bubbles:!0,composed:!0}))}):Xt(r,n,e=>j(e,this.state,this.data))).then(r=>{let i=String(this.state?.searchText??``).trim().toLowerCase(),a=i?r.filter(e=>n.some(t=>String(e[t]??``).toLowerCase().includes(i))):r,o=e.pageSize&&e.pageSize>0?e.pageSize:a.length||1,s=Number(this.state?.page??0),c=a.slice(s*o,s*o+o);this.data={...this.data,[this.id]:{page:{totalElements:a.length,pageSize:o,pageNumber:s,content:c}}},this.requestUpdate(),t?.()}).catch(e=>{console.warn(`mateu: external rows fetch failed`,e),t?.()})},this.fetchMoreElements=e=>{let{params:t,callback:n}=e.detail;this.state={...this.state,size:t.pageSize,page:t.page},this.handleSearchRequested(n)},this.directionChanged=e=>{let t=e.detail.grid._sorters;this.state={...this.state,sort:t.map(e=>({fieldId:e.__data.path,direction:e.__data.direction?Sa[e.__data.direction]:void 0}))},this.handleSearchRequested(void 0)},this._initializedForComponentId=void 0,this.evalLabel=e=>j(e,this.state,this.data),this.handleToolbarButtonClick=e=>{if(e===`import`){this.showImportDialog=!0;return}this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.handleImportUploadSuccess=e=>{let t=e.detail.xhr.responseText;this.showImportDialog=!1,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`process-import`,parameters:{fileId:t}},bubbles:!0,composed:!0}))}}get columnPrefsScope(){return window.location.pathname}get effectiveComponent(){let e=this.component,t=e?.metadata;if(!e||!t?.columns)return e;if(this._prefsSource===e&&this._prefsRevisionApplied===this._columnPrefsRevision)return this._prefsApplied;let n=Lt(this.columnPrefsScope),r=Vt(t.columns,n,e=>e.metadata??{});return this._prefsApplied=r===t.columns?e:{...e,metadata:{...t,columns:r}},this._prefsSource=e,this._prefsRevisionApplied=this._columnPrefsRevision,this._prefsApplied}get columnChooserEntries(){return(this.component?.metadata?.columns??[]).map(e=>{let t=e.metadata??{},n=t.id??e.id;return n?{id:n,label:t.label??n,protected:Bt(t)}:void 0}).filter(e=>!!e)}renderColumnChooser(){let e=this.columnChooserEntries;return e.filter(e=>!e.protected).length===0?_:w`
             <mateu-column-chooser
                 .columns="${e}"
                 .scope="${this.columnPrefsScope}"
                 @column-prefs-changed="${e=>{e.stopPropagation(),this._columnPrefsRevision++}}"
             ></mateu-column-chooser>
-        `}get cols(){return(this.effectiveComponent?.metadata)?.columns?.map(e=>e.metadata)??[]}get identifierFieldName(){let e=this.cols.find(e=>e.identifier);return e?e.id:this.cols.find(e=>e.id===`id`)?.id}get effectiveGridLayout(){let e=this.component?.metadata,t=e?.gridLayout??`auto`;return t===`auto`?e?.crudlType===`card`?`cards`:_a(this.cols,this.availableWidthPx):t}connectedCallback(){super.connectedCallback(),this.resizeObserver=new ResizeObserver(e=>{let t=e[0]?.contentRect.width;t&&Math.abs(t-this.availableWidthPx)>10&&(this.availableWidthPx=t)}),this.resizeObserver.observe(this)}disconnectedCallback(){super.disconnectedCallback(),this.resizeObserver?.disconnect()}_filterIds(e){return new Set([`searchText`,...(e.filters??[]).flatMap(e=>e.stereotype===`dateRange`||e.stereotype===`numberRange`?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId])])}_syncStateToUrl(e){let t=this._filterIds(e),n=new URLSearchParams(window.location.search);t.forEach(e=>n.delete(e)),n.delete(`page`),n.delete(`sort`),t.forEach(e=>{let t=this.state[e];t!=null&&t!==``&&n.set(e,String(t))});let r=this.state.page;r&&r>0&&n.set(`page`,String(r));let i=this.state.sort;if(i&&i.length>0){let e=i.filter(e=>e.fieldId&&e.direction).map(e=>`${e.fieldId}:${e.direction}`).join(`,`);e&&n.set(`sort`,e)}let a=n.toString(),o=a?`${window.location.pathname}?${a}`:window.location.pathname;window.location.pathname+window.location.search!==o&&history.replaceState(null,``,o)}_initStateFromUrl(e,t){let n=new URLSearchParams(window.location.search),r=this._filterIds(e),i={...t};n.forEach((e,t)=>{r.has(t)&&(i[t]=e)});let a=n.get(`page`);if(a!==null){let e=parseInt(a,10);!isNaN(e)&&e>0&&(i.page=e)}let o=n.get(`sort`);if(o){let e=o.split(`,`).map(e=>{let[t,n]=e.split(`:`);return t&&n?{fieldId:t,direction:n}:null}).filter(Boolean);e.length>0&&(i.sort=e)}return i}pageChanged(e){this.state={...this.state,page:e.detail.page},this.handleSearchRequested(void 0)}updated(e){if(super.updated(e),e.has(`component`)){let e=this.component?.id;if(e!==this._initializedForComponentId){this._initializedForComponentId=e;let t=this.component?.metadata,n=t.initialPage&&t.initialPage>0?t.initialPage:0;this.state=this._initStateFromUrl(t,{...this.state,size:t.pageSize,page:n,sort:[]}),(this.state.page!==n||this.state.sort?.length>0||[...this._filterIds(t)].some(e=>this.state[e]!=null)||t.rowsSource)&&this.handleSearchRequested(void 0)}}}render(){let e=e=>{let t=[];return e.color&&e.color!==ma.normal&&t.push(e.color),e.buttonStyle&&t.push(e.buttonStyle===ha.tertiaryInline?`tertiary-inline`:e.buttonStyle),t.length?t.join(` `):void 0},t=e=>e===`back`||e===`backToList`||!!e&&e.startsWith(`cancel`),n=t=>N.get()?.renderToolbarButton?.(t,this.evalLabel(t.label),()=>this.handleToolbarButtonClick(t.actionId))||w`
+        `}get cols(){return(this.effectiveComponent?.metadata)?.columns?.map(e=>e.metadata)??[]}get identifierFieldName(){let e=this.cols.find(e=>e.identifier);return e?e.id:this.cols.find(e=>e.id===`id`)?.id}get effectiveGridLayout(){let e=this.component?.metadata,t=e?.gridLayout??`auto`;return t===`auto`?e?.crudlType===`card`?`cards`:ya(this.cols,this.availableWidthPx):t}connectedCallback(){super.connectedCallback(),this.resizeObserver=new ResizeObserver(e=>{let t=e[0]?.contentRect.width;t&&Math.abs(t-this.availableWidthPx)>10&&(this.availableWidthPx=t)}),this.resizeObserver.observe(this)}disconnectedCallback(){super.disconnectedCallback(),this.resizeObserver?.disconnect()}_filterIds(e){return new Set([`searchText`,...(e.filters??[]).flatMap(e=>e.stereotype===`dateRange`||e.stereotype===`numberRange`?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId])])}_syncStateToUrl(e){let t=this._filterIds(e),n=new URLSearchParams(window.location.search);t.forEach(e=>n.delete(e)),n.delete(`page`),n.delete(`sort`),t.forEach(e=>{let t=this.state[e];t!=null&&t!==``&&n.set(e,String(t))});let r=this.state.page;r&&r>0&&n.set(`page`,String(r));let i=this.state.sort;if(i&&i.length>0){let e=i.filter(e=>e.fieldId&&e.direction).map(e=>`${e.fieldId}:${e.direction}`).join(`,`);e&&n.set(`sort`,e)}let a=n.toString(),o=a?`${window.location.pathname}?${a}`:window.location.pathname;window.location.pathname+window.location.search!==o&&history.replaceState(null,``,o)}_initStateFromUrl(e,t){let n=new URLSearchParams(window.location.search),r=this._filterIds(e),i={...t};n.forEach((e,t)=>{r.has(t)&&(i[t]=e)});let a=n.get(`page`);if(a!==null){let e=parseInt(a,10);!isNaN(e)&&e>0&&(i.page=e)}let o=n.get(`sort`);if(o){let e=o.split(`,`).map(e=>{let[t,n]=e.split(`:`);return t&&n?{fieldId:t,direction:n}:null}).filter(Boolean);e.length>0&&(i.sort=e)}return i}pageChanged(e){this.state={...this.state,page:e.detail.page},this.handleSearchRequested(void 0)}updated(e){if(super.updated(e),e.has(`component`)){let e=this.component?.id;if(e!==this._initializedForComponentId){this._initializedForComponentId=e;let t=this.component?.metadata,n=t.initialPage&&t.initialPage>0?t.initialPage:0;this.state=this._initStateFromUrl(t,{...this.state,size:t.pageSize,page:n,sort:[]}),(this.state.page!==n||this.state.sort?.length>0||[...this._filterIds(t)].some(e=>this.state[e]!=null)||t.rowsSource)&&this.handleSearchRequested(void 0)}}}render(){let e=e=>{let t=[];return e.color&&e.color!==ga.normal&&t.push(e.color),e.buttonStyle&&t.push(e.buttonStyle===_a.tertiaryInline?`tertiary-inline`:e.buttonStyle),t.length?t.join(` `):void 0},t=e=>e===`back`||e===`backToList`||!!e&&e.startsWith(`cancel`),n=t=>N.get()?.renderToolbarButton?.(t,this.evalLabel(t.label),()=>this.handleToolbarButtonClick(t.actionId))||w`
                 <button class="crud-btn"
                         data-action-id="${t.id}"
                         theme="${e(t)||_}"
                         @click="${()=>this.handleToolbarButtonClick(t.actionId)}"
                 >${this.evalLabel(t.label)}</button>
-            `;if(!this.component)return w`no component`;let r=this.effectiveComponent,i=r.metadata;i.serverSideOrdering=!0;let a=(()=>{let e=this;for(;e;){let t=e;if(t.tagName===`MATEU-PAGE`)return(t.component?.metadata?.toolbar?.length??0)>0;e=t.parentElement??(t.getRootNode?.()instanceof ShadowRoot?t.getRootNode().host:null)}return!1})()?[]:i?.toolbar??[],o=a.filter(e=>t(e.actionId)),s=a.filter(e=>!t(e.actionId)),c=o.length>0&&s.length>0,l=!!i?.title||!!i?.subtitle||a.length>0,u=this.effectiveGridLayout,d=this.cols,f=va(d),p=this.data[this.id]?.page?.content??[],ee=this.state[this.component?.id]?.emptyStateMessage,te=(e,t)=>{let n=t[e.id];return n==null?w``:e.dataType===`status`?w`<span theme="badge pill ${ua(n.type)}">${n.message}</span>`:e.dataType===`bool`?w`${n?`✓`:`✗`}`:typeof n==`object`?w`${n.label??n.name??n.message??``}`:w`${n}`},ne=()=>{let e=this.identifierFieldName,t=this.state._selectedId??this.appState?._splitDetailId,n=f.find(e=>e.identifier)??f[0],r=e=>e.dataType===`action`||e.dataType===`actionGroup`||e.dataType===`menu`||e.stereotype===`button`,i=f.filter(e=>e!==n&&!r(e)),a=d.filter(e=>r(e)),o=(e,t,n)=>{e.stopPropagation(),e.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_clickedRow:n}},bubbles:!0,composed:!0}))},s=e=>{let t=[];for(let n of a){let r=e[n.id];if(n.dataType===`action`){let i=r?.methodNameInCrud?r:e.action?.methodNameInCrud?e.action:{methodNameInCrud:n.id,label:n.label,icon:null,disabled:!1};t.push(w`
+            `;if(!this.component)return w`no component`;let r=this.effectiveComponent,i=r.metadata;i.serverSideOrdering=!0;let a=(()=>{let e=this;for(;e;){let t=e;if(t.tagName===`MATEU-PAGE`)return(t.component?.metadata?.toolbar?.length??0)>0;e=t.parentElement??(t.getRootNode?.()instanceof ShadowRoot?t.getRootNode().host:null)}return!1})()?[]:i?.toolbar??[],o=a.filter(e=>t(e.actionId)),s=a.filter(e=>!t(e.actionId)),c=o.length>0&&s.length>0,l=!!i?.title||!!i?.subtitle||a.length>0,u=this.effectiveGridLayout,d=this.cols,f=ba(d),p=this.data[this.id]?.page?.content??[],ee=this.state[this.component?.id]?.emptyStateMessage,te=(e,t)=>{let n=t[e.id];return n==null?w``:e.dataType===`status`?w`<span theme="badge pill ${fa(n.type)}">${n.message}</span>`:e.dataType===`bool`?w`${n?`✓`:`✗`}`:typeof n==`object`?w`${n.label??n.name??n.message??``}`:w`${n}`},ne=()=>{let e=this.identifierFieldName,t=this.state._selectedId??this.appState?._splitDetailId,n=f.find(e=>e.identifier)??f[0],r=e=>e.dataType===`action`||e.dataType===`actionGroup`||e.dataType===`menu`||e.stereotype===`button`,i=f.filter(e=>e!==n&&!r(e)),a=d.filter(e=>r(e)),o=(e,t,n)=>{e.stopPropagation(),e.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_clickedRow:n}},bubbles:!0,composed:!0}))},s=e=>{let t=[];for(let n of a){let r=e[n.id];if(n.dataType===`action`){let i=r?.methodNameInCrud?r:e.action?.methodNameInCrud?e.action:{methodNameInCrud:n.id,label:n.label,icon:null,disabled:!1};t.push(w`
                             <button class="crud-btn" theme="tertiary small" title="${i.label||_}"
                                 @click="${t=>o(t,`action-on-row-`+i.methodNameInCrud,e)}">
                                 ${i.icon?F(i.icon):_}
@@ -4694,7 +4694,7 @@ ${i}
                             ${ne(n)}
                         </div>
                     `)}
-                </div>`},h=()=>{let e=ya(d),t=e.find(e=>e.identifier)??e[0],n=e.filter(e=>e!==t);return w`
+                </div>`},h=()=>{let e=xa(d),t=e.find(e=>e.identifier)??e[0],n=e.filter(e=>e!==t);return w`
                 <div style="display: flex; height: 100%; min-height: 400px; gap: 0;">
                     <div style="width: 260px; flex-shrink: 0; border-right: 1px solid var(--lumo-contrast-20pct); overflow-y: auto;">
                         <div class="m-listbox" style="width: 100%;">
@@ -4867,7 +4867,7 @@ ${i}
         }
     
         ${R}
-    `}};O([v()],W.prototype,`component`,void 0),O([v()],W.prototype,`baseUrl`,void 0),O([v({type:Boolean})],W.prototype,`standalone`,void 0),O([v()],W.prototype,`state`,void 0),O([v()],W.prototype,`data`,void 0),O([v()],W.prototype,`appState`,void 0),O([v()],W.prototype,`appData`,void 0),O([S()],W.prototype,`showImportDialog`,void 0),O([S()],W.prototype,`availableWidthPx`,void 0),O([S()],W.prototype,`selectedItem`,void 0),O([S()],W.prototype,`_columnPrefsRevision`,void 0),W=O([h(`mateu-table-crud`)],W);var xa=function(e){return e.OnLoad=`OnLoad`,e.OnSuccess=`OnSuccess`,e.OnError=`OnError`,e.OnValueChange=`OnValueChange`,e.OnCustomEvent=`OnCustomEvent`,e.AutoSave=`AutoSave`,e}({}),Sa=class extends et{constructor(...e){super(...e),this.state={},this.data={},this.appData={},this.appState={},this.triggerOnLoad=()=>{let e=this.component;this.registerCustomEventListeners(),e.triggers?.filter(e=>e.type==xa.OnLoad).forEach(e=>{if((!e.condition||this._evalExpr(e.condition))&&!e.triggered){let n=e;n.triggered=!0;var t=n.times-1;n.timeoutMillis>0?this.scheduleOnload(n,t,this.id):this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.actionId},bubbles:!0,composed:!0}))}})},this.scheduleOnload=(e,t,n)=>{if(n!=this.component?.id)return;let r=this.callbackToken;setTimeout(()=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,callbackToken:r},bubbles:!0,composed:!0}))},e.timeoutMillis)},this._registeredCustomEventListeners=[],this.customEventManager=e=>{if(!(e instanceof CustomEvent))return;let t=e,n=(this.component.triggers??[]).filter(e=>e.type==xa.OnCustomEvent).filter(e=>e.eventName==t.type).filter(e=>e.source!==`COMPONENT`||t.detail?.__source===e.from);n.length!==0&&(n.some(e=>!e.source||e.source===`SELF`)&&(e.stopPropagation(),e.preventDefault()),n.forEach(e=>{(!e.condition||this._evalExpr(e.condition))&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:t.detail},bubbles:!0,composed:!0}))}))}}_interpolationExtra(){return{appState:this.appState??{},appData:this.appData??{},component:this.component}}_evalExpr(e){return ot(e,this.state??{},this.data??{},this._interpolationExtra())}_evalTemplate(e){return st(e,this.state??{},this.data??{},this._interpolationExtra())}isOverlayChild(e){let t=e?.metadata?.type;return t==A.Drawer||t==A.Dialog}removeSelfFromOwnerChildren(){let e=this.component;if(!e)return!1;let t=t=>{if(t===e)return!0;let n=t;return e.id!=null&&n?.id==e.id&&this.isOverlayChild(n)},n=this.parentNode;for(;n;){let e=n instanceof ShadowRoot?n.host:n,r=e.component?.children;if(Array.isArray(r)){let n=r.findIndex(t);if(n>=0)return r.splice(n,1),e.requestUpdate?.(),!0}n=n instanceof ShadowRoot?e:n.parentNode}return!1}applyFragment(e){if(this.id==e.targetComponentId){if(e.component)if(Ke.Add==e.action){if(this.component){let t=this.component.children??(this.component.children=[]),n=e.component.id?t.findIndex(t=>t.id==e.component.id&&this.isOverlayChild(t)):-1;n>=0?(t[n]=e.component,this.component={...this.component}):t.push(e.component)}}else{this.callbackToken=T();let t=!1;if(e.component?.type==k.ServerSide)if(this.component){let n=this.component,r=e.component;t=n.serverSideType==r.serverSideType;let i=t?(n.children??[]).filter(e=>this.isOverlayChild(e)):[];n.actions=r.actions,n.type=r.type,n.rules=r.rules,n.triggers=r.triggers,n.serverSideType=r.serverSideType,n.route=r.route,n.initialData=r.initialData,n.validations=r.validations,n.cssClasses=r.cssClasses,n.slot=r.slot,n.style=r.style,n.children=i.length?[...r.children??[],...i]:r.children,(n.serverSideType!=r.serverSideType||n.id!=r.id)&&setTimeout(()=>this.triggerOnLoad())}else this.component=e.component,setTimeout(()=>this.triggerOnLoad());else{let t=[e.component];this.component&&(this.component.children=t)}e.action!==Ke.ReplaceKeepData&&!t&&(this.state={},this.data={})}if(e.state&&(this.state={...this.state,...e.state}),e.data){for(let t in e.data){let n=e.data[t]?.page;n?.pageNumber>0&&this.data[t]&&this.data[t].page.content&&(n.content?n.content=[...this.data[t].page.content,...n.content]:n.content=[...this.data[t].page.content])}this.data={...this.data,...e.data}}this.registerCustomEventListeners();let t=N.getAfterRenderHook();t&&setTimeout(()=>t(this)),this.requestUpdate()}}registerCustomEventListeners(){this._registeredCustomEventListeners.forEach(({target:e,name:t})=>e.removeEventListener(t,this.customEventManager)),this._registeredCustomEventListeners=[],this.component?.triggers?.filter(e=>e.type==xa.OnCustomEvent).forEach(e=>{let t=e.source===`DOCUMENT`||e.source===`COMPONENT`?document:this;t.addEventListener(e.eventName,this.customEventManager),this._registeredCustomEventListeners.push({target:t,name:e.eventName})})}disconnectedCallback(){this._registeredCustomEventListeners.forEach(({target:e,name:t})=>e.removeEventListener(t,this.customEventManager)),this._registeredCustomEventListeners=[],super.disconnectedCallback()}connectedCallback(){super.connectedCallback(),this.component&&this.registerCustomEventListeners()}};O([v()],Sa.prototype,`state`,void 0),O([v()],Sa.prototype,`data`,void 0),O([v()],Sa.prototype,`appData`,void 0),O([v()],Sa.prototype,`appState`,void 0);var Ca=`mateu-recent-routes`,wa=8;function Ta(){try{return JSON.parse(localStorage.getItem(Ca)??`{}`)}catch{return{}}}function Ea(e){try{localStorage.setItem(Ca,JSON.stringify(e))}catch{}}function Da(e){return Ta()[e||`_`]??[]}function Oa(e,t){if(!t?.route||!t.label)return;let n=e||`_`,r=Ta(),i=(r[n]??[]).filter(e=>e.route!==t.route);i.unshift({route:t.route,label:t.label}),r[n]=i.slice(0,wa),Ea(r)}var G=class extends y{constructor(...e){super(...e),this.baseUrl=``,this.open=!1,this.queryText=``,this.dataHits=[],this.loading=!1,this.selectedIndex=0,this.fabOffset=0,this.keydownHandler=null}connectedCallback(){super.connectedCallback(),this.keydownHandler=e=>{(e.metaKey||e.ctrlKey)&&(e.key===`k`||e.key===`K`)?(e.preventDefault(),this.toggle()):e.key===`Escape`&&this.open&&this.close()},document.addEventListener(`keydown`,this.keydownHandler),this.setupFabObserver()}disconnectedCallback(){super.disconnectedCallback(),this.keydownHandler&&document.removeEventListener(`keydown`,this.keydownHandler),clearTimeout(this.searchTimer),this.fabObserver?.disconnect(),this.fabObserver=void 0}setupFabObserver(){let e=this.getRootNode(),t=e instanceof ShadowRoot?e:document.body;this.measureFabStack(),this.fabObserver?.disconnect(),this.fabObserver=new MutationObserver(()=>this.measureFabStack()),this.fabObserver.observe(t,{childList:!0,subtree:!0})}measureFabStack(){let e=(this.getRootNode().querySelectorAll?.(`.ai-fab, .app-fab, .page-fab`).length??0)*4;e!==this.fabOffset&&(this.fabOffset=e)}updated(e){e.has(`open`)&&this.open&&requestAnimationFrame(()=>this.inputEl?.focus())}toggle(){this.open?this.close():this.openCenter()}openCenter(){this.open=!0,this.queryText=``,this.dataHits=[],this.selectedIndex=0}close(){this.open=!1,this.queryText=``,this.dataHits=[],clearTimeout(this.searchTimer)}flattenMenu(e,t){let n=[];for(let r of e??[])if(!r.separator)if(r.submenus&&r.submenus.length>0){let e=t?`${t} › ${r.label}`:r.label;n.push(...this.flattenMenu(r.submenus,e))}else r.route!==void 0&&r.route!==null&&n.push({label:r.label,breadcrumb:t,route:r.route});return n}onInput(e){this.queryText=e,this.selectedIndex=0;let t=e.trim();if(clearTimeout(this.searchTimer),!t||!this.app?.globalSearchEnabled){this.dataHits=[],this.loading=!1;return}this.loading=!0,this.searchTimer=setTimeout(()=>this.fetchGlobalSearch(t),250)}async fetchGlobalSearch(e){let t=this.app;if(!t?.globalSearchEnabled){this.loading=!1;return}try{let n=(await Ge.runAction(this.baseUrl??``,t.rootRoute??``,``,`_globalsearch`,`command-center`,void 0,t.serverSideType,{},{searchText:e},this,!0))?.fragments?.map(e=>e.data).find(e=>e&&e._globalsearch);this.dataHits=n?._globalsearch??[]}catch{this.dataHits=[]}finally{this.loading=!1}}navigateTo(e,t){Oa(this.app?.serverSideType??``,{route:e,label:t}),this.close();for(let t of[`route-changed`,`navigate-to-requested`])this.dispatchEvent(new CustomEvent(t,{detail:{route:e},bubbles:!0,composed:!0}))}askAi(){let e=this.queryText.trim();this.close(),this.dispatchEvent(new CustomEvent(`mateu-open-ai`,{detail:{query:e},bubbles:!0,composed:!0}))}visibleTargets(e){if(!this.queryText.trim()){let e=this.flattenMenu(this.app?.menu,``).map(e=>({route:e.route,label:e.label})),t=Da(this.app?.serverSideType??``);return[...e,...t]}return[...e.map(e=>({route:e.route,label:e.label})),...this.dataHits.map(e=>({route:e.route,label:e.label}))]}onKeydown(e,t){if(e.key===`ArrowDown`)e.preventDefault(),this.selectedIndex=Math.min(this.selectedIndex+1,t.length-1);else if(e.key===`ArrowUp`)e.preventDefault(),this.selectedIndex=Math.max(this.selectedIndex-1,0);else if(e.key===`Enter`){let e=t[this.selectedIndex];e&&this.navigateTo(e.route,e.label)}}render(){return w`
+    `}};O([v()],W.prototype,`component`,void 0),O([v()],W.prototype,`baseUrl`,void 0),O([v({type:Boolean})],W.prototype,`standalone`,void 0),O([v()],W.prototype,`state`,void 0),O([v()],W.prototype,`data`,void 0),O([v()],W.prototype,`appState`,void 0),O([v()],W.prototype,`appData`,void 0),O([S()],W.prototype,`showImportDialog`,void 0),O([S()],W.prototype,`availableWidthPx`,void 0),O([S()],W.prototype,`selectedItem`,void 0),O([S()],W.prototype,`_columnPrefsRevision`,void 0),W=O([h(`mateu-table-crud`)],W);var Ca=function(e){return e.OnLoad=`OnLoad`,e.OnSuccess=`OnSuccess`,e.OnError=`OnError`,e.OnValueChange=`OnValueChange`,e.OnCustomEvent=`OnCustomEvent`,e.AutoSave=`AutoSave`,e}({}),wa=class extends et{constructor(...e){super(...e),this.state={},this.data={},this.appData={},this.appState={},this.triggerOnLoad=()=>{let e=this.component;this.registerCustomEventListeners(),e.triggers?.filter(e=>e.type==Ca.OnLoad).forEach(e=>{if((!e.condition||this._evalExpr(e.condition))&&!e.triggered){let n=e;n.triggered=!0;var t=n.times-1;n.timeoutMillis>0?this.scheduleOnload(n,t,this.id):this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.actionId},bubbles:!0,composed:!0}))}})},this.scheduleOnload=(e,t,n)=>{if(n!=this.component?.id)return;let r=this.callbackToken;setTimeout(()=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,callbackToken:r},bubbles:!0,composed:!0}))},e.timeoutMillis)},this._registeredCustomEventListeners=[],this.customEventManager=e=>{if(!(e instanceof CustomEvent))return;let t=e,n=(this.component.triggers??[]).filter(e=>e.type==Ca.OnCustomEvent).filter(e=>e.eventName==t.type).filter(e=>e.source!==`COMPONENT`||t.detail?.__source===e.from);n.length!==0&&(n.some(e=>!e.source||e.source===`SELF`)&&(e.stopPropagation(),e.preventDefault()),n.forEach(e=>{(!e.condition||this._evalExpr(e.condition))&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:t.detail},bubbles:!0,composed:!0}))}))}}_interpolationExtra(){return{appState:this.appState??{},appData:this.appData??{},component:this.component}}_evalExpr(e){return ot(e,this.state??{},this.data??{},this._interpolationExtra())}_evalTemplate(e){return st(e,this.state??{},this.data??{},this._interpolationExtra())}isOverlayChild(e){let t=e?.metadata?.type;return t==A.Drawer||t==A.Dialog}removeSelfFromOwnerChildren(){let e=this.component;if(!e)return!1;let t=t=>{if(t===e)return!0;let n=t;return e.id!=null&&n?.id==e.id&&this.isOverlayChild(n)},n=this.parentNode;for(;n;){let e=n instanceof ShadowRoot?n.host:n,r=e.component?.children;if(Array.isArray(r)){let n=r.findIndex(t);if(n>=0)return r.splice(n,1),e.requestUpdate?.(),!0}n=n instanceof ShadowRoot?e:n.parentNode}return!1}applyFragment(e){if(this.id==e.targetComponentId){if(e.component)if(Ke.Add==e.action){if(this.component){let t=this.component.children??(this.component.children=[]),n=e.component.id?t.findIndex(t=>t.id==e.component.id&&this.isOverlayChild(t)):-1;n>=0?(t[n]=e.component,this.component={...this.component}):t.push(e.component)}}else{this.callbackToken=T();let t=!1;if(e.component?.type==k.ServerSide)if(this.component){let n=this.component,r=e.component;t=n.serverSideType==r.serverSideType;let i=t?(n.children??[]).filter(e=>this.isOverlayChild(e)):[];n.actions=r.actions,n.type=r.type,n.rules=r.rules,n.triggers=r.triggers,n.serverSideType=r.serverSideType,n.route=r.route,n.initialData=r.initialData,n.validations=r.validations,n.cssClasses=r.cssClasses,n.slot=r.slot,n.style=r.style,n.children=i.length?[...r.children??[],...i]:r.children,(n.serverSideType!=r.serverSideType||n.id!=r.id)&&setTimeout(()=>this.triggerOnLoad())}else this.component=e.component,setTimeout(()=>this.triggerOnLoad());else{let t=[e.component];this.component&&(this.component.children=t)}e.action!==Ke.ReplaceKeepData&&!t&&(this.state={},this.data={})}if(e.state&&(this.state={...this.state,...e.state}),e.data){for(let t in e.data){let n=e.data[t]?.page;n?.pageNumber>0&&this.data[t]&&this.data[t].page.content&&(n.content?n.content=[...this.data[t].page.content,...n.content]:n.content=[...this.data[t].page.content])}this.data={...this.data,...e.data}}this.registerCustomEventListeners();let t=N.getAfterRenderHook();t&&setTimeout(()=>t(this)),this.requestUpdate()}}registerCustomEventListeners(){this._registeredCustomEventListeners.forEach(({target:e,name:t})=>e.removeEventListener(t,this.customEventManager)),this._registeredCustomEventListeners=[],this.component?.triggers?.filter(e=>e.type==Ca.OnCustomEvent).forEach(e=>{let t=e.source===`DOCUMENT`||e.source===`COMPONENT`?document:this;t.addEventListener(e.eventName,this.customEventManager),this._registeredCustomEventListeners.push({target:t,name:e.eventName})})}disconnectedCallback(){this._registeredCustomEventListeners.forEach(({target:e,name:t})=>e.removeEventListener(t,this.customEventManager)),this._registeredCustomEventListeners=[],super.disconnectedCallback()}connectedCallback(){super.connectedCallback(),this.component&&this.registerCustomEventListeners()}};O([v()],wa.prototype,`state`,void 0),O([v()],wa.prototype,`data`,void 0),O([v()],wa.prototype,`appData`,void 0),O([v()],wa.prototype,`appState`,void 0);var Ta=`mateu-recent-routes`,Ea=8;function Da(){try{return JSON.parse(localStorage.getItem(Ta)??`{}`)}catch{return{}}}function Oa(e){try{localStorage.setItem(Ta,JSON.stringify(e))}catch{}}function ka(e){return Da()[e||`_`]??[]}function Aa(e,t){if(!t?.route||!t.label)return;let n=e||`_`,r=Da(),i=(r[n]??[]).filter(e=>e.route!==t.route);i.unshift({route:t.route,label:t.label}),r[n]=i.slice(0,Ea),Oa(r)}var G=class extends y{constructor(...e){super(...e),this.baseUrl=``,this.open=!1,this.queryText=``,this.dataHits=[],this.loading=!1,this.selectedIndex=0,this.fabOffset=0,this.keydownHandler=null}connectedCallback(){super.connectedCallback(),this.keydownHandler=e=>{(e.metaKey||e.ctrlKey)&&(e.key===`k`||e.key===`K`)?(e.preventDefault(),this.toggle()):e.key===`Escape`&&this.open&&this.close()},document.addEventListener(`keydown`,this.keydownHandler),this.setupFabObserver()}disconnectedCallback(){super.disconnectedCallback(),this.keydownHandler&&document.removeEventListener(`keydown`,this.keydownHandler),clearTimeout(this.searchTimer),this.fabObserver?.disconnect(),this.fabObserver=void 0}setupFabObserver(){let e=this.getRootNode(),t=e instanceof ShadowRoot?e:document.body;this.measureFabStack(),this.fabObserver?.disconnect(),this.fabObserver=new MutationObserver(()=>this.measureFabStack()),this.fabObserver.observe(t,{childList:!0,subtree:!0})}measureFabStack(){let e=(this.getRootNode().querySelectorAll?.(`.ai-fab, .app-fab, .page-fab`).length??0)*4;e!==this.fabOffset&&(this.fabOffset=e)}updated(e){e.has(`open`)&&this.open&&requestAnimationFrame(()=>this.inputEl?.focus())}toggle(){this.open?this.close():this.openCenter()}openCenter(){this.open=!0,this.queryText=``,this.dataHits=[],this.selectedIndex=0}close(){this.open=!1,this.queryText=``,this.dataHits=[],clearTimeout(this.searchTimer)}flattenMenu(e,t){let n=[];for(let r of e??[])if(!r.separator)if(r.submenus&&r.submenus.length>0){let e=t?`${t} › ${r.label}`:r.label;n.push(...this.flattenMenu(r.submenus,e))}else r.route!==void 0&&r.route!==null&&n.push({label:r.label,breadcrumb:t,route:r.route});return n}onInput(e){this.queryText=e,this.selectedIndex=0;let t=e.trim();if(clearTimeout(this.searchTimer),!t||!this.app?.globalSearchEnabled){this.dataHits=[],this.loading=!1;return}this.loading=!0,this.searchTimer=setTimeout(()=>this.fetchGlobalSearch(t),250)}async fetchGlobalSearch(e){let t=this.app;if(!t?.globalSearchEnabled){this.loading=!1;return}try{let n=(await Ge.runAction(this.baseUrl??``,t.rootRoute??``,``,`_globalsearch`,`command-center`,void 0,t.serverSideType,{},{searchText:e},this,!0))?.fragments?.map(e=>e.data).find(e=>e&&e._globalsearch);this.dataHits=n?._globalsearch??[]}catch{this.dataHits=[]}finally{this.loading=!1}}navigateTo(e,t){Aa(this.app?.serverSideType??``,{route:e,label:t}),this.close();for(let t of[`route-changed`,`navigate-to-requested`])this.dispatchEvent(new CustomEvent(t,{detail:{route:e},bubbles:!0,composed:!0}))}askAi(){let e=this.queryText.trim();this.close(),this.dispatchEvent(new CustomEvent(`mateu-open-ai`,{detail:{query:e},bubbles:!0,composed:!0}))}visibleTargets(e){if(!this.queryText.trim()){let e=this.flattenMenu(this.app?.menu,``).map(e=>({route:e.route,label:e.label})),t=ka(this.app?.serverSideType??``);return[...e,...t]}return[...e.map(e=>({route:e.route,label:e.label})),...this.dataHits.map(e=>({route:e.route,label:e.label}))]}onKeydown(e,t){if(e.key===`ArrowDown`)e.preventDefault(),this.selectedIndex=Math.min(this.selectedIndex+1,t.length-1);else if(e.key===`ArrowUp`)e.preventDefault(),this.selectedIndex=Math.max(this.selectedIndex-1,0);else if(e.key===`Enter`){let e=t[this.selectedIndex];e&&this.navigateTo(e.route,e.label)}}render(){return w`
             <button class="cc-fab" style="bottom: ${1.5+this.fabOffset}rem;"
                 @click=${()=>this.openCenter()} title="Buscar y navegar (⌘K)" aria-label="Command center">
                 ${this.fabIcon()}
@@ -4893,7 +4893,7 @@ ${i}
                 </div>
                 <button class="cc-close" @click=${()=>this.close()} title="Cerrar">${this.clearIcon()}</button>
             </div>
-        `}renderDefault(){let e=this.flattenMenu(this.app?.menu,``),t=Da(this.app?.serverSideType??``),n=-1;return w`
+        `}renderDefault(){let e=this.flattenMenu(this.app?.menu,``),t=ka(this.app?.serverSideType??``),n=-1;return w`
             <div class="cc-columns">
                 <div class="cc-col">
                     <div class="cc-section-title">Ir a</div>
@@ -5028,7 +5028,7 @@ ${i}
             display: flex; align-items: center; justify-content: center; cursor: pointer; z-index: 1110;
         }
         .cc-close:hover { background: rgba(0,0,0,0.75); }
-    `}};O([v({attribute:!1})],G.prototype,`app`,void 0),O([v()],G.prototype,`baseUrl`,void 0),O([S()],G.prototype,`open`,void 0),O([S()],G.prototype,`queryText`,void 0),O([S()],G.prototype,`dataHits`,void 0),O([S()],G.prototype,`loading`,void 0),O([S()],G.prototype,`selectedIndex`,void 0),O([S()],G.prototype,`fabOffset`,void 0),O([b(`.cc-input`)],G.prototype,`inputEl`,void 0),G=O([h(`mateu-command-center`)],G);var ka=null;function Aa(e){let t=e.component?.metadata;t&&(t.commandCenterEnabled||t.chromeless)&&t.variant!==`MEDIATOR`?((!ka||!ka.isConnected)&&(ka=document.createElement(`mateu-command-center`),e.renderRoot.appendChild(ka)),ka.app=t,ka.baseUrl=e.baseUrl??``):ka&&e.renderRoot.contains(ka)&&(ka.remove(),ka=null)}var ja=class extends y{constructor(...e){super(...e),this.fetchStarted=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!0},this.fetchFinished=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!1},this.fetchFailed=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!1;let t=e.detail??{},n=t.failure??Fe(t.reason,{online:Ve.isOnline()});if(n.kind===`cancelled`)return;let r=t.retry;pa({text:n.message,variant:`error`,duration:r?8e3:5e3,position:`bottomEnd`,...r?{actionLabel:`Retry`,onAction:r}:{}},this)}}connectedCallback(){super.connectedCallback(),this.addEventListener(`backend-called-event`,this.fetchStarted),this.addEventListener(`backend-succeeded-event`,this.fetchFinished),this.addEventListener(`backend-cancelled-event`,this.fetchFinished),this.addEventListener(`backend-failed-event`,this.fetchFailed)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`backend-called-event`,this.fetchStarted),this.removeEventListener(`backend-succeeded-event`,this.fetchFinished),this.removeEventListener(`backend-cancelled-event`,this.fetchFinished),this.removeEventListener(`backend-failed-event`,this.fetchFailed)}render(){return w`<div class="loader-container">
+    `}};O([v({attribute:!1})],G.prototype,`app`,void 0),O([v()],G.prototype,`baseUrl`,void 0),O([S()],G.prototype,`open`,void 0),O([S()],G.prototype,`queryText`,void 0),O([S()],G.prototype,`dataHits`,void 0),O([S()],G.prototype,`loading`,void 0),O([S()],G.prototype,`selectedIndex`,void 0),O([S()],G.prototype,`fabOffset`,void 0),O([b(`.cc-input`)],G.prototype,`inputEl`,void 0),G=O([h(`mateu-command-center`)],G);var ja=null;function Ma(e){let t=e.component?.metadata;t&&(t.commandCenterEnabled||t.chromeless)&&t.variant!==`MEDIATOR`?((!ja||!ja.isConnected)&&(ja=document.createElement(`mateu-command-center`),e.renderRoot.appendChild(ja)),ja.app=t,ja.baseUrl=e.baseUrl??``):ja&&e.renderRoot.contains(ja)&&(ja.remove(),ja=null)}var Na=class extends y{constructor(...e){super(...e),this.fetchStarted=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!0},this.fetchFinished=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!1},this.fetchFailed=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!1;let t=e.detail??{},n=t.failure??Fe(t.reason,{online:Ve.isOnline()});if(n.kind===`cancelled`)return;let r=t.retry;ha({text:n.message,variant:`error`,duration:r?8e3:5e3,position:`bottomEnd`,...r?{actionLabel:`Retry`,onAction:r}:{}},this)}}connectedCallback(){super.connectedCallback(),this.addEventListener(`backend-called-event`,this.fetchStarted),this.addEventListener(`backend-succeeded-event`,this.fetchFinished),this.addEventListener(`backend-cancelled-event`,this.fetchFinished),this.addEventListener(`backend-failed-event`,this.fetchFailed)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`backend-called-event`,this.fetchStarted),this.removeEventListener(`backend-succeeded-event`,this.fetchFinished),this.removeEventListener(`backend-cancelled-event`,this.fetchFinished),this.removeEventListener(`backend-failed-event`,this.fetchFailed)}render(){return w`<div class="loader-container">
             <div style="display: flex; flex-direction: column;">
                 <slot></slot>
                 <div class="loader-frame ${this.loading?`delayed-show`:``}" style="${this.loading?`pointer-events: all;`:`display: none;`}"><div class="loader"></div></div>
@@ -5096,7 +5096,7 @@ ${i}
             animation: l5 1s infinite;
         }
         @keyframes l5 {to{transform: rotate(.5turn)}}
-  `}};O([S()],ja.prototype,`loading`,void 0),ja=O([h(`mateu-api-caller`)],ja);var Ma=new class{constructor(){this._dirty=!1,this._installed=!1,this.message=`You have unsaved changes. Are you sure you want to leave this page?`,this._onDirty=()=>{this._dirty=!0},this._onClean=()=>{this._dirty=!1},this._onBeforeUnload=e=>{this._dirty&&(e.preventDefault(),e.returnValue=``)}}install(){this._installed||(this._installed=!0,document.addEventListener(`dirty`,this._onDirty),document.addEventListener(`clean`,this._onClean),window.addEventListener(`beforeunload`,this._onBeforeUnload))}get dirty(){return this._dirty}markDirty(){this._dirty=!0}markClean(){this._dirty=!1}confirmLeave(){if(!this._dirty)return!0;let e=window.confirm(this.message);return e&&(this._dirty=!1),e}},Na,K=class extends Sa{static{Na=this}constructor(...e){super(...e),this.filter=``,this.instant=void 0,this.selectedConsumedRoute=void 0,this.selectedRoute=void 0,this.selectedUriPrefix=void 0,this.selectedBaseUrl=void 0,this.selectedServerSideType=void 0,this.selectedParams=void 0,this.tilesMenuOption=null,this.railOpenOption=null,this.commandPaletteOpen=!1,this.commandPaletteQuery=``,this.commandPaletteSelectedIndex=0,this.commandPaletteDataHits=[],this.openDataHit=e=>{Ma.confirmLeave()&&(this.commandPaletteOpen=!1,this.commandPaletteQuery=``,this.commandPaletteDataHits=[],this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:e.route},bubbles:!0,composed:!0})),this.dispatchEvent(new CustomEvent(`navigate-to-requested`,{detail:{route:e.route},bubbles:!0,composed:!0})))},this._commandPaletteHandler=null,this.pageCompact=!1,this._compactHandler=e=>{this.pageCompact=e.detail?.compact??!1},this._openAiHandler=()=>{this.chatOpen||this.showHideIa()},this.isDark=document.documentElement.getAttribute(`theme`)===`dark`,this.chatOpen=!1,this.toggleTheme=()=>{this.isDark=!this.isDark;let e=this.isDark?`dark`:`light`;document.documentElement.setAttribute(`theme`,e),localStorage.setItem(`mateu-theme`,e)},this.showHideIa=()=>{this.chat&&(this.chatOpen=!this.chatOpen,this.chat.slot=this.chatOpen?`detail`:`detail-hidden`)},this.runAction=e=>{let t=this.renderRoot.querySelector?.(`mateu-component`);t&&t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.getSelectedOption=e=>{if(e)for(let t=0;t<e.length;t++){let n=e[t];if(this.selectedRoute?this.isActiveOption(n):n.selected)return n;let r=this.getSelectedOption(n.submenus);if(r)return r}return null},this.itemSelected=e=>{let t=e.detail.value;this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix)},this.itemSelectedTiles=e=>{let t=e.detail.value._menuOption;t.submenus&&t.submenus.length>0?this.tilesMenuOption=t:(this.tilesMenuOption=null,this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix))},this.mapItemsForTiles=e=>e.map(e=>({text:e.label,consumedRoute:e.consumedRoute,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:e.selected,_menuOption:e})),this.flattenMenuForPalette=(e,t)=>{let n=[];for(let r of e)if(!r.separator)if(r.submenus&&r.submenus.length>0){let e=t?`${t} › ${r.label}`:r.label;n.push(...this.flattenMenuForPalette(r.submenus,e))}else n.push({label:r.label,breadcrumb:t,consumedRoute:r.consumedRoute,route:r.route,actionId:r.actionId,baseUrl:r.baseUrl,serverSideType:r.serverSideType,uriPrefix:r.uriPrefix});return n},this.handleCommandPaletteKeydown=(e,t)=>{let n=Math.min(t.length,10),r=n+Math.min(this.commandPaletteDataHits.length,8);if(e.key===`ArrowDown`)e.preventDefault(),this.commandPaletteSelectedIndex=Math.min(this.commandPaletteSelectedIndex+1,r-1);else if(e.key===`ArrowUp`)e.preventDefault(),this.commandPaletteSelectedIndex=Math.max(this.commandPaletteSelectedIndex-1,0);else if(e.key===`Enter`){if(this.commandPaletteSelectedIndex>=n){let e=this.commandPaletteDataHits[this.commandPaletteSelectedIndex-n];e&&this.openDataHit(e);return}let e=t[this.commandPaletteSelectedIndex];e&&(this.selectRoute(e.consumedRoute,e.route,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix),this.commandPaletteOpen=!1,this.commandPaletteQuery=``)}},this.renderCommandPalette=()=>{if(!this.commandPaletteOpen)return _;let e=this.component?.metadata;if(e?.commandCenterEnabled||!e?.menu)return _;let t=this.flattenMenuForPalette(e.menu,``),n=this.commandPaletteQuery.toLowerCase(),r=n?t.filter(e=>e.label.toLowerCase().includes(n)||e.breadcrumb.toLowerCase().includes(n)):t;return w`
+  `}};O([S()],Na.prototype,`loading`,void 0),Na=O([h(`mateu-api-caller`)],Na);var Pa=new class{constructor(){this._dirty=!1,this._installed=!1,this.message=`You have unsaved changes. Are you sure you want to leave this page?`,this._onDirty=()=>{this._dirty=!0},this._onClean=()=>{this._dirty=!1},this._onBeforeUnload=e=>{this._dirty&&(e.preventDefault(),e.returnValue=``)}}install(){this._installed||(this._installed=!0,document.addEventListener(`dirty`,this._onDirty),document.addEventListener(`clean`,this._onClean),window.addEventListener(`beforeunload`,this._onBeforeUnload))}get dirty(){return this._dirty}markDirty(){this._dirty=!0}markClean(){this._dirty=!1}confirmLeave(){if(!this._dirty)return!0;let e=window.confirm(this.message);return e&&(this._dirty=!1),e}},Fa,K=class extends wa{static{Fa=this}constructor(...e){super(...e),this.filter=``,this.instant=void 0,this.selectedConsumedRoute=void 0,this.selectedRoute=void 0,this.selectedUriPrefix=void 0,this.selectedBaseUrl=void 0,this.selectedServerSideType=void 0,this.selectedParams=void 0,this.tilesMenuOption=null,this.railOpenOption=null,this.commandPaletteOpen=!1,this.commandPaletteQuery=``,this.commandPaletteSelectedIndex=0,this.commandPaletteDataHits=[],this.openDataHit=e=>{Pa.confirmLeave()&&(this.commandPaletteOpen=!1,this.commandPaletteQuery=``,this.commandPaletteDataHits=[],this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:e.route},bubbles:!0,composed:!0})),this.dispatchEvent(new CustomEvent(`navigate-to-requested`,{detail:{route:e.route},bubbles:!0,composed:!0})))},this._commandPaletteHandler=null,this.pageCompact=!1,this._compactHandler=e=>{this.pageCompact=e.detail?.compact??!1},this._openAiHandler=()=>{this.chatOpen||this.showHideIa()},this.isDark=document.documentElement.getAttribute(`theme`)===`dark`,this.chatOpen=!1,this.toggleTheme=()=>{this.isDark=!this.isDark;let e=this.isDark?`dark`:`light`;document.documentElement.setAttribute(`theme`,e),localStorage.setItem(`mateu-theme`,e)},this.showHideIa=()=>{this.chat&&(this.chatOpen=!this.chatOpen,this.chat.slot=this.chatOpen?`detail`:`detail-hidden`)},this.runAction=e=>{let t=this.renderRoot.querySelector?.(`mateu-component`);t&&t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.getSelectedOption=e=>{if(e)for(let t=0;t<e.length;t++){let n=e[t];if(this.selectedRoute?this.isActiveOption(n):n.selected)return n;let r=this.getSelectedOption(n.submenus);if(r)return r}return null},this.itemSelected=e=>{let t=e.detail.value;this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix)},this.itemSelectedTiles=e=>{let t=e.detail.value._menuOption;t.submenus&&t.submenus.length>0?this.tilesMenuOption=t:(this.tilesMenuOption=null,this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix))},this.mapItemsForTiles=e=>e.map(e=>({text:e.label,consumedRoute:e.consumedRoute,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:e.selected,_menuOption:e})),this.flattenMenuForPalette=(e,t)=>{let n=[];for(let r of e)if(!r.separator)if(r.submenus&&r.submenus.length>0){let e=t?`${t} › ${r.label}`:r.label;n.push(...this.flattenMenuForPalette(r.submenus,e))}else n.push({label:r.label,breadcrumb:t,consumedRoute:r.consumedRoute,route:r.route,actionId:r.actionId,baseUrl:r.baseUrl,serverSideType:r.serverSideType,uriPrefix:r.uriPrefix});return n},this.handleCommandPaletteKeydown=(e,t)=>{let n=Math.min(t.length,10),r=n+Math.min(this.commandPaletteDataHits.length,8);if(e.key===`ArrowDown`)e.preventDefault(),this.commandPaletteSelectedIndex=Math.min(this.commandPaletteSelectedIndex+1,r-1);else if(e.key===`ArrowUp`)e.preventDefault(),this.commandPaletteSelectedIndex=Math.max(this.commandPaletteSelectedIndex-1,0);else if(e.key===`Enter`){if(this.commandPaletteSelectedIndex>=n){let e=this.commandPaletteDataHits[this.commandPaletteSelectedIndex-n];e&&this.openDataHit(e);return}let e=t[this.commandPaletteSelectedIndex];e&&(this.selectRoute(e.consumedRoute,e.route,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix),this.commandPaletteOpen=!1,this.commandPaletteQuery=``)}},this.renderCommandPalette=()=>{if(!this.commandPaletteOpen)return _;let e=this.component?.metadata;if(e?.commandCenterEnabled||!e?.menu)return _;let t=this.flattenMenuForPalette(e.menu,``),n=this.commandPaletteQuery.toLowerCase(),r=n?t.filter(e=>e.label.toLowerCase().includes(n)||e.breadcrumb.toLowerCase().includes(n)):t;return w`
             <div class="cmd-backdrop" @click=${()=>{this.commandPaletteOpen=!1,this.commandPaletteQuery=``}}>
                 <div class="cmd-palette" @click=${e=>e.stopPropagation()}>
                     <div class="cmd-search-wrapper">
@@ -5169,7 +5169,7 @@ ${i}
                     `)}
                 </div>
             </div>
-        `,this.goHome=()=>{Ma.confirmLeave()&&(window.history.pushState(null,``,`/`),window.dispatchEvent(new PopStateEvent(`popstate`,{state:null})))},this.selectRoute=(e,t,n,r,i,a)=>{Ma.confirmLeave()&&this._selectRoute(e,t,n,r,i,a)},this._selectRoute=(e,t,n,r,i,a)=>{{this.selectedConsumedRoute=e,this.selectedBaseUrl=r,this.selectedRoute=t,this.selectedServerSideType=i,this.selectedUriPrefix=a,this.instant=T(),this.state&&this.state._route!=null&&(this.state._route=void 0);let n=this.baseUrl??``;n.indexOf(`://`)<0&&(n.startsWith(`/`)||(n=`/`+n),n=window.location.origin+n),n.endsWith(`/`)&&(t??``).startsWith(`/`)&&(t=(t??``).substring(1));let o=new URL(n+t);if(e&&o.pathname.startsWith(e)){let t=o.pathname.substring(e.length);o=new URL(o.origin+(t||`/`))}if((window.location.pathname||o.pathname)&&window.location.pathname!=o.pathname){let e=o.pathname;o.search&&(e+=o.search),e&&!e.startsWith(`/`)&&(e=`/`+e),this.baseUrl&&e.startsWith(this.baseUrl)&&(e=e.substring(this.baseUrl.length));let t=e;this.selectedUriPrefix&&(t=t.startsWith(`/`)&&this.selectedUriPrefix.endsWith(`/`)?this.selectedUriPrefix+t.substring(1):!t.startsWith(`/`)&&!this.selectedUriPrefix.endsWith(`/`)?this.selectedUriPrefix+`/`+t:this.selectedUriPrefix+t),t==`/_page`&&(t=``),this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0}))}}},this.isActiveOption=e=>this.selectedRoute?!!e.route&&(this.selectedRoute==e.route||this.selectedRoute.startsWith(e.route+`/`)):!!e.selected,this.mapItems=(e,t)=>e.map(e=>{if(e.submenus&&e.submenus.length>0){let n=this.mapItems(e.submenus,t);return t&&e.label.toLowerCase().includes(t)&&(n=this.mapItems(e.submenus,``)),n&&n.length>0?{consumedRoute:e.consumedRoute,text:e.label,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:t||this.isActiveOption(e),children:n}:void 0}if(e.separator)return t?void 0:{component:`hr`};if(!t||e.label.toLowerCase().includes(t))return{consumedRoute:e.consumedRoute,text:e.label,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:t||this.isActiveOption(e)}}).filter(e=>e!=null),this.getSelectedIndex=e=>{if(!e)return NaN;let t=e=>{let t=(e??``).trim();return t.length>1&&t.endsWith(`/`)&&(t=t.slice(0,-1)),t},n=t(this.selectedRoute??window.location.pathname),r=NaN,i=-1;for(let a=0;a<e.length;a++){let o=t(e[a].route);o!==``&&(n===o||n.startsWith(o+`/`))&&o.length>i&&(i=o.length,r=a)}if(!Number.isNaN(r))return r;let a=this.getSelectedOption(e);return a?e.indexOf(a):NaN},this.renderOptionOnLeftMenu=e=>e.submenus&&e.submenus.length>0?w`
+        `,this.goHome=()=>{Pa.confirmLeave()&&(window.history.pushState(null,``,`/`),window.dispatchEvent(new PopStateEvent(`popstate`,{state:null})))},this.selectRoute=(e,t,n,r,i,a)=>{Pa.confirmLeave()&&this._selectRoute(e,t,n,r,i,a)},this._selectRoute=(e,t,n,r,i,a)=>{{this.selectedConsumedRoute=e,this.selectedBaseUrl=r,this.selectedRoute=t,this.selectedServerSideType=i,this.selectedUriPrefix=a,this.instant=T(),this.state&&this.state._route!=null&&(this.state._route=void 0);let n=this.baseUrl??``;n.indexOf(`://`)<0&&(n.startsWith(`/`)||(n=`/`+n),n=window.location.origin+n),n.endsWith(`/`)&&(t??``).startsWith(`/`)&&(t=(t??``).substring(1));let o=new URL(n+t);if(e&&o.pathname.startsWith(e)){let t=o.pathname.substring(e.length);o=new URL(o.origin+(t||`/`))}if((window.location.pathname||o.pathname)&&window.location.pathname!=o.pathname){let e=o.pathname;o.search&&(e+=o.search),e&&!e.startsWith(`/`)&&(e=`/`+e),this.baseUrl&&e.startsWith(this.baseUrl)&&(e=e.substring(this.baseUrl.length));let t=e;this.selectedUriPrefix&&(t=t.startsWith(`/`)&&this.selectedUriPrefix.endsWith(`/`)?this.selectedUriPrefix+t.substring(1):!t.startsWith(`/`)&&!this.selectedUriPrefix.endsWith(`/`)?this.selectedUriPrefix+`/`+t:this.selectedUriPrefix+t),t==`/_page`&&(t=``),this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0}))}}},this.isActiveOption=e=>this.selectedRoute?!!e.route&&(this.selectedRoute==e.route||this.selectedRoute.startsWith(e.route+`/`)):!!e.selected,this.mapItems=(e,t)=>e.map(e=>{if(e.submenus&&e.submenus.length>0){let n=this.mapItems(e.submenus,t);return t&&e.label.toLowerCase().includes(t)&&(n=this.mapItems(e.submenus,``)),n&&n.length>0?{consumedRoute:e.consumedRoute,text:e.label,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:t||this.isActiveOption(e),children:n}:void 0}if(e.separator)return t?void 0:{component:`hr`};if(!t||e.label.toLowerCase().includes(t))return{consumedRoute:e.consumedRoute,text:e.label,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:t||this.isActiveOption(e)}}).filter(e=>e!=null),this.getSelectedIndex=e=>{if(!e)return NaN;let t=e=>{let t=(e??``).trim();return t.length>1&&t.endsWith(`/`)&&(t=t.slice(0,-1)),t},n=t(this.selectedRoute??window.location.pathname),r=NaN,i=-1;for(let a=0;a<e.length;a++){let o=t(e[a].route);o!==``&&(n===o||n.startsWith(o+`/`))&&o.length>i&&(i=o.length,r=a)}if(!Number.isNaN(r))return r;let a=this.getSelectedOption(e);return a?e.indexOf(a):NaN},this.renderOptionOnLeftMenu=e=>e.submenus&&e.submenus.length>0?w`
                 <details open class="left-menu-group">
                     <summary>${e.label}</summary>
                     <div class="left-menu-children">
@@ -5191,8 +5191,8 @@ ${i}
                                 </div>
                         `}
 
-                            `})}`:_,this.updateRoute=e=>{e.preventDefault(),e.stopPropagation();var t=e.detail;this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix)}}createRenderRoot(){return N.mustUseShadowRoot()?super.createRenderRoot():(Na.injectLightDomStyles(),this)}static{this.lightDomStylesInjected=!1}static injectLightDomStyles(){if(Na.lightDomStylesInjected||typeof document>`u`||(Na.lightDomStylesInjected=!0,document.getElementById(`mateu-app-light-styles`)))return;let e=Na.styles,t=Array.isArray(e)?e.map(e=>e?.cssText??``).join(`
-`):e?.cssText??``;if(!t)return;let n=document.createElement(`style`);n.id=`mateu-app-light-styles`,n.textContent=t,document.head.appendChild(n)}fetchGlobalSearch(e){let t=this.component?.metadata;if(t?.globalSearchEnabled){if(clearTimeout(this._globalSearchTimer),!e){this.commandPaletteDataHits=[];return}this._globalSearchTimer=setTimeout(async()=>{try{let n=(await Ge.runAction(this.baseUrl??``,t.rootRoute??``,``,`_globalsearch`,`cmd-palette`,void 0,t.serverSideType,{},{searchText:e},this,!0))?.fragments?.map(e=>e.data).find(e=>e&&e._globalsearch);this.commandPaletteDataHits=n?._globalsearch??[]}catch{this.commandPaletteDataHits=[]}},250)}}connectedCallback(){super.connectedCallback(),this.isDark=document.documentElement.getAttribute(`theme`)===`dark`,this._commandPaletteHandler=e=>{this.component?.metadata?.commandCenterEnabled||((e.metaKey||e.ctrlKey)&&e.key===`k`&&(e.preventDefault(),this.commandPaletteOpen=!this.commandPaletteOpen,this.commandPaletteQuery=``,this.commandPaletteSelectedIndex=0),e.key===`Escape`&&this.commandPaletteOpen&&(this.commandPaletteOpen=!1,this.commandPaletteQuery=``))},document.addEventListener(`keydown`,this._commandPaletteHandler),Ma.install(),this.addEventListener(`compact-changed`,this._compactHandler),this.addEventListener(`mateu-open-ai`,this._openAiHandler)}disconnectedCallback(){super.disconnectedCallback(),this._commandPaletteHandler&&document.removeEventListener(`keydown`,this._commandPaletteHandler),this.removeEventListener(`compact-changed`,this._compactHandler),this.removeEventListener(`mateu-open-ai`,this._openAiHandler)}updated(e){if(super.updated(e),Aa(this),this.component){let t=this.component.metadata;if(t){let n=t;if(n.favicon){let e=document.querySelector(`link[rel~='icon']`);e||(e=document.createElement(`link`),e.rel=`icon`,document.head.appendChild(e)),e.href=n.favicon}e.has(`component`)&&(this.selectedRoute=n.homeRoute,this.selectedConsumedRoute=n.homeConsumedRoute,this.selectedServerSideType=n.homeServerSideType,this.selectedBaseUrl=n.homeBaseUrl,this.selectedUriPrefix=n.homeUriPrefix)}}e.has(`commandPaletteOpen`)&&this.commandPaletteOpen&&setTimeout(()=>{this.renderRoot.querySelector(`.cmd-input`)?.focus()},0)}render(){return N.get()?.renderAppComponent(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData)}static{this.styles=m`
+                            `})}`:_,this.updateRoute=e=>{e.preventDefault(),e.stopPropagation();var t=e.detail;this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix)}}createRenderRoot(){return N.mustUseShadowRoot()?super.createRenderRoot():(Fa.injectLightDomStyles(),this)}static{this.lightDomStylesInjected=!1}static injectLightDomStyles(){if(Fa.lightDomStylesInjected||typeof document>`u`||(Fa.lightDomStylesInjected=!0,document.getElementById(`mateu-app-light-styles`)))return;let e=Fa.styles,t=Array.isArray(e)?e.map(e=>e?.cssText??``).join(`
+`):e?.cssText??``;if(!t)return;let n=document.createElement(`style`);n.id=`mateu-app-light-styles`,n.textContent=t,document.head.appendChild(n)}fetchGlobalSearch(e){let t=this.component?.metadata;if(t?.globalSearchEnabled){if(clearTimeout(this._globalSearchTimer),!e){this.commandPaletteDataHits=[];return}this._globalSearchTimer=setTimeout(async()=>{try{let n=(await Ge.runAction(this.baseUrl??``,t.rootRoute??``,``,`_globalsearch`,`cmd-palette`,void 0,t.serverSideType,{},{searchText:e},this,!0))?.fragments?.map(e=>e.data).find(e=>e&&e._globalsearch);this.commandPaletteDataHits=n?._globalsearch??[]}catch{this.commandPaletteDataHits=[]}},250)}}connectedCallback(){super.connectedCallback(),this.isDark=document.documentElement.getAttribute(`theme`)===`dark`,this._commandPaletteHandler=e=>{this.component?.metadata?.commandCenterEnabled||((e.metaKey||e.ctrlKey)&&e.key===`k`&&(e.preventDefault(),this.commandPaletteOpen=!this.commandPaletteOpen,this.commandPaletteQuery=``,this.commandPaletteSelectedIndex=0),e.key===`Escape`&&this.commandPaletteOpen&&(this.commandPaletteOpen=!1,this.commandPaletteQuery=``))},document.addEventListener(`keydown`,this._commandPaletteHandler),Pa.install(),this.addEventListener(`compact-changed`,this._compactHandler),this.addEventListener(`mateu-open-ai`,this._openAiHandler)}disconnectedCallback(){super.disconnectedCallback(),this._commandPaletteHandler&&document.removeEventListener(`keydown`,this._commandPaletteHandler),this.removeEventListener(`compact-changed`,this._compactHandler),this.removeEventListener(`mateu-open-ai`,this._openAiHandler)}updated(e){if(super.updated(e),Ma(this),this.component){let t=this.component.metadata;if(t){let n=t;if(n.favicon){let e=document.querySelector(`link[rel~='icon']`);e||(e=document.createElement(`link`),e.rel=`icon`,document.head.appendChild(e)),e.href=n.favicon}e.has(`component`)&&(this.selectedRoute=n.homeRoute,this.selectedConsumedRoute=n.homeConsumedRoute,this.selectedServerSideType=n.homeServerSideType,this.selectedBaseUrl=n.homeBaseUrl,this.selectedUriPrefix=n.homeUriPrefix)}}e.has(`commandPaletteOpen`)&&this.commandPaletteOpen&&setTimeout(()=>{this.renderRoot.querySelector(`.cmd-input`)?.focus()},0)}render(){return N.get()?.renderAppComponent(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData)}static{this.styles=m`
         /* DS-neutral app chrome (replaces vaadin-app-layout / menu-bar / tabs / side-nav). */
         .m-hl { display: flex; flex-direction: row; }
         .m-vl { display: flex; flex-direction: column; }
@@ -5542,14 +5542,14 @@ ${i}
             transform: scale(1.08);
         }
 
-  `}};O([S()],K.prototype,`filter`,void 0),O([S()],K.prototype,`instant`,void 0),O([S()],K.prototype,`selectedConsumedRoute`,void 0),O([S()],K.prototype,`selectedRoute`,void 0),O([S()],K.prototype,`selectedUriPrefix`,void 0),O([S()],K.prototype,`selectedBaseUrl`,void 0),O([S()],K.prototype,`selectedServerSideType`,void 0),O([S()],K.prototype,`selectedParams`,void 0),O([S()],K.prototype,`tilesMenuOption`,void 0),O([S()],K.prototype,`railOpenOption`,void 0),O([S()],K.prototype,`commandPaletteOpen`,void 0),O([S()],K.prototype,`commandPaletteQuery`,void 0),O([S()],K.prototype,`commandPaletteSelectedIndex`,void 0),O([S()],K.prototype,`commandPaletteDataHits`,void 0),O([S()],K.prototype,`pageCompact`,void 0),O([b(`mateu-chat`)],K.prototype,`chat`,void 0),O([S()],K.prototype,`isDark`,void 0),O([S()],K.prototype,`chatOpen`,void 0),O([b(`.mateu-app-layout`)],K.prototype,`vaadinAppLayout`,void 0),K=Na=O([h(`mateu-app`)],K);var q=class extends y{constructor(...e){super(...e),this.message=`This website uses cookies.`,this.dismiss=`Ok. Thanks :).`,this.learnMore=`Learn more`,this.learnMoreLink=`https://cookiesandyou.com/`,this.showLearnMore=!0,this.position=`top`,this.cookieName=`mateu-cookieconsent`}updated(e){super.updated(e)}connectedCallback(){super.connectedCallback(),this._css=document.createElement(`style`),this._css.innerText=`.cc-window{opacity:1;transition:opacity 1s ease}.cc-window.cc-invisible{opacity:0}.cc-animate.cc-revoke{transition:transform 1s ease}.cc-animate.cc-revoke.cc-top{transform:translateY(-2em)}.cc-animate.cc-revoke.cc-bottom{transform:translateY(2em)}.cc-animate.cc-revoke.cc-active.cc-bottom,.cc-animate.cc-revoke.cc-active.cc-top,.cc-revoke:hover{transform:translateY(0)}.cc-grower{max-height:0;overflow:hidden;transition:max-height 1s}.cc-link,.cc-revoke:hover{text-decoration:underline}.cc-revoke,.cc-window{position:fixed;overflow:hidden;box-sizing:border-box;font-family:Helvetica,Calibri,Arial,sans-serif;font-size:16px;line-height:1.5em;display:flex;flex-wrap:nowrap;z-index:9999}.cc-window.cc-static{position:static}.cc-window.cc-floating{padding:2em;max-width:24em;flex-direction:column}.cc-window.cc-banner{padding:1em 1.8em;width:100%;flex-direction:row}.cc-revoke{padding:.5em}.cc-header{font-size:18px;font-weight:700}.cc-btn,.cc-close,.cc-link,.cc-revoke{cursor:pointer}.cc-link{opacity:.8;display:inline-block;padding:.2em}.cc-link:hover{opacity:1}.cc-link:active,.cc-link:visited{color:initial}.cc-btn{display:block;padding:.4em .8em;font-size:.9em;font-weight:700;border-width:2px;border-style:solid;text-align:center;white-space:nowrap}.cc-banner .cc-btn:last-child{min-width:140px}.cc-highlight .cc-btn:first-child{background-color:transparent;border-color:transparent}.cc-highlight .cc-btn:first-child:focus,.cc-highlight .cc-btn:first-child:hover{background-color:transparent;text-decoration:underline}.cc-close{display:block;position:absolute;top:.5em;right:.5em;font-size:1.6em;opacity:.9;line-height:.75}.cc-close:focus,.cc-close:hover{opacity:1}.cc-revoke.cc-top{top:0;left:3em;border-bottom-left-radius:.5em;border-bottom-right-radius:.5em}.cc-revoke.cc-bottom{bottom:0;left:3em;border-top-left-radius:.5em;border-top-right-radius:.5em}.cc-revoke.cc-left{left:3em;right:unset}.cc-revoke.cc-right{right:3em;left:unset}.cc-top{top:1em}.cc-left{left:1em}.cc-right{right:1em}.cc-bottom{bottom:1em}.cc-floating>.cc-link{margin-bottom:1em}.cc-floating .cc-message{display:block;margin-bottom:1em}.cc-window.cc-floating .cc-compliance{flex:1 0 auto}.cc-window.cc-banner{align-items:center}.cc-banner.cc-top{left:0;right:0;top:0}.cc-banner.cc-bottom{left:0;right:0;bottom:0}.cc-banner .cc-message{flex:1}.cc-compliance{display:flex;align-items:center;align-content:space-between}.cc-compliance>.cc-btn{flex:1}.cc-btn+.cc-btn{margin-left:.5em}@media print{.cc-revoke,.cc-window{display:none}}@media screen and (max-width:900px){.cc-btn{white-space:normal}}@media screen and (max-width:414px) and (orientation:portrait),screen and (max-width:736px) and (orientation:landscape){.cc-window.cc-top{top:0}.cc-window.cc-bottom{bottom:0}.cc-window.cc-banner,.cc-window.cc-left,.cc-window.cc-right{left:0;right:0}.cc-window.cc-banner{flex-direction:column}.cc-window.cc-banner .cc-compliance{flex:1}.cc-window.cc-floating{max-width:none}.cc-window .cc-message{margin-bottom:1em}.cc-window.cc-banner{align-items:unset}}.cc-floating.cc-theme-classic{padding:1.2em;border-radius:5px}.cc-floating.cc-type-info.cc-theme-classic .cc-compliance{text-align:center;display:inline;flex:none}.cc-theme-classic .cc-btn{border-radius:5px}.cc-theme-classic .cc-btn:last-child{min-width:140px}.cc-floating.cc-type-info.cc-theme-classic .cc-btn{display:inline-block}.cc-theme-edgeless.cc-window{padding:0}.cc-floating.cc-theme-edgeless .cc-message{margin:2em 2em 1.5em}.cc-banner.cc-theme-edgeless .cc-btn{margin:0;padding:.8em 1.8em;height:100%}.cc-banner.cc-theme-edgeless .cc-message{margin-left:1em}.cc-floating.cc-theme-edgeless .cc-btn+.cc-btn{margin-left:0}`,document.head.appendChild(this._css),this.__updatePopup()}disconnectedCallback(){super.disconnectedCallback(),this.__closePopup(),this._css.isConnected&&this._css.remove()}__closePopup(){let e=this.popup;e&&e.parentNode?.removeChild(e)}_show(){let e=this.popup;e&&(e.classList.remove(`cc-invisible`),e.style.display=``)}__updatePopup(){this.__closePopup(),window.cookieconsent.initialise({palette:{popup:{background:`#000`},button:{background:`rgba(22, 118, 243, 0.95)`,hover:`rgba(22, 118, 243, 1)`}},showLink:this.showLearnMore,content:{message:this.message,dismiss:this.dismiss,link:this.learnMore,href:this.learnMoreLink},cookie:{name:this.cookieName},position:this.position,elements:{messagelink:`<span id="cookieconsent:desc" class="cc-message">${this.message} <a tabindex="0" class="cc-link" href="${this.learnMoreLink}" target="_blank" rel="noopener noreferrer nofollow">${this.learnMore}</a></span>`,dismiss:`<a tabindex="0" class="cc-btn cc-dismiss">${this.dismiss}</a>`}});let e=this.popup;if(e){e.setAttribute(`role`,`alert`);let t=e.querySelector(`a.cc-btn`);t?.addEventListener(`keydown`,e=>{let n=e.keyCode||e.which;(n===32||n===13)&&t.click()})}}render(){return w`
+  `}};O([S()],K.prototype,`filter`,void 0),O([S()],K.prototype,`instant`,void 0),O([S()],K.prototype,`selectedConsumedRoute`,void 0),O([S()],K.prototype,`selectedRoute`,void 0),O([S()],K.prototype,`selectedUriPrefix`,void 0),O([S()],K.prototype,`selectedBaseUrl`,void 0),O([S()],K.prototype,`selectedServerSideType`,void 0),O([S()],K.prototype,`selectedParams`,void 0),O([S()],K.prototype,`tilesMenuOption`,void 0),O([S()],K.prototype,`railOpenOption`,void 0),O([S()],K.prototype,`commandPaletteOpen`,void 0),O([S()],K.prototype,`commandPaletteQuery`,void 0),O([S()],K.prototype,`commandPaletteSelectedIndex`,void 0),O([S()],K.prototype,`commandPaletteDataHits`,void 0),O([S()],K.prototype,`pageCompact`,void 0),O([b(`mateu-chat`)],K.prototype,`chat`,void 0),O([S()],K.prototype,`isDark`,void 0),O([S()],K.prototype,`chatOpen`,void 0),O([b(`.mateu-app-layout`)],K.prototype,`vaadinAppLayout`,void 0),K=Fa=O([h(`mateu-app`)],K);var Ia=class extends y{constructor(...e){super(...e),this.message=`This website uses cookies.`,this.dismiss=`Ok. Thanks :).`,this.learnMore=`Learn more`,this.learnMoreLink=`https://cookiesandyou.com/`,this.showLearnMore=!0,this.position=`top`,this.cookieName=`mateu-cookieconsent`}updated(e){super.updated(e)}connectedCallback(){super.connectedCallback(),this._css=document.createElement(`style`),this._css.innerText=`.cc-window{opacity:1;transition:opacity 1s ease}.cc-window.cc-invisible{opacity:0}.cc-animate.cc-revoke{transition:transform 1s ease}.cc-animate.cc-revoke.cc-top{transform:translateY(-2em)}.cc-animate.cc-revoke.cc-bottom{transform:translateY(2em)}.cc-animate.cc-revoke.cc-active.cc-bottom,.cc-animate.cc-revoke.cc-active.cc-top,.cc-revoke:hover{transform:translateY(0)}.cc-grower{max-height:0;overflow:hidden;transition:max-height 1s}.cc-link,.cc-revoke:hover{text-decoration:underline}.cc-revoke,.cc-window{position:fixed;overflow:hidden;box-sizing:border-box;font-family:Helvetica,Calibri,Arial,sans-serif;font-size:16px;line-height:1.5em;display:flex;flex-wrap:nowrap;z-index:9999}.cc-window.cc-static{position:static}.cc-window.cc-floating{padding:2em;max-width:24em;flex-direction:column}.cc-window.cc-banner{padding:1em 1.8em;width:100%;flex-direction:row}.cc-revoke{padding:.5em}.cc-header{font-size:18px;font-weight:700}.cc-btn,.cc-close,.cc-link,.cc-revoke{cursor:pointer}.cc-link{opacity:.8;display:inline-block;padding:.2em}.cc-link:hover{opacity:1}.cc-link:active,.cc-link:visited{color:initial}.cc-btn{display:block;padding:.4em .8em;font-size:.9em;font-weight:700;border-width:2px;border-style:solid;text-align:center;white-space:nowrap}.cc-banner .cc-btn:last-child{min-width:140px}.cc-highlight .cc-btn:first-child{background-color:transparent;border-color:transparent}.cc-highlight .cc-btn:first-child:focus,.cc-highlight .cc-btn:first-child:hover{background-color:transparent;text-decoration:underline}.cc-close{display:block;position:absolute;top:.5em;right:.5em;font-size:1.6em;opacity:.9;line-height:.75}.cc-close:focus,.cc-close:hover{opacity:1}.cc-revoke.cc-top{top:0;left:3em;border-bottom-left-radius:.5em;border-bottom-right-radius:.5em}.cc-revoke.cc-bottom{bottom:0;left:3em;border-top-left-radius:.5em;border-top-right-radius:.5em}.cc-revoke.cc-left{left:3em;right:unset}.cc-revoke.cc-right{right:3em;left:unset}.cc-top{top:1em}.cc-left{left:1em}.cc-right{right:1em}.cc-bottom{bottom:1em}.cc-floating>.cc-link{margin-bottom:1em}.cc-floating .cc-message{display:block;margin-bottom:1em}.cc-window.cc-floating .cc-compliance{flex:1 0 auto}.cc-window.cc-banner{align-items:center}.cc-banner.cc-top{left:0;right:0;top:0}.cc-banner.cc-bottom{left:0;right:0;bottom:0}.cc-banner .cc-message{flex:1}.cc-compliance{display:flex;align-items:center;align-content:space-between}.cc-compliance>.cc-btn{flex:1}.cc-btn+.cc-btn{margin-left:.5em}@media print{.cc-revoke,.cc-window{display:none}}@media screen and (max-width:900px){.cc-btn{white-space:normal}}@media screen and (max-width:414px) and (orientation:portrait),screen and (max-width:736px) and (orientation:landscape){.cc-window.cc-top{top:0}.cc-window.cc-bottom{bottom:0}.cc-window.cc-banner,.cc-window.cc-left,.cc-window.cc-right{left:0;right:0}.cc-window.cc-banner{flex-direction:column}.cc-window.cc-banner .cc-compliance{flex:1}.cc-window.cc-floating{max-width:none}.cc-window .cc-message{margin-bottom:1em}.cc-window.cc-banner{align-items:unset}}.cc-floating.cc-theme-classic{padding:1.2em;border-radius:5px}.cc-floating.cc-type-info.cc-theme-classic .cc-compliance{text-align:center;display:inline;flex:none}.cc-theme-classic .cc-btn{border-radius:5px}.cc-theme-classic .cc-btn:last-child{min-width:140px}.cc-floating.cc-type-info.cc-theme-classic .cc-btn{display:inline-block}.cc-theme-edgeless.cc-window{padding:0}.cc-floating.cc-theme-edgeless .cc-message{margin:2em 2em 1.5em}.cc-banner.cc-theme-edgeless .cc-btn{margin:0;padding:.8em 1.8em;height:100%}.cc-banner.cc-theme-edgeless .cc-message{margin-left:1em}.cc-floating.cc-theme-edgeless .cc-btn+.cc-btn{margin-left:0}`,document.head.appendChild(this._css),this.__updatePopup()}disconnectedCallback(){super.disconnectedCallback(),this.__closePopup(),this._css.isConnected&&this._css.remove()}__closePopup(){let e=this.popup;e&&e.parentNode?.removeChild(e)}_show(){let e=this.popup;e&&(e.classList.remove(`cc-invisible`),e.style.display=``)}__updatePopup(){this.__closePopup(),window.cookieconsent.initialise({palette:{popup:{background:`#000`},button:{background:`rgba(22, 118, 243, 0.95)`,hover:`rgba(22, 118, 243, 1)`}},showLink:this.showLearnMore,content:{message:this.message,dismiss:this.dismiss,link:this.learnMore,href:this.learnMoreLink},cookie:{name:this.cookieName},position:this.position,elements:{messagelink:`<span id="cookieconsent:desc" class="cc-message">${this.message} <a tabindex="0" class="cc-link" href="${this.learnMoreLink}" target="_blank" rel="noopener noreferrer nofollow">${this.learnMore}</a></span>`,dismiss:`<a tabindex="0" class="cc-btn cc-dismiss">${this.dismiss}</a>`}});let e=this.popup;if(e){e.setAttribute(`role`,`alert`);let t=e.querySelector(`a.cc-btn`);t?.addEventListener(`keydown`,e=>{let n=e.keyCode||e.which;(n===32||n===13)&&t.click()})}}render(){return w`
        `}static{this.styles=m`
-  `}};O([v()],q.prototype,`message`,void 0),O([v()],q.prototype,`dismiss`,void 0),O([v()],q.prototype,`learnMore`,void 0),O([v()],q.prototype,`learnMoreLink`,void 0),O([v()],q.prototype,`showLearnMore`,void 0),O([v()],q.prototype,`position`,void 0),O([v()],q.prototype,`cookieName`,void 0),O([S()],q.prototype,`_css`,void 0),O([b(`[aria-label="cookieconsent"]`)],q.prototype,`popup`,void 0),q=O([h(`mateu-cookie-consent`)],q);var Pa=class extends y{constructor(...e){super(...e),this.redispatchEvent=e=>{e instanceof CustomEvent&&(e.stopPropagation(),e.preventDefault(),this.target?.dispatchEvent(new CustomEvent(e.type,{detail:e.detail,bubbles:!0,composed:!0})))}}connectedCallback(){super.connectedCallback(),this.addEventListener(`value-changed`,this.redispatchEvent),this.addEventListener(`data-changed`,this.redispatchEvent),this.addEventListener(`action-requested`,this.redispatchEvent),this.addEventListener(`server-side-action-requested`,this.redispatchEvent),this.addEventListener(`route-changed`,this.redispatchEvent),this.addEventListener(`close-modal-requested`,this.redispatchEvent)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`value-changed`,this.redispatchEvent),this.removeEventListener(`data-changed`,this.redispatchEvent),this.removeEventListener(`action-requested`,this.redispatchEvent),this.removeEventListener(`server-side-action-requested`,this.redispatchEvent),this.removeEventListener(`route-changed`,this.redispatchEvent)}render(){return w`<slot></slot>`}static{this.styles=m`
+  `}};O([v()],Ia.prototype,`message`,void 0),O([v()],Ia.prototype,`dismiss`,void 0),O([v()],Ia.prototype,`learnMore`,void 0),O([v()],Ia.prototype,`learnMoreLink`,void 0),O([v()],Ia.prototype,`showLearnMore`,void 0),O([v()],Ia.prototype,`position`,void 0),O([v()],Ia.prototype,`cookieName`,void 0),O([S()],Ia.prototype,`_css`,void 0),O([b(`[aria-label="cookieconsent"]`)],Ia.prototype,`popup`,void 0),Ia=O([h(`mateu-cookie-consent`)],Ia);var La=class extends y{constructor(...e){super(...e),this.redispatchEvent=e=>{e instanceof CustomEvent&&(e.stopPropagation(),e.preventDefault(),this.target?.dispatchEvent(new CustomEvent(e.type,{detail:e.detail,bubbles:!0,composed:!0})))}}connectedCallback(){super.connectedCallback(),this.addEventListener(`value-changed`,this.redispatchEvent),this.addEventListener(`data-changed`,this.redispatchEvent),this.addEventListener(`action-requested`,this.redispatchEvent),this.addEventListener(`server-side-action-requested`,this.redispatchEvent),this.addEventListener(`route-changed`,this.redispatchEvent),this.addEventListener(`close-modal-requested`,this.redispatchEvent)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`value-changed`,this.redispatchEvent),this.removeEventListener(`data-changed`,this.redispatchEvent),this.removeEventListener(`action-requested`,this.redispatchEvent),this.removeEventListener(`server-side-action-requested`,this.redispatchEvent),this.removeEventListener(`route-changed`,this.redispatchEvent)}render(){return w`<slot></slot>`}static{this.styles=m`
         :host {
             /* width: 100%; */
             display: inline-block;
         }
-  `}};O([v()],Pa.prototype,`target`,void 0),Pa=O([h(`mateu-event-interceptor`)],Pa);var Fa=[`a[href]`,`button`,`input`,`select`,`textarea`,`[tabindex]`,`vaadin-button`,`vaadin-text-field`,`vaadin-combo-box`,`vaadin-select`,`vaadin-checkbox`,`vaadin-date-picker`,`ui5-button`,`oj-c-button`].join(`,`),Ia=e=>{let t=e;return t.hidden||t.hasAttribute(`disabled`)||t.getAttribute(`aria-hidden`)===`true`||t.getAttribute(`tabindex`)===`-1`?!1:!!(t.offsetParent||t.getClientRects().length)},La=e=>{let t=[],n=e=>{e.querySelectorAll(`*`).forEach(e=>{e.matches(Fa)&&Ia(e)&&t.push(e),e.shadowRoot&&n(e.shadowRoot),e instanceof HTMLSlotElement&&e.assignedElements().forEach(e=>{e.matches(Fa)&&Ia(e)&&t.push(e),n(e)})})};return n(e),t.filter((e,n)=>t.indexOf(e)===n)},Ra=(e,t={})=>{let n=za(),r=[],i=()=>{r=La(e)},a=t=>{if(t.key!==`Tab`)return;if(i(),r.length===0){t.preventDefault(),e.focus();return}let n=r[0],a=r[r.length-1],o=za();t.shiftKey&&(o===n||!o||!Ba(o,e))?(t.preventDefault(),a.focus()):!t.shiftKey&&o===a&&(t.preventDefault(),n.focus())};return e.addEventListener(`keydown`,a),requestAnimationFrame(()=>{i();let n=t.initialFocus?.()??r[0];n?n.focus():(e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus())}),{refresh:i,release(){e.removeEventListener(`keydown`,a);let t=za();(!t||t===document.body||Ba(t,e))&&n?.focus?.()}}},za=()=>{let e=document.activeElement;for(;e?.shadowRoot?.activeElement;)e=e.shadowRoot.activeElement;return e},Ba=(e,t)=>{let n=e;for(;n;){if(n===t)return!0;n=n.parentNode??n.host??null}return!1},Va=class extends Sa{constructor(...e){super(...e),this.opened=!0,this.close=()=>{this.opened=!1,this.releaseFocusTrap(),setTimeout(()=>{this.removeSelfFromOwnerChildren()||this.parentElement?.removeChild(this)},500)},this.onKeydown=e=>{e.key===`Escape`&&this.opened&&(e.stopPropagation(),this.close())}}connectedCallback(){super.connectedCallback(),this.addEventListener(`keydown`,this.onKeydown)}disconnectedCallback(){super.disconnectedCallback(),this.releaseFocusTrap()}releaseFocusTrap(){this.focusTrap?.release(),this.focusTrap=void 0}applyFragment(e){super.applyFragment(e);let t=e.state?._closeAfterMillis;t&&setTimeout(()=>this.close(),t)}updated(e){if(super.updated(e),e.has(`component`)&&this.component){let e=this.component.metadata;this.state=e.initialData}let t=this.renderRoot.querySelector(`[role="dialog"]`),n=this.component?.metadata?.modeless;this.opened&&t&&!this.focusTrap&&!n?this.focusTrap=Ra(t):this.focusTrap&&this.opened&&this.focusTrap.refresh()}render(){if(!this.opened)return w``;let e=this.component.metadata,t=it(e.headerTitle,this.state,this.data,this.appState,this.appData),n=!!(t||e.header||e.closeButtonOnHeader),r=[e.width?`width:${e.width};`:`min-width:min(90vw,28rem);`,e.height?`height:${e.height};`:``,e.top?`margin-top:${e.top};`:``].join(``);return w`
+  `}};O([v()],La.prototype,`target`,void 0),La=O([h(`mateu-event-interceptor`)],La);var Ra=[`a[href]`,`button`,`input`,`select`,`textarea`,`[tabindex]`,`vaadin-button`,`vaadin-text-field`,`vaadin-combo-box`,`vaadin-select`,`vaadin-checkbox`,`vaadin-date-picker`,`ui5-button`,`oj-c-button`].join(`,`),za=e=>{let t=e;return t.hidden||t.hasAttribute(`disabled`)||t.getAttribute(`aria-hidden`)===`true`||t.getAttribute(`tabindex`)===`-1`?!1:!!(t.offsetParent||t.getClientRects().length)},Ba=e=>{let t=[],n=e=>{e.querySelectorAll(`*`).forEach(e=>{e.matches(Ra)&&za(e)&&t.push(e),e.shadowRoot&&n(e.shadowRoot),e instanceof HTMLSlotElement&&e.assignedElements().forEach(e=>{e.matches(Ra)&&za(e)&&t.push(e),n(e)})})};return n(e),t.filter((e,n)=>t.indexOf(e)===n)},Va=(e,t={})=>{let n=Ha(),r=[],i=()=>{r=Ba(e)},a=t=>{if(t.key!==`Tab`)return;if(i(),r.length===0){t.preventDefault(),e.focus();return}let n=r[0],a=r[r.length-1],o=Ha();t.shiftKey&&(o===n||!o||!Ua(o,e))?(t.preventDefault(),a.focus()):!t.shiftKey&&o===a&&(t.preventDefault(),n.focus())};return e.addEventListener(`keydown`,a),requestAnimationFrame(()=>{i();let n=t.initialFocus?.()??r[0];n?n.focus():(e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus())}),{refresh:i,release(){e.removeEventListener(`keydown`,a);let t=Ha();(!t||t===document.body||Ua(t,e))&&n?.focus?.()}}},Ha=()=>{let e=document.activeElement;for(;e?.shadowRoot?.activeElement;)e=e.shadowRoot.activeElement;return e},Ua=(e,t)=>{let n=e;for(;n;){if(n===t)return!0;n=n.parentNode??n.host??null}return!1},Wa=class extends wa{constructor(...e){super(...e),this.opened=!0,this.close=()=>{this.opened=!1,this.releaseFocusTrap(),setTimeout(()=>{this.removeSelfFromOwnerChildren()||this.parentElement?.removeChild(this)},500)},this.onKeydown=e=>{e.key===`Escape`&&this.opened&&(e.stopPropagation(),this.close())}}connectedCallback(){super.connectedCallback(),this.addEventListener(`keydown`,this.onKeydown)}disconnectedCallback(){super.disconnectedCallback(),this.releaseFocusTrap()}releaseFocusTrap(){this.focusTrap?.release(),this.focusTrap=void 0}applyFragment(e){super.applyFragment(e);let t=e.state?._closeAfterMillis;t&&setTimeout(()=>this.close(),t)}updated(e){if(super.updated(e),e.has(`component`)&&this.component){let e=this.component.metadata;this.state=e.initialData}let t=this.renderRoot.querySelector(`[role="dialog"]`),n=this.component?.metadata?.modeless;this.opened&&t&&!this.focusTrap&&!n?this.focusTrap=Va(t):this.focusTrap&&this.opened&&this.focusTrap.refresh()}render(){if(!this.opened)return w``;let e=this.component.metadata,t=it(e.headerTitle,this.state,this.data,this.appState,this.appData),n=!!(t||e.header||e.closeButtonOnHeader),r=[e.width?`width:${e.width};`:`min-width:min(90vw,28rem);`,e.height?`height:${e.height};`:``,e.top?`margin-top:${e.top};`:``].join(``);return w`
             <div class="backdrop ${e.modeless?`modeless`:``}"
                  @click="${t=>{!e.modeless&&t.target===t.currentTarget&&this.close()}}">
                 <div class="dialog ${e.noPadding?`no-padding`:``} ${this.component?.cssClasses??``}"
@@ -5604,7 +5604,7 @@ ${i}
         .dialog-body { padding: .5rem 1.2rem; flex: 1; }
         .dialog.no-padding .dialog-body { padding: 0; }
         .dialog-footer { padding: .5rem 1.2rem 1rem; display: flex; justify-content: flex-end; gap: .5rem; }
-    `}};O([S()],Va.prototype,`opened`,void 0),Va=O([h(`mateu-dialog`)],Va);var Ha,Ua=class extends Sa{static{Ha=this}constructor(...e){super(...e),this.opened=!1,this.maximizeSteps=0,this.collapsed=!1,this.pagerMenuOpen=!1,this.onGuidedProgress=e=>{let t=e.detail;t&&t.total>0&&(this.guidedProgress=t)},this.close=()=>{this.opened=!1,this.releaseLayoutInset(),this.releaseFocusTrap(),setTimeout(()=>{this.removeSelfFromOwnerChildren()||this.parentElement?.removeChild(this)},300)},this._escListener=e=>{if(e.key!==`Escape`)return;let t=this.getRootNode().querySelectorAll(`mateu-drawer, mateu-dialog`);t[t.length-1]===this&&(e.stopPropagation(),this.close())}}jumpToStep(e){this.pagerMenuOpen=!1,e&&(this.renderRoot.querySelector(`.content mateu-component`)??this.renderRoot.querySelector(`mateu-component`))?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`goToStep`,parameters:{_stepId:e}},bubbles:!0,composed:!0}))}static{this.SIZE_LADDER=[`s`,`m`,`l`,`xl`]}static{this.SIZE_WIDTHS={s:`464px`,m:`648px`,l:`968px`,xl:`90vw`}}effectiveWidth(e){if(e.width)return e.width;if(!e.size)return;let t=Ha.SIZE_LADDER,n=Math.max(0,t.indexOf(e.size)),r=Math.min(t.length-1,n+this.maximizeSteps);return Ha.SIZE_WIDTHS[t[r]]}canMaximize(e){if(!e.maximizable)return!1;let t=Ha.SIZE_LADDER;return Math.max(0,t.indexOf(e.size??`m`))+this.maximizeSteps<t.length-1}firstUpdated(){requestAnimationFrame(()=>this.opened=!0),this.addEventListener(`mateu-guided-progress`,this.onGuidedProgress);let e=this.component?.metadata;e&&requestAnimationFrame(()=>this.applyLayoutInset(e))}releaseFocusTrap(){this.focusTrap?.release(),this.focusTrap=void 0}applyLayoutInset(e){if(!e.layout)return;let t=document.querySelector(`mateu-ui`);if(!t)return;let n=e.position??`end`,r=n===`bottom`?`var(--mateu-drawer-height, 50vh)`:this.effectiveWidth(e)??`648px`;this._insetProp=n===`start`?`paddingLeft`:n===`bottom`?`paddingBottom`:`paddingRight`,t.style.transition=`padding .25s ease`,t.style[this._insetProp]=r}releaseLayoutInset(){if(!this._insetProp)return;let e=document.querySelector(`mateu-ui`);e&&(e.style[this._insetProp]=``),this._insetProp=void 0}applyFragment(e){super.applyFragment(e);let t=e.state?._closeAfterMillis;t&&setTimeout(()=>this.close(),t)}updated(e){if(super.updated(e),e.has(`component`)&&this.component){let e=this.component.metadata;this.state=e.initialData}let t=this.component?.metadata,n=this.renderRoot.querySelector(`[role="dialog"]`);this.opened&&n&&!t?.modeless&&!t?.layout&&!this.focusTrap?this.focusTrap=Ra(n):this.focusTrap&&this.opened&&this.focusTrap.refresh()}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._escListener)}disconnectedCallback(){document.removeEventListener(`keydown`,this._escListener),this.releaseLayoutInset(),this.releaseFocusTrap(),super.disconnectedCallback()}render(){let e=this.component.metadata,t=e.position??`end`,n=it(e.headerTitle,this.state,this.data,this.appState,this.appData),r=it(e.subtitle,this.state,this.data,this.appState,this.appData),i=this.effectiveWidth(e),a=e.peerNav&&(e.peerNav.prevRoute||e.peerNav.nextRoute)?e.peerNav:void 0;return w`
+    `}};O([S()],Wa.prototype,`opened`,void 0),Wa=O([h(`mateu-dialog`)],Wa);var Ga,Ka=class extends wa{static{Ga=this}constructor(...e){super(...e),this.opened=!1,this.maximizeSteps=0,this.collapsed=!1,this.pagerMenuOpen=!1,this.onGuidedProgress=e=>{let t=e.detail;t&&t.total>0&&(this.guidedProgress=t)},this.close=()=>{this.opened=!1,this.releaseLayoutInset(),this.releaseFocusTrap(),setTimeout(()=>{this.removeSelfFromOwnerChildren()||this.parentElement?.removeChild(this)},300)},this._escListener=e=>{if(e.key!==`Escape`)return;let t=this.getRootNode().querySelectorAll(`mateu-drawer, mateu-dialog`);t[t.length-1]===this&&(e.stopPropagation(),this.close())}}jumpToStep(e){this.pagerMenuOpen=!1,e&&(this.renderRoot.querySelector(`.content mateu-component`)??this.renderRoot.querySelector(`mateu-component`))?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`goToStep`,parameters:{_stepId:e}},bubbles:!0,composed:!0}))}static{this.SIZE_LADDER=[`s`,`m`,`l`,`xl`]}static{this.SIZE_WIDTHS={s:`464px`,m:`648px`,l:`968px`,xl:`90vw`}}effectiveWidth(e){if(e.width)return e.width;if(!e.size)return;let t=Ga.SIZE_LADDER,n=Math.max(0,t.indexOf(e.size)),r=Math.min(t.length-1,n+this.maximizeSteps);return Ga.SIZE_WIDTHS[t[r]]}canMaximize(e){if(!e.maximizable)return!1;let t=Ga.SIZE_LADDER;return Math.max(0,t.indexOf(e.size??`m`))+this.maximizeSteps<t.length-1}firstUpdated(){requestAnimationFrame(()=>this.opened=!0),this.addEventListener(`mateu-guided-progress`,this.onGuidedProgress);let e=this.component?.metadata;e&&requestAnimationFrame(()=>this.applyLayoutInset(e))}releaseFocusTrap(){this.focusTrap?.release(),this.focusTrap=void 0}applyLayoutInset(e){if(!e.layout)return;let t=document.querySelector(`mateu-ui`);if(!t)return;let n=e.position??`end`,r=n===`bottom`?`var(--mateu-drawer-height, 50vh)`:this.effectiveWidth(e)??`648px`;this._insetProp=n===`start`?`paddingLeft`:n===`bottom`?`paddingBottom`:`paddingRight`,t.style.transition=`padding .25s ease`,t.style[this._insetProp]=r}releaseLayoutInset(){if(!this._insetProp)return;let e=document.querySelector(`mateu-ui`);e&&(e.style[this._insetProp]=``),this._insetProp=void 0}applyFragment(e){super.applyFragment(e);let t=e.state?._closeAfterMillis;t&&setTimeout(()=>this.close(),t)}updated(e){if(super.updated(e),e.has(`component`)&&this.component){let e=this.component.metadata;this.state=e.initialData}let t=this.component?.metadata,n=this.renderRoot.querySelector(`[role="dialog"]`);this.opened&&n&&!t?.modeless&&!t?.layout&&!this.focusTrap?this.focusTrap=Va(n):this.focusTrap&&this.opened&&this.focusTrap.refresh()}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._escListener)}disconnectedCallback(){document.removeEventListener(`keydown`,this._escListener),this.releaseLayoutInset(),this.releaseFocusTrap(),super.disconnectedCallback()}render(){let e=this.component.metadata,t=e.position??`end`,n=it(e.headerTitle,this.state,this.data,this.appState,this.appData),r=it(e.subtitle,this.state,this.data,this.appState,this.appData),i=this.effectiveWidth(e),a=e.peerNav&&(e.peerNav.prevRoute||e.peerNav.nextRoute)?e.peerNav:void 0;return w`
         ${e.modeless||e.layout?_:w`
             <div class="backdrop ${this.opened?`open`:``}" @click="${this.close}"></div>
         `}
@@ -5882,7 +5882,7 @@ ${i}
             display: flex;
             justify-content: flex-end;
         }
-  `}};O([S()],Ua.prototype,`opened`,void 0),O([S()],Ua.prototype,`maximizeSteps`,void 0),O([S()],Ua.prototype,`collapsed`,void 0),O([S()],Ua.prototype,`guidedProgress`,void 0),O([S()],Ua.prototype,`pagerMenuOpen`,void 0),Ua=Ha=O([h(`mateu-drawer`)],Ua);function Wa(e){if(e.parentElement)return e.parentElement;let t=e.getRootNode();return t instanceof ShadowRoot?t.host:null}var J=class extends y{constructor(...e){super(...e),this.appState={},this.appData={},this.standalone=!1,this.actionBanners=[],this.dismissedStaticBannerIndices=new Set,this._tocEntries=[],this._activeToc=0,this._tocVisible=!1,this._tocRebuildScheduled=!1,this._headerH=0,this._onResize=()=>this._layoutStickyTops(),this._tocLocked=!1,this._unlockToc=e=>{if(e&&e.type===`keydown`){let t=e;if(t.ctrlKey&&t.altKey&&!t.shiftKey&&!t.metaKey&&/^(?:Digit|Numpad)[1-9]$/.test(t.code))return}this._tocLocked=!1},this._actionBannerTimers=[],this._staticBannerTimers=[],this._bannersHandler=e=>{let t=e.detail,n=t.banners??[],r=t.append??!1;r?this.actionBanners=[...this.actionBanners,...n]:(this._clearActionBannerTimers(),this.actionBanners=n);let i=r?this.actionBanners.length-n.length:0;n.forEach((e,t)=>{if(e.timeoutSeconds&&e.timeoutSeconds>0){let n=i+t;this._actionBannerTimers.push(setTimeout(()=>{this.actionBanners=this.actionBanners.filter((e,t)=>t!==n)},e.timeoutSeconds*1e3))}})},this._onTocKey=e=>{if(!this._tocVisible||!e.ctrlKey||!e.altKey||e.shiftKey||e.metaKey)return;let t=/^(?:Digit|Numpad)([1-9])$/.exec(e.code);if(!t)return;let n=parseInt(t[1],10)-1;n>=this._tocEntries.length||(e.preventDefault(),this._scrollToSection(n))},this._onScrollSpy=()=>{if(this._tocLocked)return;let e=this._sectionCards();if(!e.length)return;let t=this.shadowRoot?.querySelector(`mateu-content-header`),n=t?t.getBoundingClientRect().bottom:0;for(let t of e){if(!t.classList.contains(`mateu-section--sticky`))continue;let e=t.getBoundingClientRect();e.top<=n+12+2&&(n=Math.max(n,e.bottom))}let r=n+12+4,i=0;this._tocEntries.forEach((e,t)=>{e.el.getBoundingClientRect().top<=r&&(i=t)}),this._activeToc=i}}connectedCallback(){super.connectedCallback(),document.addEventListener(`page-banners-received`,this._bannersHandler),window.addEventListener(`resize`,this._onResize),document.addEventListener(`keydown`,this._onTocKey)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`page-banners-received`,this._bannersHandler),window.removeEventListener(`resize`,this._onResize),document.removeEventListener(`keydown`,this._onTocKey),this._clearAllTimers(),this._teardownScrollSpy()}updated(e){if(super.updated(e),e.has(`component`)&&e.get(`component`)!==void 0&&(this._clearAllTimers(),this.actionBanners=[],this.dismissedStaticBannerIndices=new Set),e.has(`component`)){let e=this.component?.metadata?.level??0;this.toggleAttribute(`data-nested`,e>0),this._scheduleStaticBannerTimeouts();let t=this.component?.metadata?.pageWidth===`edgeToEdge`;this.toggleAttribute(`data-edge`,t),this.dispatchEvent(new CustomEvent(`compact-changed`,{detail:{compact:!!this.component?.style?.includes(`--mateu-compact:1`)||t},bubbles:!0,composed:!0})),this._scheduleTocRebuild()}}_scheduleStaticBannerTimeouts(){this._staticBannerTimers.forEach(e=>clearTimeout(e)),this._staticBannerTimers=[],(this.component?.metadata?.banners??[]).forEach((e,t)=>{e.timeoutSeconds&&e.timeoutSeconds>0&&this._staticBannerTimers.push(setTimeout(()=>{this.dismissedStaticBannerIndices=new Set([...this.dismissedStaticBannerIndices,t])},e.timeoutSeconds*1e3))})}_clearActionBannerTimers(){this._actionBannerTimers.forEach(e=>clearTimeout(e)),this._actionBannerTimers=[]}_clearAllTimers(){this._clearActionBannerTimers(),this._staticBannerTimers.forEach(e=>clearTimeout(e)),this._staticBannerTimers=[]}_dismissActionBanner(e){this.actionBanners=this.actionBanners.filter((t,n)=>n!==e)}_dismissStaticBanner(e){this.dismissedStaticBannerIndices=new Set([...this.dismissedStaticBannerIndices,e])}bannerThemeClass(e){let t=e.theme?.toLowerCase()??`info`;return t===`none`?``:t}_evalBannerText(e){return j(e,this.state,this.data)}_renderBanner(e,t){let n=this._evalBannerText(e.title),r=this._evalBannerText(e.description);return w`
+  `}};O([S()],Ka.prototype,`opened`,void 0),O([S()],Ka.prototype,`maximizeSteps`,void 0),O([S()],Ka.prototype,`collapsed`,void 0),O([S()],Ka.prototype,`guidedProgress`,void 0),O([S()],Ka.prototype,`pagerMenuOpen`,void 0),Ka=Ga=O([h(`mateu-drawer`)],Ka);function qa(e){if(e.parentElement)return e.parentElement;let t=e.getRootNode();return t instanceof ShadowRoot?t.host:null}var q=class extends y{constructor(...e){super(...e),this.appState={},this.appData={},this.standalone=!1,this.actionBanners=[],this.dismissedStaticBannerIndices=new Set,this._tocEntries=[],this._activeToc=0,this._tocVisible=!1,this._tocRebuildScheduled=!1,this._headerH=0,this._onResize=()=>this._layoutStickyTops(),this._tocLocked=!1,this._unlockToc=e=>{if(e&&e.type===`keydown`){let t=e;if(t.ctrlKey&&t.altKey&&!t.shiftKey&&!t.metaKey&&/^(?:Digit|Numpad)[1-9]$/.test(t.code))return}this._tocLocked=!1},this._actionBannerTimers=[],this._staticBannerTimers=[],this._bannersHandler=e=>{let t=e.detail,n=t.banners??[],r=t.append??!1;r?this.actionBanners=[...this.actionBanners,...n]:(this._clearActionBannerTimers(),this.actionBanners=n);let i=r?this.actionBanners.length-n.length:0;n.forEach((e,t)=>{if(e.timeoutSeconds&&e.timeoutSeconds>0){let n=i+t;this._actionBannerTimers.push(setTimeout(()=>{this.actionBanners=this.actionBanners.filter((e,t)=>t!==n)},e.timeoutSeconds*1e3))}})},this._onTocKey=e=>{if(!this._tocVisible||!e.ctrlKey||!e.altKey||e.shiftKey||e.metaKey)return;let t=/^(?:Digit|Numpad)([1-9])$/.exec(e.code);if(!t)return;let n=parseInt(t[1],10)-1;n>=this._tocEntries.length||(e.preventDefault(),this._scrollToSection(n))},this._onScrollSpy=()=>{if(this._tocLocked)return;let e=this._sectionCards();if(!e.length)return;let t=this.shadowRoot?.querySelector(`mateu-content-header`),n=t?t.getBoundingClientRect().bottom:0;for(let t of e){if(!t.classList.contains(`mateu-section--sticky`))continue;let e=t.getBoundingClientRect();e.top<=n+12+2&&(n=Math.max(n,e.bottom))}let r=n+12+4,i=0;this._tocEntries.forEach((e,t)=>{e.el.getBoundingClientRect().top<=r&&(i=t)}),this._activeToc=i}}connectedCallback(){super.connectedCallback(),document.addEventListener(`page-banners-received`,this._bannersHandler),window.addEventListener(`resize`,this._onResize),document.addEventListener(`keydown`,this._onTocKey)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`page-banners-received`,this._bannersHandler),window.removeEventListener(`resize`,this._onResize),document.removeEventListener(`keydown`,this._onTocKey),this._clearAllTimers(),this._teardownScrollSpy()}updated(e){if(super.updated(e),e.has(`component`)&&e.get(`component`)!==void 0&&(this._clearAllTimers(),this.actionBanners=[],this.dismissedStaticBannerIndices=new Set),e.has(`component`)){let e=this.component?.metadata?.level??0;this.toggleAttribute(`data-nested`,e>0),this._scheduleStaticBannerTimeouts();let t=this.component?.metadata?.pageWidth===`edgeToEdge`;this.toggleAttribute(`data-edge`,t),this.dispatchEvent(new CustomEvent(`compact-changed`,{detail:{compact:!!this.component?.style?.includes(`--mateu-compact:1`)||t},bubbles:!0,composed:!0})),this._scheduleTocRebuild()}}_scheduleStaticBannerTimeouts(){this._staticBannerTimers.forEach(e=>clearTimeout(e)),this._staticBannerTimers=[],(this.component?.metadata?.banners??[]).forEach((e,t)=>{e.timeoutSeconds&&e.timeoutSeconds>0&&this._staticBannerTimers.push(setTimeout(()=>{this.dismissedStaticBannerIndices=new Set([...this.dismissedStaticBannerIndices,t])},e.timeoutSeconds*1e3))})}_clearActionBannerTimers(){this._actionBannerTimers.forEach(e=>clearTimeout(e)),this._actionBannerTimers=[]}_clearAllTimers(){this._clearActionBannerTimers(),this._staticBannerTimers.forEach(e=>clearTimeout(e)),this._staticBannerTimers=[]}_dismissActionBanner(e){this.actionBanners=this.actionBanners.filter((t,n)=>n!==e)}_dismissStaticBanner(e){this.dismissedStaticBannerIndices=new Set([...this.dismissedStaticBannerIndices,e])}bannerThemeClass(e){let t=e.theme?.toLowerCase()??`info`;return t===`none`?``:t}_evalBannerText(e){return j(e,this.state,this.data)}_renderBanner(e,t){let n=this._evalBannerText(e.title),r=this._evalBannerText(e.description);return w`
             <div class="page-banner page-banner--${this.bannerThemeClass(e)}">
                 ${n||e.hasCloseButton?w`
                     <div style="display: flex; align-items: center; justify-content: space-between; color: #1a1a1a; width: 100%;">
@@ -5894,7 +5894,7 @@ ${i}
                 `:_}
                 ${r?w`<p>${r}</p>`:_}
             </div>
-        `}_onSlotChange(){this._scheduleTocRebuild()}_scheduleTocRebuild(){this._tocRebuildScheduled||(this._tocRebuildScheduled=!0,requestAnimationFrame(()=>{this._tocRebuildScheduled=!1,this._rebuildToc()}))}_sectionCards(){return Array.from(this.querySelectorAll(`.mateu-section`))}_sectionTitle(e){return e.querySelector(`[slot="title"]`)?.textContent?.trim()||e.querySelector(`h1,h2,h3,h4,h5,h6`)?.textContent?.trim()||void 0}_rebuildToc(){let e=this._sectionCards(),t=e.map(e=>({title:this._sectionTitle(e),el:e})).filter(e=>!!e.title),n=this.component?.metadata?.toc,r=t.length>4&&e.every(e=>!e.closest(`vaadin-horizontal-layout`)),i=(n===!0||n!==!1&&r)&&t.length>0;this._tocEntries=t,this._tocVisible=i,this._activeToc>=t.length&&(this._activeToc=0),this._teardownScrollSpy(),i?requestAnimationFrame(()=>{this._layoutStickyTops(),this._setupScrollSpy()}):this._layoutStickyTops()}_layoutStickyTops(){let e=this.shadowRoot?.querySelector(`mateu-content-header`);this._headerH=this._tocVisible&&e?e.offsetHeight:0,this.style.setProperty(`--mateu-header-h`,this._headerH+`px`);let t=this._headerH+12;for(let e of this._sectionCards())e.classList.contains(`mateu-section--sticky`)&&(e.style.top=t+`px`,t+=e.offsetHeight+12)}_scrollContainer(){let e=Wa(this);for(;e;){let t=getComputedStyle(e).overflowY;if((t===`auto`||t===`scroll`)&&e.scrollHeight>e.clientHeight)return e;e=Wa(e)}return null}_setupScrollSpy(){this._tocEntries.length&&(this._spyTarget=this._scrollContainer()??window,this._spyTarget.addEventListener(`scroll`,this._onScrollSpy,{passive:!0}),window.addEventListener(`wheel`,this._unlockToc,{passive:!0}),window.addEventListener(`touchstart`,this._unlockToc,{passive:!0}),window.addEventListener(`keydown`,this._unlockToc),this._onScrollSpy())}_teardownScrollSpy(){this._spyTarget?.removeEventListener(`scroll`,this._onScrollSpy),window.removeEventListener(`wheel`,this._unlockToc),window.removeEventListener(`touchstart`,this._unlockToc),window.removeEventListener(`keydown`,this._unlockToc),this._spyTarget=void 0}_scrollToSection(e){let t=this._tocEntries[e];if(!t)return;this._activeToc=e,this._tocLocked=!0;let n=this._headerH+12;for(let e of this._sectionCards()){if(e===t.el)break;e.classList.contains(`mateu-section--sticky`)&&(n+=e.offsetHeight+12)}let r=this._scrollContainer(),i=r?r.getBoundingClientRect().top:0,a=t.el.getBoundingClientRect().top-i-n;(r??window).scrollBy({top:a,behavior:`smooth`})}_showHeaderBand(){let e=this.component?.metadata,t=!!(e?.title||e?.subtitle||e?.toolbar?.length),n=!!this.component?.children?.some(e=>e.metadata?.type===A.Crud);return t&&!n&&!this._hasWelcomeBanner()}_hasWelcomeBanner(){let e=t=>t?.metadata?.type===A.HeroSection||(t?.children??[]).some(e);return(this.component?.children??[]).some(e)}render(){let e=this.component?.metadata,t=[...(e?.banners??[]).map((e,t)=>({banner:e,index:t})).filter(({index:e})=>!this.dismissedStaticBannerIndices.has(e)).map(({banner:e,index:t})=>({banner:e,onDismiss:()=>this._dismissStaticBanner(t)})),...this.actionBanners.map((e,t)=>({banner:e,onDismiss:()=>this._dismissActionBanner(t)}))];return w`<div style="display: flex; flex-direction: column; width: 100%;">${w`
+        `}_onSlotChange(){this._scheduleTocRebuild()}_scheduleTocRebuild(){this._tocRebuildScheduled||(this._tocRebuildScheduled=!0,requestAnimationFrame(()=>{this._tocRebuildScheduled=!1,this._rebuildToc()}))}_sectionCards(){return Array.from(this.querySelectorAll(`.mateu-section`))}_sectionTitle(e){return e.querySelector(`[slot="title"]`)?.textContent?.trim()||e.querySelector(`h1,h2,h3,h4,h5,h6`)?.textContent?.trim()||void 0}_rebuildToc(){let e=this._sectionCards(),t=e.map(e=>({title:this._sectionTitle(e),el:e})).filter(e=>!!e.title),n=this.component?.metadata?.toc,r=t.length>4&&e.every(e=>!e.closest(`vaadin-horizontal-layout`)),i=(n===!0||n!==!1&&r)&&t.length>0;this._tocEntries=t,this._tocVisible=i,this._activeToc>=t.length&&(this._activeToc=0),this._teardownScrollSpy(),i?requestAnimationFrame(()=>{this._layoutStickyTops(),this._setupScrollSpy()}):this._layoutStickyTops()}_layoutStickyTops(){let e=this.shadowRoot?.querySelector(`mateu-content-header`);this._headerH=this._tocVisible&&e?e.offsetHeight:0,this.style.setProperty(`--mateu-header-h`,this._headerH+`px`);let t=this._headerH+12;for(let e of this._sectionCards())e.classList.contains(`mateu-section--sticky`)&&(e.style.top=t+`px`,t+=e.offsetHeight+12)}_scrollContainer(){let e=qa(this);for(;e;){let t=getComputedStyle(e).overflowY;if((t===`auto`||t===`scroll`)&&e.scrollHeight>e.clientHeight)return e;e=qa(e)}return null}_setupScrollSpy(){this._tocEntries.length&&(this._spyTarget=this._scrollContainer()??window,this._spyTarget.addEventListener(`scroll`,this._onScrollSpy,{passive:!0}),window.addEventListener(`wheel`,this._unlockToc,{passive:!0}),window.addEventListener(`touchstart`,this._unlockToc,{passive:!0}),window.addEventListener(`keydown`,this._unlockToc),this._onScrollSpy())}_teardownScrollSpy(){this._spyTarget?.removeEventListener(`scroll`,this._onScrollSpy),window.removeEventListener(`wheel`,this._unlockToc),window.removeEventListener(`touchstart`,this._unlockToc),window.removeEventListener(`keydown`,this._unlockToc),this._spyTarget=void 0}_scrollToSection(e){let t=this._tocEntries[e];if(!t)return;this._activeToc=e,this._tocLocked=!0;let n=this._headerH+12;for(let e of this._sectionCards()){if(e===t.el)break;e.classList.contains(`mateu-section--sticky`)&&(n+=e.offsetHeight+12)}let r=this._scrollContainer(),i=r?r.getBoundingClientRect().top:0,a=t.el.getBoundingClientRect().top-i-n;(r??window).scrollBy({top:a,behavior:`smooth`})}_showHeaderBand(){let e=this.component?.metadata,t=!!(e?.title||e?.subtitle||e?.toolbar?.length),n=!!this.component?.children?.some(e=>e.metadata?.type===A.Crud);return t&&!n&&!this._hasWelcomeBanner()}_hasWelcomeBanner(){let e=t=>t?.metadata?.type===A.HeroSection||(t?.children??[]).some(e);return(this.component?.children??[]).some(e)}render(){let e=this.component?.metadata,t=[...(e?.banners??[]).map((e,t)=>({banner:e,index:t})).filter(({index:e})=>!this.dismissedStaticBannerIndices.has(e)).map(({banner:e,index:t})=>({banner:e,onDismiss:()=>this._dismissStaticBanner(t)})),...this.actionBanners.map((e,t)=>({banner:e,onDismiss:()=>this._dismissActionBanner(t)}))];return w`<div style="display: flex; flex-direction: column; width: 100%;">${w`
             <div class="page-header-wrap">
                 <mateu-content-header
                     class="${this._tocVisible?`sticky-header`:``}"
@@ -6138,7 +6138,7 @@ ${i}
             background: #fdf2f2;
             border-leftx: 4px solid var(--lumo-error-color);
         }
-    `}};O([v()],J.prototype,`component`,void 0),O([v()],J.prototype,`baseUrl`,void 0),O([v()],J.prototype,`state`,void 0),O([v()],J.prototype,`data`,void 0),O([v()],J.prototype,`appState`,void 0),O([v()],J.prototype,`appData`,void 0),O([v()],J.prototype,`value`,void 0),O([v({type:Boolean})],J.prototype,`standalone`,void 0),O([S()],J.prototype,`actionBanners`,void 0),O([S()],J.prototype,`dismissedStaticBannerIndices`,void 0),O([S()],J.prototype,`_tocEntries`,void 0),O([S()],J.prototype,`_activeToc`,void 0),O([S()],J.prototype,`_tocVisible`,void 0),J=O([h(`mateu-page`)],J);var Ga=m`
+    `}};O([v()],q.prototype,`component`,void 0),O([v()],q.prototype,`baseUrl`,void 0),O([v()],q.prototype,`state`,void 0),O([v()],q.prototype,`data`,void 0),O([v()],q.prototype,`appState`,void 0),O([v()],q.prototype,`appData`,void 0),O([v()],q.prototype,`value`,void 0),O([v({type:Boolean})],q.prototype,`standalone`,void 0),O([S()],q.prototype,`actionBanners`,void 0),O([S()],q.prototype,`dismissedStaticBannerIndices`,void 0),O([S()],q.prototype,`_tocEntries`,void 0),O([S()],q.prototype,`_activeToc`,void 0),O([S()],q.prototype,`_tocVisible`,void 0),q=O([h(`mateu-page`)],q);var Ja=m`
     .nbtn {
         display: inline-flex;
         align-items: center;
@@ -6167,25 +6167,25 @@ ${i}
     }
     .nbtn.primary:hover { background: var(--lumo-primary-color, #1676f3); filter: brightness(1.08); }
     .nbtn svg { width: 1em; height: 1em; flex-shrink: 0; }
-`,Ka=e=>C`
+`,Ya=e=>C`
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-         stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${e}</svg>`,qa=Ka(C`
+         stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${e}</svg>`,Xa=Ya(C`
     <circle cx="12" cy="12" r="3"></circle>
-    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path>`),Ja=Ka(C`
+    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path>`),Za=Ya(C`
     <line x1="12" y1="5" x2="12" y2="19"></line>
-    <line x1="5" y1="12" x2="19" y2="12"></line>`),Ya=Ka(C`
+    <line x1="5" y1="12" x2="19" y2="12"></line>`),Qa=Ya(C`
     <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
     <polyline points="7 10 12 15 17 10"></polyline>
-    <line x1="12" y1="15" x2="12" y2="3"></line>`);Ka(C`
+    <line x1="12" y1="15" x2="12" y2="3"></line>`);Ya(C`
     <rect x="9" y="2" width="6" height="5" rx="1"></rect>
     <rect x="2" y="17" width="6" height="5" rx="1"></rect>
     <rect x="16" y="17" width="6" height="5" rx="1"></rect>
-    <path d="M12 7v4M5 17v-3h14v3M12 11v3"></path>`);var Xa=Ka(C`
+    <path d="M12 7v4M5 17v-3h14v3M12 11v3"></path>`);var $a=Ya(C`
     <rect x="9" y="2" width="6" height="12" rx="3"></rect>
     <path d="M5 10v1a7 7 0 0 0 14 0v-1"></path>
-    <line x1="12" y1="18" x2="12" y2="22"></line>`),Za=Ka(C`
+    <line x1="12" y1="18" x2="12" y2="22"></line>`),eo=Ya(C`
     <line x1="18" y1="6" x2="6" y2="18"></line>
-    <line x1="6" y1="6" x2="18" y2="18"></line>`),Qa=[`#e91e63`,`#1676f3`,`#10b981`,`#8b5cf6`,`#f59e0b`,`#ef4444`],$a=e=>Qa[Math.abs(e??0)%Qa.length],eo=e=>(e??`?`).split(/\s+/).filter(e=>e).map(e=>e[0]).slice(0,2).join(``).toUpperCase()||`?`,Y=class extends y{constructor(...e){super(...e),this.localAgentUrl=`http://127.0.0.1:8776`,this.localAgentAlive=!1,this.menu=[],this.chatSessionId=T(),this.menuContextSent=!1,this.attachments=[],this.uploading=!1,this.expanded=!1,this.toggleExpanded=()=>{this.expanded=!this.expanded},this.items=[],this.listening=!1,this.recognitionAvailable=!1,this.loading=!1,this.elapsedSeconds=0,this.startListening=()=>{this.recognition&&(this.listening?(this.recognition.stop(),this.listening=!1):(this.recognition.start(),this.listening=!0))},this.onSpeechResult=e=>{if(this.recognition){let t=e,n=t.results[t.results[0].length-1][0].transcript;this.messageInputElement&&(this.messageInputElement.value=n,this.send(new CustomEvent(`submit`,{detail:{value:n},bubbles:!0,composed:!0})))}},this.probeLocalAgent=async()=>{if(this.localAgentUrl)try{let e=new AbortController,t=setTimeout(()=>e.abort(),1200),n=await fetch(this.localAgentUrl+`/health`,{signal:e.signal});clearTimeout(t),this.localAgentAlive=n.ok}catch{this.localAgentAlive=!1}},this.pickFiles=()=>this.fileInputElement?.click(),this.onFilesPicked=async e=>{let t=e.target,n=Array.from(t.files??[]);if(t.value=``,!(!n.length||!this.uploadUrl)){this.uploading=!0;try{let e=new FormData;e.append(`sessionId`,this.chatSessionId);for(let t of n)e.append(`files`,t,t.name);let t={},r=localStorage.getItem(`__mateu_auth_token`);r&&(t.Authorization=`Bearer `+r);let i=sessionStorage.getItem(`__mateu_sesion_id`);i&&(t[`X-Session-Id`]=i);let a=await fetch(this.uploadUrl,{method:`POST`,headers:t,body:e});if(!a.ok)throw Error(`Upload failed: ${a.status}`);let o=((await a.json()).files??[]).filter(e=>e&&e.path);this.attachments=[...this.attachments,...o]}catch(e){this.addMessage(`⚠️ No se pudieron subir los ficheros: ${e instanceof Error?e.message:e}`,`agent`)}finally{this.uploading=!1}}},this.removeAttachment=e=>{this.attachments=this.attachments.filter(t=>t.path!==e)},this.send=async e=>{this.messageInputElement?.setAttribute(`disabled`,`disabled`);let t=e.detail.value.trim(),n=this.localAgentAlive?this.localAgentUrl+`/mateu/agent/stream`:this.sseUrl,r=this.attachments;if(!t&&r.length===0||!n)return;let i=r.length?`${t}${t?`
+    <line x1="6" y1="6" x2="18" y2="18"></line>`),to=[`#e91e63`,`#1676f3`,`#10b981`,`#8b5cf6`,`#f59e0b`,`#ef4444`],no=e=>to[Math.abs(e??0)%to.length],ro=e=>(e??`?`).split(/\s+/).filter(e=>e).map(e=>e[0]).slice(0,2).join(``).toUpperCase()||`?`,J=class extends y{constructor(...e){super(...e),this.localAgentUrl=`http://127.0.0.1:8776`,this.localAgentAlive=!1,this.menu=[],this.chatSessionId=T(),this.menuContextSent=!1,this.attachments=[],this.uploading=!1,this.expanded=!1,this.toggleExpanded=()=>{this.expanded=!this.expanded},this.items=[],this.listening=!1,this.recognitionAvailable=!1,this.loading=!1,this.elapsedSeconds=0,this.startListening=()=>{this.recognition&&(this.listening?(this.recognition.stop(),this.listening=!1):(this.recognition.start(),this.listening=!0))},this.onSpeechResult=e=>{if(this.recognition){let t=e,n=t.results[t.results[0].length-1][0].transcript;this.messageInputElement&&(this.messageInputElement.value=n,this.send(new CustomEvent(`submit`,{detail:{value:n},bubbles:!0,composed:!0})))}},this.probeLocalAgent=async()=>{if(this.localAgentUrl)try{let e=new AbortController,t=setTimeout(()=>e.abort(),1200),n=await fetch(this.localAgentUrl+`/health`,{signal:e.signal});clearTimeout(t),this.localAgentAlive=n.ok}catch{this.localAgentAlive=!1}},this.pickFiles=()=>this.fileInputElement?.click(),this.onFilesPicked=async e=>{let t=e.target,n=Array.from(t.files??[]);if(t.value=``,!(!n.length||!this.uploadUrl)){this.uploading=!0;try{let e=new FormData;e.append(`sessionId`,this.chatSessionId);for(let t of n)e.append(`files`,t,t.name);let t={},r=localStorage.getItem(`__mateu_auth_token`);r&&(t.Authorization=`Bearer `+r);let i=sessionStorage.getItem(`__mateu_sesion_id`);i&&(t[`X-Session-Id`]=i);let a=await fetch(this.uploadUrl,{method:`POST`,headers:t,body:e});if(!a.ok)throw Error(`Upload failed: ${a.status}`);let o=((await a.json()).files??[]).filter(e=>e&&e.path);this.attachments=[...this.attachments,...o]}catch(e){this.addMessage(`⚠️ No se pudieron subir los ficheros: ${e instanceof Error?e.message:e}`,`agent`)}finally{this.uploading=!1}}},this.removeAttachment=e=>{this.attachments=this.attachments.filter(t=>t.path!==e)},this.send=async e=>{this.messageInputElement?.setAttribute(`disabled`,`disabled`);let t=e.detail.value.trim(),n=this.localAgentAlive?this.localAgentUrl+`/mateu/agent/stream`:this.sseUrl,r=this.attachments;if(!t&&r.length===0||!n)return;let i=r.length?`${t}${t?`
 
 `:``}📎 ${r.map(e=>e.name).join(`, `)}`:t;this.addMessage(i,`user`),this.attachments=[];let a=this.addMessage(``,`agent`);this.startLoading();let o=``;try{let e={Accept:`text/event-stream`,"Content-Type":`application/json`},i=localStorage.getItem(`__mateu_auth_token`);i&&(e.Authorization=`Bearer `+i);let s=sessionStorage.getItem(`__mateu_sesion_id`);s&&(e[`X-Session-Id`]=s);let c=this.contextProvider?.(),l=JSON.stringify({message:t,sessionId:this.chatSessionId,...r.length&&{attachments:r},...c!=null&&{context:c},...this.mcpUrl&&{mcpUrl:new URL(this.mcpUrl,window.location.origin).href},...!this.menuContextSent&&{menuContext:this.buildMenuContext(this.menu)}});this.menuContextSent=!0;let u=await fetch(n,{method:`POST`,headers:e,body:l});if(!u.ok){let e=await u.text();throw Error(`Servidor respondió ${u.status}: ${e}`)}let d=u.body?.getReader();if(!d)throw Error(`No se pudo obtener el reader del stream.`);let f=new TextDecoder,p=``;for(;;){let{done:e,value:t}=await d.read();if(e){if(p.trim().startsWith(`data:`)){let e=p.trim().slice(5).trim(),t=this.tryParseTokenUsage(e),n=!t&&this.tryParseCustomEvent(e);t?this.tokenUsage={...this.tokenUsage,...t}:n?n.event===`agent-error`?(o=`⚠️ `+(n.detail?.message??`Error desconocido del agente`),this.updateMessage(a,o)):this.dispatchEvent(new CustomEvent(n.event,{detail:n.detail,bubbles:!0,composed:!0})):(o+=e,this.updateMessage(a,o))}break}let n=f.decode(t,{stream:!0});p+=n;let r=p.split(`
 `);p=r.pop()||``;let i=!1;for(let e of r)if(e.trim().startsWith(`data:`)){let t=e.trim().slice(5).trim(),n=this.tryParseTokenUsage(t),r=!n&&this.tryParseCustomEvent(t);n?this.tokenUsage={...this.tokenUsage,...n}:r?r.event===`agent-error`?(o=`⚠️ `+(r.detail?.message??`Error desconocido del agente`),this.updateMessage(a,o)):this.dispatchEvent(new CustomEvent(r.event,{detail:r.detail,bubbles:!0,composed:!0})):(o+=t+`
@@ -6200,14 +6200,14 @@ ${i}
                         ${this.expanded?`⤡`:`⤢`}
                     </button>
                     <button class="chat-close" @click="${this.closeChat}" title="Cerrar">
-                        ${Za}
+                        ${eo}
                     </button>
                 </div>
                 <div class="scroll-container">
                     <div class="message-list" role="list">
                         ${this.items.map(e=>w`
                             <div class="message" role="listitem">
-                                <div class="avatar" style="background: ${$a(e.userColorIndex)};">${eo(e.userName)}</div>
+                                <div class="avatar" style="background: ${no(e.userColorIndex)};">${ro(e.userName)}</div>
                                 <div class="message-body">
                                     <div class="message-meta">
                                         <span class="message-name">${e.userName}</span>
@@ -6255,7 +6255,7 @@ ${i}
                             style="color: ${this.listening?`red`:`var(--lumo-contrast-50pct, #767676)`};"
                             @click="${this.startListening}"
                             ?disabled="${!this.recognitionAvailable}"
-                    >${Xa}</button>
+                    >${$a}</button>
                     <input class="msg-input"
                            placeholder="Message"
                            aria-label="Message"
@@ -6263,7 +6263,7 @@ ${i}
                     <button class="nbtn primary" ?disabled="${this.loading}" @click="${this.submitFromInput}">Send</button>
                 </div>
             </div>
-        `}static{this.styles=[Ga,m`
+        `}static{this.styles=[Ja,m`
         :host {
             display: block;
             height: 100%;
@@ -6588,7 +6588,7 @@ ${i}
         @keyframes spin {
             to { transform: rotate(360deg); }
         }
-    `]}};O([v({attribute:!1})],Y.prototype,`contextProvider`,void 0),O([v()],Y.prototype,`localAgentUrl`,void 0),O([v({attribute:!1})],Y.prototype,`mcpUrl`,void 0),O([S()],Y.prototype,`localAgentAlive`,void 0),O([v()],Y.prototype,`sseUrl`,void 0),O([v()],Y.prototype,`uploadUrl`,void 0),O([v({attribute:!1})],Y.prototype,`menu`,void 0),O([S()],Y.prototype,`attachments`,void 0),O([S()],Y.prototype,`uploading`,void 0),O([b(`.file-input`)],Y.prototype,`fileInputElement`,void 0),O([v({type:Boolean,reflect:!0})],Y.prototype,`expanded`,void 0),O([v()],Y.prototype,`items`,void 0),O([b(`.scroll-container`)],Y.prototype,`scrollContainer`,void 0),O([b(`.msg-input`)],Y.prototype,`messageInputElement`,void 0),O([S()],Y.prototype,`recognition`,void 0),O([S()],Y.prototype,`listening`,void 0),O([S()],Y.prototype,`recognitionAvailable`,void 0),O([S()],Y.prototype,`loading`,void 0),O([S()],Y.prototype,`elapsedSeconds`,void 0),O([S()],Y.prototype,`tokenUsage`,void 0),Y=O([h(`mateu-chat`)],Y);var to=class extends y{updated(e){super.updated(e),this.chart&&=(this.chart.destroy(),void 0),this.data&&this.createChart(this.data)}async createChart(e){let[{default:t}]=await Promise.all([E(()=>import(`./vendor-chartjs.js`).then(e=>e.n),__vite__mapDeps([3,1])),E(()=>import(`./vendor-chartjs.js`).then(e=>e.t),__vite__mapDeps([3,1]))]);if(e!==this.data)return;this.chart&&this.chart.destroy();let n={type:this.type,data:this.data,options:this.options};this.chart=new t(this.chartElement,n)}handleSlotChange(){}render(){return w`
+    `]}};O([v({attribute:!1})],J.prototype,`contextProvider`,void 0),O([v()],J.prototype,`localAgentUrl`,void 0),O([v({attribute:!1})],J.prototype,`mcpUrl`,void 0),O([S()],J.prototype,`localAgentAlive`,void 0),O([v()],J.prototype,`sseUrl`,void 0),O([v()],J.prototype,`uploadUrl`,void 0),O([v({attribute:!1})],J.prototype,`menu`,void 0),O([S()],J.prototype,`attachments`,void 0),O([S()],J.prototype,`uploading`,void 0),O([b(`.file-input`)],J.prototype,`fileInputElement`,void 0),O([v({type:Boolean,reflect:!0})],J.prototype,`expanded`,void 0),O([v()],J.prototype,`items`,void 0),O([b(`.scroll-container`)],J.prototype,`scrollContainer`,void 0),O([b(`.msg-input`)],J.prototype,`messageInputElement`,void 0),O([S()],J.prototype,`recognition`,void 0),O([S()],J.prototype,`listening`,void 0),O([S()],J.prototype,`recognitionAvailable`,void 0),O([S()],J.prototype,`loading`,void 0),O([S()],J.prototype,`elapsedSeconds`,void 0),O([S()],J.prototype,`tokenUsage`,void 0),J=O([h(`mateu-chat`)],J);var io=class extends y{updated(e){super.updated(e),this.chart&&=(this.chart.destroy(),void 0),this.data&&this.createChart(this.data)}async createChart(e){let[{default:t}]=await Promise.all([E(()=>import(`./vendor-chartjs.js`).then(e=>e.n),__vite__mapDeps([3,1])),E(()=>import(`./vendor-chartjs.js`).then(e=>e.t),__vite__mapDeps([3,1]))]);if(e!==this.data)return;this.chart&&this.chart.destroy();let n={type:this.type,data:this.data,options:this.options};this.chart=new t(this.chartElement,n)}handleSlotChange(){}render(){return w`
             <div class="container">
                 <canvas id="chart"></canvas>
             </div>
@@ -6605,7 +6605,7 @@ ${i}
         height: 100%;
         position: relative;
     }
-  `}};O([v()],to.prototype,`type`,void 0),O([v()],to.prototype,`data`,void 0),O([v()],to.prototype,`options`,void 0),O([b(`#chart`)],to.prototype,`chartElement`,void 0),to=O([h(`mateu-chart`)],to);var no=class extends y{updated(e){super.updated(e),this.chart&&=(this.chart.destroy(),void 0),this.xml&&this.createViewer(this.xml)}async createViewer(e){let{default:t}=await E(async()=>{let{default:e}=await import(`./vendor-diagrams.js`).then(e=>e.t);return{default:e}},__vite__mapDeps([4,1,2]));if(e!==this.xml)return;this.chart&&this.chart.destroy();let n={container:this.divElement};this.chart=new t(n),this.chart.importXML(e)}handleSlotChange(){}render(){return w`
+  `}};O([v()],io.prototype,`type`,void 0),O([v()],io.prototype,`data`,void 0),O([v()],io.prototype,`options`,void 0),O([b(`#chart`)],io.prototype,`chartElement`,void 0),io=O([h(`mateu-chart`)],io);var ao=class extends y{updated(e){super.updated(e),this.chart&&=(this.chart.destroy(),void 0),this.xml&&this.createViewer(this.xml)}async createViewer(e){let{default:t}=await E(async()=>{let{default:e}=await import(`./vendor-diagrams.js`).then(e=>e.t);return{default:e}},__vite__mapDeps([4,1,2]));if(e!==this.xml)return;this.chart&&this.chart.destroy();let n={container:this.divElement};this.chart=new t(n),this.chart.importXML(e)}handleSlotChange(){}render(){return w`
             <div class="container" style="width: 20rem; height: 15rem; overflow: auto;">
                 <!-- BPMN diagram container -->
                 <div id="canvas" style="width: 60rem; height: 30rem; zoom: 0.5;"></div>
@@ -6614,7 +6614,7 @@ ${i}
                 <slot @slotchange=${this.handleSlotChange}></slot>
             </div>
        `}static{this.styles=m`
-  `}};O([v()],no.prototype,`xml`,void 0),O([b(`#canvas`)],no.prototype,`divElement`,void 0),no=O([h(`mateu-bpmn`)],no);var ro=160,io=56,ao=220,oo=110,so=60,co={ACTION:`#3B82F6`,JOIN:`#8B5CF6`,FORK:`#F59E0B`,END:`#EF4444`,USER_TASK:`#10B981`,PROCESS:`#6366F1`},lo={ACTION:`▶`,JOIN:`⟨`,FORK:`⟩`,END:`◼`,USER_TASK:`👤`,PROCESS:`⚙`},uo=[`ACTION`,`JOIN`,`FORK`,`END`,`USER_TASK`,`PROCESS`];function fo(){return`step-`+Math.random().toString(36).slice(2,8)}var po=class extends y{constructor(...e){super(...e),this.value=`{"name":"New Workflow","steps":[]}`,this.wf={name:`New Workflow`,steps:[]},this.positions={},this.selectedId=null,this.showMeta=!1,this.draggingId=null,this.dragOffset={x:0,y:0},this.svgEl=null,this.onMouseMove=e=>{if(!this.draggingId||!this.svgEl)return;let t=this.toSvgPoint(e);this.positions={...this.positions,[this.draggingId]:{x:Math.max(0,t.x-this.dragOffset.x),y:Math.max(0,t.y-this.dragOffset.y)}}},this.onMouseUp=()=>{this.draggingId=null,window.removeEventListener(`mousemove`,this.onMouseMove),window.removeEventListener(`mouseup`,this.onMouseUp)}}updated(e){if(e.has(`value`)){try{this.wf=JSON.parse(this.value)}catch{}this.autoLayout()}}autoLayout(){let e=this.wf.steps??[],t={};e.forEach(e=>{t[e.id]=0});let n=!0;for(;n;)n=!1,e.forEach(e=>{if(e.preconditionStepId!=null&&t[e.preconditionStepId]!==void 0){let r=t[e.preconditionStepId]+1;r>t[e.id]&&(t[e.id]=r,n=!0)}});let r={};e.forEach(e=>{let n=t[e.id]??0;(r[n]??=[]).push(e.id)});let i={...this.positions},a=!1;Object.entries(r).forEach(([e,t])=>{let n=Number(e);t.forEach((e,t)=>{i[e]||(i[e]={x:so+n*ao,y:so+t*oo},a=!0)})}),a&&(this.positions=i)}emit(){let e=JSON.stringify(this.wf,null,2);this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e},bubbles:!0,composed:!0}))}updateWf(e){this.wf={...this.wf,...e},this.emit()}updateStep(e,t){this.wf={...this.wf,steps:this.wf.steps.map(n=>n.id===e?{...n,...t}:n)},this.emit()}addStep(){let e=fo(),t={id:e,type:`ACTION`,name:`New Step`};this.wf={...this.wf,steps:[...this.wf.steps??[],t]};let n=Object.values(this.positions).map(e=>e.y),r=n.length?Math.max(...n)+oo:so;this.positions={...this.positions,[e]:{x:so,y:r}},this.selectedId=e,this.emit()}deleteStep(e){this.wf={...this.wf,steps:this.wf.steps.filter(t=>t.id!==e).map(t=>t.preconditionStepId===e?{...t,preconditionStepId:void 0}:t)};let{[e]:t,...n}=this.positions;this.positions=n,this.selectedId===e&&(this.selectedId=null),this.emit()}onNodeMouseDown(e,t){e.preventDefault(),this.draggingId=t;let n=this.positions[t]??{x:0,y:0},r=this.toSvgPoint(e);this.dragOffset={x:r.x-n.x,y:r.y-n.y},this.svgEl=e.currentTarget.closest(`svg`),window.addEventListener(`mousemove`,this.onMouseMove),window.addEventListener(`mouseup`,this.onMouseUp)}toSvgPoint(e){if(!this.svgEl)return{x:0,y:0};let t=this.svgEl.getBoundingClientRect();return{x:e.clientX-t.left,y:e.clientY-t.top}}canvasSize(){let e=Object.values(this.positions),t=e.length?Math.max(...e.map(e=>e.x))+ro+so:600,n=e.length?Math.max(...e.map(e=>e.y))+io+so:400;return{w:Math.max(t,600),h:Math.max(n,400)}}render(){let{w:e,h:t}=this.canvasSize(),n=this.wf.steps??[];return w`
+  `}};O([v()],ao.prototype,`xml`,void 0),O([b(`#canvas`)],ao.prototype,`divElement`,void 0),ao=O([h(`mateu-bpmn`)],ao);var oo=160,so=56,co=220,lo=110,uo=60,fo={ACTION:`#3B82F6`,JOIN:`#8B5CF6`,FORK:`#F59E0B`,END:`#EF4444`,USER_TASK:`#10B981`,PROCESS:`#6366F1`},po={ACTION:`▶`,JOIN:`⟨`,FORK:`⟩`,END:`◼`,USER_TASK:`👤`,PROCESS:`⚙`},mo=[`ACTION`,`JOIN`,`FORK`,`END`,`USER_TASK`,`PROCESS`];function ho(){return`step-`+Math.random().toString(36).slice(2,8)}var go=class extends y{constructor(...e){super(...e),this.value=`{"name":"New Workflow","steps":[]}`,this.wf={name:`New Workflow`,steps:[]},this.positions={},this.selectedId=null,this.showMeta=!1,this.draggingId=null,this.dragOffset={x:0,y:0},this.svgEl=null,this.onMouseMove=e=>{if(!this.draggingId||!this.svgEl)return;let t=this.toSvgPoint(e);this.positions={...this.positions,[this.draggingId]:{x:Math.max(0,t.x-this.dragOffset.x),y:Math.max(0,t.y-this.dragOffset.y)}}},this.onMouseUp=()=>{this.draggingId=null,window.removeEventListener(`mousemove`,this.onMouseMove),window.removeEventListener(`mouseup`,this.onMouseUp)}}updated(e){if(e.has(`value`)){try{this.wf=JSON.parse(this.value)}catch{}this.autoLayout()}}autoLayout(){let e=this.wf.steps??[],t={};e.forEach(e=>{t[e.id]=0});let n=!0;for(;n;)n=!1,e.forEach(e=>{if(e.preconditionStepId!=null&&t[e.preconditionStepId]!==void 0){let r=t[e.preconditionStepId]+1;r>t[e.id]&&(t[e.id]=r,n=!0)}});let r={};e.forEach(e=>{let n=t[e.id]??0;(r[n]??=[]).push(e.id)});let i={...this.positions},a=!1;Object.entries(r).forEach(([e,t])=>{let n=Number(e);t.forEach((e,t)=>{i[e]||(i[e]={x:uo+n*co,y:uo+t*lo},a=!0)})}),a&&(this.positions=i)}emit(){let e=JSON.stringify(this.wf,null,2);this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e},bubbles:!0,composed:!0}))}updateWf(e){this.wf={...this.wf,...e},this.emit()}updateStep(e,t){this.wf={...this.wf,steps:this.wf.steps.map(n=>n.id===e?{...n,...t}:n)},this.emit()}addStep(){let e=ho(),t={id:e,type:`ACTION`,name:`New Step`};this.wf={...this.wf,steps:[...this.wf.steps??[],t]};let n=Object.values(this.positions).map(e=>e.y),r=n.length?Math.max(...n)+lo:uo;this.positions={...this.positions,[e]:{x:uo,y:r}},this.selectedId=e,this.emit()}deleteStep(e){this.wf={...this.wf,steps:this.wf.steps.filter(t=>t.id!==e).map(t=>t.preconditionStepId===e?{...t,preconditionStepId:void 0}:t)};let{[e]:t,...n}=this.positions;this.positions=n,this.selectedId===e&&(this.selectedId=null),this.emit()}onNodeMouseDown(e,t){e.preventDefault(),this.draggingId=t;let n=this.positions[t]??{x:0,y:0},r=this.toSvgPoint(e);this.dragOffset={x:r.x-n.x,y:r.y-n.y},this.svgEl=e.currentTarget.closest(`svg`),window.addEventListener(`mousemove`,this.onMouseMove),window.addEventListener(`mouseup`,this.onMouseUp)}toSvgPoint(e){if(!this.svgEl)return{x:0,y:0};let t=this.svgEl.getBoundingClientRect();return{x:e.clientX-t.left,y:e.clientY-t.top}}canvasSize(){let e=Object.values(this.positions),t=e.length?Math.max(...e.map(e=>e.x))+oo+uo:600,n=e.length?Math.max(...e.map(e=>e.y))+so+uo:400;return{w:Math.max(t,600),h:Math.max(n,400)}}render(){let{w:e,h:t}=this.canvasSize(),n=this.wf.steps??[];return w`
             <div class="root">
                 ${this.renderToolbar()}
                 ${this.showMeta?this.renderMeta():``}
@@ -6641,15 +6641,15 @@ ${i}
                 <span class="badge badge-${e.toLowerCase()}">${e}</span>
                 <div style="flex:1"></div>
                 <button class="nbtn" @click="${()=>this.showMeta=!this.showMeta}">
-                    ${qa}
+                    ${Xa}
                     Settings
                 </button>
                 <button class="nbtn primary" @click="${()=>this.addStep()}">
-                    ${Ja}
+                    ${Za}
                     Add Step
                 </button>
                 <button class="nbtn" @click="${()=>this.exportJson()}">
-                    ${Ya}
+                    ${Qa}
                     Export
                 </button>
             </div>
@@ -6678,27 +6678,27 @@ ${i}
                     `:``}
                 </div>
             </div>
-        `}renderArrow(e){if(!e.preconditionStepId)return C``;let t=this.positions[e.preconditionStepId],n=this.positions[e.id];if(!t||!n)return C``;let r=t.x+ro,i=t.y+io/2,a=n.x,o=n.y+io/2,s=(r+a)/2;return C`
+        `}renderArrow(e){if(!e.preconditionStepId)return C``;let t=this.positions[e.preconditionStepId],n=this.positions[e.id];if(!t||!n)return C``;let r=t.x+oo,i=t.y+so/2,a=n.x,o=n.y+so/2,s=(r+a)/2;return C`
             <path d="M${r},${i} C${s},${i} ${s},${o} ${a},${o}"
                   fill="none" stroke="#94a3b8" stroke-width="2"
                   marker-end="url(#arrow)"/>
-        `}renderNode(e){let t=this.positions[e.id]??{x:so,y:so},n=co[e.type]??`#64748b`,r=lo[e.type]??`•`,i=this.selectedId===e.id;return C`
+        `}renderNode(e){let t=this.positions[e.id]??{x:uo,y:uo},n=fo[e.type]??`#64748b`,r=po[e.type]??`•`,i=this.selectedId===e.id;return C`
             <g transform="translate(${t.x},${t.y})"
                style="cursor:grab"
                @mousedown="${t=>this.onNodeMouseDown(t,e.id)}"
                @click="${t=>{t.stopPropagation(),this.selectedId=e.id}}">
-                <rect width="${ro}" height="${io}" rx="8"
+                <rect width="${oo}" height="${so}" rx="8"
                       fill="white"
                       stroke="${i?n:`#e2e8f0`}"
                       stroke-width="${i?2.5:1.5}"
                       filter="url(#shadow)"/>
                 <!-- type badge -->
-                <rect x="0" y="0" width="32" height="${io}" rx="8" fill="${n}" clip-path="inset(0 -8px 0 0 round 8px)"/>
-                <rect x="24" y="0" width="8" height="${io}" fill="${n}"/>
+                <rect x="0" y="0" width="32" height="${so}" rx="8" fill="${n}" clip-path="inset(0 -8px 0 0 round 8px)"/>
+                <rect x="24" y="0" width="8" height="${so}" fill="${n}"/>
                 <text x="16" y="${33}" text-anchor="middle"
                       font-size="14" fill="white">${r}</text>
                 <!-- name -->
-                <text x="44" y="${io/2-6}" font-size="11" fill="#1e293b" font-weight="600">
+                <text x="44" y="${so/2-6}" font-size="11" fill="#1e293b" font-weight="600">
                     ${e.name.length>16?e.name.slice(0,15)+`…`:e.name}
                 </text>
                 <text x="44" y="${36}" font-size="9" fill="#94a3b8">${e.id}</text>
@@ -6723,7 +6723,7 @@ ${i}
                         @change="${t=>this.updateStep(e.id,{name:t.target.value})}"/>`)}
                     ${n(`Type`,w`
                         <select class="inp" @change="${t=>this.updateStep(e.id,{type:t.target.value})}">
-                            ${uo.map(t=>w`<option value="${t}" ?selected="${e.type===t}">${t}</option>`)}
+                            ${mo.map(t=>w`<option value="${t}" ?selected="${e.type===t}">${t}</option>`)}
                         </select>`)}
                     ${n(`Description`,w`<textarea class="inp" rows="2"
                         @change="${t=>this.updateStep(e.id,{description:t.target.value})}">${e.description??``}</textarea>`)}
@@ -6768,7 +6768,7 @@ ${i}
                         @change="${t=>this.updateStep(e.id,{childWorkflowDefinitionId:t.target.value||void 0})}"/>`):``}
                 </div>
             </div>
-        `}exportJson(){let e=JSON.stringify(this.wf,null,2),t=new Blob([e],{type:`application/json`}),n=URL.createObjectURL(t),r=document.createElement(`a`);r.href=n,r.download=(this.wf.name??`workflow`).replace(/\s+/g,`-`).toLowerCase()+`.json`,r.click(),URL.revokeObjectURL(n)}static{this.styles=[Ga,m`
+        `}exportJson(){let e=JSON.stringify(this.wf,null,2),t=new Blob([e],{type:`application/json`}),n=URL.createObjectURL(t),r=document.createElement(`a`);r.href=n,r.download=(this.wf.name??`workflow`).replace(/\s+/g,`-`).toLowerCase()+`.json`,r.click(),URL.revokeObjectURL(n)}static{this.styles=[Ja,m`
         :host { display: block; height: 100%; font-family: var(--lumo-font-family, sans-serif); }
 
         .root { display: flex; flex-direction: column; height: 100%; background: var(--lumo-base-color, #fff); }
@@ -6846,7 +6846,7 @@ ${i}
         .inp:focus { border-color: #3B82F6; }
         textarea.inp { resize: vertical; }
         input[readonly].inp { background: #f8fafc; color: #94a3b8; }
-    `]}};O([v()],po.prototype,`value`,void 0),O([S()],po.prototype,`wf`,void 0),O([S()],po.prototype,`positions`,void 0),O([S()],po.prototype,`selectedId`,void 0),O([S()],po.prototype,`showMeta`,void 0),po=O([h(`mateu-workflow`)],po);var mo=[`string`,`integer`,`number`,`bool`,`date`,`time`,`dateTime`,`dateRange`,`money`,`file`,`array`,`status`,`component`,`menu`,`range`,`action`,`actionGroup`],ho=[`regular`,`radio`,`checkbox`,`textarea`,`toggle`,`combobox`,`select`,`email`,`password`,`richText`,`listBox`,`html`,`markdown`,`image`,`icon`,`link`,`money`,`grid`,`color`,`choice`,`popover`,`slider`,`button`,`stars`],go={string:`#3B82F6`,integer:`#8B5CF6`,number:`#6366F1`,bool:`#10B981`,date:`#F59E0B`,time:`#F59E0B`,dateTime:`#F59E0B`,dateRange:`#F59E0B`,money:`#EF4444`,file:`#64748B`,array:`#0EA5E9`,status:`#EC4899`,component:`#14B8A6`,menu:`#94A3B8`,range:`#A855F7`,action:`#F97316`,actionGroup:`#FB923C`};function _o(){return`field-`+Math.random().toString(36).slice(2,8)}var vo=class extends y{constructor(...e){super(...e),this.value=`{"name":"New Form","fields":[]}`,this.form={name:`New Form`,fields:[]},this.selectedId=null,this.showMeta=!1,this.sortable=null,this.listEl=null}updated(e){if(e.has(`value`))try{this.form=JSON.parse(this.value)}catch{}this.attachSortable()}disconnectedCallback(){super.disconnectedCallback(),this.sortable?.destroy(),this.sortable=null}attachSortable(){let e=this.shadowRoot?.querySelector(`.field-list`);!e||e===this.listEl||(this.listEl=e,this.sortable?.destroy(),this.sortable=ce.create(e,{animation:150,handle:`.drag-handle`,ghostClass:`sortable-ghost`,onEnd:e=>{let{oldIndex:t,newIndex:n}=e;if(t===void 0||n===void 0||t===n)return;let r=[...this.form.fields],[i]=r.splice(t,1);r.splice(n,0,i),this.form={...this.form,fields:r},this.emit()}}))}emit(){let e=JSON.stringify(this.form,null,2);this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e},bubbles:!0,composed:!0}))}updateForm(e){this.form={...this.form,...e},this.emit()}updateField(e,t){this.form={...this.form,fields:this.form.fields.map(n=>n.id===e?{...n,...t}:n)},this.emit()}addField(){let e=_o(),t={id:e,label:`New Field`,dataType:`string`};this.form={...this.form,fields:[...this.form.fields,t]},this.selectedId=e,this.emit()}deleteField(e){this.form={...this.form,fields:this.form.fields.filter(t=>t.id!==e)},this.selectedId===e&&(this.selectedId=null),this.emit()}duplicateField(e){let t=this.form.fields.find(t=>t.id===e);if(!t)return;let n={...t,id:_o(),label:t.label+` (copy)`},r=this.form.fields.findIndex(t=>t.id===e),i=[...this.form.fields];i.splice(r+1,0,n),this.form={...this.form,fields:i},this.selectedId=n.id,this.emit()}render(){return w`
+    `]}};O([v()],go.prototype,`value`,void 0),O([S()],go.prototype,`wf`,void 0),O([S()],go.prototype,`positions`,void 0),O([S()],go.prototype,`selectedId`,void 0),O([S()],go.prototype,`showMeta`,void 0),go=O([h(`mateu-workflow`)],go);var _o=[`string`,`integer`,`number`,`bool`,`date`,`time`,`dateTime`,`dateRange`,`money`,`file`,`array`,`status`,`component`,`menu`,`range`,`action`,`actionGroup`],vo=[`regular`,`radio`,`checkbox`,`textarea`,`toggle`,`combobox`,`select`,`email`,`password`,`richText`,`listBox`,`html`,`markdown`,`image`,`icon`,`link`,`money`,`grid`,`color`,`choice`,`popover`,`slider`,`button`,`stars`],yo={string:`#3B82F6`,integer:`#8B5CF6`,number:`#6366F1`,bool:`#10B981`,date:`#F59E0B`,time:`#F59E0B`,dateTime:`#F59E0B`,dateRange:`#F59E0B`,money:`#EF4444`,file:`#64748B`,array:`#0EA5E9`,status:`#EC4899`,component:`#14B8A6`,menu:`#94A3B8`,range:`#A855F7`,action:`#F97316`,actionGroup:`#FB923C`};function bo(){return`field-`+Math.random().toString(36).slice(2,8)}var xo=class extends y{constructor(...e){super(...e),this.value=`{"name":"New Form","fields":[]}`,this.form={name:`New Form`,fields:[]},this.selectedId=null,this.showMeta=!1,this.sortable=null,this.listEl=null}updated(e){if(e.has(`value`))try{this.form=JSON.parse(this.value)}catch{}this.attachSortable()}disconnectedCallback(){super.disconnectedCallback(),this.sortable?.destroy(),this.sortable=null}attachSortable(){let e=this.shadowRoot?.querySelector(`.field-list`);!e||e===this.listEl||(this.listEl=e,this.sortable?.destroy(),this.sortable=ce.create(e,{animation:150,handle:`.drag-handle`,ghostClass:`sortable-ghost`,onEnd:e=>{let{oldIndex:t,newIndex:n}=e;if(t===void 0||n===void 0||t===n)return;let r=[...this.form.fields],[i]=r.splice(t,1);r.splice(n,0,i),this.form={...this.form,fields:r},this.emit()}}))}emit(){let e=JSON.stringify(this.form,null,2);this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e},bubbles:!0,composed:!0}))}updateForm(e){this.form={...this.form,...e},this.emit()}updateField(e,t){this.form={...this.form,fields:this.form.fields.map(n=>n.id===e?{...n,...t}:n)},this.emit()}addField(){let e=bo(),t={id:e,label:`New Field`,dataType:`string`};this.form={...this.form,fields:[...this.form.fields,t]},this.selectedId=e,this.emit()}deleteField(e){this.form={...this.form,fields:this.form.fields.filter(t=>t.id!==e)},this.selectedId===e&&(this.selectedId=null),this.emit()}duplicateField(e){let t=this.form.fields.find(t=>t.id===e);if(!t)return;let n={...t,id:bo(),label:t.label+` (copy)`},r=this.form.fields.findIndex(t=>t.id===e),i=[...this.form.fields];i.splice(r+1,0,n),this.form={...this.form,fields:i},this.selectedId=n.id,this.emit()}render(){return w`
             <div class="root">
                 ${this.renderToolbar()}
                 ${this.showMeta?this.renderMeta():_}
@@ -6860,15 +6860,15 @@ ${i}
                 <span class="form-name">${this.form.name}</span>
                 <div style="flex:1"></div>
                 <button class="nbtn" @click="${()=>this.showMeta=!this.showMeta}">
-                    ${qa}
+                    ${Xa}
                     Settings
                 </button>
                 <button class="nbtn primary" @click="${()=>this.addField()}">
-                    ${Ja}
+                    ${Za}
                     Add Field
                 </button>
                 <button class="nbtn" @click="${()=>this.exportJson()}">
-                    ${Ya}
+                    ${Qa}
                     Export
                 </button>
             </div>
@@ -6893,7 +6893,7 @@ ${i}
                     ${e.map(e=>this.renderRow(e))}
                 </div>
             </div>
-        `}renderRow(e){let t=go[e.dataType]??`#64748b`;return w`
+        `}renderRow(e){let t=yo[e.dataType]??`#64748b`;return w`
             <div role="button" tabindex="0" class="field-row ${this.selectedId===e.id?`selected`:``}"
                  data-id="${e.id}"
                  @click="${()=>this.selectedId=this.selectedId===e.id?null:e.id}" @keydown="${L(()=>this.selectedId=this.selectedId===e.id?null:e.id)}">
@@ -6928,13 +6928,13 @@ ${i}
                     ${t(`Data type`,w`
                         <select class="inp"
                                 @change="${t=>this.updateField(e.id,{dataType:t.target.value})}">
-                            ${mo.map(t=>w`
+                            ${_o.map(t=>w`
                                 <option value="${t}" ?selected="${e.dataType===t}">${t}</option>`)}
                         </select>`)}
                     ${t(`Stereotype`,w`
                         <select class="inp"
                                 @change="${t=>this.updateField(e.id,{stereotype:t.target.value||void 0})}">
-                            ${ho.map(t=>w`
+                            ${vo.map(t=>w`
                                 <option value="${t}" ?selected="${(e.stereotype??`regular`)===t}">${t}</option>`)}
                         </select>`)}
                     <div class="prop-field row">
@@ -6947,7 +6947,7 @@ ${i}
                                   @change="${t=>this.updateField(e.id,{description:t.target.value||void 0})}">${e.description??``}</textarea>`)}
                 </div>
             </div>
-        `}exportJson(){let e=JSON.stringify(this.form,null,2),t=new Blob([e],{type:`application/json`}),n=URL.createObjectURL(t),r=document.createElement(`a`);r.href=n,r.download=(this.form.name??`form`).replace(/\s+/g,`-`).toLowerCase()+`.json`,r.click(),URL.revokeObjectURL(n)}static{this.styles=[Ga,R,m`
+        `}exportJson(){let e=JSON.stringify(this.form,null,2),t=new Blob([e],{type:`application/json`}),n=URL.createObjectURL(t),r=document.createElement(`a`);r.href=n,r.download=(this.form.name??`form`).replace(/\s+/g,`-`).toLowerCase()+`.json`,r.click(),URL.revokeObjectURL(n)}static{this.styles=[Ja,R,m`
         :host { display: block; height: 100%; font-family: var(--lumo-font-family, sans-serif); }
 
         .root { display: flex; flex-direction: column; height: 100%; background: var(--lumo-base-color, #fff); }
@@ -7062,7 +7062,7 @@ ${i}
         .inp:focus { border-color: #3B82F6; }
         textarea.inp { resize: vertical; }
         input[readonly].inp { background: #f8fafc; color: #94a3b8; }
-    `]}};O([v()],vo.prototype,`value`,void 0),O([S()],vo.prototype,`form`,void 0),O([S()],vo.prototype,`selectedId`,void 0),O([S()],vo.prototype,`showMeta`,void 0),vo=O([h(`mateu-form-editor`)],vo);var yo=class extends y{constructor(...e){super(...e),this.appState={},this.appData={},this.open=!1,this.activeTab=`appstate`,this.hoveredTag=``,this.hoveredId=``,this.hoveredState=null,this.hoveredData=null,this.hoveredMeta=null,this._prevTarget=null,this._onMouseover=e=>{let t=e.target;for(;t&&!(t.tagName?.toLowerCase().startsWith(`mateu-`)&&t!==this);)t=t.parentElement;if(t===this||t===null){t===null&&this._prevTarget&&(this._prevTarget.style.outline=``,this._prevTarget.style.outlineOffset=``,this._prevTarget=null,this.hoveredTag=``,this.hoveredId=``,this.hoveredState=null,this.hoveredData=null,this.hoveredMeta=null);return}t!==this._prevTarget&&(this._prevTarget&&(this._prevTarget.style.outline=``,this._prevTarget.style.outlineOffset=``),this._prevTarget=t,t.style.outline=`2px solid #0070f3`,t.style.outlineOffset=`-2px`,this.hoveredTag=t.tagName.toLowerCase(),this.hoveredId=t.id||``,this.hoveredState=t.state,this.hoveredData=t.data,this.hoveredMeta=t.component?.metadata)}}connectedCallback(){super.connectedCallback(),document.addEventListener(`mouseover`,this._onMouseover,!0)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`mouseover`,this._onMouseover,!0),this._prevTarget&&=(this._prevTarget.style.outline=``,null)}_fmt(e){try{return JSON.stringify(e,null,2)??`null`}catch{return String(e)}}_renderTab(e,t){return w`
+    `]}};O([v()],xo.prototype,`value`,void 0),O([S()],xo.prototype,`form`,void 0),O([S()],xo.prototype,`selectedId`,void 0),O([S()],xo.prototype,`showMeta`,void 0),xo=O([h(`mateu-form-editor`)],xo);var So=class extends y{constructor(...e){super(...e),this.appState={},this.appData={},this.open=!1,this.activeTab=`appstate`,this.hoveredTag=``,this.hoveredId=``,this.hoveredState=null,this.hoveredData=null,this.hoveredMeta=null,this._prevTarget=null,this._onMouseover=e=>{let t=e.target;for(;t&&!(t.tagName?.toLowerCase().startsWith(`mateu-`)&&t!==this);)t=t.parentElement;if(t===this||t===null){t===null&&this._prevTarget&&(this._prevTarget.style.outline=``,this._prevTarget.style.outlineOffset=``,this._prevTarget=null,this.hoveredTag=``,this.hoveredId=``,this.hoveredState=null,this.hoveredData=null,this.hoveredMeta=null);return}t!==this._prevTarget&&(this._prevTarget&&(this._prevTarget.style.outline=``,this._prevTarget.style.outlineOffset=``),this._prevTarget=t,t.style.outline=`2px solid #0070f3`,t.style.outlineOffset=`-2px`,this.hoveredTag=t.tagName.toLowerCase(),this.hoveredId=t.id||``,this.hoveredState=t.state,this.hoveredData=t.data,this.hoveredMeta=t.component?.metadata)}}connectedCallback(){super.connectedCallback(),document.addEventListener(`mouseover`,this._onMouseover,!0)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`mouseover`,this._onMouseover,!0),this._prevTarget&&=(this._prevTarget.style.outline=``,null)}_fmt(e){try{return JSON.stringify(e,null,2)??`null`}catch{return String(e)}}_renderTab(e,t){return w`
             <button class="tab ${this.activeTab===e?`tab--active`:``}"
                 @click=${()=>{this.activeTab=e}}>
                 ${t}
@@ -7235,7 +7235,7 @@ ${i}
             border-bottom: 1px solid #2a2a3a;
         }
         .section-label:first-of-type { margin-top: 0; }
-    `}};O([v()],yo.prototype,`appState`,void 0),O([v()],yo.prototype,`appData`,void 0),O([S()],yo.prototype,`open`,void 0),O([S()],yo.prototype,`activeTab`,void 0),O([S()],yo.prototype,`hoveredTag`,void 0),O([S()],yo.prototype,`hoveredId`,void 0),O([S()],yo.prototype,`hoveredState`,void 0),O([S()],yo.prototype,`hoveredData`,void 0),O([S()],yo.prototype,`hoveredMeta`,void 0),yo=O([h(`mateu-debug-overlay`)],yo);var bo=function(e){return e.SetAppDataValue=`SetAppDataValue`,e.SetAppStateValue=`SetAppStateValue`,e.SetDataValue=`SetDataValue`,e.RunAction=`RunAction`,e.RunJS=`RunJS`,e.SetAttributeValue=`SetAttributeValue`,e.SetStateValue=`SetStateValue`,e.SetCssClass=`SetCssClass`,e.SetStyle=`SetStyle`,e}({}),xo=function(e){return e.required=`required`,e.disabled=`disabled`,e.hidden=`hidden`,e.pattern=`pattern`,e.minValue=`minValue`,e.maxValue=`maxValue`,e.minLength=`minLength`,e.maxLength=`maxLength`,e.css=`css`,e.style=`style`,e.theme=`theme`,e.errorMessage=`errorMessage`,e.description=`description`,e.none=`none`,e}({}),So=function(e){return e.Continue=`Continue`,e.Stop=`Stop`,e}({}),Co=12e4,wo=(e,t)=>`${e??`_`}::${t}`,To=new class{constructor(){this.started=new Map,this.listeners=new Set}begin(e,t=Date.now()){let n=this.started.get(e);return n!==void 0&&t-n<Co?!1:(this.started.set(e,t),this.emit(),!0)}end(e){this.started.delete(e)&&this.emit()}isPending(e,t=Date.now()){let n=this.started.get(e);return n!==void 0&&t-n<Co}snapshot(){return new Set(this.started.keys())}subscribe(e){return this.listeners.add(e),()=>this.listeners.delete(e)}reset(){this.started.clear(),this.emit()}emit(){let e=this.snapshot();this.listeners.forEach(t=>t(e))}},Eo=`data-mateu-pending-styles`,Do=`
+    `}};O([v()],So.prototype,`appState`,void 0),O([v()],So.prototype,`appData`,void 0),O([S()],So.prototype,`open`,void 0),O([S()],So.prototype,`activeTab`,void 0),O([S()],So.prototype,`hoveredTag`,void 0),O([S()],So.prototype,`hoveredId`,void 0),O([S()],So.prototype,`hoveredState`,void 0),O([S()],So.prototype,`hoveredData`,void 0),O([S()],So.prototype,`hoveredMeta`,void 0),So=O([h(`mateu-debug-overlay`)],So);var Co=function(e){return e.SetAppDataValue=`SetAppDataValue`,e.SetAppStateValue=`SetAppStateValue`,e.SetDataValue=`SetDataValue`,e.RunAction=`RunAction`,e.RunJS=`RunJS`,e.SetAttributeValue=`SetAttributeValue`,e.SetStateValue=`SetStateValue`,e.SetCssClass=`SetCssClass`,e.SetStyle=`SetStyle`,e}({}),wo=function(e){return e.required=`required`,e.disabled=`disabled`,e.hidden=`hidden`,e.pattern=`pattern`,e.minValue=`minValue`,e.maxValue=`maxValue`,e.minLength=`minLength`,e.maxLength=`maxLength`,e.css=`css`,e.style=`style`,e.theme=`theme`,e.errorMessage=`errorMessage`,e.description=`description`,e.none=`none`,e}({}),To=function(e){return e.Continue=`Continue`,e.Stop=`Stop`,e}({}),Eo=12e4,Do=(e,t)=>`${e??`_`}::${t}`,Oo=new class{constructor(){this.started=new Map,this.listeners=new Set}begin(e,t=Date.now()){let n=this.started.get(e);return n!==void 0&&t-n<Eo?!1:(this.started.set(e,t),this.emit(),!0)}end(e){this.started.delete(e)&&this.emit()}isPending(e,t=Date.now()){let n=this.started.get(e);return n!==void 0&&t-n<Eo}snapshot(){return new Set(this.started.keys())}subscribe(e){return this.listeners.add(e),()=>this.listeners.delete(e)}reset(){this.started.clear(),this.emit()}emit(){let e=this.snapshot();this.listeners.forEach(t=>t(e))}},ko=`data-mateu-pending-styles`,Ao=`
 [data-mateu-pending] {
     pointer-events: none;
     cursor: progress;
@@ -7249,9 +7249,9 @@ ${i}
     0%, 100% { opacity: .45; }
     50% { opacity: .85; }
 }
-`,Oo=new WeakSet,ko=e=>{if(Oo.has(e))return;Oo.add(e);let t=e;if(typeof CSSStyleSheet<`u`&&Array.isArray(t.adoptedStyleSheets))try{let e=new CSSStyleSheet;e.replaceSync(Do),t.adoptedStyleSheets=[...t.adoptedStyleSheets,e];return}catch{}let n=e instanceof Document?e.head:e;if(!n)return;let r=document.createElement(`style`);r.setAttribute(Eo,``),r.textContent=Do,n.appendChild(r)},Ao=e=>{let t=e.getRootNode();if(t instanceof ShadowRoot||t instanceof Document)return t},jo=e=>{if(!e||e.hasAttribute(`data-mateu-pending`))return;let t=Ao(e);t&&ko(t),e.setAttribute(`data-mateu-pending`,``),e.setAttribute(`aria-busy`,`true`)},Mo=e=>{e&&(e.removeAttribute(`data-mateu-pending`),e.removeAttribute(`aria-busy`))},No=e=>{let t=(typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target;return t instanceof Element?t:void 0},Po=[`button`,`a[href]`,`[role="button"]`,`[role="menuitem"]`,`input[type="button"]`,`input[type="submit"]`,`vaadin-button`,`vaadin-menu-bar-button`,`ui5-button`,`oj-c-button`,`oj-button`].join(`, `),Fo=e=>{if(!(!e||typeof e.closest!=`function`))return e.closest(Po)??void 0},Io=null,Lo=class extends Sa{constructor(...e){super(...e),this.baseUrl=``,this.route=``,this.consumedRoute=``,this.formerState={},this.applyRules=()=>{let e=this.component.rules;if(e&&e.length>0){let t=this.state,n=this.data,r=this.appState,i=this.appData,a=this.component,o=e=>ot(e,t,n,{appState:r,appData:i,component:a}),s=e=>at(e,t,n,r,i,{component:a}),c=[`state`,`data`,`appState`,`appData`,`component`],l=[t,n,r,i,a],u={...this.state},d={...this.data},f=!1,p=!1;for(let t=0;t<e.length;t++){let n=e[t];try{if(o(n.filter)){if(bo.SetStateValue==n.action||bo.SetDataValue==n.action){let e=bo.SetStateValue==n.action?u:d,t=n.fieldName.split(`,`);for(let r=0;r<t.length;r++){let i=t[r];if(!e[i]||e[i]!=n.value){let t=n.expression?s(n.expression):n.value,r=xo.none==n.fieldAttribute?i:i+`.`+n.fieldAttribute;t!=e[r]&&(e[r]=t,bo.SetStateValue==n.action&&(f=!0),bo.SetDataValue==n.action&&(p=!0))}}}if(bo.RunAction==n.action&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.actionId},bubbles:!0,composed:!0})),bo.RunJS==n.action&&Function(...c,n.value)(...l),bo.SetAttributeValue==n.action){let e=n.expression?o(n.expression):n.value;if(n.fieldAttribute==`disabled`){e?this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(n.fieldAttribute,`disabled`):this.shadowRoot?.getElementById(n.fieldName)?.removeAttribute(n.fieldAttribute);continue}this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(n.fieldAttribute,e)}if(bo.SetCssClass==n.action&&this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(`class`,n.value),bo.SetStyle==n.action&&this.shadowRoot?.getElementById(n.fieldName)?.style.setProperty(n.expression,n.value),So.Stop==n.result)break}}catch(e){console.error(`rule failed`,n,e)}}f&&(this.state=u),p&&(this.data=d),f&&this.checkValidations()}},this.skipValidation=(e,t)=>e&&t.fieldId&&!e.includes(t.fieldId)||!e&&t.fieldId&&t.fieldId.includes(`-`),this.checkValidations=e=>{let t=e?e.split(`,`):void 0,n=this.component.validations,r=!0,i=!1,a=this.data??{},o={...this.data??{},errors:{}};if(n){for(let e=0;e<n.length;e++){let r=n[e];if(this.skipValidation(t,r))continue;let i=(r.fieldId??`_component`).split(`,`);for(let e=0;e<i.length;e++){let t=i[e];o.errors[t]=[]}}for(let e=0;e<n.length;e++){let i=n[e];if(!this.skipValidation(t,i))try{let e=i.condition&&i.condition.includes("${")?this._evalTemplate(i.condition):this._evalExpr(i.condition);if(i.condition&&!e){r=!1;let e=(i.fieldId??`_component`).split(`,`);for(let t=0;t<e.length;t++){let n=e[t],r=o.errors[n];if(r||(o.errors[n]=[]),r=o.errors[n],!a[n]){let e=i.message;try{e=this._evalTemplate(i.message)}catch{}r.push(e)}}}}catch(e){console.error(`validation failed`,i,e)}}for(let e=0;e<n.length;e++){let r=n[e];if(this.skipValidation(t,r))continue;let s=(r.fieldId??`_component`).split(`,`);for(let e=0;e<s.length;e++){let t=s[e];if((a.errors||o.errors==``)&&[t].join(`,`)){i=!0;break}}}(a.errors||o.errors==``)&&[`_component`].join(`,`)&&(i=!0)}o._valid=r,o._valid!=a._valid&&(i=!0),i&&(this.data=o)},this._autoSaveTimers=new Map,this.onChange=()=>{this.applyRules()},this.closeModalRequestedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.closeModal()},this.resetFilters=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail,n={};t.fieldIds.forEach(e=>{n[e]=void 0}),n.searchText=void 0,this.state={...this.state,...n}}},this.dataChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail,n={};n[t.key]=t.value,e.type==`data-changed`&&(this.data={...this.data,...n})}},this.valueChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail;if(e.type==`value-changed`){let n={...this.state};n[t.fieldId]=t.value,this.state=n,(this.state[t.fieldId]||this.formerState[t.fieldId])&&this.state[t.fieldId]!=this.formerState[t.fieldId]&&this.component?.confirmOnNavigationIfDirty&&this.dispatchEvent(new CustomEvent(`dirty`,{detail:e.detail,bubbles:!0,composed:!0}));let r=this.component;r.triggers?.filter(e=>e.type==xa.OnValueChange).filter(e=>!e.propertyName||t.fieldId==e.propertyName).forEach(e=>{(!e.condition||this._evalExpr(e.condition))&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))}),r.triggers?.filter(e=>e.type==xa.AutoSave).forEach(e=>{let t=e.actionId,n=this._autoSaveTimers.get(t);n!==void 0&&clearTimeout(n),this._autoSaveTimers.set(t,setTimeout(()=>{this._autoSaveTimers.delete(t),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))},e.debounceMillis??800))})}}},this.actionRequestedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.manageActionRequestedEvent(e)},this.manageActionRequestedEvent=e=>{let t=e.detail,n=t?._originElement??No(e);if(e.type==`action-requested`){e.preventDefault(),e.stopPropagation();let r=this.component,i=r.actions?.find(e=>e.id==t.actionId)??r.actions?.find(e=>e.id.endsWith(`*`)&&t.actionId.startsWith(e.id.replace(`*`,``)));if(i){if(i&&i.rowsSelectedRequired&&(!this.state.crud_selected_items||this.state.crud_selected_items.length==0)){this.notify(`You first need to select some rows`);return}if(i&&i.validationRequired){let e=Io??this;if(Io=null,e.checkValidations(i.fieldsToValidate),!e.data._valid){e.notifyValidationErrors();return}}Io=null;let e={...t,initiatorComponentId:this.id};i&&i.confirmationRequired?this.callAfterConfirmation(i,()=>this.requestActionCallToServerOrBubble(e,r,i,n)):this.requestActionCallToServerOrBubble(e,r,i,n)}else{let r={...t.parameters};r.initiatorState||=this.state,Io||=this,this.dispatchEvent(new CustomEvent(e.type,{detail:{...e.detail,_originElement:n,parameters:r},bubbles:!0,composed:!0}))}}},this.buildFieldLabelMap=()=>{let e={},t=n=>{if(n)for(let r of n){let n=r.metadata;if(n?.type===A.FormField){let t=n;t.fieldId&&t.label&&(e[t.fieldId]=t.label)}t(r.children)}};return t(this.component?.children),e},this.notifyValidationErrors=()=>{let e=this.data?.errors??{},t=this.buildFieldLabelMap(),n=[];if(Object.entries(e).forEach(([e,r])=>{if(!Array.isArray(r))return;let i=e===`_component`?void 0:t[e]??e;r.forEach(e=>{e&&!n.some(t=>t.label===i&&t.msg===e)&&n.push({label:i,msg:e})})}),n.length===0){this.notify(`There are validation errors`);return}pa({text:`There are validation errors
+`,jo=new WeakSet,Mo=e=>{if(jo.has(e))return;jo.add(e);let t=e;if(typeof CSSStyleSheet<`u`&&Array.isArray(t.adoptedStyleSheets))try{let e=new CSSStyleSheet;e.replaceSync(Ao),t.adoptedStyleSheets=[...t.adoptedStyleSheets,e];return}catch{}let n=e instanceof Document?e.head:e;if(!n)return;let r=document.createElement(`style`);r.setAttribute(ko,``),r.textContent=Ao,n.appendChild(r)},No=e=>{let t=e.getRootNode();if(t instanceof ShadowRoot||t instanceof Document)return t},Po=e=>{if(!e||e.hasAttribute(`data-mateu-pending`))return;let t=No(e);t&&Mo(t),e.setAttribute(`data-mateu-pending`,``),e.setAttribute(`aria-busy`,`true`)},Fo=e=>{e&&(e.removeAttribute(`data-mateu-pending`),e.removeAttribute(`aria-busy`))},Io=e=>{let t=(typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target;return t instanceof Element?t:void 0},Lo=[`button`,`a[href]`,`[role="button"]`,`[role="menuitem"]`,`input[type="button"]`,`input[type="submit"]`,`vaadin-button`,`vaadin-menu-bar-button`,`ui5-button`,`oj-c-button`,`oj-button`].join(`, `),Ro=e=>{if(!(!e||typeof e.closest!=`function`))return e.closest(Lo)??void 0},zo=null,Bo=class extends wa{constructor(...e){super(...e),this.baseUrl=``,this.route=``,this.consumedRoute=``,this.formerState={},this.applyRules=()=>{let e=this.component.rules;if(e&&e.length>0){let t=this.state,n=this.data,r=this.appState,i=this.appData,a=this.component,o=e=>ot(e,t,n,{appState:r,appData:i,component:a}),s=e=>at(e,t,n,r,i,{component:a}),c=[`state`,`data`,`appState`,`appData`,`component`],l=[t,n,r,i,a],u={...this.state},d={...this.data},f=!1,p=!1;for(let t=0;t<e.length;t++){let n=e[t];try{if(o(n.filter)){if(Co.SetStateValue==n.action||Co.SetDataValue==n.action){let e=Co.SetStateValue==n.action?u:d,t=n.fieldName.split(`,`);for(let r=0;r<t.length;r++){let i=t[r];if(!e[i]||e[i]!=n.value){let t=n.expression?s(n.expression):n.value,r=wo.none==n.fieldAttribute?i:i+`.`+n.fieldAttribute;t!=e[r]&&(e[r]=t,Co.SetStateValue==n.action&&(f=!0),Co.SetDataValue==n.action&&(p=!0))}}}if(Co.RunAction==n.action&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.actionId},bubbles:!0,composed:!0})),Co.RunJS==n.action&&Function(...c,n.value)(...l),Co.SetAttributeValue==n.action){let e=n.expression?o(n.expression):n.value;if(n.fieldAttribute==`disabled`){e?this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(n.fieldAttribute,`disabled`):this.shadowRoot?.getElementById(n.fieldName)?.removeAttribute(n.fieldAttribute);continue}this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(n.fieldAttribute,e)}if(Co.SetCssClass==n.action&&this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(`class`,n.value),Co.SetStyle==n.action&&this.shadowRoot?.getElementById(n.fieldName)?.style.setProperty(n.expression,n.value),To.Stop==n.result)break}}catch(e){console.error(`rule failed`,n,e)}}f&&(this.state=u),p&&(this.data=d),f&&this.checkValidations()}},this.skipValidation=(e,t)=>e&&t.fieldId&&!e.includes(t.fieldId)||!e&&t.fieldId&&t.fieldId.includes(`-`),this.checkValidations=e=>{let t=e?e.split(`,`):void 0,n=this.component.validations,r=!0,i=!1,a=this.data??{},o={...this.data??{},errors:{}};if(n){for(let e=0;e<n.length;e++){let r=n[e];if(this.skipValidation(t,r))continue;let i=(r.fieldId??`_component`).split(`,`);for(let e=0;e<i.length;e++){let t=i[e];o.errors[t]=[]}}for(let e=0;e<n.length;e++){let i=n[e];if(!this.skipValidation(t,i))try{let e=i.condition&&i.condition.includes("${")?this._evalTemplate(i.condition):this._evalExpr(i.condition);if(i.condition&&!e){r=!1;let e=(i.fieldId??`_component`).split(`,`);for(let t=0;t<e.length;t++){let n=e[t],r=o.errors[n];if(r||(o.errors[n]=[]),r=o.errors[n],!a[n]){let e=i.message;try{e=this._evalTemplate(i.message)}catch{}r.push(e)}}}}catch(e){console.error(`validation failed`,i,e)}}for(let e=0;e<n.length;e++){let r=n[e];if(this.skipValidation(t,r))continue;let s=(r.fieldId??`_component`).split(`,`);for(let e=0;e<s.length;e++){let t=s[e];if((a.errors||o.errors==``)&&[t].join(`,`)){i=!0;break}}}(a.errors||o.errors==``)&&[`_component`].join(`,`)&&(i=!0)}o._valid=r,o._valid!=a._valid&&(i=!0),i&&(this.data=o)},this._autoSaveTimers=new Map,this.onChange=()=>{this.applyRules()},this.closeModalRequestedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.closeModal()},this.resetFilters=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail,n={};t.fieldIds.forEach(e=>{n[e]=void 0}),n.searchText=void 0,this.state={...this.state,...n}}},this.dataChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail,n={};n[t.key]=t.value,e.type==`data-changed`&&(this.data={...this.data,...n})}},this.valueChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail;if(e.type==`value-changed`){let n={...this.state};n[t.fieldId]=t.value,this.state=n,(this.state[t.fieldId]||this.formerState[t.fieldId])&&this.state[t.fieldId]!=this.formerState[t.fieldId]&&this.component?.confirmOnNavigationIfDirty&&this.dispatchEvent(new CustomEvent(`dirty`,{detail:e.detail,bubbles:!0,composed:!0}));let r=this.component;r.triggers?.filter(e=>e.type==Ca.OnValueChange).filter(e=>!e.propertyName||t.fieldId==e.propertyName).forEach(e=>{(!e.condition||this._evalExpr(e.condition))&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))}),r.triggers?.filter(e=>e.type==Ca.AutoSave).forEach(e=>{let t=e.actionId,n=this._autoSaveTimers.get(t);n!==void 0&&clearTimeout(n),this._autoSaveTimers.set(t,setTimeout(()=>{this._autoSaveTimers.delete(t),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))},e.debounceMillis??800))})}}},this.actionRequestedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.manageActionRequestedEvent(e)},this.manageActionRequestedEvent=e=>{let t=e.detail,n=t?._originElement??Io(e);if(e.type==`action-requested`){e.preventDefault(),e.stopPropagation();let r=this.component,i=r.actions?.find(e=>e.id==t.actionId)??r.actions?.find(e=>e.id.endsWith(`*`)&&t.actionId.startsWith(e.id.replace(`*`,``)));if(i){if(i&&i.rowsSelectedRequired&&(!this.state.crud_selected_items||this.state.crud_selected_items.length==0)){this.notify(`You first need to select some rows`);return}if(i&&i.validationRequired){let e=zo??this;if(zo=null,e.checkValidations(i.fieldsToValidate),!e.data._valid){e.notifyValidationErrors();return}}zo=null;let e={...t,initiatorComponentId:this.id};i&&i.confirmationRequired?this.callAfterConfirmation(i,()=>this.requestActionCallToServerOrBubble(e,r,i,n)):this.requestActionCallToServerOrBubble(e,r,i,n)}else{let r={...t.parameters};r.initiatorState||=this.state,zo||=this,this.dispatchEvent(new CustomEvent(e.type,{detail:{...e.detail,_originElement:n,parameters:r},bubbles:!0,composed:!0}))}}},this.buildFieldLabelMap=()=>{let e={},t=n=>{if(n)for(let r of n){let n=r.metadata;if(n?.type===A.FormField){let t=n;t.fieldId&&t.label&&(e[t.fieldId]=t.label)}t(r.children)}};return t(this.component?.children),e},this.notifyValidationErrors=()=>{let e=this.data?.errors??{},t=this.buildFieldLabelMap(),n=[];if(Object.entries(e).forEach(([e,r])=>{if(!Array.isArray(r))return;let i=e===`_component`?void 0:t[e]??e;r.forEach(e=>{e&&!n.some(t=>t.label===i&&t.msg===e)&&n.push({label:i,msg:e})})}),n.length===0){this.notify(`There are validation errors`);return}ha({text:`There are validation errors
 `+n.map(({label:e,msg:t})=>e?`• ${e}: ${t}`:`• ${t}`).join(`
-`),variant:`error`,position:`bottomEnd`,duration:Math.max(3e3,1500+n.length*1e3)},this),this.focusFirstInvalidField()},this.notify=e=>{pa({text:e,variant:`error`,position:`bottomEnd`,duration:3e3},this)},this.handleRestAction=(e,t)=>{let n=t=>{if(e.resultPath!=null){let n=Ut(t,e.resultPath);n&&typeof n==`object`&&(this.state={...this.state,...n})}let n=j(e.successMessage,this.state,this.data);n&&pa({text:n,variant:`success`,position:`bottomEnd`,duration:3e3},this)};if(e.source?.proxy){let e=t===`__restdata__`?`data`:`action`;this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:`__restfetch__`,parameters:{_sourceKind:e,_sourceId:t},callback:e=>n(e?.appData?._restfetch),callbackonly:!0},bubbles:!0,composed:!0}));return}Kt(e.source,e=>j(e,this.state,this.data)).then(n).catch(e=>{console.warn(`mateu: rest action failed`,e),pa({text:`Request failed`,variant:`error`,position:`bottomEnd`,duration:3e3},this)})},this.callAfterConfirmation=(e,t)=>{let n=`One moment, please`,r=`Are you sure?`,i=`Yes`,a=`No`;e.confirmationTexts&&(n=e.confirmationTexts.title,r=e.confirmationTexts.message,i=e.confirmationTexts.confirmationText,a=e.confirmationTexts.denialText);let o=document.createElement(`div`);o.style.cssText=`position:fixed;inset:0;z-index:1100;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.35);padding:1rem;`;let s=document.createElement(`div`);s.style.cssText=`background:var(--lumo-base-color,#fff);color:var(--lumo-body-text-color,#1a1a1a);border-radius:var(--lumo-border-radius-l,12px);box-shadow:var(--lumo-box-shadow-xl,0 12px 40px rgba(0,0,0,.3));padding:1.2rem;max-width:min(90vw,26rem);`;let c=()=>{o.parentElement&&document.body.removeChild(o)},l=`font:inherit;font-weight:600;padding:.45rem 1rem;border-radius:var(--lumo-border-radius-m,6px);cursor:pointer;`;ie(w`
+`),variant:`error`,position:`bottomEnd`,duration:Math.max(3e3,1500+n.length*1e3)},this),this.focusFirstInvalidField()},this.notify=e=>{ha({text:e,variant:`error`,position:`bottomEnd`,duration:3e3},this)},this.handleRestAction=(e,t)=>{let n=t=>{if(e.resultPath!=null){let n=Gt(t,e.resultPath);n&&typeof n==`object`&&(this.state={...this.state,...n})}let n=j(e.successMessage,this.state,this.data);n&&ha({text:n,variant:`success`,position:`bottomEnd`,duration:3e3},this)};if(e.source?.proxy){let e=t===`__restdata__`?`data`:`action`;this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:`__restfetch__`,parameters:{_sourceKind:e,_sourceId:t},callback:e=>n(e?.appData?._restfetch),callbackonly:!0},bubbles:!0,composed:!0}));return}Jt(e.source,e=>j(e,this.state,this.data)).then(n).catch(e=>{console.warn(`mateu: rest action failed`,e),ha({text:`Request failed`,variant:`error`,position:`bottomEnd`,duration:3e3},this)})},this.callAfterConfirmation=(e,t)=>{let n=`One moment, please`,r=`Are you sure?`,i=`Yes`,a=`No`;e.confirmationTexts&&(n=e.confirmationTexts.title,r=e.confirmationTexts.message,i=e.confirmationTexts.confirmationText,a=e.confirmationTexts.denialText);let o=document.createElement(`div`);o.style.cssText=`position:fixed;inset:0;z-index:1100;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.35);padding:1rem;`;let s=document.createElement(`div`);s.style.cssText=`background:var(--lumo-base-color,#fff);color:var(--lumo-body-text-color,#1a1a1a);border-radius:var(--lumo-border-radius-l,12px);box-shadow:var(--lumo-box-shadow-xl,0 12px 40px rgba(0,0,0,.3));padding:1.2rem;max-width:min(90vw,26rem);`;let c=()=>{o.parentElement&&document.body.removeChild(o)},l=`font:inherit;font-weight:600;padding:.45rem 1rem;border-radius:var(--lumo-border-radius-m,6px);cursor:pointer;`;ie(w`
             <h3 style="margin:0 0 .5rem;">${n}</h3>
             <div style="margin-bottom:1.2rem;">${r}</div>
             <div style="display:flex;justify-content:flex-end;gap:.5rem;">
@@ -7260,18 +7260,18 @@ ${i}
                 <button style="${l}border:none;background:var(--lumo-primary-color,#1676f3);color:var(--lumo-primary-contrast-color,#fff);"
                         @click="${()=>{c(),t()}}">${i}</button>
             </div>
-        `,s),o.appendChild(s),o.addEventListener(`click`,e=>{e.target===o&&c()}),document.body.appendChild(o)},this.requestActionCallToServerOrBubble=(e,t,n,r)=>{if(n&&n.bubble){let t={...e.parameters};t.initiatorState||=this.state,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{...e,_originElement:r,parameters:t},bubbles:!0,composed:!0}))}else this.requestActionCallToServer(e,t,n,r)},this.requestActionCallToServer=(e,t,n,r)=>{if(n&&n.href){window.location.href=n.href;return}if(n&&n.js)try{Function(`state`,`data`,`appState`,`appData`,`component`,n.js).call(this,this.state??{},this.data??{},this.appState??{},this.appData??{},this.component),this.state={...this.state},this.data={...this.data}}catch(e){console.error(`when evaluating `+n.js,e,this.component,this.state,this.data)}if(n&&n.customEvent&&this.dispatchEvent(new CustomEvent(n.customEvent.name,{detail:n.customEvent.detail,bubbles:!0,composed:!0})),!(n&&(n.js||n.customEvent))){if(n&&n.restAction){this.handleRestAction(n.restAction,n.id);return}if(e.actionId==`search`){let t=e.parameters?._searchState;t?this.state={...this.state,...t}:this.state.size||(this.state={...this.state,size:10,page:0,sort:[]})}if(!n?.background){if(!Re(e.actionId,n?.idempotent)&&!To.begin(wo(this.id,e.actionId)))return;let t=Fo(r);this._pendingOrigins.set(e.actionId,t),jo(t)}this.dispatchEvent(new CustomEvent(`server-side-action-requested`,{detail:{route:this.route,consumedRoute:this.consumedRoute,componentState:{...this.state},parameters:e.parameters??{},actionId:e.actionId,serverSideType:t.serverSideType,serverSideComponentRoute:t.route,initiatorComponentId:e.initiatorComponentId??t.id,initiator:this,background:n?.background,sse:n?.sse,timeoutMillis:n?.timeoutMillis,idempotent:n?.idempotent,callback:e.callback,callbackonly:e.callbackonly,callbackToken:e.callbackToken??this.callbackToken},bubbles:!0,composed:!0}))}},this.handleBackendSucceeded=e=>{e.detail.actionId&&this.component.triggers?.filter(e=>e.type==xa.OnSuccess).filter(t=>e.detail.actionId==t.calledActionId).forEach(t=>{if(!t.condition||this._evalExpr(t.condition))if(e.preventDefault(),e.stopPropagation(),t.timeoutMillis>0){let e=this.callbackToken;setTimeout(()=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,callbackToken:e},bubbles:!0,composed:!0}))},t.timeoutMillis)}else this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))})},this.handleBackendFailed=e=>{e.detail.actionId&&this.component.triggers?.filter(e=>e.type==xa.OnError).filter(t=>e.detail.actionId==t.calledActionId).forEach(t=>{(!t.condition||this._evalExpr(t.condition))&&(e.preventDefault(),e.stopPropagation(),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0})))})},this._pendingOrigins=new Map,this._backendSettledListener=e=>{((typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target)===this&&this._releasePending(e.detail?.actionId)},this._keydownListener=e=>{if(this._handleTabShortcut(e))return;let t=this.component;if(t)for(let n of t.actions??[]){let t=n.shortcut||(n.runOnEnter?`enter`:null);if(t&&this._shortcutMatchesEvent(t,e)){e.preventDefault(),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.id},bubbles:!0,composed:!0}));return}}}}createRenderRoot(){return N.mustUseShadowRoot()?super.createRenderRoot():this}updated(e){super.updated(e),e.has(`state`)&&this.state&&JSON.stringify(this.state)!=JSON.stringify({})&&this.onChange(),e.has(`component`)&&(this.formerState={...this.state},this.component?.confirmOnNavigationIfDirty&&this.dispatchEvent(new CustomEvent(`clean`,{detail:{},bubbles:!0,composed:!0})),setTimeout(()=>this.triggerOnLoad()))}focusFirstInvalidField(){let e=t=>requestAnimationFrame(()=>{let n=this.findFirstInvalid(this.renderRoot);if(n){n.focus?.(),n.scrollIntoView?.({block:`center`,behavior:`smooth`});return}t>0&&e(t-1)});e(3)}findFirstInvalid(e){if(!e?.querySelectorAll)return null;for(let t of Array.from(e.querySelectorAll(`*`))){if(t.invalid===!0)return t;if(t.shadowRoot){let e=this.findFirstInvalid(t.shadowRoot);if(e)return e}}return null}_releasePending(e){(e===void 0?Array.from(this._pendingOrigins.keys()):[e]).forEach(e=>{To.end(wo(this.id,e)),Mo(this._pendingOrigins.get(e)),this._pendingOrigins.delete(e)})}_shortcutMatchesEvent(e,t){return Ln(e,t)}_collectShortcutTabs(){let e=this.renderRoot;if(!e)return[];let t=Array.from(e.querySelectorAll(`vaadin-tab[data-shortcut]`));return e.querySelectorAll(`mateu-drawer, mateu-dialog`).forEach(e=>{let n=e.shadowRoot;n&&t.push(...Array.from(n.querySelectorAll(`vaadin-tab[data-shortcut]`)))}),t}_handleTabShortcut(e){let t=this._collectShortcutTabs();if(t.length===0)return!1;for(let n of Array.from(t)){let t=n.dataset.shortcut;if(!t||!this._shortcutMatchesEvent(t,e))continue;let r=n.closest(`vaadin-tabs`);if(!r)continue;let i=Array.from(r.querySelectorAll(`vaadin-tab`)).indexOf(n);if(!(i<0))return e.preventDefault(),r.selected=i,!0}return!1}connectedCallback(){super.connectedCallback(),this.addEventListener(`backend-call-succeeded`,this.handleBackendSucceeded),this.addEventListener(`backend-call-failed`,this.handleBackendFailed),this.addEventListener(`backend-succeeded-event`,this._backendSettledListener),this.addEventListener(`backend-failed-event`,this._backendSettledListener),this.addEventListener(`backend-cancelled-event`,this._backendSettledListener),document.addEventListener(`keydown`,this._keydownListener)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`backend-call-succeeded`,this.handleBackendSucceeded),this.removeEventListener(`backend-call-failed`,this.handleBackendFailed),this.removeEventListener(`backend-succeeded-event`,this._backendSettledListener),this.removeEventListener(`backend-failed-event`,this._backendSettledListener),this.removeEventListener(`backend-cancelled-event`,this._backendSettledListener),document.removeEventListener(`keydown`,this._keydownListener),this._releasePending()}render(){return w`<div>
+        `,s),o.appendChild(s),o.addEventListener(`click`,e=>{e.target===o&&c()}),document.body.appendChild(o)},this.requestActionCallToServerOrBubble=(e,t,n,r)=>{if(n&&n.bubble){let t={...e.parameters};t.initiatorState||=this.state,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{...e,_originElement:r,parameters:t},bubbles:!0,composed:!0}))}else this.requestActionCallToServer(e,t,n,r)},this.requestActionCallToServer=(e,t,n,r)=>{if(n&&n.href){window.location.href=n.href;return}if(n&&n.js)try{Function(`state`,`data`,`appState`,`appData`,`component`,n.js).call(this,this.state??{},this.data??{},this.appState??{},this.appData??{},this.component),this.state={...this.state},this.data={...this.data}}catch(e){console.error(`when evaluating `+n.js,e,this.component,this.state,this.data)}if(n&&n.customEvent&&this.dispatchEvent(new CustomEvent(n.customEvent.name,{detail:n.customEvent.detail,bubbles:!0,composed:!0})),!(n&&(n.js||n.customEvent))){if(n&&n.restAction){this.handleRestAction(n.restAction,n.id);return}if(e.actionId==`search`){let t=e.parameters?._searchState;t?this.state={...this.state,...t}:this.state.size||(this.state={...this.state,size:10,page:0,sort:[]})}if(!n?.background){if(!Re(e.actionId,n?.idempotent)&&!Oo.begin(Do(this.id,e.actionId)))return;let t=Ro(r);this._pendingOrigins.set(e.actionId,t),Po(t)}this.dispatchEvent(new CustomEvent(`server-side-action-requested`,{detail:{route:this.route,consumedRoute:this.consumedRoute,componentState:{...this.state},parameters:e.parameters??{},actionId:e.actionId,serverSideType:t.serverSideType,serverSideComponentRoute:t.route,initiatorComponentId:e.initiatorComponentId??t.id,initiator:this,background:n?.background,sse:n?.sse,timeoutMillis:n?.timeoutMillis,idempotent:n?.idempotent,callback:e.callback,callbackonly:e.callbackonly,callbackToken:e.callbackToken??this.callbackToken},bubbles:!0,composed:!0}))}},this.handleBackendSucceeded=e=>{e.detail.actionId&&this.component.triggers?.filter(e=>e.type==Ca.OnSuccess).filter(t=>e.detail.actionId==t.calledActionId).forEach(t=>{if(!t.condition||this._evalExpr(t.condition))if(e.preventDefault(),e.stopPropagation(),t.timeoutMillis>0){let e=this.callbackToken;setTimeout(()=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,callbackToken:e},bubbles:!0,composed:!0}))},t.timeoutMillis)}else this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))})},this.handleBackendFailed=e=>{e.detail.actionId&&this.component.triggers?.filter(e=>e.type==Ca.OnError).filter(t=>e.detail.actionId==t.calledActionId).forEach(t=>{(!t.condition||this._evalExpr(t.condition))&&(e.preventDefault(),e.stopPropagation(),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0})))})},this._pendingOrigins=new Map,this._backendSettledListener=e=>{((typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target)===this&&this._releasePending(e.detail?.actionId)},this._keydownListener=e=>{if(this._handleTabShortcut(e))return;let t=this.component;if(t)for(let n of t.actions??[]){let t=n.shortcut||(n.runOnEnter?`enter`:null);if(t&&this._shortcutMatchesEvent(t,e)){e.preventDefault(),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.id},bubbles:!0,composed:!0}));return}}}}createRenderRoot(){return N.mustUseShadowRoot()?super.createRenderRoot():this}updated(e){super.updated(e),e.has(`state`)&&this.state&&JSON.stringify(this.state)!=JSON.stringify({})&&this.onChange(),e.has(`component`)&&(this.formerState={...this.state},this.component?.confirmOnNavigationIfDirty&&this.dispatchEvent(new CustomEvent(`clean`,{detail:{},bubbles:!0,composed:!0})),setTimeout(()=>this.triggerOnLoad()))}focusFirstInvalidField(){let e=t=>requestAnimationFrame(()=>{let n=this.findFirstInvalid(this.renderRoot);if(n){n.focus?.(),n.scrollIntoView?.({block:`center`,behavior:`smooth`});return}t>0&&e(t-1)});e(3)}findFirstInvalid(e){if(!e?.querySelectorAll)return null;for(let t of Array.from(e.querySelectorAll(`*`))){if(t.invalid===!0)return t;if(t.shadowRoot){let e=this.findFirstInvalid(t.shadowRoot);if(e)return e}}return null}_releasePending(e){(e===void 0?Array.from(this._pendingOrigins.keys()):[e]).forEach(e=>{Oo.end(Do(this.id,e)),Fo(this._pendingOrigins.get(e)),this._pendingOrigins.delete(e)})}_shortcutMatchesEvent(e,t){return zn(e,t)}_collectShortcutTabs(){let e=this.renderRoot;if(!e)return[];let t=Array.from(e.querySelectorAll(`vaadin-tab[data-shortcut]`));return e.querySelectorAll(`mateu-drawer, mateu-dialog`).forEach(e=>{let n=e.shadowRoot;n&&t.push(...Array.from(n.querySelectorAll(`vaadin-tab[data-shortcut]`)))}),t}_handleTabShortcut(e){let t=this._collectShortcutTabs();if(t.length===0)return!1;for(let n of Array.from(t)){let t=n.dataset.shortcut;if(!t||!this._shortcutMatchesEvent(t,e))continue;let r=n.closest(`vaadin-tabs`);if(!r)continue;let i=Array.from(r.querySelectorAll(`vaadin-tab`)).indexOf(n);if(!(i<0))return e.preventDefault(),r.selected=i,!0}return!1}connectedCallback(){super.connectedCallback(),this.addEventListener(`backend-call-succeeded`,this.handleBackendSucceeded),this.addEventListener(`backend-call-failed`,this.handleBackendFailed),this.addEventListener(`backend-succeeded-event`,this._backendSettledListener),this.addEventListener(`backend-failed-event`,this._backendSettledListener),this.addEventListener(`backend-cancelled-event`,this._backendSettledListener),document.addEventListener(`keydown`,this._keydownListener)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`backend-call-succeeded`,this.handleBackendSucceeded),this.removeEventListener(`backend-call-failed`,this.handleBackendFailed),this.removeEventListener(`backend-succeeded-event`,this._backendSettledListener),this.removeEventListener(`backend-failed-event`,this._backendSettledListener),this.removeEventListener(`backend-cancelled-event`,this._backendSettledListener),document.removeEventListener(`keydown`,this._keydownListener),this._releasePending()}render(){return w`<div>
             <div>${this._render()}</div>
             ${this.data&&this.data.errors&&this.data.errors._component&&this.data.errors._component.length>0?w`
                 <div><ul>${this.data.errors._component.map(e=>w`<li>${e}</li>`)}</ul></div>
-            `:_}</div>`}_render(){if(this.component?.type==k.ClientSide){let e=this.component;return e.metadata?.type==A.Page?br(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!0):e.metadata?.type==A.Crud?xr(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!0):N.get()?.renderClientSideComponent(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!1)}return w`
+            `:_}</div>`}_render(){if(this.component?.type==k.ClientSide){let e=this.component;return e.metadata?.type==A.Page?Sr(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!0):e.metadata?.type==A.Crud?Cr(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!0):N.get()?.renderClientSideComponent(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!1)}return w`
             <mateu-api-caller 
                     @value-changed="${this.valueChangedListener}"
                     @data-changed="${this.dataChangedListener}"
                     @close-modal-requested="${this.closeModalRequestedListener}"
                     @filter-reset-requested="${this.resetFilters}"
                     @action-requested="${this.actionRequestedListener}">
-            ${this.component?.children?.map(e=>{if(e.type==k.ClientSide){let t=e;if(t.metadata?.type==A.Page)return br(this,t,this.baseUrl,this.state,this.data,this.appState,this.appData,!0);if(t.metadata?.type==A.Crud)return xr(this,t,this.baseUrl,this.state,this.data,this.appState,this.appData,!0)}return P(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData)})}
+            ${this.component?.children?.map(e=>{if(e.type==k.ClientSide){let t=e;if(t.metadata?.type==A.Page)return Sr(this,t,this.baseUrl,this.state,this.data,this.appState,this.appData,!0);if(t.metadata?.type==A.Crud)return Cr(this,t,this.baseUrl,this.state,this.data,this.appState,this.appData,!0)}return P(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData)})}
             </mateu-api-caller>
         `}static{this.styles=m`
         :host {
@@ -7308,9 +7308,9 @@ ${i}
             padding-block: var(--lumo-space-xs);
             box-shadow: 0 1px 0 0 var(--lumo-contrast-10pct, rgba(0, 0, 0, 0.1));
         }
-  `}};O([v()],Lo.prototype,`baseUrl`,void 0),O([v()],Lo.prototype,`route`,void 0),O([v()],Lo.prototype,`consumedRoute`,void 0),Lo=O([h(`mateu-component`)],Lo);var Ro=e=>{if(e)try{return JSON.parse(e)}catch{return{value:e}}else return{}},zo=new class{async handle(e,t){return await e.runAction(t.baseUrl,t.route,t.consumedRoute,t.actionId,t.initiatorComponentId,t.appState,t.serverSideType,t.componentState,t.parameters,t.initiator,t.background,t.options)}},Bo=new class{constructor(){this.handleUIIncrement=(e,t,n)=>{if(e?.fragments?.forEach(e=>{ue.next({command:void 0,fragment:e,ui:void 0,error:void 0,callbackToken:n})}),e?.appState&&(D.value={...e.appState},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))),e?.appData){let n=e?.appData;de.value={...e.appData,...n},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))}e?.messages?.forEach(e=>{pa({text:e.text,position:e.position,variant:e.variant,duration:e.duration,undoLabel:e.undoLabel,undoActionId:e.undoActionId,undoParameters:e.undoParameters},t)}),e?.banners&&e.banners.length>0&&document.dispatchEvent(new CustomEvent(`page-banners-received`,{detail:{banners:e.banners,append:e.appendBanners??!1},bubbles:!1,composed:!1})),e?.commands?.forEach(e=>{ue.next({command:e,fragment:void 0,ui:void 0,error:void 0,callbackToken:n})})}}async runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,te={}){let ne=()=>{this.runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,te)};try{let o=await zo.handle(e,{baseUrl:t,route:n,consumedRoute:r,actionId:i,appState:D.value,initiatorComponentId:a,componentState:c,parameters:l,serverSideType:s,initiator:u,background:d,options:{...te,retry:ne}});f&&f(o),p||this.handleUIIncrement(o,u,ee),o.messages&&o.messages.length==1&&o.messages[0].variant==`error`&&u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-succeeded`,{detail:{actionId:i,evevntId:T()},bubbles:!0,composed:!0}))}catch(e){console.warn(`Action request failed`,e),e?.__mateuReported||u.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:i,reason:this.serialize(e),retry:ne}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))}}serialize(e){return e?.message?e:JSON.stringify(e)}},Vo=new class{constructor(){this.handleUIIncrement=(e,t,n)=>{if(e?.messages?.forEach(e=>{pa({text:e.text,position:e.position,variant:e.variant,duration:e.duration,undoLabel:e.undoLabel,undoActionId:e.undoActionId,undoParameters:e.undoParameters},t)}),e?.banners&&e.banners.length>0&&document.dispatchEvent(new CustomEvent(`page-banners-received`,{detail:{banners:e.banners,append:e.appendBanners??!1},bubbles:!1,composed:!1})),e?.commands?.forEach(e=>{ue.next({command:e,fragment:void 0,ui:void 0,error:void 0,callbackToken:n})}),e?.fragments?.forEach(e=>{ue.next({command:void 0,fragment:e,ui:void 0,error:void 0,callbackToken:n})}),e?.appState&&(D.value={...e.appState},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))),e?.appData){let n=e?.appData;de.value={...e.appData,...n},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))}}}async runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,te={}){let ne=()=>{this.runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,te)};if(n){n||=`_no_route`,n&&n.startsWith(`/`)&&(n=n.substring(1));let e={serverSideType:s,appState:D.value,componentState:c,parameters:l,initiatorComponentId:a,consumedRoute:r,route:`/`+n,actionId:i};d||u.dispatchEvent(new CustomEvent(`backend-called-event`,{bubbles:!0,composed:!0,detail:{}})),fetch(t+`/mateu/v3/sse/`+n,{method:`POST`,headers:{Accept:`text/event-stream`,"Content-Type":`application/json`},body:JSON.stringify(e)}).then(async e=>{let t=e.body?.pipeThrough(new TextDecoderStream).getReader();if(t){let e=``;for(;;){let{value:n,done:r}=await t.read();if(r)break;e+=n;let a=e.split(`
+  `}};O([v()],Bo.prototype,`baseUrl`,void 0),O([v()],Bo.prototype,`route`,void 0),O([v()],Bo.prototype,`consumedRoute`,void 0),Bo=O([h(`mateu-component`)],Bo);var Vo=e=>{if(e)try{return JSON.parse(e)}catch{return{value:e}}else return{}},Ho=new class{async handle(e,t){return await e.runAction(t.baseUrl,t.route,t.consumedRoute,t.actionId,t.initiatorComponentId,t.appState,t.serverSideType,t.componentState,t.parameters,t.initiator,t.background,t.options)}},Uo=new class{constructor(){this.handleUIIncrement=(e,t,n)=>{if(e?.fragments?.forEach(e=>{ue.next({command:void 0,fragment:e,ui:void 0,error:void 0,callbackToken:n})}),e?.appState&&(D.value={...e.appState},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))),e?.appData){let n=e?.appData;de.value={...e.appData,...n},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))}e?.messages?.forEach(e=>{ha({text:e.text,position:e.position,variant:e.variant,duration:e.duration,undoLabel:e.undoLabel,undoActionId:e.undoActionId,undoParameters:e.undoParameters},t)}),e?.banners&&e.banners.length>0&&document.dispatchEvent(new CustomEvent(`page-banners-received`,{detail:{banners:e.banners,append:e.appendBanners??!1},bubbles:!1,composed:!1})),e?.commands?.forEach(e=>{ue.next({command:e,fragment:void 0,ui:void 0,error:void 0,callbackToken:n})})}}async runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,te={}){let ne=()=>{this.runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,te)};try{let o=await Ho.handle(e,{baseUrl:t,route:n,consumedRoute:r,actionId:i,appState:D.value,initiatorComponentId:a,componentState:c,parameters:l,serverSideType:s,initiator:u,background:d,options:{...te,retry:ne}});f&&f(o),p||this.handleUIIncrement(o,u,ee),o.messages&&o.messages.length==1&&o.messages[0].variant==`error`&&u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-succeeded`,{detail:{actionId:i,evevntId:T()},bubbles:!0,composed:!0}))}catch(e){console.warn(`Action request failed`,e),e?.__mateuReported||u.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:i,reason:this.serialize(e),retry:ne}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))}}serialize(e){return e?.message?e:JSON.stringify(e)}},Wo=new class{constructor(){this.handleUIIncrement=(e,t,n)=>{if(e?.messages?.forEach(e=>{ha({text:e.text,position:e.position,variant:e.variant,duration:e.duration,undoLabel:e.undoLabel,undoActionId:e.undoActionId,undoParameters:e.undoParameters},t)}),e?.banners&&e.banners.length>0&&document.dispatchEvent(new CustomEvent(`page-banners-received`,{detail:{banners:e.banners,append:e.appendBanners??!1},bubbles:!1,composed:!1})),e?.commands?.forEach(e=>{ue.next({command:e,fragment:void 0,ui:void 0,error:void 0,callbackToken:n})}),e?.fragments?.forEach(e=>{ue.next({command:void 0,fragment:e,ui:void 0,error:void 0,callbackToken:n})}),e?.appState&&(D.value={...e.appState},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))),e?.appData){let n=e?.appData;de.value={...e.appData,...n},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))}}}async runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,te={}){let ne=()=>{this.runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,te)};if(n){n||=`_no_route`,n&&n.startsWith(`/`)&&(n=n.substring(1));let e={serverSideType:s,appState:D.value,componentState:c,parameters:l,initiatorComponentId:a,consumedRoute:r,route:`/`+n,actionId:i};d||u.dispatchEvent(new CustomEvent(`backend-called-event`,{bubbles:!0,composed:!0,detail:{}})),fetch(t+`/mateu/v3/sse/`+n,{method:`POST`,headers:{Accept:`text/event-stream`,"Content-Type":`application/json`},body:JSON.stringify(e)}).then(async e=>{let t=e.body?.pipeThrough(new TextDecoderStream).getReader();if(t){let e=``;for(;;){let{value:n,done:r}=await t.read();if(r)break;e+=n;let a=e.split(`
 
-`);e=a.pop()??``;for(let e of a){let t=e.trim();if(t)if(t.startsWith(`data:`)){let e=JSON.parse(t.substring(5).trim());f&&f(e),p||this.handleUIIncrement(e,u,ee),e.messages&&e.messages.length==1&&e.messages[0].variant==`error`&&u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))}else{let e=t;try{let n=JSON.parse(t);e=n.message,n._embedded?.errors?.length>0&&n._embedded.errors[0].message&&(e=n._embedded.errors[0].message)}catch{}throw Error(e)}}}}d||u.dispatchEvent(new CustomEvent(`backend-succeeded-event`,{bubbles:!0,composed:!0,detail:{actionId:i}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-succeeded`,{detail:{actionId:i},bubbles:!0,composed:!0}))}).catch(e=>{u.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:i,reason:this.serialize(e),retry:ne}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))})}}serialize(e){return e?.message?e:JSON.stringify(e)}},Ho={fixed:`fixed`,fullWidth:`full`,edgeToEdge:`edge`},Uo=new Set([A.Gantt,A.PlanningBoard,A.Kanban,A.Bpmn,A.Workflow,A.Map]),Wo={landing:`fixed`,form:`fixed`,process:`fixed`},Go=e=>e?Ho[e]:void 0,Ko=e=>e.type==k.ClientSide?e.metadata:void 0,qo=e=>{let t=Ko(e);if(t?.type==A.Page){let e=Go(t.pageWidth);if(e)return e}for(let t of e.children??[]){let e=qo(t);if(e)return e}},Jo=e=>{let t=e.pageType;if(t)return t;let n=e=>{let t=Ko(e);if(t?.type==A.Page&&t.pageType)return t.pageType;for(let t of e.children??[]){let e=n(t);if(e)return e}};return n(e)},Yo=e=>{let t=Ko(e);if(t?.type!=A.Crud)return!1;let n=t;return n.compact?!0:(n.columns??[]).some(e=>e.metadata?.editable)},Xo=(e,t)=>t(e)||(e.children??[]).some(e=>Xo(e,t)),Zo=e=>!!e&&Xo(e,e=>Ko(e)?.type==A.HeroSection),Qo=e=>Ko(e)?.type==A.App||(e.children??[]).some(e=>Ko(e)?.type==A.App),$o=(e,t)=>e?(Go(e.pageWidth)??qo(e))||(t?.top&&Qo(e)?`edge`:Wo[Jo(e)??``]||(Xo(e,e=>{let t=Ko(e)?.type;return t!=null&&Uo.has(t)})?`edge`:Xo(e,Yo)?`full`:`fixed`)):`fixed`,es=`mateu-route-structure-cache`,ts=1,ns=50,rs=(()=>{try{return localStorage.getItem(`mateu-route-structure-cache-off`)!==`1`}catch{return!0}})(),is=()=>{try{return JSON.parse(localStorage.getItem(es)??`{}`)}catch{return{}}},as=e=>{try{localStorage.setItem(es,JSON.stringify(e))}catch{try{let t=Object.entries(e).sort((e,t)=>t[1].t-e[1].t).slice(0,Math.floor(ns/2));localStorage.setItem(es,JSON.stringify(Object.fromEntries(t)))}catch{}}},os=e=>{let t=e.initialState&&Object.keys(e.initialState).length?`#`+ls(JSON.stringify(e.initialState)):``;return[e.baseUrl,e.consumedRoute??``,e.route??``,e.serverSideType??``].join(`|`)+t},ss=e=>{if(!rs)return;let t=is()[e];if(!(!t||t.v!==ts))return{component:t.component,hash:t.hash}},cs=(e,t,n)=>{if(!rs)return;let r=is();r[e]={v:ts,t:Date.now(),component:t,hash:n};let i=Object.keys(r);if(i.length>ns){let e=i.sort((e,t)=>r[e].t-r[t].t).slice(0,i.length-ns);for(let t of e)delete r[t]}as(r)},ls=e=>{let t=2166136261;for(let n=0;n<e.length;n++)t^=e.charCodeAt(n),t=Math.imul(t,16777619);return(t>>>0).toString(36)},us=30,ds=new Map,fs=!0,ps=e=>{if(fs)return ds.get(e)},ms=(e,t)=>{if(fs&&(ds.delete(e),ds.set(e,t),ds.size>us)){let e=ds.keys().next().value;e!==void 0&&ds.delete(e)}},hs,X=class extends $e{static{hs=this}constructor(...e){super(...e),this.consumedRoute=``,this.serverSideType=void 0,this.uriPrefix=void 0,this.overrides=void 0,this.homeRoute=void 0,this.route=void 0,this.top=void 0,this.appState={},this.appData={},this.preventNavigation=!1,this.overridesParsed={},this.fragment=void 0,this.showSkeleton=!1,this.pendingRouteFocus=!1,this.hasRenderedContent=!1,this.loadLifecycleListener=e=>{if(((typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target)===this)if(clearTimeout(this.skeletonTimer),e.type===`backend-called-event`){if(this.fragment?.component)return;this.skeletonTimer=setTimeout(()=>{this.showSkeleton=!0},hs.SKELETON_DELAY_MS)}else this.showSkeleton=!1},this.actionRequestedListener=e=>{e instanceof CustomEvent&&(e.preventDefault(),e.stopPropagation(),this.manageActionEvent(e))},this.historyPushed=e=>{e instanceof CustomEvent&&(e.preventDefault(),e.stopPropagation(),this.preventNavigation=!0,this.route=e.detail.route)},this.routeChangedListener=e=>{if(e instanceof CustomEvent){e.preventDefault(),e.stopPropagation();let t=e.detail.route;typeof t==`string`&&(t===``||t.startsWith(`/`))&&this.consumedRoute&&this.consumedRoute!==`_empty`&&this.consumedRoute.startsWith(`/`)&&!t.startsWith(this.consumedRoute)&&(t=this.consumedRoute+t),this.uriPrefix&&(t=t.startsWith(`/`)&&this.uriPrefix.endsWith(`/`)?this.uriPrefix+t.substring(1):!t.startsWith(`/`)&&!this.uriPrefix.endsWith(`/`)?this.uriPrefix+`/`+t:this.uriPrefix+t),this.dispatchEvent(new CustomEvent(`url-update-requested`,{detail:{route:t},bubbles:!0,composed:!0}))}},this.backendFailedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&e.detail.actionId==``&&(this.fragment={targetComponentId:this.id,data:{},state:{},component:{type:k.ClientSide,metadata:{type:A.Element,name:`div`,content:`Not found`},id:`fieldId`},action:Ke.Replace,containerId:void 0})},this.detail1=void 0,this.manageActionEvent=e=>{e.preventDefault(),e.stopPropagation(),this.detail1=e.detail;let t=this.detail1;if(e.type==`server-side-action-requested`){let e=Bo;t.sse&&(e=Vo),e.runAction(Ge,this.baseUrl,t.route??``,t.consumedRoute,t.actionId,t.initiatorComponentId,this.getCustomisedAppState(),t.serverSideType,t.componentState,t.parameters,t.initiator,t.background,t.callback,t.callbackonly,t.callbackToken,{timeoutMillis:t.timeoutMillis,idempotent:t.idempotent,knownStructureHash:t.knownStructureHash})}},this.getCustomisedAppState=()=>{let e={...D.value};if(this.overrides){let t=Ro(this.overrides);e={...e,...t}}return e}}manageActionRequestedEvent(e){throw Error(`Method not implemented.`)}createRenderRoot(){return N.mustUseShadowRoot()?super.createRenderRoot():this}structureCacheKey(){return os({baseUrl:this.baseUrl,consumedRoute:this.consumedRoute,route:this.route,serverSideType:this.serverSideType,initialState:this.initialState})}focusNewContent(){requestAnimationFrame(()=>{let e=this.renderRoot?.querySelector?.(`h1, h2, [role="heading"]`)??this;e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus?.({preventScroll:!0})})}static{this.SKELETON_DELAY_MS=400}connectedCallback(){super.connectedCallback(),this.overridesParsed=Ro(this.overrides),this.addEventListener(`server-side-action-requested`,this.actionRequestedListener),this.addEventListener(`backend-call-failed`,this.backendFailedListener),this.addEventListener(`history-pushed`,this.historyPushed),this.addEventListener(`route-changed`,this.routeChangedListener),this.addEventListener(`backend-called-event`,this.loadLifecycleListener),this.addEventListener(`backend-succeeded-event`,this.loadLifecycleListener),this.addEventListener(`backend-failed-event`,this.loadLifecycleListener),this.addEventListener(`backend-cancelled-event`,this.loadLifecycleListener)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`server-side-action-requested`,this.actionRequestedListener),this.removeEventListener(`backend-call-failed`,this.backendFailedListener),this.removeEventListener(`history-pushed`,this.historyPushed),this.removeEventListener(`route-changed`,this.routeChangedListener),this.removeEventListener(`backend-called-event`,this.loadLifecycleListener),this.removeEventListener(`backend-succeeded-event`,this.loadLifecycleListener),this.removeEventListener(`backend-failed-event`,this.loadLifecycleListener),this.removeEventListener(`backend-cancelled-event`,this.loadLifecycleListener),clearTimeout(this.skeletonTimer)}shouldUpdate(e){if(this.fragment?.component&&[...e.keys()].every(e=>e===`appState`||e===`appData`)){let t=this.renderRoot.querySelector(`mateu-component`);if(t)return e.has(`appState`)&&(t.appState=this.appState),e.has(`appData`)&&(t.appData=this.appData),!1}return!0}updated(e){if((e.has(`id`)||e.has(`baseurl`)||e.has(`route`)||e.has(`consumedRoute`)||e.has(`instant`))&&!this.preventNavigation){this.callbackToken=this.instant||T();let e=this.structureCacheKey(),t=e===this.lastAuthoritativeKey?void 0:ps(e);if(t)queueMicrotask(()=>this.applyFragment(t));else{if(e!==this.lastAuthoritativeKey){let t=ss(e);this.currentStructureHash=t?.hash,t&&(this.fragment={targetComponentId:this.id,component:t.component,state:{},data:{},action:Ke.Replace,containerId:void 0})}this.manageActionEvent(new CustomEvent(`server-side-action-requested`,{detail:{route:this.route,consumedRoute:this.consumedRoute,userData:void 0,actionId:``,serverSideType:this.serverSideType,initiatorComponentId:this.id,initiator:this,componentState:this.initialState,knownStructureHash:this.currentStructureHash,callbackToken:this.callbackToken},bubbles:!0,composed:!0}))}}e.has(`route`)&&this.top&&(this.preventNavigation||(this.pendingRouteFocus=!0),this.preventNavigation||this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:this.route},bubbles:!0,composed:!0}))),this.preventNavigation&&=!1}applyFragment(e){if(!e.component&&this.fragment?.component){this.fragment={...this.fragment,state:{...this.fragment.state??{},...e.state??{}},data:{...this.fragment.data??{},...e.data??{}}};return}if(this.fragment=e,e.component){if(e.action!==Ke.Add){let t=this.structureCacheKey(),n=e.component.structureHash;cs(t,e.component,n),this.lastAuthoritativeKey=t,this.currentStructureHash=n,e.component.staticView&&ms(t,e)}this.pendingRouteFocus&&this.hasRenderedContent&&this.focusNewContent(),this.pendingRouteFocus=!1,this.hasRenderedContent=!0}e.component&&(this.dataset.pageWidth=$o(e.component,{top:this.top}),this.dataset.pageType=Jo(e.component)??``,this.dataset.hasWelcomeBanner=String(Zo(e.component)))}render(){return!this.fragment?.component&&this.showSkeleton?w`
+`);e=a.pop()??``;for(let e of a){let t=e.trim();if(t)if(t.startsWith(`data:`)){let e=JSON.parse(t.substring(5).trim());f&&f(e),p||this.handleUIIncrement(e,u,ee),e.messages&&e.messages.length==1&&e.messages[0].variant==`error`&&u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))}else{let e=t;try{let n=JSON.parse(t);e=n.message,n._embedded?.errors?.length>0&&n._embedded.errors[0].message&&(e=n._embedded.errors[0].message)}catch{}throw Error(e)}}}}d||u.dispatchEvent(new CustomEvent(`backend-succeeded-event`,{bubbles:!0,composed:!0,detail:{actionId:i}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-succeeded`,{detail:{actionId:i},bubbles:!0,composed:!0}))}).catch(e=>{u.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:i,reason:this.serialize(e),retry:ne}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))})}}serialize(e){return e?.message?e:JSON.stringify(e)}},Go={fixed:`fixed`,fullWidth:`full`,edgeToEdge:`edge`},Ko=new Set([A.Gantt,A.PlanningBoard,A.Kanban,A.Bpmn,A.Workflow,A.Map]),qo={landing:`fixed`,form:`fixed`,process:`fixed`},Jo=e=>e?Go[e]:void 0,Yo=e=>e.type==k.ClientSide?e.metadata:void 0,Xo=e=>{let t=Yo(e);if(t?.type==A.Page){let e=Jo(t.pageWidth);if(e)return e}for(let t of e.children??[]){let e=Xo(t);if(e)return e}},Zo=e=>{let t=e.pageType;if(t)return t;let n=e=>{let t=Yo(e);if(t?.type==A.Page&&t.pageType)return t.pageType;for(let t of e.children??[]){let e=n(t);if(e)return e}};return n(e)},Qo=e=>{let t=Yo(e);if(t?.type!=A.Crud)return!1;let n=t;return n.compact?!0:(n.columns??[]).some(e=>e.metadata?.editable)},$o=(e,t)=>t(e)||(e.children??[]).some(e=>$o(e,t)),es=e=>!!e&&$o(e,e=>Yo(e)?.type==A.HeroSection),ts=e=>Yo(e)?.type==A.App||(e.children??[]).some(e=>Yo(e)?.type==A.App),ns=(e,t)=>e?(Jo(e.pageWidth)??Xo(e))||(t?.top&&ts(e)?`edge`:qo[Zo(e)??``]||($o(e,e=>{let t=Yo(e)?.type;return t!=null&&Ko.has(t)})?`edge`:$o(e,Qo)?`full`:`fixed`)):`fixed`,rs=`mateu-route-structure-cache`,is=1,as=50,os=(()=>{try{return localStorage.getItem(`mateu-route-structure-cache-off`)!==`1`}catch{return!0}})(),ss=()=>{try{return JSON.parse(localStorage.getItem(rs)??`{}`)}catch{return{}}},cs=e=>{try{localStorage.setItem(rs,JSON.stringify(e))}catch{try{let t=Object.entries(e).sort((e,t)=>t[1].t-e[1].t).slice(0,Math.floor(as/2));localStorage.setItem(rs,JSON.stringify(Object.fromEntries(t)))}catch{}}},ls=e=>{let t=e.initialState&&Object.keys(e.initialState).length?`#`+fs(JSON.stringify(e.initialState)):``;return[e.baseUrl,e.consumedRoute??``,e.route??``,e.serverSideType??``].join(`|`)+t},us=e=>{if(!os)return;let t=ss()[e];if(!(!t||t.v!==is))return{component:t.component,hash:t.hash}},ds=(e,t,n)=>{if(!os)return;let r=ss();r[e]={v:is,t:Date.now(),component:t,hash:n};let i=Object.keys(r);if(i.length>as){let e=i.sort((e,t)=>r[e].t-r[t].t).slice(0,i.length-as);for(let t of e)delete r[t]}cs(r)},fs=e=>{let t=2166136261;for(let n=0;n<e.length;n++)t^=e.charCodeAt(n),t=Math.imul(t,16777619);return(t>>>0).toString(36)},ps=30,ms=new Map,hs=!0,gs=e=>{if(hs)return ms.get(e)},_s=(e,t)=>{if(hs&&(ms.delete(e),ms.set(e,t),ms.size>ps)){let e=ms.keys().next().value;e!==void 0&&ms.delete(e)}},vs,Y=class extends $e{static{vs=this}constructor(...e){super(...e),this.consumedRoute=``,this.serverSideType=void 0,this.uriPrefix=void 0,this.overrides=void 0,this.homeRoute=void 0,this.route=void 0,this.top=void 0,this.appState={},this.appData={},this.preventNavigation=!1,this.overridesParsed={},this.fragment=void 0,this.showSkeleton=!1,this.pendingRouteFocus=!1,this.hasRenderedContent=!1,this.loadLifecycleListener=e=>{if(((typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target)===this)if(clearTimeout(this.skeletonTimer),e.type===`backend-called-event`){if(this.fragment?.component)return;this.skeletonTimer=setTimeout(()=>{this.showSkeleton=!0},vs.SKELETON_DELAY_MS)}else this.showSkeleton=!1},this.actionRequestedListener=e=>{e instanceof CustomEvent&&(e.preventDefault(),e.stopPropagation(),this.manageActionEvent(e))},this.historyPushed=e=>{e instanceof CustomEvent&&(e.preventDefault(),e.stopPropagation(),this.preventNavigation=!0,this.route=e.detail.route)},this.routeChangedListener=e=>{if(e instanceof CustomEvent){e.preventDefault(),e.stopPropagation();let t=e.detail.route;typeof t==`string`&&(t===``||t.startsWith(`/`))&&this.consumedRoute&&this.consumedRoute!==`_empty`&&this.consumedRoute.startsWith(`/`)&&!t.startsWith(this.consumedRoute)&&(t=this.consumedRoute+t),this.uriPrefix&&(t=t.startsWith(`/`)&&this.uriPrefix.endsWith(`/`)?this.uriPrefix+t.substring(1):!t.startsWith(`/`)&&!this.uriPrefix.endsWith(`/`)?this.uriPrefix+`/`+t:this.uriPrefix+t),this.dispatchEvent(new CustomEvent(`url-update-requested`,{detail:{route:t},bubbles:!0,composed:!0}))}},this.backendFailedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&e.detail.actionId==``&&(this.fragment={targetComponentId:this.id,data:{},state:{},component:{type:k.ClientSide,metadata:{type:A.Element,name:`div`,content:`Not found`},id:`fieldId`},action:Ke.Replace,containerId:void 0})},this.detail1=void 0,this.manageActionEvent=e=>{e.preventDefault(),e.stopPropagation(),this.detail1=e.detail;let t=this.detail1;if(e.type==`server-side-action-requested`){let e=Uo;t.sse&&(e=Wo),e.runAction(Ge,this.baseUrl,t.route??``,t.consumedRoute,t.actionId,t.initiatorComponentId,this.getCustomisedAppState(),t.serverSideType,t.componentState,t.parameters,t.initiator,t.background,t.callback,t.callbackonly,t.callbackToken,{timeoutMillis:t.timeoutMillis,idempotent:t.idempotent,knownStructureHash:t.knownStructureHash})}},this.getCustomisedAppState=()=>{let e={...D.value};if(this.overrides){let t=Vo(this.overrides);e={...e,...t}}return e}}manageActionRequestedEvent(e){throw Error(`Method not implemented.`)}createRenderRoot(){return N.mustUseShadowRoot()?super.createRenderRoot():this}structureCacheKey(){return ls({baseUrl:this.baseUrl,consumedRoute:this.consumedRoute,route:this.route,serverSideType:this.serverSideType,initialState:this.initialState})}focusNewContent(){requestAnimationFrame(()=>{let e=this.renderRoot?.querySelector?.(`h1, h2, [role="heading"]`)??this;e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus?.({preventScroll:!0})})}static{this.SKELETON_DELAY_MS=400}connectedCallback(){super.connectedCallback(),this.overridesParsed=Vo(this.overrides),this.addEventListener(`server-side-action-requested`,this.actionRequestedListener),this.addEventListener(`backend-call-failed`,this.backendFailedListener),this.addEventListener(`history-pushed`,this.historyPushed),this.addEventListener(`route-changed`,this.routeChangedListener),this.addEventListener(`backend-called-event`,this.loadLifecycleListener),this.addEventListener(`backend-succeeded-event`,this.loadLifecycleListener),this.addEventListener(`backend-failed-event`,this.loadLifecycleListener),this.addEventListener(`backend-cancelled-event`,this.loadLifecycleListener)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`server-side-action-requested`,this.actionRequestedListener),this.removeEventListener(`backend-call-failed`,this.backendFailedListener),this.removeEventListener(`history-pushed`,this.historyPushed),this.removeEventListener(`route-changed`,this.routeChangedListener),this.removeEventListener(`backend-called-event`,this.loadLifecycleListener),this.removeEventListener(`backend-succeeded-event`,this.loadLifecycleListener),this.removeEventListener(`backend-failed-event`,this.loadLifecycleListener),this.removeEventListener(`backend-cancelled-event`,this.loadLifecycleListener),clearTimeout(this.skeletonTimer)}shouldUpdate(e){if(this.fragment?.component&&[...e.keys()].every(e=>e===`appState`||e===`appData`)){let t=this.renderRoot.querySelector(`mateu-component`);if(t)return e.has(`appState`)&&(t.appState=this.appState),e.has(`appData`)&&(t.appData=this.appData),!1}return!0}updated(e){if((e.has(`id`)||e.has(`baseurl`)||e.has(`route`)||e.has(`consumedRoute`)||e.has(`instant`))&&!this.preventNavigation){this.callbackToken=this.instant||T();let e=this.structureCacheKey(),t=e===this.lastAuthoritativeKey?void 0:gs(e);if(t)queueMicrotask(()=>this.applyFragment(t));else{if(e!==this.lastAuthoritativeKey){let t=us(e);this.currentStructureHash=t?.hash,t&&(this.fragment={targetComponentId:this.id,component:t.component,state:{},data:{},action:Ke.Replace,containerId:void 0})}this.manageActionEvent(new CustomEvent(`server-side-action-requested`,{detail:{route:this.route,consumedRoute:this.consumedRoute,userData:void 0,actionId:``,serverSideType:this.serverSideType,initiatorComponentId:this.id,initiator:this,componentState:this.initialState,knownStructureHash:this.currentStructureHash,callbackToken:this.callbackToken},bubbles:!0,composed:!0}))}}e.has(`route`)&&this.top&&(this.preventNavigation||(this.pendingRouteFocus=!0),this.preventNavigation||this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:this.route},bubbles:!0,composed:!0}))),this.preventNavigation&&=!1}applyFragment(e){if(!e.component&&this.fragment?.component){this.fragment={...this.fragment,state:{...this.fragment.state??{},...e.state??{}},data:{...this.fragment.data??{},...e.data??{}}};return}if(this.fragment=e,e.component){if(e.action!==Ke.Add){let t=this.structureCacheKey(),n=e.component.structureHash;ds(t,e.component,n),this.lastAuthoritativeKey=t,this.currentStructureHash=n,e.component.staticView&&_s(t,e)}this.pendingRouteFocus&&this.hasRenderedContent&&this.focusNewContent(),this.pendingRouteFocus=!1,this.hasRenderedContent=!0}e.component&&(this.dataset.pageWidth=ns(e.component,{top:this.top}),this.dataset.pageType=Zo(e.component)??``,this.dataset.hasWelcomeBanner=String(es(e.component)))}render(){return!this.fragment?.component&&this.showSkeleton?w`
                 <div class="route-skeleton" aria-busy="true" aria-live="polite">
                     <mateu-skeleton variant="text" count="1"></mateu-skeleton>
                     <mateu-skeleton variant="form" count="4"></mateu-skeleton>
@@ -7350,7 +7350,7 @@ ${i}
             max-width: 16rem;
             margin-block-end: var(--lumo-space-l, 1.5rem);
         }
-  `}};O([v()],X.prototype,`consumedRoute`,void 0),O([v()],X.prototype,`serverSideType`,void 0),O([v()],X.prototype,`uriPrefix`,void 0),O([v()],X.prototype,`overrides`,void 0),O([v()],X.prototype,`homeRoute`,void 0),O([v()],X.prototype,`route`,void 0),O([v()],X.prototype,`top`,void 0),O([v()],X.prototype,`instant`,void 0),O([v()],X.prototype,`initialState`,void 0),O([v()],X.prototype,`appState`,void 0),O([v()],X.prototype,`appData`,void 0),O([S()],X.prototype,`fragment`,void 0),O([S()],X.prototype,`showSkeleton`,void 0),X=hs=O([h(`mateu-ux`)],X);function gs(e){let t=`var(--lumo-space-m, 1rem)`,n={left:`50%`,transform:`translateX(-50%)`};switch(e){case`topStart`:return{top:t,left:t};case`topCenter`:return{top:t,...n};case`topEnd`:return{top:t,right:t};case`topStretch`:return{top:t,left:t,right:t};case`middle`:return{top:`50%`,left:`50%`,transform:`translate(-50%, -50%)`};case`bottomStart`:return{bottom:t,left:t};case`bottomCenter`:return{bottom:t,...n};case`bottomStretch`:return{bottom:t,left:t,right:t};default:return{bottom:t,right:t}}}function _s(e){switch(e){case`success`:return{bg:`var(--lumo-success-color, #2e7d32)`,fg:`#fff`};case`error`:return{bg:`var(--lumo-error-color, #c62828)`,fg:`#fff`};case`warning`:return{bg:`var(--lumo-warning-color, #f9a825)`,fg:`#1a1a1a`};case`contrast`:return{bg:`var(--lumo-contrast-90pct, #1a1a1a)`,fg:`#fff`};default:return{bg:`var(--lumo-base-color, #fff)`,fg:`var(--lumo-body-text-color, #1a1a1a)`}}}var vs={show(e,t){let{bg:n,fg:r}=_s(e.variant),i=gs(e.position),a=document.createElement(`div`),o=e.variant===`error`;a.setAttribute(`role`,o?`alert`:`status`),a.setAttribute(`aria-live`,o?`assertive`:`polite`),a.setAttribute(`aria-atomic`,`true`),Object.assign(a.style,{position:`fixed`,zIndex:`2000`,display:`flex`,alignItems:`center`,gap:`0.75rem`,maxWidth:`min(90vw, 28rem)`,padding:`0.7rem 1rem`,borderRadius:`var(--lumo-border-radius-m, 8px)`,boxShadow:`var(--lumo-box-shadow-m, 0 4px 16px rgba(0,0,0,0.2))`,background:n,color:r,font:`inherit`,fontSize:`var(--lumo-font-size-s, 0.875rem)`,opacity:`0`,transition:`opacity 0.2s ease`,...i});let s=document.createElement(`span`);s.textContent=e.text,a.appendChild(s);let c=()=>{a.style.opacity=`0`,setTimeout(()=>a.remove(),200)},l=e.onAction?{label:e.actionLabel??`Retry`,run:e.onAction}:e.undoActionId?{label:e.undoLabel??`Undo`,run:()=>t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.undoActionId,parameters:e.undoParameters??{}},bubbles:!0,composed:!0}))}:void 0;if(l){let e=document.createElement(`button`);e.textContent=l.label,e.style.cssText=`margin-left: 0.25rem; background: none; border: 1px solid currentColor; border-radius: var(--lumo-border-radius-s, 4px); color: inherit; cursor: pointer; padding: 0.15rem 0.6rem; font: inherit; font-weight: 600;`,e.addEventListener(`click`,()=>{l.run(),c()}),a.appendChild(e)}document.body.appendChild(a),requestAnimationFrame(()=>{a.style.opacity=`1`});let u=e.duration??(l?1e4:5e3);u>0&&setTimeout(c,u)}};function ys(){fa(vs)}var bs=class extends y{constructor(...e){super(...e),this.online=!0,this.recovered=!1}connectedCallback(){super.connectedCallback(),this.online=Ve.isOnline(),this.unsubscribe=Ve.subscribe(e=>{let t=!this.online;this.online=e,e&&t&&(this.recovered=!0,clearTimeout(this.recoveredTimer),this.recoveredTimer=setTimeout(()=>{this.recovered=!1},4e3))})}disconnectedCallback(){super.disconnectedCallback(),this.unsubscribe?.(),clearTimeout(this.recoveredTimer),this.releaseSpace()}updated(){let e=this.renderRoot.querySelector(`.bar`);if(!e){this.releaseSpace();return}document.body.style.setProperty(`padding-block-start`,`${e.offsetHeight}px`)}releaseSpace(){typeof document<`u`&&document.body?.style.removeProperty(`padding-block-start`)}render(){if(this.online&&!this.recovered)return _;let e=!this.online;return w`<div class="bar ${e?`offline`:`back`}" role="status" aria-live="polite">
+  `}};O([v()],Y.prototype,`consumedRoute`,void 0),O([v()],Y.prototype,`serverSideType`,void 0),O([v()],Y.prototype,`uriPrefix`,void 0),O([v()],Y.prototype,`overrides`,void 0),O([v()],Y.prototype,`homeRoute`,void 0),O([v()],Y.prototype,`route`,void 0),O([v()],Y.prototype,`top`,void 0),O([v()],Y.prototype,`instant`,void 0),O([v()],Y.prototype,`initialState`,void 0),O([v()],Y.prototype,`appState`,void 0),O([v()],Y.prototype,`appData`,void 0),O([S()],Y.prototype,`fragment`,void 0),O([S()],Y.prototype,`showSkeleton`,void 0),Y=vs=O([h(`mateu-ux`)],Y);function ys(e){let t=`var(--lumo-space-m, 1rem)`,n={left:`50%`,transform:`translateX(-50%)`};switch(e){case`topStart`:return{top:t,left:t};case`topCenter`:return{top:t,...n};case`topEnd`:return{top:t,right:t};case`topStretch`:return{top:t,left:t,right:t};case`middle`:return{top:`50%`,left:`50%`,transform:`translate(-50%, -50%)`};case`bottomStart`:return{bottom:t,left:t};case`bottomCenter`:return{bottom:t,...n};case`bottomStretch`:return{bottom:t,left:t,right:t};default:return{bottom:t,right:t}}}function bs(e){switch(e){case`success`:return{bg:`var(--lumo-success-color, #2e7d32)`,fg:`#fff`};case`error`:return{bg:`var(--lumo-error-color, #c62828)`,fg:`#fff`};case`warning`:return{bg:`var(--lumo-warning-color, #f9a825)`,fg:`#1a1a1a`};case`contrast`:return{bg:`var(--lumo-contrast-90pct, #1a1a1a)`,fg:`#fff`};default:return{bg:`var(--lumo-base-color, #fff)`,fg:`var(--lumo-body-text-color, #1a1a1a)`}}}var xs={show(e,t){let{bg:n,fg:r}=bs(e.variant),i=ys(e.position),a=document.createElement(`div`),o=e.variant===`error`;a.setAttribute(`role`,o?`alert`:`status`),a.setAttribute(`aria-live`,o?`assertive`:`polite`),a.setAttribute(`aria-atomic`,`true`),Object.assign(a.style,{position:`fixed`,zIndex:`2000`,display:`flex`,alignItems:`center`,gap:`0.75rem`,maxWidth:`min(90vw, 28rem)`,padding:`0.7rem 1rem`,borderRadius:`var(--lumo-border-radius-m, 8px)`,boxShadow:`var(--lumo-box-shadow-m, 0 4px 16px rgba(0,0,0,0.2))`,background:n,color:r,font:`inherit`,fontSize:`var(--lumo-font-size-s, 0.875rem)`,opacity:`0`,transition:`opacity 0.2s ease`,...i});let s=document.createElement(`span`);s.textContent=e.text,a.appendChild(s);let c=()=>{a.style.opacity=`0`,setTimeout(()=>a.remove(),200)},l=e.onAction?{label:e.actionLabel??`Retry`,run:e.onAction}:e.undoActionId?{label:e.undoLabel??`Undo`,run:()=>t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.undoActionId,parameters:e.undoParameters??{}},bubbles:!0,composed:!0}))}:void 0;if(l){let e=document.createElement(`button`);e.textContent=l.label,e.style.cssText=`margin-left: 0.25rem; background: none; border: 1px solid currentColor; border-radius: var(--lumo-border-radius-s, 4px); color: inherit; cursor: pointer; padding: 0.15rem 0.6rem; font: inherit; font-weight: 600;`,e.addEventListener(`click`,()=>{l.run(),c()}),a.appendChild(e)}document.body.appendChild(a),requestAnimationFrame(()=>{a.style.opacity=`1`});let u=e.duration??(l?1e4:5e3);u>0&&setTimeout(c,u)}};function Ss(){ma(xs)}var Cs=class extends y{constructor(...e){super(...e),this.online=!0,this.recovered=!1}connectedCallback(){super.connectedCallback(),this.online=Ve.isOnline(),this.unsubscribe=Ve.subscribe(e=>{let t=!this.online;this.online=e,e&&t&&(this.recovered=!0,clearTimeout(this.recoveredTimer),this.recoveredTimer=setTimeout(()=>{this.recovered=!1},4e3))})}disconnectedCallback(){super.disconnectedCallback(),this.unsubscribe?.(),clearTimeout(this.recoveredTimer),this.releaseSpace()}updated(){let e=this.renderRoot.querySelector(`.bar`);if(!e){this.releaseSpace();return}document.body.style.setProperty(`padding-block-start`,`${e.offsetHeight}px`)}releaseSpace(){typeof document<`u`&&document.body?.style.removeProperty(`padding-block-start`)}render(){if(this.online&&!this.recovered)return _;let e=!this.online;return w`<div class="bar ${e?`offline`:`back`}" role="status" aria-live="polite">
             <span class="dot"></span>
             <span>${e?`No connection — changes you make now will not be saved.`:`Connection restored.`}</span>
         </div>`}static{this.styles=m`
@@ -7392,7 +7392,7 @@ ${i}
         @media (prefers-reduced-motion: reduce) {
             .bar, .bar.offline .dot { animation: none; }
         }
-    `}};O([S()],bs.prototype,`online`,void 0),O([S()],bs.prototype,`recovered`,void 0),bs=O([h(`mateu-connectivity-banner`)],bs);var xs=null;function Ss(){if(!(typeof document>`u`)&&!(xs&&xs.isConnected)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>Ss(),{once:!0});return}xs=document.createElement(`mateu-connectivity-banner`),document.body.appendChild(xs)}}var Cs,ws=class extends y{static{Cs=this}constructor(...e){super(...e),this.skip=()=>{let e=this.findContent();e&&(e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus(),e.scrollIntoView({block:`start`}))}}static{this.TARGETS=[`.app-content`,`mateu-page`,`mateu-ux`,`mateu-component`]}findContent(){let e=new Set,t=n=>{if(e.has(n))return null;e.add(n);for(let e of Cs.TARGETS){let t=n.querySelector?.(e);if(t&&t!==this)return t}for(let e of Array.from(n.querySelectorAll?.(`*`)??[]))if(e.shadowRoot){let n=t(e.shadowRoot);if(n)return n}return null};return t(document)}render(){return w`<button class="skip" @click="${this.skip}">Skip to content</button>`}static{this.styles=m`
+    `}};O([S()],Cs.prototype,`online`,void 0),O([S()],Cs.prototype,`recovered`,void 0),Cs=O([h(`mateu-connectivity-banner`)],Cs);var ws=null;function Ts(){if(!(typeof document>`u`)&&!(ws&&ws.isConnected)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>Ts(),{once:!0});return}ws=document.createElement(`mateu-connectivity-banner`),document.body.appendChild(ws)}}var Es,Ds=class extends y{static{Es=this}constructor(...e){super(...e),this.skip=()=>{let e=this.findContent();e&&(e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus(),e.scrollIntoView({block:`start`}))}}static{this.TARGETS=[`.app-content`,`mateu-page`,`mateu-ux`,`mateu-component`]}findContent(){let e=new Set,t=n=>{if(e.has(n))return null;e.add(n);for(let e of Es.TARGETS){let t=n.querySelector?.(e);if(t&&t!==this)return t}for(let e of Array.from(n.querySelectorAll?.(`*`)??[]))if(e.shadowRoot){let n=t(e.shadowRoot);if(n)return n}return null};return t(document)}render(){return w`<button class="skip" @click="${this.skip}">Skip to content</button>`}static{this.styles=m`
         :host {
             position: fixed;
             inset-block-start: 0;
@@ -7425,7 +7425,7 @@ ${i}
             outline: 2px solid var(--lumo-body-text-color, #161513);
             outline-offset: 2px;
         }
-    `}};ws=Cs=O([h(`mateu-skip-link`)],ws);var Ts=null;function Es(){if(!(typeof document>`u`)&&!(Ts&&Ts.isConnected)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>Es(),{once:!0});return}Ts=document.createElement(`mateu-skip-link`),document.body.insertBefore(Ts,document.body.firstChild)}}ys(),Ss(),Ze(),Es();var Ds=class extends y{constructor(...e){super(...e),this.baseUrl=``,this.route=void 0,this.consumedRoute=`_empty`,this.config=void 0,this.top=`true`,this.pathPrefix=void 0,this.debug=!1,this._lastUrl=``,this.routeChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.top==`true`){let t=e.detail.route,n=this.baseUrl??``;!t||t.startsWith(`/`)?n=window.location.origin+(this.pathPrefix??``):(t=(this.pathPrefix??``)+t,n.indexOf(`://`)<0&&(n.startsWith(`/`)||(n=`/`+n),n=window.location.origin+n)),t.startsWith(this.pathPrefix+`/`)&&(t=t.substring(this.pathPrefix?.length)),n.endsWith(`/`)&&t.startsWith(`/`)&&(t=t.substring(1));let r=new URL(n+t);if((window.location.pathname||r.pathname)&&window.location.pathname!=r.pathname){let e=r.pathname;r.search&&(e+=r.search),e&&!e.startsWith(`/`)&&(e=`/`+e),window.history.pushState({},``,e),this._lastUrl=window.location.href}}},this.navigateToRequestedListener=e=>{if(e.preventDefault(),e.stopPropagation(),Ma.markClean(),e instanceof CustomEvent){let t=e.detail.route,n=this.renderRoot.querySelector(`mateu-ux`);n&&(n.setAttribute(`route`,t),n.setAttribute(`instant`,T()))}}}createRenderRoot(){return N.mustUseShadowRoot()?super.createRenderRoot():this}connectedCallback(){if(super.connectedCallback(),Ma.install(),this._lastUrl=window.location.href,window.onpopstate=e=>{if(!Ma.confirmLeave()){window.history.pushState({},``,this._lastUrl);return}let t=e.target;this.loadUrl(t)},this.top==`true`?this.loadUrl(window):this.route&&(this.consumedRoute=``),this.config)try{let e=JSON.parse(this.config);D.value={...D.value,...e}}catch{D.value={...D.value,config:this.config}}this.addEventListener(`url-update-requested`,this.routeChangedListener),this.addEventListener(`navigate-to-requested`,this.navigateToRequestedListener)}disconnectedCallback(){super.disconnectedCallback(),this.upstreamSubscription?.unsubscribe(),this.removeEventListener(`url-update-requested`,this.routeChangedListener),this.removeEventListener(`navigate-to-requested`,this.navigateToRequestedListener)}loadUrl(e){if(this.route=this.extractRouteFromUrl(e),this.setAttribute(`route`,this.route),this.instant=T(),this._lastUrl=e.location.href,e.location.search){let t=new URLSearchParams(e.location.search).get(`overrides`);if(t&&(this.config=t,this.config))try{let e=JSON.parse(this.config);D.value={...D.value,...e}}catch{D.value={...D.value,config:this.config}}}}extractRouteFromUrl(e){return this.addQueryParams(this.extractRouteWithoutParamsFromUrl(e),e.location)}extractRouteWithoutParamsFromUrl(e){let t=this.extractGrossRouteFromUrl(e);return this.pathPrefix&&t.startsWith(this.pathPrefix)?t.substring(this.pathPrefix.length):t==`/`?``:t}addQueryParams(e,t){return e+(t.search?``+t.search:``)}extractGrossRouteFromUrl(e){let t=e.location.pathname,n=this.baseUrl&&(this.baseUrl.startsWith(`http://`)||this.baseUrl.startsWith(`https://`))?this.baseUrl.substring(this.getContextPathStartingIndex(this.baseUrl)):this.baseUrl;return t.startsWith(n)?t.substring(n.length):t}getContextPathStartingIndex(e){return e.startsWith(`http:`)?e.indexOf(`/`,7):e.startsWith(`https:`)?e.indexOf(`/`,8):0}render(){return w`
+    `}};Ds=Es=O([h(`mateu-skip-link`)],Ds);var Os=null;function ks(){if(!(typeof document>`u`)&&!(Os&&Os.isConnected)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>ks(),{once:!0});return}Os=document.createElement(`mateu-skip-link`),document.body.insertBefore(Os,document.body.firstChild)}}Ss(),Ts(),Ze(),ks();var As=class extends y{constructor(...e){super(...e),this.baseUrl=``,this.route=void 0,this.consumedRoute=`_empty`,this.config=void 0,this.top=`true`,this.pathPrefix=void 0,this.debug=!1,this._lastUrl=``,this.routeChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.top==`true`){let t=e.detail.route,n=this.baseUrl??``;!t||t.startsWith(`/`)?n=window.location.origin+(this.pathPrefix??``):(t=(this.pathPrefix??``)+t,n.indexOf(`://`)<0&&(n.startsWith(`/`)||(n=`/`+n),n=window.location.origin+n)),t.startsWith(this.pathPrefix+`/`)&&(t=t.substring(this.pathPrefix?.length)),n.endsWith(`/`)&&t.startsWith(`/`)&&(t=t.substring(1));let r=new URL(n+t);if((window.location.pathname||r.pathname)&&window.location.pathname!=r.pathname){let e=r.pathname;r.search&&(e+=r.search),e&&!e.startsWith(`/`)&&(e=`/`+e),window.history.pushState({},``,e),this._lastUrl=window.location.href}}},this.navigateToRequestedListener=e=>{if(e.preventDefault(),e.stopPropagation(),Pa.markClean(),e instanceof CustomEvent){let t=e.detail.route,n=this.renderRoot.querySelector(`mateu-ux`);n&&(n.setAttribute(`route`,t),n.setAttribute(`instant`,T()))}}}createRenderRoot(){return N.mustUseShadowRoot()?super.createRenderRoot():this}connectedCallback(){if(super.connectedCallback(),Pa.install(),this._lastUrl=window.location.href,window.onpopstate=e=>{if(!Pa.confirmLeave()){window.history.pushState({},``,this._lastUrl);return}let t=e.target;this.loadUrl(t)},this.top==`true`?this.loadUrl(window):this.route&&(this.consumedRoute=``),this.config)try{let e=JSON.parse(this.config);D.value={...D.value,...e}}catch{D.value={...D.value,config:this.config}}this.addEventListener(`url-update-requested`,this.routeChangedListener),this.addEventListener(`navigate-to-requested`,this.navigateToRequestedListener)}disconnectedCallback(){super.disconnectedCallback(),this.upstreamSubscription?.unsubscribe(),this.removeEventListener(`url-update-requested`,this.routeChangedListener),this.removeEventListener(`navigate-to-requested`,this.navigateToRequestedListener)}loadUrl(e){if(this.route=this.extractRouteFromUrl(e),this.setAttribute(`route`,this.route),this.instant=T(),this._lastUrl=e.location.href,e.location.search){let t=new URLSearchParams(e.location.search).get(`overrides`);if(t&&(this.config=t,this.config))try{let e=JSON.parse(this.config);D.value={...D.value,...e}}catch{D.value={...D.value,config:this.config}}}}extractRouteFromUrl(e){return this.addQueryParams(this.extractRouteWithoutParamsFromUrl(e),e.location)}extractRouteWithoutParamsFromUrl(e){let t=this.extractGrossRouteFromUrl(e);return this.pathPrefix&&t.startsWith(this.pathPrefix)?t.substring(this.pathPrefix.length):t==`/`?``:t}addQueryParams(e,t){return e+(t.search?``+t.search:``)}extractGrossRouteFromUrl(e){let t=e.location.pathname,n=this.baseUrl&&(this.baseUrl.startsWith(`http://`)||this.baseUrl.startsWith(`https://`))?this.baseUrl.substring(this.getContextPathStartingIndex(this.baseUrl)):this.baseUrl;return t.startsWith(n)?t.substring(n.length):t}getContextPathStartingIndex(e){return e.startsWith(`http:`)?e.indexOf(`/`,7):e.startsWith(`https:`)?e.indexOf(`/`,8):0}render(){return w`
            <mateu-api-caller>
                 <mateu-ux id="_ux"
                           baseurl="${this.baseUrl}"
@@ -7449,9 +7449,9 @@ ${i}
         :host {
             --lumo-clickable-cursor: pointer;
         }
-  `}};O([v()],Ds.prototype,`baseUrl`,void 0),O([v()],Ds.prototype,`route`,void 0),O([v()],Ds.prototype,`consumedRoute`,void 0),O([v()],Ds.prototype,`config`,void 0),O([v()],Ds.prototype,`top`,void 0),O([v()],Ds.prototype,`pathPrefix`,void 0),O([S()],Ds.prototype,`instant`,void 0),O([v({type:Boolean})],Ds.prototype,`debug`,void 0),Ds=O([h(`mateu-ui`)],Ds);var Os,ks=class extends y{static{Os=this}constructor(...e){super(...e),this.baseUrl=``,this.opened=!1,this.searchText=``}static{this.SEARCHABLE_THRESHOLD=7}connectedCallback(){super.connectedCallback(),De()}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick(),this.searchTimer&&clearTimeout(this.searchTimer)}currentValue(){return String(Ce()[this.selector.fieldName]??``)}currentLabel(){let e=this.currentValue();if(!e)return`—`;let t=(this.searchedOptions??this.selector.options)?.find(t=>String(t.value)===e);if(t)return t.label;let n=we()[this.selector.fieldName];return n===void 0?e:String(n)}pick(e,t){Te(this.selector.fieldName,e,t),window.location.reload()}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}openPanel(){this.opened||(this.opened=!0,this.searchText=``,this.searchedOptions=void 0,this.remoteSearch(),this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick),this.updateComplete.then(()=>this.renderRoot.querySelector(`input.picker-search`)?.focus()))}closePanel(){this.detachOutsideClick(),this.opened=!1}onSearchInput(e){this.searchText=e.target.value,this.searchTimer&&clearTimeout(this.searchTimer),this.searchTimer=setTimeout(()=>this.remoteSearch(),300)}async remoteSearch(){let e=this.app;if(e?.serverSideType)try{let t=await Ge.runAction(this.baseUrl??``,e.rootRoute??e.initialRoute??``,``,`_appcontext-search-${this.selector.fieldName}`,`appcontext-${this.selector.fieldName}`,void 0,e.serverSideType,{},{searchText:this.searchText},this,!0);for(let e of t?.fragments??[]){let t=e.data?.[`_appcontext_${this.selector.fieldName}`]?.content;if(Array.isArray(t)){this.searchedOptions=t.map(e=>({value:e.value,label:e.label??String(e.value)}));return}}}catch{}}visibleOptions(){let e=this.searchedOptions??this.selector.options??[],t=this.searchText.trim().toLowerCase();return t?e.filter(e=>e.label.toLowerCase().includes(t)):e}renderPanel(){let e=this.currentValue(),t=this.visibleOptions();return w`
+  `}};O([v()],As.prototype,`baseUrl`,void 0),O([v()],As.prototype,`route`,void 0),O([v()],As.prototype,`consumedRoute`,void 0),O([v()],As.prototype,`config`,void 0),O([v()],As.prototype,`top`,void 0),O([v()],As.prototype,`pathPrefix`,void 0),O([S()],As.prototype,`instant`,void 0),O([v({type:Boolean})],As.prototype,`debug`,void 0),As=O([h(`mateu-ui`)],As);var js,Ms=class extends y{static{js=this}constructor(...e){super(...e),this.baseUrl=``,this.opened=!1,this.searchText=``}static{this.SEARCHABLE_THRESHOLD=7}connectedCallback(){super.connectedCallback(),De()}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick(),this.searchTimer&&clearTimeout(this.searchTimer)}currentValue(){return String(Ce()[this.selector.fieldName]??``)}currentLabel(){let e=this.currentValue();if(!e)return`—`;let t=(this.searchedOptions??this.selector.options)?.find(t=>String(t.value)===e);if(t)return t.label;let n=we()[this.selector.fieldName];return n===void 0?e:String(n)}pick(e,t){Te(this.selector.fieldName,e,t),window.location.reload()}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}openPanel(){this.opened||(this.opened=!0,this.searchText=``,this.searchedOptions=void 0,this.remoteSearch(),this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick),this.updateComplete.then(()=>this.renderRoot.querySelector(`input.picker-search`)?.focus()))}closePanel(){this.detachOutsideClick(),this.opened=!1}onSearchInput(e){this.searchText=e.target.value,this.searchTimer&&clearTimeout(this.searchTimer),this.searchTimer=setTimeout(()=>this.remoteSearch(),300)}async remoteSearch(){let e=this.app;if(e?.serverSideType)try{let t=await Ge.runAction(this.baseUrl??``,e.rootRoute??e.initialRoute??``,``,`_appcontext-search-${this.selector.fieldName}`,`appcontext-${this.selector.fieldName}`,void 0,e.serverSideType,{},{searchText:this.searchText},this,!0);for(let e of t?.fragments??[]){let t=e.data?.[`_appcontext_${this.selector.fieldName}`]?.content;if(Array.isArray(t)){this.searchedOptions=t.map(e=>({value:e.value,label:e.label??String(e.value)}));return}}}catch{}}visibleOptions(){let e=this.searchedOptions??this.selector.options??[],t=this.searchText.trim().toLowerCase();return t?e.filter(e=>e.label.toLowerCase().includes(t)):e}renderPanel(){let e=this.currentValue(),t=this.visibleOptions();return w`
             <div class="panel">
-                ${this.searchText!==``||t.length>Os.SEARCHABLE_THRESHOLD?w`
+                ${this.searchText!==``||t.length>js.SEARCHABLE_THRESHOLD?w`
                     <input class="picker-search" type="text" placeholder="Search"
                            .value="${this.searchText}"
                            @input="${this.onSearchInput}"
@@ -7543,7 +7543,7 @@ ${i}
         .option--clear {
             color: var(--lumo-secondary-text-color, rgba(0, 0, 0, 0.55));
         }
-    `}};O([v()],ks.prototype,`selector`,void 0),O([v()],ks.prototype,`app`,void 0),O([v()],ks.prototype,`baseUrl`,void 0),O([S()],ks.prototype,`opened`,void 0),O([S()],ks.prototype,`searchText`,void 0),O([S()],ks.prototype,`searchedOptions`,void 0),ks=Os=O([h(`mateu-app-context-picker`)],ks);var As=class extends y{constructor(...e){super(...e),this.baseUrl=``,this.opened=!1,this.notifications=[],this.fetched=!1}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}updated(){!this.fetched&&this.app?.serverSideType&&(this.fetched=!0,this.refresh())}unreadCount(){return this.notifications.filter(e=>e.unread).length}async runNotificationsAction(e,t){let n=this.app;if(n?.serverSideType)try{let r=await Ge.runAction(this.baseUrl??``,n.rootRoute??n.initialRoute??``,``,e,`notification-bell`,void 0,n.serverSideType,{},t,this,!0);for(let e of r?.fragments??[]){let t=e.data?._notifications;if(Array.isArray(t)){this.notifications=t;return}}}catch{}}refresh(){return this.runNotificationsAction(`_notifications-list`,{})}markRead(e){return this.runNotificationsAction(`_notifications-read`,{ids:e})}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}openPanel(){this.opened||(this.opened=!0,this.refresh(),this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick))}closePanel(){this.detachOutsideClick(),this.opened=!1}async entryClicked(e){e.unread&&await this.markRead([e.id]);let t=e.route;if(t){if(!Ma.confirmLeave())return;this.closePanel(),this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0})),this.dispatchEvent(new CustomEvent(`navigate-to-requested`,{detail:{route:t},bubbles:!0,composed:!0}))}}renderEntry(e){return w`
+    `}};O([v()],Ms.prototype,`selector`,void 0),O([v()],Ms.prototype,`app`,void 0),O([v()],Ms.prototype,`baseUrl`,void 0),O([S()],Ms.prototype,`opened`,void 0),O([S()],Ms.prototype,`searchText`,void 0),O([S()],Ms.prototype,`searchedOptions`,void 0),Ms=js=O([h(`mateu-app-context-picker`)],Ms);var Ns=class extends y{constructor(...e){super(...e),this.baseUrl=``,this.opened=!1,this.notifications=[],this.fetched=!1}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}updated(){!this.fetched&&this.app?.serverSideType&&(this.fetched=!0,this.refresh())}unreadCount(){return this.notifications.filter(e=>e.unread).length}async runNotificationsAction(e,t){let n=this.app;if(n?.serverSideType)try{let r=await Ge.runAction(this.baseUrl??``,n.rootRoute??n.initialRoute??``,``,e,`notification-bell`,void 0,n.serverSideType,{},t,this,!0);for(let e of r?.fragments??[]){let t=e.data?._notifications;if(Array.isArray(t)){this.notifications=t;return}}}catch{}}refresh(){return this.runNotificationsAction(`_notifications-list`,{})}markRead(e){return this.runNotificationsAction(`_notifications-read`,{ids:e})}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}openPanel(){this.opened||(this.opened=!0,this.refresh(),this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick))}closePanel(){this.detachOutsideClick(),this.opened=!1}async entryClicked(e){e.unread&&await this.markRead([e.id]);let t=e.route;if(t){if(!Pa.confirmLeave())return;this.closePanel(),this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0})),this.dispatchEvent(new CustomEvent(`navigate-to-requested`,{detail:{route:t},bubbles:!0,composed:!0}))}}renderEntry(e){return w`
             <div role="button" tabindex="0" class="entry ${e.unread?`entry--unread`:``}"
                  @click="${()=>this.entryClicked(e)}" @keydown="${L(()=>this.entryClicked(e))}">
                 <span class="unread-dot" aria-hidden="true"></span>
@@ -7731,47 +7731,47 @@ ${i}
         }
     
         ${R}
-    `}};O([v()],As.prototype,`app`,void 0),O([v()],As.prototype,`baseUrl`,void 0),O([S()],As.prototype,`opened`,void 0),O([S()],As.prototype,`notifications`,void 0),As=O([h(`mateu-notification-bell`)],As);var js=e=>{if(!e||!(`querySelectorAll`in e))return null;for(let t of e.querySelectorAll(`*`)){if(t.tagName?.toLowerCase()===`mateu-component`)return t;let e=js(t.shadowRoot);if(e)return e}return null},Ms=async(e,t,n)=>{let r=js(t.renderRoot??t);await Vo.runAction(Ge,t.baseUrl??``,e.rootRoute||`_no_route`,``,n,r?.id??`app-header-action`,{},e.serverSideType??``,{},{},r??t,!0,void 0,!1,``)},Ns=async(e,t,n)=>{try{await Ms(e,t,n)}catch(e){pa({text:`La acción falló: `+e,position:`bottomStart`,duration:6e3,variant:`error`},t)}},Ps=(e,t)=>{let n=e.contextSelectors??[],r=e.contextActions??[];return n.length===0&&r.length===0&&!e.notificationsEnabled?_:w`${e.notificationsEnabled?w`
+    `}};O([v()],Ns.prototype,`app`,void 0),O([v()],Ns.prototype,`baseUrl`,void 0),O([S()],Ns.prototype,`opened`,void 0),O([S()],Ns.prototype,`notifications`,void 0),Ns=O([h(`mateu-notification-bell`)],Ns);var Ps=e=>{if(!e||!(`querySelectorAll`in e))return null;for(let t of e.querySelectorAll(`*`)){if(t.tagName?.toLowerCase()===`mateu-component`)return t;let e=Ps(t.shadowRoot);if(e)return e}return null},Fs=async(e,t,n)=>{let r=Ps(t.renderRoot??t);await Wo.runAction(Ge,t.baseUrl??``,e.rootRoute||`_no_route`,``,n,r?.id??`app-header-action`,{},e.serverSideType??``,{},{},r??t,!0,void 0,!1,``)},Is=async(e,t,n)=>{try{await Fs(e,t,n)}catch(e){ha({text:`La acción falló: `+e,position:`bottomStart`,duration:6e3,variant:`error`},t)}},Ls=(e,t)=>{let n=e.contextSelectors??[],r=e.contextActions??[];return n.length===0&&r.length===0&&!e.notificationsEnabled?_:w`${e.notificationsEnabled?w`
         <mateu-notification-bell .app="${e}" .baseUrl="${t.baseUrl??``}"></mateu-notification-bell>`:_}${n.map(n=>w`
         <mateu-app-context-picker .selector="${n}" .app="${e}" .baseUrl="${t.baseUrl??``}"></mateu-app-context-picker>`)}${r.map(n=>(n.children?.length??0)>0?w`
         <details class="mateu-nav-group" style="margin-left: 0.5rem; flex-shrink: 0;">
             <summary class="app-header-action-btn">${n.label} ▾</summary>
             <div class="mateu-nav-panel" style="right: 0; left: auto;">
                 ${n.children.map(n=>w`
-                    <button class="mateu-nav-item" @click="${()=>n.actionId&&Ns(e,t,n.actionId)}">${n.label}</button>`)}
+                    <button class="mateu-nav-item" @click="${()=>n.actionId&&Is(e,t,n.actionId)}">${n.label}</button>`)}
             </div>
         </details>`:w`
         <button class="app-header-action-btn" style="margin-left: 0.5rem; flex-shrink: 0;"
-            @click="${()=>n.actionId&&Ns(e,t,n.actionId)}" title="${n.label}">${n.icon?F(n.icon):_}${n.label}</button>`)}`},Fs=(e,t)=>w`
+            @click="${()=>n.actionId&&Is(e,t,n.actionId)}" title="${n.label}">${n.icon?F(n.icon):_}${n.label}</button>`)}`},Rs=(e,t)=>w`
     <button class="mateu-nav-item ${e.selected?`mateu-nav-item--active`:``}"
             ?disabled="${e.disabled}"
-            @click="${()=>t(e)}">${e.text}</button>`,Is=(e,t,n=``)=>w`
+            @click="${()=>t(e)}">${e.text}</button>`,zs=(e,t,n=``)=>w`
     <nav class="mateu-nav ${n}">
         ${e.map(e=>(e.children?.length??0)>0?w`<details class="mateu-nav-group">
                        <summary class="mateu-nav-item">${e.text} ▾</summary>
                        <div class="mateu-nav-panel">
-                           ${e.children.map(e=>Fs(e,t))}
+                           ${e.children.map(e=>Rs(e,t))}
                        </div>
-                   </details>`:Fs(e,t))}
-    </nav>`,Ls=(e,t)=>n=>t.call(e,{detail:{value:n}}),Rs=(e,t)=>e.themeToggle?w`
+                   </details>`:Rs(e,t))}
+    </nav>`,Bs=(e,t)=>n=>t.call(e,{detail:{value:n}}),Vs=(e,t)=>e.themeToggle?w`
         <button class="app-chrome-icon-btn" @click="${t.toggleTheme}"
             title="${t.isDark?`Switch to light mode`:`Switch to dark mode`}"
             style="margin-left: 0.5rem; margin-right: 0.5rem; flex-shrink: 0;">
             ${F(t.isDark?`vaadin:sun-o`:`vaadin:moon`,`color: var(--lumo-body-text-color);`)}
         </button>
-    `:_,zs=(e,t)=>{t.filter!=e.detail.value&&(t.filter=e.detail.value)},Bs=(e,t,n)=>{let r=Vs(e,t,n),i=Z(t,n);return r==`list`||r==i?`new`:r},Vs=(e,t,n)=>{let r=e?._route;if(r!=null&&(r===``||r.startsWith(`/`))){let e=n.homeRoute??``,i=e.indexOf(`?`),a=i>=0?e.substring(i+1):``,o=Z(t,n)+r;return a?o+(o.indexOf(`?`)>=0?`&`:`?`)+a:o}return t.selectedRoute?t.selectedRoute:n.homeRoute},Z=(e,t)=>e.selectedRoute?e.selectedConsumedRoute??t.route:t.homeConsumedRoute,Hs=(e,t)=>e.selectedRoute?e.selectedBaseUrl??e.baseUrl:t.homeBaseUrl,Us=(e,t)=>e.selectedRoute?e.selectedServerSideType??t.serverSideType:t.homeServerSideType,Ws=(e,t)=>e.selectedRoute?e.selectedUriPrefix:t.homeUriPrefix,Gs=(e,t,n,r,i,a,o)=>{if(t.chromeless)return w`
+    `:_,Hs=(e,t)=>{t.filter!=e.detail.value&&(t.filter=e.detail.value)},Us=(e,t,n)=>{let r=Ws(e,t,n),i=X(t,n);return r==`list`||r==i?`new`:r},Ws=(e,t,n)=>{let r=e?._route;if(r!=null&&(r===``||r.startsWith(`/`))){let e=n.homeRoute??``,i=e.indexOf(`?`),a=i>=0?e.substring(i+1):``,o=X(t,n)+r;return a?o+(o.indexOf(`?`)>=0?`&`:`?`)+a:o}return t.selectedRoute?t.selectedRoute:n.homeRoute},X=(e,t)=>e.selectedRoute?e.selectedConsumedRoute??t.route:t.homeConsumedRoute,Gs=(e,t)=>e.selectedRoute?e.selectedBaseUrl??e.baseUrl:t.homeBaseUrl,Ks=(e,t)=>e.selectedRoute?e.selectedServerSideType??t.serverSideType:t.homeServerSideType,qs=(e,t)=>e.selectedRoute?e.selectedUriPrefix:t.homeUriPrefix,Js=(e,t,n,r,i,a,o)=>{if(t.chromeless)return w`
             <div class="app chromeless">
                 <div role="main" class="${`app-content`+(e.pageCompact?` no-padding`:``)}" style="height: 100%;">
                     <div class="m-md">
                         <div class="m-scroll" style="height: 100%;">
                             <mateu-api-caller>
                                 <mateu-ux
-                                        route="${Vs(r,e,t)}"
+                                        route="${Ws(r,e,t)}"
                                         id="ux_${e.id}"
-                                        baseUrl="${Hs(e,t)}"
-                                        consumedRoute="${Z(e,t)}"
-                                        serverSideType="${Us(e,t)}"
-                                        uriPrefix="${Ws(e,t)}"
+                                        baseUrl="${Gs(e,t)}"
+                                        consumedRoute="${X(e,t)}"
+                                        serverSideType="${Ks(e,t)}"
+                                        uriPrefix="${qs(e,t)}"
                                         style="width: 100%;"
                                         .appState="${a}"
                                         .appData="${o}"
@@ -7785,7 +7785,7 @@ ${i}
                 </div>
                 <slot></slot>
             </div>
-        `;let s=e.mapItems(t.menu,e.filter?.toLowerCase()??``),c=Z(e,t),l=Bs(r,e,t),u=l&&l!==`new`&&l.startsWith(c+`/`)?l.substring(c.length+1).split(`/`)[0]:void 0;return w`
+        `;let s=e.mapItems(t.menu,e.filter?.toLowerCase()??``),c=X(e,t),l=Us(r,e,t),u=l&&l!==`new`&&l.startsWith(c+`/`)?l.substring(c.length+1).split(`/`)[0]:void 0;return w`
                     ${t.variant==qe.MEDIATOR?w`
 
                         ${t.layout==`SPLIT`?w`
@@ -7793,12 +7793,12 @@ ${i}
                                 <mateu-api-caller>
                                     <div style="display: block; width: calc(100% - 1rem);">
                                     <mateu-ux
-                                            route="${Z(e,t)}"
+                                            route="${X(e,t)}"
                                             id="ux_${e.id}"
-                                            baseUrl="${Hs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Us(e,t)}"
-                                            uriPrefix="${Ws(e,t)}"
+                                            baseUrl="${Gs(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Ks(e,t)}"
+                                            uriPrefix="${qs(e,t)}"
                                             style="width: 100%;"
                                             .appState="${{...a,_splitDetailId:u}}"
                                             .appData="${o}"
@@ -7810,12 +7810,12 @@ ${i}
                                 <mateu-api-caller slot="detail">
                                     <div style="padding-left: 1rem; width: calc(100% - 1rem);">
                                     <mateu-ux
-                                            route="${Bs(r,e,t)}"
+                                            route="${Us(r,e,t)}"
                                             id="ux_${e.id}_detail"
-                                            baseUrl="${Hs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Us(e,t)}"
-                                            uriPrefix="${Ws(e,t)}"
+                                            baseUrl="${Gs(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Ks(e,t)}"
+                                            uriPrefix="${qs(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -7829,12 +7829,12 @@ ${i}
                         `:w`
                             <mateu-api-caller>
                                 <mateu-ux
-                                        route="${Vs(r,e,t)}"
+                                        route="${Ws(r,e,t)}"
                                         id="ux_${e.id}"
-                                        baseUrl="${Hs(e,t)}"
-                                        consumedRoute="${Z(e,t)}"
-                                        serverSideType="${Us(e,t)}"
-                                        uriPrefix="${Ws(e,t)}"
+                                        baseUrl="${Gs(e,t)}"
+                                        consumedRoute="${X(e,t)}"
+                                        serverSideType="${Ks(e,t)}"
+                                        uriPrefix="${qs(e,t)}"
                                         style="width: 100%;"
                                         .appState="${a}"
                                         .appData="${o}"
@@ -7856,7 +7856,7 @@ ${i}
                         <h2 style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; margin: 0 .5rem;">${t.title}</h2><p style="margin: 0;">${t.subtitle}</p>
                         <div class="m-hl" style="margin-left: auto; align-items: center;">
                             <slot name="widgets"></slot>
-                            ${Ps(t,e)}${Rs(t,e)}
+                            ${Ls(t,e)}${Vs(t,e)}
                         </div>
                     </header>
                     <div class="app-body">
@@ -7864,7 +7864,7 @@ ${i}
                             ${t.menu&&t.totalMenuOptions>10?w`
                                 <div style="position: sticky; top: 0; z-index: 2; background: var(--lumo-base-color); padding: .25rem 0 .5rem;">
                                     <input class="drawer-search" placeholder="Search…" style="width: calc(100% - 20px); margin: 0 10px;"
-                                           @input="${t=>zs({detail:{value:t.target.value}},e)}">
+                                           @input="${t=>Hs({detail:{value:t.target.value}},e)}">
                                 </div>
                                 `:_}
                             <nav class="side-nav">
@@ -7876,12 +7876,12 @@ ${i}
                                 <div class="m-scroll" style="height: 100%;">
                                     <mateu-api-caller>
                                         <mateu-ux
-                                                route="${Vs(r,e,t)}"
+                                                route="${Ws(r,e,t)}"
                                                 id="ux_${e.id}"
-                                                baseUrl="${Hs(e,t)}"
-                                                consumedRoute="${Z(e,t)}"
-                                                serverSideType="${Us(e,t)}"
-                                                uriPrefix="${Ws(e,t)}"
+                                                baseUrl="${Gs(e,t)}"
+                                                consumedRoute="${X(e,t)}"
+                                                serverSideType="${Ks(e,t)}"
+                                                uriPrefix="${qs(e,t)}"
                                                 style="width: 100%;"
                                                 .appState="${a}"
                                                 .appData="${o}"
@@ -7910,10 +7910,10 @@ ${i}
                             ${t.title?w`<h2 style="margin: 0 var(--lumo-space-l, 1.5rem) 0 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;">${t.title}</h2>`:_}
                         </div>
                         </a>
-                        ${(()=>{let t=Ls(e,e.itemSelected);return N.get()?.renderTopNav?.(s,t,`menu-on-top`)??Is(s,t,`menu-on-top`)})()}
+                        ${(()=>{let t=Bs(e,e.itemSelected);return N.get()?.renderTopNav?.(s,t,`menu-on-top`)??zs(s,t,`menu-on-top`)})()}
                         <div class="m-hl" style="margin-left: auto; flex-shrink: 0; align-items: center;">
                             <slot name="widgets"></slot>
-                            ${Ps(t,e)}${Rs(t,e)}
+                            ${Ls(t,e)}${Vs(t,e)}
                         </div>
                     </div>
                     <div style="flex: 1; min-height: 0; overflow-y: auto; overflow-x: hidden; box-sizing: border-box; width: 100%;">
@@ -7921,12 +7921,12 @@ ${i}
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${Vs(r,e,t)}"
+                                            route="${Ws(r,e,t)}"
                                             id="ux_${e.id}"
-                                            baseUrl="${Hs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Us(e,t)}"
-                                            uriPrefix="${Ws(e,t)}"
+                                            baseUrl="${Gs(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Ks(e,t)}"
+                                            uriPrefix="${qs(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -7954,10 +7954,10 @@ ${i}
                             ${t.title?w`<h2 style="margin: 0 var(--lumo-space-l, 1.5rem) 0 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;">${t.title}</h2>`:_}
                         </div>
                         </a>
-                        ${Is(e.mapItemsForTiles(t.menu),Ls(e,e.itemSelectedTiles),`menu-on-top`)}
+                        ${zs(e.mapItemsForTiles(t.menu),Bs(e,e.itemSelectedTiles),`menu-on-top`)}
                         <div class="m-hl" style="margin-left: auto; flex-shrink: 0; align-items: center;">
                             <slot name="widgets"></slot>
-                            ${Ps(t,e)}${Rs(t,e)}
+                            ${Ls(t,e)}${Vs(t,e)}
                         </div>
                     </div>
                     <div style="flex: 1; min-height: 0; overflow-y: auto; overflow-x: hidden; box-sizing: border-box; width: 100%;">
@@ -7966,12 +7966,12 @@ ${i}
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${Vs(r,e,t)}"
+                                            route="${Ws(r,e,t)}"
                                             id="ux_${e.id}"
-                                            baseUrl="${Hs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Us(e,t)}"
-                                            uriPrefix="${Ws(e,t)}"
+                                            baseUrl="${Gs(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Ks(e,t)}"
+                                            uriPrefix="${qs(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -7996,12 +7996,12 @@ ${i}
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${Vs(r,e,t)}"
+                                            route="${Ws(r,e,t)}"
                                             id="ux_${e.id}"
-                                            baseUrl="${Hs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Us(e,t)}"
-                                            uriPrefix="${Ws(e,t)}"
+                                            baseUrl="${Gs(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Ks(e,t)}"
+                                            uriPrefix="${qs(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -8023,7 +8023,7 @@ ${i}
                         <div class="m-vl"
                                 @navigation-requested="${e.updateRoute}">
                             ${t.menu.map(t=>e.renderOptionOnLeftMenu(t))}
-                            ${Ps(t,e)}${Rs(t,e)}
+                            ${Ls(t,e)}${Vs(t,e)}
                         </div>
                     </div>
                     <div role="main" class="${`app-content`+(e.pageCompact?` no-padding`:``)}">
@@ -8031,12 +8031,12 @@ ${i}
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${Vs(r,e,t)}"
+                                            route="${Ws(r,e,t)}"
                                             id="ux_${e.id}"
-                                            baseUrl="${Hs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Us(e,t)}"
-                                            uriPrefix="${Ws(e,t)}"
+                                            baseUrl="${Gs(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Ks(e,t)}"
+                                            uriPrefix="${qs(e,t)}"
                                             style="width: 100%; padding: 1em;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -8080,7 +8080,7 @@ ${i}
                             </nav>
                             <div class="m-hl" style="flex-shrink: 0; align-items: center;">
                                 <slot name="widgets"></slot>
-                                ${Ps(t,e)}${Rs(t,e)}
+                                ${Ls(t,e)}${Vs(t,e)}
                             </div>
                         </div>
                     </div>
@@ -8089,12 +8089,12 @@ ${i}
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${Vs(r,e,t)}"
+                                            route="${Ws(r,e,t)}"
                                             id="ux_${e.id}"
-                                            baseUrl="${Hs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Us(e,t)}"
-                                            uriPrefix="${Ws(e,t)}"
+                                            baseUrl="${Gs(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Ks(e,t)}"
+                                            uriPrefix="${qs(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -8124,7 +8124,7 @@ ${i}
             `:_}
             ${e.renderCommandPalette()}
             <slot></slot>
-       `},Ks=(e,t)=>t!=null&&e!=null&&!e.has(t),qs=typeof HTMLElement<`u`?HTMLElement:class{},Js=class extends qs{static get observedAttributes(){return[`type`,`renderer`]}connectedCallback(){this.render()}attributeChangedCallback(){this.render()}render(){let e=this.getAttribute(`type`)??`unknown`,t=this.getAttribute(`renderer`)??`unknown`;this.shadowRoot||this.attachShadow({mode:`open`}),this.shadowRoot.innerHTML=`
+       `},Ys=(e,t)=>t!=null&&e!=null&&!e.has(t),Xs=typeof HTMLElement<`u`?HTMLElement:class{},Zs=class extends Xs{static get observedAttributes(){return[`type`,`renderer`]}connectedCallback(){this.render()}attributeChangedCallback(){this.render()}render(){let e=this.getAttribute(`type`)??`unknown`,t=this.getAttribute(`renderer`)??`unknown`;this.shadowRoot||this.attachShadow({mode:`open`}),this.shadowRoot.innerHTML=`
             <style>
                 :host { display: block; }
                 .mateu-unsupported {
@@ -8143,12 +8143,12 @@ ${i}
             <div class="mateu-unsupported" role="note">
                 ⚠ Component “${e}” is not supported by the “${t}” renderer yet.
             </div>
-        `}};typeof customElements<`u`&&!customElements.get(`mateu-unsupported`)&&customElements.define(`mateu-unsupported`,Js);var Ys=new Set,Xs=(e,t,n)=>{let r=`${n}/${t}`;return Ys.has(r)||(Ys.add(r),console.warn(`[mateu] Component type "${t}" is not supported by the "${n}" renderer — rendering <mateu-unsupported> placeholder.`)),w`<mateu-unsupported
+        `}};typeof customElements<`u`&&!customElements.get(`mateu-unsupported`)&&customElements.define(`mateu-unsupported`,Zs);var Qs=new Set,$s=(e,t,n)=>{let r=`${n}/${t}`;return Qs.has(r)||(Qs.add(r),console.warn(`[mateu] Component type "${t}" is not supported by the "${n}" renderer — rendering <mateu-unsupported> placeholder.`)),w`<mateu-unsupported
             type="${t}"
             renderer="${n}"
             data-component-id="${e?.id??_}"
             slot="${e?.slot??_}"
-    ></mateu-unsupported>`},Zs=class{renderFilterBar(e,t,n,r,i,a,o,s){let c=t?.metadata;return w`
+    ></mateu-unsupported>`},ec=class{renderFilterBar(e,t,n,r,i,a,o,s){let c=t?.metadata;return w`
             <mateu-filter-bar
                 .metadata="${c}"
                 @search-requested="${e.search}"
@@ -8171,14 +8171,14 @@ ${i}
                 data-testid="pagination"
                 .pageNumber="${e.data[t?.id]?.page?.pageNumber??0}"
         ></mateu-pagination>
-        `}renderTableComponent(e,t,n,r,i,a,o){return bn(t,(e.data?.[e.id])?.page?.content??[],r[t?.id]?.emptyStateMessage)}rendererName(){return this.constructor?.name??`unknown`}supportedClientSideTypes(){}renderClientSideComponent(e,t,n,r,i,a,o,s){let c=t?.metadata?.type??t?.type,l=Object.values(A).includes(c)?c:void 0;return Ks(this.supportedClientSideTypes(),l)?Xs(t,l,this.rendererName()):sa(e,t,n,r,i,a,o,s)}renderAppComponent(e,t,n,r,i,a,o){return Gs(e,t?.metadata,n,r,i,a,o)}},Qs=(e,t,n,r,i,a,o)=>w`
+        `}renderTableComponent(e,t,n,r,i,a,o){return Sn(t,(e.data?.[e.id])?.page?.content??[],r[t?.id]?.emptyStateMessage)}rendererName(){return this.constructor?.name??`unknown`}supportedClientSideTypes(){}renderClientSideComponent(e,t,n,r,i,a,o,s){let c=t?.metadata?.type??t?.type,l=Object.values(A).includes(c)?c:void 0;return Ys(this.supportedClientSideTypes(),l)?$s(t,l,this.rendererName()):la(e,t,n,r,i,a,o,s)}renderAppComponent(e,t,n,r,i,a,o){return Js(e,t?.metadata,n,r,i,a,o)}},tc=(e,t,n,r,i,a,o)=>w`
         <vaadin-virtual-list
                 .items="${t.metadata.page.content}"
                 ${ne(t=>w`${P(e,t,n,r,i,a,o)}`,[])}
                 style="${t.style}" class="${t.cssClasses}"
                 slot="${t.slot??_}"
         ></vaadin-virtual-list>
-    `,$s=e=>{let t=e.metadata;return w`
+    `,nc=e=>{let t=e.metadata;return w`
         <vaadin-notification
                 .opened="${!0}"
                 slot="${e.slot??_}"
@@ -8191,7 +8191,7 @@ ${i}
                     </vaadin-horizontal-layout>
                 `,[])}
         ></vaadin-notification>
-    `},ec=(e,t={})=>{let n=e.metadata,r=n.valueKey?t[n.valueKey]:n.value;return w`
+    `},rc=(e,t={})=>{let n=e.metadata,r=n.valueKey?t[n.valueKey]:n.value;return w`
         <div style="${e.style}">
         <vaadin-progress-bar
                 ?indeterminate="${n.indeterminate}"
@@ -8206,7 +8206,7 @@ ${i}
     ${n.text}
   </span>`:_}
         </div>
-    `},tc=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+    `},ic=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <vaadin-details
                 ?opened="${s.opened}"
                 style="${t.style}"
@@ -8218,17 +8218,17 @@ ${i}
             </vaadin-details-summary>
             ${P(e,s.content,n,r,i,a,o)}
         </vaadin-details>
-            `},nc=(e,t,n)=>{let r=e.metadata;return w`<vaadin-avatar
+            `},ac=(e,t,n)=>{let r=e.metadata;return w`<vaadin-avatar
             img="${r.image}"
             name="${M(r.name,t,n)}"
             abbr="${r.abbreviation}"
             style="${e.style}" class="${e.cssClasses}"
             slot="${e.slot??_}"
-    ></vaadin-avatar>`},rc=e=>{let t=e.metadata;return w`<vaadin-avatar-group max-items-visible="${t.maxItemsVisible}"
+    ></vaadin-avatar>`},oc=e=>{let t=e.metadata;return w`<vaadin-avatar-group max-items-visible="${t.maxItemsVisible}"
                                      .items="${t.avatars}"
                                      style="${e.style}" class="${e.cssClasses}"
                                      slot="${e.slot??_}">
-    </vaadin-avatar-group>`},ic=(e,t,n,r,i,a,o)=>{let s=t.metadata;if(!s)return w``;let c=``;return s.variants?.map(e=>e==`stretchMedia`?`stretch-media`:e==`coverMedia`?`cover-media`:e).forEach(e=>c+=` `+e),c=c.trim(),w`
+    </vaadin-avatar-group>`},sc=(e,t,n,r,i,a,o)=>{let s=t.metadata;if(!s)return w``;let c=``;return s.variants?.map(e=>e==`stretchMedia`?`stretch-media`:e==`coverMedia`?`cover-media`:e).forEach(e=>c+=` `+e),c=c.trim(),w`
         <vaadin-card
                 style="${t.style}"
                 class="${t.cssClasses}"
@@ -8244,7 +8244,7 @@ ${i}
             ${s.footer?mt(e,s.footer,n,r,i,a,o,`footer`,!1):_}
             ${s.content?P(e,s.content,n,r,i,a,o,!1):_}
         </vaadin-card>
-    `},ac=e=>e>0&&e<640?`accordion`:`tabs`,oc=class extends y{constructor(...e){super(...e),this.tabLabels=[],this.mode=`tabs`,this.selected=0,this.selectedChangedListener=e=>{let t=e.detail?.value;typeof t==`number`&&t>=0&&(this.selected=t)}}connectedCallback(){super.connectedCallback(),this.resizeObserver=new ResizeObserver(e=>{for(let t of e)this.mode=ac(t.contentRect.width)}),this.resizeObserver.observe(this)}disconnectedCallback(){super.disconnectedCallback(),this.resizeObserver?.disconnect(),this.resizeObserver=void 0,this.detachTabsListener()}detachTabsListener(){this.slottedTabs?.removeEventListener(`selected-changed`,this.selectedChangedListener),this.slottedTabs=void 0}tabsSlotChanged(e){this.detachTabsListener();let t=e.target.assignedElements().find(e=>`selected`in e);t&&(this.slottedTabs=t,t.addEventListener(`selected-changed`,this.selectedChangedListener),t.selected=this.selected)}select(e){this.selected=e,this.slottedTabs&&(this.slottedTabs.selected=e)}updated(){this.slottedTabs&&this.slottedTabs.selected!=this.selected&&(this.slottedTabs.selected=this.selected)}static{this.styles=m`
+    `},cc=e=>e>0&&e<640?`accordion`:`tabs`,lc=class extends y{constructor(...e){super(...e),this.tabLabels=[],this.mode=`tabs`,this.selected=0,this.selectedChangedListener=e=>{let t=e.detail?.value;typeof t==`number`&&t>=0&&(this.selected=t)}}connectedCallback(){super.connectedCallback(),this.resizeObserver=new ResizeObserver(e=>{for(let t of e)this.mode=cc(t.contentRect.width)}),this.resizeObserver.observe(this)}disconnectedCallback(){super.disconnectedCallback(),this.resizeObserver?.disconnect(),this.resizeObserver=void 0,this.detachTabsListener()}detachTabsListener(){this.slottedTabs?.removeEventListener(`selected-changed`,this.selectedChangedListener),this.slottedTabs=void 0}tabsSlotChanged(e){this.detachTabsListener();let t=e.target.assignedElements().find(e=>`selected`in e);t&&(this.slottedTabs=t,t.addEventListener(`selected-changed`,this.selectedChangedListener),t.selected=this.selected)}select(e){this.selected=e,this.slottedTabs&&(this.slottedTabs.selected=e)}updated(){this.slottedTabs&&this.slottedTabs.selected!=this.selected&&(this.slottedTabs.selected=this.selected)}static{this.styles=m`
         :host {
             display: block;
         }
@@ -8328,7 +8328,7 @@ ${i}
                     `)}
                 </div>
             `}
-        `}};O([v({type:Array})],oc.prototype,`tabLabels`,void 0),O([S()],oc.prototype,`mode`,void 0),O([S()],oc.prototype,`selected`,void 0),oc=O([h(`mateu-adaptive-tabs`)],oc);var sc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;c??=``,s.columnSpacing&&(c+=`--vaadin-form-layout-column-spacing: `+s.columnSpacing+`;`);let l=s.itemRowSpacing&&s.itemRowSpacing!==`0`?s.itemRowSpacing:`var(--lumo-space-m)`;return c+=`--vaadin-form-layout-row-spacing: `+l+`;`,s.itemLabelSpacing&&(c+=`--vaadin-form-layout-label-spacing: `+s.itemLabelSpacing+`;`),s.labelsAside&&(c+=`--vaadin-form-item-label-width: 10rem;`),s.fullWidth&&(c+=`width: 100%;`),w`
+        `}};O([v({type:Array})],lc.prototype,`tabLabels`,void 0),O([S()],lc.prototype,`mode`,void 0),O([S()],lc.prototype,`selected`,void 0),lc=O([h(`mateu-adaptive-tabs`)],lc);var uc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;c??=``,s.columnSpacing&&(c+=`--vaadin-form-layout-column-spacing: `+s.columnSpacing+`;`);let l=s.itemRowSpacing&&s.itemRowSpacing!==`0`?s.itemRowSpacing:`var(--lumo-space-m)`;return c+=`--vaadin-form-layout-row-spacing: `+l+`;`,s.itemLabelSpacing&&(c+=`--vaadin-form-layout-label-spacing: `+s.itemLabelSpacing+`;`),s.labelsAside&&(c+=`--vaadin-form-item-label-width: 10rem;`),s.fullWidth&&(c+=`width: 100%;`),w`
                <vaadin-form-layout 
                        .responsiveSteps="${s.responsiveSteps||_}"  
                        style="${c||_}" 
@@ -8341,18 +8341,18 @@ ${i}
                        labels-aside="${s.labelsAside||_}"
                        slot="${t.slot||_}"
                >
-                   ${t.children?.map(t=>cc(s,e,t,n,r,i,a,o))}
+                   ${t.children?.map(t=>dc(s,e,t,n,r,i,a,o))}
                </vaadin-form-layout>
-            `},cc=(e,t,n,r,i,a,o,s)=>n.type==k.ClientSide&&n.metadata?.type==A.FormRow?uc(e,t,n,r,i,a,o,s):e.labelsAside?lc(t,n,r,i,a,o,s):P(t,n,r,i,a,o,s),lc=(e,t,n,r,i,a,o)=>{if(t.type==k.ClientSide&&t.metadata?.type==A.FormField&&t.metadata.label){let s=t.metadata,c=s.label?.includes("${")?e._evalTemplate(s.label):s.label;return w`
+            `},dc=(e,t,n,r,i,a,o,s)=>n.type==k.ClientSide&&n.metadata?.type==A.FormRow?pc(e,t,n,r,i,a,o,s):e.labelsAside?fc(t,n,r,i,a,o,s):P(t,n,r,i,a,o,s),fc=(e,t,n,r,i,a,o)=>{if(t.type==k.ClientSide&&t.metadata?.type==A.FormField&&t.metadata.label){let s=t.metadata,c=s.label?.includes("${")?e._evalTemplate(s.label):s.label;return w`
                        <vaadin-form-item data-colspan="${s.colspan}">
                            <label slot="label">${c}</label>
                            ${P(e,t,n,r,i,a,o,!0)}
                        </vaadin-form-item>
-                   `}return P(e,t,n,r,i,a,o)},uc=(e,t,n,r,i,a,o,s)=>w`
+                   `}return P(e,t,n,r,i,a,o)},pc=(e,t,n,r,i,a,o,s)=>w`
         <vaadin-form-row>
-            ${n.children?.map(n=>cc(e,t,n,r,i,a,o,s))}
+            ${n.children?.map(n=>dc(e,t,n,r,i,a,o,s))}
         </vaadin-form-row>
-            `,dc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=(s.padding?` padding`:``)+(s.spacing?` spacing`:``)+(s.spacingVariant?` spacing-`+s.spacingVariant:``)+(s.wrap?` wrap`:``),l=t.style;return s.fullWidth&&(l=l?`width: 100%;`+l:`width: 100%;`),s.justification&&(l=l?`justify-content: `+s.justification+`;`+l:`justify-content: `+s.justification+`;`),s.verticalAlignment&&(l=l?`align-items: `+s.verticalAlignment+`;`+l:`align-items: `+s.verticalAlignment+`;`),w`
+            `,mc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=(s.padding?` padding`:``)+(s.spacing?` spacing`:``)+(s.spacingVariant?` spacing-`+s.spacingVariant:``)+(s.wrap?` wrap`:``),l=t.style;return s.fullWidth&&(l=l?`width: 100%;`+l:`width: 100%;`),s.justification&&(l=l?`justify-content: `+s.justification+`;`+l:`justify-content: `+s.justification+`;`),s.verticalAlignment&&(l=l?`align-items: `+s.verticalAlignment+`;`+l:`align-items: `+s.verticalAlignment+`;`),w`
                <vaadin-horizontal-layout 
                        style="${l}" 
                        class="${t.cssClasses}"
@@ -8361,7 +8361,7 @@ ${i}
                >
                    ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
                </vaadin-horizontal-layout>
-            `},fc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=(s.padding?` padding`:``)+(s.spacing?` spacing`:``)+(s.spacingVariant?` spacing-`+s.spacingVariant:``)+(s.wrap?` wrap`:``),l=t.style;return s.fullWidth&&(l=l?`width: 100%;`+l:`width: 100%;`),s.justification&&(l=l?`justify-content: `+s.justification+`;`+l:`justify-content: `+s.justification+`;`),s.horizontalAlignment&&(l=l?`align-items: `+s.horizontalAlignment+`;`+l:`align-items: `+s.horizontalAlignment+`;`),w`
+            `},hc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=(s.padding?` padding`:``)+(s.spacing?` spacing`:``)+(s.spacingVariant?` spacing-`+s.spacingVariant:``)+(s.wrap?` wrap`:``),l=t.style;return s.fullWidth&&(l=l?`width: 100%;`+l:`width: 100%;`),s.justification&&(l=l?`justify-content: `+s.justification+`;`+l:`justify-content: `+s.justification+`;`),s.horizontalAlignment&&(l=l?`align-items: `+s.horizontalAlignment+`;`+l:`align-items: `+s.horizontalAlignment+`;`),w`
         <vaadin-vertical-layout
                 style="${l}"
                 class="${t.cssClasses}"
@@ -8370,7 +8370,7 @@ ${i}
         >
             ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </vaadin-vertical-layout>
-    `},pc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;return s.fullWidth&&(c=c?`width: 100%;`+c:`width: 100%;`),w`
+    `},gc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;return s.fullWidth&&(c=c?`width: 100%;`+c:`width: 100%;`),w`
                <vaadin-split-layout 
                        style="${c}" 
                        class="${t.cssClasses}"
@@ -8381,7 +8381,7 @@ ${i}
                    <master-content>${P(e,t.children[0],n,r,i,a,o)}</master-content>
                    <detail-content>${P(e,t.children[1],n,r,i,a,o)}</detail-content>
                </vaadin-split-layout>
-            `},mc=(e,t,n,r,i,a,o)=>{let s=t.children&&t.children.length>1?t.children[1]:null,c=i?.detailComponent??null,l=!!i?.hasDetail||!!s,u=c??s;return w`
+            `},_c=(e,t,n,r,i,a,o)=>{let s=t.children&&t.children.length>1?t.children[1]:null,c=i?.detailComponent??null,l=!!i?.hasDetail||!!s,u=c??s;return w`
                <vaadin-master-detail-layout ?has-detail="${l}"
                                             style="${t.style}"
                                             class="${t.cssClasses}"
@@ -8389,7 +8389,7 @@ ${i}
                    <div>${P(e,t.children[0],n,r,i,a,o)}</div>
                    ${l&&u?w`<div slot="detail">${P(e,u,n,r,i,a,o)}</div>`:w`<div slot="detail" style="display: flex; align-items: center; justify-content: center; height: 100%; color: var(--lumo-secondary-text-color); font-size: var(--lumo-font-size-s);">Select an item to view details</div>`}
                </vaadin-master-detail-layout>
-            `},hc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;c??=``,s.fullWidth&&(c+=`width: 100%;`);let l=s.variant;l==`equalWidth`&&(l=`equal-width-tabs`);let u=Math.max(0,(t.children??[]).findIndex(e=>e.metadata.active)),d=e=>{e.target.selected=u};if(s.adaptable){let u=(t.children??[]).map(t=>{let n=t.metadata.label;return n?.includes("${")?e._evalTemplate(n):n});return w`
+            `},vc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;c??=``,s.fullWidth&&(c+=`width: 100%;`);let l=s.variant;l==`equalWidth`&&(l=`equal-width-tabs`);let u=Math.max(0,(t.children??[]).findIndex(e=>e.metadata.active)),d=e=>{e.target.selected=u};if(s.adaptable){let u=(t.children??[]).map(t=>{let n=t.metadata.label;return n?.includes("${")?e._evalTemplate(n):n});return w`
             <mateu-adaptive-tabs
                     .tabLabels="${u}"
                     style="${c}"
@@ -8434,22 +8434,22 @@ ${i}
                     >${r}</vaadin-tab>`})}
             </vaadin-tabs>
 
-            ${t.children?.map(t=>gc(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>yc(e,t,n,r,i,a,o))}
         </vaadin-tabsheet>
-            `},gc=(e,t,n,r,i,a,o)=>{let s=t.metadata.label;return w`
+            `},yc=(e,t,n,r,i,a,o)=>{let s=t.metadata.label;return w`
         <div tab="${s?.includes("${")?e._evalTemplate(s):s}" style="padding: var(--lumo-space-m) 0;">
                    ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
                </div>
-            `},_c=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;s.fullWidth&&(c=c?`width: 100%;`+c:`width: 100%;`);let l=0;if(t.children){for(let e=0;e<t.children.length;e++)if(t.children[e].metadata?.active){l=e;break}}return w`
+            `},bc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;s.fullWidth&&(c=c?`width: 100%;`+c:`width: 100%;`);let l=0;if(t.children){for(let e=0;e<t.children.length;e++)if(t.children[e].metadata?.active){l=e;break}}return w`
                <vaadin-accordion
                        style="${t.style}"
                        class="${t.cssClasses}"
                        opened="${l}"
                        slot="${t.slot??_}"
                >
-                   ${t.children?.map(t=>vc(e,t,n,r,i,a,o,s.variant))}
+                   ${t.children?.map(t=>xc(e,t,n,r,i,a,o,s.variant))}
                </vaadin-accordion>
-            `},vc=(e,t,n,r,i,a,o,s)=>{let c=t.metadata,l=c.label?.includes("${")?e._evalTemplate(c.label):c.label;return w`
+            `},xc=(e,t,n,r,i,a,o,s)=>{let c=t.metadata,l=c.label?.includes("${")?e._evalTemplate(c.label):c.label;return w`
         <vaadin-accordion-panel style="${t.style}"
                                 class="${t.cssClasses}"
                                 theme="${s??_}"
@@ -8458,48 +8458,48 @@ ${i}
             <vaadin-accordion-heading slot="summary">${l}</vaadin-accordion-heading>
             ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </vaadin-accordion-panel>
-            `},yc=(e,t,n,r,i,a,o)=>w`
+            `},Sc=(e,t,n,r,i,a,o)=>w`
                <vaadin-scroller style="${t.style}" 
                                 class="${t.cssClasses}"
                                 slot="${t.slot??_}">
                    ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
                </vaadin-scroller>
-            `,bc=(e,t,n,r,i,a,o)=>w`
+            `,Cc=(e,t,n,r,i,a,o)=>w`
         <vaadin-board style="${t.style}" 
                       class="${t.cssClasses}"
                       slot="${t.slot??_}">
             ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </vaadin-board>
-            `,xc=(e,t,n,r,i,a,o)=>w`
+            `,wc=(e,t,n,r,i,a,o)=>w`
         <vaadin-board-row style="${t.style}" class="${t.cssClasses}">
                    ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
                </vaadin-board-row>
-            `,Sc=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+            `,Tc=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <div style="${t.style}" 
              class="${t.cssClasses}"
              board-cols="${s.boardCols??_}"
         >
                    ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
                </div>
-            `},Cc=(e,t,n)=>w`
+            `},Ec=(e,t,n)=>w`
     <vaadin-menu-bar
         .items=${e}
         class="${n??_}"
         @item-selected=${e=>t(e.detail.value)}>
-    </vaadin-menu-bar>`,wc=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
-        <vaadin-context-menu .items=${Dc(e,s.menu,n,r,i,a,o)} 
+    </vaadin-menu-bar>`,Dc=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+        <vaadin-context-menu .items=${Ac(e,s.menu,n,r,i,a,o)} 
                              style="${t.style}" 
                              class="${t.cssClasses}"
                              open-on="${s.activateOnLeftClick?`click`:_}"
                              slot="${t.slot??_}">
             ${P(e,s.wrapped,n,r,i,a,o)}
         </vaadin-context-menu>
-            `},Tc=(e,t,n,r,i)=>{let a=t.metadata;return w`
-        <vaadin-menu-bar .items=${Dc(e,a.options,n,r,i,D,de)}
+            `},Oc=(e,t,n,r,i)=>{let a=t.metadata;return w`
+        <vaadin-menu-bar .items=${Ac(e,a.options,n,r,i,D,de)}
                          style="${t.style}" class="${t.cssClasses}"
                          slot="${t.slot??_}">
         </vaadin-menu-bar>
-            `},Ec=(e,t,n,r,i,a,o)=>{let s=document.createElement(`vaadin-context-menu-item`);return ie(P(e,t,n,r,i,a,o),s),s},Dc=(e,t,n,r,i,a,o)=>t.map(t=>t.submenus?{text:t.component?void 0:t.label,route:t.path,checked:t.selected,disabled:t.disabled,className:t.className,component:t.component?Ec(e,t.component,n,r,i,a,o):void 0,children:Dc(e,t.submenus,n,r,i,a,o)}:t.separator?{component:`hr`}:{text:t.component?void 0:t.label,route:t.path,checked:t.selected,disabled:t.disabled,className:t.className,component:t.component?Ec(e,t.component,n,r,i,a,o):void 0}),Oc=class extends y{constructor(...e){super(...e),this.fieldId=``,this.signing=!1,this.hasStrokes=!1,this.drawing=!1,this.startStroke=e=>{let t=e.target;this.ensureCanvasSize(t),t.setPointerCapture(e.pointerId),this.drawing=!0;let n=t.getContext(`2d`);n.lineWidth=2,n.lineCap=`round`,n.lineJoin=`round`,n.strokeStyle=getComputedStyle(this).getPropertyValue(`--lumo-body-text-color`)||`#1a1a1a`;let[r,i]=this.pointerPosition(e);n.beginPath(),n.moveTo(r,i),e.preventDefault()},this.stroke=e=>{if(!this.drawing)return;let t=e.target.getContext(`2d`),[n,r]=this.pointerPosition(e);t.lineTo(n,r),t.stroke(),this.hasStrokes=!0,e.preventDefault()},this.endStroke=e=>{this.drawing=!1,e.target.releasePointerCapture(e.pointerId)}}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}canvas(){return this.renderRoot.querySelector(`canvas`)}pointerPosition(e){let t=e.target.getBoundingClientRect();return[e.clientX-t.left,e.clientY-t.top]}ensureCanvasSize(e){let t=e.getBoundingClientRect();(e.width!==Math.round(t.width)||e.height!==Math.round(t.height))&&(e.width=Math.round(t.width),e.height=Math.round(t.height))}clear(){let e=this.canvas();e&&e.getContext(`2d`).clearRect(0,0,e.width,e.height),this.hasStrokes=!1}accept(){let e=this.canvas();!e||!this.hasStrokes||(this.signing=!1,this.emit(e.toDataURL(`image/png`)))}renderPad(){return w`
+            `},kc=(e,t,n,r,i,a,o)=>{let s=document.createElement(`vaadin-context-menu-item`);return ie(P(e,t,n,r,i,a,o),s),s},Ac=(e,t,n,r,i,a,o)=>t.map(t=>t.submenus?{text:t.component?void 0:t.label,route:t.path,checked:t.selected,disabled:t.disabled,className:t.className,component:t.component?kc(e,t.component,n,r,i,a,o):void 0,children:Ac(e,t.submenus,n,r,i,a,o)}:t.separator?{component:`hr`}:{text:t.component?void 0:t.label,route:t.path,checked:t.selected,disabled:t.disabled,className:t.className,component:t.component?kc(e,t.component,n,r,i,a,o):void 0}),jc=class extends y{constructor(...e){super(...e),this.fieldId=``,this.signing=!1,this.hasStrokes=!1,this.drawing=!1,this.startStroke=e=>{let t=e.target;this.ensureCanvasSize(t),t.setPointerCapture(e.pointerId),this.drawing=!0;let n=t.getContext(`2d`);n.lineWidth=2,n.lineCap=`round`,n.lineJoin=`round`,n.strokeStyle=getComputedStyle(this).getPropertyValue(`--lumo-body-text-color`)||`#1a1a1a`;let[r,i]=this.pointerPosition(e);n.beginPath(),n.moveTo(r,i),e.preventDefault()},this.stroke=e=>{if(!this.drawing)return;let t=e.target.getContext(`2d`),[n,r]=this.pointerPosition(e);t.lineTo(n,r),t.stroke(),this.hasStrokes=!0,e.preventDefault()},this.endStroke=e=>{this.drawing=!1,e.target.releasePointerCapture(e.pointerId)}}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}canvas(){return this.renderRoot.querySelector(`canvas`)}pointerPosition(e){let t=e.target.getBoundingClientRect();return[e.clientX-t.left,e.clientY-t.top]}ensureCanvasSize(e){let t=e.getBoundingClientRect();(e.width!==Math.round(t.width)||e.height!==Math.round(t.height))&&(e.width=Math.round(t.width),e.height=Math.round(t.height))}clear(){let e=this.canvas();e&&e.getContext(`2d`).clearRect(0,0,e.width,e.height),this.hasStrokes=!1}accept(){let e=this.canvas();!e||!this.hasStrokes||(this.signing=!1,this.emit(e.toDataURL(`image/png`)))}renderPad(){return w`
             <canvas class="pad"
                     @pointerdown="${this.startStroke}"
                     @pointermove="${this.stroke}"
@@ -8566,7 +8566,7 @@ ${i}
         .button--danger {
             color: var(--lumo-error-text-color, rgb(179, 49, 31));
         }
-    `}};O([v()],Oc.prototype,`fieldId`,void 0),O([v()],Oc.prototype,`value`,void 0),O([S()],Oc.prototype,`signing`,void 0),O([S()],Oc.prototype,`hasStrokes`,void 0),Oc=O([h(`mateu-signature-pad`)],Oc);var kc=class extends y{constructor(...e){super(...e),this.fieldId=``,this.options=[],this.leavesOnly=!1,this.opened=!1,this.expandedItems=[],this._normalized=[],this.dataProvider=(e,t)=>{let n=e.parentItem?e.parentItem.children??[]:this.normalized;t(n,n.length)}}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}get normalized(){return this._optsSource!==this.options&&(this._optsSource=this.options,this._normalized=this.normalizeOptions(this.options??[])),this._normalized}normalizeOptions(e){return e.map(e=>{let t=e.children&&e.children.length?this.normalizeOptions(e.children):void 0;return{...e,children:t}})}ancestorsOf(e,t){for(let n of t){if(String(n.value)===e)return[];let t=n.children?this.ancestorsOf(e,n.children):null;if(t!=null)return[n,...t]}return null}labelOf(e,t){for(let n of t){if(String(n.value)===e)return n.label;let t=n.children?this.labelOf(e,n.children):null;if(t!=null)return t}return null}open(){this.opened||(this.expandedItems=this.value==null?[]:this.ancestorsOf(String(this.value),this.normalized)??[],this.opened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.close()},document.addEventListener(`mousedown`,this.outsideClick))}close(){this.detachOutsideClick(),this.opened=!1}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}pick(e){this.close(),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e.value,fieldId:this.fieldId},bubbles:!0,composed:!0}))}clear(){this.close(),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:void 0,fieldId:this.fieldId},bubbles:!0,composed:!0}))}onActiveItemChanged(e){let t=e.detail.value;if(t){if((t.children?.length??0)>0&&this.leavesOnly){this.expandedItems=this.expandedItems.includes(t)?this.expandedItems.filter(e=>e!==t):[...this.expandedItems,t],e.target.activeItem=null;return}this.pick(t)}}render(){let e=this.value!=null&&this.value!==``?this.labelOf(String(this.value),this.normalized)??String(this.value):``;return w`
+    `}};O([v()],jc.prototype,`fieldId`,void 0),O([v()],jc.prototype,`value`,void 0),O([S()],jc.prototype,`signing`,void 0),O([S()],jc.prototype,`hasStrokes`,void 0),jc=O([h(`mateu-signature-pad`)],jc);var Mc=class extends y{constructor(...e){super(...e),this.fieldId=``,this.options=[],this.leavesOnly=!1,this.opened=!1,this.expandedItems=[],this._normalized=[],this.dataProvider=(e,t)=>{let n=e.parentItem?e.parentItem.children??[]:this.normalized;t(n,n.length)}}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}get normalized(){return this._optsSource!==this.options&&(this._optsSource=this.options,this._normalized=this.normalizeOptions(this.options??[])),this._normalized}normalizeOptions(e){return e.map(e=>{let t=e.children&&e.children.length?this.normalizeOptions(e.children):void 0;return{...e,children:t}})}ancestorsOf(e,t){for(let n of t){if(String(n.value)===e)return[];let t=n.children?this.ancestorsOf(e,n.children):null;if(t!=null)return[n,...t]}return null}labelOf(e,t){for(let n of t){if(String(n.value)===e)return n.label;let t=n.children?this.labelOf(e,n.children):null;if(t!=null)return t}return null}open(){this.opened||(this.expandedItems=this.value==null?[]:this.ancestorsOf(String(this.value),this.normalized)??[],this.opened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.close()},document.addEventListener(`mousedown`,this.outsideClick))}close(){this.detachOutsideClick(),this.opened=!1}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}pick(e){this.close(),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e.value,fieldId:this.fieldId},bubbles:!0,composed:!0}))}clear(){this.close(),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:void 0,fieldId:this.fieldId},bubbles:!0,composed:!0}))}onActiveItemChanged(e){let t=e.detail.value;if(t){if((t.children?.length??0)>0&&this.leavesOnly){this.expandedItems=this.expandedItems.includes(t)?this.expandedItems.filter(e=>e!==t):[...this.expandedItems,t],e.target.activeItem=null;return}this.pick(t)}}render(){let e=this.value!=null&&this.value!==``?this.labelOf(String(this.value),this.normalized)??String(this.value):``;return w`
             <div class="root">
                 <vaadin-button class="control" theme="tertiary"
                                @click="${()=>this.opened?this.close():this.open()}">
@@ -8637,7 +8637,7 @@ ${i}
             min-width: 16rem;
             max-height: 18rem;
         }
-    `}};O([v()],kc.prototype,`fieldId`,void 0),O([v()],kc.prototype,`value`,void 0),O([v()],kc.prototype,`options`,void 0),O([v({type:Boolean})],kc.prototype,`leavesOnly`,void 0),O([S()],kc.prototype,`opened`,void 0),O([S()],kc.prototype,`expandedItems`,void 0),kc=O([h(`mateu-vaadin-tree-select`)],kc);var Ac=class extends y{constructor(...e){super(...e),this.fieldId=``,this.cameraOpen=!1,this.cameraError=!1,this.fileFallback=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>this.emit(r.result),r.readAsDataURL(n),t.value=``}}disconnectedCallback(){super.disconnectedCallback(),this.stopStream()}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}stopStream(){this.stream?.getTracks().forEach(e=>e.stop()),this.stream=void 0}async openCamera(){this.cameraError=!1;try{this.stream=await navigator.mediaDevices.getUserMedia({video:{facingMode:`environment`},audio:!1}),this.cameraOpen=!0,await this.updateComplete;let e=this.renderRoot.querySelector(`video`);e&&(e.srcObject=this.stream,await e.play())}catch{this.stopStream(),this.cameraOpen=!1,this.cameraError=!0}}closeCamera(){this.stopStream(),this.cameraOpen=!1}shoot(){let e=this.renderRoot.querySelector(`video`);if(!e||e.videoWidth===0)return;let t=document.createElement(`canvas`);t.width=e.videoWidth,t.height=e.videoHeight,t.getContext(`2d`).drawImage(e,0,0),this.closeCamera(),this.emit(t.toDataURL(`image/jpeg`,.9))}triggerFallback(){this.renderRoot.querySelector(`input[type=file]`)?.click()}render(){let e=this.value!=null&&this.value!==``;return w`
+    `}};O([v()],Mc.prototype,`fieldId`,void 0),O([v()],Mc.prototype,`value`,void 0),O([v()],Mc.prototype,`options`,void 0),O([v({type:Boolean})],Mc.prototype,`leavesOnly`,void 0),O([S()],Mc.prototype,`opened`,void 0),O([S()],Mc.prototype,`expandedItems`,void 0),Mc=O([h(`mateu-vaadin-tree-select`)],Mc);var Nc=class extends y{constructor(...e){super(...e),this.fieldId=``,this.cameraOpen=!1,this.cameraError=!1,this.fileFallback=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>this.emit(r.result),r.readAsDataURL(n),t.value=``}}disconnectedCallback(){super.disconnectedCallback(),this.stopStream()}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}stopStream(){this.stream?.getTracks().forEach(e=>e.stop()),this.stream=void 0}async openCamera(){this.cameraError=!1;try{this.stream=await navigator.mediaDevices.getUserMedia({video:{facingMode:`environment`},audio:!1}),this.cameraOpen=!0,await this.updateComplete;let e=this.renderRoot.querySelector(`video`);e&&(e.srcObject=this.stream,await e.play())}catch{this.stopStream(),this.cameraOpen=!1,this.cameraError=!0}}closeCamera(){this.stopStream(),this.cameraOpen=!1}shoot(){let e=this.renderRoot.querySelector(`video`);if(!e||e.videoWidth===0)return;let t=document.createElement(`canvas`);t.width=e.videoWidth,t.height=e.videoHeight,t.getContext(`2d`).drawImage(e,0,0),this.closeCamera(),this.emit(t.toDataURL(`image/jpeg`,.9))}triggerFallback(){this.renderRoot.querySelector(`input[type=file]`)?.click()}render(){let e=this.value!=null&&this.value!==``;return w`
             <input type="file" accept="image/*" capture="environment" style="display: none;"
                    @change="${this.fileFallback}">
             ${this.cameraOpen?w`
@@ -8715,7 +8715,7 @@ ${i}
             font-size: var(--lumo-font-size-xs, 0.75rem);
             color: var(--lumo-secondary-text-color, rgba(0, 0, 0, 0.6));
         }
-    `}};O([v()],Ac.prototype,`fieldId`,void 0),O([v()],Ac.prototype,`value`,void 0),O([S()],Ac.prototype,`cameraOpen`,void 0),O([S()],Ac.prototype,`cameraError`,void 0),Ac=O([h(`mateu-camera-capture`)],Ac);var jc,Mc=(e,t)=>{if(!e)return;if(Array.isArray(e)){let n=e.find(e=>e.key==t);return n?.value==null?void 0:String(n.value)}let n=e[t];return n==null?void 0:String(n)},Nc=class extends y{static{jc=this}constructor(...e){super(...e),this.fieldId=``,this.editable=!0,this.filePicked=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>{let e=r.result,t=e.indexOf(`,`),i=e.substring(0,t).replace(`;base64`,`;name=${encodeURIComponent(n.name)};base64`);this.emit(i+e.substring(t))},r.readAsDataURL(n),t.value=``}}static fileName(e){if(!e)return``;if(e.startsWith(`data:`)){let t=e.indexOf(`,`),n=e.substring(5,t<0?e.length:t).split(`;`).find(e=>e.startsWith(`name=`));if(n)try{return decodeURIComponent(n.substring(5))}catch{return n.substring(5)}return`Attached file`}return e.split(`/`).pop()||e}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}triggerPick(){this.renderRoot.querySelector(`input[type=file]`)?.click()}render(){let e=this.value!=null&&this.value!==``,t=jc.fileName(this.value),n=e&&this.value.startsWith(`data:`),r=e?w`<span class="file" title="${t}">📄 ${n?w`<a href="${this.value}" download="${t}">${t}</a>`:w`<a href="${this.value}" target="_blank">${t}</a>`}</span>`:_;return this.editable?w`
+    `}};O([v()],Nc.prototype,`fieldId`,void 0),O([v()],Nc.prototype,`value`,void 0),O([S()],Nc.prototype,`cameraOpen`,void 0),O([S()],Nc.prototype,`cameraError`,void 0),Nc=O([h(`mateu-camera-capture`)],Nc);var Pc,Fc=(e,t)=>{if(!e)return;if(Array.isArray(e)){let n=e.find(e=>e.key==t);return n?.value==null?void 0:String(n.value)}let n=e[t];return n==null?void 0:String(n)},Ic=class extends y{static{Pc=this}constructor(...e){super(...e),this.fieldId=``,this.editable=!0,this.filePicked=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>{let e=r.result,t=e.indexOf(`,`),i=e.substring(0,t).replace(`;base64`,`;name=${encodeURIComponent(n.name)};base64`);this.emit(i+e.substring(t))},r.readAsDataURL(n),t.value=``}}static fileName(e){if(!e)return``;if(e.startsWith(`data:`)){let t=e.indexOf(`,`),n=e.substring(5,t<0?e.length:t).split(`;`).find(e=>e.startsWith(`name=`));if(n)try{return decodeURIComponent(n.substring(5))}catch{return n.substring(5)}return`Attached file`}return e.split(`/`).pop()||e}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}triggerPick(){this.renderRoot.querySelector(`input[type=file]`)?.click()}render(){let e=this.value!=null&&this.value!==``,t=Pc.fileName(this.value),n=e&&this.value.startsWith(`data:`),r=e?w`<span class="file" title="${t}">📄 ${n?w`<a href="${this.value}" download="${t}">${t}</a>`:w`<a href="${this.value}" target="_blank">${t}</a>`}</span>`:_;return this.editable?w`
             <input type="file" accept="${this.accept||_}" style="display: none;"
                    @change="${this.filePicked}">
             <div class="row">
@@ -8763,28 +8763,28 @@ ${i}
         .button--danger {
             color: var(--lumo-error-text-color, rgb(179, 49, 31));
         }
-    `}};O([v()],Nc.prototype,`fieldId`,void 0),O([v()],Nc.prototype,`value`,void 0),O([v()],Nc.prototype,`accept`,void 0),O([v({type:Boolean})],Nc.prototype,`editable`,void 0),Nc=jc=O([h(`mateu-file-upload`)],Nc);var Pc=e=>!!e&&typeof e==`object`&&`__mateuGroup`in e,Fc=e=>String(e??``),Ic=(e,t,n)=>{let r=e??[];if(!t||!n||n.length===0)return r;let i=[],a,o=!1;return r.forEach((e,s)=>{let c=Fc(e?.[t]);if(!o||c!==a){let e=n.find(e=>Fc(e.value)===c)??{value:c,count:r.filter(e=>Fc(e?.[t])===c).length,aggregates:{}};i.push({__mateuGroup:e,__mateuGroupBy:t,_rowNumber:`__mateuGroup:${s}:${c}`}),o=!0,a=c}i.push(e)}),i},Lc=(e,t)=>e==null?``:t.dataType===`money`||t.stereotype===`money`?new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e):t.aggregate===`count`?new Intl.NumberFormat(void 0,{maximumFractionDigits:0}).format(Math.round(e)):new Intl.NumberFormat(void 0,{maximumFractionDigits:2}).format(e),Rc=(e,t)=>e&&t.includes(e)?e:t.find(e=>!!e),zc=(e,t,n)=>{let r=e.__mateuGroup;return t.id===n?`${r.value} (${r.count})`:t.aggregate?Lc(r.aggregates?.[t.id],t):``},Bc=(e,t,n)=>{let r=t?.aggregates;if(!r||!e.some(e=>e.aggregate))return;let i={};e.forEach(e=>{e.aggregate&&r[e.id]!=null&&(i[e.id]=Lc(r[e.id],e))});let a=e[0];if(a&&i[a.id]===void 0){let e=t?.page?.totalElements;i[a.id]=n&&a.id===n&&e!=null?`Total (${e})`:`Total`}return i},Vc=(e,t,n)=>F(e[n.path]?`vaadin:check`:`vaadin:minus`,`height: 16px; width: 16px; color: var(--lumo-body-text-color);`),Hc=(e,t,n,r,i)=>{let a=e[n.path],o=a;return r==`money`&&a&&a.locale&&a.currency?o=new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(a.value):i==`money`&&(o=new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(a)),w`${o}`},Uc=(e,t,n)=>{e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:n},bubbles:!0,composed:!0}))},Wc=(e,t,n,r,i,a)=>{let o=n.xcolumn??a;if(o.text)return o.actionId?w`<a href="javascript: void(0);" @click="${t=>Uc(n,o,e)}">${o.text}</a>`:w`<a href="${e[n.path]}">${o.text}</a>`;if(r==`string`){if(o.actionId)return w`<a href="javascript: void(0);" @click="${t=>Uc(n,o,e)}">${e[n.path]}</a>`;let t=e[n.path];return w`<a href="${t}">${t}</a>`}let s=e[n.path];return w`<a href="${s.href}">${s.text}</a>`},Gc=(e,t,n,r,i)=>{let a=e[n.path];return r==`string`?a.split(`,`).map(e=>F(e,`width: 16px;`)):a.split(`,`).map(e=>F(e.icon,`width: 16px;`))},Kc=(e,t,n,r,i)=>{let a=e[n.path];return w`${g(a)}`},qc=(e,t,n,r,i,a)=>r==`string`?w`<img src="${e[n.path]}" style="${`max-height: 40px; `+(a.style??``)}">`:w`<img src="${e[n.path].src}" style="${a.style??``}">`,Jc=e=>{let t={_clickedRow:e.target.row};e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+e.detail.value.methodNameInCrud,parameters:t},bubbles:!0,composed:!0}))},Yc=e=>{let t={_clickedRow:e.target.row},n=e.target.action;e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+n.methodNameInCrud,parameters:t},bubbles:!0,composed:!0}))},Xc=e=>{let t=document.createElement(`vaadin-context-menu-item`),n=document.createElement(`vaadin-icon`);return n.style.color=`var(--lumo-secondary-text-color)`,n.style.marginInlineEnd=`var(--lumo-space-s)`,n.style.padding=`var(--lumo-space-xs)`,n.setAttribute(`icon`,e.icon),t.appendChild(n),e.label&&t.appendChild(document.createTextNode(e.label)),t.disabled=e.disabled,t},Zc=(e,t,n)=>{let r=e[n.path]?.actions?.map(e=>e.icon?{component:Xc(e),methodNameInCrud:e.methodNameInCrud}:{...e,text:e.label});return!r||r.length==0?w``:w`
+    `}};O([v()],Ic.prototype,`fieldId`,void 0),O([v()],Ic.prototype,`value`,void 0),O([v()],Ic.prototype,`accept`,void 0),O([v({type:Boolean})],Ic.prototype,`editable`,void 0),Ic=Pc=O([h(`mateu-file-upload`)],Ic);var Lc=e=>!!e&&typeof e==`object`&&`__mateuGroup`in e,Rc=e=>String(e??``),zc=(e,t,n)=>{let r=e??[];if(!t||!n||n.length===0)return r;let i=[],a,o=!1;return r.forEach((e,s)=>{let c=Rc(e?.[t]);if(!o||c!==a){let e=n.find(e=>Rc(e.value)===c)??{value:c,count:r.filter(e=>Rc(e?.[t])===c).length,aggregates:{}};i.push({__mateuGroup:e,__mateuGroupBy:t,_rowNumber:`__mateuGroup:${s}:${c}`}),o=!0,a=c}i.push(e)}),i},Bc=(e,t)=>e==null?``:t.dataType===`money`||t.stereotype===`money`?new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e):t.aggregate===`count`?new Intl.NumberFormat(void 0,{maximumFractionDigits:0}).format(Math.round(e)):new Intl.NumberFormat(void 0,{maximumFractionDigits:2}).format(e),Vc=(e,t)=>e&&t.includes(e)?e:t.find(e=>!!e),Hc=(e,t,n)=>{let r=e.__mateuGroup;return t.id===n?`${r.value} (${r.count})`:t.aggregate?Bc(r.aggregates?.[t.id],t):``},Uc=(e,t,n)=>{let r=t?.aggregates;if(!r||!e.some(e=>e.aggregate))return;let i={};e.forEach(e=>{e.aggregate&&r[e.id]!=null&&(i[e.id]=Bc(r[e.id],e))});let a=e[0];if(a&&i[a.id]===void 0){let e=t?.page?.totalElements;i[a.id]=n&&a.id===n&&e!=null?`Total (${e})`:`Total`}return i},Wc=(e,t,n)=>F(e[n.path]?`vaadin:check`:`vaadin:minus`,`height: 16px; width: 16px; color: var(--lumo-body-text-color);`),Gc=(e,t,n,r,i)=>{let a=e[n.path],o=a;return r==`money`&&a&&a.locale&&a.currency?o=new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(a.value):i==`money`&&(o=new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(a)),w`${o}`},Kc=(e,t,n)=>{e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:n},bubbles:!0,composed:!0}))},qc=(e,t,n,r,i,a)=>{let o=n.xcolumn??a;if(o.text)return o.actionId?w`<a href="javascript: void(0);" @click="${t=>Kc(n,o,e)}">${o.text}</a>`:w`<a href="${e[n.path]}">${o.text}</a>`;if(r==`string`){if(o.actionId)return w`<a href="javascript: void(0);" @click="${t=>Kc(n,o,e)}">${e[n.path]}</a>`;let t=e[n.path];return w`<a href="${t}">${t}</a>`}let s=e[n.path];return w`<a href="${s.href}">${s.text}</a>`},Jc=(e,t,n,r,i)=>{let a=e[n.path];return r==`string`?a.split(`,`).map(e=>F(e,`width: 16px;`)):a.split(`,`).map(e=>F(e.icon,`width: 16px;`))},Yc=(e,t,n,r,i)=>{let a=e[n.path];return w`${g(a)}`},Xc=(e,t,n,r,i,a)=>r==`string`?w`<img src="${e[n.path]}" style="${`max-height: 40px; `+(a.style??``)}">`:w`<img src="${e[n.path].src}" style="${a.style??``}">`,Zc=e=>{let t={_clickedRow:e.target.row};e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+e.detail.value.methodNameInCrud,parameters:t},bubbles:!0,composed:!0}))},Qc=e=>{let t={_clickedRow:e.target.row},n=e.target.action;e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+n.methodNameInCrud,parameters:t},bubbles:!0,composed:!0}))},$c=e=>{let t=document.createElement(`vaadin-context-menu-item`),n=document.createElement(`vaadin-icon`);return n.style.color=`var(--lumo-secondary-text-color)`,n.style.marginInlineEnd=`var(--lumo-space-s)`,n.style.padding=`var(--lumo-space-xs)`,n.setAttribute(`icon`,e.icon),t.appendChild(n),e.label&&t.appendChild(document.createTextNode(e.label)),t.disabled=e.disabled,t},el=(e,t,n)=>{let r=e[n.path]?.actions?.map(e=>e.icon?{component:$c(e),methodNameInCrud:e.methodNameInCrud}:{...e,text:e.label});return!r||r.length==0?w``:w`
                                      <vaadin-menu-bar
                                          .items=${[{text:`···`,children:r}]}
                                          theme="tertiary"
                                          .row="${e}"
                                          data-testid="menubar-${n.path}"
-                                         @item-selected="${Jc}"
+                                         @item-selected="${Zc}"
                                      ></vaadin-menu-bar>
-                                   `},Qc=(e,t,n)=>{if(n.path==`select`)return w`
-         <vaadin-button theme="tertiary" title="Select" @click="${Yc}" .row="${e}" .action="${{actionId:n.path,icon:``,label:`Select`,disabled:!1,methodNameInCrud:`select`}}">
+                                   `},tl=(e,t,n)=>{if(n.path==`select`)return w`
+         <vaadin-button theme="tertiary" title="Select" @click="${Qc}" .row="${e}" .action="${{actionId:n.path,icon:``,label:`Select`,disabled:!1,methodNameInCrud:`select`}}">
              Select
          </vaadin-button>
     `;let r=n.path&&e[n.path]?.methodNameInCrud?e[n.path]:e.action;return r?w`
-         <vaadin-button theme="tertiary${r.icon&&!r.label?` icon`:``}" title="${r.label||_}" @click="${Yc}" .row="${e}" .action="${r}">
+         <vaadin-button theme="tertiary${r.icon&&!r.label?` icon`:``}" title="${r.label||_}" @click="${Qc}" .row="${e}" .action="${r}">
              ${r.icon?w`<vaadin-icon icon="${r.icon}"></vaadin-icon>`:_}
              ${r.label?r.label:_}
          </vaadin-button>
-    `:w``},$c=(e,t,n)=>{e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:n},bubbles:!0,composed:!0}))},el=(e,t,n,r,i,a)=>{let o=n.xcolumn??a;if(o.actionId)return w`
-            <vaadin-button theme="tertiary" @click="${t=>$c(n,o,e)}" .row="${e}">
+    `:w``},nl=(e,t,n)=>{e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:n},bubbles:!0,composed:!0}))},rl=(e,t,n,r,i,a)=>{let o=n.xcolumn??a;if(o.actionId)return w`
+            <vaadin-button theme="tertiary" @click="${t=>nl(n,o,e)}" .row="${e}">
                 ${o.text||e[n.path]}
             </vaadin-button>
-        `;let s=e[n.path];return w`<a href="${s}">${o.text||s}</a>`},tl=(e,t,n,r,i,a,o,s,c)=>{let l=e[n.path];return P(r,l,i,a,o,s,c)},nl=new WeakMap,rl=(e,t)=>nl.get(e)?.[t],il=(e,t,n)=>{let r=nl.get(e);r||(r={},nl.set(e,r)),r[t]=n},al=e=>{if(e==null||e===``)return null;let t=Number(e);return Number.isNaN(t)?null:t},ol=(e,t,n,r)=>{let i=n?.field?.fieldId,a=a=>{if(e[t.id]===a||e[t.id]==null&&(a===``||a==null))return;if(e[t.id]=a,!i){n.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`update-row`,parameters:{_editedRow:{...e}}},bubbles:!0,composed:!0}));return}let o=(n?.state??r)[i];n.dispatchEvent(new CustomEvent(`value-changed`,{detail:{fieldId:i,value:Array.isArray(o)?[...o]:o},bubbles:!0,composed:!0}))},o=e[t.id],s=o==null?``:String(o);switch(t.editorType){case`boolean`:return w`<vaadin-checkbox ?checked=${!!o} @checked-changed=${e=>a(e.detail.value)}></vaadin-checkbox>`;case`integer`:return w`<vaadin-integer-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(al(e.target.value))}></vaadin-integer-field>`;case`number`:return w`<vaadin-number-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(al(e.target.value))}></vaadin-number-field>`;case`date`:return w`<vaadin-date-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-date-picker>`;case`time`:return w`<vaadin-time-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-time-picker>`;case`datetime`:return w`<vaadin-date-time-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-date-time-picker>`;case`select`:return w`<vaadin-combo-box
+        `;let s=e[n.path];return w`<a href="${s}">${o.text||s}</a>`},il=(e,t,n,r,i,a,o,s,c)=>{let l=e[n.path];return P(r,l,i,a,o,s,c)},al=new WeakMap,ol=(e,t)=>al.get(e)?.[t],sl=(e,t,n)=>{let r=al.get(e);r||(r={},al.set(e,r)),r[t]=n},cl=e=>{if(e==null||e===``)return null;let t=Number(e);return Number.isNaN(t)?null:t},ll=(e,t,n,r)=>{let i=n?.field?.fieldId,a=a=>{if(e[t.id]===a||e[t.id]==null&&(a===``||a==null))return;if(e[t.id]=a,!i){n.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`update-row`,parameters:{_editedRow:{...e}}},bubbles:!0,composed:!0}));return}let o=(n?.state??r)[i];n.dispatchEvent(new CustomEvent(`value-changed`,{detail:{fieldId:i,value:Array.isArray(o)?[...o]:o},bubbles:!0,composed:!0}))},o=e[t.id],s=o==null?``:String(o);switch(t.editorType){case`boolean`:return w`<vaadin-checkbox ?checked=${!!o} @checked-changed=${e=>a(e.detail.value)}></vaadin-checkbox>`;case`integer`:return w`<vaadin-integer-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(cl(e.target.value))}></vaadin-integer-field>`;case`number`:return w`<vaadin-number-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(cl(e.target.value))}></vaadin-number-field>`;case`date`:return w`<vaadin-date-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-date-picker>`;case`time`:return w`<vaadin-time-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-time-picker>`;case`datetime`:return w`<vaadin-date-time-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-date-time-picker>`;case`select`:return w`<vaadin-combo-box
                 theme="small" style="width:100%;"
                 .items=${(t.editorOptions??[]).map(e=>({label:e.label,value:String(e.value)}))}
                 item-label-path="label" item-value-path="value"
@@ -8793,12 +8793,12 @@ ${i}
                 theme="small" style="width:100%;"
                 item-label-path="label" item-id-path="value"
                 .dataProvider=${(e,t)=>{n.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:i,parameters:{searchText:e.filter,size:e.pageSize,page:e.page},callback:e=>{let n=e?.fragments?.[0]?.data?.[o];t(n?.content??[],n?.totalElements??0)},callbackonly:!0},bubbles:!0,composed:!0}))}}
-                .selectedItem=${(t.editorOptions??[]).find(e=>String(e.value)===s)??(s?{value:s,label:rl(e,t.id)??s}:void 0)}
-                @selected-item-changed=${n=>{let r=n.detail.value,i=r?r.value:null;String(i??``)!==s&&(r&&il(e,t.id,r.label),a(i))}}></vaadin-combo-box>`}default:return w`<vaadin-text-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(e.target.value)}></vaadin-text-field>`}},sl=e=>ee(()=>w`<span title="${e}" style="white-space:normal;overflow-wrap:break-word;">${e}</span>`,[e]),cl=e=>e===void 0?_:d(()=>w`<span style="font-weight: 600; white-space: nowrap;">${e}</span>`,[e]),ll=e=>{e.preventDefault(),e.stopPropagation(),e.currentTarget?.dispatchEvent(new CustomEvent(`sort-direction-changed`,{detail:{grid:e.currentTarget.parentElement},bubbles:!0,composed:!0}))},ul=(e,t,n,r,i,a,o,s)=>w`
+                .selectedItem=${(t.editorOptions??[]).find(e=>String(e.value)===s)??(s?{value:s,label:ol(e,t.id)??s}:void 0)}
+                @selected-item-changed=${n=>{let r=n.detail.value,i=r?r.value:null;String(i??``)!==s&&(r&&sl(e,t.id,r.label),a(i))}}></vaadin-combo-box>`}default:return w`<vaadin-text-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(e.target.value)}></vaadin-text-field>`}},ul=e=>ee(()=>w`<span title="${e}" style="white-space:normal;overflow-wrap:break-word;">${e}</span>`,[e]),dl=e=>e===void 0?_:d(()=>w`<span style="font-weight: 600; white-space: nowrap;">${e}</span>`,[e]),fl=e=>{e.preventDefault(),e.stopPropagation(),e.currentTarget?.dispatchEvent(new CustomEvent(`sort-direction-changed`,{detail:{grid:e.currentTarget.parentElement},bubbles:!0,composed:!0}))},pl=(e,t,n,r,i,a,o,s)=>w`
 <vaadin-grid-column-group header="${j(e.label,r,i)}">
-    ${e.columns.map(e=>fl(e.metadata,t,n,r,i,a,o,s?.[e.metadata?.id]))}
+    ${e.columns.map(e=>hl(e.metadata,t,n,r,i,a,o,s?.[e.metadata?.id]))}
 </vaadin-grid-column-group>
-`,dl=(e,t,n,r,i,a,o,s)=>A.GridGroupColumn==e.metadata?.type?ul(e.metadata,t,n,r,i,a,o,s):fl(e.metadata,t,n,r,i,a,o,s?.[e.metadata?.id]),fl=(e,n,r,i,a,o,s,c)=>{let l=j(e.label,i,a);return e.sortable?w`
+`,ml=(e,t,n,r,i,a,o,s)=>A.GridGroupColumn==e.metadata?.type?pl(e.metadata,t,n,r,i,a,o,s):hl(e.metadata,t,n,r,i,a,o,s?.[e.metadata?.id]),hl=(e,n,r,i,a,o,s,c)=>{let l=j(e.label,i,a);return e.sortable?w`
                         <vaadin-grid-sort-column
                                 path="${e.id}"
                                 text-align="${e.align??_}"
@@ -8808,12 +8808,12 @@ ${i}
                                 flex-grow="${e.flexGrow??_}"
                                 ?resizable="${e.resizable}"
                                 width="${e.width??_}"
-                                @direction-changed="${ll}"
+                                @direction-changed="${fl}"
                                 data-data-type="${e.dataType}"
                                 data-stereotype="${e.stereotype}"
-                                ${sl(l)}
-                                ${cl(c)}
-                                ${t((t,c,l)=>pl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
+                                ${ul(l)}
+                                ${dl(c)}
+                                ${t((t,c,l)=>gl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
                         ></vaadin-grid-sort-column>
                     `:e.filterable?w`
                         <vaadin-grid-filter-column
@@ -8827,9 +8827,9 @@ ${i}
                                 width="${e.width??_}"
                                 data-data-type="${e.dataType}"
                                 data-stereotype="${e.stereotype}"
-                                ${sl(l)}
-                                ${cl(c)}
-                                ${t((t,c,l)=>pl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
+                                ${ul(l)}
+                                ${dl(c)}
+                                ${t((t,c,l)=>gl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
                         ></vaadin-grid-filter-column>
                     `:w`
                         <vaadin-grid-column
@@ -8844,17 +8844,17 @@ ${i}
                                 data-data-type="${e.dataType}"
                                 data-stereotype="${e.stereotype}"
                                 .xcolumn="${e}"
-                                ${sl(l)}
-                                ${cl(c)}
-                                ${t((t,c,l)=>pl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
+                                ${ul(l)}
+                                ${dl(c)}
+                                ${t((t,c,l)=>gl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
                         ></vaadin-grid-column>
-                    `},pl=(e,t,n,r,i,a,o,s,c,l)=>{let u=n.dataset.dataType??``,d=n.dataset.stereotype??``;if(Pc(e)){let t=i?.metadata,n=(t?.columns??[]).flatMap(e=>e?.metadata?.type===A.GridGroupColumn?(e.metadata.columns??[]).map(e=>e?.metadata?.id):[e?.metadata?.id]),a=zc(e,r,Rc(e.__mateuGroupBy,n)),o=e.__mateuGroup.hiddenActions??[],s=r.id===n[n.length-1]?(t?.groupActions??[]).filter(e=>!o.includes(e.actionId??e.id)):[];return s.length?w`<span style="display: flex; align-items: center; justify-content: flex-end; gap: var(--lumo-space-s); overflow: hidden;">
+                    `},gl=(e,t,n,r,i,a,o,s,c,l)=>{let u=n.dataset.dataType??``,d=n.dataset.stereotype??``;if(Lc(e)){let t=i?.metadata,n=(t?.columns??[]).flatMap(e=>e?.metadata?.type===A.GridGroupColumn?(e.metadata.columns??[]).map(e=>e?.metadata?.id):[e?.metadata?.id]),a=Hc(e,r,Vc(e.__mateuGroupBy,n)),o=e.__mateuGroup.hiddenActions??[],s=r.id===n[n.length-1]?(t?.groupActions??[]).filter(e=>!o.includes(e.actionId??e.id)):[];return s.length?w`<span style="display: flex; align-items: center; justify-content: flex-end; gap: var(--lumo-space-s); overflow: hidden;">
                 ${a?w`<span style="font-weight: 600;">${a}</span>`:_}
                 ${s.map(t=>w`
                     <vaadin-button theme="tertiary small" style="flex-shrink: 0;"
                         @click="${n=>{n.stopPropagation(),n.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+(t.actionId??t.id),parameters:{_groupValue:e.__mateuGroup.value}},bubbles:!0,composed:!0}))}}">${t.label??t.caption??``}</vaadin-button>
                 `)}
-            </span>`:w`<span title="${a}" style="font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block;">${a}</span>`}if(r.editable)return ol(e,r,i,o);if(u==`status`)return la(e,t,n);if(u==`bool`)return Vc(e,t,n);if(u==`money`||d==`money`)return Hc(e,t,n,u,d);if(u==`link`||d==`link`)return Wc(e,t,n,u,d,r);if(u==`icon`||d==`icon`)return Gc(e,t,n,u,d);if(d==`html`)return Kc(e,t,n,u,d);if(d==`image`)return qc(e,t,n,u,d,r);if(u==`menu`)return Zc(e,t,n);if(u==`component`)return tl(e,t,n,i,a,o,s,c,l);if(u==`action`)return Qc(e,t,n);if(u==`actionGroup`)return Zc(e,t,n);if(d==`button`||r.actionId)return el(e,t,n,u,d,r);let f=e[n.path];return w`<span title="${f}" style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block;">${f}</span>`},ml=()=>{let e=document.activeElement;for(;e?.shadowRoot?.activeElement;)e=e.shadowRoot.activeElement;return e},hl=(e,t)=>{let n=t;for(;n;){if(n===e)return!0;n=n.assignedSlot??n.parentNode??n.host??null}return!1},gl=class extends et{constructor(...e){super(...e),this.state={},this.data={},this.appState={},this.appData={},this.detailsOpenedItems=[],this.hoveredItem=null,this.onGridHoverMove=e=>{let t=e.currentTarget,n=t.getEventContext(e)?.item??null;n!==this.hoveredItem&&(this.hoveredItem=n,t.generateCellPartNames())},this.onGridHoverLeave=e=>{this.hoveredItem!==null&&(this.hoveredItem=null,e.currentTarget.generateCellPartNames())},this.hoverCellPartNameGenerator=(e,t)=>t?.item!=null&&t.item===this.hoveredItem?`hovered-cell`:``,this._onRowKey=e=>{let t=this.field?.rowSelectionShortcut;if(!t||!this.field?.onItemSelectionActionId||!this._isRowShortcutRelevant()||!In(t,e))return;let n=/^(?:Digit|Numpad)([1-9])$/.exec(e.code);if(!n)return;let r=this.currentItems(),i=parseInt(n[1],10)-1;i>=r.length||(e.preventDefault(),this.selectRow(r[i]))},this.handleButtonClick=e=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))}}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._onRowKey)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`keydown`,this._onRowKey)}currentItems(){return this.field?.remoteCoordinates?this.data?.[this.id]?.content??[]:this.field?.fieldId&&this.state?this.state[this.field.fieldId]??[]:[]}selectRow(e){!e||!this.field?.onItemSelectionActionId||(this.selectedItems=[e],this.state[this.id+`_selected_items`]=[e],this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.field.onItemSelectionActionId,parameters:{_clickedRow:e}},bubbles:!0,composed:!0})))}_isRowShortcutRelevant(){if(this.offsetParent===null&&this.getClientRects().length===0)return!1;let e=ml();if(e&&e!==document.body&&!hl(this,e)){let t=e.tagName?.toLowerCase()??``;if(e.isContentEditable||/^(input|textarea|select)$/.test(t)||t.startsWith(`vaadin-`)&&/(field|combo|picker|area|select)/.test(t))return!1}return!0}handleItemToggle(e){let{item:t,selected:n,shiftKey:r}=e.detail;if(this.rangeStartItem??=t,r){let e=[];this.field?.fieldId&&this.state&&this.state[this.field.fieldId]&&(e=this.state[this.field.fieldId]);let[r,i]=[this.rangeStartItem,t].map(t=>e.indexOf(t)).sort((e,t)=>e-t),a=e.slice(r,i+1),o=new Set(this.selectedItems);a.forEach(e=>{n?o.add(e):o.delete(e)}),this.selectedItems=[...o],this.state[this.id+`_selected_items`]=this.selectedItems}this.rangeStartItem=t}render(){let e=[];this.field?.fieldId&&this.state&&this.state[this.field.fieldId]&&(e=this.state[this.field.fieldId]);let t=this.state[this.field?.fieldId+`_show_detail`]||this.state._show_detail&&this.state._show_detail[this.field.fieldId];if(this.field?.remoteCoordinates){let t=this.field.remoteCoordinates;this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements?e=this.data[this.id].content:this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}if(Array.isArray(e)&&e.forEach((e,t)=>{e&&typeof e==`object`&&e._rowNumber===void 0&&(e._rowNumber=t)}),this.field?.inlineEditing)return this.renderMaster(e);if(this.field?.formPosition&&this.field?.formPosition.startsWith(`modal`)){let n=this;return w`
+            </span>`:w`<span title="${a}" style="font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block;">${a}</span>`}if(r.editable)return ll(e,r,i,o);if(u==`status`)return da(e,t,n);if(u==`bool`)return Wc(e,t,n);if(u==`money`||d==`money`)return Gc(e,t,n,u,d);if(u==`link`||d==`link`)return qc(e,t,n,u,d,r);if(u==`icon`||d==`icon`)return Jc(e,t,n,u,d);if(d==`html`)return Yc(e,t,n,u,d);if(d==`image`)return Xc(e,t,n,u,d,r);if(u==`menu`)return el(e,t,n);if(u==`component`)return il(e,t,n,i,a,o,s,c,l);if(u==`action`)return tl(e,t,n);if(u==`actionGroup`)return el(e,t,n);if(d==`button`||r.actionId)return rl(e,t,n,u,d,r);let f=e[n.path];return w`<span title="${f}" style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block;">${f}</span>`},_l=()=>{let e=document.activeElement;for(;e?.shadowRoot?.activeElement;)e=e.shadowRoot.activeElement;return e},vl=(e,t)=>{let n=t;for(;n;){if(n===e)return!0;n=n.assignedSlot??n.parentNode??n.host??null}return!1},yl=class extends et{constructor(...e){super(...e),this.state={},this.data={},this.appState={},this.appData={},this.detailsOpenedItems=[],this.hoveredItem=null,this.onGridHoverMove=e=>{let t=e.currentTarget,n=t.getEventContext(e)?.item??null;n!==this.hoveredItem&&(this.hoveredItem=n,t.generateCellPartNames())},this.onGridHoverLeave=e=>{this.hoveredItem!==null&&(this.hoveredItem=null,e.currentTarget.generateCellPartNames())},this.hoverCellPartNameGenerator=(e,t)=>t?.item!=null&&t.item===this.hoveredItem?`hovered-cell`:``,this._onRowKey=e=>{let t=this.field?.rowSelectionShortcut;if(!t||!this.field?.onItemSelectionActionId||!this._isRowShortcutRelevant()||!Rn(t,e))return;let n=/^(?:Digit|Numpad)([1-9])$/.exec(e.code);if(!n)return;let r=this.currentItems(),i=parseInt(n[1],10)-1;i>=r.length||(e.preventDefault(),this.selectRow(r[i]))},this.handleButtonClick=e=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))}}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._onRowKey)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`keydown`,this._onRowKey)}currentItems(){return this.field?.remoteCoordinates?this.data?.[this.id]?.content??[]:this.field?.fieldId&&this.state?this.state[this.field.fieldId]??[]:[]}selectRow(e){!e||!this.field?.onItemSelectionActionId||(this.selectedItems=[e],this.state[this.id+`_selected_items`]=[e],this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.field.onItemSelectionActionId,parameters:{_clickedRow:e}},bubbles:!0,composed:!0})))}_isRowShortcutRelevant(){if(this.offsetParent===null&&this.getClientRects().length===0)return!1;let e=_l();if(e&&e!==document.body&&!vl(this,e)){let t=e.tagName?.toLowerCase()??``;if(e.isContentEditable||/^(input|textarea|select)$/.test(t)||t.startsWith(`vaadin-`)&&/(field|combo|picker|area|select)/.test(t))return!1}return!0}handleItemToggle(e){let{item:t,selected:n,shiftKey:r}=e.detail;if(this.rangeStartItem??=t,r){let e=[];this.field?.fieldId&&this.state&&this.state[this.field.fieldId]&&(e=this.state[this.field.fieldId]);let[r,i]=[this.rangeStartItem,t].map(t=>e.indexOf(t)).sort((e,t)=>e-t),a=e.slice(r,i+1),o=new Set(this.selectedItems);a.forEach(e=>{n?o.add(e):o.delete(e)}),this.selectedItems=[...o],this.state[this.id+`_selected_items`]=this.selectedItems}this.rangeStartItem=t}render(){let e=[];this.field?.fieldId&&this.state&&this.state[this.field.fieldId]&&(e=this.state[this.field.fieldId]);let t=this.state[this.field?.fieldId+`_show_detail`]||this.state._show_detail&&this.state._show_detail[this.field.fieldId];if(this.field?.remoteCoordinates){let t=this.field.remoteCoordinates;this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements?e=this.data[this.id].content:this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}if(Array.isArray(e)&&e.forEach((e,t)=>{e&&typeof e==`object`&&e._rowNumber===void 0&&(e._rowNumber=t)}),this.field?.inlineEditing)return this.renderMaster(e);if(this.field?.formPosition&&this.field?.formPosition.startsWith(`modal`)){let n=this;return w`
 
                 ${this.renderMaster(e)}
 
@@ -8909,7 +8909,7 @@ ${i}
                 ${this.field?.readOnly||this.field?.inlineEditing?_:w`
                     <vaadin-grid-selection-column drag-select></vaadin-grid-selection-column>
                 `}
-                ${this.field?.columns?.map(e=>dl(e,this,this.baseUrl,this.state,this.data,this.appState,this.appData))}
+                ${this.field?.columns?.map(e=>ml(e,this,this.baseUrl,this.state,this.data,this.appState,this.appData))}
 
                 ${this.field?.inlineEditing&&!this.field?.readOnly?w`
                     <vaadin-grid-column width="3.5rem" flex-grow="0" frozen-to-end
@@ -8966,7 +8966,7 @@ ${i}
             background-color: var(--lumo-primary-color-10pct);
             cursor: pointer;
         }
-    `}};O([v()],gl.prototype,`field`,void 0),O([v()],gl.prototype,`state`,void 0),O([v()],gl.prototype,`data`,void 0),O([v()],gl.prototype,`appState`,void 0),O([v()],gl.prototype,`appData`,void 0),O([v()],gl.prototype,`selectedItems`,void 0),O([S()],gl.prototype,`detailsOpenedItems`,void 0),gl=O([h(`mateu-grid`)],gl);var _l=class extends y{constructor(...e){super(...e),this.getNewValue=e=>{if(this.field?.dataType==`array`){if(!this.value)return[e];let t=this.value;return t.indexOf(e)>=0?t.filter(t=>t!==e):[...t,e]}return e}}render(){let e=this.field?.options;if(this.field?.remoteCoordinates){let t=this.field.remoteCoordinates;this.data?.[this.field.fieldId]&&this.data[this.field.fieldId].content&&this.data[this.field.fieldId].totalElements?e=this.data[this.field.fieldId].content:this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}return w`
+    `}};O([v()],yl.prototype,`field`,void 0),O([v()],yl.prototype,`state`,void 0),O([v()],yl.prototype,`data`,void 0),O([v()],yl.prototype,`appState`,void 0),O([v()],yl.prototype,`appData`,void 0),O([v()],yl.prototype,`selectedItems`,void 0),O([S()],yl.prototype,`detailsOpenedItems`,void 0),yl=O([h(`mateu-grid`)],yl);var bl=class extends y{constructor(...e){super(...e),this.getNewValue=e=>{if(this.field?.dataType==`array`){if(!this.value)return[e];let t=this.value;return t.indexOf(e)>=0?t.filter(t=>t!==e):[...t,e]}return e}}render(){let e=this.field?.options;if(this.field?.remoteCoordinates){let t=this.field.remoteCoordinates;this.data?.[this.field.fieldId]&&this.data[this.field.fieldId].content&&this.data[this.field.fieldId].totalElements?e=this.data[this.field.fieldId].content:this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}return w`
         <div style="display: flex; gap: 1rem; padding: 1rem; flex-wrap: wrap; ${this.field?.attributes?.divStyle}">
                                     ${e?.map(e=>w`
                             <div role="button" tabindex="0" 
@@ -9014,7 +9014,7 @@ ${i}
         }
   
         ${R}
-    `}};O([v()],_l.prototype,`field`,void 0),O([v()],_l.prototype,`baseUrl`,void 0),O([v()],_l.prototype,`state`,void 0),O([v()],_l.prototype,`data`,void 0),O([v()],_l.prototype,`value`,void 0),_l=O([h(`mateu-choice`)],_l);var vl=class extends y{constructor(...e){super(...e),this.currencyChanged=e=>{this.value||={value:0,currency:`EUR`,locale:`es-ES`},this.value.currency=e.detail.value,this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:{...this.value},fieldId:this.fieldId}}))},this.valueChanged=e=>{this.value||={value:0,currency:`EUR`,locale:`es-ES`},e.detail.value&&(this.value.value=e.detail.value?parseFloat(e.detail.value):0,this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:{...this.value},fieldId:this.fieldId}})))}}render(){return w`
+    `}};O([v()],bl.prototype,`field`,void 0),O([v()],bl.prototype,`baseUrl`,void 0),O([v()],bl.prototype,`state`,void 0),O([v()],bl.prototype,`data`,void 0),O([v()],bl.prototype,`value`,void 0),bl=O([h(`mateu-choice`)],bl);var xl=class extends y{constructor(...e){super(...e),this.currencyChanged=e=>{this.value||={value:0,currency:`EUR`,locale:`es-ES`},this.value.currency=e.detail.value,this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:{...this.value},fieldId:this.fieldId}}))},this.valueChanged=e=>{this.value||={value:0,currency:`EUR`,locale:`es-ES`},e.detail.value&&(this.value.value=e.detail.value?parseFloat(e.detail.value):0,this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:{...this.value},fieldId:this.fieldId}})))}}render(){return w`
             <vaadin-number-field
                     id="${this.fieldId}"
                     label="${this.label}"
@@ -9034,7 +9034,7 @@ ${i}
                     theme="small"
             ></vaadin-select></div></vaadin-number-field>
        `}static{this.styles=m`
-  `}};O([v()],vl.prototype,`fieldId`,void 0),O([v()],vl.prototype,`label`,void 0),O([v()],vl.prototype,`state`,void 0),O([v()],vl.prototype,`data`,void 0),O([v()],vl.prototype,`value`,void 0),O([v()],vl.prototype,`autoFocus`,void 0),O([v()],vl.prototype,`required`,void 0),O([v()],vl.prototype,`colspan`,void 0),O([v()],vl.prototype,`helperText`,void 0),vl=O([h(`mateu-money-field`)],vl);var yl=`vaadin:abacus.vaadin:absolute-position.vaadin:academy-cap.vaadin:accessibility.vaadin:accordion-menu.vaadin:add-dock.vaadin:adjust.vaadin:adobe-flash.vaadin:airplane.vaadin:alarm.vaadin:align-center.vaadin:align-justify.vaadin:align-left.vaadin:align-right.vaadin:alt-a.vaadin:alt.vaadin:ambulance.vaadin:anchor.vaadin:angle-double-down.vaadin:angle-double-left.vaadin:angle-double-right.vaadin:angle-double-up.vaadin:angle-down.vaadin:angle-left.vaadin:angle-right.vaadin:angle-up.vaadin:archive.vaadin:archives.vaadin:area-select.vaadin:arrow-backward.vaadin:arrow-circle-down-o.vaadin:arrow-circle-down.vaadin:arrow-circle-left-o.vaadin:arrow-circle-left.vaadin:arrow-circle-right-o.vaadin:arrow-circle-right.vaadin:arrow-circle-up-o.vaadin:arrow-circle-up.vaadin:arrow-down.vaadin:arrow-forward.vaadin:arrow-left.vaadin:arrow-long-down.vaadin:arrow-long-left.vaadin:arrow-right.vaadin:arrow-up.vaadin:arrows-cross.vaadin:arrows-long-h.vaadin:arrows-long-right.vaadin:arrows-long-up.vaadin:arrows-long-v.vaadin:arrows.vaadin:asterisk.vaadin:at.vaadin:automation.vaadin:backspace-a.vaadin:backspace.vaadin:backwards.vaadin:ban.vaadin:bar-chart-h.vaadin:bar-chart-v.vaadin:bar-chart.vaadin:barcode.vaadin:bed.vaadin:bell-o.vaadin:bell-slash-o.vaadin:bell-slash.vaadin:bell.vaadin:boat.vaadin:bold.vaadin:bolt.vaadin:bomb.vaadin:book-dollar.vaadin:book-percent.vaadin:book.vaadin:bookmark-o.vaadin:bookmark.vaadin:briefcase.vaadin:browser.vaadin:bug-o.vaadin:bug.vaadin:building-o.vaadin:building.vaadin:bullets.vaadin:bullseye.vaadin:bus.vaadin:buss.vaadin:button.vaadin:calc-book.vaadin:calc.vaadin:calendar-briefcase.vaadin:calendar-clock.vaadin:calendar-envelope.vaadin:calendar-o.vaadin:calendar-user.vaadin:calendar.vaadin:camera.vaadin:car.vaadin:caret-down.vaadin:caret-left.vaadin:caret-right.vaadin:caret-square-down-o.vaadin:caret-square-left-o.vaadin:caret-square-right-o.vaadin:caret-square-up-o.vaadin:caret-up.vaadin:cart-o.vaadin:cart.vaadin:cash.vaadin:chart-3d.vaadin:chart-grid.vaadin:chart-line.vaadin:chart-timeline.vaadin:chart.vaadin:chat.vaadin:check-circle-o.vaadin:check-circle.vaadin:check-square-o.vaadin:check-square.vaadin:check.vaadin:chevron-circle-down-o.vaadin:chevron-circle-down.vaadin:chevron-circle-left-o.vaadin:chevron-circle-left.vaadin:chevron-circle-right-o.vaadin:chevron-circle-right.vaadin:chevron-circle-up-o.vaadin:chevron-circle-up.vaadin:chevron-down-small.vaadin:chevron-down.vaadin:chevron-left-small.vaadin:chevron-left.vaadin:chevron-right-small.vaadin:chevron-right.vaadin:chevron-up-small.vaadin:chevron-up.vaadin:child.vaadin:circle-thin.vaadin:circle.vaadin:clipboard-check.vaadin:clipboard-cross.vaadin:clipboard-heart.vaadin:clipboard-pulse.vaadin:clipboard-text.vaadin:clipboard-user.vaadin:clipboard.vaadin:clock.vaadin:close-big.vaadin:close-circle-o.vaadin:close-circle.vaadin:close-small.vaadin:close.vaadin:cloud-download-o.vaadin:cloud-download.vaadin:cloud-o.vaadin:cloud-upload-o.vaadin:cloud-upload.vaadin:cloud.vaadin:cluster.vaadin:code.vaadin:coffee.vaadin:cog-o.vaadin:cog.vaadin:cogs.vaadin:coin-piles.vaadin:coins.vaadin:combobox.vaadin:comment-ellipsis-o.vaadin:comment-ellipsis.vaadin:comment-o.vaadin:comment.vaadin:comments-o.vaadin:comments.vaadin:compile.vaadin:compress-square.vaadin:compress.vaadin:connect-o.vaadin:connect.vaadin:controller.vaadin:copy-o.vaadin:copy.vaadin:copyright.vaadin:corner-lower-left.vaadin:corner-lower-right.vaadin:corner-upper-left.vaadin:corner-upper-right.vaadin:credit-card.vaadin:crop.vaadin:cross-cutlery.vaadin:crosshairs.vaadin:css.vaadin:ctrl-a.vaadin:ctrl.vaadin:cube.vaadin:cubes.vaadin:curly-brackets.vaadin:cursor-o.vaadin:cursor.vaadin:cutlery.vaadin:dashboard.vaadin:database.vaadin:date-input.vaadin:deindent.vaadin:del-a.vaadin:del.vaadin:dental-chair.vaadin:desktop.vaadin:diamond-o.vaadin:diamond.vaadin:diploma-scroll.vaadin:diploma.vaadin:disc.vaadin:doctor-briefcase.vaadin:doctor.vaadin:dollar.vaadin:dot-circle.vaadin:download-alt.vaadin:download.vaadin:drop.vaadin:edit.vaadin:eject.vaadin:elastic.vaadin:ellipsis-circle-o.vaadin:ellipsis-circle.vaadin:ellipsis-dots-h.vaadin:ellipsis-dots-v.vaadin:ellipsis-h.vaadin:ellipsis-v.vaadin:enter-arrow.vaadin:enter.vaadin:envelope-o.vaadin:envelope-open-o.vaadin:envelope-open.vaadin:envelope.vaadin:envelopes-o.vaadin:envelopes.vaadin:eraser.vaadin:esc-a.vaadin:esc.vaadin:euro.vaadin:exchange.vaadin:exclamation-circle-o.vaadin:exclamation-circle.vaadin:exclamation.vaadin:exit-o.vaadin:exit.vaadin:expand-full.vaadin:expand-square.vaadin:expand.vaadin:external-browser.vaadin:external-link.vaadin:eye-slash.vaadin:eye.vaadin:eyedropper.vaadin:facebook-square.vaadin:facebook.vaadin:factory.vaadin:family.vaadin:fast-backward.vaadin:fast-forward.vaadin:female.vaadin:file-add.vaadin:file-code.vaadin:file-font.vaadin:file-movie.vaadin:file-o.vaadin:file-picture.vaadin:file-presentation.vaadin:file-process.vaadin:file-refresh.vaadin:file-remove.vaadin:file-search.vaadin:file-sound.vaadin:file-start.vaadin:file-table.vaadin:file-text-o.vaadin:file-text.vaadin:file-tree-small.vaadin:file-tree-sub.vaadin:file-tree.vaadin:file-zip.vaadin:file.vaadin:fill.vaadin:film.vaadin:filter.vaadin:fire.vaadin:flag-checkered.vaadin:flag-o.vaadin:flag.vaadin:flash.vaadin:flask.vaadin:flight-landing.vaadin:flight-takeoff.vaadin:flip-h.vaadin:flip-v.vaadin:folder-add.vaadin:folder-o.vaadin:folder-open-o.vaadin:folder-open.vaadin:folder-remove.vaadin:folder-search.vaadin:folder.vaadin:font.vaadin:form.vaadin:forward.vaadin:frown-o.vaadin:funcion.vaadin:function.vaadin:funnel.vaadin:gamepad.vaadin:gavel.vaadin:gift.vaadin:glass.vaadin:glasses.vaadin:globe-wire.vaadin:globe.vaadin:golf.vaadin:google-plus-square.vaadin:google-plus.vaadin:grab.vaadin:grid-bevel.vaadin:grid-big-o.vaadin:grid-big.vaadin:grid-h.vaadin:grid-small-o.vaadin:grid-small.vaadin:grid-v.vaadin:grid.vaadin:group.vaadin:hammer.vaadin:hand.vaadin:handle-corner.vaadin:hands-up.vaadin:handshake.vaadin:harddrive-o.vaadin:harddrive.vaadin:hash.vaadin:header.vaadin:headphones.vaadin:headset.vaadin:health-card.vaadin:heart-o.vaadin:heart.vaadin:home-o.vaadin:home.vaadin:hospital.vaadin:hourglass-empty.vaadin:hourglass-end.vaadin:hourglass-start.vaadin:hourglass.vaadin:inbox.vaadin:indent.vaadin:info-circle-o.vaadin:info-circle.vaadin:info.vaadin:input.vaadin:insert.vaadin:institution.vaadin:invoice.vaadin:italic.vaadin:key-o.vaadin:key.vaadin:keyboard-o.vaadin:keyboard.vaadin:laptop.vaadin:layout.vaadin:level-down-bold.vaadin:level-down.vaadin:level-left-bold.vaadin:level-left.vaadin:level-right-bold.vaadin:level-right.vaadin:level-up-bold.vaadin:level-up.vaadin:lifebuoy.vaadin:lightbulb.vaadin:line-bar-chart.vaadin:line-chart.vaadin:line-h.vaadin:line-v.vaadin:lines-list.vaadin:lines.vaadin:link.vaadin:list-ol.vaadin:list-select.vaadin:list-ul.vaadin:list.vaadin:location-arrow-circle-o.vaadin:location-arrow-circle.vaadin:location-arrow.vaadin:lock.vaadin:magic.vaadin:magnet.vaadin:mailbox.vaadin:male.vaadin:map-marker.vaadin:margin-bottom.vaadin:margin-left.vaadin:margin-right.vaadin:margin-top.vaadin:margin.vaadin:medal.vaadin:megafone.vaadin:megaphone.vaadin:meh-o.vaadin:menu.vaadin:microphone.vaadin:minus-circle-o.vaadin:minus-circle.vaadin:minus-square-o.vaadin:minus.vaadin:mobile-browser.vaadin:mobile-retro.vaadin:mobile.vaadin:modal-list.vaadin:modal.vaadin:money-deposit.vaadin:money-exchange.vaadin:money-withdraw.vaadin:money.vaadin:moon-o.vaadin:moon.vaadin:morning.vaadin:movie.vaadin:music.vaadin:mute.vaadin:native-button.vaadin:newspaper.vaadin:notebook.vaadin:nurse.vaadin:office.vaadin:open-book.vaadin:option-a.vaadin:option.vaadin:options.vaadin:orientation.vaadin:out.vaadin:outbox.vaadin:package.vaadin:padding-bottom.vaadin:padding-left.vaadin:padding-right.vaadin:padding-top.vaadin:padding.vaadin:paint-roll.vaadin:paintbrush.vaadin:palete.vaadin:palette.vaadin:panel.vaadin:paperclip.vaadin:paperplane-o.vaadin:paperplane.vaadin:paragraph.vaadin:password.vaadin:paste.vaadin:pause.vaadin:pencil.vaadin:phone-landline.vaadin:phone.vaadin:picture.vaadin:pie-bar-chart.vaadin:pie-chart.vaadin:piggy-bank-coin.vaadin:piggy-bank.vaadin:pill.vaadin:pills.vaadin:pin-post.vaadin:pin.vaadin:play-circle-o.vaadin:play-circle.vaadin:play.vaadin:plug.vaadin:plus-circle-o.vaadin:plus-circle.vaadin:plus-minus.vaadin:plus-square-o.vaadin:plus.vaadin:pointer.vaadin:power-off.vaadin:presentation.vaadin:print.vaadin:progressbar.vaadin:puzzle-piece.vaadin:pyramid-chart.vaadin:qrcode.vaadin:question-circle-o.vaadin:question-circle.vaadin:question.vaadin:quote-left.vaadin:quote-right.vaadin:random.vaadin:raster-lower-left.vaadin:raster.vaadin:records.vaadin:recycle.vaadin:refresh.vaadin:reply-all.vaadin:reply.vaadin:resize-h.vaadin:resize-v.vaadin:retweet.vaadin:rhombus.vaadin:road-branch.vaadin:road-branches.vaadin:road-split.vaadin:road.vaadin:rocket.vaadin:rotate-left.vaadin:rotate-right.vaadin:rss-square.vaadin:rss.vaadin:safe-lock.vaadin:safe.vaadin:scale-unbalance.vaadin:scale.vaadin:scatter-chart.vaadin:scissors.vaadin:screwdriver.vaadin:search-minus.vaadin:search-plus.vaadin:search.vaadin:select.vaadin:server.vaadin:share-square.vaadin:share.vaadin:shield.vaadin:shift-arrow.vaadin:shift.vaadin:shop.vaadin:sign-in-alt.vaadin:sign-in.vaadin:sign-out-alt.vaadin:sign-out.vaadin:signal.vaadin:sitemap.vaadin:slider.vaadin:sliders.vaadin:smiley-o.vaadin:sort.vaadin:sound-disable.vaadin:spark-line.vaadin:specialist.vaadin:spinner-arc.vaadin:spinner-third.vaadin:spinner.vaadin:spline-area-chart.vaadin:spline-chart.vaadin:split-h.vaadin:split-v.vaadin:split.vaadin:spoon.vaadin:square-shadow.vaadin:star-half-left-o.vaadin:star-half-left.vaadin:star-half-right-o.vaadin:star-half-right.vaadin:star-o.vaadin:star.vaadin:start-cog.vaadin:step-backward.vaadin:step-forward.vaadin:stethoscope.vaadin:stock.vaadin:stop-cog.vaadin:stop.vaadin:stopwatch.vaadin:storage.vaadin:strikethrough.vaadin:subscript.vaadin:suitcase.vaadin:sun-down.vaadin:sun-o.vaadin:sun-rise.vaadin:superscript.vaadin:sword.vaadin:tab-a.vaadin:tab.vaadin:table.vaadin:tablet.vaadin:tabs.vaadin:tag.vaadin:tags.vaadin:tasks.vaadin:taxi.vaadin:teeth.vaadin:terminal.vaadin:text-height.vaadin:text-input.vaadin:text-label.vaadin:text-width.vaadin:thin-square.vaadin:thumbs-down-o.vaadin:thumbs-down.vaadin:thumbs-up-o.vaadin:thumbs-up.vaadin:ticket.vaadin:time-backward.vaadin:time-forward.vaadin:timer.vaadin:toolbox.vaadin:tools.vaadin:tooth.vaadin:touch.vaadin:train.vaadin:trash.vaadin:tree-table.vaadin:trendind-down.vaadin:trending-down.vaadin:trending-up.vaadin:trophy.vaadin:truck.vaadin:twin-col-select.vaadin:twitter-square.vaadin:twitter.vaadin:umbrella.vaadin:underline.vaadin:unlink.vaadin:unlock.vaadin:upload-alt.vaadin:upload.vaadin:user-card.vaadin:user-check.vaadin:user-clock.vaadin:user-heart.vaadin:user-star.vaadin:user.vaadin:users.vaadin:vaadin-h.vaadin:vaadin-v.vaadin:viewport.vaadin:vimeo-square.vaadin:vimeo.vaadin:volume-down.vaadin:volume-off.vaadin:volume-up.vaadin:volume.vaadin:wallet.vaadin:warning.vaadin:workplace.vaadin:wrench.vaadin:youtube-square.vaadin:youtube`.split(`.`),bl=null,xl=()=>(bl||=Promise.all([E(()=>import(`./vendor-ui5.js`).then(e=>e.n),__vite__mapDeps([5,1])),E(()=>import(`./vendor-ui5.js`).then(e=>e.t),__vite__mapDeps([5,1]))]),bl),Q=class extends y{constructor(...e){super(...e),this.ui5FieldComponentsReady=!1,this.component=void 0,this.field=void 0,this.baseUrl=void 0,this.state={},this.data={},this.appState={},this.appData={},this.colorPickerOpened=!1,this.colorPickerValue=void 0,this.comboData=[],this._comboFilter=``,this.rendered=!1,this.renderColorPicker=()=>{this.loadUi5FieldComponents();let e=this.field?.fieldId;return w`
+  `}};O([v()],xl.prototype,`fieldId`,void 0),O([v()],xl.prototype,`label`,void 0),O([v()],xl.prototype,`state`,void 0),O([v()],xl.prototype,`data`,void 0),O([v()],xl.prototype,`value`,void 0),O([v()],xl.prototype,`autoFocus`,void 0),O([v()],xl.prototype,`required`,void 0),O([v()],xl.prototype,`colspan`,void 0),O([v()],xl.prototype,`helperText`,void 0),xl=O([h(`mateu-money-field`)],xl);var Sl=`vaadin:abacus.vaadin:absolute-position.vaadin:academy-cap.vaadin:accessibility.vaadin:accordion-menu.vaadin:add-dock.vaadin:adjust.vaadin:adobe-flash.vaadin:airplane.vaadin:alarm.vaadin:align-center.vaadin:align-justify.vaadin:align-left.vaadin:align-right.vaadin:alt-a.vaadin:alt.vaadin:ambulance.vaadin:anchor.vaadin:angle-double-down.vaadin:angle-double-left.vaadin:angle-double-right.vaadin:angle-double-up.vaadin:angle-down.vaadin:angle-left.vaadin:angle-right.vaadin:angle-up.vaadin:archive.vaadin:archives.vaadin:area-select.vaadin:arrow-backward.vaadin:arrow-circle-down-o.vaadin:arrow-circle-down.vaadin:arrow-circle-left-o.vaadin:arrow-circle-left.vaadin:arrow-circle-right-o.vaadin:arrow-circle-right.vaadin:arrow-circle-up-o.vaadin:arrow-circle-up.vaadin:arrow-down.vaadin:arrow-forward.vaadin:arrow-left.vaadin:arrow-long-down.vaadin:arrow-long-left.vaadin:arrow-right.vaadin:arrow-up.vaadin:arrows-cross.vaadin:arrows-long-h.vaadin:arrows-long-right.vaadin:arrows-long-up.vaadin:arrows-long-v.vaadin:arrows.vaadin:asterisk.vaadin:at.vaadin:automation.vaadin:backspace-a.vaadin:backspace.vaadin:backwards.vaadin:ban.vaadin:bar-chart-h.vaadin:bar-chart-v.vaadin:bar-chart.vaadin:barcode.vaadin:bed.vaadin:bell-o.vaadin:bell-slash-o.vaadin:bell-slash.vaadin:bell.vaadin:boat.vaadin:bold.vaadin:bolt.vaadin:bomb.vaadin:book-dollar.vaadin:book-percent.vaadin:book.vaadin:bookmark-o.vaadin:bookmark.vaadin:briefcase.vaadin:browser.vaadin:bug-o.vaadin:bug.vaadin:building-o.vaadin:building.vaadin:bullets.vaadin:bullseye.vaadin:bus.vaadin:buss.vaadin:button.vaadin:calc-book.vaadin:calc.vaadin:calendar-briefcase.vaadin:calendar-clock.vaadin:calendar-envelope.vaadin:calendar-o.vaadin:calendar-user.vaadin:calendar.vaadin:camera.vaadin:car.vaadin:caret-down.vaadin:caret-left.vaadin:caret-right.vaadin:caret-square-down-o.vaadin:caret-square-left-o.vaadin:caret-square-right-o.vaadin:caret-square-up-o.vaadin:caret-up.vaadin:cart-o.vaadin:cart.vaadin:cash.vaadin:chart-3d.vaadin:chart-grid.vaadin:chart-line.vaadin:chart-timeline.vaadin:chart.vaadin:chat.vaadin:check-circle-o.vaadin:check-circle.vaadin:check-square-o.vaadin:check-square.vaadin:check.vaadin:chevron-circle-down-o.vaadin:chevron-circle-down.vaadin:chevron-circle-left-o.vaadin:chevron-circle-left.vaadin:chevron-circle-right-o.vaadin:chevron-circle-right.vaadin:chevron-circle-up-o.vaadin:chevron-circle-up.vaadin:chevron-down-small.vaadin:chevron-down.vaadin:chevron-left-small.vaadin:chevron-left.vaadin:chevron-right-small.vaadin:chevron-right.vaadin:chevron-up-small.vaadin:chevron-up.vaadin:child.vaadin:circle-thin.vaadin:circle.vaadin:clipboard-check.vaadin:clipboard-cross.vaadin:clipboard-heart.vaadin:clipboard-pulse.vaadin:clipboard-text.vaadin:clipboard-user.vaadin:clipboard.vaadin:clock.vaadin:close-big.vaadin:close-circle-o.vaadin:close-circle.vaadin:close-small.vaadin:close.vaadin:cloud-download-o.vaadin:cloud-download.vaadin:cloud-o.vaadin:cloud-upload-o.vaadin:cloud-upload.vaadin:cloud.vaadin:cluster.vaadin:code.vaadin:coffee.vaadin:cog-o.vaadin:cog.vaadin:cogs.vaadin:coin-piles.vaadin:coins.vaadin:combobox.vaadin:comment-ellipsis-o.vaadin:comment-ellipsis.vaadin:comment-o.vaadin:comment.vaadin:comments-o.vaadin:comments.vaadin:compile.vaadin:compress-square.vaadin:compress.vaadin:connect-o.vaadin:connect.vaadin:controller.vaadin:copy-o.vaadin:copy.vaadin:copyright.vaadin:corner-lower-left.vaadin:corner-lower-right.vaadin:corner-upper-left.vaadin:corner-upper-right.vaadin:credit-card.vaadin:crop.vaadin:cross-cutlery.vaadin:crosshairs.vaadin:css.vaadin:ctrl-a.vaadin:ctrl.vaadin:cube.vaadin:cubes.vaadin:curly-brackets.vaadin:cursor-o.vaadin:cursor.vaadin:cutlery.vaadin:dashboard.vaadin:database.vaadin:date-input.vaadin:deindent.vaadin:del-a.vaadin:del.vaadin:dental-chair.vaadin:desktop.vaadin:diamond-o.vaadin:diamond.vaadin:diploma-scroll.vaadin:diploma.vaadin:disc.vaadin:doctor-briefcase.vaadin:doctor.vaadin:dollar.vaadin:dot-circle.vaadin:download-alt.vaadin:download.vaadin:drop.vaadin:edit.vaadin:eject.vaadin:elastic.vaadin:ellipsis-circle-o.vaadin:ellipsis-circle.vaadin:ellipsis-dots-h.vaadin:ellipsis-dots-v.vaadin:ellipsis-h.vaadin:ellipsis-v.vaadin:enter-arrow.vaadin:enter.vaadin:envelope-o.vaadin:envelope-open-o.vaadin:envelope-open.vaadin:envelope.vaadin:envelopes-o.vaadin:envelopes.vaadin:eraser.vaadin:esc-a.vaadin:esc.vaadin:euro.vaadin:exchange.vaadin:exclamation-circle-o.vaadin:exclamation-circle.vaadin:exclamation.vaadin:exit-o.vaadin:exit.vaadin:expand-full.vaadin:expand-square.vaadin:expand.vaadin:external-browser.vaadin:external-link.vaadin:eye-slash.vaadin:eye.vaadin:eyedropper.vaadin:facebook-square.vaadin:facebook.vaadin:factory.vaadin:family.vaadin:fast-backward.vaadin:fast-forward.vaadin:female.vaadin:file-add.vaadin:file-code.vaadin:file-font.vaadin:file-movie.vaadin:file-o.vaadin:file-picture.vaadin:file-presentation.vaadin:file-process.vaadin:file-refresh.vaadin:file-remove.vaadin:file-search.vaadin:file-sound.vaadin:file-start.vaadin:file-table.vaadin:file-text-o.vaadin:file-text.vaadin:file-tree-small.vaadin:file-tree-sub.vaadin:file-tree.vaadin:file-zip.vaadin:file.vaadin:fill.vaadin:film.vaadin:filter.vaadin:fire.vaadin:flag-checkered.vaadin:flag-o.vaadin:flag.vaadin:flash.vaadin:flask.vaadin:flight-landing.vaadin:flight-takeoff.vaadin:flip-h.vaadin:flip-v.vaadin:folder-add.vaadin:folder-o.vaadin:folder-open-o.vaadin:folder-open.vaadin:folder-remove.vaadin:folder-search.vaadin:folder.vaadin:font.vaadin:form.vaadin:forward.vaadin:frown-o.vaadin:funcion.vaadin:function.vaadin:funnel.vaadin:gamepad.vaadin:gavel.vaadin:gift.vaadin:glass.vaadin:glasses.vaadin:globe-wire.vaadin:globe.vaadin:golf.vaadin:google-plus-square.vaadin:google-plus.vaadin:grab.vaadin:grid-bevel.vaadin:grid-big-o.vaadin:grid-big.vaadin:grid-h.vaadin:grid-small-o.vaadin:grid-small.vaadin:grid-v.vaadin:grid.vaadin:group.vaadin:hammer.vaadin:hand.vaadin:handle-corner.vaadin:hands-up.vaadin:handshake.vaadin:harddrive-o.vaadin:harddrive.vaadin:hash.vaadin:header.vaadin:headphones.vaadin:headset.vaadin:health-card.vaadin:heart-o.vaadin:heart.vaadin:home-o.vaadin:home.vaadin:hospital.vaadin:hourglass-empty.vaadin:hourglass-end.vaadin:hourglass-start.vaadin:hourglass.vaadin:inbox.vaadin:indent.vaadin:info-circle-o.vaadin:info-circle.vaadin:info.vaadin:input.vaadin:insert.vaadin:institution.vaadin:invoice.vaadin:italic.vaadin:key-o.vaadin:key.vaadin:keyboard-o.vaadin:keyboard.vaadin:laptop.vaadin:layout.vaadin:level-down-bold.vaadin:level-down.vaadin:level-left-bold.vaadin:level-left.vaadin:level-right-bold.vaadin:level-right.vaadin:level-up-bold.vaadin:level-up.vaadin:lifebuoy.vaadin:lightbulb.vaadin:line-bar-chart.vaadin:line-chart.vaadin:line-h.vaadin:line-v.vaadin:lines-list.vaadin:lines.vaadin:link.vaadin:list-ol.vaadin:list-select.vaadin:list-ul.vaadin:list.vaadin:location-arrow-circle-o.vaadin:location-arrow-circle.vaadin:location-arrow.vaadin:lock.vaadin:magic.vaadin:magnet.vaadin:mailbox.vaadin:male.vaadin:map-marker.vaadin:margin-bottom.vaadin:margin-left.vaadin:margin-right.vaadin:margin-top.vaadin:margin.vaadin:medal.vaadin:megafone.vaadin:megaphone.vaadin:meh-o.vaadin:menu.vaadin:microphone.vaadin:minus-circle-o.vaadin:minus-circle.vaadin:minus-square-o.vaadin:minus.vaadin:mobile-browser.vaadin:mobile-retro.vaadin:mobile.vaadin:modal-list.vaadin:modal.vaadin:money-deposit.vaadin:money-exchange.vaadin:money-withdraw.vaadin:money.vaadin:moon-o.vaadin:moon.vaadin:morning.vaadin:movie.vaadin:music.vaadin:mute.vaadin:native-button.vaadin:newspaper.vaadin:notebook.vaadin:nurse.vaadin:office.vaadin:open-book.vaadin:option-a.vaadin:option.vaadin:options.vaadin:orientation.vaadin:out.vaadin:outbox.vaadin:package.vaadin:padding-bottom.vaadin:padding-left.vaadin:padding-right.vaadin:padding-top.vaadin:padding.vaadin:paint-roll.vaadin:paintbrush.vaadin:palete.vaadin:palette.vaadin:panel.vaadin:paperclip.vaadin:paperplane-o.vaadin:paperplane.vaadin:paragraph.vaadin:password.vaadin:paste.vaadin:pause.vaadin:pencil.vaadin:phone-landline.vaadin:phone.vaadin:picture.vaadin:pie-bar-chart.vaadin:pie-chart.vaadin:piggy-bank-coin.vaadin:piggy-bank.vaadin:pill.vaadin:pills.vaadin:pin-post.vaadin:pin.vaadin:play-circle-o.vaadin:play-circle.vaadin:play.vaadin:plug.vaadin:plus-circle-o.vaadin:plus-circle.vaadin:plus-minus.vaadin:plus-square-o.vaadin:plus.vaadin:pointer.vaadin:power-off.vaadin:presentation.vaadin:print.vaadin:progressbar.vaadin:puzzle-piece.vaadin:pyramid-chart.vaadin:qrcode.vaadin:question-circle-o.vaadin:question-circle.vaadin:question.vaadin:quote-left.vaadin:quote-right.vaadin:random.vaadin:raster-lower-left.vaadin:raster.vaadin:records.vaadin:recycle.vaadin:refresh.vaadin:reply-all.vaadin:reply.vaadin:resize-h.vaadin:resize-v.vaadin:retweet.vaadin:rhombus.vaadin:road-branch.vaadin:road-branches.vaadin:road-split.vaadin:road.vaadin:rocket.vaadin:rotate-left.vaadin:rotate-right.vaadin:rss-square.vaadin:rss.vaadin:safe-lock.vaadin:safe.vaadin:scale-unbalance.vaadin:scale.vaadin:scatter-chart.vaadin:scissors.vaadin:screwdriver.vaadin:search-minus.vaadin:search-plus.vaadin:search.vaadin:select.vaadin:server.vaadin:share-square.vaadin:share.vaadin:shield.vaadin:shift-arrow.vaadin:shift.vaadin:shop.vaadin:sign-in-alt.vaadin:sign-in.vaadin:sign-out-alt.vaadin:sign-out.vaadin:signal.vaadin:sitemap.vaadin:slider.vaadin:sliders.vaadin:smiley-o.vaadin:sort.vaadin:sound-disable.vaadin:spark-line.vaadin:specialist.vaadin:spinner-arc.vaadin:spinner-third.vaadin:spinner.vaadin:spline-area-chart.vaadin:spline-chart.vaadin:split-h.vaadin:split-v.vaadin:split.vaadin:spoon.vaadin:square-shadow.vaadin:star-half-left-o.vaadin:star-half-left.vaadin:star-half-right-o.vaadin:star-half-right.vaadin:star-o.vaadin:star.vaadin:start-cog.vaadin:step-backward.vaadin:step-forward.vaadin:stethoscope.vaadin:stock.vaadin:stop-cog.vaadin:stop.vaadin:stopwatch.vaadin:storage.vaadin:strikethrough.vaadin:subscript.vaadin:suitcase.vaadin:sun-down.vaadin:sun-o.vaadin:sun-rise.vaadin:superscript.vaadin:sword.vaadin:tab-a.vaadin:tab.vaadin:table.vaadin:tablet.vaadin:tabs.vaadin:tag.vaadin:tags.vaadin:tasks.vaadin:taxi.vaadin:teeth.vaadin:terminal.vaadin:text-height.vaadin:text-input.vaadin:text-label.vaadin:text-width.vaadin:thin-square.vaadin:thumbs-down-o.vaadin:thumbs-down.vaadin:thumbs-up-o.vaadin:thumbs-up.vaadin:ticket.vaadin:time-backward.vaadin:time-forward.vaadin:timer.vaadin:toolbox.vaadin:tools.vaadin:tooth.vaadin:touch.vaadin:train.vaadin:trash.vaadin:tree-table.vaadin:trendind-down.vaadin:trending-down.vaadin:trending-up.vaadin:trophy.vaadin:truck.vaadin:twin-col-select.vaadin:twitter-square.vaadin:twitter.vaadin:umbrella.vaadin:underline.vaadin:unlink.vaadin:unlock.vaadin:upload-alt.vaadin:upload.vaadin:user-card.vaadin:user-check.vaadin:user-clock.vaadin:user-heart.vaadin:user-star.vaadin:user.vaadin:users.vaadin:vaadin-h.vaadin:vaadin-v.vaadin:viewport.vaadin:vimeo-square.vaadin:vimeo.vaadin:volume-down.vaadin:volume-off.vaadin:volume-up.vaadin:volume.vaadin:wallet.vaadin:warning.vaadin:workplace.vaadin:wrench.vaadin:youtube-square.vaadin:youtube`.split(`.`),Cl=null,wl=()=>(Cl||=Promise.all([E(()=>import(`./vendor-ui5.js`).then(e=>e.n),__vite__mapDeps([5,1])),E(()=>import(`./vendor-ui5.js`).then(e=>e.t),__vite__mapDeps([5,1]))]),Cl),Z=class extends y{constructor(...e){super(...e),this.ui5FieldComponentsReady=!1,this.component=void 0,this.field=void 0,this.baseUrl=void 0,this.state={},this.data={},this.appState={},this.appData={},this.colorPickerOpened=!1,this.colorPickerValue=void 0,this.comboData=[],this._comboFilter=``,this.rendered=!1,this.renderColorPicker=()=>{this.loadUi5FieldComponents();let e=this.field?.fieldId;return w`
             <ui5-color-picker value="${this.state&&e in this.state?this.state[e]:this.field?.initialValue}" @change="${e=>this.colorPickerValue=e.target.value}">Picker</ui5-color-picker>
         `},this.saveColor=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.colorPickerValue,fieldId:this.field.fieldId},bubbles:!0,composed:!0})),this.colorPickerOpened=!1},this.renderColorPickerFooter=()=>w`<vaadin-button @click="${()=>this.colorPickerOpened=!1}">Cancel</vaadin-button>
         <vaadin-button theme="primary" @click="${this.saveColor}">Save</vaadin-button>`,this.checked=e=>{let t=e.target;this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t.checked,fieldId:this.field.fieldId},bubbles:!0,composed:!0}))},this.convert=e=>this.field?.dataType==`integer`?parseInt(e):e,this.multiComboBoxValueChanged=e=>{if(this.rendered){let t=this.field?.fieldId,n=this.state&&t in this.state?this.state[t]:this.field?.initialValue,r;e.detail.value&&(r=e.detail.value.map(e=>e.value),r&&r.length>0&&(this.data[this.id]||(this.data[this.id]={}),this.data[this.id].content||(this.data[this.id].content=[]),this.data[this.id]&&this.data[this.id].content&&e.detail.value.forEach(e=>{this.data[this.id].content?.find(t=>e.value==t.value)||this.data[this.id].content.push(e)}))),this.compareArrays(r,n)||this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}},this.valueChanged=e=>{this.rendered&&e.detail.value!==void 0&&e.detail.value!=this.state[this.field.fieldId]&&this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.convert(e.detail.value),fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.selectedItems=e=>{if(e&&e.length>0)if(this.field?.remoteCoordinates){if(this.comboData&&this.comboData.length>0)return this.comboData?.filter(t=>e.indexOf(t.value)>=0);if(this.data[this.id]&&this.data[this.id].content&&this.data[this.id].content.length>0)return this.data[this.id].content.filter(t=>e.indexOf(t.value)>=0)}else return this.field?.options?.filter(t=>e.indexOf(t.value)>=0);return[]},this.selectedIndex=e=>{if(e)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content){let t=this.data[this.id].content.find(t=>t.value==e);if(t)return this.data[this.id].content.indexOf(t)}}else{let t=this.field?.options?.find(t=>t.value==e);if(t)return this.field?.options?.indexOf(t)}},this.selectedIndexes=e=>{if(e&&e.length>0)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content)return this.data[this.id].content.filter(t=>e.indexOf(t.value)>=0).map(e=>this.data[this.id].content.indexOf(e))}else return this.field?.options?.filter(t=>e.indexOf(t.value)>=0).map(e=>this.field?.options?.indexOf(e));return[]},this.compareArrays=(e,t)=>this.falsy(e)&&this.falsy(t)||e&&t&&e.length===t.length&&e.every((e,n)=>e===t[n]),this.falsy=e=>!e||e.length==0,this.listItemsSelected=e=>{let t=this.field?.fieldId,n=this.state&&t in this.state?this.state[t]:this.field?.initialValue,r;this.rendered&&(e.detail.value&&(this.field?.remoteCoordinates?this.data[this.id]&&this.data[this.id].content&&(r=e.detail.value.map(e=>this.data[this.id].content[e].value)):r=e.detail.value.map(e=>this.field.options[e].value)),this.compareArrays(r,n)||this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r,fieldId:this.field?.fieldId},bubbles:!0,composed:!0})))},this.listItemSelected=e=>{let t;if(e.detail.value||e.detail.value==0)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content){let n=this.data[this.id].content[e.detail.value];n&&(t=n.value)}}else{let n=this.field.options[e.detail.value];n&&(t=n.value)}this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.mapPosition=e=>{switch(e){case`topStretch`:return`top-stretch`;case`topStart`:return`top-start`;case`topCenter`:return`top-center`;case`topEnd`:return`top-end`;case`middle`:return`middle`;case`bottomStart`:return`bottom-start`;case`bottomEnd`:return`bottom-end`;case`bottomStretch`:return`bottom-stretch`;case`bottomCenter`:return`bottom-center`}return`bottom-end`},this.helperShownInControl=!1,this.lastAnnouncedError=``,this.controlOwnsValidity=!1,this.fileUploaded=e=>{let t=this.field?.fieldId??``,n=this.state[t];n.push({id:e.detail.xhr.responseText,name:e.detail.file.name}),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:n,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.fileChanged=e=>{let t=this.field?.fieldId??``,n=(e.detail.value??[]).filter(e=>e.id).map(e=>e.id),r=(this.state[t]??[]).map(e=>e.id);if(!this.compareArrays(r,n)){let t=(e.detail.value??[]).filter(e=>e.id).map(e=>({id:e.id,name:e.name}));this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}},this.triggerImageUpload=()=>{(this.renderRoot?.querySelector(`input[type="file"]`))?.click()},this.imageUpload=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r.result,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},r.readAsDataURL(n),t.value=``},this.imageDelete=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:``,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.iconComboboxRenderer=e=>w`
@@ -9075,7 +9075,7 @@ ${i}
 
             </vaadin-horizontal-layout>
                             `:e.label}
-`,this.filteredIcons=[],this.navLinkOffset=null,this.iconFilterChanged=e=>{this.filteredIcons=yl.filter(t=>!e.detail.value||t.indexOf(e.detail.value)>=0)}}loadUi5FieldComponents(){this.ui5FieldComponentsReady||xl().then(()=>{this.ui5FieldComponentsReady=!0})}remoteComboDataProvider(e){return(t,n)=>{let{filter:i,page:a,pageSize:o}=t,s=i??``;this._comboFilter=s,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{searchText:i,fieldId:this.field?.fieldId,size:o,page:a,sort:void 0},callback:e=>{if(s===this._comboFilter)if(e?.messages?.forEach(e=>{r.show(e.text,{position:e.position?this.mapPosition(e.position):void 0,theme:e.variant,duration:e.duration})}),!e.fragments||e.fragments.length==0)this.comboData=[],n([],0);else{let t=e.fragments[0].data?.[this.id];this.comboData=t?.content,n(t?.content,t?.totalElements)}},callbackonly:!0},bubbles:!0,composed:!0}))}}disconnectedCallback(){super.disconnectedCallback(),this.rendered=!1}renderNavLink(){let e=this.field?.link;if(!e?.href)return _;let t=j(e.href,this.state,this.data)??e.href,n=j(e.title,this.state,this.data)||t,r=e.icon||(t.startsWith(`http`)?`vaadin:external-link`:`vaadin:link`),i=this.navLinkOffset??`calc(var(--lumo-font-size-s) * 1.6 + (var(--lumo-size-m) - var(--lumo-icon-size-s)) / 2)`;return w`<a
+`,this.filteredIcons=[],this.navLinkOffset=null,this.iconFilterChanged=e=>{this.filteredIcons=Sl.filter(t=>!e.detail.value||t.indexOf(e.detail.value)>=0)}}loadUi5FieldComponents(){this.ui5FieldComponentsReady||wl().then(()=>{this.ui5FieldComponentsReady=!0})}remoteComboDataProvider(e){return(t,n)=>{let{filter:i,page:a,pageSize:o}=t,s=i??``;this._comboFilter=s,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{searchText:i,fieldId:this.field?.fieldId,size:o,page:a,sort:void 0},callback:e=>{if(s===this._comboFilter)if(e?.messages?.forEach(e=>{r.show(e.text,{position:e.position?this.mapPosition(e.position):void 0,theme:e.variant,duration:e.duration})}),!e.fragments||e.fragments.length==0)this.comboData=[],n([],0);else{let t=e.fragments[0].data?.[this.id];this.comboData=t?.content,n(t?.content,t?.totalElements)}},callbackonly:!0},bubbles:!0,composed:!0}))}}disconnectedCallback(){super.disconnectedCallback(),this.rendered=!1}renderNavLink(){let e=this.field?.link;if(!e?.href)return _;let t=j(e.href,this.state,this.data)??e.href,n=j(e.title,this.state,this.data)||t,r=e.icon||(t.startsWith(`http`)?`vaadin:external-link`:`vaadin:link`),i=this.navLinkOffset??`calc(var(--lumo-font-size-s) * 1.6 + (var(--lumo-size-m) - var(--lumo-icon-size-s)) / 2)`;return w`<a
                 data-navlink
                 href="${t}"
                 title="${n}"
@@ -9089,7 +9089,7 @@ ${i}
             ${i?w`
                 <div role="alert"><ul>${r.map(e=>w`<li>${e}</li>`)}</ul></div>
             `:_}
-        </div>`}async firstUpdated(){this.filteredIcons=yl}update(e){e.has(`component`)&&(this.rendered=!1),super.update(e)}updated(e){super.updated(e),this.positionNavLink(),this.applyValidationState(),this.controlOwnsValidity=!!this.validatableControl()}renderField(){let e=this.field?.fieldId??``,t=this.state&&e in this.state?this.state[e]:this.field?.initialValue,n=j(this.field?.label+``,this.state,this.data),r=this.labelAlreadyRendered||!n||n==`null`?_:n;return this.field?.propertyRow?this.renderPropertyRowField(e,t,r,n):this.field?.stereotype==`badge`?this.renderBadgeField(e,t,r,n):this.field?.stereotype==`plainText`?this.renderPlainTextField(e,t,r,n):this.field?.stereotype==`bulletedList`?this.renderBulletedListField(e,t,r,n):this.field?.readOnly&&this.field.stereotype!=`grid`&&this.field.dataType!=`status`&&this.field?.dataType!=`money`?this.renderReadOnlyField(e,t,r,n):this.field?.dataType==`file`?this.renderFileField(e,t,r,n):this.field?.dataType==`string`?this.renderStringField(e,t,r,n):this.field?.dataType==`number`?this.renderNumberField(e,t,r,n):this.field?.dataType==`integer`?this.renderIntegerField(e,t,r,n):this.field?.dataType==`bool`?this.renderBoolField(e,t,r,n):this.field?.dataType==`dateRange`?this.renderDateRangeField(e,t,r,n):this.field?.dataType==`date`?this.renderDateField(e,t,r,n):this.field?.dataType==`dateTime`?this.renderDateTimeField(e,t,r,n):this.field?.dataType==`time`?this.renderTimeField(e,t,r,n):this.field?.dataType==`array`?this.renderArrayField(e,t,r,n):this.field?.dataType==`money`?this.renderMoneyField(e,t,r,n):this.field?.dataType==`status`?this.renderStatusField(e,t,r,n):this.field?.dataType==`range`?this.renderRangeField(e,t,r,n):w`<p>Unknown field type ${this.field?.dataType} / ${this.field?.stereotype}</p>`}renderBadgeField(e,t,n,r){if(!this.field)return w``;let i=t===!0||t===`true`;return w`<vaadin-custom-field
+        </div>`}async firstUpdated(){this.filteredIcons=Sl}update(e){e.has(`component`)&&(this.rendered=!1),super.update(e)}updated(e){super.updated(e),this.positionNavLink(),this.applyValidationState(),this.controlOwnsValidity=!!this.validatableControl()}renderField(){let e=this.field?.fieldId??``,t=this.state&&e in this.state?this.state[e]:this.field?.initialValue,n=j(this.field?.label+``,this.state,this.data),r=this.labelAlreadyRendered||!n||n==`null`?_:n;return this.field?.propertyRow?this.renderPropertyRowField(e,t,r,n):this.field?.stereotype==`badge`?this.renderBadgeField(e,t,r,n):this.field?.stereotype==`plainText`?this.renderPlainTextField(e,t,r,n):this.field?.stereotype==`bulletedList`?this.renderBulletedListField(e,t,r,n):this.field?.readOnly&&this.field.stereotype!=`grid`&&this.field.dataType!=`status`&&this.field?.dataType!=`money`?this.renderReadOnlyField(e,t,r,n):this.field?.dataType==`file`?this.renderFileField(e,t,r,n):this.field?.dataType==`string`?this.renderStringField(e,t,r,n):this.field?.dataType==`number`?this.renderNumberField(e,t,r,n):this.field?.dataType==`integer`?this.renderIntegerField(e,t,r,n):this.field?.dataType==`bool`?this.renderBoolField(e,t,r,n):this.field?.dataType==`dateRange`?this.renderDateRangeField(e,t,r,n):this.field?.dataType==`date`?this.renderDateField(e,t,r,n):this.field?.dataType==`dateTime`?this.renderDateTimeField(e,t,r,n):this.field?.dataType==`time`?this.renderTimeField(e,t,r,n):this.field?.dataType==`array`?this.renderArrayField(e,t,r,n):this.field?.dataType==`money`?this.renderMoneyField(e,t,r,n):this.field?.dataType==`status`?this.renderStatusField(e,t,r,n):this.field?.dataType==`range`?this.renderRangeField(e,t,r,n):w`<p>Unknown field type ${this.field?.dataType} / ${this.field?.stereotype}</p>`}renderBadgeField(e,t,n,r){if(!this.field)return w``;let i=t===!0||t===`true`;return w`<vaadin-custom-field
                     id="${this.field.fieldId}"
                     .helperText="${this.helperText()}"
                     data-colspan="${this.field?.colspan}"
@@ -9174,7 +9174,7 @@ ${i}
                             <vaadin-button theme="icon" @click="${e=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`codesearch-`+this.field?.fieldId,parameters:{}},bubbles:!0,composed:!0}))}}"><vaadin-icon icon="lumo:search"></vaadin-icon></vaadin-button>
                         </vaadin-horizontal-layout>
                     </vaadin-custom-field>
-                `;if(this.field?.stereotype==`select`){if(this.field?.optionsSource){let e=this.field.optionsSource,r=j(e.url,this.state,this.data)??e.url;this.data[this.id]?.sourceSignature!==r&&(this.data[this.id]={content:this.data[this.id]?.content??[],sourceSignature:r},e.proxy?this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`__restfetch__`,parameters:{_sourceKind:`options`,_sourceId:this.field.fieldId},callback:t=>{let n=t?.appData?._restfetch,i=Wt(n,e.itemsPath,e.valuePath,e.labelPath);this.data[this.id]={content:i,totalElements:i.length,sourceSignature:r},this.requestUpdate()},callbackonly:!0},bubbles:!0,composed:!0})):qt(e,e=>j(e,this.state,this.data)).then(e=>{this.data[this.id]={content:e,totalElements:e.length,sourceSignature:r},this.requestUpdate()}).catch(e=>console.warn(`mateu: external options fetch failed`,e)));let i=t;return t&&t.value&&(i=t.value),w`
+                `;if(this.field?.stereotype==`select`){if(this.field?.optionsSource){let e=this.field.optionsSource,r=j(e.url,this.state,this.data)??e.url;this.data[this.id]?.sourceSignature!==r&&(this.data[this.id]={content:this.data[this.id]?.content??[],sourceSignature:r},e.proxy?this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`__restfetch__`,parameters:{_sourceKind:`options`,_sourceId:this.field.fieldId},callback:t=>{let n=t?.appData?._restfetch,i=Kt(n,e.itemsPath,e.valuePath,e.labelPath);this.data[this.id]={content:i,totalElements:i.length,sourceSignature:r},this.requestUpdate()},callbackonly:!0},bubbles:!0,composed:!0})):Yt(e,e=>j(e,this.state,this.data)).then(e=>{this.data[this.id]={content:e,totalElements:e.length,sourceSignature:r},this.requestUpdate()}).catch(e=>console.warn(`mateu: external options fetch failed`,e)));let i=t;return t&&t.value&&(i=t.value),w`
                     <vaadin-select
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9577,7 +9577,7 @@ ${i}
                     >
                         <mateu-camera-capture .fieldId="${this.field.fieldId}" .value="${t}"></mateu-camera-capture>
                     </vaadin-custom-field>
-                `;if(this.field?.stereotype==`fileUpload`){let e=Mc(this.field.attributes,`accept`);return w`
+                `;if(this.field?.stereotype==`fileUpload`){let e=Fc(this.field.attributes,`accept`);return w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9929,7 +9929,7 @@ ${i}
                         .helperText="${this.helperText()}"
                         data-colspan="${this.field.colspan}"
                 >
-                    ${i?w`<span theme="badge pill ${ua(i.type)}">${i.message}</span>`:w``}                    
+                    ${i?w`<span theme="badge pill ${fa(i.type)}">${i.message}</span>`:w``}                    
                 </vaadin-custom-field>
             `}renderRangeField(e,t,n,r){if(!this.field)return w``;this.loadUi5FieldComponents();let i=t;return w`
                 <vaadin-custom-field
@@ -10027,7 +10027,7 @@ ${i}
             text-overflow: clip;
             height: auto;
         }
-  `}};O([S()],Q.prototype,`ui5FieldComponentsReady`,void 0),O([v()],Q.prototype,`component`,void 0),O([v()],Q.prototype,`field`,void 0),O([v()],Q.prototype,`baseUrl`,void 0),O([v()],Q.prototype,`state`,void 0),O([v()],Q.prototype,`data`,void 0),O([v()],Q.prototype,`appState`,void 0),O([v()],Q.prototype,`appData`,void 0),O([v()],Q.prototype,`labelAlreadyRendered`,void 0),O([S()],Q.prototype,`colorPickerOpened`,void 0),O([S()],Q.prototype,`colorPickerValue`,void 0),O([S()],Q.prototype,`controlOwnsValidity`,void 0),O([S()],Q.prototype,`filteredIcons`,void 0),O([S()],Q.prototype,`navLinkOffset`,void 0),Q=O([h(`mateu-field`)],Q);var Sl=(e,t,n,r,i,a,o,s)=>{let c=t.metadata;return w`
+  `}};O([S()],Z.prototype,`ui5FieldComponentsReady`,void 0),O([v()],Z.prototype,`component`,void 0),O([v()],Z.prototype,`field`,void 0),O([v()],Z.prototype,`baseUrl`,void 0),O([v()],Z.prototype,`state`,void 0),O([v()],Z.prototype,`data`,void 0),O([v()],Z.prototype,`appState`,void 0),O([v()],Z.prototype,`appData`,void 0),O([v()],Z.prototype,`labelAlreadyRendered`,void 0),O([S()],Z.prototype,`colorPickerOpened`,void 0),O([S()],Z.prototype,`colorPickerValue`,void 0),O([S()],Z.prototype,`controlOwnsValidity`,void 0),O([S()],Z.prototype,`filteredIcons`,void 0),O([S()],Z.prototype,`navLinkOffset`,void 0),Z=O([h(`mateu-field`)],Z);var Tl=(e,t,n,r,i,a,o,s)=>{let c=t.metadata;return w`
         <mateu-field
                 id="${t.id}"
                 .component="${t}"
@@ -10036,7 +10036,7 @@ ${i}
                 .data="${i}"
                 .appState="${a}"
                 .appdata="${o}"
-                style="${ia(t,i)}" class="${t.cssClasses}"
+                style="${oa(t,i)}" class="${t.cssClasses}"
                 slot="${t.slot??_}"
                 data-colspan="${c.colspan}"
                 colspan="${(c.colspan??1)>1?c.colspan:_}"
@@ -10044,7 +10044,7 @@ ${i}
         >
             ${t.children?.map(t=>P(e,t,n,r,i,a,o,s))}
         </mateu-field>
-    `},Cl=(e,n,r,i,a,o,s)=>{let c=n.metadata;if(c.tree)return w`
+    `},El=(e,n,r,i,a,o,s)=>{let c=n.metadata;if(c.tree)return w`
         <vaadin-grid style="${n.style}" class="${n.cssClasses}"
                      .itemHasChildrenPath="${`children`}" .dataProvider="${async(e,t)=>{let n=e.parentItem?e.parentItem.children:c.page.content;t(n,n.length)}}"
                      slot="${n.slot??_}"
@@ -10057,7 +10057,7 @@ ${i}
                                 flex-grow="${l?.flexGrow??_}"
                                 width="${l?.width??_}"
                                 .column="${n.metadata}"
-                                ${t((t,n,c)=>pl(t,n,c,l,e,r,i,a,o,s),[])}></vaadin-grid-column>
+                                ${t((t,n,c)=>gl(t,n,c,l,e,r,i,a,o,s),[])}></vaadin-grid-column>
 `:w`
             <vaadin-grid-tree-column path="${n.id}"
                                 header="${l?.label??_}"
@@ -10075,9 +10075,9 @@ ${i}
                 .items="${l}"
                 all-rows-visible
         >
-            ${c?.content?.map(t=>dl(t,e,r,i,a,o,s))}
+            ${c?.content?.map(t=>ml(t,e,r,i,a,o,s))}
         </vaadin-grid>
-    `},$=class extends y{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.detailsOpenedItems=[],this.pagesRequested=[],this.emptyArray=e=>!e||e.length==0,this.dataProvider=(e,t)=>{let n=this.data[this.id]?.page;if(this.metadata?.infiniteScrolling&&e.page>0){let r=!1;n&&n.content&&(n.content.length>=(e.page+1)*e.pageSize||n.content.length==n.totalElements)&&(t(n.content.slice(e.page*e.pageSize,(e.page+1)*e.pageSize),n.totalElements),r=!0,this.grid&&this.grid.recalculateColumnWidths()),r||this.pagesRequested.find(t=>t==e.page)||(this.pagesRequested.push(e.page),this.dispatchEvent(new CustomEvent(`fetch-more-elements`,{detail:{params:e,callback:()=>{this.data[this.id]?.page?.content&&(t(this.data[this.id].page.content.slice(e.page*e.pageSize,(e.page+1)*e.pageSize),this.data[this.id].page.totalElements),this.grid&&this.grid.recalculateColumnWidths())}},bubbles:!0,composed:!0})))}else{let e=this.metadata?.infiniteScrolling?n?.totalElements:n?.content?.length??0;t(n?.content??[],e),this.grid&&this.grid.recalculateColumnWidths()}},this._onActionRequested=e=>{let t=e.detail,n=this.identifierFieldName;if(!n||!t.parameters||t.actionId?.startsWith(`action-on-row-`))return;let r=t.parameters[n];r!==void 0&&(this.state._selectedId=String(r),this._applyCellPartNameGenerator(),this.grid?.requestContentUpdate())},this.tooltipGenerator=e=>{let t=``,{column:n,item:r}=e,i=this.metadata?.columns?.find(e=>e.metadata.id==n?.path);if(i?.metadata){let e=(i?.metadata).tooltipPath;e&&n&&r&&(t=r[e])}return t}}get identifierFieldName(){let e=this.metadata?.columns?.find(e=>e.metadata?.identifier);if(e)return e.metadata?.id;if(this.metadata?.columns?.find(e=>e.metadata?.id===`id`))return`id`}_applyCellPartNameGenerator(){if(!this.grid)return;let e=this.identifierFieldName,t=this.state?._selectedId??this.appState?._splitDetailId,n=!!this.metadata?.groupBy;e&&t!==void 0||n?this.grid.cellPartNameGenerator=(n,r)=>{let i=r.item;return Pc(i)?`mateu-group-row`:e&&t!==void 0&&String(i[e])===String(t)?`selected-row`:``}:this.grid.cellPartNameGenerator=null}connectedCallback(){super.connectedCallback(),this.addEventListener(`action-requested`,this._onActionRequested)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`action-requested`,this._onActionRequested)}updated(e){super.updated(e),this._applyCellPartNameGenerator(),this.grid?.clearCache(),this.grid?.requestContentUpdate(),this.grid?.recalculateColumnWidths(),this.pagesRequested=[]}render(){let e=this.data[this.id],r=e?.page,i=this.metadata?.groupBy,a=this.metadata?.infiniteScrolling?void 0:r?.content?Ic(r.content,i,e?.groups):r?.content,o=Bc((this.metadata?.columns??[]).flatMap(e=>e.metadata?.type===A.GridGroupColumn?(e.metadata.columns??[]).map(e=>e.metadata):[e.metadata]),e,i),s=``;return this.metadata?.wrapCellContent&&(s+=` wrap-cell-content`),this.metadata?.compact&&(s+=` compact`),this.metadata?.noBorder&&(s+=` no-border`),this.metadata?.noRowBorder&&(s+=` no-row-borders`),this.metadata?.columnBorders&&(s+=` column-borders`),this.metadata?.rowStripes&&(s+=` row-stripes`),w`
+    `},Q=class extends y{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.detailsOpenedItems=[],this.pagesRequested=[],this.emptyArray=e=>!e||e.length==0,this.dataProvider=(e,t)=>{let n=this.data[this.id]?.page;if(this.metadata?.infiniteScrolling&&e.page>0){let r=!1;n&&n.content&&(n.content.length>=(e.page+1)*e.pageSize||n.content.length==n.totalElements)&&(t(n.content.slice(e.page*e.pageSize,(e.page+1)*e.pageSize),n.totalElements),r=!0,this.grid&&this.grid.recalculateColumnWidths()),r||this.pagesRequested.find(t=>t==e.page)||(this.pagesRequested.push(e.page),this.dispatchEvent(new CustomEvent(`fetch-more-elements`,{detail:{params:e,callback:()=>{this.data[this.id]?.page?.content&&(t(this.data[this.id].page.content.slice(e.page*e.pageSize,(e.page+1)*e.pageSize),this.data[this.id].page.totalElements),this.grid&&this.grid.recalculateColumnWidths())}},bubbles:!0,composed:!0})))}else{let e=this.metadata?.infiniteScrolling?n?.totalElements:n?.content?.length??0;t(n?.content??[],e),this.grid&&this.grid.recalculateColumnWidths()}},this._onActionRequested=e=>{let t=e.detail,n=this.identifierFieldName;if(!n||!t.parameters||t.actionId?.startsWith(`action-on-row-`))return;let r=t.parameters[n];r!==void 0&&(this.state._selectedId=String(r),this._applyCellPartNameGenerator(),this.grid?.requestContentUpdate())},this.tooltipGenerator=e=>{let t=``,{column:n,item:r}=e,i=this.metadata?.columns?.find(e=>e.metadata.id==n?.path);if(i?.metadata){let e=(i?.metadata).tooltipPath;e&&n&&r&&(t=r[e])}return t}}get identifierFieldName(){let e=this.metadata?.columns?.find(e=>e.metadata?.identifier);if(e)return e.metadata?.id;if(this.metadata?.columns?.find(e=>e.metadata?.id===`id`))return`id`}_applyCellPartNameGenerator(){if(!this.grid)return;let e=this.identifierFieldName,t=this.state?._selectedId??this.appState?._splitDetailId,n=!!this.metadata?.groupBy;e&&t!==void 0||n?this.grid.cellPartNameGenerator=(n,r)=>{let i=r.item;return Lc(i)?`mateu-group-row`:e&&t!==void 0&&String(i[e])===String(t)?`selected-row`:``}:this.grid.cellPartNameGenerator=null}connectedCallback(){super.connectedCallback(),this.addEventListener(`action-requested`,this._onActionRequested)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`action-requested`,this._onActionRequested)}updated(e){super.updated(e),this._applyCellPartNameGenerator(),this.grid?.clearCache(),this.grid?.requestContentUpdate(),this.grid?.recalculateColumnWidths(),this.pagesRequested=[]}render(){let e=this.data[this.id],r=e?.page,i=this.metadata?.groupBy,a=this.metadata?.infiniteScrolling?void 0:r?.content?zc(r.content,i,e?.groups):r?.content,o=Uc((this.metadata?.columns??[]).flatMap(e=>e.metadata?.type===A.GridGroupColumn?(e.metadata.columns??[]).map(e=>e.metadata):[e.metadata]),e,i),s=``;return this.metadata?.wrapCellContent&&(s+=` wrap-cell-content`),this.metadata?.compact&&(s+=` compact`),this.metadata?.noBorder&&(s+=` no-border`),this.metadata?.noRowBorder&&(s+=` no-row-borders`),this.metadata?.columnBorders&&(s+=` column-borders`),this.metadata?.rowStripes&&(s+=` row-stripes`),w`
             <vaadin-grid
                     .items="${a}"
                     item-id-path="_rowNumber"
@@ -10089,8 +10089,8 @@ ${i}
                     .dataProvider="${this.metadata?.infiniteScrolling?this.dataProvider:void 0}"
                     page-size="${this.metadata?.pageSize}"
                     multi-sort-on-shift-click
-                    @selected-items-changed="${e=>{let t=(e.detail.value??[]).filter(e=>!Pc(e));this.emptyArray(this.state[this.id+`_selected_items`])&&this.emptyArray(t)||(this.state[this.id+`_selected_items`]=t,this.metadata?.onRowSelectionChangedActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.metadata?.onRowSelectionChangedActionId},bubbles:!0,composed:!0})))}}"
-                    @active-item-changed="${x(this.metadata?.detailPath&&!this.metadata?.useButtonForDetail?e=>{if(this.metadata?.detailPath){let t=e.detail.value;if(t&&Pc(t))return;t?this.detailsOpenedItems=[t]:this.detailsOpenedItems=[]}}:void 0)}"
+                    @selected-items-changed="${e=>{let t=(e.detail.value??[]).filter(e=>!Lc(e));this.emptyArray(this.state[this.id+`_selected_items`])&&this.emptyArray(t)||(this.state[this.id+`_selected_items`]=t,this.metadata?.onRowSelectionChangedActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.metadata?.onRowSelectionChangedActionId},bubbles:!0,composed:!0})))}}"
+                    @active-item-changed="${x(this.metadata?.detailPath&&!this.metadata?.useButtonForDetail?e=>{if(this.metadata?.detailPath){let t=e.detail.value;if(t&&Lc(t))return;t?this.detailsOpenedItems=[t]:this.detailsOpenedItems=[]}}:void 0)}"
                     .detailsOpenedItems="${this.detailsOpenedItems}"
                     ${x(this.metadata?.detailPath?n(e=>w`${P(this,e[this.metadata?.detailPath],this.baseUrl,this.state,this.data,this.appState,this.appData)}`):void 0)}
                     theme="${s}"
@@ -10099,7 +10099,7 @@ ${i}
                 ${this.metadata?.rowsSelectionEnabled?w`
                     <vaadin-grid-selection-column></vaadin-grid-selection-column>
                 `:_}
-                ${this.metadata?.columns?.map(e=>dl(e,this,this.baseUrl,this.state,this.data,this.appState,this.appData,o))}
+                ${this.metadata?.columns?.map(e=>ml(e,this,this.baseUrl,this.state,this.data,this.appState,this.appData,o))}
                 ${this.metadata?.useButtonForDetail?w`
                     <vaadin-grid-column
                             width="44px"
@@ -10138,7 +10138,7 @@ ${i}
             background-color: var(--lumo-contrast-5pct, rgba(0, 0, 0, 0.04));
             font-weight: 600;
         }
-  `}};O([v()],$.prototype,`id`,void 0),O([v()],$.prototype,`metadata`,void 0),O([v()],$.prototype,`baseUrl`,void 0),O([v()],$.prototype,`state`,void 0),O([v()],$.prototype,`data`,void 0),O([v()],$.prototype,`appState`,void 0),O([v()],$.prototype,`appData`,void 0),O([v()],$.prototype,`emptyStateMessage`,void 0),O([S()],$.prototype,`detailsOpenedItems`,void 0),O([b(`vaadin-grid`)],$.prototype,`grid`,void 0),$=O([h(`mateu-table`)],$);var wl=(e,t,n,r,i,a,o)=>w`
+  `}};O([v()],Q.prototype,`id`,void 0),O([v()],Q.prototype,`metadata`,void 0),O([v()],Q.prototype,`baseUrl`,void 0),O([v()],Q.prototype,`state`,void 0),O([v()],Q.prototype,`data`,void 0),O([v()],Q.prototype,`appState`,void 0),O([v()],Q.prototype,`appData`,void 0),O([v()],Q.prototype,`emptyStateMessage`,void 0),O([S()],Q.prototype,`detailsOpenedItems`,void 0),O([b(`vaadin-grid`)],Q.prototype,`grid`,void 0),Q=O([h(`mateu-table`)],Q);var Dl=(e,t,n,r,i,a,o)=>w`
     <mateu-table
             id="${t.id}"
             baseUrl="${n}"
@@ -10151,7 +10151,7 @@ ${i}
             slot="${t.slot??_}"
     >
         ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
-    </mateu-table>`,Tl=(e,t,n,r,i,a)=>w`
+    </mateu-table>`,Ol=(e,t,n,r,i,a)=>w`
     <mateu-table id="${e.id}"
                  .metadata="${t?.metadata}"
                  .data="${e.data}"
@@ -10162,7 +10162,7 @@ ${i}
                  @sort-direction-changed="${e.directionChanged}"
                  @fetch-more-elements="${e.fetchMoreElements}"
                  baseUrl="${n}"
-    ></mateu-table>`,El=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+    ></mateu-table>`,kl=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <div id="show-notifications" slot="${t.slot??_}">${P(e,s.wrapped,n,r,i,a,o)}</div>
         <vaadin-popover
                 for="show-notifications"
@@ -10174,14 +10174,14 @@ ${i}
                 ${te(()=>w`${P(e,s.content,n,r,i,a,o)}`,[])}
                 style="${t.style}" class="${t.cssClasses}"
         ></vaadin-popover>
-    `},Dl=(e,t,n)=>{let r=e;return w`
+    `},Al=(e,t,n)=>{let r=e;return w`
         <vaadin-button
                 data-action-id="${r.id}"
                 theme="${ht(e)||_}"
                 @click="${n}"
                 ?disabled="${r.disabled}"
         >${r.iconOnLeft?w`<vaadin-icon icon="${r.iconOnLeft}"></vaadin-icon>`:_}${t}${r.iconOnRight?w`<vaadin-icon icon="${r.iconOnRight}"></vaadin-icon>`:_}</vaadin-button>
-    `},Ol=e=>w`
+    `},jl=e=>w`
     <div style="display: flex; gap: var(--lumo-space-xs, .25rem); align-items: center;" class="peer-nav">
         <vaadin-button theme="tertiary icon" class="peer-nav-prev" title="${e.prevLabel??`Previous`}"
                 ?disabled="${!e.prevRoute}"
@@ -10193,30 +10193,30 @@ ${i}
                 @click="${()=>{e.nextRoute&&(window.location.href=e.nextRoute)}}">
             <vaadin-icon icon="vaadin:angle-right"></vaadin-icon>
         </vaadin-button>
-    </div>`,kl={"vaadin:wifi":`vaadin:connect`,"vaadin:pen":`vaadin:pencil`,"vaadin:automation":`vaadin:cogs`},Al=(e,t,n)=>w`<vaadin-icon icon="${kl[e]??e}" style="${t??_}" class="${n??_}"></vaadin-icon>`,jl=(e,t,n)=>{let r=e.metadata,i=j(r.label,t,n),a=``;return r.buttonStyle&&(a+=` `+r.buttonStyle),r.color&&r.color!==`none`&&r.color!==`normal`&&(a+=` `+r.color),r.size&&r.size!==`none`&&r.size!==`normal`&&(a+=` `+r.size),w`<vaadin-button
+    </div>`,Ml={"vaadin:wifi":`vaadin:connect`,"vaadin:pen":`vaadin:pencil`,"vaadin:automation":`vaadin:cogs`},Nl=(e,t,n)=>w`<vaadin-icon icon="${Ml[e]??e}" style="${t??_}" class="${n??_}"></vaadin-icon>`,Pl=(e,t,n)=>{let r=e.metadata,i=j(r.label,t,n),a=``;return r.buttonStyle&&(a+=` `+r.buttonStyle),r.color&&r.color!==`none`&&r.color!==`normal`&&(a+=` `+r.color),r.size&&r.size!==`none`&&r.size!==`normal`&&(a+=` `+r.size),w`<vaadin-button
             id="${e.id}"
             data-action-id="${r.actionId}"
-            @click="${e=>zn(e,r)}"
+            @click="${e=>Vn(e,r)}"
             style="${e.style}"
             class="${e.cssClasses}"
             theme="${a}"
             ?disabled="${r.disabled}"
-            title="${r.shortcut?`${i} (${Rn(r.shortcut)})`:_}"
+            title="${r.shortcut?`${i} (${Bn(r.shortcut)})`:_}"
             slot="${e.slot??_}"
-    >${r.iconOnLeft?w`<vaadin-icon icon="${r.iconOnLeft}"></vaadin-icon>`:_}${i}${r.iconOnRight?w`<vaadin-icon icon="${r.iconOnRight}"></vaadin-icon>`:_}</vaadin-button>`},Ml=e=>{let t=e.metadata;return w`
+    >${r.iconOnLeft?w`<vaadin-icon icon="${r.iconOnLeft}"></vaadin-icon>`:_}${i}${r.iconOnRight?w`<vaadin-icon icon="${r.iconOnRight}"></vaadin-icon>`:_}</vaadin-button>`},Fl=e=>{let t=e.metadata;return w`
         <vaadin-message-input
                 style="${e.style}" class="${e.cssClasses}"
                 slot="${e.slot??_}"
                 @submit="${e=>{let n=e.detail?.value??``;!t.actionId||!n.trim()||e.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:{message:n}},bubbles:!0,composed:!0}))}}"
         ></vaadin-message-input>
-    `},Nl=e=>{let t=(e.metadata.items??[]).map(e=>({text:e.text,time:e.time,userName:e.userName,userImg:e.userImg,userAbbr:e.userAbbr,userColorIndex:e.userColorIndex}));return w`
+    `},Il=e=>{let t=(e.metadata.items??[]).map(e=>({text:e.text,time:e.time,userName:e.userName,userImg:e.userImg,userAbbr:e.userAbbr,userColorIndex:e.userColorIndex}));return w`
         <vaadin-message-list
                 markdown
                 style="${e.style}" class="${e.cssClasses}"
                 slot="${e.slot??_}"
                 .items="${t}"
         ></vaadin-message-list>
-    `},Pl=(e,t)=>{e&&e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},Fl=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!1;if(s.openedCondition)try{c=at(s.openedCondition,r,i,a,o)}catch(e){console.error(`when evaluating `+s.openedCondition+` :`+e+`, where data is `+i+` and state is `+r)}return w`
+    `},Ll=(e,t)=>{e&&e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},Rl=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!1;if(s.openedCondition)try{c=at(s.openedCondition,r,i,a,o)}catch(e){console.error(`when evaluating `+s.openedCondition+` :`+e+`, where data is `+i+` and state is `+r)}return w`
         <vaadin-confirm-dialog
                 header="${s.header}"
                 ?cancel-button-visible="${s.canCancel}"
@@ -10224,15 +10224,15 @@ ${i}
                 reject-text="${s.rejectText}"
                 confirm-text="${s.confirmText}"
                 .opened="${c}"
-                @confirm="${e=>Pl(e.currentTarget,s.confirmActionId)}"
-                @reject="${e=>Pl(e.currentTarget,s.rejectActionId)}"
-                @cancel="${e=>Pl(e.currentTarget,s.cancelActionId)}"
+                @confirm="${e=>Ll(e.currentTarget,s.confirmActionId)}"
+                @reject="${e=>Ll(e.currentTarget,s.rejectActionId)}"
+                @cancel="${e=>Ll(e.currentTarget,s.cancelActionId)}"
                 style="${t.style}" class="${t.cssClasses}"
                 slot="${t.slot??_}"
         >
             ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </vaadin-confirm-dialog>
-    `},Il=class extends y{constructor(...e){super(...e),this.panels=[],this.headerTitle=``,this.badges=[],this.navigation=null,this.overviewEditActionId=``,this._raf=0,this._snapping=!1,this._less=!1,this._more=!1,this._onScroll=()=>{this._raf||=requestAnimationFrame(()=>{this._raf=0,this._syncPin()})},this._onScrollEnd=()=>{this._snapping||this._snapToNearest()},this._fit=()=>{let e=this.getBoundingClientRect().top;this.style.setProperty(`--mateu-foldout-fill`,`${Math.max(240,window.innerHeight-e)}px`),this._syncPin()},this._onKeydown=e=>{if(e.key!==`ArrowRight`&&e.key!==`ArrowLeft`||e.defaultPrevented||e.ctrlKey||e.metaKey||e.altKey||this._isEditingContext())return;let t=this._rail;!t||t.scrollWidth<=t.clientWidth||(e.preventDefault(),this._step(e.key===`ArrowRight`?1:-1))}}navAction(e){e&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{}},bubbles:!0,composed:!0}))}_stride(){let e=this.renderRoot.querySelectorAll(`.section`);return e.length>1?e[1].offsetLeft:this._rail?.clientWidth??0}_boundaries(){let e=this._rail;if(!e)return[];let t=e.scrollWidth-e.clientWidth,n=[...this.renderRoot.querySelectorAll(`.section`)].map(e=>Math.max(0,Math.min(e.offsetLeft,t)));return[...new Set(n)]}_snapToNearest(){let e=this._rail;if(!e)return;let t=this._boundaries();if(!t.length)return;let n=t.reduce((t,n)=>Math.abs(n-e.scrollLeft)<Math.abs(t-e.scrollLeft)?n:t);Math.abs(n-e.scrollLeft)<1||(this._snapping=!0,e.scrollTo({left:n,behavior:`smooth`}),window.setTimeout(()=>{this._snapping=!1},400))}_syncPin(){let e=this._rail,t=this._first;if(!e||!t)return;let n=this._stride(),r=Math.min(e.scrollLeft,n);t.style.transform=r?`translateX(${r}px)`:``,t.classList.toggle(`floating`,e.scrollLeft>0);let i=e.scrollWidth-e.clientWidth,a=i>32;this._less=a&&e.scrollLeft>2,this._more=a&&e.scrollLeft<i-2}_step(e){let t=this._rail;if(!t)return;let n=this._boundaries();if(!n.length)return;let r=n.reduce((e,r,i)=>Math.abs(r-t.scrollLeft)<Math.abs(n[e]-t.scrollLeft)?i:e,0),i=n[Math.max(0,Math.min(r+e,n.length-1))];this._snapping=!0,t.scrollTo({left:i,behavior:`smooth`}),window.setTimeout(()=>{this._snapping=!1},400)}_isEditingContext(){let e=document.activeElement;for(;e&&e.shadowRoot&&e.shadowRoot.activeElement;)e=e.shadowRoot.activeElement;if(!e)return!1;let t=e.tagName;return t===`INPUT`||t===`TEXTAREA`||t===`SELECT`||e.isContentEditable}_sectionFlex(e,t){if(!e.width)return _;let n=parseFloat(e.width)||1;return t===this.panels.length-1&&n<22?`flex: 22 1 var(--mateu-foldout-overview-width, 22rem);`:`flex: ${n} 1 ${e.width};`}firstUpdated(){this._fit(),this._resizeObserver=new ResizeObserver(()=>this._syncPin()),this._rail&&this._resizeObserver.observe(this._rail);for(let e of this.renderRoot.querySelectorAll(`.section`))this._resizeObserver.observe(e)}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._onKeydown),window.addEventListener(`resize`,this._fit)}disconnectedCallback(){document.removeEventListener(`keydown`,this._onKeydown),window.removeEventListener(`resize`,this._fit),this._resizeObserver?.disconnect(),this._resizeObserver=void 0,this._raf&&=(cancelAnimationFrame(this._raf),0),super.disconnectedCallback()}static{this.styles=m`
+    `},$=class extends y{constructor(...e){super(...e),this.panels=[],this.headerTitle=``,this.badges=[],this.navigation=null,this.overviewEditActionId=``,this._raf=0,this._snapping=!1,this._less=!1,this._more=!1,this._onScroll=()=>{this._raf||=requestAnimationFrame(()=>{this._raf=0,this._syncPin()})},this._onScrollEnd=()=>{this._snapping||this._snapToNearest()},this._fit=()=>{let e=this.getBoundingClientRect().top;this.style.setProperty(`--mateu-foldout-fill`,`${Math.max(240,window.innerHeight-e)}px`),this._syncPin()},this._onKeydown=e=>{if(e.key!==`ArrowRight`&&e.key!==`ArrowLeft`||e.defaultPrevented||e.ctrlKey||e.metaKey||e.altKey||this._isEditingContext())return;let t=this._rail;!t||t.scrollWidth<=t.clientWidth||(e.preventDefault(),this._step(e.key===`ArrowRight`?1:-1))}}navAction(e){e&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{}},bubbles:!0,composed:!0}))}_stride(){let e=this.renderRoot.querySelectorAll(`.section`);return e.length>1?e[1].offsetLeft:this._rail?.clientWidth??0}_boundaries(){let e=this._rail;if(!e)return[];let t=e.scrollWidth-e.clientWidth,n=[...this.renderRoot.querySelectorAll(`.section`)].map(e=>Math.max(0,Math.min(e.offsetLeft,t)));return[...new Set(n)]}_snapToNearest(){let e=this._rail;if(!e)return;let t=this._boundaries();if(!t.length)return;let n=t.reduce((t,n)=>Math.abs(n-e.scrollLeft)<Math.abs(t-e.scrollLeft)?n:t);Math.abs(n-e.scrollLeft)<1||(this._snapping=!0,e.scrollTo({left:n,behavior:`smooth`}),window.setTimeout(()=>{this._snapping=!1},400))}_syncPin(){let e=this._rail,t=this._first;if(!e||!t)return;let n=this._stride(),r=Math.min(e.scrollLeft,n);t.style.transform=r?`translateX(${r}px)`:``,t.classList.toggle(`floating`,e.scrollLeft>0);let i=e.scrollWidth-e.clientWidth,a=i>32;this._less=a&&e.scrollLeft>2,this._more=a&&e.scrollLeft<i-2}_step(e){let t=this._rail;if(!t)return;let n=this._boundaries();if(!n.length)return;let r=n.reduce((e,r,i)=>Math.abs(r-t.scrollLeft)<Math.abs(n[e]-t.scrollLeft)?i:e,0),i=n[Math.max(0,Math.min(r+e,n.length-1))];this._snapping=!0,t.scrollTo({left:i,behavior:`smooth`}),window.setTimeout(()=>{this._snapping=!1},400)}_isEditingContext(){let e=document.activeElement;for(;e&&e.shadowRoot&&e.shadowRoot.activeElement;)e=e.shadowRoot.activeElement;if(!e)return!1;let t=e.tagName;return t===`INPUT`||t===`TEXTAREA`||t===`SELECT`||e.isContentEditable}_sectionFlex(e,t){if(!e.width)return _;let n=parseFloat(e.width)||1;return t===this.panels.length-1&&n<22?`flex: 22 1 var(--mateu-foldout-overview-width, 22rem);`:`flex: ${n} 1 ${e.width};`}firstUpdated(){this._fit(),this._resizeObserver=new ResizeObserver(()=>this._syncPin()),this._rail&&this._resizeObserver.observe(this._rail);for(let e of this.renderRoot.querySelectorAll(`.section`))this._resizeObserver.observe(e)}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._onKeydown),window.addEventListener(`resize`,this._fit)}disconnectedCallback(){document.removeEventListener(`keydown`,this._onKeydown),window.removeEventListener(`resize`,this._fit),this._resizeObserver?.disconnect(),this._resizeObserver=void 0,this._raf&&=(cancelAnimationFrame(this._raf),0),super.disconnectedCallback()}static{this.styles=m`
         :host {
             position: relative;
             display: flex;
@@ -10493,7 +10493,7 @@ ${i}
                     </svg>
                 </button>
             `:_}
-        `}};O([v({type:Array})],Il.prototype,`panels`,void 0),O([v({type:String})],Il.prototype,`headerTitle`,void 0),O([v({type:Array})],Il.prototype,`badges`,void 0),O([v({attribute:!1})],Il.prototype,`navigation`,void 0),O([v({type:String})],Il.prototype,`overviewEditActionId`,void 0),O([b(`.rail`)],Il.prototype,`_rail`,void 0),O([b(`.section--first`)],Il.prototype,`_first`,void 0),O([S()],Il.prototype,`_less`,void 0),O([S()],Il.prototype,`_more`,void 0),Il=O([h(`mateu-vaadin-foldout`)],Il);var Ll=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+        `}};O([v({type:Array})],$.prototype,`panels`,void 0),O([v({type:String})],$.prototype,`headerTitle`,void 0),O([v({type:Array})],$.prototype,`badges`,void 0),O([v({attribute:!1})],$.prototype,`navigation`,void 0),O([v({type:String})],$.prototype,`overviewEditActionId`,void 0),O([b(`.rail`)],$.prototype,`_rail`,void 0),O([b(`.section--first`)],$.prototype,`_first`,void 0),O([S()],$.prototype,`_less`,void 0),O([S()],$.prototype,`_more`,void 0),$=O([h(`mateu-vaadin-foldout`)],$);var zl=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <mateu-vaadin-foldout
                 .panels="${s.panels??[]}"
                 .headerTitle="${s.headerTitle??``}"
@@ -10506,7 +10506,7 @@ ${i}
         >
             ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </mateu-vaadin-foldout>
-    `},Rl=class extends y{constructor(...e){super(...e),this.rows=[],this.columns=[],this.navigable=!1,this.expandedItems=[],this._normalized=[],this.dataProvider=(e,t)=>{let n=e.parentItem?e.parentItem.children??[]:this.normalized;t(n,n.length)}}get normalized(){return this._src!==this.rows&&(this._src=this.rows,this._normalized=this.normalizeRows(this.rows??[])),this._normalized}normalizeRows(e){return(e??[]).map(e=>{let t=Array.isArray(e.children)&&e.children.length?this.normalizeRows(e.children):void 0;return{...e,children:t}})}collectGroups(e,t=[]){return e.forEach(e=>{e.children&&e.children.length&&(t.push(e),this.collectGroups(e.children,t))}),t}willUpdate(){this._expandedSrc!==this.rows&&(this._expandedSrc=this.rows,this.expandedItems=this.collectGroups(this.normalized))}updated(e){e.has(`rows`)&&this._grid?.clearCache?.()}dispatch(e,t){this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:t},bubbles:!0,composed:!0}))}render(){let e=this.columns??[],n=e[0],r=e.slice(1);return w`
+    `},Bl=class extends y{constructor(...e){super(...e),this.rows=[],this.columns=[],this.navigable=!1,this.expandedItems=[],this._normalized=[],this.dataProvider=(e,t)=>{let n=e.parentItem?e.parentItem.children??[]:this.normalized;t(n,n.length)}}get normalized(){return this._src!==this.rows&&(this._src=this.rows,this._normalized=this.normalizeRows(this.rows??[])),this._normalized}normalizeRows(e){return(e??[]).map(e=>{let t=Array.isArray(e.children)&&e.children.length?this.normalizeRows(e.children):void 0;return{...e,children:t}})}collectGroups(e,t=[]){return e.forEach(e=>{e.children&&e.children.length&&(t.push(e),this.collectGroups(e.children,t))}),t}willUpdate(){this._expandedSrc!==this.rows&&(this._expandedSrc=this.rows,this.expandedItems=this.collectGroups(this.normalized))}updated(e){e.has(`rows`)&&this._grid?.clearCache?.()}dispatch(e,t){this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:t},bubbles:!0,composed:!0}))}render(){let e=this.columns??[],n=e[0],r=e.slice(1);return w`
             <vaadin-grid
                     theme="compact no-row-borders"
                     all-rows-visible
@@ -10536,11 +10536,11 @@ ${i}
             max-height: min(60vh, 32rem);
             min-width: 22rem;
         }
-    `}};O([v({attribute:!1})],Rl.prototype,`rows`,void 0),O([v({attribute:!1})],Rl.prototype,`columns`,void 0),O([v()],Rl.prototype,`idField`,void 0),O([v({type:Boolean})],Rl.prototype,`navigable`,void 0),O([v()],Rl.prototype,`selectedId`,void 0),O([S()],Rl.prototype,`expandedItems`,void 0),O([b(`vaadin-grid`)],Rl.prototype,`_grid`,void 0),Rl=O([h(`mateu-vaadin-tree`)],Rl);var zl={[A.VirtualList]:(e,t,n,r,i,a,o)=>Qs(e,t,n,r,i,a,o),[A.Notification]:(e,t)=>$s(t),[A.ProgressBar]:(e,t,n,r)=>ec(t,r),[A.Details]:(e,t,n,r,i,a,o)=>tc(e,t,n,r,i,a,o),[A.Avatar]:(e,t,n,r,i)=>nc(t,r,i),[A.AvatarGroup]:(e,t)=>rc(t),[A.Card]:(e,t,n,r,i,a,o)=>ic(e,t,n,r,i,a,o),[A.Button]:(e,t,n,r,i)=>jl(t,r,i),[A.MessageInput]:(e,t)=>Ml(t),[A.MessageList]:(e,t)=>Nl(t),[A.ConfirmDialog]:(e,t,n,r,i,a,o)=>Fl(e,t,n,r,i,a,o),[A.FormLayout]:(e,t,n,r,i,a,o)=>sc(e,t,n,r,i,a,o),[A.HorizontalLayout]:(e,t,n,r,i,a,o)=>dc(e,t,n,r,i,a,o),[A.VerticalLayout]:(e,t,n,r,i,a,o)=>fc(e,t,n,r,i,a,o),[A.SplitLayout]:(e,t,n,r,i,a,o)=>pc(e,t,n,r,i,a,o),[A.MasterDetailLayout]:(e,t,n,r,i,a,o)=>mc(e,t,n,r,i,a,o),[A.TabLayout]:(e,t,n,r,i,a,o)=>hc(e,t,n,r,i,a,o),[A.AccordionLayout]:(e,t,n,r,i,a,o)=>_c(e,t,n,r,i,a,o),[A.BoardLayout]:(e,t,n,r,i,a,o)=>bc(e,t,n,r,i,a,o),[A.BoardLayoutRow]:(e,t,n,r,i,a,o)=>xc(e,t,n,r,i,a,o),[A.BoardLayoutItem]:(e,t,n,r,i,a,o)=>Sc(e,t,n,r,i,a,o),[A.Scroller]:(e,t,n,r,i,a,o)=>yc(e,t,n,r,i,a,o),[A.MenuBar]:(e,t,n,r,i)=>Tc(e,t,n,r,i),[A.ContextMenu]:(e,t,n,r,i,a,o)=>wc(e,t,n,r,i,a,o),[A.FormField]:(e,t,n,r,i,a,o,s)=>Sl(e,t,n,r,i,a,o,s),[A.Grid]:(e,t,n,r,i,a,o)=>Cl(e,t,n,r,i,a,o),[A.Table]:(e,t,n,r,i,a,o)=>wl(e,t,n,r,i,a,o),[A.Popover]:(e,t,n,r,i,a,o)=>El(e,t,n,r,i,a,o),[A.FoldoutLayout]:(e,t,n,r,i,a,o)=>Ll(e,t,n,r,i,a,o)},Bl=class extends Zs{rendererName(){return`vaadin`}renderClientSideComponent(e,t,n,r,i,a,o,s){let c=t?.metadata?.type,l=c?zl[c]:void 0;return l&&t?l(e,t,n,r,i,a,o,s):super.renderClientSideComponent(e,t,n,r,i,a,o,s)}renderTableComponent(e,t,n,r,i,a,o){return Tl(e,t,n,r,a,o)}renderTreeComponent(e,t){return w`
+    `}};O([v({attribute:!1})],Bl.prototype,`rows`,void 0),O([v({attribute:!1})],Bl.prototype,`columns`,void 0),O([v()],Bl.prototype,`idField`,void 0),O([v({type:Boolean})],Bl.prototype,`navigable`,void 0),O([v()],Bl.prototype,`selectedId`,void 0),O([S()],Bl.prototype,`expandedItems`,void 0),O([b(`vaadin-grid`)],Bl.prototype,`_grid`,void 0),Bl=O([h(`mateu-vaadin-tree`)],Bl);var Vl={[A.VirtualList]:(e,t,n,r,i,a,o)=>tc(e,t,n,r,i,a,o),[A.Notification]:(e,t)=>nc(t),[A.ProgressBar]:(e,t,n,r)=>rc(t,r),[A.Details]:(e,t,n,r,i,a,o)=>ic(e,t,n,r,i,a,o),[A.Avatar]:(e,t,n,r,i)=>ac(t,r,i),[A.AvatarGroup]:(e,t)=>oc(t),[A.Card]:(e,t,n,r,i,a,o)=>sc(e,t,n,r,i,a,o),[A.Button]:(e,t,n,r,i)=>Pl(t,r,i),[A.MessageInput]:(e,t)=>Fl(t),[A.MessageList]:(e,t)=>Il(t),[A.ConfirmDialog]:(e,t,n,r,i,a,o)=>Rl(e,t,n,r,i,a,o),[A.FormLayout]:(e,t,n,r,i,a,o)=>uc(e,t,n,r,i,a,o),[A.HorizontalLayout]:(e,t,n,r,i,a,o)=>mc(e,t,n,r,i,a,o),[A.VerticalLayout]:(e,t,n,r,i,a,o)=>hc(e,t,n,r,i,a,o),[A.SplitLayout]:(e,t,n,r,i,a,o)=>gc(e,t,n,r,i,a,o),[A.MasterDetailLayout]:(e,t,n,r,i,a,o)=>_c(e,t,n,r,i,a,o),[A.TabLayout]:(e,t,n,r,i,a,o)=>vc(e,t,n,r,i,a,o),[A.AccordionLayout]:(e,t,n,r,i,a,o)=>bc(e,t,n,r,i,a,o),[A.BoardLayout]:(e,t,n,r,i,a,o)=>Cc(e,t,n,r,i,a,o),[A.BoardLayoutRow]:(e,t,n,r,i,a,o)=>wc(e,t,n,r,i,a,o),[A.BoardLayoutItem]:(e,t,n,r,i,a,o)=>Tc(e,t,n,r,i,a,o),[A.Scroller]:(e,t,n,r,i,a,o)=>Sc(e,t,n,r,i,a,o),[A.MenuBar]:(e,t,n,r,i)=>Oc(e,t,n,r,i),[A.ContextMenu]:(e,t,n,r,i,a,o)=>Dc(e,t,n,r,i,a,o),[A.FormField]:(e,t,n,r,i,a,o,s)=>Tl(e,t,n,r,i,a,o,s),[A.Grid]:(e,t,n,r,i,a,o)=>El(e,t,n,r,i,a,o),[A.Table]:(e,t,n,r,i,a,o)=>Dl(e,t,n,r,i,a,o),[A.Popover]:(e,t,n,r,i,a,o)=>kl(e,t,n,r,i,a,o),[A.FoldoutLayout]:(e,t,n,r,i,a,o)=>zl(e,t,n,r,i,a,o)},Hl=class extends ec{rendererName(){return`vaadin`}renderClientSideComponent(e,t,n,r,i,a,o,s){let c=t?.metadata?.type,l=c?Vl[c]:void 0;return l&&t?l(e,t,n,r,i,a,o,s):super.renderClientSideComponent(e,t,n,r,i,a,o,s)}renderTableComponent(e,t,n,r,i,a,o){return Ol(e,t,n,r,a,o)}renderTreeComponent(e,t){return w`
             <mateu-vaadin-tree
                     .rows="${t.rows}"
                     .columns="${t.columns}"
                     .idField="${t.idField}"
                     .navigable="${t.navigable}"
                     .selectedId="${t.selectedId}"
-            ></mateu-vaadin-tree>`}renderToolbarButton(e,t,n){return Dl(e,t,n)}renderPeerNav(e){return Ol(e)}renderIcon(e,t,n){return Al(e,t,n)}renderTopNav(e,t,n){return Cc(e,t,n)}};function Vl(e){switch(e){case`topStretch`:return`top-stretch`;case`topStart`:return`top-start`;case`topCenter`:return`top-center`;case`topEnd`:return`top-end`;case`middle`:return`middle`;case`bottomStart`:return`bottom-start`;case`bottomEnd`:return`bottom-end`;case`bottomStretch`:return`bottom-stretch`;case`bottomCenter`:return`bottom-center`}return`bottom-end`}function Hl(e,t){if(e.onAction)return{label:e.actionLabel??`Retry`,run:e.onAction};if(e.undoActionId)return{label:e.undoLabel??`Undo`,run:()=>t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.undoActionId,parameters:e.undoParameters??{}},bubbles:!0,composed:!0}))}}function Ul(e,t){let n=new r;n.position=Vl(e.position),n.duration=e.duration??1e4,e.variant&&n.setAttribute(`theme`,e.variant),n.renderer=r=>{if(r.firstElementChild)return;let i=document.createElement(`span`);i.textContent=e.text;let a=Hl(e,t),o=document.createElement(`button`);o.textContent=a.label,o.style.cssText=`margin-left: 0.75rem; background: none; border: 1px solid currentColor; border-radius: var(--lumo-border-radius-s, 4px); color: inherit; cursor: pointer; padding: 0.15rem 0.6rem; font: inherit; font-weight: 600;`,o.addEventListener(`click`,()=>{a.run(),n.opened=!1}),r.append(i,o)},document.body.appendChild(n),n.opened=!0,n.addEventListener(`opened-changed`,e=>{e.detail.value||n.remove()})}N.set(new Bl),fa({show(e,t){if(Qe(e.text,{politeness:e.variant===`error`?`assertive`:`polite`}),e.undoActionId||e.onAction){Ul(e,t);return}r.show(e.text,{position:e.position?Vl(e.position):`bottom-end`,theme:e.variant,duration:e.duration})}});
+            ></mateu-vaadin-tree>`}renderToolbarButton(e,t,n){return Al(e,t,n)}renderPeerNav(e){return jl(e)}renderIcon(e,t,n){return Nl(e,t,n)}renderTopNav(e,t,n){return Ec(e,t,n)}};function Ul(e){switch(e){case`topStretch`:return`top-stretch`;case`topStart`:return`top-start`;case`topCenter`:return`top-center`;case`topEnd`:return`top-end`;case`middle`:return`middle`;case`bottomStart`:return`bottom-start`;case`bottomEnd`:return`bottom-end`;case`bottomStretch`:return`bottom-stretch`;case`bottomCenter`:return`bottom-center`}return`bottom-end`}function Wl(e,t){if(e.onAction)return{label:e.actionLabel??`Retry`,run:e.onAction};if(e.undoActionId)return{label:e.undoLabel??`Undo`,run:()=>t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.undoActionId,parameters:e.undoParameters??{}},bubbles:!0,composed:!0}))}}function Gl(e,t){let n=new r;n.position=Ul(e.position),n.duration=e.duration??1e4,e.variant&&n.setAttribute(`theme`,e.variant),n.renderer=r=>{if(r.firstElementChild)return;let i=document.createElement(`span`);i.textContent=e.text;let a=Wl(e,t),o=document.createElement(`button`);o.textContent=a.label,o.style.cssText=`margin-left: 0.75rem; background: none; border: 1px solid currentColor; border-radius: var(--lumo-border-radius-s, 4px); color: inherit; cursor: pointer; padding: 0.15rem 0.6rem; font: inherit; font-weight: 600;`,o.addEventListener(`click`,()=>{a.run(),n.opened=!1}),r.append(i,o)},document.body.appendChild(n),n.opened=!0,n.addEventListener(`opened-changed`,e=>{e.detail.value||n.remove()})}N.set(new Hl),ma({show(e,t){if(Qe(e.text,{politeness:e.variant===`error`?`assertive`:`polite`}),e.undoActionId||e.onAction){Gl(e,t);return}r.show(e.text,{position:e.position?Ul(e.position):`bottom-end`,theme:e.variant,duration:e.duration})}});

--- a/backend/shared/frontend/vaadin-lit/src/main/resources/static/assets/mateu-vaadin.js
+++ b/backend/shared/frontend/vaadin-lit/src/main/resources/static/assets/mateu-vaadin.js
@@ -933,7 +933,7 @@ ${i}
             opacity: 0.4;
             cursor: default;
         }
-    `}};O([v()],Ht.prototype,`columns`,void 0),O([v()],Ht.prototype,`scope`,void 0),O([S()],Ht.prototype,`panelOpened`,void 0),O([S()],Ht.prototype,`revision`,void 0),Ht=O([h(`mateu-column-chooser`)],Ht);function Ut(e,t){return t?t.split(`.`).reduce((e,t)=>typeof e==`object`&&e?e[t]:void 0,e):e}function Wt(e,t,n=`value`,r=`label`){let i=Ut(e,t);return Array.isArray(i)?i.map(e=>{if(typeof e==`object`&&e){let t=Ut(e,n),i=Ut(e,r);return{value:t??i,label:String(i??t??``)}}return{value:e,label:String(e)}}):[]}function Gt(e,t,n){let r=Ut(e,t);return Array.isArray(r)?r.map(e=>{let t={};for(let r of n)t[r]=Ut(e,r);return t}):[]}async function Kt(e,t=e=>e,n=fetch){let r=t(e.url)??e.url,i=(e.method||`GET`).toUpperCase(),a={};for(let[n,r]of Object.entries(e.headers??{}))a[n]=t(r)??r;let o={method:i,headers:a};i!==`GET`&&i!==`HEAD`&&e.body&&(o.body=t(e.body)??e.body);let s=await n(r,o);if(!s.ok)throw Error(`External REST fetch failed: ${s.status}`);return s.json()}async function qt(e,t=e=>e,n=fetch){return Wt(await Kt(e,t,n),e.itemsPath,e.valuePath,e.labelPath)}async function Jt(e,t,n=e=>e,r=fetch){return Gt(await Kt(e,n,r),e.itemsPath,t)}var Yt=class extends y{constructor(...e){super(...e),this.totalElements=0,this.pageSize=100,this.pageNumber=0,this.totalPages=0}updated(e){super.updated(e),(e.has(`totalElements`)||e.has(`pageSize`))&&(this.totalPages=Math.ceil(this.totalElements/this.pageSize))}dispatch(e){this.dispatchEvent(new CustomEvent(`page-changed`,{bubbles:!0,composed:!0,detail:{page:e}}))}render(){if(!this.totalElements)return _;let e=this.totalPages>1,t=this.pageNumber,n=t===0,r=t>=this.totalPages-1;return w`
+    `}};O([v()],Ht.prototype,`columns`,void 0),O([v()],Ht.prototype,`scope`,void 0),O([S()],Ht.prototype,`panelOpened`,void 0),O([S()],Ht.prototype,`revision`,void 0),Ht=O([h(`mateu-column-chooser`)],Ht);var Ut;async function Wt(e){if(!Ut)return{};try{return await Ut(e)??{}}catch(e){return console.warn(`mateu: external auth provider failed`,e),{}}}function Gt(e,t){return t?t.split(`.`).reduce((e,t)=>typeof e==`object`&&e?e[t]:void 0,e):e}function Kt(e,t,n=`value`,r=`label`){let i=Gt(e,t);return Array.isArray(i)?i.map(e=>{if(typeof e==`object`&&e){let t=Gt(e,n),i=Gt(e,r);return{value:t??i,label:String(i??t??``)}}return{value:e,label:String(e)}}):[]}function qt(e,t,n){let r=Gt(e,t);return Array.isArray(r)?r.map(e=>{let t={};for(let r of n)t[r]=Gt(e,r);return t}):[]}async function Jt(e,t=e=>e,n=fetch){let r=t(e.url)??e.url,i=(e.method||`GET`).toUpperCase(),a={};for(let[n,r]of Object.entries(e.headers??{}))a[n]=t(r)??r;Object.assign(a,await Wt({url:r,method:i}));let o={method:i,headers:a};i!==`GET`&&i!==`HEAD`&&e.body&&(o.body=t(e.body)??e.body);let s=await n(r,o);if(!s.ok)throw Error(`External REST fetch failed: ${s.status}`);return s.json()}async function Yt(e,t=e=>e,n=fetch){return Kt(await Jt(e,t,n),e.itemsPath,e.valuePath,e.labelPath)}async function Xt(e,t,n=e=>e,r=fetch){return qt(await Jt(e,n,r),e.itemsPath,t)}var Zt=class extends y{constructor(...e){super(...e),this.totalElements=0,this.pageSize=100,this.pageNumber=0,this.totalPages=0}updated(e){super.updated(e),(e.has(`totalElements`)||e.has(`pageSize`))&&(this.totalPages=Math.ceil(this.totalElements/this.pageSize))}dispatch(e){this.dispatchEvent(new CustomEvent(`page-changed`,{bubbles:!0,composed:!0,detail:{page:e}}))}render(){if(!this.totalElements)return _;let e=this.totalPages>1,t=this.pageNumber,n=t===0,r=t>=this.totalPages-1;return w`
             <div class="bar">
                 ${e?w`
                     <button class="nav" title="First page" ?disabled="${n}"
@@ -997,34 +997,34 @@ ${i}
             align-self: center;
             margin: 0 4px;
         }
-    `}};O([v()],Yt.prototype,`totalElements`,void 0),O([v()],Yt.prototype,`pageSize`,void 0),O([v()],Yt.prototype,`pageNumber`,void 0),O([S()],Yt.prototype,`totalPages`,void 0),Yt=O([h(`mateu-pagination`)],Yt);var Xt=`var(--lumo-space-m, 1rem)`,Zt=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.columnWidth||`13rem`,l=`display: grid; grid-template-columns: ${s.maxColumns&&s.maxColumns>0?`repeat(${s.maxColumns}, minmax(0, 1fr))`:`repeat(auto-fill, minmax(min(100%, ${c}), 1fr))`}; gap: ${Xt} var(--lumo-space-l, 1.5rem); align-items: start;`;return s.labelsAside&&(l+=` --mateu-label-width: 10rem;`),s.fullWidth&&(l+=` width: 100%;`),l+=t.style??``,w`
+    `}};O([v()],Zt.prototype,`totalElements`,void 0),O([v()],Zt.prototype,`pageSize`,void 0),O([v()],Zt.prototype,`pageNumber`,void 0),O([S()],Zt.prototype,`totalPages`,void 0),Zt=O([h(`mateu-pagination`)],Zt);var Qt=`var(--lumo-space-m, 1rem)`,$t=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.columnWidth||`13rem`,l=`display: grid; grid-template-columns: ${s.maxColumns&&s.maxColumns>0?`repeat(${s.maxColumns}, minmax(0, 1fr))`:`repeat(auto-fill, minmax(min(100%, ${c}), 1fr))`}; gap: ${Qt} var(--lumo-space-l, 1.5rem); align-items: start;`;return s.labelsAside&&(l+=` --mateu-label-width: 10rem;`),s.fullWidth&&(l+=` width: 100%;`),l+=t.style??``,w`
         <div style="${l}" class="${t.cssClasses}" slot="${t.slot||_}">
-            ${t.children?.map(t=>Qt(s,e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>en(s,e,t,n,r,i,a,o))}
         </div>
-    `},Qt=(e,t,n,r,i,a,o,s)=>n.type==k.ClientSide&&n.metadata?.type==A.FormRow?tn(e,t,n,r,i,a,o,s):w`<div style="grid-column: span ${$t(n)}; min-width: 0;">${e.labelsAside?en(t,n,r,i,a,o,s):P(t,n,r,i,a,o,s)}</div>`,$t=e=>{if(e.type==k.ClientSide){let t=e.metadata;if(t?.type==A.FormField)return t.colspan||1}return 1},en=(e,t,n,r,i,a,o)=>{if(t.type==k.ClientSide&&t.metadata?.type==A.FormField&&t.metadata.label){let s=t.metadata;return w`
-            <div style="display: flex; gap: ${Xt}; align-items: baseline;">
+    `},en=(e,t,n,r,i,a,o,s)=>n.type==k.ClientSide&&n.metadata?.type==A.FormRow?rn(e,t,n,r,i,a,o,s):w`<div style="grid-column: span ${tn(n)}; min-width: 0;">${e.labelsAside?nn(t,n,r,i,a,o,s):P(t,n,r,i,a,o,s)}</div>`,tn=e=>{if(e.type==k.ClientSide){let t=e.metadata;if(t?.type==A.FormField)return t.colspan||1}return 1},nn=(e,t,n,r,i,a,o)=>{if(t.type==k.ClientSide&&t.metadata?.type==A.FormField&&t.metadata.label){let s=t.metadata;return w`
+            <div style="display: flex; gap: ${Qt}; align-items: baseline;">
                 <label style="flex: 0 0 var(--mateu-label-width, 10rem); color: var(--lumo-secondary-text-color, #667);">${s.label?.includes("${")?e._evalTemplate(s.label):s.label}</label>
                 <div style="flex: 1; min-width: 0;">${P(e,t,n,r,i,a,o,!0)}</div>
             </div>
-        `}return P(e,t,n,r,i,a,o)},tn=(e,t,n,r,i,a,o,s)=>w`
-        <div style="grid-column: 1 / -1; display: flex; gap: ${Xt}; flex-wrap: wrap;">
-            ${n.children?.map(c=>w`<div style="flex: 1 1 ${100/Math.max(1,n.children.length)}%; min-width: min(100%, 13rem);">${Qt(e,t,c,r,i,a,o,s)}</div>`)}
+        `}return P(e,t,n,r,i,a,o)},rn=(e,t,n,r,i,a,o,s)=>w`
+        <div style="grid-column: 1 / -1; display: flex; gap: ${Qt}; flex-wrap: wrap;">
+            ${n.children?.map(c=>w`<div style="flex: 1 1 ${100/Math.max(1,n.children.length)}%; min-width: min(100%, 13rem);">${en(e,t,c,r,i,a,o,s)}</div>`)}
         </div>
-    `,nn=(e,t,n,r,i,a,o,s)=>{let c=n.metadata,l=`display: flex; flex-direction: ${e};`;c.spacing&&(l+=` gap: ${Xt};`),c.padding&&(l+=` padding: var(--lumo-space-m, 1rem);`),c.wrap&&(l+=` flex-wrap: wrap;`),c.fullWidth&&(l+=` width: 100%;`),c.justification&&(l+=` justify-content: ${c.justification};`);let u=e===`row`?c.verticalAlignment:c.horizontalAlignment;return u&&(l+=` align-items: ${u};`),l+=n.style??``,w`
+    `,an=(e,t,n,r,i,a,o,s)=>{let c=n.metadata,l=`display: flex; flex-direction: ${e};`;c.spacing&&(l+=` gap: ${Qt};`),c.padding&&(l+=` padding: var(--lumo-space-m, 1rem);`),c.wrap&&(l+=` flex-wrap: wrap;`),c.fullWidth&&(l+=` width: 100%;`),c.justification&&(l+=` justify-content: ${c.justification};`);let u=e===`row`?c.verticalAlignment:c.horizontalAlignment;return u&&(l+=` align-items: ${u};`),l+=n.style??``,w`
         <div style="${l}" class="${n.cssClasses}" slot="${n.slot??_}">
             ${n.children?.map(e=>P(t,e,r,i,a,o,s))}
         </div>
-    `},rn=(e,t,n,r,i,a,o)=>nn(`row`,e,t,n,r,i,a,o),an=(e,t,n,r,i,a,o)=>nn(`column`,e,t,n,r,i,a,o),on=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=`display: flex; flex-direction: ${s.orientation===`vertical`?`column`:`row`}; gap: var(--lumo-space-s, 0.5rem);`;return s.fullWidth&&(c+=` width: 100%;`),c+=t.style??``,w`
+    `},on=(e,t,n,r,i,a,o)=>an(`row`,e,t,n,r,i,a,o),sn=(e,t,n,r,i,a,o)=>an(`column`,e,t,n,r,i,a,o),cn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=`display: flex; flex-direction: ${s.orientation===`vertical`?`column`:`row`}; gap: var(--lumo-space-s, 0.5rem);`;return s.fullWidth&&(c+=` width: 100%;`),c+=t.style??``,w`
         <div style="${c}" class="${t.cssClasses}" slot="${t.slot??_}">
             <div style="flex: 1; min-width: 0; min-height: 0;">${P(e,t.children[0],n,r,i,a,o)}</div>
             <div style="flex: 1; min-width: 0; min-height: 0;">${P(e,t.children[1],n,r,i,a,o)}</div>
         </div>
-    `},sn=(e,t,n,r,i,a,o)=>{let s=t.children&&t.children.length>1?t.children[1]:null,c=i?.detailComponent??null,l=!!i?.hasDetail||!!s,u=c??s;return w`
+    `},ln=(e,t,n,r,i,a,o)=>{let s=t.children&&t.children.length>1?t.children[1]:null,c=i?.detailComponent??null,l=!!i?.hasDetail||!!s,u=c??s;return w`
         <div style="display: flex; gap: var(--lumo-space-m, 1rem); ${t.style??``}" class="${t.cssClasses}" slot="${t.slot??_}">
             <div style="flex: 1; min-width: 0;">${P(e,t.children[0],n,r,i,a,o)}</div>
             ${l&&u?w`<div style="flex: 1; min-width: 0;">${P(e,u,n,r,i,a,o)}</div>`:w`<div style="flex: 1; display: flex; align-items: center; justify-content: center; color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-s, .875rem);">Select an item to view details</div>`}
         </div>
-    `},cn=(e,t,n,r,i,a,o)=>{let s=t.style??``;t.metadata.fullWidth&&(s+=` width: 100%;`);let c=Math.max(0,(t.children??[]).findIndex(e=>e.metadata.active));return w`
+    `},un=(e,t,n,r,i,a,o)=>{let s=t.style??``;t.metadata.fullWidth&&(s+=` width: 100%;`);let c=Math.max(0,(t.children??[]).findIndex(e=>e.metadata.active));return w`
         <div style="${s}" class="${t.cssClasses}" slot="${t.slot??_}">
             ${t.children?.map((t,s)=>{let l=t,u=l.metadata.label,d=u?.includes("${")?e._evalTemplate(u):u;return w`
                     <details ?open="${s===c}" style="border-bottom: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));">
@@ -1035,42 +1035,42 @@ ${i}
                     </details>
                 `})}
         </div>
-    `},ln=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style??``;return s.fullWidth&&(c+=` width: 100%;`),w`
+    `},dn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style??``;return s.fullWidth&&(c+=` width: 100%;`),w`
         <div style="${c}" class="${t.cssClasses}" slot="${t.slot??_}">
-            ${t.children?.map(t=>un(e,t,n,r,i,a,o,s.variant))}
+            ${t.children?.map(t=>fn(e,t,n,r,i,a,o,s.variant))}
         </div>
-    `},un=(e,t,n,r,i,a,o,s)=>{let c=t.metadata,l=c.label?.includes("${")?e._evalTemplate(c.label):c.label;return w`
+    `},fn=(e,t,n,r,i,a,o,s)=>{let c=t.metadata,l=c.label?.includes("${")?e._evalTemplate(c.label):c.label;return w`
         <details ?open="${c.active}" style="border-bottom: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1)); ${t.style??``}" class="${t.cssClasses}">
             <summary style="cursor: pointer; padding: var(--lumo-space-s, .5rem) 0; font-weight: 600; ${c.disabled?`pointer-events: none; opacity: .5;`:``}">${l}</summary>
             <div style="padding: var(--lumo-space-s, .5rem) 0;">
                 ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
             </div>
         </details>
-    `},dn=(e,t,n,r,i,a,o)=>w`
+    `},pn=(e,t,n,r,i,a,o)=>w`
         <div style="overflow: auto; ${t.style??``}" class="${t.cssClasses}" slot="${t.slot??_}">
             ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `,fn=(e,t,n,r,i,a,o)=>w`
+    `,mn=(e,t,n,r,i,a,o)=>w`
         <div style="width: 100%; ${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
             ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `,pn=(e,t,n,r,i,a,o)=>w`
+    `,hn=(e,t,n,r,i,a,o)=>w`
         <div style="max-width: min(100%, 1200px); margin: auto; ${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
             ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `,mn=(e,t,n,r,i,a,o)=>w`
-        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr)); gap: ${Xt}; ${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
-            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
-        </div>
-    `,hn=(e,t,n,r,i,a,o)=>w`
-        <div style="display: flex; gap: ${Xt}; flex-wrap: wrap; ${t.style}" class="${t.cssClasses}">
-            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
-        </div>
     `,gn=(e,t,n,r,i,a,o)=>w`
+        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr)); gap: ${Qt}; ${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
+        </div>
+    `,_n=(e,t,n,r,i,a,o)=>w`
+        <div style="display: flex; gap: ${Qt}; flex-wrap: wrap; ${t.style}" class="${t.cssClasses}">
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
+        </div>
+    `,vn=(e,t,n,r,i,a,o)=>w`
         <div style="flex: ${t.metadata.boardCols??1} 1 0; min-width: min(100%, 12rem); ${t.style}" class="${t.cssClasses}">
             ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `,_n=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+    `,yn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <div
                 style="display: flex; flex-direction: column; overflow: auto; ${t.style}"
                 class="${t.cssClasses}"
@@ -1078,16 +1078,16 @@ ${i}
         >
             ${s.page.content.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `},vn=e=>{let t=e.metadata;return(t?.content??t?.columns??[]).filter(e=>e&&e.metadata).map(e=>{let t=e.metadata;return{id:e.id??``,label:t?.label??e.id??``,autoWidth:t?.autoWidth,width:t?.width}})},yn=(e,t)=>{let n=e?.[t];return n==null?``:typeof n==`object`?n.text??n.label??n.value??``:String(n)},bn=(e,t,n)=>{let r=vn(e);return w`
+    `},bn=e=>{let t=e.metadata;return(t?.content??t?.columns??[]).filter(e=>e&&e.metadata).map(e=>{let t=e.metadata;return{id:e.id??``,label:t?.label??e.id??``,autoWidth:t?.autoWidth,width:t?.width}})},xn=(e,t)=>{let n=e?.[t];return n==null?``:typeof n==`object`?n.text??n.label??n.value??``:String(n)},Sn=(e,t,n)=>{let r=bn(e);return w`
         <div style="overflow:auto; width:100%; ${e.style}" class="${e.cssClasses}" slot="${e.slot??_}">
             <table style="border-collapse:collapse; width:100%; font-size: var(--lumo-font-size-s,.875rem);">
                 <thead><tr>${r.map(e=>w`<th style="${`text-align:left; padding:.45rem .6rem; border-bottom:2px solid var(--lumo-contrast-20pct,rgba(0,0,0,.2)); font-weight:600; white-space:nowrap; color: var(--lumo-secondary-text-color,#556);`}">${e.label}</th>`)}</tr></thead>
                 <tbody>
-                    ${(t??[]).length===0?w`<tr><td colspan="${Math.max(1,r.length)}" style="padding:1.5rem; text-align:center; color: var(--lumo-secondary-text-color,#888);">${n??`No data.`}</td></tr>`:t.map(e=>w`<tr>${r.map(t=>w`<td style="${`padding:.4rem .6rem; border-bottom:1px solid var(--lumo-contrast-10pct,rgba(0,0,0,.08)); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:24rem;`}" title="${yn(e,t.id)}">${yn(e,t.id)}</td>`)}</tr>`)}
+                    ${(t??[]).length===0?w`<tr><td colspan="${Math.max(1,r.length)}" style="padding:1.5rem; text-align:center; color: var(--lumo-secondary-text-color,#888);">${n??`No data.`}</td></tr>`:t.map(e=>w`<tr>${r.map(t=>w`<td style="${`padding:.4rem .6rem; border-bottom:1px solid var(--lumo-contrast-10pct,rgba(0,0,0,.08)); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:24rem;`}" title="${xn(e,t.id)}">${xn(e,t.id)}</td>`)}</tr>`)}
                 </tbody>
             </table>
         </div>
-    `},xn=(e,t)=>{let n=e.metadata;return e.id&&t&&t[e.id]?t[e.id]:n?.page?.content??[]},Sn=e=>{let t=e.metadata.items??[];return w`
+    `},Cn=(e,t)=>{let n=e.metadata;return e.id&&t&&t[e.id]?t[e.id]:n?.page?.content??[]},wn=e=>{let t=e.metadata.items??[];return w`
         <div class="mateu-message-list ${e.cssClasses??``}"
              style="display:flex; flex-direction:column; gap:.75rem; ${e.style??``}"
              slot="${e.slot??_}">
@@ -1106,7 +1106,7 @@ ${i}
                 </div>
             `)}
         </div>
-    `},Cn=(e,t,n,r,i,a,o)=>t.separator?w`<span style="align-self: stretch; width: 1px; background: var(--lumo-contrast-20pct, rgba(0,0,0,.2));"></span>`:t.submenus?w`
+    `},Tn=(e,t,n,r,i,a,o)=>t.separator?w`<span style="align-self: stretch; width: 1px; background: var(--lumo-contrast-20pct, rgba(0,0,0,.2));"></span>`:t.submenus?w`
             <details style="position: relative;">
                 <summary style="cursor: pointer; list-style: none; padding: .35rem .7rem; border-radius: var(--lumo-border-radius-m, 6px);">
                     ${t.component?P(e,t.component,n,r,i,a,o):t.label} ▾
@@ -1114,7 +1114,7 @@ ${i}
                 <div style="display: flex; flex-direction: column; gap: .1rem; padding: .3rem; min-width: 10rem;
                             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1)); border-radius: var(--lumo-border-radius-m, 6px);
                             background: var(--lumo-base-color, #fff); box-shadow: var(--lumo-box-shadow-s, 0 2px 8px rgba(0,0,0,.15));">
-                    ${t.submenus.map(t=>Cn(e,t,n,r,i,a,o))}
+                    ${t.submenus.map(t=>Tn(e,t,n,r,i,a,o))}
                 </div>
             </details>
         `:w`
@@ -1124,16 +1124,16 @@ ${i}
                      ${t.selected?`background: var(--lumo-primary-color-10pct, rgba(26,115,232,.12));`:``}">
             ${t.component?P(e,t.component,n,r,i,a,o):t.label}
         </span>
-    `,wn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+    `,En=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <div style="display: flex; flex-wrap: wrap; gap: .25rem; align-items: center; ${t.style}"
              class="${t.cssClasses}" slot="${t.slot??_}">
-            ${s.options?.map(t=>Cn(e,t,n,r,i,a??{},o??{}))}
+            ${s.options?.map(t=>Tn(e,t,n,r,i,a??{},o??{}))}
         </div>
-    `},Tn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+    `},Dn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <div style="${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
             ${P(e,s.wrapped,n,r,i,a,o)}
         </div>
-    `},En=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.content?.metadata,l=c?.type==A.Notice&&c.fullWidth===!0;return w`
+    `},On=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.content?.metadata,l=c?.type==A.Notice&&c.fullWidth===!0;return w`
         <div style="display:flex; flex-direction:column; ${l?`width: 100%; `:``}${t.style}"
              class="${t.cssClasses}"
              slot="${t.slot??_}"
@@ -1142,7 +1142,7 @@ ${i}
             ${s.label?w`<label style="font-size: var(--lumo-font-size-s,.875rem); color: var(--lumo-secondary-text-color,#667); margin-bottom:.15rem;">${s.label}</label>`:_}
             ${P(e,s.content,n,r,i,a,o)}
         </div>
-            `},Dn=e=>{let t=e.metadata,n=e=>{let n=e.closest(`.mateu-message-input`)?.querySelector(`input`),r=n?.value??``;!t.actionId||!r.trim()||(e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:{message:r}},bubbles:!0,composed:!0})),n&&(n.value=``))};return w`
+            `},kn=e=>{let t=e.metadata,n=e=>{let n=e.closest(`.mateu-message-input`)?.querySelector(`input`),r=n?.value??``;!t.actionId||!r.trim()||(e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:{message:r}},bubbles:!0,composed:!0})),n&&(n.value=``))};return w`
         <div class="mateu-message-input ${e.cssClasses??``}"
              style="display:flex; gap:.5rem; align-items:center; ${e.style??``}"
              slot="${e.slot??_}">
@@ -1152,62 +1152,62 @@ ${i}
             <button style="font:inherit; font-weight:500; cursor:pointer; padding:.5rem 1rem; border:none; border-radius:var(--lumo-border-radius-m,6px); background:var(--lumo-primary-color,#3b5bdb); color:var(--lumo-primary-contrast-color,#fff);"
                     @click="${e=>n(e.currentTarget)}">Send</button>
         </div>
-    `},On=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`<span title="${s.text}" style="${t.style}" class="${t.cssClasses}" slot="${t.slot??_}"
-        >${P(e,s.wrapped,n,r,i,a,o)}</span>`},kn=e=>{if(e instanceof CustomEvent)return e.detail;let t={};for(let n in e){let r=e[n];[`number`,`string`,`boolean`].indexOf(typeof r)>=0&&(t[n]=e[n])}return t},An=(e,t,n)=>{for(let n in t.attributes)e.setAttribute(n,t.attributes[n]);n.style&&e.setAttribute(`style`,n.style),n.cssClasses&&e.setAttribute(`class`,n.cssClasses),n.slot&&e.setAttribute(`slot`,n.slot),t.content&&(t.html?e.innerHTML=t.content:e.append(t.content))},jn=e=>{let t=e.name,n=e.attributes?e.attributes.import:void 0;n&&t.includes(`-`)&&!customElements.get(t)&&E(()=>import(n),[])},Mn=(e,t,n)=>{jn(t);let r=t.name;return t.attributes&&t.attributes.id&&(r=`#`+t.attributes.id),setTimeout(()=>{let i=e.shadowRoot?.querySelector(`.element-container`)?.querySelector(r);if(i){for(;i.firstChild;)i.removeChild(i.lastChild);An(i,t,n)}else{let r=document.createElement(t.name);An(r,t,n);for(let n in t.on)r.addEventListener(n,r=>{let i=kn(r);e.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.on[n],parameters:{event:i}},bubbles:!0,composed:!0}))});e.shadowRoot?.querySelector(`.element-container`)?.appendChild(r)}}),w`<div class="element-container"></div>`},Nn=function(e){return e.div=`div`,e.p=`p`,e.h1=`h1`,e.h2=`h2`,e.h3=`h3`,e.h4=`h4`,e.h5=`h5`,e.h6=`h6`,e.span=`span`,e}({}),Pn=(e,t,n,r,i)=>{let a=e.metadata,o=a.attributes?.[`data-colspan`],s=it(a.text,t,n,r,i),c={xl:`var(--lumo-font-size-xl, 1.375rem)`,l:`var(--lumo-font-size-l, 1.125rem)`,s:`var(--lumo-font-size-s, .875rem)`,xs:`var(--lumo-font-size-xs, .8125rem)`},l=(a.size&&c[a.size]?`font-size: ${c[a.size]}; `:``)+(a.noMargins?`margin-block-start: 0; margin-block-end: 0; `:``);return Nn.h1==a.container?w`
+    `},An=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`<span title="${s.text}" style="${t.style}" class="${t.cssClasses}" slot="${t.slot??_}"
+        >${P(e,s.wrapped,n,r,i,a,o)}</span>`},jn=e=>{if(e instanceof CustomEvent)return e.detail;let t={};for(let n in e){let r=e[n];[`number`,`string`,`boolean`].indexOf(typeof r)>=0&&(t[n]=e[n])}return t},Mn=(e,t,n)=>{for(let n in t.attributes)e.setAttribute(n,t.attributes[n]);n.style&&e.setAttribute(`style`,n.style),n.cssClasses&&e.setAttribute(`class`,n.cssClasses),n.slot&&e.setAttribute(`slot`,n.slot),t.content&&(t.html?e.innerHTML=t.content:e.append(t.content))},Nn=e=>{let t=e.name,n=e.attributes?e.attributes.import:void 0;n&&t.includes(`-`)&&!customElements.get(t)&&E(()=>import(n),[])},Pn=(e,t,n)=>{Nn(t);let r=t.name;return t.attributes&&t.attributes.id&&(r=`#`+t.attributes.id),setTimeout(()=>{let i=e.shadowRoot?.querySelector(`.element-container`)?.querySelector(r);if(i){for(;i.firstChild;)i.removeChild(i.lastChild);Mn(i,t,n)}else{let r=document.createElement(t.name);Mn(r,t,n);for(let n in t.on)r.addEventListener(n,r=>{let i=jn(r);e.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.on[n],parameters:{event:i}},bubbles:!0,composed:!0}))});e.shadowRoot?.querySelector(`.element-container`)?.appendChild(r)}}),w`<div class="element-container"></div>`},Fn=function(e){return e.div=`div`,e.p=`p`,e.h1=`h1`,e.h2=`h2`,e.h3=`h3`,e.h4=`h4`,e.h5=`h5`,e.h6=`h6`,e.span=`span`,e}({}),In=(e,t,n,r,i)=>{let a=e.metadata,o=a.attributes?.[`data-colspan`],s=it(a.text,t,n,r,i),c={xl:`var(--lumo-font-size-xl, 1.375rem)`,l:`var(--lumo-font-size-l, 1.125rem)`,s:`var(--lumo-font-size-s, .875rem)`,xs:`var(--lumo-font-size-xs, .8125rem)`},l=(a.size&&c[a.size]?`font-size: ${c[a.size]}; `:``)+(a.noMargins?`margin-block-start: 0; margin-block-end: 0; `:``);return Fn.h1==a.container?w`
             <h1 style="${l}${e.style}" class="${e.cssClasses}"
                 id="${x(e.id)}"
                 data-colspan="${x(o)}"
                 slot="${e.slot??_}">
                 ${s??_}
             </h1>
-        `:Nn.h2==a.container?w`
+        `:Fn.h2==a.container?w`
             <h2 style="${l}${e.style}" class="${e.cssClasses}"
                 id="${x(e.id)}"
                 data-colspan="${x(o)}"
                 slot="${e.slot??_}">
                 ${s??_}
             </h2>
-        `:Nn.h3==a.container?w`
+        `:Fn.h3==a.container?w`
             <h3 style="${l}${e.style}" class="${e.cssClasses}"
                 id="${x(e.id)}"
                 data-colspan="${x(o)}"
                 slot="${e.slot??_}">
                 ${s??_}
             </h3>
-        `:Nn.h4==a.container?w`
+        `:Fn.h4==a.container?w`
             <h4 style="${l}${e.style}" class="${e.cssClasses}"
                 id="${x(e.id)}"
                 data-colspan="${x(o)}"
                 slot="${e.slot??_}">
                 ${s??_}
             </h4>
-        `:Nn.h5==a.container?w`
+        `:Fn.h5==a.container?w`
             <h5 style="${l}${e.style}" class="${e.cssClasses}"
                 id="${x(e.id)}"
                 data-colspan="${x(o)}"
                 slot="${e.slot??_}">
                 ${s??_}
             </h5>
-        `:Nn.h6==a.container?w`
+        `:Fn.h6==a.container?w`
             <h6 style="${l}${e.style}" class="${e.cssClasses}"
                 id="${x(e.id)}"
                 data-colspan="${x(o)}"
                 slot="${e.slot??_}">
                 ${s??_}
             </h6>
-        `:Nn.p==a.container?w`
+        `:Fn.p==a.container?w`
                <p style="${l}${e.style}" class="${e.cssClasses}"
                   id="${x(e.id)}"
                   data-colspan="${x(o)}"
                   slot="${e.slot??_}">
                    ${s??_}
                </p>
-            `:Nn.div==a.container?w`
+            `:Fn.div==a.container?w`
                <div style="${l}${e.style}" class="${e.cssClasses}"
                     id="${x(e.id)}"
                     data-colspan="${x(o)}"
                     slot="${e.slot??_}">${s?g(s):_}</div>
-            `:Nn.span==a.container?w`
+            `:Fn.span==a.container?w`
                <span style="${l}${e.style}" class="${e.cssClasses}"
                      id="${x(e.id)}"
                      data-colspan="${x(o)}"
@@ -1219,20 +1219,20 @@ ${i}
                        slot="${e.slot??_}">
                    Unknown text container: ${a.container} 
                </p>
-            `},Fn=e=>{let t=e.metadata;return w`<a href="${t.url}" target="${t.target??_}"
+            `},Ln=e=>{let t=e.metadata;return w`<a href="${t.url}" target="${t.target??_}"
                    rel="${t.target===`_blank`?`noopener`:_}"
                    style="${e.style}" class="${e.cssClasses}"
-                   slot="${e.slot??_}">${t.text}</a>`},In=(e,t)=>{let n=e.toLowerCase().split(`+`);return t.ctrlKey===n.includes(`ctrl`)&&t.altKey===n.includes(`alt`)&&t.shiftKey===n.includes(`shift`)&&t.metaKey===n.includes(`meta`)},Ln=(e,t)=>{if(!In(e,t))return!1;let n=e.toLowerCase().split(`+`),r=n[n.length-1];return!!(t.key.toLowerCase()===r||/^[a-z]$/.test(r)&&t.code===`Key`+r.toUpperCase()||/^[0-9]$/.test(r)&&(t.code===`Digit`+r||t.code===`Numpad`+r))},Rn=e=>e?e.split(`+`).map(e=>e.length<=1?e.toUpperCase():e.charAt(0).toUpperCase()+e.slice(1)).join(`+`):void 0,zn=(e,t)=>{let n=e.currentTarget.dataset.actionId;e.currentTarget?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:n,parameters:t.parameters},bubbles:!0,composed:!0}))},Bn=`display:inline-flex; align-items:center; justify-content:center; gap:.4em; box-sizing:border-box; font:inherit; font-weight:500; cursor:pointer; border-radius:var(--lumo-border-radius-m,6px); border:1px solid transparent; line-height:1; white-space:nowrap;`,Vn=e=>{let t=e.buttonStyle??``,n=e.color&&e.color!==`none`&&e.color!==`normal`?e.color:``,r=e.size,i=n===`success`?`var(--lumo-success-color,#1a7f37)`:n===`error`?`var(--lumo-error-color,#c5221f)`:n===`contrast`?`var(--lumo-contrast,#161513)`:`var(--lumo-primary-color,#3b5bdb)`,a=n===`success`?`var(--lumo-success-contrast-color,#fff)`:n===`error`?`var(--lumo-error-contrast-color,#fff)`:n===`contrast`?`var(--lumo-base-color,#fff)`:`var(--lumo-primary-contrast-color,#fff)`,o=n===`success`?`var(--lumo-success-text-color,#1a7f37)`:n===`error`?`var(--lumo-error-text-color,#c5221f)`:n===`contrast`?`var(--lumo-body-text-color,#161513)`:`var(--lumo-primary-text-color,#3b5bdb)`,s;return s=t===`primary`?`background:${i}; color:${a};`:t===`tertiary`||t===`tertiaryInline`?`background:transparent; color:${o};`:`background:var(--lumo-contrast-5pct,rgba(0,0,0,.04)); color:${o}; border-color:var(--lumo-contrast-20pct,rgba(0,0,0,.16));`,`${Bn}${s}${r===`small`?`padding:.25rem .6rem; font-size:var(--lumo-font-size-s,.875rem);`:r===`large`?`padding:.65rem 1.4rem; font-size:var(--lumo-font-size-l,1.125rem);`:`padding:.45rem 1rem; font-size:var(--lumo-font-size-m,1rem);`}`},Hn=(e,t,n)=>{let r=e.metadata,i=j(r.label,t,n);return w`<button
+                   slot="${e.slot??_}">${t.text}</a>`},Rn=(e,t)=>{let n=e.toLowerCase().split(`+`);return t.ctrlKey===n.includes(`ctrl`)&&t.altKey===n.includes(`alt`)&&t.shiftKey===n.includes(`shift`)&&t.metaKey===n.includes(`meta`)},zn=(e,t)=>{if(!Rn(e,t))return!1;let n=e.toLowerCase().split(`+`),r=n[n.length-1];return!!(t.key.toLowerCase()===r||/^[a-z]$/.test(r)&&t.code===`Key`+r.toUpperCase()||/^[0-9]$/.test(r)&&(t.code===`Digit`+r||t.code===`Numpad`+r))},Bn=e=>e?e.split(`+`).map(e=>e.length<=1?e.toUpperCase():e.charAt(0).toUpperCase()+e.slice(1)).join(`+`):void 0,Vn=(e,t)=>{let n=e.currentTarget.dataset.actionId;e.currentTarget?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:n,parameters:t.parameters},bubbles:!0,composed:!0}))},Hn=`display:inline-flex; align-items:center; justify-content:center; gap:.4em; box-sizing:border-box; font:inherit; font-weight:500; cursor:pointer; border-radius:var(--lumo-border-radius-m,6px); border:1px solid transparent; line-height:1; white-space:nowrap;`,Un=e=>{let t=e.buttonStyle??``,n=e.color&&e.color!==`none`&&e.color!==`normal`?e.color:``,r=e.size,i=n===`success`?`var(--lumo-success-color,#1a7f37)`:n===`error`?`var(--lumo-error-color,#c5221f)`:n===`contrast`?`var(--lumo-contrast,#161513)`:`var(--lumo-primary-color,#3b5bdb)`,a=n===`success`?`var(--lumo-success-contrast-color,#fff)`:n===`error`?`var(--lumo-error-contrast-color,#fff)`:n===`contrast`?`var(--lumo-base-color,#fff)`:`var(--lumo-primary-contrast-color,#fff)`,o=n===`success`?`var(--lumo-success-text-color,#1a7f37)`:n===`error`?`var(--lumo-error-text-color,#c5221f)`:n===`contrast`?`var(--lumo-body-text-color,#161513)`:`var(--lumo-primary-text-color,#3b5bdb)`,s;return s=t===`primary`?`background:${i}; color:${a};`:t===`tertiary`||t===`tertiaryInline`?`background:transparent; color:${o};`:`background:var(--lumo-contrast-5pct,rgba(0,0,0,.04)); color:${o}; border-color:var(--lumo-contrast-20pct,rgba(0,0,0,.16));`,`${Hn}${s}${r===`small`?`padding:.25rem .6rem; font-size:var(--lumo-font-size-s,.875rem);`:r===`large`?`padding:.65rem 1.4rem; font-size:var(--lumo-font-size-l,1.125rem);`:`padding:.45rem 1rem; font-size:var(--lumo-font-size-m,1rem);`}`},Wn=(e,t,n)=>{let r=e.metadata,i=j(r.label,t,n);return w`<button
             id="${e.id}"
             data-action-id="${r.actionId}"
-            @click="${e=>zn(e,r)}"
-            style="${Vn(r)}${e.style}"
+            @click="${e=>Vn(e,r)}"
+            style="${Un(r)}${e.style}"
             class="${e.cssClasses}"
             ?disabled="${r.disabled}"
-            title="${r.shortcut?`${i} (${Rn(r.shortcut)})`:_}"
+            title="${r.shortcut?`${i} (${Bn(r.shortcut)})`:_}"
             slot="${e.slot??_}"
-    >${r.iconOnLeft?F(r.iconOnLeft):_}${i}${r.iconOnRight?F(r.iconOnRight):_}</button>`},Un=`display:block; box-sizing:border-box; background:var(--lumo-base-color,#fff); border:1px solid var(--lumo-contrast-10pct,rgba(0,0,0,.1)); border-radius:var(--lumo-border-radius-l,12px); box-shadow:var(--lumo-box-shadow-xs,0 1px 3px rgba(0,0,0,.08)); overflow:hidden;`,Wn=(e,t,n,r,i,a,o)=>{let s=t.metadata;if(!s)return w``;let c=t=>t?P(e,t,n,r,i,a,o,!1):_,l=s.header||s.headerPrefix||s.headerSuffix||s.title||s.subtitle;return w`
-        <div style="${Un}${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
+    >${r.iconOnLeft?F(r.iconOnLeft):_}${i}${r.iconOnRight?F(r.iconOnRight):_}</button>`},Gn=`display:block; box-sizing:border-box; background:var(--lumo-base-color,#fff); border:1px solid var(--lumo-contrast-10pct,rgba(0,0,0,.1)); border-radius:var(--lumo-border-radius-l,12px); box-shadow:var(--lumo-box-shadow-xs,0 1px 3px rgba(0,0,0,.08)); overflow:hidden;`,Kn=(e,t,n,r,i,a,o)=>{let s=t.metadata;if(!s)return w``;let c=t=>t?P(e,t,n,r,i,a,o,!1):_,l=s.header||s.headerPrefix||s.headerSuffix||s.title||s.subtitle;return w`
+        <div style="${Gn}${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
             ${s.media?c(s.media):_}
             ${l?w`<div style="display:flex; align-items:flex-start; gap:.75rem; padding:1rem 1.25rem ${s.content||s.footer?`0`:`1rem`};">
                 ${s.headerPrefix?c(s.headerPrefix):_}
@@ -1246,7 +1246,7 @@ ${i}
             ${s.content?w`<div style="padding:1rem 1.25rem;">${c(s.content)}</div>`:_}
             ${s.footer?w`<div style="padding:0 1.25rem 1rem;">${c(s.footer)}</div>`:_}
         </div>
-    `},Gn=e=>{let t=e.metadata;return w`
+    `},qn=e=>{let t=e.metadata;return w`
         <mateu-chart 
                 style="${e.style}" 
                 class="${e.cssClasses}"
@@ -1256,7 +1256,7 @@ ${i}
                 .options="${t.chartOptions}"
         >
         </mateu-chart>
-    `},Kn=e=>{let t=e.metadata;return F(t.icon,e.style,e.cssClasses,e.slot)},qn=(e,t)=>{e&&e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},Jn=`font:inherit; font-weight:500; cursor:pointer; padding:.45rem 1rem; border-radius:var(--lumo-border-radius-m,6px);`,Yn=`${Jn} background:var(--lumo-contrast-5pct,rgba(0,0,0,.04)); color:var(--lumo-body-text-color,#161513); border:1px solid var(--lumo-contrast-20pct,rgba(0,0,0,.16));`,Xn=`${Jn} background:var(--lumo-primary-color,#3b5bdb); color:var(--lumo-primary-contrast-color,#fff); border:1px solid transparent;`,Zn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!1;if(s.openedCondition)try{c=at(s.openedCondition,r,i,a,o)}catch(e){console.error(`when evaluating `+s.openedCondition+` :`+e+`, where data is `+i+` and state is `+r)}return c?w`
+    `},Jn=e=>{let t=e.metadata;return F(t.icon,e.style,e.cssClasses,e.slot)},Yn=(e,t)=>{e&&e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},Xn=`font:inherit; font-weight:500; cursor:pointer; padding:.45rem 1rem; border-radius:var(--lumo-border-radius-m,6px);`,Zn=`${Xn} background:var(--lumo-contrast-5pct,rgba(0,0,0,.04)); color:var(--lumo-body-text-color,#161513); border:1px solid var(--lumo-contrast-20pct,rgba(0,0,0,.16));`,Qn=`${Xn} background:var(--lumo-primary-color,#3b5bdb); color:var(--lumo-primary-contrast-color,#fff); border:1px solid transparent;`,$n=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!1;if(s.openedCondition)try{c=at(s.openedCondition,r,i,a,o)}catch(e){console.error(`when evaluating `+s.openedCondition+` :`+e+`, where data is `+i+` and state is `+r)}return c?w`
         <div class="mateu-confirm-dialog ${t.cssClasses??``}"
              style="position:fixed; inset:0; z-index:1000; display:flex; align-items:center; justify-content:center; background:rgba(0,0,0,.4); ${t.style??``}"
              slot="${t.slot??_}">
@@ -1264,13 +1264,13 @@ ${i}
                 ${s.header?w`<h3 style="margin:0 0 .75rem; font-size:1.15rem;">${s.header}</h3>`:_}
                 <div>${t.children?.map(t=>P(e,t,n,r,i,a,o))}</div>
                 <div style="display:flex; gap:.5rem; justify-content:flex-end; margin-top:1.25rem;">
-                    ${s.canCancel?w`<button style="${Yn}" @click="${e=>qn(e.currentTarget,s.cancelActionId)}">${s.rejectText&&!s.canReject?s.rejectText:`Cancel`}</button>`:_}
-                    ${s.canReject?w`<button style="${Yn}" @click="${e=>qn(e.currentTarget,s.rejectActionId)}">${s.rejectText||`No`}</button>`:_}
-                    <button style="${Xn}" @click="${e=>qn(e.currentTarget,s.confirmActionId)}">${s.confirmText||`OK`}</button>
+                    ${s.canCancel?w`<button style="${Zn}" @click="${e=>Yn(e.currentTarget,s.cancelActionId)}">${s.rejectText&&!s.canReject?s.rejectText:`Cancel`}</button>`:_}
+                    ${s.canReject?w`<button style="${Zn}" @click="${e=>Yn(e.currentTarget,s.rejectActionId)}">${s.rejectText||`No`}</button>`:_}
+                    <button style="${Qn}" @click="${e=>Yn(e.currentTarget,s.confirmActionId)}">${s.confirmText||`OK`}</button>
                 </div>
             </div>
         </div>
-    `:w``},Qn=e=>{let t=e.metadata,n;return t.position&&(n={Top:`top`,Bottom:`bottom`,TopLeft:`top-left`,TopRight:`top-right`,BottomLeft:`bottom-left`,BottomRight:`bottom-right`}[t.position]),w`
+    `:w``},er=e=>{let t=e.metadata,n;return t.position&&(n={Top:`top`,Bottom:`bottom`,TopLeft:`top-left`,TopRight:`top-right`,BottomLeft:`bottom-left`,BottomRight:`bottom-right`}[t.position]),w`
         <mateu-cookie-consent style="${e.style}" class="${e.cssClasses}"
                                slot="${e.slot??_}"
                                position="${n??_}"
@@ -1281,7 +1281,7 @@ ${i}
                                .learnMoreLink="${t.learnMoreLink??_}"
                                .dismiss="${t.dismiss??_}"
         ></mateu-cookie-consent>
-    `},$n=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+    `},tr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <details
                 ?open="${s.opened}"
                 style="${t.style}"
@@ -1291,7 +1291,7 @@ ${i}
             <summary>${P(e,s.summary,n,r,i,a,o)}</summary>
             ${P(e,s.content,n,r,i,a,o)}
         </details>
-            `},er=(e,t,n,r,i,a)=>w`
+            `},nr=(e,t,n,r,i,a)=>w`
         <mateu-dialog
                 id="${e.metadata.id}"
             .component="${e}"
@@ -1301,7 +1301,7 @@ ${i}
             .appState="${i}"
             .appdata="${a}"
         ></mateu-dialog>
-            `,tr=(e,t,n,r,i,a)=>w`
+            `,rr=(e,t,n,r,i,a)=>w`
         <mateu-drawer
                 id="${e.metadata.id}"
             .component="${e}"
@@ -1311,7 +1311,7 @@ ${i}
             .appState="${i}"
             .appdata="${a}"
         ></mateu-drawer>
-            `,nr=e=>{let t=e.metadata;return w`
+            `,ir=e=>{let t=e.metadata;return w`
         <mateu-api-caller>
         <mateu-ux baseUrl="${t.baseUrl}"  
                   route="${t.route}" 
@@ -1323,11 +1323,11 @@ ${i}
                   slot="${e.slot??_}"
         ></mateu-ux>
         </mateu-api-caller>
-            `},rr=e=>w`
+            `},ar=e=>w`
         <mateu-markdown .content=${e.metadata.markdown}
                         style="${e.style}" class="${e.cssClasses}"
                         slot="${e.slot??_}"></mateu-markdown>
-            `,ir=e=>{let t=e.metadata;return w`
+            `,or=e=>{let t=e.metadata;return w`
         <div
             role="status"
             slot="${e.slot??_}"
@@ -1340,7 +1340,7 @@ ${i}
             ${t.title?w`<strong>${t.title}</strong>`:_}
             ${t.text?w`<span>${t.text}</span>`:_}
         </div>
-    `},ar=(e,t={})=>{let n=e.metadata,r=n.valueKey?t[n.valueKey]:n.value,i=n.max&&n.max!=0?n.max:1,a=!n.indeterminate&&r!=null;return w`
+    `},sr=(e,t={})=>{let n=e.metadata,r=n.valueKey?t[n.valueKey]:n.value,i=n.max&&n.max!=0?n.max:1,a=!n.indeterminate&&r!=null;return w`
         <div style="${e.style}" class="${e.cssClasses}" slot="${e.slot??_}">
             <progress
                     style="width:100%;"
@@ -1351,7 +1351,7 @@ ${i}
     ${n.text}
   </span>`:_}
         </div>
-    `},or=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+    `},cr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <details style="position: relative; ${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
             <summary style="list-style: none; cursor: pointer;">${P(e,s.wrapped,n,r,i,a,o)}</summary>
             <div style="position: absolute; z-index: 100; min-width: 300px; margin-top: .25rem; padding: .6rem .8rem;
@@ -1360,20 +1360,20 @@ ${i}
                 ${P(e,s.content,n,r,i,a,o)}
             </div>
         </details>
-    `},sr=e=>{let t=e.metadata;return w`
+    `},lr=e=>{let t=e.metadata;return w`
         <mateu-map position="${t.position}" zoom="${t.zoom}"
                    style="${e.style}" class="${e.cssClasses}"
                    slot="${e.slot??_}"></mateu-map>
-            `},cr=e=>w`
+            `},ur=e=>w`
         <img src="${e.metadata.src}" style="${e.style}" class="${e.cssClasses}"
              slot="${e.slot??_}">
-            `,lr=e=>{let t=e.metadata;return w`<div style="display:flex; align-items:center; gap:0.5rem;" slot="${e.slot??_}">
+            `,dr=e=>{let t=e.metadata;return w`<div style="display:flex; align-items:center; gap:0.5rem;" slot="${e.slot??_}">
         ${t.breadcrumbs.map(e=>w`
             <a href="${e.link}">${e.text}</a>
             <span>/</span>
         `)}
         <span style="${e.style}" class="${e.cssClasses}">${t.currentItemText}</span>
-    </div>`},ur=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+    </div>`},fr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <skeleton-carousel 
                 id="${t.id}"
                 ?dots = "${s.dots}" 
@@ -1384,26 +1384,26 @@ ${i}
         >
             ${t.children?.map(t=>w`<div>${P(e,t,n,r,i,a,o)}</div>`)}
         </skeleton-carousel>
-    `},dr=(e,t,n,r)=>{let i=e.metadata;return w`
+    `},pr=(e,t,n,r)=>{let i=e.metadata;return w`
         <div style="display: flex; gap: 3rem; ${e.style}" class="${e.cssClasses}" slot="${e.slot??_}">
-            ${i.menu.map(e=>fr(e))}
+            ${i.menu.map(e=>mr(e))}
         </div>
-            `},fr=e=>w`
+            `},mr=e=>w`
         ${e.submenus?w`
                 <details open>
                     <summary>${e.label}</summary>
                     <div style="display:flex; flex-direction:column; gap:0.25rem; padding-left:0.5rem;">
-                        ${e.submenus.map(e=>fr(e))}
+                        ${e.submenus.map(e=>mr(e))}
                     </div>
                 </details>
             `:w`
                 <a href="${e.path}">${e.label}</a>
         `}
-        `,pr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`<div
+        `,hr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`<div
                 slot="${t.slot??_}"
                 style="${t.style}" class="${t.cssClasses}"
         >${s.content?g(s.content):_}${t.children?.map(t=>P(e,t,n,r,i,a,o))}</div>
-    `},mr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.title?.includes("${")?e._evalTemplate(s.title):s.title;return w`<div
+    `},gr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.title?.includes("${")?e._evalTemplate(s.title):s.title;return w`<div
                 slot="${t.slot??_}"
                 style="width: 100%; margin-bottom: var(--lumo-space-m); ${t.style}"
                 class="${t.cssClasses}"
@@ -1411,24 +1411,24 @@ ${i}
         ${c?w`<div style="font-size: var(--lumo-font-size-l); font-weight: 600; color: var(--lumo-header-text-color); margin-bottom: var(--lumo-space-s);">${c}</div>`:_}
         ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
     </div>
-    `},hr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.title?.includes("${")?e._evalTemplate(s.title):s.title;return w`
+    `},_r=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.title?.includes("${")?e._evalTemplate(s.title):s.title;return w`
         <div
                 slot="${t.slot??_}"
                 style="${t.style}" class="${t.cssClasses}"
         >
         <h4>${c}</h4>
         ${t.children?.map(t=>P(e,t,n,r,i,a,o))}</div>
-    `},gr=(e,t,n)=>{n.dispatchEvent(new CustomEvent(`value-changed`,{detail:{fieldId:e,value:t},bubbles:!0,composed:!0}))},_r=e=>t=>{let n=t.target,r=n.type===`checkbox`?n.checked:n.value;gr(e.fieldId,r,n)},vr=(e,t)=>{let n=e.metadata,r=t?.[n.fieldId]??``,i=n,a=i.dataType,o=i.stereotype,s=!!i.readOnly,c=!!i.disabled,l=i.options,u=n.label?w`<label style="display:block; font-size: var(--lumo-font-size-s,.875rem); color: var(--lumo-secondary-text-color,#667); margin-bottom:.15rem;">${n.label}</label>`:_,d=`width:100%; box-sizing:border-box; padding:.4rem .6rem; border:1px solid var(--lumo-contrast-30pct,rgba(0,0,0,.3)); border-radius: var(--lumo-border-radius-m,6px); font:inherit; background: var(--lumo-base-color,#fff); color: var(--lumo-body-text-color,#1a1a1a);`,f;return f=s||o===`plainText`?w`<div style="padding:.4rem 0;">${String(r??``)}</div>`:a===`boolean`||o===`checkbox`||o===`badge`?w`<input type="checkbox" ?checked="${!!r}" ?disabled="${c}" @change="${_r(n)}">`:l&&l.length?w`
-            <select style="${d}" ?disabled="${c}" @change="${_r(n)}">
+    `},vr=(e,t,n)=>{n.dispatchEvent(new CustomEvent(`value-changed`,{detail:{fieldId:e,value:t},bubbles:!0,composed:!0}))},yr=e=>t=>{let n=t.target,r=n.type===`checkbox`?n.checked:n.value;vr(e.fieldId,r,n)},br=(e,t)=>{let n=e.metadata,r=t?.[n.fieldId]??``,i=n,a=i.dataType,o=i.stereotype,s=!!i.readOnly,c=!!i.disabled,l=i.options,u=n.label?w`<label style="display:block; font-size: var(--lumo-font-size-s,.875rem); color: var(--lumo-secondary-text-color,#667); margin-bottom:.15rem;">${n.label}</label>`:_,d=`width:100%; box-sizing:border-box; padding:.4rem .6rem; border:1px solid var(--lumo-contrast-30pct,rgba(0,0,0,.3)); border-radius: var(--lumo-border-radius-m,6px); font:inherit; background: var(--lumo-base-color,#fff); color: var(--lumo-body-text-color,#1a1a1a);`,f;return f=s||o===`plainText`?w`<div style="padding:.4rem 0;">${String(r??``)}</div>`:a===`boolean`||o===`checkbox`||o===`badge`?w`<input type="checkbox" ?checked="${!!r}" ?disabled="${c}" @change="${yr(n)}">`:l&&l.length?w`
+            <select style="${d}" ?disabled="${c}" @change="${yr(n)}">
                 <option value="">—</option>
                 ${l.map(e=>w`<option value="${e.value}" ?selected="${e.value===r}">${e.label}</option>`)}
-            </select>`:o===`textarea`||o===`richText`||o===`html`?w`<textarea style="${d}" rows="3" ?disabled="${c}" @input="${_r(n)}">${String(r??``)}</textarea>`:w`<input type="${a===`integer`||a===`number`||a===`double`||a===`money`?`number`:a===`date`?`date`:a===`datetime`?`datetime-local`:a===`time`?`time`:o===`password`?`password`:a===`email`?`email`:`text`}" style="${d}" .value="${String(r??``)}"
-                              placeholder="${i.placeholder??_}" ?disabled="${c}" @input="${_r(n)}">`,w`
+            </select>`:o===`textarea`||o===`richText`||o===`html`?w`<textarea style="${d}" rows="3" ?disabled="${c}" @input="${yr(n)}">${String(r??``)}</textarea>`:w`<input type="${a===`integer`||a===`number`||a===`double`||a===`money`?`number`:a===`date`?`date`:a===`datetime`?`datetime-local`:a===`time`?`time`:o===`password`?`password`:a===`email`?`email`:`text`}" style="${d}" .value="${String(r??``)}"
+                              placeholder="${i.placeholder??_}" ?disabled="${c}" @input="${yr(n)}">`,w`
         <div style="${e.style}" class="${e.cssClasses}" slot="${e.slot??_}">
             ${u}
             ${f}
         </div>
-    `},yr=e=>{let t=e.metadata;if((t?.level??0)>0)return e;let n=e=>{if(e?.metadata?.type===A.EntityHeader)return e;let t=e?.metadata?.content,r=[...e?.children??[],...Array.isArray(t)?t:t?[t]:[]];for(let e of r){let t=n(e);if(t)return t}},r;for(let t of e.children??[])if(r=n(t),r)break;if(!r)return e;let i=r.metadata;r.__hoistedToPageHeader=!0;let a=[...(i.facts??[]).filter(e=>e.label||e.value).map(e=>({title:e.label??``,text:e.value??``})),...i.metricLabel?[{title:i.metricLabel,text:i.metricValue??``}]:[]],o=(i.badges??[]).filter(e=>e.label).map(e=>({text:e.label,color:e.color})),s={...t,title:i.title||t.title,subtitle:i.subtitle??t.subtitle,kpis:[...t.kpis??[],...a],kpisBelow:!0,badges:[...t.badges??[],...o]};return{...e,metadata:s}},br=(e,t,n,r,i,a,o,s)=>{let c=yr(t),l=c.metadata,u=l?.fabs??[];return w`<mateu-page
+    `},xr=e=>{let t=e.metadata;if((t?.level??0)>0)return e;let n=e=>{if(e?.metadata?.type===A.EntityHeader)return e;let t=e?.metadata?.content,r=[...e?.children??[],...Array.isArray(t)?t:t?[t]:[]];for(let e of r){let t=n(e);if(t)return t}},r;for(let t of e.children??[])if(r=n(t),r)break;if(!r)return e;let i=r.metadata;r.__hoistedToPageHeader=!0;let a=[...(i.facts??[]).filter(e=>e.label||e.value).map(e=>({title:e.label??``,text:e.value??``})),...i.metricLabel?[{title:i.metricLabel,text:i.metricValue??``}]:[]],o=(i.badges??[]).filter(e=>e.label).map(e=>({text:e.label,color:e.color})),s={...t,title:i.title||t.title,subtitle:i.subtitle??t.subtitle,kpis:[...t.kpis??[],...a],kpisBelow:!0,badges:[...t.badges??[],...o]};return{...e,metadata:s}},Sr=(e,t,n,r,i,a,o,s)=>{let c=xr(t),l=c.metadata,u=l?.fabs??[];return w`<mateu-page
             .component="${c}"
             baseUrl="${n}"
             .state="${r}"
@@ -1452,7 +1452,7 @@ ${i}
             </button>
         `)}
 </mateu-page>
-    `},xr=(e,t,n,r,i,a,o,s)=>w`<mateu-table-crud
+    `},Cr=(e,t,n,r,i,a,o,s)=>w`<mateu-table-crud
             id="${t.id}"
             baseUrl="${n}"
             .component="${t}"
@@ -1467,7 +1467,7 @@ ${i}
             ?standalone="${s??!1}"
     >
         ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
-    </mateu-table-crud>`,Sr=e=>{let t=e.metadata;return w`
+    </mateu-table-crud>`,wr=e=>{let t=e.metadata;return w`
         <mateu-bpmn
                 style="${e.style}"
                 class="${e.cssClasses}"
@@ -1475,35 +1475,35 @@ ${i}
                 xml="${t.xml}"
         >
         </mateu-bpmn>
-    `},Cr=(e,t,n)=>w`<mateu-chat sseUrl="${e.metadata.sseUrl}"
+    `},Tr=(e,t,n)=>w`<mateu-chat sseUrl="${e.metadata.sseUrl}"
                             style="${e.style}" 
                             class="${e.cssClasses}" 
-                            slot="${e.slot??_}"></mateu-chat>`,wr=e=>{let t=e.metadata;return w`
+                            slot="${e.slot??_}"></mateu-chat>`,Er=e=>{let t=e.metadata;return w`
         <mateu-workflow
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
                 value="${t.value??`{"name":"New Workflow","steps":[]}`}"
         ></mateu-workflow>
-    `},Tr=e=>{let t=e.metadata;return w`
+    `},Dr=e=>{let t=e.metadata;return w`
         <mateu-form-editor
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
                 value="${t.value??`{"name":"New Form","fields":[]}`}"
         ></mateu-form-editor>
-    `},Er=`
+    `},Or=`
     background: var(--lumo-base-color, #fff);
     border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.08));
     border-radius: var(--lumo-border-radius-l, 12px);
     padding: var(--lumo-space-m, 1rem);
     box-sizing: border-box;
-`,Dr=e=>e==`up`?`var(--lumo-success-text-color, #1a7f37)`:e==`down`?`var(--lumo-error-text-color, #c5221f)`:`var(--lumo-secondary-text-color, #666)`,Or=e=>e==`up`?`▲`:e==`down`?`▼`:``,kr=(e,t)=>{t.actionId&&e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))},Ar=e=>{let t=e.metadata,n=!!t.actionId;return w`
+`,kr=e=>e==`up`?`var(--lumo-success-text-color, #1a7f37)`:e==`down`?`var(--lumo-error-text-color, #c5221f)`:`var(--lumo-secondary-text-color, #666)`,Ar=e=>e==`up`?`▲`:e==`down`?`▼`:``,jr=(e,t)=>{t.actionId&&e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))},Mr=e=>{let t=e.metadata,n=!!t.actionId;return w`
         <div class="mateu-metric-card ${e.cssClasses??``}"
-             style="${Er} display: flex; flex-direction: column; gap: .25rem; min-width: 11rem; flex: 1; ${n?`cursor: pointer;`:``} ${e.style??``}"
+             style="${Or} display: flex; flex-direction: column; gap: .25rem; min-width: 11rem; flex: 1; ${n?`cursor: pointer;`:``} ${e.style??``}"
              slot="${e.slot??_}"
              role="${n?`button`:_}"
-             @click="${e=>kr(e,t)}"
+             @click="${e=>jr(e,t)}"
         >
             <div style="display: flex; align-items: center; justify-content: space-between; gap: .5rem;">
                 <span style="font-size: var(--lumo-font-size-s, .875rem); color: var(--lumo-secondary-text-color, #666);">${t.title}</span>
@@ -1514,25 +1514,25 @@ ${i}
                 ${t.unit?w`<span style="font-size: var(--lumo-font-size-m, 1rem); color: var(--lumo-secondary-text-color, #666);">${t.unit}</span>`:_}
             </div>
             ${t.trend||t.trendLabel?w`
-                <span style="font-size: var(--lumo-font-size-s, .875rem); color: ${Dr(t.trend)};">
-                    ${Or(t.trend)} ${t.trendLabel??_}
+                <span style="font-size: var(--lumo-font-size-s, .875rem); color: ${kr(t.trend)};">
+                    ${Ar(t.trend)} ${t.trendLabel??_}
                 </span>
             `:_}
             ${t.description?w`<span style="font-size: var(--lumo-font-size-xs, .8rem); color: var(--lumo-tertiary-text-color, #999);">${t.description}</span>`:_}
         </div>
-    `},jr=(e,t,n,r,i,a,o)=>w`
+    `},Nr=(e,t,n,r,i,a,o)=>w`
         <div class="mateu-scoreboard ${t.cssClasses??``}"
              style="display: flex; flex-wrap: wrap; gap: var(--lumo-space-m, 1rem); grid-column: 1 / -1; ${t.style??``}"
              slot="${t.slot??_}"
         >
             ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `,Mr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.colSpan&&s.colSpan>1?`grid-column: span ${s.colSpan};`:``,l=s.rowSpan&&s.rowSpan>1?`grid-row: span ${s.rowSpan};`:``,u=t.children??[];return u.length===1&&u[0].metadata?.type===`MetricCard`?w`
+    `,Pr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.colSpan&&s.colSpan>1?`grid-column: span ${s.colSpan};`:``,l=s.rowSpan&&s.rowSpan>1?`grid-row: span ${s.rowSpan};`:``,u=t.children??[];return u.length===1&&u[0].metadata?.type===`MetricCard`?w`
             <div style="min-width: 0; ${c} ${l} ${t.style??``}" slot="${t.slot??_}">
                 ${P(e,u[0],n,r,i,a,o)}
             </div>`:w`
         <div class="mateu-dashboard-panel ${t.cssClasses??``}"
-             style="${Er} display: flex; flex-direction: column; gap: .5rem; min-width: 0; ${c} ${l} ${t.style??``}"
+             style="${Or} display: flex; flex-direction: column; gap: .5rem; min-width: 0; ${c} ${l} ${t.style??``}"
              slot="${t.slot??_}"
         >
             ${s.title?w`
@@ -1545,14 +1545,14 @@ ${i}
                 ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
             </div>
         </div>
-    `},Nr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.columns&&s.columns>0?`repeat(${s.columns}, minmax(0, 1fr))`:`repeat(auto-fit, minmax(20rem, 1fr))`;return w`
+    `},Fr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.columns&&s.columns>0?`repeat(${s.columns}, minmax(0, 1fr))`:`repeat(auto-fit, minmax(20rem, 1fr))`;return w`
         <div class="mateu-dashboard ${t.cssClasses??``}"
              style="display: grid; grid-template-columns: ${c}; gap: var(--lumo-space-m, 1rem); align-items: stretch; ${t.style??``}"
              slot="${t.slot??_}"
         >
             ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `},Pr=class extends y{constructor(...e){super(...e),this.panels=[],this.headerTitle=``,this.badges=[],this.orientation=`vertical`,this.navigation=null,this.overviewEditActionId=``,this.openPanels=new Set,this.expandedPanel=null,this._onPopState=()=>{let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(e.startsWith(`expand=`)){let t=e.slice(7),n=this.panels.findIndex((e,n)=>this.panelAnchor(e,n)===t);this.expandedPanel=n>=0?n:null}else this.expandedPanel=null},this.initialized=!1}navAction(e){e&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{}},bubbles:!0,composed:!0}))}connectedCallback(){super.connectedCallback(),window.addEventListener(`popstate`,this._onPopState)}disconnectedCallback(){window.removeEventListener(`popstate`,this._onPopState),super.disconnectedCallback()}willUpdate(){if(!this.initialized&&this.panels.length){this.openPanels=new Set(this.panels.map((e,t)=>e.open?t:-1).filter(e=>e>=0));let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(e.startsWith(`expand=`)){let t=e.slice(7),n=this.panels.findIndex((e,n)=>this.panelAnchor(e,n)===t);n>=0&&(this.expandedPanel=n)}else if(e){let t=this.panels.findIndex((t,n)=>this.panelAnchor(t,n)===e);t>=0&&this.openPanels.add(t)}this.initialized=!0}}firstUpdated(){let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(!e)return;let t=this.renderRoot.querySelector(`[data-anchor="${CSS.escape(e)}"]`);t&&t.scrollIntoView({block:`nearest`})}panelAnchor(e,t){return(e.title??``).toLowerCase().replace(/[^a-z0-9]+/g,`-`).replace(/^-|-$/g,``)||`panel-${t}`}bookmarkPanel(e){let t=this.panelAnchor(this.panels[e],e);try{history.replaceState(history.state,``,`#`+t)}catch{}}clearBookmark(e){let t=this.panelAnchor(this.panels[e],e);if(decodeURIComponent((location.hash||``).replace(/^#/,``))===t)try{history.replaceState(history.state,``,location.pathname+location.search)}catch{}}expandPanel(e,t){t?.stopPropagation(),this.expandedPanel=e;let n=this.panelAnchor(this.panels[e],e);try{history.pushState(history.state,``,`#expand=`+n)}catch{}}collapsePanel(){try{history.back()}catch{this.expandedPanel=null}}toggle(e){let t=new Set(this.openPanels);t.has(e)?(t.delete(e),this.clearBookmark(e)):(t.add(e),this.bookmarkPanel(e)),this.openPanels=t}static{this.styles=m`
+    `},Ir=class extends y{constructor(...e){super(...e),this.panels=[],this.headerTitle=``,this.badges=[],this.orientation=`vertical`,this.navigation=null,this.overviewEditActionId=``,this.openPanels=new Set,this.expandedPanel=null,this._onPopState=()=>{let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(e.startsWith(`expand=`)){let t=e.slice(7),n=this.panels.findIndex((e,n)=>this.panelAnchor(e,n)===t);this.expandedPanel=n>=0?n:null}else this.expandedPanel=null},this.initialized=!1}navAction(e){e&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{}},bubbles:!0,composed:!0}))}connectedCallback(){super.connectedCallback(),window.addEventListener(`popstate`,this._onPopState)}disconnectedCallback(){window.removeEventListener(`popstate`,this._onPopState),super.disconnectedCallback()}willUpdate(){if(!this.initialized&&this.panels.length){this.openPanels=new Set(this.panels.map((e,t)=>e.open?t:-1).filter(e=>e>=0));let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(e.startsWith(`expand=`)){let t=e.slice(7),n=this.panels.findIndex((e,n)=>this.panelAnchor(e,n)===t);n>=0&&(this.expandedPanel=n)}else if(e){let t=this.panels.findIndex((t,n)=>this.panelAnchor(t,n)===e);t>=0&&this.openPanels.add(t)}this.initialized=!0}}firstUpdated(){let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(!e)return;let t=this.renderRoot.querySelector(`[data-anchor="${CSS.escape(e)}"]`);t&&t.scrollIntoView({block:`nearest`})}panelAnchor(e,t){return(e.title??``).toLowerCase().replace(/[^a-z0-9]+/g,`-`).replace(/^-|-$/g,``)||`panel-${t}`}bookmarkPanel(e){let t=this.panelAnchor(this.panels[e],e);try{history.replaceState(history.state,``,`#`+t)}catch{}}clearBookmark(e){let t=this.panelAnchor(this.panels[e],e);if(decodeURIComponent((location.hash||``).replace(/^#/,``))===t)try{history.replaceState(history.state,``,location.pathname+location.search)}catch{}}expandPanel(e,t){t?.stopPropagation(),this.expandedPanel=e;let n=this.panelAnchor(this.panels[e],e);try{history.pushState(history.state,``,`#expand=`+n)}catch{}}collapsePanel(){try{history.back()}catch{this.expandedPanel=null}}toggle(e){let t=new Set(this.openPanels);t.has(e)?(t.delete(e),this.clearBookmark(e)):(t.add(e),this.bookmarkPanel(e)),this.openPanels=t}static{this.styles=m`
         :host {
             display: flex;
             flex-direction: column;
@@ -1938,7 +1938,7 @@ ${i}
                     `)}
                 </div>
             </div>
-        `}};O([v({type:Array})],Pr.prototype,`panels`,void 0),O([v({type:String})],Pr.prototype,`headerTitle`,void 0),O([v({type:Array})],Pr.prototype,`badges`,void 0),O([v({type:String,reflect:!0})],Pr.prototype,`orientation`,void 0),O([v({attribute:!1})],Pr.prototype,`navigation`,void 0),O([v({type:String})],Pr.prototype,`overviewEditActionId`,void 0),O([S()],Pr.prototype,`openPanels`,void 0),O([S()],Pr.prototype,`expandedPanel`,void 0),Pr=O([h(`mateu-foldout`)],Pr);var Fr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+        `}};O([v({type:Array})],Ir.prototype,`panels`,void 0),O([v({type:String})],Ir.prototype,`headerTitle`,void 0),O([v({type:Array})],Ir.prototype,`badges`,void 0),O([v({type:String,reflect:!0})],Ir.prototype,`orientation`,void 0),O([v({attribute:!1})],Ir.prototype,`navigation`,void 0),O([v({type:String})],Ir.prototype,`overviewEditActionId`,void 0),O([S()],Ir.prototype,`openPanels`,void 0),O([S()],Ir.prototype,`expandedPanel`,void 0),Ir=O([h(`mateu-foldout`)],Ir);var Lr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <mateu-foldout
                 .panels="${s.panels??[]}"
                 .headerTitle="${s.headerTitle??``}"
@@ -1952,7 +1952,7 @@ ${i}
         >
             ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </mateu-foldout>
-    `},Ir=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.children??[],l=e=>c.filter(t=>(t.slot??``).startsWith(e)),u=l(`main-`),d=l(`aside-`),f=l(`footer-`),p=s.asideWidth&&s.asideWidth.trim()?s.asideWidth:`32%`,ee=s.asidePosition===`start`,te=s.asideSticky!==!1,ne=t=>t.map(t=>P(e,t,n,r,i,a,o)),re=w`
+    `},Rr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.children??[],l=e=>c.filter(t=>(t.slot??``).startsWith(e)),u=l(`main-`),d=l(`aside-`),f=l(`footer-`),p=s.asideWidth&&s.asideWidth.trim()?s.asideWidth:`32%`,ee=s.asidePosition===`start`,te=s.asideSticky!==!1,ne=t=>t.map(t=>P(e,t,n,r,i,a,o)),re=w`
         <div class="mateu-content-main"
              style="flex: 1 1 0; min-width: min(20rem, 100%); box-sizing: border-box;">
             ${ne(u)}
@@ -1973,7 +1973,7 @@ ${i}
                     ${ne(f)}
                 </div>`:_}
         </div>
-    `},Lr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!!s.image,l=c?`background-image: linear-gradient(rgba(0,0,0,.35), rgba(0,0,0,.35)), url('${s.image}'); background-size: cover; background-position: center; color: #fff;`:``,u=s.centered===!1?`flex-start`:`center`,d=s.centered===!1?`left`:`center`;return w`
+    `},zr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!!s.image,l=c?`background-image: linear-gradient(rgba(0,0,0,.35), rgba(0,0,0,.35)), url('${s.image}'); background-size: cover; background-position: center; color: #fff;`:``,u=s.centered===!1?`flex-start`:`center`,d=s.centered===!1?`left`:`center`;return w`
         <div class="mateu-hero ${t.cssClasses??``}"
              style="display: flex; flex-direction: column; align-items: ${u}; justify-content: center; gap: var(--lumo-space-m, 1rem); text-align: ${d}; padding: var(--lumo-space-xl, 2.5rem) var(--lumo-space-l, 1.5rem); border-radius: var(--lumo-border-radius-l, 12px); min-height: ${s.height??`12rem`}; box-sizing: border-box; ${l} ${t.style??``}"
              slot="${t.slot??_}"
@@ -1997,7 +1997,7 @@ ${i}
         outline-offset: 2px;
         border-radius: var(--lumo-border-radius-s, 4px);
     }
-`,Rr=1440*60*1e3,zr=class extends y{constructor(...e){super(...e),this.tasks=[],this.onTaskSelectionActionId=``}selectTask(e){this.onTaskSelectionActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.onTaskSelectionActionId,parameters:{_clickedTaskId:e.id}},bubbles:!0,composed:!0}))}static{this.styles=m`
+`,Br=1440*60*1e3,Vr=class extends y{constructor(...e){super(...e),this.tasks=[],this.onTaskSelectionActionId=``}selectTask(e){this.onTaskSelectionActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.onTaskSelectionActionId,parameters:{_clickedTaskId:e.id}},bubbles:!0,composed:!0}))}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2073,7 +2073,7 @@ ${i}
         }
     
         ${R}
-    `}range(){let e=this.tasks.flatMap(e=>[e.start,e.end]).filter(e=>!!e).map(e=>new Date(e+`T00:00:00`).getTime());return e.length?{min:Math.min(...e)-Rr,max:Math.max(...e)+2*Rr}:null}months(e,t){let n=[],r=new Date(e);for(r.setDate(1);r.getTime()<=t;){let i=Math.max(r.getTime(),e),a=new Date(r.getFullYear(),r.getMonth()+1,1),o=Math.min(a.getTime(),t);n.push({label:r.toLocaleDateString(void 0,{month:`short`,year:`2-digit`}),from:i,to:o}),r.setMonth(r.getMonth()+1)}return n}render(){let e=this.range();if(!e)return w``;let t=e.max-e.min,n=n=>(n-e.min)/t*100,r=Date.now();return w`
+    `}range(){let e=this.tasks.flatMap(e=>[e.start,e.end]).filter(e=>!!e).map(e=>new Date(e+`T00:00:00`).getTime());return e.length?{min:Math.min(...e)-Br,max:Math.max(...e)+2*Br}:null}months(e,t){let n=[],r=new Date(e);for(r.setDate(1);r.getTime()<=t;){let i=Math.max(r.getTime(),e),a=new Date(r.getFullYear(),r.getMonth()+1,1),o=Math.min(a.getTime(),t);n.push({label:r.toLocaleDateString(void 0,{month:`short`,year:`2-digit`}),from:i,to:o}),r.setMonth(r.getMonth()+1)}return n}render(){let e=this.range();if(!e)return w``;let t=e.max-e.min,n=n=>(n-e.min)/t*100,r=Date.now();return w`
             <div class="frame">
                 <div class="head">Task</div>
                 <div class="head months">
@@ -2081,7 +2081,7 @@ ${i}
                         <div class="month" style="width: ${(e.to-e.from)/t*100}%;">${e.label}</div>
                     `)}
                 </div>
-                ${this.tasks.map(i=>{let a=new Date(i.start+`T00:00:00`).getTime(),o=new Date(i.end+`T00:00:00`).getTime()+Rr;return w`
+                ${this.tasks.map(i=>{let a=new Date(i.start+`T00:00:00`).getTime(),o=new Date(i.end+`T00:00:00`).getTime()+Br;return w`
                         <div class="label" title="${i.title}">${i.title}</div>
                         <div class="lane">
                             ${r>=e.min&&r<=e.max?w`<div class="today" style="left: ${n(r)}%;"></div>`:_}
@@ -2096,7 +2096,7 @@ ${i}
                         </div>
                     `})}
             </div>
-        `}};O([v({type:Array})],zr.prototype,`tasks`,void 0),O([v()],zr.prototype,`onTaskSelectionActionId`,void 0),zr=O([h(`mateu-gantt`)],zr);var Br=e=>{let t=e.metadata;return w`
+        `}};O([v({type:Array})],Vr.prototype,`tasks`,void 0),O([v()],Vr.prototype,`onTaskSelectionActionId`,void 0),Vr=O([h(`mateu-gantt`)],Vr);var Hr=e=>{let t=e.metadata;return w`
         <mateu-gantt
                 .tasks="${t.tasks??[]}"
                 .onTaskSelectionActionId="${t.onTaskSelectionActionId??``}"
@@ -2104,7 +2104,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-gantt>
-    `},z,Vr=class extends y{static{z=this}constructor(...e){super(...e),this.resources=[],this.blocks=[],this.drag=null,this.dragStartX=0,this.dragStartY=0,this.laneRects=[],this.onDragKeydown=e=>{e.key===`Escape`&&this.drag&&(e.stopPropagation(),this.endDrag())}}static{this.styles=m`
+    `},z,Ur=class extends y{static{z=this}constructor(...e){super(...e),this.resources=[],this.blocks=[],this.drag=null,this.dragStartX=0,this.dragStartY=0,this.laneRects=[],this.onDragKeydown=e=>{e.key===`Escape`&&this.drag&&(e.stopPropagation(),this.endDrag())}}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2279,7 +2279,7 @@ ${i}
                          style="left: ${o.targetStartIdx*i}%; width: ${Math.min(o.duration,t.days-o.targetStartIdx)*i}%;"></div>
                 `:_}
             </div>
-        `}};O([v({type:Array})],Vr.prototype,`resources`,void 0),O([v({type:Array})],Vr.prototype,`blocks`,void 0),O([v()],Vr.prototype,`from`,void 0),O([v()],Vr.prototype,`to`,void 0),O([v()],Vr.prototype,`moveActionId`,void 0),O([v()],Vr.prototype,`selectActionId`,void 0),O([S()],Vr.prototype,`drag`,void 0),Vr=z=O([h(`mateu-planning-board`)],Vr);var Hr=e=>{let t=e.metadata;return w`
+        `}};O([v({type:Array})],Ur.prototype,`resources`,void 0),O([v({type:Array})],Ur.prototype,`blocks`,void 0),O([v()],Ur.prototype,`from`,void 0),O([v()],Ur.prototype,`to`,void 0),O([v()],Ur.prototype,`moveActionId`,void 0),O([v()],Ur.prototype,`selectActionId`,void 0),O([S()],Ur.prototype,`drag`,void 0),Ur=z=O([h(`mateu-planning-board`)],Ur);var Wr=e=>{let t=e.metadata;return w`
         <mateu-planning-board
                 .resources="${t.resources??[]}"
                 .blocks="${t.blocks??[]}"
@@ -2291,7 +2291,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-planning-board>
-    `},Ur=class extends y{constructor(...e){super(...e),this.columns=[]}static{this.styles=m`
+    `},Gr=class extends y{constructor(...e){super(...e),this.columns=[]}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2395,14 +2395,14 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};O([v({type:Array})],Ur.prototype,`columns`,void 0),Ur=O([h(`mateu-kanban`)],Ur);var Wr=e=>w`
+        `}};O([v({type:Array})],Gr.prototype,`columns`,void 0),Gr=O([h(`mateu-kanban`)],Gr);var Kr=e=>w`
         <mateu-kanban
                 .columns="${e.metadata.columns??[]}"
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-kanban>
-    `,Gr=class extends y{constructor(...e){super(...e),this.items=[]}static{this.styles=m`
+    `,qr=class extends y{constructor(...e){super(...e),this.items=[]}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2493,14 +2493,14 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};O([v({type:Array})],Gr.prototype,`items`,void 0),Gr=O([h(`mateu-timeline`)],Gr);var Kr=e=>w`
+        `}};O([v({type:Array})],qr.prototype,`items`,void 0),qr=O([h(`mateu-timeline`)],qr);var Jr=e=>w`
         <mateu-timeline
                 .items="${e.metadata.items??[]}"
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-timeline>
-    `,qr=class extends y{constructor(...e){super(...e),this.steps=[],this.vertical=!1}static{this.styles=m`
+    `,Yr=class extends y{constructor(...e){super(...e),this.steps=[],this.vertical=!1}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2614,7 +2614,7 @@ ${i}
                         </div>
                     `})}
             </div>
-        `}};O([v({type:Array})],qr.prototype,`steps`,void 0),O([v({type:Boolean,reflect:!0})],qr.prototype,`vertical`,void 0),qr=O([h(`mateu-progress-steps`)],qr);var Jr=e=>{let t=e.metadata;return w`
+        `}};O([v({type:Array})],Yr.prototype,`steps`,void 0),O([v({type:Boolean,reflect:!0})],Yr.prototype,`vertical`,void 0),Yr=O([h(`mateu-progress-steps`)],Yr);var Xr=e=>{let t=e.metadata;return w`
         <mateu-progress-steps
                 .steps="${t.steps??[]}"
                 ?vertical="${t.vertical??!1}"
@@ -2622,7 +2622,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-progress-steps>
-    `},Yr=class extends y{constructor(...e){super(...e),this.spark=[]}static{this.styles=m`
+    `},Zr=class extends y{constructor(...e){super(...e),this.spark=[]}static{this.styles=m`
         :host {
             display: block;
         }
@@ -2693,7 +2693,7 @@ ${i}
                     ${this.sparkline()}
                 </div>
             </div>
-        `}};O([v()],Yr.prototype,`label`,void 0),O([v()],Yr.prototype,`value`,void 0),O([v()],Yr.prototype,`unit`,void 0),O([v()],Yr.prototype,`delta`,void 0),O([v()],Yr.prototype,`trend`,void 0),O([v({type:Array})],Yr.prototype,`spark`,void 0),O([v()],Yr.prototype,`actionId`,void 0),Yr=O([h(`mateu-stat`)],Yr);var Xr=e=>{let t=e.metadata;return w`
+        `}};O([v()],Zr.prototype,`label`,void 0),O([v()],Zr.prototype,`value`,void 0),O([v()],Zr.prototype,`unit`,void 0),O([v()],Zr.prototype,`delta`,void 0),O([v()],Zr.prototype,`trend`,void 0),O([v({type:Array})],Zr.prototype,`spark`,void 0),O([v()],Zr.prototype,`actionId`,void 0),Zr=O([h(`mateu-stat`)],Zr);var Qr=e=>{let t=e.metadata;return w`
         <mateu-stat
                 label="${t.label??_}"
                 value="${t.value??_}"
@@ -2706,7 +2706,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-stat>
-    `},Zr=class extends y{constructor(...e){super(...e),this.events=[]}static{this.styles=m`
+    `},$r=class extends y{constructor(...e){super(...e),this.events=[]}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2797,7 +2797,7 @@ ${i}
                 ${l.map(e=>w`<div class="dow">${e}</div>`)}
                 ${u}
             </div>
-        `}};O([v()],Zr.prototype,`month`,void 0),O([v({type:Array})],Zr.prototype,`events`,void 0),Zr=O([h(`mateu-calendar`)],Zr);var Qr=e=>{let t=e.metadata;return w`
+        `}};O([v()],$r.prototype,`month`,void 0),O([v({type:Array})],$r.prototype,`events`,void 0),$r=O([h(`mateu-calendar`)],$r);var ei=e=>{let t=e.metadata;return w`
         <mateu-calendar
                 month="${t.month??_}"
                 .events="${t.events??[]}"
@@ -2805,7 +2805,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-calendar>
-    `},$r=class extends y{constructor(...e){super(...e),this.plans=[]}static{this.styles=m`
+    `},ti=class extends y{constructor(...e){super(...e),this.plans=[]}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2917,14 +2917,14 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};O([v({type:Array})],$r.prototype,`plans`,void 0),$r=O([h(`mateu-pricing-table`)],$r);var ei=e=>w`
+        `}};O([v({type:Array})],ti.prototype,`plans`,void 0),ti=O([h(`mateu-pricing-table`)],ti);var ni=e=>w`
         <mateu-pricing-table
                 .plans="${e.metadata.plans??[]}"
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-pricing-table>
-    `,ti=class extends y{static{this.styles=m`
+    `,ri=class extends y{static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -3032,14 +3032,14 @@ ${i}
                 </div>
                 ${e.children&&e.children.length?w`<ul>${e.children.map(e=>this.renderNode(e))}</ul>`:_}
             </li>
-        `}render(){return this.root?w`<div class="tree"><ul>${this.renderNode(this.root)}</ul></div>`:w``}};O([v({attribute:!1})],ti.prototype,`root`,void 0),ti=O([h(`mateu-org-chart`)],ti);var ni=e=>w`
+        `}render(){return this.root?w`<div class="tree"><ul>${this.renderNode(this.root)}</ul></div>`:w``}};O([v({attribute:!1})],ri.prototype,`root`,void 0),ri=O([h(`mateu-org-chart`)],ri);var ii=e=>w`
         <mateu-org-chart
                 .root="${e.metadata.root}"
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-org-chart>
-    `,ri=1440*60*1e3,ii=class extends y{constructor(...e){super(...e),this.cells=[]}static{this.styles=m`
+    `,ai=1440*60*1e3,oi=class extends y{constructor(...e){super(...e),this.cells=[]}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -3063,7 +3063,7 @@ ${i}
             margin-top: .15rem;
         }
         .legend .cell { width: 10px; height: 10px; }
-    `}color(e,t){if(e<=0||t<=0)return`var(--lumo-contrast-10pct, #ebedf0)`;let n=e/t;return`color-mix(in srgb, var(--lumo-primary-color, #1a73e8) ${Math.round((n>.75?1:n>.5?.75:n>.25?.5:.3)*100)}%, transparent)`}render(){let e=this.cells.filter(e=>!!e.date);if(!e.length)return w``;let t=e.map(e=>new Date(e.date+`T00:00:00`).getTime()),n=Math.min(...t),r=Math.max(...t),i=new Date(n);i.setDate(i.getDate()-(i.getDay()+6)%7);let a={};for(let t of e)a[t.date]=t;let o=Math.max(...e.map(e=>e.value??0),1),s=[];for(let e=i.getTime();e<=r;e+=ri){let t=new Date(e),n=t.toISOString().slice(0,10),r=a[n],i=r?.value??0,c=(t.getDay()+6)%7+1,l=r?.label??`${n}: ${i}`;s.push(w`
+    `}color(e,t){if(e<=0||t<=0)return`var(--lumo-contrast-10pct, #ebedf0)`;let n=e/t;return`color-mix(in srgb, var(--lumo-primary-color, #1a73e8) ${Math.round((n>.75?1:n>.5?.75:n>.25?.5:.3)*100)}%, transparent)`}render(){let e=this.cells.filter(e=>!!e.date);if(!e.length)return w``;let t=e.map(e=>new Date(e.date+`T00:00:00`).getTime()),n=Math.min(...t),r=Math.max(...t),i=new Date(n);i.setDate(i.getDate()-(i.getDay()+6)%7);let a={};for(let t of e)a[t.date]=t;let o=Math.max(...e.map(e=>e.value??0),1),s=[];for(let e=i.getTime();e<=r;e+=ai){let t=new Date(e),n=t.toISOString().slice(0,10),r=a[n],i=r?.value??0,c=(t.getDay()+6)%7+1,l=r?.label??`${n}: ${i}`;s.push(w`
                 <div class="cell" style="grid-row: ${c}; --cell: ${this.color(i,o)};" title="${l}"></div>
             `)}return w`
             <div class="wrap">
@@ -3078,14 +3078,14 @@ ${i}
                     <span>More</span>
                 </div>
             </div>
-        `}};O([v({type:Array})],ii.prototype,`cells`,void 0),ii=O([h(`mateu-heatmap`)],ii);var ai=e=>w`
+        `}};O([v({type:Array})],oi.prototype,`cells`,void 0),oi=O([h(`mateu-heatmap`)],oi);var si=e=>w`
         <mateu-heatmap
                 .cells="${e.metadata.cells??[]}"
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-heatmap>
-    `,oi=class extends y{constructor(...e){super(...e),this.stages=[]}static{this.styles=m`
+    `,ci=class extends y{constructor(...e){super(...e),this.stages=[]}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .funnel { display: flex; flex-direction: column; gap: .35rem; }
         .stage { display: flex; flex-direction: column; align-items: center; gap: .1rem; }
@@ -3118,14 +3118,14 @@ ${i}
                         </div>
                     `})}
             </div>
-        `}};O([v({type:Array})],oi.prototype,`stages`,void 0),oi=O([h(`mateu-funnel`)],oi);var si=e=>w`
+        `}};O([v({type:Array})],ci.prototype,`stages`,void 0),ci=O([h(`mateu-funnel`)],ci);var li=e=>w`
         <mateu-funnel
                 .stages="${e.metadata.stages??[]}"
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-funnel>
-    `,ci=class extends y{constructor(...e){super(...e),this.values=[],this.labels=[],this.area=!1}static{this.styles=m`
+    `,ui=class extends y{constructor(...e){super(...e),this.values=[],this.labels=[],this.area=!1}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .title { font-weight: 600; margin-bottom: .35rem; color: var(--lumo-body-text-color, #222); }
         svg { display: block; width: 100%; height: auto; overflow: visible; }
@@ -3138,7 +3138,7 @@ ${i}
                 ${a.map((t,n)=>n===l||n===u?C`<circle cx="${t[0]}" cy="${t[1]}" r="3.2" fill="${c}"><title>${this.labels[n]??``}: ${e[n]}</title></circle>`:C`<circle cx="${t[0]}" cy="${t[1]}" r="6" fill="transparent"><title>${this.labels[n]??``}: ${e[n]}</title></circle>`)}
             </svg>
             ${this.labels&&this.labels.length?w`<div class="labels"><span>${this.labels[0]}</span><span>${this.labels[this.labels.length-1]}</span></div>`:_}
-        `}};O([v()],ci.prototype,`heading`,void 0),O([v({type:Array})],ci.prototype,`values`,void 0),O([v({type:Array})],ci.prototype,`labels`,void 0),O([v()],ci.prototype,`color`,void 0),O([v({type:Boolean})],ci.prototype,`area`,void 0),ci=O([h(`mateu-trend-chart`)],ci);var li=e=>{let t=e.metadata;return w`
+        `}};O([v()],ui.prototype,`heading`,void 0),O([v({type:Array})],ui.prototype,`values`,void 0),O([v({type:Array})],ui.prototype,`labels`,void 0),O([v()],ui.prototype,`color`,void 0),O([v({type:Boolean})],ui.prototype,`area`,void 0),ui=O([h(`mateu-trend-chart`)],ui);var di=e=>{let t=e.metadata;return w`
         <mateu-trend-chart
                 heading="${t.title??_}"
                 color="${t.color??_}"
@@ -3149,7 +3149,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-trend-chart>
-    `},ui=class extends y{constructor(...e){super(...e),this.features=[],this.columns=0}static{this.styles=m`
+    `},fi=class extends y{constructor(...e){super(...e),this.features=[],this.columns=0}static{this.styles=m`
         :host { display: block; width: 100%; }
         .grid {
             display: grid;
@@ -3190,7 +3190,7 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};O([v({type:Array})],ui.prototype,`features`,void 0),O([v({type:Number})],ui.prototype,`columns`,void 0),ui=O([h(`mateu-feature-grid`)],ui);var di=e=>{let t=e.metadata;return w`
+        `}};O([v({type:Array})],fi.prototype,`features`,void 0),O([v({type:Number})],fi.prototype,`columns`,void 0),fi=O([h(`mateu-feature-grid`)],fi);var pi=e=>{let t=e.metadata;return w`
         <mateu-feature-grid
                 .features="${t.features??[]}"
                 .columns="${t.columns??0}"
@@ -3198,7 +3198,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-feature-grid>
-    `},fi=class extends y{constructor(...e){super(...e),this.items=[]}static{this.styles=m`
+    `},mi=class extends y{constructor(...e){super(...e),this.items=[]}static{this.styles=m`
         :host { display: block; width: 100%; }
         .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr)); gap: var(--lumo-space-m, 1rem); }
         .card {
@@ -3238,14 +3238,14 @@ ${i}
                         </div>
                     `})}
             </div>
-        `}};O([v({type:Array})],fi.prototype,`items`,void 0),fi=O([h(`mateu-testimonials`)],fi);var pi=e=>w`
+        `}};O([v({type:Array})],mi.prototype,`items`,void 0),mi=O([h(`mateu-testimonials`)],mi);var hi=e=>w`
         <mateu-testimonials
                 .items="${e.metadata.items??[]}"
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-testimonials>
-    `,mi=class extends y{constructor(...e){super(...e),this.items=[],this.openSet=new Set,this.seeded=!1}static{this.styles=m`
+    `,gi=class extends y{constructor(...e){super(...e),this.items=[],this.openSet=new Set,this.seeded=!1}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-m, 1rem); }
         .list {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -3282,14 +3282,14 @@ ${i}
                         </div>
                     `})}
             </div>
-        `}};O([v({type:Array})],mi.prototype,`items`,void 0),O([S()],mi.prototype,`openSet`,void 0),mi=O([h(`mateu-faq`)],mi);var hi=e=>w`
+        `}};O([v({type:Array})],gi.prototype,`items`,void 0),O([S()],gi.prototype,`openSet`,void 0),gi=O([h(`mateu-faq`)],gi);var _i=e=>w`
         <mateu-faq
                 .items="${e.metadata.items??[]}"
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-faq>
-    `,gi=class extends y{static{this.styles=m`
+    `,vi=class extends y{static{this.styles=m`
         :host { display: block; width: 100%; }
         .callout {
             display: flex; gap: 1rem; align-items: flex-start;
@@ -3318,7 +3318,7 @@ ${i}
                     ${this.ctaLabel?w`<button class="cta" @click="${()=>this.cta()}">${this.ctaLabel}</button>`:_}
                 </div>
             </div>
-        `}};O([v()],gi.prototype,`heading`,void 0),O([v()],gi.prototype,`description`,void 0),O([v()],gi.prototype,`icon`,void 0),O([v()],gi.prototype,`ctaLabel`,void 0),O([v()],gi.prototype,`actionId`,void 0),O([v()],gi.prototype,`theme`,void 0),gi=O([h(`mateu-callout-card`)],gi);var _i=e=>{let t=e.metadata;return w`
+        `}};O([v()],vi.prototype,`heading`,void 0),O([v()],vi.prototype,`description`,void 0),O([v()],vi.prototype,`icon`,void 0),O([v()],vi.prototype,`ctaLabel`,void 0),O([v()],vi.prototype,`actionId`,void 0),O([v()],vi.prototype,`theme`,void 0),vi=O([h(`mateu-callout-card`)],vi);var yi=e=>{let t=e.metadata;return w`
         <mateu-callout-card
                 heading="${t.title??_}"
                 description="${t.description??_}"
@@ -3330,7 +3330,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-callout-card>
-    `},vi=class extends y{constructor(...e){super(...e),this.comments=[]}static{this.styles=m`
+    `},bi=class extends y{constructor(...e){super(...e),this.comments=[]}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .thread { display: flex; flex-direction: column; gap: 1rem; }
         .replies {
@@ -3362,14 +3362,14 @@ ${i}
                     ${e.replies&&e.replies.length?w`<div class="replies">${e.replies.map(e=>this.renderComment(e))}</div>`:_}
                 </div>
             </div>
-        `}render(){return w`<div class="thread">${this.comments.map(e=>this.renderComment(e))}</div>`}};O([v({type:Array})],vi.prototype,`comments`,void 0),vi=O([h(`mateu-comment-thread`)],vi);var yi=e=>w`
+        `}render(){return w`<div class="thread">${this.comments.map(e=>this.renderComment(e))}</div>`}};O([v({type:Array})],bi.prototype,`comments`,void 0),bi=O([h(`mateu-comment-thread`)],bi);var xi=e=>w`
         <mateu-comment-thread
                 .comments="${e.metadata.comments??[]}"
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-comment-thread>
-    `,bi={pdf:`📕`,image:`🖼️`,img:`🖼️`,doc:`📘`,docx:`📘`,word:`📘`,xls:`📗`,xlsx:`📗`,excel:`📗`,sheet:`📗`,zip:`🗜️`,archive:`🗜️`,video:`🎬`,audio:`🎵`,code:`💻`,csv:`📄`,txt:`📄`},xi=class extends y{constructor(...e){super(...e),this.files=[]}static{this.styles=m`
+    `,Si={pdf:`📕`,image:`🖼️`,img:`🖼️`,doc:`📘`,docx:`📘`,word:`📘`,xls:`📗`,xlsx:`📗`,excel:`📗`,sheet:`📗`,zip:`🗜️`,archive:`🗜️`,video:`🎬`,audio:`🎵`,code:`💻`,csv:`📄`,txt:`📄`},Ci=class extends y{constructor(...e){super(...e),this.files=[]}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .list {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -3386,7 +3386,7 @@ ${i}
         .dl { color: var(--lumo-primary-color, #1a73e8); flex: 0 0 auto; }
     
         ${R}
-    `}icon(e){return e&&bi[e.toLowerCase()]||`📄`}clickFile(e,t){e.url||e.actionId&&(t.preventDefault(),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_file:e}},bubbles:!0,composed:!0})))}render(){return w`
+    `}icon(e){return e&&Si[e.toLowerCase()]||`📄`}clickFile(e,t){e.url||e.actionId&&(t.preventDefault(),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_file:e}},bubbles:!0,composed:!0})))}render(){return w`
             <div class="list">
                 ${this.files.map(e=>{let t=!!e.url||!!e.actionId,n=w`
                         <span class="icon">${this.icon(e.type)}</span>
@@ -3395,14 +3395,14 @@ ${i}
                         ${e.url?w`<span class="dl">⬇</span>`:_}
                     `;return e.url?w`<a class="file clickable" href="${e.url}" download target="_blank" rel="noopener">${n}</a>`:w`<div role="button" tabindex="0" class="file ${t?`clickable`:``}" @click="${t=>this.clickFile(e,t)}" @keydown="${L(t=>this.clickFile(e,t))}">${n}</div>`})}
             </div>
-        `}};O([v({type:Array})],xi.prototype,`files`,void 0),xi=O([h(`mateu-file-list`)],xi);var Si=e=>w`
+        `}};O([v({type:Array})],Ci.prototype,`files`,void 0),Ci=O([h(`mateu-file-list`)],Ci);var wi=e=>w`
         <mateu-file-list
                 .files="${e.metadata.files??[]}"
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-file-list>
-    `,Ci=class extends y{constructor(...e){super(...e),this.items=[],this.localDone=new Map}static{this.styles=m`
+    `,Ti=class extends y{constructor(...e){super(...e),this.items=[],this.localDone=new Map}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .head { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: .5rem; }
         .title { font-weight: 700; color: var(--lumo-body-text-color, #222); }
@@ -3432,7 +3432,7 @@ ${i}
                         <span class="label">${e.label}</span>
                     </div>
                 `})}
-        `}};O([v()],Ci.prototype,`heading`,void 0),O([v({type:Array})],Ci.prototype,`items`,void 0),O([S()],Ci.prototype,`localDone`,void 0),Ci=O([h(`mateu-checklist`)],Ci);var wi=e=>{let t=e.metadata;return w`
+        `}};O([v()],Ti.prototype,`heading`,void 0),O([v({type:Array})],Ti.prototype,`items`,void 0),O([S()],Ti.prototype,`localDone`,void 0),Ti=O([h(`mateu-checklist`)],Ti);var Ei=e=>{let t=e.metadata;return w`
         <mateu-checklist
                 heading="${t.title??_}"
                 .items="${t.items??[]}"
@@ -3440,7 +3440,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-checklist>
-    `},Ti=class extends y{static{this.styles=m`
+    `},Di=class extends y{static{this.styles=m`
         :host { display: block; width: 100%; }
         .card {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -3480,7 +3480,7 @@ ${i}
                     </div>
                 </div>
             </div>
-        `}};O([v()],Ti.prototype,`heading`,void 0),O([v()],Ti.prototype,`leftLabel`,void 0),O([v()],Ti.prototype,`leftValue`,void 0),O([v()],Ti.prototype,`rightLabel`,void 0),O([v()],Ti.prototype,`rightValue`,void 0),O([v()],Ti.prototype,`delta`,void 0),O([v()],Ti.prototype,`trend`,void 0),Ti=O([h(`mateu-comparison-card`)],Ti);var Ei=e=>{let t=e.metadata;return w`
+        `}};O([v()],Di.prototype,`heading`,void 0),O([v()],Di.prototype,`leftLabel`,void 0),O([v()],Di.prototype,`leftValue`,void 0),O([v()],Di.prototype,`rightLabel`,void 0),O([v()],Di.prototype,`rightValue`,void 0),O([v()],Di.prototype,`delta`,void 0),O([v()],Di.prototype,`trend`,void 0),Di=O([h(`mateu-comparison-card`)],Di);var Oi=e=>{let t=e.metadata;return w`
         <mateu-comparison-card
                 heading="${t.title??_}"
                 leftLabel="${t.leftLabel??_}"
@@ -3493,7 +3493,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-comparison-card>
-    `},Di=m`
+    `},ki=m`
     .chip {
         display: inline-flex;
         align-items: center;
@@ -3523,7 +3523,7 @@ ${i}
         color: var(--lumo-contrast-80pct, #333);
         background: var(--lumo-contrast-10pct, rgba(0, 0, 0, .08));
     }
-`,Oi=new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}),ki=e=>Oi.format(e),Ai=(e,t)=>{let n=e<0?`-`:``,r=ki(Math.abs(e));return t?`${n}${t} ${r}`:`${n}${r}`},ji=(e,t)=>t?`${ki(e)} ${t}`:ki(e),Mi=class extends y{constructor(...e){super(...e),this.title=``,this.badges=[],this.facts=[]}static{this.styles=[Di,m`
+`,Ai=new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}),ji=e=>Ai.format(e),Mi=(e,t)=>{let n=e<0?`-`:``,r=ji(Math.abs(e));return t?`${n}${t} ${r}`:`${n}${r}`},Ni=(e,t)=>t?`${ji(e)} ${t}`:ji(e),Pi=class extends y{constructor(...e){super(...e),this.title=``,this.badges=[],this.facts=[]}static{this.styles=[ki,m`
         :host { display: block; width: 100%; }
         .card {
             display: flex;
@@ -3606,7 +3606,7 @@ ${i}
                     </div>
                 `:_}
             </div>
-        `}};O([v()],Mi.prototype,`title`,void 0),O([v({type:Array})],Mi.prototype,`badges`,void 0),O([v()],Mi.prototype,`subtitle`,void 0),O([v({type:Array})],Mi.prototype,`facts`,void 0),O([v()],Mi.prototype,`metricLabel`,void 0),O([v()],Mi.prototype,`metricValue`,void 0),O([v()],Mi.prototype,`metricCaption`,void 0),Mi=O([h(`mateu-entity-header`)],Mi);var Ni=e=>{if(e.__hoistedToPageHeader)return w``;let t=e.metadata;return w`
+        `}};O([v()],Pi.prototype,`title`,void 0),O([v({type:Array})],Pi.prototype,`badges`,void 0),O([v()],Pi.prototype,`subtitle`,void 0),O([v({type:Array})],Pi.prototype,`facts`,void 0),O([v()],Pi.prototype,`metricLabel`,void 0),O([v()],Pi.prototype,`metricValue`,void 0),O([v()],Pi.prototype,`metricCaption`,void 0),Pi=O([h(`mateu-entity-header`)],Pi);var Fi=e=>{if(e.__hoistedToPageHeader)return w``;let t=e.metadata;return w`
         <mateu-entity-header
                 .title="${t.title??``}"
                 .badges="${t.badges??[]}"
@@ -3619,7 +3619,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-entity-header>
-    `},Pi=class extends y{constructor(...e){super(...e),this.value=0,this.max=0}static{this.styles=m`
+    `},Ii=class extends y{constructor(...e){super(...e),this.value=0,this.max=0}static{this.styles=m`
         :host { display: block; width: 100%; }
         .meter { display: flex; flex-direction: column; gap: .35rem; }
         .label {
@@ -3644,13 +3644,13 @@ ${i}
     `}fillColor(){return this.dangerAt!=null&&this.value>=this.dangerAt?`error`:this.warnAt!=null&&this.value>=this.warnAt?`warning`:this.warnAt!=null||this.dangerAt!=null?`success`:`primary`}render(){let e=this.max>0?Math.min(Math.max(this.value/this.max,0),1):0,t=Math.round(e*100);return w`
             <div class="meter">
                 ${this.label?w`<span class="label">${this.label}</span>`:_}
-                <span class="value">${ji(this.value,this.unit)}</span>
+                <span class="value">${Ni(this.value,this.unit)}</span>
                 <div class="track">
                     <div class="fill ${this.fillColor()}" style="width: ${t}%"></div>
                 </div>
                 <span class="caption">${this.caption?this.caption:`${t}%`}</span>
             </div>
-        `}};O([v()],Pi.prototype,`label`,void 0),O([v({type:Number})],Pi.prototype,`value`,void 0),O([v({type:Number})],Pi.prototype,`max`,void 0),O([v()],Pi.prototype,`unit`,void 0),O([v()],Pi.prototype,`caption`,void 0),O([v({type:Number})],Pi.prototype,`warnAt`,void 0),O([v({type:Number})],Pi.prototype,`dangerAt`,void 0),Pi=O([h(`mateu-meter`)],Pi);var Fi=e=>{let t=e.metadata;return w`
+        `}};O([v()],Ii.prototype,`label`,void 0),O([v({type:Number})],Ii.prototype,`value`,void 0),O([v({type:Number})],Ii.prototype,`max`,void 0),O([v()],Ii.prototype,`unit`,void 0),O([v()],Ii.prototype,`caption`,void 0),O([v({type:Number})],Ii.prototype,`warnAt`,void 0),O([v({type:Number})],Ii.prototype,`dangerAt`,void 0),Ii=O([h(`mateu-meter`)],Ii);var Li=e=>{let t=e.metadata;return w`
         <mateu-meter
                 .label="${t.label}"
                 .value="${t.value??0}"
@@ -3663,7 +3663,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-meter>
-    `},Ii=class extends y{constructor(...e){super(...e),this.total=0,this.done=0}static{this.styles=m`
+    `},Ri=class extends y{constructor(...e){super(...e),this.total=0,this.done=0}static{this.styles=m`
         :host { display: block; width: 100%; }
         .banner {
             display: flex; align-items: center; gap: .8rem; flex-wrap: wrap;
@@ -3718,7 +3718,7 @@ ${i}
                 <span class="spacer"></span>
                 ${t?w`<button @click="${()=>this.runAction()}">${this.actionLabel} →</button>`:_}
             </div>
-        `}};O([v()],Ii.prototype,`label`,void 0),O([v({type:Number})],Ii.prototype,`total`,void 0),O([v({type:Number})],Ii.prototype,`done`,void 0),O([v()],Ii.prototype,`actionLabel`,void 0),O([v()],Ii.prototype,`actionId`,void 0),Ii=O([h(`mateu-task-progress`)],Ii);var Li=e=>{let t=e.metadata;return w`
+        `}};O([v()],Ri.prototype,`label`,void 0),O([v({type:Number})],Ri.prototype,`total`,void 0),O([v({type:Number})],Ri.prototype,`done`,void 0),O([v()],Ri.prototype,`actionLabel`,void 0),O([v()],Ri.prototype,`actionId`,void 0),Ri=O([h(`mateu-task-progress`)],Ri);var zi=e=>{let t=e.metadata;return w`
         <mateu-task-progress
                 .label="${t.label}"
                 .total="${t.total??0}"
@@ -3729,7 +3729,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-task-progress>
-    `},Ri=class extends y{constructor(...e){super(...e),this.items=[],this.compact=!1,this.frameless=!1,this.columns=0,this.itemHeadingLevel=3}static{this.styles=[Di,R,m`
+    `},Bi=class extends y{constructor(...e){super(...e),this.items=[],this.compact=!1,this.frameless=!1,this.columns=0,this.itemHeadingLevel=3}static{this.styles=[ki,R,m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .list {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -3872,7 +3872,7 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};O([v({type:Array})],Ri.prototype,`items`,void 0),O([v({type:Boolean})],Ri.prototype,`compact`,void 0),O([v({type:Boolean})],Ri.prototype,`frameless`,void 0),O([v()],Ri.prototype,`rowActionId`,void 0),O([v({type:Number})],Ri.prototype,`columns`,void 0),O([v({type:Number})],Ri.prototype,`itemHeadingLevel`,void 0),Ri=O([h(`mateu-status-list`)],Ri);var zi=e=>{let t=e.metadata;return w`
+        `}};O([v({type:Array})],Bi.prototype,`items`,void 0),O([v({type:Boolean})],Bi.prototype,`compact`,void 0),O([v({type:Boolean})],Bi.prototype,`frameless`,void 0),O([v()],Bi.prototype,`rowActionId`,void 0),O([v({type:Number})],Bi.prototype,`columns`,void 0),O([v({type:Number})],Bi.prototype,`itemHeadingLevel`,void 0),Bi=O([h(`mateu-status-list`)],Bi);var Vi=e=>{let t=e.metadata;return w`
         <mateu-status-list
                 .items="${t.items??[]}"
                 ?compact="${t.compact??!1}"
@@ -3884,7 +3884,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-status-list>
-    `},Bi=class extends y{constructor(...e){super(...e),this.items=[]}static{this.styles=m`
+    `},Hi=class extends y{constructor(...e){super(...e),this.items=[]}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         ul {
             margin: 0; padding-inline-start: 1.2rem;
@@ -3899,20 +3899,20 @@ ${i}
             <ul>
                 ${this.items.map(e=>w`<li>${e}</li>`)}
             </ul>
-        `}};O([v({type:Array})],Bi.prototype,`items`,void 0),Bi=O([h(`mateu-bulleted-list`)],Bi);var Vi=e=>w`
+        `}};O([v({type:Array})],Hi.prototype,`items`,void 0),Hi=O([h(`mateu-bulleted-list`)],Hi);var Ui=e=>w`
         <mateu-bulleted-list
                 .items="${e.metadata.items??[]}"
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-bulleted-list>
-    `,Hi=e=>{let t=e.metadata.attributes?.[`data-colspan`];return w`
+    `,Wi=e=>{let t=e.metadata.attributes?.[`data-colspan`];return w`
         <hr style="border: none; border-top: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1)); width: 100%; margin: var(--lumo-space-s, .5rem) 0; ${e.style??``}"
             class="${e.cssClasses??_}"
             id="${x(e.id??void 0)}"
             data-colspan="${x(t)}"
             slot="${e.slot??_}"/>
-    `},Ui={info:`ℹ`,success:`✓`,warning:`!`,danger:`!`},B=class extends y{constructor(...e){super(...e),this.text=``,this.theme=`info`,this.noIcon=!1,this.slim=!1,this.fullWidth=!1,this.hasContent=!1,this.inlineContent=!1}static{this.styles=m`
+    `},Gi={info:`ℹ`,success:`✓`,warning:`!`,danger:`!`},B=class extends y{constructor(...e){super(...e),this.text=``,this.theme=`info`,this.noIcon=!1,this.slim=!1,this.fullWidth=!1,this.hasContent=!1,this.inlineContent=!1}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .notice {
             display: flex;
@@ -3977,14 +3977,14 @@ ${i}
         .danger  .icon  { background: #b25b3d; }
     `}runAction(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId},bubbles:!0,composed:!0}))}render(){let e=!!this.text&&!!this.text.trim();if(!e&&!this.hasContent)return w``;let t=[`info`,`success`,`warning`,`danger`].includes(this.theme)?this.theme:`info`;return w`
             <div class="notice ${t} ${this.slim?`slim`:``}">
-                ${this.noIcon?_:w`<span class="icon ${this.icon?`custom`:``}">${this.icon||Ui[t]}</span>`}
+                ${this.noIcon?_:w`<span class="icon ${this.icon?`custom`:``}">${this.icon||Gi[t]}</span>`}
                 <div class="body ${this.inlineContent?`inline`:``}">
                     ${e?w`<span class="text">${this.text}</span>`:_}
                     ${this.hasContent?w`<div class="content"><slot></slot></div>`:_}
                 </div>
                 ${this.actionLabel&&this.actionId?w`<button class="notice-action" @click="${()=>this.runAction()}">${this.actionLabel}</button>`:this.status?w`<span class="status">${this.status}</span>`:_}
             </div>
-        `}};O([v()],B.prototype,`text`,void 0),O([v()],B.prototype,`theme`,void 0),O([v()],B.prototype,`icon`,void 0),O([v({type:Boolean})],B.prototype,`noIcon`,void 0),O([v()],B.prototype,`actionLabel`,void 0),O([v()],B.prototype,`actionId`,void 0),O([v()],B.prototype,`status`,void 0),O([v({type:Boolean})],B.prototype,`slim`,void 0),O([v({type:Boolean})],B.prototype,`fullWidth`,void 0),O([v({type:Boolean})],B.prototype,`hasContent`,void 0),O([v({type:Boolean})],B.prototype,`inlineContent`,void 0),B=O([h(`mateu-notice`)],B);var Wi=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=it(s.text??``,r,i,a,o)??``,l=t.children??[];return w`
+        `}};O([v()],B.prototype,`text`,void 0),O([v()],B.prototype,`theme`,void 0),O([v()],B.prototype,`icon`,void 0),O([v({type:Boolean})],B.prototype,`noIcon`,void 0),O([v()],B.prototype,`actionLabel`,void 0),O([v()],B.prototype,`actionId`,void 0),O([v()],B.prototype,`status`,void 0),O([v({type:Boolean})],B.prototype,`slim`,void 0),O([v({type:Boolean})],B.prototype,`fullWidth`,void 0),O([v({type:Boolean})],B.prototype,`hasContent`,void 0),O([v({type:Boolean})],B.prototype,`inlineContent`,void 0),B=O([h(`mateu-notice`)],B);var Ki=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=it(s.text??``,r,i,a,o)??``,l=t.children??[];return w`
         <mateu-notice
                 text="${c}"
                 theme="${s.theme??`info`}"
@@ -4002,7 +4002,7 @@ ${i}
                 class="${t.cssClasses??_}"
                 slot="${t.slot??_}"
         >${l.map(t=>P(e,t,n,r,i,a,o))}</mateu-notice>
-    `},Gi=class extends y{constructor(...e){super(...e),this.groups=[]}static{this.styles=[Di,R,m`
+    `},qi=class extends y{constructor(...e){super(...e),this.groups=[]}static{this.styles=[ki,R,m`
         :host { display: block; width: 100%; }
         .rail { display: flex; flex-direction: column; gap: var(--lumo-space-m, 1rem); }
         .group { display: flex; flex-direction: column; gap: .45rem; }
@@ -4065,7 +4065,7 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};O([v()],Gi.prototype,`actionId`,void 0),O([v({type:Array})],Gi.prototype,`groups`,void 0),O([S()],Gi.prototype,`selectedId`,void 0),Gi=O([h(`mateu-task-queue`)],Gi);var Ki=e=>{let t=e.metadata;return w`
+        `}};O([v()],qi.prototype,`actionId`,void 0),O([v({type:Array})],qi.prototype,`groups`,void 0),O([S()],qi.prototype,`selectedId`,void 0),qi=O([h(`mateu-task-queue`)],qi);var Ji=e=>{let t=e.metadata;return w`
         <mateu-task-queue
                 .actionId="${t.actionId}"
                 .groups="${t.groups??[]}"
@@ -4073,7 +4073,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-task-queue>
-    `},qi=class extends y{constructor(...e){super(...e),this.columns=0,this.items=[]}static{this.styles=[Di,R,m`
+    `},Yi=class extends y{constructor(...e){super(...e),this.columns=0,this.items=[]}static{this.styles=[ki,R,m`
         /* explicit line-height: inside a form field wrapper the inherited one is the 44px
            field height, which blows up every text row */
         :host { display: block; width: 100%; line-height: var(--lumo-line-height-m, 1.4); }
@@ -4137,7 +4137,7 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};O([v()],qi.prototype,`actionId`,void 0),O([v({type:Number})],qi.prototype,`columns`,void 0),O([v()],qi.prototype,`recommendedLabel`,void 0),O([v({type:Array})],qi.prototype,`items`,void 0),O([S()],qi.prototype,`selectedId`,void 0),qi=O([h(`mateu-resource-grid`)],qi);var Ji=e=>{let t=e.metadata;return w`
+        `}};O([v()],Yi.prototype,`actionId`,void 0),O([v({type:Number})],Yi.prototype,`columns`,void 0),O([v()],Yi.prototype,`recommendedLabel`,void 0),O([v({type:Array})],Yi.prototype,`items`,void 0),O([S()],Yi.prototype,`selectedId`,void 0),Yi=O([h(`mateu-resource-grid`)],Yi);var Xi=e=>{let t=e.metadata;return w`
         <mateu-resource-grid
                 .actionId="${t.actionId}"
                 .columns="${t.columns??0}"
@@ -4235,7 +4235,7 @@ ${i}
                         `:_}
                 </div>
             </div>
-        `}};O([v()],V.prototype,`tag`,void 0),O([v()],V.prototype,`title`,void 0),O([v()],V.prototype,`subtitle`,void 0),O([v()],V.prototype,`image`,void 0),O([v({type:Array})],V.prototype,`features`,void 0),O([v()],V.prototype,`priceLabel`,void 0),O([v()],V.prototype,`actionLabel`,void 0),O([v()],V.prototype,`actionId`,void 0),O([v({type:Boolean})],V.prototype,`current`,void 0),O([v()],V.prototype,`currentLabel`,void 0),O([v({type:Boolean})],V.prototype,`added`,void 0),O([v()],V.prototype,`addedLabel`,void 0),V=O([h(`mateu-offer-card`)],V);var Yi=e=>{let t=e.metadata;return w`
+        `}};O([v()],V.prototype,`tag`,void 0),O([v()],V.prototype,`title`,void 0),O([v()],V.prototype,`subtitle`,void 0),O([v()],V.prototype,`image`,void 0),O([v({type:Array})],V.prototype,`features`,void 0),O([v()],V.prototype,`priceLabel`,void 0),O([v()],V.prototype,`actionLabel`,void 0),O([v()],V.prototype,`actionId`,void 0),O([v({type:Boolean})],V.prototype,`current`,void 0),O([v()],V.prototype,`currentLabel`,void 0),O([v({type:Boolean})],V.prototype,`added`,void 0),O([v()],V.prototype,`addedLabel`,void 0),V=O([h(`mateu-offer-card`)],V);var Zi=e=>{let t=e.metadata;return w`
         <mateu-offer-card
                 .tag="${t.tag}"
                 .title="${t.title??``}"
@@ -4253,7 +4253,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-offer-card>
-    `},Xi=class extends y{constructor(...e){super(...e),this.items=[],this.added=new Set}static{this.styles=m`
+    `},Qi=class extends y{constructor(...e){super(...e),this.items=[],this.added=new Set}static{this.styles=m`
         :host { display: block; width: 100%; }
         .header { display: flex; align-items: baseline; justify-content: flex-end; gap: .4rem; margin-bottom: .6rem; }
         .total-label { font-size: var(--lumo-font-size-s, .875rem); color: var(--lumo-secondary-text-color, #888); }
@@ -4321,7 +4321,7 @@ ${i}
     `}willUpdate(e){e.has(`items`)&&(this.added=new Set(this.items.filter(e=>e.added).map(e=>e.id)))}total(){return this.items.filter(e=>e.id!=null&&this.added.has(e.id)).reduce((e,t)=>e+(t.price??0),0)}toggle(e){if(e.id==null)return;let t=new Set(this.added),n=!t.has(e.id);n?t.add(e.id):t.delete(e.id),this.added=t,this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{_item:e.id,_added:n,_total:this.total()}},bubbles:!0,composed:!0}))}render(){return w`
             <div class="header">
                 ${this.totalLabel?w`<span class="total-label">${this.totalLabel}:</span>`:_}
-                <span class="total">${Ai(this.total(),this.currency)}</span>
+                <span class="total">${Mi(this.total(),this.currency)}</span>
             </div>
             <div class="grid">
                 ${this.items.map(e=>{let t=e.id!=null&&this.added.has(e.id);return w`
@@ -4331,7 +4331,7 @@ ${i}
                             ${e.description?w`<span class="description">${e.description}</span>`:_}
                             ${e.includedLabel?w`<span class="included">${e.includedLabel}</span>`:w`
                                     ${e.price==null?_:w`
-                                        <span class="price">${Ai(e.price,this.currency)}${e.unit?` / ${e.unit}`:``}</span>
+                                        <span class="price">${Mi(e.price,this.currency)}${e.unit?` / ${e.unit}`:``}</span>
                                     `}
                                     <button class="toggle ${t?`on`:``}" @click="${()=>this.toggle(e)}"
                                             aria-pressed="${t}">${t?`✓`:`+`}</button>
@@ -4339,7 +4339,7 @@ ${i}
                         </div>
                     `})}
             </div>
-        `}};O([v()],Xi.prototype,`totalLabel`,void 0),O([v()],Xi.prototype,`currency`,void 0),O([v()],Xi.prototype,`actionId`,void 0),O([v({type:Array})],Xi.prototype,`items`,void 0),O([S()],Xi.prototype,`added`,void 0),Xi=O([h(`mateu-addon-picker`)],Xi);var Zi=e=>{let t=e.metadata;return w`
+        `}};O([v()],Qi.prototype,`totalLabel`,void 0),O([v()],Qi.prototype,`currency`,void 0),O([v()],Qi.prototype,`actionId`,void 0),O([v({type:Array})],Qi.prototype,`items`,void 0),O([S()],Qi.prototype,`added`,void 0),Qi=O([h(`mateu-addon-picker`)],Qi);var $i=e=>{let t=e.metadata;return w`
         <mateu-addon-picker
                 .totalLabel="${t.totalLabel}"
                 .currency="${t.currency}"
@@ -4349,7 +4349,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-addon-picker>
-    `},Qi=class extends y{constructor(...e){super(...e),this.lines=[]}static{this.styles=m`
+    `},ea=class extends y{constructor(...e){super(...e),this.lines=[]}static{this.styles=m`
         :host {
             display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem);
             /* an ancestor (e.g. a form-layout row) may set an inherited line-height like 44px —
@@ -4391,14 +4391,14 @@ ${i}
                 <div class="row">
                     <span class="dot"></span>
                     <span class="concept">${e.concept}</span>
-                    ${e.included?w`<span class="included-label">${e.includedLabel||`Included`}</span>`:w`<span class="amount ${(e.amount??0)<0?`negative`:``}">${Ai(e.amount??0,this.currency)}</span>`}
+                    ${e.included?w`<span class="included-label">${e.includedLabel||`Included`}</span>`:w`<span class="amount ${(e.amount??0)<0?`negative`:``}">${Mi(e.amount??0,this.currency)}</span>`}
                 </div>
             `)}
             <div class="total-row">
                 <span class="total-label">${this.totalLabel||`Total`}</span>
-                <span class="total">${Ai(this.computedTotal(),this.currency)}</span>
+                <span class="total">${Mi(this.computedTotal(),this.currency)}</span>
             </div>
-        `}};O([v()],Qi.prototype,`currency`,void 0),O([v()],Qi.prototype,`totalLabel`,void 0),O([v({type:Array})],Qi.prototype,`lines`,void 0),O([v({type:Number})],Qi.prototype,`total`,void 0),Qi=O([h(`mateu-ledger`)],Qi);var $i=e=>{let t=e.metadata;return w`
+        `}};O([v()],ea.prototype,`currency`,void 0),O([v()],ea.prototype,`totalLabel`,void 0),O([v({type:Array})],ea.prototype,`lines`,void 0),O([v({type:Number})],ea.prototype,`total`,void 0),ea=O([h(`mateu-ledger`)],ea);var ta=e=>{let t=e.metadata;return w`
         <mateu-ledger
                 .currency="${t.currency}"
                 .totalLabel="${t.totalLabel}"
@@ -4408,7 +4408,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-ledger>
-    `},ea=class extends y{constructor(...e){super(...e),this.methods=[]}static{this.styles=m`
+    `},na=class extends y{constructor(...e){super(...e),this.methods=[]}static{this.styles=m`
         :host { display: block; width: 100%; }
         .bar { display: flex; align-items: stretch; gap: .6rem; flex-wrap: wrap; }
         .methods { display: flex; gap: .4rem; flex-wrap: wrap; }
@@ -4470,7 +4470,7 @@ ${i}
                 <span class="spacer"></span>
                 ${this.confirmLabel&&this.actionId?w`<button class="confirm" @click="${()=>this.confirm()}">${this.confirmLabel}</button>`:_}
             </div>
-        `}};O([v()],ea.prototype,`actionId`,void 0),O([v()],ea.prototype,`methodActionId`,void 0),O([v({type:Array})],ea.prototype,`methods`,void 0),O([v()],ea.prototype,`selected`,void 0),O([v()],ea.prototype,`contextLabel`,void 0),O([v()],ea.prototype,`contextValue`,void 0),O([v()],ea.prototype,`confirmLabel`,void 0),O([S()],ea.prototype,`selectedId`,void 0),ea=O([h(`mateu-payment-picker`)],ea);var ta=e=>{let t=e.metadata;return w`
+        `}};O([v()],na.prototype,`actionId`,void 0),O([v()],na.prototype,`methodActionId`,void 0),O([v({type:Array})],na.prototype,`methods`,void 0),O([v()],na.prototype,`selected`,void 0),O([v()],na.prototype,`contextLabel`,void 0),O([v()],na.prototype,`contextValue`,void 0),O([v()],na.prototype,`confirmLabel`,void 0),O([S()],na.prototype,`selectedId`,void 0),na=O([h(`mateu-payment-picker`)],na);var ra=e=>{let t=e.metadata;return w`
         <mateu-payment-picker
                 .actionId="${t.actionId}"
                 .methodActionId="${t.methodActionId}"
@@ -4483,7 +4483,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-payment-picker>
-    `},na=class extends y{constructor(...e){super(...e),this.items=[]}static{this.styles=m`
+    `},ia=class extends y{constructor(...e){super(...e),this.items=[]}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .list {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -4537,14 +4537,14 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};O([v({type:Array})],na.prototype,`items`,void 0),na=O([h(`mateu-process-monitor`)],na);var ra=e=>w`
+        `}};O([v({type:Array})],ia.prototype,`items`,void 0),ia=O([h(`mateu-process-monitor`)],ia);var aa=e=>w`
         <mateu-process-monitor
                 .items="${e.metadata.items??[]}"
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-process-monitor>
-    `,ia=(e,t)=>{let n=e.style;return e.id&&(n&&!n.endsWith(`;`)&&(n+=`;`),n??=``,t[e.id+`.hidden`]==1&&(n+=`display: none;`)),n},aa=(e,t)=>{let n={...e.metadata};if(e.id&&n){if(n.type==A.Button){let r=n;t[e.id+`.disabled`]==1&&(r.disabled=!0)}if(n.type==A.FormField){let r=n;t[e.id+`.disabled`]==1&&(r.disabled=!0)}}return n},H=e=>t=>e(t.container,t.component,t.baseUrl,t.state,t.data,t.appState,t.appData),oa={[A.Bpmn]:({component:e})=>Sr(e),[A.Workflow]:({component:e})=>wr(e),[A.FormEditor]:({component:e})=>Tr(e),[A.Page]:H(br),[A.Div]:H(pr),[A.Directory]:({component:e,baseUrl:t,state:n,data:r})=>dr(e,t,n,r),[A.FormLayout]:H(Zt),[A.HorizontalLayout]:H(rn),[A.VerticalLayout]:H(an),[A.SplitLayout]:H(on),[A.MasterDetailLayout]:H(sn),[A.TabLayout]:H(cn),[A.AccordionLayout]:H(ln),[A.BoardLayout]:H(mn),[A.BoardLayoutRow]:H(hn),[A.BoardLayoutItem]:H(gn),[A.Scroller]:H(dn),[A.FullWidth]:H(fn),[A.Container]:H(pn),[A.Form]:({container:e,component:t,baseUrl:n,state:r,data:i,appState:a,appData:o})=>{let s=t.metadata;return w`<mateu-form
+    `,oa=(e,t)=>{let n=e.style;return e.id&&(n&&!n.endsWith(`;`)&&(n+=`;`),n??=``,t[e.id+`.hidden`]==1&&(n+=`display: none;`)),n},sa=(e,t)=>{let n={...e.metadata};if(e.id&&n){if(n.type==A.Button){let r=n;t[e.id+`.disabled`]==1&&(r.disabled=!0)}if(n.type==A.FormField){let r=n;t[e.id+`.disabled`]==1&&(r.disabled=!0)}}return n},H=e=>t=>e(t.container,t.component,t.baseUrl,t.state,t.data,t.appState,t.appData),ca={[A.Bpmn]:({component:e})=>wr(e),[A.Workflow]:({component:e})=>Er(e),[A.FormEditor]:({component:e})=>Dr(e),[A.Page]:H(Sr),[A.Div]:H(hr),[A.Directory]:({component:e,baseUrl:t,state:n,data:r})=>pr(e,t,n,r),[A.FormLayout]:H($t),[A.HorizontalLayout]:H(on),[A.VerticalLayout]:H(sn),[A.SplitLayout]:H(cn),[A.MasterDetailLayout]:H(ln),[A.TabLayout]:H(un),[A.AccordionLayout]:H(dn),[A.BoardLayout]:H(gn),[A.BoardLayoutRow]:H(_n),[A.BoardLayoutItem]:H(vn),[A.Scroller]:H(pn),[A.FullWidth]:H(mn),[A.Container]:H(hn),[A.Form]:({container:e,component:t,baseUrl:n,state:r,data:i,appState:a,appData:o})=>{let s=t.metadata;return w`<mateu-form
             id="${t.id}"
         baseUrl="${n}"
             .component="${t}"
@@ -4562,7 +4562,7 @@ ${i}
                ${P(e,{id:t.actionId,metadata:t,type:k.ClientSide,slot:`buttons`},void 0,r,i,a,o)}
 `)}
 
-            </mateu-form>`},[A.Table]:({component:e,state:t,data:n})=>bn(e,(e.id?n?.[e.id]:void 0)?.page?.content??xn(e,t)),[A.Crud]:H(xr),[A.App]:({container:e,component:t,baseUrl:n,state:r,data:i,appState:a,appData:o})=>w`
+            </mateu-form>`},[A.Table]:({component:e,state:t,data:n})=>Sn(e,(e.id?n?.[e.id]:void 0)?.page?.content??Cn(e,t)),[A.Crud]:H(Cr),[A.App]:({container:e,component:t,baseUrl:n,state:r,data:i,appState:a,appData:o})=>w`
             <mateu-app
                         id="${t.id}"
                         baseUrl="${n}"
@@ -4575,12 +4575,12 @@ ${i}
                         .appData="${o}"
             >
              ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
-         </mateu-app>`,[A.Element]:({container:e,component:t})=>Mn(e,t.metadata,t),[A.FormField]:({component:e,state:t})=>vr(e,t),[A.Text]:({component:e,state:t,data:n,appState:r,appData:i})=>Pn(e,t,n,r,i),[A.Avatar]:({component:e,state:t,data:n})=>ut(e,t,n),[A.Chat]:({component:e,state:t,data:n})=>Cr(e,t,n),[A.AvatarGroup]:({component:e})=>dt(e),[A.Badge]:({component:e,state:t,data:n})=>ft(e,t,n),[A.Breadcrumbs]:({component:e})=>lr(e),[A.Anchor]:({component:e})=>Fn(e),[A.Button]:({component:e,state:t,data:n})=>Hn(e,t,n),[A.Card]:H(Wn),[A.Chart]:({component:e})=>Gn(e),[A.Icon]:({component:e})=>Kn(e),[A.ConfirmDialog]:H(Zn),[A.ContextMenu]:H(Tn),[A.CookieConsent]:({component:e})=>Qn(e),[A.Details]:H($n),[A.Dialog]:({component:e,baseUrl:t,state:n,data:r,appState:i,appData:a})=>er(e,t,n,r,i,a),[A.Drawer]:({component:e,baseUrl:t,state:n,data:r,appState:i,appData:a})=>tr(e,t,n,r,i,a),[A.Image]:({component:e})=>cr(e),[A.Map]:({component:e})=>sr(e),[A.Markdown]:({component:e})=>rr(e),[A.MicroFrontend]:({component:e})=>nr(e),[A.Notification]:({component:e})=>ir(e),[A.ProgressBar]:({component:e,state:t})=>ar(e,t),[A.Popover]:H(or),[A.CarouselLayout]:H(ur),[A.Tooltip]:H(On),[A.MessageInput]:({component:e})=>Dn(e),[A.MessageList]:({component:e})=>Sn(e),[A.CustomField]:H(En),[A.MenuBar]:({container:e,component:t,baseUrl:n,state:r,data:i})=>wn(e,t,n,r,i),[A.Grid]:({component:e,state:t})=>bn(e,xn(e,t)),[A.VirtualList]:H(_n),[A.FormSection]:H(mr),[A.FormSubSection]:H(hr),[A.MetricCard]:({component:e})=>Ar(e),[A.Scoreboard]:H(jr),[A.DashboardPanel]:H(Mr),[A.DashboardLayout]:H(Nr),[A.FoldoutLayout]:H(Fr),[A.ContentLayout]:H(Ir),[A.HeroSection]:H(Lr),[A.EmptyState]:({component:e})=>Ct(e),[A.Skeleton]:({component:e})=>wt(e),[A.Gantt]:({component:e})=>Br(e),[A.PlanningBoard]:({component:e})=>Hr(e),[A.Kanban]:({component:e})=>Wr(e),[A.Timeline]:({component:e})=>Kr(e),[A.ProgressSteps]:({component:e})=>Jr(e),[A.Stat]:({component:e})=>Xr(e),[A.Calendar]:({component:e})=>Qr(e),[A.PricingTable]:({component:e})=>ei(e),[A.OrgChart]:({component:e})=>ni(e),[A.Heatmap]:({component:e})=>ai(e),[A.Funnel]:({component:e})=>si(e),[A.TrendChart]:({component:e})=>li(e),[A.FeatureGrid]:({component:e})=>di(e),[A.Testimonials]:({component:e})=>pi(e),[A.Faq]:({component:e})=>hi(e),[A.CalloutCard]:({component:e})=>_i(e),[A.CommentThread]:({component:e})=>yi(e),[A.FileList]:({component:e})=>Si(e),[A.Checklist]:({component:e})=>wi(e),[A.ComparisonCard]:({component:e})=>Ei(e),[A.EntityHeader]:({component:e})=>Ni(e),[A.Meter]:({component:e})=>Fi(e),[A.TaskProgress]:({component:e})=>Li(e),[A.StatusList]:({component:e})=>zi(e),[A.BulletedList]:({component:e})=>Vi(e),[A.Separator]:({component:e})=>Hi(e),[A.Notice]:H(Wi),[A.TaskQueue]:({component:e})=>Ki(e),[A.ResourceGrid]:({component:e})=>Ji(e),[A.OfferCard]:({component:e})=>Yi(e),[A.AddOnPicker]:({component:e})=>Zi(e),[A.Ledger]:({component:e})=>$i(e),[A.PaymentPicker]:({component:e})=>ta(e),[A.ProcessMonitor]:({component:e})=>ra(e)},sa=(e,t,n,r,i,a,o,s)=>{if(!t?.metadata)return t==null?(console.warn(`No metadata for component`,t),w`<p>No metadata for component</p>`):sa(e,{id:T(),metadata:t,type:k.ClientSide},n,r,i,a,o,s);let c=t.metadata.type,l={...t,style:ia(t,i),metadata:aa(t,i)},u=oa[c];return u?u({container:e,component:l,baseUrl:n,state:r,data:i,appState:a,appData:o,labelAlreadyRendered:s}):w`<p ${l?.slot??_}>Unknown metadata type ${c} for component ${l?.id}</p>`},ca=function(e){return e.NONE=`NONE`,e.INFO=`INFO`,e.SUCCESS=`SUCCESS`,e.WARNING=`WARNING`,e.DANGER=`DANGER`,e}({}),la=(e,t,n)=>{let r=e[n.path];return r?w`<span theme="badge pill ${ua(r.type)}">${r.message}</span>`:w``},ua=e=>{switch(e){case ca.SUCCESS:return`success`;case ca.WARNING:return`warning`;case ca.DANGER:return`error`;case ca.NONE:return`contrast`}return``},U=class extends y{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.respondToVisibility=(e,t)=>{var n={root:document.documentElement};new IntersectionObserver(e=>{e.forEach(e=>{t(e.intersectionRatio>0)})},n).observe(e)},this.keepAsking=!1,this.askToUpper=()=>{let e=this.data[this.id]?.page,t=e?.content?.length/e?.pageSize;this.dispatchEvent(new CustomEvent(`fetch-more-elements`,{detail:{params:{page:t,pageSize:this.metadata?.pageSize},callback:()=>{this.keepAsking&&this.askToUpper()}},bubbles:!0,composed:!0}))},this.renderItem=e=>e.card?sa(this,e.card,this.baseUrl,this.state,this.data,this.appState,this.appData,!1):e.title?w`<div class="neutral-card">
+         </mateu-app>`,[A.Element]:({container:e,component:t})=>Pn(e,t.metadata,t),[A.FormField]:({component:e,state:t})=>br(e,t),[A.Text]:({component:e,state:t,data:n,appState:r,appData:i})=>In(e,t,n,r,i),[A.Avatar]:({component:e,state:t,data:n})=>ut(e,t,n),[A.Chat]:({component:e,state:t,data:n})=>Tr(e,t,n),[A.AvatarGroup]:({component:e})=>dt(e),[A.Badge]:({component:e,state:t,data:n})=>ft(e,t,n),[A.Breadcrumbs]:({component:e})=>dr(e),[A.Anchor]:({component:e})=>Ln(e),[A.Button]:({component:e,state:t,data:n})=>Wn(e,t,n),[A.Card]:H(Kn),[A.Chart]:({component:e})=>qn(e),[A.Icon]:({component:e})=>Jn(e),[A.ConfirmDialog]:H($n),[A.ContextMenu]:H(Dn),[A.CookieConsent]:({component:e})=>er(e),[A.Details]:H(tr),[A.Dialog]:({component:e,baseUrl:t,state:n,data:r,appState:i,appData:a})=>nr(e,t,n,r,i,a),[A.Drawer]:({component:e,baseUrl:t,state:n,data:r,appState:i,appData:a})=>rr(e,t,n,r,i,a),[A.Image]:({component:e})=>ur(e),[A.Map]:({component:e})=>lr(e),[A.Markdown]:({component:e})=>ar(e),[A.MicroFrontend]:({component:e})=>ir(e),[A.Notification]:({component:e})=>or(e),[A.ProgressBar]:({component:e,state:t})=>sr(e,t),[A.Popover]:H(cr),[A.CarouselLayout]:H(fr),[A.Tooltip]:H(An),[A.MessageInput]:({component:e})=>kn(e),[A.MessageList]:({component:e})=>wn(e),[A.CustomField]:H(On),[A.MenuBar]:({container:e,component:t,baseUrl:n,state:r,data:i})=>En(e,t,n,r,i),[A.Grid]:({component:e,state:t})=>Sn(e,Cn(e,t)),[A.VirtualList]:H(yn),[A.FormSection]:H(gr),[A.FormSubSection]:H(_r),[A.MetricCard]:({component:e})=>Mr(e),[A.Scoreboard]:H(Nr),[A.DashboardPanel]:H(Pr),[A.DashboardLayout]:H(Fr),[A.FoldoutLayout]:H(Lr),[A.ContentLayout]:H(Rr),[A.HeroSection]:H(zr),[A.EmptyState]:({component:e})=>Ct(e),[A.Skeleton]:({component:e})=>wt(e),[A.Gantt]:({component:e})=>Hr(e),[A.PlanningBoard]:({component:e})=>Wr(e),[A.Kanban]:({component:e})=>Kr(e),[A.Timeline]:({component:e})=>Jr(e),[A.ProgressSteps]:({component:e})=>Xr(e),[A.Stat]:({component:e})=>Qr(e),[A.Calendar]:({component:e})=>ei(e),[A.PricingTable]:({component:e})=>ni(e),[A.OrgChart]:({component:e})=>ii(e),[A.Heatmap]:({component:e})=>si(e),[A.Funnel]:({component:e})=>li(e),[A.TrendChart]:({component:e})=>di(e),[A.FeatureGrid]:({component:e})=>pi(e),[A.Testimonials]:({component:e})=>hi(e),[A.Faq]:({component:e})=>_i(e),[A.CalloutCard]:({component:e})=>yi(e),[A.CommentThread]:({component:e})=>xi(e),[A.FileList]:({component:e})=>wi(e),[A.Checklist]:({component:e})=>Ei(e),[A.ComparisonCard]:({component:e})=>Oi(e),[A.EntityHeader]:({component:e})=>Fi(e),[A.Meter]:({component:e})=>Li(e),[A.TaskProgress]:({component:e})=>zi(e),[A.StatusList]:({component:e})=>Vi(e),[A.BulletedList]:({component:e})=>Ui(e),[A.Separator]:({component:e})=>Wi(e),[A.Notice]:H(Ki),[A.TaskQueue]:({component:e})=>Ji(e),[A.ResourceGrid]:({component:e})=>Xi(e),[A.OfferCard]:({component:e})=>Zi(e),[A.AddOnPicker]:({component:e})=>$i(e),[A.Ledger]:({component:e})=>ta(e),[A.PaymentPicker]:({component:e})=>ra(e),[A.ProcessMonitor]:({component:e})=>aa(e)},la=(e,t,n,r,i,a,o,s)=>{if(!t?.metadata)return t==null?(console.warn(`No metadata for component`,t),w`<p>No metadata for component</p>`):la(e,{id:T(),metadata:t,type:k.ClientSide},n,r,i,a,o,s);let c=t.metadata.type,l={...t,style:oa(t,i),metadata:sa(t,i)},u=ca[c];return u?u({container:e,component:l,baseUrl:n,state:r,data:i,appState:a,appData:o,labelAlreadyRendered:s}):w`<p ${l?.slot??_}>Unknown metadata type ${c} for component ${l?.id}</p>`},ua=function(e){return e.NONE=`NONE`,e.INFO=`INFO`,e.SUCCESS=`SUCCESS`,e.WARNING=`WARNING`,e.DANGER=`DANGER`,e}({}),da=(e,t,n)=>{let r=e[n.path];return r?w`<span theme="badge pill ${fa(r.type)}">${r.message}</span>`:w``},fa=e=>{switch(e){case ua.SUCCESS:return`success`;case ua.WARNING:return`warning`;case ua.DANGER:return`error`;case ua.NONE:return`contrast`}return``},U=class extends y{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.respondToVisibility=(e,t)=>{var n={root:document.documentElement};new IntersectionObserver(e=>{e.forEach(e=>{t(e.intersectionRatio>0)})},n).observe(e)},this.keepAsking=!1,this.askToUpper=()=>{let e=this.data[this.id]?.page,t=e?.content?.length/e?.pageSize;this.dispatchEvent(new CustomEvent(`fetch-more-elements`,{detail:{params:{page:t,pageSize:this.metadata?.pageSize},callback:()=>{this.keepAsking&&this.askToUpper()}},bubbles:!0,composed:!0}))},this.renderItem=e=>e.card?la(this,e.card,this.baseUrl,this.state,this.data,this.appState,this.appData,!1):e.title?w`<div class="neutral-card">
                 ${e.image?w`<img class="card-media" src="${e.image}" alt="" />`:_}
                 <div class="card-body">
                     <div class="card-head">
                         ${e.title?w`<span class="card-title">${e.title}</span>`:_}
-                        ${e.status?w`<span theme="badge ${ua(e.status.type)}">${e.status.message}</span>`:_}
+                        ${e.status?w`<span theme="badge ${fa(e.status.type)}">${e.status.message}</span>`:_}
                     </div>
                     ${e.subtitle?w`<div class="card-subtitle">${e.subtitle}</div>`:_}
                     ${e.content?w`<div>${e.content}</div>`:_}
@@ -4618,19 +4618,19 @@ ${i}
         .neutral-card .card-subtitle { color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-s, .875rem); }
     
         ${R}
-    `}};O([v()],U.prototype,`id`,void 0),O([v()],U.prototype,`metadata`,void 0),O([v()],U.prototype,`baseUrl`,void 0),O([v()],U.prototype,`state`,void 0),O([v()],U.prototype,`data`,void 0),O([v()],U.prototype,`appState`,void 0),O([v()],U.prototype,`appData`,void 0),O([v()],U.prototype,`emptyStateMessage`,void 0),O([S()],U.prototype,`keepAsking`,void 0),O([b(`#ask-for-more`)],U.prototype,`askForMore`,void 0),O([S()],U.prototype,`hasMore`,void 0),U=O([h(`mateu-card-list`)],U);var da={show:e=>console.debug(`[mateu] no notifier registered, dropping toast:`,e.text)};function fa(e){da=e}function pa(e,t){da.show(e,t)}var ma=function(e){return e.none=`none`,e.success=`success`,e.error=`error`,e.warning=`warning`,e.contrast=`contrast`,e.normal=`normal`,e}({}),ha=function(e){return e.primary=`primary`,e.secondary=`secondary`,e.tertiary=`tertiary`,e.tertiaryInline=`tertiaryInline`,e}({});function ga(e){if(e.weight!=null)return e.weight;let t=e.stereotype??``;if(t===`icon`)return 1;if(t===`image`)return 4;if(t===`html`||t===`richText`||t===`markdown`||t===`textarea`)return 5;if(t===`link`)return 2.5;if(t===`combobox`||t===`select`)return 2;let n=e.dataType??``;return n===`bool`?1:n===`status`||n===`integer`?1.5:n===`number`||n===`date`||n===`money`?2:n===`dateTime`||n===`dateRange`?2.5:3}function _a(e,t){if(e.length===0)return`table`;let n=e.reduce((e,t)=>e+ga(t),0)/(t/76);if(n<=1.1)return`table`;if(n>1.6||e.length>10)return`masterDetail`;let r=e.filter(e=>e.identifier||(e.priority??2**53-1)<=2),i=r.reduce((e,t)=>e+ga(t),0);return r.length>0&&i<=8?`list`:e.some(e=>e.stereotype===`image`||e.stereotype===`html`)||r.length===0&&e.length>=4&&e.length<=8?`cards`:`masterDetail`}function va(e){return e.filter(e=>e.identifier||(e.priority??2**53-1)<=2).sort((e,t)=>(e.priority??2**53-1)-(t.priority??2**53-1))}function ya(e){let t=va(e);return t.length>0?t:e.slice(0,3)}var ba={asc:`ascending`,desc:`descending`},W=class extends y{constructor(...e){super(...e),this.component=void 0,this.standalone=!1,this.state={},this.data={},this.appState={},this.appData={},this.showImportDialog=!1,this.availableWidthPx=1024,this.selectedItem=null,this._columnPrefsRevision=0,this._prefsRevisionApplied=-1,this.search=()=>{let e=this.component.metadata;this.state={...this.state,size:e.pageSize,page:0,crud_selected_items:[]},this._syncStateToUrl(e),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`search`,parameters:{crudId:this.id,_searchState:{...this.state}}},bubbles:!0,composed:!0}))},this.notify=e=>{pa({text:e,position:`bottomEnd`,variant:`error`,duration:3e3},this)},this.handleSearchRequested=e=>{this.state={...this.state,crud_selected_items:[]};let t=this.component.metadata;if(this._syncStateToUrl(t),t.rowsSource){this._fetchRowsFromRest(t,e);return}!t.infiniteScrolling&&this.data?.[this.id]?.page&&(this.data[this.id].page.content=[]),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`search`,parameters:{crudId:this.id,_searchState:{...this.state}},callback:e},bubbles:!0,composed:!0}))},this._fetchRowsFromRest=(e,t)=>{let n=this.cols.map(e=>e.id).filter(Boolean),r=e.rowsSource;(r.proxy?new Promise(e=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`__restfetch__`,parameters:{_sourceKind:`rows`,_sourceId:this.id},callback:t=>e(Gt(t?.appData?._restfetch,r.itemsPath,n)),callbackonly:!0},bubbles:!0,composed:!0}))}):Jt(r,n,e=>j(e,this.state,this.data))).then(r=>{let i=String(this.state?.searchText??``).trim().toLowerCase(),a=i?r.filter(e=>n.some(t=>String(e[t]??``).toLowerCase().includes(i))):r,o=e.pageSize&&e.pageSize>0?e.pageSize:a.length||1,s=Number(this.state?.page??0),c=a.slice(s*o,s*o+o);this.data={...this.data,[this.id]:{page:{totalElements:a.length,pageSize:o,pageNumber:s,content:c}}},this.requestUpdate(),t?.()}).catch(e=>{console.warn(`mateu: external rows fetch failed`,e),t?.()})},this.fetchMoreElements=e=>{let{params:t,callback:n}=e.detail;this.state={...this.state,size:t.pageSize,page:t.page},this.handleSearchRequested(n)},this.directionChanged=e=>{let t=e.detail.grid._sorters;this.state={...this.state,sort:t.map(e=>({fieldId:e.__data.path,direction:e.__data.direction?ba[e.__data.direction]:void 0}))},this.handleSearchRequested(void 0)},this._initializedForComponentId=void 0,this.evalLabel=e=>j(e,this.state,this.data),this.handleToolbarButtonClick=e=>{if(e===`import`){this.showImportDialog=!0;return}this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.handleImportUploadSuccess=e=>{let t=e.detail.xhr.responseText;this.showImportDialog=!1,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`process-import`,parameters:{fileId:t}},bubbles:!0,composed:!0}))}}get columnPrefsScope(){return window.location.pathname}get effectiveComponent(){let e=this.component,t=e?.metadata;if(!e||!t?.columns)return e;if(this._prefsSource===e&&this._prefsRevisionApplied===this._columnPrefsRevision)return this._prefsApplied;let n=Lt(this.columnPrefsScope),r=Vt(t.columns,n,e=>e.metadata??{});return this._prefsApplied=r===t.columns?e:{...e,metadata:{...t,columns:r}},this._prefsSource=e,this._prefsRevisionApplied=this._columnPrefsRevision,this._prefsApplied}get columnChooserEntries(){return(this.component?.metadata?.columns??[]).map(e=>{let t=e.metadata??{},n=t.id??e.id;return n?{id:n,label:t.label??n,protected:Bt(t)}:void 0}).filter(e=>!!e)}renderColumnChooser(){let e=this.columnChooserEntries;return e.filter(e=>!e.protected).length===0?_:w`
+    `}};O([v()],U.prototype,`id`,void 0),O([v()],U.prototype,`metadata`,void 0),O([v()],U.prototype,`baseUrl`,void 0),O([v()],U.prototype,`state`,void 0),O([v()],U.prototype,`data`,void 0),O([v()],U.prototype,`appState`,void 0),O([v()],U.prototype,`appData`,void 0),O([v()],U.prototype,`emptyStateMessage`,void 0),O([S()],U.prototype,`keepAsking`,void 0),O([b(`#ask-for-more`)],U.prototype,`askForMore`,void 0),O([S()],U.prototype,`hasMore`,void 0),U=O([h(`mateu-card-list`)],U);var pa={show:e=>console.debug(`[mateu] no notifier registered, dropping toast:`,e.text)};function ma(e){pa=e}function ha(e,t){pa.show(e,t)}var ga=function(e){return e.none=`none`,e.success=`success`,e.error=`error`,e.warning=`warning`,e.contrast=`contrast`,e.normal=`normal`,e}({}),_a=function(e){return e.primary=`primary`,e.secondary=`secondary`,e.tertiary=`tertiary`,e.tertiaryInline=`tertiaryInline`,e}({});function va(e){if(e.weight!=null)return e.weight;let t=e.stereotype??``;if(t===`icon`)return 1;if(t===`image`)return 4;if(t===`html`||t===`richText`||t===`markdown`||t===`textarea`)return 5;if(t===`link`)return 2.5;if(t===`combobox`||t===`select`)return 2;let n=e.dataType??``;return n===`bool`?1:n===`status`||n===`integer`?1.5:n===`number`||n===`date`||n===`money`?2:n===`dateTime`||n===`dateRange`?2.5:3}function ya(e,t){if(e.length===0)return`table`;let n=e.reduce((e,t)=>e+va(t),0)/(t/76);if(n<=1.1)return`table`;if(n>1.6||e.length>10)return`masterDetail`;let r=e.filter(e=>e.identifier||(e.priority??2**53-1)<=2),i=r.reduce((e,t)=>e+va(t),0);return r.length>0&&i<=8?`list`:e.some(e=>e.stereotype===`image`||e.stereotype===`html`)||r.length===0&&e.length>=4&&e.length<=8?`cards`:`masterDetail`}function ba(e){return e.filter(e=>e.identifier||(e.priority??2**53-1)<=2).sort((e,t)=>(e.priority??2**53-1)-(t.priority??2**53-1))}function xa(e){let t=ba(e);return t.length>0?t:e.slice(0,3)}var Sa={asc:`ascending`,desc:`descending`},W=class extends y{constructor(...e){super(...e),this.component=void 0,this.standalone=!1,this.state={},this.data={},this.appState={},this.appData={},this.showImportDialog=!1,this.availableWidthPx=1024,this.selectedItem=null,this._columnPrefsRevision=0,this._prefsRevisionApplied=-1,this.search=()=>{let e=this.component.metadata;this.state={...this.state,size:e.pageSize,page:0,crud_selected_items:[]},this._syncStateToUrl(e),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`search`,parameters:{crudId:this.id,_searchState:{...this.state}}},bubbles:!0,composed:!0}))},this.notify=e=>{ha({text:e,position:`bottomEnd`,variant:`error`,duration:3e3},this)},this.handleSearchRequested=e=>{this.state={...this.state,crud_selected_items:[]};let t=this.component.metadata;if(this._syncStateToUrl(t),t.rowsSource){this._fetchRowsFromRest(t,e);return}!t.infiniteScrolling&&this.data?.[this.id]?.page&&(this.data[this.id].page.content=[]),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`search`,parameters:{crudId:this.id,_searchState:{...this.state}},callback:e},bubbles:!0,composed:!0}))},this._fetchRowsFromRest=(e,t)=>{let n=this.cols.map(e=>e.id).filter(Boolean),r=e.rowsSource;(r.proxy?new Promise(e=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`__restfetch__`,parameters:{_sourceKind:`rows`,_sourceId:this.id},callback:t=>e(qt(t?.appData?._restfetch,r.itemsPath,n)),callbackonly:!0},bubbles:!0,composed:!0}))}):Xt(r,n,e=>j(e,this.state,this.data))).then(r=>{let i=String(this.state?.searchText??``).trim().toLowerCase(),a=i?r.filter(e=>n.some(t=>String(e[t]??``).toLowerCase().includes(i))):r,o=e.pageSize&&e.pageSize>0?e.pageSize:a.length||1,s=Number(this.state?.page??0),c=a.slice(s*o,s*o+o);this.data={...this.data,[this.id]:{page:{totalElements:a.length,pageSize:o,pageNumber:s,content:c}}},this.requestUpdate(),t?.()}).catch(e=>{console.warn(`mateu: external rows fetch failed`,e),t?.()})},this.fetchMoreElements=e=>{let{params:t,callback:n}=e.detail;this.state={...this.state,size:t.pageSize,page:t.page},this.handleSearchRequested(n)},this.directionChanged=e=>{let t=e.detail.grid._sorters;this.state={...this.state,sort:t.map(e=>({fieldId:e.__data.path,direction:e.__data.direction?Sa[e.__data.direction]:void 0}))},this.handleSearchRequested(void 0)},this._initializedForComponentId=void 0,this.evalLabel=e=>j(e,this.state,this.data),this.handleToolbarButtonClick=e=>{if(e===`import`){this.showImportDialog=!0;return}this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.handleImportUploadSuccess=e=>{let t=e.detail.xhr.responseText;this.showImportDialog=!1,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`process-import`,parameters:{fileId:t}},bubbles:!0,composed:!0}))}}get columnPrefsScope(){return window.location.pathname}get effectiveComponent(){let e=this.component,t=e?.metadata;if(!e||!t?.columns)return e;if(this._prefsSource===e&&this._prefsRevisionApplied===this._columnPrefsRevision)return this._prefsApplied;let n=Lt(this.columnPrefsScope),r=Vt(t.columns,n,e=>e.metadata??{});return this._prefsApplied=r===t.columns?e:{...e,metadata:{...t,columns:r}},this._prefsSource=e,this._prefsRevisionApplied=this._columnPrefsRevision,this._prefsApplied}get columnChooserEntries(){return(this.component?.metadata?.columns??[]).map(e=>{let t=e.metadata??{},n=t.id??e.id;return n?{id:n,label:t.label??n,protected:Bt(t)}:void 0}).filter(e=>!!e)}renderColumnChooser(){let e=this.columnChooserEntries;return e.filter(e=>!e.protected).length===0?_:w`
             <mateu-column-chooser
                 .columns="${e}"
                 .scope="${this.columnPrefsScope}"
                 @column-prefs-changed="${e=>{e.stopPropagation(),this._columnPrefsRevision++}}"
             ></mateu-column-chooser>
-        `}get cols(){return(this.effectiveComponent?.metadata)?.columns?.map(e=>e.metadata)??[]}get identifierFieldName(){let e=this.cols.find(e=>e.identifier);return e?e.id:this.cols.find(e=>e.id===`id`)?.id}get effectiveGridLayout(){let e=this.component?.metadata,t=e?.gridLayout??`auto`;return t===`auto`?e?.crudlType===`card`?`cards`:_a(this.cols,this.availableWidthPx):t}connectedCallback(){super.connectedCallback(),this.resizeObserver=new ResizeObserver(e=>{let t=e[0]?.contentRect.width;t&&Math.abs(t-this.availableWidthPx)>10&&(this.availableWidthPx=t)}),this.resizeObserver.observe(this)}disconnectedCallback(){super.disconnectedCallback(),this.resizeObserver?.disconnect()}_filterIds(e){return new Set([`searchText`,...(e.filters??[]).flatMap(e=>e.stereotype===`dateRange`||e.stereotype===`numberRange`?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId])])}_syncStateToUrl(e){let t=this._filterIds(e),n=new URLSearchParams(window.location.search);t.forEach(e=>n.delete(e)),n.delete(`page`),n.delete(`sort`),t.forEach(e=>{let t=this.state[e];t!=null&&t!==``&&n.set(e,String(t))});let r=this.state.page;r&&r>0&&n.set(`page`,String(r));let i=this.state.sort;if(i&&i.length>0){let e=i.filter(e=>e.fieldId&&e.direction).map(e=>`${e.fieldId}:${e.direction}`).join(`,`);e&&n.set(`sort`,e)}let a=n.toString(),o=a?`${window.location.pathname}?${a}`:window.location.pathname;window.location.pathname+window.location.search!==o&&history.replaceState(null,``,o)}_initStateFromUrl(e,t){let n=new URLSearchParams(window.location.search),r=this._filterIds(e),i={...t};n.forEach((e,t)=>{r.has(t)&&(i[t]=e)});let a=n.get(`page`);if(a!==null){let e=parseInt(a,10);!isNaN(e)&&e>0&&(i.page=e)}let o=n.get(`sort`);if(o){let e=o.split(`,`).map(e=>{let[t,n]=e.split(`:`);return t&&n?{fieldId:t,direction:n}:null}).filter(Boolean);e.length>0&&(i.sort=e)}return i}pageChanged(e){this.state={...this.state,page:e.detail.page},this.handleSearchRequested(void 0)}updated(e){if(super.updated(e),e.has(`component`)){let e=this.component?.id;if(e!==this._initializedForComponentId){this._initializedForComponentId=e;let t=this.component?.metadata,n=t.initialPage&&t.initialPage>0?t.initialPage:0;this.state=this._initStateFromUrl(t,{...this.state,size:t.pageSize,page:n,sort:[]}),(this.state.page!==n||this.state.sort?.length>0||[...this._filterIds(t)].some(e=>this.state[e]!=null)||t.rowsSource)&&this.handleSearchRequested(void 0)}}}render(){let e=e=>{let t=[];return e.color&&e.color!==ma.normal&&t.push(e.color),e.buttonStyle&&t.push(e.buttonStyle===ha.tertiaryInline?`tertiary-inline`:e.buttonStyle),t.length?t.join(` `):void 0},t=e=>e===`back`||e===`backToList`||!!e&&e.startsWith(`cancel`),n=t=>N.get()?.renderToolbarButton?.(t,this.evalLabel(t.label),()=>this.handleToolbarButtonClick(t.actionId))||w`
+        `}get cols(){return(this.effectiveComponent?.metadata)?.columns?.map(e=>e.metadata)??[]}get identifierFieldName(){let e=this.cols.find(e=>e.identifier);return e?e.id:this.cols.find(e=>e.id===`id`)?.id}get effectiveGridLayout(){let e=this.component?.metadata,t=e?.gridLayout??`auto`;return t===`auto`?e?.crudlType===`card`?`cards`:ya(this.cols,this.availableWidthPx):t}connectedCallback(){super.connectedCallback(),this.resizeObserver=new ResizeObserver(e=>{let t=e[0]?.contentRect.width;t&&Math.abs(t-this.availableWidthPx)>10&&(this.availableWidthPx=t)}),this.resizeObserver.observe(this)}disconnectedCallback(){super.disconnectedCallback(),this.resizeObserver?.disconnect()}_filterIds(e){return new Set([`searchText`,...(e.filters??[]).flatMap(e=>e.stereotype===`dateRange`||e.stereotype===`numberRange`?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId])])}_syncStateToUrl(e){let t=this._filterIds(e),n=new URLSearchParams(window.location.search);t.forEach(e=>n.delete(e)),n.delete(`page`),n.delete(`sort`),t.forEach(e=>{let t=this.state[e];t!=null&&t!==``&&n.set(e,String(t))});let r=this.state.page;r&&r>0&&n.set(`page`,String(r));let i=this.state.sort;if(i&&i.length>0){let e=i.filter(e=>e.fieldId&&e.direction).map(e=>`${e.fieldId}:${e.direction}`).join(`,`);e&&n.set(`sort`,e)}let a=n.toString(),o=a?`${window.location.pathname}?${a}`:window.location.pathname;window.location.pathname+window.location.search!==o&&history.replaceState(null,``,o)}_initStateFromUrl(e,t){let n=new URLSearchParams(window.location.search),r=this._filterIds(e),i={...t};n.forEach((e,t)=>{r.has(t)&&(i[t]=e)});let a=n.get(`page`);if(a!==null){let e=parseInt(a,10);!isNaN(e)&&e>0&&(i.page=e)}let o=n.get(`sort`);if(o){let e=o.split(`,`).map(e=>{let[t,n]=e.split(`:`);return t&&n?{fieldId:t,direction:n}:null}).filter(Boolean);e.length>0&&(i.sort=e)}return i}pageChanged(e){this.state={...this.state,page:e.detail.page},this.handleSearchRequested(void 0)}updated(e){if(super.updated(e),e.has(`component`)){let e=this.component?.id;if(e!==this._initializedForComponentId){this._initializedForComponentId=e;let t=this.component?.metadata,n=t.initialPage&&t.initialPage>0?t.initialPage:0;this.state=this._initStateFromUrl(t,{...this.state,size:t.pageSize,page:n,sort:[]}),(this.state.page!==n||this.state.sort?.length>0||[...this._filterIds(t)].some(e=>this.state[e]!=null)||t.rowsSource)&&this.handleSearchRequested(void 0)}}}render(){let e=e=>{let t=[];return e.color&&e.color!==ga.normal&&t.push(e.color),e.buttonStyle&&t.push(e.buttonStyle===_a.tertiaryInline?`tertiary-inline`:e.buttonStyle),t.length?t.join(` `):void 0},t=e=>e===`back`||e===`backToList`||!!e&&e.startsWith(`cancel`),n=t=>N.get()?.renderToolbarButton?.(t,this.evalLabel(t.label),()=>this.handleToolbarButtonClick(t.actionId))||w`
                 <button class="crud-btn"
                         data-action-id="${t.id}"
                         theme="${e(t)||_}"
                         @click="${()=>this.handleToolbarButtonClick(t.actionId)}"
                 >${this.evalLabel(t.label)}</button>
-            `;if(!this.component)return w`no component`;let r=this.effectiveComponent,i=r.metadata;i.serverSideOrdering=!0;let a=(()=>{let e=this;for(;e;){let t=e;if(t.tagName===`MATEU-PAGE`)return(t.component?.metadata?.toolbar?.length??0)>0;e=t.parentElement??(t.getRootNode?.()instanceof ShadowRoot?t.getRootNode().host:null)}return!1})()?[]:i?.toolbar??[],o=a.filter(e=>t(e.actionId)),s=a.filter(e=>!t(e.actionId)),c=o.length>0&&s.length>0,l=!!i?.title||!!i?.subtitle||a.length>0,u=this.effectiveGridLayout,d=this.cols,f=va(d),p=this.data[this.id]?.page?.content??[],ee=this.state[this.component?.id]?.emptyStateMessage,te=(e,t)=>{let n=t[e.id];return n==null?w``:e.dataType===`status`?w`<span theme="badge pill ${ua(n.type)}">${n.message}</span>`:e.dataType===`bool`?w`${n?`✓`:`✗`}`:typeof n==`object`?w`${n.label??n.name??n.message??``}`:w`${n}`},ne=()=>{let e=this.identifierFieldName,t=this.state._selectedId??this.appState?._splitDetailId,n=f.find(e=>e.identifier)??f[0],r=e=>e.dataType===`action`||e.dataType===`actionGroup`||e.dataType===`menu`||e.stereotype===`button`,i=f.filter(e=>e!==n&&!r(e)),a=d.filter(e=>r(e)),o=(e,t,n)=>{e.stopPropagation(),e.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_clickedRow:n}},bubbles:!0,composed:!0}))},s=e=>{let t=[];for(let n of a){let r=e[n.id];if(n.dataType===`action`){let i=r?.methodNameInCrud?r:e.action?.methodNameInCrud?e.action:{methodNameInCrud:n.id,label:n.label,icon:null,disabled:!1};t.push(w`
+            `;if(!this.component)return w`no component`;let r=this.effectiveComponent,i=r.metadata;i.serverSideOrdering=!0;let a=(()=>{let e=this;for(;e;){let t=e;if(t.tagName===`MATEU-PAGE`)return(t.component?.metadata?.toolbar?.length??0)>0;e=t.parentElement??(t.getRootNode?.()instanceof ShadowRoot?t.getRootNode().host:null)}return!1})()?[]:i?.toolbar??[],o=a.filter(e=>t(e.actionId)),s=a.filter(e=>!t(e.actionId)),c=o.length>0&&s.length>0,l=!!i?.title||!!i?.subtitle||a.length>0,u=this.effectiveGridLayout,d=this.cols,f=ba(d),p=this.data[this.id]?.page?.content??[],ee=this.state[this.component?.id]?.emptyStateMessage,te=(e,t)=>{let n=t[e.id];return n==null?w``:e.dataType===`status`?w`<span theme="badge pill ${fa(n.type)}">${n.message}</span>`:e.dataType===`bool`?w`${n?`✓`:`✗`}`:typeof n==`object`?w`${n.label??n.name??n.message??``}`:w`${n}`},ne=()=>{let e=this.identifierFieldName,t=this.state._selectedId??this.appState?._splitDetailId,n=f.find(e=>e.identifier)??f[0],r=e=>e.dataType===`action`||e.dataType===`actionGroup`||e.dataType===`menu`||e.stereotype===`button`,i=f.filter(e=>e!==n&&!r(e)),a=d.filter(e=>r(e)),o=(e,t,n)=>{e.stopPropagation(),e.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_clickedRow:n}},bubbles:!0,composed:!0}))},s=e=>{let t=[];for(let n of a){let r=e[n.id];if(n.dataType===`action`){let i=r?.methodNameInCrud?r:e.action?.methodNameInCrud?e.action:{methodNameInCrud:n.id,label:n.label,icon:null,disabled:!1};t.push(w`
                             <button class="crud-btn" theme="tertiary small" title="${i.label||_}"
                                 @click="${t=>o(t,`action-on-row-`+i.methodNameInCrud,e)}">
                                 ${i.icon?F(i.icon):_}
@@ -4694,7 +4694,7 @@ ${i}
                             ${ne(n)}
                         </div>
                     `)}
-                </div>`},h=()=>{let e=ya(d),t=e.find(e=>e.identifier)??e[0],n=e.filter(e=>e!==t);return w`
+                </div>`},h=()=>{let e=xa(d),t=e.find(e=>e.identifier)??e[0],n=e.filter(e=>e!==t);return w`
                 <div style="display: flex; height: 100%; min-height: 400px; gap: 0;">
                     <div style="width: 260px; flex-shrink: 0; border-right: 1px solid var(--lumo-contrast-20pct); overflow-y: auto;">
                         <div class="m-listbox" style="width: 100%;">
@@ -4867,7 +4867,7 @@ ${i}
         }
     
         ${R}
-    `}};O([v()],W.prototype,`component`,void 0),O([v()],W.prototype,`baseUrl`,void 0),O([v({type:Boolean})],W.prototype,`standalone`,void 0),O([v()],W.prototype,`state`,void 0),O([v()],W.prototype,`data`,void 0),O([v()],W.prototype,`appState`,void 0),O([v()],W.prototype,`appData`,void 0),O([S()],W.prototype,`showImportDialog`,void 0),O([S()],W.prototype,`availableWidthPx`,void 0),O([S()],W.prototype,`selectedItem`,void 0),O([S()],W.prototype,`_columnPrefsRevision`,void 0),W=O([h(`mateu-table-crud`)],W);var xa=function(e){return e.OnLoad=`OnLoad`,e.OnSuccess=`OnSuccess`,e.OnError=`OnError`,e.OnValueChange=`OnValueChange`,e.OnCustomEvent=`OnCustomEvent`,e.AutoSave=`AutoSave`,e}({}),Sa=class extends et{constructor(...e){super(...e),this.state={},this.data={},this.appData={},this.appState={},this.triggerOnLoad=()=>{let e=this.component;this.registerCustomEventListeners(),e.triggers?.filter(e=>e.type==xa.OnLoad).forEach(e=>{if((!e.condition||this._evalExpr(e.condition))&&!e.triggered){let n=e;n.triggered=!0;var t=n.times-1;n.timeoutMillis>0?this.scheduleOnload(n,t,this.id):this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.actionId},bubbles:!0,composed:!0}))}})},this.scheduleOnload=(e,t,n)=>{if(n!=this.component?.id)return;let r=this.callbackToken;setTimeout(()=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,callbackToken:r},bubbles:!0,composed:!0}))},e.timeoutMillis)},this._registeredCustomEventListeners=[],this.customEventManager=e=>{if(!(e instanceof CustomEvent))return;let t=e,n=(this.component.triggers??[]).filter(e=>e.type==xa.OnCustomEvent).filter(e=>e.eventName==t.type).filter(e=>e.source!==`COMPONENT`||t.detail?.__source===e.from);n.length!==0&&(n.some(e=>!e.source||e.source===`SELF`)&&(e.stopPropagation(),e.preventDefault()),n.forEach(e=>{(!e.condition||this._evalExpr(e.condition))&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:t.detail},bubbles:!0,composed:!0}))}))}}_interpolationExtra(){return{appState:this.appState??{},appData:this.appData??{},component:this.component}}_evalExpr(e){return ot(e,this.state??{},this.data??{},this._interpolationExtra())}_evalTemplate(e){return st(e,this.state??{},this.data??{},this._interpolationExtra())}isOverlayChild(e){let t=e?.metadata?.type;return t==A.Drawer||t==A.Dialog}removeSelfFromOwnerChildren(){let e=this.component;if(!e)return!1;let t=t=>{if(t===e)return!0;let n=t;return e.id!=null&&n?.id==e.id&&this.isOverlayChild(n)},n=this.parentNode;for(;n;){let e=n instanceof ShadowRoot?n.host:n,r=e.component?.children;if(Array.isArray(r)){let n=r.findIndex(t);if(n>=0)return r.splice(n,1),e.requestUpdate?.(),!0}n=n instanceof ShadowRoot?e:n.parentNode}return!1}applyFragment(e){if(this.id==e.targetComponentId){if(e.component)if(Ke.Add==e.action){if(this.component){let t=this.component.children??(this.component.children=[]),n=e.component.id?t.findIndex(t=>t.id==e.component.id&&this.isOverlayChild(t)):-1;n>=0?(t[n]=e.component,this.component={...this.component}):t.push(e.component)}}else{this.callbackToken=T();let t=!1;if(e.component?.type==k.ServerSide)if(this.component){let n=this.component,r=e.component;t=n.serverSideType==r.serverSideType;let i=t?(n.children??[]).filter(e=>this.isOverlayChild(e)):[];n.actions=r.actions,n.type=r.type,n.rules=r.rules,n.triggers=r.triggers,n.serverSideType=r.serverSideType,n.route=r.route,n.initialData=r.initialData,n.validations=r.validations,n.cssClasses=r.cssClasses,n.slot=r.slot,n.style=r.style,n.children=i.length?[...r.children??[],...i]:r.children,(n.serverSideType!=r.serverSideType||n.id!=r.id)&&setTimeout(()=>this.triggerOnLoad())}else this.component=e.component,setTimeout(()=>this.triggerOnLoad());else{let t=[e.component];this.component&&(this.component.children=t)}e.action!==Ke.ReplaceKeepData&&!t&&(this.state={},this.data={})}if(e.state&&(this.state={...this.state,...e.state}),e.data){for(let t in e.data){let n=e.data[t]?.page;n?.pageNumber>0&&this.data[t]&&this.data[t].page.content&&(n.content?n.content=[...this.data[t].page.content,...n.content]:n.content=[...this.data[t].page.content])}this.data={...this.data,...e.data}}this.registerCustomEventListeners();let t=N.getAfterRenderHook();t&&setTimeout(()=>t(this)),this.requestUpdate()}}registerCustomEventListeners(){this._registeredCustomEventListeners.forEach(({target:e,name:t})=>e.removeEventListener(t,this.customEventManager)),this._registeredCustomEventListeners=[],this.component?.triggers?.filter(e=>e.type==xa.OnCustomEvent).forEach(e=>{let t=e.source===`DOCUMENT`||e.source===`COMPONENT`?document:this;t.addEventListener(e.eventName,this.customEventManager),this._registeredCustomEventListeners.push({target:t,name:e.eventName})})}disconnectedCallback(){this._registeredCustomEventListeners.forEach(({target:e,name:t})=>e.removeEventListener(t,this.customEventManager)),this._registeredCustomEventListeners=[],super.disconnectedCallback()}connectedCallback(){super.connectedCallback(),this.component&&this.registerCustomEventListeners()}};O([v()],Sa.prototype,`state`,void 0),O([v()],Sa.prototype,`data`,void 0),O([v()],Sa.prototype,`appData`,void 0),O([v()],Sa.prototype,`appState`,void 0);var Ca=`mateu-recent-routes`,wa=8;function Ta(){try{return JSON.parse(localStorage.getItem(Ca)??`{}`)}catch{return{}}}function Ea(e){try{localStorage.setItem(Ca,JSON.stringify(e))}catch{}}function Da(e){return Ta()[e||`_`]??[]}function Oa(e,t){if(!t?.route||!t.label)return;let n=e||`_`,r=Ta(),i=(r[n]??[]).filter(e=>e.route!==t.route);i.unshift({route:t.route,label:t.label}),r[n]=i.slice(0,wa),Ea(r)}var G=class extends y{constructor(...e){super(...e),this.baseUrl=``,this.open=!1,this.queryText=``,this.dataHits=[],this.loading=!1,this.selectedIndex=0,this.fabOffset=0,this.keydownHandler=null}connectedCallback(){super.connectedCallback(),this.keydownHandler=e=>{(e.metaKey||e.ctrlKey)&&(e.key===`k`||e.key===`K`)?(e.preventDefault(),this.toggle()):e.key===`Escape`&&this.open&&this.close()},document.addEventListener(`keydown`,this.keydownHandler),this.setupFabObserver()}disconnectedCallback(){super.disconnectedCallback(),this.keydownHandler&&document.removeEventListener(`keydown`,this.keydownHandler),clearTimeout(this.searchTimer),this.fabObserver?.disconnect(),this.fabObserver=void 0}setupFabObserver(){let e=this.getRootNode(),t=e instanceof ShadowRoot?e:document.body;this.measureFabStack(),this.fabObserver?.disconnect(),this.fabObserver=new MutationObserver(()=>this.measureFabStack()),this.fabObserver.observe(t,{childList:!0,subtree:!0})}measureFabStack(){let e=(this.getRootNode().querySelectorAll?.(`.ai-fab, .app-fab, .page-fab`).length??0)*4;e!==this.fabOffset&&(this.fabOffset=e)}updated(e){e.has(`open`)&&this.open&&requestAnimationFrame(()=>this.inputEl?.focus())}toggle(){this.open?this.close():this.openCenter()}openCenter(){this.open=!0,this.queryText=``,this.dataHits=[],this.selectedIndex=0}close(){this.open=!1,this.queryText=``,this.dataHits=[],clearTimeout(this.searchTimer)}flattenMenu(e,t){let n=[];for(let r of e??[])if(!r.separator)if(r.submenus&&r.submenus.length>0){let e=t?`${t} › ${r.label}`:r.label;n.push(...this.flattenMenu(r.submenus,e))}else r.route!==void 0&&r.route!==null&&n.push({label:r.label,breadcrumb:t,route:r.route});return n}onInput(e){this.queryText=e,this.selectedIndex=0;let t=e.trim();if(clearTimeout(this.searchTimer),!t||!this.app?.globalSearchEnabled){this.dataHits=[],this.loading=!1;return}this.loading=!0,this.searchTimer=setTimeout(()=>this.fetchGlobalSearch(t),250)}async fetchGlobalSearch(e){let t=this.app;if(!t?.globalSearchEnabled){this.loading=!1;return}try{let n=(await Ge.runAction(this.baseUrl??``,t.rootRoute??``,``,`_globalsearch`,`command-center`,void 0,t.serverSideType,{},{searchText:e},this,!0))?.fragments?.map(e=>e.data).find(e=>e&&e._globalsearch);this.dataHits=n?._globalsearch??[]}catch{this.dataHits=[]}finally{this.loading=!1}}navigateTo(e,t){Oa(this.app?.serverSideType??``,{route:e,label:t}),this.close();for(let t of[`route-changed`,`navigate-to-requested`])this.dispatchEvent(new CustomEvent(t,{detail:{route:e},bubbles:!0,composed:!0}))}askAi(){let e=this.queryText.trim();this.close(),this.dispatchEvent(new CustomEvent(`mateu-open-ai`,{detail:{query:e},bubbles:!0,composed:!0}))}visibleTargets(e){if(!this.queryText.trim()){let e=this.flattenMenu(this.app?.menu,``).map(e=>({route:e.route,label:e.label})),t=Da(this.app?.serverSideType??``);return[...e,...t]}return[...e.map(e=>({route:e.route,label:e.label})),...this.dataHits.map(e=>({route:e.route,label:e.label}))]}onKeydown(e,t){if(e.key===`ArrowDown`)e.preventDefault(),this.selectedIndex=Math.min(this.selectedIndex+1,t.length-1);else if(e.key===`ArrowUp`)e.preventDefault(),this.selectedIndex=Math.max(this.selectedIndex-1,0);else if(e.key===`Enter`){let e=t[this.selectedIndex];e&&this.navigateTo(e.route,e.label)}}render(){return w`
+    `}};O([v()],W.prototype,`component`,void 0),O([v()],W.prototype,`baseUrl`,void 0),O([v({type:Boolean})],W.prototype,`standalone`,void 0),O([v()],W.prototype,`state`,void 0),O([v()],W.prototype,`data`,void 0),O([v()],W.prototype,`appState`,void 0),O([v()],W.prototype,`appData`,void 0),O([S()],W.prototype,`showImportDialog`,void 0),O([S()],W.prototype,`availableWidthPx`,void 0),O([S()],W.prototype,`selectedItem`,void 0),O([S()],W.prototype,`_columnPrefsRevision`,void 0),W=O([h(`mateu-table-crud`)],W);var Ca=function(e){return e.OnLoad=`OnLoad`,e.OnSuccess=`OnSuccess`,e.OnError=`OnError`,e.OnValueChange=`OnValueChange`,e.OnCustomEvent=`OnCustomEvent`,e.AutoSave=`AutoSave`,e}({}),wa=class extends et{constructor(...e){super(...e),this.state={},this.data={},this.appData={},this.appState={},this.triggerOnLoad=()=>{let e=this.component;this.registerCustomEventListeners(),e.triggers?.filter(e=>e.type==Ca.OnLoad).forEach(e=>{if((!e.condition||this._evalExpr(e.condition))&&!e.triggered){let n=e;n.triggered=!0;var t=n.times-1;n.timeoutMillis>0?this.scheduleOnload(n,t,this.id):this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.actionId},bubbles:!0,composed:!0}))}})},this.scheduleOnload=(e,t,n)=>{if(n!=this.component?.id)return;let r=this.callbackToken;setTimeout(()=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,callbackToken:r},bubbles:!0,composed:!0}))},e.timeoutMillis)},this._registeredCustomEventListeners=[],this.customEventManager=e=>{if(!(e instanceof CustomEvent))return;let t=e,n=(this.component.triggers??[]).filter(e=>e.type==Ca.OnCustomEvent).filter(e=>e.eventName==t.type).filter(e=>e.source!==`COMPONENT`||t.detail?.__source===e.from);n.length!==0&&(n.some(e=>!e.source||e.source===`SELF`)&&(e.stopPropagation(),e.preventDefault()),n.forEach(e=>{(!e.condition||this._evalExpr(e.condition))&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:t.detail},bubbles:!0,composed:!0}))}))}}_interpolationExtra(){return{appState:this.appState??{},appData:this.appData??{},component:this.component}}_evalExpr(e){return ot(e,this.state??{},this.data??{},this._interpolationExtra())}_evalTemplate(e){return st(e,this.state??{},this.data??{},this._interpolationExtra())}isOverlayChild(e){let t=e?.metadata?.type;return t==A.Drawer||t==A.Dialog}removeSelfFromOwnerChildren(){let e=this.component;if(!e)return!1;let t=t=>{if(t===e)return!0;let n=t;return e.id!=null&&n?.id==e.id&&this.isOverlayChild(n)},n=this.parentNode;for(;n;){let e=n instanceof ShadowRoot?n.host:n,r=e.component?.children;if(Array.isArray(r)){let n=r.findIndex(t);if(n>=0)return r.splice(n,1),e.requestUpdate?.(),!0}n=n instanceof ShadowRoot?e:n.parentNode}return!1}applyFragment(e){if(this.id==e.targetComponentId){if(e.component)if(Ke.Add==e.action){if(this.component){let t=this.component.children??(this.component.children=[]),n=e.component.id?t.findIndex(t=>t.id==e.component.id&&this.isOverlayChild(t)):-1;n>=0?(t[n]=e.component,this.component={...this.component}):t.push(e.component)}}else{this.callbackToken=T();let t=!1;if(e.component?.type==k.ServerSide)if(this.component){let n=this.component,r=e.component;t=n.serverSideType==r.serverSideType;let i=t?(n.children??[]).filter(e=>this.isOverlayChild(e)):[];n.actions=r.actions,n.type=r.type,n.rules=r.rules,n.triggers=r.triggers,n.serverSideType=r.serverSideType,n.route=r.route,n.initialData=r.initialData,n.validations=r.validations,n.cssClasses=r.cssClasses,n.slot=r.slot,n.style=r.style,n.children=i.length?[...r.children??[],...i]:r.children,(n.serverSideType!=r.serverSideType||n.id!=r.id)&&setTimeout(()=>this.triggerOnLoad())}else this.component=e.component,setTimeout(()=>this.triggerOnLoad());else{let t=[e.component];this.component&&(this.component.children=t)}e.action!==Ke.ReplaceKeepData&&!t&&(this.state={},this.data={})}if(e.state&&(this.state={...this.state,...e.state}),e.data){for(let t in e.data){let n=e.data[t]?.page;n?.pageNumber>0&&this.data[t]&&this.data[t].page.content&&(n.content?n.content=[...this.data[t].page.content,...n.content]:n.content=[...this.data[t].page.content])}this.data={...this.data,...e.data}}this.registerCustomEventListeners();let t=N.getAfterRenderHook();t&&setTimeout(()=>t(this)),this.requestUpdate()}}registerCustomEventListeners(){this._registeredCustomEventListeners.forEach(({target:e,name:t})=>e.removeEventListener(t,this.customEventManager)),this._registeredCustomEventListeners=[],this.component?.triggers?.filter(e=>e.type==Ca.OnCustomEvent).forEach(e=>{let t=e.source===`DOCUMENT`||e.source===`COMPONENT`?document:this;t.addEventListener(e.eventName,this.customEventManager),this._registeredCustomEventListeners.push({target:t,name:e.eventName})})}disconnectedCallback(){this._registeredCustomEventListeners.forEach(({target:e,name:t})=>e.removeEventListener(t,this.customEventManager)),this._registeredCustomEventListeners=[],super.disconnectedCallback()}connectedCallback(){super.connectedCallback(),this.component&&this.registerCustomEventListeners()}};O([v()],wa.prototype,`state`,void 0),O([v()],wa.prototype,`data`,void 0),O([v()],wa.prototype,`appData`,void 0),O([v()],wa.prototype,`appState`,void 0);var Ta=`mateu-recent-routes`,Ea=8;function Da(){try{return JSON.parse(localStorage.getItem(Ta)??`{}`)}catch{return{}}}function Oa(e){try{localStorage.setItem(Ta,JSON.stringify(e))}catch{}}function ka(e){return Da()[e||`_`]??[]}function Aa(e,t){if(!t?.route||!t.label)return;let n=e||`_`,r=Da(),i=(r[n]??[]).filter(e=>e.route!==t.route);i.unshift({route:t.route,label:t.label}),r[n]=i.slice(0,Ea),Oa(r)}var G=class extends y{constructor(...e){super(...e),this.baseUrl=``,this.open=!1,this.queryText=``,this.dataHits=[],this.loading=!1,this.selectedIndex=0,this.fabOffset=0,this.keydownHandler=null}connectedCallback(){super.connectedCallback(),this.keydownHandler=e=>{(e.metaKey||e.ctrlKey)&&(e.key===`k`||e.key===`K`)?(e.preventDefault(),this.toggle()):e.key===`Escape`&&this.open&&this.close()},document.addEventListener(`keydown`,this.keydownHandler),this.setupFabObserver()}disconnectedCallback(){super.disconnectedCallback(),this.keydownHandler&&document.removeEventListener(`keydown`,this.keydownHandler),clearTimeout(this.searchTimer),this.fabObserver?.disconnect(),this.fabObserver=void 0}setupFabObserver(){let e=this.getRootNode(),t=e instanceof ShadowRoot?e:document.body;this.measureFabStack(),this.fabObserver?.disconnect(),this.fabObserver=new MutationObserver(()=>this.measureFabStack()),this.fabObserver.observe(t,{childList:!0,subtree:!0})}measureFabStack(){let e=(this.getRootNode().querySelectorAll?.(`.ai-fab, .app-fab, .page-fab`).length??0)*4;e!==this.fabOffset&&(this.fabOffset=e)}updated(e){e.has(`open`)&&this.open&&requestAnimationFrame(()=>this.inputEl?.focus())}toggle(){this.open?this.close():this.openCenter()}openCenter(){this.open=!0,this.queryText=``,this.dataHits=[],this.selectedIndex=0}close(){this.open=!1,this.queryText=``,this.dataHits=[],clearTimeout(this.searchTimer)}flattenMenu(e,t){let n=[];for(let r of e??[])if(!r.separator)if(r.submenus&&r.submenus.length>0){let e=t?`${t} › ${r.label}`:r.label;n.push(...this.flattenMenu(r.submenus,e))}else r.route!==void 0&&r.route!==null&&n.push({label:r.label,breadcrumb:t,route:r.route});return n}onInput(e){this.queryText=e,this.selectedIndex=0;let t=e.trim();if(clearTimeout(this.searchTimer),!t||!this.app?.globalSearchEnabled){this.dataHits=[],this.loading=!1;return}this.loading=!0,this.searchTimer=setTimeout(()=>this.fetchGlobalSearch(t),250)}async fetchGlobalSearch(e){let t=this.app;if(!t?.globalSearchEnabled){this.loading=!1;return}try{let n=(await Ge.runAction(this.baseUrl??``,t.rootRoute??``,``,`_globalsearch`,`command-center`,void 0,t.serverSideType,{},{searchText:e},this,!0))?.fragments?.map(e=>e.data).find(e=>e&&e._globalsearch);this.dataHits=n?._globalsearch??[]}catch{this.dataHits=[]}finally{this.loading=!1}}navigateTo(e,t){Aa(this.app?.serverSideType??``,{route:e,label:t}),this.close();for(let t of[`route-changed`,`navigate-to-requested`])this.dispatchEvent(new CustomEvent(t,{detail:{route:e},bubbles:!0,composed:!0}))}askAi(){let e=this.queryText.trim();this.close(),this.dispatchEvent(new CustomEvent(`mateu-open-ai`,{detail:{query:e},bubbles:!0,composed:!0}))}visibleTargets(e){if(!this.queryText.trim()){let e=this.flattenMenu(this.app?.menu,``).map(e=>({route:e.route,label:e.label})),t=ka(this.app?.serverSideType??``);return[...e,...t]}return[...e.map(e=>({route:e.route,label:e.label})),...this.dataHits.map(e=>({route:e.route,label:e.label}))]}onKeydown(e,t){if(e.key===`ArrowDown`)e.preventDefault(),this.selectedIndex=Math.min(this.selectedIndex+1,t.length-1);else if(e.key===`ArrowUp`)e.preventDefault(),this.selectedIndex=Math.max(this.selectedIndex-1,0);else if(e.key===`Enter`){let e=t[this.selectedIndex];e&&this.navigateTo(e.route,e.label)}}render(){return w`
             <button class="cc-fab" style="bottom: ${1.5+this.fabOffset}rem;"
                 @click=${()=>this.openCenter()} title="Buscar y navegar (⌘K)" aria-label="Command center">
                 ${this.fabIcon()}
@@ -4893,7 +4893,7 @@ ${i}
                 </div>
                 <button class="cc-close" @click=${()=>this.close()} title="Cerrar">${this.clearIcon()}</button>
             </div>
-        `}renderDefault(){let e=this.flattenMenu(this.app?.menu,``),t=Da(this.app?.serverSideType??``),n=-1;return w`
+        `}renderDefault(){let e=this.flattenMenu(this.app?.menu,``),t=ka(this.app?.serverSideType??``),n=-1;return w`
             <div class="cc-columns">
                 <div class="cc-col">
                     <div class="cc-section-title">Ir a</div>
@@ -5028,7 +5028,7 @@ ${i}
             display: flex; align-items: center; justify-content: center; cursor: pointer; z-index: 1110;
         }
         .cc-close:hover { background: rgba(0,0,0,0.75); }
-    `}};O([v({attribute:!1})],G.prototype,`app`,void 0),O([v()],G.prototype,`baseUrl`,void 0),O([S()],G.prototype,`open`,void 0),O([S()],G.prototype,`queryText`,void 0),O([S()],G.prototype,`dataHits`,void 0),O([S()],G.prototype,`loading`,void 0),O([S()],G.prototype,`selectedIndex`,void 0),O([S()],G.prototype,`fabOffset`,void 0),O([b(`.cc-input`)],G.prototype,`inputEl`,void 0),G=O([h(`mateu-command-center`)],G);var ka=null;function Aa(e){let t=e.component?.metadata;t&&(t.commandCenterEnabled||t.chromeless)&&t.variant!==`MEDIATOR`?((!ka||!ka.isConnected)&&(ka=document.createElement(`mateu-command-center`),e.renderRoot.appendChild(ka)),ka.app=t,ka.baseUrl=e.baseUrl??``):ka&&e.renderRoot.contains(ka)&&(ka.remove(),ka=null)}var ja=class extends y{constructor(...e){super(...e),this.fetchStarted=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!0},this.fetchFinished=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!1},this.fetchFailed=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!1;let t=e.detail??{},n=t.failure??Fe(t.reason,{online:Ve.isOnline()});if(n.kind===`cancelled`)return;let r=t.retry;pa({text:n.message,variant:`error`,duration:r?8e3:5e3,position:`bottomEnd`,...r?{actionLabel:`Retry`,onAction:r}:{}},this)}}connectedCallback(){super.connectedCallback(),this.addEventListener(`backend-called-event`,this.fetchStarted),this.addEventListener(`backend-succeeded-event`,this.fetchFinished),this.addEventListener(`backend-cancelled-event`,this.fetchFinished),this.addEventListener(`backend-failed-event`,this.fetchFailed)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`backend-called-event`,this.fetchStarted),this.removeEventListener(`backend-succeeded-event`,this.fetchFinished),this.removeEventListener(`backend-cancelled-event`,this.fetchFinished),this.removeEventListener(`backend-failed-event`,this.fetchFailed)}render(){return w`<div class="loader-container">
+    `}};O([v({attribute:!1})],G.prototype,`app`,void 0),O([v()],G.prototype,`baseUrl`,void 0),O([S()],G.prototype,`open`,void 0),O([S()],G.prototype,`queryText`,void 0),O([S()],G.prototype,`dataHits`,void 0),O([S()],G.prototype,`loading`,void 0),O([S()],G.prototype,`selectedIndex`,void 0),O([S()],G.prototype,`fabOffset`,void 0),O([b(`.cc-input`)],G.prototype,`inputEl`,void 0),G=O([h(`mateu-command-center`)],G);var ja=null;function Ma(e){let t=e.component?.metadata;t&&(t.commandCenterEnabled||t.chromeless)&&t.variant!==`MEDIATOR`?((!ja||!ja.isConnected)&&(ja=document.createElement(`mateu-command-center`),e.renderRoot.appendChild(ja)),ja.app=t,ja.baseUrl=e.baseUrl??``):ja&&e.renderRoot.contains(ja)&&(ja.remove(),ja=null)}var Na=class extends y{constructor(...e){super(...e),this.fetchStarted=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!0},this.fetchFinished=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!1},this.fetchFailed=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!1;let t=e.detail??{},n=t.failure??Fe(t.reason,{online:Ve.isOnline()});if(n.kind===`cancelled`)return;let r=t.retry;ha({text:n.message,variant:`error`,duration:r?8e3:5e3,position:`bottomEnd`,...r?{actionLabel:`Retry`,onAction:r}:{}},this)}}connectedCallback(){super.connectedCallback(),this.addEventListener(`backend-called-event`,this.fetchStarted),this.addEventListener(`backend-succeeded-event`,this.fetchFinished),this.addEventListener(`backend-cancelled-event`,this.fetchFinished),this.addEventListener(`backend-failed-event`,this.fetchFailed)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`backend-called-event`,this.fetchStarted),this.removeEventListener(`backend-succeeded-event`,this.fetchFinished),this.removeEventListener(`backend-cancelled-event`,this.fetchFinished),this.removeEventListener(`backend-failed-event`,this.fetchFailed)}render(){return w`<div class="loader-container">
             <div style="display: flex; flex-direction: column;">
                 <slot></slot>
                 <div class="loader-frame ${this.loading?`delayed-show`:``}" style="${this.loading?`pointer-events: all;`:`display: none;`}"><div class="loader"></div></div>
@@ -5096,7 +5096,7 @@ ${i}
             animation: l5 1s infinite;
         }
         @keyframes l5 {to{transform: rotate(.5turn)}}
-  `}};O([S()],ja.prototype,`loading`,void 0),ja=O([h(`mateu-api-caller`)],ja);var Ma=new class{constructor(){this._dirty=!1,this._installed=!1,this.message=`You have unsaved changes. Are you sure you want to leave this page?`,this._onDirty=()=>{this._dirty=!0},this._onClean=()=>{this._dirty=!1},this._onBeforeUnload=e=>{this._dirty&&(e.preventDefault(),e.returnValue=``)}}install(){this._installed||(this._installed=!0,document.addEventListener(`dirty`,this._onDirty),document.addEventListener(`clean`,this._onClean),window.addEventListener(`beforeunload`,this._onBeforeUnload))}get dirty(){return this._dirty}markDirty(){this._dirty=!0}markClean(){this._dirty=!1}confirmLeave(){if(!this._dirty)return!0;let e=window.confirm(this.message);return e&&(this._dirty=!1),e}},Na,K=class extends Sa{static{Na=this}constructor(...e){super(...e),this.filter=``,this.instant=void 0,this.selectedConsumedRoute=void 0,this.selectedRoute=void 0,this.selectedUriPrefix=void 0,this.selectedBaseUrl=void 0,this.selectedServerSideType=void 0,this.selectedParams=void 0,this.tilesMenuOption=null,this.railOpenOption=null,this.commandPaletteOpen=!1,this.commandPaletteQuery=``,this.commandPaletteSelectedIndex=0,this.commandPaletteDataHits=[],this.openDataHit=e=>{Ma.confirmLeave()&&(this.commandPaletteOpen=!1,this.commandPaletteQuery=``,this.commandPaletteDataHits=[],this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:e.route},bubbles:!0,composed:!0})),this.dispatchEvent(new CustomEvent(`navigate-to-requested`,{detail:{route:e.route},bubbles:!0,composed:!0})))},this._commandPaletteHandler=null,this.pageCompact=!1,this._compactHandler=e=>{this.pageCompact=e.detail?.compact??!1},this._openAiHandler=()=>{this.chatOpen||this.showHideIa()},this.isDark=document.documentElement.getAttribute(`theme`)===`dark`,this.chatOpen=!1,this.toggleTheme=()=>{this.isDark=!this.isDark;let e=this.isDark?`dark`:`light`;document.documentElement.setAttribute(`theme`,e),localStorage.setItem(`mateu-theme`,e)},this.showHideIa=()=>{this.chat&&(this.chatOpen=!this.chatOpen,this.chat.slot=this.chatOpen?`detail`:`detail-hidden`)},this.runAction=e=>{let t=this.renderRoot.querySelector?.(`mateu-component`);t&&t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.getSelectedOption=e=>{if(e)for(let t=0;t<e.length;t++){let n=e[t];if(this.selectedRoute?this.isActiveOption(n):n.selected)return n;let r=this.getSelectedOption(n.submenus);if(r)return r}return null},this.itemSelected=e=>{let t=e.detail.value;this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix)},this.itemSelectedTiles=e=>{let t=e.detail.value._menuOption;t.submenus&&t.submenus.length>0?this.tilesMenuOption=t:(this.tilesMenuOption=null,this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix))},this.mapItemsForTiles=e=>e.map(e=>({text:e.label,consumedRoute:e.consumedRoute,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:e.selected,_menuOption:e})),this.flattenMenuForPalette=(e,t)=>{let n=[];for(let r of e)if(!r.separator)if(r.submenus&&r.submenus.length>0){let e=t?`${t} › ${r.label}`:r.label;n.push(...this.flattenMenuForPalette(r.submenus,e))}else n.push({label:r.label,breadcrumb:t,consumedRoute:r.consumedRoute,route:r.route,actionId:r.actionId,baseUrl:r.baseUrl,serverSideType:r.serverSideType,uriPrefix:r.uriPrefix});return n},this.handleCommandPaletteKeydown=(e,t)=>{let n=Math.min(t.length,10),r=n+Math.min(this.commandPaletteDataHits.length,8);if(e.key===`ArrowDown`)e.preventDefault(),this.commandPaletteSelectedIndex=Math.min(this.commandPaletteSelectedIndex+1,r-1);else if(e.key===`ArrowUp`)e.preventDefault(),this.commandPaletteSelectedIndex=Math.max(this.commandPaletteSelectedIndex-1,0);else if(e.key===`Enter`){if(this.commandPaletteSelectedIndex>=n){let e=this.commandPaletteDataHits[this.commandPaletteSelectedIndex-n];e&&this.openDataHit(e);return}let e=t[this.commandPaletteSelectedIndex];e&&(this.selectRoute(e.consumedRoute,e.route,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix),this.commandPaletteOpen=!1,this.commandPaletteQuery=``)}},this.renderCommandPalette=()=>{if(!this.commandPaletteOpen)return _;let e=this.component?.metadata;if(e?.commandCenterEnabled||!e?.menu)return _;let t=this.flattenMenuForPalette(e.menu,``),n=this.commandPaletteQuery.toLowerCase(),r=n?t.filter(e=>e.label.toLowerCase().includes(n)||e.breadcrumb.toLowerCase().includes(n)):t;return w`
+  `}};O([S()],Na.prototype,`loading`,void 0),Na=O([h(`mateu-api-caller`)],Na);var Pa=new class{constructor(){this._dirty=!1,this._installed=!1,this.message=`You have unsaved changes. Are you sure you want to leave this page?`,this._onDirty=()=>{this._dirty=!0},this._onClean=()=>{this._dirty=!1},this._onBeforeUnload=e=>{this._dirty&&(e.preventDefault(),e.returnValue=``)}}install(){this._installed||(this._installed=!0,document.addEventListener(`dirty`,this._onDirty),document.addEventListener(`clean`,this._onClean),window.addEventListener(`beforeunload`,this._onBeforeUnload))}get dirty(){return this._dirty}markDirty(){this._dirty=!0}markClean(){this._dirty=!1}confirmLeave(){if(!this._dirty)return!0;let e=window.confirm(this.message);return e&&(this._dirty=!1),e}},Fa,K=class extends wa{static{Fa=this}constructor(...e){super(...e),this.filter=``,this.instant=void 0,this.selectedConsumedRoute=void 0,this.selectedRoute=void 0,this.selectedUriPrefix=void 0,this.selectedBaseUrl=void 0,this.selectedServerSideType=void 0,this.selectedParams=void 0,this.tilesMenuOption=null,this.railOpenOption=null,this.commandPaletteOpen=!1,this.commandPaletteQuery=``,this.commandPaletteSelectedIndex=0,this.commandPaletteDataHits=[],this.openDataHit=e=>{Pa.confirmLeave()&&(this.commandPaletteOpen=!1,this.commandPaletteQuery=``,this.commandPaletteDataHits=[],this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:e.route},bubbles:!0,composed:!0})),this.dispatchEvent(new CustomEvent(`navigate-to-requested`,{detail:{route:e.route},bubbles:!0,composed:!0})))},this._commandPaletteHandler=null,this.pageCompact=!1,this._compactHandler=e=>{this.pageCompact=e.detail?.compact??!1},this._openAiHandler=()=>{this.chatOpen||this.showHideIa()},this.isDark=document.documentElement.getAttribute(`theme`)===`dark`,this.chatOpen=!1,this.toggleTheme=()=>{this.isDark=!this.isDark;let e=this.isDark?`dark`:`light`;document.documentElement.setAttribute(`theme`,e),localStorage.setItem(`mateu-theme`,e)},this.showHideIa=()=>{this.chat&&(this.chatOpen=!this.chatOpen,this.chat.slot=this.chatOpen?`detail`:`detail-hidden`)},this.runAction=e=>{let t=this.renderRoot.querySelector?.(`mateu-component`);t&&t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.getSelectedOption=e=>{if(e)for(let t=0;t<e.length;t++){let n=e[t];if(this.selectedRoute?this.isActiveOption(n):n.selected)return n;let r=this.getSelectedOption(n.submenus);if(r)return r}return null},this.itemSelected=e=>{let t=e.detail.value;this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix)},this.itemSelectedTiles=e=>{let t=e.detail.value._menuOption;t.submenus&&t.submenus.length>0?this.tilesMenuOption=t:(this.tilesMenuOption=null,this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix))},this.mapItemsForTiles=e=>e.map(e=>({text:e.label,consumedRoute:e.consumedRoute,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:e.selected,_menuOption:e})),this.flattenMenuForPalette=(e,t)=>{let n=[];for(let r of e)if(!r.separator)if(r.submenus&&r.submenus.length>0){let e=t?`${t} › ${r.label}`:r.label;n.push(...this.flattenMenuForPalette(r.submenus,e))}else n.push({label:r.label,breadcrumb:t,consumedRoute:r.consumedRoute,route:r.route,actionId:r.actionId,baseUrl:r.baseUrl,serverSideType:r.serverSideType,uriPrefix:r.uriPrefix});return n},this.handleCommandPaletteKeydown=(e,t)=>{let n=Math.min(t.length,10),r=n+Math.min(this.commandPaletteDataHits.length,8);if(e.key===`ArrowDown`)e.preventDefault(),this.commandPaletteSelectedIndex=Math.min(this.commandPaletteSelectedIndex+1,r-1);else if(e.key===`ArrowUp`)e.preventDefault(),this.commandPaletteSelectedIndex=Math.max(this.commandPaletteSelectedIndex-1,0);else if(e.key===`Enter`){if(this.commandPaletteSelectedIndex>=n){let e=this.commandPaletteDataHits[this.commandPaletteSelectedIndex-n];e&&this.openDataHit(e);return}let e=t[this.commandPaletteSelectedIndex];e&&(this.selectRoute(e.consumedRoute,e.route,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix),this.commandPaletteOpen=!1,this.commandPaletteQuery=``)}},this.renderCommandPalette=()=>{if(!this.commandPaletteOpen)return _;let e=this.component?.metadata;if(e?.commandCenterEnabled||!e?.menu)return _;let t=this.flattenMenuForPalette(e.menu,``),n=this.commandPaletteQuery.toLowerCase(),r=n?t.filter(e=>e.label.toLowerCase().includes(n)||e.breadcrumb.toLowerCase().includes(n)):t;return w`
             <div class="cmd-backdrop" @click=${()=>{this.commandPaletteOpen=!1,this.commandPaletteQuery=``}}>
                 <div class="cmd-palette" @click=${e=>e.stopPropagation()}>
                     <div class="cmd-search-wrapper">
@@ -5169,7 +5169,7 @@ ${i}
                     `)}
                 </div>
             </div>
-        `,this.goHome=()=>{Ma.confirmLeave()&&(window.history.pushState(null,``,`/`),window.dispatchEvent(new PopStateEvent(`popstate`,{state:null})))},this.selectRoute=(e,t,n,r,i,a)=>{Ma.confirmLeave()&&this._selectRoute(e,t,n,r,i,a)},this._selectRoute=(e,t,n,r,i,a)=>{{this.selectedConsumedRoute=e,this.selectedBaseUrl=r,this.selectedRoute=t,this.selectedServerSideType=i,this.selectedUriPrefix=a,this.instant=T(),this.state&&this.state._route!=null&&(this.state._route=void 0);let n=this.baseUrl??``;n.indexOf(`://`)<0&&(n.startsWith(`/`)||(n=`/`+n),n=window.location.origin+n),n.endsWith(`/`)&&(t??``).startsWith(`/`)&&(t=(t??``).substring(1));let o=new URL(n+t);if(e&&o.pathname.startsWith(e)){let t=o.pathname.substring(e.length);o=new URL(o.origin+(t||`/`))}if((window.location.pathname||o.pathname)&&window.location.pathname!=o.pathname){let e=o.pathname;o.search&&(e+=o.search),e&&!e.startsWith(`/`)&&(e=`/`+e),this.baseUrl&&e.startsWith(this.baseUrl)&&(e=e.substring(this.baseUrl.length));let t=e;this.selectedUriPrefix&&(t=t.startsWith(`/`)&&this.selectedUriPrefix.endsWith(`/`)?this.selectedUriPrefix+t.substring(1):!t.startsWith(`/`)&&!this.selectedUriPrefix.endsWith(`/`)?this.selectedUriPrefix+`/`+t:this.selectedUriPrefix+t),t==`/_page`&&(t=``),this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0}))}}},this.isActiveOption=e=>this.selectedRoute?!!e.route&&(this.selectedRoute==e.route||this.selectedRoute.startsWith(e.route+`/`)):!!e.selected,this.mapItems=(e,t)=>e.map(e=>{if(e.submenus&&e.submenus.length>0){let n=this.mapItems(e.submenus,t);return t&&e.label.toLowerCase().includes(t)&&(n=this.mapItems(e.submenus,``)),n&&n.length>0?{consumedRoute:e.consumedRoute,text:e.label,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:t||this.isActiveOption(e),children:n}:void 0}if(e.separator)return t?void 0:{component:`hr`};if(!t||e.label.toLowerCase().includes(t))return{consumedRoute:e.consumedRoute,text:e.label,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:t||this.isActiveOption(e)}}).filter(e=>e!=null),this.getSelectedIndex=e=>{if(!e)return NaN;let t=e=>{let t=(e??``).trim();return t.length>1&&t.endsWith(`/`)&&(t=t.slice(0,-1)),t},n=t(this.selectedRoute??window.location.pathname),r=NaN,i=-1;for(let a=0;a<e.length;a++){let o=t(e[a].route);o!==``&&(n===o||n.startsWith(o+`/`))&&o.length>i&&(i=o.length,r=a)}if(!Number.isNaN(r))return r;let a=this.getSelectedOption(e);return a?e.indexOf(a):NaN},this.renderOptionOnLeftMenu=e=>e.submenus&&e.submenus.length>0?w`
+        `,this.goHome=()=>{Pa.confirmLeave()&&(window.history.pushState(null,``,`/`),window.dispatchEvent(new PopStateEvent(`popstate`,{state:null})))},this.selectRoute=(e,t,n,r,i,a)=>{Pa.confirmLeave()&&this._selectRoute(e,t,n,r,i,a)},this._selectRoute=(e,t,n,r,i,a)=>{{this.selectedConsumedRoute=e,this.selectedBaseUrl=r,this.selectedRoute=t,this.selectedServerSideType=i,this.selectedUriPrefix=a,this.instant=T(),this.state&&this.state._route!=null&&(this.state._route=void 0);let n=this.baseUrl??``;n.indexOf(`://`)<0&&(n.startsWith(`/`)||(n=`/`+n),n=window.location.origin+n),n.endsWith(`/`)&&(t??``).startsWith(`/`)&&(t=(t??``).substring(1));let o=new URL(n+t);if(e&&o.pathname.startsWith(e)){let t=o.pathname.substring(e.length);o=new URL(o.origin+(t||`/`))}if((window.location.pathname||o.pathname)&&window.location.pathname!=o.pathname){let e=o.pathname;o.search&&(e+=o.search),e&&!e.startsWith(`/`)&&(e=`/`+e),this.baseUrl&&e.startsWith(this.baseUrl)&&(e=e.substring(this.baseUrl.length));let t=e;this.selectedUriPrefix&&(t=t.startsWith(`/`)&&this.selectedUriPrefix.endsWith(`/`)?this.selectedUriPrefix+t.substring(1):!t.startsWith(`/`)&&!this.selectedUriPrefix.endsWith(`/`)?this.selectedUriPrefix+`/`+t:this.selectedUriPrefix+t),t==`/_page`&&(t=``),this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0}))}}},this.isActiveOption=e=>this.selectedRoute?!!e.route&&(this.selectedRoute==e.route||this.selectedRoute.startsWith(e.route+`/`)):!!e.selected,this.mapItems=(e,t)=>e.map(e=>{if(e.submenus&&e.submenus.length>0){let n=this.mapItems(e.submenus,t);return t&&e.label.toLowerCase().includes(t)&&(n=this.mapItems(e.submenus,``)),n&&n.length>0?{consumedRoute:e.consumedRoute,text:e.label,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:t||this.isActiveOption(e),children:n}:void 0}if(e.separator)return t?void 0:{component:`hr`};if(!t||e.label.toLowerCase().includes(t))return{consumedRoute:e.consumedRoute,text:e.label,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:t||this.isActiveOption(e)}}).filter(e=>e!=null),this.getSelectedIndex=e=>{if(!e)return NaN;let t=e=>{let t=(e??``).trim();return t.length>1&&t.endsWith(`/`)&&(t=t.slice(0,-1)),t},n=t(this.selectedRoute??window.location.pathname),r=NaN,i=-1;for(let a=0;a<e.length;a++){let o=t(e[a].route);o!==``&&(n===o||n.startsWith(o+`/`))&&o.length>i&&(i=o.length,r=a)}if(!Number.isNaN(r))return r;let a=this.getSelectedOption(e);return a?e.indexOf(a):NaN},this.renderOptionOnLeftMenu=e=>e.submenus&&e.submenus.length>0?w`
                 <details open class="left-menu-group">
                     <summary>${e.label}</summary>
                     <div class="left-menu-children">
@@ -5191,8 +5191,8 @@ ${i}
                                 </div>
                         `}
 
-                            `})}`:_,this.updateRoute=e=>{e.preventDefault(),e.stopPropagation();var t=e.detail;this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix)}}createRenderRoot(){return N.mustUseShadowRoot()?super.createRenderRoot():(Na.injectLightDomStyles(),this)}static{this.lightDomStylesInjected=!1}static injectLightDomStyles(){if(Na.lightDomStylesInjected||typeof document>`u`||(Na.lightDomStylesInjected=!0,document.getElementById(`mateu-app-light-styles`)))return;let e=Na.styles,t=Array.isArray(e)?e.map(e=>e?.cssText??``).join(`
-`):e?.cssText??``;if(!t)return;let n=document.createElement(`style`);n.id=`mateu-app-light-styles`,n.textContent=t,document.head.appendChild(n)}fetchGlobalSearch(e){let t=this.component?.metadata;if(t?.globalSearchEnabled){if(clearTimeout(this._globalSearchTimer),!e){this.commandPaletteDataHits=[];return}this._globalSearchTimer=setTimeout(async()=>{try{let n=(await Ge.runAction(this.baseUrl??``,t.rootRoute??``,``,`_globalsearch`,`cmd-palette`,void 0,t.serverSideType,{},{searchText:e},this,!0))?.fragments?.map(e=>e.data).find(e=>e&&e._globalsearch);this.commandPaletteDataHits=n?._globalsearch??[]}catch{this.commandPaletteDataHits=[]}},250)}}connectedCallback(){super.connectedCallback(),this.isDark=document.documentElement.getAttribute(`theme`)===`dark`,this._commandPaletteHandler=e=>{this.component?.metadata?.commandCenterEnabled||((e.metaKey||e.ctrlKey)&&e.key===`k`&&(e.preventDefault(),this.commandPaletteOpen=!this.commandPaletteOpen,this.commandPaletteQuery=``,this.commandPaletteSelectedIndex=0),e.key===`Escape`&&this.commandPaletteOpen&&(this.commandPaletteOpen=!1,this.commandPaletteQuery=``))},document.addEventListener(`keydown`,this._commandPaletteHandler),Ma.install(),this.addEventListener(`compact-changed`,this._compactHandler),this.addEventListener(`mateu-open-ai`,this._openAiHandler)}disconnectedCallback(){super.disconnectedCallback(),this._commandPaletteHandler&&document.removeEventListener(`keydown`,this._commandPaletteHandler),this.removeEventListener(`compact-changed`,this._compactHandler),this.removeEventListener(`mateu-open-ai`,this._openAiHandler)}updated(e){if(super.updated(e),Aa(this),this.component){let t=this.component.metadata;if(t){let n=t;if(n.favicon){let e=document.querySelector(`link[rel~='icon']`);e||(e=document.createElement(`link`),e.rel=`icon`,document.head.appendChild(e)),e.href=n.favicon}e.has(`component`)&&(this.selectedRoute=n.homeRoute,this.selectedConsumedRoute=n.homeConsumedRoute,this.selectedServerSideType=n.homeServerSideType,this.selectedBaseUrl=n.homeBaseUrl,this.selectedUriPrefix=n.homeUriPrefix)}}e.has(`commandPaletteOpen`)&&this.commandPaletteOpen&&setTimeout(()=>{this.renderRoot.querySelector(`.cmd-input`)?.focus()},0)}render(){return N.get()?.renderAppComponent(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData)}static{this.styles=m`
+                            `})}`:_,this.updateRoute=e=>{e.preventDefault(),e.stopPropagation();var t=e.detail;this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix)}}createRenderRoot(){return N.mustUseShadowRoot()?super.createRenderRoot():(Fa.injectLightDomStyles(),this)}static{this.lightDomStylesInjected=!1}static injectLightDomStyles(){if(Fa.lightDomStylesInjected||typeof document>`u`||(Fa.lightDomStylesInjected=!0,document.getElementById(`mateu-app-light-styles`)))return;let e=Fa.styles,t=Array.isArray(e)?e.map(e=>e?.cssText??``).join(`
+`):e?.cssText??``;if(!t)return;let n=document.createElement(`style`);n.id=`mateu-app-light-styles`,n.textContent=t,document.head.appendChild(n)}fetchGlobalSearch(e){let t=this.component?.metadata;if(t?.globalSearchEnabled){if(clearTimeout(this._globalSearchTimer),!e){this.commandPaletteDataHits=[];return}this._globalSearchTimer=setTimeout(async()=>{try{let n=(await Ge.runAction(this.baseUrl??``,t.rootRoute??``,``,`_globalsearch`,`cmd-palette`,void 0,t.serverSideType,{},{searchText:e},this,!0))?.fragments?.map(e=>e.data).find(e=>e&&e._globalsearch);this.commandPaletteDataHits=n?._globalsearch??[]}catch{this.commandPaletteDataHits=[]}},250)}}connectedCallback(){super.connectedCallback(),this.isDark=document.documentElement.getAttribute(`theme`)===`dark`,this._commandPaletteHandler=e=>{this.component?.metadata?.commandCenterEnabled||((e.metaKey||e.ctrlKey)&&e.key===`k`&&(e.preventDefault(),this.commandPaletteOpen=!this.commandPaletteOpen,this.commandPaletteQuery=``,this.commandPaletteSelectedIndex=0),e.key===`Escape`&&this.commandPaletteOpen&&(this.commandPaletteOpen=!1,this.commandPaletteQuery=``))},document.addEventListener(`keydown`,this._commandPaletteHandler),Pa.install(),this.addEventListener(`compact-changed`,this._compactHandler),this.addEventListener(`mateu-open-ai`,this._openAiHandler)}disconnectedCallback(){super.disconnectedCallback(),this._commandPaletteHandler&&document.removeEventListener(`keydown`,this._commandPaletteHandler),this.removeEventListener(`compact-changed`,this._compactHandler),this.removeEventListener(`mateu-open-ai`,this._openAiHandler)}updated(e){if(super.updated(e),Ma(this),this.component){let t=this.component.metadata;if(t){let n=t;if(n.favicon){let e=document.querySelector(`link[rel~='icon']`);e||(e=document.createElement(`link`),e.rel=`icon`,document.head.appendChild(e)),e.href=n.favicon}e.has(`component`)&&(this.selectedRoute=n.homeRoute,this.selectedConsumedRoute=n.homeConsumedRoute,this.selectedServerSideType=n.homeServerSideType,this.selectedBaseUrl=n.homeBaseUrl,this.selectedUriPrefix=n.homeUriPrefix)}}e.has(`commandPaletteOpen`)&&this.commandPaletteOpen&&setTimeout(()=>{this.renderRoot.querySelector(`.cmd-input`)?.focus()},0)}render(){return N.get()?.renderAppComponent(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData)}static{this.styles=m`
         /* DS-neutral app chrome (replaces vaadin-app-layout / menu-bar / tabs / side-nav). */
         .m-hl { display: flex; flex-direction: row; }
         .m-vl { display: flex; flex-direction: column; }
@@ -5542,14 +5542,14 @@ ${i}
             transform: scale(1.08);
         }
 
-  `}};O([S()],K.prototype,`filter`,void 0),O([S()],K.prototype,`instant`,void 0),O([S()],K.prototype,`selectedConsumedRoute`,void 0),O([S()],K.prototype,`selectedRoute`,void 0),O([S()],K.prototype,`selectedUriPrefix`,void 0),O([S()],K.prototype,`selectedBaseUrl`,void 0),O([S()],K.prototype,`selectedServerSideType`,void 0),O([S()],K.prototype,`selectedParams`,void 0),O([S()],K.prototype,`tilesMenuOption`,void 0),O([S()],K.prototype,`railOpenOption`,void 0),O([S()],K.prototype,`commandPaletteOpen`,void 0),O([S()],K.prototype,`commandPaletteQuery`,void 0),O([S()],K.prototype,`commandPaletteSelectedIndex`,void 0),O([S()],K.prototype,`commandPaletteDataHits`,void 0),O([S()],K.prototype,`pageCompact`,void 0),O([b(`mateu-chat`)],K.prototype,`chat`,void 0),O([S()],K.prototype,`isDark`,void 0),O([S()],K.prototype,`chatOpen`,void 0),O([b(`.mateu-app-layout`)],K.prototype,`vaadinAppLayout`,void 0),K=Na=O([h(`mateu-app`)],K);var q=class extends y{constructor(...e){super(...e),this.message=`This website uses cookies.`,this.dismiss=`Ok. Thanks :).`,this.learnMore=`Learn more`,this.learnMoreLink=`https://cookiesandyou.com/`,this.showLearnMore=!0,this.position=`top`,this.cookieName=`mateu-cookieconsent`}updated(e){super.updated(e)}connectedCallback(){super.connectedCallback(),this._css=document.createElement(`style`),this._css.innerText=`.cc-window{opacity:1;transition:opacity 1s ease}.cc-window.cc-invisible{opacity:0}.cc-animate.cc-revoke{transition:transform 1s ease}.cc-animate.cc-revoke.cc-top{transform:translateY(-2em)}.cc-animate.cc-revoke.cc-bottom{transform:translateY(2em)}.cc-animate.cc-revoke.cc-active.cc-bottom,.cc-animate.cc-revoke.cc-active.cc-top,.cc-revoke:hover{transform:translateY(0)}.cc-grower{max-height:0;overflow:hidden;transition:max-height 1s}.cc-link,.cc-revoke:hover{text-decoration:underline}.cc-revoke,.cc-window{position:fixed;overflow:hidden;box-sizing:border-box;font-family:Helvetica,Calibri,Arial,sans-serif;font-size:16px;line-height:1.5em;display:flex;flex-wrap:nowrap;z-index:9999}.cc-window.cc-static{position:static}.cc-window.cc-floating{padding:2em;max-width:24em;flex-direction:column}.cc-window.cc-banner{padding:1em 1.8em;width:100%;flex-direction:row}.cc-revoke{padding:.5em}.cc-header{font-size:18px;font-weight:700}.cc-btn,.cc-close,.cc-link,.cc-revoke{cursor:pointer}.cc-link{opacity:.8;display:inline-block;padding:.2em}.cc-link:hover{opacity:1}.cc-link:active,.cc-link:visited{color:initial}.cc-btn{display:block;padding:.4em .8em;font-size:.9em;font-weight:700;border-width:2px;border-style:solid;text-align:center;white-space:nowrap}.cc-banner .cc-btn:last-child{min-width:140px}.cc-highlight .cc-btn:first-child{background-color:transparent;border-color:transparent}.cc-highlight .cc-btn:first-child:focus,.cc-highlight .cc-btn:first-child:hover{background-color:transparent;text-decoration:underline}.cc-close{display:block;position:absolute;top:.5em;right:.5em;font-size:1.6em;opacity:.9;line-height:.75}.cc-close:focus,.cc-close:hover{opacity:1}.cc-revoke.cc-top{top:0;left:3em;border-bottom-left-radius:.5em;border-bottom-right-radius:.5em}.cc-revoke.cc-bottom{bottom:0;left:3em;border-top-left-radius:.5em;border-top-right-radius:.5em}.cc-revoke.cc-left{left:3em;right:unset}.cc-revoke.cc-right{right:3em;left:unset}.cc-top{top:1em}.cc-left{left:1em}.cc-right{right:1em}.cc-bottom{bottom:1em}.cc-floating>.cc-link{margin-bottom:1em}.cc-floating .cc-message{display:block;margin-bottom:1em}.cc-window.cc-floating .cc-compliance{flex:1 0 auto}.cc-window.cc-banner{align-items:center}.cc-banner.cc-top{left:0;right:0;top:0}.cc-banner.cc-bottom{left:0;right:0;bottom:0}.cc-banner .cc-message{flex:1}.cc-compliance{display:flex;align-items:center;align-content:space-between}.cc-compliance>.cc-btn{flex:1}.cc-btn+.cc-btn{margin-left:.5em}@media print{.cc-revoke,.cc-window{display:none}}@media screen and (max-width:900px){.cc-btn{white-space:normal}}@media screen and (max-width:414px) and (orientation:portrait),screen and (max-width:736px) and (orientation:landscape){.cc-window.cc-top{top:0}.cc-window.cc-bottom{bottom:0}.cc-window.cc-banner,.cc-window.cc-left,.cc-window.cc-right{left:0;right:0}.cc-window.cc-banner{flex-direction:column}.cc-window.cc-banner .cc-compliance{flex:1}.cc-window.cc-floating{max-width:none}.cc-window .cc-message{margin-bottom:1em}.cc-window.cc-banner{align-items:unset}}.cc-floating.cc-theme-classic{padding:1.2em;border-radius:5px}.cc-floating.cc-type-info.cc-theme-classic .cc-compliance{text-align:center;display:inline;flex:none}.cc-theme-classic .cc-btn{border-radius:5px}.cc-theme-classic .cc-btn:last-child{min-width:140px}.cc-floating.cc-type-info.cc-theme-classic .cc-btn{display:inline-block}.cc-theme-edgeless.cc-window{padding:0}.cc-floating.cc-theme-edgeless .cc-message{margin:2em 2em 1.5em}.cc-banner.cc-theme-edgeless .cc-btn{margin:0;padding:.8em 1.8em;height:100%}.cc-banner.cc-theme-edgeless .cc-message{margin-left:1em}.cc-floating.cc-theme-edgeless .cc-btn+.cc-btn{margin-left:0}`,document.head.appendChild(this._css),this.__updatePopup()}disconnectedCallback(){super.disconnectedCallback(),this.__closePopup(),this._css.isConnected&&this._css.remove()}__closePopup(){let e=this.popup;e&&e.parentNode?.removeChild(e)}_show(){let e=this.popup;e&&(e.classList.remove(`cc-invisible`),e.style.display=``)}__updatePopup(){this.__closePopup(),window.cookieconsent.initialise({palette:{popup:{background:`#000`},button:{background:`rgba(22, 118, 243, 0.95)`,hover:`rgba(22, 118, 243, 1)`}},showLink:this.showLearnMore,content:{message:this.message,dismiss:this.dismiss,link:this.learnMore,href:this.learnMoreLink},cookie:{name:this.cookieName},position:this.position,elements:{messagelink:`<span id="cookieconsent:desc" class="cc-message">${this.message} <a tabindex="0" class="cc-link" href="${this.learnMoreLink}" target="_blank" rel="noopener noreferrer nofollow">${this.learnMore}</a></span>`,dismiss:`<a tabindex="0" class="cc-btn cc-dismiss">${this.dismiss}</a>`}});let e=this.popup;if(e){e.setAttribute(`role`,`alert`);let t=e.querySelector(`a.cc-btn`);t?.addEventListener(`keydown`,e=>{let n=e.keyCode||e.which;(n===32||n===13)&&t.click()})}}render(){return w`
+  `}};O([S()],K.prototype,`filter`,void 0),O([S()],K.prototype,`instant`,void 0),O([S()],K.prototype,`selectedConsumedRoute`,void 0),O([S()],K.prototype,`selectedRoute`,void 0),O([S()],K.prototype,`selectedUriPrefix`,void 0),O([S()],K.prototype,`selectedBaseUrl`,void 0),O([S()],K.prototype,`selectedServerSideType`,void 0),O([S()],K.prototype,`selectedParams`,void 0),O([S()],K.prototype,`tilesMenuOption`,void 0),O([S()],K.prototype,`railOpenOption`,void 0),O([S()],K.prototype,`commandPaletteOpen`,void 0),O([S()],K.prototype,`commandPaletteQuery`,void 0),O([S()],K.prototype,`commandPaletteSelectedIndex`,void 0),O([S()],K.prototype,`commandPaletteDataHits`,void 0),O([S()],K.prototype,`pageCompact`,void 0),O([b(`mateu-chat`)],K.prototype,`chat`,void 0),O([S()],K.prototype,`isDark`,void 0),O([S()],K.prototype,`chatOpen`,void 0),O([b(`.mateu-app-layout`)],K.prototype,`vaadinAppLayout`,void 0),K=Fa=O([h(`mateu-app`)],K);var Ia=class extends y{constructor(...e){super(...e),this.message=`This website uses cookies.`,this.dismiss=`Ok. Thanks :).`,this.learnMore=`Learn more`,this.learnMoreLink=`https://cookiesandyou.com/`,this.showLearnMore=!0,this.position=`top`,this.cookieName=`mateu-cookieconsent`}updated(e){super.updated(e)}connectedCallback(){super.connectedCallback(),this._css=document.createElement(`style`),this._css.innerText=`.cc-window{opacity:1;transition:opacity 1s ease}.cc-window.cc-invisible{opacity:0}.cc-animate.cc-revoke{transition:transform 1s ease}.cc-animate.cc-revoke.cc-top{transform:translateY(-2em)}.cc-animate.cc-revoke.cc-bottom{transform:translateY(2em)}.cc-animate.cc-revoke.cc-active.cc-bottom,.cc-animate.cc-revoke.cc-active.cc-top,.cc-revoke:hover{transform:translateY(0)}.cc-grower{max-height:0;overflow:hidden;transition:max-height 1s}.cc-link,.cc-revoke:hover{text-decoration:underline}.cc-revoke,.cc-window{position:fixed;overflow:hidden;box-sizing:border-box;font-family:Helvetica,Calibri,Arial,sans-serif;font-size:16px;line-height:1.5em;display:flex;flex-wrap:nowrap;z-index:9999}.cc-window.cc-static{position:static}.cc-window.cc-floating{padding:2em;max-width:24em;flex-direction:column}.cc-window.cc-banner{padding:1em 1.8em;width:100%;flex-direction:row}.cc-revoke{padding:.5em}.cc-header{font-size:18px;font-weight:700}.cc-btn,.cc-close,.cc-link,.cc-revoke{cursor:pointer}.cc-link{opacity:.8;display:inline-block;padding:.2em}.cc-link:hover{opacity:1}.cc-link:active,.cc-link:visited{color:initial}.cc-btn{display:block;padding:.4em .8em;font-size:.9em;font-weight:700;border-width:2px;border-style:solid;text-align:center;white-space:nowrap}.cc-banner .cc-btn:last-child{min-width:140px}.cc-highlight .cc-btn:first-child{background-color:transparent;border-color:transparent}.cc-highlight .cc-btn:first-child:focus,.cc-highlight .cc-btn:first-child:hover{background-color:transparent;text-decoration:underline}.cc-close{display:block;position:absolute;top:.5em;right:.5em;font-size:1.6em;opacity:.9;line-height:.75}.cc-close:focus,.cc-close:hover{opacity:1}.cc-revoke.cc-top{top:0;left:3em;border-bottom-left-radius:.5em;border-bottom-right-radius:.5em}.cc-revoke.cc-bottom{bottom:0;left:3em;border-top-left-radius:.5em;border-top-right-radius:.5em}.cc-revoke.cc-left{left:3em;right:unset}.cc-revoke.cc-right{right:3em;left:unset}.cc-top{top:1em}.cc-left{left:1em}.cc-right{right:1em}.cc-bottom{bottom:1em}.cc-floating>.cc-link{margin-bottom:1em}.cc-floating .cc-message{display:block;margin-bottom:1em}.cc-window.cc-floating .cc-compliance{flex:1 0 auto}.cc-window.cc-banner{align-items:center}.cc-banner.cc-top{left:0;right:0;top:0}.cc-banner.cc-bottom{left:0;right:0;bottom:0}.cc-banner .cc-message{flex:1}.cc-compliance{display:flex;align-items:center;align-content:space-between}.cc-compliance>.cc-btn{flex:1}.cc-btn+.cc-btn{margin-left:.5em}@media print{.cc-revoke,.cc-window{display:none}}@media screen and (max-width:900px){.cc-btn{white-space:normal}}@media screen and (max-width:414px) and (orientation:portrait),screen and (max-width:736px) and (orientation:landscape){.cc-window.cc-top{top:0}.cc-window.cc-bottom{bottom:0}.cc-window.cc-banner,.cc-window.cc-left,.cc-window.cc-right{left:0;right:0}.cc-window.cc-banner{flex-direction:column}.cc-window.cc-banner .cc-compliance{flex:1}.cc-window.cc-floating{max-width:none}.cc-window .cc-message{margin-bottom:1em}.cc-window.cc-banner{align-items:unset}}.cc-floating.cc-theme-classic{padding:1.2em;border-radius:5px}.cc-floating.cc-type-info.cc-theme-classic .cc-compliance{text-align:center;display:inline;flex:none}.cc-theme-classic .cc-btn{border-radius:5px}.cc-theme-classic .cc-btn:last-child{min-width:140px}.cc-floating.cc-type-info.cc-theme-classic .cc-btn{display:inline-block}.cc-theme-edgeless.cc-window{padding:0}.cc-floating.cc-theme-edgeless .cc-message{margin:2em 2em 1.5em}.cc-banner.cc-theme-edgeless .cc-btn{margin:0;padding:.8em 1.8em;height:100%}.cc-banner.cc-theme-edgeless .cc-message{margin-left:1em}.cc-floating.cc-theme-edgeless .cc-btn+.cc-btn{margin-left:0}`,document.head.appendChild(this._css),this.__updatePopup()}disconnectedCallback(){super.disconnectedCallback(),this.__closePopup(),this._css.isConnected&&this._css.remove()}__closePopup(){let e=this.popup;e&&e.parentNode?.removeChild(e)}_show(){let e=this.popup;e&&(e.classList.remove(`cc-invisible`),e.style.display=``)}__updatePopup(){this.__closePopup(),window.cookieconsent.initialise({palette:{popup:{background:`#000`},button:{background:`rgba(22, 118, 243, 0.95)`,hover:`rgba(22, 118, 243, 1)`}},showLink:this.showLearnMore,content:{message:this.message,dismiss:this.dismiss,link:this.learnMore,href:this.learnMoreLink},cookie:{name:this.cookieName},position:this.position,elements:{messagelink:`<span id="cookieconsent:desc" class="cc-message">${this.message} <a tabindex="0" class="cc-link" href="${this.learnMoreLink}" target="_blank" rel="noopener noreferrer nofollow">${this.learnMore}</a></span>`,dismiss:`<a tabindex="0" class="cc-btn cc-dismiss">${this.dismiss}</a>`}});let e=this.popup;if(e){e.setAttribute(`role`,`alert`);let t=e.querySelector(`a.cc-btn`);t?.addEventListener(`keydown`,e=>{let n=e.keyCode||e.which;(n===32||n===13)&&t.click()})}}render(){return w`
        `}static{this.styles=m`
-  `}};O([v()],q.prototype,`message`,void 0),O([v()],q.prototype,`dismiss`,void 0),O([v()],q.prototype,`learnMore`,void 0),O([v()],q.prototype,`learnMoreLink`,void 0),O([v()],q.prototype,`showLearnMore`,void 0),O([v()],q.prototype,`position`,void 0),O([v()],q.prototype,`cookieName`,void 0),O([S()],q.prototype,`_css`,void 0),O([b(`[aria-label="cookieconsent"]`)],q.prototype,`popup`,void 0),q=O([h(`mateu-cookie-consent`)],q);var Pa=class extends y{constructor(...e){super(...e),this.redispatchEvent=e=>{e instanceof CustomEvent&&(e.stopPropagation(),e.preventDefault(),this.target?.dispatchEvent(new CustomEvent(e.type,{detail:e.detail,bubbles:!0,composed:!0})))}}connectedCallback(){super.connectedCallback(),this.addEventListener(`value-changed`,this.redispatchEvent),this.addEventListener(`data-changed`,this.redispatchEvent),this.addEventListener(`action-requested`,this.redispatchEvent),this.addEventListener(`server-side-action-requested`,this.redispatchEvent),this.addEventListener(`route-changed`,this.redispatchEvent),this.addEventListener(`close-modal-requested`,this.redispatchEvent)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`value-changed`,this.redispatchEvent),this.removeEventListener(`data-changed`,this.redispatchEvent),this.removeEventListener(`action-requested`,this.redispatchEvent),this.removeEventListener(`server-side-action-requested`,this.redispatchEvent),this.removeEventListener(`route-changed`,this.redispatchEvent)}render(){return w`<slot></slot>`}static{this.styles=m`
+  `}};O([v()],Ia.prototype,`message`,void 0),O([v()],Ia.prototype,`dismiss`,void 0),O([v()],Ia.prototype,`learnMore`,void 0),O([v()],Ia.prototype,`learnMoreLink`,void 0),O([v()],Ia.prototype,`showLearnMore`,void 0),O([v()],Ia.prototype,`position`,void 0),O([v()],Ia.prototype,`cookieName`,void 0),O([S()],Ia.prototype,`_css`,void 0),O([b(`[aria-label="cookieconsent"]`)],Ia.prototype,`popup`,void 0),Ia=O([h(`mateu-cookie-consent`)],Ia);var La=class extends y{constructor(...e){super(...e),this.redispatchEvent=e=>{e instanceof CustomEvent&&(e.stopPropagation(),e.preventDefault(),this.target?.dispatchEvent(new CustomEvent(e.type,{detail:e.detail,bubbles:!0,composed:!0})))}}connectedCallback(){super.connectedCallback(),this.addEventListener(`value-changed`,this.redispatchEvent),this.addEventListener(`data-changed`,this.redispatchEvent),this.addEventListener(`action-requested`,this.redispatchEvent),this.addEventListener(`server-side-action-requested`,this.redispatchEvent),this.addEventListener(`route-changed`,this.redispatchEvent),this.addEventListener(`close-modal-requested`,this.redispatchEvent)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`value-changed`,this.redispatchEvent),this.removeEventListener(`data-changed`,this.redispatchEvent),this.removeEventListener(`action-requested`,this.redispatchEvent),this.removeEventListener(`server-side-action-requested`,this.redispatchEvent),this.removeEventListener(`route-changed`,this.redispatchEvent)}render(){return w`<slot></slot>`}static{this.styles=m`
         :host {
             /* width: 100%; */
             display: inline-block;
         }
-  `}};O([v()],Pa.prototype,`target`,void 0),Pa=O([h(`mateu-event-interceptor`)],Pa);var Fa=[`a[href]`,`button`,`input`,`select`,`textarea`,`[tabindex]`,`vaadin-button`,`vaadin-text-field`,`vaadin-combo-box`,`vaadin-select`,`vaadin-checkbox`,`vaadin-date-picker`,`ui5-button`,`oj-c-button`].join(`,`),Ia=e=>{let t=e;return t.hidden||t.hasAttribute(`disabled`)||t.getAttribute(`aria-hidden`)===`true`||t.getAttribute(`tabindex`)===`-1`?!1:!!(t.offsetParent||t.getClientRects().length)},La=e=>{let t=[],n=e=>{e.querySelectorAll(`*`).forEach(e=>{e.matches(Fa)&&Ia(e)&&t.push(e),e.shadowRoot&&n(e.shadowRoot),e instanceof HTMLSlotElement&&e.assignedElements().forEach(e=>{e.matches(Fa)&&Ia(e)&&t.push(e),n(e)})})};return n(e),t.filter((e,n)=>t.indexOf(e)===n)},Ra=(e,t={})=>{let n=za(),r=[],i=()=>{r=La(e)},a=t=>{if(t.key!==`Tab`)return;if(i(),r.length===0){t.preventDefault(),e.focus();return}let n=r[0],a=r[r.length-1],o=za();t.shiftKey&&(o===n||!o||!Ba(o,e))?(t.preventDefault(),a.focus()):!t.shiftKey&&o===a&&(t.preventDefault(),n.focus())};return e.addEventListener(`keydown`,a),requestAnimationFrame(()=>{i();let n=t.initialFocus?.()??r[0];n?n.focus():(e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus())}),{refresh:i,release(){e.removeEventListener(`keydown`,a);let t=za();(!t||t===document.body||Ba(t,e))&&n?.focus?.()}}},za=()=>{let e=document.activeElement;for(;e?.shadowRoot?.activeElement;)e=e.shadowRoot.activeElement;return e},Ba=(e,t)=>{let n=e;for(;n;){if(n===t)return!0;n=n.parentNode??n.host??null}return!1},Va=class extends Sa{constructor(...e){super(...e),this.opened=!0,this.close=()=>{this.opened=!1,this.releaseFocusTrap(),setTimeout(()=>{this.removeSelfFromOwnerChildren()||this.parentElement?.removeChild(this)},500)},this.onKeydown=e=>{e.key===`Escape`&&this.opened&&(e.stopPropagation(),this.close())}}connectedCallback(){super.connectedCallback(),this.addEventListener(`keydown`,this.onKeydown)}disconnectedCallback(){super.disconnectedCallback(),this.releaseFocusTrap()}releaseFocusTrap(){this.focusTrap?.release(),this.focusTrap=void 0}applyFragment(e){super.applyFragment(e);let t=e.state?._closeAfterMillis;t&&setTimeout(()=>this.close(),t)}updated(e){if(super.updated(e),e.has(`component`)&&this.component){let e=this.component.metadata;this.state=e.initialData}let t=this.renderRoot.querySelector(`[role="dialog"]`),n=this.component?.metadata?.modeless;this.opened&&t&&!this.focusTrap&&!n?this.focusTrap=Ra(t):this.focusTrap&&this.opened&&this.focusTrap.refresh()}render(){if(!this.opened)return w``;let e=this.component.metadata,t=it(e.headerTitle,this.state,this.data,this.appState,this.appData),n=!!(t||e.header||e.closeButtonOnHeader),r=[e.width?`width:${e.width};`:`min-width:min(90vw,28rem);`,e.height?`height:${e.height};`:``,e.top?`margin-top:${e.top};`:``].join(``);return w`
+  `}};O([v()],La.prototype,`target`,void 0),La=O([h(`mateu-event-interceptor`)],La);var Ra=[`a[href]`,`button`,`input`,`select`,`textarea`,`[tabindex]`,`vaadin-button`,`vaadin-text-field`,`vaadin-combo-box`,`vaadin-select`,`vaadin-checkbox`,`vaadin-date-picker`,`ui5-button`,`oj-c-button`].join(`,`),za=e=>{let t=e;return t.hidden||t.hasAttribute(`disabled`)||t.getAttribute(`aria-hidden`)===`true`||t.getAttribute(`tabindex`)===`-1`?!1:!!(t.offsetParent||t.getClientRects().length)},Ba=e=>{let t=[],n=e=>{e.querySelectorAll(`*`).forEach(e=>{e.matches(Ra)&&za(e)&&t.push(e),e.shadowRoot&&n(e.shadowRoot),e instanceof HTMLSlotElement&&e.assignedElements().forEach(e=>{e.matches(Ra)&&za(e)&&t.push(e),n(e)})})};return n(e),t.filter((e,n)=>t.indexOf(e)===n)},Va=(e,t={})=>{let n=Ha(),r=[],i=()=>{r=Ba(e)},a=t=>{if(t.key!==`Tab`)return;if(i(),r.length===0){t.preventDefault(),e.focus();return}let n=r[0],a=r[r.length-1],o=Ha();t.shiftKey&&(o===n||!o||!Ua(o,e))?(t.preventDefault(),a.focus()):!t.shiftKey&&o===a&&(t.preventDefault(),n.focus())};return e.addEventListener(`keydown`,a),requestAnimationFrame(()=>{i();let n=t.initialFocus?.()??r[0];n?n.focus():(e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus())}),{refresh:i,release(){e.removeEventListener(`keydown`,a);let t=Ha();(!t||t===document.body||Ua(t,e))&&n?.focus?.()}}},Ha=()=>{let e=document.activeElement;for(;e?.shadowRoot?.activeElement;)e=e.shadowRoot.activeElement;return e},Ua=(e,t)=>{let n=e;for(;n;){if(n===t)return!0;n=n.parentNode??n.host??null}return!1},Wa=class extends wa{constructor(...e){super(...e),this.opened=!0,this.close=()=>{this.opened=!1,this.releaseFocusTrap(),setTimeout(()=>{this.removeSelfFromOwnerChildren()||this.parentElement?.removeChild(this)},500)},this.onKeydown=e=>{e.key===`Escape`&&this.opened&&(e.stopPropagation(),this.close())}}connectedCallback(){super.connectedCallback(),this.addEventListener(`keydown`,this.onKeydown)}disconnectedCallback(){super.disconnectedCallback(),this.releaseFocusTrap()}releaseFocusTrap(){this.focusTrap?.release(),this.focusTrap=void 0}applyFragment(e){super.applyFragment(e);let t=e.state?._closeAfterMillis;t&&setTimeout(()=>this.close(),t)}updated(e){if(super.updated(e),e.has(`component`)&&this.component){let e=this.component.metadata;this.state=e.initialData}let t=this.renderRoot.querySelector(`[role="dialog"]`),n=this.component?.metadata?.modeless;this.opened&&t&&!this.focusTrap&&!n?this.focusTrap=Va(t):this.focusTrap&&this.opened&&this.focusTrap.refresh()}render(){if(!this.opened)return w``;let e=this.component.metadata,t=it(e.headerTitle,this.state,this.data,this.appState,this.appData),n=!!(t||e.header||e.closeButtonOnHeader),r=[e.width?`width:${e.width};`:`min-width:min(90vw,28rem);`,e.height?`height:${e.height};`:``,e.top?`margin-top:${e.top};`:``].join(``);return w`
             <div class="backdrop ${e.modeless?`modeless`:``}"
                  @click="${t=>{!e.modeless&&t.target===t.currentTarget&&this.close()}}">
                 <div class="dialog ${e.noPadding?`no-padding`:``} ${this.component?.cssClasses??``}"
@@ -5604,7 +5604,7 @@ ${i}
         .dialog-body { padding: .5rem 1.2rem; flex: 1; }
         .dialog.no-padding .dialog-body { padding: 0; }
         .dialog-footer { padding: .5rem 1.2rem 1rem; display: flex; justify-content: flex-end; gap: .5rem; }
-    `}};O([S()],Va.prototype,`opened`,void 0),Va=O([h(`mateu-dialog`)],Va);var Ha,Ua=class extends Sa{static{Ha=this}constructor(...e){super(...e),this.opened=!1,this.maximizeSteps=0,this.collapsed=!1,this.pagerMenuOpen=!1,this.onGuidedProgress=e=>{let t=e.detail;t&&t.total>0&&(this.guidedProgress=t)},this.close=()=>{this.opened=!1,this.releaseLayoutInset(),this.releaseFocusTrap(),setTimeout(()=>{this.removeSelfFromOwnerChildren()||this.parentElement?.removeChild(this)},300)},this._escListener=e=>{if(e.key!==`Escape`)return;let t=this.getRootNode().querySelectorAll(`mateu-drawer, mateu-dialog`);t[t.length-1]===this&&(e.stopPropagation(),this.close())}}jumpToStep(e){this.pagerMenuOpen=!1,e&&(this.renderRoot.querySelector(`.content mateu-component`)??this.renderRoot.querySelector(`mateu-component`))?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`goToStep`,parameters:{_stepId:e}},bubbles:!0,composed:!0}))}static{this.SIZE_LADDER=[`s`,`m`,`l`,`xl`]}static{this.SIZE_WIDTHS={s:`464px`,m:`648px`,l:`968px`,xl:`90vw`}}effectiveWidth(e){if(e.width)return e.width;if(!e.size)return;let t=Ha.SIZE_LADDER,n=Math.max(0,t.indexOf(e.size)),r=Math.min(t.length-1,n+this.maximizeSteps);return Ha.SIZE_WIDTHS[t[r]]}canMaximize(e){if(!e.maximizable)return!1;let t=Ha.SIZE_LADDER;return Math.max(0,t.indexOf(e.size??`m`))+this.maximizeSteps<t.length-1}firstUpdated(){requestAnimationFrame(()=>this.opened=!0),this.addEventListener(`mateu-guided-progress`,this.onGuidedProgress);let e=this.component?.metadata;e&&requestAnimationFrame(()=>this.applyLayoutInset(e))}releaseFocusTrap(){this.focusTrap?.release(),this.focusTrap=void 0}applyLayoutInset(e){if(!e.layout)return;let t=document.querySelector(`mateu-ui`);if(!t)return;let n=e.position??`end`,r=n===`bottom`?`var(--mateu-drawer-height, 50vh)`:this.effectiveWidth(e)??`648px`;this._insetProp=n===`start`?`paddingLeft`:n===`bottom`?`paddingBottom`:`paddingRight`,t.style.transition=`padding .25s ease`,t.style[this._insetProp]=r}releaseLayoutInset(){if(!this._insetProp)return;let e=document.querySelector(`mateu-ui`);e&&(e.style[this._insetProp]=``),this._insetProp=void 0}applyFragment(e){super.applyFragment(e);let t=e.state?._closeAfterMillis;t&&setTimeout(()=>this.close(),t)}updated(e){if(super.updated(e),e.has(`component`)&&this.component){let e=this.component.metadata;this.state=e.initialData}let t=this.component?.metadata,n=this.renderRoot.querySelector(`[role="dialog"]`);this.opened&&n&&!t?.modeless&&!t?.layout&&!this.focusTrap?this.focusTrap=Ra(n):this.focusTrap&&this.opened&&this.focusTrap.refresh()}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._escListener)}disconnectedCallback(){document.removeEventListener(`keydown`,this._escListener),this.releaseLayoutInset(),this.releaseFocusTrap(),super.disconnectedCallback()}render(){let e=this.component.metadata,t=e.position??`end`,n=it(e.headerTitle,this.state,this.data,this.appState,this.appData),r=it(e.subtitle,this.state,this.data,this.appState,this.appData),i=this.effectiveWidth(e),a=e.peerNav&&(e.peerNav.prevRoute||e.peerNav.nextRoute)?e.peerNav:void 0;return w`
+    `}};O([S()],Wa.prototype,`opened`,void 0),Wa=O([h(`mateu-dialog`)],Wa);var Ga,Ka=class extends wa{static{Ga=this}constructor(...e){super(...e),this.opened=!1,this.maximizeSteps=0,this.collapsed=!1,this.pagerMenuOpen=!1,this.onGuidedProgress=e=>{let t=e.detail;t&&t.total>0&&(this.guidedProgress=t)},this.close=()=>{this.opened=!1,this.releaseLayoutInset(),this.releaseFocusTrap(),setTimeout(()=>{this.removeSelfFromOwnerChildren()||this.parentElement?.removeChild(this)},300)},this._escListener=e=>{if(e.key!==`Escape`)return;let t=this.getRootNode().querySelectorAll(`mateu-drawer, mateu-dialog`);t[t.length-1]===this&&(e.stopPropagation(),this.close())}}jumpToStep(e){this.pagerMenuOpen=!1,e&&(this.renderRoot.querySelector(`.content mateu-component`)??this.renderRoot.querySelector(`mateu-component`))?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`goToStep`,parameters:{_stepId:e}},bubbles:!0,composed:!0}))}static{this.SIZE_LADDER=[`s`,`m`,`l`,`xl`]}static{this.SIZE_WIDTHS={s:`464px`,m:`648px`,l:`968px`,xl:`90vw`}}effectiveWidth(e){if(e.width)return e.width;if(!e.size)return;let t=Ga.SIZE_LADDER,n=Math.max(0,t.indexOf(e.size)),r=Math.min(t.length-1,n+this.maximizeSteps);return Ga.SIZE_WIDTHS[t[r]]}canMaximize(e){if(!e.maximizable)return!1;let t=Ga.SIZE_LADDER;return Math.max(0,t.indexOf(e.size??`m`))+this.maximizeSteps<t.length-1}firstUpdated(){requestAnimationFrame(()=>this.opened=!0),this.addEventListener(`mateu-guided-progress`,this.onGuidedProgress);let e=this.component?.metadata;e&&requestAnimationFrame(()=>this.applyLayoutInset(e))}releaseFocusTrap(){this.focusTrap?.release(),this.focusTrap=void 0}applyLayoutInset(e){if(!e.layout)return;let t=document.querySelector(`mateu-ui`);if(!t)return;let n=e.position??`end`,r=n===`bottom`?`var(--mateu-drawer-height, 50vh)`:this.effectiveWidth(e)??`648px`;this._insetProp=n===`start`?`paddingLeft`:n===`bottom`?`paddingBottom`:`paddingRight`,t.style.transition=`padding .25s ease`,t.style[this._insetProp]=r}releaseLayoutInset(){if(!this._insetProp)return;let e=document.querySelector(`mateu-ui`);e&&(e.style[this._insetProp]=``),this._insetProp=void 0}applyFragment(e){super.applyFragment(e);let t=e.state?._closeAfterMillis;t&&setTimeout(()=>this.close(),t)}updated(e){if(super.updated(e),e.has(`component`)&&this.component){let e=this.component.metadata;this.state=e.initialData}let t=this.component?.metadata,n=this.renderRoot.querySelector(`[role="dialog"]`);this.opened&&n&&!t?.modeless&&!t?.layout&&!this.focusTrap?this.focusTrap=Va(n):this.focusTrap&&this.opened&&this.focusTrap.refresh()}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._escListener)}disconnectedCallback(){document.removeEventListener(`keydown`,this._escListener),this.releaseLayoutInset(),this.releaseFocusTrap(),super.disconnectedCallback()}render(){let e=this.component.metadata,t=e.position??`end`,n=it(e.headerTitle,this.state,this.data,this.appState,this.appData),r=it(e.subtitle,this.state,this.data,this.appState,this.appData),i=this.effectiveWidth(e),a=e.peerNav&&(e.peerNav.prevRoute||e.peerNav.nextRoute)?e.peerNav:void 0;return w`
         ${e.modeless||e.layout?_:w`
             <div class="backdrop ${this.opened?`open`:``}" @click="${this.close}"></div>
         `}
@@ -5882,7 +5882,7 @@ ${i}
             display: flex;
             justify-content: flex-end;
         }
-  `}};O([S()],Ua.prototype,`opened`,void 0),O([S()],Ua.prototype,`maximizeSteps`,void 0),O([S()],Ua.prototype,`collapsed`,void 0),O([S()],Ua.prototype,`guidedProgress`,void 0),O([S()],Ua.prototype,`pagerMenuOpen`,void 0),Ua=Ha=O([h(`mateu-drawer`)],Ua);function Wa(e){if(e.parentElement)return e.parentElement;let t=e.getRootNode();return t instanceof ShadowRoot?t.host:null}var J=class extends y{constructor(...e){super(...e),this.appState={},this.appData={},this.standalone=!1,this.actionBanners=[],this.dismissedStaticBannerIndices=new Set,this._tocEntries=[],this._activeToc=0,this._tocVisible=!1,this._tocRebuildScheduled=!1,this._headerH=0,this._onResize=()=>this._layoutStickyTops(),this._tocLocked=!1,this._unlockToc=e=>{if(e&&e.type===`keydown`){let t=e;if(t.ctrlKey&&t.altKey&&!t.shiftKey&&!t.metaKey&&/^(?:Digit|Numpad)[1-9]$/.test(t.code))return}this._tocLocked=!1},this._actionBannerTimers=[],this._staticBannerTimers=[],this._bannersHandler=e=>{let t=e.detail,n=t.banners??[],r=t.append??!1;r?this.actionBanners=[...this.actionBanners,...n]:(this._clearActionBannerTimers(),this.actionBanners=n);let i=r?this.actionBanners.length-n.length:0;n.forEach((e,t)=>{if(e.timeoutSeconds&&e.timeoutSeconds>0){let n=i+t;this._actionBannerTimers.push(setTimeout(()=>{this.actionBanners=this.actionBanners.filter((e,t)=>t!==n)},e.timeoutSeconds*1e3))}})},this._onTocKey=e=>{if(!this._tocVisible||!e.ctrlKey||!e.altKey||e.shiftKey||e.metaKey)return;let t=/^(?:Digit|Numpad)([1-9])$/.exec(e.code);if(!t)return;let n=parseInt(t[1],10)-1;n>=this._tocEntries.length||(e.preventDefault(),this._scrollToSection(n))},this._onScrollSpy=()=>{if(this._tocLocked)return;let e=this._sectionCards();if(!e.length)return;let t=this.shadowRoot?.querySelector(`mateu-content-header`),n=t?t.getBoundingClientRect().bottom:0;for(let t of e){if(!t.classList.contains(`mateu-section--sticky`))continue;let e=t.getBoundingClientRect();e.top<=n+12+2&&(n=Math.max(n,e.bottom))}let r=n+12+4,i=0;this._tocEntries.forEach((e,t)=>{e.el.getBoundingClientRect().top<=r&&(i=t)}),this._activeToc=i}}connectedCallback(){super.connectedCallback(),document.addEventListener(`page-banners-received`,this._bannersHandler),window.addEventListener(`resize`,this._onResize),document.addEventListener(`keydown`,this._onTocKey)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`page-banners-received`,this._bannersHandler),window.removeEventListener(`resize`,this._onResize),document.removeEventListener(`keydown`,this._onTocKey),this._clearAllTimers(),this._teardownScrollSpy()}updated(e){if(super.updated(e),e.has(`component`)&&e.get(`component`)!==void 0&&(this._clearAllTimers(),this.actionBanners=[],this.dismissedStaticBannerIndices=new Set),e.has(`component`)){let e=this.component?.metadata?.level??0;this.toggleAttribute(`data-nested`,e>0),this._scheduleStaticBannerTimeouts();let t=this.component?.metadata?.pageWidth===`edgeToEdge`;this.toggleAttribute(`data-edge`,t),this.dispatchEvent(new CustomEvent(`compact-changed`,{detail:{compact:!!this.component?.style?.includes(`--mateu-compact:1`)||t},bubbles:!0,composed:!0})),this._scheduleTocRebuild()}}_scheduleStaticBannerTimeouts(){this._staticBannerTimers.forEach(e=>clearTimeout(e)),this._staticBannerTimers=[],(this.component?.metadata?.banners??[]).forEach((e,t)=>{e.timeoutSeconds&&e.timeoutSeconds>0&&this._staticBannerTimers.push(setTimeout(()=>{this.dismissedStaticBannerIndices=new Set([...this.dismissedStaticBannerIndices,t])},e.timeoutSeconds*1e3))})}_clearActionBannerTimers(){this._actionBannerTimers.forEach(e=>clearTimeout(e)),this._actionBannerTimers=[]}_clearAllTimers(){this._clearActionBannerTimers(),this._staticBannerTimers.forEach(e=>clearTimeout(e)),this._staticBannerTimers=[]}_dismissActionBanner(e){this.actionBanners=this.actionBanners.filter((t,n)=>n!==e)}_dismissStaticBanner(e){this.dismissedStaticBannerIndices=new Set([...this.dismissedStaticBannerIndices,e])}bannerThemeClass(e){let t=e.theme?.toLowerCase()??`info`;return t===`none`?``:t}_evalBannerText(e){return j(e,this.state,this.data)}_renderBanner(e,t){let n=this._evalBannerText(e.title),r=this._evalBannerText(e.description);return w`
+  `}};O([S()],Ka.prototype,`opened`,void 0),O([S()],Ka.prototype,`maximizeSteps`,void 0),O([S()],Ka.prototype,`collapsed`,void 0),O([S()],Ka.prototype,`guidedProgress`,void 0),O([S()],Ka.prototype,`pagerMenuOpen`,void 0),Ka=Ga=O([h(`mateu-drawer`)],Ka);function qa(e){if(e.parentElement)return e.parentElement;let t=e.getRootNode();return t instanceof ShadowRoot?t.host:null}var q=class extends y{constructor(...e){super(...e),this.appState={},this.appData={},this.standalone=!1,this.actionBanners=[],this.dismissedStaticBannerIndices=new Set,this._tocEntries=[],this._activeToc=0,this._tocVisible=!1,this._tocRebuildScheduled=!1,this._headerH=0,this._onResize=()=>this._layoutStickyTops(),this._tocLocked=!1,this._unlockToc=e=>{if(e&&e.type===`keydown`){let t=e;if(t.ctrlKey&&t.altKey&&!t.shiftKey&&!t.metaKey&&/^(?:Digit|Numpad)[1-9]$/.test(t.code))return}this._tocLocked=!1},this._actionBannerTimers=[],this._staticBannerTimers=[],this._bannersHandler=e=>{let t=e.detail,n=t.banners??[],r=t.append??!1;r?this.actionBanners=[...this.actionBanners,...n]:(this._clearActionBannerTimers(),this.actionBanners=n);let i=r?this.actionBanners.length-n.length:0;n.forEach((e,t)=>{if(e.timeoutSeconds&&e.timeoutSeconds>0){let n=i+t;this._actionBannerTimers.push(setTimeout(()=>{this.actionBanners=this.actionBanners.filter((e,t)=>t!==n)},e.timeoutSeconds*1e3))}})},this._onTocKey=e=>{if(!this._tocVisible||!e.ctrlKey||!e.altKey||e.shiftKey||e.metaKey)return;let t=/^(?:Digit|Numpad)([1-9])$/.exec(e.code);if(!t)return;let n=parseInt(t[1],10)-1;n>=this._tocEntries.length||(e.preventDefault(),this._scrollToSection(n))},this._onScrollSpy=()=>{if(this._tocLocked)return;let e=this._sectionCards();if(!e.length)return;let t=this.shadowRoot?.querySelector(`mateu-content-header`),n=t?t.getBoundingClientRect().bottom:0;for(let t of e){if(!t.classList.contains(`mateu-section--sticky`))continue;let e=t.getBoundingClientRect();e.top<=n+12+2&&(n=Math.max(n,e.bottom))}let r=n+12+4,i=0;this._tocEntries.forEach((e,t)=>{e.el.getBoundingClientRect().top<=r&&(i=t)}),this._activeToc=i}}connectedCallback(){super.connectedCallback(),document.addEventListener(`page-banners-received`,this._bannersHandler),window.addEventListener(`resize`,this._onResize),document.addEventListener(`keydown`,this._onTocKey)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`page-banners-received`,this._bannersHandler),window.removeEventListener(`resize`,this._onResize),document.removeEventListener(`keydown`,this._onTocKey),this._clearAllTimers(),this._teardownScrollSpy()}updated(e){if(super.updated(e),e.has(`component`)&&e.get(`component`)!==void 0&&(this._clearAllTimers(),this.actionBanners=[],this.dismissedStaticBannerIndices=new Set),e.has(`component`)){let e=this.component?.metadata?.level??0;this.toggleAttribute(`data-nested`,e>0),this._scheduleStaticBannerTimeouts();let t=this.component?.metadata?.pageWidth===`edgeToEdge`;this.toggleAttribute(`data-edge`,t),this.dispatchEvent(new CustomEvent(`compact-changed`,{detail:{compact:!!this.component?.style?.includes(`--mateu-compact:1`)||t},bubbles:!0,composed:!0})),this._scheduleTocRebuild()}}_scheduleStaticBannerTimeouts(){this._staticBannerTimers.forEach(e=>clearTimeout(e)),this._staticBannerTimers=[],(this.component?.metadata?.banners??[]).forEach((e,t)=>{e.timeoutSeconds&&e.timeoutSeconds>0&&this._staticBannerTimers.push(setTimeout(()=>{this.dismissedStaticBannerIndices=new Set([...this.dismissedStaticBannerIndices,t])},e.timeoutSeconds*1e3))})}_clearActionBannerTimers(){this._actionBannerTimers.forEach(e=>clearTimeout(e)),this._actionBannerTimers=[]}_clearAllTimers(){this._clearActionBannerTimers(),this._staticBannerTimers.forEach(e=>clearTimeout(e)),this._staticBannerTimers=[]}_dismissActionBanner(e){this.actionBanners=this.actionBanners.filter((t,n)=>n!==e)}_dismissStaticBanner(e){this.dismissedStaticBannerIndices=new Set([...this.dismissedStaticBannerIndices,e])}bannerThemeClass(e){let t=e.theme?.toLowerCase()??`info`;return t===`none`?``:t}_evalBannerText(e){return j(e,this.state,this.data)}_renderBanner(e,t){let n=this._evalBannerText(e.title),r=this._evalBannerText(e.description);return w`
             <div class="page-banner page-banner--${this.bannerThemeClass(e)}">
                 ${n||e.hasCloseButton?w`
                     <div style="display: flex; align-items: center; justify-content: space-between; color: #1a1a1a; width: 100%;">
@@ -5894,7 +5894,7 @@ ${i}
                 `:_}
                 ${r?w`<p>${r}</p>`:_}
             </div>
-        `}_onSlotChange(){this._scheduleTocRebuild()}_scheduleTocRebuild(){this._tocRebuildScheduled||(this._tocRebuildScheduled=!0,requestAnimationFrame(()=>{this._tocRebuildScheduled=!1,this._rebuildToc()}))}_sectionCards(){return Array.from(this.querySelectorAll(`.mateu-section`))}_sectionTitle(e){return e.querySelector(`[slot="title"]`)?.textContent?.trim()||e.querySelector(`h1,h2,h3,h4,h5,h6`)?.textContent?.trim()||void 0}_rebuildToc(){let e=this._sectionCards(),t=e.map(e=>({title:this._sectionTitle(e),el:e})).filter(e=>!!e.title),n=this.component?.metadata?.toc,r=t.length>4&&e.every(e=>!e.closest(`vaadin-horizontal-layout`)),i=(n===!0||n!==!1&&r)&&t.length>0;this._tocEntries=t,this._tocVisible=i,this._activeToc>=t.length&&(this._activeToc=0),this._teardownScrollSpy(),i?requestAnimationFrame(()=>{this._layoutStickyTops(),this._setupScrollSpy()}):this._layoutStickyTops()}_layoutStickyTops(){let e=this.shadowRoot?.querySelector(`mateu-content-header`);this._headerH=this._tocVisible&&e?e.offsetHeight:0,this.style.setProperty(`--mateu-header-h`,this._headerH+`px`);let t=this._headerH+12;for(let e of this._sectionCards())e.classList.contains(`mateu-section--sticky`)&&(e.style.top=t+`px`,t+=e.offsetHeight+12)}_scrollContainer(){let e=Wa(this);for(;e;){let t=getComputedStyle(e).overflowY;if((t===`auto`||t===`scroll`)&&e.scrollHeight>e.clientHeight)return e;e=Wa(e)}return null}_setupScrollSpy(){this._tocEntries.length&&(this._spyTarget=this._scrollContainer()??window,this._spyTarget.addEventListener(`scroll`,this._onScrollSpy,{passive:!0}),window.addEventListener(`wheel`,this._unlockToc,{passive:!0}),window.addEventListener(`touchstart`,this._unlockToc,{passive:!0}),window.addEventListener(`keydown`,this._unlockToc),this._onScrollSpy())}_teardownScrollSpy(){this._spyTarget?.removeEventListener(`scroll`,this._onScrollSpy),window.removeEventListener(`wheel`,this._unlockToc),window.removeEventListener(`touchstart`,this._unlockToc),window.removeEventListener(`keydown`,this._unlockToc),this._spyTarget=void 0}_scrollToSection(e){let t=this._tocEntries[e];if(!t)return;this._activeToc=e,this._tocLocked=!0;let n=this._headerH+12;for(let e of this._sectionCards()){if(e===t.el)break;e.classList.contains(`mateu-section--sticky`)&&(n+=e.offsetHeight+12)}let r=this._scrollContainer(),i=r?r.getBoundingClientRect().top:0,a=t.el.getBoundingClientRect().top-i-n;(r??window).scrollBy({top:a,behavior:`smooth`})}_showHeaderBand(){let e=this.component?.metadata,t=!!(e?.title||e?.subtitle||e?.toolbar?.length),n=!!this.component?.children?.some(e=>e.metadata?.type===A.Crud);return t&&!n&&!this._hasWelcomeBanner()}_hasWelcomeBanner(){let e=t=>t?.metadata?.type===A.HeroSection||(t?.children??[]).some(e);return(this.component?.children??[]).some(e)}render(){let e=this.component?.metadata,t=[...(e?.banners??[]).map((e,t)=>({banner:e,index:t})).filter(({index:e})=>!this.dismissedStaticBannerIndices.has(e)).map(({banner:e,index:t})=>({banner:e,onDismiss:()=>this._dismissStaticBanner(t)})),...this.actionBanners.map((e,t)=>({banner:e,onDismiss:()=>this._dismissActionBanner(t)}))];return w`<div style="display: flex; flex-direction: column; width: 100%;">${w`
+        `}_onSlotChange(){this._scheduleTocRebuild()}_scheduleTocRebuild(){this._tocRebuildScheduled||(this._tocRebuildScheduled=!0,requestAnimationFrame(()=>{this._tocRebuildScheduled=!1,this._rebuildToc()}))}_sectionCards(){return Array.from(this.querySelectorAll(`.mateu-section`))}_sectionTitle(e){return e.querySelector(`[slot="title"]`)?.textContent?.trim()||e.querySelector(`h1,h2,h3,h4,h5,h6`)?.textContent?.trim()||void 0}_rebuildToc(){let e=this._sectionCards(),t=e.map(e=>({title:this._sectionTitle(e),el:e})).filter(e=>!!e.title),n=this.component?.metadata?.toc,r=t.length>4&&e.every(e=>!e.closest(`vaadin-horizontal-layout`)),i=(n===!0||n!==!1&&r)&&t.length>0;this._tocEntries=t,this._tocVisible=i,this._activeToc>=t.length&&(this._activeToc=0),this._teardownScrollSpy(),i?requestAnimationFrame(()=>{this._layoutStickyTops(),this._setupScrollSpy()}):this._layoutStickyTops()}_layoutStickyTops(){let e=this.shadowRoot?.querySelector(`mateu-content-header`);this._headerH=this._tocVisible&&e?e.offsetHeight:0,this.style.setProperty(`--mateu-header-h`,this._headerH+`px`);let t=this._headerH+12;for(let e of this._sectionCards())e.classList.contains(`mateu-section--sticky`)&&(e.style.top=t+`px`,t+=e.offsetHeight+12)}_scrollContainer(){let e=qa(this);for(;e;){let t=getComputedStyle(e).overflowY;if((t===`auto`||t===`scroll`)&&e.scrollHeight>e.clientHeight)return e;e=qa(e)}return null}_setupScrollSpy(){this._tocEntries.length&&(this._spyTarget=this._scrollContainer()??window,this._spyTarget.addEventListener(`scroll`,this._onScrollSpy,{passive:!0}),window.addEventListener(`wheel`,this._unlockToc,{passive:!0}),window.addEventListener(`touchstart`,this._unlockToc,{passive:!0}),window.addEventListener(`keydown`,this._unlockToc),this._onScrollSpy())}_teardownScrollSpy(){this._spyTarget?.removeEventListener(`scroll`,this._onScrollSpy),window.removeEventListener(`wheel`,this._unlockToc),window.removeEventListener(`touchstart`,this._unlockToc),window.removeEventListener(`keydown`,this._unlockToc),this._spyTarget=void 0}_scrollToSection(e){let t=this._tocEntries[e];if(!t)return;this._activeToc=e,this._tocLocked=!0;let n=this._headerH+12;for(let e of this._sectionCards()){if(e===t.el)break;e.classList.contains(`mateu-section--sticky`)&&(n+=e.offsetHeight+12)}let r=this._scrollContainer(),i=r?r.getBoundingClientRect().top:0,a=t.el.getBoundingClientRect().top-i-n;(r??window).scrollBy({top:a,behavior:`smooth`})}_showHeaderBand(){let e=this.component?.metadata,t=!!(e?.title||e?.subtitle||e?.toolbar?.length),n=!!this.component?.children?.some(e=>e.metadata?.type===A.Crud);return t&&!n&&!this._hasWelcomeBanner()}_hasWelcomeBanner(){let e=t=>t?.metadata?.type===A.HeroSection||(t?.children??[]).some(e);return(this.component?.children??[]).some(e)}render(){let e=this.component?.metadata,t=[...(e?.banners??[]).map((e,t)=>({banner:e,index:t})).filter(({index:e})=>!this.dismissedStaticBannerIndices.has(e)).map(({banner:e,index:t})=>({banner:e,onDismiss:()=>this._dismissStaticBanner(t)})),...this.actionBanners.map((e,t)=>({banner:e,onDismiss:()=>this._dismissActionBanner(t)}))];return w`<div style="display: flex; flex-direction: column; width: 100%;">${w`
             <div class="page-header-wrap">
                 <mateu-content-header
                     class="${this._tocVisible?`sticky-header`:``}"
@@ -6138,7 +6138,7 @@ ${i}
             background: #fdf2f2;
             border-leftx: 4px solid var(--lumo-error-color);
         }
-    `}};O([v()],J.prototype,`component`,void 0),O([v()],J.prototype,`baseUrl`,void 0),O([v()],J.prototype,`state`,void 0),O([v()],J.prototype,`data`,void 0),O([v()],J.prototype,`appState`,void 0),O([v()],J.prototype,`appData`,void 0),O([v()],J.prototype,`value`,void 0),O([v({type:Boolean})],J.prototype,`standalone`,void 0),O([S()],J.prototype,`actionBanners`,void 0),O([S()],J.prototype,`dismissedStaticBannerIndices`,void 0),O([S()],J.prototype,`_tocEntries`,void 0),O([S()],J.prototype,`_activeToc`,void 0),O([S()],J.prototype,`_tocVisible`,void 0),J=O([h(`mateu-page`)],J);var Ga=m`
+    `}};O([v()],q.prototype,`component`,void 0),O([v()],q.prototype,`baseUrl`,void 0),O([v()],q.prototype,`state`,void 0),O([v()],q.prototype,`data`,void 0),O([v()],q.prototype,`appState`,void 0),O([v()],q.prototype,`appData`,void 0),O([v()],q.prototype,`value`,void 0),O([v({type:Boolean})],q.prototype,`standalone`,void 0),O([S()],q.prototype,`actionBanners`,void 0),O([S()],q.prototype,`dismissedStaticBannerIndices`,void 0),O([S()],q.prototype,`_tocEntries`,void 0),O([S()],q.prototype,`_activeToc`,void 0),O([S()],q.prototype,`_tocVisible`,void 0),q=O([h(`mateu-page`)],q);var Ja=m`
     .nbtn {
         display: inline-flex;
         align-items: center;
@@ -6167,25 +6167,25 @@ ${i}
     }
     .nbtn.primary:hover { background: var(--lumo-primary-color, #1676f3); filter: brightness(1.08); }
     .nbtn svg { width: 1em; height: 1em; flex-shrink: 0; }
-`,Ka=e=>C`
+`,Ya=e=>C`
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-         stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${e}</svg>`,qa=Ka(C`
+         stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${e}</svg>`,Xa=Ya(C`
     <circle cx="12" cy="12" r="3"></circle>
-    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path>`),Ja=Ka(C`
+    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path>`),Za=Ya(C`
     <line x1="12" y1="5" x2="12" y2="19"></line>
-    <line x1="5" y1="12" x2="19" y2="12"></line>`),Ya=Ka(C`
+    <line x1="5" y1="12" x2="19" y2="12"></line>`),Qa=Ya(C`
     <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
     <polyline points="7 10 12 15 17 10"></polyline>
-    <line x1="12" y1="15" x2="12" y2="3"></line>`);Ka(C`
+    <line x1="12" y1="15" x2="12" y2="3"></line>`);Ya(C`
     <rect x="9" y="2" width="6" height="5" rx="1"></rect>
     <rect x="2" y="17" width="6" height="5" rx="1"></rect>
     <rect x="16" y="17" width="6" height="5" rx="1"></rect>
-    <path d="M12 7v4M5 17v-3h14v3M12 11v3"></path>`);var Xa=Ka(C`
+    <path d="M12 7v4M5 17v-3h14v3M12 11v3"></path>`);var $a=Ya(C`
     <rect x="9" y="2" width="6" height="12" rx="3"></rect>
     <path d="M5 10v1a7 7 0 0 0 14 0v-1"></path>
-    <line x1="12" y1="18" x2="12" y2="22"></line>`),Za=Ka(C`
+    <line x1="12" y1="18" x2="12" y2="22"></line>`),eo=Ya(C`
     <line x1="18" y1="6" x2="6" y2="18"></line>
-    <line x1="6" y1="6" x2="18" y2="18"></line>`),Qa=[`#e91e63`,`#1676f3`,`#10b981`,`#8b5cf6`,`#f59e0b`,`#ef4444`],$a=e=>Qa[Math.abs(e??0)%Qa.length],eo=e=>(e??`?`).split(/\s+/).filter(e=>e).map(e=>e[0]).slice(0,2).join(``).toUpperCase()||`?`,Y=class extends y{constructor(...e){super(...e),this.localAgentUrl=`http://127.0.0.1:8776`,this.localAgentAlive=!1,this.menu=[],this.chatSessionId=T(),this.menuContextSent=!1,this.attachments=[],this.uploading=!1,this.expanded=!1,this.toggleExpanded=()=>{this.expanded=!this.expanded},this.items=[],this.listening=!1,this.recognitionAvailable=!1,this.loading=!1,this.elapsedSeconds=0,this.startListening=()=>{this.recognition&&(this.listening?(this.recognition.stop(),this.listening=!1):(this.recognition.start(),this.listening=!0))},this.onSpeechResult=e=>{if(this.recognition){let t=e,n=t.results[t.results[0].length-1][0].transcript;this.messageInputElement&&(this.messageInputElement.value=n,this.send(new CustomEvent(`submit`,{detail:{value:n},bubbles:!0,composed:!0})))}},this.probeLocalAgent=async()=>{if(this.localAgentUrl)try{let e=new AbortController,t=setTimeout(()=>e.abort(),1200),n=await fetch(this.localAgentUrl+`/health`,{signal:e.signal});clearTimeout(t),this.localAgentAlive=n.ok}catch{this.localAgentAlive=!1}},this.pickFiles=()=>this.fileInputElement?.click(),this.onFilesPicked=async e=>{let t=e.target,n=Array.from(t.files??[]);if(t.value=``,!(!n.length||!this.uploadUrl)){this.uploading=!0;try{let e=new FormData;e.append(`sessionId`,this.chatSessionId);for(let t of n)e.append(`files`,t,t.name);let t={},r=localStorage.getItem(`__mateu_auth_token`);r&&(t.Authorization=`Bearer `+r);let i=sessionStorage.getItem(`__mateu_sesion_id`);i&&(t[`X-Session-Id`]=i);let a=await fetch(this.uploadUrl,{method:`POST`,headers:t,body:e});if(!a.ok)throw Error(`Upload failed: ${a.status}`);let o=((await a.json()).files??[]).filter(e=>e&&e.path);this.attachments=[...this.attachments,...o]}catch(e){this.addMessage(`⚠️ No se pudieron subir los ficheros: ${e instanceof Error?e.message:e}`,`agent`)}finally{this.uploading=!1}}},this.removeAttachment=e=>{this.attachments=this.attachments.filter(t=>t.path!==e)},this.send=async e=>{this.messageInputElement?.setAttribute(`disabled`,`disabled`);let t=e.detail.value.trim(),n=this.localAgentAlive?this.localAgentUrl+`/mateu/agent/stream`:this.sseUrl,r=this.attachments;if(!t&&r.length===0||!n)return;let i=r.length?`${t}${t?`
+    <line x1="6" y1="6" x2="18" y2="18"></line>`),to=[`#e91e63`,`#1676f3`,`#10b981`,`#8b5cf6`,`#f59e0b`,`#ef4444`],no=e=>to[Math.abs(e??0)%to.length],ro=e=>(e??`?`).split(/\s+/).filter(e=>e).map(e=>e[0]).slice(0,2).join(``).toUpperCase()||`?`,J=class extends y{constructor(...e){super(...e),this.localAgentUrl=`http://127.0.0.1:8776`,this.localAgentAlive=!1,this.menu=[],this.chatSessionId=T(),this.menuContextSent=!1,this.attachments=[],this.uploading=!1,this.expanded=!1,this.toggleExpanded=()=>{this.expanded=!this.expanded},this.items=[],this.listening=!1,this.recognitionAvailable=!1,this.loading=!1,this.elapsedSeconds=0,this.startListening=()=>{this.recognition&&(this.listening?(this.recognition.stop(),this.listening=!1):(this.recognition.start(),this.listening=!0))},this.onSpeechResult=e=>{if(this.recognition){let t=e,n=t.results[t.results[0].length-1][0].transcript;this.messageInputElement&&(this.messageInputElement.value=n,this.send(new CustomEvent(`submit`,{detail:{value:n},bubbles:!0,composed:!0})))}},this.probeLocalAgent=async()=>{if(this.localAgentUrl)try{let e=new AbortController,t=setTimeout(()=>e.abort(),1200),n=await fetch(this.localAgentUrl+`/health`,{signal:e.signal});clearTimeout(t),this.localAgentAlive=n.ok}catch{this.localAgentAlive=!1}},this.pickFiles=()=>this.fileInputElement?.click(),this.onFilesPicked=async e=>{let t=e.target,n=Array.from(t.files??[]);if(t.value=``,!(!n.length||!this.uploadUrl)){this.uploading=!0;try{let e=new FormData;e.append(`sessionId`,this.chatSessionId);for(let t of n)e.append(`files`,t,t.name);let t={},r=localStorage.getItem(`__mateu_auth_token`);r&&(t.Authorization=`Bearer `+r);let i=sessionStorage.getItem(`__mateu_sesion_id`);i&&(t[`X-Session-Id`]=i);let a=await fetch(this.uploadUrl,{method:`POST`,headers:t,body:e});if(!a.ok)throw Error(`Upload failed: ${a.status}`);let o=((await a.json()).files??[]).filter(e=>e&&e.path);this.attachments=[...this.attachments,...o]}catch(e){this.addMessage(`⚠️ No se pudieron subir los ficheros: ${e instanceof Error?e.message:e}`,`agent`)}finally{this.uploading=!1}}},this.removeAttachment=e=>{this.attachments=this.attachments.filter(t=>t.path!==e)},this.send=async e=>{this.messageInputElement?.setAttribute(`disabled`,`disabled`);let t=e.detail.value.trim(),n=this.localAgentAlive?this.localAgentUrl+`/mateu/agent/stream`:this.sseUrl,r=this.attachments;if(!t&&r.length===0||!n)return;let i=r.length?`${t}${t?`
 
 `:``}📎 ${r.map(e=>e.name).join(`, `)}`:t;this.addMessage(i,`user`),this.attachments=[];let a=this.addMessage(``,`agent`);this.startLoading();let o=``;try{let e={Accept:`text/event-stream`,"Content-Type":`application/json`},i=localStorage.getItem(`__mateu_auth_token`);i&&(e.Authorization=`Bearer `+i);let s=sessionStorage.getItem(`__mateu_sesion_id`);s&&(e[`X-Session-Id`]=s);let c=this.contextProvider?.(),l=JSON.stringify({message:t,sessionId:this.chatSessionId,...r.length&&{attachments:r},...c!=null&&{context:c},...this.mcpUrl&&{mcpUrl:new URL(this.mcpUrl,window.location.origin).href},...!this.menuContextSent&&{menuContext:this.buildMenuContext(this.menu)}});this.menuContextSent=!0;let u=await fetch(n,{method:`POST`,headers:e,body:l});if(!u.ok){let e=await u.text();throw Error(`Servidor respondió ${u.status}: ${e}`)}let d=u.body?.getReader();if(!d)throw Error(`No se pudo obtener el reader del stream.`);let f=new TextDecoder,p=``;for(;;){let{done:e,value:t}=await d.read();if(e){if(p.trim().startsWith(`data:`)){let e=p.trim().slice(5).trim(),t=this.tryParseTokenUsage(e),n=!t&&this.tryParseCustomEvent(e);t?this.tokenUsage={...this.tokenUsage,...t}:n?n.event===`agent-error`?(o=`⚠️ `+(n.detail?.message??`Error desconocido del agente`),this.updateMessage(a,o)):this.dispatchEvent(new CustomEvent(n.event,{detail:n.detail,bubbles:!0,composed:!0})):(o+=e,this.updateMessage(a,o))}break}let n=f.decode(t,{stream:!0});p+=n;let r=p.split(`
 `);p=r.pop()||``;let i=!1;for(let e of r)if(e.trim().startsWith(`data:`)){let t=e.trim().slice(5).trim(),n=this.tryParseTokenUsage(t),r=!n&&this.tryParseCustomEvent(t);n?this.tokenUsage={...this.tokenUsage,...n}:r?r.event===`agent-error`?(o=`⚠️ `+(r.detail?.message??`Error desconocido del agente`),this.updateMessage(a,o)):this.dispatchEvent(new CustomEvent(r.event,{detail:r.detail,bubbles:!0,composed:!0})):(o+=t+`
@@ -6200,14 +6200,14 @@ ${i}
                         ${this.expanded?`⤡`:`⤢`}
                     </button>
                     <button class="chat-close" @click="${this.closeChat}" title="Cerrar">
-                        ${Za}
+                        ${eo}
                     </button>
                 </div>
                 <div class="scroll-container">
                     <div class="message-list" role="list">
                         ${this.items.map(e=>w`
                             <div class="message" role="listitem">
-                                <div class="avatar" style="background: ${$a(e.userColorIndex)};">${eo(e.userName)}</div>
+                                <div class="avatar" style="background: ${no(e.userColorIndex)};">${ro(e.userName)}</div>
                                 <div class="message-body">
                                     <div class="message-meta">
                                         <span class="message-name">${e.userName}</span>
@@ -6255,7 +6255,7 @@ ${i}
                             style="color: ${this.listening?`red`:`var(--lumo-contrast-50pct, #767676)`};"
                             @click="${this.startListening}"
                             ?disabled="${!this.recognitionAvailable}"
-                    >${Xa}</button>
+                    >${$a}</button>
                     <input class="msg-input"
                            placeholder="Message"
                            aria-label="Message"
@@ -6263,7 +6263,7 @@ ${i}
                     <button class="nbtn primary" ?disabled="${this.loading}" @click="${this.submitFromInput}">Send</button>
                 </div>
             </div>
-        `}static{this.styles=[Ga,m`
+        `}static{this.styles=[Ja,m`
         :host {
             display: block;
             height: 100%;
@@ -6588,7 +6588,7 @@ ${i}
         @keyframes spin {
             to { transform: rotate(360deg); }
         }
-    `]}};O([v({attribute:!1})],Y.prototype,`contextProvider`,void 0),O([v()],Y.prototype,`localAgentUrl`,void 0),O([v({attribute:!1})],Y.prototype,`mcpUrl`,void 0),O([S()],Y.prototype,`localAgentAlive`,void 0),O([v()],Y.prototype,`sseUrl`,void 0),O([v()],Y.prototype,`uploadUrl`,void 0),O([v({attribute:!1})],Y.prototype,`menu`,void 0),O([S()],Y.prototype,`attachments`,void 0),O([S()],Y.prototype,`uploading`,void 0),O([b(`.file-input`)],Y.prototype,`fileInputElement`,void 0),O([v({type:Boolean,reflect:!0})],Y.prototype,`expanded`,void 0),O([v()],Y.prototype,`items`,void 0),O([b(`.scroll-container`)],Y.prototype,`scrollContainer`,void 0),O([b(`.msg-input`)],Y.prototype,`messageInputElement`,void 0),O([S()],Y.prototype,`recognition`,void 0),O([S()],Y.prototype,`listening`,void 0),O([S()],Y.prototype,`recognitionAvailable`,void 0),O([S()],Y.prototype,`loading`,void 0),O([S()],Y.prototype,`elapsedSeconds`,void 0),O([S()],Y.prototype,`tokenUsage`,void 0),Y=O([h(`mateu-chat`)],Y);var to=class extends y{updated(e){super.updated(e),this.chart&&=(this.chart.destroy(),void 0),this.data&&this.createChart(this.data)}async createChart(e){let[{default:t}]=await Promise.all([E(()=>import(`./vendor-chartjs.js`).then(e=>e.n),__vite__mapDeps([3,1])),E(()=>import(`./vendor-chartjs.js`).then(e=>e.t),__vite__mapDeps([3,1]))]);if(e!==this.data)return;this.chart&&this.chart.destroy();let n={type:this.type,data:this.data,options:this.options};this.chart=new t(this.chartElement,n)}handleSlotChange(){}render(){return w`
+    `]}};O([v({attribute:!1})],J.prototype,`contextProvider`,void 0),O([v()],J.prototype,`localAgentUrl`,void 0),O([v({attribute:!1})],J.prototype,`mcpUrl`,void 0),O([S()],J.prototype,`localAgentAlive`,void 0),O([v()],J.prototype,`sseUrl`,void 0),O([v()],J.prototype,`uploadUrl`,void 0),O([v({attribute:!1})],J.prototype,`menu`,void 0),O([S()],J.prototype,`attachments`,void 0),O([S()],J.prototype,`uploading`,void 0),O([b(`.file-input`)],J.prototype,`fileInputElement`,void 0),O([v({type:Boolean,reflect:!0})],J.prototype,`expanded`,void 0),O([v()],J.prototype,`items`,void 0),O([b(`.scroll-container`)],J.prototype,`scrollContainer`,void 0),O([b(`.msg-input`)],J.prototype,`messageInputElement`,void 0),O([S()],J.prototype,`recognition`,void 0),O([S()],J.prototype,`listening`,void 0),O([S()],J.prototype,`recognitionAvailable`,void 0),O([S()],J.prototype,`loading`,void 0),O([S()],J.prototype,`elapsedSeconds`,void 0),O([S()],J.prototype,`tokenUsage`,void 0),J=O([h(`mateu-chat`)],J);var io=class extends y{updated(e){super.updated(e),this.chart&&=(this.chart.destroy(),void 0),this.data&&this.createChart(this.data)}async createChart(e){let[{default:t}]=await Promise.all([E(()=>import(`./vendor-chartjs.js`).then(e=>e.n),__vite__mapDeps([3,1])),E(()=>import(`./vendor-chartjs.js`).then(e=>e.t),__vite__mapDeps([3,1]))]);if(e!==this.data)return;this.chart&&this.chart.destroy();let n={type:this.type,data:this.data,options:this.options};this.chart=new t(this.chartElement,n)}handleSlotChange(){}render(){return w`
             <div class="container">
                 <canvas id="chart"></canvas>
             </div>
@@ -6605,7 +6605,7 @@ ${i}
         height: 100%;
         position: relative;
     }
-  `}};O([v()],to.prototype,`type`,void 0),O([v()],to.prototype,`data`,void 0),O([v()],to.prototype,`options`,void 0),O([b(`#chart`)],to.prototype,`chartElement`,void 0),to=O([h(`mateu-chart`)],to);var no=class extends y{updated(e){super.updated(e),this.chart&&=(this.chart.destroy(),void 0),this.xml&&this.createViewer(this.xml)}async createViewer(e){let{default:t}=await E(async()=>{let{default:e}=await import(`./vendor-diagrams.js`).then(e=>e.t);return{default:e}},__vite__mapDeps([4,1,2]));if(e!==this.xml)return;this.chart&&this.chart.destroy();let n={container:this.divElement};this.chart=new t(n),this.chart.importXML(e)}handleSlotChange(){}render(){return w`
+  `}};O([v()],io.prototype,`type`,void 0),O([v()],io.prototype,`data`,void 0),O([v()],io.prototype,`options`,void 0),O([b(`#chart`)],io.prototype,`chartElement`,void 0),io=O([h(`mateu-chart`)],io);var ao=class extends y{updated(e){super.updated(e),this.chart&&=(this.chart.destroy(),void 0),this.xml&&this.createViewer(this.xml)}async createViewer(e){let{default:t}=await E(async()=>{let{default:e}=await import(`./vendor-diagrams.js`).then(e=>e.t);return{default:e}},__vite__mapDeps([4,1,2]));if(e!==this.xml)return;this.chart&&this.chart.destroy();let n={container:this.divElement};this.chart=new t(n),this.chart.importXML(e)}handleSlotChange(){}render(){return w`
             <div class="container" style="width: 20rem; height: 15rem; overflow: auto;">
                 <!-- BPMN diagram container -->
                 <div id="canvas" style="width: 60rem; height: 30rem; zoom: 0.5;"></div>
@@ -6614,7 +6614,7 @@ ${i}
                 <slot @slotchange=${this.handleSlotChange}></slot>
             </div>
        `}static{this.styles=m`
-  `}};O([v()],no.prototype,`xml`,void 0),O([b(`#canvas`)],no.prototype,`divElement`,void 0),no=O([h(`mateu-bpmn`)],no);var ro=160,io=56,ao=220,oo=110,so=60,co={ACTION:`#3B82F6`,JOIN:`#8B5CF6`,FORK:`#F59E0B`,END:`#EF4444`,USER_TASK:`#10B981`,PROCESS:`#6366F1`},lo={ACTION:`▶`,JOIN:`⟨`,FORK:`⟩`,END:`◼`,USER_TASK:`👤`,PROCESS:`⚙`},uo=[`ACTION`,`JOIN`,`FORK`,`END`,`USER_TASK`,`PROCESS`];function fo(){return`step-`+Math.random().toString(36).slice(2,8)}var po=class extends y{constructor(...e){super(...e),this.value=`{"name":"New Workflow","steps":[]}`,this.wf={name:`New Workflow`,steps:[]},this.positions={},this.selectedId=null,this.showMeta=!1,this.draggingId=null,this.dragOffset={x:0,y:0},this.svgEl=null,this.onMouseMove=e=>{if(!this.draggingId||!this.svgEl)return;let t=this.toSvgPoint(e);this.positions={...this.positions,[this.draggingId]:{x:Math.max(0,t.x-this.dragOffset.x),y:Math.max(0,t.y-this.dragOffset.y)}}},this.onMouseUp=()=>{this.draggingId=null,window.removeEventListener(`mousemove`,this.onMouseMove),window.removeEventListener(`mouseup`,this.onMouseUp)}}updated(e){if(e.has(`value`)){try{this.wf=JSON.parse(this.value)}catch{}this.autoLayout()}}autoLayout(){let e=this.wf.steps??[],t={};e.forEach(e=>{t[e.id]=0});let n=!0;for(;n;)n=!1,e.forEach(e=>{if(e.preconditionStepId!=null&&t[e.preconditionStepId]!==void 0){let r=t[e.preconditionStepId]+1;r>t[e.id]&&(t[e.id]=r,n=!0)}});let r={};e.forEach(e=>{let n=t[e.id]??0;(r[n]??=[]).push(e.id)});let i={...this.positions},a=!1;Object.entries(r).forEach(([e,t])=>{let n=Number(e);t.forEach((e,t)=>{i[e]||(i[e]={x:so+n*ao,y:so+t*oo},a=!0)})}),a&&(this.positions=i)}emit(){let e=JSON.stringify(this.wf,null,2);this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e},bubbles:!0,composed:!0}))}updateWf(e){this.wf={...this.wf,...e},this.emit()}updateStep(e,t){this.wf={...this.wf,steps:this.wf.steps.map(n=>n.id===e?{...n,...t}:n)},this.emit()}addStep(){let e=fo(),t={id:e,type:`ACTION`,name:`New Step`};this.wf={...this.wf,steps:[...this.wf.steps??[],t]};let n=Object.values(this.positions).map(e=>e.y),r=n.length?Math.max(...n)+oo:so;this.positions={...this.positions,[e]:{x:so,y:r}},this.selectedId=e,this.emit()}deleteStep(e){this.wf={...this.wf,steps:this.wf.steps.filter(t=>t.id!==e).map(t=>t.preconditionStepId===e?{...t,preconditionStepId:void 0}:t)};let{[e]:t,...n}=this.positions;this.positions=n,this.selectedId===e&&(this.selectedId=null),this.emit()}onNodeMouseDown(e,t){e.preventDefault(),this.draggingId=t;let n=this.positions[t]??{x:0,y:0},r=this.toSvgPoint(e);this.dragOffset={x:r.x-n.x,y:r.y-n.y},this.svgEl=e.currentTarget.closest(`svg`),window.addEventListener(`mousemove`,this.onMouseMove),window.addEventListener(`mouseup`,this.onMouseUp)}toSvgPoint(e){if(!this.svgEl)return{x:0,y:0};let t=this.svgEl.getBoundingClientRect();return{x:e.clientX-t.left,y:e.clientY-t.top}}canvasSize(){let e=Object.values(this.positions),t=e.length?Math.max(...e.map(e=>e.x))+ro+so:600,n=e.length?Math.max(...e.map(e=>e.y))+io+so:400;return{w:Math.max(t,600),h:Math.max(n,400)}}render(){let{w:e,h:t}=this.canvasSize(),n=this.wf.steps??[];return w`
+  `}};O([v()],ao.prototype,`xml`,void 0),O([b(`#canvas`)],ao.prototype,`divElement`,void 0),ao=O([h(`mateu-bpmn`)],ao);var oo=160,so=56,co=220,lo=110,uo=60,fo={ACTION:`#3B82F6`,JOIN:`#8B5CF6`,FORK:`#F59E0B`,END:`#EF4444`,USER_TASK:`#10B981`,PROCESS:`#6366F1`},po={ACTION:`▶`,JOIN:`⟨`,FORK:`⟩`,END:`◼`,USER_TASK:`👤`,PROCESS:`⚙`},mo=[`ACTION`,`JOIN`,`FORK`,`END`,`USER_TASK`,`PROCESS`];function ho(){return`step-`+Math.random().toString(36).slice(2,8)}var go=class extends y{constructor(...e){super(...e),this.value=`{"name":"New Workflow","steps":[]}`,this.wf={name:`New Workflow`,steps:[]},this.positions={},this.selectedId=null,this.showMeta=!1,this.draggingId=null,this.dragOffset={x:0,y:0},this.svgEl=null,this.onMouseMove=e=>{if(!this.draggingId||!this.svgEl)return;let t=this.toSvgPoint(e);this.positions={...this.positions,[this.draggingId]:{x:Math.max(0,t.x-this.dragOffset.x),y:Math.max(0,t.y-this.dragOffset.y)}}},this.onMouseUp=()=>{this.draggingId=null,window.removeEventListener(`mousemove`,this.onMouseMove),window.removeEventListener(`mouseup`,this.onMouseUp)}}updated(e){if(e.has(`value`)){try{this.wf=JSON.parse(this.value)}catch{}this.autoLayout()}}autoLayout(){let e=this.wf.steps??[],t={};e.forEach(e=>{t[e.id]=0});let n=!0;for(;n;)n=!1,e.forEach(e=>{if(e.preconditionStepId!=null&&t[e.preconditionStepId]!==void 0){let r=t[e.preconditionStepId]+1;r>t[e.id]&&(t[e.id]=r,n=!0)}});let r={};e.forEach(e=>{let n=t[e.id]??0;(r[n]??=[]).push(e.id)});let i={...this.positions},a=!1;Object.entries(r).forEach(([e,t])=>{let n=Number(e);t.forEach((e,t)=>{i[e]||(i[e]={x:uo+n*co,y:uo+t*lo},a=!0)})}),a&&(this.positions=i)}emit(){let e=JSON.stringify(this.wf,null,2);this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e},bubbles:!0,composed:!0}))}updateWf(e){this.wf={...this.wf,...e},this.emit()}updateStep(e,t){this.wf={...this.wf,steps:this.wf.steps.map(n=>n.id===e?{...n,...t}:n)},this.emit()}addStep(){let e=ho(),t={id:e,type:`ACTION`,name:`New Step`};this.wf={...this.wf,steps:[...this.wf.steps??[],t]};let n=Object.values(this.positions).map(e=>e.y),r=n.length?Math.max(...n)+lo:uo;this.positions={...this.positions,[e]:{x:uo,y:r}},this.selectedId=e,this.emit()}deleteStep(e){this.wf={...this.wf,steps:this.wf.steps.filter(t=>t.id!==e).map(t=>t.preconditionStepId===e?{...t,preconditionStepId:void 0}:t)};let{[e]:t,...n}=this.positions;this.positions=n,this.selectedId===e&&(this.selectedId=null),this.emit()}onNodeMouseDown(e,t){e.preventDefault(),this.draggingId=t;let n=this.positions[t]??{x:0,y:0},r=this.toSvgPoint(e);this.dragOffset={x:r.x-n.x,y:r.y-n.y},this.svgEl=e.currentTarget.closest(`svg`),window.addEventListener(`mousemove`,this.onMouseMove),window.addEventListener(`mouseup`,this.onMouseUp)}toSvgPoint(e){if(!this.svgEl)return{x:0,y:0};let t=this.svgEl.getBoundingClientRect();return{x:e.clientX-t.left,y:e.clientY-t.top}}canvasSize(){let e=Object.values(this.positions),t=e.length?Math.max(...e.map(e=>e.x))+oo+uo:600,n=e.length?Math.max(...e.map(e=>e.y))+so+uo:400;return{w:Math.max(t,600),h:Math.max(n,400)}}render(){let{w:e,h:t}=this.canvasSize(),n=this.wf.steps??[];return w`
             <div class="root">
                 ${this.renderToolbar()}
                 ${this.showMeta?this.renderMeta():``}
@@ -6641,15 +6641,15 @@ ${i}
                 <span class="badge badge-${e.toLowerCase()}">${e}</span>
                 <div style="flex:1"></div>
                 <button class="nbtn" @click="${()=>this.showMeta=!this.showMeta}">
-                    ${qa}
+                    ${Xa}
                     Settings
                 </button>
                 <button class="nbtn primary" @click="${()=>this.addStep()}">
-                    ${Ja}
+                    ${Za}
                     Add Step
                 </button>
                 <button class="nbtn" @click="${()=>this.exportJson()}">
-                    ${Ya}
+                    ${Qa}
                     Export
                 </button>
             </div>
@@ -6678,27 +6678,27 @@ ${i}
                     `:``}
                 </div>
             </div>
-        `}renderArrow(e){if(!e.preconditionStepId)return C``;let t=this.positions[e.preconditionStepId],n=this.positions[e.id];if(!t||!n)return C``;let r=t.x+ro,i=t.y+io/2,a=n.x,o=n.y+io/2,s=(r+a)/2;return C`
+        `}renderArrow(e){if(!e.preconditionStepId)return C``;let t=this.positions[e.preconditionStepId],n=this.positions[e.id];if(!t||!n)return C``;let r=t.x+oo,i=t.y+so/2,a=n.x,o=n.y+so/2,s=(r+a)/2;return C`
             <path d="M${r},${i} C${s},${i} ${s},${o} ${a},${o}"
                   fill="none" stroke="#94a3b8" stroke-width="2"
                   marker-end="url(#arrow)"/>
-        `}renderNode(e){let t=this.positions[e.id]??{x:so,y:so},n=co[e.type]??`#64748b`,r=lo[e.type]??`•`,i=this.selectedId===e.id;return C`
+        `}renderNode(e){let t=this.positions[e.id]??{x:uo,y:uo},n=fo[e.type]??`#64748b`,r=po[e.type]??`•`,i=this.selectedId===e.id;return C`
             <g transform="translate(${t.x},${t.y})"
                style="cursor:grab"
                @mousedown="${t=>this.onNodeMouseDown(t,e.id)}"
                @click="${t=>{t.stopPropagation(),this.selectedId=e.id}}">
-                <rect width="${ro}" height="${io}" rx="8"
+                <rect width="${oo}" height="${so}" rx="8"
                       fill="white"
                       stroke="${i?n:`#e2e8f0`}"
                       stroke-width="${i?2.5:1.5}"
                       filter="url(#shadow)"/>
                 <!-- type badge -->
-                <rect x="0" y="0" width="32" height="${io}" rx="8" fill="${n}" clip-path="inset(0 -8px 0 0 round 8px)"/>
-                <rect x="24" y="0" width="8" height="${io}" fill="${n}"/>
+                <rect x="0" y="0" width="32" height="${so}" rx="8" fill="${n}" clip-path="inset(0 -8px 0 0 round 8px)"/>
+                <rect x="24" y="0" width="8" height="${so}" fill="${n}"/>
                 <text x="16" y="${33}" text-anchor="middle"
                       font-size="14" fill="white">${r}</text>
                 <!-- name -->
-                <text x="44" y="${io/2-6}" font-size="11" fill="#1e293b" font-weight="600">
+                <text x="44" y="${so/2-6}" font-size="11" fill="#1e293b" font-weight="600">
                     ${e.name.length>16?e.name.slice(0,15)+`…`:e.name}
                 </text>
                 <text x="44" y="${36}" font-size="9" fill="#94a3b8">${e.id}</text>
@@ -6723,7 +6723,7 @@ ${i}
                         @change="${t=>this.updateStep(e.id,{name:t.target.value})}"/>`)}
                     ${n(`Type`,w`
                         <select class="inp" @change="${t=>this.updateStep(e.id,{type:t.target.value})}">
-                            ${uo.map(t=>w`<option value="${t}" ?selected="${e.type===t}">${t}</option>`)}
+                            ${mo.map(t=>w`<option value="${t}" ?selected="${e.type===t}">${t}</option>`)}
                         </select>`)}
                     ${n(`Description`,w`<textarea class="inp" rows="2"
                         @change="${t=>this.updateStep(e.id,{description:t.target.value})}">${e.description??``}</textarea>`)}
@@ -6768,7 +6768,7 @@ ${i}
                         @change="${t=>this.updateStep(e.id,{childWorkflowDefinitionId:t.target.value||void 0})}"/>`):``}
                 </div>
             </div>
-        `}exportJson(){let e=JSON.stringify(this.wf,null,2),t=new Blob([e],{type:`application/json`}),n=URL.createObjectURL(t),r=document.createElement(`a`);r.href=n,r.download=(this.wf.name??`workflow`).replace(/\s+/g,`-`).toLowerCase()+`.json`,r.click(),URL.revokeObjectURL(n)}static{this.styles=[Ga,m`
+        `}exportJson(){let e=JSON.stringify(this.wf,null,2),t=new Blob([e],{type:`application/json`}),n=URL.createObjectURL(t),r=document.createElement(`a`);r.href=n,r.download=(this.wf.name??`workflow`).replace(/\s+/g,`-`).toLowerCase()+`.json`,r.click(),URL.revokeObjectURL(n)}static{this.styles=[Ja,m`
         :host { display: block; height: 100%; font-family: var(--lumo-font-family, sans-serif); }
 
         .root { display: flex; flex-direction: column; height: 100%; background: var(--lumo-base-color, #fff); }
@@ -6846,7 +6846,7 @@ ${i}
         .inp:focus { border-color: #3B82F6; }
         textarea.inp { resize: vertical; }
         input[readonly].inp { background: #f8fafc; color: #94a3b8; }
-    `]}};O([v()],po.prototype,`value`,void 0),O([S()],po.prototype,`wf`,void 0),O([S()],po.prototype,`positions`,void 0),O([S()],po.prototype,`selectedId`,void 0),O([S()],po.prototype,`showMeta`,void 0),po=O([h(`mateu-workflow`)],po);var mo=[`string`,`integer`,`number`,`bool`,`date`,`time`,`dateTime`,`dateRange`,`money`,`file`,`array`,`status`,`component`,`menu`,`range`,`action`,`actionGroup`],ho=[`regular`,`radio`,`checkbox`,`textarea`,`toggle`,`combobox`,`select`,`email`,`password`,`richText`,`listBox`,`html`,`markdown`,`image`,`icon`,`link`,`money`,`grid`,`color`,`choice`,`popover`,`slider`,`button`,`stars`],go={string:`#3B82F6`,integer:`#8B5CF6`,number:`#6366F1`,bool:`#10B981`,date:`#F59E0B`,time:`#F59E0B`,dateTime:`#F59E0B`,dateRange:`#F59E0B`,money:`#EF4444`,file:`#64748B`,array:`#0EA5E9`,status:`#EC4899`,component:`#14B8A6`,menu:`#94A3B8`,range:`#A855F7`,action:`#F97316`,actionGroup:`#FB923C`};function _o(){return`field-`+Math.random().toString(36).slice(2,8)}var vo=class extends y{constructor(...e){super(...e),this.value=`{"name":"New Form","fields":[]}`,this.form={name:`New Form`,fields:[]},this.selectedId=null,this.showMeta=!1,this.sortable=null,this.listEl=null}updated(e){if(e.has(`value`))try{this.form=JSON.parse(this.value)}catch{}this.attachSortable()}disconnectedCallback(){super.disconnectedCallback(),this.sortable?.destroy(),this.sortable=null}attachSortable(){let e=this.shadowRoot?.querySelector(`.field-list`);!e||e===this.listEl||(this.listEl=e,this.sortable?.destroy(),this.sortable=ce.create(e,{animation:150,handle:`.drag-handle`,ghostClass:`sortable-ghost`,onEnd:e=>{let{oldIndex:t,newIndex:n}=e;if(t===void 0||n===void 0||t===n)return;let r=[...this.form.fields],[i]=r.splice(t,1);r.splice(n,0,i),this.form={...this.form,fields:r},this.emit()}}))}emit(){let e=JSON.stringify(this.form,null,2);this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e},bubbles:!0,composed:!0}))}updateForm(e){this.form={...this.form,...e},this.emit()}updateField(e,t){this.form={...this.form,fields:this.form.fields.map(n=>n.id===e?{...n,...t}:n)},this.emit()}addField(){let e=_o(),t={id:e,label:`New Field`,dataType:`string`};this.form={...this.form,fields:[...this.form.fields,t]},this.selectedId=e,this.emit()}deleteField(e){this.form={...this.form,fields:this.form.fields.filter(t=>t.id!==e)},this.selectedId===e&&(this.selectedId=null),this.emit()}duplicateField(e){let t=this.form.fields.find(t=>t.id===e);if(!t)return;let n={...t,id:_o(),label:t.label+` (copy)`},r=this.form.fields.findIndex(t=>t.id===e),i=[...this.form.fields];i.splice(r+1,0,n),this.form={...this.form,fields:i},this.selectedId=n.id,this.emit()}render(){return w`
+    `]}};O([v()],go.prototype,`value`,void 0),O([S()],go.prototype,`wf`,void 0),O([S()],go.prototype,`positions`,void 0),O([S()],go.prototype,`selectedId`,void 0),O([S()],go.prototype,`showMeta`,void 0),go=O([h(`mateu-workflow`)],go);var _o=[`string`,`integer`,`number`,`bool`,`date`,`time`,`dateTime`,`dateRange`,`money`,`file`,`array`,`status`,`component`,`menu`,`range`,`action`,`actionGroup`],vo=[`regular`,`radio`,`checkbox`,`textarea`,`toggle`,`combobox`,`select`,`email`,`password`,`richText`,`listBox`,`html`,`markdown`,`image`,`icon`,`link`,`money`,`grid`,`color`,`choice`,`popover`,`slider`,`button`,`stars`],yo={string:`#3B82F6`,integer:`#8B5CF6`,number:`#6366F1`,bool:`#10B981`,date:`#F59E0B`,time:`#F59E0B`,dateTime:`#F59E0B`,dateRange:`#F59E0B`,money:`#EF4444`,file:`#64748B`,array:`#0EA5E9`,status:`#EC4899`,component:`#14B8A6`,menu:`#94A3B8`,range:`#A855F7`,action:`#F97316`,actionGroup:`#FB923C`};function bo(){return`field-`+Math.random().toString(36).slice(2,8)}var xo=class extends y{constructor(...e){super(...e),this.value=`{"name":"New Form","fields":[]}`,this.form={name:`New Form`,fields:[]},this.selectedId=null,this.showMeta=!1,this.sortable=null,this.listEl=null}updated(e){if(e.has(`value`))try{this.form=JSON.parse(this.value)}catch{}this.attachSortable()}disconnectedCallback(){super.disconnectedCallback(),this.sortable?.destroy(),this.sortable=null}attachSortable(){let e=this.shadowRoot?.querySelector(`.field-list`);!e||e===this.listEl||(this.listEl=e,this.sortable?.destroy(),this.sortable=ce.create(e,{animation:150,handle:`.drag-handle`,ghostClass:`sortable-ghost`,onEnd:e=>{let{oldIndex:t,newIndex:n}=e;if(t===void 0||n===void 0||t===n)return;let r=[...this.form.fields],[i]=r.splice(t,1);r.splice(n,0,i),this.form={...this.form,fields:r},this.emit()}}))}emit(){let e=JSON.stringify(this.form,null,2);this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e},bubbles:!0,composed:!0}))}updateForm(e){this.form={...this.form,...e},this.emit()}updateField(e,t){this.form={...this.form,fields:this.form.fields.map(n=>n.id===e?{...n,...t}:n)},this.emit()}addField(){let e=bo(),t={id:e,label:`New Field`,dataType:`string`};this.form={...this.form,fields:[...this.form.fields,t]},this.selectedId=e,this.emit()}deleteField(e){this.form={...this.form,fields:this.form.fields.filter(t=>t.id!==e)},this.selectedId===e&&(this.selectedId=null),this.emit()}duplicateField(e){let t=this.form.fields.find(t=>t.id===e);if(!t)return;let n={...t,id:bo(),label:t.label+` (copy)`},r=this.form.fields.findIndex(t=>t.id===e),i=[...this.form.fields];i.splice(r+1,0,n),this.form={...this.form,fields:i},this.selectedId=n.id,this.emit()}render(){return w`
             <div class="root">
                 ${this.renderToolbar()}
                 ${this.showMeta?this.renderMeta():_}
@@ -6860,15 +6860,15 @@ ${i}
                 <span class="form-name">${this.form.name}</span>
                 <div style="flex:1"></div>
                 <button class="nbtn" @click="${()=>this.showMeta=!this.showMeta}">
-                    ${qa}
+                    ${Xa}
                     Settings
                 </button>
                 <button class="nbtn primary" @click="${()=>this.addField()}">
-                    ${Ja}
+                    ${Za}
                     Add Field
                 </button>
                 <button class="nbtn" @click="${()=>this.exportJson()}">
-                    ${Ya}
+                    ${Qa}
                     Export
                 </button>
             </div>
@@ -6893,7 +6893,7 @@ ${i}
                     ${e.map(e=>this.renderRow(e))}
                 </div>
             </div>
-        `}renderRow(e){let t=go[e.dataType]??`#64748b`;return w`
+        `}renderRow(e){let t=yo[e.dataType]??`#64748b`;return w`
             <div role="button" tabindex="0" class="field-row ${this.selectedId===e.id?`selected`:``}"
                  data-id="${e.id}"
                  @click="${()=>this.selectedId=this.selectedId===e.id?null:e.id}" @keydown="${L(()=>this.selectedId=this.selectedId===e.id?null:e.id)}">
@@ -6928,13 +6928,13 @@ ${i}
                     ${t(`Data type`,w`
                         <select class="inp"
                                 @change="${t=>this.updateField(e.id,{dataType:t.target.value})}">
-                            ${mo.map(t=>w`
+                            ${_o.map(t=>w`
                                 <option value="${t}" ?selected="${e.dataType===t}">${t}</option>`)}
                         </select>`)}
                     ${t(`Stereotype`,w`
                         <select class="inp"
                                 @change="${t=>this.updateField(e.id,{stereotype:t.target.value||void 0})}">
-                            ${ho.map(t=>w`
+                            ${vo.map(t=>w`
                                 <option value="${t}" ?selected="${(e.stereotype??`regular`)===t}">${t}</option>`)}
                         </select>`)}
                     <div class="prop-field row">
@@ -6947,7 +6947,7 @@ ${i}
                                   @change="${t=>this.updateField(e.id,{description:t.target.value||void 0})}">${e.description??``}</textarea>`)}
                 </div>
             </div>
-        `}exportJson(){let e=JSON.stringify(this.form,null,2),t=new Blob([e],{type:`application/json`}),n=URL.createObjectURL(t),r=document.createElement(`a`);r.href=n,r.download=(this.form.name??`form`).replace(/\s+/g,`-`).toLowerCase()+`.json`,r.click(),URL.revokeObjectURL(n)}static{this.styles=[Ga,R,m`
+        `}exportJson(){let e=JSON.stringify(this.form,null,2),t=new Blob([e],{type:`application/json`}),n=URL.createObjectURL(t),r=document.createElement(`a`);r.href=n,r.download=(this.form.name??`form`).replace(/\s+/g,`-`).toLowerCase()+`.json`,r.click(),URL.revokeObjectURL(n)}static{this.styles=[Ja,R,m`
         :host { display: block; height: 100%; font-family: var(--lumo-font-family, sans-serif); }
 
         .root { display: flex; flex-direction: column; height: 100%; background: var(--lumo-base-color, #fff); }
@@ -7062,7 +7062,7 @@ ${i}
         .inp:focus { border-color: #3B82F6; }
         textarea.inp { resize: vertical; }
         input[readonly].inp { background: #f8fafc; color: #94a3b8; }
-    `]}};O([v()],vo.prototype,`value`,void 0),O([S()],vo.prototype,`form`,void 0),O([S()],vo.prototype,`selectedId`,void 0),O([S()],vo.prototype,`showMeta`,void 0),vo=O([h(`mateu-form-editor`)],vo);var yo=class extends y{constructor(...e){super(...e),this.appState={},this.appData={},this.open=!1,this.activeTab=`appstate`,this.hoveredTag=``,this.hoveredId=``,this.hoveredState=null,this.hoveredData=null,this.hoveredMeta=null,this._prevTarget=null,this._onMouseover=e=>{let t=e.target;for(;t&&!(t.tagName?.toLowerCase().startsWith(`mateu-`)&&t!==this);)t=t.parentElement;if(t===this||t===null){t===null&&this._prevTarget&&(this._prevTarget.style.outline=``,this._prevTarget.style.outlineOffset=``,this._prevTarget=null,this.hoveredTag=``,this.hoveredId=``,this.hoveredState=null,this.hoveredData=null,this.hoveredMeta=null);return}t!==this._prevTarget&&(this._prevTarget&&(this._prevTarget.style.outline=``,this._prevTarget.style.outlineOffset=``),this._prevTarget=t,t.style.outline=`2px solid #0070f3`,t.style.outlineOffset=`-2px`,this.hoveredTag=t.tagName.toLowerCase(),this.hoveredId=t.id||``,this.hoveredState=t.state,this.hoveredData=t.data,this.hoveredMeta=t.component?.metadata)}}connectedCallback(){super.connectedCallback(),document.addEventListener(`mouseover`,this._onMouseover,!0)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`mouseover`,this._onMouseover,!0),this._prevTarget&&=(this._prevTarget.style.outline=``,null)}_fmt(e){try{return JSON.stringify(e,null,2)??`null`}catch{return String(e)}}_renderTab(e,t){return w`
+    `]}};O([v()],xo.prototype,`value`,void 0),O([S()],xo.prototype,`form`,void 0),O([S()],xo.prototype,`selectedId`,void 0),O([S()],xo.prototype,`showMeta`,void 0),xo=O([h(`mateu-form-editor`)],xo);var So=class extends y{constructor(...e){super(...e),this.appState={},this.appData={},this.open=!1,this.activeTab=`appstate`,this.hoveredTag=``,this.hoveredId=``,this.hoveredState=null,this.hoveredData=null,this.hoveredMeta=null,this._prevTarget=null,this._onMouseover=e=>{let t=e.target;for(;t&&!(t.tagName?.toLowerCase().startsWith(`mateu-`)&&t!==this);)t=t.parentElement;if(t===this||t===null){t===null&&this._prevTarget&&(this._prevTarget.style.outline=``,this._prevTarget.style.outlineOffset=``,this._prevTarget=null,this.hoveredTag=``,this.hoveredId=``,this.hoveredState=null,this.hoveredData=null,this.hoveredMeta=null);return}t!==this._prevTarget&&(this._prevTarget&&(this._prevTarget.style.outline=``,this._prevTarget.style.outlineOffset=``),this._prevTarget=t,t.style.outline=`2px solid #0070f3`,t.style.outlineOffset=`-2px`,this.hoveredTag=t.tagName.toLowerCase(),this.hoveredId=t.id||``,this.hoveredState=t.state,this.hoveredData=t.data,this.hoveredMeta=t.component?.metadata)}}connectedCallback(){super.connectedCallback(),document.addEventListener(`mouseover`,this._onMouseover,!0)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`mouseover`,this._onMouseover,!0),this._prevTarget&&=(this._prevTarget.style.outline=``,null)}_fmt(e){try{return JSON.stringify(e,null,2)??`null`}catch{return String(e)}}_renderTab(e,t){return w`
             <button class="tab ${this.activeTab===e?`tab--active`:``}"
                 @click=${()=>{this.activeTab=e}}>
                 ${t}
@@ -7235,7 +7235,7 @@ ${i}
             border-bottom: 1px solid #2a2a3a;
         }
         .section-label:first-of-type { margin-top: 0; }
-    `}};O([v()],yo.prototype,`appState`,void 0),O([v()],yo.prototype,`appData`,void 0),O([S()],yo.prototype,`open`,void 0),O([S()],yo.prototype,`activeTab`,void 0),O([S()],yo.prototype,`hoveredTag`,void 0),O([S()],yo.prototype,`hoveredId`,void 0),O([S()],yo.prototype,`hoveredState`,void 0),O([S()],yo.prototype,`hoveredData`,void 0),O([S()],yo.prototype,`hoveredMeta`,void 0),yo=O([h(`mateu-debug-overlay`)],yo);var bo=function(e){return e.SetAppDataValue=`SetAppDataValue`,e.SetAppStateValue=`SetAppStateValue`,e.SetDataValue=`SetDataValue`,e.RunAction=`RunAction`,e.RunJS=`RunJS`,e.SetAttributeValue=`SetAttributeValue`,e.SetStateValue=`SetStateValue`,e.SetCssClass=`SetCssClass`,e.SetStyle=`SetStyle`,e}({}),xo=function(e){return e.required=`required`,e.disabled=`disabled`,e.hidden=`hidden`,e.pattern=`pattern`,e.minValue=`minValue`,e.maxValue=`maxValue`,e.minLength=`minLength`,e.maxLength=`maxLength`,e.css=`css`,e.style=`style`,e.theme=`theme`,e.errorMessage=`errorMessage`,e.description=`description`,e.none=`none`,e}({}),So=function(e){return e.Continue=`Continue`,e.Stop=`Stop`,e}({}),Co=12e4,wo=(e,t)=>`${e??`_`}::${t}`,To=new class{constructor(){this.started=new Map,this.listeners=new Set}begin(e,t=Date.now()){let n=this.started.get(e);return n!==void 0&&t-n<Co?!1:(this.started.set(e,t),this.emit(),!0)}end(e){this.started.delete(e)&&this.emit()}isPending(e,t=Date.now()){let n=this.started.get(e);return n!==void 0&&t-n<Co}snapshot(){return new Set(this.started.keys())}subscribe(e){return this.listeners.add(e),()=>this.listeners.delete(e)}reset(){this.started.clear(),this.emit()}emit(){let e=this.snapshot();this.listeners.forEach(t=>t(e))}},Eo=`data-mateu-pending-styles`,Do=`
+    `}};O([v()],So.prototype,`appState`,void 0),O([v()],So.prototype,`appData`,void 0),O([S()],So.prototype,`open`,void 0),O([S()],So.prototype,`activeTab`,void 0),O([S()],So.prototype,`hoveredTag`,void 0),O([S()],So.prototype,`hoveredId`,void 0),O([S()],So.prototype,`hoveredState`,void 0),O([S()],So.prototype,`hoveredData`,void 0),O([S()],So.prototype,`hoveredMeta`,void 0),So=O([h(`mateu-debug-overlay`)],So);var Co=function(e){return e.SetAppDataValue=`SetAppDataValue`,e.SetAppStateValue=`SetAppStateValue`,e.SetDataValue=`SetDataValue`,e.RunAction=`RunAction`,e.RunJS=`RunJS`,e.SetAttributeValue=`SetAttributeValue`,e.SetStateValue=`SetStateValue`,e.SetCssClass=`SetCssClass`,e.SetStyle=`SetStyle`,e}({}),wo=function(e){return e.required=`required`,e.disabled=`disabled`,e.hidden=`hidden`,e.pattern=`pattern`,e.minValue=`minValue`,e.maxValue=`maxValue`,e.minLength=`minLength`,e.maxLength=`maxLength`,e.css=`css`,e.style=`style`,e.theme=`theme`,e.errorMessage=`errorMessage`,e.description=`description`,e.none=`none`,e}({}),To=function(e){return e.Continue=`Continue`,e.Stop=`Stop`,e}({}),Eo=12e4,Do=(e,t)=>`${e??`_`}::${t}`,Oo=new class{constructor(){this.started=new Map,this.listeners=new Set}begin(e,t=Date.now()){let n=this.started.get(e);return n!==void 0&&t-n<Eo?!1:(this.started.set(e,t),this.emit(),!0)}end(e){this.started.delete(e)&&this.emit()}isPending(e,t=Date.now()){let n=this.started.get(e);return n!==void 0&&t-n<Eo}snapshot(){return new Set(this.started.keys())}subscribe(e){return this.listeners.add(e),()=>this.listeners.delete(e)}reset(){this.started.clear(),this.emit()}emit(){let e=this.snapshot();this.listeners.forEach(t=>t(e))}},ko=`data-mateu-pending-styles`,Ao=`
 [data-mateu-pending] {
     pointer-events: none;
     cursor: progress;
@@ -7249,9 +7249,9 @@ ${i}
     0%, 100% { opacity: .45; }
     50% { opacity: .85; }
 }
-`,Oo=new WeakSet,ko=e=>{if(Oo.has(e))return;Oo.add(e);let t=e;if(typeof CSSStyleSheet<`u`&&Array.isArray(t.adoptedStyleSheets))try{let e=new CSSStyleSheet;e.replaceSync(Do),t.adoptedStyleSheets=[...t.adoptedStyleSheets,e];return}catch{}let n=e instanceof Document?e.head:e;if(!n)return;let r=document.createElement(`style`);r.setAttribute(Eo,``),r.textContent=Do,n.appendChild(r)},Ao=e=>{let t=e.getRootNode();if(t instanceof ShadowRoot||t instanceof Document)return t},jo=e=>{if(!e||e.hasAttribute(`data-mateu-pending`))return;let t=Ao(e);t&&ko(t),e.setAttribute(`data-mateu-pending`,``),e.setAttribute(`aria-busy`,`true`)},Mo=e=>{e&&(e.removeAttribute(`data-mateu-pending`),e.removeAttribute(`aria-busy`))},No=e=>{let t=(typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target;return t instanceof Element?t:void 0},Po=[`button`,`a[href]`,`[role="button"]`,`[role="menuitem"]`,`input[type="button"]`,`input[type="submit"]`,`vaadin-button`,`vaadin-menu-bar-button`,`ui5-button`,`oj-c-button`,`oj-button`].join(`, `),Fo=e=>{if(!(!e||typeof e.closest!=`function`))return e.closest(Po)??void 0},Io=null,Lo=class extends Sa{constructor(...e){super(...e),this.baseUrl=``,this.route=``,this.consumedRoute=``,this.formerState={},this.applyRules=()=>{let e=this.component.rules;if(e&&e.length>0){let t=this.state,n=this.data,r=this.appState,i=this.appData,a=this.component,o=e=>ot(e,t,n,{appState:r,appData:i,component:a}),s=e=>at(e,t,n,r,i,{component:a}),c=[`state`,`data`,`appState`,`appData`,`component`],l=[t,n,r,i,a],u={...this.state},d={...this.data},f=!1,p=!1;for(let t=0;t<e.length;t++){let n=e[t];try{if(o(n.filter)){if(bo.SetStateValue==n.action||bo.SetDataValue==n.action){let e=bo.SetStateValue==n.action?u:d,t=n.fieldName.split(`,`);for(let r=0;r<t.length;r++){let i=t[r];if(!e[i]||e[i]!=n.value){let t=n.expression?s(n.expression):n.value,r=xo.none==n.fieldAttribute?i:i+`.`+n.fieldAttribute;t!=e[r]&&(e[r]=t,bo.SetStateValue==n.action&&(f=!0),bo.SetDataValue==n.action&&(p=!0))}}}if(bo.RunAction==n.action&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.actionId},bubbles:!0,composed:!0})),bo.RunJS==n.action&&Function(...c,n.value)(...l),bo.SetAttributeValue==n.action){let e=n.expression?o(n.expression):n.value;if(n.fieldAttribute==`disabled`){e?this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(n.fieldAttribute,`disabled`):this.shadowRoot?.getElementById(n.fieldName)?.removeAttribute(n.fieldAttribute);continue}this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(n.fieldAttribute,e)}if(bo.SetCssClass==n.action&&this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(`class`,n.value),bo.SetStyle==n.action&&this.shadowRoot?.getElementById(n.fieldName)?.style.setProperty(n.expression,n.value),So.Stop==n.result)break}}catch(e){console.error(`rule failed`,n,e)}}f&&(this.state=u),p&&(this.data=d),f&&this.checkValidations()}},this.skipValidation=(e,t)=>e&&t.fieldId&&!e.includes(t.fieldId)||!e&&t.fieldId&&t.fieldId.includes(`-`),this.checkValidations=e=>{let t=e?e.split(`,`):void 0,n=this.component.validations,r=!0,i=!1,a=this.data??{},o={...this.data??{},errors:{}};if(n){for(let e=0;e<n.length;e++){let r=n[e];if(this.skipValidation(t,r))continue;let i=(r.fieldId??`_component`).split(`,`);for(let e=0;e<i.length;e++){let t=i[e];o.errors[t]=[]}}for(let e=0;e<n.length;e++){let i=n[e];if(!this.skipValidation(t,i))try{let e=i.condition&&i.condition.includes("${")?this._evalTemplate(i.condition):this._evalExpr(i.condition);if(i.condition&&!e){r=!1;let e=(i.fieldId??`_component`).split(`,`);for(let t=0;t<e.length;t++){let n=e[t],r=o.errors[n];if(r||(o.errors[n]=[]),r=o.errors[n],!a[n]){let e=i.message;try{e=this._evalTemplate(i.message)}catch{}r.push(e)}}}}catch(e){console.error(`validation failed`,i,e)}}for(let e=0;e<n.length;e++){let r=n[e];if(this.skipValidation(t,r))continue;let s=(r.fieldId??`_component`).split(`,`);for(let e=0;e<s.length;e++){let t=s[e];if((a.errors||o.errors==``)&&[t].join(`,`)){i=!0;break}}}(a.errors||o.errors==``)&&[`_component`].join(`,`)&&(i=!0)}o._valid=r,o._valid!=a._valid&&(i=!0),i&&(this.data=o)},this._autoSaveTimers=new Map,this.onChange=()=>{this.applyRules()},this.closeModalRequestedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.closeModal()},this.resetFilters=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail,n={};t.fieldIds.forEach(e=>{n[e]=void 0}),n.searchText=void 0,this.state={...this.state,...n}}},this.dataChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail,n={};n[t.key]=t.value,e.type==`data-changed`&&(this.data={...this.data,...n})}},this.valueChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail;if(e.type==`value-changed`){let n={...this.state};n[t.fieldId]=t.value,this.state=n,(this.state[t.fieldId]||this.formerState[t.fieldId])&&this.state[t.fieldId]!=this.formerState[t.fieldId]&&this.component?.confirmOnNavigationIfDirty&&this.dispatchEvent(new CustomEvent(`dirty`,{detail:e.detail,bubbles:!0,composed:!0}));let r=this.component;r.triggers?.filter(e=>e.type==xa.OnValueChange).filter(e=>!e.propertyName||t.fieldId==e.propertyName).forEach(e=>{(!e.condition||this._evalExpr(e.condition))&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))}),r.triggers?.filter(e=>e.type==xa.AutoSave).forEach(e=>{let t=e.actionId,n=this._autoSaveTimers.get(t);n!==void 0&&clearTimeout(n),this._autoSaveTimers.set(t,setTimeout(()=>{this._autoSaveTimers.delete(t),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))},e.debounceMillis??800))})}}},this.actionRequestedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.manageActionRequestedEvent(e)},this.manageActionRequestedEvent=e=>{let t=e.detail,n=t?._originElement??No(e);if(e.type==`action-requested`){e.preventDefault(),e.stopPropagation();let r=this.component,i=r.actions?.find(e=>e.id==t.actionId)??r.actions?.find(e=>e.id.endsWith(`*`)&&t.actionId.startsWith(e.id.replace(`*`,``)));if(i){if(i&&i.rowsSelectedRequired&&(!this.state.crud_selected_items||this.state.crud_selected_items.length==0)){this.notify(`You first need to select some rows`);return}if(i&&i.validationRequired){let e=Io??this;if(Io=null,e.checkValidations(i.fieldsToValidate),!e.data._valid){e.notifyValidationErrors();return}}Io=null;let e={...t,initiatorComponentId:this.id};i&&i.confirmationRequired?this.callAfterConfirmation(i,()=>this.requestActionCallToServerOrBubble(e,r,i,n)):this.requestActionCallToServerOrBubble(e,r,i,n)}else{let r={...t.parameters};r.initiatorState||=this.state,Io||=this,this.dispatchEvent(new CustomEvent(e.type,{detail:{...e.detail,_originElement:n,parameters:r},bubbles:!0,composed:!0}))}}},this.buildFieldLabelMap=()=>{let e={},t=n=>{if(n)for(let r of n){let n=r.metadata;if(n?.type===A.FormField){let t=n;t.fieldId&&t.label&&(e[t.fieldId]=t.label)}t(r.children)}};return t(this.component?.children),e},this.notifyValidationErrors=()=>{let e=this.data?.errors??{},t=this.buildFieldLabelMap(),n=[];if(Object.entries(e).forEach(([e,r])=>{if(!Array.isArray(r))return;let i=e===`_component`?void 0:t[e]??e;r.forEach(e=>{e&&!n.some(t=>t.label===i&&t.msg===e)&&n.push({label:i,msg:e})})}),n.length===0){this.notify(`There are validation errors`);return}pa({text:`There are validation errors
+`,jo=new WeakSet,Mo=e=>{if(jo.has(e))return;jo.add(e);let t=e;if(typeof CSSStyleSheet<`u`&&Array.isArray(t.adoptedStyleSheets))try{let e=new CSSStyleSheet;e.replaceSync(Ao),t.adoptedStyleSheets=[...t.adoptedStyleSheets,e];return}catch{}let n=e instanceof Document?e.head:e;if(!n)return;let r=document.createElement(`style`);r.setAttribute(ko,``),r.textContent=Ao,n.appendChild(r)},No=e=>{let t=e.getRootNode();if(t instanceof ShadowRoot||t instanceof Document)return t},Po=e=>{if(!e||e.hasAttribute(`data-mateu-pending`))return;let t=No(e);t&&Mo(t),e.setAttribute(`data-mateu-pending`,``),e.setAttribute(`aria-busy`,`true`)},Fo=e=>{e&&(e.removeAttribute(`data-mateu-pending`),e.removeAttribute(`aria-busy`))},Io=e=>{let t=(typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target;return t instanceof Element?t:void 0},Lo=[`button`,`a[href]`,`[role="button"]`,`[role="menuitem"]`,`input[type="button"]`,`input[type="submit"]`,`vaadin-button`,`vaadin-menu-bar-button`,`ui5-button`,`oj-c-button`,`oj-button`].join(`, `),Ro=e=>{if(!(!e||typeof e.closest!=`function`))return e.closest(Lo)??void 0},zo=null,Bo=class extends wa{constructor(...e){super(...e),this.baseUrl=``,this.route=``,this.consumedRoute=``,this.formerState={},this.applyRules=()=>{let e=this.component.rules;if(e&&e.length>0){let t=this.state,n=this.data,r=this.appState,i=this.appData,a=this.component,o=e=>ot(e,t,n,{appState:r,appData:i,component:a}),s=e=>at(e,t,n,r,i,{component:a}),c=[`state`,`data`,`appState`,`appData`,`component`],l=[t,n,r,i,a],u={...this.state},d={...this.data},f=!1,p=!1;for(let t=0;t<e.length;t++){let n=e[t];try{if(o(n.filter)){if(Co.SetStateValue==n.action||Co.SetDataValue==n.action){let e=Co.SetStateValue==n.action?u:d,t=n.fieldName.split(`,`);for(let r=0;r<t.length;r++){let i=t[r];if(!e[i]||e[i]!=n.value){let t=n.expression?s(n.expression):n.value,r=wo.none==n.fieldAttribute?i:i+`.`+n.fieldAttribute;t!=e[r]&&(e[r]=t,Co.SetStateValue==n.action&&(f=!0),Co.SetDataValue==n.action&&(p=!0))}}}if(Co.RunAction==n.action&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.actionId},bubbles:!0,composed:!0})),Co.RunJS==n.action&&Function(...c,n.value)(...l),Co.SetAttributeValue==n.action){let e=n.expression?o(n.expression):n.value;if(n.fieldAttribute==`disabled`){e?this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(n.fieldAttribute,`disabled`):this.shadowRoot?.getElementById(n.fieldName)?.removeAttribute(n.fieldAttribute);continue}this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(n.fieldAttribute,e)}if(Co.SetCssClass==n.action&&this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(`class`,n.value),Co.SetStyle==n.action&&this.shadowRoot?.getElementById(n.fieldName)?.style.setProperty(n.expression,n.value),To.Stop==n.result)break}}catch(e){console.error(`rule failed`,n,e)}}f&&(this.state=u),p&&(this.data=d),f&&this.checkValidations()}},this.skipValidation=(e,t)=>e&&t.fieldId&&!e.includes(t.fieldId)||!e&&t.fieldId&&t.fieldId.includes(`-`),this.checkValidations=e=>{let t=e?e.split(`,`):void 0,n=this.component.validations,r=!0,i=!1,a=this.data??{},o={...this.data??{},errors:{}};if(n){for(let e=0;e<n.length;e++){let r=n[e];if(this.skipValidation(t,r))continue;let i=(r.fieldId??`_component`).split(`,`);for(let e=0;e<i.length;e++){let t=i[e];o.errors[t]=[]}}for(let e=0;e<n.length;e++){let i=n[e];if(!this.skipValidation(t,i))try{let e=i.condition&&i.condition.includes("${")?this._evalTemplate(i.condition):this._evalExpr(i.condition);if(i.condition&&!e){r=!1;let e=(i.fieldId??`_component`).split(`,`);for(let t=0;t<e.length;t++){let n=e[t],r=o.errors[n];if(r||(o.errors[n]=[]),r=o.errors[n],!a[n]){let e=i.message;try{e=this._evalTemplate(i.message)}catch{}r.push(e)}}}}catch(e){console.error(`validation failed`,i,e)}}for(let e=0;e<n.length;e++){let r=n[e];if(this.skipValidation(t,r))continue;let s=(r.fieldId??`_component`).split(`,`);for(let e=0;e<s.length;e++){let t=s[e];if((a.errors||o.errors==``)&&[t].join(`,`)){i=!0;break}}}(a.errors||o.errors==``)&&[`_component`].join(`,`)&&(i=!0)}o._valid=r,o._valid!=a._valid&&(i=!0),i&&(this.data=o)},this._autoSaveTimers=new Map,this.onChange=()=>{this.applyRules()},this.closeModalRequestedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.closeModal()},this.resetFilters=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail,n={};t.fieldIds.forEach(e=>{n[e]=void 0}),n.searchText=void 0,this.state={...this.state,...n}}},this.dataChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail,n={};n[t.key]=t.value,e.type==`data-changed`&&(this.data={...this.data,...n})}},this.valueChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail;if(e.type==`value-changed`){let n={...this.state};n[t.fieldId]=t.value,this.state=n,(this.state[t.fieldId]||this.formerState[t.fieldId])&&this.state[t.fieldId]!=this.formerState[t.fieldId]&&this.component?.confirmOnNavigationIfDirty&&this.dispatchEvent(new CustomEvent(`dirty`,{detail:e.detail,bubbles:!0,composed:!0}));let r=this.component;r.triggers?.filter(e=>e.type==Ca.OnValueChange).filter(e=>!e.propertyName||t.fieldId==e.propertyName).forEach(e=>{(!e.condition||this._evalExpr(e.condition))&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))}),r.triggers?.filter(e=>e.type==Ca.AutoSave).forEach(e=>{let t=e.actionId,n=this._autoSaveTimers.get(t);n!==void 0&&clearTimeout(n),this._autoSaveTimers.set(t,setTimeout(()=>{this._autoSaveTimers.delete(t),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))},e.debounceMillis??800))})}}},this.actionRequestedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.manageActionRequestedEvent(e)},this.manageActionRequestedEvent=e=>{let t=e.detail,n=t?._originElement??Io(e);if(e.type==`action-requested`){e.preventDefault(),e.stopPropagation();let r=this.component,i=r.actions?.find(e=>e.id==t.actionId)??r.actions?.find(e=>e.id.endsWith(`*`)&&t.actionId.startsWith(e.id.replace(`*`,``)));if(i){if(i&&i.rowsSelectedRequired&&(!this.state.crud_selected_items||this.state.crud_selected_items.length==0)){this.notify(`You first need to select some rows`);return}if(i&&i.validationRequired){let e=zo??this;if(zo=null,e.checkValidations(i.fieldsToValidate),!e.data._valid){e.notifyValidationErrors();return}}zo=null;let e={...t,initiatorComponentId:this.id};i&&i.confirmationRequired?this.callAfterConfirmation(i,()=>this.requestActionCallToServerOrBubble(e,r,i,n)):this.requestActionCallToServerOrBubble(e,r,i,n)}else{let r={...t.parameters};r.initiatorState||=this.state,zo||=this,this.dispatchEvent(new CustomEvent(e.type,{detail:{...e.detail,_originElement:n,parameters:r},bubbles:!0,composed:!0}))}}},this.buildFieldLabelMap=()=>{let e={},t=n=>{if(n)for(let r of n){let n=r.metadata;if(n?.type===A.FormField){let t=n;t.fieldId&&t.label&&(e[t.fieldId]=t.label)}t(r.children)}};return t(this.component?.children),e},this.notifyValidationErrors=()=>{let e=this.data?.errors??{},t=this.buildFieldLabelMap(),n=[];if(Object.entries(e).forEach(([e,r])=>{if(!Array.isArray(r))return;let i=e===`_component`?void 0:t[e]??e;r.forEach(e=>{e&&!n.some(t=>t.label===i&&t.msg===e)&&n.push({label:i,msg:e})})}),n.length===0){this.notify(`There are validation errors`);return}ha({text:`There are validation errors
 `+n.map(({label:e,msg:t})=>e?`• ${e}: ${t}`:`• ${t}`).join(`
-`),variant:`error`,position:`bottomEnd`,duration:Math.max(3e3,1500+n.length*1e3)},this),this.focusFirstInvalidField()},this.notify=e=>{pa({text:e,variant:`error`,position:`bottomEnd`,duration:3e3},this)},this.handleRestAction=(e,t)=>{let n=t=>{if(e.resultPath!=null){let n=Ut(t,e.resultPath);n&&typeof n==`object`&&(this.state={...this.state,...n})}let n=j(e.successMessage,this.state,this.data);n&&pa({text:n,variant:`success`,position:`bottomEnd`,duration:3e3},this)};if(e.source?.proxy){let e=t===`__restdata__`?`data`:`action`;this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:`__restfetch__`,parameters:{_sourceKind:e,_sourceId:t},callback:e=>n(e?.appData?._restfetch),callbackonly:!0},bubbles:!0,composed:!0}));return}Kt(e.source,e=>j(e,this.state,this.data)).then(n).catch(e=>{console.warn(`mateu: rest action failed`,e),pa({text:`Request failed`,variant:`error`,position:`bottomEnd`,duration:3e3},this)})},this.callAfterConfirmation=(e,t)=>{let n=`One moment, please`,r=`Are you sure?`,i=`Yes`,a=`No`;e.confirmationTexts&&(n=e.confirmationTexts.title,r=e.confirmationTexts.message,i=e.confirmationTexts.confirmationText,a=e.confirmationTexts.denialText);let o=document.createElement(`div`);o.style.cssText=`position:fixed;inset:0;z-index:1100;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.35);padding:1rem;`;let s=document.createElement(`div`);s.style.cssText=`background:var(--lumo-base-color,#fff);color:var(--lumo-body-text-color,#1a1a1a);border-radius:var(--lumo-border-radius-l,12px);box-shadow:var(--lumo-box-shadow-xl,0 12px 40px rgba(0,0,0,.3));padding:1.2rem;max-width:min(90vw,26rem);`;let c=()=>{o.parentElement&&document.body.removeChild(o)},l=`font:inherit;font-weight:600;padding:.45rem 1rem;border-radius:var(--lumo-border-radius-m,6px);cursor:pointer;`;ie(w`
+`),variant:`error`,position:`bottomEnd`,duration:Math.max(3e3,1500+n.length*1e3)},this),this.focusFirstInvalidField()},this.notify=e=>{ha({text:e,variant:`error`,position:`bottomEnd`,duration:3e3},this)},this.handleRestAction=(e,t)=>{let n=t=>{if(e.resultPath!=null){let n=Gt(t,e.resultPath);n&&typeof n==`object`&&(this.state={...this.state,...n})}let n=j(e.successMessage,this.state,this.data);n&&ha({text:n,variant:`success`,position:`bottomEnd`,duration:3e3},this)};if(e.source?.proxy){let e=t===`__restdata__`?`data`:`action`;this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:`__restfetch__`,parameters:{_sourceKind:e,_sourceId:t},callback:e=>n(e?.appData?._restfetch),callbackonly:!0},bubbles:!0,composed:!0}));return}Jt(e.source,e=>j(e,this.state,this.data)).then(n).catch(e=>{console.warn(`mateu: rest action failed`,e),ha({text:`Request failed`,variant:`error`,position:`bottomEnd`,duration:3e3},this)})},this.callAfterConfirmation=(e,t)=>{let n=`One moment, please`,r=`Are you sure?`,i=`Yes`,a=`No`;e.confirmationTexts&&(n=e.confirmationTexts.title,r=e.confirmationTexts.message,i=e.confirmationTexts.confirmationText,a=e.confirmationTexts.denialText);let o=document.createElement(`div`);o.style.cssText=`position:fixed;inset:0;z-index:1100;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.35);padding:1rem;`;let s=document.createElement(`div`);s.style.cssText=`background:var(--lumo-base-color,#fff);color:var(--lumo-body-text-color,#1a1a1a);border-radius:var(--lumo-border-radius-l,12px);box-shadow:var(--lumo-box-shadow-xl,0 12px 40px rgba(0,0,0,.3));padding:1.2rem;max-width:min(90vw,26rem);`;let c=()=>{o.parentElement&&document.body.removeChild(o)},l=`font:inherit;font-weight:600;padding:.45rem 1rem;border-radius:var(--lumo-border-radius-m,6px);cursor:pointer;`;ie(w`
             <h3 style="margin:0 0 .5rem;">${n}</h3>
             <div style="margin-bottom:1.2rem;">${r}</div>
             <div style="display:flex;justify-content:flex-end;gap:.5rem;">
@@ -7260,18 +7260,18 @@ ${i}
                 <button style="${l}border:none;background:var(--lumo-primary-color,#1676f3);color:var(--lumo-primary-contrast-color,#fff);"
                         @click="${()=>{c(),t()}}">${i}</button>
             </div>
-        `,s),o.appendChild(s),o.addEventListener(`click`,e=>{e.target===o&&c()}),document.body.appendChild(o)},this.requestActionCallToServerOrBubble=(e,t,n,r)=>{if(n&&n.bubble){let t={...e.parameters};t.initiatorState||=this.state,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{...e,_originElement:r,parameters:t},bubbles:!0,composed:!0}))}else this.requestActionCallToServer(e,t,n,r)},this.requestActionCallToServer=(e,t,n,r)=>{if(n&&n.href){window.location.href=n.href;return}if(n&&n.js)try{Function(`state`,`data`,`appState`,`appData`,`component`,n.js).call(this,this.state??{},this.data??{},this.appState??{},this.appData??{},this.component),this.state={...this.state},this.data={...this.data}}catch(e){console.error(`when evaluating `+n.js,e,this.component,this.state,this.data)}if(n&&n.customEvent&&this.dispatchEvent(new CustomEvent(n.customEvent.name,{detail:n.customEvent.detail,bubbles:!0,composed:!0})),!(n&&(n.js||n.customEvent))){if(n&&n.restAction){this.handleRestAction(n.restAction,n.id);return}if(e.actionId==`search`){let t=e.parameters?._searchState;t?this.state={...this.state,...t}:this.state.size||(this.state={...this.state,size:10,page:0,sort:[]})}if(!n?.background){if(!Re(e.actionId,n?.idempotent)&&!To.begin(wo(this.id,e.actionId)))return;let t=Fo(r);this._pendingOrigins.set(e.actionId,t),jo(t)}this.dispatchEvent(new CustomEvent(`server-side-action-requested`,{detail:{route:this.route,consumedRoute:this.consumedRoute,componentState:{...this.state},parameters:e.parameters??{},actionId:e.actionId,serverSideType:t.serverSideType,serverSideComponentRoute:t.route,initiatorComponentId:e.initiatorComponentId??t.id,initiator:this,background:n?.background,sse:n?.sse,timeoutMillis:n?.timeoutMillis,idempotent:n?.idempotent,callback:e.callback,callbackonly:e.callbackonly,callbackToken:e.callbackToken??this.callbackToken},bubbles:!0,composed:!0}))}},this.handleBackendSucceeded=e=>{e.detail.actionId&&this.component.triggers?.filter(e=>e.type==xa.OnSuccess).filter(t=>e.detail.actionId==t.calledActionId).forEach(t=>{if(!t.condition||this._evalExpr(t.condition))if(e.preventDefault(),e.stopPropagation(),t.timeoutMillis>0){let e=this.callbackToken;setTimeout(()=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,callbackToken:e},bubbles:!0,composed:!0}))},t.timeoutMillis)}else this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))})},this.handleBackendFailed=e=>{e.detail.actionId&&this.component.triggers?.filter(e=>e.type==xa.OnError).filter(t=>e.detail.actionId==t.calledActionId).forEach(t=>{(!t.condition||this._evalExpr(t.condition))&&(e.preventDefault(),e.stopPropagation(),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0})))})},this._pendingOrigins=new Map,this._backendSettledListener=e=>{((typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target)===this&&this._releasePending(e.detail?.actionId)},this._keydownListener=e=>{if(this._handleTabShortcut(e))return;let t=this.component;if(t)for(let n of t.actions??[]){let t=n.shortcut||(n.runOnEnter?`enter`:null);if(t&&this._shortcutMatchesEvent(t,e)){e.preventDefault(),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.id},bubbles:!0,composed:!0}));return}}}}createRenderRoot(){return N.mustUseShadowRoot()?super.createRenderRoot():this}updated(e){super.updated(e),e.has(`state`)&&this.state&&JSON.stringify(this.state)!=JSON.stringify({})&&this.onChange(),e.has(`component`)&&(this.formerState={...this.state},this.component?.confirmOnNavigationIfDirty&&this.dispatchEvent(new CustomEvent(`clean`,{detail:{},bubbles:!0,composed:!0})),setTimeout(()=>this.triggerOnLoad()))}focusFirstInvalidField(){let e=t=>requestAnimationFrame(()=>{let n=this.findFirstInvalid(this.renderRoot);if(n){n.focus?.(),n.scrollIntoView?.({block:`center`,behavior:`smooth`});return}t>0&&e(t-1)});e(3)}findFirstInvalid(e){if(!e?.querySelectorAll)return null;for(let t of Array.from(e.querySelectorAll(`*`))){if(t.invalid===!0)return t;if(t.shadowRoot){let e=this.findFirstInvalid(t.shadowRoot);if(e)return e}}return null}_releasePending(e){(e===void 0?Array.from(this._pendingOrigins.keys()):[e]).forEach(e=>{To.end(wo(this.id,e)),Mo(this._pendingOrigins.get(e)),this._pendingOrigins.delete(e)})}_shortcutMatchesEvent(e,t){return Ln(e,t)}_collectShortcutTabs(){let e=this.renderRoot;if(!e)return[];let t=Array.from(e.querySelectorAll(`vaadin-tab[data-shortcut]`));return e.querySelectorAll(`mateu-drawer, mateu-dialog`).forEach(e=>{let n=e.shadowRoot;n&&t.push(...Array.from(n.querySelectorAll(`vaadin-tab[data-shortcut]`)))}),t}_handleTabShortcut(e){let t=this._collectShortcutTabs();if(t.length===0)return!1;for(let n of Array.from(t)){let t=n.dataset.shortcut;if(!t||!this._shortcutMatchesEvent(t,e))continue;let r=n.closest(`vaadin-tabs`);if(!r)continue;let i=Array.from(r.querySelectorAll(`vaadin-tab`)).indexOf(n);if(!(i<0))return e.preventDefault(),r.selected=i,!0}return!1}connectedCallback(){super.connectedCallback(),this.addEventListener(`backend-call-succeeded`,this.handleBackendSucceeded),this.addEventListener(`backend-call-failed`,this.handleBackendFailed),this.addEventListener(`backend-succeeded-event`,this._backendSettledListener),this.addEventListener(`backend-failed-event`,this._backendSettledListener),this.addEventListener(`backend-cancelled-event`,this._backendSettledListener),document.addEventListener(`keydown`,this._keydownListener)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`backend-call-succeeded`,this.handleBackendSucceeded),this.removeEventListener(`backend-call-failed`,this.handleBackendFailed),this.removeEventListener(`backend-succeeded-event`,this._backendSettledListener),this.removeEventListener(`backend-failed-event`,this._backendSettledListener),this.removeEventListener(`backend-cancelled-event`,this._backendSettledListener),document.removeEventListener(`keydown`,this._keydownListener),this._releasePending()}render(){return w`<div>
+        `,s),o.appendChild(s),o.addEventListener(`click`,e=>{e.target===o&&c()}),document.body.appendChild(o)},this.requestActionCallToServerOrBubble=(e,t,n,r)=>{if(n&&n.bubble){let t={...e.parameters};t.initiatorState||=this.state,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{...e,_originElement:r,parameters:t},bubbles:!0,composed:!0}))}else this.requestActionCallToServer(e,t,n,r)},this.requestActionCallToServer=(e,t,n,r)=>{if(n&&n.href){window.location.href=n.href;return}if(n&&n.js)try{Function(`state`,`data`,`appState`,`appData`,`component`,n.js).call(this,this.state??{},this.data??{},this.appState??{},this.appData??{},this.component),this.state={...this.state},this.data={...this.data}}catch(e){console.error(`when evaluating `+n.js,e,this.component,this.state,this.data)}if(n&&n.customEvent&&this.dispatchEvent(new CustomEvent(n.customEvent.name,{detail:n.customEvent.detail,bubbles:!0,composed:!0})),!(n&&(n.js||n.customEvent))){if(n&&n.restAction){this.handleRestAction(n.restAction,n.id);return}if(e.actionId==`search`){let t=e.parameters?._searchState;t?this.state={...this.state,...t}:this.state.size||(this.state={...this.state,size:10,page:0,sort:[]})}if(!n?.background){if(!Re(e.actionId,n?.idempotent)&&!Oo.begin(Do(this.id,e.actionId)))return;let t=Ro(r);this._pendingOrigins.set(e.actionId,t),Po(t)}this.dispatchEvent(new CustomEvent(`server-side-action-requested`,{detail:{route:this.route,consumedRoute:this.consumedRoute,componentState:{...this.state},parameters:e.parameters??{},actionId:e.actionId,serverSideType:t.serverSideType,serverSideComponentRoute:t.route,initiatorComponentId:e.initiatorComponentId??t.id,initiator:this,background:n?.background,sse:n?.sse,timeoutMillis:n?.timeoutMillis,idempotent:n?.idempotent,callback:e.callback,callbackonly:e.callbackonly,callbackToken:e.callbackToken??this.callbackToken},bubbles:!0,composed:!0}))}},this.handleBackendSucceeded=e=>{e.detail.actionId&&this.component.triggers?.filter(e=>e.type==Ca.OnSuccess).filter(t=>e.detail.actionId==t.calledActionId).forEach(t=>{if(!t.condition||this._evalExpr(t.condition))if(e.preventDefault(),e.stopPropagation(),t.timeoutMillis>0){let e=this.callbackToken;setTimeout(()=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,callbackToken:e},bubbles:!0,composed:!0}))},t.timeoutMillis)}else this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))})},this.handleBackendFailed=e=>{e.detail.actionId&&this.component.triggers?.filter(e=>e.type==Ca.OnError).filter(t=>e.detail.actionId==t.calledActionId).forEach(t=>{(!t.condition||this._evalExpr(t.condition))&&(e.preventDefault(),e.stopPropagation(),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0})))})},this._pendingOrigins=new Map,this._backendSettledListener=e=>{((typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target)===this&&this._releasePending(e.detail?.actionId)},this._keydownListener=e=>{if(this._handleTabShortcut(e))return;let t=this.component;if(t)for(let n of t.actions??[]){let t=n.shortcut||(n.runOnEnter?`enter`:null);if(t&&this._shortcutMatchesEvent(t,e)){e.preventDefault(),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.id},bubbles:!0,composed:!0}));return}}}}createRenderRoot(){return N.mustUseShadowRoot()?super.createRenderRoot():this}updated(e){super.updated(e),e.has(`state`)&&this.state&&JSON.stringify(this.state)!=JSON.stringify({})&&this.onChange(),e.has(`component`)&&(this.formerState={...this.state},this.component?.confirmOnNavigationIfDirty&&this.dispatchEvent(new CustomEvent(`clean`,{detail:{},bubbles:!0,composed:!0})),setTimeout(()=>this.triggerOnLoad()))}focusFirstInvalidField(){let e=t=>requestAnimationFrame(()=>{let n=this.findFirstInvalid(this.renderRoot);if(n){n.focus?.(),n.scrollIntoView?.({block:`center`,behavior:`smooth`});return}t>0&&e(t-1)});e(3)}findFirstInvalid(e){if(!e?.querySelectorAll)return null;for(let t of Array.from(e.querySelectorAll(`*`))){if(t.invalid===!0)return t;if(t.shadowRoot){let e=this.findFirstInvalid(t.shadowRoot);if(e)return e}}return null}_releasePending(e){(e===void 0?Array.from(this._pendingOrigins.keys()):[e]).forEach(e=>{Oo.end(Do(this.id,e)),Fo(this._pendingOrigins.get(e)),this._pendingOrigins.delete(e)})}_shortcutMatchesEvent(e,t){return zn(e,t)}_collectShortcutTabs(){let e=this.renderRoot;if(!e)return[];let t=Array.from(e.querySelectorAll(`vaadin-tab[data-shortcut]`));return e.querySelectorAll(`mateu-drawer, mateu-dialog`).forEach(e=>{let n=e.shadowRoot;n&&t.push(...Array.from(n.querySelectorAll(`vaadin-tab[data-shortcut]`)))}),t}_handleTabShortcut(e){let t=this._collectShortcutTabs();if(t.length===0)return!1;for(let n of Array.from(t)){let t=n.dataset.shortcut;if(!t||!this._shortcutMatchesEvent(t,e))continue;let r=n.closest(`vaadin-tabs`);if(!r)continue;let i=Array.from(r.querySelectorAll(`vaadin-tab`)).indexOf(n);if(!(i<0))return e.preventDefault(),r.selected=i,!0}return!1}connectedCallback(){super.connectedCallback(),this.addEventListener(`backend-call-succeeded`,this.handleBackendSucceeded),this.addEventListener(`backend-call-failed`,this.handleBackendFailed),this.addEventListener(`backend-succeeded-event`,this._backendSettledListener),this.addEventListener(`backend-failed-event`,this._backendSettledListener),this.addEventListener(`backend-cancelled-event`,this._backendSettledListener),document.addEventListener(`keydown`,this._keydownListener)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`backend-call-succeeded`,this.handleBackendSucceeded),this.removeEventListener(`backend-call-failed`,this.handleBackendFailed),this.removeEventListener(`backend-succeeded-event`,this._backendSettledListener),this.removeEventListener(`backend-failed-event`,this._backendSettledListener),this.removeEventListener(`backend-cancelled-event`,this._backendSettledListener),document.removeEventListener(`keydown`,this._keydownListener),this._releasePending()}render(){return w`<div>
             <div>${this._render()}</div>
             ${this.data&&this.data.errors&&this.data.errors._component&&this.data.errors._component.length>0?w`
                 <div><ul>${this.data.errors._component.map(e=>w`<li>${e}</li>`)}</ul></div>
-            `:_}</div>`}_render(){if(this.component?.type==k.ClientSide){let e=this.component;return e.metadata?.type==A.Page?br(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!0):e.metadata?.type==A.Crud?xr(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!0):N.get()?.renderClientSideComponent(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!1)}return w`
+            `:_}</div>`}_render(){if(this.component?.type==k.ClientSide){let e=this.component;return e.metadata?.type==A.Page?Sr(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!0):e.metadata?.type==A.Crud?Cr(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!0):N.get()?.renderClientSideComponent(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!1)}return w`
             <mateu-api-caller 
                     @value-changed="${this.valueChangedListener}"
                     @data-changed="${this.dataChangedListener}"
                     @close-modal-requested="${this.closeModalRequestedListener}"
                     @filter-reset-requested="${this.resetFilters}"
                     @action-requested="${this.actionRequestedListener}">
-            ${this.component?.children?.map(e=>{if(e.type==k.ClientSide){let t=e;if(t.metadata?.type==A.Page)return br(this,t,this.baseUrl,this.state,this.data,this.appState,this.appData,!0);if(t.metadata?.type==A.Crud)return xr(this,t,this.baseUrl,this.state,this.data,this.appState,this.appData,!0)}return P(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData)})}
+            ${this.component?.children?.map(e=>{if(e.type==k.ClientSide){let t=e;if(t.metadata?.type==A.Page)return Sr(this,t,this.baseUrl,this.state,this.data,this.appState,this.appData,!0);if(t.metadata?.type==A.Crud)return Cr(this,t,this.baseUrl,this.state,this.data,this.appState,this.appData,!0)}return P(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData)})}
             </mateu-api-caller>
         `}static{this.styles=m`
         :host {
@@ -7308,9 +7308,9 @@ ${i}
             padding-block: var(--lumo-space-xs);
             box-shadow: 0 1px 0 0 var(--lumo-contrast-10pct, rgba(0, 0, 0, 0.1));
         }
-  `}};O([v()],Lo.prototype,`baseUrl`,void 0),O([v()],Lo.prototype,`route`,void 0),O([v()],Lo.prototype,`consumedRoute`,void 0),Lo=O([h(`mateu-component`)],Lo);var Ro=e=>{if(e)try{return JSON.parse(e)}catch{return{value:e}}else return{}},zo=new class{async handle(e,t){return await e.runAction(t.baseUrl,t.route,t.consumedRoute,t.actionId,t.initiatorComponentId,t.appState,t.serverSideType,t.componentState,t.parameters,t.initiator,t.background,t.options)}},Bo=new class{constructor(){this.handleUIIncrement=(e,t,n)=>{if(e?.fragments?.forEach(e=>{ue.next({command:void 0,fragment:e,ui:void 0,error:void 0,callbackToken:n})}),e?.appState&&(D.value={...e.appState},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))),e?.appData){let n=e?.appData;de.value={...e.appData,...n},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))}e?.messages?.forEach(e=>{pa({text:e.text,position:e.position,variant:e.variant,duration:e.duration,undoLabel:e.undoLabel,undoActionId:e.undoActionId,undoParameters:e.undoParameters},t)}),e?.banners&&e.banners.length>0&&document.dispatchEvent(new CustomEvent(`page-banners-received`,{detail:{banners:e.banners,append:e.appendBanners??!1},bubbles:!1,composed:!1})),e?.commands?.forEach(e=>{ue.next({command:e,fragment:void 0,ui:void 0,error:void 0,callbackToken:n})})}}async runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,te={}){let ne=()=>{this.runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,te)};try{let o=await zo.handle(e,{baseUrl:t,route:n,consumedRoute:r,actionId:i,appState:D.value,initiatorComponentId:a,componentState:c,parameters:l,serverSideType:s,initiator:u,background:d,options:{...te,retry:ne}});f&&f(o),p||this.handleUIIncrement(o,u,ee),o.messages&&o.messages.length==1&&o.messages[0].variant==`error`&&u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-succeeded`,{detail:{actionId:i,evevntId:T()},bubbles:!0,composed:!0}))}catch(e){console.warn(`Action request failed`,e),e?.__mateuReported||u.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:i,reason:this.serialize(e),retry:ne}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))}}serialize(e){return e?.message?e:JSON.stringify(e)}},Vo=new class{constructor(){this.handleUIIncrement=(e,t,n)=>{if(e?.messages?.forEach(e=>{pa({text:e.text,position:e.position,variant:e.variant,duration:e.duration,undoLabel:e.undoLabel,undoActionId:e.undoActionId,undoParameters:e.undoParameters},t)}),e?.banners&&e.banners.length>0&&document.dispatchEvent(new CustomEvent(`page-banners-received`,{detail:{banners:e.banners,append:e.appendBanners??!1},bubbles:!1,composed:!1})),e?.commands?.forEach(e=>{ue.next({command:e,fragment:void 0,ui:void 0,error:void 0,callbackToken:n})}),e?.fragments?.forEach(e=>{ue.next({command:void 0,fragment:e,ui:void 0,error:void 0,callbackToken:n})}),e?.appState&&(D.value={...e.appState},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))),e?.appData){let n=e?.appData;de.value={...e.appData,...n},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))}}}async runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,te={}){let ne=()=>{this.runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,te)};if(n){n||=`_no_route`,n&&n.startsWith(`/`)&&(n=n.substring(1));let e={serverSideType:s,appState:D.value,componentState:c,parameters:l,initiatorComponentId:a,consumedRoute:r,route:`/`+n,actionId:i};d||u.dispatchEvent(new CustomEvent(`backend-called-event`,{bubbles:!0,composed:!0,detail:{}})),fetch(t+`/mateu/v3/sse/`+n,{method:`POST`,headers:{Accept:`text/event-stream`,"Content-Type":`application/json`},body:JSON.stringify(e)}).then(async e=>{let t=e.body?.pipeThrough(new TextDecoderStream).getReader();if(t){let e=``;for(;;){let{value:n,done:r}=await t.read();if(r)break;e+=n;let a=e.split(`
+  `}};O([v()],Bo.prototype,`baseUrl`,void 0),O([v()],Bo.prototype,`route`,void 0),O([v()],Bo.prototype,`consumedRoute`,void 0),Bo=O([h(`mateu-component`)],Bo);var Vo=e=>{if(e)try{return JSON.parse(e)}catch{return{value:e}}else return{}},Ho=new class{async handle(e,t){return await e.runAction(t.baseUrl,t.route,t.consumedRoute,t.actionId,t.initiatorComponentId,t.appState,t.serverSideType,t.componentState,t.parameters,t.initiator,t.background,t.options)}},Uo=new class{constructor(){this.handleUIIncrement=(e,t,n)=>{if(e?.fragments?.forEach(e=>{ue.next({command:void 0,fragment:e,ui:void 0,error:void 0,callbackToken:n})}),e?.appState&&(D.value={...e.appState},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))),e?.appData){let n=e?.appData;de.value={...e.appData,...n},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))}e?.messages?.forEach(e=>{ha({text:e.text,position:e.position,variant:e.variant,duration:e.duration,undoLabel:e.undoLabel,undoActionId:e.undoActionId,undoParameters:e.undoParameters},t)}),e?.banners&&e.banners.length>0&&document.dispatchEvent(new CustomEvent(`page-banners-received`,{detail:{banners:e.banners,append:e.appendBanners??!1},bubbles:!1,composed:!1})),e?.commands?.forEach(e=>{ue.next({command:e,fragment:void 0,ui:void 0,error:void 0,callbackToken:n})})}}async runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,te={}){let ne=()=>{this.runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,te)};try{let o=await Ho.handle(e,{baseUrl:t,route:n,consumedRoute:r,actionId:i,appState:D.value,initiatorComponentId:a,componentState:c,parameters:l,serverSideType:s,initiator:u,background:d,options:{...te,retry:ne}});f&&f(o),p||this.handleUIIncrement(o,u,ee),o.messages&&o.messages.length==1&&o.messages[0].variant==`error`&&u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-succeeded`,{detail:{actionId:i,evevntId:T()},bubbles:!0,composed:!0}))}catch(e){console.warn(`Action request failed`,e),e?.__mateuReported||u.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:i,reason:this.serialize(e),retry:ne}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))}}serialize(e){return e?.message?e:JSON.stringify(e)}},Wo=new class{constructor(){this.handleUIIncrement=(e,t,n)=>{if(e?.messages?.forEach(e=>{ha({text:e.text,position:e.position,variant:e.variant,duration:e.duration,undoLabel:e.undoLabel,undoActionId:e.undoActionId,undoParameters:e.undoParameters},t)}),e?.banners&&e.banners.length>0&&document.dispatchEvent(new CustomEvent(`page-banners-received`,{detail:{banners:e.banners,append:e.appendBanners??!1},bubbles:!1,composed:!1})),e?.commands?.forEach(e=>{ue.next({command:e,fragment:void 0,ui:void 0,error:void 0,callbackToken:n})}),e?.fragments?.forEach(e=>{ue.next({command:void 0,fragment:e,ui:void 0,error:void 0,callbackToken:n})}),e?.appState&&(D.value={...e.appState},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))),e?.appData){let n=e?.appData;de.value={...e.appData,...n},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))}}}async runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,te={}){let ne=()=>{this.runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,te)};if(n){n||=`_no_route`,n&&n.startsWith(`/`)&&(n=n.substring(1));let e={serverSideType:s,appState:D.value,componentState:c,parameters:l,initiatorComponentId:a,consumedRoute:r,route:`/`+n,actionId:i};d||u.dispatchEvent(new CustomEvent(`backend-called-event`,{bubbles:!0,composed:!0,detail:{}})),fetch(t+`/mateu/v3/sse/`+n,{method:`POST`,headers:{Accept:`text/event-stream`,"Content-Type":`application/json`},body:JSON.stringify(e)}).then(async e=>{let t=e.body?.pipeThrough(new TextDecoderStream).getReader();if(t){let e=``;for(;;){let{value:n,done:r}=await t.read();if(r)break;e+=n;let a=e.split(`
 
-`);e=a.pop()??``;for(let e of a){let t=e.trim();if(t)if(t.startsWith(`data:`)){let e=JSON.parse(t.substring(5).trim());f&&f(e),p||this.handleUIIncrement(e,u,ee),e.messages&&e.messages.length==1&&e.messages[0].variant==`error`&&u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))}else{let e=t;try{let n=JSON.parse(t);e=n.message,n._embedded?.errors?.length>0&&n._embedded.errors[0].message&&(e=n._embedded.errors[0].message)}catch{}throw Error(e)}}}}d||u.dispatchEvent(new CustomEvent(`backend-succeeded-event`,{bubbles:!0,composed:!0,detail:{actionId:i}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-succeeded`,{detail:{actionId:i},bubbles:!0,composed:!0}))}).catch(e=>{u.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:i,reason:this.serialize(e),retry:ne}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))})}}serialize(e){return e?.message?e:JSON.stringify(e)}},Ho={fixed:`fixed`,fullWidth:`full`,edgeToEdge:`edge`},Uo=new Set([A.Gantt,A.PlanningBoard,A.Kanban,A.Bpmn,A.Workflow,A.Map]),Wo={landing:`fixed`,form:`fixed`,process:`fixed`},Go=e=>e?Ho[e]:void 0,Ko=e=>e.type==k.ClientSide?e.metadata:void 0,qo=e=>{let t=Ko(e);if(t?.type==A.Page){let e=Go(t.pageWidth);if(e)return e}for(let t of e.children??[]){let e=qo(t);if(e)return e}},Jo=e=>{let t=e.pageType;if(t)return t;let n=e=>{let t=Ko(e);if(t?.type==A.Page&&t.pageType)return t.pageType;for(let t of e.children??[]){let e=n(t);if(e)return e}};return n(e)},Yo=e=>{let t=Ko(e);if(t?.type!=A.Crud)return!1;let n=t;return n.compact?!0:(n.columns??[]).some(e=>e.metadata?.editable)},Xo=(e,t)=>t(e)||(e.children??[]).some(e=>Xo(e,t)),Zo=e=>!!e&&Xo(e,e=>Ko(e)?.type==A.HeroSection),Qo=e=>Ko(e)?.type==A.App||(e.children??[]).some(e=>Ko(e)?.type==A.App),$o=(e,t)=>e?(Go(e.pageWidth)??qo(e))||(t?.top&&Qo(e)?`edge`:Wo[Jo(e)??``]||(Xo(e,e=>{let t=Ko(e)?.type;return t!=null&&Uo.has(t)})?`edge`:Xo(e,Yo)?`full`:`fixed`)):`fixed`,es=`mateu-route-structure-cache`,ts=1,ns=50,rs=(()=>{try{return localStorage.getItem(`mateu-route-structure-cache-off`)!==`1`}catch{return!0}})(),is=()=>{try{return JSON.parse(localStorage.getItem(es)??`{}`)}catch{return{}}},as=e=>{try{localStorage.setItem(es,JSON.stringify(e))}catch{try{let t=Object.entries(e).sort((e,t)=>t[1].t-e[1].t).slice(0,Math.floor(ns/2));localStorage.setItem(es,JSON.stringify(Object.fromEntries(t)))}catch{}}},os=e=>{let t=e.initialState&&Object.keys(e.initialState).length?`#`+ls(JSON.stringify(e.initialState)):``;return[e.baseUrl,e.consumedRoute??``,e.route??``,e.serverSideType??``].join(`|`)+t},ss=e=>{if(!rs)return;let t=is()[e];if(!(!t||t.v!==ts))return{component:t.component,hash:t.hash}},cs=(e,t,n)=>{if(!rs)return;let r=is();r[e]={v:ts,t:Date.now(),component:t,hash:n};let i=Object.keys(r);if(i.length>ns){let e=i.sort((e,t)=>r[e].t-r[t].t).slice(0,i.length-ns);for(let t of e)delete r[t]}as(r)},ls=e=>{let t=2166136261;for(let n=0;n<e.length;n++)t^=e.charCodeAt(n),t=Math.imul(t,16777619);return(t>>>0).toString(36)},us=30,ds=new Map,fs=!0,ps=e=>{if(fs)return ds.get(e)},ms=(e,t)=>{if(fs&&(ds.delete(e),ds.set(e,t),ds.size>us)){let e=ds.keys().next().value;e!==void 0&&ds.delete(e)}},hs,X=class extends $e{static{hs=this}constructor(...e){super(...e),this.consumedRoute=``,this.serverSideType=void 0,this.uriPrefix=void 0,this.overrides=void 0,this.homeRoute=void 0,this.route=void 0,this.top=void 0,this.appState={},this.appData={},this.preventNavigation=!1,this.overridesParsed={},this.fragment=void 0,this.showSkeleton=!1,this.pendingRouteFocus=!1,this.hasRenderedContent=!1,this.loadLifecycleListener=e=>{if(((typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target)===this)if(clearTimeout(this.skeletonTimer),e.type===`backend-called-event`){if(this.fragment?.component)return;this.skeletonTimer=setTimeout(()=>{this.showSkeleton=!0},hs.SKELETON_DELAY_MS)}else this.showSkeleton=!1},this.actionRequestedListener=e=>{e instanceof CustomEvent&&(e.preventDefault(),e.stopPropagation(),this.manageActionEvent(e))},this.historyPushed=e=>{e instanceof CustomEvent&&(e.preventDefault(),e.stopPropagation(),this.preventNavigation=!0,this.route=e.detail.route)},this.routeChangedListener=e=>{if(e instanceof CustomEvent){e.preventDefault(),e.stopPropagation();let t=e.detail.route;typeof t==`string`&&(t===``||t.startsWith(`/`))&&this.consumedRoute&&this.consumedRoute!==`_empty`&&this.consumedRoute.startsWith(`/`)&&!t.startsWith(this.consumedRoute)&&(t=this.consumedRoute+t),this.uriPrefix&&(t=t.startsWith(`/`)&&this.uriPrefix.endsWith(`/`)?this.uriPrefix+t.substring(1):!t.startsWith(`/`)&&!this.uriPrefix.endsWith(`/`)?this.uriPrefix+`/`+t:this.uriPrefix+t),this.dispatchEvent(new CustomEvent(`url-update-requested`,{detail:{route:t},bubbles:!0,composed:!0}))}},this.backendFailedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&e.detail.actionId==``&&(this.fragment={targetComponentId:this.id,data:{},state:{},component:{type:k.ClientSide,metadata:{type:A.Element,name:`div`,content:`Not found`},id:`fieldId`},action:Ke.Replace,containerId:void 0})},this.detail1=void 0,this.manageActionEvent=e=>{e.preventDefault(),e.stopPropagation(),this.detail1=e.detail;let t=this.detail1;if(e.type==`server-side-action-requested`){let e=Bo;t.sse&&(e=Vo),e.runAction(Ge,this.baseUrl,t.route??``,t.consumedRoute,t.actionId,t.initiatorComponentId,this.getCustomisedAppState(),t.serverSideType,t.componentState,t.parameters,t.initiator,t.background,t.callback,t.callbackonly,t.callbackToken,{timeoutMillis:t.timeoutMillis,idempotent:t.idempotent,knownStructureHash:t.knownStructureHash})}},this.getCustomisedAppState=()=>{let e={...D.value};if(this.overrides){let t=Ro(this.overrides);e={...e,...t}}return e}}manageActionRequestedEvent(e){throw Error(`Method not implemented.`)}createRenderRoot(){return N.mustUseShadowRoot()?super.createRenderRoot():this}structureCacheKey(){return os({baseUrl:this.baseUrl,consumedRoute:this.consumedRoute,route:this.route,serverSideType:this.serverSideType,initialState:this.initialState})}focusNewContent(){requestAnimationFrame(()=>{let e=this.renderRoot?.querySelector?.(`h1, h2, [role="heading"]`)??this;e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus?.({preventScroll:!0})})}static{this.SKELETON_DELAY_MS=400}connectedCallback(){super.connectedCallback(),this.overridesParsed=Ro(this.overrides),this.addEventListener(`server-side-action-requested`,this.actionRequestedListener),this.addEventListener(`backend-call-failed`,this.backendFailedListener),this.addEventListener(`history-pushed`,this.historyPushed),this.addEventListener(`route-changed`,this.routeChangedListener),this.addEventListener(`backend-called-event`,this.loadLifecycleListener),this.addEventListener(`backend-succeeded-event`,this.loadLifecycleListener),this.addEventListener(`backend-failed-event`,this.loadLifecycleListener),this.addEventListener(`backend-cancelled-event`,this.loadLifecycleListener)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`server-side-action-requested`,this.actionRequestedListener),this.removeEventListener(`backend-call-failed`,this.backendFailedListener),this.removeEventListener(`history-pushed`,this.historyPushed),this.removeEventListener(`route-changed`,this.routeChangedListener),this.removeEventListener(`backend-called-event`,this.loadLifecycleListener),this.removeEventListener(`backend-succeeded-event`,this.loadLifecycleListener),this.removeEventListener(`backend-failed-event`,this.loadLifecycleListener),this.removeEventListener(`backend-cancelled-event`,this.loadLifecycleListener),clearTimeout(this.skeletonTimer)}shouldUpdate(e){if(this.fragment?.component&&[...e.keys()].every(e=>e===`appState`||e===`appData`)){let t=this.renderRoot.querySelector(`mateu-component`);if(t)return e.has(`appState`)&&(t.appState=this.appState),e.has(`appData`)&&(t.appData=this.appData),!1}return!0}updated(e){if((e.has(`id`)||e.has(`baseurl`)||e.has(`route`)||e.has(`consumedRoute`)||e.has(`instant`))&&!this.preventNavigation){this.callbackToken=this.instant||T();let e=this.structureCacheKey(),t=e===this.lastAuthoritativeKey?void 0:ps(e);if(t)queueMicrotask(()=>this.applyFragment(t));else{if(e!==this.lastAuthoritativeKey){let t=ss(e);this.currentStructureHash=t?.hash,t&&(this.fragment={targetComponentId:this.id,component:t.component,state:{},data:{},action:Ke.Replace,containerId:void 0})}this.manageActionEvent(new CustomEvent(`server-side-action-requested`,{detail:{route:this.route,consumedRoute:this.consumedRoute,userData:void 0,actionId:``,serverSideType:this.serverSideType,initiatorComponentId:this.id,initiator:this,componentState:this.initialState,knownStructureHash:this.currentStructureHash,callbackToken:this.callbackToken},bubbles:!0,composed:!0}))}}e.has(`route`)&&this.top&&(this.preventNavigation||(this.pendingRouteFocus=!0),this.preventNavigation||this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:this.route},bubbles:!0,composed:!0}))),this.preventNavigation&&=!1}applyFragment(e){if(!e.component&&this.fragment?.component){this.fragment={...this.fragment,state:{...this.fragment.state??{},...e.state??{}},data:{...this.fragment.data??{},...e.data??{}}};return}if(this.fragment=e,e.component){if(e.action!==Ke.Add){let t=this.structureCacheKey(),n=e.component.structureHash;cs(t,e.component,n),this.lastAuthoritativeKey=t,this.currentStructureHash=n,e.component.staticView&&ms(t,e)}this.pendingRouteFocus&&this.hasRenderedContent&&this.focusNewContent(),this.pendingRouteFocus=!1,this.hasRenderedContent=!0}e.component&&(this.dataset.pageWidth=$o(e.component,{top:this.top}),this.dataset.pageType=Jo(e.component)??``,this.dataset.hasWelcomeBanner=String(Zo(e.component)))}render(){return!this.fragment?.component&&this.showSkeleton?w`
+`);e=a.pop()??``;for(let e of a){let t=e.trim();if(t)if(t.startsWith(`data:`)){let e=JSON.parse(t.substring(5).trim());f&&f(e),p||this.handleUIIncrement(e,u,ee),e.messages&&e.messages.length==1&&e.messages[0].variant==`error`&&u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))}else{let e=t;try{let n=JSON.parse(t);e=n.message,n._embedded?.errors?.length>0&&n._embedded.errors[0].message&&(e=n._embedded.errors[0].message)}catch{}throw Error(e)}}}}d||u.dispatchEvent(new CustomEvent(`backend-succeeded-event`,{bubbles:!0,composed:!0,detail:{actionId:i}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-succeeded`,{detail:{actionId:i},bubbles:!0,composed:!0}))}).catch(e=>{u.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:i,reason:this.serialize(e),retry:ne}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))})}}serialize(e){return e?.message?e:JSON.stringify(e)}},Go={fixed:`fixed`,fullWidth:`full`,edgeToEdge:`edge`},Ko=new Set([A.Gantt,A.PlanningBoard,A.Kanban,A.Bpmn,A.Workflow,A.Map]),qo={landing:`fixed`,form:`fixed`,process:`fixed`},Jo=e=>e?Go[e]:void 0,Yo=e=>e.type==k.ClientSide?e.metadata:void 0,Xo=e=>{let t=Yo(e);if(t?.type==A.Page){let e=Jo(t.pageWidth);if(e)return e}for(let t of e.children??[]){let e=Xo(t);if(e)return e}},Zo=e=>{let t=e.pageType;if(t)return t;let n=e=>{let t=Yo(e);if(t?.type==A.Page&&t.pageType)return t.pageType;for(let t of e.children??[]){let e=n(t);if(e)return e}};return n(e)},Qo=e=>{let t=Yo(e);if(t?.type!=A.Crud)return!1;let n=t;return n.compact?!0:(n.columns??[]).some(e=>e.metadata?.editable)},$o=(e,t)=>t(e)||(e.children??[]).some(e=>$o(e,t)),es=e=>!!e&&$o(e,e=>Yo(e)?.type==A.HeroSection),ts=e=>Yo(e)?.type==A.App||(e.children??[]).some(e=>Yo(e)?.type==A.App),ns=(e,t)=>e?(Jo(e.pageWidth)??Xo(e))||(t?.top&&ts(e)?`edge`:qo[Zo(e)??``]||($o(e,e=>{let t=Yo(e)?.type;return t!=null&&Ko.has(t)})?`edge`:$o(e,Qo)?`full`:`fixed`)):`fixed`,rs=`mateu-route-structure-cache`,is=1,as=50,os=(()=>{try{return localStorage.getItem(`mateu-route-structure-cache-off`)!==`1`}catch{return!0}})(),ss=()=>{try{return JSON.parse(localStorage.getItem(rs)??`{}`)}catch{return{}}},cs=e=>{try{localStorage.setItem(rs,JSON.stringify(e))}catch{try{let t=Object.entries(e).sort((e,t)=>t[1].t-e[1].t).slice(0,Math.floor(as/2));localStorage.setItem(rs,JSON.stringify(Object.fromEntries(t)))}catch{}}},ls=e=>{let t=e.initialState&&Object.keys(e.initialState).length?`#`+fs(JSON.stringify(e.initialState)):``;return[e.baseUrl,e.consumedRoute??``,e.route??``,e.serverSideType??``].join(`|`)+t},us=e=>{if(!os)return;let t=ss()[e];if(!(!t||t.v!==is))return{component:t.component,hash:t.hash}},ds=(e,t,n)=>{if(!os)return;let r=ss();r[e]={v:is,t:Date.now(),component:t,hash:n};let i=Object.keys(r);if(i.length>as){let e=i.sort((e,t)=>r[e].t-r[t].t).slice(0,i.length-as);for(let t of e)delete r[t]}cs(r)},fs=e=>{let t=2166136261;for(let n=0;n<e.length;n++)t^=e.charCodeAt(n),t=Math.imul(t,16777619);return(t>>>0).toString(36)},ps=30,ms=new Map,hs=!0,gs=e=>{if(hs)return ms.get(e)},_s=(e,t)=>{if(hs&&(ms.delete(e),ms.set(e,t),ms.size>ps)){let e=ms.keys().next().value;e!==void 0&&ms.delete(e)}},vs,Y=class extends $e{static{vs=this}constructor(...e){super(...e),this.consumedRoute=``,this.serverSideType=void 0,this.uriPrefix=void 0,this.overrides=void 0,this.homeRoute=void 0,this.route=void 0,this.top=void 0,this.appState={},this.appData={},this.preventNavigation=!1,this.overridesParsed={},this.fragment=void 0,this.showSkeleton=!1,this.pendingRouteFocus=!1,this.hasRenderedContent=!1,this.loadLifecycleListener=e=>{if(((typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target)===this)if(clearTimeout(this.skeletonTimer),e.type===`backend-called-event`){if(this.fragment?.component)return;this.skeletonTimer=setTimeout(()=>{this.showSkeleton=!0},vs.SKELETON_DELAY_MS)}else this.showSkeleton=!1},this.actionRequestedListener=e=>{e instanceof CustomEvent&&(e.preventDefault(),e.stopPropagation(),this.manageActionEvent(e))},this.historyPushed=e=>{e instanceof CustomEvent&&(e.preventDefault(),e.stopPropagation(),this.preventNavigation=!0,this.route=e.detail.route)},this.routeChangedListener=e=>{if(e instanceof CustomEvent){e.preventDefault(),e.stopPropagation();let t=e.detail.route;typeof t==`string`&&(t===``||t.startsWith(`/`))&&this.consumedRoute&&this.consumedRoute!==`_empty`&&this.consumedRoute.startsWith(`/`)&&!t.startsWith(this.consumedRoute)&&(t=this.consumedRoute+t),this.uriPrefix&&(t=t.startsWith(`/`)&&this.uriPrefix.endsWith(`/`)?this.uriPrefix+t.substring(1):!t.startsWith(`/`)&&!this.uriPrefix.endsWith(`/`)?this.uriPrefix+`/`+t:this.uriPrefix+t),this.dispatchEvent(new CustomEvent(`url-update-requested`,{detail:{route:t},bubbles:!0,composed:!0}))}},this.backendFailedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&e.detail.actionId==``&&(this.fragment={targetComponentId:this.id,data:{},state:{},component:{type:k.ClientSide,metadata:{type:A.Element,name:`div`,content:`Not found`},id:`fieldId`},action:Ke.Replace,containerId:void 0})},this.detail1=void 0,this.manageActionEvent=e=>{e.preventDefault(),e.stopPropagation(),this.detail1=e.detail;let t=this.detail1;if(e.type==`server-side-action-requested`){let e=Uo;t.sse&&(e=Wo),e.runAction(Ge,this.baseUrl,t.route??``,t.consumedRoute,t.actionId,t.initiatorComponentId,this.getCustomisedAppState(),t.serverSideType,t.componentState,t.parameters,t.initiator,t.background,t.callback,t.callbackonly,t.callbackToken,{timeoutMillis:t.timeoutMillis,idempotent:t.idempotent,knownStructureHash:t.knownStructureHash})}},this.getCustomisedAppState=()=>{let e={...D.value};if(this.overrides){let t=Vo(this.overrides);e={...e,...t}}return e}}manageActionRequestedEvent(e){throw Error(`Method not implemented.`)}createRenderRoot(){return N.mustUseShadowRoot()?super.createRenderRoot():this}structureCacheKey(){return ls({baseUrl:this.baseUrl,consumedRoute:this.consumedRoute,route:this.route,serverSideType:this.serverSideType,initialState:this.initialState})}focusNewContent(){requestAnimationFrame(()=>{let e=this.renderRoot?.querySelector?.(`h1, h2, [role="heading"]`)??this;e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus?.({preventScroll:!0})})}static{this.SKELETON_DELAY_MS=400}connectedCallback(){super.connectedCallback(),this.overridesParsed=Vo(this.overrides),this.addEventListener(`server-side-action-requested`,this.actionRequestedListener),this.addEventListener(`backend-call-failed`,this.backendFailedListener),this.addEventListener(`history-pushed`,this.historyPushed),this.addEventListener(`route-changed`,this.routeChangedListener),this.addEventListener(`backend-called-event`,this.loadLifecycleListener),this.addEventListener(`backend-succeeded-event`,this.loadLifecycleListener),this.addEventListener(`backend-failed-event`,this.loadLifecycleListener),this.addEventListener(`backend-cancelled-event`,this.loadLifecycleListener)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`server-side-action-requested`,this.actionRequestedListener),this.removeEventListener(`backend-call-failed`,this.backendFailedListener),this.removeEventListener(`history-pushed`,this.historyPushed),this.removeEventListener(`route-changed`,this.routeChangedListener),this.removeEventListener(`backend-called-event`,this.loadLifecycleListener),this.removeEventListener(`backend-succeeded-event`,this.loadLifecycleListener),this.removeEventListener(`backend-failed-event`,this.loadLifecycleListener),this.removeEventListener(`backend-cancelled-event`,this.loadLifecycleListener),clearTimeout(this.skeletonTimer)}shouldUpdate(e){if(this.fragment?.component&&[...e.keys()].every(e=>e===`appState`||e===`appData`)){let t=this.renderRoot.querySelector(`mateu-component`);if(t)return e.has(`appState`)&&(t.appState=this.appState),e.has(`appData`)&&(t.appData=this.appData),!1}return!0}updated(e){if((e.has(`id`)||e.has(`baseurl`)||e.has(`route`)||e.has(`consumedRoute`)||e.has(`instant`))&&!this.preventNavigation){this.callbackToken=this.instant||T();let e=this.structureCacheKey(),t=e===this.lastAuthoritativeKey?void 0:gs(e);if(t)queueMicrotask(()=>this.applyFragment(t));else{if(e!==this.lastAuthoritativeKey){let t=us(e);this.currentStructureHash=t?.hash,t&&(this.fragment={targetComponentId:this.id,component:t.component,state:{},data:{},action:Ke.Replace,containerId:void 0})}this.manageActionEvent(new CustomEvent(`server-side-action-requested`,{detail:{route:this.route,consumedRoute:this.consumedRoute,userData:void 0,actionId:``,serverSideType:this.serverSideType,initiatorComponentId:this.id,initiator:this,componentState:this.initialState,knownStructureHash:this.currentStructureHash,callbackToken:this.callbackToken},bubbles:!0,composed:!0}))}}e.has(`route`)&&this.top&&(this.preventNavigation||(this.pendingRouteFocus=!0),this.preventNavigation||this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:this.route},bubbles:!0,composed:!0}))),this.preventNavigation&&=!1}applyFragment(e){if(!e.component&&this.fragment?.component){this.fragment={...this.fragment,state:{...this.fragment.state??{},...e.state??{}},data:{...this.fragment.data??{},...e.data??{}}};return}if(this.fragment=e,e.component){if(e.action!==Ke.Add){let t=this.structureCacheKey(),n=e.component.structureHash;ds(t,e.component,n),this.lastAuthoritativeKey=t,this.currentStructureHash=n,e.component.staticView&&_s(t,e)}this.pendingRouteFocus&&this.hasRenderedContent&&this.focusNewContent(),this.pendingRouteFocus=!1,this.hasRenderedContent=!0}e.component&&(this.dataset.pageWidth=ns(e.component,{top:this.top}),this.dataset.pageType=Zo(e.component)??``,this.dataset.hasWelcomeBanner=String(es(e.component)))}render(){return!this.fragment?.component&&this.showSkeleton?w`
                 <div class="route-skeleton" aria-busy="true" aria-live="polite">
                     <mateu-skeleton variant="text" count="1"></mateu-skeleton>
                     <mateu-skeleton variant="form" count="4"></mateu-skeleton>
@@ -7350,7 +7350,7 @@ ${i}
             max-width: 16rem;
             margin-block-end: var(--lumo-space-l, 1.5rem);
         }
-  `}};O([v()],X.prototype,`consumedRoute`,void 0),O([v()],X.prototype,`serverSideType`,void 0),O([v()],X.prototype,`uriPrefix`,void 0),O([v()],X.prototype,`overrides`,void 0),O([v()],X.prototype,`homeRoute`,void 0),O([v()],X.prototype,`route`,void 0),O([v()],X.prototype,`top`,void 0),O([v()],X.prototype,`instant`,void 0),O([v()],X.prototype,`initialState`,void 0),O([v()],X.prototype,`appState`,void 0),O([v()],X.prototype,`appData`,void 0),O([S()],X.prototype,`fragment`,void 0),O([S()],X.prototype,`showSkeleton`,void 0),X=hs=O([h(`mateu-ux`)],X);function gs(e){let t=`var(--lumo-space-m, 1rem)`,n={left:`50%`,transform:`translateX(-50%)`};switch(e){case`topStart`:return{top:t,left:t};case`topCenter`:return{top:t,...n};case`topEnd`:return{top:t,right:t};case`topStretch`:return{top:t,left:t,right:t};case`middle`:return{top:`50%`,left:`50%`,transform:`translate(-50%, -50%)`};case`bottomStart`:return{bottom:t,left:t};case`bottomCenter`:return{bottom:t,...n};case`bottomStretch`:return{bottom:t,left:t,right:t};default:return{bottom:t,right:t}}}function _s(e){switch(e){case`success`:return{bg:`var(--lumo-success-color, #2e7d32)`,fg:`#fff`};case`error`:return{bg:`var(--lumo-error-color, #c62828)`,fg:`#fff`};case`warning`:return{bg:`var(--lumo-warning-color, #f9a825)`,fg:`#1a1a1a`};case`contrast`:return{bg:`var(--lumo-contrast-90pct, #1a1a1a)`,fg:`#fff`};default:return{bg:`var(--lumo-base-color, #fff)`,fg:`var(--lumo-body-text-color, #1a1a1a)`}}}var vs={show(e,t){let{bg:n,fg:r}=_s(e.variant),i=gs(e.position),a=document.createElement(`div`),o=e.variant===`error`;a.setAttribute(`role`,o?`alert`:`status`),a.setAttribute(`aria-live`,o?`assertive`:`polite`),a.setAttribute(`aria-atomic`,`true`),Object.assign(a.style,{position:`fixed`,zIndex:`2000`,display:`flex`,alignItems:`center`,gap:`0.75rem`,maxWidth:`min(90vw, 28rem)`,padding:`0.7rem 1rem`,borderRadius:`var(--lumo-border-radius-m, 8px)`,boxShadow:`var(--lumo-box-shadow-m, 0 4px 16px rgba(0,0,0,0.2))`,background:n,color:r,font:`inherit`,fontSize:`var(--lumo-font-size-s, 0.875rem)`,opacity:`0`,transition:`opacity 0.2s ease`,...i});let s=document.createElement(`span`);s.textContent=e.text,a.appendChild(s);let c=()=>{a.style.opacity=`0`,setTimeout(()=>a.remove(),200)},l=e.onAction?{label:e.actionLabel??`Retry`,run:e.onAction}:e.undoActionId?{label:e.undoLabel??`Undo`,run:()=>t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.undoActionId,parameters:e.undoParameters??{}},bubbles:!0,composed:!0}))}:void 0;if(l){let e=document.createElement(`button`);e.textContent=l.label,e.style.cssText=`margin-left: 0.25rem; background: none; border: 1px solid currentColor; border-radius: var(--lumo-border-radius-s, 4px); color: inherit; cursor: pointer; padding: 0.15rem 0.6rem; font: inherit; font-weight: 600;`,e.addEventListener(`click`,()=>{l.run(),c()}),a.appendChild(e)}document.body.appendChild(a),requestAnimationFrame(()=>{a.style.opacity=`1`});let u=e.duration??(l?1e4:5e3);u>0&&setTimeout(c,u)}};function ys(){fa(vs)}var bs=class extends y{constructor(...e){super(...e),this.online=!0,this.recovered=!1}connectedCallback(){super.connectedCallback(),this.online=Ve.isOnline(),this.unsubscribe=Ve.subscribe(e=>{let t=!this.online;this.online=e,e&&t&&(this.recovered=!0,clearTimeout(this.recoveredTimer),this.recoveredTimer=setTimeout(()=>{this.recovered=!1},4e3))})}disconnectedCallback(){super.disconnectedCallback(),this.unsubscribe?.(),clearTimeout(this.recoveredTimer),this.releaseSpace()}updated(){let e=this.renderRoot.querySelector(`.bar`);if(!e){this.releaseSpace();return}document.body.style.setProperty(`padding-block-start`,`${e.offsetHeight}px`)}releaseSpace(){typeof document<`u`&&document.body?.style.removeProperty(`padding-block-start`)}render(){if(this.online&&!this.recovered)return _;let e=!this.online;return w`<div class="bar ${e?`offline`:`back`}" role="status" aria-live="polite">
+  `}};O([v()],Y.prototype,`consumedRoute`,void 0),O([v()],Y.prototype,`serverSideType`,void 0),O([v()],Y.prototype,`uriPrefix`,void 0),O([v()],Y.prototype,`overrides`,void 0),O([v()],Y.prototype,`homeRoute`,void 0),O([v()],Y.prototype,`route`,void 0),O([v()],Y.prototype,`top`,void 0),O([v()],Y.prototype,`instant`,void 0),O([v()],Y.prototype,`initialState`,void 0),O([v()],Y.prototype,`appState`,void 0),O([v()],Y.prototype,`appData`,void 0),O([S()],Y.prototype,`fragment`,void 0),O([S()],Y.prototype,`showSkeleton`,void 0),Y=vs=O([h(`mateu-ux`)],Y);function ys(e){let t=`var(--lumo-space-m, 1rem)`,n={left:`50%`,transform:`translateX(-50%)`};switch(e){case`topStart`:return{top:t,left:t};case`topCenter`:return{top:t,...n};case`topEnd`:return{top:t,right:t};case`topStretch`:return{top:t,left:t,right:t};case`middle`:return{top:`50%`,left:`50%`,transform:`translate(-50%, -50%)`};case`bottomStart`:return{bottom:t,left:t};case`bottomCenter`:return{bottom:t,...n};case`bottomStretch`:return{bottom:t,left:t,right:t};default:return{bottom:t,right:t}}}function bs(e){switch(e){case`success`:return{bg:`var(--lumo-success-color, #2e7d32)`,fg:`#fff`};case`error`:return{bg:`var(--lumo-error-color, #c62828)`,fg:`#fff`};case`warning`:return{bg:`var(--lumo-warning-color, #f9a825)`,fg:`#1a1a1a`};case`contrast`:return{bg:`var(--lumo-contrast-90pct, #1a1a1a)`,fg:`#fff`};default:return{bg:`var(--lumo-base-color, #fff)`,fg:`var(--lumo-body-text-color, #1a1a1a)`}}}var xs={show(e,t){let{bg:n,fg:r}=bs(e.variant),i=ys(e.position),a=document.createElement(`div`),o=e.variant===`error`;a.setAttribute(`role`,o?`alert`:`status`),a.setAttribute(`aria-live`,o?`assertive`:`polite`),a.setAttribute(`aria-atomic`,`true`),Object.assign(a.style,{position:`fixed`,zIndex:`2000`,display:`flex`,alignItems:`center`,gap:`0.75rem`,maxWidth:`min(90vw, 28rem)`,padding:`0.7rem 1rem`,borderRadius:`var(--lumo-border-radius-m, 8px)`,boxShadow:`var(--lumo-box-shadow-m, 0 4px 16px rgba(0,0,0,0.2))`,background:n,color:r,font:`inherit`,fontSize:`var(--lumo-font-size-s, 0.875rem)`,opacity:`0`,transition:`opacity 0.2s ease`,...i});let s=document.createElement(`span`);s.textContent=e.text,a.appendChild(s);let c=()=>{a.style.opacity=`0`,setTimeout(()=>a.remove(),200)},l=e.onAction?{label:e.actionLabel??`Retry`,run:e.onAction}:e.undoActionId?{label:e.undoLabel??`Undo`,run:()=>t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.undoActionId,parameters:e.undoParameters??{}},bubbles:!0,composed:!0}))}:void 0;if(l){let e=document.createElement(`button`);e.textContent=l.label,e.style.cssText=`margin-left: 0.25rem; background: none; border: 1px solid currentColor; border-radius: var(--lumo-border-radius-s, 4px); color: inherit; cursor: pointer; padding: 0.15rem 0.6rem; font: inherit; font-weight: 600;`,e.addEventListener(`click`,()=>{l.run(),c()}),a.appendChild(e)}document.body.appendChild(a),requestAnimationFrame(()=>{a.style.opacity=`1`});let u=e.duration??(l?1e4:5e3);u>0&&setTimeout(c,u)}};function Ss(){ma(xs)}var Cs=class extends y{constructor(...e){super(...e),this.online=!0,this.recovered=!1}connectedCallback(){super.connectedCallback(),this.online=Ve.isOnline(),this.unsubscribe=Ve.subscribe(e=>{let t=!this.online;this.online=e,e&&t&&(this.recovered=!0,clearTimeout(this.recoveredTimer),this.recoveredTimer=setTimeout(()=>{this.recovered=!1},4e3))})}disconnectedCallback(){super.disconnectedCallback(),this.unsubscribe?.(),clearTimeout(this.recoveredTimer),this.releaseSpace()}updated(){let e=this.renderRoot.querySelector(`.bar`);if(!e){this.releaseSpace();return}document.body.style.setProperty(`padding-block-start`,`${e.offsetHeight}px`)}releaseSpace(){typeof document<`u`&&document.body?.style.removeProperty(`padding-block-start`)}render(){if(this.online&&!this.recovered)return _;let e=!this.online;return w`<div class="bar ${e?`offline`:`back`}" role="status" aria-live="polite">
             <span class="dot"></span>
             <span>${e?`No connection — changes you make now will not be saved.`:`Connection restored.`}</span>
         </div>`}static{this.styles=m`
@@ -7392,7 +7392,7 @@ ${i}
         @media (prefers-reduced-motion: reduce) {
             .bar, .bar.offline .dot { animation: none; }
         }
-    `}};O([S()],bs.prototype,`online`,void 0),O([S()],bs.prototype,`recovered`,void 0),bs=O([h(`mateu-connectivity-banner`)],bs);var xs=null;function Ss(){if(!(typeof document>`u`)&&!(xs&&xs.isConnected)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>Ss(),{once:!0});return}xs=document.createElement(`mateu-connectivity-banner`),document.body.appendChild(xs)}}var Cs,ws=class extends y{static{Cs=this}constructor(...e){super(...e),this.skip=()=>{let e=this.findContent();e&&(e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus(),e.scrollIntoView({block:`start`}))}}static{this.TARGETS=[`.app-content`,`mateu-page`,`mateu-ux`,`mateu-component`]}findContent(){let e=new Set,t=n=>{if(e.has(n))return null;e.add(n);for(let e of Cs.TARGETS){let t=n.querySelector?.(e);if(t&&t!==this)return t}for(let e of Array.from(n.querySelectorAll?.(`*`)??[]))if(e.shadowRoot){let n=t(e.shadowRoot);if(n)return n}return null};return t(document)}render(){return w`<button class="skip" @click="${this.skip}">Skip to content</button>`}static{this.styles=m`
+    `}};O([S()],Cs.prototype,`online`,void 0),O([S()],Cs.prototype,`recovered`,void 0),Cs=O([h(`mateu-connectivity-banner`)],Cs);var ws=null;function Ts(){if(!(typeof document>`u`)&&!(ws&&ws.isConnected)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>Ts(),{once:!0});return}ws=document.createElement(`mateu-connectivity-banner`),document.body.appendChild(ws)}}var Es,Ds=class extends y{static{Es=this}constructor(...e){super(...e),this.skip=()=>{let e=this.findContent();e&&(e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus(),e.scrollIntoView({block:`start`}))}}static{this.TARGETS=[`.app-content`,`mateu-page`,`mateu-ux`,`mateu-component`]}findContent(){let e=new Set,t=n=>{if(e.has(n))return null;e.add(n);for(let e of Es.TARGETS){let t=n.querySelector?.(e);if(t&&t!==this)return t}for(let e of Array.from(n.querySelectorAll?.(`*`)??[]))if(e.shadowRoot){let n=t(e.shadowRoot);if(n)return n}return null};return t(document)}render(){return w`<button class="skip" @click="${this.skip}">Skip to content</button>`}static{this.styles=m`
         :host {
             position: fixed;
             inset-block-start: 0;
@@ -7425,7 +7425,7 @@ ${i}
             outline: 2px solid var(--lumo-body-text-color, #161513);
             outline-offset: 2px;
         }
-    `}};ws=Cs=O([h(`mateu-skip-link`)],ws);var Ts=null;function Es(){if(!(typeof document>`u`)&&!(Ts&&Ts.isConnected)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>Es(),{once:!0});return}Ts=document.createElement(`mateu-skip-link`),document.body.insertBefore(Ts,document.body.firstChild)}}ys(),Ss(),Ze(),Es();var Ds=class extends y{constructor(...e){super(...e),this.baseUrl=``,this.route=void 0,this.consumedRoute=`_empty`,this.config=void 0,this.top=`true`,this.pathPrefix=void 0,this.debug=!1,this._lastUrl=``,this.routeChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.top==`true`){let t=e.detail.route,n=this.baseUrl??``;!t||t.startsWith(`/`)?n=window.location.origin+(this.pathPrefix??``):(t=(this.pathPrefix??``)+t,n.indexOf(`://`)<0&&(n.startsWith(`/`)||(n=`/`+n),n=window.location.origin+n)),t.startsWith(this.pathPrefix+`/`)&&(t=t.substring(this.pathPrefix?.length)),n.endsWith(`/`)&&t.startsWith(`/`)&&(t=t.substring(1));let r=new URL(n+t);if((window.location.pathname||r.pathname)&&window.location.pathname!=r.pathname){let e=r.pathname;r.search&&(e+=r.search),e&&!e.startsWith(`/`)&&(e=`/`+e),window.history.pushState({},``,e),this._lastUrl=window.location.href}}},this.navigateToRequestedListener=e=>{if(e.preventDefault(),e.stopPropagation(),Ma.markClean(),e instanceof CustomEvent){let t=e.detail.route,n=this.renderRoot.querySelector(`mateu-ux`);n&&(n.setAttribute(`route`,t),n.setAttribute(`instant`,T()))}}}createRenderRoot(){return N.mustUseShadowRoot()?super.createRenderRoot():this}connectedCallback(){if(super.connectedCallback(),Ma.install(),this._lastUrl=window.location.href,window.onpopstate=e=>{if(!Ma.confirmLeave()){window.history.pushState({},``,this._lastUrl);return}let t=e.target;this.loadUrl(t)},this.top==`true`?this.loadUrl(window):this.route&&(this.consumedRoute=``),this.config)try{let e=JSON.parse(this.config);D.value={...D.value,...e}}catch{D.value={...D.value,config:this.config}}this.addEventListener(`url-update-requested`,this.routeChangedListener),this.addEventListener(`navigate-to-requested`,this.navigateToRequestedListener)}disconnectedCallback(){super.disconnectedCallback(),this.upstreamSubscription?.unsubscribe(),this.removeEventListener(`url-update-requested`,this.routeChangedListener),this.removeEventListener(`navigate-to-requested`,this.navigateToRequestedListener)}loadUrl(e){if(this.route=this.extractRouteFromUrl(e),this.setAttribute(`route`,this.route),this.instant=T(),this._lastUrl=e.location.href,e.location.search){let t=new URLSearchParams(e.location.search).get(`overrides`);if(t&&(this.config=t,this.config))try{let e=JSON.parse(this.config);D.value={...D.value,...e}}catch{D.value={...D.value,config:this.config}}}}extractRouteFromUrl(e){return this.addQueryParams(this.extractRouteWithoutParamsFromUrl(e),e.location)}extractRouteWithoutParamsFromUrl(e){let t=this.extractGrossRouteFromUrl(e);return this.pathPrefix&&t.startsWith(this.pathPrefix)?t.substring(this.pathPrefix.length):t==`/`?``:t}addQueryParams(e,t){return e+(t.search?``+t.search:``)}extractGrossRouteFromUrl(e){let t=e.location.pathname,n=this.baseUrl&&(this.baseUrl.startsWith(`http://`)||this.baseUrl.startsWith(`https://`))?this.baseUrl.substring(this.getContextPathStartingIndex(this.baseUrl)):this.baseUrl;return t.startsWith(n)?t.substring(n.length):t}getContextPathStartingIndex(e){return e.startsWith(`http:`)?e.indexOf(`/`,7):e.startsWith(`https:`)?e.indexOf(`/`,8):0}render(){return w`
+    `}};Ds=Es=O([h(`mateu-skip-link`)],Ds);var Os=null;function ks(){if(!(typeof document>`u`)&&!(Os&&Os.isConnected)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>ks(),{once:!0});return}Os=document.createElement(`mateu-skip-link`),document.body.insertBefore(Os,document.body.firstChild)}}Ss(),Ts(),Ze(),ks();var As=class extends y{constructor(...e){super(...e),this.baseUrl=``,this.route=void 0,this.consumedRoute=`_empty`,this.config=void 0,this.top=`true`,this.pathPrefix=void 0,this.debug=!1,this._lastUrl=``,this.routeChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.top==`true`){let t=e.detail.route,n=this.baseUrl??``;!t||t.startsWith(`/`)?n=window.location.origin+(this.pathPrefix??``):(t=(this.pathPrefix??``)+t,n.indexOf(`://`)<0&&(n.startsWith(`/`)||(n=`/`+n),n=window.location.origin+n)),t.startsWith(this.pathPrefix+`/`)&&(t=t.substring(this.pathPrefix?.length)),n.endsWith(`/`)&&t.startsWith(`/`)&&(t=t.substring(1));let r=new URL(n+t);if((window.location.pathname||r.pathname)&&window.location.pathname!=r.pathname){let e=r.pathname;r.search&&(e+=r.search),e&&!e.startsWith(`/`)&&(e=`/`+e),window.history.pushState({},``,e),this._lastUrl=window.location.href}}},this.navigateToRequestedListener=e=>{if(e.preventDefault(),e.stopPropagation(),Pa.markClean(),e instanceof CustomEvent){let t=e.detail.route,n=this.renderRoot.querySelector(`mateu-ux`);n&&(n.setAttribute(`route`,t),n.setAttribute(`instant`,T()))}}}createRenderRoot(){return N.mustUseShadowRoot()?super.createRenderRoot():this}connectedCallback(){if(super.connectedCallback(),Pa.install(),this._lastUrl=window.location.href,window.onpopstate=e=>{if(!Pa.confirmLeave()){window.history.pushState({},``,this._lastUrl);return}let t=e.target;this.loadUrl(t)},this.top==`true`?this.loadUrl(window):this.route&&(this.consumedRoute=``),this.config)try{let e=JSON.parse(this.config);D.value={...D.value,...e}}catch{D.value={...D.value,config:this.config}}this.addEventListener(`url-update-requested`,this.routeChangedListener),this.addEventListener(`navigate-to-requested`,this.navigateToRequestedListener)}disconnectedCallback(){super.disconnectedCallback(),this.upstreamSubscription?.unsubscribe(),this.removeEventListener(`url-update-requested`,this.routeChangedListener),this.removeEventListener(`navigate-to-requested`,this.navigateToRequestedListener)}loadUrl(e){if(this.route=this.extractRouteFromUrl(e),this.setAttribute(`route`,this.route),this.instant=T(),this._lastUrl=e.location.href,e.location.search){let t=new URLSearchParams(e.location.search).get(`overrides`);if(t&&(this.config=t,this.config))try{let e=JSON.parse(this.config);D.value={...D.value,...e}}catch{D.value={...D.value,config:this.config}}}}extractRouteFromUrl(e){return this.addQueryParams(this.extractRouteWithoutParamsFromUrl(e),e.location)}extractRouteWithoutParamsFromUrl(e){let t=this.extractGrossRouteFromUrl(e);return this.pathPrefix&&t.startsWith(this.pathPrefix)?t.substring(this.pathPrefix.length):t==`/`?``:t}addQueryParams(e,t){return e+(t.search?``+t.search:``)}extractGrossRouteFromUrl(e){let t=e.location.pathname,n=this.baseUrl&&(this.baseUrl.startsWith(`http://`)||this.baseUrl.startsWith(`https://`))?this.baseUrl.substring(this.getContextPathStartingIndex(this.baseUrl)):this.baseUrl;return t.startsWith(n)?t.substring(n.length):t}getContextPathStartingIndex(e){return e.startsWith(`http:`)?e.indexOf(`/`,7):e.startsWith(`https:`)?e.indexOf(`/`,8):0}render(){return w`
            <mateu-api-caller>
                 <mateu-ux id="_ux"
                           baseurl="${this.baseUrl}"
@@ -7449,9 +7449,9 @@ ${i}
         :host {
             --lumo-clickable-cursor: pointer;
         }
-  `}};O([v()],Ds.prototype,`baseUrl`,void 0),O([v()],Ds.prototype,`route`,void 0),O([v()],Ds.prototype,`consumedRoute`,void 0),O([v()],Ds.prototype,`config`,void 0),O([v()],Ds.prototype,`top`,void 0),O([v()],Ds.prototype,`pathPrefix`,void 0),O([S()],Ds.prototype,`instant`,void 0),O([v({type:Boolean})],Ds.prototype,`debug`,void 0),Ds=O([h(`mateu-ui`)],Ds);var Os,ks=class extends y{static{Os=this}constructor(...e){super(...e),this.baseUrl=``,this.opened=!1,this.searchText=``}static{this.SEARCHABLE_THRESHOLD=7}connectedCallback(){super.connectedCallback(),De()}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick(),this.searchTimer&&clearTimeout(this.searchTimer)}currentValue(){return String(Ce()[this.selector.fieldName]??``)}currentLabel(){let e=this.currentValue();if(!e)return`—`;let t=(this.searchedOptions??this.selector.options)?.find(t=>String(t.value)===e);if(t)return t.label;let n=we()[this.selector.fieldName];return n===void 0?e:String(n)}pick(e,t){Te(this.selector.fieldName,e,t),window.location.reload()}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}openPanel(){this.opened||(this.opened=!0,this.searchText=``,this.searchedOptions=void 0,this.remoteSearch(),this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick),this.updateComplete.then(()=>this.renderRoot.querySelector(`input.picker-search`)?.focus()))}closePanel(){this.detachOutsideClick(),this.opened=!1}onSearchInput(e){this.searchText=e.target.value,this.searchTimer&&clearTimeout(this.searchTimer),this.searchTimer=setTimeout(()=>this.remoteSearch(),300)}async remoteSearch(){let e=this.app;if(e?.serverSideType)try{let t=await Ge.runAction(this.baseUrl??``,e.rootRoute??e.initialRoute??``,``,`_appcontext-search-${this.selector.fieldName}`,`appcontext-${this.selector.fieldName}`,void 0,e.serverSideType,{},{searchText:this.searchText},this,!0);for(let e of t?.fragments??[]){let t=e.data?.[`_appcontext_${this.selector.fieldName}`]?.content;if(Array.isArray(t)){this.searchedOptions=t.map(e=>({value:e.value,label:e.label??String(e.value)}));return}}}catch{}}visibleOptions(){let e=this.searchedOptions??this.selector.options??[],t=this.searchText.trim().toLowerCase();return t?e.filter(e=>e.label.toLowerCase().includes(t)):e}renderPanel(){let e=this.currentValue(),t=this.visibleOptions();return w`
+  `}};O([v()],As.prototype,`baseUrl`,void 0),O([v()],As.prototype,`route`,void 0),O([v()],As.prototype,`consumedRoute`,void 0),O([v()],As.prototype,`config`,void 0),O([v()],As.prototype,`top`,void 0),O([v()],As.prototype,`pathPrefix`,void 0),O([S()],As.prototype,`instant`,void 0),O([v({type:Boolean})],As.prototype,`debug`,void 0),As=O([h(`mateu-ui`)],As);var js,Ms=class extends y{static{js=this}constructor(...e){super(...e),this.baseUrl=``,this.opened=!1,this.searchText=``}static{this.SEARCHABLE_THRESHOLD=7}connectedCallback(){super.connectedCallback(),De()}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick(),this.searchTimer&&clearTimeout(this.searchTimer)}currentValue(){return String(Ce()[this.selector.fieldName]??``)}currentLabel(){let e=this.currentValue();if(!e)return`—`;let t=(this.searchedOptions??this.selector.options)?.find(t=>String(t.value)===e);if(t)return t.label;let n=we()[this.selector.fieldName];return n===void 0?e:String(n)}pick(e,t){Te(this.selector.fieldName,e,t),window.location.reload()}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}openPanel(){this.opened||(this.opened=!0,this.searchText=``,this.searchedOptions=void 0,this.remoteSearch(),this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick),this.updateComplete.then(()=>this.renderRoot.querySelector(`input.picker-search`)?.focus()))}closePanel(){this.detachOutsideClick(),this.opened=!1}onSearchInput(e){this.searchText=e.target.value,this.searchTimer&&clearTimeout(this.searchTimer),this.searchTimer=setTimeout(()=>this.remoteSearch(),300)}async remoteSearch(){let e=this.app;if(e?.serverSideType)try{let t=await Ge.runAction(this.baseUrl??``,e.rootRoute??e.initialRoute??``,``,`_appcontext-search-${this.selector.fieldName}`,`appcontext-${this.selector.fieldName}`,void 0,e.serverSideType,{},{searchText:this.searchText},this,!0);for(let e of t?.fragments??[]){let t=e.data?.[`_appcontext_${this.selector.fieldName}`]?.content;if(Array.isArray(t)){this.searchedOptions=t.map(e=>({value:e.value,label:e.label??String(e.value)}));return}}}catch{}}visibleOptions(){let e=this.searchedOptions??this.selector.options??[],t=this.searchText.trim().toLowerCase();return t?e.filter(e=>e.label.toLowerCase().includes(t)):e}renderPanel(){let e=this.currentValue(),t=this.visibleOptions();return w`
             <div class="panel">
-                ${this.searchText!==``||t.length>Os.SEARCHABLE_THRESHOLD?w`
+                ${this.searchText!==``||t.length>js.SEARCHABLE_THRESHOLD?w`
                     <input class="picker-search" type="text" placeholder="Search"
                            .value="${this.searchText}"
                            @input="${this.onSearchInput}"
@@ -7543,7 +7543,7 @@ ${i}
         .option--clear {
             color: var(--lumo-secondary-text-color, rgba(0, 0, 0, 0.55));
         }
-    `}};O([v()],ks.prototype,`selector`,void 0),O([v()],ks.prototype,`app`,void 0),O([v()],ks.prototype,`baseUrl`,void 0),O([S()],ks.prototype,`opened`,void 0),O([S()],ks.prototype,`searchText`,void 0),O([S()],ks.prototype,`searchedOptions`,void 0),ks=Os=O([h(`mateu-app-context-picker`)],ks);var As=class extends y{constructor(...e){super(...e),this.baseUrl=``,this.opened=!1,this.notifications=[],this.fetched=!1}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}updated(){!this.fetched&&this.app?.serverSideType&&(this.fetched=!0,this.refresh())}unreadCount(){return this.notifications.filter(e=>e.unread).length}async runNotificationsAction(e,t){let n=this.app;if(n?.serverSideType)try{let r=await Ge.runAction(this.baseUrl??``,n.rootRoute??n.initialRoute??``,``,e,`notification-bell`,void 0,n.serverSideType,{},t,this,!0);for(let e of r?.fragments??[]){let t=e.data?._notifications;if(Array.isArray(t)){this.notifications=t;return}}}catch{}}refresh(){return this.runNotificationsAction(`_notifications-list`,{})}markRead(e){return this.runNotificationsAction(`_notifications-read`,{ids:e})}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}openPanel(){this.opened||(this.opened=!0,this.refresh(),this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick))}closePanel(){this.detachOutsideClick(),this.opened=!1}async entryClicked(e){e.unread&&await this.markRead([e.id]);let t=e.route;if(t){if(!Ma.confirmLeave())return;this.closePanel(),this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0})),this.dispatchEvent(new CustomEvent(`navigate-to-requested`,{detail:{route:t},bubbles:!0,composed:!0}))}}renderEntry(e){return w`
+    `}};O([v()],Ms.prototype,`selector`,void 0),O([v()],Ms.prototype,`app`,void 0),O([v()],Ms.prototype,`baseUrl`,void 0),O([S()],Ms.prototype,`opened`,void 0),O([S()],Ms.prototype,`searchText`,void 0),O([S()],Ms.prototype,`searchedOptions`,void 0),Ms=js=O([h(`mateu-app-context-picker`)],Ms);var Ns=class extends y{constructor(...e){super(...e),this.baseUrl=``,this.opened=!1,this.notifications=[],this.fetched=!1}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}updated(){!this.fetched&&this.app?.serverSideType&&(this.fetched=!0,this.refresh())}unreadCount(){return this.notifications.filter(e=>e.unread).length}async runNotificationsAction(e,t){let n=this.app;if(n?.serverSideType)try{let r=await Ge.runAction(this.baseUrl??``,n.rootRoute??n.initialRoute??``,``,e,`notification-bell`,void 0,n.serverSideType,{},t,this,!0);for(let e of r?.fragments??[]){let t=e.data?._notifications;if(Array.isArray(t)){this.notifications=t;return}}}catch{}}refresh(){return this.runNotificationsAction(`_notifications-list`,{})}markRead(e){return this.runNotificationsAction(`_notifications-read`,{ids:e})}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}openPanel(){this.opened||(this.opened=!0,this.refresh(),this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick))}closePanel(){this.detachOutsideClick(),this.opened=!1}async entryClicked(e){e.unread&&await this.markRead([e.id]);let t=e.route;if(t){if(!Pa.confirmLeave())return;this.closePanel(),this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0})),this.dispatchEvent(new CustomEvent(`navigate-to-requested`,{detail:{route:t},bubbles:!0,composed:!0}))}}renderEntry(e){return w`
             <div role="button" tabindex="0" class="entry ${e.unread?`entry--unread`:``}"
                  @click="${()=>this.entryClicked(e)}" @keydown="${L(()=>this.entryClicked(e))}">
                 <span class="unread-dot" aria-hidden="true"></span>
@@ -7731,47 +7731,47 @@ ${i}
         }
     
         ${R}
-    `}};O([v()],As.prototype,`app`,void 0),O([v()],As.prototype,`baseUrl`,void 0),O([S()],As.prototype,`opened`,void 0),O([S()],As.prototype,`notifications`,void 0),As=O([h(`mateu-notification-bell`)],As);var js=e=>{if(!e||!(`querySelectorAll`in e))return null;for(let t of e.querySelectorAll(`*`)){if(t.tagName?.toLowerCase()===`mateu-component`)return t;let e=js(t.shadowRoot);if(e)return e}return null},Ms=async(e,t,n)=>{let r=js(t.renderRoot??t);await Vo.runAction(Ge,t.baseUrl??``,e.rootRoute||`_no_route`,``,n,r?.id??`app-header-action`,{},e.serverSideType??``,{},{},r??t,!0,void 0,!1,``)},Ns=async(e,t,n)=>{try{await Ms(e,t,n)}catch(e){pa({text:`La acción falló: `+e,position:`bottomStart`,duration:6e3,variant:`error`},t)}},Ps=(e,t)=>{let n=e.contextSelectors??[],r=e.contextActions??[];return n.length===0&&r.length===0&&!e.notificationsEnabled?_:w`${e.notificationsEnabled?w`
+    `}};O([v()],Ns.prototype,`app`,void 0),O([v()],Ns.prototype,`baseUrl`,void 0),O([S()],Ns.prototype,`opened`,void 0),O([S()],Ns.prototype,`notifications`,void 0),Ns=O([h(`mateu-notification-bell`)],Ns);var Ps=e=>{if(!e||!(`querySelectorAll`in e))return null;for(let t of e.querySelectorAll(`*`)){if(t.tagName?.toLowerCase()===`mateu-component`)return t;let e=Ps(t.shadowRoot);if(e)return e}return null},Fs=async(e,t,n)=>{let r=Ps(t.renderRoot??t);await Wo.runAction(Ge,t.baseUrl??``,e.rootRoute||`_no_route`,``,n,r?.id??`app-header-action`,{},e.serverSideType??``,{},{},r??t,!0,void 0,!1,``)},Is=async(e,t,n)=>{try{await Fs(e,t,n)}catch(e){ha({text:`La acción falló: `+e,position:`bottomStart`,duration:6e3,variant:`error`},t)}},Ls=(e,t)=>{let n=e.contextSelectors??[],r=e.contextActions??[];return n.length===0&&r.length===0&&!e.notificationsEnabled?_:w`${e.notificationsEnabled?w`
         <mateu-notification-bell .app="${e}" .baseUrl="${t.baseUrl??``}"></mateu-notification-bell>`:_}${n.map(n=>w`
         <mateu-app-context-picker .selector="${n}" .app="${e}" .baseUrl="${t.baseUrl??``}"></mateu-app-context-picker>`)}${r.map(n=>(n.children?.length??0)>0?w`
         <details class="mateu-nav-group" style="margin-left: 0.5rem; flex-shrink: 0;">
             <summary class="app-header-action-btn">${n.label} ▾</summary>
             <div class="mateu-nav-panel" style="right: 0; left: auto;">
                 ${n.children.map(n=>w`
-                    <button class="mateu-nav-item" @click="${()=>n.actionId&&Ns(e,t,n.actionId)}">${n.label}</button>`)}
+                    <button class="mateu-nav-item" @click="${()=>n.actionId&&Is(e,t,n.actionId)}">${n.label}</button>`)}
             </div>
         </details>`:w`
         <button class="app-header-action-btn" style="margin-left: 0.5rem; flex-shrink: 0;"
-            @click="${()=>n.actionId&&Ns(e,t,n.actionId)}" title="${n.label}">${n.icon?F(n.icon):_}${n.label}</button>`)}`},Fs=(e,t)=>w`
+            @click="${()=>n.actionId&&Is(e,t,n.actionId)}" title="${n.label}">${n.icon?F(n.icon):_}${n.label}</button>`)}`},Rs=(e,t)=>w`
     <button class="mateu-nav-item ${e.selected?`mateu-nav-item--active`:``}"
             ?disabled="${e.disabled}"
-            @click="${()=>t(e)}">${e.text}</button>`,Is=(e,t,n=``)=>w`
+            @click="${()=>t(e)}">${e.text}</button>`,zs=(e,t,n=``)=>w`
     <nav class="mateu-nav ${n}">
         ${e.map(e=>(e.children?.length??0)>0?w`<details class="mateu-nav-group">
                        <summary class="mateu-nav-item">${e.text} ▾</summary>
                        <div class="mateu-nav-panel">
-                           ${e.children.map(e=>Fs(e,t))}
+                           ${e.children.map(e=>Rs(e,t))}
                        </div>
-                   </details>`:Fs(e,t))}
-    </nav>`,Ls=(e,t)=>n=>t.call(e,{detail:{value:n}}),Rs=(e,t)=>e.themeToggle?w`
+                   </details>`:Rs(e,t))}
+    </nav>`,Bs=(e,t)=>n=>t.call(e,{detail:{value:n}}),Vs=(e,t)=>e.themeToggle?w`
         <button class="app-chrome-icon-btn" @click="${t.toggleTheme}"
             title="${t.isDark?`Switch to light mode`:`Switch to dark mode`}"
             style="margin-left: 0.5rem; margin-right: 0.5rem; flex-shrink: 0;">
             ${F(t.isDark?`vaadin:sun-o`:`vaadin:moon`,`color: var(--lumo-body-text-color);`)}
         </button>
-    `:_,zs=(e,t)=>{t.filter!=e.detail.value&&(t.filter=e.detail.value)},Bs=(e,t,n)=>{let r=Vs(e,t,n),i=Z(t,n);return r==`list`||r==i?`new`:r},Vs=(e,t,n)=>{let r=e?._route;if(r!=null&&(r===``||r.startsWith(`/`))){let e=n.homeRoute??``,i=e.indexOf(`?`),a=i>=0?e.substring(i+1):``,o=Z(t,n)+r;return a?o+(o.indexOf(`?`)>=0?`&`:`?`)+a:o}return t.selectedRoute?t.selectedRoute:n.homeRoute},Z=(e,t)=>e.selectedRoute?e.selectedConsumedRoute??t.route:t.homeConsumedRoute,Hs=(e,t)=>e.selectedRoute?e.selectedBaseUrl??e.baseUrl:t.homeBaseUrl,Us=(e,t)=>e.selectedRoute?e.selectedServerSideType??t.serverSideType:t.homeServerSideType,Ws=(e,t)=>e.selectedRoute?e.selectedUriPrefix:t.homeUriPrefix,Gs=(e,t,n,r,i,a,o)=>{if(t.chromeless)return w`
+    `:_,Hs=(e,t)=>{t.filter!=e.detail.value&&(t.filter=e.detail.value)},Us=(e,t,n)=>{let r=Ws(e,t,n),i=X(t,n);return r==`list`||r==i?`new`:r},Ws=(e,t,n)=>{let r=e?._route;if(r!=null&&(r===``||r.startsWith(`/`))){let e=n.homeRoute??``,i=e.indexOf(`?`),a=i>=0?e.substring(i+1):``,o=X(t,n)+r;return a?o+(o.indexOf(`?`)>=0?`&`:`?`)+a:o}return t.selectedRoute?t.selectedRoute:n.homeRoute},X=(e,t)=>e.selectedRoute?e.selectedConsumedRoute??t.route:t.homeConsumedRoute,Gs=(e,t)=>e.selectedRoute?e.selectedBaseUrl??e.baseUrl:t.homeBaseUrl,Ks=(e,t)=>e.selectedRoute?e.selectedServerSideType??t.serverSideType:t.homeServerSideType,qs=(e,t)=>e.selectedRoute?e.selectedUriPrefix:t.homeUriPrefix,Js=(e,t,n,r,i,a,o)=>{if(t.chromeless)return w`
             <div class="app chromeless">
                 <div role="main" class="${`app-content`+(e.pageCompact?` no-padding`:``)}" style="height: 100%;">
                     <div class="m-md">
                         <div class="m-scroll" style="height: 100%;">
                             <mateu-api-caller>
                                 <mateu-ux
-                                        route="${Vs(r,e,t)}"
+                                        route="${Ws(r,e,t)}"
                                         id="ux_${e.id}"
-                                        baseUrl="${Hs(e,t)}"
-                                        consumedRoute="${Z(e,t)}"
-                                        serverSideType="${Us(e,t)}"
-                                        uriPrefix="${Ws(e,t)}"
+                                        baseUrl="${Gs(e,t)}"
+                                        consumedRoute="${X(e,t)}"
+                                        serverSideType="${Ks(e,t)}"
+                                        uriPrefix="${qs(e,t)}"
                                         style="width: 100%;"
                                         .appState="${a}"
                                         .appData="${o}"
@@ -7785,7 +7785,7 @@ ${i}
                 </div>
                 <slot></slot>
             </div>
-        `;let s=e.mapItems(t.menu,e.filter?.toLowerCase()??``),c=Z(e,t),l=Bs(r,e,t),u=l&&l!==`new`&&l.startsWith(c+`/`)?l.substring(c.length+1).split(`/`)[0]:void 0;return w`
+        `;let s=e.mapItems(t.menu,e.filter?.toLowerCase()??``),c=X(e,t),l=Us(r,e,t),u=l&&l!==`new`&&l.startsWith(c+`/`)?l.substring(c.length+1).split(`/`)[0]:void 0;return w`
                     ${t.variant==qe.MEDIATOR?w`
 
                         ${t.layout==`SPLIT`?w`
@@ -7793,12 +7793,12 @@ ${i}
                                 <mateu-api-caller>
                                     <div style="display: block; width: calc(100% - 1rem);">
                                     <mateu-ux
-                                            route="${Z(e,t)}"
+                                            route="${X(e,t)}"
                                             id="ux_${e.id}"
-                                            baseUrl="${Hs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Us(e,t)}"
-                                            uriPrefix="${Ws(e,t)}"
+                                            baseUrl="${Gs(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Ks(e,t)}"
+                                            uriPrefix="${qs(e,t)}"
                                             style="width: 100%;"
                                             .appState="${{...a,_splitDetailId:u}}"
                                             .appData="${o}"
@@ -7810,12 +7810,12 @@ ${i}
                                 <mateu-api-caller slot="detail">
                                     <div style="padding-left: 1rem; width: calc(100% - 1rem);">
                                     <mateu-ux
-                                            route="${Bs(r,e,t)}"
+                                            route="${Us(r,e,t)}"
                                             id="ux_${e.id}_detail"
-                                            baseUrl="${Hs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Us(e,t)}"
-                                            uriPrefix="${Ws(e,t)}"
+                                            baseUrl="${Gs(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Ks(e,t)}"
+                                            uriPrefix="${qs(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -7829,12 +7829,12 @@ ${i}
                         `:w`
                             <mateu-api-caller>
                                 <mateu-ux
-                                        route="${Vs(r,e,t)}"
+                                        route="${Ws(r,e,t)}"
                                         id="ux_${e.id}"
-                                        baseUrl="${Hs(e,t)}"
-                                        consumedRoute="${Z(e,t)}"
-                                        serverSideType="${Us(e,t)}"
-                                        uriPrefix="${Ws(e,t)}"
+                                        baseUrl="${Gs(e,t)}"
+                                        consumedRoute="${X(e,t)}"
+                                        serverSideType="${Ks(e,t)}"
+                                        uriPrefix="${qs(e,t)}"
                                         style="width: 100%;"
                                         .appState="${a}"
                                         .appData="${o}"
@@ -7856,7 +7856,7 @@ ${i}
                         <h2 style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; margin: 0 .5rem;">${t.title}</h2><p style="margin: 0;">${t.subtitle}</p>
                         <div class="m-hl" style="margin-left: auto; align-items: center;">
                             <slot name="widgets"></slot>
-                            ${Ps(t,e)}${Rs(t,e)}
+                            ${Ls(t,e)}${Vs(t,e)}
                         </div>
                     </header>
                     <div class="app-body">
@@ -7864,7 +7864,7 @@ ${i}
                             ${t.menu&&t.totalMenuOptions>10?w`
                                 <div style="position: sticky; top: 0; z-index: 2; background: var(--lumo-base-color); padding: .25rem 0 .5rem;">
                                     <input class="drawer-search" placeholder="Search…" style="width: calc(100% - 20px); margin: 0 10px;"
-                                           @input="${t=>zs({detail:{value:t.target.value}},e)}">
+                                           @input="${t=>Hs({detail:{value:t.target.value}},e)}">
                                 </div>
                                 `:_}
                             <nav class="side-nav">
@@ -7876,12 +7876,12 @@ ${i}
                                 <div class="m-scroll" style="height: 100%;">
                                     <mateu-api-caller>
                                         <mateu-ux
-                                                route="${Vs(r,e,t)}"
+                                                route="${Ws(r,e,t)}"
                                                 id="ux_${e.id}"
-                                                baseUrl="${Hs(e,t)}"
-                                                consumedRoute="${Z(e,t)}"
-                                                serverSideType="${Us(e,t)}"
-                                                uriPrefix="${Ws(e,t)}"
+                                                baseUrl="${Gs(e,t)}"
+                                                consumedRoute="${X(e,t)}"
+                                                serverSideType="${Ks(e,t)}"
+                                                uriPrefix="${qs(e,t)}"
                                                 style="width: 100%;"
                                                 .appState="${a}"
                                                 .appData="${o}"
@@ -7910,10 +7910,10 @@ ${i}
                             ${t.title?w`<h2 style="margin: 0 var(--lumo-space-l, 1.5rem) 0 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;">${t.title}</h2>`:_}
                         </div>
                         </a>
-                        ${(()=>{let t=Ls(e,e.itemSelected);return N.get()?.renderTopNav?.(s,t,`menu-on-top`)??Is(s,t,`menu-on-top`)})()}
+                        ${(()=>{let t=Bs(e,e.itemSelected);return N.get()?.renderTopNav?.(s,t,`menu-on-top`)??zs(s,t,`menu-on-top`)})()}
                         <div class="m-hl" style="margin-left: auto; flex-shrink: 0; align-items: center;">
                             <slot name="widgets"></slot>
-                            ${Ps(t,e)}${Rs(t,e)}
+                            ${Ls(t,e)}${Vs(t,e)}
                         </div>
                     </div>
                     <div style="flex: 1; min-height: 0; overflow-y: auto; overflow-x: hidden; box-sizing: border-box; width: 100%;">
@@ -7921,12 +7921,12 @@ ${i}
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${Vs(r,e,t)}"
+                                            route="${Ws(r,e,t)}"
                                             id="ux_${e.id}"
-                                            baseUrl="${Hs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Us(e,t)}"
-                                            uriPrefix="${Ws(e,t)}"
+                                            baseUrl="${Gs(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Ks(e,t)}"
+                                            uriPrefix="${qs(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -7954,10 +7954,10 @@ ${i}
                             ${t.title?w`<h2 style="margin: 0 var(--lumo-space-l, 1.5rem) 0 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;">${t.title}</h2>`:_}
                         </div>
                         </a>
-                        ${Is(e.mapItemsForTiles(t.menu),Ls(e,e.itemSelectedTiles),`menu-on-top`)}
+                        ${zs(e.mapItemsForTiles(t.menu),Bs(e,e.itemSelectedTiles),`menu-on-top`)}
                         <div class="m-hl" style="margin-left: auto; flex-shrink: 0; align-items: center;">
                             <slot name="widgets"></slot>
-                            ${Ps(t,e)}${Rs(t,e)}
+                            ${Ls(t,e)}${Vs(t,e)}
                         </div>
                     </div>
                     <div style="flex: 1; min-height: 0; overflow-y: auto; overflow-x: hidden; box-sizing: border-box; width: 100%;">
@@ -7966,12 +7966,12 @@ ${i}
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${Vs(r,e,t)}"
+                                            route="${Ws(r,e,t)}"
                                             id="ux_${e.id}"
-                                            baseUrl="${Hs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Us(e,t)}"
-                                            uriPrefix="${Ws(e,t)}"
+                                            baseUrl="${Gs(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Ks(e,t)}"
+                                            uriPrefix="${qs(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -7996,12 +7996,12 @@ ${i}
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${Vs(r,e,t)}"
+                                            route="${Ws(r,e,t)}"
                                             id="ux_${e.id}"
-                                            baseUrl="${Hs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Us(e,t)}"
-                                            uriPrefix="${Ws(e,t)}"
+                                            baseUrl="${Gs(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Ks(e,t)}"
+                                            uriPrefix="${qs(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -8023,7 +8023,7 @@ ${i}
                         <div class="m-vl"
                                 @navigation-requested="${e.updateRoute}">
                             ${t.menu.map(t=>e.renderOptionOnLeftMenu(t))}
-                            ${Ps(t,e)}${Rs(t,e)}
+                            ${Ls(t,e)}${Vs(t,e)}
                         </div>
                     </div>
                     <div role="main" class="${`app-content`+(e.pageCompact?` no-padding`:``)}">
@@ -8031,12 +8031,12 @@ ${i}
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${Vs(r,e,t)}"
+                                            route="${Ws(r,e,t)}"
                                             id="ux_${e.id}"
-                                            baseUrl="${Hs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Us(e,t)}"
-                                            uriPrefix="${Ws(e,t)}"
+                                            baseUrl="${Gs(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Ks(e,t)}"
+                                            uriPrefix="${qs(e,t)}"
                                             style="width: 100%; padding: 1em;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -8080,7 +8080,7 @@ ${i}
                             </nav>
                             <div class="m-hl" style="flex-shrink: 0; align-items: center;">
                                 <slot name="widgets"></slot>
-                                ${Ps(t,e)}${Rs(t,e)}
+                                ${Ls(t,e)}${Vs(t,e)}
                             </div>
                         </div>
                     </div>
@@ -8089,12 +8089,12 @@ ${i}
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${Vs(r,e,t)}"
+                                            route="${Ws(r,e,t)}"
                                             id="ux_${e.id}"
-                                            baseUrl="${Hs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Us(e,t)}"
-                                            uriPrefix="${Ws(e,t)}"
+                                            baseUrl="${Gs(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Ks(e,t)}"
+                                            uriPrefix="${qs(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -8124,7 +8124,7 @@ ${i}
             `:_}
             ${e.renderCommandPalette()}
             <slot></slot>
-       `},Ks=(e,t)=>t!=null&&e!=null&&!e.has(t),qs=typeof HTMLElement<`u`?HTMLElement:class{},Js=class extends qs{static get observedAttributes(){return[`type`,`renderer`]}connectedCallback(){this.render()}attributeChangedCallback(){this.render()}render(){let e=this.getAttribute(`type`)??`unknown`,t=this.getAttribute(`renderer`)??`unknown`;this.shadowRoot||this.attachShadow({mode:`open`}),this.shadowRoot.innerHTML=`
+       `},Ys=(e,t)=>t!=null&&e!=null&&!e.has(t),Xs=typeof HTMLElement<`u`?HTMLElement:class{},Zs=class extends Xs{static get observedAttributes(){return[`type`,`renderer`]}connectedCallback(){this.render()}attributeChangedCallback(){this.render()}render(){let e=this.getAttribute(`type`)??`unknown`,t=this.getAttribute(`renderer`)??`unknown`;this.shadowRoot||this.attachShadow({mode:`open`}),this.shadowRoot.innerHTML=`
             <style>
                 :host { display: block; }
                 .mateu-unsupported {
@@ -8143,12 +8143,12 @@ ${i}
             <div class="mateu-unsupported" role="note">
                 ⚠ Component “${e}” is not supported by the “${t}” renderer yet.
             </div>
-        `}};typeof customElements<`u`&&!customElements.get(`mateu-unsupported`)&&customElements.define(`mateu-unsupported`,Js);var Ys=new Set,Xs=(e,t,n)=>{let r=`${n}/${t}`;return Ys.has(r)||(Ys.add(r),console.warn(`[mateu] Component type "${t}" is not supported by the "${n}" renderer — rendering <mateu-unsupported> placeholder.`)),w`<mateu-unsupported
+        `}};typeof customElements<`u`&&!customElements.get(`mateu-unsupported`)&&customElements.define(`mateu-unsupported`,Zs);var Qs=new Set,$s=(e,t,n)=>{let r=`${n}/${t}`;return Qs.has(r)||(Qs.add(r),console.warn(`[mateu] Component type "${t}" is not supported by the "${n}" renderer — rendering <mateu-unsupported> placeholder.`)),w`<mateu-unsupported
             type="${t}"
             renderer="${n}"
             data-component-id="${e?.id??_}"
             slot="${e?.slot??_}"
-    ></mateu-unsupported>`},Zs=class{renderFilterBar(e,t,n,r,i,a,o,s){let c=t?.metadata;return w`
+    ></mateu-unsupported>`},ec=class{renderFilterBar(e,t,n,r,i,a,o,s){let c=t?.metadata;return w`
             <mateu-filter-bar
                 .metadata="${c}"
                 @search-requested="${e.search}"
@@ -8171,14 +8171,14 @@ ${i}
                 data-testid="pagination"
                 .pageNumber="${e.data[t?.id]?.page?.pageNumber??0}"
         ></mateu-pagination>
-        `}renderTableComponent(e,t,n,r,i,a,o){return bn(t,(e.data?.[e.id])?.page?.content??[],r[t?.id]?.emptyStateMessage)}rendererName(){return this.constructor?.name??`unknown`}supportedClientSideTypes(){}renderClientSideComponent(e,t,n,r,i,a,o,s){let c=t?.metadata?.type??t?.type,l=Object.values(A).includes(c)?c:void 0;return Ks(this.supportedClientSideTypes(),l)?Xs(t,l,this.rendererName()):sa(e,t,n,r,i,a,o,s)}renderAppComponent(e,t,n,r,i,a,o){return Gs(e,t?.metadata,n,r,i,a,o)}},Qs=(e,t,n,r,i,a,o)=>w`
+        `}renderTableComponent(e,t,n,r,i,a,o){return Sn(t,(e.data?.[e.id])?.page?.content??[],r[t?.id]?.emptyStateMessage)}rendererName(){return this.constructor?.name??`unknown`}supportedClientSideTypes(){}renderClientSideComponent(e,t,n,r,i,a,o,s){let c=t?.metadata?.type??t?.type,l=Object.values(A).includes(c)?c:void 0;return Ys(this.supportedClientSideTypes(),l)?$s(t,l,this.rendererName()):la(e,t,n,r,i,a,o,s)}renderAppComponent(e,t,n,r,i,a,o){return Js(e,t?.metadata,n,r,i,a,o)}},tc=(e,t,n,r,i,a,o)=>w`
         <vaadin-virtual-list
                 .items="${t.metadata.page.content}"
                 ${ne(t=>w`${P(e,t,n,r,i,a,o)}`,[])}
                 style="${t.style}" class="${t.cssClasses}"
                 slot="${t.slot??_}"
         ></vaadin-virtual-list>
-    `,$s=e=>{let t=e.metadata;return w`
+    `,nc=e=>{let t=e.metadata;return w`
         <vaadin-notification
                 .opened="${!0}"
                 slot="${e.slot??_}"
@@ -8191,7 +8191,7 @@ ${i}
                     </vaadin-horizontal-layout>
                 `,[])}
         ></vaadin-notification>
-    `},ec=(e,t={})=>{let n=e.metadata,r=n.valueKey?t[n.valueKey]:n.value;return w`
+    `},rc=(e,t={})=>{let n=e.metadata,r=n.valueKey?t[n.valueKey]:n.value;return w`
         <div style="${e.style}">
         <vaadin-progress-bar
                 ?indeterminate="${n.indeterminate}"
@@ -8206,7 +8206,7 @@ ${i}
     ${n.text}
   </span>`:_}
         </div>
-    `},tc=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+    `},ic=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <vaadin-details
                 ?opened="${s.opened}"
                 style="${t.style}"
@@ -8218,17 +8218,17 @@ ${i}
             </vaadin-details-summary>
             ${P(e,s.content,n,r,i,a,o)}
         </vaadin-details>
-            `},nc=(e,t,n)=>{let r=e.metadata;return w`<vaadin-avatar
+            `},ac=(e,t,n)=>{let r=e.metadata;return w`<vaadin-avatar
             img="${r.image}"
             name="${M(r.name,t,n)}"
             abbr="${r.abbreviation}"
             style="${e.style}" class="${e.cssClasses}"
             slot="${e.slot??_}"
-    ></vaadin-avatar>`},rc=e=>{let t=e.metadata;return w`<vaadin-avatar-group max-items-visible="${t.maxItemsVisible}"
+    ></vaadin-avatar>`},oc=e=>{let t=e.metadata;return w`<vaadin-avatar-group max-items-visible="${t.maxItemsVisible}"
                                      .items="${t.avatars}"
                                      style="${e.style}" class="${e.cssClasses}"
                                      slot="${e.slot??_}">
-    </vaadin-avatar-group>`},ic=(e,t,n,r,i,a,o)=>{let s=t.metadata;if(!s)return w``;let c=``;return s.variants?.map(e=>e==`stretchMedia`?`stretch-media`:e==`coverMedia`?`cover-media`:e).forEach(e=>c+=` `+e),c=c.trim(),w`
+    </vaadin-avatar-group>`},sc=(e,t,n,r,i,a,o)=>{let s=t.metadata;if(!s)return w``;let c=``;return s.variants?.map(e=>e==`stretchMedia`?`stretch-media`:e==`coverMedia`?`cover-media`:e).forEach(e=>c+=` `+e),c=c.trim(),w`
         <vaadin-card
                 style="${t.style}"
                 class="${t.cssClasses}"
@@ -8244,7 +8244,7 @@ ${i}
             ${s.footer?mt(e,s.footer,n,r,i,a,o,`footer`,!1):_}
             ${s.content?P(e,s.content,n,r,i,a,o,!1):_}
         </vaadin-card>
-    `},ac=e=>e>0&&e<640?`accordion`:`tabs`,oc=class extends y{constructor(...e){super(...e),this.tabLabels=[],this.mode=`tabs`,this.selected=0,this.selectedChangedListener=e=>{let t=e.detail?.value;typeof t==`number`&&t>=0&&(this.selected=t)}}connectedCallback(){super.connectedCallback(),this.resizeObserver=new ResizeObserver(e=>{for(let t of e)this.mode=ac(t.contentRect.width)}),this.resizeObserver.observe(this)}disconnectedCallback(){super.disconnectedCallback(),this.resizeObserver?.disconnect(),this.resizeObserver=void 0,this.detachTabsListener()}detachTabsListener(){this.slottedTabs?.removeEventListener(`selected-changed`,this.selectedChangedListener),this.slottedTabs=void 0}tabsSlotChanged(e){this.detachTabsListener();let t=e.target.assignedElements().find(e=>`selected`in e);t&&(this.slottedTabs=t,t.addEventListener(`selected-changed`,this.selectedChangedListener),t.selected=this.selected)}select(e){this.selected=e,this.slottedTabs&&(this.slottedTabs.selected=e)}updated(){this.slottedTabs&&this.slottedTabs.selected!=this.selected&&(this.slottedTabs.selected=this.selected)}static{this.styles=m`
+    `},cc=e=>e>0&&e<640?`accordion`:`tabs`,lc=class extends y{constructor(...e){super(...e),this.tabLabels=[],this.mode=`tabs`,this.selected=0,this.selectedChangedListener=e=>{let t=e.detail?.value;typeof t==`number`&&t>=0&&(this.selected=t)}}connectedCallback(){super.connectedCallback(),this.resizeObserver=new ResizeObserver(e=>{for(let t of e)this.mode=cc(t.contentRect.width)}),this.resizeObserver.observe(this)}disconnectedCallback(){super.disconnectedCallback(),this.resizeObserver?.disconnect(),this.resizeObserver=void 0,this.detachTabsListener()}detachTabsListener(){this.slottedTabs?.removeEventListener(`selected-changed`,this.selectedChangedListener),this.slottedTabs=void 0}tabsSlotChanged(e){this.detachTabsListener();let t=e.target.assignedElements().find(e=>`selected`in e);t&&(this.slottedTabs=t,t.addEventListener(`selected-changed`,this.selectedChangedListener),t.selected=this.selected)}select(e){this.selected=e,this.slottedTabs&&(this.slottedTabs.selected=e)}updated(){this.slottedTabs&&this.slottedTabs.selected!=this.selected&&(this.slottedTabs.selected=this.selected)}static{this.styles=m`
         :host {
             display: block;
         }
@@ -8328,7 +8328,7 @@ ${i}
                     `)}
                 </div>
             `}
-        `}};O([v({type:Array})],oc.prototype,`tabLabels`,void 0),O([S()],oc.prototype,`mode`,void 0),O([S()],oc.prototype,`selected`,void 0),oc=O([h(`mateu-adaptive-tabs`)],oc);var sc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;c??=``,s.columnSpacing&&(c+=`--vaadin-form-layout-column-spacing: `+s.columnSpacing+`;`);let l=s.itemRowSpacing&&s.itemRowSpacing!==`0`?s.itemRowSpacing:`var(--lumo-space-m)`;return c+=`--vaadin-form-layout-row-spacing: `+l+`;`,s.itemLabelSpacing&&(c+=`--vaadin-form-layout-label-spacing: `+s.itemLabelSpacing+`;`),s.labelsAside&&(c+=`--vaadin-form-item-label-width: 10rem;`),s.fullWidth&&(c+=`width: 100%;`),w`
+        `}};O([v({type:Array})],lc.prototype,`tabLabels`,void 0),O([S()],lc.prototype,`mode`,void 0),O([S()],lc.prototype,`selected`,void 0),lc=O([h(`mateu-adaptive-tabs`)],lc);var uc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;c??=``,s.columnSpacing&&(c+=`--vaadin-form-layout-column-spacing: `+s.columnSpacing+`;`);let l=s.itemRowSpacing&&s.itemRowSpacing!==`0`?s.itemRowSpacing:`var(--lumo-space-m)`;return c+=`--vaadin-form-layout-row-spacing: `+l+`;`,s.itemLabelSpacing&&(c+=`--vaadin-form-layout-label-spacing: `+s.itemLabelSpacing+`;`),s.labelsAside&&(c+=`--vaadin-form-item-label-width: 10rem;`),s.fullWidth&&(c+=`width: 100%;`),w`
                <vaadin-form-layout 
                        .responsiveSteps="${s.responsiveSteps||_}"  
                        style="${c||_}" 
@@ -8341,18 +8341,18 @@ ${i}
                        labels-aside="${s.labelsAside||_}"
                        slot="${t.slot||_}"
                >
-                   ${t.children?.map(t=>cc(s,e,t,n,r,i,a,o))}
+                   ${t.children?.map(t=>dc(s,e,t,n,r,i,a,o))}
                </vaadin-form-layout>
-            `},cc=(e,t,n,r,i,a,o,s)=>n.type==k.ClientSide&&n.metadata?.type==A.FormRow?uc(e,t,n,r,i,a,o,s):e.labelsAside?lc(t,n,r,i,a,o,s):P(t,n,r,i,a,o,s),lc=(e,t,n,r,i,a,o)=>{if(t.type==k.ClientSide&&t.metadata?.type==A.FormField&&t.metadata.label){let s=t.metadata,c=s.label?.includes("${")?e._evalTemplate(s.label):s.label;return w`
+            `},dc=(e,t,n,r,i,a,o,s)=>n.type==k.ClientSide&&n.metadata?.type==A.FormRow?pc(e,t,n,r,i,a,o,s):e.labelsAside?fc(t,n,r,i,a,o,s):P(t,n,r,i,a,o,s),fc=(e,t,n,r,i,a,o)=>{if(t.type==k.ClientSide&&t.metadata?.type==A.FormField&&t.metadata.label){let s=t.metadata,c=s.label?.includes("${")?e._evalTemplate(s.label):s.label;return w`
                        <vaadin-form-item data-colspan="${s.colspan}">
                            <label slot="label">${c}</label>
                            ${P(e,t,n,r,i,a,o,!0)}
                        </vaadin-form-item>
-                   `}return P(e,t,n,r,i,a,o)},uc=(e,t,n,r,i,a,o,s)=>w`
+                   `}return P(e,t,n,r,i,a,o)},pc=(e,t,n,r,i,a,o,s)=>w`
         <vaadin-form-row>
-            ${n.children?.map(n=>cc(e,t,n,r,i,a,o,s))}
+            ${n.children?.map(n=>dc(e,t,n,r,i,a,o,s))}
         </vaadin-form-row>
-            `,dc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=(s.padding?` padding`:``)+(s.spacing?` spacing`:``)+(s.spacingVariant?` spacing-`+s.spacingVariant:``)+(s.wrap?` wrap`:``),l=t.style;return s.fullWidth&&(l=l?`width: 100%;`+l:`width: 100%;`),s.justification&&(l=l?`justify-content: `+s.justification+`;`+l:`justify-content: `+s.justification+`;`),s.verticalAlignment&&(l=l?`align-items: `+s.verticalAlignment+`;`+l:`align-items: `+s.verticalAlignment+`;`),w`
+            `,mc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=(s.padding?` padding`:``)+(s.spacing?` spacing`:``)+(s.spacingVariant?` spacing-`+s.spacingVariant:``)+(s.wrap?` wrap`:``),l=t.style;return s.fullWidth&&(l=l?`width: 100%;`+l:`width: 100%;`),s.justification&&(l=l?`justify-content: `+s.justification+`;`+l:`justify-content: `+s.justification+`;`),s.verticalAlignment&&(l=l?`align-items: `+s.verticalAlignment+`;`+l:`align-items: `+s.verticalAlignment+`;`),w`
                <vaadin-horizontal-layout 
                        style="${l}" 
                        class="${t.cssClasses}"
@@ -8361,7 +8361,7 @@ ${i}
                >
                    ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
                </vaadin-horizontal-layout>
-            `},fc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=(s.padding?` padding`:``)+(s.spacing?` spacing`:``)+(s.spacingVariant?` spacing-`+s.spacingVariant:``)+(s.wrap?` wrap`:``),l=t.style;return s.fullWidth&&(l=l?`width: 100%;`+l:`width: 100%;`),s.justification&&(l=l?`justify-content: `+s.justification+`;`+l:`justify-content: `+s.justification+`;`),s.horizontalAlignment&&(l=l?`align-items: `+s.horizontalAlignment+`;`+l:`align-items: `+s.horizontalAlignment+`;`),w`
+            `},hc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=(s.padding?` padding`:``)+(s.spacing?` spacing`:``)+(s.spacingVariant?` spacing-`+s.spacingVariant:``)+(s.wrap?` wrap`:``),l=t.style;return s.fullWidth&&(l=l?`width: 100%;`+l:`width: 100%;`),s.justification&&(l=l?`justify-content: `+s.justification+`;`+l:`justify-content: `+s.justification+`;`),s.horizontalAlignment&&(l=l?`align-items: `+s.horizontalAlignment+`;`+l:`align-items: `+s.horizontalAlignment+`;`),w`
         <vaadin-vertical-layout
                 style="${l}"
                 class="${t.cssClasses}"
@@ -8370,7 +8370,7 @@ ${i}
         >
             ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </vaadin-vertical-layout>
-    `},pc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;return s.fullWidth&&(c=c?`width: 100%;`+c:`width: 100%;`),w`
+    `},gc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;return s.fullWidth&&(c=c?`width: 100%;`+c:`width: 100%;`),w`
                <vaadin-split-layout 
                        style="${c}" 
                        class="${t.cssClasses}"
@@ -8381,7 +8381,7 @@ ${i}
                    <master-content>${P(e,t.children[0],n,r,i,a,o)}</master-content>
                    <detail-content>${P(e,t.children[1],n,r,i,a,o)}</detail-content>
                </vaadin-split-layout>
-            `},mc=(e,t,n,r,i,a,o)=>{let s=t.children&&t.children.length>1?t.children[1]:null,c=i?.detailComponent??null,l=!!i?.hasDetail||!!s,u=c??s;return w`
+            `},_c=(e,t,n,r,i,a,o)=>{let s=t.children&&t.children.length>1?t.children[1]:null,c=i?.detailComponent??null,l=!!i?.hasDetail||!!s,u=c??s;return w`
                <vaadin-master-detail-layout ?has-detail="${l}"
                                             style="${t.style}"
                                             class="${t.cssClasses}"
@@ -8389,7 +8389,7 @@ ${i}
                    <div>${P(e,t.children[0],n,r,i,a,o)}</div>
                    ${l&&u?w`<div slot="detail">${P(e,u,n,r,i,a,o)}</div>`:w`<div slot="detail" style="display: flex; align-items: center; justify-content: center; height: 100%; color: var(--lumo-secondary-text-color); font-size: var(--lumo-font-size-s);">Select an item to view details</div>`}
                </vaadin-master-detail-layout>
-            `},hc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;c??=``,s.fullWidth&&(c+=`width: 100%;`);let l=s.variant;l==`equalWidth`&&(l=`equal-width-tabs`);let u=Math.max(0,(t.children??[]).findIndex(e=>e.metadata.active)),d=e=>{e.target.selected=u};if(s.adaptable){let u=(t.children??[]).map(t=>{let n=t.metadata.label;return n?.includes("${")?e._evalTemplate(n):n});return w`
+            `},vc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;c??=``,s.fullWidth&&(c+=`width: 100%;`);let l=s.variant;l==`equalWidth`&&(l=`equal-width-tabs`);let u=Math.max(0,(t.children??[]).findIndex(e=>e.metadata.active)),d=e=>{e.target.selected=u};if(s.adaptable){let u=(t.children??[]).map(t=>{let n=t.metadata.label;return n?.includes("${")?e._evalTemplate(n):n});return w`
             <mateu-adaptive-tabs
                     .tabLabels="${u}"
                     style="${c}"
@@ -8434,22 +8434,22 @@ ${i}
                     >${r}</vaadin-tab>`})}
             </vaadin-tabs>
 
-            ${t.children?.map(t=>gc(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>yc(e,t,n,r,i,a,o))}
         </vaadin-tabsheet>
-            `},gc=(e,t,n,r,i,a,o)=>{let s=t.metadata.label;return w`
+            `},yc=(e,t,n,r,i,a,o)=>{let s=t.metadata.label;return w`
         <div tab="${s?.includes("${")?e._evalTemplate(s):s}" style="padding: var(--lumo-space-m) 0;">
                    ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
                </div>
-            `},_c=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;s.fullWidth&&(c=c?`width: 100%;`+c:`width: 100%;`);let l=0;if(t.children){for(let e=0;e<t.children.length;e++)if(t.children[e].metadata?.active){l=e;break}}return w`
+            `},bc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;s.fullWidth&&(c=c?`width: 100%;`+c:`width: 100%;`);let l=0;if(t.children){for(let e=0;e<t.children.length;e++)if(t.children[e].metadata?.active){l=e;break}}return w`
                <vaadin-accordion
                        style="${t.style}"
                        class="${t.cssClasses}"
                        opened="${l}"
                        slot="${t.slot??_}"
                >
-                   ${t.children?.map(t=>vc(e,t,n,r,i,a,o,s.variant))}
+                   ${t.children?.map(t=>xc(e,t,n,r,i,a,o,s.variant))}
                </vaadin-accordion>
-            `},vc=(e,t,n,r,i,a,o,s)=>{let c=t.metadata,l=c.label?.includes("${")?e._evalTemplate(c.label):c.label;return w`
+            `},xc=(e,t,n,r,i,a,o,s)=>{let c=t.metadata,l=c.label?.includes("${")?e._evalTemplate(c.label):c.label;return w`
         <vaadin-accordion-panel style="${t.style}"
                                 class="${t.cssClasses}"
                                 theme="${s??_}"
@@ -8458,48 +8458,48 @@ ${i}
             <vaadin-accordion-heading slot="summary">${l}</vaadin-accordion-heading>
             ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </vaadin-accordion-panel>
-            `},yc=(e,t,n,r,i,a,o)=>w`
+            `},Sc=(e,t,n,r,i,a,o)=>w`
                <vaadin-scroller style="${t.style}" 
                                 class="${t.cssClasses}"
                                 slot="${t.slot??_}">
                    ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
                </vaadin-scroller>
-            `,bc=(e,t,n,r,i,a,o)=>w`
+            `,Cc=(e,t,n,r,i,a,o)=>w`
         <vaadin-board style="${t.style}" 
                       class="${t.cssClasses}"
                       slot="${t.slot??_}">
             ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </vaadin-board>
-            `,xc=(e,t,n,r,i,a,o)=>w`
+            `,wc=(e,t,n,r,i,a,o)=>w`
         <vaadin-board-row style="${t.style}" class="${t.cssClasses}">
                    ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
                </vaadin-board-row>
-            `,Sc=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+            `,Tc=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <div style="${t.style}" 
              class="${t.cssClasses}"
              board-cols="${s.boardCols??_}"
         >
                    ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
                </div>
-            `},Cc=(e,t,n)=>w`
+            `},Ec=(e,t,n)=>w`
     <vaadin-menu-bar
         .items=${e}
         class="${n??_}"
         @item-selected=${e=>t(e.detail.value)}>
-    </vaadin-menu-bar>`,wc=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
-        <vaadin-context-menu .items=${Dc(e,s.menu,n,r,i,a,o)} 
+    </vaadin-menu-bar>`,Dc=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+        <vaadin-context-menu .items=${Ac(e,s.menu,n,r,i,a,o)} 
                              style="${t.style}" 
                              class="${t.cssClasses}"
                              open-on="${s.activateOnLeftClick?`click`:_}"
                              slot="${t.slot??_}">
             ${P(e,s.wrapped,n,r,i,a,o)}
         </vaadin-context-menu>
-            `},Tc=(e,t,n,r,i)=>{let a=t.metadata;return w`
-        <vaadin-menu-bar .items=${Dc(e,a.options,n,r,i,D,de)}
+            `},Oc=(e,t,n,r,i)=>{let a=t.metadata;return w`
+        <vaadin-menu-bar .items=${Ac(e,a.options,n,r,i,D,de)}
                          style="${t.style}" class="${t.cssClasses}"
                          slot="${t.slot??_}">
         </vaadin-menu-bar>
-            `},Ec=(e,t,n,r,i,a,o)=>{let s=document.createElement(`vaadin-context-menu-item`);return ie(P(e,t,n,r,i,a,o),s),s},Dc=(e,t,n,r,i,a,o)=>t.map(t=>t.submenus?{text:t.component?void 0:t.label,route:t.path,checked:t.selected,disabled:t.disabled,className:t.className,component:t.component?Ec(e,t.component,n,r,i,a,o):void 0,children:Dc(e,t.submenus,n,r,i,a,o)}:t.separator?{component:`hr`}:{text:t.component?void 0:t.label,route:t.path,checked:t.selected,disabled:t.disabled,className:t.className,component:t.component?Ec(e,t.component,n,r,i,a,o):void 0}),Oc=class extends y{constructor(...e){super(...e),this.fieldId=``,this.signing=!1,this.hasStrokes=!1,this.drawing=!1,this.startStroke=e=>{let t=e.target;this.ensureCanvasSize(t),t.setPointerCapture(e.pointerId),this.drawing=!0;let n=t.getContext(`2d`);n.lineWidth=2,n.lineCap=`round`,n.lineJoin=`round`,n.strokeStyle=getComputedStyle(this).getPropertyValue(`--lumo-body-text-color`)||`#1a1a1a`;let[r,i]=this.pointerPosition(e);n.beginPath(),n.moveTo(r,i),e.preventDefault()},this.stroke=e=>{if(!this.drawing)return;let t=e.target.getContext(`2d`),[n,r]=this.pointerPosition(e);t.lineTo(n,r),t.stroke(),this.hasStrokes=!0,e.preventDefault()},this.endStroke=e=>{this.drawing=!1,e.target.releasePointerCapture(e.pointerId)}}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}canvas(){return this.renderRoot.querySelector(`canvas`)}pointerPosition(e){let t=e.target.getBoundingClientRect();return[e.clientX-t.left,e.clientY-t.top]}ensureCanvasSize(e){let t=e.getBoundingClientRect();(e.width!==Math.round(t.width)||e.height!==Math.round(t.height))&&(e.width=Math.round(t.width),e.height=Math.round(t.height))}clear(){let e=this.canvas();e&&e.getContext(`2d`).clearRect(0,0,e.width,e.height),this.hasStrokes=!1}accept(){let e=this.canvas();!e||!this.hasStrokes||(this.signing=!1,this.emit(e.toDataURL(`image/png`)))}renderPad(){return w`
+            `},kc=(e,t,n,r,i,a,o)=>{let s=document.createElement(`vaadin-context-menu-item`);return ie(P(e,t,n,r,i,a,o),s),s},Ac=(e,t,n,r,i,a,o)=>t.map(t=>t.submenus?{text:t.component?void 0:t.label,route:t.path,checked:t.selected,disabled:t.disabled,className:t.className,component:t.component?kc(e,t.component,n,r,i,a,o):void 0,children:Ac(e,t.submenus,n,r,i,a,o)}:t.separator?{component:`hr`}:{text:t.component?void 0:t.label,route:t.path,checked:t.selected,disabled:t.disabled,className:t.className,component:t.component?kc(e,t.component,n,r,i,a,o):void 0}),jc=class extends y{constructor(...e){super(...e),this.fieldId=``,this.signing=!1,this.hasStrokes=!1,this.drawing=!1,this.startStroke=e=>{let t=e.target;this.ensureCanvasSize(t),t.setPointerCapture(e.pointerId),this.drawing=!0;let n=t.getContext(`2d`);n.lineWidth=2,n.lineCap=`round`,n.lineJoin=`round`,n.strokeStyle=getComputedStyle(this).getPropertyValue(`--lumo-body-text-color`)||`#1a1a1a`;let[r,i]=this.pointerPosition(e);n.beginPath(),n.moveTo(r,i),e.preventDefault()},this.stroke=e=>{if(!this.drawing)return;let t=e.target.getContext(`2d`),[n,r]=this.pointerPosition(e);t.lineTo(n,r),t.stroke(),this.hasStrokes=!0,e.preventDefault()},this.endStroke=e=>{this.drawing=!1,e.target.releasePointerCapture(e.pointerId)}}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}canvas(){return this.renderRoot.querySelector(`canvas`)}pointerPosition(e){let t=e.target.getBoundingClientRect();return[e.clientX-t.left,e.clientY-t.top]}ensureCanvasSize(e){let t=e.getBoundingClientRect();(e.width!==Math.round(t.width)||e.height!==Math.round(t.height))&&(e.width=Math.round(t.width),e.height=Math.round(t.height))}clear(){let e=this.canvas();e&&e.getContext(`2d`).clearRect(0,0,e.width,e.height),this.hasStrokes=!1}accept(){let e=this.canvas();!e||!this.hasStrokes||(this.signing=!1,this.emit(e.toDataURL(`image/png`)))}renderPad(){return w`
             <canvas class="pad"
                     @pointerdown="${this.startStroke}"
                     @pointermove="${this.stroke}"
@@ -8566,7 +8566,7 @@ ${i}
         .button--danger {
             color: var(--lumo-error-text-color, rgb(179, 49, 31));
         }
-    `}};O([v()],Oc.prototype,`fieldId`,void 0),O([v()],Oc.prototype,`value`,void 0),O([S()],Oc.prototype,`signing`,void 0),O([S()],Oc.prototype,`hasStrokes`,void 0),Oc=O([h(`mateu-signature-pad`)],Oc);var kc=class extends y{constructor(...e){super(...e),this.fieldId=``,this.options=[],this.leavesOnly=!1,this.opened=!1,this.expandedItems=[],this._normalized=[],this.dataProvider=(e,t)=>{let n=e.parentItem?e.parentItem.children??[]:this.normalized;t(n,n.length)}}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}get normalized(){return this._optsSource!==this.options&&(this._optsSource=this.options,this._normalized=this.normalizeOptions(this.options??[])),this._normalized}normalizeOptions(e){return e.map(e=>{let t=e.children&&e.children.length?this.normalizeOptions(e.children):void 0;return{...e,children:t}})}ancestorsOf(e,t){for(let n of t){if(String(n.value)===e)return[];let t=n.children?this.ancestorsOf(e,n.children):null;if(t!=null)return[n,...t]}return null}labelOf(e,t){for(let n of t){if(String(n.value)===e)return n.label;let t=n.children?this.labelOf(e,n.children):null;if(t!=null)return t}return null}open(){this.opened||(this.expandedItems=this.value==null?[]:this.ancestorsOf(String(this.value),this.normalized)??[],this.opened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.close()},document.addEventListener(`mousedown`,this.outsideClick))}close(){this.detachOutsideClick(),this.opened=!1}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}pick(e){this.close(),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e.value,fieldId:this.fieldId},bubbles:!0,composed:!0}))}clear(){this.close(),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:void 0,fieldId:this.fieldId},bubbles:!0,composed:!0}))}onActiveItemChanged(e){let t=e.detail.value;if(t){if((t.children?.length??0)>0&&this.leavesOnly){this.expandedItems=this.expandedItems.includes(t)?this.expandedItems.filter(e=>e!==t):[...this.expandedItems,t],e.target.activeItem=null;return}this.pick(t)}}render(){let e=this.value!=null&&this.value!==``?this.labelOf(String(this.value),this.normalized)??String(this.value):``;return w`
+    `}};O([v()],jc.prototype,`fieldId`,void 0),O([v()],jc.prototype,`value`,void 0),O([S()],jc.prototype,`signing`,void 0),O([S()],jc.prototype,`hasStrokes`,void 0),jc=O([h(`mateu-signature-pad`)],jc);var Mc=class extends y{constructor(...e){super(...e),this.fieldId=``,this.options=[],this.leavesOnly=!1,this.opened=!1,this.expandedItems=[],this._normalized=[],this.dataProvider=(e,t)=>{let n=e.parentItem?e.parentItem.children??[]:this.normalized;t(n,n.length)}}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}get normalized(){return this._optsSource!==this.options&&(this._optsSource=this.options,this._normalized=this.normalizeOptions(this.options??[])),this._normalized}normalizeOptions(e){return e.map(e=>{let t=e.children&&e.children.length?this.normalizeOptions(e.children):void 0;return{...e,children:t}})}ancestorsOf(e,t){for(let n of t){if(String(n.value)===e)return[];let t=n.children?this.ancestorsOf(e,n.children):null;if(t!=null)return[n,...t]}return null}labelOf(e,t){for(let n of t){if(String(n.value)===e)return n.label;let t=n.children?this.labelOf(e,n.children):null;if(t!=null)return t}return null}open(){this.opened||(this.expandedItems=this.value==null?[]:this.ancestorsOf(String(this.value),this.normalized)??[],this.opened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.close()},document.addEventListener(`mousedown`,this.outsideClick))}close(){this.detachOutsideClick(),this.opened=!1}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}pick(e){this.close(),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e.value,fieldId:this.fieldId},bubbles:!0,composed:!0}))}clear(){this.close(),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:void 0,fieldId:this.fieldId},bubbles:!0,composed:!0}))}onActiveItemChanged(e){let t=e.detail.value;if(t){if((t.children?.length??0)>0&&this.leavesOnly){this.expandedItems=this.expandedItems.includes(t)?this.expandedItems.filter(e=>e!==t):[...this.expandedItems,t],e.target.activeItem=null;return}this.pick(t)}}render(){let e=this.value!=null&&this.value!==``?this.labelOf(String(this.value),this.normalized)??String(this.value):``;return w`
             <div class="root">
                 <vaadin-button class="control" theme="tertiary"
                                @click="${()=>this.opened?this.close():this.open()}">
@@ -8637,7 +8637,7 @@ ${i}
             min-width: 16rem;
             max-height: 18rem;
         }
-    `}};O([v()],kc.prototype,`fieldId`,void 0),O([v()],kc.prototype,`value`,void 0),O([v()],kc.prototype,`options`,void 0),O([v({type:Boolean})],kc.prototype,`leavesOnly`,void 0),O([S()],kc.prototype,`opened`,void 0),O([S()],kc.prototype,`expandedItems`,void 0),kc=O([h(`mateu-vaadin-tree-select`)],kc);var Ac=class extends y{constructor(...e){super(...e),this.fieldId=``,this.cameraOpen=!1,this.cameraError=!1,this.fileFallback=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>this.emit(r.result),r.readAsDataURL(n),t.value=``}}disconnectedCallback(){super.disconnectedCallback(),this.stopStream()}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}stopStream(){this.stream?.getTracks().forEach(e=>e.stop()),this.stream=void 0}async openCamera(){this.cameraError=!1;try{this.stream=await navigator.mediaDevices.getUserMedia({video:{facingMode:`environment`},audio:!1}),this.cameraOpen=!0,await this.updateComplete;let e=this.renderRoot.querySelector(`video`);e&&(e.srcObject=this.stream,await e.play())}catch{this.stopStream(),this.cameraOpen=!1,this.cameraError=!0}}closeCamera(){this.stopStream(),this.cameraOpen=!1}shoot(){let e=this.renderRoot.querySelector(`video`);if(!e||e.videoWidth===0)return;let t=document.createElement(`canvas`);t.width=e.videoWidth,t.height=e.videoHeight,t.getContext(`2d`).drawImage(e,0,0),this.closeCamera(),this.emit(t.toDataURL(`image/jpeg`,.9))}triggerFallback(){this.renderRoot.querySelector(`input[type=file]`)?.click()}render(){let e=this.value!=null&&this.value!==``;return w`
+    `}};O([v()],Mc.prototype,`fieldId`,void 0),O([v()],Mc.prototype,`value`,void 0),O([v()],Mc.prototype,`options`,void 0),O([v({type:Boolean})],Mc.prototype,`leavesOnly`,void 0),O([S()],Mc.prototype,`opened`,void 0),O([S()],Mc.prototype,`expandedItems`,void 0),Mc=O([h(`mateu-vaadin-tree-select`)],Mc);var Nc=class extends y{constructor(...e){super(...e),this.fieldId=``,this.cameraOpen=!1,this.cameraError=!1,this.fileFallback=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>this.emit(r.result),r.readAsDataURL(n),t.value=``}}disconnectedCallback(){super.disconnectedCallback(),this.stopStream()}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}stopStream(){this.stream?.getTracks().forEach(e=>e.stop()),this.stream=void 0}async openCamera(){this.cameraError=!1;try{this.stream=await navigator.mediaDevices.getUserMedia({video:{facingMode:`environment`},audio:!1}),this.cameraOpen=!0,await this.updateComplete;let e=this.renderRoot.querySelector(`video`);e&&(e.srcObject=this.stream,await e.play())}catch{this.stopStream(),this.cameraOpen=!1,this.cameraError=!0}}closeCamera(){this.stopStream(),this.cameraOpen=!1}shoot(){let e=this.renderRoot.querySelector(`video`);if(!e||e.videoWidth===0)return;let t=document.createElement(`canvas`);t.width=e.videoWidth,t.height=e.videoHeight,t.getContext(`2d`).drawImage(e,0,0),this.closeCamera(),this.emit(t.toDataURL(`image/jpeg`,.9))}triggerFallback(){this.renderRoot.querySelector(`input[type=file]`)?.click()}render(){let e=this.value!=null&&this.value!==``;return w`
             <input type="file" accept="image/*" capture="environment" style="display: none;"
                    @change="${this.fileFallback}">
             ${this.cameraOpen?w`
@@ -8715,7 +8715,7 @@ ${i}
             font-size: var(--lumo-font-size-xs, 0.75rem);
             color: var(--lumo-secondary-text-color, rgba(0, 0, 0, 0.6));
         }
-    `}};O([v()],Ac.prototype,`fieldId`,void 0),O([v()],Ac.prototype,`value`,void 0),O([S()],Ac.prototype,`cameraOpen`,void 0),O([S()],Ac.prototype,`cameraError`,void 0),Ac=O([h(`mateu-camera-capture`)],Ac);var jc,Mc=(e,t)=>{if(!e)return;if(Array.isArray(e)){let n=e.find(e=>e.key==t);return n?.value==null?void 0:String(n.value)}let n=e[t];return n==null?void 0:String(n)},Nc=class extends y{static{jc=this}constructor(...e){super(...e),this.fieldId=``,this.editable=!0,this.filePicked=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>{let e=r.result,t=e.indexOf(`,`),i=e.substring(0,t).replace(`;base64`,`;name=${encodeURIComponent(n.name)};base64`);this.emit(i+e.substring(t))},r.readAsDataURL(n),t.value=``}}static fileName(e){if(!e)return``;if(e.startsWith(`data:`)){let t=e.indexOf(`,`),n=e.substring(5,t<0?e.length:t).split(`;`).find(e=>e.startsWith(`name=`));if(n)try{return decodeURIComponent(n.substring(5))}catch{return n.substring(5)}return`Attached file`}return e.split(`/`).pop()||e}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}triggerPick(){this.renderRoot.querySelector(`input[type=file]`)?.click()}render(){let e=this.value!=null&&this.value!==``,t=jc.fileName(this.value),n=e&&this.value.startsWith(`data:`),r=e?w`<span class="file" title="${t}">📄 ${n?w`<a href="${this.value}" download="${t}">${t}</a>`:w`<a href="${this.value}" target="_blank">${t}</a>`}</span>`:_;return this.editable?w`
+    `}};O([v()],Nc.prototype,`fieldId`,void 0),O([v()],Nc.prototype,`value`,void 0),O([S()],Nc.prototype,`cameraOpen`,void 0),O([S()],Nc.prototype,`cameraError`,void 0),Nc=O([h(`mateu-camera-capture`)],Nc);var Pc,Fc=(e,t)=>{if(!e)return;if(Array.isArray(e)){let n=e.find(e=>e.key==t);return n?.value==null?void 0:String(n.value)}let n=e[t];return n==null?void 0:String(n)},Ic=class extends y{static{Pc=this}constructor(...e){super(...e),this.fieldId=``,this.editable=!0,this.filePicked=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>{let e=r.result,t=e.indexOf(`,`),i=e.substring(0,t).replace(`;base64`,`;name=${encodeURIComponent(n.name)};base64`);this.emit(i+e.substring(t))},r.readAsDataURL(n),t.value=``}}static fileName(e){if(!e)return``;if(e.startsWith(`data:`)){let t=e.indexOf(`,`),n=e.substring(5,t<0?e.length:t).split(`;`).find(e=>e.startsWith(`name=`));if(n)try{return decodeURIComponent(n.substring(5))}catch{return n.substring(5)}return`Attached file`}return e.split(`/`).pop()||e}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}triggerPick(){this.renderRoot.querySelector(`input[type=file]`)?.click()}render(){let e=this.value!=null&&this.value!==``,t=Pc.fileName(this.value),n=e&&this.value.startsWith(`data:`),r=e?w`<span class="file" title="${t}">📄 ${n?w`<a href="${this.value}" download="${t}">${t}</a>`:w`<a href="${this.value}" target="_blank">${t}</a>`}</span>`:_;return this.editable?w`
             <input type="file" accept="${this.accept||_}" style="display: none;"
                    @change="${this.filePicked}">
             <div class="row">
@@ -8763,28 +8763,28 @@ ${i}
         .button--danger {
             color: var(--lumo-error-text-color, rgb(179, 49, 31));
         }
-    `}};O([v()],Nc.prototype,`fieldId`,void 0),O([v()],Nc.prototype,`value`,void 0),O([v()],Nc.prototype,`accept`,void 0),O([v({type:Boolean})],Nc.prototype,`editable`,void 0),Nc=jc=O([h(`mateu-file-upload`)],Nc);var Pc=e=>!!e&&typeof e==`object`&&`__mateuGroup`in e,Fc=e=>String(e??``),Ic=(e,t,n)=>{let r=e??[];if(!t||!n||n.length===0)return r;let i=[],a,o=!1;return r.forEach((e,s)=>{let c=Fc(e?.[t]);if(!o||c!==a){let e=n.find(e=>Fc(e.value)===c)??{value:c,count:r.filter(e=>Fc(e?.[t])===c).length,aggregates:{}};i.push({__mateuGroup:e,__mateuGroupBy:t,_rowNumber:`__mateuGroup:${s}:${c}`}),o=!0,a=c}i.push(e)}),i},Lc=(e,t)=>e==null?``:t.dataType===`money`||t.stereotype===`money`?new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e):t.aggregate===`count`?new Intl.NumberFormat(void 0,{maximumFractionDigits:0}).format(Math.round(e)):new Intl.NumberFormat(void 0,{maximumFractionDigits:2}).format(e),Rc=(e,t)=>e&&t.includes(e)?e:t.find(e=>!!e),zc=(e,t,n)=>{let r=e.__mateuGroup;return t.id===n?`${r.value} (${r.count})`:t.aggregate?Lc(r.aggregates?.[t.id],t):``},Bc=(e,t,n)=>{let r=t?.aggregates;if(!r||!e.some(e=>e.aggregate))return;let i={};e.forEach(e=>{e.aggregate&&r[e.id]!=null&&(i[e.id]=Lc(r[e.id],e))});let a=e[0];if(a&&i[a.id]===void 0){let e=t?.page?.totalElements;i[a.id]=n&&a.id===n&&e!=null?`Total (${e})`:`Total`}return i},Vc=(e,t,n)=>F(e[n.path]?`vaadin:check`:`vaadin:minus`,`height: 16px; width: 16px; color: var(--lumo-body-text-color);`),Hc=(e,t,n,r,i)=>{let a=e[n.path],o=a;return r==`money`&&a&&a.locale&&a.currency?o=new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(a.value):i==`money`&&(o=new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(a)),w`${o}`},Uc=(e,t,n)=>{e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:n},bubbles:!0,composed:!0}))},Wc=(e,t,n,r,i,a)=>{let o=n.xcolumn??a;if(o.text)return o.actionId?w`<a href="javascript: void(0);" @click="${t=>Uc(n,o,e)}">${o.text}</a>`:w`<a href="${e[n.path]}">${o.text}</a>`;if(r==`string`){if(o.actionId)return w`<a href="javascript: void(0);" @click="${t=>Uc(n,o,e)}">${e[n.path]}</a>`;let t=e[n.path];return w`<a href="${t}">${t}</a>`}let s=e[n.path];return w`<a href="${s.href}">${s.text}</a>`},Gc=(e,t,n,r,i)=>{let a=e[n.path];return r==`string`?a.split(`,`).map(e=>F(e,`width: 16px;`)):a.split(`,`).map(e=>F(e.icon,`width: 16px;`))},Kc=(e,t,n,r,i)=>{let a=e[n.path];return w`${g(a)}`},qc=(e,t,n,r,i,a)=>r==`string`?w`<img src="${e[n.path]}" style="${`max-height: 40px; `+(a.style??``)}">`:w`<img src="${e[n.path].src}" style="${a.style??``}">`,Jc=e=>{let t={_clickedRow:e.target.row};e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+e.detail.value.methodNameInCrud,parameters:t},bubbles:!0,composed:!0}))},Yc=e=>{let t={_clickedRow:e.target.row},n=e.target.action;e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+n.methodNameInCrud,parameters:t},bubbles:!0,composed:!0}))},Xc=e=>{let t=document.createElement(`vaadin-context-menu-item`),n=document.createElement(`vaadin-icon`);return n.style.color=`var(--lumo-secondary-text-color)`,n.style.marginInlineEnd=`var(--lumo-space-s)`,n.style.padding=`var(--lumo-space-xs)`,n.setAttribute(`icon`,e.icon),t.appendChild(n),e.label&&t.appendChild(document.createTextNode(e.label)),t.disabled=e.disabled,t},Zc=(e,t,n)=>{let r=e[n.path]?.actions?.map(e=>e.icon?{component:Xc(e),methodNameInCrud:e.methodNameInCrud}:{...e,text:e.label});return!r||r.length==0?w``:w`
+    `}};O([v()],Ic.prototype,`fieldId`,void 0),O([v()],Ic.prototype,`value`,void 0),O([v()],Ic.prototype,`accept`,void 0),O([v({type:Boolean})],Ic.prototype,`editable`,void 0),Ic=Pc=O([h(`mateu-file-upload`)],Ic);var Lc=e=>!!e&&typeof e==`object`&&`__mateuGroup`in e,Rc=e=>String(e??``),zc=(e,t,n)=>{let r=e??[];if(!t||!n||n.length===0)return r;let i=[],a,o=!1;return r.forEach((e,s)=>{let c=Rc(e?.[t]);if(!o||c!==a){let e=n.find(e=>Rc(e.value)===c)??{value:c,count:r.filter(e=>Rc(e?.[t])===c).length,aggregates:{}};i.push({__mateuGroup:e,__mateuGroupBy:t,_rowNumber:`__mateuGroup:${s}:${c}`}),o=!0,a=c}i.push(e)}),i},Bc=(e,t)=>e==null?``:t.dataType===`money`||t.stereotype===`money`?new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e):t.aggregate===`count`?new Intl.NumberFormat(void 0,{maximumFractionDigits:0}).format(Math.round(e)):new Intl.NumberFormat(void 0,{maximumFractionDigits:2}).format(e),Vc=(e,t)=>e&&t.includes(e)?e:t.find(e=>!!e),Hc=(e,t,n)=>{let r=e.__mateuGroup;return t.id===n?`${r.value} (${r.count})`:t.aggregate?Bc(r.aggregates?.[t.id],t):``},Uc=(e,t,n)=>{let r=t?.aggregates;if(!r||!e.some(e=>e.aggregate))return;let i={};e.forEach(e=>{e.aggregate&&r[e.id]!=null&&(i[e.id]=Bc(r[e.id],e))});let a=e[0];if(a&&i[a.id]===void 0){let e=t?.page?.totalElements;i[a.id]=n&&a.id===n&&e!=null?`Total (${e})`:`Total`}return i},Wc=(e,t,n)=>F(e[n.path]?`vaadin:check`:`vaadin:minus`,`height: 16px; width: 16px; color: var(--lumo-body-text-color);`),Gc=(e,t,n,r,i)=>{let a=e[n.path],o=a;return r==`money`&&a&&a.locale&&a.currency?o=new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(a.value):i==`money`&&(o=new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(a)),w`${o}`},Kc=(e,t,n)=>{e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:n},bubbles:!0,composed:!0}))},qc=(e,t,n,r,i,a)=>{let o=n.xcolumn??a;if(o.text)return o.actionId?w`<a href="javascript: void(0);" @click="${t=>Kc(n,o,e)}">${o.text}</a>`:w`<a href="${e[n.path]}">${o.text}</a>`;if(r==`string`){if(o.actionId)return w`<a href="javascript: void(0);" @click="${t=>Kc(n,o,e)}">${e[n.path]}</a>`;let t=e[n.path];return w`<a href="${t}">${t}</a>`}let s=e[n.path];return w`<a href="${s.href}">${s.text}</a>`},Jc=(e,t,n,r,i)=>{let a=e[n.path];return r==`string`?a.split(`,`).map(e=>F(e,`width: 16px;`)):a.split(`,`).map(e=>F(e.icon,`width: 16px;`))},Yc=(e,t,n,r,i)=>{let a=e[n.path];return w`${g(a)}`},Xc=(e,t,n,r,i,a)=>r==`string`?w`<img src="${e[n.path]}" style="${`max-height: 40px; `+(a.style??``)}">`:w`<img src="${e[n.path].src}" style="${a.style??``}">`,Zc=e=>{let t={_clickedRow:e.target.row};e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+e.detail.value.methodNameInCrud,parameters:t},bubbles:!0,composed:!0}))},Qc=e=>{let t={_clickedRow:e.target.row},n=e.target.action;e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+n.methodNameInCrud,parameters:t},bubbles:!0,composed:!0}))},$c=e=>{let t=document.createElement(`vaadin-context-menu-item`),n=document.createElement(`vaadin-icon`);return n.style.color=`var(--lumo-secondary-text-color)`,n.style.marginInlineEnd=`var(--lumo-space-s)`,n.style.padding=`var(--lumo-space-xs)`,n.setAttribute(`icon`,e.icon),t.appendChild(n),e.label&&t.appendChild(document.createTextNode(e.label)),t.disabled=e.disabled,t},el=(e,t,n)=>{let r=e[n.path]?.actions?.map(e=>e.icon?{component:$c(e),methodNameInCrud:e.methodNameInCrud}:{...e,text:e.label});return!r||r.length==0?w``:w`
                                      <vaadin-menu-bar
                                          .items=${[{text:`···`,children:r}]}
                                          theme="tertiary"
                                          .row="${e}"
                                          data-testid="menubar-${n.path}"
-                                         @item-selected="${Jc}"
+                                         @item-selected="${Zc}"
                                      ></vaadin-menu-bar>
-                                   `},Qc=(e,t,n)=>{if(n.path==`select`)return w`
-         <vaadin-button theme="tertiary" title="Select" @click="${Yc}" .row="${e}" .action="${{actionId:n.path,icon:``,label:`Select`,disabled:!1,methodNameInCrud:`select`}}">
+                                   `},tl=(e,t,n)=>{if(n.path==`select`)return w`
+         <vaadin-button theme="tertiary" title="Select" @click="${Qc}" .row="${e}" .action="${{actionId:n.path,icon:``,label:`Select`,disabled:!1,methodNameInCrud:`select`}}">
              Select
          </vaadin-button>
     `;let r=n.path&&e[n.path]?.methodNameInCrud?e[n.path]:e.action;return r?w`
-         <vaadin-button theme="tertiary${r.icon&&!r.label?` icon`:``}" title="${r.label||_}" @click="${Yc}" .row="${e}" .action="${r}">
+         <vaadin-button theme="tertiary${r.icon&&!r.label?` icon`:``}" title="${r.label||_}" @click="${Qc}" .row="${e}" .action="${r}">
              ${r.icon?w`<vaadin-icon icon="${r.icon}"></vaadin-icon>`:_}
              ${r.label?r.label:_}
          </vaadin-button>
-    `:w``},$c=(e,t,n)=>{e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:n},bubbles:!0,composed:!0}))},el=(e,t,n,r,i,a)=>{let o=n.xcolumn??a;if(o.actionId)return w`
-            <vaadin-button theme="tertiary" @click="${t=>$c(n,o,e)}" .row="${e}">
+    `:w``},nl=(e,t,n)=>{e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:n},bubbles:!0,composed:!0}))},rl=(e,t,n,r,i,a)=>{let o=n.xcolumn??a;if(o.actionId)return w`
+            <vaadin-button theme="tertiary" @click="${t=>nl(n,o,e)}" .row="${e}">
                 ${o.text||e[n.path]}
             </vaadin-button>
-        `;let s=e[n.path];return w`<a href="${s}">${o.text||s}</a>`},tl=(e,t,n,r,i,a,o,s,c)=>{let l=e[n.path];return P(r,l,i,a,o,s,c)},nl=new WeakMap,rl=(e,t)=>nl.get(e)?.[t],il=(e,t,n)=>{let r=nl.get(e);r||(r={},nl.set(e,r)),r[t]=n},al=e=>{if(e==null||e===``)return null;let t=Number(e);return Number.isNaN(t)?null:t},ol=(e,t,n,r)=>{let i=n?.field?.fieldId,a=a=>{if(e[t.id]===a||e[t.id]==null&&(a===``||a==null))return;if(e[t.id]=a,!i){n.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`update-row`,parameters:{_editedRow:{...e}}},bubbles:!0,composed:!0}));return}let o=(n?.state??r)[i];n.dispatchEvent(new CustomEvent(`value-changed`,{detail:{fieldId:i,value:Array.isArray(o)?[...o]:o},bubbles:!0,composed:!0}))},o=e[t.id],s=o==null?``:String(o);switch(t.editorType){case`boolean`:return w`<vaadin-checkbox ?checked=${!!o} @checked-changed=${e=>a(e.detail.value)}></vaadin-checkbox>`;case`integer`:return w`<vaadin-integer-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(al(e.target.value))}></vaadin-integer-field>`;case`number`:return w`<vaadin-number-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(al(e.target.value))}></vaadin-number-field>`;case`date`:return w`<vaadin-date-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-date-picker>`;case`time`:return w`<vaadin-time-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-time-picker>`;case`datetime`:return w`<vaadin-date-time-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-date-time-picker>`;case`select`:return w`<vaadin-combo-box
+        `;let s=e[n.path];return w`<a href="${s}">${o.text||s}</a>`},il=(e,t,n,r,i,a,o,s,c)=>{let l=e[n.path];return P(r,l,i,a,o,s,c)},al=new WeakMap,ol=(e,t)=>al.get(e)?.[t],sl=(e,t,n)=>{let r=al.get(e);r||(r={},al.set(e,r)),r[t]=n},cl=e=>{if(e==null||e===``)return null;let t=Number(e);return Number.isNaN(t)?null:t},ll=(e,t,n,r)=>{let i=n?.field?.fieldId,a=a=>{if(e[t.id]===a||e[t.id]==null&&(a===``||a==null))return;if(e[t.id]=a,!i){n.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`update-row`,parameters:{_editedRow:{...e}}},bubbles:!0,composed:!0}));return}let o=(n?.state??r)[i];n.dispatchEvent(new CustomEvent(`value-changed`,{detail:{fieldId:i,value:Array.isArray(o)?[...o]:o},bubbles:!0,composed:!0}))},o=e[t.id],s=o==null?``:String(o);switch(t.editorType){case`boolean`:return w`<vaadin-checkbox ?checked=${!!o} @checked-changed=${e=>a(e.detail.value)}></vaadin-checkbox>`;case`integer`:return w`<vaadin-integer-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(cl(e.target.value))}></vaadin-integer-field>`;case`number`:return w`<vaadin-number-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(cl(e.target.value))}></vaadin-number-field>`;case`date`:return w`<vaadin-date-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-date-picker>`;case`time`:return w`<vaadin-time-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-time-picker>`;case`datetime`:return w`<vaadin-date-time-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-date-time-picker>`;case`select`:return w`<vaadin-combo-box
                 theme="small" style="width:100%;"
                 .items=${(t.editorOptions??[]).map(e=>({label:e.label,value:String(e.value)}))}
                 item-label-path="label" item-value-path="value"
@@ -8793,12 +8793,12 @@ ${i}
                 theme="small" style="width:100%;"
                 item-label-path="label" item-id-path="value"
                 .dataProvider=${(e,t)=>{n.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:i,parameters:{searchText:e.filter,size:e.pageSize,page:e.page},callback:e=>{let n=e?.fragments?.[0]?.data?.[o];t(n?.content??[],n?.totalElements??0)},callbackonly:!0},bubbles:!0,composed:!0}))}}
-                .selectedItem=${(t.editorOptions??[]).find(e=>String(e.value)===s)??(s?{value:s,label:rl(e,t.id)??s}:void 0)}
-                @selected-item-changed=${n=>{let r=n.detail.value,i=r?r.value:null;String(i??``)!==s&&(r&&il(e,t.id,r.label),a(i))}}></vaadin-combo-box>`}default:return w`<vaadin-text-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(e.target.value)}></vaadin-text-field>`}},sl=e=>ee(()=>w`<span title="${e}" style="white-space:normal;overflow-wrap:break-word;">${e}</span>`,[e]),cl=e=>e===void 0?_:d(()=>w`<span style="font-weight: 600; white-space: nowrap;">${e}</span>`,[e]),ll=e=>{e.preventDefault(),e.stopPropagation(),e.currentTarget?.dispatchEvent(new CustomEvent(`sort-direction-changed`,{detail:{grid:e.currentTarget.parentElement},bubbles:!0,composed:!0}))},ul=(e,t,n,r,i,a,o,s)=>w`
+                .selectedItem=${(t.editorOptions??[]).find(e=>String(e.value)===s)??(s?{value:s,label:ol(e,t.id)??s}:void 0)}
+                @selected-item-changed=${n=>{let r=n.detail.value,i=r?r.value:null;String(i??``)!==s&&(r&&sl(e,t.id,r.label),a(i))}}></vaadin-combo-box>`}default:return w`<vaadin-text-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(e.target.value)}></vaadin-text-field>`}},ul=e=>ee(()=>w`<span title="${e}" style="white-space:normal;overflow-wrap:break-word;">${e}</span>`,[e]),dl=e=>e===void 0?_:d(()=>w`<span style="font-weight: 600; white-space: nowrap;">${e}</span>`,[e]),fl=e=>{e.preventDefault(),e.stopPropagation(),e.currentTarget?.dispatchEvent(new CustomEvent(`sort-direction-changed`,{detail:{grid:e.currentTarget.parentElement},bubbles:!0,composed:!0}))},pl=(e,t,n,r,i,a,o,s)=>w`
 <vaadin-grid-column-group header="${j(e.label,r,i)}">
-    ${e.columns.map(e=>fl(e.metadata,t,n,r,i,a,o,s?.[e.metadata?.id]))}
+    ${e.columns.map(e=>hl(e.metadata,t,n,r,i,a,o,s?.[e.metadata?.id]))}
 </vaadin-grid-column-group>
-`,dl=(e,t,n,r,i,a,o,s)=>A.GridGroupColumn==e.metadata?.type?ul(e.metadata,t,n,r,i,a,o,s):fl(e.metadata,t,n,r,i,a,o,s?.[e.metadata?.id]),fl=(e,n,r,i,a,o,s,c)=>{let l=j(e.label,i,a);return e.sortable?w`
+`,ml=(e,t,n,r,i,a,o,s)=>A.GridGroupColumn==e.metadata?.type?pl(e.metadata,t,n,r,i,a,o,s):hl(e.metadata,t,n,r,i,a,o,s?.[e.metadata?.id]),hl=(e,n,r,i,a,o,s,c)=>{let l=j(e.label,i,a);return e.sortable?w`
                         <vaadin-grid-sort-column
                                 path="${e.id}"
                                 text-align="${e.align??_}"
@@ -8808,12 +8808,12 @@ ${i}
                                 flex-grow="${e.flexGrow??_}"
                                 ?resizable="${e.resizable}"
                                 width="${e.width??_}"
-                                @direction-changed="${ll}"
+                                @direction-changed="${fl}"
                                 data-data-type="${e.dataType}"
                                 data-stereotype="${e.stereotype}"
-                                ${sl(l)}
-                                ${cl(c)}
-                                ${t((t,c,l)=>pl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
+                                ${ul(l)}
+                                ${dl(c)}
+                                ${t((t,c,l)=>gl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
                         ></vaadin-grid-sort-column>
                     `:e.filterable?w`
                         <vaadin-grid-filter-column
@@ -8827,9 +8827,9 @@ ${i}
                                 width="${e.width??_}"
                                 data-data-type="${e.dataType}"
                                 data-stereotype="${e.stereotype}"
-                                ${sl(l)}
-                                ${cl(c)}
-                                ${t((t,c,l)=>pl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
+                                ${ul(l)}
+                                ${dl(c)}
+                                ${t((t,c,l)=>gl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
                         ></vaadin-grid-filter-column>
                     `:w`
                         <vaadin-grid-column
@@ -8844,17 +8844,17 @@ ${i}
                                 data-data-type="${e.dataType}"
                                 data-stereotype="${e.stereotype}"
                                 .xcolumn="${e}"
-                                ${sl(l)}
-                                ${cl(c)}
-                                ${t((t,c,l)=>pl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
+                                ${ul(l)}
+                                ${dl(c)}
+                                ${t((t,c,l)=>gl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
                         ></vaadin-grid-column>
-                    `},pl=(e,t,n,r,i,a,o,s,c,l)=>{let u=n.dataset.dataType??``,d=n.dataset.stereotype??``;if(Pc(e)){let t=i?.metadata,n=(t?.columns??[]).flatMap(e=>e?.metadata?.type===A.GridGroupColumn?(e.metadata.columns??[]).map(e=>e?.metadata?.id):[e?.metadata?.id]),a=zc(e,r,Rc(e.__mateuGroupBy,n)),o=e.__mateuGroup.hiddenActions??[],s=r.id===n[n.length-1]?(t?.groupActions??[]).filter(e=>!o.includes(e.actionId??e.id)):[];return s.length?w`<span style="display: flex; align-items: center; justify-content: flex-end; gap: var(--lumo-space-s); overflow: hidden;">
+                    `},gl=(e,t,n,r,i,a,o,s,c,l)=>{let u=n.dataset.dataType??``,d=n.dataset.stereotype??``;if(Lc(e)){let t=i?.metadata,n=(t?.columns??[]).flatMap(e=>e?.metadata?.type===A.GridGroupColumn?(e.metadata.columns??[]).map(e=>e?.metadata?.id):[e?.metadata?.id]),a=Hc(e,r,Vc(e.__mateuGroupBy,n)),o=e.__mateuGroup.hiddenActions??[],s=r.id===n[n.length-1]?(t?.groupActions??[]).filter(e=>!o.includes(e.actionId??e.id)):[];return s.length?w`<span style="display: flex; align-items: center; justify-content: flex-end; gap: var(--lumo-space-s); overflow: hidden;">
                 ${a?w`<span style="font-weight: 600;">${a}</span>`:_}
                 ${s.map(t=>w`
                     <vaadin-button theme="tertiary small" style="flex-shrink: 0;"
                         @click="${n=>{n.stopPropagation(),n.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+(t.actionId??t.id),parameters:{_groupValue:e.__mateuGroup.value}},bubbles:!0,composed:!0}))}}">${t.label??t.caption??``}</vaadin-button>
                 `)}
-            </span>`:w`<span title="${a}" style="font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block;">${a}</span>`}if(r.editable)return ol(e,r,i,o);if(u==`status`)return la(e,t,n);if(u==`bool`)return Vc(e,t,n);if(u==`money`||d==`money`)return Hc(e,t,n,u,d);if(u==`link`||d==`link`)return Wc(e,t,n,u,d,r);if(u==`icon`||d==`icon`)return Gc(e,t,n,u,d);if(d==`html`)return Kc(e,t,n,u,d);if(d==`image`)return qc(e,t,n,u,d,r);if(u==`menu`)return Zc(e,t,n);if(u==`component`)return tl(e,t,n,i,a,o,s,c,l);if(u==`action`)return Qc(e,t,n);if(u==`actionGroup`)return Zc(e,t,n);if(d==`button`||r.actionId)return el(e,t,n,u,d,r);let f=e[n.path];return w`<span title="${f}" style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block;">${f}</span>`},ml=()=>{let e=document.activeElement;for(;e?.shadowRoot?.activeElement;)e=e.shadowRoot.activeElement;return e},hl=(e,t)=>{let n=t;for(;n;){if(n===e)return!0;n=n.assignedSlot??n.parentNode??n.host??null}return!1},gl=class extends et{constructor(...e){super(...e),this.state={},this.data={},this.appState={},this.appData={},this.detailsOpenedItems=[],this.hoveredItem=null,this.onGridHoverMove=e=>{let t=e.currentTarget,n=t.getEventContext(e)?.item??null;n!==this.hoveredItem&&(this.hoveredItem=n,t.generateCellPartNames())},this.onGridHoverLeave=e=>{this.hoveredItem!==null&&(this.hoveredItem=null,e.currentTarget.generateCellPartNames())},this.hoverCellPartNameGenerator=(e,t)=>t?.item!=null&&t.item===this.hoveredItem?`hovered-cell`:``,this._onRowKey=e=>{let t=this.field?.rowSelectionShortcut;if(!t||!this.field?.onItemSelectionActionId||!this._isRowShortcutRelevant()||!In(t,e))return;let n=/^(?:Digit|Numpad)([1-9])$/.exec(e.code);if(!n)return;let r=this.currentItems(),i=parseInt(n[1],10)-1;i>=r.length||(e.preventDefault(),this.selectRow(r[i]))},this.handleButtonClick=e=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))}}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._onRowKey)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`keydown`,this._onRowKey)}currentItems(){return this.field?.remoteCoordinates?this.data?.[this.id]?.content??[]:this.field?.fieldId&&this.state?this.state[this.field.fieldId]??[]:[]}selectRow(e){!e||!this.field?.onItemSelectionActionId||(this.selectedItems=[e],this.state[this.id+`_selected_items`]=[e],this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.field.onItemSelectionActionId,parameters:{_clickedRow:e}},bubbles:!0,composed:!0})))}_isRowShortcutRelevant(){if(this.offsetParent===null&&this.getClientRects().length===0)return!1;let e=ml();if(e&&e!==document.body&&!hl(this,e)){let t=e.tagName?.toLowerCase()??``;if(e.isContentEditable||/^(input|textarea|select)$/.test(t)||t.startsWith(`vaadin-`)&&/(field|combo|picker|area|select)/.test(t))return!1}return!0}handleItemToggle(e){let{item:t,selected:n,shiftKey:r}=e.detail;if(this.rangeStartItem??=t,r){let e=[];this.field?.fieldId&&this.state&&this.state[this.field.fieldId]&&(e=this.state[this.field.fieldId]);let[r,i]=[this.rangeStartItem,t].map(t=>e.indexOf(t)).sort((e,t)=>e-t),a=e.slice(r,i+1),o=new Set(this.selectedItems);a.forEach(e=>{n?o.add(e):o.delete(e)}),this.selectedItems=[...o],this.state[this.id+`_selected_items`]=this.selectedItems}this.rangeStartItem=t}render(){let e=[];this.field?.fieldId&&this.state&&this.state[this.field.fieldId]&&(e=this.state[this.field.fieldId]);let t=this.state[this.field?.fieldId+`_show_detail`]||this.state._show_detail&&this.state._show_detail[this.field.fieldId];if(this.field?.remoteCoordinates){let t=this.field.remoteCoordinates;this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements?e=this.data[this.id].content:this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}if(Array.isArray(e)&&e.forEach((e,t)=>{e&&typeof e==`object`&&e._rowNumber===void 0&&(e._rowNumber=t)}),this.field?.inlineEditing)return this.renderMaster(e);if(this.field?.formPosition&&this.field?.formPosition.startsWith(`modal`)){let n=this;return w`
+            </span>`:w`<span title="${a}" style="font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block;">${a}</span>`}if(r.editable)return ll(e,r,i,o);if(u==`status`)return da(e,t,n);if(u==`bool`)return Wc(e,t,n);if(u==`money`||d==`money`)return Gc(e,t,n,u,d);if(u==`link`||d==`link`)return qc(e,t,n,u,d,r);if(u==`icon`||d==`icon`)return Jc(e,t,n,u,d);if(d==`html`)return Yc(e,t,n,u,d);if(d==`image`)return Xc(e,t,n,u,d,r);if(u==`menu`)return el(e,t,n);if(u==`component`)return il(e,t,n,i,a,o,s,c,l);if(u==`action`)return tl(e,t,n);if(u==`actionGroup`)return el(e,t,n);if(d==`button`||r.actionId)return rl(e,t,n,u,d,r);let f=e[n.path];return w`<span title="${f}" style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block;">${f}</span>`},_l=()=>{let e=document.activeElement;for(;e?.shadowRoot?.activeElement;)e=e.shadowRoot.activeElement;return e},vl=(e,t)=>{let n=t;for(;n;){if(n===e)return!0;n=n.assignedSlot??n.parentNode??n.host??null}return!1},yl=class extends et{constructor(...e){super(...e),this.state={},this.data={},this.appState={},this.appData={},this.detailsOpenedItems=[],this.hoveredItem=null,this.onGridHoverMove=e=>{let t=e.currentTarget,n=t.getEventContext(e)?.item??null;n!==this.hoveredItem&&(this.hoveredItem=n,t.generateCellPartNames())},this.onGridHoverLeave=e=>{this.hoveredItem!==null&&(this.hoveredItem=null,e.currentTarget.generateCellPartNames())},this.hoverCellPartNameGenerator=(e,t)=>t?.item!=null&&t.item===this.hoveredItem?`hovered-cell`:``,this._onRowKey=e=>{let t=this.field?.rowSelectionShortcut;if(!t||!this.field?.onItemSelectionActionId||!this._isRowShortcutRelevant()||!Rn(t,e))return;let n=/^(?:Digit|Numpad)([1-9])$/.exec(e.code);if(!n)return;let r=this.currentItems(),i=parseInt(n[1],10)-1;i>=r.length||(e.preventDefault(),this.selectRow(r[i]))},this.handleButtonClick=e=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))}}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._onRowKey)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`keydown`,this._onRowKey)}currentItems(){return this.field?.remoteCoordinates?this.data?.[this.id]?.content??[]:this.field?.fieldId&&this.state?this.state[this.field.fieldId]??[]:[]}selectRow(e){!e||!this.field?.onItemSelectionActionId||(this.selectedItems=[e],this.state[this.id+`_selected_items`]=[e],this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.field.onItemSelectionActionId,parameters:{_clickedRow:e}},bubbles:!0,composed:!0})))}_isRowShortcutRelevant(){if(this.offsetParent===null&&this.getClientRects().length===0)return!1;let e=_l();if(e&&e!==document.body&&!vl(this,e)){let t=e.tagName?.toLowerCase()??``;if(e.isContentEditable||/^(input|textarea|select)$/.test(t)||t.startsWith(`vaadin-`)&&/(field|combo|picker|area|select)/.test(t))return!1}return!0}handleItemToggle(e){let{item:t,selected:n,shiftKey:r}=e.detail;if(this.rangeStartItem??=t,r){let e=[];this.field?.fieldId&&this.state&&this.state[this.field.fieldId]&&(e=this.state[this.field.fieldId]);let[r,i]=[this.rangeStartItem,t].map(t=>e.indexOf(t)).sort((e,t)=>e-t),a=e.slice(r,i+1),o=new Set(this.selectedItems);a.forEach(e=>{n?o.add(e):o.delete(e)}),this.selectedItems=[...o],this.state[this.id+`_selected_items`]=this.selectedItems}this.rangeStartItem=t}render(){let e=[];this.field?.fieldId&&this.state&&this.state[this.field.fieldId]&&(e=this.state[this.field.fieldId]);let t=this.state[this.field?.fieldId+`_show_detail`]||this.state._show_detail&&this.state._show_detail[this.field.fieldId];if(this.field?.remoteCoordinates){let t=this.field.remoteCoordinates;this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements?e=this.data[this.id].content:this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}if(Array.isArray(e)&&e.forEach((e,t)=>{e&&typeof e==`object`&&e._rowNumber===void 0&&(e._rowNumber=t)}),this.field?.inlineEditing)return this.renderMaster(e);if(this.field?.formPosition&&this.field?.formPosition.startsWith(`modal`)){let n=this;return w`
 
                 ${this.renderMaster(e)}
 
@@ -8909,7 +8909,7 @@ ${i}
                 ${this.field?.readOnly||this.field?.inlineEditing?_:w`
                     <vaadin-grid-selection-column drag-select></vaadin-grid-selection-column>
                 `}
-                ${this.field?.columns?.map(e=>dl(e,this,this.baseUrl,this.state,this.data,this.appState,this.appData))}
+                ${this.field?.columns?.map(e=>ml(e,this,this.baseUrl,this.state,this.data,this.appState,this.appData))}
 
                 ${this.field?.inlineEditing&&!this.field?.readOnly?w`
                     <vaadin-grid-column width="3.5rem" flex-grow="0" frozen-to-end
@@ -8966,7 +8966,7 @@ ${i}
             background-color: var(--lumo-primary-color-10pct);
             cursor: pointer;
         }
-    `}};O([v()],gl.prototype,`field`,void 0),O([v()],gl.prototype,`state`,void 0),O([v()],gl.prototype,`data`,void 0),O([v()],gl.prototype,`appState`,void 0),O([v()],gl.prototype,`appData`,void 0),O([v()],gl.prototype,`selectedItems`,void 0),O([S()],gl.prototype,`detailsOpenedItems`,void 0),gl=O([h(`mateu-grid`)],gl);var _l=class extends y{constructor(...e){super(...e),this.getNewValue=e=>{if(this.field?.dataType==`array`){if(!this.value)return[e];let t=this.value;return t.indexOf(e)>=0?t.filter(t=>t!==e):[...t,e]}return e}}render(){let e=this.field?.options;if(this.field?.remoteCoordinates){let t=this.field.remoteCoordinates;this.data?.[this.field.fieldId]&&this.data[this.field.fieldId].content&&this.data[this.field.fieldId].totalElements?e=this.data[this.field.fieldId].content:this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}return w`
+    `}};O([v()],yl.prototype,`field`,void 0),O([v()],yl.prototype,`state`,void 0),O([v()],yl.prototype,`data`,void 0),O([v()],yl.prototype,`appState`,void 0),O([v()],yl.prototype,`appData`,void 0),O([v()],yl.prototype,`selectedItems`,void 0),O([S()],yl.prototype,`detailsOpenedItems`,void 0),yl=O([h(`mateu-grid`)],yl);var bl=class extends y{constructor(...e){super(...e),this.getNewValue=e=>{if(this.field?.dataType==`array`){if(!this.value)return[e];let t=this.value;return t.indexOf(e)>=0?t.filter(t=>t!==e):[...t,e]}return e}}render(){let e=this.field?.options;if(this.field?.remoteCoordinates){let t=this.field.remoteCoordinates;this.data?.[this.field.fieldId]&&this.data[this.field.fieldId].content&&this.data[this.field.fieldId].totalElements?e=this.data[this.field.fieldId].content:this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}return w`
         <div style="display: flex; gap: 1rem; padding: 1rem; flex-wrap: wrap; ${this.field?.attributes?.divStyle}">
                                     ${e?.map(e=>w`
                             <div role="button" tabindex="0" 
@@ -9014,7 +9014,7 @@ ${i}
         }
   
         ${R}
-    `}};O([v()],_l.prototype,`field`,void 0),O([v()],_l.prototype,`baseUrl`,void 0),O([v()],_l.prototype,`state`,void 0),O([v()],_l.prototype,`data`,void 0),O([v()],_l.prototype,`value`,void 0),_l=O([h(`mateu-choice`)],_l);var vl=class extends y{constructor(...e){super(...e),this.currencyChanged=e=>{this.value||={value:0,currency:`EUR`,locale:`es-ES`},this.value.currency=e.detail.value,this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:{...this.value},fieldId:this.fieldId}}))},this.valueChanged=e=>{this.value||={value:0,currency:`EUR`,locale:`es-ES`},e.detail.value&&(this.value.value=e.detail.value?parseFloat(e.detail.value):0,this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:{...this.value},fieldId:this.fieldId}})))}}render(){return w`
+    `}};O([v()],bl.prototype,`field`,void 0),O([v()],bl.prototype,`baseUrl`,void 0),O([v()],bl.prototype,`state`,void 0),O([v()],bl.prototype,`data`,void 0),O([v()],bl.prototype,`value`,void 0),bl=O([h(`mateu-choice`)],bl);var xl=class extends y{constructor(...e){super(...e),this.currencyChanged=e=>{this.value||={value:0,currency:`EUR`,locale:`es-ES`},this.value.currency=e.detail.value,this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:{...this.value},fieldId:this.fieldId}}))},this.valueChanged=e=>{this.value||={value:0,currency:`EUR`,locale:`es-ES`},e.detail.value&&(this.value.value=e.detail.value?parseFloat(e.detail.value):0,this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:{...this.value},fieldId:this.fieldId}})))}}render(){return w`
             <vaadin-number-field
                     id="${this.fieldId}"
                     label="${this.label}"
@@ -9034,7 +9034,7 @@ ${i}
                     theme="small"
             ></vaadin-select></div></vaadin-number-field>
        `}static{this.styles=m`
-  `}};O([v()],vl.prototype,`fieldId`,void 0),O([v()],vl.prototype,`label`,void 0),O([v()],vl.prototype,`state`,void 0),O([v()],vl.prototype,`data`,void 0),O([v()],vl.prototype,`value`,void 0),O([v()],vl.prototype,`autoFocus`,void 0),O([v()],vl.prototype,`required`,void 0),O([v()],vl.prototype,`colspan`,void 0),O([v()],vl.prototype,`helperText`,void 0),vl=O([h(`mateu-money-field`)],vl);var yl=`vaadin:abacus.vaadin:absolute-position.vaadin:academy-cap.vaadin:accessibility.vaadin:accordion-menu.vaadin:add-dock.vaadin:adjust.vaadin:adobe-flash.vaadin:airplane.vaadin:alarm.vaadin:align-center.vaadin:align-justify.vaadin:align-left.vaadin:align-right.vaadin:alt-a.vaadin:alt.vaadin:ambulance.vaadin:anchor.vaadin:angle-double-down.vaadin:angle-double-left.vaadin:angle-double-right.vaadin:angle-double-up.vaadin:angle-down.vaadin:angle-left.vaadin:angle-right.vaadin:angle-up.vaadin:archive.vaadin:archives.vaadin:area-select.vaadin:arrow-backward.vaadin:arrow-circle-down-o.vaadin:arrow-circle-down.vaadin:arrow-circle-left-o.vaadin:arrow-circle-left.vaadin:arrow-circle-right-o.vaadin:arrow-circle-right.vaadin:arrow-circle-up-o.vaadin:arrow-circle-up.vaadin:arrow-down.vaadin:arrow-forward.vaadin:arrow-left.vaadin:arrow-long-down.vaadin:arrow-long-left.vaadin:arrow-right.vaadin:arrow-up.vaadin:arrows-cross.vaadin:arrows-long-h.vaadin:arrows-long-right.vaadin:arrows-long-up.vaadin:arrows-long-v.vaadin:arrows.vaadin:asterisk.vaadin:at.vaadin:automation.vaadin:backspace-a.vaadin:backspace.vaadin:backwards.vaadin:ban.vaadin:bar-chart-h.vaadin:bar-chart-v.vaadin:bar-chart.vaadin:barcode.vaadin:bed.vaadin:bell-o.vaadin:bell-slash-o.vaadin:bell-slash.vaadin:bell.vaadin:boat.vaadin:bold.vaadin:bolt.vaadin:bomb.vaadin:book-dollar.vaadin:book-percent.vaadin:book.vaadin:bookmark-o.vaadin:bookmark.vaadin:briefcase.vaadin:browser.vaadin:bug-o.vaadin:bug.vaadin:building-o.vaadin:building.vaadin:bullets.vaadin:bullseye.vaadin:bus.vaadin:buss.vaadin:button.vaadin:calc-book.vaadin:calc.vaadin:calendar-briefcase.vaadin:calendar-clock.vaadin:calendar-envelope.vaadin:calendar-o.vaadin:calendar-user.vaadin:calendar.vaadin:camera.vaadin:car.vaadin:caret-down.vaadin:caret-left.vaadin:caret-right.vaadin:caret-square-down-o.vaadin:caret-square-left-o.vaadin:caret-square-right-o.vaadin:caret-square-up-o.vaadin:caret-up.vaadin:cart-o.vaadin:cart.vaadin:cash.vaadin:chart-3d.vaadin:chart-grid.vaadin:chart-line.vaadin:chart-timeline.vaadin:chart.vaadin:chat.vaadin:check-circle-o.vaadin:check-circle.vaadin:check-square-o.vaadin:check-square.vaadin:check.vaadin:chevron-circle-down-o.vaadin:chevron-circle-down.vaadin:chevron-circle-left-o.vaadin:chevron-circle-left.vaadin:chevron-circle-right-o.vaadin:chevron-circle-right.vaadin:chevron-circle-up-o.vaadin:chevron-circle-up.vaadin:chevron-down-small.vaadin:chevron-down.vaadin:chevron-left-small.vaadin:chevron-left.vaadin:chevron-right-small.vaadin:chevron-right.vaadin:chevron-up-small.vaadin:chevron-up.vaadin:child.vaadin:circle-thin.vaadin:circle.vaadin:clipboard-check.vaadin:clipboard-cross.vaadin:clipboard-heart.vaadin:clipboard-pulse.vaadin:clipboard-text.vaadin:clipboard-user.vaadin:clipboard.vaadin:clock.vaadin:close-big.vaadin:close-circle-o.vaadin:close-circle.vaadin:close-small.vaadin:close.vaadin:cloud-download-o.vaadin:cloud-download.vaadin:cloud-o.vaadin:cloud-upload-o.vaadin:cloud-upload.vaadin:cloud.vaadin:cluster.vaadin:code.vaadin:coffee.vaadin:cog-o.vaadin:cog.vaadin:cogs.vaadin:coin-piles.vaadin:coins.vaadin:combobox.vaadin:comment-ellipsis-o.vaadin:comment-ellipsis.vaadin:comment-o.vaadin:comment.vaadin:comments-o.vaadin:comments.vaadin:compile.vaadin:compress-square.vaadin:compress.vaadin:connect-o.vaadin:connect.vaadin:controller.vaadin:copy-o.vaadin:copy.vaadin:copyright.vaadin:corner-lower-left.vaadin:corner-lower-right.vaadin:corner-upper-left.vaadin:corner-upper-right.vaadin:credit-card.vaadin:crop.vaadin:cross-cutlery.vaadin:crosshairs.vaadin:css.vaadin:ctrl-a.vaadin:ctrl.vaadin:cube.vaadin:cubes.vaadin:curly-brackets.vaadin:cursor-o.vaadin:cursor.vaadin:cutlery.vaadin:dashboard.vaadin:database.vaadin:date-input.vaadin:deindent.vaadin:del-a.vaadin:del.vaadin:dental-chair.vaadin:desktop.vaadin:diamond-o.vaadin:diamond.vaadin:diploma-scroll.vaadin:diploma.vaadin:disc.vaadin:doctor-briefcase.vaadin:doctor.vaadin:dollar.vaadin:dot-circle.vaadin:download-alt.vaadin:download.vaadin:drop.vaadin:edit.vaadin:eject.vaadin:elastic.vaadin:ellipsis-circle-o.vaadin:ellipsis-circle.vaadin:ellipsis-dots-h.vaadin:ellipsis-dots-v.vaadin:ellipsis-h.vaadin:ellipsis-v.vaadin:enter-arrow.vaadin:enter.vaadin:envelope-o.vaadin:envelope-open-o.vaadin:envelope-open.vaadin:envelope.vaadin:envelopes-o.vaadin:envelopes.vaadin:eraser.vaadin:esc-a.vaadin:esc.vaadin:euro.vaadin:exchange.vaadin:exclamation-circle-o.vaadin:exclamation-circle.vaadin:exclamation.vaadin:exit-o.vaadin:exit.vaadin:expand-full.vaadin:expand-square.vaadin:expand.vaadin:external-browser.vaadin:external-link.vaadin:eye-slash.vaadin:eye.vaadin:eyedropper.vaadin:facebook-square.vaadin:facebook.vaadin:factory.vaadin:family.vaadin:fast-backward.vaadin:fast-forward.vaadin:female.vaadin:file-add.vaadin:file-code.vaadin:file-font.vaadin:file-movie.vaadin:file-o.vaadin:file-picture.vaadin:file-presentation.vaadin:file-process.vaadin:file-refresh.vaadin:file-remove.vaadin:file-search.vaadin:file-sound.vaadin:file-start.vaadin:file-table.vaadin:file-text-o.vaadin:file-text.vaadin:file-tree-small.vaadin:file-tree-sub.vaadin:file-tree.vaadin:file-zip.vaadin:file.vaadin:fill.vaadin:film.vaadin:filter.vaadin:fire.vaadin:flag-checkered.vaadin:flag-o.vaadin:flag.vaadin:flash.vaadin:flask.vaadin:flight-landing.vaadin:flight-takeoff.vaadin:flip-h.vaadin:flip-v.vaadin:folder-add.vaadin:folder-o.vaadin:folder-open-o.vaadin:folder-open.vaadin:folder-remove.vaadin:folder-search.vaadin:folder.vaadin:font.vaadin:form.vaadin:forward.vaadin:frown-o.vaadin:funcion.vaadin:function.vaadin:funnel.vaadin:gamepad.vaadin:gavel.vaadin:gift.vaadin:glass.vaadin:glasses.vaadin:globe-wire.vaadin:globe.vaadin:golf.vaadin:google-plus-square.vaadin:google-plus.vaadin:grab.vaadin:grid-bevel.vaadin:grid-big-o.vaadin:grid-big.vaadin:grid-h.vaadin:grid-small-o.vaadin:grid-small.vaadin:grid-v.vaadin:grid.vaadin:group.vaadin:hammer.vaadin:hand.vaadin:handle-corner.vaadin:hands-up.vaadin:handshake.vaadin:harddrive-o.vaadin:harddrive.vaadin:hash.vaadin:header.vaadin:headphones.vaadin:headset.vaadin:health-card.vaadin:heart-o.vaadin:heart.vaadin:home-o.vaadin:home.vaadin:hospital.vaadin:hourglass-empty.vaadin:hourglass-end.vaadin:hourglass-start.vaadin:hourglass.vaadin:inbox.vaadin:indent.vaadin:info-circle-o.vaadin:info-circle.vaadin:info.vaadin:input.vaadin:insert.vaadin:institution.vaadin:invoice.vaadin:italic.vaadin:key-o.vaadin:key.vaadin:keyboard-o.vaadin:keyboard.vaadin:laptop.vaadin:layout.vaadin:level-down-bold.vaadin:level-down.vaadin:level-left-bold.vaadin:level-left.vaadin:level-right-bold.vaadin:level-right.vaadin:level-up-bold.vaadin:level-up.vaadin:lifebuoy.vaadin:lightbulb.vaadin:line-bar-chart.vaadin:line-chart.vaadin:line-h.vaadin:line-v.vaadin:lines-list.vaadin:lines.vaadin:link.vaadin:list-ol.vaadin:list-select.vaadin:list-ul.vaadin:list.vaadin:location-arrow-circle-o.vaadin:location-arrow-circle.vaadin:location-arrow.vaadin:lock.vaadin:magic.vaadin:magnet.vaadin:mailbox.vaadin:male.vaadin:map-marker.vaadin:margin-bottom.vaadin:margin-left.vaadin:margin-right.vaadin:margin-top.vaadin:margin.vaadin:medal.vaadin:megafone.vaadin:megaphone.vaadin:meh-o.vaadin:menu.vaadin:microphone.vaadin:minus-circle-o.vaadin:minus-circle.vaadin:minus-square-o.vaadin:minus.vaadin:mobile-browser.vaadin:mobile-retro.vaadin:mobile.vaadin:modal-list.vaadin:modal.vaadin:money-deposit.vaadin:money-exchange.vaadin:money-withdraw.vaadin:money.vaadin:moon-o.vaadin:moon.vaadin:morning.vaadin:movie.vaadin:music.vaadin:mute.vaadin:native-button.vaadin:newspaper.vaadin:notebook.vaadin:nurse.vaadin:office.vaadin:open-book.vaadin:option-a.vaadin:option.vaadin:options.vaadin:orientation.vaadin:out.vaadin:outbox.vaadin:package.vaadin:padding-bottom.vaadin:padding-left.vaadin:padding-right.vaadin:padding-top.vaadin:padding.vaadin:paint-roll.vaadin:paintbrush.vaadin:palete.vaadin:palette.vaadin:panel.vaadin:paperclip.vaadin:paperplane-o.vaadin:paperplane.vaadin:paragraph.vaadin:password.vaadin:paste.vaadin:pause.vaadin:pencil.vaadin:phone-landline.vaadin:phone.vaadin:picture.vaadin:pie-bar-chart.vaadin:pie-chart.vaadin:piggy-bank-coin.vaadin:piggy-bank.vaadin:pill.vaadin:pills.vaadin:pin-post.vaadin:pin.vaadin:play-circle-o.vaadin:play-circle.vaadin:play.vaadin:plug.vaadin:plus-circle-o.vaadin:plus-circle.vaadin:plus-minus.vaadin:plus-square-o.vaadin:plus.vaadin:pointer.vaadin:power-off.vaadin:presentation.vaadin:print.vaadin:progressbar.vaadin:puzzle-piece.vaadin:pyramid-chart.vaadin:qrcode.vaadin:question-circle-o.vaadin:question-circle.vaadin:question.vaadin:quote-left.vaadin:quote-right.vaadin:random.vaadin:raster-lower-left.vaadin:raster.vaadin:records.vaadin:recycle.vaadin:refresh.vaadin:reply-all.vaadin:reply.vaadin:resize-h.vaadin:resize-v.vaadin:retweet.vaadin:rhombus.vaadin:road-branch.vaadin:road-branches.vaadin:road-split.vaadin:road.vaadin:rocket.vaadin:rotate-left.vaadin:rotate-right.vaadin:rss-square.vaadin:rss.vaadin:safe-lock.vaadin:safe.vaadin:scale-unbalance.vaadin:scale.vaadin:scatter-chart.vaadin:scissors.vaadin:screwdriver.vaadin:search-minus.vaadin:search-plus.vaadin:search.vaadin:select.vaadin:server.vaadin:share-square.vaadin:share.vaadin:shield.vaadin:shift-arrow.vaadin:shift.vaadin:shop.vaadin:sign-in-alt.vaadin:sign-in.vaadin:sign-out-alt.vaadin:sign-out.vaadin:signal.vaadin:sitemap.vaadin:slider.vaadin:sliders.vaadin:smiley-o.vaadin:sort.vaadin:sound-disable.vaadin:spark-line.vaadin:specialist.vaadin:spinner-arc.vaadin:spinner-third.vaadin:spinner.vaadin:spline-area-chart.vaadin:spline-chart.vaadin:split-h.vaadin:split-v.vaadin:split.vaadin:spoon.vaadin:square-shadow.vaadin:star-half-left-o.vaadin:star-half-left.vaadin:star-half-right-o.vaadin:star-half-right.vaadin:star-o.vaadin:star.vaadin:start-cog.vaadin:step-backward.vaadin:step-forward.vaadin:stethoscope.vaadin:stock.vaadin:stop-cog.vaadin:stop.vaadin:stopwatch.vaadin:storage.vaadin:strikethrough.vaadin:subscript.vaadin:suitcase.vaadin:sun-down.vaadin:sun-o.vaadin:sun-rise.vaadin:superscript.vaadin:sword.vaadin:tab-a.vaadin:tab.vaadin:table.vaadin:tablet.vaadin:tabs.vaadin:tag.vaadin:tags.vaadin:tasks.vaadin:taxi.vaadin:teeth.vaadin:terminal.vaadin:text-height.vaadin:text-input.vaadin:text-label.vaadin:text-width.vaadin:thin-square.vaadin:thumbs-down-o.vaadin:thumbs-down.vaadin:thumbs-up-o.vaadin:thumbs-up.vaadin:ticket.vaadin:time-backward.vaadin:time-forward.vaadin:timer.vaadin:toolbox.vaadin:tools.vaadin:tooth.vaadin:touch.vaadin:train.vaadin:trash.vaadin:tree-table.vaadin:trendind-down.vaadin:trending-down.vaadin:trending-up.vaadin:trophy.vaadin:truck.vaadin:twin-col-select.vaadin:twitter-square.vaadin:twitter.vaadin:umbrella.vaadin:underline.vaadin:unlink.vaadin:unlock.vaadin:upload-alt.vaadin:upload.vaadin:user-card.vaadin:user-check.vaadin:user-clock.vaadin:user-heart.vaadin:user-star.vaadin:user.vaadin:users.vaadin:vaadin-h.vaadin:vaadin-v.vaadin:viewport.vaadin:vimeo-square.vaadin:vimeo.vaadin:volume-down.vaadin:volume-off.vaadin:volume-up.vaadin:volume.vaadin:wallet.vaadin:warning.vaadin:workplace.vaadin:wrench.vaadin:youtube-square.vaadin:youtube`.split(`.`),bl=null,xl=()=>(bl||=Promise.all([E(()=>import(`./vendor-ui5.js`).then(e=>e.n),__vite__mapDeps([5,1])),E(()=>import(`./vendor-ui5.js`).then(e=>e.t),__vite__mapDeps([5,1]))]),bl),Q=class extends y{constructor(...e){super(...e),this.ui5FieldComponentsReady=!1,this.component=void 0,this.field=void 0,this.baseUrl=void 0,this.state={},this.data={},this.appState={},this.appData={},this.colorPickerOpened=!1,this.colorPickerValue=void 0,this.comboData=[],this._comboFilter=``,this.rendered=!1,this.renderColorPicker=()=>{this.loadUi5FieldComponents();let e=this.field?.fieldId;return w`
+  `}};O([v()],xl.prototype,`fieldId`,void 0),O([v()],xl.prototype,`label`,void 0),O([v()],xl.prototype,`state`,void 0),O([v()],xl.prototype,`data`,void 0),O([v()],xl.prototype,`value`,void 0),O([v()],xl.prototype,`autoFocus`,void 0),O([v()],xl.prototype,`required`,void 0),O([v()],xl.prototype,`colspan`,void 0),O([v()],xl.prototype,`helperText`,void 0),xl=O([h(`mateu-money-field`)],xl);var Sl=`vaadin:abacus.vaadin:absolute-position.vaadin:academy-cap.vaadin:accessibility.vaadin:accordion-menu.vaadin:add-dock.vaadin:adjust.vaadin:adobe-flash.vaadin:airplane.vaadin:alarm.vaadin:align-center.vaadin:align-justify.vaadin:align-left.vaadin:align-right.vaadin:alt-a.vaadin:alt.vaadin:ambulance.vaadin:anchor.vaadin:angle-double-down.vaadin:angle-double-left.vaadin:angle-double-right.vaadin:angle-double-up.vaadin:angle-down.vaadin:angle-left.vaadin:angle-right.vaadin:angle-up.vaadin:archive.vaadin:archives.vaadin:area-select.vaadin:arrow-backward.vaadin:arrow-circle-down-o.vaadin:arrow-circle-down.vaadin:arrow-circle-left-o.vaadin:arrow-circle-left.vaadin:arrow-circle-right-o.vaadin:arrow-circle-right.vaadin:arrow-circle-up-o.vaadin:arrow-circle-up.vaadin:arrow-down.vaadin:arrow-forward.vaadin:arrow-left.vaadin:arrow-long-down.vaadin:arrow-long-left.vaadin:arrow-right.vaadin:arrow-up.vaadin:arrows-cross.vaadin:arrows-long-h.vaadin:arrows-long-right.vaadin:arrows-long-up.vaadin:arrows-long-v.vaadin:arrows.vaadin:asterisk.vaadin:at.vaadin:automation.vaadin:backspace-a.vaadin:backspace.vaadin:backwards.vaadin:ban.vaadin:bar-chart-h.vaadin:bar-chart-v.vaadin:bar-chart.vaadin:barcode.vaadin:bed.vaadin:bell-o.vaadin:bell-slash-o.vaadin:bell-slash.vaadin:bell.vaadin:boat.vaadin:bold.vaadin:bolt.vaadin:bomb.vaadin:book-dollar.vaadin:book-percent.vaadin:book.vaadin:bookmark-o.vaadin:bookmark.vaadin:briefcase.vaadin:browser.vaadin:bug-o.vaadin:bug.vaadin:building-o.vaadin:building.vaadin:bullets.vaadin:bullseye.vaadin:bus.vaadin:buss.vaadin:button.vaadin:calc-book.vaadin:calc.vaadin:calendar-briefcase.vaadin:calendar-clock.vaadin:calendar-envelope.vaadin:calendar-o.vaadin:calendar-user.vaadin:calendar.vaadin:camera.vaadin:car.vaadin:caret-down.vaadin:caret-left.vaadin:caret-right.vaadin:caret-square-down-o.vaadin:caret-square-left-o.vaadin:caret-square-right-o.vaadin:caret-square-up-o.vaadin:caret-up.vaadin:cart-o.vaadin:cart.vaadin:cash.vaadin:chart-3d.vaadin:chart-grid.vaadin:chart-line.vaadin:chart-timeline.vaadin:chart.vaadin:chat.vaadin:check-circle-o.vaadin:check-circle.vaadin:check-square-o.vaadin:check-square.vaadin:check.vaadin:chevron-circle-down-o.vaadin:chevron-circle-down.vaadin:chevron-circle-left-o.vaadin:chevron-circle-left.vaadin:chevron-circle-right-o.vaadin:chevron-circle-right.vaadin:chevron-circle-up-o.vaadin:chevron-circle-up.vaadin:chevron-down-small.vaadin:chevron-down.vaadin:chevron-left-small.vaadin:chevron-left.vaadin:chevron-right-small.vaadin:chevron-right.vaadin:chevron-up-small.vaadin:chevron-up.vaadin:child.vaadin:circle-thin.vaadin:circle.vaadin:clipboard-check.vaadin:clipboard-cross.vaadin:clipboard-heart.vaadin:clipboard-pulse.vaadin:clipboard-text.vaadin:clipboard-user.vaadin:clipboard.vaadin:clock.vaadin:close-big.vaadin:close-circle-o.vaadin:close-circle.vaadin:close-small.vaadin:close.vaadin:cloud-download-o.vaadin:cloud-download.vaadin:cloud-o.vaadin:cloud-upload-o.vaadin:cloud-upload.vaadin:cloud.vaadin:cluster.vaadin:code.vaadin:coffee.vaadin:cog-o.vaadin:cog.vaadin:cogs.vaadin:coin-piles.vaadin:coins.vaadin:combobox.vaadin:comment-ellipsis-o.vaadin:comment-ellipsis.vaadin:comment-o.vaadin:comment.vaadin:comments-o.vaadin:comments.vaadin:compile.vaadin:compress-square.vaadin:compress.vaadin:connect-o.vaadin:connect.vaadin:controller.vaadin:copy-o.vaadin:copy.vaadin:copyright.vaadin:corner-lower-left.vaadin:corner-lower-right.vaadin:corner-upper-left.vaadin:corner-upper-right.vaadin:credit-card.vaadin:crop.vaadin:cross-cutlery.vaadin:crosshairs.vaadin:css.vaadin:ctrl-a.vaadin:ctrl.vaadin:cube.vaadin:cubes.vaadin:curly-brackets.vaadin:cursor-o.vaadin:cursor.vaadin:cutlery.vaadin:dashboard.vaadin:database.vaadin:date-input.vaadin:deindent.vaadin:del-a.vaadin:del.vaadin:dental-chair.vaadin:desktop.vaadin:diamond-o.vaadin:diamond.vaadin:diploma-scroll.vaadin:diploma.vaadin:disc.vaadin:doctor-briefcase.vaadin:doctor.vaadin:dollar.vaadin:dot-circle.vaadin:download-alt.vaadin:download.vaadin:drop.vaadin:edit.vaadin:eject.vaadin:elastic.vaadin:ellipsis-circle-o.vaadin:ellipsis-circle.vaadin:ellipsis-dots-h.vaadin:ellipsis-dots-v.vaadin:ellipsis-h.vaadin:ellipsis-v.vaadin:enter-arrow.vaadin:enter.vaadin:envelope-o.vaadin:envelope-open-o.vaadin:envelope-open.vaadin:envelope.vaadin:envelopes-o.vaadin:envelopes.vaadin:eraser.vaadin:esc-a.vaadin:esc.vaadin:euro.vaadin:exchange.vaadin:exclamation-circle-o.vaadin:exclamation-circle.vaadin:exclamation.vaadin:exit-o.vaadin:exit.vaadin:expand-full.vaadin:expand-square.vaadin:expand.vaadin:external-browser.vaadin:external-link.vaadin:eye-slash.vaadin:eye.vaadin:eyedropper.vaadin:facebook-square.vaadin:facebook.vaadin:factory.vaadin:family.vaadin:fast-backward.vaadin:fast-forward.vaadin:female.vaadin:file-add.vaadin:file-code.vaadin:file-font.vaadin:file-movie.vaadin:file-o.vaadin:file-picture.vaadin:file-presentation.vaadin:file-process.vaadin:file-refresh.vaadin:file-remove.vaadin:file-search.vaadin:file-sound.vaadin:file-start.vaadin:file-table.vaadin:file-text-o.vaadin:file-text.vaadin:file-tree-small.vaadin:file-tree-sub.vaadin:file-tree.vaadin:file-zip.vaadin:file.vaadin:fill.vaadin:film.vaadin:filter.vaadin:fire.vaadin:flag-checkered.vaadin:flag-o.vaadin:flag.vaadin:flash.vaadin:flask.vaadin:flight-landing.vaadin:flight-takeoff.vaadin:flip-h.vaadin:flip-v.vaadin:folder-add.vaadin:folder-o.vaadin:folder-open-o.vaadin:folder-open.vaadin:folder-remove.vaadin:folder-search.vaadin:folder.vaadin:font.vaadin:form.vaadin:forward.vaadin:frown-o.vaadin:funcion.vaadin:function.vaadin:funnel.vaadin:gamepad.vaadin:gavel.vaadin:gift.vaadin:glass.vaadin:glasses.vaadin:globe-wire.vaadin:globe.vaadin:golf.vaadin:google-plus-square.vaadin:google-plus.vaadin:grab.vaadin:grid-bevel.vaadin:grid-big-o.vaadin:grid-big.vaadin:grid-h.vaadin:grid-small-o.vaadin:grid-small.vaadin:grid-v.vaadin:grid.vaadin:group.vaadin:hammer.vaadin:hand.vaadin:handle-corner.vaadin:hands-up.vaadin:handshake.vaadin:harddrive-o.vaadin:harddrive.vaadin:hash.vaadin:header.vaadin:headphones.vaadin:headset.vaadin:health-card.vaadin:heart-o.vaadin:heart.vaadin:home-o.vaadin:home.vaadin:hospital.vaadin:hourglass-empty.vaadin:hourglass-end.vaadin:hourglass-start.vaadin:hourglass.vaadin:inbox.vaadin:indent.vaadin:info-circle-o.vaadin:info-circle.vaadin:info.vaadin:input.vaadin:insert.vaadin:institution.vaadin:invoice.vaadin:italic.vaadin:key-o.vaadin:key.vaadin:keyboard-o.vaadin:keyboard.vaadin:laptop.vaadin:layout.vaadin:level-down-bold.vaadin:level-down.vaadin:level-left-bold.vaadin:level-left.vaadin:level-right-bold.vaadin:level-right.vaadin:level-up-bold.vaadin:level-up.vaadin:lifebuoy.vaadin:lightbulb.vaadin:line-bar-chart.vaadin:line-chart.vaadin:line-h.vaadin:line-v.vaadin:lines-list.vaadin:lines.vaadin:link.vaadin:list-ol.vaadin:list-select.vaadin:list-ul.vaadin:list.vaadin:location-arrow-circle-o.vaadin:location-arrow-circle.vaadin:location-arrow.vaadin:lock.vaadin:magic.vaadin:magnet.vaadin:mailbox.vaadin:male.vaadin:map-marker.vaadin:margin-bottom.vaadin:margin-left.vaadin:margin-right.vaadin:margin-top.vaadin:margin.vaadin:medal.vaadin:megafone.vaadin:megaphone.vaadin:meh-o.vaadin:menu.vaadin:microphone.vaadin:minus-circle-o.vaadin:minus-circle.vaadin:minus-square-o.vaadin:minus.vaadin:mobile-browser.vaadin:mobile-retro.vaadin:mobile.vaadin:modal-list.vaadin:modal.vaadin:money-deposit.vaadin:money-exchange.vaadin:money-withdraw.vaadin:money.vaadin:moon-o.vaadin:moon.vaadin:morning.vaadin:movie.vaadin:music.vaadin:mute.vaadin:native-button.vaadin:newspaper.vaadin:notebook.vaadin:nurse.vaadin:office.vaadin:open-book.vaadin:option-a.vaadin:option.vaadin:options.vaadin:orientation.vaadin:out.vaadin:outbox.vaadin:package.vaadin:padding-bottom.vaadin:padding-left.vaadin:padding-right.vaadin:padding-top.vaadin:padding.vaadin:paint-roll.vaadin:paintbrush.vaadin:palete.vaadin:palette.vaadin:panel.vaadin:paperclip.vaadin:paperplane-o.vaadin:paperplane.vaadin:paragraph.vaadin:password.vaadin:paste.vaadin:pause.vaadin:pencil.vaadin:phone-landline.vaadin:phone.vaadin:picture.vaadin:pie-bar-chart.vaadin:pie-chart.vaadin:piggy-bank-coin.vaadin:piggy-bank.vaadin:pill.vaadin:pills.vaadin:pin-post.vaadin:pin.vaadin:play-circle-o.vaadin:play-circle.vaadin:play.vaadin:plug.vaadin:plus-circle-o.vaadin:plus-circle.vaadin:plus-minus.vaadin:plus-square-o.vaadin:plus.vaadin:pointer.vaadin:power-off.vaadin:presentation.vaadin:print.vaadin:progressbar.vaadin:puzzle-piece.vaadin:pyramid-chart.vaadin:qrcode.vaadin:question-circle-o.vaadin:question-circle.vaadin:question.vaadin:quote-left.vaadin:quote-right.vaadin:random.vaadin:raster-lower-left.vaadin:raster.vaadin:records.vaadin:recycle.vaadin:refresh.vaadin:reply-all.vaadin:reply.vaadin:resize-h.vaadin:resize-v.vaadin:retweet.vaadin:rhombus.vaadin:road-branch.vaadin:road-branches.vaadin:road-split.vaadin:road.vaadin:rocket.vaadin:rotate-left.vaadin:rotate-right.vaadin:rss-square.vaadin:rss.vaadin:safe-lock.vaadin:safe.vaadin:scale-unbalance.vaadin:scale.vaadin:scatter-chart.vaadin:scissors.vaadin:screwdriver.vaadin:search-minus.vaadin:search-plus.vaadin:search.vaadin:select.vaadin:server.vaadin:share-square.vaadin:share.vaadin:shield.vaadin:shift-arrow.vaadin:shift.vaadin:shop.vaadin:sign-in-alt.vaadin:sign-in.vaadin:sign-out-alt.vaadin:sign-out.vaadin:signal.vaadin:sitemap.vaadin:slider.vaadin:sliders.vaadin:smiley-o.vaadin:sort.vaadin:sound-disable.vaadin:spark-line.vaadin:specialist.vaadin:spinner-arc.vaadin:spinner-third.vaadin:spinner.vaadin:spline-area-chart.vaadin:spline-chart.vaadin:split-h.vaadin:split-v.vaadin:split.vaadin:spoon.vaadin:square-shadow.vaadin:star-half-left-o.vaadin:star-half-left.vaadin:star-half-right-o.vaadin:star-half-right.vaadin:star-o.vaadin:star.vaadin:start-cog.vaadin:step-backward.vaadin:step-forward.vaadin:stethoscope.vaadin:stock.vaadin:stop-cog.vaadin:stop.vaadin:stopwatch.vaadin:storage.vaadin:strikethrough.vaadin:subscript.vaadin:suitcase.vaadin:sun-down.vaadin:sun-o.vaadin:sun-rise.vaadin:superscript.vaadin:sword.vaadin:tab-a.vaadin:tab.vaadin:table.vaadin:tablet.vaadin:tabs.vaadin:tag.vaadin:tags.vaadin:tasks.vaadin:taxi.vaadin:teeth.vaadin:terminal.vaadin:text-height.vaadin:text-input.vaadin:text-label.vaadin:text-width.vaadin:thin-square.vaadin:thumbs-down-o.vaadin:thumbs-down.vaadin:thumbs-up-o.vaadin:thumbs-up.vaadin:ticket.vaadin:time-backward.vaadin:time-forward.vaadin:timer.vaadin:toolbox.vaadin:tools.vaadin:tooth.vaadin:touch.vaadin:train.vaadin:trash.vaadin:tree-table.vaadin:trendind-down.vaadin:trending-down.vaadin:trending-up.vaadin:trophy.vaadin:truck.vaadin:twin-col-select.vaadin:twitter-square.vaadin:twitter.vaadin:umbrella.vaadin:underline.vaadin:unlink.vaadin:unlock.vaadin:upload-alt.vaadin:upload.vaadin:user-card.vaadin:user-check.vaadin:user-clock.vaadin:user-heart.vaadin:user-star.vaadin:user.vaadin:users.vaadin:vaadin-h.vaadin:vaadin-v.vaadin:viewport.vaadin:vimeo-square.vaadin:vimeo.vaadin:volume-down.vaadin:volume-off.vaadin:volume-up.vaadin:volume.vaadin:wallet.vaadin:warning.vaadin:workplace.vaadin:wrench.vaadin:youtube-square.vaadin:youtube`.split(`.`),Cl=null,wl=()=>(Cl||=Promise.all([E(()=>import(`./vendor-ui5.js`).then(e=>e.n),__vite__mapDeps([5,1])),E(()=>import(`./vendor-ui5.js`).then(e=>e.t),__vite__mapDeps([5,1]))]),Cl),Z=class extends y{constructor(...e){super(...e),this.ui5FieldComponentsReady=!1,this.component=void 0,this.field=void 0,this.baseUrl=void 0,this.state={},this.data={},this.appState={},this.appData={},this.colorPickerOpened=!1,this.colorPickerValue=void 0,this.comboData=[],this._comboFilter=``,this.rendered=!1,this.renderColorPicker=()=>{this.loadUi5FieldComponents();let e=this.field?.fieldId;return w`
             <ui5-color-picker value="${this.state&&e in this.state?this.state[e]:this.field?.initialValue}" @change="${e=>this.colorPickerValue=e.target.value}">Picker</ui5-color-picker>
         `},this.saveColor=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.colorPickerValue,fieldId:this.field.fieldId},bubbles:!0,composed:!0})),this.colorPickerOpened=!1},this.renderColorPickerFooter=()=>w`<vaadin-button @click="${()=>this.colorPickerOpened=!1}">Cancel</vaadin-button>
         <vaadin-button theme="primary" @click="${this.saveColor}">Save</vaadin-button>`,this.checked=e=>{let t=e.target;this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t.checked,fieldId:this.field.fieldId},bubbles:!0,composed:!0}))},this.convert=e=>this.field?.dataType==`integer`?parseInt(e):e,this.multiComboBoxValueChanged=e=>{if(this.rendered){let t=this.field?.fieldId,n=this.state&&t in this.state?this.state[t]:this.field?.initialValue,r;e.detail.value&&(r=e.detail.value.map(e=>e.value),r&&r.length>0&&(this.data[this.id]||(this.data[this.id]={}),this.data[this.id].content||(this.data[this.id].content=[]),this.data[this.id]&&this.data[this.id].content&&e.detail.value.forEach(e=>{this.data[this.id].content?.find(t=>e.value==t.value)||this.data[this.id].content.push(e)}))),this.compareArrays(r,n)||this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}},this.valueChanged=e=>{this.rendered&&e.detail.value!==void 0&&e.detail.value!=this.state[this.field.fieldId]&&this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.convert(e.detail.value),fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.selectedItems=e=>{if(e&&e.length>0)if(this.field?.remoteCoordinates){if(this.comboData&&this.comboData.length>0)return this.comboData?.filter(t=>e.indexOf(t.value)>=0);if(this.data[this.id]&&this.data[this.id].content&&this.data[this.id].content.length>0)return this.data[this.id].content.filter(t=>e.indexOf(t.value)>=0)}else return this.field?.options?.filter(t=>e.indexOf(t.value)>=0);return[]},this.selectedIndex=e=>{if(e)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content){let t=this.data[this.id].content.find(t=>t.value==e);if(t)return this.data[this.id].content.indexOf(t)}}else{let t=this.field?.options?.find(t=>t.value==e);if(t)return this.field?.options?.indexOf(t)}},this.selectedIndexes=e=>{if(e&&e.length>0)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content)return this.data[this.id].content.filter(t=>e.indexOf(t.value)>=0).map(e=>this.data[this.id].content.indexOf(e))}else return this.field?.options?.filter(t=>e.indexOf(t.value)>=0).map(e=>this.field?.options?.indexOf(e));return[]},this.compareArrays=(e,t)=>this.falsy(e)&&this.falsy(t)||e&&t&&e.length===t.length&&e.every((e,n)=>e===t[n]),this.falsy=e=>!e||e.length==0,this.listItemsSelected=e=>{let t=this.field?.fieldId,n=this.state&&t in this.state?this.state[t]:this.field?.initialValue,r;this.rendered&&(e.detail.value&&(this.field?.remoteCoordinates?this.data[this.id]&&this.data[this.id].content&&(r=e.detail.value.map(e=>this.data[this.id].content[e].value)):r=e.detail.value.map(e=>this.field.options[e].value)),this.compareArrays(r,n)||this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r,fieldId:this.field?.fieldId},bubbles:!0,composed:!0})))},this.listItemSelected=e=>{let t;if(e.detail.value||e.detail.value==0)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content){let n=this.data[this.id].content[e.detail.value];n&&(t=n.value)}}else{let n=this.field.options[e.detail.value];n&&(t=n.value)}this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.mapPosition=e=>{switch(e){case`topStretch`:return`top-stretch`;case`topStart`:return`top-start`;case`topCenter`:return`top-center`;case`topEnd`:return`top-end`;case`middle`:return`middle`;case`bottomStart`:return`bottom-start`;case`bottomEnd`:return`bottom-end`;case`bottomStretch`:return`bottom-stretch`;case`bottomCenter`:return`bottom-center`}return`bottom-end`},this.helperShownInControl=!1,this.lastAnnouncedError=``,this.controlOwnsValidity=!1,this.fileUploaded=e=>{let t=this.field?.fieldId??``,n=this.state[t];n.push({id:e.detail.xhr.responseText,name:e.detail.file.name}),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:n,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.fileChanged=e=>{let t=this.field?.fieldId??``,n=(e.detail.value??[]).filter(e=>e.id).map(e=>e.id),r=(this.state[t]??[]).map(e=>e.id);if(!this.compareArrays(r,n)){let t=(e.detail.value??[]).filter(e=>e.id).map(e=>({id:e.id,name:e.name}));this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}},this.triggerImageUpload=()=>{(this.renderRoot?.querySelector(`input[type="file"]`))?.click()},this.imageUpload=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r.result,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},r.readAsDataURL(n),t.value=``},this.imageDelete=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:``,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.iconComboboxRenderer=e=>w`
@@ -9075,7 +9075,7 @@ ${i}
 
             </vaadin-horizontal-layout>
                             `:e.label}
-`,this.filteredIcons=[],this.navLinkOffset=null,this.iconFilterChanged=e=>{this.filteredIcons=yl.filter(t=>!e.detail.value||t.indexOf(e.detail.value)>=0)}}loadUi5FieldComponents(){this.ui5FieldComponentsReady||xl().then(()=>{this.ui5FieldComponentsReady=!0})}remoteComboDataProvider(e){return(t,n)=>{let{filter:i,page:a,pageSize:o}=t,s=i??``;this._comboFilter=s,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{searchText:i,fieldId:this.field?.fieldId,size:o,page:a,sort:void 0},callback:e=>{if(s===this._comboFilter)if(e?.messages?.forEach(e=>{r.show(e.text,{position:e.position?this.mapPosition(e.position):void 0,theme:e.variant,duration:e.duration})}),!e.fragments||e.fragments.length==0)this.comboData=[],n([],0);else{let t=e.fragments[0].data?.[this.id];this.comboData=t?.content,n(t?.content,t?.totalElements)}},callbackonly:!0},bubbles:!0,composed:!0}))}}disconnectedCallback(){super.disconnectedCallback(),this.rendered=!1}renderNavLink(){let e=this.field?.link;if(!e?.href)return _;let t=j(e.href,this.state,this.data)??e.href,n=j(e.title,this.state,this.data)||t,r=e.icon||(t.startsWith(`http`)?`vaadin:external-link`:`vaadin:link`),i=this.navLinkOffset??`calc(var(--lumo-font-size-s) * 1.6 + (var(--lumo-size-m) - var(--lumo-icon-size-s)) / 2)`;return w`<a
+`,this.filteredIcons=[],this.navLinkOffset=null,this.iconFilterChanged=e=>{this.filteredIcons=Sl.filter(t=>!e.detail.value||t.indexOf(e.detail.value)>=0)}}loadUi5FieldComponents(){this.ui5FieldComponentsReady||wl().then(()=>{this.ui5FieldComponentsReady=!0})}remoteComboDataProvider(e){return(t,n)=>{let{filter:i,page:a,pageSize:o}=t,s=i??``;this._comboFilter=s,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{searchText:i,fieldId:this.field?.fieldId,size:o,page:a,sort:void 0},callback:e=>{if(s===this._comboFilter)if(e?.messages?.forEach(e=>{r.show(e.text,{position:e.position?this.mapPosition(e.position):void 0,theme:e.variant,duration:e.duration})}),!e.fragments||e.fragments.length==0)this.comboData=[],n([],0);else{let t=e.fragments[0].data?.[this.id];this.comboData=t?.content,n(t?.content,t?.totalElements)}},callbackonly:!0},bubbles:!0,composed:!0}))}}disconnectedCallback(){super.disconnectedCallback(),this.rendered=!1}renderNavLink(){let e=this.field?.link;if(!e?.href)return _;let t=j(e.href,this.state,this.data)??e.href,n=j(e.title,this.state,this.data)||t,r=e.icon||(t.startsWith(`http`)?`vaadin:external-link`:`vaadin:link`),i=this.navLinkOffset??`calc(var(--lumo-font-size-s) * 1.6 + (var(--lumo-size-m) - var(--lumo-icon-size-s)) / 2)`;return w`<a
                 data-navlink
                 href="${t}"
                 title="${n}"
@@ -9089,7 +9089,7 @@ ${i}
             ${i?w`
                 <div role="alert"><ul>${r.map(e=>w`<li>${e}</li>`)}</ul></div>
             `:_}
-        </div>`}async firstUpdated(){this.filteredIcons=yl}update(e){e.has(`component`)&&(this.rendered=!1),super.update(e)}updated(e){super.updated(e),this.positionNavLink(),this.applyValidationState(),this.controlOwnsValidity=!!this.validatableControl()}renderField(){let e=this.field?.fieldId??``,t=this.state&&e in this.state?this.state[e]:this.field?.initialValue,n=j(this.field?.label+``,this.state,this.data),r=this.labelAlreadyRendered||!n||n==`null`?_:n;return this.field?.propertyRow?this.renderPropertyRowField(e,t,r,n):this.field?.stereotype==`badge`?this.renderBadgeField(e,t,r,n):this.field?.stereotype==`plainText`?this.renderPlainTextField(e,t,r,n):this.field?.stereotype==`bulletedList`?this.renderBulletedListField(e,t,r,n):this.field?.readOnly&&this.field.stereotype!=`grid`&&this.field.dataType!=`status`&&this.field?.dataType!=`money`?this.renderReadOnlyField(e,t,r,n):this.field?.dataType==`file`?this.renderFileField(e,t,r,n):this.field?.dataType==`string`?this.renderStringField(e,t,r,n):this.field?.dataType==`number`?this.renderNumberField(e,t,r,n):this.field?.dataType==`integer`?this.renderIntegerField(e,t,r,n):this.field?.dataType==`bool`?this.renderBoolField(e,t,r,n):this.field?.dataType==`dateRange`?this.renderDateRangeField(e,t,r,n):this.field?.dataType==`date`?this.renderDateField(e,t,r,n):this.field?.dataType==`dateTime`?this.renderDateTimeField(e,t,r,n):this.field?.dataType==`time`?this.renderTimeField(e,t,r,n):this.field?.dataType==`array`?this.renderArrayField(e,t,r,n):this.field?.dataType==`money`?this.renderMoneyField(e,t,r,n):this.field?.dataType==`status`?this.renderStatusField(e,t,r,n):this.field?.dataType==`range`?this.renderRangeField(e,t,r,n):w`<p>Unknown field type ${this.field?.dataType} / ${this.field?.stereotype}</p>`}renderBadgeField(e,t,n,r){if(!this.field)return w``;let i=t===!0||t===`true`;return w`<vaadin-custom-field
+        </div>`}async firstUpdated(){this.filteredIcons=Sl}update(e){e.has(`component`)&&(this.rendered=!1),super.update(e)}updated(e){super.updated(e),this.positionNavLink(),this.applyValidationState(),this.controlOwnsValidity=!!this.validatableControl()}renderField(){let e=this.field?.fieldId??``,t=this.state&&e in this.state?this.state[e]:this.field?.initialValue,n=j(this.field?.label+``,this.state,this.data),r=this.labelAlreadyRendered||!n||n==`null`?_:n;return this.field?.propertyRow?this.renderPropertyRowField(e,t,r,n):this.field?.stereotype==`badge`?this.renderBadgeField(e,t,r,n):this.field?.stereotype==`plainText`?this.renderPlainTextField(e,t,r,n):this.field?.stereotype==`bulletedList`?this.renderBulletedListField(e,t,r,n):this.field?.readOnly&&this.field.stereotype!=`grid`&&this.field.dataType!=`status`&&this.field?.dataType!=`money`?this.renderReadOnlyField(e,t,r,n):this.field?.dataType==`file`?this.renderFileField(e,t,r,n):this.field?.dataType==`string`?this.renderStringField(e,t,r,n):this.field?.dataType==`number`?this.renderNumberField(e,t,r,n):this.field?.dataType==`integer`?this.renderIntegerField(e,t,r,n):this.field?.dataType==`bool`?this.renderBoolField(e,t,r,n):this.field?.dataType==`dateRange`?this.renderDateRangeField(e,t,r,n):this.field?.dataType==`date`?this.renderDateField(e,t,r,n):this.field?.dataType==`dateTime`?this.renderDateTimeField(e,t,r,n):this.field?.dataType==`time`?this.renderTimeField(e,t,r,n):this.field?.dataType==`array`?this.renderArrayField(e,t,r,n):this.field?.dataType==`money`?this.renderMoneyField(e,t,r,n):this.field?.dataType==`status`?this.renderStatusField(e,t,r,n):this.field?.dataType==`range`?this.renderRangeField(e,t,r,n):w`<p>Unknown field type ${this.field?.dataType} / ${this.field?.stereotype}</p>`}renderBadgeField(e,t,n,r){if(!this.field)return w``;let i=t===!0||t===`true`;return w`<vaadin-custom-field
                     id="${this.field.fieldId}"
                     .helperText="${this.helperText()}"
                     data-colspan="${this.field?.colspan}"
@@ -9174,7 +9174,7 @@ ${i}
                             <vaadin-button theme="icon" @click="${e=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`codesearch-`+this.field?.fieldId,parameters:{}},bubbles:!0,composed:!0}))}}"><vaadin-icon icon="lumo:search"></vaadin-icon></vaadin-button>
                         </vaadin-horizontal-layout>
                     </vaadin-custom-field>
-                `;if(this.field?.stereotype==`select`){if(this.field?.optionsSource){let e=this.field.optionsSource,r=j(e.url,this.state,this.data)??e.url;this.data[this.id]?.sourceSignature!==r&&(this.data[this.id]={content:this.data[this.id]?.content??[],sourceSignature:r},e.proxy?this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`__restfetch__`,parameters:{_sourceKind:`options`,_sourceId:this.field.fieldId},callback:t=>{let n=t?.appData?._restfetch,i=Wt(n,e.itemsPath,e.valuePath,e.labelPath);this.data[this.id]={content:i,totalElements:i.length,sourceSignature:r},this.requestUpdate()},callbackonly:!0},bubbles:!0,composed:!0})):qt(e,e=>j(e,this.state,this.data)).then(e=>{this.data[this.id]={content:e,totalElements:e.length,sourceSignature:r},this.requestUpdate()}).catch(e=>console.warn(`mateu: external options fetch failed`,e)));let i=t;return t&&t.value&&(i=t.value),w`
+                `;if(this.field?.stereotype==`select`){if(this.field?.optionsSource){let e=this.field.optionsSource,r=j(e.url,this.state,this.data)??e.url;this.data[this.id]?.sourceSignature!==r&&(this.data[this.id]={content:this.data[this.id]?.content??[],sourceSignature:r},e.proxy?this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`__restfetch__`,parameters:{_sourceKind:`options`,_sourceId:this.field.fieldId},callback:t=>{let n=t?.appData?._restfetch,i=Kt(n,e.itemsPath,e.valuePath,e.labelPath);this.data[this.id]={content:i,totalElements:i.length,sourceSignature:r},this.requestUpdate()},callbackonly:!0},bubbles:!0,composed:!0})):Yt(e,e=>j(e,this.state,this.data)).then(e=>{this.data[this.id]={content:e,totalElements:e.length,sourceSignature:r},this.requestUpdate()}).catch(e=>console.warn(`mateu: external options fetch failed`,e)));let i=t;return t&&t.value&&(i=t.value),w`
                     <vaadin-select
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9577,7 +9577,7 @@ ${i}
                     >
                         <mateu-camera-capture .fieldId="${this.field.fieldId}" .value="${t}"></mateu-camera-capture>
                     </vaadin-custom-field>
-                `;if(this.field?.stereotype==`fileUpload`){let e=Mc(this.field.attributes,`accept`);return w`
+                `;if(this.field?.stereotype==`fileUpload`){let e=Fc(this.field.attributes,`accept`);return w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9929,7 +9929,7 @@ ${i}
                         .helperText="${this.helperText()}"
                         data-colspan="${this.field.colspan}"
                 >
-                    ${i?w`<span theme="badge pill ${ua(i.type)}">${i.message}</span>`:w``}                    
+                    ${i?w`<span theme="badge pill ${fa(i.type)}">${i.message}</span>`:w``}                    
                 </vaadin-custom-field>
             `}renderRangeField(e,t,n,r){if(!this.field)return w``;this.loadUi5FieldComponents();let i=t;return w`
                 <vaadin-custom-field
@@ -10027,7 +10027,7 @@ ${i}
             text-overflow: clip;
             height: auto;
         }
-  `}};O([S()],Q.prototype,`ui5FieldComponentsReady`,void 0),O([v()],Q.prototype,`component`,void 0),O([v()],Q.prototype,`field`,void 0),O([v()],Q.prototype,`baseUrl`,void 0),O([v()],Q.prototype,`state`,void 0),O([v()],Q.prototype,`data`,void 0),O([v()],Q.prototype,`appState`,void 0),O([v()],Q.prototype,`appData`,void 0),O([v()],Q.prototype,`labelAlreadyRendered`,void 0),O([S()],Q.prototype,`colorPickerOpened`,void 0),O([S()],Q.prototype,`colorPickerValue`,void 0),O([S()],Q.prototype,`controlOwnsValidity`,void 0),O([S()],Q.prototype,`filteredIcons`,void 0),O([S()],Q.prototype,`navLinkOffset`,void 0),Q=O([h(`mateu-field`)],Q);var Sl=(e,t,n,r,i,a,o,s)=>{let c=t.metadata;return w`
+  `}};O([S()],Z.prototype,`ui5FieldComponentsReady`,void 0),O([v()],Z.prototype,`component`,void 0),O([v()],Z.prototype,`field`,void 0),O([v()],Z.prototype,`baseUrl`,void 0),O([v()],Z.prototype,`state`,void 0),O([v()],Z.prototype,`data`,void 0),O([v()],Z.prototype,`appState`,void 0),O([v()],Z.prototype,`appData`,void 0),O([v()],Z.prototype,`labelAlreadyRendered`,void 0),O([S()],Z.prototype,`colorPickerOpened`,void 0),O([S()],Z.prototype,`colorPickerValue`,void 0),O([S()],Z.prototype,`controlOwnsValidity`,void 0),O([S()],Z.prototype,`filteredIcons`,void 0),O([S()],Z.prototype,`navLinkOffset`,void 0),Z=O([h(`mateu-field`)],Z);var Tl=(e,t,n,r,i,a,o,s)=>{let c=t.metadata;return w`
         <mateu-field
                 id="${t.id}"
                 .component="${t}"
@@ -10036,7 +10036,7 @@ ${i}
                 .data="${i}"
                 .appState="${a}"
                 .appdata="${o}"
-                style="${ia(t,i)}" class="${t.cssClasses}"
+                style="${oa(t,i)}" class="${t.cssClasses}"
                 slot="${t.slot??_}"
                 data-colspan="${c.colspan}"
                 colspan="${(c.colspan??1)>1?c.colspan:_}"
@@ -10044,7 +10044,7 @@ ${i}
         >
             ${t.children?.map(t=>P(e,t,n,r,i,a,o,s))}
         </mateu-field>
-    `},Cl=(e,n,r,i,a,o,s)=>{let c=n.metadata;if(c.tree)return w`
+    `},El=(e,n,r,i,a,o,s)=>{let c=n.metadata;if(c.tree)return w`
         <vaadin-grid style="${n.style}" class="${n.cssClasses}"
                      .itemHasChildrenPath="${`children`}" .dataProvider="${async(e,t)=>{let n=e.parentItem?e.parentItem.children:c.page.content;t(n,n.length)}}"
                      slot="${n.slot??_}"
@@ -10057,7 +10057,7 @@ ${i}
                                 flex-grow="${l?.flexGrow??_}"
                                 width="${l?.width??_}"
                                 .column="${n.metadata}"
-                                ${t((t,n,c)=>pl(t,n,c,l,e,r,i,a,o,s),[])}></vaadin-grid-column>
+                                ${t((t,n,c)=>gl(t,n,c,l,e,r,i,a,o,s),[])}></vaadin-grid-column>
 `:w`
             <vaadin-grid-tree-column path="${n.id}"
                                 header="${l?.label??_}"
@@ -10075,9 +10075,9 @@ ${i}
                 .items="${l}"
                 all-rows-visible
         >
-            ${c?.content?.map(t=>dl(t,e,r,i,a,o,s))}
+            ${c?.content?.map(t=>ml(t,e,r,i,a,o,s))}
         </vaadin-grid>
-    `},$=class extends y{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.detailsOpenedItems=[],this.pagesRequested=[],this.emptyArray=e=>!e||e.length==0,this.dataProvider=(e,t)=>{let n=this.data[this.id]?.page;if(this.metadata?.infiniteScrolling&&e.page>0){let r=!1;n&&n.content&&(n.content.length>=(e.page+1)*e.pageSize||n.content.length==n.totalElements)&&(t(n.content.slice(e.page*e.pageSize,(e.page+1)*e.pageSize),n.totalElements),r=!0,this.grid&&this.grid.recalculateColumnWidths()),r||this.pagesRequested.find(t=>t==e.page)||(this.pagesRequested.push(e.page),this.dispatchEvent(new CustomEvent(`fetch-more-elements`,{detail:{params:e,callback:()=>{this.data[this.id]?.page?.content&&(t(this.data[this.id].page.content.slice(e.page*e.pageSize,(e.page+1)*e.pageSize),this.data[this.id].page.totalElements),this.grid&&this.grid.recalculateColumnWidths())}},bubbles:!0,composed:!0})))}else{let e=this.metadata?.infiniteScrolling?n?.totalElements:n?.content?.length??0;t(n?.content??[],e),this.grid&&this.grid.recalculateColumnWidths()}},this._onActionRequested=e=>{let t=e.detail,n=this.identifierFieldName;if(!n||!t.parameters||t.actionId?.startsWith(`action-on-row-`))return;let r=t.parameters[n];r!==void 0&&(this.state._selectedId=String(r),this._applyCellPartNameGenerator(),this.grid?.requestContentUpdate())},this.tooltipGenerator=e=>{let t=``,{column:n,item:r}=e,i=this.metadata?.columns?.find(e=>e.metadata.id==n?.path);if(i?.metadata){let e=(i?.metadata).tooltipPath;e&&n&&r&&(t=r[e])}return t}}get identifierFieldName(){let e=this.metadata?.columns?.find(e=>e.metadata?.identifier);if(e)return e.metadata?.id;if(this.metadata?.columns?.find(e=>e.metadata?.id===`id`))return`id`}_applyCellPartNameGenerator(){if(!this.grid)return;let e=this.identifierFieldName,t=this.state?._selectedId??this.appState?._splitDetailId,n=!!this.metadata?.groupBy;e&&t!==void 0||n?this.grid.cellPartNameGenerator=(n,r)=>{let i=r.item;return Pc(i)?`mateu-group-row`:e&&t!==void 0&&String(i[e])===String(t)?`selected-row`:``}:this.grid.cellPartNameGenerator=null}connectedCallback(){super.connectedCallback(),this.addEventListener(`action-requested`,this._onActionRequested)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`action-requested`,this._onActionRequested)}updated(e){super.updated(e),this._applyCellPartNameGenerator(),this.grid?.clearCache(),this.grid?.requestContentUpdate(),this.grid?.recalculateColumnWidths(),this.pagesRequested=[]}render(){let e=this.data[this.id],r=e?.page,i=this.metadata?.groupBy,a=this.metadata?.infiniteScrolling?void 0:r?.content?Ic(r.content,i,e?.groups):r?.content,o=Bc((this.metadata?.columns??[]).flatMap(e=>e.metadata?.type===A.GridGroupColumn?(e.metadata.columns??[]).map(e=>e.metadata):[e.metadata]),e,i),s=``;return this.metadata?.wrapCellContent&&(s+=` wrap-cell-content`),this.metadata?.compact&&(s+=` compact`),this.metadata?.noBorder&&(s+=` no-border`),this.metadata?.noRowBorder&&(s+=` no-row-borders`),this.metadata?.columnBorders&&(s+=` column-borders`),this.metadata?.rowStripes&&(s+=` row-stripes`),w`
+    `},Q=class extends y{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.detailsOpenedItems=[],this.pagesRequested=[],this.emptyArray=e=>!e||e.length==0,this.dataProvider=(e,t)=>{let n=this.data[this.id]?.page;if(this.metadata?.infiniteScrolling&&e.page>0){let r=!1;n&&n.content&&(n.content.length>=(e.page+1)*e.pageSize||n.content.length==n.totalElements)&&(t(n.content.slice(e.page*e.pageSize,(e.page+1)*e.pageSize),n.totalElements),r=!0,this.grid&&this.grid.recalculateColumnWidths()),r||this.pagesRequested.find(t=>t==e.page)||(this.pagesRequested.push(e.page),this.dispatchEvent(new CustomEvent(`fetch-more-elements`,{detail:{params:e,callback:()=>{this.data[this.id]?.page?.content&&(t(this.data[this.id].page.content.slice(e.page*e.pageSize,(e.page+1)*e.pageSize),this.data[this.id].page.totalElements),this.grid&&this.grid.recalculateColumnWidths())}},bubbles:!0,composed:!0})))}else{let e=this.metadata?.infiniteScrolling?n?.totalElements:n?.content?.length??0;t(n?.content??[],e),this.grid&&this.grid.recalculateColumnWidths()}},this._onActionRequested=e=>{let t=e.detail,n=this.identifierFieldName;if(!n||!t.parameters||t.actionId?.startsWith(`action-on-row-`))return;let r=t.parameters[n];r!==void 0&&(this.state._selectedId=String(r),this._applyCellPartNameGenerator(),this.grid?.requestContentUpdate())},this.tooltipGenerator=e=>{let t=``,{column:n,item:r}=e,i=this.metadata?.columns?.find(e=>e.metadata.id==n?.path);if(i?.metadata){let e=(i?.metadata).tooltipPath;e&&n&&r&&(t=r[e])}return t}}get identifierFieldName(){let e=this.metadata?.columns?.find(e=>e.metadata?.identifier);if(e)return e.metadata?.id;if(this.metadata?.columns?.find(e=>e.metadata?.id===`id`))return`id`}_applyCellPartNameGenerator(){if(!this.grid)return;let e=this.identifierFieldName,t=this.state?._selectedId??this.appState?._splitDetailId,n=!!this.metadata?.groupBy;e&&t!==void 0||n?this.grid.cellPartNameGenerator=(n,r)=>{let i=r.item;return Lc(i)?`mateu-group-row`:e&&t!==void 0&&String(i[e])===String(t)?`selected-row`:``}:this.grid.cellPartNameGenerator=null}connectedCallback(){super.connectedCallback(),this.addEventListener(`action-requested`,this._onActionRequested)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`action-requested`,this._onActionRequested)}updated(e){super.updated(e),this._applyCellPartNameGenerator(),this.grid?.clearCache(),this.grid?.requestContentUpdate(),this.grid?.recalculateColumnWidths(),this.pagesRequested=[]}render(){let e=this.data[this.id],r=e?.page,i=this.metadata?.groupBy,a=this.metadata?.infiniteScrolling?void 0:r?.content?zc(r.content,i,e?.groups):r?.content,o=Uc((this.metadata?.columns??[]).flatMap(e=>e.metadata?.type===A.GridGroupColumn?(e.metadata.columns??[]).map(e=>e.metadata):[e.metadata]),e,i),s=``;return this.metadata?.wrapCellContent&&(s+=` wrap-cell-content`),this.metadata?.compact&&(s+=` compact`),this.metadata?.noBorder&&(s+=` no-border`),this.metadata?.noRowBorder&&(s+=` no-row-borders`),this.metadata?.columnBorders&&(s+=` column-borders`),this.metadata?.rowStripes&&(s+=` row-stripes`),w`
             <vaadin-grid
                     .items="${a}"
                     item-id-path="_rowNumber"
@@ -10089,8 +10089,8 @@ ${i}
                     .dataProvider="${this.metadata?.infiniteScrolling?this.dataProvider:void 0}"
                     page-size="${this.metadata?.pageSize}"
                     multi-sort-on-shift-click
-                    @selected-items-changed="${e=>{let t=(e.detail.value??[]).filter(e=>!Pc(e));this.emptyArray(this.state[this.id+`_selected_items`])&&this.emptyArray(t)||(this.state[this.id+`_selected_items`]=t,this.metadata?.onRowSelectionChangedActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.metadata?.onRowSelectionChangedActionId},bubbles:!0,composed:!0})))}}"
-                    @active-item-changed="${x(this.metadata?.detailPath&&!this.metadata?.useButtonForDetail?e=>{if(this.metadata?.detailPath){let t=e.detail.value;if(t&&Pc(t))return;t?this.detailsOpenedItems=[t]:this.detailsOpenedItems=[]}}:void 0)}"
+                    @selected-items-changed="${e=>{let t=(e.detail.value??[]).filter(e=>!Lc(e));this.emptyArray(this.state[this.id+`_selected_items`])&&this.emptyArray(t)||(this.state[this.id+`_selected_items`]=t,this.metadata?.onRowSelectionChangedActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.metadata?.onRowSelectionChangedActionId},bubbles:!0,composed:!0})))}}"
+                    @active-item-changed="${x(this.metadata?.detailPath&&!this.metadata?.useButtonForDetail?e=>{if(this.metadata?.detailPath){let t=e.detail.value;if(t&&Lc(t))return;t?this.detailsOpenedItems=[t]:this.detailsOpenedItems=[]}}:void 0)}"
                     .detailsOpenedItems="${this.detailsOpenedItems}"
                     ${x(this.metadata?.detailPath?n(e=>w`${P(this,e[this.metadata?.detailPath],this.baseUrl,this.state,this.data,this.appState,this.appData)}`):void 0)}
                     theme="${s}"
@@ -10099,7 +10099,7 @@ ${i}
                 ${this.metadata?.rowsSelectionEnabled?w`
                     <vaadin-grid-selection-column></vaadin-grid-selection-column>
                 `:_}
-                ${this.metadata?.columns?.map(e=>dl(e,this,this.baseUrl,this.state,this.data,this.appState,this.appData,o))}
+                ${this.metadata?.columns?.map(e=>ml(e,this,this.baseUrl,this.state,this.data,this.appState,this.appData,o))}
                 ${this.metadata?.useButtonForDetail?w`
                     <vaadin-grid-column
                             width="44px"
@@ -10138,7 +10138,7 @@ ${i}
             background-color: var(--lumo-contrast-5pct, rgba(0, 0, 0, 0.04));
             font-weight: 600;
         }
-  `}};O([v()],$.prototype,`id`,void 0),O([v()],$.prototype,`metadata`,void 0),O([v()],$.prototype,`baseUrl`,void 0),O([v()],$.prototype,`state`,void 0),O([v()],$.prototype,`data`,void 0),O([v()],$.prototype,`appState`,void 0),O([v()],$.prototype,`appData`,void 0),O([v()],$.prototype,`emptyStateMessage`,void 0),O([S()],$.prototype,`detailsOpenedItems`,void 0),O([b(`vaadin-grid`)],$.prototype,`grid`,void 0),$=O([h(`mateu-table`)],$);var wl=(e,t,n,r,i,a,o)=>w`
+  `}};O([v()],Q.prototype,`id`,void 0),O([v()],Q.prototype,`metadata`,void 0),O([v()],Q.prototype,`baseUrl`,void 0),O([v()],Q.prototype,`state`,void 0),O([v()],Q.prototype,`data`,void 0),O([v()],Q.prototype,`appState`,void 0),O([v()],Q.prototype,`appData`,void 0),O([v()],Q.prototype,`emptyStateMessage`,void 0),O([S()],Q.prototype,`detailsOpenedItems`,void 0),O([b(`vaadin-grid`)],Q.prototype,`grid`,void 0),Q=O([h(`mateu-table`)],Q);var Dl=(e,t,n,r,i,a,o)=>w`
     <mateu-table
             id="${t.id}"
             baseUrl="${n}"
@@ -10151,7 +10151,7 @@ ${i}
             slot="${t.slot??_}"
     >
         ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
-    </mateu-table>`,Tl=(e,t,n,r,i,a)=>w`
+    </mateu-table>`,Ol=(e,t,n,r,i,a)=>w`
     <mateu-table id="${e.id}"
                  .metadata="${t?.metadata}"
                  .data="${e.data}"
@@ -10162,7 +10162,7 @@ ${i}
                  @sort-direction-changed="${e.directionChanged}"
                  @fetch-more-elements="${e.fetchMoreElements}"
                  baseUrl="${n}"
-    ></mateu-table>`,El=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+    ></mateu-table>`,kl=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <div id="show-notifications" slot="${t.slot??_}">${P(e,s.wrapped,n,r,i,a,o)}</div>
         <vaadin-popover
                 for="show-notifications"
@@ -10174,14 +10174,14 @@ ${i}
                 ${te(()=>w`${P(e,s.content,n,r,i,a,o)}`,[])}
                 style="${t.style}" class="${t.cssClasses}"
         ></vaadin-popover>
-    `},Dl=(e,t,n)=>{let r=e;return w`
+    `},Al=(e,t,n)=>{let r=e;return w`
         <vaadin-button
                 data-action-id="${r.id}"
                 theme="${ht(e)||_}"
                 @click="${n}"
                 ?disabled="${r.disabled}"
         >${r.iconOnLeft?w`<vaadin-icon icon="${r.iconOnLeft}"></vaadin-icon>`:_}${t}${r.iconOnRight?w`<vaadin-icon icon="${r.iconOnRight}"></vaadin-icon>`:_}</vaadin-button>
-    `},Ol=e=>w`
+    `},jl=e=>w`
     <div style="display: flex; gap: var(--lumo-space-xs, .25rem); align-items: center;" class="peer-nav">
         <vaadin-button theme="tertiary icon" class="peer-nav-prev" title="${e.prevLabel??`Previous`}"
                 ?disabled="${!e.prevRoute}"
@@ -10193,30 +10193,30 @@ ${i}
                 @click="${()=>{e.nextRoute&&(window.location.href=e.nextRoute)}}">
             <vaadin-icon icon="vaadin:angle-right"></vaadin-icon>
         </vaadin-button>
-    </div>`,kl={"vaadin:wifi":`vaadin:connect`,"vaadin:pen":`vaadin:pencil`,"vaadin:automation":`vaadin:cogs`},Al=(e,t,n)=>w`<vaadin-icon icon="${kl[e]??e}" style="${t??_}" class="${n??_}"></vaadin-icon>`,jl=(e,t,n)=>{let r=e.metadata,i=j(r.label,t,n),a=``;return r.buttonStyle&&(a+=` `+r.buttonStyle),r.color&&r.color!==`none`&&r.color!==`normal`&&(a+=` `+r.color),r.size&&r.size!==`none`&&r.size!==`normal`&&(a+=` `+r.size),w`<vaadin-button
+    </div>`,Ml={"vaadin:wifi":`vaadin:connect`,"vaadin:pen":`vaadin:pencil`,"vaadin:automation":`vaadin:cogs`},Nl=(e,t,n)=>w`<vaadin-icon icon="${Ml[e]??e}" style="${t??_}" class="${n??_}"></vaadin-icon>`,Pl=(e,t,n)=>{let r=e.metadata,i=j(r.label,t,n),a=``;return r.buttonStyle&&(a+=` `+r.buttonStyle),r.color&&r.color!==`none`&&r.color!==`normal`&&(a+=` `+r.color),r.size&&r.size!==`none`&&r.size!==`normal`&&(a+=` `+r.size),w`<vaadin-button
             id="${e.id}"
             data-action-id="${r.actionId}"
-            @click="${e=>zn(e,r)}"
+            @click="${e=>Vn(e,r)}"
             style="${e.style}"
             class="${e.cssClasses}"
             theme="${a}"
             ?disabled="${r.disabled}"
-            title="${r.shortcut?`${i} (${Rn(r.shortcut)})`:_}"
+            title="${r.shortcut?`${i} (${Bn(r.shortcut)})`:_}"
             slot="${e.slot??_}"
-    >${r.iconOnLeft?w`<vaadin-icon icon="${r.iconOnLeft}"></vaadin-icon>`:_}${i}${r.iconOnRight?w`<vaadin-icon icon="${r.iconOnRight}"></vaadin-icon>`:_}</vaadin-button>`},Ml=e=>{let t=e.metadata;return w`
+    >${r.iconOnLeft?w`<vaadin-icon icon="${r.iconOnLeft}"></vaadin-icon>`:_}${i}${r.iconOnRight?w`<vaadin-icon icon="${r.iconOnRight}"></vaadin-icon>`:_}</vaadin-button>`},Fl=e=>{let t=e.metadata;return w`
         <vaadin-message-input
                 style="${e.style}" class="${e.cssClasses}"
                 slot="${e.slot??_}"
                 @submit="${e=>{let n=e.detail?.value??``;!t.actionId||!n.trim()||e.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:{message:n}},bubbles:!0,composed:!0}))}}"
         ></vaadin-message-input>
-    `},Nl=e=>{let t=(e.metadata.items??[]).map(e=>({text:e.text,time:e.time,userName:e.userName,userImg:e.userImg,userAbbr:e.userAbbr,userColorIndex:e.userColorIndex}));return w`
+    `},Il=e=>{let t=(e.metadata.items??[]).map(e=>({text:e.text,time:e.time,userName:e.userName,userImg:e.userImg,userAbbr:e.userAbbr,userColorIndex:e.userColorIndex}));return w`
         <vaadin-message-list
                 markdown
                 style="${e.style}" class="${e.cssClasses}"
                 slot="${e.slot??_}"
                 .items="${t}"
         ></vaadin-message-list>
-    `},Pl=(e,t)=>{e&&e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},Fl=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!1;if(s.openedCondition)try{c=at(s.openedCondition,r,i,a,o)}catch(e){console.error(`when evaluating `+s.openedCondition+` :`+e+`, where data is `+i+` and state is `+r)}return w`
+    `},Ll=(e,t)=>{e&&e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},Rl=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!1;if(s.openedCondition)try{c=at(s.openedCondition,r,i,a,o)}catch(e){console.error(`when evaluating `+s.openedCondition+` :`+e+`, where data is `+i+` and state is `+r)}return w`
         <vaadin-confirm-dialog
                 header="${s.header}"
                 ?cancel-button-visible="${s.canCancel}"
@@ -10224,15 +10224,15 @@ ${i}
                 reject-text="${s.rejectText}"
                 confirm-text="${s.confirmText}"
                 .opened="${c}"
-                @confirm="${e=>Pl(e.currentTarget,s.confirmActionId)}"
-                @reject="${e=>Pl(e.currentTarget,s.rejectActionId)}"
-                @cancel="${e=>Pl(e.currentTarget,s.cancelActionId)}"
+                @confirm="${e=>Ll(e.currentTarget,s.confirmActionId)}"
+                @reject="${e=>Ll(e.currentTarget,s.rejectActionId)}"
+                @cancel="${e=>Ll(e.currentTarget,s.cancelActionId)}"
                 style="${t.style}" class="${t.cssClasses}"
                 slot="${t.slot??_}"
         >
             ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </vaadin-confirm-dialog>
-    `},Il=class extends y{constructor(...e){super(...e),this.panels=[],this.headerTitle=``,this.badges=[],this.navigation=null,this.overviewEditActionId=``,this._raf=0,this._snapping=!1,this._less=!1,this._more=!1,this._onScroll=()=>{this._raf||=requestAnimationFrame(()=>{this._raf=0,this._syncPin()})},this._onScrollEnd=()=>{this._snapping||this._snapToNearest()},this._fit=()=>{let e=this.getBoundingClientRect().top;this.style.setProperty(`--mateu-foldout-fill`,`${Math.max(240,window.innerHeight-e)}px`),this._syncPin()},this._onKeydown=e=>{if(e.key!==`ArrowRight`&&e.key!==`ArrowLeft`||e.defaultPrevented||e.ctrlKey||e.metaKey||e.altKey||this._isEditingContext())return;let t=this._rail;!t||t.scrollWidth<=t.clientWidth||(e.preventDefault(),this._step(e.key===`ArrowRight`?1:-1))}}navAction(e){e&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{}},bubbles:!0,composed:!0}))}_stride(){let e=this.renderRoot.querySelectorAll(`.section`);return e.length>1?e[1].offsetLeft:this._rail?.clientWidth??0}_boundaries(){let e=this._rail;if(!e)return[];let t=e.scrollWidth-e.clientWidth,n=[...this.renderRoot.querySelectorAll(`.section`)].map(e=>Math.max(0,Math.min(e.offsetLeft,t)));return[...new Set(n)]}_snapToNearest(){let e=this._rail;if(!e)return;let t=this._boundaries();if(!t.length)return;let n=t.reduce((t,n)=>Math.abs(n-e.scrollLeft)<Math.abs(t-e.scrollLeft)?n:t);Math.abs(n-e.scrollLeft)<1||(this._snapping=!0,e.scrollTo({left:n,behavior:`smooth`}),window.setTimeout(()=>{this._snapping=!1},400))}_syncPin(){let e=this._rail,t=this._first;if(!e||!t)return;let n=this._stride(),r=Math.min(e.scrollLeft,n);t.style.transform=r?`translateX(${r}px)`:``,t.classList.toggle(`floating`,e.scrollLeft>0);let i=e.scrollWidth-e.clientWidth,a=i>32;this._less=a&&e.scrollLeft>2,this._more=a&&e.scrollLeft<i-2}_step(e){let t=this._rail;if(!t)return;let n=this._boundaries();if(!n.length)return;let r=n.reduce((e,r,i)=>Math.abs(r-t.scrollLeft)<Math.abs(n[e]-t.scrollLeft)?i:e,0),i=n[Math.max(0,Math.min(r+e,n.length-1))];this._snapping=!0,t.scrollTo({left:i,behavior:`smooth`}),window.setTimeout(()=>{this._snapping=!1},400)}_isEditingContext(){let e=document.activeElement;for(;e&&e.shadowRoot&&e.shadowRoot.activeElement;)e=e.shadowRoot.activeElement;if(!e)return!1;let t=e.tagName;return t===`INPUT`||t===`TEXTAREA`||t===`SELECT`||e.isContentEditable}_sectionFlex(e,t){if(!e.width)return _;let n=parseFloat(e.width)||1;return t===this.panels.length-1&&n<22?`flex: 22 1 var(--mateu-foldout-overview-width, 22rem);`:`flex: ${n} 1 ${e.width};`}firstUpdated(){this._fit(),this._resizeObserver=new ResizeObserver(()=>this._syncPin()),this._rail&&this._resizeObserver.observe(this._rail);for(let e of this.renderRoot.querySelectorAll(`.section`))this._resizeObserver.observe(e)}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._onKeydown),window.addEventListener(`resize`,this._fit)}disconnectedCallback(){document.removeEventListener(`keydown`,this._onKeydown),window.removeEventListener(`resize`,this._fit),this._resizeObserver?.disconnect(),this._resizeObserver=void 0,this._raf&&=(cancelAnimationFrame(this._raf),0),super.disconnectedCallback()}static{this.styles=m`
+    `},$=class extends y{constructor(...e){super(...e),this.panels=[],this.headerTitle=``,this.badges=[],this.navigation=null,this.overviewEditActionId=``,this._raf=0,this._snapping=!1,this._less=!1,this._more=!1,this._onScroll=()=>{this._raf||=requestAnimationFrame(()=>{this._raf=0,this._syncPin()})},this._onScrollEnd=()=>{this._snapping||this._snapToNearest()},this._fit=()=>{let e=this.getBoundingClientRect().top;this.style.setProperty(`--mateu-foldout-fill`,`${Math.max(240,window.innerHeight-e)}px`),this._syncPin()},this._onKeydown=e=>{if(e.key!==`ArrowRight`&&e.key!==`ArrowLeft`||e.defaultPrevented||e.ctrlKey||e.metaKey||e.altKey||this._isEditingContext())return;let t=this._rail;!t||t.scrollWidth<=t.clientWidth||(e.preventDefault(),this._step(e.key===`ArrowRight`?1:-1))}}navAction(e){e&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{}},bubbles:!0,composed:!0}))}_stride(){let e=this.renderRoot.querySelectorAll(`.section`);return e.length>1?e[1].offsetLeft:this._rail?.clientWidth??0}_boundaries(){let e=this._rail;if(!e)return[];let t=e.scrollWidth-e.clientWidth,n=[...this.renderRoot.querySelectorAll(`.section`)].map(e=>Math.max(0,Math.min(e.offsetLeft,t)));return[...new Set(n)]}_snapToNearest(){let e=this._rail;if(!e)return;let t=this._boundaries();if(!t.length)return;let n=t.reduce((t,n)=>Math.abs(n-e.scrollLeft)<Math.abs(t-e.scrollLeft)?n:t);Math.abs(n-e.scrollLeft)<1||(this._snapping=!0,e.scrollTo({left:n,behavior:`smooth`}),window.setTimeout(()=>{this._snapping=!1},400))}_syncPin(){let e=this._rail,t=this._first;if(!e||!t)return;let n=this._stride(),r=Math.min(e.scrollLeft,n);t.style.transform=r?`translateX(${r}px)`:``,t.classList.toggle(`floating`,e.scrollLeft>0);let i=e.scrollWidth-e.clientWidth,a=i>32;this._less=a&&e.scrollLeft>2,this._more=a&&e.scrollLeft<i-2}_step(e){let t=this._rail;if(!t)return;let n=this._boundaries();if(!n.length)return;let r=n.reduce((e,r,i)=>Math.abs(r-t.scrollLeft)<Math.abs(n[e]-t.scrollLeft)?i:e,0),i=n[Math.max(0,Math.min(r+e,n.length-1))];this._snapping=!0,t.scrollTo({left:i,behavior:`smooth`}),window.setTimeout(()=>{this._snapping=!1},400)}_isEditingContext(){let e=document.activeElement;for(;e&&e.shadowRoot&&e.shadowRoot.activeElement;)e=e.shadowRoot.activeElement;if(!e)return!1;let t=e.tagName;return t===`INPUT`||t===`TEXTAREA`||t===`SELECT`||e.isContentEditable}_sectionFlex(e,t){if(!e.width)return _;let n=parseFloat(e.width)||1;return t===this.panels.length-1&&n<22?`flex: 22 1 var(--mateu-foldout-overview-width, 22rem);`:`flex: ${n} 1 ${e.width};`}firstUpdated(){this._fit(),this._resizeObserver=new ResizeObserver(()=>this._syncPin()),this._rail&&this._resizeObserver.observe(this._rail);for(let e of this.renderRoot.querySelectorAll(`.section`))this._resizeObserver.observe(e)}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._onKeydown),window.addEventListener(`resize`,this._fit)}disconnectedCallback(){document.removeEventListener(`keydown`,this._onKeydown),window.removeEventListener(`resize`,this._fit),this._resizeObserver?.disconnect(),this._resizeObserver=void 0,this._raf&&=(cancelAnimationFrame(this._raf),0),super.disconnectedCallback()}static{this.styles=m`
         :host {
             position: relative;
             display: flex;
@@ -10493,7 +10493,7 @@ ${i}
                     </svg>
                 </button>
             `:_}
-        `}};O([v({type:Array})],Il.prototype,`panels`,void 0),O([v({type:String})],Il.prototype,`headerTitle`,void 0),O([v({type:Array})],Il.prototype,`badges`,void 0),O([v({attribute:!1})],Il.prototype,`navigation`,void 0),O([v({type:String})],Il.prototype,`overviewEditActionId`,void 0),O([b(`.rail`)],Il.prototype,`_rail`,void 0),O([b(`.section--first`)],Il.prototype,`_first`,void 0),O([S()],Il.prototype,`_less`,void 0),O([S()],Il.prototype,`_more`,void 0),Il=O([h(`mateu-vaadin-foldout`)],Il);var Ll=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+        `}};O([v({type:Array})],$.prototype,`panels`,void 0),O([v({type:String})],$.prototype,`headerTitle`,void 0),O([v({type:Array})],$.prototype,`badges`,void 0),O([v({attribute:!1})],$.prototype,`navigation`,void 0),O([v({type:String})],$.prototype,`overviewEditActionId`,void 0),O([b(`.rail`)],$.prototype,`_rail`,void 0),O([b(`.section--first`)],$.prototype,`_first`,void 0),O([S()],$.prototype,`_less`,void 0),O([S()],$.prototype,`_more`,void 0),$=O([h(`mateu-vaadin-foldout`)],$);var zl=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <mateu-vaadin-foldout
                 .panels="${s.panels??[]}"
                 .headerTitle="${s.headerTitle??``}"
@@ -10506,7 +10506,7 @@ ${i}
         >
             ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </mateu-vaadin-foldout>
-    `},Rl=class extends y{constructor(...e){super(...e),this.rows=[],this.columns=[],this.navigable=!1,this.expandedItems=[],this._normalized=[],this.dataProvider=(e,t)=>{let n=e.parentItem?e.parentItem.children??[]:this.normalized;t(n,n.length)}}get normalized(){return this._src!==this.rows&&(this._src=this.rows,this._normalized=this.normalizeRows(this.rows??[])),this._normalized}normalizeRows(e){return(e??[]).map(e=>{let t=Array.isArray(e.children)&&e.children.length?this.normalizeRows(e.children):void 0;return{...e,children:t}})}collectGroups(e,t=[]){return e.forEach(e=>{e.children&&e.children.length&&(t.push(e),this.collectGroups(e.children,t))}),t}willUpdate(){this._expandedSrc!==this.rows&&(this._expandedSrc=this.rows,this.expandedItems=this.collectGroups(this.normalized))}updated(e){e.has(`rows`)&&this._grid?.clearCache?.()}dispatch(e,t){this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:t},bubbles:!0,composed:!0}))}render(){let e=this.columns??[],n=e[0],r=e.slice(1);return w`
+    `},Bl=class extends y{constructor(...e){super(...e),this.rows=[],this.columns=[],this.navigable=!1,this.expandedItems=[],this._normalized=[],this.dataProvider=(e,t)=>{let n=e.parentItem?e.parentItem.children??[]:this.normalized;t(n,n.length)}}get normalized(){return this._src!==this.rows&&(this._src=this.rows,this._normalized=this.normalizeRows(this.rows??[])),this._normalized}normalizeRows(e){return(e??[]).map(e=>{let t=Array.isArray(e.children)&&e.children.length?this.normalizeRows(e.children):void 0;return{...e,children:t}})}collectGroups(e,t=[]){return e.forEach(e=>{e.children&&e.children.length&&(t.push(e),this.collectGroups(e.children,t))}),t}willUpdate(){this._expandedSrc!==this.rows&&(this._expandedSrc=this.rows,this.expandedItems=this.collectGroups(this.normalized))}updated(e){e.has(`rows`)&&this._grid?.clearCache?.()}dispatch(e,t){this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:t},bubbles:!0,composed:!0}))}render(){let e=this.columns??[],n=e[0],r=e.slice(1);return w`
             <vaadin-grid
                     theme="compact no-row-borders"
                     all-rows-visible
@@ -10536,11 +10536,11 @@ ${i}
             max-height: min(60vh, 32rem);
             min-width: 22rem;
         }
-    `}};O([v({attribute:!1})],Rl.prototype,`rows`,void 0),O([v({attribute:!1})],Rl.prototype,`columns`,void 0),O([v()],Rl.prototype,`idField`,void 0),O([v({type:Boolean})],Rl.prototype,`navigable`,void 0),O([v()],Rl.prototype,`selectedId`,void 0),O([S()],Rl.prototype,`expandedItems`,void 0),O([b(`vaadin-grid`)],Rl.prototype,`_grid`,void 0),Rl=O([h(`mateu-vaadin-tree`)],Rl);var zl={[A.VirtualList]:(e,t,n,r,i,a,o)=>Qs(e,t,n,r,i,a,o),[A.Notification]:(e,t)=>$s(t),[A.ProgressBar]:(e,t,n,r)=>ec(t,r),[A.Details]:(e,t,n,r,i,a,o)=>tc(e,t,n,r,i,a,o),[A.Avatar]:(e,t,n,r,i)=>nc(t,r,i),[A.AvatarGroup]:(e,t)=>rc(t),[A.Card]:(e,t,n,r,i,a,o)=>ic(e,t,n,r,i,a,o),[A.Button]:(e,t,n,r,i)=>jl(t,r,i),[A.MessageInput]:(e,t)=>Ml(t),[A.MessageList]:(e,t)=>Nl(t),[A.ConfirmDialog]:(e,t,n,r,i,a,o)=>Fl(e,t,n,r,i,a,o),[A.FormLayout]:(e,t,n,r,i,a,o)=>sc(e,t,n,r,i,a,o),[A.HorizontalLayout]:(e,t,n,r,i,a,o)=>dc(e,t,n,r,i,a,o),[A.VerticalLayout]:(e,t,n,r,i,a,o)=>fc(e,t,n,r,i,a,o),[A.SplitLayout]:(e,t,n,r,i,a,o)=>pc(e,t,n,r,i,a,o),[A.MasterDetailLayout]:(e,t,n,r,i,a,o)=>mc(e,t,n,r,i,a,o),[A.TabLayout]:(e,t,n,r,i,a,o)=>hc(e,t,n,r,i,a,o),[A.AccordionLayout]:(e,t,n,r,i,a,o)=>_c(e,t,n,r,i,a,o),[A.BoardLayout]:(e,t,n,r,i,a,o)=>bc(e,t,n,r,i,a,o),[A.BoardLayoutRow]:(e,t,n,r,i,a,o)=>xc(e,t,n,r,i,a,o),[A.BoardLayoutItem]:(e,t,n,r,i,a,o)=>Sc(e,t,n,r,i,a,o),[A.Scroller]:(e,t,n,r,i,a,o)=>yc(e,t,n,r,i,a,o),[A.MenuBar]:(e,t,n,r,i)=>Tc(e,t,n,r,i),[A.ContextMenu]:(e,t,n,r,i,a,o)=>wc(e,t,n,r,i,a,o),[A.FormField]:(e,t,n,r,i,a,o,s)=>Sl(e,t,n,r,i,a,o,s),[A.Grid]:(e,t,n,r,i,a,o)=>Cl(e,t,n,r,i,a,o),[A.Table]:(e,t,n,r,i,a,o)=>wl(e,t,n,r,i,a,o),[A.Popover]:(e,t,n,r,i,a,o)=>El(e,t,n,r,i,a,o),[A.FoldoutLayout]:(e,t,n,r,i,a,o)=>Ll(e,t,n,r,i,a,o)},Bl=class extends Zs{rendererName(){return`vaadin`}renderClientSideComponent(e,t,n,r,i,a,o,s){let c=t?.metadata?.type,l=c?zl[c]:void 0;return l&&t?l(e,t,n,r,i,a,o,s):super.renderClientSideComponent(e,t,n,r,i,a,o,s)}renderTableComponent(e,t,n,r,i,a,o){return Tl(e,t,n,r,a,o)}renderTreeComponent(e,t){return w`
+    `}};O([v({attribute:!1})],Bl.prototype,`rows`,void 0),O([v({attribute:!1})],Bl.prototype,`columns`,void 0),O([v()],Bl.prototype,`idField`,void 0),O([v({type:Boolean})],Bl.prototype,`navigable`,void 0),O([v()],Bl.prototype,`selectedId`,void 0),O([S()],Bl.prototype,`expandedItems`,void 0),O([b(`vaadin-grid`)],Bl.prototype,`_grid`,void 0),Bl=O([h(`mateu-vaadin-tree`)],Bl);var Vl={[A.VirtualList]:(e,t,n,r,i,a,o)=>tc(e,t,n,r,i,a,o),[A.Notification]:(e,t)=>nc(t),[A.ProgressBar]:(e,t,n,r)=>rc(t,r),[A.Details]:(e,t,n,r,i,a,o)=>ic(e,t,n,r,i,a,o),[A.Avatar]:(e,t,n,r,i)=>ac(t,r,i),[A.AvatarGroup]:(e,t)=>oc(t),[A.Card]:(e,t,n,r,i,a,o)=>sc(e,t,n,r,i,a,o),[A.Button]:(e,t,n,r,i)=>Pl(t,r,i),[A.MessageInput]:(e,t)=>Fl(t),[A.MessageList]:(e,t)=>Il(t),[A.ConfirmDialog]:(e,t,n,r,i,a,o)=>Rl(e,t,n,r,i,a,o),[A.FormLayout]:(e,t,n,r,i,a,o)=>uc(e,t,n,r,i,a,o),[A.HorizontalLayout]:(e,t,n,r,i,a,o)=>mc(e,t,n,r,i,a,o),[A.VerticalLayout]:(e,t,n,r,i,a,o)=>hc(e,t,n,r,i,a,o),[A.SplitLayout]:(e,t,n,r,i,a,o)=>gc(e,t,n,r,i,a,o),[A.MasterDetailLayout]:(e,t,n,r,i,a,o)=>_c(e,t,n,r,i,a,o),[A.TabLayout]:(e,t,n,r,i,a,o)=>vc(e,t,n,r,i,a,o),[A.AccordionLayout]:(e,t,n,r,i,a,o)=>bc(e,t,n,r,i,a,o),[A.BoardLayout]:(e,t,n,r,i,a,o)=>Cc(e,t,n,r,i,a,o),[A.BoardLayoutRow]:(e,t,n,r,i,a,o)=>wc(e,t,n,r,i,a,o),[A.BoardLayoutItem]:(e,t,n,r,i,a,o)=>Tc(e,t,n,r,i,a,o),[A.Scroller]:(e,t,n,r,i,a,o)=>Sc(e,t,n,r,i,a,o),[A.MenuBar]:(e,t,n,r,i)=>Oc(e,t,n,r,i),[A.ContextMenu]:(e,t,n,r,i,a,o)=>Dc(e,t,n,r,i,a,o),[A.FormField]:(e,t,n,r,i,a,o,s)=>Tl(e,t,n,r,i,a,o,s),[A.Grid]:(e,t,n,r,i,a,o)=>El(e,t,n,r,i,a,o),[A.Table]:(e,t,n,r,i,a,o)=>Dl(e,t,n,r,i,a,o),[A.Popover]:(e,t,n,r,i,a,o)=>kl(e,t,n,r,i,a,o),[A.FoldoutLayout]:(e,t,n,r,i,a,o)=>zl(e,t,n,r,i,a,o)},Hl=class extends ec{rendererName(){return`vaadin`}renderClientSideComponent(e,t,n,r,i,a,o,s){let c=t?.metadata?.type,l=c?Vl[c]:void 0;return l&&t?l(e,t,n,r,i,a,o,s):super.renderClientSideComponent(e,t,n,r,i,a,o,s)}renderTableComponent(e,t,n,r,i,a,o){return Ol(e,t,n,r,a,o)}renderTreeComponent(e,t){return w`
             <mateu-vaadin-tree
                     .rows="${t.rows}"
                     .columns="${t.columns}"
                     .idField="${t.idField}"
                     .navigable="${t.navigable}"
                     .selectedId="${t.selectedId}"
-            ></mateu-vaadin-tree>`}renderToolbarButton(e,t,n){return Dl(e,t,n)}renderPeerNav(e){return Ol(e)}renderIcon(e,t,n){return Al(e,t,n)}renderTopNav(e,t,n){return Cc(e,t,n)}};function Vl(e){switch(e){case`topStretch`:return`top-stretch`;case`topStart`:return`top-start`;case`topCenter`:return`top-center`;case`topEnd`:return`top-end`;case`middle`:return`middle`;case`bottomStart`:return`bottom-start`;case`bottomEnd`:return`bottom-end`;case`bottomStretch`:return`bottom-stretch`;case`bottomCenter`:return`bottom-center`}return`bottom-end`}function Hl(e,t){if(e.onAction)return{label:e.actionLabel??`Retry`,run:e.onAction};if(e.undoActionId)return{label:e.undoLabel??`Undo`,run:()=>t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.undoActionId,parameters:e.undoParameters??{}},bubbles:!0,composed:!0}))}}function Ul(e,t){let n=new r;n.position=Vl(e.position),n.duration=e.duration??1e4,e.variant&&n.setAttribute(`theme`,e.variant),n.renderer=r=>{if(r.firstElementChild)return;let i=document.createElement(`span`);i.textContent=e.text;let a=Hl(e,t),o=document.createElement(`button`);o.textContent=a.label,o.style.cssText=`margin-left: 0.75rem; background: none; border: 1px solid currentColor; border-radius: var(--lumo-border-radius-s, 4px); color: inherit; cursor: pointer; padding: 0.15rem 0.6rem; font: inherit; font-weight: 600;`,o.addEventListener(`click`,()=>{a.run(),n.opened=!1}),r.append(i,o)},document.body.appendChild(n),n.opened=!0,n.addEventListener(`opened-changed`,e=>{e.detail.value||n.remove()})}N.set(new Bl),fa({show(e,t){if(Qe(e.text,{politeness:e.variant===`error`?`assertive`:`polite`}),e.undoActionId||e.onAction){Ul(e,t);return}r.show(e.text,{position:e.position?Vl(e.position):`bottom-end`,theme:e.variant,duration:e.duration})}});
+            ></mateu-vaadin-tree>`}renderToolbarButton(e,t,n){return Al(e,t,n)}renderPeerNav(e){return jl(e)}renderIcon(e,t,n){return Nl(e,t,n)}renderTopNav(e,t,n){return Ec(e,t,n)}};function Ul(e){switch(e){case`topStretch`:return`top-stretch`;case`topStart`:return`top-start`;case`topCenter`:return`top-center`;case`topEnd`:return`top-end`;case`middle`:return`middle`;case`bottomStart`:return`bottom-start`;case`bottomEnd`:return`bottom-end`;case`bottomStretch`:return`bottom-stretch`;case`bottomCenter`:return`bottom-center`}return`bottom-end`}function Wl(e,t){if(e.onAction)return{label:e.actionLabel??`Retry`,run:e.onAction};if(e.undoActionId)return{label:e.undoLabel??`Undo`,run:()=>t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.undoActionId,parameters:e.undoParameters??{}},bubbles:!0,composed:!0}))}}function Gl(e,t){let n=new r;n.position=Ul(e.position),n.duration=e.duration??1e4,e.variant&&n.setAttribute(`theme`,e.variant),n.renderer=r=>{if(r.firstElementChild)return;let i=document.createElement(`span`);i.textContent=e.text;let a=Wl(e,t),o=document.createElement(`button`);o.textContent=a.label,o.style.cssText=`margin-left: 0.75rem; background: none; border: 1px solid currentColor; border-radius: var(--lumo-border-radius-s, 4px); color: inherit; cursor: pointer; padding: 0.15rem 0.6rem; font: inherit; font-weight: 600;`,o.addEventListener(`click`,()=>{a.run(),n.opened=!1}),r.append(i,o)},document.body.appendChild(n),n.opened=!0,n.addEventListener(`opened-changed`,e=>{e.detail.value||n.remove()})}N.set(new Hl),ma({show(e,t){if(Qe(e.text,{politeness:e.variant===`error`?`assertive`:`polite`}),e.undoActionId||e.onAction){Gl(e,t);return}r.show(e.text,{position:e.position?Ul(e.position):`bottom-end`,theme:e.variant,duration:e.duration})}});

--- a/demo/sites/vaadin/assets/mateu-vaadin.js
+++ b/demo/sites/vaadin/assets/mateu-vaadin.js
@@ -933,7 +933,7 @@ ${i}
             opacity: 0.4;
             cursor: default;
         }
-    `}};O([v()],Ht.prototype,`columns`,void 0),O([v()],Ht.prototype,`scope`,void 0),O([S()],Ht.prototype,`panelOpened`,void 0),O([S()],Ht.prototype,`revision`,void 0),Ht=O([h(`mateu-column-chooser`)],Ht);function Ut(e,t){return t?t.split(`.`).reduce((e,t)=>typeof e==`object`&&e?e[t]:void 0,e):e}function Wt(e,t,n=`value`,r=`label`){let i=Ut(e,t);return Array.isArray(i)?i.map(e=>{if(typeof e==`object`&&e){let t=Ut(e,n),i=Ut(e,r);return{value:t??i,label:String(i??t??``)}}return{value:e,label:String(e)}}):[]}function Gt(e,t,n){let r=Ut(e,t);return Array.isArray(r)?r.map(e=>{let t={};for(let r of n)t[r]=Ut(e,r);return t}):[]}async function Kt(e,t=e=>e,n=fetch){let r=t(e.url)??e.url,i=(e.method||`GET`).toUpperCase(),a={};for(let[n,r]of Object.entries(e.headers??{}))a[n]=t(r)??r;let o={method:i,headers:a};i!==`GET`&&i!==`HEAD`&&e.body&&(o.body=t(e.body)??e.body);let s=await n(r,o);if(!s.ok)throw Error(`External REST fetch failed: ${s.status}`);return s.json()}async function qt(e,t=e=>e,n=fetch){return Wt(await Kt(e,t,n),e.itemsPath,e.valuePath,e.labelPath)}async function Jt(e,t,n=e=>e,r=fetch){return Gt(await Kt(e,n,r),e.itemsPath,t)}var Yt=class extends y{constructor(...e){super(...e),this.totalElements=0,this.pageSize=100,this.pageNumber=0,this.totalPages=0}updated(e){super.updated(e),(e.has(`totalElements`)||e.has(`pageSize`))&&(this.totalPages=Math.ceil(this.totalElements/this.pageSize))}dispatch(e){this.dispatchEvent(new CustomEvent(`page-changed`,{bubbles:!0,composed:!0,detail:{page:e}}))}render(){if(!this.totalElements)return _;let e=this.totalPages>1,t=this.pageNumber,n=t===0,r=t>=this.totalPages-1;return w`
+    `}};O([v()],Ht.prototype,`columns`,void 0),O([v()],Ht.prototype,`scope`,void 0),O([S()],Ht.prototype,`panelOpened`,void 0),O([S()],Ht.prototype,`revision`,void 0),Ht=O([h(`mateu-column-chooser`)],Ht);var Ut;async function Wt(e){if(!Ut)return{};try{return await Ut(e)??{}}catch(e){return console.warn(`mateu: external auth provider failed`,e),{}}}function Gt(e,t){return t?t.split(`.`).reduce((e,t)=>typeof e==`object`&&e?e[t]:void 0,e):e}function Kt(e,t,n=`value`,r=`label`){let i=Gt(e,t);return Array.isArray(i)?i.map(e=>{if(typeof e==`object`&&e){let t=Gt(e,n),i=Gt(e,r);return{value:t??i,label:String(i??t??``)}}return{value:e,label:String(e)}}):[]}function qt(e,t,n){let r=Gt(e,t);return Array.isArray(r)?r.map(e=>{let t={};for(let r of n)t[r]=Gt(e,r);return t}):[]}async function Jt(e,t=e=>e,n=fetch){let r=t(e.url)??e.url,i=(e.method||`GET`).toUpperCase(),a={};for(let[n,r]of Object.entries(e.headers??{}))a[n]=t(r)??r;Object.assign(a,await Wt({url:r,method:i}));let o={method:i,headers:a};i!==`GET`&&i!==`HEAD`&&e.body&&(o.body=t(e.body)??e.body);let s=await n(r,o);if(!s.ok)throw Error(`External REST fetch failed: ${s.status}`);return s.json()}async function Yt(e,t=e=>e,n=fetch){return Kt(await Jt(e,t,n),e.itemsPath,e.valuePath,e.labelPath)}async function Xt(e,t,n=e=>e,r=fetch){return qt(await Jt(e,n,r),e.itemsPath,t)}var Zt=class extends y{constructor(...e){super(...e),this.totalElements=0,this.pageSize=100,this.pageNumber=0,this.totalPages=0}updated(e){super.updated(e),(e.has(`totalElements`)||e.has(`pageSize`))&&(this.totalPages=Math.ceil(this.totalElements/this.pageSize))}dispatch(e){this.dispatchEvent(new CustomEvent(`page-changed`,{bubbles:!0,composed:!0,detail:{page:e}}))}render(){if(!this.totalElements)return _;let e=this.totalPages>1,t=this.pageNumber,n=t===0,r=t>=this.totalPages-1;return w`
             <div class="bar">
                 ${e?w`
                     <button class="nav" title="First page" ?disabled="${n}"
@@ -997,34 +997,34 @@ ${i}
             align-self: center;
             margin: 0 4px;
         }
-    `}};O([v()],Yt.prototype,`totalElements`,void 0),O([v()],Yt.prototype,`pageSize`,void 0),O([v()],Yt.prototype,`pageNumber`,void 0),O([S()],Yt.prototype,`totalPages`,void 0),Yt=O([h(`mateu-pagination`)],Yt);var Xt=`var(--lumo-space-m, 1rem)`,Zt=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.columnWidth||`13rem`,l=`display: grid; grid-template-columns: ${s.maxColumns&&s.maxColumns>0?`repeat(${s.maxColumns}, minmax(0, 1fr))`:`repeat(auto-fill, minmax(min(100%, ${c}), 1fr))`}; gap: ${Xt} var(--lumo-space-l, 1.5rem); align-items: start;`;return s.labelsAside&&(l+=` --mateu-label-width: 10rem;`),s.fullWidth&&(l+=` width: 100%;`),l+=t.style??``,w`
+    `}};O([v()],Zt.prototype,`totalElements`,void 0),O([v()],Zt.prototype,`pageSize`,void 0),O([v()],Zt.prototype,`pageNumber`,void 0),O([S()],Zt.prototype,`totalPages`,void 0),Zt=O([h(`mateu-pagination`)],Zt);var Qt=`var(--lumo-space-m, 1rem)`,$t=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.columnWidth||`13rem`,l=`display: grid; grid-template-columns: ${s.maxColumns&&s.maxColumns>0?`repeat(${s.maxColumns}, minmax(0, 1fr))`:`repeat(auto-fill, minmax(min(100%, ${c}), 1fr))`}; gap: ${Qt} var(--lumo-space-l, 1.5rem); align-items: start;`;return s.labelsAside&&(l+=` --mateu-label-width: 10rem;`),s.fullWidth&&(l+=` width: 100%;`),l+=t.style??``,w`
         <div style="${l}" class="${t.cssClasses}" slot="${t.slot||_}">
-            ${t.children?.map(t=>Qt(s,e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>en(s,e,t,n,r,i,a,o))}
         </div>
-    `},Qt=(e,t,n,r,i,a,o,s)=>n.type==k.ClientSide&&n.metadata?.type==A.FormRow?tn(e,t,n,r,i,a,o,s):w`<div style="grid-column: span ${$t(n)}; min-width: 0;">${e.labelsAside?en(t,n,r,i,a,o,s):P(t,n,r,i,a,o,s)}</div>`,$t=e=>{if(e.type==k.ClientSide){let t=e.metadata;if(t?.type==A.FormField)return t.colspan||1}return 1},en=(e,t,n,r,i,a,o)=>{if(t.type==k.ClientSide&&t.metadata?.type==A.FormField&&t.metadata.label){let s=t.metadata;return w`
-            <div style="display: flex; gap: ${Xt}; align-items: baseline;">
+    `},en=(e,t,n,r,i,a,o,s)=>n.type==k.ClientSide&&n.metadata?.type==A.FormRow?rn(e,t,n,r,i,a,o,s):w`<div style="grid-column: span ${tn(n)}; min-width: 0;">${e.labelsAside?nn(t,n,r,i,a,o,s):P(t,n,r,i,a,o,s)}</div>`,tn=e=>{if(e.type==k.ClientSide){let t=e.metadata;if(t?.type==A.FormField)return t.colspan||1}return 1},nn=(e,t,n,r,i,a,o)=>{if(t.type==k.ClientSide&&t.metadata?.type==A.FormField&&t.metadata.label){let s=t.metadata;return w`
+            <div style="display: flex; gap: ${Qt}; align-items: baseline;">
                 <label style="flex: 0 0 var(--mateu-label-width, 10rem); color: var(--lumo-secondary-text-color, #667);">${s.label?.includes("${")?e._evalTemplate(s.label):s.label}</label>
                 <div style="flex: 1; min-width: 0;">${P(e,t,n,r,i,a,o,!0)}</div>
             </div>
-        `}return P(e,t,n,r,i,a,o)},tn=(e,t,n,r,i,a,o,s)=>w`
-        <div style="grid-column: 1 / -1; display: flex; gap: ${Xt}; flex-wrap: wrap;">
-            ${n.children?.map(c=>w`<div style="flex: 1 1 ${100/Math.max(1,n.children.length)}%; min-width: min(100%, 13rem);">${Qt(e,t,c,r,i,a,o,s)}</div>`)}
+        `}return P(e,t,n,r,i,a,o)},rn=(e,t,n,r,i,a,o,s)=>w`
+        <div style="grid-column: 1 / -1; display: flex; gap: ${Qt}; flex-wrap: wrap;">
+            ${n.children?.map(c=>w`<div style="flex: 1 1 ${100/Math.max(1,n.children.length)}%; min-width: min(100%, 13rem);">${en(e,t,c,r,i,a,o,s)}</div>`)}
         </div>
-    `,nn=(e,t,n,r,i,a,o,s)=>{let c=n.metadata,l=`display: flex; flex-direction: ${e};`;c.spacing&&(l+=` gap: ${Xt};`),c.padding&&(l+=` padding: var(--lumo-space-m, 1rem);`),c.wrap&&(l+=` flex-wrap: wrap;`),c.fullWidth&&(l+=` width: 100%;`),c.justification&&(l+=` justify-content: ${c.justification};`);let u=e===`row`?c.verticalAlignment:c.horizontalAlignment;return u&&(l+=` align-items: ${u};`),l+=n.style??``,w`
+    `,an=(e,t,n,r,i,a,o,s)=>{let c=n.metadata,l=`display: flex; flex-direction: ${e};`;c.spacing&&(l+=` gap: ${Qt};`),c.padding&&(l+=` padding: var(--lumo-space-m, 1rem);`),c.wrap&&(l+=` flex-wrap: wrap;`),c.fullWidth&&(l+=` width: 100%;`),c.justification&&(l+=` justify-content: ${c.justification};`);let u=e===`row`?c.verticalAlignment:c.horizontalAlignment;return u&&(l+=` align-items: ${u};`),l+=n.style??``,w`
         <div style="${l}" class="${n.cssClasses}" slot="${n.slot??_}">
             ${n.children?.map(e=>P(t,e,r,i,a,o,s))}
         </div>
-    `},rn=(e,t,n,r,i,a,o)=>nn(`row`,e,t,n,r,i,a,o),an=(e,t,n,r,i,a,o)=>nn(`column`,e,t,n,r,i,a,o),on=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=`display: flex; flex-direction: ${s.orientation===`vertical`?`column`:`row`}; gap: var(--lumo-space-s, 0.5rem);`;return s.fullWidth&&(c+=` width: 100%;`),c+=t.style??``,w`
+    `},on=(e,t,n,r,i,a,o)=>an(`row`,e,t,n,r,i,a,o),sn=(e,t,n,r,i,a,o)=>an(`column`,e,t,n,r,i,a,o),cn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=`display: flex; flex-direction: ${s.orientation===`vertical`?`column`:`row`}; gap: var(--lumo-space-s, 0.5rem);`;return s.fullWidth&&(c+=` width: 100%;`),c+=t.style??``,w`
         <div style="${c}" class="${t.cssClasses}" slot="${t.slot??_}">
             <div style="flex: 1; min-width: 0; min-height: 0;">${P(e,t.children[0],n,r,i,a,o)}</div>
             <div style="flex: 1; min-width: 0; min-height: 0;">${P(e,t.children[1],n,r,i,a,o)}</div>
         </div>
-    `},sn=(e,t,n,r,i,a,o)=>{let s=t.children&&t.children.length>1?t.children[1]:null,c=i?.detailComponent??null,l=!!i?.hasDetail||!!s,u=c??s;return w`
+    `},ln=(e,t,n,r,i,a,o)=>{let s=t.children&&t.children.length>1?t.children[1]:null,c=i?.detailComponent??null,l=!!i?.hasDetail||!!s,u=c??s;return w`
         <div style="display: flex; gap: var(--lumo-space-m, 1rem); ${t.style??``}" class="${t.cssClasses}" slot="${t.slot??_}">
             <div style="flex: 1; min-width: 0;">${P(e,t.children[0],n,r,i,a,o)}</div>
             ${l&&u?w`<div style="flex: 1; min-width: 0;">${P(e,u,n,r,i,a,o)}</div>`:w`<div style="flex: 1; display: flex; align-items: center; justify-content: center; color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-s, .875rem);">Select an item to view details</div>`}
         </div>
-    `},cn=(e,t,n,r,i,a,o)=>{let s=t.style??``;t.metadata.fullWidth&&(s+=` width: 100%;`);let c=Math.max(0,(t.children??[]).findIndex(e=>e.metadata.active));return w`
+    `},un=(e,t,n,r,i,a,o)=>{let s=t.style??``;t.metadata.fullWidth&&(s+=` width: 100%;`);let c=Math.max(0,(t.children??[]).findIndex(e=>e.metadata.active));return w`
         <div style="${s}" class="${t.cssClasses}" slot="${t.slot??_}">
             ${t.children?.map((t,s)=>{let l=t,u=l.metadata.label,d=u?.includes("${")?e._evalTemplate(u):u;return w`
                     <details ?open="${s===c}" style="border-bottom: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));">
@@ -1035,42 +1035,42 @@ ${i}
                     </details>
                 `})}
         </div>
-    `},ln=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style??``;return s.fullWidth&&(c+=` width: 100%;`),w`
+    `},dn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style??``;return s.fullWidth&&(c+=` width: 100%;`),w`
         <div style="${c}" class="${t.cssClasses}" slot="${t.slot??_}">
-            ${t.children?.map(t=>un(e,t,n,r,i,a,o,s.variant))}
+            ${t.children?.map(t=>fn(e,t,n,r,i,a,o,s.variant))}
         </div>
-    `},un=(e,t,n,r,i,a,o,s)=>{let c=t.metadata,l=c.label?.includes("${")?e._evalTemplate(c.label):c.label;return w`
+    `},fn=(e,t,n,r,i,a,o,s)=>{let c=t.metadata,l=c.label?.includes("${")?e._evalTemplate(c.label):c.label;return w`
         <details ?open="${c.active}" style="border-bottom: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1)); ${t.style??``}" class="${t.cssClasses}">
             <summary style="cursor: pointer; padding: var(--lumo-space-s, .5rem) 0; font-weight: 600; ${c.disabled?`pointer-events: none; opacity: .5;`:``}">${l}</summary>
             <div style="padding: var(--lumo-space-s, .5rem) 0;">
                 ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
             </div>
         </details>
-    `},dn=(e,t,n,r,i,a,o)=>w`
+    `},pn=(e,t,n,r,i,a,o)=>w`
         <div style="overflow: auto; ${t.style??``}" class="${t.cssClasses}" slot="${t.slot??_}">
             ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `,fn=(e,t,n,r,i,a,o)=>w`
+    `,mn=(e,t,n,r,i,a,o)=>w`
         <div style="width: 100%; ${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
             ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `,pn=(e,t,n,r,i,a,o)=>w`
+    `,hn=(e,t,n,r,i,a,o)=>w`
         <div style="max-width: min(100%, 1200px); margin: auto; ${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
             ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `,mn=(e,t,n,r,i,a,o)=>w`
-        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr)); gap: ${Xt}; ${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
-            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
-        </div>
-    `,hn=(e,t,n,r,i,a,o)=>w`
-        <div style="display: flex; gap: ${Xt}; flex-wrap: wrap; ${t.style}" class="${t.cssClasses}">
-            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
-        </div>
     `,gn=(e,t,n,r,i,a,o)=>w`
+        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr)); gap: ${Qt}; ${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
+        </div>
+    `,_n=(e,t,n,r,i,a,o)=>w`
+        <div style="display: flex; gap: ${Qt}; flex-wrap: wrap; ${t.style}" class="${t.cssClasses}">
+            ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
+        </div>
+    `,vn=(e,t,n,r,i,a,o)=>w`
         <div style="flex: ${t.metadata.boardCols??1} 1 0; min-width: min(100%, 12rem); ${t.style}" class="${t.cssClasses}">
             ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `,_n=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+    `,yn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <div
                 style="display: flex; flex-direction: column; overflow: auto; ${t.style}"
                 class="${t.cssClasses}"
@@ -1078,16 +1078,16 @@ ${i}
         >
             ${s.page.content.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `},vn=e=>{let t=e.metadata;return(t?.content??t?.columns??[]).filter(e=>e&&e.metadata).map(e=>{let t=e.metadata;return{id:e.id??``,label:t?.label??e.id??``,autoWidth:t?.autoWidth,width:t?.width}})},yn=(e,t)=>{let n=e?.[t];return n==null?``:typeof n==`object`?n.text??n.label??n.value??``:String(n)},bn=(e,t,n)=>{let r=vn(e);return w`
+    `},bn=e=>{let t=e.metadata;return(t?.content??t?.columns??[]).filter(e=>e&&e.metadata).map(e=>{let t=e.metadata;return{id:e.id??``,label:t?.label??e.id??``,autoWidth:t?.autoWidth,width:t?.width}})},xn=(e,t)=>{let n=e?.[t];return n==null?``:typeof n==`object`?n.text??n.label??n.value??``:String(n)},Sn=(e,t,n)=>{let r=bn(e);return w`
         <div style="overflow:auto; width:100%; ${e.style}" class="${e.cssClasses}" slot="${e.slot??_}">
             <table style="border-collapse:collapse; width:100%; font-size: var(--lumo-font-size-s,.875rem);">
                 <thead><tr>${r.map(e=>w`<th style="${`text-align:left; padding:.45rem .6rem; border-bottom:2px solid var(--lumo-contrast-20pct,rgba(0,0,0,.2)); font-weight:600; white-space:nowrap; color: var(--lumo-secondary-text-color,#556);`}">${e.label}</th>`)}</tr></thead>
                 <tbody>
-                    ${(t??[]).length===0?w`<tr><td colspan="${Math.max(1,r.length)}" style="padding:1.5rem; text-align:center; color: var(--lumo-secondary-text-color,#888);">${n??`No data.`}</td></tr>`:t.map(e=>w`<tr>${r.map(t=>w`<td style="${`padding:.4rem .6rem; border-bottom:1px solid var(--lumo-contrast-10pct,rgba(0,0,0,.08)); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:24rem;`}" title="${yn(e,t.id)}">${yn(e,t.id)}</td>`)}</tr>`)}
+                    ${(t??[]).length===0?w`<tr><td colspan="${Math.max(1,r.length)}" style="padding:1.5rem; text-align:center; color: var(--lumo-secondary-text-color,#888);">${n??`No data.`}</td></tr>`:t.map(e=>w`<tr>${r.map(t=>w`<td style="${`padding:.4rem .6rem; border-bottom:1px solid var(--lumo-contrast-10pct,rgba(0,0,0,.08)); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:24rem;`}" title="${xn(e,t.id)}">${xn(e,t.id)}</td>`)}</tr>`)}
                 </tbody>
             </table>
         </div>
-    `},xn=(e,t)=>{let n=e.metadata;return e.id&&t&&t[e.id]?t[e.id]:n?.page?.content??[]},Sn=e=>{let t=e.metadata.items??[];return w`
+    `},Cn=(e,t)=>{let n=e.metadata;return e.id&&t&&t[e.id]?t[e.id]:n?.page?.content??[]},wn=e=>{let t=e.metadata.items??[];return w`
         <div class="mateu-message-list ${e.cssClasses??``}"
              style="display:flex; flex-direction:column; gap:.75rem; ${e.style??``}"
              slot="${e.slot??_}">
@@ -1106,7 +1106,7 @@ ${i}
                 </div>
             `)}
         </div>
-    `},Cn=(e,t,n,r,i,a,o)=>t.separator?w`<span style="align-self: stretch; width: 1px; background: var(--lumo-contrast-20pct, rgba(0,0,0,.2));"></span>`:t.submenus?w`
+    `},Tn=(e,t,n,r,i,a,o)=>t.separator?w`<span style="align-self: stretch; width: 1px; background: var(--lumo-contrast-20pct, rgba(0,0,0,.2));"></span>`:t.submenus?w`
             <details style="position: relative;">
                 <summary style="cursor: pointer; list-style: none; padding: .35rem .7rem; border-radius: var(--lumo-border-radius-m, 6px);">
                     ${t.component?P(e,t.component,n,r,i,a,o):t.label} ▾
@@ -1114,7 +1114,7 @@ ${i}
                 <div style="display: flex; flex-direction: column; gap: .1rem; padding: .3rem; min-width: 10rem;
                             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1)); border-radius: var(--lumo-border-radius-m, 6px);
                             background: var(--lumo-base-color, #fff); box-shadow: var(--lumo-box-shadow-s, 0 2px 8px rgba(0,0,0,.15));">
-                    ${t.submenus.map(t=>Cn(e,t,n,r,i,a,o))}
+                    ${t.submenus.map(t=>Tn(e,t,n,r,i,a,o))}
                 </div>
             </details>
         `:w`
@@ -1124,16 +1124,16 @@ ${i}
                      ${t.selected?`background: var(--lumo-primary-color-10pct, rgba(26,115,232,.12));`:``}">
             ${t.component?P(e,t.component,n,r,i,a,o):t.label}
         </span>
-    `,wn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+    `,En=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <div style="display: flex; flex-wrap: wrap; gap: .25rem; align-items: center; ${t.style}"
              class="${t.cssClasses}" slot="${t.slot??_}">
-            ${s.options?.map(t=>Cn(e,t,n,r,i,a??{},o??{}))}
+            ${s.options?.map(t=>Tn(e,t,n,r,i,a??{},o??{}))}
         </div>
-    `},Tn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+    `},Dn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <div style="${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
             ${P(e,s.wrapped,n,r,i,a,o)}
         </div>
-    `},En=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.content?.metadata,l=c?.type==A.Notice&&c.fullWidth===!0;return w`
+    `},On=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.content?.metadata,l=c?.type==A.Notice&&c.fullWidth===!0;return w`
         <div style="display:flex; flex-direction:column; ${l?`width: 100%; `:``}${t.style}"
              class="${t.cssClasses}"
              slot="${t.slot??_}"
@@ -1142,7 +1142,7 @@ ${i}
             ${s.label?w`<label style="font-size: var(--lumo-font-size-s,.875rem); color: var(--lumo-secondary-text-color,#667); margin-bottom:.15rem;">${s.label}</label>`:_}
             ${P(e,s.content,n,r,i,a,o)}
         </div>
-            `},Dn=e=>{let t=e.metadata,n=e=>{let n=e.closest(`.mateu-message-input`)?.querySelector(`input`),r=n?.value??``;!t.actionId||!r.trim()||(e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:{message:r}},bubbles:!0,composed:!0})),n&&(n.value=``))};return w`
+            `},kn=e=>{let t=e.metadata,n=e=>{let n=e.closest(`.mateu-message-input`)?.querySelector(`input`),r=n?.value??``;!t.actionId||!r.trim()||(e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:{message:r}},bubbles:!0,composed:!0})),n&&(n.value=``))};return w`
         <div class="mateu-message-input ${e.cssClasses??``}"
              style="display:flex; gap:.5rem; align-items:center; ${e.style??``}"
              slot="${e.slot??_}">
@@ -1152,62 +1152,62 @@ ${i}
             <button style="font:inherit; font-weight:500; cursor:pointer; padding:.5rem 1rem; border:none; border-radius:var(--lumo-border-radius-m,6px); background:var(--lumo-primary-color,#3b5bdb); color:var(--lumo-primary-contrast-color,#fff);"
                     @click="${e=>n(e.currentTarget)}">Send</button>
         </div>
-    `},On=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`<span title="${s.text}" style="${t.style}" class="${t.cssClasses}" slot="${t.slot??_}"
-        >${P(e,s.wrapped,n,r,i,a,o)}</span>`},kn=e=>{if(e instanceof CustomEvent)return e.detail;let t={};for(let n in e){let r=e[n];[`number`,`string`,`boolean`].indexOf(typeof r)>=0&&(t[n]=e[n])}return t},An=(e,t,n)=>{for(let n in t.attributes)e.setAttribute(n,t.attributes[n]);n.style&&e.setAttribute(`style`,n.style),n.cssClasses&&e.setAttribute(`class`,n.cssClasses),n.slot&&e.setAttribute(`slot`,n.slot),t.content&&(t.html?e.innerHTML=t.content:e.append(t.content))},jn=e=>{let t=e.name,n=e.attributes?e.attributes.import:void 0;n&&t.includes(`-`)&&!customElements.get(t)&&E(()=>import(n),[])},Mn=(e,t,n)=>{jn(t);let r=t.name;return t.attributes&&t.attributes.id&&(r=`#`+t.attributes.id),setTimeout(()=>{let i=e.shadowRoot?.querySelector(`.element-container`)?.querySelector(r);if(i){for(;i.firstChild;)i.removeChild(i.lastChild);An(i,t,n)}else{let r=document.createElement(t.name);An(r,t,n);for(let n in t.on)r.addEventListener(n,r=>{let i=kn(r);e.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.on[n],parameters:{event:i}},bubbles:!0,composed:!0}))});e.shadowRoot?.querySelector(`.element-container`)?.appendChild(r)}}),w`<div class="element-container"></div>`},Nn=function(e){return e.div=`div`,e.p=`p`,e.h1=`h1`,e.h2=`h2`,e.h3=`h3`,e.h4=`h4`,e.h5=`h5`,e.h6=`h6`,e.span=`span`,e}({}),Pn=(e,t,n,r,i)=>{let a=e.metadata,o=a.attributes?.[`data-colspan`],s=it(a.text,t,n,r,i),c={xl:`var(--lumo-font-size-xl, 1.375rem)`,l:`var(--lumo-font-size-l, 1.125rem)`,s:`var(--lumo-font-size-s, .875rem)`,xs:`var(--lumo-font-size-xs, .8125rem)`},l=(a.size&&c[a.size]?`font-size: ${c[a.size]}; `:``)+(a.noMargins?`margin-block-start: 0; margin-block-end: 0; `:``);return Nn.h1==a.container?w`
+    `},An=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`<span title="${s.text}" style="${t.style}" class="${t.cssClasses}" slot="${t.slot??_}"
+        >${P(e,s.wrapped,n,r,i,a,o)}</span>`},jn=e=>{if(e instanceof CustomEvent)return e.detail;let t={};for(let n in e){let r=e[n];[`number`,`string`,`boolean`].indexOf(typeof r)>=0&&(t[n]=e[n])}return t},Mn=(e,t,n)=>{for(let n in t.attributes)e.setAttribute(n,t.attributes[n]);n.style&&e.setAttribute(`style`,n.style),n.cssClasses&&e.setAttribute(`class`,n.cssClasses),n.slot&&e.setAttribute(`slot`,n.slot),t.content&&(t.html?e.innerHTML=t.content:e.append(t.content))},Nn=e=>{let t=e.name,n=e.attributes?e.attributes.import:void 0;n&&t.includes(`-`)&&!customElements.get(t)&&E(()=>import(n),[])},Pn=(e,t,n)=>{Nn(t);let r=t.name;return t.attributes&&t.attributes.id&&(r=`#`+t.attributes.id),setTimeout(()=>{let i=e.shadowRoot?.querySelector(`.element-container`)?.querySelector(r);if(i){for(;i.firstChild;)i.removeChild(i.lastChild);Mn(i,t,n)}else{let r=document.createElement(t.name);Mn(r,t,n);for(let n in t.on)r.addEventListener(n,r=>{let i=jn(r);e.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.on[n],parameters:{event:i}},bubbles:!0,composed:!0}))});e.shadowRoot?.querySelector(`.element-container`)?.appendChild(r)}}),w`<div class="element-container"></div>`},Fn=function(e){return e.div=`div`,e.p=`p`,e.h1=`h1`,e.h2=`h2`,e.h3=`h3`,e.h4=`h4`,e.h5=`h5`,e.h6=`h6`,e.span=`span`,e}({}),In=(e,t,n,r,i)=>{let a=e.metadata,o=a.attributes?.[`data-colspan`],s=it(a.text,t,n,r,i),c={xl:`var(--lumo-font-size-xl, 1.375rem)`,l:`var(--lumo-font-size-l, 1.125rem)`,s:`var(--lumo-font-size-s, .875rem)`,xs:`var(--lumo-font-size-xs, .8125rem)`},l=(a.size&&c[a.size]?`font-size: ${c[a.size]}; `:``)+(a.noMargins?`margin-block-start: 0; margin-block-end: 0; `:``);return Fn.h1==a.container?w`
             <h1 style="${l}${e.style}" class="${e.cssClasses}"
                 id="${x(e.id)}"
                 data-colspan="${x(o)}"
                 slot="${e.slot??_}">
                 ${s??_}
             </h1>
-        `:Nn.h2==a.container?w`
+        `:Fn.h2==a.container?w`
             <h2 style="${l}${e.style}" class="${e.cssClasses}"
                 id="${x(e.id)}"
                 data-colspan="${x(o)}"
                 slot="${e.slot??_}">
                 ${s??_}
             </h2>
-        `:Nn.h3==a.container?w`
+        `:Fn.h3==a.container?w`
             <h3 style="${l}${e.style}" class="${e.cssClasses}"
                 id="${x(e.id)}"
                 data-colspan="${x(o)}"
                 slot="${e.slot??_}">
                 ${s??_}
             </h3>
-        `:Nn.h4==a.container?w`
+        `:Fn.h4==a.container?w`
             <h4 style="${l}${e.style}" class="${e.cssClasses}"
                 id="${x(e.id)}"
                 data-colspan="${x(o)}"
                 slot="${e.slot??_}">
                 ${s??_}
             </h4>
-        `:Nn.h5==a.container?w`
+        `:Fn.h5==a.container?w`
             <h5 style="${l}${e.style}" class="${e.cssClasses}"
                 id="${x(e.id)}"
                 data-colspan="${x(o)}"
                 slot="${e.slot??_}">
                 ${s??_}
             </h5>
-        `:Nn.h6==a.container?w`
+        `:Fn.h6==a.container?w`
             <h6 style="${l}${e.style}" class="${e.cssClasses}"
                 id="${x(e.id)}"
                 data-colspan="${x(o)}"
                 slot="${e.slot??_}">
                 ${s??_}
             </h6>
-        `:Nn.p==a.container?w`
+        `:Fn.p==a.container?w`
                <p style="${l}${e.style}" class="${e.cssClasses}"
                   id="${x(e.id)}"
                   data-colspan="${x(o)}"
                   slot="${e.slot??_}">
                    ${s??_}
                </p>
-            `:Nn.div==a.container?w`
+            `:Fn.div==a.container?w`
                <div style="${l}${e.style}" class="${e.cssClasses}"
                     id="${x(e.id)}"
                     data-colspan="${x(o)}"
                     slot="${e.slot??_}">${s?g(s):_}</div>
-            `:Nn.span==a.container?w`
+            `:Fn.span==a.container?w`
                <span style="${l}${e.style}" class="${e.cssClasses}"
                      id="${x(e.id)}"
                      data-colspan="${x(o)}"
@@ -1219,20 +1219,20 @@ ${i}
                        slot="${e.slot??_}">
                    Unknown text container: ${a.container} 
                </p>
-            `},Fn=e=>{let t=e.metadata;return w`<a href="${t.url}" target="${t.target??_}"
+            `},Ln=e=>{let t=e.metadata;return w`<a href="${t.url}" target="${t.target??_}"
                    rel="${t.target===`_blank`?`noopener`:_}"
                    style="${e.style}" class="${e.cssClasses}"
-                   slot="${e.slot??_}">${t.text}</a>`},In=(e,t)=>{let n=e.toLowerCase().split(`+`);return t.ctrlKey===n.includes(`ctrl`)&&t.altKey===n.includes(`alt`)&&t.shiftKey===n.includes(`shift`)&&t.metaKey===n.includes(`meta`)},Ln=(e,t)=>{if(!In(e,t))return!1;let n=e.toLowerCase().split(`+`),r=n[n.length-1];return!!(t.key.toLowerCase()===r||/^[a-z]$/.test(r)&&t.code===`Key`+r.toUpperCase()||/^[0-9]$/.test(r)&&(t.code===`Digit`+r||t.code===`Numpad`+r))},Rn=e=>e?e.split(`+`).map(e=>e.length<=1?e.toUpperCase():e.charAt(0).toUpperCase()+e.slice(1)).join(`+`):void 0,zn=(e,t)=>{let n=e.currentTarget.dataset.actionId;e.currentTarget?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:n,parameters:t.parameters},bubbles:!0,composed:!0}))},Bn=`display:inline-flex; align-items:center; justify-content:center; gap:.4em; box-sizing:border-box; font:inherit; font-weight:500; cursor:pointer; border-radius:var(--lumo-border-radius-m,6px); border:1px solid transparent; line-height:1; white-space:nowrap;`,Vn=e=>{let t=e.buttonStyle??``,n=e.color&&e.color!==`none`&&e.color!==`normal`?e.color:``,r=e.size,i=n===`success`?`var(--lumo-success-color,#1a7f37)`:n===`error`?`var(--lumo-error-color,#c5221f)`:n===`contrast`?`var(--lumo-contrast,#161513)`:`var(--lumo-primary-color,#3b5bdb)`,a=n===`success`?`var(--lumo-success-contrast-color,#fff)`:n===`error`?`var(--lumo-error-contrast-color,#fff)`:n===`contrast`?`var(--lumo-base-color,#fff)`:`var(--lumo-primary-contrast-color,#fff)`,o=n===`success`?`var(--lumo-success-text-color,#1a7f37)`:n===`error`?`var(--lumo-error-text-color,#c5221f)`:n===`contrast`?`var(--lumo-body-text-color,#161513)`:`var(--lumo-primary-text-color,#3b5bdb)`,s;return s=t===`primary`?`background:${i}; color:${a};`:t===`tertiary`||t===`tertiaryInline`?`background:transparent; color:${o};`:`background:var(--lumo-contrast-5pct,rgba(0,0,0,.04)); color:${o}; border-color:var(--lumo-contrast-20pct,rgba(0,0,0,.16));`,`${Bn}${s}${r===`small`?`padding:.25rem .6rem; font-size:var(--lumo-font-size-s,.875rem);`:r===`large`?`padding:.65rem 1.4rem; font-size:var(--lumo-font-size-l,1.125rem);`:`padding:.45rem 1rem; font-size:var(--lumo-font-size-m,1rem);`}`},Hn=(e,t,n)=>{let r=e.metadata,i=j(r.label,t,n);return w`<button
+                   slot="${e.slot??_}">${t.text}</a>`},Rn=(e,t)=>{let n=e.toLowerCase().split(`+`);return t.ctrlKey===n.includes(`ctrl`)&&t.altKey===n.includes(`alt`)&&t.shiftKey===n.includes(`shift`)&&t.metaKey===n.includes(`meta`)},zn=(e,t)=>{if(!Rn(e,t))return!1;let n=e.toLowerCase().split(`+`),r=n[n.length-1];return!!(t.key.toLowerCase()===r||/^[a-z]$/.test(r)&&t.code===`Key`+r.toUpperCase()||/^[0-9]$/.test(r)&&(t.code===`Digit`+r||t.code===`Numpad`+r))},Bn=e=>e?e.split(`+`).map(e=>e.length<=1?e.toUpperCase():e.charAt(0).toUpperCase()+e.slice(1)).join(`+`):void 0,Vn=(e,t)=>{let n=e.currentTarget.dataset.actionId;e.currentTarget?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:n,parameters:t.parameters},bubbles:!0,composed:!0}))},Hn=`display:inline-flex; align-items:center; justify-content:center; gap:.4em; box-sizing:border-box; font:inherit; font-weight:500; cursor:pointer; border-radius:var(--lumo-border-radius-m,6px); border:1px solid transparent; line-height:1; white-space:nowrap;`,Un=e=>{let t=e.buttonStyle??``,n=e.color&&e.color!==`none`&&e.color!==`normal`?e.color:``,r=e.size,i=n===`success`?`var(--lumo-success-color,#1a7f37)`:n===`error`?`var(--lumo-error-color,#c5221f)`:n===`contrast`?`var(--lumo-contrast,#161513)`:`var(--lumo-primary-color,#3b5bdb)`,a=n===`success`?`var(--lumo-success-contrast-color,#fff)`:n===`error`?`var(--lumo-error-contrast-color,#fff)`:n===`contrast`?`var(--lumo-base-color,#fff)`:`var(--lumo-primary-contrast-color,#fff)`,o=n===`success`?`var(--lumo-success-text-color,#1a7f37)`:n===`error`?`var(--lumo-error-text-color,#c5221f)`:n===`contrast`?`var(--lumo-body-text-color,#161513)`:`var(--lumo-primary-text-color,#3b5bdb)`,s;return s=t===`primary`?`background:${i}; color:${a};`:t===`tertiary`||t===`tertiaryInline`?`background:transparent; color:${o};`:`background:var(--lumo-contrast-5pct,rgba(0,0,0,.04)); color:${o}; border-color:var(--lumo-contrast-20pct,rgba(0,0,0,.16));`,`${Hn}${s}${r===`small`?`padding:.25rem .6rem; font-size:var(--lumo-font-size-s,.875rem);`:r===`large`?`padding:.65rem 1.4rem; font-size:var(--lumo-font-size-l,1.125rem);`:`padding:.45rem 1rem; font-size:var(--lumo-font-size-m,1rem);`}`},Wn=(e,t,n)=>{let r=e.metadata,i=j(r.label,t,n);return w`<button
             id="${e.id}"
             data-action-id="${r.actionId}"
-            @click="${e=>zn(e,r)}"
-            style="${Vn(r)}${e.style}"
+            @click="${e=>Vn(e,r)}"
+            style="${Un(r)}${e.style}"
             class="${e.cssClasses}"
             ?disabled="${r.disabled}"
-            title="${r.shortcut?`${i} (${Rn(r.shortcut)})`:_}"
+            title="${r.shortcut?`${i} (${Bn(r.shortcut)})`:_}"
             slot="${e.slot??_}"
-    >${r.iconOnLeft?F(r.iconOnLeft):_}${i}${r.iconOnRight?F(r.iconOnRight):_}</button>`},Un=`display:block; box-sizing:border-box; background:var(--lumo-base-color,#fff); border:1px solid var(--lumo-contrast-10pct,rgba(0,0,0,.1)); border-radius:var(--lumo-border-radius-l,12px); box-shadow:var(--lumo-box-shadow-xs,0 1px 3px rgba(0,0,0,.08)); overflow:hidden;`,Wn=(e,t,n,r,i,a,o)=>{let s=t.metadata;if(!s)return w``;let c=t=>t?P(e,t,n,r,i,a,o,!1):_,l=s.header||s.headerPrefix||s.headerSuffix||s.title||s.subtitle;return w`
-        <div style="${Un}${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
+    >${r.iconOnLeft?F(r.iconOnLeft):_}${i}${r.iconOnRight?F(r.iconOnRight):_}</button>`},Gn=`display:block; box-sizing:border-box; background:var(--lumo-base-color,#fff); border:1px solid var(--lumo-contrast-10pct,rgba(0,0,0,.1)); border-radius:var(--lumo-border-radius-l,12px); box-shadow:var(--lumo-box-shadow-xs,0 1px 3px rgba(0,0,0,.08)); overflow:hidden;`,Kn=(e,t,n,r,i,a,o)=>{let s=t.metadata;if(!s)return w``;let c=t=>t?P(e,t,n,r,i,a,o,!1):_,l=s.header||s.headerPrefix||s.headerSuffix||s.title||s.subtitle;return w`
+        <div style="${Gn}${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
             ${s.media?c(s.media):_}
             ${l?w`<div style="display:flex; align-items:flex-start; gap:.75rem; padding:1rem 1.25rem ${s.content||s.footer?`0`:`1rem`};">
                 ${s.headerPrefix?c(s.headerPrefix):_}
@@ -1246,7 +1246,7 @@ ${i}
             ${s.content?w`<div style="padding:1rem 1.25rem;">${c(s.content)}</div>`:_}
             ${s.footer?w`<div style="padding:0 1.25rem 1rem;">${c(s.footer)}</div>`:_}
         </div>
-    `},Gn=e=>{let t=e.metadata;return w`
+    `},qn=e=>{let t=e.metadata;return w`
         <mateu-chart 
                 style="${e.style}" 
                 class="${e.cssClasses}"
@@ -1256,7 +1256,7 @@ ${i}
                 .options="${t.chartOptions}"
         >
         </mateu-chart>
-    `},Kn=e=>{let t=e.metadata;return F(t.icon,e.style,e.cssClasses,e.slot)},qn=(e,t)=>{e&&e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},Jn=`font:inherit; font-weight:500; cursor:pointer; padding:.45rem 1rem; border-radius:var(--lumo-border-radius-m,6px);`,Yn=`${Jn} background:var(--lumo-contrast-5pct,rgba(0,0,0,.04)); color:var(--lumo-body-text-color,#161513); border:1px solid var(--lumo-contrast-20pct,rgba(0,0,0,.16));`,Xn=`${Jn} background:var(--lumo-primary-color,#3b5bdb); color:var(--lumo-primary-contrast-color,#fff); border:1px solid transparent;`,Zn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!1;if(s.openedCondition)try{c=at(s.openedCondition,r,i,a,o)}catch(e){console.error(`when evaluating `+s.openedCondition+` :`+e+`, where data is `+i+` and state is `+r)}return c?w`
+    `},Jn=e=>{let t=e.metadata;return F(t.icon,e.style,e.cssClasses,e.slot)},Yn=(e,t)=>{e&&e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},Xn=`font:inherit; font-weight:500; cursor:pointer; padding:.45rem 1rem; border-radius:var(--lumo-border-radius-m,6px);`,Zn=`${Xn} background:var(--lumo-contrast-5pct,rgba(0,0,0,.04)); color:var(--lumo-body-text-color,#161513); border:1px solid var(--lumo-contrast-20pct,rgba(0,0,0,.16));`,Qn=`${Xn} background:var(--lumo-primary-color,#3b5bdb); color:var(--lumo-primary-contrast-color,#fff); border:1px solid transparent;`,$n=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!1;if(s.openedCondition)try{c=at(s.openedCondition,r,i,a,o)}catch(e){console.error(`when evaluating `+s.openedCondition+` :`+e+`, where data is `+i+` and state is `+r)}return c?w`
         <div class="mateu-confirm-dialog ${t.cssClasses??``}"
              style="position:fixed; inset:0; z-index:1000; display:flex; align-items:center; justify-content:center; background:rgba(0,0,0,.4); ${t.style??``}"
              slot="${t.slot??_}">
@@ -1264,13 +1264,13 @@ ${i}
                 ${s.header?w`<h3 style="margin:0 0 .75rem; font-size:1.15rem;">${s.header}</h3>`:_}
                 <div>${t.children?.map(t=>P(e,t,n,r,i,a,o))}</div>
                 <div style="display:flex; gap:.5rem; justify-content:flex-end; margin-top:1.25rem;">
-                    ${s.canCancel?w`<button style="${Yn}" @click="${e=>qn(e.currentTarget,s.cancelActionId)}">${s.rejectText&&!s.canReject?s.rejectText:`Cancel`}</button>`:_}
-                    ${s.canReject?w`<button style="${Yn}" @click="${e=>qn(e.currentTarget,s.rejectActionId)}">${s.rejectText||`No`}</button>`:_}
-                    <button style="${Xn}" @click="${e=>qn(e.currentTarget,s.confirmActionId)}">${s.confirmText||`OK`}</button>
+                    ${s.canCancel?w`<button style="${Zn}" @click="${e=>Yn(e.currentTarget,s.cancelActionId)}">${s.rejectText&&!s.canReject?s.rejectText:`Cancel`}</button>`:_}
+                    ${s.canReject?w`<button style="${Zn}" @click="${e=>Yn(e.currentTarget,s.rejectActionId)}">${s.rejectText||`No`}</button>`:_}
+                    <button style="${Qn}" @click="${e=>Yn(e.currentTarget,s.confirmActionId)}">${s.confirmText||`OK`}</button>
                 </div>
             </div>
         </div>
-    `:w``},Qn=e=>{let t=e.metadata,n;return t.position&&(n={Top:`top`,Bottom:`bottom`,TopLeft:`top-left`,TopRight:`top-right`,BottomLeft:`bottom-left`,BottomRight:`bottom-right`}[t.position]),w`
+    `:w``},er=e=>{let t=e.metadata,n;return t.position&&(n={Top:`top`,Bottom:`bottom`,TopLeft:`top-left`,TopRight:`top-right`,BottomLeft:`bottom-left`,BottomRight:`bottom-right`}[t.position]),w`
         <mateu-cookie-consent style="${e.style}" class="${e.cssClasses}"
                                slot="${e.slot??_}"
                                position="${n??_}"
@@ -1281,7 +1281,7 @@ ${i}
                                .learnMoreLink="${t.learnMoreLink??_}"
                                .dismiss="${t.dismiss??_}"
         ></mateu-cookie-consent>
-    `},$n=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+    `},tr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <details
                 ?open="${s.opened}"
                 style="${t.style}"
@@ -1291,7 +1291,7 @@ ${i}
             <summary>${P(e,s.summary,n,r,i,a,o)}</summary>
             ${P(e,s.content,n,r,i,a,o)}
         </details>
-            `},er=(e,t,n,r,i,a)=>w`
+            `},nr=(e,t,n,r,i,a)=>w`
         <mateu-dialog
                 id="${e.metadata.id}"
             .component="${e}"
@@ -1301,7 +1301,7 @@ ${i}
             .appState="${i}"
             .appdata="${a}"
         ></mateu-dialog>
-            `,tr=(e,t,n,r,i,a)=>w`
+            `,rr=(e,t,n,r,i,a)=>w`
         <mateu-drawer
                 id="${e.metadata.id}"
             .component="${e}"
@@ -1311,7 +1311,7 @@ ${i}
             .appState="${i}"
             .appdata="${a}"
         ></mateu-drawer>
-            `,nr=e=>{let t=e.metadata;return w`
+            `,ir=e=>{let t=e.metadata;return w`
         <mateu-api-caller>
         <mateu-ux baseUrl="${t.baseUrl}"  
                   route="${t.route}" 
@@ -1323,11 +1323,11 @@ ${i}
                   slot="${e.slot??_}"
         ></mateu-ux>
         </mateu-api-caller>
-            `},rr=e=>w`
+            `},ar=e=>w`
         <mateu-markdown .content=${e.metadata.markdown}
                         style="${e.style}" class="${e.cssClasses}"
                         slot="${e.slot??_}"></mateu-markdown>
-            `,ir=e=>{let t=e.metadata;return w`
+            `,or=e=>{let t=e.metadata;return w`
         <div
             role="status"
             slot="${e.slot??_}"
@@ -1340,7 +1340,7 @@ ${i}
             ${t.title?w`<strong>${t.title}</strong>`:_}
             ${t.text?w`<span>${t.text}</span>`:_}
         </div>
-    `},ar=(e,t={})=>{let n=e.metadata,r=n.valueKey?t[n.valueKey]:n.value,i=n.max&&n.max!=0?n.max:1,a=!n.indeterminate&&r!=null;return w`
+    `},sr=(e,t={})=>{let n=e.metadata,r=n.valueKey?t[n.valueKey]:n.value,i=n.max&&n.max!=0?n.max:1,a=!n.indeterminate&&r!=null;return w`
         <div style="${e.style}" class="${e.cssClasses}" slot="${e.slot??_}">
             <progress
                     style="width:100%;"
@@ -1351,7 +1351,7 @@ ${i}
     ${n.text}
   </span>`:_}
         </div>
-    `},or=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+    `},cr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <details style="position: relative; ${t.style}" class="${t.cssClasses}" slot="${t.slot??_}">
             <summary style="list-style: none; cursor: pointer;">${P(e,s.wrapped,n,r,i,a,o)}</summary>
             <div style="position: absolute; z-index: 100; min-width: 300px; margin-top: .25rem; padding: .6rem .8rem;
@@ -1360,20 +1360,20 @@ ${i}
                 ${P(e,s.content,n,r,i,a,o)}
             </div>
         </details>
-    `},sr=e=>{let t=e.metadata;return w`
+    `},lr=e=>{let t=e.metadata;return w`
         <mateu-map position="${t.position}" zoom="${t.zoom}"
                    style="${e.style}" class="${e.cssClasses}"
                    slot="${e.slot??_}"></mateu-map>
-            `},cr=e=>w`
+            `},ur=e=>w`
         <img src="${e.metadata.src}" style="${e.style}" class="${e.cssClasses}"
              slot="${e.slot??_}">
-            `,lr=e=>{let t=e.metadata;return w`<div style="display:flex; align-items:center; gap:0.5rem;" slot="${e.slot??_}">
+            `,dr=e=>{let t=e.metadata;return w`<div style="display:flex; align-items:center; gap:0.5rem;" slot="${e.slot??_}">
         ${t.breadcrumbs.map(e=>w`
             <a href="${e.link}">${e.text}</a>
             <span>/</span>
         `)}
         <span style="${e.style}" class="${e.cssClasses}">${t.currentItemText}</span>
-    </div>`},ur=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+    </div>`},fr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <skeleton-carousel 
                 id="${t.id}"
                 ?dots = "${s.dots}" 
@@ -1384,26 +1384,26 @@ ${i}
         >
             ${t.children?.map(t=>w`<div>${P(e,t,n,r,i,a,o)}</div>`)}
         </skeleton-carousel>
-    `},dr=(e,t,n,r)=>{let i=e.metadata;return w`
+    `},pr=(e,t,n,r)=>{let i=e.metadata;return w`
         <div style="display: flex; gap: 3rem; ${e.style}" class="${e.cssClasses}" slot="${e.slot??_}">
-            ${i.menu.map(e=>fr(e))}
+            ${i.menu.map(e=>mr(e))}
         </div>
-            `},fr=e=>w`
+            `},mr=e=>w`
         ${e.submenus?w`
                 <details open>
                     <summary>${e.label}</summary>
                     <div style="display:flex; flex-direction:column; gap:0.25rem; padding-left:0.5rem;">
-                        ${e.submenus.map(e=>fr(e))}
+                        ${e.submenus.map(e=>mr(e))}
                     </div>
                 </details>
             `:w`
                 <a href="${e.path}">${e.label}</a>
         `}
-        `,pr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`<div
+        `,hr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`<div
                 slot="${t.slot??_}"
                 style="${t.style}" class="${t.cssClasses}"
         >${s.content?g(s.content):_}${t.children?.map(t=>P(e,t,n,r,i,a,o))}</div>
-    `},mr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.title?.includes("${")?e._evalTemplate(s.title):s.title;return w`<div
+    `},gr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.title?.includes("${")?e._evalTemplate(s.title):s.title;return w`<div
                 slot="${t.slot??_}"
                 style="width: 100%; margin-bottom: var(--lumo-space-m); ${t.style}"
                 class="${t.cssClasses}"
@@ -1411,24 +1411,24 @@ ${i}
         ${c?w`<div style="font-size: var(--lumo-font-size-l); font-weight: 600; color: var(--lumo-header-text-color); margin-bottom: var(--lumo-space-s);">${c}</div>`:_}
         ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
     </div>
-    `},hr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.title?.includes("${")?e._evalTemplate(s.title):s.title;return w`
+    `},_r=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.title?.includes("${")?e._evalTemplate(s.title):s.title;return w`
         <div
                 slot="${t.slot??_}"
                 style="${t.style}" class="${t.cssClasses}"
         >
         <h4>${c}</h4>
         ${t.children?.map(t=>P(e,t,n,r,i,a,o))}</div>
-    `},gr=(e,t,n)=>{n.dispatchEvent(new CustomEvent(`value-changed`,{detail:{fieldId:e,value:t},bubbles:!0,composed:!0}))},_r=e=>t=>{let n=t.target,r=n.type===`checkbox`?n.checked:n.value;gr(e.fieldId,r,n)},vr=(e,t)=>{let n=e.metadata,r=t?.[n.fieldId]??``,i=n,a=i.dataType,o=i.stereotype,s=!!i.readOnly,c=!!i.disabled,l=i.options,u=n.label?w`<label style="display:block; font-size: var(--lumo-font-size-s,.875rem); color: var(--lumo-secondary-text-color,#667); margin-bottom:.15rem;">${n.label}</label>`:_,d=`width:100%; box-sizing:border-box; padding:.4rem .6rem; border:1px solid var(--lumo-contrast-30pct,rgba(0,0,0,.3)); border-radius: var(--lumo-border-radius-m,6px); font:inherit; background: var(--lumo-base-color,#fff); color: var(--lumo-body-text-color,#1a1a1a);`,f;return f=s||o===`plainText`?w`<div style="padding:.4rem 0;">${String(r??``)}</div>`:a===`boolean`||o===`checkbox`||o===`badge`?w`<input type="checkbox" ?checked="${!!r}" ?disabled="${c}" @change="${_r(n)}">`:l&&l.length?w`
-            <select style="${d}" ?disabled="${c}" @change="${_r(n)}">
+    `},vr=(e,t,n)=>{n.dispatchEvent(new CustomEvent(`value-changed`,{detail:{fieldId:e,value:t},bubbles:!0,composed:!0}))},yr=e=>t=>{let n=t.target,r=n.type===`checkbox`?n.checked:n.value;vr(e.fieldId,r,n)},br=(e,t)=>{let n=e.metadata,r=t?.[n.fieldId]??``,i=n,a=i.dataType,o=i.stereotype,s=!!i.readOnly,c=!!i.disabled,l=i.options,u=n.label?w`<label style="display:block; font-size: var(--lumo-font-size-s,.875rem); color: var(--lumo-secondary-text-color,#667); margin-bottom:.15rem;">${n.label}</label>`:_,d=`width:100%; box-sizing:border-box; padding:.4rem .6rem; border:1px solid var(--lumo-contrast-30pct,rgba(0,0,0,.3)); border-radius: var(--lumo-border-radius-m,6px); font:inherit; background: var(--lumo-base-color,#fff); color: var(--lumo-body-text-color,#1a1a1a);`,f;return f=s||o===`plainText`?w`<div style="padding:.4rem 0;">${String(r??``)}</div>`:a===`boolean`||o===`checkbox`||o===`badge`?w`<input type="checkbox" ?checked="${!!r}" ?disabled="${c}" @change="${yr(n)}">`:l&&l.length?w`
+            <select style="${d}" ?disabled="${c}" @change="${yr(n)}">
                 <option value="">—</option>
                 ${l.map(e=>w`<option value="${e.value}" ?selected="${e.value===r}">${e.label}</option>`)}
-            </select>`:o===`textarea`||o===`richText`||o===`html`?w`<textarea style="${d}" rows="3" ?disabled="${c}" @input="${_r(n)}">${String(r??``)}</textarea>`:w`<input type="${a===`integer`||a===`number`||a===`double`||a===`money`?`number`:a===`date`?`date`:a===`datetime`?`datetime-local`:a===`time`?`time`:o===`password`?`password`:a===`email`?`email`:`text`}" style="${d}" .value="${String(r??``)}"
-                              placeholder="${i.placeholder??_}" ?disabled="${c}" @input="${_r(n)}">`,w`
+            </select>`:o===`textarea`||o===`richText`||o===`html`?w`<textarea style="${d}" rows="3" ?disabled="${c}" @input="${yr(n)}">${String(r??``)}</textarea>`:w`<input type="${a===`integer`||a===`number`||a===`double`||a===`money`?`number`:a===`date`?`date`:a===`datetime`?`datetime-local`:a===`time`?`time`:o===`password`?`password`:a===`email`?`email`:`text`}" style="${d}" .value="${String(r??``)}"
+                              placeholder="${i.placeholder??_}" ?disabled="${c}" @input="${yr(n)}">`,w`
         <div style="${e.style}" class="${e.cssClasses}" slot="${e.slot??_}">
             ${u}
             ${f}
         </div>
-    `},yr=e=>{let t=e.metadata;if((t?.level??0)>0)return e;let n=e=>{if(e?.metadata?.type===A.EntityHeader)return e;let t=e?.metadata?.content,r=[...e?.children??[],...Array.isArray(t)?t:t?[t]:[]];for(let e of r){let t=n(e);if(t)return t}},r;for(let t of e.children??[])if(r=n(t),r)break;if(!r)return e;let i=r.metadata;r.__hoistedToPageHeader=!0;let a=[...(i.facts??[]).filter(e=>e.label||e.value).map(e=>({title:e.label??``,text:e.value??``})),...i.metricLabel?[{title:i.metricLabel,text:i.metricValue??``}]:[]],o=(i.badges??[]).filter(e=>e.label).map(e=>({text:e.label,color:e.color})),s={...t,title:i.title||t.title,subtitle:i.subtitle??t.subtitle,kpis:[...t.kpis??[],...a],kpisBelow:!0,badges:[...t.badges??[],...o]};return{...e,metadata:s}},br=(e,t,n,r,i,a,o,s)=>{let c=yr(t),l=c.metadata,u=l?.fabs??[];return w`<mateu-page
+    `},xr=e=>{let t=e.metadata;if((t?.level??0)>0)return e;let n=e=>{if(e?.metadata?.type===A.EntityHeader)return e;let t=e?.metadata?.content,r=[...e?.children??[],...Array.isArray(t)?t:t?[t]:[]];for(let e of r){let t=n(e);if(t)return t}},r;for(let t of e.children??[])if(r=n(t),r)break;if(!r)return e;let i=r.metadata;r.__hoistedToPageHeader=!0;let a=[...(i.facts??[]).filter(e=>e.label||e.value).map(e=>({title:e.label??``,text:e.value??``})),...i.metricLabel?[{title:i.metricLabel,text:i.metricValue??``}]:[]],o=(i.badges??[]).filter(e=>e.label).map(e=>({text:e.label,color:e.color})),s={...t,title:i.title||t.title,subtitle:i.subtitle??t.subtitle,kpis:[...t.kpis??[],...a],kpisBelow:!0,badges:[...t.badges??[],...o]};return{...e,metadata:s}},Sr=(e,t,n,r,i,a,o,s)=>{let c=xr(t),l=c.metadata,u=l?.fabs??[];return w`<mateu-page
             .component="${c}"
             baseUrl="${n}"
             .state="${r}"
@@ -1452,7 +1452,7 @@ ${i}
             </button>
         `)}
 </mateu-page>
-    `},xr=(e,t,n,r,i,a,o,s)=>w`<mateu-table-crud
+    `},Cr=(e,t,n,r,i,a,o,s)=>w`<mateu-table-crud
             id="${t.id}"
             baseUrl="${n}"
             .component="${t}"
@@ -1467,7 +1467,7 @@ ${i}
             ?standalone="${s??!1}"
     >
         ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
-    </mateu-table-crud>`,Sr=e=>{let t=e.metadata;return w`
+    </mateu-table-crud>`,wr=e=>{let t=e.metadata;return w`
         <mateu-bpmn
                 style="${e.style}"
                 class="${e.cssClasses}"
@@ -1475,35 +1475,35 @@ ${i}
                 xml="${t.xml}"
         >
         </mateu-bpmn>
-    `},Cr=(e,t,n)=>w`<mateu-chat sseUrl="${e.metadata.sseUrl}"
+    `},Tr=(e,t,n)=>w`<mateu-chat sseUrl="${e.metadata.sseUrl}"
                             style="${e.style}" 
                             class="${e.cssClasses}" 
-                            slot="${e.slot??_}"></mateu-chat>`,wr=e=>{let t=e.metadata;return w`
+                            slot="${e.slot??_}"></mateu-chat>`,Er=e=>{let t=e.metadata;return w`
         <mateu-workflow
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
                 value="${t.value??`{"name":"New Workflow","steps":[]}`}"
         ></mateu-workflow>
-    `},Tr=e=>{let t=e.metadata;return w`
+    `},Dr=e=>{let t=e.metadata;return w`
         <mateu-form-editor
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
                 value="${t.value??`{"name":"New Form","fields":[]}`}"
         ></mateu-form-editor>
-    `},Er=`
+    `},Or=`
     background: var(--lumo-base-color, #fff);
     border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.08));
     border-radius: var(--lumo-border-radius-l, 12px);
     padding: var(--lumo-space-m, 1rem);
     box-sizing: border-box;
-`,Dr=e=>e==`up`?`var(--lumo-success-text-color, #1a7f37)`:e==`down`?`var(--lumo-error-text-color, #c5221f)`:`var(--lumo-secondary-text-color, #666)`,Or=e=>e==`up`?`▲`:e==`down`?`▼`:``,kr=(e,t)=>{t.actionId&&e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))},Ar=e=>{let t=e.metadata,n=!!t.actionId;return w`
+`,kr=e=>e==`up`?`var(--lumo-success-text-color, #1a7f37)`:e==`down`?`var(--lumo-error-text-color, #c5221f)`:`var(--lumo-secondary-text-color, #666)`,Ar=e=>e==`up`?`▲`:e==`down`?`▼`:``,jr=(e,t)=>{t.actionId&&e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))},Mr=e=>{let t=e.metadata,n=!!t.actionId;return w`
         <div class="mateu-metric-card ${e.cssClasses??``}"
-             style="${Er} display: flex; flex-direction: column; gap: .25rem; min-width: 11rem; flex: 1; ${n?`cursor: pointer;`:``} ${e.style??``}"
+             style="${Or} display: flex; flex-direction: column; gap: .25rem; min-width: 11rem; flex: 1; ${n?`cursor: pointer;`:``} ${e.style??``}"
              slot="${e.slot??_}"
              role="${n?`button`:_}"
-             @click="${e=>kr(e,t)}"
+             @click="${e=>jr(e,t)}"
         >
             <div style="display: flex; align-items: center; justify-content: space-between; gap: .5rem;">
                 <span style="font-size: var(--lumo-font-size-s, .875rem); color: var(--lumo-secondary-text-color, #666);">${t.title}</span>
@@ -1514,25 +1514,25 @@ ${i}
                 ${t.unit?w`<span style="font-size: var(--lumo-font-size-m, 1rem); color: var(--lumo-secondary-text-color, #666);">${t.unit}</span>`:_}
             </div>
             ${t.trend||t.trendLabel?w`
-                <span style="font-size: var(--lumo-font-size-s, .875rem); color: ${Dr(t.trend)};">
-                    ${Or(t.trend)} ${t.trendLabel??_}
+                <span style="font-size: var(--lumo-font-size-s, .875rem); color: ${kr(t.trend)};">
+                    ${Ar(t.trend)} ${t.trendLabel??_}
                 </span>
             `:_}
             ${t.description?w`<span style="font-size: var(--lumo-font-size-xs, .8rem); color: var(--lumo-tertiary-text-color, #999);">${t.description}</span>`:_}
         </div>
-    `},jr=(e,t,n,r,i,a,o)=>w`
+    `},Nr=(e,t,n,r,i,a,o)=>w`
         <div class="mateu-scoreboard ${t.cssClasses??``}"
              style="display: flex; flex-wrap: wrap; gap: var(--lumo-space-m, 1rem); grid-column: 1 / -1; ${t.style??``}"
              slot="${t.slot??_}"
         >
             ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `,Mr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.colSpan&&s.colSpan>1?`grid-column: span ${s.colSpan};`:``,l=s.rowSpan&&s.rowSpan>1?`grid-row: span ${s.rowSpan};`:``,u=t.children??[];return u.length===1&&u[0].metadata?.type===`MetricCard`?w`
+    `,Pr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.colSpan&&s.colSpan>1?`grid-column: span ${s.colSpan};`:``,l=s.rowSpan&&s.rowSpan>1?`grid-row: span ${s.rowSpan};`:``,u=t.children??[];return u.length===1&&u[0].metadata?.type===`MetricCard`?w`
             <div style="min-width: 0; ${c} ${l} ${t.style??``}" slot="${t.slot??_}">
                 ${P(e,u[0],n,r,i,a,o)}
             </div>`:w`
         <div class="mateu-dashboard-panel ${t.cssClasses??``}"
-             style="${Er} display: flex; flex-direction: column; gap: .5rem; min-width: 0; ${c} ${l} ${t.style??``}"
+             style="${Or} display: flex; flex-direction: column; gap: .5rem; min-width: 0; ${c} ${l} ${t.style??``}"
              slot="${t.slot??_}"
         >
             ${s.title?w`
@@ -1545,14 +1545,14 @@ ${i}
                 ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
             </div>
         </div>
-    `},Nr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.columns&&s.columns>0?`repeat(${s.columns}, minmax(0, 1fr))`:`repeat(auto-fit, minmax(20rem, 1fr))`;return w`
+    `},Fr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.columns&&s.columns>0?`repeat(${s.columns}, minmax(0, 1fr))`:`repeat(auto-fit, minmax(20rem, 1fr))`;return w`
         <div class="mateu-dashboard ${t.cssClasses??``}"
              style="display: grid; grid-template-columns: ${c}; gap: var(--lumo-space-m, 1rem); align-items: stretch; ${t.style??``}"
              slot="${t.slot??_}"
         >
             ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </div>
-    `},Pr=class extends y{constructor(...e){super(...e),this.panels=[],this.headerTitle=``,this.badges=[],this.orientation=`vertical`,this.navigation=null,this.overviewEditActionId=``,this.openPanels=new Set,this.expandedPanel=null,this._onPopState=()=>{let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(e.startsWith(`expand=`)){let t=e.slice(7),n=this.panels.findIndex((e,n)=>this.panelAnchor(e,n)===t);this.expandedPanel=n>=0?n:null}else this.expandedPanel=null},this.initialized=!1}navAction(e){e&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{}},bubbles:!0,composed:!0}))}connectedCallback(){super.connectedCallback(),window.addEventListener(`popstate`,this._onPopState)}disconnectedCallback(){window.removeEventListener(`popstate`,this._onPopState),super.disconnectedCallback()}willUpdate(){if(!this.initialized&&this.panels.length){this.openPanels=new Set(this.panels.map((e,t)=>e.open?t:-1).filter(e=>e>=0));let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(e.startsWith(`expand=`)){let t=e.slice(7),n=this.panels.findIndex((e,n)=>this.panelAnchor(e,n)===t);n>=0&&(this.expandedPanel=n)}else if(e){let t=this.panels.findIndex((t,n)=>this.panelAnchor(t,n)===e);t>=0&&this.openPanels.add(t)}this.initialized=!0}}firstUpdated(){let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(!e)return;let t=this.renderRoot.querySelector(`[data-anchor="${CSS.escape(e)}"]`);t&&t.scrollIntoView({block:`nearest`})}panelAnchor(e,t){return(e.title??``).toLowerCase().replace(/[^a-z0-9]+/g,`-`).replace(/^-|-$/g,``)||`panel-${t}`}bookmarkPanel(e){let t=this.panelAnchor(this.panels[e],e);try{history.replaceState(history.state,``,`#`+t)}catch{}}clearBookmark(e){let t=this.panelAnchor(this.panels[e],e);if(decodeURIComponent((location.hash||``).replace(/^#/,``))===t)try{history.replaceState(history.state,``,location.pathname+location.search)}catch{}}expandPanel(e,t){t?.stopPropagation(),this.expandedPanel=e;let n=this.panelAnchor(this.panels[e],e);try{history.pushState(history.state,``,`#expand=`+n)}catch{}}collapsePanel(){try{history.back()}catch{this.expandedPanel=null}}toggle(e){let t=new Set(this.openPanels);t.has(e)?(t.delete(e),this.clearBookmark(e)):(t.add(e),this.bookmarkPanel(e)),this.openPanels=t}static{this.styles=m`
+    `},Ir=class extends y{constructor(...e){super(...e),this.panels=[],this.headerTitle=``,this.badges=[],this.orientation=`vertical`,this.navigation=null,this.overviewEditActionId=``,this.openPanels=new Set,this.expandedPanel=null,this._onPopState=()=>{let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(e.startsWith(`expand=`)){let t=e.slice(7),n=this.panels.findIndex((e,n)=>this.panelAnchor(e,n)===t);this.expandedPanel=n>=0?n:null}else this.expandedPanel=null},this.initialized=!1}navAction(e){e&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{}},bubbles:!0,composed:!0}))}connectedCallback(){super.connectedCallback(),window.addEventListener(`popstate`,this._onPopState)}disconnectedCallback(){window.removeEventListener(`popstate`,this._onPopState),super.disconnectedCallback()}willUpdate(){if(!this.initialized&&this.panels.length){this.openPanels=new Set(this.panels.map((e,t)=>e.open?t:-1).filter(e=>e>=0));let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(e.startsWith(`expand=`)){let t=e.slice(7),n=this.panels.findIndex((e,n)=>this.panelAnchor(e,n)===t);n>=0&&(this.expandedPanel=n)}else if(e){let t=this.panels.findIndex((t,n)=>this.panelAnchor(t,n)===e);t>=0&&this.openPanels.add(t)}this.initialized=!0}}firstUpdated(){let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(!e)return;let t=this.renderRoot.querySelector(`[data-anchor="${CSS.escape(e)}"]`);t&&t.scrollIntoView({block:`nearest`})}panelAnchor(e,t){return(e.title??``).toLowerCase().replace(/[^a-z0-9]+/g,`-`).replace(/^-|-$/g,``)||`panel-${t}`}bookmarkPanel(e){let t=this.panelAnchor(this.panels[e],e);try{history.replaceState(history.state,``,`#`+t)}catch{}}clearBookmark(e){let t=this.panelAnchor(this.panels[e],e);if(decodeURIComponent((location.hash||``).replace(/^#/,``))===t)try{history.replaceState(history.state,``,location.pathname+location.search)}catch{}}expandPanel(e,t){t?.stopPropagation(),this.expandedPanel=e;let n=this.panelAnchor(this.panels[e],e);try{history.pushState(history.state,``,`#expand=`+n)}catch{}}collapsePanel(){try{history.back()}catch{this.expandedPanel=null}}toggle(e){let t=new Set(this.openPanels);t.has(e)?(t.delete(e),this.clearBookmark(e)):(t.add(e),this.bookmarkPanel(e)),this.openPanels=t}static{this.styles=m`
         :host {
             display: flex;
             flex-direction: column;
@@ -1938,7 +1938,7 @@ ${i}
                     `)}
                 </div>
             </div>
-        `}};O([v({type:Array})],Pr.prototype,`panels`,void 0),O([v({type:String})],Pr.prototype,`headerTitle`,void 0),O([v({type:Array})],Pr.prototype,`badges`,void 0),O([v({type:String,reflect:!0})],Pr.prototype,`orientation`,void 0),O([v({attribute:!1})],Pr.prototype,`navigation`,void 0),O([v({type:String})],Pr.prototype,`overviewEditActionId`,void 0),O([S()],Pr.prototype,`openPanels`,void 0),O([S()],Pr.prototype,`expandedPanel`,void 0),Pr=O([h(`mateu-foldout`)],Pr);var Fr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+        `}};O([v({type:Array})],Ir.prototype,`panels`,void 0),O([v({type:String})],Ir.prototype,`headerTitle`,void 0),O([v({type:Array})],Ir.prototype,`badges`,void 0),O([v({type:String,reflect:!0})],Ir.prototype,`orientation`,void 0),O([v({attribute:!1})],Ir.prototype,`navigation`,void 0),O([v({type:String})],Ir.prototype,`overviewEditActionId`,void 0),O([S()],Ir.prototype,`openPanels`,void 0),O([S()],Ir.prototype,`expandedPanel`,void 0),Ir=O([h(`mateu-foldout`)],Ir);var Lr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <mateu-foldout
                 .panels="${s.panels??[]}"
                 .headerTitle="${s.headerTitle??``}"
@@ -1952,7 +1952,7 @@ ${i}
         >
             ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </mateu-foldout>
-    `},Ir=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.children??[],l=e=>c.filter(t=>(t.slot??``).startsWith(e)),u=l(`main-`),d=l(`aside-`),f=l(`footer-`),p=s.asideWidth&&s.asideWidth.trim()?s.asideWidth:`32%`,ee=s.asidePosition===`start`,te=s.asideSticky!==!1,ne=t=>t.map(t=>P(e,t,n,r,i,a,o)),re=w`
+    `},Rr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.children??[],l=e=>c.filter(t=>(t.slot??``).startsWith(e)),u=l(`main-`),d=l(`aside-`),f=l(`footer-`),p=s.asideWidth&&s.asideWidth.trim()?s.asideWidth:`32%`,ee=s.asidePosition===`start`,te=s.asideSticky!==!1,ne=t=>t.map(t=>P(e,t,n,r,i,a,o)),re=w`
         <div class="mateu-content-main"
              style="flex: 1 1 0; min-width: min(20rem, 100%); box-sizing: border-box;">
             ${ne(u)}
@@ -1973,7 +1973,7 @@ ${i}
                     ${ne(f)}
                 </div>`:_}
         </div>
-    `},Lr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!!s.image,l=c?`background-image: linear-gradient(rgba(0,0,0,.35), rgba(0,0,0,.35)), url('${s.image}'); background-size: cover; background-position: center; color: #fff;`:``,u=s.centered===!1?`flex-start`:`center`,d=s.centered===!1?`left`:`center`;return w`
+    `},zr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!!s.image,l=c?`background-image: linear-gradient(rgba(0,0,0,.35), rgba(0,0,0,.35)), url('${s.image}'); background-size: cover; background-position: center; color: #fff;`:``,u=s.centered===!1?`flex-start`:`center`,d=s.centered===!1?`left`:`center`;return w`
         <div class="mateu-hero ${t.cssClasses??``}"
              style="display: flex; flex-direction: column; align-items: ${u}; justify-content: center; gap: var(--lumo-space-m, 1rem); text-align: ${d}; padding: var(--lumo-space-xl, 2.5rem) var(--lumo-space-l, 1.5rem); border-radius: var(--lumo-border-radius-l, 12px); min-height: ${s.height??`12rem`}; box-sizing: border-box; ${l} ${t.style??``}"
              slot="${t.slot??_}"
@@ -1997,7 +1997,7 @@ ${i}
         outline-offset: 2px;
         border-radius: var(--lumo-border-radius-s, 4px);
     }
-`,Rr=1440*60*1e3,zr=class extends y{constructor(...e){super(...e),this.tasks=[],this.onTaskSelectionActionId=``}selectTask(e){this.onTaskSelectionActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.onTaskSelectionActionId,parameters:{_clickedTaskId:e.id}},bubbles:!0,composed:!0}))}static{this.styles=m`
+`,Br=1440*60*1e3,Vr=class extends y{constructor(...e){super(...e),this.tasks=[],this.onTaskSelectionActionId=``}selectTask(e){this.onTaskSelectionActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.onTaskSelectionActionId,parameters:{_clickedTaskId:e.id}},bubbles:!0,composed:!0}))}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2073,7 +2073,7 @@ ${i}
         }
     
         ${R}
-    `}range(){let e=this.tasks.flatMap(e=>[e.start,e.end]).filter(e=>!!e).map(e=>new Date(e+`T00:00:00`).getTime());return e.length?{min:Math.min(...e)-Rr,max:Math.max(...e)+2*Rr}:null}months(e,t){let n=[],r=new Date(e);for(r.setDate(1);r.getTime()<=t;){let i=Math.max(r.getTime(),e),a=new Date(r.getFullYear(),r.getMonth()+1,1),o=Math.min(a.getTime(),t);n.push({label:r.toLocaleDateString(void 0,{month:`short`,year:`2-digit`}),from:i,to:o}),r.setMonth(r.getMonth()+1)}return n}render(){let e=this.range();if(!e)return w``;let t=e.max-e.min,n=n=>(n-e.min)/t*100,r=Date.now();return w`
+    `}range(){let e=this.tasks.flatMap(e=>[e.start,e.end]).filter(e=>!!e).map(e=>new Date(e+`T00:00:00`).getTime());return e.length?{min:Math.min(...e)-Br,max:Math.max(...e)+2*Br}:null}months(e,t){let n=[],r=new Date(e);for(r.setDate(1);r.getTime()<=t;){let i=Math.max(r.getTime(),e),a=new Date(r.getFullYear(),r.getMonth()+1,1),o=Math.min(a.getTime(),t);n.push({label:r.toLocaleDateString(void 0,{month:`short`,year:`2-digit`}),from:i,to:o}),r.setMonth(r.getMonth()+1)}return n}render(){let e=this.range();if(!e)return w``;let t=e.max-e.min,n=n=>(n-e.min)/t*100,r=Date.now();return w`
             <div class="frame">
                 <div class="head">Task</div>
                 <div class="head months">
@@ -2081,7 +2081,7 @@ ${i}
                         <div class="month" style="width: ${(e.to-e.from)/t*100}%;">${e.label}</div>
                     `)}
                 </div>
-                ${this.tasks.map(i=>{let a=new Date(i.start+`T00:00:00`).getTime(),o=new Date(i.end+`T00:00:00`).getTime()+Rr;return w`
+                ${this.tasks.map(i=>{let a=new Date(i.start+`T00:00:00`).getTime(),o=new Date(i.end+`T00:00:00`).getTime()+Br;return w`
                         <div class="label" title="${i.title}">${i.title}</div>
                         <div class="lane">
                             ${r>=e.min&&r<=e.max?w`<div class="today" style="left: ${n(r)}%;"></div>`:_}
@@ -2096,7 +2096,7 @@ ${i}
                         </div>
                     `})}
             </div>
-        `}};O([v({type:Array})],zr.prototype,`tasks`,void 0),O([v()],zr.prototype,`onTaskSelectionActionId`,void 0),zr=O([h(`mateu-gantt`)],zr);var Br=e=>{let t=e.metadata;return w`
+        `}};O([v({type:Array})],Vr.prototype,`tasks`,void 0),O([v()],Vr.prototype,`onTaskSelectionActionId`,void 0),Vr=O([h(`mateu-gantt`)],Vr);var Hr=e=>{let t=e.metadata;return w`
         <mateu-gantt
                 .tasks="${t.tasks??[]}"
                 .onTaskSelectionActionId="${t.onTaskSelectionActionId??``}"
@@ -2104,7 +2104,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-gantt>
-    `},z,Vr=class extends y{static{z=this}constructor(...e){super(...e),this.resources=[],this.blocks=[],this.drag=null,this.dragStartX=0,this.dragStartY=0,this.laneRects=[],this.onDragKeydown=e=>{e.key===`Escape`&&this.drag&&(e.stopPropagation(),this.endDrag())}}static{this.styles=m`
+    `},z,Ur=class extends y{static{z=this}constructor(...e){super(...e),this.resources=[],this.blocks=[],this.drag=null,this.dragStartX=0,this.dragStartY=0,this.laneRects=[],this.onDragKeydown=e=>{e.key===`Escape`&&this.drag&&(e.stopPropagation(),this.endDrag())}}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2279,7 +2279,7 @@ ${i}
                          style="left: ${o.targetStartIdx*i}%; width: ${Math.min(o.duration,t.days-o.targetStartIdx)*i}%;"></div>
                 `:_}
             </div>
-        `}};O([v({type:Array})],Vr.prototype,`resources`,void 0),O([v({type:Array})],Vr.prototype,`blocks`,void 0),O([v()],Vr.prototype,`from`,void 0),O([v()],Vr.prototype,`to`,void 0),O([v()],Vr.prototype,`moveActionId`,void 0),O([v()],Vr.prototype,`selectActionId`,void 0),O([S()],Vr.prototype,`drag`,void 0),Vr=z=O([h(`mateu-planning-board`)],Vr);var Hr=e=>{let t=e.metadata;return w`
+        `}};O([v({type:Array})],Ur.prototype,`resources`,void 0),O([v({type:Array})],Ur.prototype,`blocks`,void 0),O([v()],Ur.prototype,`from`,void 0),O([v()],Ur.prototype,`to`,void 0),O([v()],Ur.prototype,`moveActionId`,void 0),O([v()],Ur.prototype,`selectActionId`,void 0),O([S()],Ur.prototype,`drag`,void 0),Ur=z=O([h(`mateu-planning-board`)],Ur);var Wr=e=>{let t=e.metadata;return w`
         <mateu-planning-board
                 .resources="${t.resources??[]}"
                 .blocks="${t.blocks??[]}"
@@ -2291,7 +2291,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-planning-board>
-    `},Ur=class extends y{constructor(...e){super(...e),this.columns=[]}static{this.styles=m`
+    `},Gr=class extends y{constructor(...e){super(...e),this.columns=[]}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2395,14 +2395,14 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};O([v({type:Array})],Ur.prototype,`columns`,void 0),Ur=O([h(`mateu-kanban`)],Ur);var Wr=e=>w`
+        `}};O([v({type:Array})],Gr.prototype,`columns`,void 0),Gr=O([h(`mateu-kanban`)],Gr);var Kr=e=>w`
         <mateu-kanban
                 .columns="${e.metadata.columns??[]}"
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-kanban>
-    `,Gr=class extends y{constructor(...e){super(...e),this.items=[]}static{this.styles=m`
+    `,qr=class extends y{constructor(...e){super(...e),this.items=[]}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2493,14 +2493,14 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};O([v({type:Array})],Gr.prototype,`items`,void 0),Gr=O([h(`mateu-timeline`)],Gr);var Kr=e=>w`
+        `}};O([v({type:Array})],qr.prototype,`items`,void 0),qr=O([h(`mateu-timeline`)],qr);var Jr=e=>w`
         <mateu-timeline
                 .items="${e.metadata.items??[]}"
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-timeline>
-    `,qr=class extends y{constructor(...e){super(...e),this.steps=[],this.vertical=!1}static{this.styles=m`
+    `,Yr=class extends y{constructor(...e){super(...e),this.steps=[],this.vertical=!1}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2614,7 +2614,7 @@ ${i}
                         </div>
                     `})}
             </div>
-        `}};O([v({type:Array})],qr.prototype,`steps`,void 0),O([v({type:Boolean,reflect:!0})],qr.prototype,`vertical`,void 0),qr=O([h(`mateu-progress-steps`)],qr);var Jr=e=>{let t=e.metadata;return w`
+        `}};O([v({type:Array})],Yr.prototype,`steps`,void 0),O([v({type:Boolean,reflect:!0})],Yr.prototype,`vertical`,void 0),Yr=O([h(`mateu-progress-steps`)],Yr);var Xr=e=>{let t=e.metadata;return w`
         <mateu-progress-steps
                 .steps="${t.steps??[]}"
                 ?vertical="${t.vertical??!1}"
@@ -2622,7 +2622,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-progress-steps>
-    `},Yr=class extends y{constructor(...e){super(...e),this.spark=[]}static{this.styles=m`
+    `},Zr=class extends y{constructor(...e){super(...e),this.spark=[]}static{this.styles=m`
         :host {
             display: block;
         }
@@ -2693,7 +2693,7 @@ ${i}
                     ${this.sparkline()}
                 </div>
             </div>
-        `}};O([v()],Yr.prototype,`label`,void 0),O([v()],Yr.prototype,`value`,void 0),O([v()],Yr.prototype,`unit`,void 0),O([v()],Yr.prototype,`delta`,void 0),O([v()],Yr.prototype,`trend`,void 0),O([v({type:Array})],Yr.prototype,`spark`,void 0),O([v()],Yr.prototype,`actionId`,void 0),Yr=O([h(`mateu-stat`)],Yr);var Xr=e=>{let t=e.metadata;return w`
+        `}};O([v()],Zr.prototype,`label`,void 0),O([v()],Zr.prototype,`value`,void 0),O([v()],Zr.prototype,`unit`,void 0),O([v()],Zr.prototype,`delta`,void 0),O([v()],Zr.prototype,`trend`,void 0),O([v({type:Array})],Zr.prototype,`spark`,void 0),O([v()],Zr.prototype,`actionId`,void 0),Zr=O([h(`mateu-stat`)],Zr);var Qr=e=>{let t=e.metadata;return w`
         <mateu-stat
                 label="${t.label??_}"
                 value="${t.value??_}"
@@ -2706,7 +2706,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-stat>
-    `},Zr=class extends y{constructor(...e){super(...e),this.events=[]}static{this.styles=m`
+    `},$r=class extends y{constructor(...e){super(...e),this.events=[]}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2797,7 +2797,7 @@ ${i}
                 ${l.map(e=>w`<div class="dow">${e}</div>`)}
                 ${u}
             </div>
-        `}};O([v()],Zr.prototype,`month`,void 0),O([v({type:Array})],Zr.prototype,`events`,void 0),Zr=O([h(`mateu-calendar`)],Zr);var Qr=e=>{let t=e.metadata;return w`
+        `}};O([v()],$r.prototype,`month`,void 0),O([v({type:Array})],$r.prototype,`events`,void 0),$r=O([h(`mateu-calendar`)],$r);var ei=e=>{let t=e.metadata;return w`
         <mateu-calendar
                 month="${t.month??_}"
                 .events="${t.events??[]}"
@@ -2805,7 +2805,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-calendar>
-    `},$r=class extends y{constructor(...e){super(...e),this.plans=[]}static{this.styles=m`
+    `},ti=class extends y{constructor(...e){super(...e),this.plans=[]}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -2917,14 +2917,14 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};O([v({type:Array})],$r.prototype,`plans`,void 0),$r=O([h(`mateu-pricing-table`)],$r);var ei=e=>w`
+        `}};O([v({type:Array})],ti.prototype,`plans`,void 0),ti=O([h(`mateu-pricing-table`)],ti);var ni=e=>w`
         <mateu-pricing-table
                 .plans="${e.metadata.plans??[]}"
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-pricing-table>
-    `,ti=class extends y{static{this.styles=m`
+    `,ri=class extends y{static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -3032,14 +3032,14 @@ ${i}
                 </div>
                 ${e.children&&e.children.length?w`<ul>${e.children.map(e=>this.renderNode(e))}</ul>`:_}
             </li>
-        `}render(){return this.root?w`<div class="tree"><ul>${this.renderNode(this.root)}</ul></div>`:w``}};O([v({attribute:!1})],ti.prototype,`root`,void 0),ti=O([h(`mateu-org-chart`)],ti);var ni=e=>w`
+        `}render(){return this.root?w`<div class="tree"><ul>${this.renderNode(this.root)}</ul></div>`:w``}};O([v({attribute:!1})],ri.prototype,`root`,void 0),ri=O([h(`mateu-org-chart`)],ri);var ii=e=>w`
         <mateu-org-chart
                 .root="${e.metadata.root}"
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-org-chart>
-    `,ri=1440*60*1e3,ii=class extends y{constructor(...e){super(...e),this.cells=[]}static{this.styles=m`
+    `,ai=1440*60*1e3,oi=class extends y{constructor(...e){super(...e),this.cells=[]}static{this.styles=m`
         :host {
             display: block;
             width: 100%;
@@ -3063,7 +3063,7 @@ ${i}
             margin-top: .15rem;
         }
         .legend .cell { width: 10px; height: 10px; }
-    `}color(e,t){if(e<=0||t<=0)return`var(--lumo-contrast-10pct, #ebedf0)`;let n=e/t;return`color-mix(in srgb, var(--lumo-primary-color, #1a73e8) ${Math.round((n>.75?1:n>.5?.75:n>.25?.5:.3)*100)}%, transparent)`}render(){let e=this.cells.filter(e=>!!e.date);if(!e.length)return w``;let t=e.map(e=>new Date(e.date+`T00:00:00`).getTime()),n=Math.min(...t),r=Math.max(...t),i=new Date(n);i.setDate(i.getDate()-(i.getDay()+6)%7);let a={};for(let t of e)a[t.date]=t;let o=Math.max(...e.map(e=>e.value??0),1),s=[];for(let e=i.getTime();e<=r;e+=ri){let t=new Date(e),n=t.toISOString().slice(0,10),r=a[n],i=r?.value??0,c=(t.getDay()+6)%7+1,l=r?.label??`${n}: ${i}`;s.push(w`
+    `}color(e,t){if(e<=0||t<=0)return`var(--lumo-contrast-10pct, #ebedf0)`;let n=e/t;return`color-mix(in srgb, var(--lumo-primary-color, #1a73e8) ${Math.round((n>.75?1:n>.5?.75:n>.25?.5:.3)*100)}%, transparent)`}render(){let e=this.cells.filter(e=>!!e.date);if(!e.length)return w``;let t=e.map(e=>new Date(e.date+`T00:00:00`).getTime()),n=Math.min(...t),r=Math.max(...t),i=new Date(n);i.setDate(i.getDate()-(i.getDay()+6)%7);let a={};for(let t of e)a[t.date]=t;let o=Math.max(...e.map(e=>e.value??0),1),s=[];for(let e=i.getTime();e<=r;e+=ai){let t=new Date(e),n=t.toISOString().slice(0,10),r=a[n],i=r?.value??0,c=(t.getDay()+6)%7+1,l=r?.label??`${n}: ${i}`;s.push(w`
                 <div class="cell" style="grid-row: ${c}; --cell: ${this.color(i,o)};" title="${l}"></div>
             `)}return w`
             <div class="wrap">
@@ -3078,14 +3078,14 @@ ${i}
                     <span>More</span>
                 </div>
             </div>
-        `}};O([v({type:Array})],ii.prototype,`cells`,void 0),ii=O([h(`mateu-heatmap`)],ii);var ai=e=>w`
+        `}};O([v({type:Array})],oi.prototype,`cells`,void 0),oi=O([h(`mateu-heatmap`)],oi);var si=e=>w`
         <mateu-heatmap
                 .cells="${e.metadata.cells??[]}"
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-heatmap>
-    `,oi=class extends y{constructor(...e){super(...e),this.stages=[]}static{this.styles=m`
+    `,ci=class extends y{constructor(...e){super(...e),this.stages=[]}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .funnel { display: flex; flex-direction: column; gap: .35rem; }
         .stage { display: flex; flex-direction: column; align-items: center; gap: .1rem; }
@@ -3118,14 +3118,14 @@ ${i}
                         </div>
                     `})}
             </div>
-        `}};O([v({type:Array})],oi.prototype,`stages`,void 0),oi=O([h(`mateu-funnel`)],oi);var si=e=>w`
+        `}};O([v({type:Array})],ci.prototype,`stages`,void 0),ci=O([h(`mateu-funnel`)],ci);var li=e=>w`
         <mateu-funnel
                 .stages="${e.metadata.stages??[]}"
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-funnel>
-    `,ci=class extends y{constructor(...e){super(...e),this.values=[],this.labels=[],this.area=!1}static{this.styles=m`
+    `,ui=class extends y{constructor(...e){super(...e),this.values=[],this.labels=[],this.area=!1}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .title { font-weight: 600; margin-bottom: .35rem; color: var(--lumo-body-text-color, #222); }
         svg { display: block; width: 100%; height: auto; overflow: visible; }
@@ -3138,7 +3138,7 @@ ${i}
                 ${a.map((t,n)=>n===l||n===u?C`<circle cx="${t[0]}" cy="${t[1]}" r="3.2" fill="${c}"><title>${this.labels[n]??``}: ${e[n]}</title></circle>`:C`<circle cx="${t[0]}" cy="${t[1]}" r="6" fill="transparent"><title>${this.labels[n]??``}: ${e[n]}</title></circle>`)}
             </svg>
             ${this.labels&&this.labels.length?w`<div class="labels"><span>${this.labels[0]}</span><span>${this.labels[this.labels.length-1]}</span></div>`:_}
-        `}};O([v()],ci.prototype,`heading`,void 0),O([v({type:Array})],ci.prototype,`values`,void 0),O([v({type:Array})],ci.prototype,`labels`,void 0),O([v()],ci.prototype,`color`,void 0),O([v({type:Boolean})],ci.prototype,`area`,void 0),ci=O([h(`mateu-trend-chart`)],ci);var li=e=>{let t=e.metadata;return w`
+        `}};O([v()],ui.prototype,`heading`,void 0),O([v({type:Array})],ui.prototype,`values`,void 0),O([v({type:Array})],ui.prototype,`labels`,void 0),O([v()],ui.prototype,`color`,void 0),O([v({type:Boolean})],ui.prototype,`area`,void 0),ui=O([h(`mateu-trend-chart`)],ui);var di=e=>{let t=e.metadata;return w`
         <mateu-trend-chart
                 heading="${t.title??_}"
                 color="${t.color??_}"
@@ -3149,7 +3149,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-trend-chart>
-    `},ui=class extends y{constructor(...e){super(...e),this.features=[],this.columns=0}static{this.styles=m`
+    `},fi=class extends y{constructor(...e){super(...e),this.features=[],this.columns=0}static{this.styles=m`
         :host { display: block; width: 100%; }
         .grid {
             display: grid;
@@ -3190,7 +3190,7 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};O([v({type:Array})],ui.prototype,`features`,void 0),O([v({type:Number})],ui.prototype,`columns`,void 0),ui=O([h(`mateu-feature-grid`)],ui);var di=e=>{let t=e.metadata;return w`
+        `}};O([v({type:Array})],fi.prototype,`features`,void 0),O([v({type:Number})],fi.prototype,`columns`,void 0),fi=O([h(`mateu-feature-grid`)],fi);var pi=e=>{let t=e.metadata;return w`
         <mateu-feature-grid
                 .features="${t.features??[]}"
                 .columns="${t.columns??0}"
@@ -3198,7 +3198,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-feature-grid>
-    `},fi=class extends y{constructor(...e){super(...e),this.items=[]}static{this.styles=m`
+    `},mi=class extends y{constructor(...e){super(...e),this.items=[]}static{this.styles=m`
         :host { display: block; width: 100%; }
         .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr)); gap: var(--lumo-space-m, 1rem); }
         .card {
@@ -3238,14 +3238,14 @@ ${i}
                         </div>
                     `})}
             </div>
-        `}};O([v({type:Array})],fi.prototype,`items`,void 0),fi=O([h(`mateu-testimonials`)],fi);var pi=e=>w`
+        `}};O([v({type:Array})],mi.prototype,`items`,void 0),mi=O([h(`mateu-testimonials`)],mi);var hi=e=>w`
         <mateu-testimonials
                 .items="${e.metadata.items??[]}"
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-testimonials>
-    `,mi=class extends y{constructor(...e){super(...e),this.items=[],this.openSet=new Set,this.seeded=!1}static{this.styles=m`
+    `,gi=class extends y{constructor(...e){super(...e),this.items=[],this.openSet=new Set,this.seeded=!1}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-m, 1rem); }
         .list {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -3282,14 +3282,14 @@ ${i}
                         </div>
                     `})}
             </div>
-        `}};O([v({type:Array})],mi.prototype,`items`,void 0),O([S()],mi.prototype,`openSet`,void 0),mi=O([h(`mateu-faq`)],mi);var hi=e=>w`
+        `}};O([v({type:Array})],gi.prototype,`items`,void 0),O([S()],gi.prototype,`openSet`,void 0),gi=O([h(`mateu-faq`)],gi);var _i=e=>w`
         <mateu-faq
                 .items="${e.metadata.items??[]}"
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-faq>
-    `,gi=class extends y{static{this.styles=m`
+    `,vi=class extends y{static{this.styles=m`
         :host { display: block; width: 100%; }
         .callout {
             display: flex; gap: 1rem; align-items: flex-start;
@@ -3318,7 +3318,7 @@ ${i}
                     ${this.ctaLabel?w`<button class="cta" @click="${()=>this.cta()}">${this.ctaLabel}</button>`:_}
                 </div>
             </div>
-        `}};O([v()],gi.prototype,`heading`,void 0),O([v()],gi.prototype,`description`,void 0),O([v()],gi.prototype,`icon`,void 0),O([v()],gi.prototype,`ctaLabel`,void 0),O([v()],gi.prototype,`actionId`,void 0),O([v()],gi.prototype,`theme`,void 0),gi=O([h(`mateu-callout-card`)],gi);var _i=e=>{let t=e.metadata;return w`
+        `}};O([v()],vi.prototype,`heading`,void 0),O([v()],vi.prototype,`description`,void 0),O([v()],vi.prototype,`icon`,void 0),O([v()],vi.prototype,`ctaLabel`,void 0),O([v()],vi.prototype,`actionId`,void 0),O([v()],vi.prototype,`theme`,void 0),vi=O([h(`mateu-callout-card`)],vi);var yi=e=>{let t=e.metadata;return w`
         <mateu-callout-card
                 heading="${t.title??_}"
                 description="${t.description??_}"
@@ -3330,7 +3330,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-callout-card>
-    `},vi=class extends y{constructor(...e){super(...e),this.comments=[]}static{this.styles=m`
+    `},bi=class extends y{constructor(...e){super(...e),this.comments=[]}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .thread { display: flex; flex-direction: column; gap: 1rem; }
         .replies {
@@ -3362,14 +3362,14 @@ ${i}
                     ${e.replies&&e.replies.length?w`<div class="replies">${e.replies.map(e=>this.renderComment(e))}</div>`:_}
                 </div>
             </div>
-        `}render(){return w`<div class="thread">${this.comments.map(e=>this.renderComment(e))}</div>`}};O([v({type:Array})],vi.prototype,`comments`,void 0),vi=O([h(`mateu-comment-thread`)],vi);var yi=e=>w`
+        `}render(){return w`<div class="thread">${this.comments.map(e=>this.renderComment(e))}</div>`}};O([v({type:Array})],bi.prototype,`comments`,void 0),bi=O([h(`mateu-comment-thread`)],bi);var xi=e=>w`
         <mateu-comment-thread
                 .comments="${e.metadata.comments??[]}"
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-comment-thread>
-    `,bi={pdf:`📕`,image:`🖼️`,img:`🖼️`,doc:`📘`,docx:`📘`,word:`📘`,xls:`📗`,xlsx:`📗`,excel:`📗`,sheet:`📗`,zip:`🗜️`,archive:`🗜️`,video:`🎬`,audio:`🎵`,code:`💻`,csv:`📄`,txt:`📄`},xi=class extends y{constructor(...e){super(...e),this.files=[]}static{this.styles=m`
+    `,Si={pdf:`📕`,image:`🖼️`,img:`🖼️`,doc:`📘`,docx:`📘`,word:`📘`,xls:`📗`,xlsx:`📗`,excel:`📗`,sheet:`📗`,zip:`🗜️`,archive:`🗜️`,video:`🎬`,audio:`🎵`,code:`💻`,csv:`📄`,txt:`📄`},Ci=class extends y{constructor(...e){super(...e),this.files=[]}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .list {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -3386,7 +3386,7 @@ ${i}
         .dl { color: var(--lumo-primary-color, #1a73e8); flex: 0 0 auto; }
     
         ${R}
-    `}icon(e){return e&&bi[e.toLowerCase()]||`📄`}clickFile(e,t){e.url||e.actionId&&(t.preventDefault(),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_file:e}},bubbles:!0,composed:!0})))}render(){return w`
+    `}icon(e){return e&&Si[e.toLowerCase()]||`📄`}clickFile(e,t){e.url||e.actionId&&(t.preventDefault(),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_file:e}},bubbles:!0,composed:!0})))}render(){return w`
             <div class="list">
                 ${this.files.map(e=>{let t=!!e.url||!!e.actionId,n=w`
                         <span class="icon">${this.icon(e.type)}</span>
@@ -3395,14 +3395,14 @@ ${i}
                         ${e.url?w`<span class="dl">⬇</span>`:_}
                     `;return e.url?w`<a class="file clickable" href="${e.url}" download target="_blank" rel="noopener">${n}</a>`:w`<div role="button" tabindex="0" class="file ${t?`clickable`:``}" @click="${t=>this.clickFile(e,t)}" @keydown="${L(t=>this.clickFile(e,t))}">${n}</div>`})}
             </div>
-        `}};O([v({type:Array})],xi.prototype,`files`,void 0),xi=O([h(`mateu-file-list`)],xi);var Si=e=>w`
+        `}};O([v({type:Array})],Ci.prototype,`files`,void 0),Ci=O([h(`mateu-file-list`)],Ci);var wi=e=>w`
         <mateu-file-list
                 .files="${e.metadata.files??[]}"
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-file-list>
-    `,Ci=class extends y{constructor(...e){super(...e),this.items=[],this.localDone=new Map}static{this.styles=m`
+    `,Ti=class extends y{constructor(...e){super(...e),this.items=[],this.localDone=new Map}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .head { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: .5rem; }
         .title { font-weight: 700; color: var(--lumo-body-text-color, #222); }
@@ -3432,7 +3432,7 @@ ${i}
                         <span class="label">${e.label}</span>
                     </div>
                 `})}
-        `}};O([v()],Ci.prototype,`heading`,void 0),O([v({type:Array})],Ci.prototype,`items`,void 0),O([S()],Ci.prototype,`localDone`,void 0),Ci=O([h(`mateu-checklist`)],Ci);var wi=e=>{let t=e.metadata;return w`
+        `}};O([v()],Ti.prototype,`heading`,void 0),O([v({type:Array})],Ti.prototype,`items`,void 0),O([S()],Ti.prototype,`localDone`,void 0),Ti=O([h(`mateu-checklist`)],Ti);var Ei=e=>{let t=e.metadata;return w`
         <mateu-checklist
                 heading="${t.title??_}"
                 .items="${t.items??[]}"
@@ -3440,7 +3440,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-checklist>
-    `},Ti=class extends y{static{this.styles=m`
+    `},Di=class extends y{static{this.styles=m`
         :host { display: block; width: 100%; }
         .card {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -3480,7 +3480,7 @@ ${i}
                     </div>
                 </div>
             </div>
-        `}};O([v()],Ti.prototype,`heading`,void 0),O([v()],Ti.prototype,`leftLabel`,void 0),O([v()],Ti.prototype,`leftValue`,void 0),O([v()],Ti.prototype,`rightLabel`,void 0),O([v()],Ti.prototype,`rightValue`,void 0),O([v()],Ti.prototype,`delta`,void 0),O([v()],Ti.prototype,`trend`,void 0),Ti=O([h(`mateu-comparison-card`)],Ti);var Ei=e=>{let t=e.metadata;return w`
+        `}};O([v()],Di.prototype,`heading`,void 0),O([v()],Di.prototype,`leftLabel`,void 0),O([v()],Di.prototype,`leftValue`,void 0),O([v()],Di.prototype,`rightLabel`,void 0),O([v()],Di.prototype,`rightValue`,void 0),O([v()],Di.prototype,`delta`,void 0),O([v()],Di.prototype,`trend`,void 0),Di=O([h(`mateu-comparison-card`)],Di);var Oi=e=>{let t=e.metadata;return w`
         <mateu-comparison-card
                 heading="${t.title??_}"
                 leftLabel="${t.leftLabel??_}"
@@ -3493,7 +3493,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-comparison-card>
-    `},Di=m`
+    `},ki=m`
     .chip {
         display: inline-flex;
         align-items: center;
@@ -3523,7 +3523,7 @@ ${i}
         color: var(--lumo-contrast-80pct, #333);
         background: var(--lumo-contrast-10pct, rgba(0, 0, 0, .08));
     }
-`,Oi=new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}),ki=e=>Oi.format(e),Ai=(e,t)=>{let n=e<0?`-`:``,r=ki(Math.abs(e));return t?`${n}${t} ${r}`:`${n}${r}`},ji=(e,t)=>t?`${ki(e)} ${t}`:ki(e),Mi=class extends y{constructor(...e){super(...e),this.title=``,this.badges=[],this.facts=[]}static{this.styles=[Di,m`
+`,Ai=new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}),ji=e=>Ai.format(e),Mi=(e,t)=>{let n=e<0?`-`:``,r=ji(Math.abs(e));return t?`${n}${t} ${r}`:`${n}${r}`},Ni=(e,t)=>t?`${ji(e)} ${t}`:ji(e),Pi=class extends y{constructor(...e){super(...e),this.title=``,this.badges=[],this.facts=[]}static{this.styles=[ki,m`
         :host { display: block; width: 100%; }
         .card {
             display: flex;
@@ -3606,7 +3606,7 @@ ${i}
                     </div>
                 `:_}
             </div>
-        `}};O([v()],Mi.prototype,`title`,void 0),O([v({type:Array})],Mi.prototype,`badges`,void 0),O([v()],Mi.prototype,`subtitle`,void 0),O([v({type:Array})],Mi.prototype,`facts`,void 0),O([v()],Mi.prototype,`metricLabel`,void 0),O([v()],Mi.prototype,`metricValue`,void 0),O([v()],Mi.prototype,`metricCaption`,void 0),Mi=O([h(`mateu-entity-header`)],Mi);var Ni=e=>{if(e.__hoistedToPageHeader)return w``;let t=e.metadata;return w`
+        `}};O([v()],Pi.prototype,`title`,void 0),O([v({type:Array})],Pi.prototype,`badges`,void 0),O([v()],Pi.prototype,`subtitle`,void 0),O([v({type:Array})],Pi.prototype,`facts`,void 0),O([v()],Pi.prototype,`metricLabel`,void 0),O([v()],Pi.prototype,`metricValue`,void 0),O([v()],Pi.prototype,`metricCaption`,void 0),Pi=O([h(`mateu-entity-header`)],Pi);var Fi=e=>{if(e.__hoistedToPageHeader)return w``;let t=e.metadata;return w`
         <mateu-entity-header
                 .title="${t.title??``}"
                 .badges="${t.badges??[]}"
@@ -3619,7 +3619,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-entity-header>
-    `},Pi=class extends y{constructor(...e){super(...e),this.value=0,this.max=0}static{this.styles=m`
+    `},Ii=class extends y{constructor(...e){super(...e),this.value=0,this.max=0}static{this.styles=m`
         :host { display: block; width: 100%; }
         .meter { display: flex; flex-direction: column; gap: .35rem; }
         .label {
@@ -3644,13 +3644,13 @@ ${i}
     `}fillColor(){return this.dangerAt!=null&&this.value>=this.dangerAt?`error`:this.warnAt!=null&&this.value>=this.warnAt?`warning`:this.warnAt!=null||this.dangerAt!=null?`success`:`primary`}render(){let e=this.max>0?Math.min(Math.max(this.value/this.max,0),1):0,t=Math.round(e*100);return w`
             <div class="meter">
                 ${this.label?w`<span class="label">${this.label}</span>`:_}
-                <span class="value">${ji(this.value,this.unit)}</span>
+                <span class="value">${Ni(this.value,this.unit)}</span>
                 <div class="track">
                     <div class="fill ${this.fillColor()}" style="width: ${t}%"></div>
                 </div>
                 <span class="caption">${this.caption?this.caption:`${t}%`}</span>
             </div>
-        `}};O([v()],Pi.prototype,`label`,void 0),O([v({type:Number})],Pi.prototype,`value`,void 0),O([v({type:Number})],Pi.prototype,`max`,void 0),O([v()],Pi.prototype,`unit`,void 0),O([v()],Pi.prototype,`caption`,void 0),O([v({type:Number})],Pi.prototype,`warnAt`,void 0),O([v({type:Number})],Pi.prototype,`dangerAt`,void 0),Pi=O([h(`mateu-meter`)],Pi);var Fi=e=>{let t=e.metadata;return w`
+        `}};O([v()],Ii.prototype,`label`,void 0),O([v({type:Number})],Ii.prototype,`value`,void 0),O([v({type:Number})],Ii.prototype,`max`,void 0),O([v()],Ii.prototype,`unit`,void 0),O([v()],Ii.prototype,`caption`,void 0),O([v({type:Number})],Ii.prototype,`warnAt`,void 0),O([v({type:Number})],Ii.prototype,`dangerAt`,void 0),Ii=O([h(`mateu-meter`)],Ii);var Li=e=>{let t=e.metadata;return w`
         <mateu-meter
                 .label="${t.label}"
                 .value="${t.value??0}"
@@ -3663,7 +3663,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-meter>
-    `},Ii=class extends y{constructor(...e){super(...e),this.total=0,this.done=0}static{this.styles=m`
+    `},Ri=class extends y{constructor(...e){super(...e),this.total=0,this.done=0}static{this.styles=m`
         :host { display: block; width: 100%; }
         .banner {
             display: flex; align-items: center; gap: .8rem; flex-wrap: wrap;
@@ -3718,7 +3718,7 @@ ${i}
                 <span class="spacer"></span>
                 ${t?w`<button @click="${()=>this.runAction()}">${this.actionLabel} →</button>`:_}
             </div>
-        `}};O([v()],Ii.prototype,`label`,void 0),O([v({type:Number})],Ii.prototype,`total`,void 0),O([v({type:Number})],Ii.prototype,`done`,void 0),O([v()],Ii.prototype,`actionLabel`,void 0),O([v()],Ii.prototype,`actionId`,void 0),Ii=O([h(`mateu-task-progress`)],Ii);var Li=e=>{let t=e.metadata;return w`
+        `}};O([v()],Ri.prototype,`label`,void 0),O([v({type:Number})],Ri.prototype,`total`,void 0),O([v({type:Number})],Ri.prototype,`done`,void 0),O([v()],Ri.prototype,`actionLabel`,void 0),O([v()],Ri.prototype,`actionId`,void 0),Ri=O([h(`mateu-task-progress`)],Ri);var zi=e=>{let t=e.metadata;return w`
         <mateu-task-progress
                 .label="${t.label}"
                 .total="${t.total??0}"
@@ -3729,7 +3729,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-task-progress>
-    `},Ri=class extends y{constructor(...e){super(...e),this.items=[],this.compact=!1,this.frameless=!1,this.columns=0,this.itemHeadingLevel=3}static{this.styles=[Di,R,m`
+    `},Bi=class extends y{constructor(...e){super(...e),this.items=[],this.compact=!1,this.frameless=!1,this.columns=0,this.itemHeadingLevel=3}static{this.styles=[ki,R,m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .list {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -3872,7 +3872,7 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};O([v({type:Array})],Ri.prototype,`items`,void 0),O([v({type:Boolean})],Ri.prototype,`compact`,void 0),O([v({type:Boolean})],Ri.prototype,`frameless`,void 0),O([v()],Ri.prototype,`rowActionId`,void 0),O([v({type:Number})],Ri.prototype,`columns`,void 0),O([v({type:Number})],Ri.prototype,`itemHeadingLevel`,void 0),Ri=O([h(`mateu-status-list`)],Ri);var zi=e=>{let t=e.metadata;return w`
+        `}};O([v({type:Array})],Bi.prototype,`items`,void 0),O([v({type:Boolean})],Bi.prototype,`compact`,void 0),O([v({type:Boolean})],Bi.prototype,`frameless`,void 0),O([v()],Bi.prototype,`rowActionId`,void 0),O([v({type:Number})],Bi.prototype,`columns`,void 0),O([v({type:Number})],Bi.prototype,`itemHeadingLevel`,void 0),Bi=O([h(`mateu-status-list`)],Bi);var Vi=e=>{let t=e.metadata;return w`
         <mateu-status-list
                 .items="${t.items??[]}"
                 ?compact="${t.compact??!1}"
@@ -3884,7 +3884,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-status-list>
-    `},Bi=class extends y{constructor(...e){super(...e),this.items=[]}static{this.styles=m`
+    `},Hi=class extends y{constructor(...e){super(...e),this.items=[]}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         ul {
             margin: 0; padding-inline-start: 1.2rem;
@@ -3899,20 +3899,20 @@ ${i}
             <ul>
                 ${this.items.map(e=>w`<li>${e}</li>`)}
             </ul>
-        `}};O([v({type:Array})],Bi.prototype,`items`,void 0),Bi=O([h(`mateu-bulleted-list`)],Bi);var Vi=e=>w`
+        `}};O([v({type:Array})],Hi.prototype,`items`,void 0),Hi=O([h(`mateu-bulleted-list`)],Hi);var Ui=e=>w`
         <mateu-bulleted-list
                 .items="${e.metadata.items??[]}"
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-bulleted-list>
-    `,Hi=e=>{let t=e.metadata.attributes?.[`data-colspan`];return w`
+    `,Wi=e=>{let t=e.metadata.attributes?.[`data-colspan`];return w`
         <hr style="border: none; border-top: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1)); width: 100%; margin: var(--lumo-space-s, .5rem) 0; ${e.style??``}"
             class="${e.cssClasses??_}"
             id="${x(e.id??void 0)}"
             data-colspan="${x(t)}"
             slot="${e.slot??_}"/>
-    `},Ui={info:`ℹ`,success:`✓`,warning:`!`,danger:`!`},B=class extends y{constructor(...e){super(...e),this.text=``,this.theme=`info`,this.noIcon=!1,this.slim=!1,this.fullWidth=!1,this.hasContent=!1,this.inlineContent=!1}static{this.styles=m`
+    `},Gi={info:`ℹ`,success:`✓`,warning:`!`,danger:`!`},B=class extends y{constructor(...e){super(...e),this.text=``,this.theme=`info`,this.noIcon=!1,this.slim=!1,this.fullWidth=!1,this.hasContent=!1,this.inlineContent=!1}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .notice {
             display: flex;
@@ -3977,14 +3977,14 @@ ${i}
         .danger  .icon  { background: #b25b3d; }
     `}runAction(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId},bubbles:!0,composed:!0}))}render(){let e=!!this.text&&!!this.text.trim();if(!e&&!this.hasContent)return w``;let t=[`info`,`success`,`warning`,`danger`].includes(this.theme)?this.theme:`info`;return w`
             <div class="notice ${t} ${this.slim?`slim`:``}">
-                ${this.noIcon?_:w`<span class="icon ${this.icon?`custom`:``}">${this.icon||Ui[t]}</span>`}
+                ${this.noIcon?_:w`<span class="icon ${this.icon?`custom`:``}">${this.icon||Gi[t]}</span>`}
                 <div class="body ${this.inlineContent?`inline`:``}">
                     ${e?w`<span class="text">${this.text}</span>`:_}
                     ${this.hasContent?w`<div class="content"><slot></slot></div>`:_}
                 </div>
                 ${this.actionLabel&&this.actionId?w`<button class="notice-action" @click="${()=>this.runAction()}">${this.actionLabel}</button>`:this.status?w`<span class="status">${this.status}</span>`:_}
             </div>
-        `}};O([v()],B.prototype,`text`,void 0),O([v()],B.prototype,`theme`,void 0),O([v()],B.prototype,`icon`,void 0),O([v({type:Boolean})],B.prototype,`noIcon`,void 0),O([v()],B.prototype,`actionLabel`,void 0),O([v()],B.prototype,`actionId`,void 0),O([v()],B.prototype,`status`,void 0),O([v({type:Boolean})],B.prototype,`slim`,void 0),O([v({type:Boolean})],B.prototype,`fullWidth`,void 0),O([v({type:Boolean})],B.prototype,`hasContent`,void 0),O([v({type:Boolean})],B.prototype,`inlineContent`,void 0),B=O([h(`mateu-notice`)],B);var Wi=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=it(s.text??``,r,i,a,o)??``,l=t.children??[];return w`
+        `}};O([v()],B.prototype,`text`,void 0),O([v()],B.prototype,`theme`,void 0),O([v()],B.prototype,`icon`,void 0),O([v({type:Boolean})],B.prototype,`noIcon`,void 0),O([v()],B.prototype,`actionLabel`,void 0),O([v()],B.prototype,`actionId`,void 0),O([v()],B.prototype,`status`,void 0),O([v({type:Boolean})],B.prototype,`slim`,void 0),O([v({type:Boolean})],B.prototype,`fullWidth`,void 0),O([v({type:Boolean})],B.prototype,`hasContent`,void 0),O([v({type:Boolean})],B.prototype,`inlineContent`,void 0),B=O([h(`mateu-notice`)],B);var Ki=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=it(s.text??``,r,i,a,o)??``,l=t.children??[];return w`
         <mateu-notice
                 text="${c}"
                 theme="${s.theme??`info`}"
@@ -4002,7 +4002,7 @@ ${i}
                 class="${t.cssClasses??_}"
                 slot="${t.slot??_}"
         >${l.map(t=>P(e,t,n,r,i,a,o))}</mateu-notice>
-    `},Gi=class extends y{constructor(...e){super(...e),this.groups=[]}static{this.styles=[Di,R,m`
+    `},qi=class extends y{constructor(...e){super(...e),this.groups=[]}static{this.styles=[ki,R,m`
         :host { display: block; width: 100%; }
         .rail { display: flex; flex-direction: column; gap: var(--lumo-space-m, 1rem); }
         .group { display: flex; flex-direction: column; gap: .45rem; }
@@ -4065,7 +4065,7 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};O([v()],Gi.prototype,`actionId`,void 0),O([v({type:Array})],Gi.prototype,`groups`,void 0),O([S()],Gi.prototype,`selectedId`,void 0),Gi=O([h(`mateu-task-queue`)],Gi);var Ki=e=>{let t=e.metadata;return w`
+        `}};O([v()],qi.prototype,`actionId`,void 0),O([v({type:Array})],qi.prototype,`groups`,void 0),O([S()],qi.prototype,`selectedId`,void 0),qi=O([h(`mateu-task-queue`)],qi);var Ji=e=>{let t=e.metadata;return w`
         <mateu-task-queue
                 .actionId="${t.actionId}"
                 .groups="${t.groups??[]}"
@@ -4073,7 +4073,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-task-queue>
-    `},qi=class extends y{constructor(...e){super(...e),this.columns=0,this.items=[]}static{this.styles=[Di,R,m`
+    `},Yi=class extends y{constructor(...e){super(...e),this.columns=0,this.items=[]}static{this.styles=[ki,R,m`
         /* explicit line-height: inside a form field wrapper the inherited one is the 44px
            field height, which blows up every text row */
         :host { display: block; width: 100%; line-height: var(--lumo-line-height-m, 1.4); }
@@ -4137,7 +4137,7 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};O([v()],qi.prototype,`actionId`,void 0),O([v({type:Number})],qi.prototype,`columns`,void 0),O([v()],qi.prototype,`recommendedLabel`,void 0),O([v({type:Array})],qi.prototype,`items`,void 0),O([S()],qi.prototype,`selectedId`,void 0),qi=O([h(`mateu-resource-grid`)],qi);var Ji=e=>{let t=e.metadata;return w`
+        `}};O([v()],Yi.prototype,`actionId`,void 0),O([v({type:Number})],Yi.prototype,`columns`,void 0),O([v()],Yi.prototype,`recommendedLabel`,void 0),O([v({type:Array})],Yi.prototype,`items`,void 0),O([S()],Yi.prototype,`selectedId`,void 0),Yi=O([h(`mateu-resource-grid`)],Yi);var Xi=e=>{let t=e.metadata;return w`
         <mateu-resource-grid
                 .actionId="${t.actionId}"
                 .columns="${t.columns??0}"
@@ -4235,7 +4235,7 @@ ${i}
                         `:_}
                 </div>
             </div>
-        `}};O([v()],V.prototype,`tag`,void 0),O([v()],V.prototype,`title`,void 0),O([v()],V.prototype,`subtitle`,void 0),O([v()],V.prototype,`image`,void 0),O([v({type:Array})],V.prototype,`features`,void 0),O([v()],V.prototype,`priceLabel`,void 0),O([v()],V.prototype,`actionLabel`,void 0),O([v()],V.prototype,`actionId`,void 0),O([v({type:Boolean})],V.prototype,`current`,void 0),O([v()],V.prototype,`currentLabel`,void 0),O([v({type:Boolean})],V.prototype,`added`,void 0),O([v()],V.prototype,`addedLabel`,void 0),V=O([h(`mateu-offer-card`)],V);var Yi=e=>{let t=e.metadata;return w`
+        `}};O([v()],V.prototype,`tag`,void 0),O([v()],V.prototype,`title`,void 0),O([v()],V.prototype,`subtitle`,void 0),O([v()],V.prototype,`image`,void 0),O([v({type:Array})],V.prototype,`features`,void 0),O([v()],V.prototype,`priceLabel`,void 0),O([v()],V.prototype,`actionLabel`,void 0),O([v()],V.prototype,`actionId`,void 0),O([v({type:Boolean})],V.prototype,`current`,void 0),O([v()],V.prototype,`currentLabel`,void 0),O([v({type:Boolean})],V.prototype,`added`,void 0),O([v()],V.prototype,`addedLabel`,void 0),V=O([h(`mateu-offer-card`)],V);var Zi=e=>{let t=e.metadata;return w`
         <mateu-offer-card
                 .tag="${t.tag}"
                 .title="${t.title??``}"
@@ -4253,7 +4253,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-offer-card>
-    `},Xi=class extends y{constructor(...e){super(...e),this.items=[],this.added=new Set}static{this.styles=m`
+    `},Qi=class extends y{constructor(...e){super(...e),this.items=[],this.added=new Set}static{this.styles=m`
         :host { display: block; width: 100%; }
         .header { display: flex; align-items: baseline; justify-content: flex-end; gap: .4rem; margin-bottom: .6rem; }
         .total-label { font-size: var(--lumo-font-size-s, .875rem); color: var(--lumo-secondary-text-color, #888); }
@@ -4321,7 +4321,7 @@ ${i}
     `}willUpdate(e){e.has(`items`)&&(this.added=new Set(this.items.filter(e=>e.added).map(e=>e.id)))}total(){return this.items.filter(e=>e.id!=null&&this.added.has(e.id)).reduce((e,t)=>e+(t.price??0),0)}toggle(e){if(e.id==null)return;let t=new Set(this.added),n=!t.has(e.id);n?t.add(e.id):t.delete(e.id),this.added=t,this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{_item:e.id,_added:n,_total:this.total()}},bubbles:!0,composed:!0}))}render(){return w`
             <div class="header">
                 ${this.totalLabel?w`<span class="total-label">${this.totalLabel}:</span>`:_}
-                <span class="total">${Ai(this.total(),this.currency)}</span>
+                <span class="total">${Mi(this.total(),this.currency)}</span>
             </div>
             <div class="grid">
                 ${this.items.map(e=>{let t=e.id!=null&&this.added.has(e.id);return w`
@@ -4331,7 +4331,7 @@ ${i}
                             ${e.description?w`<span class="description">${e.description}</span>`:_}
                             ${e.includedLabel?w`<span class="included">${e.includedLabel}</span>`:w`
                                     ${e.price==null?_:w`
-                                        <span class="price">${Ai(e.price,this.currency)}${e.unit?` / ${e.unit}`:``}</span>
+                                        <span class="price">${Mi(e.price,this.currency)}${e.unit?` / ${e.unit}`:``}</span>
                                     `}
                                     <button class="toggle ${t?`on`:``}" @click="${()=>this.toggle(e)}"
                                             aria-pressed="${t}">${t?`✓`:`+`}</button>
@@ -4339,7 +4339,7 @@ ${i}
                         </div>
                     `})}
             </div>
-        `}};O([v()],Xi.prototype,`totalLabel`,void 0),O([v()],Xi.prototype,`currency`,void 0),O([v()],Xi.prototype,`actionId`,void 0),O([v({type:Array})],Xi.prototype,`items`,void 0),O([S()],Xi.prototype,`added`,void 0),Xi=O([h(`mateu-addon-picker`)],Xi);var Zi=e=>{let t=e.metadata;return w`
+        `}};O([v()],Qi.prototype,`totalLabel`,void 0),O([v()],Qi.prototype,`currency`,void 0),O([v()],Qi.prototype,`actionId`,void 0),O([v({type:Array})],Qi.prototype,`items`,void 0),O([S()],Qi.prototype,`added`,void 0),Qi=O([h(`mateu-addon-picker`)],Qi);var $i=e=>{let t=e.metadata;return w`
         <mateu-addon-picker
                 .totalLabel="${t.totalLabel}"
                 .currency="${t.currency}"
@@ -4349,7 +4349,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-addon-picker>
-    `},Qi=class extends y{constructor(...e){super(...e),this.lines=[]}static{this.styles=m`
+    `},ea=class extends y{constructor(...e){super(...e),this.lines=[]}static{this.styles=m`
         :host {
             display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem);
             /* an ancestor (e.g. a form-layout row) may set an inherited line-height like 44px —
@@ -4391,14 +4391,14 @@ ${i}
                 <div class="row">
                     <span class="dot"></span>
                     <span class="concept">${e.concept}</span>
-                    ${e.included?w`<span class="included-label">${e.includedLabel||`Included`}</span>`:w`<span class="amount ${(e.amount??0)<0?`negative`:``}">${Ai(e.amount??0,this.currency)}</span>`}
+                    ${e.included?w`<span class="included-label">${e.includedLabel||`Included`}</span>`:w`<span class="amount ${(e.amount??0)<0?`negative`:``}">${Mi(e.amount??0,this.currency)}</span>`}
                 </div>
             `)}
             <div class="total-row">
                 <span class="total-label">${this.totalLabel||`Total`}</span>
-                <span class="total">${Ai(this.computedTotal(),this.currency)}</span>
+                <span class="total">${Mi(this.computedTotal(),this.currency)}</span>
             </div>
-        `}};O([v()],Qi.prototype,`currency`,void 0),O([v()],Qi.prototype,`totalLabel`,void 0),O([v({type:Array})],Qi.prototype,`lines`,void 0),O([v({type:Number})],Qi.prototype,`total`,void 0),Qi=O([h(`mateu-ledger`)],Qi);var $i=e=>{let t=e.metadata;return w`
+        `}};O([v()],ea.prototype,`currency`,void 0),O([v()],ea.prototype,`totalLabel`,void 0),O([v({type:Array})],ea.prototype,`lines`,void 0),O([v({type:Number})],ea.prototype,`total`,void 0),ea=O([h(`mateu-ledger`)],ea);var ta=e=>{let t=e.metadata;return w`
         <mateu-ledger
                 .currency="${t.currency}"
                 .totalLabel="${t.totalLabel}"
@@ -4408,7 +4408,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-ledger>
-    `},ea=class extends y{constructor(...e){super(...e),this.methods=[]}static{this.styles=m`
+    `},na=class extends y{constructor(...e){super(...e),this.methods=[]}static{this.styles=m`
         :host { display: block; width: 100%; }
         .bar { display: flex; align-items: stretch; gap: .6rem; flex-wrap: wrap; }
         .methods { display: flex; gap: .4rem; flex-wrap: wrap; }
@@ -4470,7 +4470,7 @@ ${i}
                 <span class="spacer"></span>
                 ${this.confirmLabel&&this.actionId?w`<button class="confirm" @click="${()=>this.confirm()}">${this.confirmLabel}</button>`:_}
             </div>
-        `}};O([v()],ea.prototype,`actionId`,void 0),O([v()],ea.prototype,`methodActionId`,void 0),O([v({type:Array})],ea.prototype,`methods`,void 0),O([v()],ea.prototype,`selected`,void 0),O([v()],ea.prototype,`contextLabel`,void 0),O([v()],ea.prototype,`contextValue`,void 0),O([v()],ea.prototype,`confirmLabel`,void 0),O([S()],ea.prototype,`selectedId`,void 0),ea=O([h(`mateu-payment-picker`)],ea);var ta=e=>{let t=e.metadata;return w`
+        `}};O([v()],na.prototype,`actionId`,void 0),O([v()],na.prototype,`methodActionId`,void 0),O([v({type:Array})],na.prototype,`methods`,void 0),O([v()],na.prototype,`selected`,void 0),O([v()],na.prototype,`contextLabel`,void 0),O([v()],na.prototype,`contextValue`,void 0),O([v()],na.prototype,`confirmLabel`,void 0),O([S()],na.prototype,`selectedId`,void 0),na=O([h(`mateu-payment-picker`)],na);var ra=e=>{let t=e.metadata;return w`
         <mateu-payment-picker
                 .actionId="${t.actionId}"
                 .methodActionId="${t.methodActionId}"
@@ -4483,7 +4483,7 @@ ${i}
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-payment-picker>
-    `},na=class extends y{constructor(...e){super(...e),this.items=[]}static{this.styles=m`
+    `},ia=class extends y{constructor(...e){super(...e),this.items=[]}static{this.styles=m`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .list {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -4537,14 +4537,14 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};O([v({type:Array})],na.prototype,`items`,void 0),na=O([h(`mateu-process-monitor`)],na);var ra=e=>w`
+        `}};O([v({type:Array})],ia.prototype,`items`,void 0),ia=O([h(`mateu-process-monitor`)],ia);var aa=e=>w`
         <mateu-process-monitor
                 .items="${e.metadata.items??[]}"
                 style="${e.style??_}"
                 class="${e.cssClasses??_}"
                 slot="${e.slot??_}"
         ></mateu-process-monitor>
-    `,ia=(e,t)=>{let n=e.style;return e.id&&(n&&!n.endsWith(`;`)&&(n+=`;`),n??=``,t[e.id+`.hidden`]==1&&(n+=`display: none;`)),n},aa=(e,t)=>{let n={...e.metadata};if(e.id&&n){if(n.type==A.Button){let r=n;t[e.id+`.disabled`]==1&&(r.disabled=!0)}if(n.type==A.FormField){let r=n;t[e.id+`.disabled`]==1&&(r.disabled=!0)}}return n},H=e=>t=>e(t.container,t.component,t.baseUrl,t.state,t.data,t.appState,t.appData),oa={[A.Bpmn]:({component:e})=>Sr(e),[A.Workflow]:({component:e})=>wr(e),[A.FormEditor]:({component:e})=>Tr(e),[A.Page]:H(br),[A.Div]:H(pr),[A.Directory]:({component:e,baseUrl:t,state:n,data:r})=>dr(e,t,n,r),[A.FormLayout]:H(Zt),[A.HorizontalLayout]:H(rn),[A.VerticalLayout]:H(an),[A.SplitLayout]:H(on),[A.MasterDetailLayout]:H(sn),[A.TabLayout]:H(cn),[A.AccordionLayout]:H(ln),[A.BoardLayout]:H(mn),[A.BoardLayoutRow]:H(hn),[A.BoardLayoutItem]:H(gn),[A.Scroller]:H(dn),[A.FullWidth]:H(fn),[A.Container]:H(pn),[A.Form]:({container:e,component:t,baseUrl:n,state:r,data:i,appState:a,appData:o})=>{let s=t.metadata;return w`<mateu-form
+    `,oa=(e,t)=>{let n=e.style;return e.id&&(n&&!n.endsWith(`;`)&&(n+=`;`),n??=``,t[e.id+`.hidden`]==1&&(n+=`display: none;`)),n},sa=(e,t)=>{let n={...e.metadata};if(e.id&&n){if(n.type==A.Button){let r=n;t[e.id+`.disabled`]==1&&(r.disabled=!0)}if(n.type==A.FormField){let r=n;t[e.id+`.disabled`]==1&&(r.disabled=!0)}}return n},H=e=>t=>e(t.container,t.component,t.baseUrl,t.state,t.data,t.appState,t.appData),ca={[A.Bpmn]:({component:e})=>wr(e),[A.Workflow]:({component:e})=>Er(e),[A.FormEditor]:({component:e})=>Dr(e),[A.Page]:H(Sr),[A.Div]:H(hr),[A.Directory]:({component:e,baseUrl:t,state:n,data:r})=>pr(e,t,n,r),[A.FormLayout]:H($t),[A.HorizontalLayout]:H(on),[A.VerticalLayout]:H(sn),[A.SplitLayout]:H(cn),[A.MasterDetailLayout]:H(ln),[A.TabLayout]:H(un),[A.AccordionLayout]:H(dn),[A.BoardLayout]:H(gn),[A.BoardLayoutRow]:H(_n),[A.BoardLayoutItem]:H(vn),[A.Scroller]:H(pn),[A.FullWidth]:H(mn),[A.Container]:H(hn),[A.Form]:({container:e,component:t,baseUrl:n,state:r,data:i,appState:a,appData:o})=>{let s=t.metadata;return w`<mateu-form
             id="${t.id}"
         baseUrl="${n}"
             .component="${t}"
@@ -4562,7 +4562,7 @@ ${i}
                ${P(e,{id:t.actionId,metadata:t,type:k.ClientSide,slot:`buttons`},void 0,r,i,a,o)}
 `)}
 
-            </mateu-form>`},[A.Table]:({component:e,state:t,data:n})=>bn(e,(e.id?n?.[e.id]:void 0)?.page?.content??xn(e,t)),[A.Crud]:H(xr),[A.App]:({container:e,component:t,baseUrl:n,state:r,data:i,appState:a,appData:o})=>w`
+            </mateu-form>`},[A.Table]:({component:e,state:t,data:n})=>Sn(e,(e.id?n?.[e.id]:void 0)?.page?.content??Cn(e,t)),[A.Crud]:H(Cr),[A.App]:({container:e,component:t,baseUrl:n,state:r,data:i,appState:a,appData:o})=>w`
             <mateu-app
                         id="${t.id}"
                         baseUrl="${n}"
@@ -4575,12 +4575,12 @@ ${i}
                         .appData="${o}"
             >
              ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
-         </mateu-app>`,[A.Element]:({container:e,component:t})=>Mn(e,t.metadata,t),[A.FormField]:({component:e,state:t})=>vr(e,t),[A.Text]:({component:e,state:t,data:n,appState:r,appData:i})=>Pn(e,t,n,r,i),[A.Avatar]:({component:e,state:t,data:n})=>ut(e,t,n),[A.Chat]:({component:e,state:t,data:n})=>Cr(e,t,n),[A.AvatarGroup]:({component:e})=>dt(e),[A.Badge]:({component:e,state:t,data:n})=>ft(e,t,n),[A.Breadcrumbs]:({component:e})=>lr(e),[A.Anchor]:({component:e})=>Fn(e),[A.Button]:({component:e,state:t,data:n})=>Hn(e,t,n),[A.Card]:H(Wn),[A.Chart]:({component:e})=>Gn(e),[A.Icon]:({component:e})=>Kn(e),[A.ConfirmDialog]:H(Zn),[A.ContextMenu]:H(Tn),[A.CookieConsent]:({component:e})=>Qn(e),[A.Details]:H($n),[A.Dialog]:({component:e,baseUrl:t,state:n,data:r,appState:i,appData:a})=>er(e,t,n,r,i,a),[A.Drawer]:({component:e,baseUrl:t,state:n,data:r,appState:i,appData:a})=>tr(e,t,n,r,i,a),[A.Image]:({component:e})=>cr(e),[A.Map]:({component:e})=>sr(e),[A.Markdown]:({component:e})=>rr(e),[A.MicroFrontend]:({component:e})=>nr(e),[A.Notification]:({component:e})=>ir(e),[A.ProgressBar]:({component:e,state:t})=>ar(e,t),[A.Popover]:H(or),[A.CarouselLayout]:H(ur),[A.Tooltip]:H(On),[A.MessageInput]:({component:e})=>Dn(e),[A.MessageList]:({component:e})=>Sn(e),[A.CustomField]:H(En),[A.MenuBar]:({container:e,component:t,baseUrl:n,state:r,data:i})=>wn(e,t,n,r,i),[A.Grid]:({component:e,state:t})=>bn(e,xn(e,t)),[A.VirtualList]:H(_n),[A.FormSection]:H(mr),[A.FormSubSection]:H(hr),[A.MetricCard]:({component:e})=>Ar(e),[A.Scoreboard]:H(jr),[A.DashboardPanel]:H(Mr),[A.DashboardLayout]:H(Nr),[A.FoldoutLayout]:H(Fr),[A.ContentLayout]:H(Ir),[A.HeroSection]:H(Lr),[A.EmptyState]:({component:e})=>Ct(e),[A.Skeleton]:({component:e})=>wt(e),[A.Gantt]:({component:e})=>Br(e),[A.PlanningBoard]:({component:e})=>Hr(e),[A.Kanban]:({component:e})=>Wr(e),[A.Timeline]:({component:e})=>Kr(e),[A.ProgressSteps]:({component:e})=>Jr(e),[A.Stat]:({component:e})=>Xr(e),[A.Calendar]:({component:e})=>Qr(e),[A.PricingTable]:({component:e})=>ei(e),[A.OrgChart]:({component:e})=>ni(e),[A.Heatmap]:({component:e})=>ai(e),[A.Funnel]:({component:e})=>si(e),[A.TrendChart]:({component:e})=>li(e),[A.FeatureGrid]:({component:e})=>di(e),[A.Testimonials]:({component:e})=>pi(e),[A.Faq]:({component:e})=>hi(e),[A.CalloutCard]:({component:e})=>_i(e),[A.CommentThread]:({component:e})=>yi(e),[A.FileList]:({component:e})=>Si(e),[A.Checklist]:({component:e})=>wi(e),[A.ComparisonCard]:({component:e})=>Ei(e),[A.EntityHeader]:({component:e})=>Ni(e),[A.Meter]:({component:e})=>Fi(e),[A.TaskProgress]:({component:e})=>Li(e),[A.StatusList]:({component:e})=>zi(e),[A.BulletedList]:({component:e})=>Vi(e),[A.Separator]:({component:e})=>Hi(e),[A.Notice]:H(Wi),[A.TaskQueue]:({component:e})=>Ki(e),[A.ResourceGrid]:({component:e})=>Ji(e),[A.OfferCard]:({component:e})=>Yi(e),[A.AddOnPicker]:({component:e})=>Zi(e),[A.Ledger]:({component:e})=>$i(e),[A.PaymentPicker]:({component:e})=>ta(e),[A.ProcessMonitor]:({component:e})=>ra(e)},sa=(e,t,n,r,i,a,o,s)=>{if(!t?.metadata)return t==null?(console.warn(`No metadata for component`,t),w`<p>No metadata for component</p>`):sa(e,{id:T(),metadata:t,type:k.ClientSide},n,r,i,a,o,s);let c=t.metadata.type,l={...t,style:ia(t,i),metadata:aa(t,i)},u=oa[c];return u?u({container:e,component:l,baseUrl:n,state:r,data:i,appState:a,appData:o,labelAlreadyRendered:s}):w`<p ${l?.slot??_}>Unknown metadata type ${c} for component ${l?.id}</p>`},ca=function(e){return e.NONE=`NONE`,e.INFO=`INFO`,e.SUCCESS=`SUCCESS`,e.WARNING=`WARNING`,e.DANGER=`DANGER`,e}({}),la=(e,t,n)=>{let r=e[n.path];return r?w`<span theme="badge pill ${ua(r.type)}">${r.message}</span>`:w``},ua=e=>{switch(e){case ca.SUCCESS:return`success`;case ca.WARNING:return`warning`;case ca.DANGER:return`error`;case ca.NONE:return`contrast`}return``},U=class extends y{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.respondToVisibility=(e,t)=>{var n={root:document.documentElement};new IntersectionObserver(e=>{e.forEach(e=>{t(e.intersectionRatio>0)})},n).observe(e)},this.keepAsking=!1,this.askToUpper=()=>{let e=this.data[this.id]?.page,t=e?.content?.length/e?.pageSize;this.dispatchEvent(new CustomEvent(`fetch-more-elements`,{detail:{params:{page:t,pageSize:this.metadata?.pageSize},callback:()=>{this.keepAsking&&this.askToUpper()}},bubbles:!0,composed:!0}))},this.renderItem=e=>e.card?sa(this,e.card,this.baseUrl,this.state,this.data,this.appState,this.appData,!1):e.title?w`<div class="neutral-card">
+         </mateu-app>`,[A.Element]:({container:e,component:t})=>Pn(e,t.metadata,t),[A.FormField]:({component:e,state:t})=>br(e,t),[A.Text]:({component:e,state:t,data:n,appState:r,appData:i})=>In(e,t,n,r,i),[A.Avatar]:({component:e,state:t,data:n})=>ut(e,t,n),[A.Chat]:({component:e,state:t,data:n})=>Tr(e,t,n),[A.AvatarGroup]:({component:e})=>dt(e),[A.Badge]:({component:e,state:t,data:n})=>ft(e,t,n),[A.Breadcrumbs]:({component:e})=>dr(e),[A.Anchor]:({component:e})=>Ln(e),[A.Button]:({component:e,state:t,data:n})=>Wn(e,t,n),[A.Card]:H(Kn),[A.Chart]:({component:e})=>qn(e),[A.Icon]:({component:e})=>Jn(e),[A.ConfirmDialog]:H($n),[A.ContextMenu]:H(Dn),[A.CookieConsent]:({component:e})=>er(e),[A.Details]:H(tr),[A.Dialog]:({component:e,baseUrl:t,state:n,data:r,appState:i,appData:a})=>nr(e,t,n,r,i,a),[A.Drawer]:({component:e,baseUrl:t,state:n,data:r,appState:i,appData:a})=>rr(e,t,n,r,i,a),[A.Image]:({component:e})=>ur(e),[A.Map]:({component:e})=>lr(e),[A.Markdown]:({component:e})=>ar(e),[A.MicroFrontend]:({component:e})=>ir(e),[A.Notification]:({component:e})=>or(e),[A.ProgressBar]:({component:e,state:t})=>sr(e,t),[A.Popover]:H(cr),[A.CarouselLayout]:H(fr),[A.Tooltip]:H(An),[A.MessageInput]:({component:e})=>kn(e),[A.MessageList]:({component:e})=>wn(e),[A.CustomField]:H(On),[A.MenuBar]:({container:e,component:t,baseUrl:n,state:r,data:i})=>En(e,t,n,r,i),[A.Grid]:({component:e,state:t})=>Sn(e,Cn(e,t)),[A.VirtualList]:H(yn),[A.FormSection]:H(gr),[A.FormSubSection]:H(_r),[A.MetricCard]:({component:e})=>Mr(e),[A.Scoreboard]:H(Nr),[A.DashboardPanel]:H(Pr),[A.DashboardLayout]:H(Fr),[A.FoldoutLayout]:H(Lr),[A.ContentLayout]:H(Rr),[A.HeroSection]:H(zr),[A.EmptyState]:({component:e})=>Ct(e),[A.Skeleton]:({component:e})=>wt(e),[A.Gantt]:({component:e})=>Hr(e),[A.PlanningBoard]:({component:e})=>Wr(e),[A.Kanban]:({component:e})=>Kr(e),[A.Timeline]:({component:e})=>Jr(e),[A.ProgressSteps]:({component:e})=>Xr(e),[A.Stat]:({component:e})=>Qr(e),[A.Calendar]:({component:e})=>ei(e),[A.PricingTable]:({component:e})=>ni(e),[A.OrgChart]:({component:e})=>ii(e),[A.Heatmap]:({component:e})=>si(e),[A.Funnel]:({component:e})=>li(e),[A.TrendChart]:({component:e})=>di(e),[A.FeatureGrid]:({component:e})=>pi(e),[A.Testimonials]:({component:e})=>hi(e),[A.Faq]:({component:e})=>_i(e),[A.CalloutCard]:({component:e})=>yi(e),[A.CommentThread]:({component:e})=>xi(e),[A.FileList]:({component:e})=>wi(e),[A.Checklist]:({component:e})=>Ei(e),[A.ComparisonCard]:({component:e})=>Oi(e),[A.EntityHeader]:({component:e})=>Fi(e),[A.Meter]:({component:e})=>Li(e),[A.TaskProgress]:({component:e})=>zi(e),[A.StatusList]:({component:e})=>Vi(e),[A.BulletedList]:({component:e})=>Ui(e),[A.Separator]:({component:e})=>Wi(e),[A.Notice]:H(Ki),[A.TaskQueue]:({component:e})=>Ji(e),[A.ResourceGrid]:({component:e})=>Xi(e),[A.OfferCard]:({component:e})=>Zi(e),[A.AddOnPicker]:({component:e})=>$i(e),[A.Ledger]:({component:e})=>ta(e),[A.PaymentPicker]:({component:e})=>ra(e),[A.ProcessMonitor]:({component:e})=>aa(e)},la=(e,t,n,r,i,a,o,s)=>{if(!t?.metadata)return t==null?(console.warn(`No metadata for component`,t),w`<p>No metadata for component</p>`):la(e,{id:T(),metadata:t,type:k.ClientSide},n,r,i,a,o,s);let c=t.metadata.type,l={...t,style:oa(t,i),metadata:sa(t,i)},u=ca[c];return u?u({container:e,component:l,baseUrl:n,state:r,data:i,appState:a,appData:o,labelAlreadyRendered:s}):w`<p ${l?.slot??_}>Unknown metadata type ${c} for component ${l?.id}</p>`},ua=function(e){return e.NONE=`NONE`,e.INFO=`INFO`,e.SUCCESS=`SUCCESS`,e.WARNING=`WARNING`,e.DANGER=`DANGER`,e}({}),da=(e,t,n)=>{let r=e[n.path];return r?w`<span theme="badge pill ${fa(r.type)}">${r.message}</span>`:w``},fa=e=>{switch(e){case ua.SUCCESS:return`success`;case ua.WARNING:return`warning`;case ua.DANGER:return`error`;case ua.NONE:return`contrast`}return``},U=class extends y{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.respondToVisibility=(e,t)=>{var n={root:document.documentElement};new IntersectionObserver(e=>{e.forEach(e=>{t(e.intersectionRatio>0)})},n).observe(e)},this.keepAsking=!1,this.askToUpper=()=>{let e=this.data[this.id]?.page,t=e?.content?.length/e?.pageSize;this.dispatchEvent(new CustomEvent(`fetch-more-elements`,{detail:{params:{page:t,pageSize:this.metadata?.pageSize},callback:()=>{this.keepAsking&&this.askToUpper()}},bubbles:!0,composed:!0}))},this.renderItem=e=>e.card?la(this,e.card,this.baseUrl,this.state,this.data,this.appState,this.appData,!1):e.title?w`<div class="neutral-card">
                 ${e.image?w`<img class="card-media" src="${e.image}" alt="" />`:_}
                 <div class="card-body">
                     <div class="card-head">
                         ${e.title?w`<span class="card-title">${e.title}</span>`:_}
-                        ${e.status?w`<span theme="badge ${ua(e.status.type)}">${e.status.message}</span>`:_}
+                        ${e.status?w`<span theme="badge ${fa(e.status.type)}">${e.status.message}</span>`:_}
                     </div>
                     ${e.subtitle?w`<div class="card-subtitle">${e.subtitle}</div>`:_}
                     ${e.content?w`<div>${e.content}</div>`:_}
@@ -4618,19 +4618,19 @@ ${i}
         .neutral-card .card-subtitle { color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-s, .875rem); }
     
         ${R}
-    `}};O([v()],U.prototype,`id`,void 0),O([v()],U.prototype,`metadata`,void 0),O([v()],U.prototype,`baseUrl`,void 0),O([v()],U.prototype,`state`,void 0),O([v()],U.prototype,`data`,void 0),O([v()],U.prototype,`appState`,void 0),O([v()],U.prototype,`appData`,void 0),O([v()],U.prototype,`emptyStateMessage`,void 0),O([S()],U.prototype,`keepAsking`,void 0),O([b(`#ask-for-more`)],U.prototype,`askForMore`,void 0),O([S()],U.prototype,`hasMore`,void 0),U=O([h(`mateu-card-list`)],U);var da={show:e=>console.debug(`[mateu] no notifier registered, dropping toast:`,e.text)};function fa(e){da=e}function pa(e,t){da.show(e,t)}var ma=function(e){return e.none=`none`,e.success=`success`,e.error=`error`,e.warning=`warning`,e.contrast=`contrast`,e.normal=`normal`,e}({}),ha=function(e){return e.primary=`primary`,e.secondary=`secondary`,e.tertiary=`tertiary`,e.tertiaryInline=`tertiaryInline`,e}({});function ga(e){if(e.weight!=null)return e.weight;let t=e.stereotype??``;if(t===`icon`)return 1;if(t===`image`)return 4;if(t===`html`||t===`richText`||t===`markdown`||t===`textarea`)return 5;if(t===`link`)return 2.5;if(t===`combobox`||t===`select`)return 2;let n=e.dataType??``;return n===`bool`?1:n===`status`||n===`integer`?1.5:n===`number`||n===`date`||n===`money`?2:n===`dateTime`||n===`dateRange`?2.5:3}function _a(e,t){if(e.length===0)return`table`;let n=e.reduce((e,t)=>e+ga(t),0)/(t/76);if(n<=1.1)return`table`;if(n>1.6||e.length>10)return`masterDetail`;let r=e.filter(e=>e.identifier||(e.priority??2**53-1)<=2),i=r.reduce((e,t)=>e+ga(t),0);return r.length>0&&i<=8?`list`:e.some(e=>e.stereotype===`image`||e.stereotype===`html`)||r.length===0&&e.length>=4&&e.length<=8?`cards`:`masterDetail`}function va(e){return e.filter(e=>e.identifier||(e.priority??2**53-1)<=2).sort((e,t)=>(e.priority??2**53-1)-(t.priority??2**53-1))}function ya(e){let t=va(e);return t.length>0?t:e.slice(0,3)}var ba={asc:`ascending`,desc:`descending`},W=class extends y{constructor(...e){super(...e),this.component=void 0,this.standalone=!1,this.state={},this.data={},this.appState={},this.appData={},this.showImportDialog=!1,this.availableWidthPx=1024,this.selectedItem=null,this._columnPrefsRevision=0,this._prefsRevisionApplied=-1,this.search=()=>{let e=this.component.metadata;this.state={...this.state,size:e.pageSize,page:0,crud_selected_items:[]},this._syncStateToUrl(e),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`search`,parameters:{crudId:this.id,_searchState:{...this.state}}},bubbles:!0,composed:!0}))},this.notify=e=>{pa({text:e,position:`bottomEnd`,variant:`error`,duration:3e3},this)},this.handleSearchRequested=e=>{this.state={...this.state,crud_selected_items:[]};let t=this.component.metadata;if(this._syncStateToUrl(t),t.rowsSource){this._fetchRowsFromRest(t,e);return}!t.infiniteScrolling&&this.data?.[this.id]?.page&&(this.data[this.id].page.content=[]),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`search`,parameters:{crudId:this.id,_searchState:{...this.state}},callback:e},bubbles:!0,composed:!0}))},this._fetchRowsFromRest=(e,t)=>{let n=this.cols.map(e=>e.id).filter(Boolean),r=e.rowsSource;(r.proxy?new Promise(e=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`__restfetch__`,parameters:{_sourceKind:`rows`,_sourceId:this.id},callback:t=>e(Gt(t?.appData?._restfetch,r.itemsPath,n)),callbackonly:!0},bubbles:!0,composed:!0}))}):Jt(r,n,e=>j(e,this.state,this.data))).then(r=>{let i=String(this.state?.searchText??``).trim().toLowerCase(),a=i?r.filter(e=>n.some(t=>String(e[t]??``).toLowerCase().includes(i))):r,o=e.pageSize&&e.pageSize>0?e.pageSize:a.length||1,s=Number(this.state?.page??0),c=a.slice(s*o,s*o+o);this.data={...this.data,[this.id]:{page:{totalElements:a.length,pageSize:o,pageNumber:s,content:c}}},this.requestUpdate(),t?.()}).catch(e=>{console.warn(`mateu: external rows fetch failed`,e),t?.()})},this.fetchMoreElements=e=>{let{params:t,callback:n}=e.detail;this.state={...this.state,size:t.pageSize,page:t.page},this.handleSearchRequested(n)},this.directionChanged=e=>{let t=e.detail.grid._sorters;this.state={...this.state,sort:t.map(e=>({fieldId:e.__data.path,direction:e.__data.direction?ba[e.__data.direction]:void 0}))},this.handleSearchRequested(void 0)},this._initializedForComponentId=void 0,this.evalLabel=e=>j(e,this.state,this.data),this.handleToolbarButtonClick=e=>{if(e===`import`){this.showImportDialog=!0;return}this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.handleImportUploadSuccess=e=>{let t=e.detail.xhr.responseText;this.showImportDialog=!1,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`process-import`,parameters:{fileId:t}},bubbles:!0,composed:!0}))}}get columnPrefsScope(){return window.location.pathname}get effectiveComponent(){let e=this.component,t=e?.metadata;if(!e||!t?.columns)return e;if(this._prefsSource===e&&this._prefsRevisionApplied===this._columnPrefsRevision)return this._prefsApplied;let n=Lt(this.columnPrefsScope),r=Vt(t.columns,n,e=>e.metadata??{});return this._prefsApplied=r===t.columns?e:{...e,metadata:{...t,columns:r}},this._prefsSource=e,this._prefsRevisionApplied=this._columnPrefsRevision,this._prefsApplied}get columnChooserEntries(){return(this.component?.metadata?.columns??[]).map(e=>{let t=e.metadata??{},n=t.id??e.id;return n?{id:n,label:t.label??n,protected:Bt(t)}:void 0}).filter(e=>!!e)}renderColumnChooser(){let e=this.columnChooserEntries;return e.filter(e=>!e.protected).length===0?_:w`
+    `}};O([v()],U.prototype,`id`,void 0),O([v()],U.prototype,`metadata`,void 0),O([v()],U.prototype,`baseUrl`,void 0),O([v()],U.prototype,`state`,void 0),O([v()],U.prototype,`data`,void 0),O([v()],U.prototype,`appState`,void 0),O([v()],U.prototype,`appData`,void 0),O([v()],U.prototype,`emptyStateMessage`,void 0),O([S()],U.prototype,`keepAsking`,void 0),O([b(`#ask-for-more`)],U.prototype,`askForMore`,void 0),O([S()],U.prototype,`hasMore`,void 0),U=O([h(`mateu-card-list`)],U);var pa={show:e=>console.debug(`[mateu] no notifier registered, dropping toast:`,e.text)};function ma(e){pa=e}function ha(e,t){pa.show(e,t)}var ga=function(e){return e.none=`none`,e.success=`success`,e.error=`error`,e.warning=`warning`,e.contrast=`contrast`,e.normal=`normal`,e}({}),_a=function(e){return e.primary=`primary`,e.secondary=`secondary`,e.tertiary=`tertiary`,e.tertiaryInline=`tertiaryInline`,e}({});function va(e){if(e.weight!=null)return e.weight;let t=e.stereotype??``;if(t===`icon`)return 1;if(t===`image`)return 4;if(t===`html`||t===`richText`||t===`markdown`||t===`textarea`)return 5;if(t===`link`)return 2.5;if(t===`combobox`||t===`select`)return 2;let n=e.dataType??``;return n===`bool`?1:n===`status`||n===`integer`?1.5:n===`number`||n===`date`||n===`money`?2:n===`dateTime`||n===`dateRange`?2.5:3}function ya(e,t){if(e.length===0)return`table`;let n=e.reduce((e,t)=>e+va(t),0)/(t/76);if(n<=1.1)return`table`;if(n>1.6||e.length>10)return`masterDetail`;let r=e.filter(e=>e.identifier||(e.priority??2**53-1)<=2),i=r.reduce((e,t)=>e+va(t),0);return r.length>0&&i<=8?`list`:e.some(e=>e.stereotype===`image`||e.stereotype===`html`)||r.length===0&&e.length>=4&&e.length<=8?`cards`:`masterDetail`}function ba(e){return e.filter(e=>e.identifier||(e.priority??2**53-1)<=2).sort((e,t)=>(e.priority??2**53-1)-(t.priority??2**53-1))}function xa(e){let t=ba(e);return t.length>0?t:e.slice(0,3)}var Sa={asc:`ascending`,desc:`descending`},W=class extends y{constructor(...e){super(...e),this.component=void 0,this.standalone=!1,this.state={},this.data={},this.appState={},this.appData={},this.showImportDialog=!1,this.availableWidthPx=1024,this.selectedItem=null,this._columnPrefsRevision=0,this._prefsRevisionApplied=-1,this.search=()=>{let e=this.component.metadata;this.state={...this.state,size:e.pageSize,page:0,crud_selected_items:[]},this._syncStateToUrl(e),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`search`,parameters:{crudId:this.id,_searchState:{...this.state}}},bubbles:!0,composed:!0}))},this.notify=e=>{ha({text:e,position:`bottomEnd`,variant:`error`,duration:3e3},this)},this.handleSearchRequested=e=>{this.state={...this.state,crud_selected_items:[]};let t=this.component.metadata;if(this._syncStateToUrl(t),t.rowsSource){this._fetchRowsFromRest(t,e);return}!t.infiniteScrolling&&this.data?.[this.id]?.page&&(this.data[this.id].page.content=[]),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`search`,parameters:{crudId:this.id,_searchState:{...this.state}},callback:e},bubbles:!0,composed:!0}))},this._fetchRowsFromRest=(e,t)=>{let n=this.cols.map(e=>e.id).filter(Boolean),r=e.rowsSource;(r.proxy?new Promise(e=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`__restfetch__`,parameters:{_sourceKind:`rows`,_sourceId:this.id},callback:t=>e(qt(t?.appData?._restfetch,r.itemsPath,n)),callbackonly:!0},bubbles:!0,composed:!0}))}):Xt(r,n,e=>j(e,this.state,this.data))).then(r=>{let i=String(this.state?.searchText??``).trim().toLowerCase(),a=i?r.filter(e=>n.some(t=>String(e[t]??``).toLowerCase().includes(i))):r,o=e.pageSize&&e.pageSize>0?e.pageSize:a.length||1,s=Number(this.state?.page??0),c=a.slice(s*o,s*o+o);this.data={...this.data,[this.id]:{page:{totalElements:a.length,pageSize:o,pageNumber:s,content:c}}},this.requestUpdate(),t?.()}).catch(e=>{console.warn(`mateu: external rows fetch failed`,e),t?.()})},this.fetchMoreElements=e=>{let{params:t,callback:n}=e.detail;this.state={...this.state,size:t.pageSize,page:t.page},this.handleSearchRequested(n)},this.directionChanged=e=>{let t=e.detail.grid._sorters;this.state={...this.state,sort:t.map(e=>({fieldId:e.__data.path,direction:e.__data.direction?Sa[e.__data.direction]:void 0}))},this.handleSearchRequested(void 0)},this._initializedForComponentId=void 0,this.evalLabel=e=>j(e,this.state,this.data),this.handleToolbarButtonClick=e=>{if(e===`import`){this.showImportDialog=!0;return}this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.handleImportUploadSuccess=e=>{let t=e.detail.xhr.responseText;this.showImportDialog=!1,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`process-import`,parameters:{fileId:t}},bubbles:!0,composed:!0}))}}get columnPrefsScope(){return window.location.pathname}get effectiveComponent(){let e=this.component,t=e?.metadata;if(!e||!t?.columns)return e;if(this._prefsSource===e&&this._prefsRevisionApplied===this._columnPrefsRevision)return this._prefsApplied;let n=Lt(this.columnPrefsScope),r=Vt(t.columns,n,e=>e.metadata??{});return this._prefsApplied=r===t.columns?e:{...e,metadata:{...t,columns:r}},this._prefsSource=e,this._prefsRevisionApplied=this._columnPrefsRevision,this._prefsApplied}get columnChooserEntries(){return(this.component?.metadata?.columns??[]).map(e=>{let t=e.metadata??{},n=t.id??e.id;return n?{id:n,label:t.label??n,protected:Bt(t)}:void 0}).filter(e=>!!e)}renderColumnChooser(){let e=this.columnChooserEntries;return e.filter(e=>!e.protected).length===0?_:w`
             <mateu-column-chooser
                 .columns="${e}"
                 .scope="${this.columnPrefsScope}"
                 @column-prefs-changed="${e=>{e.stopPropagation(),this._columnPrefsRevision++}}"
             ></mateu-column-chooser>
-        `}get cols(){return(this.effectiveComponent?.metadata)?.columns?.map(e=>e.metadata)??[]}get identifierFieldName(){let e=this.cols.find(e=>e.identifier);return e?e.id:this.cols.find(e=>e.id===`id`)?.id}get effectiveGridLayout(){let e=this.component?.metadata,t=e?.gridLayout??`auto`;return t===`auto`?e?.crudlType===`card`?`cards`:_a(this.cols,this.availableWidthPx):t}connectedCallback(){super.connectedCallback(),this.resizeObserver=new ResizeObserver(e=>{let t=e[0]?.contentRect.width;t&&Math.abs(t-this.availableWidthPx)>10&&(this.availableWidthPx=t)}),this.resizeObserver.observe(this)}disconnectedCallback(){super.disconnectedCallback(),this.resizeObserver?.disconnect()}_filterIds(e){return new Set([`searchText`,...(e.filters??[]).flatMap(e=>e.stereotype===`dateRange`||e.stereotype===`numberRange`?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId])])}_syncStateToUrl(e){let t=this._filterIds(e),n=new URLSearchParams(window.location.search);t.forEach(e=>n.delete(e)),n.delete(`page`),n.delete(`sort`),t.forEach(e=>{let t=this.state[e];t!=null&&t!==``&&n.set(e,String(t))});let r=this.state.page;r&&r>0&&n.set(`page`,String(r));let i=this.state.sort;if(i&&i.length>0){let e=i.filter(e=>e.fieldId&&e.direction).map(e=>`${e.fieldId}:${e.direction}`).join(`,`);e&&n.set(`sort`,e)}let a=n.toString(),o=a?`${window.location.pathname}?${a}`:window.location.pathname;window.location.pathname+window.location.search!==o&&history.replaceState(null,``,o)}_initStateFromUrl(e,t){let n=new URLSearchParams(window.location.search),r=this._filterIds(e),i={...t};n.forEach((e,t)=>{r.has(t)&&(i[t]=e)});let a=n.get(`page`);if(a!==null){let e=parseInt(a,10);!isNaN(e)&&e>0&&(i.page=e)}let o=n.get(`sort`);if(o){let e=o.split(`,`).map(e=>{let[t,n]=e.split(`:`);return t&&n?{fieldId:t,direction:n}:null}).filter(Boolean);e.length>0&&(i.sort=e)}return i}pageChanged(e){this.state={...this.state,page:e.detail.page},this.handleSearchRequested(void 0)}updated(e){if(super.updated(e),e.has(`component`)){let e=this.component?.id;if(e!==this._initializedForComponentId){this._initializedForComponentId=e;let t=this.component?.metadata,n=t.initialPage&&t.initialPage>0?t.initialPage:0;this.state=this._initStateFromUrl(t,{...this.state,size:t.pageSize,page:n,sort:[]}),(this.state.page!==n||this.state.sort?.length>0||[...this._filterIds(t)].some(e=>this.state[e]!=null)||t.rowsSource)&&this.handleSearchRequested(void 0)}}}render(){let e=e=>{let t=[];return e.color&&e.color!==ma.normal&&t.push(e.color),e.buttonStyle&&t.push(e.buttonStyle===ha.tertiaryInline?`tertiary-inline`:e.buttonStyle),t.length?t.join(` `):void 0},t=e=>e===`back`||e===`backToList`||!!e&&e.startsWith(`cancel`),n=t=>N.get()?.renderToolbarButton?.(t,this.evalLabel(t.label),()=>this.handleToolbarButtonClick(t.actionId))||w`
+        `}get cols(){return(this.effectiveComponent?.metadata)?.columns?.map(e=>e.metadata)??[]}get identifierFieldName(){let e=this.cols.find(e=>e.identifier);return e?e.id:this.cols.find(e=>e.id===`id`)?.id}get effectiveGridLayout(){let e=this.component?.metadata,t=e?.gridLayout??`auto`;return t===`auto`?e?.crudlType===`card`?`cards`:ya(this.cols,this.availableWidthPx):t}connectedCallback(){super.connectedCallback(),this.resizeObserver=new ResizeObserver(e=>{let t=e[0]?.contentRect.width;t&&Math.abs(t-this.availableWidthPx)>10&&(this.availableWidthPx=t)}),this.resizeObserver.observe(this)}disconnectedCallback(){super.disconnectedCallback(),this.resizeObserver?.disconnect()}_filterIds(e){return new Set([`searchText`,...(e.filters??[]).flatMap(e=>e.stereotype===`dateRange`||e.stereotype===`numberRange`?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId])])}_syncStateToUrl(e){let t=this._filterIds(e),n=new URLSearchParams(window.location.search);t.forEach(e=>n.delete(e)),n.delete(`page`),n.delete(`sort`),t.forEach(e=>{let t=this.state[e];t!=null&&t!==``&&n.set(e,String(t))});let r=this.state.page;r&&r>0&&n.set(`page`,String(r));let i=this.state.sort;if(i&&i.length>0){let e=i.filter(e=>e.fieldId&&e.direction).map(e=>`${e.fieldId}:${e.direction}`).join(`,`);e&&n.set(`sort`,e)}let a=n.toString(),o=a?`${window.location.pathname}?${a}`:window.location.pathname;window.location.pathname+window.location.search!==o&&history.replaceState(null,``,o)}_initStateFromUrl(e,t){let n=new URLSearchParams(window.location.search),r=this._filterIds(e),i={...t};n.forEach((e,t)=>{r.has(t)&&(i[t]=e)});let a=n.get(`page`);if(a!==null){let e=parseInt(a,10);!isNaN(e)&&e>0&&(i.page=e)}let o=n.get(`sort`);if(o){let e=o.split(`,`).map(e=>{let[t,n]=e.split(`:`);return t&&n?{fieldId:t,direction:n}:null}).filter(Boolean);e.length>0&&(i.sort=e)}return i}pageChanged(e){this.state={...this.state,page:e.detail.page},this.handleSearchRequested(void 0)}updated(e){if(super.updated(e),e.has(`component`)){let e=this.component?.id;if(e!==this._initializedForComponentId){this._initializedForComponentId=e;let t=this.component?.metadata,n=t.initialPage&&t.initialPage>0?t.initialPage:0;this.state=this._initStateFromUrl(t,{...this.state,size:t.pageSize,page:n,sort:[]}),(this.state.page!==n||this.state.sort?.length>0||[...this._filterIds(t)].some(e=>this.state[e]!=null)||t.rowsSource)&&this.handleSearchRequested(void 0)}}}render(){let e=e=>{let t=[];return e.color&&e.color!==ga.normal&&t.push(e.color),e.buttonStyle&&t.push(e.buttonStyle===_a.tertiaryInline?`tertiary-inline`:e.buttonStyle),t.length?t.join(` `):void 0},t=e=>e===`back`||e===`backToList`||!!e&&e.startsWith(`cancel`),n=t=>N.get()?.renderToolbarButton?.(t,this.evalLabel(t.label),()=>this.handleToolbarButtonClick(t.actionId))||w`
                 <button class="crud-btn"
                         data-action-id="${t.id}"
                         theme="${e(t)||_}"
                         @click="${()=>this.handleToolbarButtonClick(t.actionId)}"
                 >${this.evalLabel(t.label)}</button>
-            `;if(!this.component)return w`no component`;let r=this.effectiveComponent,i=r.metadata;i.serverSideOrdering=!0;let a=(()=>{let e=this;for(;e;){let t=e;if(t.tagName===`MATEU-PAGE`)return(t.component?.metadata?.toolbar?.length??0)>0;e=t.parentElement??(t.getRootNode?.()instanceof ShadowRoot?t.getRootNode().host:null)}return!1})()?[]:i?.toolbar??[],o=a.filter(e=>t(e.actionId)),s=a.filter(e=>!t(e.actionId)),c=o.length>0&&s.length>0,l=!!i?.title||!!i?.subtitle||a.length>0,u=this.effectiveGridLayout,d=this.cols,f=va(d),p=this.data[this.id]?.page?.content??[],ee=this.state[this.component?.id]?.emptyStateMessage,te=(e,t)=>{let n=t[e.id];return n==null?w``:e.dataType===`status`?w`<span theme="badge pill ${ua(n.type)}">${n.message}</span>`:e.dataType===`bool`?w`${n?`✓`:`✗`}`:typeof n==`object`?w`${n.label??n.name??n.message??``}`:w`${n}`},ne=()=>{let e=this.identifierFieldName,t=this.state._selectedId??this.appState?._splitDetailId,n=f.find(e=>e.identifier)??f[0],r=e=>e.dataType===`action`||e.dataType===`actionGroup`||e.dataType===`menu`||e.stereotype===`button`,i=f.filter(e=>e!==n&&!r(e)),a=d.filter(e=>r(e)),o=(e,t,n)=>{e.stopPropagation(),e.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_clickedRow:n}},bubbles:!0,composed:!0}))},s=e=>{let t=[];for(let n of a){let r=e[n.id];if(n.dataType===`action`){let i=r?.methodNameInCrud?r:e.action?.methodNameInCrud?e.action:{methodNameInCrud:n.id,label:n.label,icon:null,disabled:!1};t.push(w`
+            `;if(!this.component)return w`no component`;let r=this.effectiveComponent,i=r.metadata;i.serverSideOrdering=!0;let a=(()=>{let e=this;for(;e;){let t=e;if(t.tagName===`MATEU-PAGE`)return(t.component?.metadata?.toolbar?.length??0)>0;e=t.parentElement??(t.getRootNode?.()instanceof ShadowRoot?t.getRootNode().host:null)}return!1})()?[]:i?.toolbar??[],o=a.filter(e=>t(e.actionId)),s=a.filter(e=>!t(e.actionId)),c=o.length>0&&s.length>0,l=!!i?.title||!!i?.subtitle||a.length>0,u=this.effectiveGridLayout,d=this.cols,f=ba(d),p=this.data[this.id]?.page?.content??[],ee=this.state[this.component?.id]?.emptyStateMessage,te=(e,t)=>{let n=t[e.id];return n==null?w``:e.dataType===`status`?w`<span theme="badge pill ${fa(n.type)}">${n.message}</span>`:e.dataType===`bool`?w`${n?`✓`:`✗`}`:typeof n==`object`?w`${n.label??n.name??n.message??``}`:w`${n}`},ne=()=>{let e=this.identifierFieldName,t=this.state._selectedId??this.appState?._splitDetailId,n=f.find(e=>e.identifier)??f[0],r=e=>e.dataType===`action`||e.dataType===`actionGroup`||e.dataType===`menu`||e.stereotype===`button`,i=f.filter(e=>e!==n&&!r(e)),a=d.filter(e=>r(e)),o=(e,t,n)=>{e.stopPropagation(),e.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_clickedRow:n}},bubbles:!0,composed:!0}))},s=e=>{let t=[];for(let n of a){let r=e[n.id];if(n.dataType===`action`){let i=r?.methodNameInCrud?r:e.action?.methodNameInCrud?e.action:{methodNameInCrud:n.id,label:n.label,icon:null,disabled:!1};t.push(w`
                             <button class="crud-btn" theme="tertiary small" title="${i.label||_}"
                                 @click="${t=>o(t,`action-on-row-`+i.methodNameInCrud,e)}">
                                 ${i.icon?F(i.icon):_}
@@ -4694,7 +4694,7 @@ ${i}
                             ${ne(n)}
                         </div>
                     `)}
-                </div>`},h=()=>{let e=ya(d),t=e.find(e=>e.identifier)??e[0],n=e.filter(e=>e!==t);return w`
+                </div>`},h=()=>{let e=xa(d),t=e.find(e=>e.identifier)??e[0],n=e.filter(e=>e!==t);return w`
                 <div style="display: flex; height: 100%; min-height: 400px; gap: 0;">
                     <div style="width: 260px; flex-shrink: 0; border-right: 1px solid var(--lumo-contrast-20pct); overflow-y: auto;">
                         <div class="m-listbox" style="width: 100%;">
@@ -4867,7 +4867,7 @@ ${i}
         }
     
         ${R}
-    `}};O([v()],W.prototype,`component`,void 0),O([v()],W.prototype,`baseUrl`,void 0),O([v({type:Boolean})],W.prototype,`standalone`,void 0),O([v()],W.prototype,`state`,void 0),O([v()],W.prototype,`data`,void 0),O([v()],W.prototype,`appState`,void 0),O([v()],W.prototype,`appData`,void 0),O([S()],W.prototype,`showImportDialog`,void 0),O([S()],W.prototype,`availableWidthPx`,void 0),O([S()],W.prototype,`selectedItem`,void 0),O([S()],W.prototype,`_columnPrefsRevision`,void 0),W=O([h(`mateu-table-crud`)],W);var xa=function(e){return e.OnLoad=`OnLoad`,e.OnSuccess=`OnSuccess`,e.OnError=`OnError`,e.OnValueChange=`OnValueChange`,e.OnCustomEvent=`OnCustomEvent`,e.AutoSave=`AutoSave`,e}({}),Sa=class extends et{constructor(...e){super(...e),this.state={},this.data={},this.appData={},this.appState={},this.triggerOnLoad=()=>{let e=this.component;this.registerCustomEventListeners(),e.triggers?.filter(e=>e.type==xa.OnLoad).forEach(e=>{if((!e.condition||this._evalExpr(e.condition))&&!e.triggered){let n=e;n.triggered=!0;var t=n.times-1;n.timeoutMillis>0?this.scheduleOnload(n,t,this.id):this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.actionId},bubbles:!0,composed:!0}))}})},this.scheduleOnload=(e,t,n)=>{if(n!=this.component?.id)return;let r=this.callbackToken;setTimeout(()=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,callbackToken:r},bubbles:!0,composed:!0}))},e.timeoutMillis)},this._registeredCustomEventListeners=[],this.customEventManager=e=>{if(!(e instanceof CustomEvent))return;let t=e,n=(this.component.triggers??[]).filter(e=>e.type==xa.OnCustomEvent).filter(e=>e.eventName==t.type).filter(e=>e.source!==`COMPONENT`||t.detail?.__source===e.from);n.length!==0&&(n.some(e=>!e.source||e.source===`SELF`)&&(e.stopPropagation(),e.preventDefault()),n.forEach(e=>{(!e.condition||this._evalExpr(e.condition))&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:t.detail},bubbles:!0,composed:!0}))}))}}_interpolationExtra(){return{appState:this.appState??{},appData:this.appData??{},component:this.component}}_evalExpr(e){return ot(e,this.state??{},this.data??{},this._interpolationExtra())}_evalTemplate(e){return st(e,this.state??{},this.data??{},this._interpolationExtra())}isOverlayChild(e){let t=e?.metadata?.type;return t==A.Drawer||t==A.Dialog}removeSelfFromOwnerChildren(){let e=this.component;if(!e)return!1;let t=t=>{if(t===e)return!0;let n=t;return e.id!=null&&n?.id==e.id&&this.isOverlayChild(n)},n=this.parentNode;for(;n;){let e=n instanceof ShadowRoot?n.host:n,r=e.component?.children;if(Array.isArray(r)){let n=r.findIndex(t);if(n>=0)return r.splice(n,1),e.requestUpdate?.(),!0}n=n instanceof ShadowRoot?e:n.parentNode}return!1}applyFragment(e){if(this.id==e.targetComponentId){if(e.component)if(Ke.Add==e.action){if(this.component){let t=this.component.children??(this.component.children=[]),n=e.component.id?t.findIndex(t=>t.id==e.component.id&&this.isOverlayChild(t)):-1;n>=0?(t[n]=e.component,this.component={...this.component}):t.push(e.component)}}else{this.callbackToken=T();let t=!1;if(e.component?.type==k.ServerSide)if(this.component){let n=this.component,r=e.component;t=n.serverSideType==r.serverSideType;let i=t?(n.children??[]).filter(e=>this.isOverlayChild(e)):[];n.actions=r.actions,n.type=r.type,n.rules=r.rules,n.triggers=r.triggers,n.serverSideType=r.serverSideType,n.route=r.route,n.initialData=r.initialData,n.validations=r.validations,n.cssClasses=r.cssClasses,n.slot=r.slot,n.style=r.style,n.children=i.length?[...r.children??[],...i]:r.children,(n.serverSideType!=r.serverSideType||n.id!=r.id)&&setTimeout(()=>this.triggerOnLoad())}else this.component=e.component,setTimeout(()=>this.triggerOnLoad());else{let t=[e.component];this.component&&(this.component.children=t)}e.action!==Ke.ReplaceKeepData&&!t&&(this.state={},this.data={})}if(e.state&&(this.state={...this.state,...e.state}),e.data){for(let t in e.data){let n=e.data[t]?.page;n?.pageNumber>0&&this.data[t]&&this.data[t].page.content&&(n.content?n.content=[...this.data[t].page.content,...n.content]:n.content=[...this.data[t].page.content])}this.data={...this.data,...e.data}}this.registerCustomEventListeners();let t=N.getAfterRenderHook();t&&setTimeout(()=>t(this)),this.requestUpdate()}}registerCustomEventListeners(){this._registeredCustomEventListeners.forEach(({target:e,name:t})=>e.removeEventListener(t,this.customEventManager)),this._registeredCustomEventListeners=[],this.component?.triggers?.filter(e=>e.type==xa.OnCustomEvent).forEach(e=>{let t=e.source===`DOCUMENT`||e.source===`COMPONENT`?document:this;t.addEventListener(e.eventName,this.customEventManager),this._registeredCustomEventListeners.push({target:t,name:e.eventName})})}disconnectedCallback(){this._registeredCustomEventListeners.forEach(({target:e,name:t})=>e.removeEventListener(t,this.customEventManager)),this._registeredCustomEventListeners=[],super.disconnectedCallback()}connectedCallback(){super.connectedCallback(),this.component&&this.registerCustomEventListeners()}};O([v()],Sa.prototype,`state`,void 0),O([v()],Sa.prototype,`data`,void 0),O([v()],Sa.prototype,`appData`,void 0),O([v()],Sa.prototype,`appState`,void 0);var Ca=`mateu-recent-routes`,wa=8;function Ta(){try{return JSON.parse(localStorage.getItem(Ca)??`{}`)}catch{return{}}}function Ea(e){try{localStorage.setItem(Ca,JSON.stringify(e))}catch{}}function Da(e){return Ta()[e||`_`]??[]}function Oa(e,t){if(!t?.route||!t.label)return;let n=e||`_`,r=Ta(),i=(r[n]??[]).filter(e=>e.route!==t.route);i.unshift({route:t.route,label:t.label}),r[n]=i.slice(0,wa),Ea(r)}var G=class extends y{constructor(...e){super(...e),this.baseUrl=``,this.open=!1,this.queryText=``,this.dataHits=[],this.loading=!1,this.selectedIndex=0,this.fabOffset=0,this.keydownHandler=null}connectedCallback(){super.connectedCallback(),this.keydownHandler=e=>{(e.metaKey||e.ctrlKey)&&(e.key===`k`||e.key===`K`)?(e.preventDefault(),this.toggle()):e.key===`Escape`&&this.open&&this.close()},document.addEventListener(`keydown`,this.keydownHandler),this.setupFabObserver()}disconnectedCallback(){super.disconnectedCallback(),this.keydownHandler&&document.removeEventListener(`keydown`,this.keydownHandler),clearTimeout(this.searchTimer),this.fabObserver?.disconnect(),this.fabObserver=void 0}setupFabObserver(){let e=this.getRootNode(),t=e instanceof ShadowRoot?e:document.body;this.measureFabStack(),this.fabObserver?.disconnect(),this.fabObserver=new MutationObserver(()=>this.measureFabStack()),this.fabObserver.observe(t,{childList:!0,subtree:!0})}measureFabStack(){let e=(this.getRootNode().querySelectorAll?.(`.ai-fab, .app-fab, .page-fab`).length??0)*4;e!==this.fabOffset&&(this.fabOffset=e)}updated(e){e.has(`open`)&&this.open&&requestAnimationFrame(()=>this.inputEl?.focus())}toggle(){this.open?this.close():this.openCenter()}openCenter(){this.open=!0,this.queryText=``,this.dataHits=[],this.selectedIndex=0}close(){this.open=!1,this.queryText=``,this.dataHits=[],clearTimeout(this.searchTimer)}flattenMenu(e,t){let n=[];for(let r of e??[])if(!r.separator)if(r.submenus&&r.submenus.length>0){let e=t?`${t} › ${r.label}`:r.label;n.push(...this.flattenMenu(r.submenus,e))}else r.route!==void 0&&r.route!==null&&n.push({label:r.label,breadcrumb:t,route:r.route});return n}onInput(e){this.queryText=e,this.selectedIndex=0;let t=e.trim();if(clearTimeout(this.searchTimer),!t||!this.app?.globalSearchEnabled){this.dataHits=[],this.loading=!1;return}this.loading=!0,this.searchTimer=setTimeout(()=>this.fetchGlobalSearch(t),250)}async fetchGlobalSearch(e){let t=this.app;if(!t?.globalSearchEnabled){this.loading=!1;return}try{let n=(await Ge.runAction(this.baseUrl??``,t.rootRoute??``,``,`_globalsearch`,`command-center`,void 0,t.serverSideType,{},{searchText:e},this,!0))?.fragments?.map(e=>e.data).find(e=>e&&e._globalsearch);this.dataHits=n?._globalsearch??[]}catch{this.dataHits=[]}finally{this.loading=!1}}navigateTo(e,t){Oa(this.app?.serverSideType??``,{route:e,label:t}),this.close();for(let t of[`route-changed`,`navigate-to-requested`])this.dispatchEvent(new CustomEvent(t,{detail:{route:e},bubbles:!0,composed:!0}))}askAi(){let e=this.queryText.trim();this.close(),this.dispatchEvent(new CustomEvent(`mateu-open-ai`,{detail:{query:e},bubbles:!0,composed:!0}))}visibleTargets(e){if(!this.queryText.trim()){let e=this.flattenMenu(this.app?.menu,``).map(e=>({route:e.route,label:e.label})),t=Da(this.app?.serverSideType??``);return[...e,...t]}return[...e.map(e=>({route:e.route,label:e.label})),...this.dataHits.map(e=>({route:e.route,label:e.label}))]}onKeydown(e,t){if(e.key===`ArrowDown`)e.preventDefault(),this.selectedIndex=Math.min(this.selectedIndex+1,t.length-1);else if(e.key===`ArrowUp`)e.preventDefault(),this.selectedIndex=Math.max(this.selectedIndex-1,0);else if(e.key===`Enter`){let e=t[this.selectedIndex];e&&this.navigateTo(e.route,e.label)}}render(){return w`
+    `}};O([v()],W.prototype,`component`,void 0),O([v()],W.prototype,`baseUrl`,void 0),O([v({type:Boolean})],W.prototype,`standalone`,void 0),O([v()],W.prototype,`state`,void 0),O([v()],W.prototype,`data`,void 0),O([v()],W.prototype,`appState`,void 0),O([v()],W.prototype,`appData`,void 0),O([S()],W.prototype,`showImportDialog`,void 0),O([S()],W.prototype,`availableWidthPx`,void 0),O([S()],W.prototype,`selectedItem`,void 0),O([S()],W.prototype,`_columnPrefsRevision`,void 0),W=O([h(`mateu-table-crud`)],W);var Ca=function(e){return e.OnLoad=`OnLoad`,e.OnSuccess=`OnSuccess`,e.OnError=`OnError`,e.OnValueChange=`OnValueChange`,e.OnCustomEvent=`OnCustomEvent`,e.AutoSave=`AutoSave`,e}({}),wa=class extends et{constructor(...e){super(...e),this.state={},this.data={},this.appData={},this.appState={},this.triggerOnLoad=()=>{let e=this.component;this.registerCustomEventListeners(),e.triggers?.filter(e=>e.type==Ca.OnLoad).forEach(e=>{if((!e.condition||this._evalExpr(e.condition))&&!e.triggered){let n=e;n.triggered=!0;var t=n.times-1;n.timeoutMillis>0?this.scheduleOnload(n,t,this.id):this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.actionId},bubbles:!0,composed:!0}))}})},this.scheduleOnload=(e,t,n)=>{if(n!=this.component?.id)return;let r=this.callbackToken;setTimeout(()=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,callbackToken:r},bubbles:!0,composed:!0}))},e.timeoutMillis)},this._registeredCustomEventListeners=[],this.customEventManager=e=>{if(!(e instanceof CustomEvent))return;let t=e,n=(this.component.triggers??[]).filter(e=>e.type==Ca.OnCustomEvent).filter(e=>e.eventName==t.type).filter(e=>e.source!==`COMPONENT`||t.detail?.__source===e.from);n.length!==0&&(n.some(e=>!e.source||e.source===`SELF`)&&(e.stopPropagation(),e.preventDefault()),n.forEach(e=>{(!e.condition||this._evalExpr(e.condition))&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:t.detail},bubbles:!0,composed:!0}))}))}}_interpolationExtra(){return{appState:this.appState??{},appData:this.appData??{},component:this.component}}_evalExpr(e){return ot(e,this.state??{},this.data??{},this._interpolationExtra())}_evalTemplate(e){return st(e,this.state??{},this.data??{},this._interpolationExtra())}isOverlayChild(e){let t=e?.metadata?.type;return t==A.Drawer||t==A.Dialog}removeSelfFromOwnerChildren(){let e=this.component;if(!e)return!1;let t=t=>{if(t===e)return!0;let n=t;return e.id!=null&&n?.id==e.id&&this.isOverlayChild(n)},n=this.parentNode;for(;n;){let e=n instanceof ShadowRoot?n.host:n,r=e.component?.children;if(Array.isArray(r)){let n=r.findIndex(t);if(n>=0)return r.splice(n,1),e.requestUpdate?.(),!0}n=n instanceof ShadowRoot?e:n.parentNode}return!1}applyFragment(e){if(this.id==e.targetComponentId){if(e.component)if(Ke.Add==e.action){if(this.component){let t=this.component.children??(this.component.children=[]),n=e.component.id?t.findIndex(t=>t.id==e.component.id&&this.isOverlayChild(t)):-1;n>=0?(t[n]=e.component,this.component={...this.component}):t.push(e.component)}}else{this.callbackToken=T();let t=!1;if(e.component?.type==k.ServerSide)if(this.component){let n=this.component,r=e.component;t=n.serverSideType==r.serverSideType;let i=t?(n.children??[]).filter(e=>this.isOverlayChild(e)):[];n.actions=r.actions,n.type=r.type,n.rules=r.rules,n.triggers=r.triggers,n.serverSideType=r.serverSideType,n.route=r.route,n.initialData=r.initialData,n.validations=r.validations,n.cssClasses=r.cssClasses,n.slot=r.slot,n.style=r.style,n.children=i.length?[...r.children??[],...i]:r.children,(n.serverSideType!=r.serverSideType||n.id!=r.id)&&setTimeout(()=>this.triggerOnLoad())}else this.component=e.component,setTimeout(()=>this.triggerOnLoad());else{let t=[e.component];this.component&&(this.component.children=t)}e.action!==Ke.ReplaceKeepData&&!t&&(this.state={},this.data={})}if(e.state&&(this.state={...this.state,...e.state}),e.data){for(let t in e.data){let n=e.data[t]?.page;n?.pageNumber>0&&this.data[t]&&this.data[t].page.content&&(n.content?n.content=[...this.data[t].page.content,...n.content]:n.content=[...this.data[t].page.content])}this.data={...this.data,...e.data}}this.registerCustomEventListeners();let t=N.getAfterRenderHook();t&&setTimeout(()=>t(this)),this.requestUpdate()}}registerCustomEventListeners(){this._registeredCustomEventListeners.forEach(({target:e,name:t})=>e.removeEventListener(t,this.customEventManager)),this._registeredCustomEventListeners=[],this.component?.triggers?.filter(e=>e.type==Ca.OnCustomEvent).forEach(e=>{let t=e.source===`DOCUMENT`||e.source===`COMPONENT`?document:this;t.addEventListener(e.eventName,this.customEventManager),this._registeredCustomEventListeners.push({target:t,name:e.eventName})})}disconnectedCallback(){this._registeredCustomEventListeners.forEach(({target:e,name:t})=>e.removeEventListener(t,this.customEventManager)),this._registeredCustomEventListeners=[],super.disconnectedCallback()}connectedCallback(){super.connectedCallback(),this.component&&this.registerCustomEventListeners()}};O([v()],wa.prototype,`state`,void 0),O([v()],wa.prototype,`data`,void 0),O([v()],wa.prototype,`appData`,void 0),O([v()],wa.prototype,`appState`,void 0);var Ta=`mateu-recent-routes`,Ea=8;function Da(){try{return JSON.parse(localStorage.getItem(Ta)??`{}`)}catch{return{}}}function Oa(e){try{localStorage.setItem(Ta,JSON.stringify(e))}catch{}}function ka(e){return Da()[e||`_`]??[]}function Aa(e,t){if(!t?.route||!t.label)return;let n=e||`_`,r=Da(),i=(r[n]??[]).filter(e=>e.route!==t.route);i.unshift({route:t.route,label:t.label}),r[n]=i.slice(0,Ea),Oa(r)}var G=class extends y{constructor(...e){super(...e),this.baseUrl=``,this.open=!1,this.queryText=``,this.dataHits=[],this.loading=!1,this.selectedIndex=0,this.fabOffset=0,this.keydownHandler=null}connectedCallback(){super.connectedCallback(),this.keydownHandler=e=>{(e.metaKey||e.ctrlKey)&&(e.key===`k`||e.key===`K`)?(e.preventDefault(),this.toggle()):e.key===`Escape`&&this.open&&this.close()},document.addEventListener(`keydown`,this.keydownHandler),this.setupFabObserver()}disconnectedCallback(){super.disconnectedCallback(),this.keydownHandler&&document.removeEventListener(`keydown`,this.keydownHandler),clearTimeout(this.searchTimer),this.fabObserver?.disconnect(),this.fabObserver=void 0}setupFabObserver(){let e=this.getRootNode(),t=e instanceof ShadowRoot?e:document.body;this.measureFabStack(),this.fabObserver?.disconnect(),this.fabObserver=new MutationObserver(()=>this.measureFabStack()),this.fabObserver.observe(t,{childList:!0,subtree:!0})}measureFabStack(){let e=(this.getRootNode().querySelectorAll?.(`.ai-fab, .app-fab, .page-fab`).length??0)*4;e!==this.fabOffset&&(this.fabOffset=e)}updated(e){e.has(`open`)&&this.open&&requestAnimationFrame(()=>this.inputEl?.focus())}toggle(){this.open?this.close():this.openCenter()}openCenter(){this.open=!0,this.queryText=``,this.dataHits=[],this.selectedIndex=0}close(){this.open=!1,this.queryText=``,this.dataHits=[],clearTimeout(this.searchTimer)}flattenMenu(e,t){let n=[];for(let r of e??[])if(!r.separator)if(r.submenus&&r.submenus.length>0){let e=t?`${t} › ${r.label}`:r.label;n.push(...this.flattenMenu(r.submenus,e))}else r.route!==void 0&&r.route!==null&&n.push({label:r.label,breadcrumb:t,route:r.route});return n}onInput(e){this.queryText=e,this.selectedIndex=0;let t=e.trim();if(clearTimeout(this.searchTimer),!t||!this.app?.globalSearchEnabled){this.dataHits=[],this.loading=!1;return}this.loading=!0,this.searchTimer=setTimeout(()=>this.fetchGlobalSearch(t),250)}async fetchGlobalSearch(e){let t=this.app;if(!t?.globalSearchEnabled){this.loading=!1;return}try{let n=(await Ge.runAction(this.baseUrl??``,t.rootRoute??``,``,`_globalsearch`,`command-center`,void 0,t.serverSideType,{},{searchText:e},this,!0))?.fragments?.map(e=>e.data).find(e=>e&&e._globalsearch);this.dataHits=n?._globalsearch??[]}catch{this.dataHits=[]}finally{this.loading=!1}}navigateTo(e,t){Aa(this.app?.serverSideType??``,{route:e,label:t}),this.close();for(let t of[`route-changed`,`navigate-to-requested`])this.dispatchEvent(new CustomEvent(t,{detail:{route:e},bubbles:!0,composed:!0}))}askAi(){let e=this.queryText.trim();this.close(),this.dispatchEvent(new CustomEvent(`mateu-open-ai`,{detail:{query:e},bubbles:!0,composed:!0}))}visibleTargets(e){if(!this.queryText.trim()){let e=this.flattenMenu(this.app?.menu,``).map(e=>({route:e.route,label:e.label})),t=ka(this.app?.serverSideType??``);return[...e,...t]}return[...e.map(e=>({route:e.route,label:e.label})),...this.dataHits.map(e=>({route:e.route,label:e.label}))]}onKeydown(e,t){if(e.key===`ArrowDown`)e.preventDefault(),this.selectedIndex=Math.min(this.selectedIndex+1,t.length-1);else if(e.key===`ArrowUp`)e.preventDefault(),this.selectedIndex=Math.max(this.selectedIndex-1,0);else if(e.key===`Enter`){let e=t[this.selectedIndex];e&&this.navigateTo(e.route,e.label)}}render(){return w`
             <button class="cc-fab" style="bottom: ${1.5+this.fabOffset}rem;"
                 @click=${()=>this.openCenter()} title="Buscar y navegar (⌘K)" aria-label="Command center">
                 ${this.fabIcon()}
@@ -4893,7 +4893,7 @@ ${i}
                 </div>
                 <button class="cc-close" @click=${()=>this.close()} title="Cerrar">${this.clearIcon()}</button>
             </div>
-        `}renderDefault(){let e=this.flattenMenu(this.app?.menu,``),t=Da(this.app?.serverSideType??``),n=-1;return w`
+        `}renderDefault(){let e=this.flattenMenu(this.app?.menu,``),t=ka(this.app?.serverSideType??``),n=-1;return w`
             <div class="cc-columns">
                 <div class="cc-col">
                     <div class="cc-section-title">Ir a</div>
@@ -5028,7 +5028,7 @@ ${i}
             display: flex; align-items: center; justify-content: center; cursor: pointer; z-index: 1110;
         }
         .cc-close:hover { background: rgba(0,0,0,0.75); }
-    `}};O([v({attribute:!1})],G.prototype,`app`,void 0),O([v()],G.prototype,`baseUrl`,void 0),O([S()],G.prototype,`open`,void 0),O([S()],G.prototype,`queryText`,void 0),O([S()],G.prototype,`dataHits`,void 0),O([S()],G.prototype,`loading`,void 0),O([S()],G.prototype,`selectedIndex`,void 0),O([S()],G.prototype,`fabOffset`,void 0),O([b(`.cc-input`)],G.prototype,`inputEl`,void 0),G=O([h(`mateu-command-center`)],G);var ka=null;function Aa(e){let t=e.component?.metadata;t&&(t.commandCenterEnabled||t.chromeless)&&t.variant!==`MEDIATOR`?((!ka||!ka.isConnected)&&(ka=document.createElement(`mateu-command-center`),e.renderRoot.appendChild(ka)),ka.app=t,ka.baseUrl=e.baseUrl??``):ka&&e.renderRoot.contains(ka)&&(ka.remove(),ka=null)}var ja=class extends y{constructor(...e){super(...e),this.fetchStarted=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!0},this.fetchFinished=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!1},this.fetchFailed=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!1;let t=e.detail??{},n=t.failure??Fe(t.reason,{online:Ve.isOnline()});if(n.kind===`cancelled`)return;let r=t.retry;pa({text:n.message,variant:`error`,duration:r?8e3:5e3,position:`bottomEnd`,...r?{actionLabel:`Retry`,onAction:r}:{}},this)}}connectedCallback(){super.connectedCallback(),this.addEventListener(`backend-called-event`,this.fetchStarted),this.addEventListener(`backend-succeeded-event`,this.fetchFinished),this.addEventListener(`backend-cancelled-event`,this.fetchFinished),this.addEventListener(`backend-failed-event`,this.fetchFailed)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`backend-called-event`,this.fetchStarted),this.removeEventListener(`backend-succeeded-event`,this.fetchFinished),this.removeEventListener(`backend-cancelled-event`,this.fetchFinished),this.removeEventListener(`backend-failed-event`,this.fetchFailed)}render(){return w`<div class="loader-container">
+    `}};O([v({attribute:!1})],G.prototype,`app`,void 0),O([v()],G.prototype,`baseUrl`,void 0),O([S()],G.prototype,`open`,void 0),O([S()],G.prototype,`queryText`,void 0),O([S()],G.prototype,`dataHits`,void 0),O([S()],G.prototype,`loading`,void 0),O([S()],G.prototype,`selectedIndex`,void 0),O([S()],G.prototype,`fabOffset`,void 0),O([b(`.cc-input`)],G.prototype,`inputEl`,void 0),G=O([h(`mateu-command-center`)],G);var ja=null;function Ma(e){let t=e.component?.metadata;t&&(t.commandCenterEnabled||t.chromeless)&&t.variant!==`MEDIATOR`?((!ja||!ja.isConnected)&&(ja=document.createElement(`mateu-command-center`),e.renderRoot.appendChild(ja)),ja.app=t,ja.baseUrl=e.baseUrl??``):ja&&e.renderRoot.contains(ja)&&(ja.remove(),ja=null)}var Na=class extends y{constructor(...e){super(...e),this.fetchStarted=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!0},this.fetchFinished=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!1},this.fetchFailed=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!1;let t=e.detail??{},n=t.failure??Fe(t.reason,{online:Ve.isOnline()});if(n.kind===`cancelled`)return;let r=t.retry;ha({text:n.message,variant:`error`,duration:r?8e3:5e3,position:`bottomEnd`,...r?{actionLabel:`Retry`,onAction:r}:{}},this)}}connectedCallback(){super.connectedCallback(),this.addEventListener(`backend-called-event`,this.fetchStarted),this.addEventListener(`backend-succeeded-event`,this.fetchFinished),this.addEventListener(`backend-cancelled-event`,this.fetchFinished),this.addEventListener(`backend-failed-event`,this.fetchFailed)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`backend-called-event`,this.fetchStarted),this.removeEventListener(`backend-succeeded-event`,this.fetchFinished),this.removeEventListener(`backend-cancelled-event`,this.fetchFinished),this.removeEventListener(`backend-failed-event`,this.fetchFailed)}render(){return w`<div class="loader-container">
             <div style="display: flex; flex-direction: column;">
                 <slot></slot>
                 <div class="loader-frame ${this.loading?`delayed-show`:``}" style="${this.loading?`pointer-events: all;`:`display: none;`}"><div class="loader"></div></div>
@@ -5096,7 +5096,7 @@ ${i}
             animation: l5 1s infinite;
         }
         @keyframes l5 {to{transform: rotate(.5turn)}}
-  `}};O([S()],ja.prototype,`loading`,void 0),ja=O([h(`mateu-api-caller`)],ja);var Ma=new class{constructor(){this._dirty=!1,this._installed=!1,this.message=`You have unsaved changes. Are you sure you want to leave this page?`,this._onDirty=()=>{this._dirty=!0},this._onClean=()=>{this._dirty=!1},this._onBeforeUnload=e=>{this._dirty&&(e.preventDefault(),e.returnValue=``)}}install(){this._installed||(this._installed=!0,document.addEventListener(`dirty`,this._onDirty),document.addEventListener(`clean`,this._onClean),window.addEventListener(`beforeunload`,this._onBeforeUnload))}get dirty(){return this._dirty}markDirty(){this._dirty=!0}markClean(){this._dirty=!1}confirmLeave(){if(!this._dirty)return!0;let e=window.confirm(this.message);return e&&(this._dirty=!1),e}},Na,K=class extends Sa{static{Na=this}constructor(...e){super(...e),this.filter=``,this.instant=void 0,this.selectedConsumedRoute=void 0,this.selectedRoute=void 0,this.selectedUriPrefix=void 0,this.selectedBaseUrl=void 0,this.selectedServerSideType=void 0,this.selectedParams=void 0,this.tilesMenuOption=null,this.railOpenOption=null,this.commandPaletteOpen=!1,this.commandPaletteQuery=``,this.commandPaletteSelectedIndex=0,this.commandPaletteDataHits=[],this.openDataHit=e=>{Ma.confirmLeave()&&(this.commandPaletteOpen=!1,this.commandPaletteQuery=``,this.commandPaletteDataHits=[],this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:e.route},bubbles:!0,composed:!0})),this.dispatchEvent(new CustomEvent(`navigate-to-requested`,{detail:{route:e.route},bubbles:!0,composed:!0})))},this._commandPaletteHandler=null,this.pageCompact=!1,this._compactHandler=e=>{this.pageCompact=e.detail?.compact??!1},this._openAiHandler=()=>{this.chatOpen||this.showHideIa()},this.isDark=document.documentElement.getAttribute(`theme`)===`dark`,this.chatOpen=!1,this.toggleTheme=()=>{this.isDark=!this.isDark;let e=this.isDark?`dark`:`light`;document.documentElement.setAttribute(`theme`,e),localStorage.setItem(`mateu-theme`,e)},this.showHideIa=()=>{this.chat&&(this.chatOpen=!this.chatOpen,this.chat.slot=this.chatOpen?`detail`:`detail-hidden`)},this.runAction=e=>{let t=this.renderRoot.querySelector?.(`mateu-component`);t&&t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.getSelectedOption=e=>{if(e)for(let t=0;t<e.length;t++){let n=e[t];if(this.selectedRoute?this.isActiveOption(n):n.selected)return n;let r=this.getSelectedOption(n.submenus);if(r)return r}return null},this.itemSelected=e=>{let t=e.detail.value;this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix)},this.itemSelectedTiles=e=>{let t=e.detail.value._menuOption;t.submenus&&t.submenus.length>0?this.tilesMenuOption=t:(this.tilesMenuOption=null,this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix))},this.mapItemsForTiles=e=>e.map(e=>({text:e.label,consumedRoute:e.consumedRoute,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:e.selected,_menuOption:e})),this.flattenMenuForPalette=(e,t)=>{let n=[];for(let r of e)if(!r.separator)if(r.submenus&&r.submenus.length>0){let e=t?`${t} › ${r.label}`:r.label;n.push(...this.flattenMenuForPalette(r.submenus,e))}else n.push({label:r.label,breadcrumb:t,consumedRoute:r.consumedRoute,route:r.route,actionId:r.actionId,baseUrl:r.baseUrl,serverSideType:r.serverSideType,uriPrefix:r.uriPrefix});return n},this.handleCommandPaletteKeydown=(e,t)=>{let n=Math.min(t.length,10),r=n+Math.min(this.commandPaletteDataHits.length,8);if(e.key===`ArrowDown`)e.preventDefault(),this.commandPaletteSelectedIndex=Math.min(this.commandPaletteSelectedIndex+1,r-1);else if(e.key===`ArrowUp`)e.preventDefault(),this.commandPaletteSelectedIndex=Math.max(this.commandPaletteSelectedIndex-1,0);else if(e.key===`Enter`){if(this.commandPaletteSelectedIndex>=n){let e=this.commandPaletteDataHits[this.commandPaletteSelectedIndex-n];e&&this.openDataHit(e);return}let e=t[this.commandPaletteSelectedIndex];e&&(this.selectRoute(e.consumedRoute,e.route,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix),this.commandPaletteOpen=!1,this.commandPaletteQuery=``)}},this.renderCommandPalette=()=>{if(!this.commandPaletteOpen)return _;let e=this.component?.metadata;if(e?.commandCenterEnabled||!e?.menu)return _;let t=this.flattenMenuForPalette(e.menu,``),n=this.commandPaletteQuery.toLowerCase(),r=n?t.filter(e=>e.label.toLowerCase().includes(n)||e.breadcrumb.toLowerCase().includes(n)):t;return w`
+  `}};O([S()],Na.prototype,`loading`,void 0),Na=O([h(`mateu-api-caller`)],Na);var Pa=new class{constructor(){this._dirty=!1,this._installed=!1,this.message=`You have unsaved changes. Are you sure you want to leave this page?`,this._onDirty=()=>{this._dirty=!0},this._onClean=()=>{this._dirty=!1},this._onBeforeUnload=e=>{this._dirty&&(e.preventDefault(),e.returnValue=``)}}install(){this._installed||(this._installed=!0,document.addEventListener(`dirty`,this._onDirty),document.addEventListener(`clean`,this._onClean),window.addEventListener(`beforeunload`,this._onBeforeUnload))}get dirty(){return this._dirty}markDirty(){this._dirty=!0}markClean(){this._dirty=!1}confirmLeave(){if(!this._dirty)return!0;let e=window.confirm(this.message);return e&&(this._dirty=!1),e}},Fa,K=class extends wa{static{Fa=this}constructor(...e){super(...e),this.filter=``,this.instant=void 0,this.selectedConsumedRoute=void 0,this.selectedRoute=void 0,this.selectedUriPrefix=void 0,this.selectedBaseUrl=void 0,this.selectedServerSideType=void 0,this.selectedParams=void 0,this.tilesMenuOption=null,this.railOpenOption=null,this.commandPaletteOpen=!1,this.commandPaletteQuery=``,this.commandPaletteSelectedIndex=0,this.commandPaletteDataHits=[],this.openDataHit=e=>{Pa.confirmLeave()&&(this.commandPaletteOpen=!1,this.commandPaletteQuery=``,this.commandPaletteDataHits=[],this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:e.route},bubbles:!0,composed:!0})),this.dispatchEvent(new CustomEvent(`navigate-to-requested`,{detail:{route:e.route},bubbles:!0,composed:!0})))},this._commandPaletteHandler=null,this.pageCompact=!1,this._compactHandler=e=>{this.pageCompact=e.detail?.compact??!1},this._openAiHandler=()=>{this.chatOpen||this.showHideIa()},this.isDark=document.documentElement.getAttribute(`theme`)===`dark`,this.chatOpen=!1,this.toggleTheme=()=>{this.isDark=!this.isDark;let e=this.isDark?`dark`:`light`;document.documentElement.setAttribute(`theme`,e),localStorage.setItem(`mateu-theme`,e)},this.showHideIa=()=>{this.chat&&(this.chatOpen=!this.chatOpen,this.chat.slot=this.chatOpen?`detail`:`detail-hidden`)},this.runAction=e=>{let t=this.renderRoot.querySelector?.(`mateu-component`);t&&t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.getSelectedOption=e=>{if(e)for(let t=0;t<e.length;t++){let n=e[t];if(this.selectedRoute?this.isActiveOption(n):n.selected)return n;let r=this.getSelectedOption(n.submenus);if(r)return r}return null},this.itemSelected=e=>{let t=e.detail.value;this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix)},this.itemSelectedTiles=e=>{let t=e.detail.value._menuOption;t.submenus&&t.submenus.length>0?this.tilesMenuOption=t:(this.tilesMenuOption=null,this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix))},this.mapItemsForTiles=e=>e.map(e=>({text:e.label,consumedRoute:e.consumedRoute,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:e.selected,_menuOption:e})),this.flattenMenuForPalette=(e,t)=>{let n=[];for(let r of e)if(!r.separator)if(r.submenus&&r.submenus.length>0){let e=t?`${t} › ${r.label}`:r.label;n.push(...this.flattenMenuForPalette(r.submenus,e))}else n.push({label:r.label,breadcrumb:t,consumedRoute:r.consumedRoute,route:r.route,actionId:r.actionId,baseUrl:r.baseUrl,serverSideType:r.serverSideType,uriPrefix:r.uriPrefix});return n},this.handleCommandPaletteKeydown=(e,t)=>{let n=Math.min(t.length,10),r=n+Math.min(this.commandPaletteDataHits.length,8);if(e.key===`ArrowDown`)e.preventDefault(),this.commandPaletteSelectedIndex=Math.min(this.commandPaletteSelectedIndex+1,r-1);else if(e.key===`ArrowUp`)e.preventDefault(),this.commandPaletteSelectedIndex=Math.max(this.commandPaletteSelectedIndex-1,0);else if(e.key===`Enter`){if(this.commandPaletteSelectedIndex>=n){let e=this.commandPaletteDataHits[this.commandPaletteSelectedIndex-n];e&&this.openDataHit(e);return}let e=t[this.commandPaletteSelectedIndex];e&&(this.selectRoute(e.consumedRoute,e.route,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix),this.commandPaletteOpen=!1,this.commandPaletteQuery=``)}},this.renderCommandPalette=()=>{if(!this.commandPaletteOpen)return _;let e=this.component?.metadata;if(e?.commandCenterEnabled||!e?.menu)return _;let t=this.flattenMenuForPalette(e.menu,``),n=this.commandPaletteQuery.toLowerCase(),r=n?t.filter(e=>e.label.toLowerCase().includes(n)||e.breadcrumb.toLowerCase().includes(n)):t;return w`
             <div class="cmd-backdrop" @click=${()=>{this.commandPaletteOpen=!1,this.commandPaletteQuery=``}}>
                 <div class="cmd-palette" @click=${e=>e.stopPropagation()}>
                     <div class="cmd-search-wrapper">
@@ -5169,7 +5169,7 @@ ${i}
                     `)}
                 </div>
             </div>
-        `,this.goHome=()=>{Ma.confirmLeave()&&(window.history.pushState(null,``,`/`),window.dispatchEvent(new PopStateEvent(`popstate`,{state:null})))},this.selectRoute=(e,t,n,r,i,a)=>{Ma.confirmLeave()&&this._selectRoute(e,t,n,r,i,a)},this._selectRoute=(e,t,n,r,i,a)=>{{this.selectedConsumedRoute=e,this.selectedBaseUrl=r,this.selectedRoute=t,this.selectedServerSideType=i,this.selectedUriPrefix=a,this.instant=T(),this.state&&this.state._route!=null&&(this.state._route=void 0);let n=this.baseUrl??``;n.indexOf(`://`)<0&&(n.startsWith(`/`)||(n=`/`+n),n=window.location.origin+n),n.endsWith(`/`)&&(t??``).startsWith(`/`)&&(t=(t??``).substring(1));let o=new URL(n+t);if(e&&o.pathname.startsWith(e)){let t=o.pathname.substring(e.length);o=new URL(o.origin+(t||`/`))}if((window.location.pathname||o.pathname)&&window.location.pathname!=o.pathname){let e=o.pathname;o.search&&(e+=o.search),e&&!e.startsWith(`/`)&&(e=`/`+e),this.baseUrl&&e.startsWith(this.baseUrl)&&(e=e.substring(this.baseUrl.length));let t=e;this.selectedUriPrefix&&(t=t.startsWith(`/`)&&this.selectedUriPrefix.endsWith(`/`)?this.selectedUriPrefix+t.substring(1):!t.startsWith(`/`)&&!this.selectedUriPrefix.endsWith(`/`)?this.selectedUriPrefix+`/`+t:this.selectedUriPrefix+t),t==`/_page`&&(t=``),this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0}))}}},this.isActiveOption=e=>this.selectedRoute?!!e.route&&(this.selectedRoute==e.route||this.selectedRoute.startsWith(e.route+`/`)):!!e.selected,this.mapItems=(e,t)=>e.map(e=>{if(e.submenus&&e.submenus.length>0){let n=this.mapItems(e.submenus,t);return t&&e.label.toLowerCase().includes(t)&&(n=this.mapItems(e.submenus,``)),n&&n.length>0?{consumedRoute:e.consumedRoute,text:e.label,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:t||this.isActiveOption(e),children:n}:void 0}if(e.separator)return t?void 0:{component:`hr`};if(!t||e.label.toLowerCase().includes(t))return{consumedRoute:e.consumedRoute,text:e.label,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:t||this.isActiveOption(e)}}).filter(e=>e!=null),this.getSelectedIndex=e=>{if(!e)return NaN;let t=e=>{let t=(e??``).trim();return t.length>1&&t.endsWith(`/`)&&(t=t.slice(0,-1)),t},n=t(this.selectedRoute??window.location.pathname),r=NaN,i=-1;for(let a=0;a<e.length;a++){let o=t(e[a].route);o!==``&&(n===o||n.startsWith(o+`/`))&&o.length>i&&(i=o.length,r=a)}if(!Number.isNaN(r))return r;let a=this.getSelectedOption(e);return a?e.indexOf(a):NaN},this.renderOptionOnLeftMenu=e=>e.submenus&&e.submenus.length>0?w`
+        `,this.goHome=()=>{Pa.confirmLeave()&&(window.history.pushState(null,``,`/`),window.dispatchEvent(new PopStateEvent(`popstate`,{state:null})))},this.selectRoute=(e,t,n,r,i,a)=>{Pa.confirmLeave()&&this._selectRoute(e,t,n,r,i,a)},this._selectRoute=(e,t,n,r,i,a)=>{{this.selectedConsumedRoute=e,this.selectedBaseUrl=r,this.selectedRoute=t,this.selectedServerSideType=i,this.selectedUriPrefix=a,this.instant=T(),this.state&&this.state._route!=null&&(this.state._route=void 0);let n=this.baseUrl??``;n.indexOf(`://`)<0&&(n.startsWith(`/`)||(n=`/`+n),n=window.location.origin+n),n.endsWith(`/`)&&(t??``).startsWith(`/`)&&(t=(t??``).substring(1));let o=new URL(n+t);if(e&&o.pathname.startsWith(e)){let t=o.pathname.substring(e.length);o=new URL(o.origin+(t||`/`))}if((window.location.pathname||o.pathname)&&window.location.pathname!=o.pathname){let e=o.pathname;o.search&&(e+=o.search),e&&!e.startsWith(`/`)&&(e=`/`+e),this.baseUrl&&e.startsWith(this.baseUrl)&&(e=e.substring(this.baseUrl.length));let t=e;this.selectedUriPrefix&&(t=t.startsWith(`/`)&&this.selectedUriPrefix.endsWith(`/`)?this.selectedUriPrefix+t.substring(1):!t.startsWith(`/`)&&!this.selectedUriPrefix.endsWith(`/`)?this.selectedUriPrefix+`/`+t:this.selectedUriPrefix+t),t==`/_page`&&(t=``),this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0}))}}},this.isActiveOption=e=>this.selectedRoute?!!e.route&&(this.selectedRoute==e.route||this.selectedRoute.startsWith(e.route+`/`)):!!e.selected,this.mapItems=(e,t)=>e.map(e=>{if(e.submenus&&e.submenus.length>0){let n=this.mapItems(e.submenus,t);return t&&e.label.toLowerCase().includes(t)&&(n=this.mapItems(e.submenus,``)),n&&n.length>0?{consumedRoute:e.consumedRoute,text:e.label,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:t||this.isActiveOption(e),children:n}:void 0}if(e.separator)return t?void 0:{component:`hr`};if(!t||e.label.toLowerCase().includes(t))return{consumedRoute:e.consumedRoute,text:e.label,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:t||this.isActiveOption(e)}}).filter(e=>e!=null),this.getSelectedIndex=e=>{if(!e)return NaN;let t=e=>{let t=(e??``).trim();return t.length>1&&t.endsWith(`/`)&&(t=t.slice(0,-1)),t},n=t(this.selectedRoute??window.location.pathname),r=NaN,i=-1;for(let a=0;a<e.length;a++){let o=t(e[a].route);o!==``&&(n===o||n.startsWith(o+`/`))&&o.length>i&&(i=o.length,r=a)}if(!Number.isNaN(r))return r;let a=this.getSelectedOption(e);return a?e.indexOf(a):NaN},this.renderOptionOnLeftMenu=e=>e.submenus&&e.submenus.length>0?w`
                 <details open class="left-menu-group">
                     <summary>${e.label}</summary>
                     <div class="left-menu-children">
@@ -5191,8 +5191,8 @@ ${i}
                                 </div>
                         `}
 
-                            `})}`:_,this.updateRoute=e=>{e.preventDefault(),e.stopPropagation();var t=e.detail;this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix)}}createRenderRoot(){return N.mustUseShadowRoot()?super.createRenderRoot():(Na.injectLightDomStyles(),this)}static{this.lightDomStylesInjected=!1}static injectLightDomStyles(){if(Na.lightDomStylesInjected||typeof document>`u`||(Na.lightDomStylesInjected=!0,document.getElementById(`mateu-app-light-styles`)))return;let e=Na.styles,t=Array.isArray(e)?e.map(e=>e?.cssText??``).join(`
-`):e?.cssText??``;if(!t)return;let n=document.createElement(`style`);n.id=`mateu-app-light-styles`,n.textContent=t,document.head.appendChild(n)}fetchGlobalSearch(e){let t=this.component?.metadata;if(t?.globalSearchEnabled){if(clearTimeout(this._globalSearchTimer),!e){this.commandPaletteDataHits=[];return}this._globalSearchTimer=setTimeout(async()=>{try{let n=(await Ge.runAction(this.baseUrl??``,t.rootRoute??``,``,`_globalsearch`,`cmd-palette`,void 0,t.serverSideType,{},{searchText:e},this,!0))?.fragments?.map(e=>e.data).find(e=>e&&e._globalsearch);this.commandPaletteDataHits=n?._globalsearch??[]}catch{this.commandPaletteDataHits=[]}},250)}}connectedCallback(){super.connectedCallback(),this.isDark=document.documentElement.getAttribute(`theme`)===`dark`,this._commandPaletteHandler=e=>{this.component?.metadata?.commandCenterEnabled||((e.metaKey||e.ctrlKey)&&e.key===`k`&&(e.preventDefault(),this.commandPaletteOpen=!this.commandPaletteOpen,this.commandPaletteQuery=``,this.commandPaletteSelectedIndex=0),e.key===`Escape`&&this.commandPaletteOpen&&(this.commandPaletteOpen=!1,this.commandPaletteQuery=``))},document.addEventListener(`keydown`,this._commandPaletteHandler),Ma.install(),this.addEventListener(`compact-changed`,this._compactHandler),this.addEventListener(`mateu-open-ai`,this._openAiHandler)}disconnectedCallback(){super.disconnectedCallback(),this._commandPaletteHandler&&document.removeEventListener(`keydown`,this._commandPaletteHandler),this.removeEventListener(`compact-changed`,this._compactHandler),this.removeEventListener(`mateu-open-ai`,this._openAiHandler)}updated(e){if(super.updated(e),Aa(this),this.component){let t=this.component.metadata;if(t){let n=t;if(n.favicon){let e=document.querySelector(`link[rel~='icon']`);e||(e=document.createElement(`link`),e.rel=`icon`,document.head.appendChild(e)),e.href=n.favicon}e.has(`component`)&&(this.selectedRoute=n.homeRoute,this.selectedConsumedRoute=n.homeConsumedRoute,this.selectedServerSideType=n.homeServerSideType,this.selectedBaseUrl=n.homeBaseUrl,this.selectedUriPrefix=n.homeUriPrefix)}}e.has(`commandPaletteOpen`)&&this.commandPaletteOpen&&setTimeout(()=>{this.renderRoot.querySelector(`.cmd-input`)?.focus()},0)}render(){return N.get()?.renderAppComponent(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData)}static{this.styles=m`
+                            `})}`:_,this.updateRoute=e=>{e.preventDefault(),e.stopPropagation();var t=e.detail;this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix)}}createRenderRoot(){return N.mustUseShadowRoot()?super.createRenderRoot():(Fa.injectLightDomStyles(),this)}static{this.lightDomStylesInjected=!1}static injectLightDomStyles(){if(Fa.lightDomStylesInjected||typeof document>`u`||(Fa.lightDomStylesInjected=!0,document.getElementById(`mateu-app-light-styles`)))return;let e=Fa.styles,t=Array.isArray(e)?e.map(e=>e?.cssText??``).join(`
+`):e?.cssText??``;if(!t)return;let n=document.createElement(`style`);n.id=`mateu-app-light-styles`,n.textContent=t,document.head.appendChild(n)}fetchGlobalSearch(e){let t=this.component?.metadata;if(t?.globalSearchEnabled){if(clearTimeout(this._globalSearchTimer),!e){this.commandPaletteDataHits=[];return}this._globalSearchTimer=setTimeout(async()=>{try{let n=(await Ge.runAction(this.baseUrl??``,t.rootRoute??``,``,`_globalsearch`,`cmd-palette`,void 0,t.serverSideType,{},{searchText:e},this,!0))?.fragments?.map(e=>e.data).find(e=>e&&e._globalsearch);this.commandPaletteDataHits=n?._globalsearch??[]}catch{this.commandPaletteDataHits=[]}},250)}}connectedCallback(){super.connectedCallback(),this.isDark=document.documentElement.getAttribute(`theme`)===`dark`,this._commandPaletteHandler=e=>{this.component?.metadata?.commandCenterEnabled||((e.metaKey||e.ctrlKey)&&e.key===`k`&&(e.preventDefault(),this.commandPaletteOpen=!this.commandPaletteOpen,this.commandPaletteQuery=``,this.commandPaletteSelectedIndex=0),e.key===`Escape`&&this.commandPaletteOpen&&(this.commandPaletteOpen=!1,this.commandPaletteQuery=``))},document.addEventListener(`keydown`,this._commandPaletteHandler),Pa.install(),this.addEventListener(`compact-changed`,this._compactHandler),this.addEventListener(`mateu-open-ai`,this._openAiHandler)}disconnectedCallback(){super.disconnectedCallback(),this._commandPaletteHandler&&document.removeEventListener(`keydown`,this._commandPaletteHandler),this.removeEventListener(`compact-changed`,this._compactHandler),this.removeEventListener(`mateu-open-ai`,this._openAiHandler)}updated(e){if(super.updated(e),Ma(this),this.component){let t=this.component.metadata;if(t){let n=t;if(n.favicon){let e=document.querySelector(`link[rel~='icon']`);e||(e=document.createElement(`link`),e.rel=`icon`,document.head.appendChild(e)),e.href=n.favicon}e.has(`component`)&&(this.selectedRoute=n.homeRoute,this.selectedConsumedRoute=n.homeConsumedRoute,this.selectedServerSideType=n.homeServerSideType,this.selectedBaseUrl=n.homeBaseUrl,this.selectedUriPrefix=n.homeUriPrefix)}}e.has(`commandPaletteOpen`)&&this.commandPaletteOpen&&setTimeout(()=>{this.renderRoot.querySelector(`.cmd-input`)?.focus()},0)}render(){return N.get()?.renderAppComponent(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData)}static{this.styles=m`
         /* DS-neutral app chrome (replaces vaadin-app-layout / menu-bar / tabs / side-nav). */
         .m-hl { display: flex; flex-direction: row; }
         .m-vl { display: flex; flex-direction: column; }
@@ -5542,14 +5542,14 @@ ${i}
             transform: scale(1.08);
         }
 
-  `}};O([S()],K.prototype,`filter`,void 0),O([S()],K.prototype,`instant`,void 0),O([S()],K.prototype,`selectedConsumedRoute`,void 0),O([S()],K.prototype,`selectedRoute`,void 0),O([S()],K.prototype,`selectedUriPrefix`,void 0),O([S()],K.prototype,`selectedBaseUrl`,void 0),O([S()],K.prototype,`selectedServerSideType`,void 0),O([S()],K.prototype,`selectedParams`,void 0),O([S()],K.prototype,`tilesMenuOption`,void 0),O([S()],K.prototype,`railOpenOption`,void 0),O([S()],K.prototype,`commandPaletteOpen`,void 0),O([S()],K.prototype,`commandPaletteQuery`,void 0),O([S()],K.prototype,`commandPaletteSelectedIndex`,void 0),O([S()],K.prototype,`commandPaletteDataHits`,void 0),O([S()],K.prototype,`pageCompact`,void 0),O([b(`mateu-chat`)],K.prototype,`chat`,void 0),O([S()],K.prototype,`isDark`,void 0),O([S()],K.prototype,`chatOpen`,void 0),O([b(`.mateu-app-layout`)],K.prototype,`vaadinAppLayout`,void 0),K=Na=O([h(`mateu-app`)],K);var q=class extends y{constructor(...e){super(...e),this.message=`This website uses cookies.`,this.dismiss=`Ok. Thanks :).`,this.learnMore=`Learn more`,this.learnMoreLink=`https://cookiesandyou.com/`,this.showLearnMore=!0,this.position=`top`,this.cookieName=`mateu-cookieconsent`}updated(e){super.updated(e)}connectedCallback(){super.connectedCallback(),this._css=document.createElement(`style`),this._css.innerText=`.cc-window{opacity:1;transition:opacity 1s ease}.cc-window.cc-invisible{opacity:0}.cc-animate.cc-revoke{transition:transform 1s ease}.cc-animate.cc-revoke.cc-top{transform:translateY(-2em)}.cc-animate.cc-revoke.cc-bottom{transform:translateY(2em)}.cc-animate.cc-revoke.cc-active.cc-bottom,.cc-animate.cc-revoke.cc-active.cc-top,.cc-revoke:hover{transform:translateY(0)}.cc-grower{max-height:0;overflow:hidden;transition:max-height 1s}.cc-link,.cc-revoke:hover{text-decoration:underline}.cc-revoke,.cc-window{position:fixed;overflow:hidden;box-sizing:border-box;font-family:Helvetica,Calibri,Arial,sans-serif;font-size:16px;line-height:1.5em;display:flex;flex-wrap:nowrap;z-index:9999}.cc-window.cc-static{position:static}.cc-window.cc-floating{padding:2em;max-width:24em;flex-direction:column}.cc-window.cc-banner{padding:1em 1.8em;width:100%;flex-direction:row}.cc-revoke{padding:.5em}.cc-header{font-size:18px;font-weight:700}.cc-btn,.cc-close,.cc-link,.cc-revoke{cursor:pointer}.cc-link{opacity:.8;display:inline-block;padding:.2em}.cc-link:hover{opacity:1}.cc-link:active,.cc-link:visited{color:initial}.cc-btn{display:block;padding:.4em .8em;font-size:.9em;font-weight:700;border-width:2px;border-style:solid;text-align:center;white-space:nowrap}.cc-banner .cc-btn:last-child{min-width:140px}.cc-highlight .cc-btn:first-child{background-color:transparent;border-color:transparent}.cc-highlight .cc-btn:first-child:focus,.cc-highlight .cc-btn:first-child:hover{background-color:transparent;text-decoration:underline}.cc-close{display:block;position:absolute;top:.5em;right:.5em;font-size:1.6em;opacity:.9;line-height:.75}.cc-close:focus,.cc-close:hover{opacity:1}.cc-revoke.cc-top{top:0;left:3em;border-bottom-left-radius:.5em;border-bottom-right-radius:.5em}.cc-revoke.cc-bottom{bottom:0;left:3em;border-top-left-radius:.5em;border-top-right-radius:.5em}.cc-revoke.cc-left{left:3em;right:unset}.cc-revoke.cc-right{right:3em;left:unset}.cc-top{top:1em}.cc-left{left:1em}.cc-right{right:1em}.cc-bottom{bottom:1em}.cc-floating>.cc-link{margin-bottom:1em}.cc-floating .cc-message{display:block;margin-bottom:1em}.cc-window.cc-floating .cc-compliance{flex:1 0 auto}.cc-window.cc-banner{align-items:center}.cc-banner.cc-top{left:0;right:0;top:0}.cc-banner.cc-bottom{left:0;right:0;bottom:0}.cc-banner .cc-message{flex:1}.cc-compliance{display:flex;align-items:center;align-content:space-between}.cc-compliance>.cc-btn{flex:1}.cc-btn+.cc-btn{margin-left:.5em}@media print{.cc-revoke,.cc-window{display:none}}@media screen and (max-width:900px){.cc-btn{white-space:normal}}@media screen and (max-width:414px) and (orientation:portrait),screen and (max-width:736px) and (orientation:landscape){.cc-window.cc-top{top:0}.cc-window.cc-bottom{bottom:0}.cc-window.cc-banner,.cc-window.cc-left,.cc-window.cc-right{left:0;right:0}.cc-window.cc-banner{flex-direction:column}.cc-window.cc-banner .cc-compliance{flex:1}.cc-window.cc-floating{max-width:none}.cc-window .cc-message{margin-bottom:1em}.cc-window.cc-banner{align-items:unset}}.cc-floating.cc-theme-classic{padding:1.2em;border-radius:5px}.cc-floating.cc-type-info.cc-theme-classic .cc-compliance{text-align:center;display:inline;flex:none}.cc-theme-classic .cc-btn{border-radius:5px}.cc-theme-classic .cc-btn:last-child{min-width:140px}.cc-floating.cc-type-info.cc-theme-classic .cc-btn{display:inline-block}.cc-theme-edgeless.cc-window{padding:0}.cc-floating.cc-theme-edgeless .cc-message{margin:2em 2em 1.5em}.cc-banner.cc-theme-edgeless .cc-btn{margin:0;padding:.8em 1.8em;height:100%}.cc-banner.cc-theme-edgeless .cc-message{margin-left:1em}.cc-floating.cc-theme-edgeless .cc-btn+.cc-btn{margin-left:0}`,document.head.appendChild(this._css),this.__updatePopup()}disconnectedCallback(){super.disconnectedCallback(),this.__closePopup(),this._css.isConnected&&this._css.remove()}__closePopup(){let e=this.popup;e&&e.parentNode?.removeChild(e)}_show(){let e=this.popup;e&&(e.classList.remove(`cc-invisible`),e.style.display=``)}__updatePopup(){this.__closePopup(),window.cookieconsent.initialise({palette:{popup:{background:`#000`},button:{background:`rgba(22, 118, 243, 0.95)`,hover:`rgba(22, 118, 243, 1)`}},showLink:this.showLearnMore,content:{message:this.message,dismiss:this.dismiss,link:this.learnMore,href:this.learnMoreLink},cookie:{name:this.cookieName},position:this.position,elements:{messagelink:`<span id="cookieconsent:desc" class="cc-message">${this.message} <a tabindex="0" class="cc-link" href="${this.learnMoreLink}" target="_blank" rel="noopener noreferrer nofollow">${this.learnMore}</a></span>`,dismiss:`<a tabindex="0" class="cc-btn cc-dismiss">${this.dismiss}</a>`}});let e=this.popup;if(e){e.setAttribute(`role`,`alert`);let t=e.querySelector(`a.cc-btn`);t?.addEventListener(`keydown`,e=>{let n=e.keyCode||e.which;(n===32||n===13)&&t.click()})}}render(){return w`
+  `}};O([S()],K.prototype,`filter`,void 0),O([S()],K.prototype,`instant`,void 0),O([S()],K.prototype,`selectedConsumedRoute`,void 0),O([S()],K.prototype,`selectedRoute`,void 0),O([S()],K.prototype,`selectedUriPrefix`,void 0),O([S()],K.prototype,`selectedBaseUrl`,void 0),O([S()],K.prototype,`selectedServerSideType`,void 0),O([S()],K.prototype,`selectedParams`,void 0),O([S()],K.prototype,`tilesMenuOption`,void 0),O([S()],K.prototype,`railOpenOption`,void 0),O([S()],K.prototype,`commandPaletteOpen`,void 0),O([S()],K.prototype,`commandPaletteQuery`,void 0),O([S()],K.prototype,`commandPaletteSelectedIndex`,void 0),O([S()],K.prototype,`commandPaletteDataHits`,void 0),O([S()],K.prototype,`pageCompact`,void 0),O([b(`mateu-chat`)],K.prototype,`chat`,void 0),O([S()],K.prototype,`isDark`,void 0),O([S()],K.prototype,`chatOpen`,void 0),O([b(`.mateu-app-layout`)],K.prototype,`vaadinAppLayout`,void 0),K=Fa=O([h(`mateu-app`)],K);var Ia=class extends y{constructor(...e){super(...e),this.message=`This website uses cookies.`,this.dismiss=`Ok. Thanks :).`,this.learnMore=`Learn more`,this.learnMoreLink=`https://cookiesandyou.com/`,this.showLearnMore=!0,this.position=`top`,this.cookieName=`mateu-cookieconsent`}updated(e){super.updated(e)}connectedCallback(){super.connectedCallback(),this._css=document.createElement(`style`),this._css.innerText=`.cc-window{opacity:1;transition:opacity 1s ease}.cc-window.cc-invisible{opacity:0}.cc-animate.cc-revoke{transition:transform 1s ease}.cc-animate.cc-revoke.cc-top{transform:translateY(-2em)}.cc-animate.cc-revoke.cc-bottom{transform:translateY(2em)}.cc-animate.cc-revoke.cc-active.cc-bottom,.cc-animate.cc-revoke.cc-active.cc-top,.cc-revoke:hover{transform:translateY(0)}.cc-grower{max-height:0;overflow:hidden;transition:max-height 1s}.cc-link,.cc-revoke:hover{text-decoration:underline}.cc-revoke,.cc-window{position:fixed;overflow:hidden;box-sizing:border-box;font-family:Helvetica,Calibri,Arial,sans-serif;font-size:16px;line-height:1.5em;display:flex;flex-wrap:nowrap;z-index:9999}.cc-window.cc-static{position:static}.cc-window.cc-floating{padding:2em;max-width:24em;flex-direction:column}.cc-window.cc-banner{padding:1em 1.8em;width:100%;flex-direction:row}.cc-revoke{padding:.5em}.cc-header{font-size:18px;font-weight:700}.cc-btn,.cc-close,.cc-link,.cc-revoke{cursor:pointer}.cc-link{opacity:.8;display:inline-block;padding:.2em}.cc-link:hover{opacity:1}.cc-link:active,.cc-link:visited{color:initial}.cc-btn{display:block;padding:.4em .8em;font-size:.9em;font-weight:700;border-width:2px;border-style:solid;text-align:center;white-space:nowrap}.cc-banner .cc-btn:last-child{min-width:140px}.cc-highlight .cc-btn:first-child{background-color:transparent;border-color:transparent}.cc-highlight .cc-btn:first-child:focus,.cc-highlight .cc-btn:first-child:hover{background-color:transparent;text-decoration:underline}.cc-close{display:block;position:absolute;top:.5em;right:.5em;font-size:1.6em;opacity:.9;line-height:.75}.cc-close:focus,.cc-close:hover{opacity:1}.cc-revoke.cc-top{top:0;left:3em;border-bottom-left-radius:.5em;border-bottom-right-radius:.5em}.cc-revoke.cc-bottom{bottom:0;left:3em;border-top-left-radius:.5em;border-top-right-radius:.5em}.cc-revoke.cc-left{left:3em;right:unset}.cc-revoke.cc-right{right:3em;left:unset}.cc-top{top:1em}.cc-left{left:1em}.cc-right{right:1em}.cc-bottom{bottom:1em}.cc-floating>.cc-link{margin-bottom:1em}.cc-floating .cc-message{display:block;margin-bottom:1em}.cc-window.cc-floating .cc-compliance{flex:1 0 auto}.cc-window.cc-banner{align-items:center}.cc-banner.cc-top{left:0;right:0;top:0}.cc-banner.cc-bottom{left:0;right:0;bottom:0}.cc-banner .cc-message{flex:1}.cc-compliance{display:flex;align-items:center;align-content:space-between}.cc-compliance>.cc-btn{flex:1}.cc-btn+.cc-btn{margin-left:.5em}@media print{.cc-revoke,.cc-window{display:none}}@media screen and (max-width:900px){.cc-btn{white-space:normal}}@media screen and (max-width:414px) and (orientation:portrait),screen and (max-width:736px) and (orientation:landscape){.cc-window.cc-top{top:0}.cc-window.cc-bottom{bottom:0}.cc-window.cc-banner,.cc-window.cc-left,.cc-window.cc-right{left:0;right:0}.cc-window.cc-banner{flex-direction:column}.cc-window.cc-banner .cc-compliance{flex:1}.cc-window.cc-floating{max-width:none}.cc-window .cc-message{margin-bottom:1em}.cc-window.cc-banner{align-items:unset}}.cc-floating.cc-theme-classic{padding:1.2em;border-radius:5px}.cc-floating.cc-type-info.cc-theme-classic .cc-compliance{text-align:center;display:inline;flex:none}.cc-theme-classic .cc-btn{border-radius:5px}.cc-theme-classic .cc-btn:last-child{min-width:140px}.cc-floating.cc-type-info.cc-theme-classic .cc-btn{display:inline-block}.cc-theme-edgeless.cc-window{padding:0}.cc-floating.cc-theme-edgeless .cc-message{margin:2em 2em 1.5em}.cc-banner.cc-theme-edgeless .cc-btn{margin:0;padding:.8em 1.8em;height:100%}.cc-banner.cc-theme-edgeless .cc-message{margin-left:1em}.cc-floating.cc-theme-edgeless .cc-btn+.cc-btn{margin-left:0}`,document.head.appendChild(this._css),this.__updatePopup()}disconnectedCallback(){super.disconnectedCallback(),this.__closePopup(),this._css.isConnected&&this._css.remove()}__closePopup(){let e=this.popup;e&&e.parentNode?.removeChild(e)}_show(){let e=this.popup;e&&(e.classList.remove(`cc-invisible`),e.style.display=``)}__updatePopup(){this.__closePopup(),window.cookieconsent.initialise({palette:{popup:{background:`#000`},button:{background:`rgba(22, 118, 243, 0.95)`,hover:`rgba(22, 118, 243, 1)`}},showLink:this.showLearnMore,content:{message:this.message,dismiss:this.dismiss,link:this.learnMore,href:this.learnMoreLink},cookie:{name:this.cookieName},position:this.position,elements:{messagelink:`<span id="cookieconsent:desc" class="cc-message">${this.message} <a tabindex="0" class="cc-link" href="${this.learnMoreLink}" target="_blank" rel="noopener noreferrer nofollow">${this.learnMore}</a></span>`,dismiss:`<a tabindex="0" class="cc-btn cc-dismiss">${this.dismiss}</a>`}});let e=this.popup;if(e){e.setAttribute(`role`,`alert`);let t=e.querySelector(`a.cc-btn`);t?.addEventListener(`keydown`,e=>{let n=e.keyCode||e.which;(n===32||n===13)&&t.click()})}}render(){return w`
        `}static{this.styles=m`
-  `}};O([v()],q.prototype,`message`,void 0),O([v()],q.prototype,`dismiss`,void 0),O([v()],q.prototype,`learnMore`,void 0),O([v()],q.prototype,`learnMoreLink`,void 0),O([v()],q.prototype,`showLearnMore`,void 0),O([v()],q.prototype,`position`,void 0),O([v()],q.prototype,`cookieName`,void 0),O([S()],q.prototype,`_css`,void 0),O([b(`[aria-label="cookieconsent"]`)],q.prototype,`popup`,void 0),q=O([h(`mateu-cookie-consent`)],q);var Pa=class extends y{constructor(...e){super(...e),this.redispatchEvent=e=>{e instanceof CustomEvent&&(e.stopPropagation(),e.preventDefault(),this.target?.dispatchEvent(new CustomEvent(e.type,{detail:e.detail,bubbles:!0,composed:!0})))}}connectedCallback(){super.connectedCallback(),this.addEventListener(`value-changed`,this.redispatchEvent),this.addEventListener(`data-changed`,this.redispatchEvent),this.addEventListener(`action-requested`,this.redispatchEvent),this.addEventListener(`server-side-action-requested`,this.redispatchEvent),this.addEventListener(`route-changed`,this.redispatchEvent),this.addEventListener(`close-modal-requested`,this.redispatchEvent)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`value-changed`,this.redispatchEvent),this.removeEventListener(`data-changed`,this.redispatchEvent),this.removeEventListener(`action-requested`,this.redispatchEvent),this.removeEventListener(`server-side-action-requested`,this.redispatchEvent),this.removeEventListener(`route-changed`,this.redispatchEvent)}render(){return w`<slot></slot>`}static{this.styles=m`
+  `}};O([v()],Ia.prototype,`message`,void 0),O([v()],Ia.prototype,`dismiss`,void 0),O([v()],Ia.prototype,`learnMore`,void 0),O([v()],Ia.prototype,`learnMoreLink`,void 0),O([v()],Ia.prototype,`showLearnMore`,void 0),O([v()],Ia.prototype,`position`,void 0),O([v()],Ia.prototype,`cookieName`,void 0),O([S()],Ia.prototype,`_css`,void 0),O([b(`[aria-label="cookieconsent"]`)],Ia.prototype,`popup`,void 0),Ia=O([h(`mateu-cookie-consent`)],Ia);var La=class extends y{constructor(...e){super(...e),this.redispatchEvent=e=>{e instanceof CustomEvent&&(e.stopPropagation(),e.preventDefault(),this.target?.dispatchEvent(new CustomEvent(e.type,{detail:e.detail,bubbles:!0,composed:!0})))}}connectedCallback(){super.connectedCallback(),this.addEventListener(`value-changed`,this.redispatchEvent),this.addEventListener(`data-changed`,this.redispatchEvent),this.addEventListener(`action-requested`,this.redispatchEvent),this.addEventListener(`server-side-action-requested`,this.redispatchEvent),this.addEventListener(`route-changed`,this.redispatchEvent),this.addEventListener(`close-modal-requested`,this.redispatchEvent)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`value-changed`,this.redispatchEvent),this.removeEventListener(`data-changed`,this.redispatchEvent),this.removeEventListener(`action-requested`,this.redispatchEvent),this.removeEventListener(`server-side-action-requested`,this.redispatchEvent),this.removeEventListener(`route-changed`,this.redispatchEvent)}render(){return w`<slot></slot>`}static{this.styles=m`
         :host {
             /* width: 100%; */
             display: inline-block;
         }
-  `}};O([v()],Pa.prototype,`target`,void 0),Pa=O([h(`mateu-event-interceptor`)],Pa);var Fa=[`a[href]`,`button`,`input`,`select`,`textarea`,`[tabindex]`,`vaadin-button`,`vaadin-text-field`,`vaadin-combo-box`,`vaadin-select`,`vaadin-checkbox`,`vaadin-date-picker`,`ui5-button`,`oj-c-button`].join(`,`),Ia=e=>{let t=e;return t.hidden||t.hasAttribute(`disabled`)||t.getAttribute(`aria-hidden`)===`true`||t.getAttribute(`tabindex`)===`-1`?!1:!!(t.offsetParent||t.getClientRects().length)},La=e=>{let t=[],n=e=>{e.querySelectorAll(`*`).forEach(e=>{e.matches(Fa)&&Ia(e)&&t.push(e),e.shadowRoot&&n(e.shadowRoot),e instanceof HTMLSlotElement&&e.assignedElements().forEach(e=>{e.matches(Fa)&&Ia(e)&&t.push(e),n(e)})})};return n(e),t.filter((e,n)=>t.indexOf(e)===n)},Ra=(e,t={})=>{let n=za(),r=[],i=()=>{r=La(e)},a=t=>{if(t.key!==`Tab`)return;if(i(),r.length===0){t.preventDefault(),e.focus();return}let n=r[0],a=r[r.length-1],o=za();t.shiftKey&&(o===n||!o||!Ba(o,e))?(t.preventDefault(),a.focus()):!t.shiftKey&&o===a&&(t.preventDefault(),n.focus())};return e.addEventListener(`keydown`,a),requestAnimationFrame(()=>{i();let n=t.initialFocus?.()??r[0];n?n.focus():(e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus())}),{refresh:i,release(){e.removeEventListener(`keydown`,a);let t=za();(!t||t===document.body||Ba(t,e))&&n?.focus?.()}}},za=()=>{let e=document.activeElement;for(;e?.shadowRoot?.activeElement;)e=e.shadowRoot.activeElement;return e},Ba=(e,t)=>{let n=e;for(;n;){if(n===t)return!0;n=n.parentNode??n.host??null}return!1},Va=class extends Sa{constructor(...e){super(...e),this.opened=!0,this.close=()=>{this.opened=!1,this.releaseFocusTrap(),setTimeout(()=>{this.removeSelfFromOwnerChildren()||this.parentElement?.removeChild(this)},500)},this.onKeydown=e=>{e.key===`Escape`&&this.opened&&(e.stopPropagation(),this.close())}}connectedCallback(){super.connectedCallback(),this.addEventListener(`keydown`,this.onKeydown)}disconnectedCallback(){super.disconnectedCallback(),this.releaseFocusTrap()}releaseFocusTrap(){this.focusTrap?.release(),this.focusTrap=void 0}applyFragment(e){super.applyFragment(e);let t=e.state?._closeAfterMillis;t&&setTimeout(()=>this.close(),t)}updated(e){if(super.updated(e),e.has(`component`)&&this.component){let e=this.component.metadata;this.state=e.initialData}let t=this.renderRoot.querySelector(`[role="dialog"]`),n=this.component?.metadata?.modeless;this.opened&&t&&!this.focusTrap&&!n?this.focusTrap=Ra(t):this.focusTrap&&this.opened&&this.focusTrap.refresh()}render(){if(!this.opened)return w``;let e=this.component.metadata,t=it(e.headerTitle,this.state,this.data,this.appState,this.appData),n=!!(t||e.header||e.closeButtonOnHeader),r=[e.width?`width:${e.width};`:`min-width:min(90vw,28rem);`,e.height?`height:${e.height};`:``,e.top?`margin-top:${e.top};`:``].join(``);return w`
+  `}};O([v()],La.prototype,`target`,void 0),La=O([h(`mateu-event-interceptor`)],La);var Ra=[`a[href]`,`button`,`input`,`select`,`textarea`,`[tabindex]`,`vaadin-button`,`vaadin-text-field`,`vaadin-combo-box`,`vaadin-select`,`vaadin-checkbox`,`vaadin-date-picker`,`ui5-button`,`oj-c-button`].join(`,`),za=e=>{let t=e;return t.hidden||t.hasAttribute(`disabled`)||t.getAttribute(`aria-hidden`)===`true`||t.getAttribute(`tabindex`)===`-1`?!1:!!(t.offsetParent||t.getClientRects().length)},Ba=e=>{let t=[],n=e=>{e.querySelectorAll(`*`).forEach(e=>{e.matches(Ra)&&za(e)&&t.push(e),e.shadowRoot&&n(e.shadowRoot),e instanceof HTMLSlotElement&&e.assignedElements().forEach(e=>{e.matches(Ra)&&za(e)&&t.push(e),n(e)})})};return n(e),t.filter((e,n)=>t.indexOf(e)===n)},Va=(e,t={})=>{let n=Ha(),r=[],i=()=>{r=Ba(e)},a=t=>{if(t.key!==`Tab`)return;if(i(),r.length===0){t.preventDefault(),e.focus();return}let n=r[0],a=r[r.length-1],o=Ha();t.shiftKey&&(o===n||!o||!Ua(o,e))?(t.preventDefault(),a.focus()):!t.shiftKey&&o===a&&(t.preventDefault(),n.focus())};return e.addEventListener(`keydown`,a),requestAnimationFrame(()=>{i();let n=t.initialFocus?.()??r[0];n?n.focus():(e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus())}),{refresh:i,release(){e.removeEventListener(`keydown`,a);let t=Ha();(!t||t===document.body||Ua(t,e))&&n?.focus?.()}}},Ha=()=>{let e=document.activeElement;for(;e?.shadowRoot?.activeElement;)e=e.shadowRoot.activeElement;return e},Ua=(e,t)=>{let n=e;for(;n;){if(n===t)return!0;n=n.parentNode??n.host??null}return!1},Wa=class extends wa{constructor(...e){super(...e),this.opened=!0,this.close=()=>{this.opened=!1,this.releaseFocusTrap(),setTimeout(()=>{this.removeSelfFromOwnerChildren()||this.parentElement?.removeChild(this)},500)},this.onKeydown=e=>{e.key===`Escape`&&this.opened&&(e.stopPropagation(),this.close())}}connectedCallback(){super.connectedCallback(),this.addEventListener(`keydown`,this.onKeydown)}disconnectedCallback(){super.disconnectedCallback(),this.releaseFocusTrap()}releaseFocusTrap(){this.focusTrap?.release(),this.focusTrap=void 0}applyFragment(e){super.applyFragment(e);let t=e.state?._closeAfterMillis;t&&setTimeout(()=>this.close(),t)}updated(e){if(super.updated(e),e.has(`component`)&&this.component){let e=this.component.metadata;this.state=e.initialData}let t=this.renderRoot.querySelector(`[role="dialog"]`),n=this.component?.metadata?.modeless;this.opened&&t&&!this.focusTrap&&!n?this.focusTrap=Va(t):this.focusTrap&&this.opened&&this.focusTrap.refresh()}render(){if(!this.opened)return w``;let e=this.component.metadata,t=it(e.headerTitle,this.state,this.data,this.appState,this.appData),n=!!(t||e.header||e.closeButtonOnHeader),r=[e.width?`width:${e.width};`:`min-width:min(90vw,28rem);`,e.height?`height:${e.height};`:``,e.top?`margin-top:${e.top};`:``].join(``);return w`
             <div class="backdrop ${e.modeless?`modeless`:``}"
                  @click="${t=>{!e.modeless&&t.target===t.currentTarget&&this.close()}}">
                 <div class="dialog ${e.noPadding?`no-padding`:``} ${this.component?.cssClasses??``}"
@@ -5604,7 +5604,7 @@ ${i}
         .dialog-body { padding: .5rem 1.2rem; flex: 1; }
         .dialog.no-padding .dialog-body { padding: 0; }
         .dialog-footer { padding: .5rem 1.2rem 1rem; display: flex; justify-content: flex-end; gap: .5rem; }
-    `}};O([S()],Va.prototype,`opened`,void 0),Va=O([h(`mateu-dialog`)],Va);var Ha,Ua=class extends Sa{static{Ha=this}constructor(...e){super(...e),this.opened=!1,this.maximizeSteps=0,this.collapsed=!1,this.pagerMenuOpen=!1,this.onGuidedProgress=e=>{let t=e.detail;t&&t.total>0&&(this.guidedProgress=t)},this.close=()=>{this.opened=!1,this.releaseLayoutInset(),this.releaseFocusTrap(),setTimeout(()=>{this.removeSelfFromOwnerChildren()||this.parentElement?.removeChild(this)},300)},this._escListener=e=>{if(e.key!==`Escape`)return;let t=this.getRootNode().querySelectorAll(`mateu-drawer, mateu-dialog`);t[t.length-1]===this&&(e.stopPropagation(),this.close())}}jumpToStep(e){this.pagerMenuOpen=!1,e&&(this.renderRoot.querySelector(`.content mateu-component`)??this.renderRoot.querySelector(`mateu-component`))?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`goToStep`,parameters:{_stepId:e}},bubbles:!0,composed:!0}))}static{this.SIZE_LADDER=[`s`,`m`,`l`,`xl`]}static{this.SIZE_WIDTHS={s:`464px`,m:`648px`,l:`968px`,xl:`90vw`}}effectiveWidth(e){if(e.width)return e.width;if(!e.size)return;let t=Ha.SIZE_LADDER,n=Math.max(0,t.indexOf(e.size)),r=Math.min(t.length-1,n+this.maximizeSteps);return Ha.SIZE_WIDTHS[t[r]]}canMaximize(e){if(!e.maximizable)return!1;let t=Ha.SIZE_LADDER;return Math.max(0,t.indexOf(e.size??`m`))+this.maximizeSteps<t.length-1}firstUpdated(){requestAnimationFrame(()=>this.opened=!0),this.addEventListener(`mateu-guided-progress`,this.onGuidedProgress);let e=this.component?.metadata;e&&requestAnimationFrame(()=>this.applyLayoutInset(e))}releaseFocusTrap(){this.focusTrap?.release(),this.focusTrap=void 0}applyLayoutInset(e){if(!e.layout)return;let t=document.querySelector(`mateu-ui`);if(!t)return;let n=e.position??`end`,r=n===`bottom`?`var(--mateu-drawer-height, 50vh)`:this.effectiveWidth(e)??`648px`;this._insetProp=n===`start`?`paddingLeft`:n===`bottom`?`paddingBottom`:`paddingRight`,t.style.transition=`padding .25s ease`,t.style[this._insetProp]=r}releaseLayoutInset(){if(!this._insetProp)return;let e=document.querySelector(`mateu-ui`);e&&(e.style[this._insetProp]=``),this._insetProp=void 0}applyFragment(e){super.applyFragment(e);let t=e.state?._closeAfterMillis;t&&setTimeout(()=>this.close(),t)}updated(e){if(super.updated(e),e.has(`component`)&&this.component){let e=this.component.metadata;this.state=e.initialData}let t=this.component?.metadata,n=this.renderRoot.querySelector(`[role="dialog"]`);this.opened&&n&&!t?.modeless&&!t?.layout&&!this.focusTrap?this.focusTrap=Ra(n):this.focusTrap&&this.opened&&this.focusTrap.refresh()}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._escListener)}disconnectedCallback(){document.removeEventListener(`keydown`,this._escListener),this.releaseLayoutInset(),this.releaseFocusTrap(),super.disconnectedCallback()}render(){let e=this.component.metadata,t=e.position??`end`,n=it(e.headerTitle,this.state,this.data,this.appState,this.appData),r=it(e.subtitle,this.state,this.data,this.appState,this.appData),i=this.effectiveWidth(e),a=e.peerNav&&(e.peerNav.prevRoute||e.peerNav.nextRoute)?e.peerNav:void 0;return w`
+    `}};O([S()],Wa.prototype,`opened`,void 0),Wa=O([h(`mateu-dialog`)],Wa);var Ga,Ka=class extends wa{static{Ga=this}constructor(...e){super(...e),this.opened=!1,this.maximizeSteps=0,this.collapsed=!1,this.pagerMenuOpen=!1,this.onGuidedProgress=e=>{let t=e.detail;t&&t.total>0&&(this.guidedProgress=t)},this.close=()=>{this.opened=!1,this.releaseLayoutInset(),this.releaseFocusTrap(),setTimeout(()=>{this.removeSelfFromOwnerChildren()||this.parentElement?.removeChild(this)},300)},this._escListener=e=>{if(e.key!==`Escape`)return;let t=this.getRootNode().querySelectorAll(`mateu-drawer, mateu-dialog`);t[t.length-1]===this&&(e.stopPropagation(),this.close())}}jumpToStep(e){this.pagerMenuOpen=!1,e&&(this.renderRoot.querySelector(`.content mateu-component`)??this.renderRoot.querySelector(`mateu-component`))?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`goToStep`,parameters:{_stepId:e}},bubbles:!0,composed:!0}))}static{this.SIZE_LADDER=[`s`,`m`,`l`,`xl`]}static{this.SIZE_WIDTHS={s:`464px`,m:`648px`,l:`968px`,xl:`90vw`}}effectiveWidth(e){if(e.width)return e.width;if(!e.size)return;let t=Ga.SIZE_LADDER,n=Math.max(0,t.indexOf(e.size)),r=Math.min(t.length-1,n+this.maximizeSteps);return Ga.SIZE_WIDTHS[t[r]]}canMaximize(e){if(!e.maximizable)return!1;let t=Ga.SIZE_LADDER;return Math.max(0,t.indexOf(e.size??`m`))+this.maximizeSteps<t.length-1}firstUpdated(){requestAnimationFrame(()=>this.opened=!0),this.addEventListener(`mateu-guided-progress`,this.onGuidedProgress);let e=this.component?.metadata;e&&requestAnimationFrame(()=>this.applyLayoutInset(e))}releaseFocusTrap(){this.focusTrap?.release(),this.focusTrap=void 0}applyLayoutInset(e){if(!e.layout)return;let t=document.querySelector(`mateu-ui`);if(!t)return;let n=e.position??`end`,r=n===`bottom`?`var(--mateu-drawer-height, 50vh)`:this.effectiveWidth(e)??`648px`;this._insetProp=n===`start`?`paddingLeft`:n===`bottom`?`paddingBottom`:`paddingRight`,t.style.transition=`padding .25s ease`,t.style[this._insetProp]=r}releaseLayoutInset(){if(!this._insetProp)return;let e=document.querySelector(`mateu-ui`);e&&(e.style[this._insetProp]=``),this._insetProp=void 0}applyFragment(e){super.applyFragment(e);let t=e.state?._closeAfterMillis;t&&setTimeout(()=>this.close(),t)}updated(e){if(super.updated(e),e.has(`component`)&&this.component){let e=this.component.metadata;this.state=e.initialData}let t=this.component?.metadata,n=this.renderRoot.querySelector(`[role="dialog"]`);this.opened&&n&&!t?.modeless&&!t?.layout&&!this.focusTrap?this.focusTrap=Va(n):this.focusTrap&&this.opened&&this.focusTrap.refresh()}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._escListener)}disconnectedCallback(){document.removeEventListener(`keydown`,this._escListener),this.releaseLayoutInset(),this.releaseFocusTrap(),super.disconnectedCallback()}render(){let e=this.component.metadata,t=e.position??`end`,n=it(e.headerTitle,this.state,this.data,this.appState,this.appData),r=it(e.subtitle,this.state,this.data,this.appState,this.appData),i=this.effectiveWidth(e),a=e.peerNav&&(e.peerNav.prevRoute||e.peerNav.nextRoute)?e.peerNav:void 0;return w`
         ${e.modeless||e.layout?_:w`
             <div class="backdrop ${this.opened?`open`:``}" @click="${this.close}"></div>
         `}
@@ -5882,7 +5882,7 @@ ${i}
             display: flex;
             justify-content: flex-end;
         }
-  `}};O([S()],Ua.prototype,`opened`,void 0),O([S()],Ua.prototype,`maximizeSteps`,void 0),O([S()],Ua.prototype,`collapsed`,void 0),O([S()],Ua.prototype,`guidedProgress`,void 0),O([S()],Ua.prototype,`pagerMenuOpen`,void 0),Ua=Ha=O([h(`mateu-drawer`)],Ua);function Wa(e){if(e.parentElement)return e.parentElement;let t=e.getRootNode();return t instanceof ShadowRoot?t.host:null}var J=class extends y{constructor(...e){super(...e),this.appState={},this.appData={},this.standalone=!1,this.actionBanners=[],this.dismissedStaticBannerIndices=new Set,this._tocEntries=[],this._activeToc=0,this._tocVisible=!1,this._tocRebuildScheduled=!1,this._headerH=0,this._onResize=()=>this._layoutStickyTops(),this._tocLocked=!1,this._unlockToc=e=>{if(e&&e.type===`keydown`){let t=e;if(t.ctrlKey&&t.altKey&&!t.shiftKey&&!t.metaKey&&/^(?:Digit|Numpad)[1-9]$/.test(t.code))return}this._tocLocked=!1},this._actionBannerTimers=[],this._staticBannerTimers=[],this._bannersHandler=e=>{let t=e.detail,n=t.banners??[],r=t.append??!1;r?this.actionBanners=[...this.actionBanners,...n]:(this._clearActionBannerTimers(),this.actionBanners=n);let i=r?this.actionBanners.length-n.length:0;n.forEach((e,t)=>{if(e.timeoutSeconds&&e.timeoutSeconds>0){let n=i+t;this._actionBannerTimers.push(setTimeout(()=>{this.actionBanners=this.actionBanners.filter((e,t)=>t!==n)},e.timeoutSeconds*1e3))}})},this._onTocKey=e=>{if(!this._tocVisible||!e.ctrlKey||!e.altKey||e.shiftKey||e.metaKey)return;let t=/^(?:Digit|Numpad)([1-9])$/.exec(e.code);if(!t)return;let n=parseInt(t[1],10)-1;n>=this._tocEntries.length||(e.preventDefault(),this._scrollToSection(n))},this._onScrollSpy=()=>{if(this._tocLocked)return;let e=this._sectionCards();if(!e.length)return;let t=this.shadowRoot?.querySelector(`mateu-content-header`),n=t?t.getBoundingClientRect().bottom:0;for(let t of e){if(!t.classList.contains(`mateu-section--sticky`))continue;let e=t.getBoundingClientRect();e.top<=n+12+2&&(n=Math.max(n,e.bottom))}let r=n+12+4,i=0;this._tocEntries.forEach((e,t)=>{e.el.getBoundingClientRect().top<=r&&(i=t)}),this._activeToc=i}}connectedCallback(){super.connectedCallback(),document.addEventListener(`page-banners-received`,this._bannersHandler),window.addEventListener(`resize`,this._onResize),document.addEventListener(`keydown`,this._onTocKey)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`page-banners-received`,this._bannersHandler),window.removeEventListener(`resize`,this._onResize),document.removeEventListener(`keydown`,this._onTocKey),this._clearAllTimers(),this._teardownScrollSpy()}updated(e){if(super.updated(e),e.has(`component`)&&e.get(`component`)!==void 0&&(this._clearAllTimers(),this.actionBanners=[],this.dismissedStaticBannerIndices=new Set),e.has(`component`)){let e=this.component?.metadata?.level??0;this.toggleAttribute(`data-nested`,e>0),this._scheduleStaticBannerTimeouts();let t=this.component?.metadata?.pageWidth===`edgeToEdge`;this.toggleAttribute(`data-edge`,t),this.dispatchEvent(new CustomEvent(`compact-changed`,{detail:{compact:!!this.component?.style?.includes(`--mateu-compact:1`)||t},bubbles:!0,composed:!0})),this._scheduleTocRebuild()}}_scheduleStaticBannerTimeouts(){this._staticBannerTimers.forEach(e=>clearTimeout(e)),this._staticBannerTimers=[],(this.component?.metadata?.banners??[]).forEach((e,t)=>{e.timeoutSeconds&&e.timeoutSeconds>0&&this._staticBannerTimers.push(setTimeout(()=>{this.dismissedStaticBannerIndices=new Set([...this.dismissedStaticBannerIndices,t])},e.timeoutSeconds*1e3))})}_clearActionBannerTimers(){this._actionBannerTimers.forEach(e=>clearTimeout(e)),this._actionBannerTimers=[]}_clearAllTimers(){this._clearActionBannerTimers(),this._staticBannerTimers.forEach(e=>clearTimeout(e)),this._staticBannerTimers=[]}_dismissActionBanner(e){this.actionBanners=this.actionBanners.filter((t,n)=>n!==e)}_dismissStaticBanner(e){this.dismissedStaticBannerIndices=new Set([...this.dismissedStaticBannerIndices,e])}bannerThemeClass(e){let t=e.theme?.toLowerCase()??`info`;return t===`none`?``:t}_evalBannerText(e){return j(e,this.state,this.data)}_renderBanner(e,t){let n=this._evalBannerText(e.title),r=this._evalBannerText(e.description);return w`
+  `}};O([S()],Ka.prototype,`opened`,void 0),O([S()],Ka.prototype,`maximizeSteps`,void 0),O([S()],Ka.prototype,`collapsed`,void 0),O([S()],Ka.prototype,`guidedProgress`,void 0),O([S()],Ka.prototype,`pagerMenuOpen`,void 0),Ka=Ga=O([h(`mateu-drawer`)],Ka);function qa(e){if(e.parentElement)return e.parentElement;let t=e.getRootNode();return t instanceof ShadowRoot?t.host:null}var q=class extends y{constructor(...e){super(...e),this.appState={},this.appData={},this.standalone=!1,this.actionBanners=[],this.dismissedStaticBannerIndices=new Set,this._tocEntries=[],this._activeToc=0,this._tocVisible=!1,this._tocRebuildScheduled=!1,this._headerH=0,this._onResize=()=>this._layoutStickyTops(),this._tocLocked=!1,this._unlockToc=e=>{if(e&&e.type===`keydown`){let t=e;if(t.ctrlKey&&t.altKey&&!t.shiftKey&&!t.metaKey&&/^(?:Digit|Numpad)[1-9]$/.test(t.code))return}this._tocLocked=!1},this._actionBannerTimers=[],this._staticBannerTimers=[],this._bannersHandler=e=>{let t=e.detail,n=t.banners??[],r=t.append??!1;r?this.actionBanners=[...this.actionBanners,...n]:(this._clearActionBannerTimers(),this.actionBanners=n);let i=r?this.actionBanners.length-n.length:0;n.forEach((e,t)=>{if(e.timeoutSeconds&&e.timeoutSeconds>0){let n=i+t;this._actionBannerTimers.push(setTimeout(()=>{this.actionBanners=this.actionBanners.filter((e,t)=>t!==n)},e.timeoutSeconds*1e3))}})},this._onTocKey=e=>{if(!this._tocVisible||!e.ctrlKey||!e.altKey||e.shiftKey||e.metaKey)return;let t=/^(?:Digit|Numpad)([1-9])$/.exec(e.code);if(!t)return;let n=parseInt(t[1],10)-1;n>=this._tocEntries.length||(e.preventDefault(),this._scrollToSection(n))},this._onScrollSpy=()=>{if(this._tocLocked)return;let e=this._sectionCards();if(!e.length)return;let t=this.shadowRoot?.querySelector(`mateu-content-header`),n=t?t.getBoundingClientRect().bottom:0;for(let t of e){if(!t.classList.contains(`mateu-section--sticky`))continue;let e=t.getBoundingClientRect();e.top<=n+12+2&&(n=Math.max(n,e.bottom))}let r=n+12+4,i=0;this._tocEntries.forEach((e,t)=>{e.el.getBoundingClientRect().top<=r&&(i=t)}),this._activeToc=i}}connectedCallback(){super.connectedCallback(),document.addEventListener(`page-banners-received`,this._bannersHandler),window.addEventListener(`resize`,this._onResize),document.addEventListener(`keydown`,this._onTocKey)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`page-banners-received`,this._bannersHandler),window.removeEventListener(`resize`,this._onResize),document.removeEventListener(`keydown`,this._onTocKey),this._clearAllTimers(),this._teardownScrollSpy()}updated(e){if(super.updated(e),e.has(`component`)&&e.get(`component`)!==void 0&&(this._clearAllTimers(),this.actionBanners=[],this.dismissedStaticBannerIndices=new Set),e.has(`component`)){let e=this.component?.metadata?.level??0;this.toggleAttribute(`data-nested`,e>0),this._scheduleStaticBannerTimeouts();let t=this.component?.metadata?.pageWidth===`edgeToEdge`;this.toggleAttribute(`data-edge`,t),this.dispatchEvent(new CustomEvent(`compact-changed`,{detail:{compact:!!this.component?.style?.includes(`--mateu-compact:1`)||t},bubbles:!0,composed:!0})),this._scheduleTocRebuild()}}_scheduleStaticBannerTimeouts(){this._staticBannerTimers.forEach(e=>clearTimeout(e)),this._staticBannerTimers=[],(this.component?.metadata?.banners??[]).forEach((e,t)=>{e.timeoutSeconds&&e.timeoutSeconds>0&&this._staticBannerTimers.push(setTimeout(()=>{this.dismissedStaticBannerIndices=new Set([...this.dismissedStaticBannerIndices,t])},e.timeoutSeconds*1e3))})}_clearActionBannerTimers(){this._actionBannerTimers.forEach(e=>clearTimeout(e)),this._actionBannerTimers=[]}_clearAllTimers(){this._clearActionBannerTimers(),this._staticBannerTimers.forEach(e=>clearTimeout(e)),this._staticBannerTimers=[]}_dismissActionBanner(e){this.actionBanners=this.actionBanners.filter((t,n)=>n!==e)}_dismissStaticBanner(e){this.dismissedStaticBannerIndices=new Set([...this.dismissedStaticBannerIndices,e])}bannerThemeClass(e){let t=e.theme?.toLowerCase()??`info`;return t===`none`?``:t}_evalBannerText(e){return j(e,this.state,this.data)}_renderBanner(e,t){let n=this._evalBannerText(e.title),r=this._evalBannerText(e.description);return w`
             <div class="page-banner page-banner--${this.bannerThemeClass(e)}">
                 ${n||e.hasCloseButton?w`
                     <div style="display: flex; align-items: center; justify-content: space-between; color: #1a1a1a; width: 100%;">
@@ -5894,7 +5894,7 @@ ${i}
                 `:_}
                 ${r?w`<p>${r}</p>`:_}
             </div>
-        `}_onSlotChange(){this._scheduleTocRebuild()}_scheduleTocRebuild(){this._tocRebuildScheduled||(this._tocRebuildScheduled=!0,requestAnimationFrame(()=>{this._tocRebuildScheduled=!1,this._rebuildToc()}))}_sectionCards(){return Array.from(this.querySelectorAll(`.mateu-section`))}_sectionTitle(e){return e.querySelector(`[slot="title"]`)?.textContent?.trim()||e.querySelector(`h1,h2,h3,h4,h5,h6`)?.textContent?.trim()||void 0}_rebuildToc(){let e=this._sectionCards(),t=e.map(e=>({title:this._sectionTitle(e),el:e})).filter(e=>!!e.title),n=this.component?.metadata?.toc,r=t.length>4&&e.every(e=>!e.closest(`vaadin-horizontal-layout`)),i=(n===!0||n!==!1&&r)&&t.length>0;this._tocEntries=t,this._tocVisible=i,this._activeToc>=t.length&&(this._activeToc=0),this._teardownScrollSpy(),i?requestAnimationFrame(()=>{this._layoutStickyTops(),this._setupScrollSpy()}):this._layoutStickyTops()}_layoutStickyTops(){let e=this.shadowRoot?.querySelector(`mateu-content-header`);this._headerH=this._tocVisible&&e?e.offsetHeight:0,this.style.setProperty(`--mateu-header-h`,this._headerH+`px`);let t=this._headerH+12;for(let e of this._sectionCards())e.classList.contains(`mateu-section--sticky`)&&(e.style.top=t+`px`,t+=e.offsetHeight+12)}_scrollContainer(){let e=Wa(this);for(;e;){let t=getComputedStyle(e).overflowY;if((t===`auto`||t===`scroll`)&&e.scrollHeight>e.clientHeight)return e;e=Wa(e)}return null}_setupScrollSpy(){this._tocEntries.length&&(this._spyTarget=this._scrollContainer()??window,this._spyTarget.addEventListener(`scroll`,this._onScrollSpy,{passive:!0}),window.addEventListener(`wheel`,this._unlockToc,{passive:!0}),window.addEventListener(`touchstart`,this._unlockToc,{passive:!0}),window.addEventListener(`keydown`,this._unlockToc),this._onScrollSpy())}_teardownScrollSpy(){this._spyTarget?.removeEventListener(`scroll`,this._onScrollSpy),window.removeEventListener(`wheel`,this._unlockToc),window.removeEventListener(`touchstart`,this._unlockToc),window.removeEventListener(`keydown`,this._unlockToc),this._spyTarget=void 0}_scrollToSection(e){let t=this._tocEntries[e];if(!t)return;this._activeToc=e,this._tocLocked=!0;let n=this._headerH+12;for(let e of this._sectionCards()){if(e===t.el)break;e.classList.contains(`mateu-section--sticky`)&&(n+=e.offsetHeight+12)}let r=this._scrollContainer(),i=r?r.getBoundingClientRect().top:0,a=t.el.getBoundingClientRect().top-i-n;(r??window).scrollBy({top:a,behavior:`smooth`})}_showHeaderBand(){let e=this.component?.metadata,t=!!(e?.title||e?.subtitle||e?.toolbar?.length),n=!!this.component?.children?.some(e=>e.metadata?.type===A.Crud);return t&&!n&&!this._hasWelcomeBanner()}_hasWelcomeBanner(){let e=t=>t?.metadata?.type===A.HeroSection||(t?.children??[]).some(e);return(this.component?.children??[]).some(e)}render(){let e=this.component?.metadata,t=[...(e?.banners??[]).map((e,t)=>({banner:e,index:t})).filter(({index:e})=>!this.dismissedStaticBannerIndices.has(e)).map(({banner:e,index:t})=>({banner:e,onDismiss:()=>this._dismissStaticBanner(t)})),...this.actionBanners.map((e,t)=>({banner:e,onDismiss:()=>this._dismissActionBanner(t)}))];return w`<div style="display: flex; flex-direction: column; width: 100%;">${w`
+        `}_onSlotChange(){this._scheduleTocRebuild()}_scheduleTocRebuild(){this._tocRebuildScheduled||(this._tocRebuildScheduled=!0,requestAnimationFrame(()=>{this._tocRebuildScheduled=!1,this._rebuildToc()}))}_sectionCards(){return Array.from(this.querySelectorAll(`.mateu-section`))}_sectionTitle(e){return e.querySelector(`[slot="title"]`)?.textContent?.trim()||e.querySelector(`h1,h2,h3,h4,h5,h6`)?.textContent?.trim()||void 0}_rebuildToc(){let e=this._sectionCards(),t=e.map(e=>({title:this._sectionTitle(e),el:e})).filter(e=>!!e.title),n=this.component?.metadata?.toc,r=t.length>4&&e.every(e=>!e.closest(`vaadin-horizontal-layout`)),i=(n===!0||n!==!1&&r)&&t.length>0;this._tocEntries=t,this._tocVisible=i,this._activeToc>=t.length&&(this._activeToc=0),this._teardownScrollSpy(),i?requestAnimationFrame(()=>{this._layoutStickyTops(),this._setupScrollSpy()}):this._layoutStickyTops()}_layoutStickyTops(){let e=this.shadowRoot?.querySelector(`mateu-content-header`);this._headerH=this._tocVisible&&e?e.offsetHeight:0,this.style.setProperty(`--mateu-header-h`,this._headerH+`px`);let t=this._headerH+12;for(let e of this._sectionCards())e.classList.contains(`mateu-section--sticky`)&&(e.style.top=t+`px`,t+=e.offsetHeight+12)}_scrollContainer(){let e=qa(this);for(;e;){let t=getComputedStyle(e).overflowY;if((t===`auto`||t===`scroll`)&&e.scrollHeight>e.clientHeight)return e;e=qa(e)}return null}_setupScrollSpy(){this._tocEntries.length&&(this._spyTarget=this._scrollContainer()??window,this._spyTarget.addEventListener(`scroll`,this._onScrollSpy,{passive:!0}),window.addEventListener(`wheel`,this._unlockToc,{passive:!0}),window.addEventListener(`touchstart`,this._unlockToc,{passive:!0}),window.addEventListener(`keydown`,this._unlockToc),this._onScrollSpy())}_teardownScrollSpy(){this._spyTarget?.removeEventListener(`scroll`,this._onScrollSpy),window.removeEventListener(`wheel`,this._unlockToc),window.removeEventListener(`touchstart`,this._unlockToc),window.removeEventListener(`keydown`,this._unlockToc),this._spyTarget=void 0}_scrollToSection(e){let t=this._tocEntries[e];if(!t)return;this._activeToc=e,this._tocLocked=!0;let n=this._headerH+12;for(let e of this._sectionCards()){if(e===t.el)break;e.classList.contains(`mateu-section--sticky`)&&(n+=e.offsetHeight+12)}let r=this._scrollContainer(),i=r?r.getBoundingClientRect().top:0,a=t.el.getBoundingClientRect().top-i-n;(r??window).scrollBy({top:a,behavior:`smooth`})}_showHeaderBand(){let e=this.component?.metadata,t=!!(e?.title||e?.subtitle||e?.toolbar?.length),n=!!this.component?.children?.some(e=>e.metadata?.type===A.Crud);return t&&!n&&!this._hasWelcomeBanner()}_hasWelcomeBanner(){let e=t=>t?.metadata?.type===A.HeroSection||(t?.children??[]).some(e);return(this.component?.children??[]).some(e)}render(){let e=this.component?.metadata,t=[...(e?.banners??[]).map((e,t)=>({banner:e,index:t})).filter(({index:e})=>!this.dismissedStaticBannerIndices.has(e)).map(({banner:e,index:t})=>({banner:e,onDismiss:()=>this._dismissStaticBanner(t)})),...this.actionBanners.map((e,t)=>({banner:e,onDismiss:()=>this._dismissActionBanner(t)}))];return w`<div style="display: flex; flex-direction: column; width: 100%;">${w`
             <div class="page-header-wrap">
                 <mateu-content-header
                     class="${this._tocVisible?`sticky-header`:``}"
@@ -6138,7 +6138,7 @@ ${i}
             background: #fdf2f2;
             border-leftx: 4px solid var(--lumo-error-color);
         }
-    `}};O([v()],J.prototype,`component`,void 0),O([v()],J.prototype,`baseUrl`,void 0),O([v()],J.prototype,`state`,void 0),O([v()],J.prototype,`data`,void 0),O([v()],J.prototype,`appState`,void 0),O([v()],J.prototype,`appData`,void 0),O([v()],J.prototype,`value`,void 0),O([v({type:Boolean})],J.prototype,`standalone`,void 0),O([S()],J.prototype,`actionBanners`,void 0),O([S()],J.prototype,`dismissedStaticBannerIndices`,void 0),O([S()],J.prototype,`_tocEntries`,void 0),O([S()],J.prototype,`_activeToc`,void 0),O([S()],J.prototype,`_tocVisible`,void 0),J=O([h(`mateu-page`)],J);var Ga=m`
+    `}};O([v()],q.prototype,`component`,void 0),O([v()],q.prototype,`baseUrl`,void 0),O([v()],q.prototype,`state`,void 0),O([v()],q.prototype,`data`,void 0),O([v()],q.prototype,`appState`,void 0),O([v()],q.prototype,`appData`,void 0),O([v()],q.prototype,`value`,void 0),O([v({type:Boolean})],q.prototype,`standalone`,void 0),O([S()],q.prototype,`actionBanners`,void 0),O([S()],q.prototype,`dismissedStaticBannerIndices`,void 0),O([S()],q.prototype,`_tocEntries`,void 0),O([S()],q.prototype,`_activeToc`,void 0),O([S()],q.prototype,`_tocVisible`,void 0),q=O([h(`mateu-page`)],q);var Ja=m`
     .nbtn {
         display: inline-flex;
         align-items: center;
@@ -6167,25 +6167,25 @@ ${i}
     }
     .nbtn.primary:hover { background: var(--lumo-primary-color, #1676f3); filter: brightness(1.08); }
     .nbtn svg { width: 1em; height: 1em; flex-shrink: 0; }
-`,Ka=e=>C`
+`,Ya=e=>C`
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-         stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${e}</svg>`,qa=Ka(C`
+         stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${e}</svg>`,Xa=Ya(C`
     <circle cx="12" cy="12" r="3"></circle>
-    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path>`),Ja=Ka(C`
+    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path>`),Za=Ya(C`
     <line x1="12" y1="5" x2="12" y2="19"></line>
-    <line x1="5" y1="12" x2="19" y2="12"></line>`),Ya=Ka(C`
+    <line x1="5" y1="12" x2="19" y2="12"></line>`),Qa=Ya(C`
     <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
     <polyline points="7 10 12 15 17 10"></polyline>
-    <line x1="12" y1="15" x2="12" y2="3"></line>`);Ka(C`
+    <line x1="12" y1="15" x2="12" y2="3"></line>`);Ya(C`
     <rect x="9" y="2" width="6" height="5" rx="1"></rect>
     <rect x="2" y="17" width="6" height="5" rx="1"></rect>
     <rect x="16" y="17" width="6" height="5" rx="1"></rect>
-    <path d="M12 7v4M5 17v-3h14v3M12 11v3"></path>`);var Xa=Ka(C`
+    <path d="M12 7v4M5 17v-3h14v3M12 11v3"></path>`);var $a=Ya(C`
     <rect x="9" y="2" width="6" height="12" rx="3"></rect>
     <path d="M5 10v1a7 7 0 0 0 14 0v-1"></path>
-    <line x1="12" y1="18" x2="12" y2="22"></line>`),Za=Ka(C`
+    <line x1="12" y1="18" x2="12" y2="22"></line>`),eo=Ya(C`
     <line x1="18" y1="6" x2="6" y2="18"></line>
-    <line x1="6" y1="6" x2="18" y2="18"></line>`),Qa=[`#e91e63`,`#1676f3`,`#10b981`,`#8b5cf6`,`#f59e0b`,`#ef4444`],$a=e=>Qa[Math.abs(e??0)%Qa.length],eo=e=>(e??`?`).split(/\s+/).filter(e=>e).map(e=>e[0]).slice(0,2).join(``).toUpperCase()||`?`,Y=class extends y{constructor(...e){super(...e),this.localAgentUrl=`http://127.0.0.1:8776`,this.localAgentAlive=!1,this.menu=[],this.chatSessionId=T(),this.menuContextSent=!1,this.attachments=[],this.uploading=!1,this.expanded=!1,this.toggleExpanded=()=>{this.expanded=!this.expanded},this.items=[],this.listening=!1,this.recognitionAvailable=!1,this.loading=!1,this.elapsedSeconds=0,this.startListening=()=>{this.recognition&&(this.listening?(this.recognition.stop(),this.listening=!1):(this.recognition.start(),this.listening=!0))},this.onSpeechResult=e=>{if(this.recognition){let t=e,n=t.results[t.results[0].length-1][0].transcript;this.messageInputElement&&(this.messageInputElement.value=n,this.send(new CustomEvent(`submit`,{detail:{value:n},bubbles:!0,composed:!0})))}},this.probeLocalAgent=async()=>{if(this.localAgentUrl)try{let e=new AbortController,t=setTimeout(()=>e.abort(),1200),n=await fetch(this.localAgentUrl+`/health`,{signal:e.signal});clearTimeout(t),this.localAgentAlive=n.ok}catch{this.localAgentAlive=!1}},this.pickFiles=()=>this.fileInputElement?.click(),this.onFilesPicked=async e=>{let t=e.target,n=Array.from(t.files??[]);if(t.value=``,!(!n.length||!this.uploadUrl)){this.uploading=!0;try{let e=new FormData;e.append(`sessionId`,this.chatSessionId);for(let t of n)e.append(`files`,t,t.name);let t={},r=localStorage.getItem(`__mateu_auth_token`);r&&(t.Authorization=`Bearer `+r);let i=sessionStorage.getItem(`__mateu_sesion_id`);i&&(t[`X-Session-Id`]=i);let a=await fetch(this.uploadUrl,{method:`POST`,headers:t,body:e});if(!a.ok)throw Error(`Upload failed: ${a.status}`);let o=((await a.json()).files??[]).filter(e=>e&&e.path);this.attachments=[...this.attachments,...o]}catch(e){this.addMessage(`⚠️ No se pudieron subir los ficheros: ${e instanceof Error?e.message:e}`,`agent`)}finally{this.uploading=!1}}},this.removeAttachment=e=>{this.attachments=this.attachments.filter(t=>t.path!==e)},this.send=async e=>{this.messageInputElement?.setAttribute(`disabled`,`disabled`);let t=e.detail.value.trim(),n=this.localAgentAlive?this.localAgentUrl+`/mateu/agent/stream`:this.sseUrl,r=this.attachments;if(!t&&r.length===0||!n)return;let i=r.length?`${t}${t?`
+    <line x1="6" y1="6" x2="18" y2="18"></line>`),to=[`#e91e63`,`#1676f3`,`#10b981`,`#8b5cf6`,`#f59e0b`,`#ef4444`],no=e=>to[Math.abs(e??0)%to.length],ro=e=>(e??`?`).split(/\s+/).filter(e=>e).map(e=>e[0]).slice(0,2).join(``).toUpperCase()||`?`,J=class extends y{constructor(...e){super(...e),this.localAgentUrl=`http://127.0.0.1:8776`,this.localAgentAlive=!1,this.menu=[],this.chatSessionId=T(),this.menuContextSent=!1,this.attachments=[],this.uploading=!1,this.expanded=!1,this.toggleExpanded=()=>{this.expanded=!this.expanded},this.items=[],this.listening=!1,this.recognitionAvailable=!1,this.loading=!1,this.elapsedSeconds=0,this.startListening=()=>{this.recognition&&(this.listening?(this.recognition.stop(),this.listening=!1):(this.recognition.start(),this.listening=!0))},this.onSpeechResult=e=>{if(this.recognition){let t=e,n=t.results[t.results[0].length-1][0].transcript;this.messageInputElement&&(this.messageInputElement.value=n,this.send(new CustomEvent(`submit`,{detail:{value:n},bubbles:!0,composed:!0})))}},this.probeLocalAgent=async()=>{if(this.localAgentUrl)try{let e=new AbortController,t=setTimeout(()=>e.abort(),1200),n=await fetch(this.localAgentUrl+`/health`,{signal:e.signal});clearTimeout(t),this.localAgentAlive=n.ok}catch{this.localAgentAlive=!1}},this.pickFiles=()=>this.fileInputElement?.click(),this.onFilesPicked=async e=>{let t=e.target,n=Array.from(t.files??[]);if(t.value=``,!(!n.length||!this.uploadUrl)){this.uploading=!0;try{let e=new FormData;e.append(`sessionId`,this.chatSessionId);for(let t of n)e.append(`files`,t,t.name);let t={},r=localStorage.getItem(`__mateu_auth_token`);r&&(t.Authorization=`Bearer `+r);let i=sessionStorage.getItem(`__mateu_sesion_id`);i&&(t[`X-Session-Id`]=i);let a=await fetch(this.uploadUrl,{method:`POST`,headers:t,body:e});if(!a.ok)throw Error(`Upload failed: ${a.status}`);let o=((await a.json()).files??[]).filter(e=>e&&e.path);this.attachments=[...this.attachments,...o]}catch(e){this.addMessage(`⚠️ No se pudieron subir los ficheros: ${e instanceof Error?e.message:e}`,`agent`)}finally{this.uploading=!1}}},this.removeAttachment=e=>{this.attachments=this.attachments.filter(t=>t.path!==e)},this.send=async e=>{this.messageInputElement?.setAttribute(`disabled`,`disabled`);let t=e.detail.value.trim(),n=this.localAgentAlive?this.localAgentUrl+`/mateu/agent/stream`:this.sseUrl,r=this.attachments;if(!t&&r.length===0||!n)return;let i=r.length?`${t}${t?`
 
 `:``}📎 ${r.map(e=>e.name).join(`, `)}`:t;this.addMessage(i,`user`),this.attachments=[];let a=this.addMessage(``,`agent`);this.startLoading();let o=``;try{let e={Accept:`text/event-stream`,"Content-Type":`application/json`},i=localStorage.getItem(`__mateu_auth_token`);i&&(e.Authorization=`Bearer `+i);let s=sessionStorage.getItem(`__mateu_sesion_id`);s&&(e[`X-Session-Id`]=s);let c=this.contextProvider?.(),l=JSON.stringify({message:t,sessionId:this.chatSessionId,...r.length&&{attachments:r},...c!=null&&{context:c},...this.mcpUrl&&{mcpUrl:new URL(this.mcpUrl,window.location.origin).href},...!this.menuContextSent&&{menuContext:this.buildMenuContext(this.menu)}});this.menuContextSent=!0;let u=await fetch(n,{method:`POST`,headers:e,body:l});if(!u.ok){let e=await u.text();throw Error(`Servidor respondió ${u.status}: ${e}`)}let d=u.body?.getReader();if(!d)throw Error(`No se pudo obtener el reader del stream.`);let f=new TextDecoder,p=``;for(;;){let{done:e,value:t}=await d.read();if(e){if(p.trim().startsWith(`data:`)){let e=p.trim().slice(5).trim(),t=this.tryParseTokenUsage(e),n=!t&&this.tryParseCustomEvent(e);t?this.tokenUsage={...this.tokenUsage,...t}:n?n.event===`agent-error`?(o=`⚠️ `+(n.detail?.message??`Error desconocido del agente`),this.updateMessage(a,o)):this.dispatchEvent(new CustomEvent(n.event,{detail:n.detail,bubbles:!0,composed:!0})):(o+=e,this.updateMessage(a,o))}break}let n=f.decode(t,{stream:!0});p+=n;let r=p.split(`
 `);p=r.pop()||``;let i=!1;for(let e of r)if(e.trim().startsWith(`data:`)){let t=e.trim().slice(5).trim(),n=this.tryParseTokenUsage(t),r=!n&&this.tryParseCustomEvent(t);n?this.tokenUsage={...this.tokenUsage,...n}:r?r.event===`agent-error`?(o=`⚠️ `+(r.detail?.message??`Error desconocido del agente`),this.updateMessage(a,o)):this.dispatchEvent(new CustomEvent(r.event,{detail:r.detail,bubbles:!0,composed:!0})):(o+=t+`
@@ -6200,14 +6200,14 @@ ${i}
                         ${this.expanded?`⤡`:`⤢`}
                     </button>
                     <button class="chat-close" @click="${this.closeChat}" title="Cerrar">
-                        ${Za}
+                        ${eo}
                     </button>
                 </div>
                 <div class="scroll-container">
                     <div class="message-list" role="list">
                         ${this.items.map(e=>w`
                             <div class="message" role="listitem">
-                                <div class="avatar" style="background: ${$a(e.userColorIndex)};">${eo(e.userName)}</div>
+                                <div class="avatar" style="background: ${no(e.userColorIndex)};">${ro(e.userName)}</div>
                                 <div class="message-body">
                                     <div class="message-meta">
                                         <span class="message-name">${e.userName}</span>
@@ -6255,7 +6255,7 @@ ${i}
                             style="color: ${this.listening?`red`:`var(--lumo-contrast-50pct, #767676)`};"
                             @click="${this.startListening}"
                             ?disabled="${!this.recognitionAvailable}"
-                    >${Xa}</button>
+                    >${$a}</button>
                     <input class="msg-input"
                            placeholder="Message"
                            aria-label="Message"
@@ -6263,7 +6263,7 @@ ${i}
                     <button class="nbtn primary" ?disabled="${this.loading}" @click="${this.submitFromInput}">Send</button>
                 </div>
             </div>
-        `}static{this.styles=[Ga,m`
+        `}static{this.styles=[Ja,m`
         :host {
             display: block;
             height: 100%;
@@ -6588,7 +6588,7 @@ ${i}
         @keyframes spin {
             to { transform: rotate(360deg); }
         }
-    `]}};O([v({attribute:!1})],Y.prototype,`contextProvider`,void 0),O([v()],Y.prototype,`localAgentUrl`,void 0),O([v({attribute:!1})],Y.prototype,`mcpUrl`,void 0),O([S()],Y.prototype,`localAgentAlive`,void 0),O([v()],Y.prototype,`sseUrl`,void 0),O([v()],Y.prototype,`uploadUrl`,void 0),O([v({attribute:!1})],Y.prototype,`menu`,void 0),O([S()],Y.prototype,`attachments`,void 0),O([S()],Y.prototype,`uploading`,void 0),O([b(`.file-input`)],Y.prototype,`fileInputElement`,void 0),O([v({type:Boolean,reflect:!0})],Y.prototype,`expanded`,void 0),O([v()],Y.prototype,`items`,void 0),O([b(`.scroll-container`)],Y.prototype,`scrollContainer`,void 0),O([b(`.msg-input`)],Y.prototype,`messageInputElement`,void 0),O([S()],Y.prototype,`recognition`,void 0),O([S()],Y.prototype,`listening`,void 0),O([S()],Y.prototype,`recognitionAvailable`,void 0),O([S()],Y.prototype,`loading`,void 0),O([S()],Y.prototype,`elapsedSeconds`,void 0),O([S()],Y.prototype,`tokenUsage`,void 0),Y=O([h(`mateu-chat`)],Y);var to=class extends y{updated(e){super.updated(e),this.chart&&=(this.chart.destroy(),void 0),this.data&&this.createChart(this.data)}async createChart(e){let[{default:t}]=await Promise.all([E(()=>import(`./vendor-chartjs.js`).then(e=>e.n),__vite__mapDeps([3,1])),E(()=>import(`./vendor-chartjs.js`).then(e=>e.t),__vite__mapDeps([3,1]))]);if(e!==this.data)return;this.chart&&this.chart.destroy();let n={type:this.type,data:this.data,options:this.options};this.chart=new t(this.chartElement,n)}handleSlotChange(){}render(){return w`
+    `]}};O([v({attribute:!1})],J.prototype,`contextProvider`,void 0),O([v()],J.prototype,`localAgentUrl`,void 0),O([v({attribute:!1})],J.prototype,`mcpUrl`,void 0),O([S()],J.prototype,`localAgentAlive`,void 0),O([v()],J.prototype,`sseUrl`,void 0),O([v()],J.prototype,`uploadUrl`,void 0),O([v({attribute:!1})],J.prototype,`menu`,void 0),O([S()],J.prototype,`attachments`,void 0),O([S()],J.prototype,`uploading`,void 0),O([b(`.file-input`)],J.prototype,`fileInputElement`,void 0),O([v({type:Boolean,reflect:!0})],J.prototype,`expanded`,void 0),O([v()],J.prototype,`items`,void 0),O([b(`.scroll-container`)],J.prototype,`scrollContainer`,void 0),O([b(`.msg-input`)],J.prototype,`messageInputElement`,void 0),O([S()],J.prototype,`recognition`,void 0),O([S()],J.prototype,`listening`,void 0),O([S()],J.prototype,`recognitionAvailable`,void 0),O([S()],J.prototype,`loading`,void 0),O([S()],J.prototype,`elapsedSeconds`,void 0),O([S()],J.prototype,`tokenUsage`,void 0),J=O([h(`mateu-chat`)],J);var io=class extends y{updated(e){super.updated(e),this.chart&&=(this.chart.destroy(),void 0),this.data&&this.createChart(this.data)}async createChart(e){let[{default:t}]=await Promise.all([E(()=>import(`./vendor-chartjs.js`).then(e=>e.n),__vite__mapDeps([3,1])),E(()=>import(`./vendor-chartjs.js`).then(e=>e.t),__vite__mapDeps([3,1]))]);if(e!==this.data)return;this.chart&&this.chart.destroy();let n={type:this.type,data:this.data,options:this.options};this.chart=new t(this.chartElement,n)}handleSlotChange(){}render(){return w`
             <div class="container">
                 <canvas id="chart"></canvas>
             </div>
@@ -6605,7 +6605,7 @@ ${i}
         height: 100%;
         position: relative;
     }
-  `}};O([v()],to.prototype,`type`,void 0),O([v()],to.prototype,`data`,void 0),O([v()],to.prototype,`options`,void 0),O([b(`#chart`)],to.prototype,`chartElement`,void 0),to=O([h(`mateu-chart`)],to);var no=class extends y{updated(e){super.updated(e),this.chart&&=(this.chart.destroy(),void 0),this.xml&&this.createViewer(this.xml)}async createViewer(e){let{default:t}=await E(async()=>{let{default:e}=await import(`./vendor-diagrams.js`).then(e=>e.t);return{default:e}},__vite__mapDeps([4,1,2]));if(e!==this.xml)return;this.chart&&this.chart.destroy();let n={container:this.divElement};this.chart=new t(n),this.chart.importXML(e)}handleSlotChange(){}render(){return w`
+  `}};O([v()],io.prototype,`type`,void 0),O([v()],io.prototype,`data`,void 0),O([v()],io.prototype,`options`,void 0),O([b(`#chart`)],io.prototype,`chartElement`,void 0),io=O([h(`mateu-chart`)],io);var ao=class extends y{updated(e){super.updated(e),this.chart&&=(this.chart.destroy(),void 0),this.xml&&this.createViewer(this.xml)}async createViewer(e){let{default:t}=await E(async()=>{let{default:e}=await import(`./vendor-diagrams.js`).then(e=>e.t);return{default:e}},__vite__mapDeps([4,1,2]));if(e!==this.xml)return;this.chart&&this.chart.destroy();let n={container:this.divElement};this.chart=new t(n),this.chart.importXML(e)}handleSlotChange(){}render(){return w`
             <div class="container" style="width: 20rem; height: 15rem; overflow: auto;">
                 <!-- BPMN diagram container -->
                 <div id="canvas" style="width: 60rem; height: 30rem; zoom: 0.5;"></div>
@@ -6614,7 +6614,7 @@ ${i}
                 <slot @slotchange=${this.handleSlotChange}></slot>
             </div>
        `}static{this.styles=m`
-  `}};O([v()],no.prototype,`xml`,void 0),O([b(`#canvas`)],no.prototype,`divElement`,void 0),no=O([h(`mateu-bpmn`)],no);var ro=160,io=56,ao=220,oo=110,so=60,co={ACTION:`#3B82F6`,JOIN:`#8B5CF6`,FORK:`#F59E0B`,END:`#EF4444`,USER_TASK:`#10B981`,PROCESS:`#6366F1`},lo={ACTION:`▶`,JOIN:`⟨`,FORK:`⟩`,END:`◼`,USER_TASK:`👤`,PROCESS:`⚙`},uo=[`ACTION`,`JOIN`,`FORK`,`END`,`USER_TASK`,`PROCESS`];function fo(){return`step-`+Math.random().toString(36).slice(2,8)}var po=class extends y{constructor(...e){super(...e),this.value=`{"name":"New Workflow","steps":[]}`,this.wf={name:`New Workflow`,steps:[]},this.positions={},this.selectedId=null,this.showMeta=!1,this.draggingId=null,this.dragOffset={x:0,y:0},this.svgEl=null,this.onMouseMove=e=>{if(!this.draggingId||!this.svgEl)return;let t=this.toSvgPoint(e);this.positions={...this.positions,[this.draggingId]:{x:Math.max(0,t.x-this.dragOffset.x),y:Math.max(0,t.y-this.dragOffset.y)}}},this.onMouseUp=()=>{this.draggingId=null,window.removeEventListener(`mousemove`,this.onMouseMove),window.removeEventListener(`mouseup`,this.onMouseUp)}}updated(e){if(e.has(`value`)){try{this.wf=JSON.parse(this.value)}catch{}this.autoLayout()}}autoLayout(){let e=this.wf.steps??[],t={};e.forEach(e=>{t[e.id]=0});let n=!0;for(;n;)n=!1,e.forEach(e=>{if(e.preconditionStepId!=null&&t[e.preconditionStepId]!==void 0){let r=t[e.preconditionStepId]+1;r>t[e.id]&&(t[e.id]=r,n=!0)}});let r={};e.forEach(e=>{let n=t[e.id]??0;(r[n]??=[]).push(e.id)});let i={...this.positions},a=!1;Object.entries(r).forEach(([e,t])=>{let n=Number(e);t.forEach((e,t)=>{i[e]||(i[e]={x:so+n*ao,y:so+t*oo},a=!0)})}),a&&(this.positions=i)}emit(){let e=JSON.stringify(this.wf,null,2);this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e},bubbles:!0,composed:!0}))}updateWf(e){this.wf={...this.wf,...e},this.emit()}updateStep(e,t){this.wf={...this.wf,steps:this.wf.steps.map(n=>n.id===e?{...n,...t}:n)},this.emit()}addStep(){let e=fo(),t={id:e,type:`ACTION`,name:`New Step`};this.wf={...this.wf,steps:[...this.wf.steps??[],t]};let n=Object.values(this.positions).map(e=>e.y),r=n.length?Math.max(...n)+oo:so;this.positions={...this.positions,[e]:{x:so,y:r}},this.selectedId=e,this.emit()}deleteStep(e){this.wf={...this.wf,steps:this.wf.steps.filter(t=>t.id!==e).map(t=>t.preconditionStepId===e?{...t,preconditionStepId:void 0}:t)};let{[e]:t,...n}=this.positions;this.positions=n,this.selectedId===e&&(this.selectedId=null),this.emit()}onNodeMouseDown(e,t){e.preventDefault(),this.draggingId=t;let n=this.positions[t]??{x:0,y:0},r=this.toSvgPoint(e);this.dragOffset={x:r.x-n.x,y:r.y-n.y},this.svgEl=e.currentTarget.closest(`svg`),window.addEventListener(`mousemove`,this.onMouseMove),window.addEventListener(`mouseup`,this.onMouseUp)}toSvgPoint(e){if(!this.svgEl)return{x:0,y:0};let t=this.svgEl.getBoundingClientRect();return{x:e.clientX-t.left,y:e.clientY-t.top}}canvasSize(){let e=Object.values(this.positions),t=e.length?Math.max(...e.map(e=>e.x))+ro+so:600,n=e.length?Math.max(...e.map(e=>e.y))+io+so:400;return{w:Math.max(t,600),h:Math.max(n,400)}}render(){let{w:e,h:t}=this.canvasSize(),n=this.wf.steps??[];return w`
+  `}};O([v()],ao.prototype,`xml`,void 0),O([b(`#canvas`)],ao.prototype,`divElement`,void 0),ao=O([h(`mateu-bpmn`)],ao);var oo=160,so=56,co=220,lo=110,uo=60,fo={ACTION:`#3B82F6`,JOIN:`#8B5CF6`,FORK:`#F59E0B`,END:`#EF4444`,USER_TASK:`#10B981`,PROCESS:`#6366F1`},po={ACTION:`▶`,JOIN:`⟨`,FORK:`⟩`,END:`◼`,USER_TASK:`👤`,PROCESS:`⚙`},mo=[`ACTION`,`JOIN`,`FORK`,`END`,`USER_TASK`,`PROCESS`];function ho(){return`step-`+Math.random().toString(36).slice(2,8)}var go=class extends y{constructor(...e){super(...e),this.value=`{"name":"New Workflow","steps":[]}`,this.wf={name:`New Workflow`,steps:[]},this.positions={},this.selectedId=null,this.showMeta=!1,this.draggingId=null,this.dragOffset={x:0,y:0},this.svgEl=null,this.onMouseMove=e=>{if(!this.draggingId||!this.svgEl)return;let t=this.toSvgPoint(e);this.positions={...this.positions,[this.draggingId]:{x:Math.max(0,t.x-this.dragOffset.x),y:Math.max(0,t.y-this.dragOffset.y)}}},this.onMouseUp=()=>{this.draggingId=null,window.removeEventListener(`mousemove`,this.onMouseMove),window.removeEventListener(`mouseup`,this.onMouseUp)}}updated(e){if(e.has(`value`)){try{this.wf=JSON.parse(this.value)}catch{}this.autoLayout()}}autoLayout(){let e=this.wf.steps??[],t={};e.forEach(e=>{t[e.id]=0});let n=!0;for(;n;)n=!1,e.forEach(e=>{if(e.preconditionStepId!=null&&t[e.preconditionStepId]!==void 0){let r=t[e.preconditionStepId]+1;r>t[e.id]&&(t[e.id]=r,n=!0)}});let r={};e.forEach(e=>{let n=t[e.id]??0;(r[n]??=[]).push(e.id)});let i={...this.positions},a=!1;Object.entries(r).forEach(([e,t])=>{let n=Number(e);t.forEach((e,t)=>{i[e]||(i[e]={x:uo+n*co,y:uo+t*lo},a=!0)})}),a&&(this.positions=i)}emit(){let e=JSON.stringify(this.wf,null,2);this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e},bubbles:!0,composed:!0}))}updateWf(e){this.wf={...this.wf,...e},this.emit()}updateStep(e,t){this.wf={...this.wf,steps:this.wf.steps.map(n=>n.id===e?{...n,...t}:n)},this.emit()}addStep(){let e=ho(),t={id:e,type:`ACTION`,name:`New Step`};this.wf={...this.wf,steps:[...this.wf.steps??[],t]};let n=Object.values(this.positions).map(e=>e.y),r=n.length?Math.max(...n)+lo:uo;this.positions={...this.positions,[e]:{x:uo,y:r}},this.selectedId=e,this.emit()}deleteStep(e){this.wf={...this.wf,steps:this.wf.steps.filter(t=>t.id!==e).map(t=>t.preconditionStepId===e?{...t,preconditionStepId:void 0}:t)};let{[e]:t,...n}=this.positions;this.positions=n,this.selectedId===e&&(this.selectedId=null),this.emit()}onNodeMouseDown(e,t){e.preventDefault(),this.draggingId=t;let n=this.positions[t]??{x:0,y:0},r=this.toSvgPoint(e);this.dragOffset={x:r.x-n.x,y:r.y-n.y},this.svgEl=e.currentTarget.closest(`svg`),window.addEventListener(`mousemove`,this.onMouseMove),window.addEventListener(`mouseup`,this.onMouseUp)}toSvgPoint(e){if(!this.svgEl)return{x:0,y:0};let t=this.svgEl.getBoundingClientRect();return{x:e.clientX-t.left,y:e.clientY-t.top}}canvasSize(){let e=Object.values(this.positions),t=e.length?Math.max(...e.map(e=>e.x))+oo+uo:600,n=e.length?Math.max(...e.map(e=>e.y))+so+uo:400;return{w:Math.max(t,600),h:Math.max(n,400)}}render(){let{w:e,h:t}=this.canvasSize(),n=this.wf.steps??[];return w`
             <div class="root">
                 ${this.renderToolbar()}
                 ${this.showMeta?this.renderMeta():``}
@@ -6641,15 +6641,15 @@ ${i}
                 <span class="badge badge-${e.toLowerCase()}">${e}</span>
                 <div style="flex:1"></div>
                 <button class="nbtn" @click="${()=>this.showMeta=!this.showMeta}">
-                    ${qa}
+                    ${Xa}
                     Settings
                 </button>
                 <button class="nbtn primary" @click="${()=>this.addStep()}">
-                    ${Ja}
+                    ${Za}
                     Add Step
                 </button>
                 <button class="nbtn" @click="${()=>this.exportJson()}">
-                    ${Ya}
+                    ${Qa}
                     Export
                 </button>
             </div>
@@ -6678,27 +6678,27 @@ ${i}
                     `:``}
                 </div>
             </div>
-        `}renderArrow(e){if(!e.preconditionStepId)return C``;let t=this.positions[e.preconditionStepId],n=this.positions[e.id];if(!t||!n)return C``;let r=t.x+ro,i=t.y+io/2,a=n.x,o=n.y+io/2,s=(r+a)/2;return C`
+        `}renderArrow(e){if(!e.preconditionStepId)return C``;let t=this.positions[e.preconditionStepId],n=this.positions[e.id];if(!t||!n)return C``;let r=t.x+oo,i=t.y+so/2,a=n.x,o=n.y+so/2,s=(r+a)/2;return C`
             <path d="M${r},${i} C${s},${i} ${s},${o} ${a},${o}"
                   fill="none" stroke="#94a3b8" stroke-width="2"
                   marker-end="url(#arrow)"/>
-        `}renderNode(e){let t=this.positions[e.id]??{x:so,y:so},n=co[e.type]??`#64748b`,r=lo[e.type]??`•`,i=this.selectedId===e.id;return C`
+        `}renderNode(e){let t=this.positions[e.id]??{x:uo,y:uo},n=fo[e.type]??`#64748b`,r=po[e.type]??`•`,i=this.selectedId===e.id;return C`
             <g transform="translate(${t.x},${t.y})"
                style="cursor:grab"
                @mousedown="${t=>this.onNodeMouseDown(t,e.id)}"
                @click="${t=>{t.stopPropagation(),this.selectedId=e.id}}">
-                <rect width="${ro}" height="${io}" rx="8"
+                <rect width="${oo}" height="${so}" rx="8"
                       fill="white"
                       stroke="${i?n:`#e2e8f0`}"
                       stroke-width="${i?2.5:1.5}"
                       filter="url(#shadow)"/>
                 <!-- type badge -->
-                <rect x="0" y="0" width="32" height="${io}" rx="8" fill="${n}" clip-path="inset(0 -8px 0 0 round 8px)"/>
-                <rect x="24" y="0" width="8" height="${io}" fill="${n}"/>
+                <rect x="0" y="0" width="32" height="${so}" rx="8" fill="${n}" clip-path="inset(0 -8px 0 0 round 8px)"/>
+                <rect x="24" y="0" width="8" height="${so}" fill="${n}"/>
                 <text x="16" y="${33}" text-anchor="middle"
                       font-size="14" fill="white">${r}</text>
                 <!-- name -->
-                <text x="44" y="${io/2-6}" font-size="11" fill="#1e293b" font-weight="600">
+                <text x="44" y="${so/2-6}" font-size="11" fill="#1e293b" font-weight="600">
                     ${e.name.length>16?e.name.slice(0,15)+`…`:e.name}
                 </text>
                 <text x="44" y="${36}" font-size="9" fill="#94a3b8">${e.id}</text>
@@ -6723,7 +6723,7 @@ ${i}
                         @change="${t=>this.updateStep(e.id,{name:t.target.value})}"/>`)}
                     ${n(`Type`,w`
                         <select class="inp" @change="${t=>this.updateStep(e.id,{type:t.target.value})}">
-                            ${uo.map(t=>w`<option value="${t}" ?selected="${e.type===t}">${t}</option>`)}
+                            ${mo.map(t=>w`<option value="${t}" ?selected="${e.type===t}">${t}</option>`)}
                         </select>`)}
                     ${n(`Description`,w`<textarea class="inp" rows="2"
                         @change="${t=>this.updateStep(e.id,{description:t.target.value})}">${e.description??``}</textarea>`)}
@@ -6768,7 +6768,7 @@ ${i}
                         @change="${t=>this.updateStep(e.id,{childWorkflowDefinitionId:t.target.value||void 0})}"/>`):``}
                 </div>
             </div>
-        `}exportJson(){let e=JSON.stringify(this.wf,null,2),t=new Blob([e],{type:`application/json`}),n=URL.createObjectURL(t),r=document.createElement(`a`);r.href=n,r.download=(this.wf.name??`workflow`).replace(/\s+/g,`-`).toLowerCase()+`.json`,r.click(),URL.revokeObjectURL(n)}static{this.styles=[Ga,m`
+        `}exportJson(){let e=JSON.stringify(this.wf,null,2),t=new Blob([e],{type:`application/json`}),n=URL.createObjectURL(t),r=document.createElement(`a`);r.href=n,r.download=(this.wf.name??`workflow`).replace(/\s+/g,`-`).toLowerCase()+`.json`,r.click(),URL.revokeObjectURL(n)}static{this.styles=[Ja,m`
         :host { display: block; height: 100%; font-family: var(--lumo-font-family, sans-serif); }
 
         .root { display: flex; flex-direction: column; height: 100%; background: var(--lumo-base-color, #fff); }
@@ -6846,7 +6846,7 @@ ${i}
         .inp:focus { border-color: #3B82F6; }
         textarea.inp { resize: vertical; }
         input[readonly].inp { background: #f8fafc; color: #94a3b8; }
-    `]}};O([v()],po.prototype,`value`,void 0),O([S()],po.prototype,`wf`,void 0),O([S()],po.prototype,`positions`,void 0),O([S()],po.prototype,`selectedId`,void 0),O([S()],po.prototype,`showMeta`,void 0),po=O([h(`mateu-workflow`)],po);var mo=[`string`,`integer`,`number`,`bool`,`date`,`time`,`dateTime`,`dateRange`,`money`,`file`,`array`,`status`,`component`,`menu`,`range`,`action`,`actionGroup`],ho=[`regular`,`radio`,`checkbox`,`textarea`,`toggle`,`combobox`,`select`,`email`,`password`,`richText`,`listBox`,`html`,`markdown`,`image`,`icon`,`link`,`money`,`grid`,`color`,`choice`,`popover`,`slider`,`button`,`stars`],go={string:`#3B82F6`,integer:`#8B5CF6`,number:`#6366F1`,bool:`#10B981`,date:`#F59E0B`,time:`#F59E0B`,dateTime:`#F59E0B`,dateRange:`#F59E0B`,money:`#EF4444`,file:`#64748B`,array:`#0EA5E9`,status:`#EC4899`,component:`#14B8A6`,menu:`#94A3B8`,range:`#A855F7`,action:`#F97316`,actionGroup:`#FB923C`};function _o(){return`field-`+Math.random().toString(36).slice(2,8)}var vo=class extends y{constructor(...e){super(...e),this.value=`{"name":"New Form","fields":[]}`,this.form={name:`New Form`,fields:[]},this.selectedId=null,this.showMeta=!1,this.sortable=null,this.listEl=null}updated(e){if(e.has(`value`))try{this.form=JSON.parse(this.value)}catch{}this.attachSortable()}disconnectedCallback(){super.disconnectedCallback(),this.sortable?.destroy(),this.sortable=null}attachSortable(){let e=this.shadowRoot?.querySelector(`.field-list`);!e||e===this.listEl||(this.listEl=e,this.sortable?.destroy(),this.sortable=ce.create(e,{animation:150,handle:`.drag-handle`,ghostClass:`sortable-ghost`,onEnd:e=>{let{oldIndex:t,newIndex:n}=e;if(t===void 0||n===void 0||t===n)return;let r=[...this.form.fields],[i]=r.splice(t,1);r.splice(n,0,i),this.form={...this.form,fields:r},this.emit()}}))}emit(){let e=JSON.stringify(this.form,null,2);this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e},bubbles:!0,composed:!0}))}updateForm(e){this.form={...this.form,...e},this.emit()}updateField(e,t){this.form={...this.form,fields:this.form.fields.map(n=>n.id===e?{...n,...t}:n)},this.emit()}addField(){let e=_o(),t={id:e,label:`New Field`,dataType:`string`};this.form={...this.form,fields:[...this.form.fields,t]},this.selectedId=e,this.emit()}deleteField(e){this.form={...this.form,fields:this.form.fields.filter(t=>t.id!==e)},this.selectedId===e&&(this.selectedId=null),this.emit()}duplicateField(e){let t=this.form.fields.find(t=>t.id===e);if(!t)return;let n={...t,id:_o(),label:t.label+` (copy)`},r=this.form.fields.findIndex(t=>t.id===e),i=[...this.form.fields];i.splice(r+1,0,n),this.form={...this.form,fields:i},this.selectedId=n.id,this.emit()}render(){return w`
+    `]}};O([v()],go.prototype,`value`,void 0),O([S()],go.prototype,`wf`,void 0),O([S()],go.prototype,`positions`,void 0),O([S()],go.prototype,`selectedId`,void 0),O([S()],go.prototype,`showMeta`,void 0),go=O([h(`mateu-workflow`)],go);var _o=[`string`,`integer`,`number`,`bool`,`date`,`time`,`dateTime`,`dateRange`,`money`,`file`,`array`,`status`,`component`,`menu`,`range`,`action`,`actionGroup`],vo=[`regular`,`radio`,`checkbox`,`textarea`,`toggle`,`combobox`,`select`,`email`,`password`,`richText`,`listBox`,`html`,`markdown`,`image`,`icon`,`link`,`money`,`grid`,`color`,`choice`,`popover`,`slider`,`button`,`stars`],yo={string:`#3B82F6`,integer:`#8B5CF6`,number:`#6366F1`,bool:`#10B981`,date:`#F59E0B`,time:`#F59E0B`,dateTime:`#F59E0B`,dateRange:`#F59E0B`,money:`#EF4444`,file:`#64748B`,array:`#0EA5E9`,status:`#EC4899`,component:`#14B8A6`,menu:`#94A3B8`,range:`#A855F7`,action:`#F97316`,actionGroup:`#FB923C`};function bo(){return`field-`+Math.random().toString(36).slice(2,8)}var xo=class extends y{constructor(...e){super(...e),this.value=`{"name":"New Form","fields":[]}`,this.form={name:`New Form`,fields:[]},this.selectedId=null,this.showMeta=!1,this.sortable=null,this.listEl=null}updated(e){if(e.has(`value`))try{this.form=JSON.parse(this.value)}catch{}this.attachSortable()}disconnectedCallback(){super.disconnectedCallback(),this.sortable?.destroy(),this.sortable=null}attachSortable(){let e=this.shadowRoot?.querySelector(`.field-list`);!e||e===this.listEl||(this.listEl=e,this.sortable?.destroy(),this.sortable=ce.create(e,{animation:150,handle:`.drag-handle`,ghostClass:`sortable-ghost`,onEnd:e=>{let{oldIndex:t,newIndex:n}=e;if(t===void 0||n===void 0||t===n)return;let r=[...this.form.fields],[i]=r.splice(t,1);r.splice(n,0,i),this.form={...this.form,fields:r},this.emit()}}))}emit(){let e=JSON.stringify(this.form,null,2);this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e},bubbles:!0,composed:!0}))}updateForm(e){this.form={...this.form,...e},this.emit()}updateField(e,t){this.form={...this.form,fields:this.form.fields.map(n=>n.id===e?{...n,...t}:n)},this.emit()}addField(){let e=bo(),t={id:e,label:`New Field`,dataType:`string`};this.form={...this.form,fields:[...this.form.fields,t]},this.selectedId=e,this.emit()}deleteField(e){this.form={...this.form,fields:this.form.fields.filter(t=>t.id!==e)},this.selectedId===e&&(this.selectedId=null),this.emit()}duplicateField(e){let t=this.form.fields.find(t=>t.id===e);if(!t)return;let n={...t,id:bo(),label:t.label+` (copy)`},r=this.form.fields.findIndex(t=>t.id===e),i=[...this.form.fields];i.splice(r+1,0,n),this.form={...this.form,fields:i},this.selectedId=n.id,this.emit()}render(){return w`
             <div class="root">
                 ${this.renderToolbar()}
                 ${this.showMeta?this.renderMeta():_}
@@ -6860,15 +6860,15 @@ ${i}
                 <span class="form-name">${this.form.name}</span>
                 <div style="flex:1"></div>
                 <button class="nbtn" @click="${()=>this.showMeta=!this.showMeta}">
-                    ${qa}
+                    ${Xa}
                     Settings
                 </button>
                 <button class="nbtn primary" @click="${()=>this.addField()}">
-                    ${Ja}
+                    ${Za}
                     Add Field
                 </button>
                 <button class="nbtn" @click="${()=>this.exportJson()}">
-                    ${Ya}
+                    ${Qa}
                     Export
                 </button>
             </div>
@@ -6893,7 +6893,7 @@ ${i}
                     ${e.map(e=>this.renderRow(e))}
                 </div>
             </div>
-        `}renderRow(e){let t=go[e.dataType]??`#64748b`;return w`
+        `}renderRow(e){let t=yo[e.dataType]??`#64748b`;return w`
             <div role="button" tabindex="0" class="field-row ${this.selectedId===e.id?`selected`:``}"
                  data-id="${e.id}"
                  @click="${()=>this.selectedId=this.selectedId===e.id?null:e.id}" @keydown="${L(()=>this.selectedId=this.selectedId===e.id?null:e.id)}">
@@ -6928,13 +6928,13 @@ ${i}
                     ${t(`Data type`,w`
                         <select class="inp"
                                 @change="${t=>this.updateField(e.id,{dataType:t.target.value})}">
-                            ${mo.map(t=>w`
+                            ${_o.map(t=>w`
                                 <option value="${t}" ?selected="${e.dataType===t}">${t}</option>`)}
                         </select>`)}
                     ${t(`Stereotype`,w`
                         <select class="inp"
                                 @change="${t=>this.updateField(e.id,{stereotype:t.target.value||void 0})}">
-                            ${ho.map(t=>w`
+                            ${vo.map(t=>w`
                                 <option value="${t}" ?selected="${(e.stereotype??`regular`)===t}">${t}</option>`)}
                         </select>`)}
                     <div class="prop-field row">
@@ -6947,7 +6947,7 @@ ${i}
                                   @change="${t=>this.updateField(e.id,{description:t.target.value||void 0})}">${e.description??``}</textarea>`)}
                 </div>
             </div>
-        `}exportJson(){let e=JSON.stringify(this.form,null,2),t=new Blob([e],{type:`application/json`}),n=URL.createObjectURL(t),r=document.createElement(`a`);r.href=n,r.download=(this.form.name??`form`).replace(/\s+/g,`-`).toLowerCase()+`.json`,r.click(),URL.revokeObjectURL(n)}static{this.styles=[Ga,R,m`
+        `}exportJson(){let e=JSON.stringify(this.form,null,2),t=new Blob([e],{type:`application/json`}),n=URL.createObjectURL(t),r=document.createElement(`a`);r.href=n,r.download=(this.form.name??`form`).replace(/\s+/g,`-`).toLowerCase()+`.json`,r.click(),URL.revokeObjectURL(n)}static{this.styles=[Ja,R,m`
         :host { display: block; height: 100%; font-family: var(--lumo-font-family, sans-serif); }
 
         .root { display: flex; flex-direction: column; height: 100%; background: var(--lumo-base-color, #fff); }
@@ -7062,7 +7062,7 @@ ${i}
         .inp:focus { border-color: #3B82F6; }
         textarea.inp { resize: vertical; }
         input[readonly].inp { background: #f8fafc; color: #94a3b8; }
-    `]}};O([v()],vo.prototype,`value`,void 0),O([S()],vo.prototype,`form`,void 0),O([S()],vo.prototype,`selectedId`,void 0),O([S()],vo.prototype,`showMeta`,void 0),vo=O([h(`mateu-form-editor`)],vo);var yo=class extends y{constructor(...e){super(...e),this.appState={},this.appData={},this.open=!1,this.activeTab=`appstate`,this.hoveredTag=``,this.hoveredId=``,this.hoveredState=null,this.hoveredData=null,this.hoveredMeta=null,this._prevTarget=null,this._onMouseover=e=>{let t=e.target;for(;t&&!(t.tagName?.toLowerCase().startsWith(`mateu-`)&&t!==this);)t=t.parentElement;if(t===this||t===null){t===null&&this._prevTarget&&(this._prevTarget.style.outline=``,this._prevTarget.style.outlineOffset=``,this._prevTarget=null,this.hoveredTag=``,this.hoveredId=``,this.hoveredState=null,this.hoveredData=null,this.hoveredMeta=null);return}t!==this._prevTarget&&(this._prevTarget&&(this._prevTarget.style.outline=``,this._prevTarget.style.outlineOffset=``),this._prevTarget=t,t.style.outline=`2px solid #0070f3`,t.style.outlineOffset=`-2px`,this.hoveredTag=t.tagName.toLowerCase(),this.hoveredId=t.id||``,this.hoveredState=t.state,this.hoveredData=t.data,this.hoveredMeta=t.component?.metadata)}}connectedCallback(){super.connectedCallback(),document.addEventListener(`mouseover`,this._onMouseover,!0)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`mouseover`,this._onMouseover,!0),this._prevTarget&&=(this._prevTarget.style.outline=``,null)}_fmt(e){try{return JSON.stringify(e,null,2)??`null`}catch{return String(e)}}_renderTab(e,t){return w`
+    `]}};O([v()],xo.prototype,`value`,void 0),O([S()],xo.prototype,`form`,void 0),O([S()],xo.prototype,`selectedId`,void 0),O([S()],xo.prototype,`showMeta`,void 0),xo=O([h(`mateu-form-editor`)],xo);var So=class extends y{constructor(...e){super(...e),this.appState={},this.appData={},this.open=!1,this.activeTab=`appstate`,this.hoveredTag=``,this.hoveredId=``,this.hoveredState=null,this.hoveredData=null,this.hoveredMeta=null,this._prevTarget=null,this._onMouseover=e=>{let t=e.target;for(;t&&!(t.tagName?.toLowerCase().startsWith(`mateu-`)&&t!==this);)t=t.parentElement;if(t===this||t===null){t===null&&this._prevTarget&&(this._prevTarget.style.outline=``,this._prevTarget.style.outlineOffset=``,this._prevTarget=null,this.hoveredTag=``,this.hoveredId=``,this.hoveredState=null,this.hoveredData=null,this.hoveredMeta=null);return}t!==this._prevTarget&&(this._prevTarget&&(this._prevTarget.style.outline=``,this._prevTarget.style.outlineOffset=``),this._prevTarget=t,t.style.outline=`2px solid #0070f3`,t.style.outlineOffset=`-2px`,this.hoveredTag=t.tagName.toLowerCase(),this.hoveredId=t.id||``,this.hoveredState=t.state,this.hoveredData=t.data,this.hoveredMeta=t.component?.metadata)}}connectedCallback(){super.connectedCallback(),document.addEventListener(`mouseover`,this._onMouseover,!0)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`mouseover`,this._onMouseover,!0),this._prevTarget&&=(this._prevTarget.style.outline=``,null)}_fmt(e){try{return JSON.stringify(e,null,2)??`null`}catch{return String(e)}}_renderTab(e,t){return w`
             <button class="tab ${this.activeTab===e?`tab--active`:``}"
                 @click=${()=>{this.activeTab=e}}>
                 ${t}
@@ -7235,7 +7235,7 @@ ${i}
             border-bottom: 1px solid #2a2a3a;
         }
         .section-label:first-of-type { margin-top: 0; }
-    `}};O([v()],yo.prototype,`appState`,void 0),O([v()],yo.prototype,`appData`,void 0),O([S()],yo.prototype,`open`,void 0),O([S()],yo.prototype,`activeTab`,void 0),O([S()],yo.prototype,`hoveredTag`,void 0),O([S()],yo.prototype,`hoveredId`,void 0),O([S()],yo.prototype,`hoveredState`,void 0),O([S()],yo.prototype,`hoveredData`,void 0),O([S()],yo.prototype,`hoveredMeta`,void 0),yo=O([h(`mateu-debug-overlay`)],yo);var bo=function(e){return e.SetAppDataValue=`SetAppDataValue`,e.SetAppStateValue=`SetAppStateValue`,e.SetDataValue=`SetDataValue`,e.RunAction=`RunAction`,e.RunJS=`RunJS`,e.SetAttributeValue=`SetAttributeValue`,e.SetStateValue=`SetStateValue`,e.SetCssClass=`SetCssClass`,e.SetStyle=`SetStyle`,e}({}),xo=function(e){return e.required=`required`,e.disabled=`disabled`,e.hidden=`hidden`,e.pattern=`pattern`,e.minValue=`minValue`,e.maxValue=`maxValue`,e.minLength=`minLength`,e.maxLength=`maxLength`,e.css=`css`,e.style=`style`,e.theme=`theme`,e.errorMessage=`errorMessage`,e.description=`description`,e.none=`none`,e}({}),So=function(e){return e.Continue=`Continue`,e.Stop=`Stop`,e}({}),Co=12e4,wo=(e,t)=>`${e??`_`}::${t}`,To=new class{constructor(){this.started=new Map,this.listeners=new Set}begin(e,t=Date.now()){let n=this.started.get(e);return n!==void 0&&t-n<Co?!1:(this.started.set(e,t),this.emit(),!0)}end(e){this.started.delete(e)&&this.emit()}isPending(e,t=Date.now()){let n=this.started.get(e);return n!==void 0&&t-n<Co}snapshot(){return new Set(this.started.keys())}subscribe(e){return this.listeners.add(e),()=>this.listeners.delete(e)}reset(){this.started.clear(),this.emit()}emit(){let e=this.snapshot();this.listeners.forEach(t=>t(e))}},Eo=`data-mateu-pending-styles`,Do=`
+    `}};O([v()],So.prototype,`appState`,void 0),O([v()],So.prototype,`appData`,void 0),O([S()],So.prototype,`open`,void 0),O([S()],So.prototype,`activeTab`,void 0),O([S()],So.prototype,`hoveredTag`,void 0),O([S()],So.prototype,`hoveredId`,void 0),O([S()],So.prototype,`hoveredState`,void 0),O([S()],So.prototype,`hoveredData`,void 0),O([S()],So.prototype,`hoveredMeta`,void 0),So=O([h(`mateu-debug-overlay`)],So);var Co=function(e){return e.SetAppDataValue=`SetAppDataValue`,e.SetAppStateValue=`SetAppStateValue`,e.SetDataValue=`SetDataValue`,e.RunAction=`RunAction`,e.RunJS=`RunJS`,e.SetAttributeValue=`SetAttributeValue`,e.SetStateValue=`SetStateValue`,e.SetCssClass=`SetCssClass`,e.SetStyle=`SetStyle`,e}({}),wo=function(e){return e.required=`required`,e.disabled=`disabled`,e.hidden=`hidden`,e.pattern=`pattern`,e.minValue=`minValue`,e.maxValue=`maxValue`,e.minLength=`minLength`,e.maxLength=`maxLength`,e.css=`css`,e.style=`style`,e.theme=`theme`,e.errorMessage=`errorMessage`,e.description=`description`,e.none=`none`,e}({}),To=function(e){return e.Continue=`Continue`,e.Stop=`Stop`,e}({}),Eo=12e4,Do=(e,t)=>`${e??`_`}::${t}`,Oo=new class{constructor(){this.started=new Map,this.listeners=new Set}begin(e,t=Date.now()){let n=this.started.get(e);return n!==void 0&&t-n<Eo?!1:(this.started.set(e,t),this.emit(),!0)}end(e){this.started.delete(e)&&this.emit()}isPending(e,t=Date.now()){let n=this.started.get(e);return n!==void 0&&t-n<Eo}snapshot(){return new Set(this.started.keys())}subscribe(e){return this.listeners.add(e),()=>this.listeners.delete(e)}reset(){this.started.clear(),this.emit()}emit(){let e=this.snapshot();this.listeners.forEach(t=>t(e))}},ko=`data-mateu-pending-styles`,Ao=`
 [data-mateu-pending] {
     pointer-events: none;
     cursor: progress;
@@ -7249,9 +7249,9 @@ ${i}
     0%, 100% { opacity: .45; }
     50% { opacity: .85; }
 }
-`,Oo=new WeakSet,ko=e=>{if(Oo.has(e))return;Oo.add(e);let t=e;if(typeof CSSStyleSheet<`u`&&Array.isArray(t.adoptedStyleSheets))try{let e=new CSSStyleSheet;e.replaceSync(Do),t.adoptedStyleSheets=[...t.adoptedStyleSheets,e];return}catch{}let n=e instanceof Document?e.head:e;if(!n)return;let r=document.createElement(`style`);r.setAttribute(Eo,``),r.textContent=Do,n.appendChild(r)},Ao=e=>{let t=e.getRootNode();if(t instanceof ShadowRoot||t instanceof Document)return t},jo=e=>{if(!e||e.hasAttribute(`data-mateu-pending`))return;let t=Ao(e);t&&ko(t),e.setAttribute(`data-mateu-pending`,``),e.setAttribute(`aria-busy`,`true`)},Mo=e=>{e&&(e.removeAttribute(`data-mateu-pending`),e.removeAttribute(`aria-busy`))},No=e=>{let t=(typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target;return t instanceof Element?t:void 0},Po=[`button`,`a[href]`,`[role="button"]`,`[role="menuitem"]`,`input[type="button"]`,`input[type="submit"]`,`vaadin-button`,`vaadin-menu-bar-button`,`ui5-button`,`oj-c-button`,`oj-button`].join(`, `),Fo=e=>{if(!(!e||typeof e.closest!=`function`))return e.closest(Po)??void 0},Io=null,Lo=class extends Sa{constructor(...e){super(...e),this.baseUrl=``,this.route=``,this.consumedRoute=``,this.formerState={},this.applyRules=()=>{let e=this.component.rules;if(e&&e.length>0){let t=this.state,n=this.data,r=this.appState,i=this.appData,a=this.component,o=e=>ot(e,t,n,{appState:r,appData:i,component:a}),s=e=>at(e,t,n,r,i,{component:a}),c=[`state`,`data`,`appState`,`appData`,`component`],l=[t,n,r,i,a],u={...this.state},d={...this.data},f=!1,p=!1;for(let t=0;t<e.length;t++){let n=e[t];try{if(o(n.filter)){if(bo.SetStateValue==n.action||bo.SetDataValue==n.action){let e=bo.SetStateValue==n.action?u:d,t=n.fieldName.split(`,`);for(let r=0;r<t.length;r++){let i=t[r];if(!e[i]||e[i]!=n.value){let t=n.expression?s(n.expression):n.value,r=xo.none==n.fieldAttribute?i:i+`.`+n.fieldAttribute;t!=e[r]&&(e[r]=t,bo.SetStateValue==n.action&&(f=!0),bo.SetDataValue==n.action&&(p=!0))}}}if(bo.RunAction==n.action&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.actionId},bubbles:!0,composed:!0})),bo.RunJS==n.action&&Function(...c,n.value)(...l),bo.SetAttributeValue==n.action){let e=n.expression?o(n.expression):n.value;if(n.fieldAttribute==`disabled`){e?this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(n.fieldAttribute,`disabled`):this.shadowRoot?.getElementById(n.fieldName)?.removeAttribute(n.fieldAttribute);continue}this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(n.fieldAttribute,e)}if(bo.SetCssClass==n.action&&this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(`class`,n.value),bo.SetStyle==n.action&&this.shadowRoot?.getElementById(n.fieldName)?.style.setProperty(n.expression,n.value),So.Stop==n.result)break}}catch(e){console.error(`rule failed`,n,e)}}f&&(this.state=u),p&&(this.data=d),f&&this.checkValidations()}},this.skipValidation=(e,t)=>e&&t.fieldId&&!e.includes(t.fieldId)||!e&&t.fieldId&&t.fieldId.includes(`-`),this.checkValidations=e=>{let t=e?e.split(`,`):void 0,n=this.component.validations,r=!0,i=!1,a=this.data??{},o={...this.data??{},errors:{}};if(n){for(let e=0;e<n.length;e++){let r=n[e];if(this.skipValidation(t,r))continue;let i=(r.fieldId??`_component`).split(`,`);for(let e=0;e<i.length;e++){let t=i[e];o.errors[t]=[]}}for(let e=0;e<n.length;e++){let i=n[e];if(!this.skipValidation(t,i))try{let e=i.condition&&i.condition.includes("${")?this._evalTemplate(i.condition):this._evalExpr(i.condition);if(i.condition&&!e){r=!1;let e=(i.fieldId??`_component`).split(`,`);for(let t=0;t<e.length;t++){let n=e[t],r=o.errors[n];if(r||(o.errors[n]=[]),r=o.errors[n],!a[n]){let e=i.message;try{e=this._evalTemplate(i.message)}catch{}r.push(e)}}}}catch(e){console.error(`validation failed`,i,e)}}for(let e=0;e<n.length;e++){let r=n[e];if(this.skipValidation(t,r))continue;let s=(r.fieldId??`_component`).split(`,`);for(let e=0;e<s.length;e++){let t=s[e];if((a.errors||o.errors==``)&&[t].join(`,`)){i=!0;break}}}(a.errors||o.errors==``)&&[`_component`].join(`,`)&&(i=!0)}o._valid=r,o._valid!=a._valid&&(i=!0),i&&(this.data=o)},this._autoSaveTimers=new Map,this.onChange=()=>{this.applyRules()},this.closeModalRequestedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.closeModal()},this.resetFilters=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail,n={};t.fieldIds.forEach(e=>{n[e]=void 0}),n.searchText=void 0,this.state={...this.state,...n}}},this.dataChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail,n={};n[t.key]=t.value,e.type==`data-changed`&&(this.data={...this.data,...n})}},this.valueChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail;if(e.type==`value-changed`){let n={...this.state};n[t.fieldId]=t.value,this.state=n,(this.state[t.fieldId]||this.formerState[t.fieldId])&&this.state[t.fieldId]!=this.formerState[t.fieldId]&&this.component?.confirmOnNavigationIfDirty&&this.dispatchEvent(new CustomEvent(`dirty`,{detail:e.detail,bubbles:!0,composed:!0}));let r=this.component;r.triggers?.filter(e=>e.type==xa.OnValueChange).filter(e=>!e.propertyName||t.fieldId==e.propertyName).forEach(e=>{(!e.condition||this._evalExpr(e.condition))&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))}),r.triggers?.filter(e=>e.type==xa.AutoSave).forEach(e=>{let t=e.actionId,n=this._autoSaveTimers.get(t);n!==void 0&&clearTimeout(n),this._autoSaveTimers.set(t,setTimeout(()=>{this._autoSaveTimers.delete(t),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))},e.debounceMillis??800))})}}},this.actionRequestedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.manageActionRequestedEvent(e)},this.manageActionRequestedEvent=e=>{let t=e.detail,n=t?._originElement??No(e);if(e.type==`action-requested`){e.preventDefault(),e.stopPropagation();let r=this.component,i=r.actions?.find(e=>e.id==t.actionId)??r.actions?.find(e=>e.id.endsWith(`*`)&&t.actionId.startsWith(e.id.replace(`*`,``)));if(i){if(i&&i.rowsSelectedRequired&&(!this.state.crud_selected_items||this.state.crud_selected_items.length==0)){this.notify(`You first need to select some rows`);return}if(i&&i.validationRequired){let e=Io??this;if(Io=null,e.checkValidations(i.fieldsToValidate),!e.data._valid){e.notifyValidationErrors();return}}Io=null;let e={...t,initiatorComponentId:this.id};i&&i.confirmationRequired?this.callAfterConfirmation(i,()=>this.requestActionCallToServerOrBubble(e,r,i,n)):this.requestActionCallToServerOrBubble(e,r,i,n)}else{let r={...t.parameters};r.initiatorState||=this.state,Io||=this,this.dispatchEvent(new CustomEvent(e.type,{detail:{...e.detail,_originElement:n,parameters:r},bubbles:!0,composed:!0}))}}},this.buildFieldLabelMap=()=>{let e={},t=n=>{if(n)for(let r of n){let n=r.metadata;if(n?.type===A.FormField){let t=n;t.fieldId&&t.label&&(e[t.fieldId]=t.label)}t(r.children)}};return t(this.component?.children),e},this.notifyValidationErrors=()=>{let e=this.data?.errors??{},t=this.buildFieldLabelMap(),n=[];if(Object.entries(e).forEach(([e,r])=>{if(!Array.isArray(r))return;let i=e===`_component`?void 0:t[e]??e;r.forEach(e=>{e&&!n.some(t=>t.label===i&&t.msg===e)&&n.push({label:i,msg:e})})}),n.length===0){this.notify(`There are validation errors`);return}pa({text:`There are validation errors
+`,jo=new WeakSet,Mo=e=>{if(jo.has(e))return;jo.add(e);let t=e;if(typeof CSSStyleSheet<`u`&&Array.isArray(t.adoptedStyleSheets))try{let e=new CSSStyleSheet;e.replaceSync(Ao),t.adoptedStyleSheets=[...t.adoptedStyleSheets,e];return}catch{}let n=e instanceof Document?e.head:e;if(!n)return;let r=document.createElement(`style`);r.setAttribute(ko,``),r.textContent=Ao,n.appendChild(r)},No=e=>{let t=e.getRootNode();if(t instanceof ShadowRoot||t instanceof Document)return t},Po=e=>{if(!e||e.hasAttribute(`data-mateu-pending`))return;let t=No(e);t&&Mo(t),e.setAttribute(`data-mateu-pending`,``),e.setAttribute(`aria-busy`,`true`)},Fo=e=>{e&&(e.removeAttribute(`data-mateu-pending`),e.removeAttribute(`aria-busy`))},Io=e=>{let t=(typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target;return t instanceof Element?t:void 0},Lo=[`button`,`a[href]`,`[role="button"]`,`[role="menuitem"]`,`input[type="button"]`,`input[type="submit"]`,`vaadin-button`,`vaadin-menu-bar-button`,`ui5-button`,`oj-c-button`,`oj-button`].join(`, `),Ro=e=>{if(!(!e||typeof e.closest!=`function`))return e.closest(Lo)??void 0},zo=null,Bo=class extends wa{constructor(...e){super(...e),this.baseUrl=``,this.route=``,this.consumedRoute=``,this.formerState={},this.applyRules=()=>{let e=this.component.rules;if(e&&e.length>0){let t=this.state,n=this.data,r=this.appState,i=this.appData,a=this.component,o=e=>ot(e,t,n,{appState:r,appData:i,component:a}),s=e=>at(e,t,n,r,i,{component:a}),c=[`state`,`data`,`appState`,`appData`,`component`],l=[t,n,r,i,a],u={...this.state},d={...this.data},f=!1,p=!1;for(let t=0;t<e.length;t++){let n=e[t];try{if(o(n.filter)){if(Co.SetStateValue==n.action||Co.SetDataValue==n.action){let e=Co.SetStateValue==n.action?u:d,t=n.fieldName.split(`,`);for(let r=0;r<t.length;r++){let i=t[r];if(!e[i]||e[i]!=n.value){let t=n.expression?s(n.expression):n.value,r=wo.none==n.fieldAttribute?i:i+`.`+n.fieldAttribute;t!=e[r]&&(e[r]=t,Co.SetStateValue==n.action&&(f=!0),Co.SetDataValue==n.action&&(p=!0))}}}if(Co.RunAction==n.action&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.actionId},bubbles:!0,composed:!0})),Co.RunJS==n.action&&Function(...c,n.value)(...l),Co.SetAttributeValue==n.action){let e=n.expression?o(n.expression):n.value;if(n.fieldAttribute==`disabled`){e?this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(n.fieldAttribute,`disabled`):this.shadowRoot?.getElementById(n.fieldName)?.removeAttribute(n.fieldAttribute);continue}this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(n.fieldAttribute,e)}if(Co.SetCssClass==n.action&&this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(`class`,n.value),Co.SetStyle==n.action&&this.shadowRoot?.getElementById(n.fieldName)?.style.setProperty(n.expression,n.value),To.Stop==n.result)break}}catch(e){console.error(`rule failed`,n,e)}}f&&(this.state=u),p&&(this.data=d),f&&this.checkValidations()}},this.skipValidation=(e,t)=>e&&t.fieldId&&!e.includes(t.fieldId)||!e&&t.fieldId&&t.fieldId.includes(`-`),this.checkValidations=e=>{let t=e?e.split(`,`):void 0,n=this.component.validations,r=!0,i=!1,a=this.data??{},o={...this.data??{},errors:{}};if(n){for(let e=0;e<n.length;e++){let r=n[e];if(this.skipValidation(t,r))continue;let i=(r.fieldId??`_component`).split(`,`);for(let e=0;e<i.length;e++){let t=i[e];o.errors[t]=[]}}for(let e=0;e<n.length;e++){let i=n[e];if(!this.skipValidation(t,i))try{let e=i.condition&&i.condition.includes("${")?this._evalTemplate(i.condition):this._evalExpr(i.condition);if(i.condition&&!e){r=!1;let e=(i.fieldId??`_component`).split(`,`);for(let t=0;t<e.length;t++){let n=e[t],r=o.errors[n];if(r||(o.errors[n]=[]),r=o.errors[n],!a[n]){let e=i.message;try{e=this._evalTemplate(i.message)}catch{}r.push(e)}}}}catch(e){console.error(`validation failed`,i,e)}}for(let e=0;e<n.length;e++){let r=n[e];if(this.skipValidation(t,r))continue;let s=(r.fieldId??`_component`).split(`,`);for(let e=0;e<s.length;e++){let t=s[e];if((a.errors||o.errors==``)&&[t].join(`,`)){i=!0;break}}}(a.errors||o.errors==``)&&[`_component`].join(`,`)&&(i=!0)}o._valid=r,o._valid!=a._valid&&(i=!0),i&&(this.data=o)},this._autoSaveTimers=new Map,this.onChange=()=>{this.applyRules()},this.closeModalRequestedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.closeModal()},this.resetFilters=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail,n={};t.fieldIds.forEach(e=>{n[e]=void 0}),n.searchText=void 0,this.state={...this.state,...n}}},this.dataChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail,n={};n[t.key]=t.value,e.type==`data-changed`&&(this.data={...this.data,...n})}},this.valueChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail;if(e.type==`value-changed`){let n={...this.state};n[t.fieldId]=t.value,this.state=n,(this.state[t.fieldId]||this.formerState[t.fieldId])&&this.state[t.fieldId]!=this.formerState[t.fieldId]&&this.component?.confirmOnNavigationIfDirty&&this.dispatchEvent(new CustomEvent(`dirty`,{detail:e.detail,bubbles:!0,composed:!0}));let r=this.component;r.triggers?.filter(e=>e.type==Ca.OnValueChange).filter(e=>!e.propertyName||t.fieldId==e.propertyName).forEach(e=>{(!e.condition||this._evalExpr(e.condition))&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))}),r.triggers?.filter(e=>e.type==Ca.AutoSave).forEach(e=>{let t=e.actionId,n=this._autoSaveTimers.get(t);n!==void 0&&clearTimeout(n),this._autoSaveTimers.set(t,setTimeout(()=>{this._autoSaveTimers.delete(t),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))},e.debounceMillis??800))})}}},this.actionRequestedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.manageActionRequestedEvent(e)},this.manageActionRequestedEvent=e=>{let t=e.detail,n=t?._originElement??Io(e);if(e.type==`action-requested`){e.preventDefault(),e.stopPropagation();let r=this.component,i=r.actions?.find(e=>e.id==t.actionId)??r.actions?.find(e=>e.id.endsWith(`*`)&&t.actionId.startsWith(e.id.replace(`*`,``)));if(i){if(i&&i.rowsSelectedRequired&&(!this.state.crud_selected_items||this.state.crud_selected_items.length==0)){this.notify(`You first need to select some rows`);return}if(i&&i.validationRequired){let e=zo??this;if(zo=null,e.checkValidations(i.fieldsToValidate),!e.data._valid){e.notifyValidationErrors();return}}zo=null;let e={...t,initiatorComponentId:this.id};i&&i.confirmationRequired?this.callAfterConfirmation(i,()=>this.requestActionCallToServerOrBubble(e,r,i,n)):this.requestActionCallToServerOrBubble(e,r,i,n)}else{let r={...t.parameters};r.initiatorState||=this.state,zo||=this,this.dispatchEvent(new CustomEvent(e.type,{detail:{...e.detail,_originElement:n,parameters:r},bubbles:!0,composed:!0}))}}},this.buildFieldLabelMap=()=>{let e={},t=n=>{if(n)for(let r of n){let n=r.metadata;if(n?.type===A.FormField){let t=n;t.fieldId&&t.label&&(e[t.fieldId]=t.label)}t(r.children)}};return t(this.component?.children),e},this.notifyValidationErrors=()=>{let e=this.data?.errors??{},t=this.buildFieldLabelMap(),n=[];if(Object.entries(e).forEach(([e,r])=>{if(!Array.isArray(r))return;let i=e===`_component`?void 0:t[e]??e;r.forEach(e=>{e&&!n.some(t=>t.label===i&&t.msg===e)&&n.push({label:i,msg:e})})}),n.length===0){this.notify(`There are validation errors`);return}ha({text:`There are validation errors
 `+n.map(({label:e,msg:t})=>e?`• ${e}: ${t}`:`• ${t}`).join(`
-`),variant:`error`,position:`bottomEnd`,duration:Math.max(3e3,1500+n.length*1e3)},this),this.focusFirstInvalidField()},this.notify=e=>{pa({text:e,variant:`error`,position:`bottomEnd`,duration:3e3},this)},this.handleRestAction=(e,t)=>{let n=t=>{if(e.resultPath!=null){let n=Ut(t,e.resultPath);n&&typeof n==`object`&&(this.state={...this.state,...n})}let n=j(e.successMessage,this.state,this.data);n&&pa({text:n,variant:`success`,position:`bottomEnd`,duration:3e3},this)};if(e.source?.proxy){let e=t===`__restdata__`?`data`:`action`;this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:`__restfetch__`,parameters:{_sourceKind:e,_sourceId:t},callback:e=>n(e?.appData?._restfetch),callbackonly:!0},bubbles:!0,composed:!0}));return}Kt(e.source,e=>j(e,this.state,this.data)).then(n).catch(e=>{console.warn(`mateu: rest action failed`,e),pa({text:`Request failed`,variant:`error`,position:`bottomEnd`,duration:3e3},this)})},this.callAfterConfirmation=(e,t)=>{let n=`One moment, please`,r=`Are you sure?`,i=`Yes`,a=`No`;e.confirmationTexts&&(n=e.confirmationTexts.title,r=e.confirmationTexts.message,i=e.confirmationTexts.confirmationText,a=e.confirmationTexts.denialText);let o=document.createElement(`div`);o.style.cssText=`position:fixed;inset:0;z-index:1100;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.35);padding:1rem;`;let s=document.createElement(`div`);s.style.cssText=`background:var(--lumo-base-color,#fff);color:var(--lumo-body-text-color,#1a1a1a);border-radius:var(--lumo-border-radius-l,12px);box-shadow:var(--lumo-box-shadow-xl,0 12px 40px rgba(0,0,0,.3));padding:1.2rem;max-width:min(90vw,26rem);`;let c=()=>{o.parentElement&&document.body.removeChild(o)},l=`font:inherit;font-weight:600;padding:.45rem 1rem;border-radius:var(--lumo-border-radius-m,6px);cursor:pointer;`;ie(w`
+`),variant:`error`,position:`bottomEnd`,duration:Math.max(3e3,1500+n.length*1e3)},this),this.focusFirstInvalidField()},this.notify=e=>{ha({text:e,variant:`error`,position:`bottomEnd`,duration:3e3},this)},this.handleRestAction=(e,t)=>{let n=t=>{if(e.resultPath!=null){let n=Gt(t,e.resultPath);n&&typeof n==`object`&&(this.state={...this.state,...n})}let n=j(e.successMessage,this.state,this.data);n&&ha({text:n,variant:`success`,position:`bottomEnd`,duration:3e3},this)};if(e.source?.proxy){let e=t===`__restdata__`?`data`:`action`;this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:`__restfetch__`,parameters:{_sourceKind:e,_sourceId:t},callback:e=>n(e?.appData?._restfetch),callbackonly:!0},bubbles:!0,composed:!0}));return}Jt(e.source,e=>j(e,this.state,this.data)).then(n).catch(e=>{console.warn(`mateu: rest action failed`,e),ha({text:`Request failed`,variant:`error`,position:`bottomEnd`,duration:3e3},this)})},this.callAfterConfirmation=(e,t)=>{let n=`One moment, please`,r=`Are you sure?`,i=`Yes`,a=`No`;e.confirmationTexts&&(n=e.confirmationTexts.title,r=e.confirmationTexts.message,i=e.confirmationTexts.confirmationText,a=e.confirmationTexts.denialText);let o=document.createElement(`div`);o.style.cssText=`position:fixed;inset:0;z-index:1100;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.35);padding:1rem;`;let s=document.createElement(`div`);s.style.cssText=`background:var(--lumo-base-color,#fff);color:var(--lumo-body-text-color,#1a1a1a);border-radius:var(--lumo-border-radius-l,12px);box-shadow:var(--lumo-box-shadow-xl,0 12px 40px rgba(0,0,0,.3));padding:1.2rem;max-width:min(90vw,26rem);`;let c=()=>{o.parentElement&&document.body.removeChild(o)},l=`font:inherit;font-weight:600;padding:.45rem 1rem;border-radius:var(--lumo-border-radius-m,6px);cursor:pointer;`;ie(w`
             <h3 style="margin:0 0 .5rem;">${n}</h3>
             <div style="margin-bottom:1.2rem;">${r}</div>
             <div style="display:flex;justify-content:flex-end;gap:.5rem;">
@@ -7260,18 +7260,18 @@ ${i}
                 <button style="${l}border:none;background:var(--lumo-primary-color,#1676f3);color:var(--lumo-primary-contrast-color,#fff);"
                         @click="${()=>{c(),t()}}">${i}</button>
             </div>
-        `,s),o.appendChild(s),o.addEventListener(`click`,e=>{e.target===o&&c()}),document.body.appendChild(o)},this.requestActionCallToServerOrBubble=(e,t,n,r)=>{if(n&&n.bubble){let t={...e.parameters};t.initiatorState||=this.state,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{...e,_originElement:r,parameters:t},bubbles:!0,composed:!0}))}else this.requestActionCallToServer(e,t,n,r)},this.requestActionCallToServer=(e,t,n,r)=>{if(n&&n.href){window.location.href=n.href;return}if(n&&n.js)try{Function(`state`,`data`,`appState`,`appData`,`component`,n.js).call(this,this.state??{},this.data??{},this.appState??{},this.appData??{},this.component),this.state={...this.state},this.data={...this.data}}catch(e){console.error(`when evaluating `+n.js,e,this.component,this.state,this.data)}if(n&&n.customEvent&&this.dispatchEvent(new CustomEvent(n.customEvent.name,{detail:n.customEvent.detail,bubbles:!0,composed:!0})),!(n&&(n.js||n.customEvent))){if(n&&n.restAction){this.handleRestAction(n.restAction,n.id);return}if(e.actionId==`search`){let t=e.parameters?._searchState;t?this.state={...this.state,...t}:this.state.size||(this.state={...this.state,size:10,page:0,sort:[]})}if(!n?.background){if(!Re(e.actionId,n?.idempotent)&&!To.begin(wo(this.id,e.actionId)))return;let t=Fo(r);this._pendingOrigins.set(e.actionId,t),jo(t)}this.dispatchEvent(new CustomEvent(`server-side-action-requested`,{detail:{route:this.route,consumedRoute:this.consumedRoute,componentState:{...this.state},parameters:e.parameters??{},actionId:e.actionId,serverSideType:t.serverSideType,serverSideComponentRoute:t.route,initiatorComponentId:e.initiatorComponentId??t.id,initiator:this,background:n?.background,sse:n?.sse,timeoutMillis:n?.timeoutMillis,idempotent:n?.idempotent,callback:e.callback,callbackonly:e.callbackonly,callbackToken:e.callbackToken??this.callbackToken},bubbles:!0,composed:!0}))}},this.handleBackendSucceeded=e=>{e.detail.actionId&&this.component.triggers?.filter(e=>e.type==xa.OnSuccess).filter(t=>e.detail.actionId==t.calledActionId).forEach(t=>{if(!t.condition||this._evalExpr(t.condition))if(e.preventDefault(),e.stopPropagation(),t.timeoutMillis>0){let e=this.callbackToken;setTimeout(()=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,callbackToken:e},bubbles:!0,composed:!0}))},t.timeoutMillis)}else this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))})},this.handleBackendFailed=e=>{e.detail.actionId&&this.component.triggers?.filter(e=>e.type==xa.OnError).filter(t=>e.detail.actionId==t.calledActionId).forEach(t=>{(!t.condition||this._evalExpr(t.condition))&&(e.preventDefault(),e.stopPropagation(),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0})))})},this._pendingOrigins=new Map,this._backendSettledListener=e=>{((typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target)===this&&this._releasePending(e.detail?.actionId)},this._keydownListener=e=>{if(this._handleTabShortcut(e))return;let t=this.component;if(t)for(let n of t.actions??[]){let t=n.shortcut||(n.runOnEnter?`enter`:null);if(t&&this._shortcutMatchesEvent(t,e)){e.preventDefault(),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.id},bubbles:!0,composed:!0}));return}}}}createRenderRoot(){return N.mustUseShadowRoot()?super.createRenderRoot():this}updated(e){super.updated(e),e.has(`state`)&&this.state&&JSON.stringify(this.state)!=JSON.stringify({})&&this.onChange(),e.has(`component`)&&(this.formerState={...this.state},this.component?.confirmOnNavigationIfDirty&&this.dispatchEvent(new CustomEvent(`clean`,{detail:{},bubbles:!0,composed:!0})),setTimeout(()=>this.triggerOnLoad()))}focusFirstInvalidField(){let e=t=>requestAnimationFrame(()=>{let n=this.findFirstInvalid(this.renderRoot);if(n){n.focus?.(),n.scrollIntoView?.({block:`center`,behavior:`smooth`});return}t>0&&e(t-1)});e(3)}findFirstInvalid(e){if(!e?.querySelectorAll)return null;for(let t of Array.from(e.querySelectorAll(`*`))){if(t.invalid===!0)return t;if(t.shadowRoot){let e=this.findFirstInvalid(t.shadowRoot);if(e)return e}}return null}_releasePending(e){(e===void 0?Array.from(this._pendingOrigins.keys()):[e]).forEach(e=>{To.end(wo(this.id,e)),Mo(this._pendingOrigins.get(e)),this._pendingOrigins.delete(e)})}_shortcutMatchesEvent(e,t){return Ln(e,t)}_collectShortcutTabs(){let e=this.renderRoot;if(!e)return[];let t=Array.from(e.querySelectorAll(`vaadin-tab[data-shortcut]`));return e.querySelectorAll(`mateu-drawer, mateu-dialog`).forEach(e=>{let n=e.shadowRoot;n&&t.push(...Array.from(n.querySelectorAll(`vaadin-tab[data-shortcut]`)))}),t}_handleTabShortcut(e){let t=this._collectShortcutTabs();if(t.length===0)return!1;for(let n of Array.from(t)){let t=n.dataset.shortcut;if(!t||!this._shortcutMatchesEvent(t,e))continue;let r=n.closest(`vaadin-tabs`);if(!r)continue;let i=Array.from(r.querySelectorAll(`vaadin-tab`)).indexOf(n);if(!(i<0))return e.preventDefault(),r.selected=i,!0}return!1}connectedCallback(){super.connectedCallback(),this.addEventListener(`backend-call-succeeded`,this.handleBackendSucceeded),this.addEventListener(`backend-call-failed`,this.handleBackendFailed),this.addEventListener(`backend-succeeded-event`,this._backendSettledListener),this.addEventListener(`backend-failed-event`,this._backendSettledListener),this.addEventListener(`backend-cancelled-event`,this._backendSettledListener),document.addEventListener(`keydown`,this._keydownListener)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`backend-call-succeeded`,this.handleBackendSucceeded),this.removeEventListener(`backend-call-failed`,this.handleBackendFailed),this.removeEventListener(`backend-succeeded-event`,this._backendSettledListener),this.removeEventListener(`backend-failed-event`,this._backendSettledListener),this.removeEventListener(`backend-cancelled-event`,this._backendSettledListener),document.removeEventListener(`keydown`,this._keydownListener),this._releasePending()}render(){return w`<div>
+        `,s),o.appendChild(s),o.addEventListener(`click`,e=>{e.target===o&&c()}),document.body.appendChild(o)},this.requestActionCallToServerOrBubble=(e,t,n,r)=>{if(n&&n.bubble){let t={...e.parameters};t.initiatorState||=this.state,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{...e,_originElement:r,parameters:t},bubbles:!0,composed:!0}))}else this.requestActionCallToServer(e,t,n,r)},this.requestActionCallToServer=(e,t,n,r)=>{if(n&&n.href){window.location.href=n.href;return}if(n&&n.js)try{Function(`state`,`data`,`appState`,`appData`,`component`,n.js).call(this,this.state??{},this.data??{},this.appState??{},this.appData??{},this.component),this.state={...this.state},this.data={...this.data}}catch(e){console.error(`when evaluating `+n.js,e,this.component,this.state,this.data)}if(n&&n.customEvent&&this.dispatchEvent(new CustomEvent(n.customEvent.name,{detail:n.customEvent.detail,bubbles:!0,composed:!0})),!(n&&(n.js||n.customEvent))){if(n&&n.restAction){this.handleRestAction(n.restAction,n.id);return}if(e.actionId==`search`){let t=e.parameters?._searchState;t?this.state={...this.state,...t}:this.state.size||(this.state={...this.state,size:10,page:0,sort:[]})}if(!n?.background){if(!Re(e.actionId,n?.idempotent)&&!Oo.begin(Do(this.id,e.actionId)))return;let t=Ro(r);this._pendingOrigins.set(e.actionId,t),Po(t)}this.dispatchEvent(new CustomEvent(`server-side-action-requested`,{detail:{route:this.route,consumedRoute:this.consumedRoute,componentState:{...this.state},parameters:e.parameters??{},actionId:e.actionId,serverSideType:t.serverSideType,serverSideComponentRoute:t.route,initiatorComponentId:e.initiatorComponentId??t.id,initiator:this,background:n?.background,sse:n?.sse,timeoutMillis:n?.timeoutMillis,idempotent:n?.idempotent,callback:e.callback,callbackonly:e.callbackonly,callbackToken:e.callbackToken??this.callbackToken},bubbles:!0,composed:!0}))}},this.handleBackendSucceeded=e=>{e.detail.actionId&&this.component.triggers?.filter(e=>e.type==Ca.OnSuccess).filter(t=>e.detail.actionId==t.calledActionId).forEach(t=>{if(!t.condition||this._evalExpr(t.condition))if(e.preventDefault(),e.stopPropagation(),t.timeoutMillis>0){let e=this.callbackToken;setTimeout(()=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,callbackToken:e},bubbles:!0,composed:!0}))},t.timeoutMillis)}else this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))})},this.handleBackendFailed=e=>{e.detail.actionId&&this.component.triggers?.filter(e=>e.type==Ca.OnError).filter(t=>e.detail.actionId==t.calledActionId).forEach(t=>{(!t.condition||this._evalExpr(t.condition))&&(e.preventDefault(),e.stopPropagation(),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0})))})},this._pendingOrigins=new Map,this._backendSettledListener=e=>{((typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target)===this&&this._releasePending(e.detail?.actionId)},this._keydownListener=e=>{if(this._handleTabShortcut(e))return;let t=this.component;if(t)for(let n of t.actions??[]){let t=n.shortcut||(n.runOnEnter?`enter`:null);if(t&&this._shortcutMatchesEvent(t,e)){e.preventDefault(),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.id},bubbles:!0,composed:!0}));return}}}}createRenderRoot(){return N.mustUseShadowRoot()?super.createRenderRoot():this}updated(e){super.updated(e),e.has(`state`)&&this.state&&JSON.stringify(this.state)!=JSON.stringify({})&&this.onChange(),e.has(`component`)&&(this.formerState={...this.state},this.component?.confirmOnNavigationIfDirty&&this.dispatchEvent(new CustomEvent(`clean`,{detail:{},bubbles:!0,composed:!0})),setTimeout(()=>this.triggerOnLoad()))}focusFirstInvalidField(){let e=t=>requestAnimationFrame(()=>{let n=this.findFirstInvalid(this.renderRoot);if(n){n.focus?.(),n.scrollIntoView?.({block:`center`,behavior:`smooth`});return}t>0&&e(t-1)});e(3)}findFirstInvalid(e){if(!e?.querySelectorAll)return null;for(let t of Array.from(e.querySelectorAll(`*`))){if(t.invalid===!0)return t;if(t.shadowRoot){let e=this.findFirstInvalid(t.shadowRoot);if(e)return e}}return null}_releasePending(e){(e===void 0?Array.from(this._pendingOrigins.keys()):[e]).forEach(e=>{Oo.end(Do(this.id,e)),Fo(this._pendingOrigins.get(e)),this._pendingOrigins.delete(e)})}_shortcutMatchesEvent(e,t){return zn(e,t)}_collectShortcutTabs(){let e=this.renderRoot;if(!e)return[];let t=Array.from(e.querySelectorAll(`vaadin-tab[data-shortcut]`));return e.querySelectorAll(`mateu-drawer, mateu-dialog`).forEach(e=>{let n=e.shadowRoot;n&&t.push(...Array.from(n.querySelectorAll(`vaadin-tab[data-shortcut]`)))}),t}_handleTabShortcut(e){let t=this._collectShortcutTabs();if(t.length===0)return!1;for(let n of Array.from(t)){let t=n.dataset.shortcut;if(!t||!this._shortcutMatchesEvent(t,e))continue;let r=n.closest(`vaadin-tabs`);if(!r)continue;let i=Array.from(r.querySelectorAll(`vaadin-tab`)).indexOf(n);if(!(i<0))return e.preventDefault(),r.selected=i,!0}return!1}connectedCallback(){super.connectedCallback(),this.addEventListener(`backend-call-succeeded`,this.handleBackendSucceeded),this.addEventListener(`backend-call-failed`,this.handleBackendFailed),this.addEventListener(`backend-succeeded-event`,this._backendSettledListener),this.addEventListener(`backend-failed-event`,this._backendSettledListener),this.addEventListener(`backend-cancelled-event`,this._backendSettledListener),document.addEventListener(`keydown`,this._keydownListener)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`backend-call-succeeded`,this.handleBackendSucceeded),this.removeEventListener(`backend-call-failed`,this.handleBackendFailed),this.removeEventListener(`backend-succeeded-event`,this._backendSettledListener),this.removeEventListener(`backend-failed-event`,this._backendSettledListener),this.removeEventListener(`backend-cancelled-event`,this._backendSettledListener),document.removeEventListener(`keydown`,this._keydownListener),this._releasePending()}render(){return w`<div>
             <div>${this._render()}</div>
             ${this.data&&this.data.errors&&this.data.errors._component&&this.data.errors._component.length>0?w`
                 <div><ul>${this.data.errors._component.map(e=>w`<li>${e}</li>`)}</ul></div>
-            `:_}</div>`}_render(){if(this.component?.type==k.ClientSide){let e=this.component;return e.metadata?.type==A.Page?br(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!0):e.metadata?.type==A.Crud?xr(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!0):N.get()?.renderClientSideComponent(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!1)}return w`
+            `:_}</div>`}_render(){if(this.component?.type==k.ClientSide){let e=this.component;return e.metadata?.type==A.Page?Sr(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!0):e.metadata?.type==A.Crud?Cr(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!0):N.get()?.renderClientSideComponent(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!1)}return w`
             <mateu-api-caller 
                     @value-changed="${this.valueChangedListener}"
                     @data-changed="${this.dataChangedListener}"
                     @close-modal-requested="${this.closeModalRequestedListener}"
                     @filter-reset-requested="${this.resetFilters}"
                     @action-requested="${this.actionRequestedListener}">
-            ${this.component?.children?.map(e=>{if(e.type==k.ClientSide){let t=e;if(t.metadata?.type==A.Page)return br(this,t,this.baseUrl,this.state,this.data,this.appState,this.appData,!0);if(t.metadata?.type==A.Crud)return xr(this,t,this.baseUrl,this.state,this.data,this.appState,this.appData,!0)}return P(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData)})}
+            ${this.component?.children?.map(e=>{if(e.type==k.ClientSide){let t=e;if(t.metadata?.type==A.Page)return Sr(this,t,this.baseUrl,this.state,this.data,this.appState,this.appData,!0);if(t.metadata?.type==A.Crud)return Cr(this,t,this.baseUrl,this.state,this.data,this.appState,this.appData,!0)}return P(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData)})}
             </mateu-api-caller>
         `}static{this.styles=m`
         :host {
@@ -7308,9 +7308,9 @@ ${i}
             padding-block: var(--lumo-space-xs);
             box-shadow: 0 1px 0 0 var(--lumo-contrast-10pct, rgba(0, 0, 0, 0.1));
         }
-  `}};O([v()],Lo.prototype,`baseUrl`,void 0),O([v()],Lo.prototype,`route`,void 0),O([v()],Lo.prototype,`consumedRoute`,void 0),Lo=O([h(`mateu-component`)],Lo);var Ro=e=>{if(e)try{return JSON.parse(e)}catch{return{value:e}}else return{}},zo=new class{async handle(e,t){return await e.runAction(t.baseUrl,t.route,t.consumedRoute,t.actionId,t.initiatorComponentId,t.appState,t.serverSideType,t.componentState,t.parameters,t.initiator,t.background,t.options)}},Bo=new class{constructor(){this.handleUIIncrement=(e,t,n)=>{if(e?.fragments?.forEach(e=>{ue.next({command:void 0,fragment:e,ui:void 0,error:void 0,callbackToken:n})}),e?.appState&&(D.value={...e.appState},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))),e?.appData){let n=e?.appData;de.value={...e.appData,...n},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))}e?.messages?.forEach(e=>{pa({text:e.text,position:e.position,variant:e.variant,duration:e.duration,undoLabel:e.undoLabel,undoActionId:e.undoActionId,undoParameters:e.undoParameters},t)}),e?.banners&&e.banners.length>0&&document.dispatchEvent(new CustomEvent(`page-banners-received`,{detail:{banners:e.banners,append:e.appendBanners??!1},bubbles:!1,composed:!1})),e?.commands?.forEach(e=>{ue.next({command:e,fragment:void 0,ui:void 0,error:void 0,callbackToken:n})})}}async runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,te={}){let ne=()=>{this.runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,te)};try{let o=await zo.handle(e,{baseUrl:t,route:n,consumedRoute:r,actionId:i,appState:D.value,initiatorComponentId:a,componentState:c,parameters:l,serverSideType:s,initiator:u,background:d,options:{...te,retry:ne}});f&&f(o),p||this.handleUIIncrement(o,u,ee),o.messages&&o.messages.length==1&&o.messages[0].variant==`error`&&u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-succeeded`,{detail:{actionId:i,evevntId:T()},bubbles:!0,composed:!0}))}catch(e){console.warn(`Action request failed`,e),e?.__mateuReported||u.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:i,reason:this.serialize(e),retry:ne}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))}}serialize(e){return e?.message?e:JSON.stringify(e)}},Vo=new class{constructor(){this.handleUIIncrement=(e,t,n)=>{if(e?.messages?.forEach(e=>{pa({text:e.text,position:e.position,variant:e.variant,duration:e.duration,undoLabel:e.undoLabel,undoActionId:e.undoActionId,undoParameters:e.undoParameters},t)}),e?.banners&&e.banners.length>0&&document.dispatchEvent(new CustomEvent(`page-banners-received`,{detail:{banners:e.banners,append:e.appendBanners??!1},bubbles:!1,composed:!1})),e?.commands?.forEach(e=>{ue.next({command:e,fragment:void 0,ui:void 0,error:void 0,callbackToken:n})}),e?.fragments?.forEach(e=>{ue.next({command:void 0,fragment:e,ui:void 0,error:void 0,callbackToken:n})}),e?.appState&&(D.value={...e.appState},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))),e?.appData){let n=e?.appData;de.value={...e.appData,...n},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))}}}async runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,te={}){let ne=()=>{this.runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,te)};if(n){n||=`_no_route`,n&&n.startsWith(`/`)&&(n=n.substring(1));let e={serverSideType:s,appState:D.value,componentState:c,parameters:l,initiatorComponentId:a,consumedRoute:r,route:`/`+n,actionId:i};d||u.dispatchEvent(new CustomEvent(`backend-called-event`,{bubbles:!0,composed:!0,detail:{}})),fetch(t+`/mateu/v3/sse/`+n,{method:`POST`,headers:{Accept:`text/event-stream`,"Content-Type":`application/json`},body:JSON.stringify(e)}).then(async e=>{let t=e.body?.pipeThrough(new TextDecoderStream).getReader();if(t){let e=``;for(;;){let{value:n,done:r}=await t.read();if(r)break;e+=n;let a=e.split(`
+  `}};O([v()],Bo.prototype,`baseUrl`,void 0),O([v()],Bo.prototype,`route`,void 0),O([v()],Bo.prototype,`consumedRoute`,void 0),Bo=O([h(`mateu-component`)],Bo);var Vo=e=>{if(e)try{return JSON.parse(e)}catch{return{value:e}}else return{}},Ho=new class{async handle(e,t){return await e.runAction(t.baseUrl,t.route,t.consumedRoute,t.actionId,t.initiatorComponentId,t.appState,t.serverSideType,t.componentState,t.parameters,t.initiator,t.background,t.options)}},Uo=new class{constructor(){this.handleUIIncrement=(e,t,n)=>{if(e?.fragments?.forEach(e=>{ue.next({command:void 0,fragment:e,ui:void 0,error:void 0,callbackToken:n})}),e?.appState&&(D.value={...e.appState},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))),e?.appData){let n=e?.appData;de.value={...e.appData,...n},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))}e?.messages?.forEach(e=>{ha({text:e.text,position:e.position,variant:e.variant,duration:e.duration,undoLabel:e.undoLabel,undoActionId:e.undoActionId,undoParameters:e.undoParameters},t)}),e?.banners&&e.banners.length>0&&document.dispatchEvent(new CustomEvent(`page-banners-received`,{detail:{banners:e.banners,append:e.appendBanners??!1},bubbles:!1,composed:!1})),e?.commands?.forEach(e=>{ue.next({command:e,fragment:void 0,ui:void 0,error:void 0,callbackToken:n})})}}async runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,te={}){let ne=()=>{this.runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,te)};try{let o=await Ho.handle(e,{baseUrl:t,route:n,consumedRoute:r,actionId:i,appState:D.value,initiatorComponentId:a,componentState:c,parameters:l,serverSideType:s,initiator:u,background:d,options:{...te,retry:ne}});f&&f(o),p||this.handleUIIncrement(o,u,ee),o.messages&&o.messages.length==1&&o.messages[0].variant==`error`&&u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-succeeded`,{detail:{actionId:i,evevntId:T()},bubbles:!0,composed:!0}))}catch(e){console.warn(`Action request failed`,e),e?.__mateuReported||u.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:i,reason:this.serialize(e),retry:ne}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))}}serialize(e){return e?.message?e:JSON.stringify(e)}},Wo=new class{constructor(){this.handleUIIncrement=(e,t,n)=>{if(e?.messages?.forEach(e=>{ha({text:e.text,position:e.position,variant:e.variant,duration:e.duration,undoLabel:e.undoLabel,undoActionId:e.undoActionId,undoParameters:e.undoParameters},t)}),e?.banners&&e.banners.length>0&&document.dispatchEvent(new CustomEvent(`page-banners-received`,{detail:{banners:e.banners,append:e.appendBanners??!1},bubbles:!1,composed:!1})),e?.commands?.forEach(e=>{ue.next({command:e,fragment:void 0,ui:void 0,error:void 0,callbackToken:n})}),e?.fragments?.forEach(e=>{ue.next({command:void 0,fragment:e,ui:void 0,error:void 0,callbackToken:n})}),e?.appState&&(D.value={...e.appState},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))),e?.appData){let n=e?.appData;de.value={...e.appData,...n},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))}}}async runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,te={}){let ne=()=>{this.runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,te)};if(n){n||=`_no_route`,n&&n.startsWith(`/`)&&(n=n.substring(1));let e={serverSideType:s,appState:D.value,componentState:c,parameters:l,initiatorComponentId:a,consumedRoute:r,route:`/`+n,actionId:i};d||u.dispatchEvent(new CustomEvent(`backend-called-event`,{bubbles:!0,composed:!0,detail:{}})),fetch(t+`/mateu/v3/sse/`+n,{method:`POST`,headers:{Accept:`text/event-stream`,"Content-Type":`application/json`},body:JSON.stringify(e)}).then(async e=>{let t=e.body?.pipeThrough(new TextDecoderStream).getReader();if(t){let e=``;for(;;){let{value:n,done:r}=await t.read();if(r)break;e+=n;let a=e.split(`
 
-`);e=a.pop()??``;for(let e of a){let t=e.trim();if(t)if(t.startsWith(`data:`)){let e=JSON.parse(t.substring(5).trim());f&&f(e),p||this.handleUIIncrement(e,u,ee),e.messages&&e.messages.length==1&&e.messages[0].variant==`error`&&u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))}else{let e=t;try{let n=JSON.parse(t);e=n.message,n._embedded?.errors?.length>0&&n._embedded.errors[0].message&&(e=n._embedded.errors[0].message)}catch{}throw Error(e)}}}}d||u.dispatchEvent(new CustomEvent(`backend-succeeded-event`,{bubbles:!0,composed:!0,detail:{actionId:i}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-succeeded`,{detail:{actionId:i},bubbles:!0,composed:!0}))}).catch(e=>{u.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:i,reason:this.serialize(e),retry:ne}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))})}}serialize(e){return e?.message?e:JSON.stringify(e)}},Ho={fixed:`fixed`,fullWidth:`full`,edgeToEdge:`edge`},Uo=new Set([A.Gantt,A.PlanningBoard,A.Kanban,A.Bpmn,A.Workflow,A.Map]),Wo={landing:`fixed`,form:`fixed`,process:`fixed`},Go=e=>e?Ho[e]:void 0,Ko=e=>e.type==k.ClientSide?e.metadata:void 0,qo=e=>{let t=Ko(e);if(t?.type==A.Page){let e=Go(t.pageWidth);if(e)return e}for(let t of e.children??[]){let e=qo(t);if(e)return e}},Jo=e=>{let t=e.pageType;if(t)return t;let n=e=>{let t=Ko(e);if(t?.type==A.Page&&t.pageType)return t.pageType;for(let t of e.children??[]){let e=n(t);if(e)return e}};return n(e)},Yo=e=>{let t=Ko(e);if(t?.type!=A.Crud)return!1;let n=t;return n.compact?!0:(n.columns??[]).some(e=>e.metadata?.editable)},Xo=(e,t)=>t(e)||(e.children??[]).some(e=>Xo(e,t)),Zo=e=>!!e&&Xo(e,e=>Ko(e)?.type==A.HeroSection),Qo=e=>Ko(e)?.type==A.App||(e.children??[]).some(e=>Ko(e)?.type==A.App),$o=(e,t)=>e?(Go(e.pageWidth)??qo(e))||(t?.top&&Qo(e)?`edge`:Wo[Jo(e)??``]||(Xo(e,e=>{let t=Ko(e)?.type;return t!=null&&Uo.has(t)})?`edge`:Xo(e,Yo)?`full`:`fixed`)):`fixed`,es=`mateu-route-structure-cache`,ts=1,ns=50,rs=(()=>{try{return localStorage.getItem(`mateu-route-structure-cache-off`)!==`1`}catch{return!0}})(),is=()=>{try{return JSON.parse(localStorage.getItem(es)??`{}`)}catch{return{}}},as=e=>{try{localStorage.setItem(es,JSON.stringify(e))}catch{try{let t=Object.entries(e).sort((e,t)=>t[1].t-e[1].t).slice(0,Math.floor(ns/2));localStorage.setItem(es,JSON.stringify(Object.fromEntries(t)))}catch{}}},os=e=>{let t=e.initialState&&Object.keys(e.initialState).length?`#`+ls(JSON.stringify(e.initialState)):``;return[e.baseUrl,e.consumedRoute??``,e.route??``,e.serverSideType??``].join(`|`)+t},ss=e=>{if(!rs)return;let t=is()[e];if(!(!t||t.v!==ts))return{component:t.component,hash:t.hash}},cs=(e,t,n)=>{if(!rs)return;let r=is();r[e]={v:ts,t:Date.now(),component:t,hash:n};let i=Object.keys(r);if(i.length>ns){let e=i.sort((e,t)=>r[e].t-r[t].t).slice(0,i.length-ns);for(let t of e)delete r[t]}as(r)},ls=e=>{let t=2166136261;for(let n=0;n<e.length;n++)t^=e.charCodeAt(n),t=Math.imul(t,16777619);return(t>>>0).toString(36)},us=30,ds=new Map,fs=!0,ps=e=>{if(fs)return ds.get(e)},ms=(e,t)=>{if(fs&&(ds.delete(e),ds.set(e,t),ds.size>us)){let e=ds.keys().next().value;e!==void 0&&ds.delete(e)}},hs,X=class extends $e{static{hs=this}constructor(...e){super(...e),this.consumedRoute=``,this.serverSideType=void 0,this.uriPrefix=void 0,this.overrides=void 0,this.homeRoute=void 0,this.route=void 0,this.top=void 0,this.appState={},this.appData={},this.preventNavigation=!1,this.overridesParsed={},this.fragment=void 0,this.showSkeleton=!1,this.pendingRouteFocus=!1,this.hasRenderedContent=!1,this.loadLifecycleListener=e=>{if(((typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target)===this)if(clearTimeout(this.skeletonTimer),e.type===`backend-called-event`){if(this.fragment?.component)return;this.skeletonTimer=setTimeout(()=>{this.showSkeleton=!0},hs.SKELETON_DELAY_MS)}else this.showSkeleton=!1},this.actionRequestedListener=e=>{e instanceof CustomEvent&&(e.preventDefault(),e.stopPropagation(),this.manageActionEvent(e))},this.historyPushed=e=>{e instanceof CustomEvent&&(e.preventDefault(),e.stopPropagation(),this.preventNavigation=!0,this.route=e.detail.route)},this.routeChangedListener=e=>{if(e instanceof CustomEvent){e.preventDefault(),e.stopPropagation();let t=e.detail.route;typeof t==`string`&&(t===``||t.startsWith(`/`))&&this.consumedRoute&&this.consumedRoute!==`_empty`&&this.consumedRoute.startsWith(`/`)&&!t.startsWith(this.consumedRoute)&&(t=this.consumedRoute+t),this.uriPrefix&&(t=t.startsWith(`/`)&&this.uriPrefix.endsWith(`/`)?this.uriPrefix+t.substring(1):!t.startsWith(`/`)&&!this.uriPrefix.endsWith(`/`)?this.uriPrefix+`/`+t:this.uriPrefix+t),this.dispatchEvent(new CustomEvent(`url-update-requested`,{detail:{route:t},bubbles:!0,composed:!0}))}},this.backendFailedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&e.detail.actionId==``&&(this.fragment={targetComponentId:this.id,data:{},state:{},component:{type:k.ClientSide,metadata:{type:A.Element,name:`div`,content:`Not found`},id:`fieldId`},action:Ke.Replace,containerId:void 0})},this.detail1=void 0,this.manageActionEvent=e=>{e.preventDefault(),e.stopPropagation(),this.detail1=e.detail;let t=this.detail1;if(e.type==`server-side-action-requested`){let e=Bo;t.sse&&(e=Vo),e.runAction(Ge,this.baseUrl,t.route??``,t.consumedRoute,t.actionId,t.initiatorComponentId,this.getCustomisedAppState(),t.serverSideType,t.componentState,t.parameters,t.initiator,t.background,t.callback,t.callbackonly,t.callbackToken,{timeoutMillis:t.timeoutMillis,idempotent:t.idempotent,knownStructureHash:t.knownStructureHash})}},this.getCustomisedAppState=()=>{let e={...D.value};if(this.overrides){let t=Ro(this.overrides);e={...e,...t}}return e}}manageActionRequestedEvent(e){throw Error(`Method not implemented.`)}createRenderRoot(){return N.mustUseShadowRoot()?super.createRenderRoot():this}structureCacheKey(){return os({baseUrl:this.baseUrl,consumedRoute:this.consumedRoute,route:this.route,serverSideType:this.serverSideType,initialState:this.initialState})}focusNewContent(){requestAnimationFrame(()=>{let e=this.renderRoot?.querySelector?.(`h1, h2, [role="heading"]`)??this;e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus?.({preventScroll:!0})})}static{this.SKELETON_DELAY_MS=400}connectedCallback(){super.connectedCallback(),this.overridesParsed=Ro(this.overrides),this.addEventListener(`server-side-action-requested`,this.actionRequestedListener),this.addEventListener(`backend-call-failed`,this.backendFailedListener),this.addEventListener(`history-pushed`,this.historyPushed),this.addEventListener(`route-changed`,this.routeChangedListener),this.addEventListener(`backend-called-event`,this.loadLifecycleListener),this.addEventListener(`backend-succeeded-event`,this.loadLifecycleListener),this.addEventListener(`backend-failed-event`,this.loadLifecycleListener),this.addEventListener(`backend-cancelled-event`,this.loadLifecycleListener)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`server-side-action-requested`,this.actionRequestedListener),this.removeEventListener(`backend-call-failed`,this.backendFailedListener),this.removeEventListener(`history-pushed`,this.historyPushed),this.removeEventListener(`route-changed`,this.routeChangedListener),this.removeEventListener(`backend-called-event`,this.loadLifecycleListener),this.removeEventListener(`backend-succeeded-event`,this.loadLifecycleListener),this.removeEventListener(`backend-failed-event`,this.loadLifecycleListener),this.removeEventListener(`backend-cancelled-event`,this.loadLifecycleListener),clearTimeout(this.skeletonTimer)}shouldUpdate(e){if(this.fragment?.component&&[...e.keys()].every(e=>e===`appState`||e===`appData`)){let t=this.renderRoot.querySelector(`mateu-component`);if(t)return e.has(`appState`)&&(t.appState=this.appState),e.has(`appData`)&&(t.appData=this.appData),!1}return!0}updated(e){if((e.has(`id`)||e.has(`baseurl`)||e.has(`route`)||e.has(`consumedRoute`)||e.has(`instant`))&&!this.preventNavigation){this.callbackToken=this.instant||T();let e=this.structureCacheKey(),t=e===this.lastAuthoritativeKey?void 0:ps(e);if(t)queueMicrotask(()=>this.applyFragment(t));else{if(e!==this.lastAuthoritativeKey){let t=ss(e);this.currentStructureHash=t?.hash,t&&(this.fragment={targetComponentId:this.id,component:t.component,state:{},data:{},action:Ke.Replace,containerId:void 0})}this.manageActionEvent(new CustomEvent(`server-side-action-requested`,{detail:{route:this.route,consumedRoute:this.consumedRoute,userData:void 0,actionId:``,serverSideType:this.serverSideType,initiatorComponentId:this.id,initiator:this,componentState:this.initialState,knownStructureHash:this.currentStructureHash,callbackToken:this.callbackToken},bubbles:!0,composed:!0}))}}e.has(`route`)&&this.top&&(this.preventNavigation||(this.pendingRouteFocus=!0),this.preventNavigation||this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:this.route},bubbles:!0,composed:!0}))),this.preventNavigation&&=!1}applyFragment(e){if(!e.component&&this.fragment?.component){this.fragment={...this.fragment,state:{...this.fragment.state??{},...e.state??{}},data:{...this.fragment.data??{},...e.data??{}}};return}if(this.fragment=e,e.component){if(e.action!==Ke.Add){let t=this.structureCacheKey(),n=e.component.structureHash;cs(t,e.component,n),this.lastAuthoritativeKey=t,this.currentStructureHash=n,e.component.staticView&&ms(t,e)}this.pendingRouteFocus&&this.hasRenderedContent&&this.focusNewContent(),this.pendingRouteFocus=!1,this.hasRenderedContent=!0}e.component&&(this.dataset.pageWidth=$o(e.component,{top:this.top}),this.dataset.pageType=Jo(e.component)??``,this.dataset.hasWelcomeBanner=String(Zo(e.component)))}render(){return!this.fragment?.component&&this.showSkeleton?w`
+`);e=a.pop()??``;for(let e of a){let t=e.trim();if(t)if(t.startsWith(`data:`)){let e=JSON.parse(t.substring(5).trim());f&&f(e),p||this.handleUIIncrement(e,u,ee),e.messages&&e.messages.length==1&&e.messages[0].variant==`error`&&u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))}else{let e=t;try{let n=JSON.parse(t);e=n.message,n._embedded?.errors?.length>0&&n._embedded.errors[0].message&&(e=n._embedded.errors[0].message)}catch{}throw Error(e)}}}}d||u.dispatchEvent(new CustomEvent(`backend-succeeded-event`,{bubbles:!0,composed:!0,detail:{actionId:i}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-succeeded`,{detail:{actionId:i},bubbles:!0,composed:!0}))}).catch(e=>{u.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:i,reason:this.serialize(e),retry:ne}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))})}}serialize(e){return e?.message?e:JSON.stringify(e)}},Go={fixed:`fixed`,fullWidth:`full`,edgeToEdge:`edge`},Ko=new Set([A.Gantt,A.PlanningBoard,A.Kanban,A.Bpmn,A.Workflow,A.Map]),qo={landing:`fixed`,form:`fixed`,process:`fixed`},Jo=e=>e?Go[e]:void 0,Yo=e=>e.type==k.ClientSide?e.metadata:void 0,Xo=e=>{let t=Yo(e);if(t?.type==A.Page){let e=Jo(t.pageWidth);if(e)return e}for(let t of e.children??[]){let e=Xo(t);if(e)return e}},Zo=e=>{let t=e.pageType;if(t)return t;let n=e=>{let t=Yo(e);if(t?.type==A.Page&&t.pageType)return t.pageType;for(let t of e.children??[]){let e=n(t);if(e)return e}};return n(e)},Qo=e=>{let t=Yo(e);if(t?.type!=A.Crud)return!1;let n=t;return n.compact?!0:(n.columns??[]).some(e=>e.metadata?.editable)},$o=(e,t)=>t(e)||(e.children??[]).some(e=>$o(e,t)),es=e=>!!e&&$o(e,e=>Yo(e)?.type==A.HeroSection),ts=e=>Yo(e)?.type==A.App||(e.children??[]).some(e=>Yo(e)?.type==A.App),ns=(e,t)=>e?(Jo(e.pageWidth)??Xo(e))||(t?.top&&ts(e)?`edge`:qo[Zo(e)??``]||($o(e,e=>{let t=Yo(e)?.type;return t!=null&&Ko.has(t)})?`edge`:$o(e,Qo)?`full`:`fixed`)):`fixed`,rs=`mateu-route-structure-cache`,is=1,as=50,os=(()=>{try{return localStorage.getItem(`mateu-route-structure-cache-off`)!==`1`}catch{return!0}})(),ss=()=>{try{return JSON.parse(localStorage.getItem(rs)??`{}`)}catch{return{}}},cs=e=>{try{localStorage.setItem(rs,JSON.stringify(e))}catch{try{let t=Object.entries(e).sort((e,t)=>t[1].t-e[1].t).slice(0,Math.floor(as/2));localStorage.setItem(rs,JSON.stringify(Object.fromEntries(t)))}catch{}}},ls=e=>{let t=e.initialState&&Object.keys(e.initialState).length?`#`+fs(JSON.stringify(e.initialState)):``;return[e.baseUrl,e.consumedRoute??``,e.route??``,e.serverSideType??``].join(`|`)+t},us=e=>{if(!os)return;let t=ss()[e];if(!(!t||t.v!==is))return{component:t.component,hash:t.hash}},ds=(e,t,n)=>{if(!os)return;let r=ss();r[e]={v:is,t:Date.now(),component:t,hash:n};let i=Object.keys(r);if(i.length>as){let e=i.sort((e,t)=>r[e].t-r[t].t).slice(0,i.length-as);for(let t of e)delete r[t]}cs(r)},fs=e=>{let t=2166136261;for(let n=0;n<e.length;n++)t^=e.charCodeAt(n),t=Math.imul(t,16777619);return(t>>>0).toString(36)},ps=30,ms=new Map,hs=!0,gs=e=>{if(hs)return ms.get(e)},_s=(e,t)=>{if(hs&&(ms.delete(e),ms.set(e,t),ms.size>ps)){let e=ms.keys().next().value;e!==void 0&&ms.delete(e)}},vs,Y=class extends $e{static{vs=this}constructor(...e){super(...e),this.consumedRoute=``,this.serverSideType=void 0,this.uriPrefix=void 0,this.overrides=void 0,this.homeRoute=void 0,this.route=void 0,this.top=void 0,this.appState={},this.appData={},this.preventNavigation=!1,this.overridesParsed={},this.fragment=void 0,this.showSkeleton=!1,this.pendingRouteFocus=!1,this.hasRenderedContent=!1,this.loadLifecycleListener=e=>{if(((typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target)===this)if(clearTimeout(this.skeletonTimer),e.type===`backend-called-event`){if(this.fragment?.component)return;this.skeletonTimer=setTimeout(()=>{this.showSkeleton=!0},vs.SKELETON_DELAY_MS)}else this.showSkeleton=!1},this.actionRequestedListener=e=>{e instanceof CustomEvent&&(e.preventDefault(),e.stopPropagation(),this.manageActionEvent(e))},this.historyPushed=e=>{e instanceof CustomEvent&&(e.preventDefault(),e.stopPropagation(),this.preventNavigation=!0,this.route=e.detail.route)},this.routeChangedListener=e=>{if(e instanceof CustomEvent){e.preventDefault(),e.stopPropagation();let t=e.detail.route;typeof t==`string`&&(t===``||t.startsWith(`/`))&&this.consumedRoute&&this.consumedRoute!==`_empty`&&this.consumedRoute.startsWith(`/`)&&!t.startsWith(this.consumedRoute)&&(t=this.consumedRoute+t),this.uriPrefix&&(t=t.startsWith(`/`)&&this.uriPrefix.endsWith(`/`)?this.uriPrefix+t.substring(1):!t.startsWith(`/`)&&!this.uriPrefix.endsWith(`/`)?this.uriPrefix+`/`+t:this.uriPrefix+t),this.dispatchEvent(new CustomEvent(`url-update-requested`,{detail:{route:t},bubbles:!0,composed:!0}))}},this.backendFailedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&e.detail.actionId==``&&(this.fragment={targetComponentId:this.id,data:{},state:{},component:{type:k.ClientSide,metadata:{type:A.Element,name:`div`,content:`Not found`},id:`fieldId`},action:Ke.Replace,containerId:void 0})},this.detail1=void 0,this.manageActionEvent=e=>{e.preventDefault(),e.stopPropagation(),this.detail1=e.detail;let t=this.detail1;if(e.type==`server-side-action-requested`){let e=Uo;t.sse&&(e=Wo),e.runAction(Ge,this.baseUrl,t.route??``,t.consumedRoute,t.actionId,t.initiatorComponentId,this.getCustomisedAppState(),t.serverSideType,t.componentState,t.parameters,t.initiator,t.background,t.callback,t.callbackonly,t.callbackToken,{timeoutMillis:t.timeoutMillis,idempotent:t.idempotent,knownStructureHash:t.knownStructureHash})}},this.getCustomisedAppState=()=>{let e={...D.value};if(this.overrides){let t=Vo(this.overrides);e={...e,...t}}return e}}manageActionRequestedEvent(e){throw Error(`Method not implemented.`)}createRenderRoot(){return N.mustUseShadowRoot()?super.createRenderRoot():this}structureCacheKey(){return ls({baseUrl:this.baseUrl,consumedRoute:this.consumedRoute,route:this.route,serverSideType:this.serverSideType,initialState:this.initialState})}focusNewContent(){requestAnimationFrame(()=>{let e=this.renderRoot?.querySelector?.(`h1, h2, [role="heading"]`)??this;e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus?.({preventScroll:!0})})}static{this.SKELETON_DELAY_MS=400}connectedCallback(){super.connectedCallback(),this.overridesParsed=Vo(this.overrides),this.addEventListener(`server-side-action-requested`,this.actionRequestedListener),this.addEventListener(`backend-call-failed`,this.backendFailedListener),this.addEventListener(`history-pushed`,this.historyPushed),this.addEventListener(`route-changed`,this.routeChangedListener),this.addEventListener(`backend-called-event`,this.loadLifecycleListener),this.addEventListener(`backend-succeeded-event`,this.loadLifecycleListener),this.addEventListener(`backend-failed-event`,this.loadLifecycleListener),this.addEventListener(`backend-cancelled-event`,this.loadLifecycleListener)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`server-side-action-requested`,this.actionRequestedListener),this.removeEventListener(`backend-call-failed`,this.backendFailedListener),this.removeEventListener(`history-pushed`,this.historyPushed),this.removeEventListener(`route-changed`,this.routeChangedListener),this.removeEventListener(`backend-called-event`,this.loadLifecycleListener),this.removeEventListener(`backend-succeeded-event`,this.loadLifecycleListener),this.removeEventListener(`backend-failed-event`,this.loadLifecycleListener),this.removeEventListener(`backend-cancelled-event`,this.loadLifecycleListener),clearTimeout(this.skeletonTimer)}shouldUpdate(e){if(this.fragment?.component&&[...e.keys()].every(e=>e===`appState`||e===`appData`)){let t=this.renderRoot.querySelector(`mateu-component`);if(t)return e.has(`appState`)&&(t.appState=this.appState),e.has(`appData`)&&(t.appData=this.appData),!1}return!0}updated(e){if((e.has(`id`)||e.has(`baseurl`)||e.has(`route`)||e.has(`consumedRoute`)||e.has(`instant`))&&!this.preventNavigation){this.callbackToken=this.instant||T();let e=this.structureCacheKey(),t=e===this.lastAuthoritativeKey?void 0:gs(e);if(t)queueMicrotask(()=>this.applyFragment(t));else{if(e!==this.lastAuthoritativeKey){let t=us(e);this.currentStructureHash=t?.hash,t&&(this.fragment={targetComponentId:this.id,component:t.component,state:{},data:{},action:Ke.Replace,containerId:void 0})}this.manageActionEvent(new CustomEvent(`server-side-action-requested`,{detail:{route:this.route,consumedRoute:this.consumedRoute,userData:void 0,actionId:``,serverSideType:this.serverSideType,initiatorComponentId:this.id,initiator:this,componentState:this.initialState,knownStructureHash:this.currentStructureHash,callbackToken:this.callbackToken},bubbles:!0,composed:!0}))}}e.has(`route`)&&this.top&&(this.preventNavigation||(this.pendingRouteFocus=!0),this.preventNavigation||this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:this.route},bubbles:!0,composed:!0}))),this.preventNavigation&&=!1}applyFragment(e){if(!e.component&&this.fragment?.component){this.fragment={...this.fragment,state:{...this.fragment.state??{},...e.state??{}},data:{...this.fragment.data??{},...e.data??{}}};return}if(this.fragment=e,e.component){if(e.action!==Ke.Add){let t=this.structureCacheKey(),n=e.component.structureHash;ds(t,e.component,n),this.lastAuthoritativeKey=t,this.currentStructureHash=n,e.component.staticView&&_s(t,e)}this.pendingRouteFocus&&this.hasRenderedContent&&this.focusNewContent(),this.pendingRouteFocus=!1,this.hasRenderedContent=!0}e.component&&(this.dataset.pageWidth=ns(e.component,{top:this.top}),this.dataset.pageType=Zo(e.component)??``,this.dataset.hasWelcomeBanner=String(es(e.component)))}render(){return!this.fragment?.component&&this.showSkeleton?w`
                 <div class="route-skeleton" aria-busy="true" aria-live="polite">
                     <mateu-skeleton variant="text" count="1"></mateu-skeleton>
                     <mateu-skeleton variant="form" count="4"></mateu-skeleton>
@@ -7350,7 +7350,7 @@ ${i}
             max-width: 16rem;
             margin-block-end: var(--lumo-space-l, 1.5rem);
         }
-  `}};O([v()],X.prototype,`consumedRoute`,void 0),O([v()],X.prototype,`serverSideType`,void 0),O([v()],X.prototype,`uriPrefix`,void 0),O([v()],X.prototype,`overrides`,void 0),O([v()],X.prototype,`homeRoute`,void 0),O([v()],X.prototype,`route`,void 0),O([v()],X.prototype,`top`,void 0),O([v()],X.prototype,`instant`,void 0),O([v()],X.prototype,`initialState`,void 0),O([v()],X.prototype,`appState`,void 0),O([v()],X.prototype,`appData`,void 0),O([S()],X.prototype,`fragment`,void 0),O([S()],X.prototype,`showSkeleton`,void 0),X=hs=O([h(`mateu-ux`)],X);function gs(e){let t=`var(--lumo-space-m, 1rem)`,n={left:`50%`,transform:`translateX(-50%)`};switch(e){case`topStart`:return{top:t,left:t};case`topCenter`:return{top:t,...n};case`topEnd`:return{top:t,right:t};case`topStretch`:return{top:t,left:t,right:t};case`middle`:return{top:`50%`,left:`50%`,transform:`translate(-50%, -50%)`};case`bottomStart`:return{bottom:t,left:t};case`bottomCenter`:return{bottom:t,...n};case`bottomStretch`:return{bottom:t,left:t,right:t};default:return{bottom:t,right:t}}}function _s(e){switch(e){case`success`:return{bg:`var(--lumo-success-color, #2e7d32)`,fg:`#fff`};case`error`:return{bg:`var(--lumo-error-color, #c62828)`,fg:`#fff`};case`warning`:return{bg:`var(--lumo-warning-color, #f9a825)`,fg:`#1a1a1a`};case`contrast`:return{bg:`var(--lumo-contrast-90pct, #1a1a1a)`,fg:`#fff`};default:return{bg:`var(--lumo-base-color, #fff)`,fg:`var(--lumo-body-text-color, #1a1a1a)`}}}var vs={show(e,t){let{bg:n,fg:r}=_s(e.variant),i=gs(e.position),a=document.createElement(`div`),o=e.variant===`error`;a.setAttribute(`role`,o?`alert`:`status`),a.setAttribute(`aria-live`,o?`assertive`:`polite`),a.setAttribute(`aria-atomic`,`true`),Object.assign(a.style,{position:`fixed`,zIndex:`2000`,display:`flex`,alignItems:`center`,gap:`0.75rem`,maxWidth:`min(90vw, 28rem)`,padding:`0.7rem 1rem`,borderRadius:`var(--lumo-border-radius-m, 8px)`,boxShadow:`var(--lumo-box-shadow-m, 0 4px 16px rgba(0,0,0,0.2))`,background:n,color:r,font:`inherit`,fontSize:`var(--lumo-font-size-s, 0.875rem)`,opacity:`0`,transition:`opacity 0.2s ease`,...i});let s=document.createElement(`span`);s.textContent=e.text,a.appendChild(s);let c=()=>{a.style.opacity=`0`,setTimeout(()=>a.remove(),200)},l=e.onAction?{label:e.actionLabel??`Retry`,run:e.onAction}:e.undoActionId?{label:e.undoLabel??`Undo`,run:()=>t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.undoActionId,parameters:e.undoParameters??{}},bubbles:!0,composed:!0}))}:void 0;if(l){let e=document.createElement(`button`);e.textContent=l.label,e.style.cssText=`margin-left: 0.25rem; background: none; border: 1px solid currentColor; border-radius: var(--lumo-border-radius-s, 4px); color: inherit; cursor: pointer; padding: 0.15rem 0.6rem; font: inherit; font-weight: 600;`,e.addEventListener(`click`,()=>{l.run(),c()}),a.appendChild(e)}document.body.appendChild(a),requestAnimationFrame(()=>{a.style.opacity=`1`});let u=e.duration??(l?1e4:5e3);u>0&&setTimeout(c,u)}};function ys(){fa(vs)}var bs=class extends y{constructor(...e){super(...e),this.online=!0,this.recovered=!1}connectedCallback(){super.connectedCallback(),this.online=Ve.isOnline(),this.unsubscribe=Ve.subscribe(e=>{let t=!this.online;this.online=e,e&&t&&(this.recovered=!0,clearTimeout(this.recoveredTimer),this.recoveredTimer=setTimeout(()=>{this.recovered=!1},4e3))})}disconnectedCallback(){super.disconnectedCallback(),this.unsubscribe?.(),clearTimeout(this.recoveredTimer),this.releaseSpace()}updated(){let e=this.renderRoot.querySelector(`.bar`);if(!e){this.releaseSpace();return}document.body.style.setProperty(`padding-block-start`,`${e.offsetHeight}px`)}releaseSpace(){typeof document<`u`&&document.body?.style.removeProperty(`padding-block-start`)}render(){if(this.online&&!this.recovered)return _;let e=!this.online;return w`<div class="bar ${e?`offline`:`back`}" role="status" aria-live="polite">
+  `}};O([v()],Y.prototype,`consumedRoute`,void 0),O([v()],Y.prototype,`serverSideType`,void 0),O([v()],Y.prototype,`uriPrefix`,void 0),O([v()],Y.prototype,`overrides`,void 0),O([v()],Y.prototype,`homeRoute`,void 0),O([v()],Y.prototype,`route`,void 0),O([v()],Y.prototype,`top`,void 0),O([v()],Y.prototype,`instant`,void 0),O([v()],Y.prototype,`initialState`,void 0),O([v()],Y.prototype,`appState`,void 0),O([v()],Y.prototype,`appData`,void 0),O([S()],Y.prototype,`fragment`,void 0),O([S()],Y.prototype,`showSkeleton`,void 0),Y=vs=O([h(`mateu-ux`)],Y);function ys(e){let t=`var(--lumo-space-m, 1rem)`,n={left:`50%`,transform:`translateX(-50%)`};switch(e){case`topStart`:return{top:t,left:t};case`topCenter`:return{top:t,...n};case`topEnd`:return{top:t,right:t};case`topStretch`:return{top:t,left:t,right:t};case`middle`:return{top:`50%`,left:`50%`,transform:`translate(-50%, -50%)`};case`bottomStart`:return{bottom:t,left:t};case`bottomCenter`:return{bottom:t,...n};case`bottomStretch`:return{bottom:t,left:t,right:t};default:return{bottom:t,right:t}}}function bs(e){switch(e){case`success`:return{bg:`var(--lumo-success-color, #2e7d32)`,fg:`#fff`};case`error`:return{bg:`var(--lumo-error-color, #c62828)`,fg:`#fff`};case`warning`:return{bg:`var(--lumo-warning-color, #f9a825)`,fg:`#1a1a1a`};case`contrast`:return{bg:`var(--lumo-contrast-90pct, #1a1a1a)`,fg:`#fff`};default:return{bg:`var(--lumo-base-color, #fff)`,fg:`var(--lumo-body-text-color, #1a1a1a)`}}}var xs={show(e,t){let{bg:n,fg:r}=bs(e.variant),i=ys(e.position),a=document.createElement(`div`),o=e.variant===`error`;a.setAttribute(`role`,o?`alert`:`status`),a.setAttribute(`aria-live`,o?`assertive`:`polite`),a.setAttribute(`aria-atomic`,`true`),Object.assign(a.style,{position:`fixed`,zIndex:`2000`,display:`flex`,alignItems:`center`,gap:`0.75rem`,maxWidth:`min(90vw, 28rem)`,padding:`0.7rem 1rem`,borderRadius:`var(--lumo-border-radius-m, 8px)`,boxShadow:`var(--lumo-box-shadow-m, 0 4px 16px rgba(0,0,0,0.2))`,background:n,color:r,font:`inherit`,fontSize:`var(--lumo-font-size-s, 0.875rem)`,opacity:`0`,transition:`opacity 0.2s ease`,...i});let s=document.createElement(`span`);s.textContent=e.text,a.appendChild(s);let c=()=>{a.style.opacity=`0`,setTimeout(()=>a.remove(),200)},l=e.onAction?{label:e.actionLabel??`Retry`,run:e.onAction}:e.undoActionId?{label:e.undoLabel??`Undo`,run:()=>t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.undoActionId,parameters:e.undoParameters??{}},bubbles:!0,composed:!0}))}:void 0;if(l){let e=document.createElement(`button`);e.textContent=l.label,e.style.cssText=`margin-left: 0.25rem; background: none; border: 1px solid currentColor; border-radius: var(--lumo-border-radius-s, 4px); color: inherit; cursor: pointer; padding: 0.15rem 0.6rem; font: inherit; font-weight: 600;`,e.addEventListener(`click`,()=>{l.run(),c()}),a.appendChild(e)}document.body.appendChild(a),requestAnimationFrame(()=>{a.style.opacity=`1`});let u=e.duration??(l?1e4:5e3);u>0&&setTimeout(c,u)}};function Ss(){ma(xs)}var Cs=class extends y{constructor(...e){super(...e),this.online=!0,this.recovered=!1}connectedCallback(){super.connectedCallback(),this.online=Ve.isOnline(),this.unsubscribe=Ve.subscribe(e=>{let t=!this.online;this.online=e,e&&t&&(this.recovered=!0,clearTimeout(this.recoveredTimer),this.recoveredTimer=setTimeout(()=>{this.recovered=!1},4e3))})}disconnectedCallback(){super.disconnectedCallback(),this.unsubscribe?.(),clearTimeout(this.recoveredTimer),this.releaseSpace()}updated(){let e=this.renderRoot.querySelector(`.bar`);if(!e){this.releaseSpace();return}document.body.style.setProperty(`padding-block-start`,`${e.offsetHeight}px`)}releaseSpace(){typeof document<`u`&&document.body?.style.removeProperty(`padding-block-start`)}render(){if(this.online&&!this.recovered)return _;let e=!this.online;return w`<div class="bar ${e?`offline`:`back`}" role="status" aria-live="polite">
             <span class="dot"></span>
             <span>${e?`No connection — changes you make now will not be saved.`:`Connection restored.`}</span>
         </div>`}static{this.styles=m`
@@ -7392,7 +7392,7 @@ ${i}
         @media (prefers-reduced-motion: reduce) {
             .bar, .bar.offline .dot { animation: none; }
         }
-    `}};O([S()],bs.prototype,`online`,void 0),O([S()],bs.prototype,`recovered`,void 0),bs=O([h(`mateu-connectivity-banner`)],bs);var xs=null;function Ss(){if(!(typeof document>`u`)&&!(xs&&xs.isConnected)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>Ss(),{once:!0});return}xs=document.createElement(`mateu-connectivity-banner`),document.body.appendChild(xs)}}var Cs,ws=class extends y{static{Cs=this}constructor(...e){super(...e),this.skip=()=>{let e=this.findContent();e&&(e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus(),e.scrollIntoView({block:`start`}))}}static{this.TARGETS=[`.app-content`,`mateu-page`,`mateu-ux`,`mateu-component`]}findContent(){let e=new Set,t=n=>{if(e.has(n))return null;e.add(n);for(let e of Cs.TARGETS){let t=n.querySelector?.(e);if(t&&t!==this)return t}for(let e of Array.from(n.querySelectorAll?.(`*`)??[]))if(e.shadowRoot){let n=t(e.shadowRoot);if(n)return n}return null};return t(document)}render(){return w`<button class="skip" @click="${this.skip}">Skip to content</button>`}static{this.styles=m`
+    `}};O([S()],Cs.prototype,`online`,void 0),O([S()],Cs.prototype,`recovered`,void 0),Cs=O([h(`mateu-connectivity-banner`)],Cs);var ws=null;function Ts(){if(!(typeof document>`u`)&&!(ws&&ws.isConnected)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>Ts(),{once:!0});return}ws=document.createElement(`mateu-connectivity-banner`),document.body.appendChild(ws)}}var Es,Ds=class extends y{static{Es=this}constructor(...e){super(...e),this.skip=()=>{let e=this.findContent();e&&(e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus(),e.scrollIntoView({block:`start`}))}}static{this.TARGETS=[`.app-content`,`mateu-page`,`mateu-ux`,`mateu-component`]}findContent(){let e=new Set,t=n=>{if(e.has(n))return null;e.add(n);for(let e of Es.TARGETS){let t=n.querySelector?.(e);if(t&&t!==this)return t}for(let e of Array.from(n.querySelectorAll?.(`*`)??[]))if(e.shadowRoot){let n=t(e.shadowRoot);if(n)return n}return null};return t(document)}render(){return w`<button class="skip" @click="${this.skip}">Skip to content</button>`}static{this.styles=m`
         :host {
             position: fixed;
             inset-block-start: 0;
@@ -7425,7 +7425,7 @@ ${i}
             outline: 2px solid var(--lumo-body-text-color, #161513);
             outline-offset: 2px;
         }
-    `}};ws=Cs=O([h(`mateu-skip-link`)],ws);var Ts=null;function Es(){if(!(typeof document>`u`)&&!(Ts&&Ts.isConnected)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>Es(),{once:!0});return}Ts=document.createElement(`mateu-skip-link`),document.body.insertBefore(Ts,document.body.firstChild)}}ys(),Ss(),Ze(),Es();var Ds=class extends y{constructor(...e){super(...e),this.baseUrl=``,this.route=void 0,this.consumedRoute=`_empty`,this.config=void 0,this.top=`true`,this.pathPrefix=void 0,this.debug=!1,this._lastUrl=``,this.routeChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.top==`true`){let t=e.detail.route,n=this.baseUrl??``;!t||t.startsWith(`/`)?n=window.location.origin+(this.pathPrefix??``):(t=(this.pathPrefix??``)+t,n.indexOf(`://`)<0&&(n.startsWith(`/`)||(n=`/`+n),n=window.location.origin+n)),t.startsWith(this.pathPrefix+`/`)&&(t=t.substring(this.pathPrefix?.length)),n.endsWith(`/`)&&t.startsWith(`/`)&&(t=t.substring(1));let r=new URL(n+t);if((window.location.pathname||r.pathname)&&window.location.pathname!=r.pathname){let e=r.pathname;r.search&&(e+=r.search),e&&!e.startsWith(`/`)&&(e=`/`+e),window.history.pushState({},``,e),this._lastUrl=window.location.href}}},this.navigateToRequestedListener=e=>{if(e.preventDefault(),e.stopPropagation(),Ma.markClean(),e instanceof CustomEvent){let t=e.detail.route,n=this.renderRoot.querySelector(`mateu-ux`);n&&(n.setAttribute(`route`,t),n.setAttribute(`instant`,T()))}}}createRenderRoot(){return N.mustUseShadowRoot()?super.createRenderRoot():this}connectedCallback(){if(super.connectedCallback(),Ma.install(),this._lastUrl=window.location.href,window.onpopstate=e=>{if(!Ma.confirmLeave()){window.history.pushState({},``,this._lastUrl);return}let t=e.target;this.loadUrl(t)},this.top==`true`?this.loadUrl(window):this.route&&(this.consumedRoute=``),this.config)try{let e=JSON.parse(this.config);D.value={...D.value,...e}}catch{D.value={...D.value,config:this.config}}this.addEventListener(`url-update-requested`,this.routeChangedListener),this.addEventListener(`navigate-to-requested`,this.navigateToRequestedListener)}disconnectedCallback(){super.disconnectedCallback(),this.upstreamSubscription?.unsubscribe(),this.removeEventListener(`url-update-requested`,this.routeChangedListener),this.removeEventListener(`navigate-to-requested`,this.navigateToRequestedListener)}loadUrl(e){if(this.route=this.extractRouteFromUrl(e),this.setAttribute(`route`,this.route),this.instant=T(),this._lastUrl=e.location.href,e.location.search){let t=new URLSearchParams(e.location.search).get(`overrides`);if(t&&(this.config=t,this.config))try{let e=JSON.parse(this.config);D.value={...D.value,...e}}catch{D.value={...D.value,config:this.config}}}}extractRouteFromUrl(e){return this.addQueryParams(this.extractRouteWithoutParamsFromUrl(e),e.location)}extractRouteWithoutParamsFromUrl(e){let t=this.extractGrossRouteFromUrl(e);return this.pathPrefix&&t.startsWith(this.pathPrefix)?t.substring(this.pathPrefix.length):t==`/`?``:t}addQueryParams(e,t){return e+(t.search?``+t.search:``)}extractGrossRouteFromUrl(e){let t=e.location.pathname,n=this.baseUrl&&(this.baseUrl.startsWith(`http://`)||this.baseUrl.startsWith(`https://`))?this.baseUrl.substring(this.getContextPathStartingIndex(this.baseUrl)):this.baseUrl;return t.startsWith(n)?t.substring(n.length):t}getContextPathStartingIndex(e){return e.startsWith(`http:`)?e.indexOf(`/`,7):e.startsWith(`https:`)?e.indexOf(`/`,8):0}render(){return w`
+    `}};Ds=Es=O([h(`mateu-skip-link`)],Ds);var Os=null;function ks(){if(!(typeof document>`u`)&&!(Os&&Os.isConnected)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>ks(),{once:!0});return}Os=document.createElement(`mateu-skip-link`),document.body.insertBefore(Os,document.body.firstChild)}}Ss(),Ts(),Ze(),ks();var As=class extends y{constructor(...e){super(...e),this.baseUrl=``,this.route=void 0,this.consumedRoute=`_empty`,this.config=void 0,this.top=`true`,this.pathPrefix=void 0,this.debug=!1,this._lastUrl=``,this.routeChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.top==`true`){let t=e.detail.route,n=this.baseUrl??``;!t||t.startsWith(`/`)?n=window.location.origin+(this.pathPrefix??``):(t=(this.pathPrefix??``)+t,n.indexOf(`://`)<0&&(n.startsWith(`/`)||(n=`/`+n),n=window.location.origin+n)),t.startsWith(this.pathPrefix+`/`)&&(t=t.substring(this.pathPrefix?.length)),n.endsWith(`/`)&&t.startsWith(`/`)&&(t=t.substring(1));let r=new URL(n+t);if((window.location.pathname||r.pathname)&&window.location.pathname!=r.pathname){let e=r.pathname;r.search&&(e+=r.search),e&&!e.startsWith(`/`)&&(e=`/`+e),window.history.pushState({},``,e),this._lastUrl=window.location.href}}},this.navigateToRequestedListener=e=>{if(e.preventDefault(),e.stopPropagation(),Pa.markClean(),e instanceof CustomEvent){let t=e.detail.route,n=this.renderRoot.querySelector(`mateu-ux`);n&&(n.setAttribute(`route`,t),n.setAttribute(`instant`,T()))}}}createRenderRoot(){return N.mustUseShadowRoot()?super.createRenderRoot():this}connectedCallback(){if(super.connectedCallback(),Pa.install(),this._lastUrl=window.location.href,window.onpopstate=e=>{if(!Pa.confirmLeave()){window.history.pushState({},``,this._lastUrl);return}let t=e.target;this.loadUrl(t)},this.top==`true`?this.loadUrl(window):this.route&&(this.consumedRoute=``),this.config)try{let e=JSON.parse(this.config);D.value={...D.value,...e}}catch{D.value={...D.value,config:this.config}}this.addEventListener(`url-update-requested`,this.routeChangedListener),this.addEventListener(`navigate-to-requested`,this.navigateToRequestedListener)}disconnectedCallback(){super.disconnectedCallback(),this.upstreamSubscription?.unsubscribe(),this.removeEventListener(`url-update-requested`,this.routeChangedListener),this.removeEventListener(`navigate-to-requested`,this.navigateToRequestedListener)}loadUrl(e){if(this.route=this.extractRouteFromUrl(e),this.setAttribute(`route`,this.route),this.instant=T(),this._lastUrl=e.location.href,e.location.search){let t=new URLSearchParams(e.location.search).get(`overrides`);if(t&&(this.config=t,this.config))try{let e=JSON.parse(this.config);D.value={...D.value,...e}}catch{D.value={...D.value,config:this.config}}}}extractRouteFromUrl(e){return this.addQueryParams(this.extractRouteWithoutParamsFromUrl(e),e.location)}extractRouteWithoutParamsFromUrl(e){let t=this.extractGrossRouteFromUrl(e);return this.pathPrefix&&t.startsWith(this.pathPrefix)?t.substring(this.pathPrefix.length):t==`/`?``:t}addQueryParams(e,t){return e+(t.search?``+t.search:``)}extractGrossRouteFromUrl(e){let t=e.location.pathname,n=this.baseUrl&&(this.baseUrl.startsWith(`http://`)||this.baseUrl.startsWith(`https://`))?this.baseUrl.substring(this.getContextPathStartingIndex(this.baseUrl)):this.baseUrl;return t.startsWith(n)?t.substring(n.length):t}getContextPathStartingIndex(e){return e.startsWith(`http:`)?e.indexOf(`/`,7):e.startsWith(`https:`)?e.indexOf(`/`,8):0}render(){return w`
            <mateu-api-caller>
                 <mateu-ux id="_ux"
                           baseurl="${this.baseUrl}"
@@ -7449,9 +7449,9 @@ ${i}
         :host {
             --lumo-clickable-cursor: pointer;
         }
-  `}};O([v()],Ds.prototype,`baseUrl`,void 0),O([v()],Ds.prototype,`route`,void 0),O([v()],Ds.prototype,`consumedRoute`,void 0),O([v()],Ds.prototype,`config`,void 0),O([v()],Ds.prototype,`top`,void 0),O([v()],Ds.prototype,`pathPrefix`,void 0),O([S()],Ds.prototype,`instant`,void 0),O([v({type:Boolean})],Ds.prototype,`debug`,void 0),Ds=O([h(`mateu-ui`)],Ds);var Os,ks=class extends y{static{Os=this}constructor(...e){super(...e),this.baseUrl=``,this.opened=!1,this.searchText=``}static{this.SEARCHABLE_THRESHOLD=7}connectedCallback(){super.connectedCallback(),De()}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick(),this.searchTimer&&clearTimeout(this.searchTimer)}currentValue(){return String(Ce()[this.selector.fieldName]??``)}currentLabel(){let e=this.currentValue();if(!e)return`—`;let t=(this.searchedOptions??this.selector.options)?.find(t=>String(t.value)===e);if(t)return t.label;let n=we()[this.selector.fieldName];return n===void 0?e:String(n)}pick(e,t){Te(this.selector.fieldName,e,t),window.location.reload()}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}openPanel(){this.opened||(this.opened=!0,this.searchText=``,this.searchedOptions=void 0,this.remoteSearch(),this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick),this.updateComplete.then(()=>this.renderRoot.querySelector(`input.picker-search`)?.focus()))}closePanel(){this.detachOutsideClick(),this.opened=!1}onSearchInput(e){this.searchText=e.target.value,this.searchTimer&&clearTimeout(this.searchTimer),this.searchTimer=setTimeout(()=>this.remoteSearch(),300)}async remoteSearch(){let e=this.app;if(e?.serverSideType)try{let t=await Ge.runAction(this.baseUrl??``,e.rootRoute??e.initialRoute??``,``,`_appcontext-search-${this.selector.fieldName}`,`appcontext-${this.selector.fieldName}`,void 0,e.serverSideType,{},{searchText:this.searchText},this,!0);for(let e of t?.fragments??[]){let t=e.data?.[`_appcontext_${this.selector.fieldName}`]?.content;if(Array.isArray(t)){this.searchedOptions=t.map(e=>({value:e.value,label:e.label??String(e.value)}));return}}}catch{}}visibleOptions(){let e=this.searchedOptions??this.selector.options??[],t=this.searchText.trim().toLowerCase();return t?e.filter(e=>e.label.toLowerCase().includes(t)):e}renderPanel(){let e=this.currentValue(),t=this.visibleOptions();return w`
+  `}};O([v()],As.prototype,`baseUrl`,void 0),O([v()],As.prototype,`route`,void 0),O([v()],As.prototype,`consumedRoute`,void 0),O([v()],As.prototype,`config`,void 0),O([v()],As.prototype,`top`,void 0),O([v()],As.prototype,`pathPrefix`,void 0),O([S()],As.prototype,`instant`,void 0),O([v({type:Boolean})],As.prototype,`debug`,void 0),As=O([h(`mateu-ui`)],As);var js,Ms=class extends y{static{js=this}constructor(...e){super(...e),this.baseUrl=``,this.opened=!1,this.searchText=``}static{this.SEARCHABLE_THRESHOLD=7}connectedCallback(){super.connectedCallback(),De()}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick(),this.searchTimer&&clearTimeout(this.searchTimer)}currentValue(){return String(Ce()[this.selector.fieldName]??``)}currentLabel(){let e=this.currentValue();if(!e)return`—`;let t=(this.searchedOptions??this.selector.options)?.find(t=>String(t.value)===e);if(t)return t.label;let n=we()[this.selector.fieldName];return n===void 0?e:String(n)}pick(e,t){Te(this.selector.fieldName,e,t),window.location.reload()}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}openPanel(){this.opened||(this.opened=!0,this.searchText=``,this.searchedOptions=void 0,this.remoteSearch(),this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick),this.updateComplete.then(()=>this.renderRoot.querySelector(`input.picker-search`)?.focus()))}closePanel(){this.detachOutsideClick(),this.opened=!1}onSearchInput(e){this.searchText=e.target.value,this.searchTimer&&clearTimeout(this.searchTimer),this.searchTimer=setTimeout(()=>this.remoteSearch(),300)}async remoteSearch(){let e=this.app;if(e?.serverSideType)try{let t=await Ge.runAction(this.baseUrl??``,e.rootRoute??e.initialRoute??``,``,`_appcontext-search-${this.selector.fieldName}`,`appcontext-${this.selector.fieldName}`,void 0,e.serverSideType,{},{searchText:this.searchText},this,!0);for(let e of t?.fragments??[]){let t=e.data?.[`_appcontext_${this.selector.fieldName}`]?.content;if(Array.isArray(t)){this.searchedOptions=t.map(e=>({value:e.value,label:e.label??String(e.value)}));return}}}catch{}}visibleOptions(){let e=this.searchedOptions??this.selector.options??[],t=this.searchText.trim().toLowerCase();return t?e.filter(e=>e.label.toLowerCase().includes(t)):e}renderPanel(){let e=this.currentValue(),t=this.visibleOptions();return w`
             <div class="panel">
-                ${this.searchText!==``||t.length>Os.SEARCHABLE_THRESHOLD?w`
+                ${this.searchText!==``||t.length>js.SEARCHABLE_THRESHOLD?w`
                     <input class="picker-search" type="text" placeholder="Search"
                            .value="${this.searchText}"
                            @input="${this.onSearchInput}"
@@ -7543,7 +7543,7 @@ ${i}
         .option--clear {
             color: var(--lumo-secondary-text-color, rgba(0, 0, 0, 0.55));
         }
-    `}};O([v()],ks.prototype,`selector`,void 0),O([v()],ks.prototype,`app`,void 0),O([v()],ks.prototype,`baseUrl`,void 0),O([S()],ks.prototype,`opened`,void 0),O([S()],ks.prototype,`searchText`,void 0),O([S()],ks.prototype,`searchedOptions`,void 0),ks=Os=O([h(`mateu-app-context-picker`)],ks);var As=class extends y{constructor(...e){super(...e),this.baseUrl=``,this.opened=!1,this.notifications=[],this.fetched=!1}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}updated(){!this.fetched&&this.app?.serverSideType&&(this.fetched=!0,this.refresh())}unreadCount(){return this.notifications.filter(e=>e.unread).length}async runNotificationsAction(e,t){let n=this.app;if(n?.serverSideType)try{let r=await Ge.runAction(this.baseUrl??``,n.rootRoute??n.initialRoute??``,``,e,`notification-bell`,void 0,n.serverSideType,{},t,this,!0);for(let e of r?.fragments??[]){let t=e.data?._notifications;if(Array.isArray(t)){this.notifications=t;return}}}catch{}}refresh(){return this.runNotificationsAction(`_notifications-list`,{})}markRead(e){return this.runNotificationsAction(`_notifications-read`,{ids:e})}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}openPanel(){this.opened||(this.opened=!0,this.refresh(),this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick))}closePanel(){this.detachOutsideClick(),this.opened=!1}async entryClicked(e){e.unread&&await this.markRead([e.id]);let t=e.route;if(t){if(!Ma.confirmLeave())return;this.closePanel(),this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0})),this.dispatchEvent(new CustomEvent(`navigate-to-requested`,{detail:{route:t},bubbles:!0,composed:!0}))}}renderEntry(e){return w`
+    `}};O([v()],Ms.prototype,`selector`,void 0),O([v()],Ms.prototype,`app`,void 0),O([v()],Ms.prototype,`baseUrl`,void 0),O([S()],Ms.prototype,`opened`,void 0),O([S()],Ms.prototype,`searchText`,void 0),O([S()],Ms.prototype,`searchedOptions`,void 0),Ms=js=O([h(`mateu-app-context-picker`)],Ms);var Ns=class extends y{constructor(...e){super(...e),this.baseUrl=``,this.opened=!1,this.notifications=[],this.fetched=!1}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}updated(){!this.fetched&&this.app?.serverSideType&&(this.fetched=!0,this.refresh())}unreadCount(){return this.notifications.filter(e=>e.unread).length}async runNotificationsAction(e,t){let n=this.app;if(n?.serverSideType)try{let r=await Ge.runAction(this.baseUrl??``,n.rootRoute??n.initialRoute??``,``,e,`notification-bell`,void 0,n.serverSideType,{},t,this,!0);for(let e of r?.fragments??[]){let t=e.data?._notifications;if(Array.isArray(t)){this.notifications=t;return}}}catch{}}refresh(){return this.runNotificationsAction(`_notifications-list`,{})}markRead(e){return this.runNotificationsAction(`_notifications-read`,{ids:e})}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}openPanel(){this.opened||(this.opened=!0,this.refresh(),this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick))}closePanel(){this.detachOutsideClick(),this.opened=!1}async entryClicked(e){e.unread&&await this.markRead([e.id]);let t=e.route;if(t){if(!Pa.confirmLeave())return;this.closePanel(),this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0})),this.dispatchEvent(new CustomEvent(`navigate-to-requested`,{detail:{route:t},bubbles:!0,composed:!0}))}}renderEntry(e){return w`
             <div role="button" tabindex="0" class="entry ${e.unread?`entry--unread`:``}"
                  @click="${()=>this.entryClicked(e)}" @keydown="${L(()=>this.entryClicked(e))}">
                 <span class="unread-dot" aria-hidden="true"></span>
@@ -7731,47 +7731,47 @@ ${i}
         }
     
         ${R}
-    `}};O([v()],As.prototype,`app`,void 0),O([v()],As.prototype,`baseUrl`,void 0),O([S()],As.prototype,`opened`,void 0),O([S()],As.prototype,`notifications`,void 0),As=O([h(`mateu-notification-bell`)],As);var js=e=>{if(!e||!(`querySelectorAll`in e))return null;for(let t of e.querySelectorAll(`*`)){if(t.tagName?.toLowerCase()===`mateu-component`)return t;let e=js(t.shadowRoot);if(e)return e}return null},Ms=async(e,t,n)=>{let r=js(t.renderRoot??t);await Vo.runAction(Ge,t.baseUrl??``,e.rootRoute||`_no_route`,``,n,r?.id??`app-header-action`,{},e.serverSideType??``,{},{},r??t,!0,void 0,!1,``)},Ns=async(e,t,n)=>{try{await Ms(e,t,n)}catch(e){pa({text:`La acción falló: `+e,position:`bottomStart`,duration:6e3,variant:`error`},t)}},Ps=(e,t)=>{let n=e.contextSelectors??[],r=e.contextActions??[];return n.length===0&&r.length===0&&!e.notificationsEnabled?_:w`${e.notificationsEnabled?w`
+    `}};O([v()],Ns.prototype,`app`,void 0),O([v()],Ns.prototype,`baseUrl`,void 0),O([S()],Ns.prototype,`opened`,void 0),O([S()],Ns.prototype,`notifications`,void 0),Ns=O([h(`mateu-notification-bell`)],Ns);var Ps=e=>{if(!e||!(`querySelectorAll`in e))return null;for(let t of e.querySelectorAll(`*`)){if(t.tagName?.toLowerCase()===`mateu-component`)return t;let e=Ps(t.shadowRoot);if(e)return e}return null},Fs=async(e,t,n)=>{let r=Ps(t.renderRoot??t);await Wo.runAction(Ge,t.baseUrl??``,e.rootRoute||`_no_route`,``,n,r?.id??`app-header-action`,{},e.serverSideType??``,{},{},r??t,!0,void 0,!1,``)},Is=async(e,t,n)=>{try{await Fs(e,t,n)}catch(e){ha({text:`La acción falló: `+e,position:`bottomStart`,duration:6e3,variant:`error`},t)}},Ls=(e,t)=>{let n=e.contextSelectors??[],r=e.contextActions??[];return n.length===0&&r.length===0&&!e.notificationsEnabled?_:w`${e.notificationsEnabled?w`
         <mateu-notification-bell .app="${e}" .baseUrl="${t.baseUrl??``}"></mateu-notification-bell>`:_}${n.map(n=>w`
         <mateu-app-context-picker .selector="${n}" .app="${e}" .baseUrl="${t.baseUrl??``}"></mateu-app-context-picker>`)}${r.map(n=>(n.children?.length??0)>0?w`
         <details class="mateu-nav-group" style="margin-left: 0.5rem; flex-shrink: 0;">
             <summary class="app-header-action-btn">${n.label} ▾</summary>
             <div class="mateu-nav-panel" style="right: 0; left: auto;">
                 ${n.children.map(n=>w`
-                    <button class="mateu-nav-item" @click="${()=>n.actionId&&Ns(e,t,n.actionId)}">${n.label}</button>`)}
+                    <button class="mateu-nav-item" @click="${()=>n.actionId&&Is(e,t,n.actionId)}">${n.label}</button>`)}
             </div>
         </details>`:w`
         <button class="app-header-action-btn" style="margin-left: 0.5rem; flex-shrink: 0;"
-            @click="${()=>n.actionId&&Ns(e,t,n.actionId)}" title="${n.label}">${n.icon?F(n.icon):_}${n.label}</button>`)}`},Fs=(e,t)=>w`
+            @click="${()=>n.actionId&&Is(e,t,n.actionId)}" title="${n.label}">${n.icon?F(n.icon):_}${n.label}</button>`)}`},Rs=(e,t)=>w`
     <button class="mateu-nav-item ${e.selected?`mateu-nav-item--active`:``}"
             ?disabled="${e.disabled}"
-            @click="${()=>t(e)}">${e.text}</button>`,Is=(e,t,n=``)=>w`
+            @click="${()=>t(e)}">${e.text}</button>`,zs=(e,t,n=``)=>w`
     <nav class="mateu-nav ${n}">
         ${e.map(e=>(e.children?.length??0)>0?w`<details class="mateu-nav-group">
                        <summary class="mateu-nav-item">${e.text} ▾</summary>
                        <div class="mateu-nav-panel">
-                           ${e.children.map(e=>Fs(e,t))}
+                           ${e.children.map(e=>Rs(e,t))}
                        </div>
-                   </details>`:Fs(e,t))}
-    </nav>`,Ls=(e,t)=>n=>t.call(e,{detail:{value:n}}),Rs=(e,t)=>e.themeToggle?w`
+                   </details>`:Rs(e,t))}
+    </nav>`,Bs=(e,t)=>n=>t.call(e,{detail:{value:n}}),Vs=(e,t)=>e.themeToggle?w`
         <button class="app-chrome-icon-btn" @click="${t.toggleTheme}"
             title="${t.isDark?`Switch to light mode`:`Switch to dark mode`}"
             style="margin-left: 0.5rem; margin-right: 0.5rem; flex-shrink: 0;">
             ${F(t.isDark?`vaadin:sun-o`:`vaadin:moon`,`color: var(--lumo-body-text-color);`)}
         </button>
-    `:_,zs=(e,t)=>{t.filter!=e.detail.value&&(t.filter=e.detail.value)},Bs=(e,t,n)=>{let r=Vs(e,t,n),i=Z(t,n);return r==`list`||r==i?`new`:r},Vs=(e,t,n)=>{let r=e?._route;if(r!=null&&(r===``||r.startsWith(`/`))){let e=n.homeRoute??``,i=e.indexOf(`?`),a=i>=0?e.substring(i+1):``,o=Z(t,n)+r;return a?o+(o.indexOf(`?`)>=0?`&`:`?`)+a:o}return t.selectedRoute?t.selectedRoute:n.homeRoute},Z=(e,t)=>e.selectedRoute?e.selectedConsumedRoute??t.route:t.homeConsumedRoute,Hs=(e,t)=>e.selectedRoute?e.selectedBaseUrl??e.baseUrl:t.homeBaseUrl,Us=(e,t)=>e.selectedRoute?e.selectedServerSideType??t.serverSideType:t.homeServerSideType,Ws=(e,t)=>e.selectedRoute?e.selectedUriPrefix:t.homeUriPrefix,Gs=(e,t,n,r,i,a,o)=>{if(t.chromeless)return w`
+    `:_,Hs=(e,t)=>{t.filter!=e.detail.value&&(t.filter=e.detail.value)},Us=(e,t,n)=>{let r=Ws(e,t,n),i=X(t,n);return r==`list`||r==i?`new`:r},Ws=(e,t,n)=>{let r=e?._route;if(r!=null&&(r===``||r.startsWith(`/`))){let e=n.homeRoute??``,i=e.indexOf(`?`),a=i>=0?e.substring(i+1):``,o=X(t,n)+r;return a?o+(o.indexOf(`?`)>=0?`&`:`?`)+a:o}return t.selectedRoute?t.selectedRoute:n.homeRoute},X=(e,t)=>e.selectedRoute?e.selectedConsumedRoute??t.route:t.homeConsumedRoute,Gs=(e,t)=>e.selectedRoute?e.selectedBaseUrl??e.baseUrl:t.homeBaseUrl,Ks=(e,t)=>e.selectedRoute?e.selectedServerSideType??t.serverSideType:t.homeServerSideType,qs=(e,t)=>e.selectedRoute?e.selectedUriPrefix:t.homeUriPrefix,Js=(e,t,n,r,i,a,o)=>{if(t.chromeless)return w`
             <div class="app chromeless">
                 <div role="main" class="${`app-content`+(e.pageCompact?` no-padding`:``)}" style="height: 100%;">
                     <div class="m-md">
                         <div class="m-scroll" style="height: 100%;">
                             <mateu-api-caller>
                                 <mateu-ux
-                                        route="${Vs(r,e,t)}"
+                                        route="${Ws(r,e,t)}"
                                         id="ux_${e.id}"
-                                        baseUrl="${Hs(e,t)}"
-                                        consumedRoute="${Z(e,t)}"
-                                        serverSideType="${Us(e,t)}"
-                                        uriPrefix="${Ws(e,t)}"
+                                        baseUrl="${Gs(e,t)}"
+                                        consumedRoute="${X(e,t)}"
+                                        serverSideType="${Ks(e,t)}"
+                                        uriPrefix="${qs(e,t)}"
                                         style="width: 100%;"
                                         .appState="${a}"
                                         .appData="${o}"
@@ -7785,7 +7785,7 @@ ${i}
                 </div>
                 <slot></slot>
             </div>
-        `;let s=e.mapItems(t.menu,e.filter?.toLowerCase()??``),c=Z(e,t),l=Bs(r,e,t),u=l&&l!==`new`&&l.startsWith(c+`/`)?l.substring(c.length+1).split(`/`)[0]:void 0;return w`
+        `;let s=e.mapItems(t.menu,e.filter?.toLowerCase()??``),c=X(e,t),l=Us(r,e,t),u=l&&l!==`new`&&l.startsWith(c+`/`)?l.substring(c.length+1).split(`/`)[0]:void 0;return w`
                     ${t.variant==qe.MEDIATOR?w`
 
                         ${t.layout==`SPLIT`?w`
@@ -7793,12 +7793,12 @@ ${i}
                                 <mateu-api-caller>
                                     <div style="display: block; width: calc(100% - 1rem);">
                                     <mateu-ux
-                                            route="${Z(e,t)}"
+                                            route="${X(e,t)}"
                                             id="ux_${e.id}"
-                                            baseUrl="${Hs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Us(e,t)}"
-                                            uriPrefix="${Ws(e,t)}"
+                                            baseUrl="${Gs(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Ks(e,t)}"
+                                            uriPrefix="${qs(e,t)}"
                                             style="width: 100%;"
                                             .appState="${{...a,_splitDetailId:u}}"
                                             .appData="${o}"
@@ -7810,12 +7810,12 @@ ${i}
                                 <mateu-api-caller slot="detail">
                                     <div style="padding-left: 1rem; width: calc(100% - 1rem);">
                                     <mateu-ux
-                                            route="${Bs(r,e,t)}"
+                                            route="${Us(r,e,t)}"
                                             id="ux_${e.id}_detail"
-                                            baseUrl="${Hs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Us(e,t)}"
-                                            uriPrefix="${Ws(e,t)}"
+                                            baseUrl="${Gs(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Ks(e,t)}"
+                                            uriPrefix="${qs(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -7829,12 +7829,12 @@ ${i}
                         `:w`
                             <mateu-api-caller>
                                 <mateu-ux
-                                        route="${Vs(r,e,t)}"
+                                        route="${Ws(r,e,t)}"
                                         id="ux_${e.id}"
-                                        baseUrl="${Hs(e,t)}"
-                                        consumedRoute="${Z(e,t)}"
-                                        serverSideType="${Us(e,t)}"
-                                        uriPrefix="${Ws(e,t)}"
+                                        baseUrl="${Gs(e,t)}"
+                                        consumedRoute="${X(e,t)}"
+                                        serverSideType="${Ks(e,t)}"
+                                        uriPrefix="${qs(e,t)}"
                                         style="width: 100%;"
                                         .appState="${a}"
                                         .appData="${o}"
@@ -7856,7 +7856,7 @@ ${i}
                         <h2 style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; margin: 0 .5rem;">${t.title}</h2><p style="margin: 0;">${t.subtitle}</p>
                         <div class="m-hl" style="margin-left: auto; align-items: center;">
                             <slot name="widgets"></slot>
-                            ${Ps(t,e)}${Rs(t,e)}
+                            ${Ls(t,e)}${Vs(t,e)}
                         </div>
                     </header>
                     <div class="app-body">
@@ -7864,7 +7864,7 @@ ${i}
                             ${t.menu&&t.totalMenuOptions>10?w`
                                 <div style="position: sticky; top: 0; z-index: 2; background: var(--lumo-base-color); padding: .25rem 0 .5rem;">
                                     <input class="drawer-search" placeholder="Search…" style="width: calc(100% - 20px); margin: 0 10px;"
-                                           @input="${t=>zs({detail:{value:t.target.value}},e)}">
+                                           @input="${t=>Hs({detail:{value:t.target.value}},e)}">
                                 </div>
                                 `:_}
                             <nav class="side-nav">
@@ -7876,12 +7876,12 @@ ${i}
                                 <div class="m-scroll" style="height: 100%;">
                                     <mateu-api-caller>
                                         <mateu-ux
-                                                route="${Vs(r,e,t)}"
+                                                route="${Ws(r,e,t)}"
                                                 id="ux_${e.id}"
-                                                baseUrl="${Hs(e,t)}"
-                                                consumedRoute="${Z(e,t)}"
-                                                serverSideType="${Us(e,t)}"
-                                                uriPrefix="${Ws(e,t)}"
+                                                baseUrl="${Gs(e,t)}"
+                                                consumedRoute="${X(e,t)}"
+                                                serverSideType="${Ks(e,t)}"
+                                                uriPrefix="${qs(e,t)}"
                                                 style="width: 100%;"
                                                 .appState="${a}"
                                                 .appData="${o}"
@@ -7910,10 +7910,10 @@ ${i}
                             ${t.title?w`<h2 style="margin: 0 var(--lumo-space-l, 1.5rem) 0 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;">${t.title}</h2>`:_}
                         </div>
                         </a>
-                        ${(()=>{let t=Ls(e,e.itemSelected);return N.get()?.renderTopNav?.(s,t,`menu-on-top`)??Is(s,t,`menu-on-top`)})()}
+                        ${(()=>{let t=Bs(e,e.itemSelected);return N.get()?.renderTopNav?.(s,t,`menu-on-top`)??zs(s,t,`menu-on-top`)})()}
                         <div class="m-hl" style="margin-left: auto; flex-shrink: 0; align-items: center;">
                             <slot name="widgets"></slot>
-                            ${Ps(t,e)}${Rs(t,e)}
+                            ${Ls(t,e)}${Vs(t,e)}
                         </div>
                     </div>
                     <div style="flex: 1; min-height: 0; overflow-y: auto; overflow-x: hidden; box-sizing: border-box; width: 100%;">
@@ -7921,12 +7921,12 @@ ${i}
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${Vs(r,e,t)}"
+                                            route="${Ws(r,e,t)}"
                                             id="ux_${e.id}"
-                                            baseUrl="${Hs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Us(e,t)}"
-                                            uriPrefix="${Ws(e,t)}"
+                                            baseUrl="${Gs(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Ks(e,t)}"
+                                            uriPrefix="${qs(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -7954,10 +7954,10 @@ ${i}
                             ${t.title?w`<h2 style="margin: 0 var(--lumo-space-l, 1.5rem) 0 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;">${t.title}</h2>`:_}
                         </div>
                         </a>
-                        ${Is(e.mapItemsForTiles(t.menu),Ls(e,e.itemSelectedTiles),`menu-on-top`)}
+                        ${zs(e.mapItemsForTiles(t.menu),Bs(e,e.itemSelectedTiles),`menu-on-top`)}
                         <div class="m-hl" style="margin-left: auto; flex-shrink: 0; align-items: center;">
                             <slot name="widgets"></slot>
-                            ${Ps(t,e)}${Rs(t,e)}
+                            ${Ls(t,e)}${Vs(t,e)}
                         </div>
                     </div>
                     <div style="flex: 1; min-height: 0; overflow-y: auto; overflow-x: hidden; box-sizing: border-box; width: 100%;">
@@ -7966,12 +7966,12 @@ ${i}
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${Vs(r,e,t)}"
+                                            route="${Ws(r,e,t)}"
                                             id="ux_${e.id}"
-                                            baseUrl="${Hs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Us(e,t)}"
-                                            uriPrefix="${Ws(e,t)}"
+                                            baseUrl="${Gs(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Ks(e,t)}"
+                                            uriPrefix="${qs(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -7996,12 +7996,12 @@ ${i}
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${Vs(r,e,t)}"
+                                            route="${Ws(r,e,t)}"
                                             id="ux_${e.id}"
-                                            baseUrl="${Hs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Us(e,t)}"
-                                            uriPrefix="${Ws(e,t)}"
+                                            baseUrl="${Gs(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Ks(e,t)}"
+                                            uriPrefix="${qs(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -8023,7 +8023,7 @@ ${i}
                         <div class="m-vl"
                                 @navigation-requested="${e.updateRoute}">
                             ${t.menu.map(t=>e.renderOptionOnLeftMenu(t))}
-                            ${Ps(t,e)}${Rs(t,e)}
+                            ${Ls(t,e)}${Vs(t,e)}
                         </div>
                     </div>
                     <div role="main" class="${`app-content`+(e.pageCompact?` no-padding`:``)}">
@@ -8031,12 +8031,12 @@ ${i}
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${Vs(r,e,t)}"
+                                            route="${Ws(r,e,t)}"
                                             id="ux_${e.id}"
-                                            baseUrl="${Hs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Us(e,t)}"
-                                            uriPrefix="${Ws(e,t)}"
+                                            baseUrl="${Gs(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Ks(e,t)}"
+                                            uriPrefix="${qs(e,t)}"
                                             style="width: 100%; padding: 1em;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -8080,7 +8080,7 @@ ${i}
                             </nav>
                             <div class="m-hl" style="flex-shrink: 0; align-items: center;">
                                 <slot name="widgets"></slot>
-                                ${Ps(t,e)}${Rs(t,e)}
+                                ${Ls(t,e)}${Vs(t,e)}
                             </div>
                         </div>
                     </div>
@@ -8089,12 +8089,12 @@ ${i}
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${Vs(r,e,t)}"
+                                            route="${Ws(r,e,t)}"
                                             id="ux_${e.id}"
-                                            baseUrl="${Hs(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${Us(e,t)}"
-                                            uriPrefix="${Ws(e,t)}"
+                                            baseUrl="${Gs(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${Ks(e,t)}"
+                                            uriPrefix="${qs(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -8124,7 +8124,7 @@ ${i}
             `:_}
             ${e.renderCommandPalette()}
             <slot></slot>
-       `},Ks=(e,t)=>t!=null&&e!=null&&!e.has(t),qs=typeof HTMLElement<`u`?HTMLElement:class{},Js=class extends qs{static get observedAttributes(){return[`type`,`renderer`]}connectedCallback(){this.render()}attributeChangedCallback(){this.render()}render(){let e=this.getAttribute(`type`)??`unknown`,t=this.getAttribute(`renderer`)??`unknown`;this.shadowRoot||this.attachShadow({mode:`open`}),this.shadowRoot.innerHTML=`
+       `},Ys=(e,t)=>t!=null&&e!=null&&!e.has(t),Xs=typeof HTMLElement<`u`?HTMLElement:class{},Zs=class extends Xs{static get observedAttributes(){return[`type`,`renderer`]}connectedCallback(){this.render()}attributeChangedCallback(){this.render()}render(){let e=this.getAttribute(`type`)??`unknown`,t=this.getAttribute(`renderer`)??`unknown`;this.shadowRoot||this.attachShadow({mode:`open`}),this.shadowRoot.innerHTML=`
             <style>
                 :host { display: block; }
                 .mateu-unsupported {
@@ -8143,12 +8143,12 @@ ${i}
             <div class="mateu-unsupported" role="note">
                 ⚠ Component “${e}” is not supported by the “${t}” renderer yet.
             </div>
-        `}};typeof customElements<`u`&&!customElements.get(`mateu-unsupported`)&&customElements.define(`mateu-unsupported`,Js);var Ys=new Set,Xs=(e,t,n)=>{let r=`${n}/${t}`;return Ys.has(r)||(Ys.add(r),console.warn(`[mateu] Component type "${t}" is not supported by the "${n}" renderer — rendering <mateu-unsupported> placeholder.`)),w`<mateu-unsupported
+        `}};typeof customElements<`u`&&!customElements.get(`mateu-unsupported`)&&customElements.define(`mateu-unsupported`,Zs);var Qs=new Set,$s=(e,t,n)=>{let r=`${n}/${t}`;return Qs.has(r)||(Qs.add(r),console.warn(`[mateu] Component type "${t}" is not supported by the "${n}" renderer — rendering <mateu-unsupported> placeholder.`)),w`<mateu-unsupported
             type="${t}"
             renderer="${n}"
             data-component-id="${e?.id??_}"
             slot="${e?.slot??_}"
-    ></mateu-unsupported>`},Zs=class{renderFilterBar(e,t,n,r,i,a,o,s){let c=t?.metadata;return w`
+    ></mateu-unsupported>`},ec=class{renderFilterBar(e,t,n,r,i,a,o,s){let c=t?.metadata;return w`
             <mateu-filter-bar
                 .metadata="${c}"
                 @search-requested="${e.search}"
@@ -8171,14 +8171,14 @@ ${i}
                 data-testid="pagination"
                 .pageNumber="${e.data[t?.id]?.page?.pageNumber??0}"
         ></mateu-pagination>
-        `}renderTableComponent(e,t,n,r,i,a,o){return bn(t,(e.data?.[e.id])?.page?.content??[],r[t?.id]?.emptyStateMessage)}rendererName(){return this.constructor?.name??`unknown`}supportedClientSideTypes(){}renderClientSideComponent(e,t,n,r,i,a,o,s){let c=t?.metadata?.type??t?.type,l=Object.values(A).includes(c)?c:void 0;return Ks(this.supportedClientSideTypes(),l)?Xs(t,l,this.rendererName()):sa(e,t,n,r,i,a,o,s)}renderAppComponent(e,t,n,r,i,a,o){return Gs(e,t?.metadata,n,r,i,a,o)}},Qs=(e,t,n,r,i,a,o)=>w`
+        `}renderTableComponent(e,t,n,r,i,a,o){return Sn(t,(e.data?.[e.id])?.page?.content??[],r[t?.id]?.emptyStateMessage)}rendererName(){return this.constructor?.name??`unknown`}supportedClientSideTypes(){}renderClientSideComponent(e,t,n,r,i,a,o,s){let c=t?.metadata?.type??t?.type,l=Object.values(A).includes(c)?c:void 0;return Ys(this.supportedClientSideTypes(),l)?$s(t,l,this.rendererName()):la(e,t,n,r,i,a,o,s)}renderAppComponent(e,t,n,r,i,a,o){return Js(e,t?.metadata,n,r,i,a,o)}},tc=(e,t,n,r,i,a,o)=>w`
         <vaadin-virtual-list
                 .items="${t.metadata.page.content}"
                 ${ne(t=>w`${P(e,t,n,r,i,a,o)}`,[])}
                 style="${t.style}" class="${t.cssClasses}"
                 slot="${t.slot??_}"
         ></vaadin-virtual-list>
-    `,$s=e=>{let t=e.metadata;return w`
+    `,nc=e=>{let t=e.metadata;return w`
         <vaadin-notification
                 .opened="${!0}"
                 slot="${e.slot??_}"
@@ -8191,7 +8191,7 @@ ${i}
                     </vaadin-horizontal-layout>
                 `,[])}
         ></vaadin-notification>
-    `},ec=(e,t={})=>{let n=e.metadata,r=n.valueKey?t[n.valueKey]:n.value;return w`
+    `},rc=(e,t={})=>{let n=e.metadata,r=n.valueKey?t[n.valueKey]:n.value;return w`
         <div style="${e.style}">
         <vaadin-progress-bar
                 ?indeterminate="${n.indeterminate}"
@@ -8206,7 +8206,7 @@ ${i}
     ${n.text}
   </span>`:_}
         </div>
-    `},tc=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+    `},ic=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <vaadin-details
                 ?opened="${s.opened}"
                 style="${t.style}"
@@ -8218,17 +8218,17 @@ ${i}
             </vaadin-details-summary>
             ${P(e,s.content,n,r,i,a,o)}
         </vaadin-details>
-            `},nc=(e,t,n)=>{let r=e.metadata;return w`<vaadin-avatar
+            `},ac=(e,t,n)=>{let r=e.metadata;return w`<vaadin-avatar
             img="${r.image}"
             name="${M(r.name,t,n)}"
             abbr="${r.abbreviation}"
             style="${e.style}" class="${e.cssClasses}"
             slot="${e.slot??_}"
-    ></vaadin-avatar>`},rc=e=>{let t=e.metadata;return w`<vaadin-avatar-group max-items-visible="${t.maxItemsVisible}"
+    ></vaadin-avatar>`},oc=e=>{let t=e.metadata;return w`<vaadin-avatar-group max-items-visible="${t.maxItemsVisible}"
                                      .items="${t.avatars}"
                                      style="${e.style}" class="${e.cssClasses}"
                                      slot="${e.slot??_}">
-    </vaadin-avatar-group>`},ic=(e,t,n,r,i,a,o)=>{let s=t.metadata;if(!s)return w``;let c=``;return s.variants?.map(e=>e==`stretchMedia`?`stretch-media`:e==`coverMedia`?`cover-media`:e).forEach(e=>c+=` `+e),c=c.trim(),w`
+    </vaadin-avatar-group>`},sc=(e,t,n,r,i,a,o)=>{let s=t.metadata;if(!s)return w``;let c=``;return s.variants?.map(e=>e==`stretchMedia`?`stretch-media`:e==`coverMedia`?`cover-media`:e).forEach(e=>c+=` `+e),c=c.trim(),w`
         <vaadin-card
                 style="${t.style}"
                 class="${t.cssClasses}"
@@ -8244,7 +8244,7 @@ ${i}
             ${s.footer?mt(e,s.footer,n,r,i,a,o,`footer`,!1):_}
             ${s.content?P(e,s.content,n,r,i,a,o,!1):_}
         </vaadin-card>
-    `},ac=e=>e>0&&e<640?`accordion`:`tabs`,oc=class extends y{constructor(...e){super(...e),this.tabLabels=[],this.mode=`tabs`,this.selected=0,this.selectedChangedListener=e=>{let t=e.detail?.value;typeof t==`number`&&t>=0&&(this.selected=t)}}connectedCallback(){super.connectedCallback(),this.resizeObserver=new ResizeObserver(e=>{for(let t of e)this.mode=ac(t.contentRect.width)}),this.resizeObserver.observe(this)}disconnectedCallback(){super.disconnectedCallback(),this.resizeObserver?.disconnect(),this.resizeObserver=void 0,this.detachTabsListener()}detachTabsListener(){this.slottedTabs?.removeEventListener(`selected-changed`,this.selectedChangedListener),this.slottedTabs=void 0}tabsSlotChanged(e){this.detachTabsListener();let t=e.target.assignedElements().find(e=>`selected`in e);t&&(this.slottedTabs=t,t.addEventListener(`selected-changed`,this.selectedChangedListener),t.selected=this.selected)}select(e){this.selected=e,this.slottedTabs&&(this.slottedTabs.selected=e)}updated(){this.slottedTabs&&this.slottedTabs.selected!=this.selected&&(this.slottedTabs.selected=this.selected)}static{this.styles=m`
+    `},cc=e=>e>0&&e<640?`accordion`:`tabs`,lc=class extends y{constructor(...e){super(...e),this.tabLabels=[],this.mode=`tabs`,this.selected=0,this.selectedChangedListener=e=>{let t=e.detail?.value;typeof t==`number`&&t>=0&&(this.selected=t)}}connectedCallback(){super.connectedCallback(),this.resizeObserver=new ResizeObserver(e=>{for(let t of e)this.mode=cc(t.contentRect.width)}),this.resizeObserver.observe(this)}disconnectedCallback(){super.disconnectedCallback(),this.resizeObserver?.disconnect(),this.resizeObserver=void 0,this.detachTabsListener()}detachTabsListener(){this.slottedTabs?.removeEventListener(`selected-changed`,this.selectedChangedListener),this.slottedTabs=void 0}tabsSlotChanged(e){this.detachTabsListener();let t=e.target.assignedElements().find(e=>`selected`in e);t&&(this.slottedTabs=t,t.addEventListener(`selected-changed`,this.selectedChangedListener),t.selected=this.selected)}select(e){this.selected=e,this.slottedTabs&&(this.slottedTabs.selected=e)}updated(){this.slottedTabs&&this.slottedTabs.selected!=this.selected&&(this.slottedTabs.selected=this.selected)}static{this.styles=m`
         :host {
             display: block;
         }
@@ -8328,7 +8328,7 @@ ${i}
                     `)}
                 </div>
             `}
-        `}};O([v({type:Array})],oc.prototype,`tabLabels`,void 0),O([S()],oc.prototype,`mode`,void 0),O([S()],oc.prototype,`selected`,void 0),oc=O([h(`mateu-adaptive-tabs`)],oc);var sc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;c??=``,s.columnSpacing&&(c+=`--vaadin-form-layout-column-spacing: `+s.columnSpacing+`;`);let l=s.itemRowSpacing&&s.itemRowSpacing!==`0`?s.itemRowSpacing:`var(--lumo-space-m)`;return c+=`--vaadin-form-layout-row-spacing: `+l+`;`,s.itemLabelSpacing&&(c+=`--vaadin-form-layout-label-spacing: `+s.itemLabelSpacing+`;`),s.labelsAside&&(c+=`--vaadin-form-item-label-width: 10rem;`),s.fullWidth&&(c+=`width: 100%;`),w`
+        `}};O([v({type:Array})],lc.prototype,`tabLabels`,void 0),O([S()],lc.prototype,`mode`,void 0),O([S()],lc.prototype,`selected`,void 0),lc=O([h(`mateu-adaptive-tabs`)],lc);var uc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;c??=``,s.columnSpacing&&(c+=`--vaadin-form-layout-column-spacing: `+s.columnSpacing+`;`);let l=s.itemRowSpacing&&s.itemRowSpacing!==`0`?s.itemRowSpacing:`var(--lumo-space-m)`;return c+=`--vaadin-form-layout-row-spacing: `+l+`;`,s.itemLabelSpacing&&(c+=`--vaadin-form-layout-label-spacing: `+s.itemLabelSpacing+`;`),s.labelsAside&&(c+=`--vaadin-form-item-label-width: 10rem;`),s.fullWidth&&(c+=`width: 100%;`),w`
                <vaadin-form-layout 
                        .responsiveSteps="${s.responsiveSteps||_}"  
                        style="${c||_}" 
@@ -8341,18 +8341,18 @@ ${i}
                        labels-aside="${s.labelsAside||_}"
                        slot="${t.slot||_}"
                >
-                   ${t.children?.map(t=>cc(s,e,t,n,r,i,a,o))}
+                   ${t.children?.map(t=>dc(s,e,t,n,r,i,a,o))}
                </vaadin-form-layout>
-            `},cc=(e,t,n,r,i,a,o,s)=>n.type==k.ClientSide&&n.metadata?.type==A.FormRow?uc(e,t,n,r,i,a,o,s):e.labelsAside?lc(t,n,r,i,a,o,s):P(t,n,r,i,a,o,s),lc=(e,t,n,r,i,a,o)=>{if(t.type==k.ClientSide&&t.metadata?.type==A.FormField&&t.metadata.label){let s=t.metadata,c=s.label?.includes("${")?e._evalTemplate(s.label):s.label;return w`
+            `},dc=(e,t,n,r,i,a,o,s)=>n.type==k.ClientSide&&n.metadata?.type==A.FormRow?pc(e,t,n,r,i,a,o,s):e.labelsAside?fc(t,n,r,i,a,o,s):P(t,n,r,i,a,o,s),fc=(e,t,n,r,i,a,o)=>{if(t.type==k.ClientSide&&t.metadata?.type==A.FormField&&t.metadata.label){let s=t.metadata,c=s.label?.includes("${")?e._evalTemplate(s.label):s.label;return w`
                        <vaadin-form-item data-colspan="${s.colspan}">
                            <label slot="label">${c}</label>
                            ${P(e,t,n,r,i,a,o,!0)}
                        </vaadin-form-item>
-                   `}return P(e,t,n,r,i,a,o)},uc=(e,t,n,r,i,a,o,s)=>w`
+                   `}return P(e,t,n,r,i,a,o)},pc=(e,t,n,r,i,a,o,s)=>w`
         <vaadin-form-row>
-            ${n.children?.map(n=>cc(e,t,n,r,i,a,o,s))}
+            ${n.children?.map(n=>dc(e,t,n,r,i,a,o,s))}
         </vaadin-form-row>
-            `,dc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=(s.padding?` padding`:``)+(s.spacing?` spacing`:``)+(s.spacingVariant?` spacing-`+s.spacingVariant:``)+(s.wrap?` wrap`:``),l=t.style;return s.fullWidth&&(l=l?`width: 100%;`+l:`width: 100%;`),s.justification&&(l=l?`justify-content: `+s.justification+`;`+l:`justify-content: `+s.justification+`;`),s.verticalAlignment&&(l=l?`align-items: `+s.verticalAlignment+`;`+l:`align-items: `+s.verticalAlignment+`;`),w`
+            `,mc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=(s.padding?` padding`:``)+(s.spacing?` spacing`:``)+(s.spacingVariant?` spacing-`+s.spacingVariant:``)+(s.wrap?` wrap`:``),l=t.style;return s.fullWidth&&(l=l?`width: 100%;`+l:`width: 100%;`),s.justification&&(l=l?`justify-content: `+s.justification+`;`+l:`justify-content: `+s.justification+`;`),s.verticalAlignment&&(l=l?`align-items: `+s.verticalAlignment+`;`+l:`align-items: `+s.verticalAlignment+`;`),w`
                <vaadin-horizontal-layout 
                        style="${l}" 
                        class="${t.cssClasses}"
@@ -8361,7 +8361,7 @@ ${i}
                >
                    ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
                </vaadin-horizontal-layout>
-            `},fc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=(s.padding?` padding`:``)+(s.spacing?` spacing`:``)+(s.spacingVariant?` spacing-`+s.spacingVariant:``)+(s.wrap?` wrap`:``),l=t.style;return s.fullWidth&&(l=l?`width: 100%;`+l:`width: 100%;`),s.justification&&(l=l?`justify-content: `+s.justification+`;`+l:`justify-content: `+s.justification+`;`),s.horizontalAlignment&&(l=l?`align-items: `+s.horizontalAlignment+`;`+l:`align-items: `+s.horizontalAlignment+`;`),w`
+            `},hc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=(s.padding?` padding`:``)+(s.spacing?` spacing`:``)+(s.spacingVariant?` spacing-`+s.spacingVariant:``)+(s.wrap?` wrap`:``),l=t.style;return s.fullWidth&&(l=l?`width: 100%;`+l:`width: 100%;`),s.justification&&(l=l?`justify-content: `+s.justification+`;`+l:`justify-content: `+s.justification+`;`),s.horizontalAlignment&&(l=l?`align-items: `+s.horizontalAlignment+`;`+l:`align-items: `+s.horizontalAlignment+`;`),w`
         <vaadin-vertical-layout
                 style="${l}"
                 class="${t.cssClasses}"
@@ -8370,7 +8370,7 @@ ${i}
         >
             ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </vaadin-vertical-layout>
-    `},pc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;return s.fullWidth&&(c=c?`width: 100%;`+c:`width: 100%;`),w`
+    `},gc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;return s.fullWidth&&(c=c?`width: 100%;`+c:`width: 100%;`),w`
                <vaadin-split-layout 
                        style="${c}" 
                        class="${t.cssClasses}"
@@ -8381,7 +8381,7 @@ ${i}
                    <master-content>${P(e,t.children[0],n,r,i,a,o)}</master-content>
                    <detail-content>${P(e,t.children[1],n,r,i,a,o)}</detail-content>
                </vaadin-split-layout>
-            `},mc=(e,t,n,r,i,a,o)=>{let s=t.children&&t.children.length>1?t.children[1]:null,c=i?.detailComponent??null,l=!!i?.hasDetail||!!s,u=c??s;return w`
+            `},_c=(e,t,n,r,i,a,o)=>{let s=t.children&&t.children.length>1?t.children[1]:null,c=i?.detailComponent??null,l=!!i?.hasDetail||!!s,u=c??s;return w`
                <vaadin-master-detail-layout ?has-detail="${l}"
                                             style="${t.style}"
                                             class="${t.cssClasses}"
@@ -8389,7 +8389,7 @@ ${i}
                    <div>${P(e,t.children[0],n,r,i,a,o)}</div>
                    ${l&&u?w`<div slot="detail">${P(e,u,n,r,i,a,o)}</div>`:w`<div slot="detail" style="display: flex; align-items: center; justify-content: center; height: 100%; color: var(--lumo-secondary-text-color); font-size: var(--lumo-font-size-s);">Select an item to view details</div>`}
                </vaadin-master-detail-layout>
-            `},hc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;c??=``,s.fullWidth&&(c+=`width: 100%;`);let l=s.variant;l==`equalWidth`&&(l=`equal-width-tabs`);let u=Math.max(0,(t.children??[]).findIndex(e=>e.metadata.active)),d=e=>{e.target.selected=u};if(s.adaptable){let u=(t.children??[]).map(t=>{let n=t.metadata.label;return n?.includes("${")?e._evalTemplate(n):n});return w`
+            `},vc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;c??=``,s.fullWidth&&(c+=`width: 100%;`);let l=s.variant;l==`equalWidth`&&(l=`equal-width-tabs`);let u=Math.max(0,(t.children??[]).findIndex(e=>e.metadata.active)),d=e=>{e.target.selected=u};if(s.adaptable){let u=(t.children??[]).map(t=>{let n=t.metadata.label;return n?.includes("${")?e._evalTemplate(n):n});return w`
             <mateu-adaptive-tabs
                     .tabLabels="${u}"
                     style="${c}"
@@ -8434,22 +8434,22 @@ ${i}
                     >${r}</vaadin-tab>`})}
             </vaadin-tabs>
 
-            ${t.children?.map(t=>gc(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>yc(e,t,n,r,i,a,o))}
         </vaadin-tabsheet>
-            `},gc=(e,t,n,r,i,a,o)=>{let s=t.metadata.label;return w`
+            `},yc=(e,t,n,r,i,a,o)=>{let s=t.metadata.label;return w`
         <div tab="${s?.includes("${")?e._evalTemplate(s):s}" style="padding: var(--lumo-space-m) 0;">
                    ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
                </div>
-            `},_c=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;s.fullWidth&&(c=c?`width: 100%;`+c:`width: 100%;`);let l=0;if(t.children){for(let e=0;e<t.children.length;e++)if(t.children[e].metadata?.active){l=e;break}}return w`
+            `},bc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;s.fullWidth&&(c=c?`width: 100%;`+c:`width: 100%;`);let l=0;if(t.children){for(let e=0;e<t.children.length;e++)if(t.children[e].metadata?.active){l=e;break}}return w`
                <vaadin-accordion
                        style="${t.style}"
                        class="${t.cssClasses}"
                        opened="${l}"
                        slot="${t.slot??_}"
                >
-                   ${t.children?.map(t=>vc(e,t,n,r,i,a,o,s.variant))}
+                   ${t.children?.map(t=>xc(e,t,n,r,i,a,o,s.variant))}
                </vaadin-accordion>
-            `},vc=(e,t,n,r,i,a,o,s)=>{let c=t.metadata,l=c.label?.includes("${")?e._evalTemplate(c.label):c.label;return w`
+            `},xc=(e,t,n,r,i,a,o,s)=>{let c=t.metadata,l=c.label?.includes("${")?e._evalTemplate(c.label):c.label;return w`
         <vaadin-accordion-panel style="${t.style}"
                                 class="${t.cssClasses}"
                                 theme="${s??_}"
@@ -8458,48 +8458,48 @@ ${i}
             <vaadin-accordion-heading slot="summary">${l}</vaadin-accordion-heading>
             ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </vaadin-accordion-panel>
-            `},yc=(e,t,n,r,i,a,o)=>w`
+            `},Sc=(e,t,n,r,i,a,o)=>w`
                <vaadin-scroller style="${t.style}" 
                                 class="${t.cssClasses}"
                                 slot="${t.slot??_}">
                    ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
                </vaadin-scroller>
-            `,bc=(e,t,n,r,i,a,o)=>w`
+            `,Cc=(e,t,n,r,i,a,o)=>w`
         <vaadin-board style="${t.style}" 
                       class="${t.cssClasses}"
                       slot="${t.slot??_}">
             ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </vaadin-board>
-            `,xc=(e,t,n,r,i,a,o)=>w`
+            `,wc=(e,t,n,r,i,a,o)=>w`
         <vaadin-board-row style="${t.style}" class="${t.cssClasses}">
                    ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
                </vaadin-board-row>
-            `,Sc=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+            `,Tc=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <div style="${t.style}" 
              class="${t.cssClasses}"
              board-cols="${s.boardCols??_}"
         >
                    ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
                </div>
-            `},Cc=(e,t,n)=>w`
+            `},Ec=(e,t,n)=>w`
     <vaadin-menu-bar
         .items=${e}
         class="${n??_}"
         @item-selected=${e=>t(e.detail.value)}>
-    </vaadin-menu-bar>`,wc=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
-        <vaadin-context-menu .items=${Dc(e,s.menu,n,r,i,a,o)} 
+    </vaadin-menu-bar>`,Dc=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+        <vaadin-context-menu .items=${Ac(e,s.menu,n,r,i,a,o)} 
                              style="${t.style}" 
                              class="${t.cssClasses}"
                              open-on="${s.activateOnLeftClick?`click`:_}"
                              slot="${t.slot??_}">
             ${P(e,s.wrapped,n,r,i,a,o)}
         </vaadin-context-menu>
-            `},Tc=(e,t,n,r,i)=>{let a=t.metadata;return w`
-        <vaadin-menu-bar .items=${Dc(e,a.options,n,r,i,D,de)}
+            `},Oc=(e,t,n,r,i)=>{let a=t.metadata;return w`
+        <vaadin-menu-bar .items=${Ac(e,a.options,n,r,i,D,de)}
                          style="${t.style}" class="${t.cssClasses}"
                          slot="${t.slot??_}">
         </vaadin-menu-bar>
-            `},Ec=(e,t,n,r,i,a,o)=>{let s=document.createElement(`vaadin-context-menu-item`);return ie(P(e,t,n,r,i,a,o),s),s},Dc=(e,t,n,r,i,a,o)=>t.map(t=>t.submenus?{text:t.component?void 0:t.label,route:t.path,checked:t.selected,disabled:t.disabled,className:t.className,component:t.component?Ec(e,t.component,n,r,i,a,o):void 0,children:Dc(e,t.submenus,n,r,i,a,o)}:t.separator?{component:`hr`}:{text:t.component?void 0:t.label,route:t.path,checked:t.selected,disabled:t.disabled,className:t.className,component:t.component?Ec(e,t.component,n,r,i,a,o):void 0}),Oc=class extends y{constructor(...e){super(...e),this.fieldId=``,this.signing=!1,this.hasStrokes=!1,this.drawing=!1,this.startStroke=e=>{let t=e.target;this.ensureCanvasSize(t),t.setPointerCapture(e.pointerId),this.drawing=!0;let n=t.getContext(`2d`);n.lineWidth=2,n.lineCap=`round`,n.lineJoin=`round`,n.strokeStyle=getComputedStyle(this).getPropertyValue(`--lumo-body-text-color`)||`#1a1a1a`;let[r,i]=this.pointerPosition(e);n.beginPath(),n.moveTo(r,i),e.preventDefault()},this.stroke=e=>{if(!this.drawing)return;let t=e.target.getContext(`2d`),[n,r]=this.pointerPosition(e);t.lineTo(n,r),t.stroke(),this.hasStrokes=!0,e.preventDefault()},this.endStroke=e=>{this.drawing=!1,e.target.releasePointerCapture(e.pointerId)}}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}canvas(){return this.renderRoot.querySelector(`canvas`)}pointerPosition(e){let t=e.target.getBoundingClientRect();return[e.clientX-t.left,e.clientY-t.top]}ensureCanvasSize(e){let t=e.getBoundingClientRect();(e.width!==Math.round(t.width)||e.height!==Math.round(t.height))&&(e.width=Math.round(t.width),e.height=Math.round(t.height))}clear(){let e=this.canvas();e&&e.getContext(`2d`).clearRect(0,0,e.width,e.height),this.hasStrokes=!1}accept(){let e=this.canvas();!e||!this.hasStrokes||(this.signing=!1,this.emit(e.toDataURL(`image/png`)))}renderPad(){return w`
+            `},kc=(e,t,n,r,i,a,o)=>{let s=document.createElement(`vaadin-context-menu-item`);return ie(P(e,t,n,r,i,a,o),s),s},Ac=(e,t,n,r,i,a,o)=>t.map(t=>t.submenus?{text:t.component?void 0:t.label,route:t.path,checked:t.selected,disabled:t.disabled,className:t.className,component:t.component?kc(e,t.component,n,r,i,a,o):void 0,children:Ac(e,t.submenus,n,r,i,a,o)}:t.separator?{component:`hr`}:{text:t.component?void 0:t.label,route:t.path,checked:t.selected,disabled:t.disabled,className:t.className,component:t.component?kc(e,t.component,n,r,i,a,o):void 0}),jc=class extends y{constructor(...e){super(...e),this.fieldId=``,this.signing=!1,this.hasStrokes=!1,this.drawing=!1,this.startStroke=e=>{let t=e.target;this.ensureCanvasSize(t),t.setPointerCapture(e.pointerId),this.drawing=!0;let n=t.getContext(`2d`);n.lineWidth=2,n.lineCap=`round`,n.lineJoin=`round`,n.strokeStyle=getComputedStyle(this).getPropertyValue(`--lumo-body-text-color`)||`#1a1a1a`;let[r,i]=this.pointerPosition(e);n.beginPath(),n.moveTo(r,i),e.preventDefault()},this.stroke=e=>{if(!this.drawing)return;let t=e.target.getContext(`2d`),[n,r]=this.pointerPosition(e);t.lineTo(n,r),t.stroke(),this.hasStrokes=!0,e.preventDefault()},this.endStroke=e=>{this.drawing=!1,e.target.releasePointerCapture(e.pointerId)}}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}canvas(){return this.renderRoot.querySelector(`canvas`)}pointerPosition(e){let t=e.target.getBoundingClientRect();return[e.clientX-t.left,e.clientY-t.top]}ensureCanvasSize(e){let t=e.getBoundingClientRect();(e.width!==Math.round(t.width)||e.height!==Math.round(t.height))&&(e.width=Math.round(t.width),e.height=Math.round(t.height))}clear(){let e=this.canvas();e&&e.getContext(`2d`).clearRect(0,0,e.width,e.height),this.hasStrokes=!1}accept(){let e=this.canvas();!e||!this.hasStrokes||(this.signing=!1,this.emit(e.toDataURL(`image/png`)))}renderPad(){return w`
             <canvas class="pad"
                     @pointerdown="${this.startStroke}"
                     @pointermove="${this.stroke}"
@@ -8566,7 +8566,7 @@ ${i}
         .button--danger {
             color: var(--lumo-error-text-color, rgb(179, 49, 31));
         }
-    `}};O([v()],Oc.prototype,`fieldId`,void 0),O([v()],Oc.prototype,`value`,void 0),O([S()],Oc.prototype,`signing`,void 0),O([S()],Oc.prototype,`hasStrokes`,void 0),Oc=O([h(`mateu-signature-pad`)],Oc);var kc=class extends y{constructor(...e){super(...e),this.fieldId=``,this.options=[],this.leavesOnly=!1,this.opened=!1,this.expandedItems=[],this._normalized=[],this.dataProvider=(e,t)=>{let n=e.parentItem?e.parentItem.children??[]:this.normalized;t(n,n.length)}}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}get normalized(){return this._optsSource!==this.options&&(this._optsSource=this.options,this._normalized=this.normalizeOptions(this.options??[])),this._normalized}normalizeOptions(e){return e.map(e=>{let t=e.children&&e.children.length?this.normalizeOptions(e.children):void 0;return{...e,children:t}})}ancestorsOf(e,t){for(let n of t){if(String(n.value)===e)return[];let t=n.children?this.ancestorsOf(e,n.children):null;if(t!=null)return[n,...t]}return null}labelOf(e,t){for(let n of t){if(String(n.value)===e)return n.label;let t=n.children?this.labelOf(e,n.children):null;if(t!=null)return t}return null}open(){this.opened||(this.expandedItems=this.value==null?[]:this.ancestorsOf(String(this.value),this.normalized)??[],this.opened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.close()},document.addEventListener(`mousedown`,this.outsideClick))}close(){this.detachOutsideClick(),this.opened=!1}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}pick(e){this.close(),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e.value,fieldId:this.fieldId},bubbles:!0,composed:!0}))}clear(){this.close(),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:void 0,fieldId:this.fieldId},bubbles:!0,composed:!0}))}onActiveItemChanged(e){let t=e.detail.value;if(t){if((t.children?.length??0)>0&&this.leavesOnly){this.expandedItems=this.expandedItems.includes(t)?this.expandedItems.filter(e=>e!==t):[...this.expandedItems,t],e.target.activeItem=null;return}this.pick(t)}}render(){let e=this.value!=null&&this.value!==``?this.labelOf(String(this.value),this.normalized)??String(this.value):``;return w`
+    `}};O([v()],jc.prototype,`fieldId`,void 0),O([v()],jc.prototype,`value`,void 0),O([S()],jc.prototype,`signing`,void 0),O([S()],jc.prototype,`hasStrokes`,void 0),jc=O([h(`mateu-signature-pad`)],jc);var Mc=class extends y{constructor(...e){super(...e),this.fieldId=``,this.options=[],this.leavesOnly=!1,this.opened=!1,this.expandedItems=[],this._normalized=[],this.dataProvider=(e,t)=>{let n=e.parentItem?e.parentItem.children??[]:this.normalized;t(n,n.length)}}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}get normalized(){return this._optsSource!==this.options&&(this._optsSource=this.options,this._normalized=this.normalizeOptions(this.options??[])),this._normalized}normalizeOptions(e){return e.map(e=>{let t=e.children&&e.children.length?this.normalizeOptions(e.children):void 0;return{...e,children:t}})}ancestorsOf(e,t){for(let n of t){if(String(n.value)===e)return[];let t=n.children?this.ancestorsOf(e,n.children):null;if(t!=null)return[n,...t]}return null}labelOf(e,t){for(let n of t){if(String(n.value)===e)return n.label;let t=n.children?this.labelOf(e,n.children):null;if(t!=null)return t}return null}open(){this.opened||(this.expandedItems=this.value==null?[]:this.ancestorsOf(String(this.value),this.normalized)??[],this.opened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.close()},document.addEventListener(`mousedown`,this.outsideClick))}close(){this.detachOutsideClick(),this.opened=!1}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}pick(e){this.close(),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e.value,fieldId:this.fieldId},bubbles:!0,composed:!0}))}clear(){this.close(),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:void 0,fieldId:this.fieldId},bubbles:!0,composed:!0}))}onActiveItemChanged(e){let t=e.detail.value;if(t){if((t.children?.length??0)>0&&this.leavesOnly){this.expandedItems=this.expandedItems.includes(t)?this.expandedItems.filter(e=>e!==t):[...this.expandedItems,t],e.target.activeItem=null;return}this.pick(t)}}render(){let e=this.value!=null&&this.value!==``?this.labelOf(String(this.value),this.normalized)??String(this.value):``;return w`
             <div class="root">
                 <vaadin-button class="control" theme="tertiary"
                                @click="${()=>this.opened?this.close():this.open()}">
@@ -8637,7 +8637,7 @@ ${i}
             min-width: 16rem;
             max-height: 18rem;
         }
-    `}};O([v()],kc.prototype,`fieldId`,void 0),O([v()],kc.prototype,`value`,void 0),O([v()],kc.prototype,`options`,void 0),O([v({type:Boolean})],kc.prototype,`leavesOnly`,void 0),O([S()],kc.prototype,`opened`,void 0),O([S()],kc.prototype,`expandedItems`,void 0),kc=O([h(`mateu-vaadin-tree-select`)],kc);var Ac=class extends y{constructor(...e){super(...e),this.fieldId=``,this.cameraOpen=!1,this.cameraError=!1,this.fileFallback=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>this.emit(r.result),r.readAsDataURL(n),t.value=``}}disconnectedCallback(){super.disconnectedCallback(),this.stopStream()}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}stopStream(){this.stream?.getTracks().forEach(e=>e.stop()),this.stream=void 0}async openCamera(){this.cameraError=!1;try{this.stream=await navigator.mediaDevices.getUserMedia({video:{facingMode:`environment`},audio:!1}),this.cameraOpen=!0,await this.updateComplete;let e=this.renderRoot.querySelector(`video`);e&&(e.srcObject=this.stream,await e.play())}catch{this.stopStream(),this.cameraOpen=!1,this.cameraError=!0}}closeCamera(){this.stopStream(),this.cameraOpen=!1}shoot(){let e=this.renderRoot.querySelector(`video`);if(!e||e.videoWidth===0)return;let t=document.createElement(`canvas`);t.width=e.videoWidth,t.height=e.videoHeight,t.getContext(`2d`).drawImage(e,0,0),this.closeCamera(),this.emit(t.toDataURL(`image/jpeg`,.9))}triggerFallback(){this.renderRoot.querySelector(`input[type=file]`)?.click()}render(){let e=this.value!=null&&this.value!==``;return w`
+    `}};O([v()],Mc.prototype,`fieldId`,void 0),O([v()],Mc.prototype,`value`,void 0),O([v()],Mc.prototype,`options`,void 0),O([v({type:Boolean})],Mc.prototype,`leavesOnly`,void 0),O([S()],Mc.prototype,`opened`,void 0),O([S()],Mc.prototype,`expandedItems`,void 0),Mc=O([h(`mateu-vaadin-tree-select`)],Mc);var Nc=class extends y{constructor(...e){super(...e),this.fieldId=``,this.cameraOpen=!1,this.cameraError=!1,this.fileFallback=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>this.emit(r.result),r.readAsDataURL(n),t.value=``}}disconnectedCallback(){super.disconnectedCallback(),this.stopStream()}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}stopStream(){this.stream?.getTracks().forEach(e=>e.stop()),this.stream=void 0}async openCamera(){this.cameraError=!1;try{this.stream=await navigator.mediaDevices.getUserMedia({video:{facingMode:`environment`},audio:!1}),this.cameraOpen=!0,await this.updateComplete;let e=this.renderRoot.querySelector(`video`);e&&(e.srcObject=this.stream,await e.play())}catch{this.stopStream(),this.cameraOpen=!1,this.cameraError=!0}}closeCamera(){this.stopStream(),this.cameraOpen=!1}shoot(){let e=this.renderRoot.querySelector(`video`);if(!e||e.videoWidth===0)return;let t=document.createElement(`canvas`);t.width=e.videoWidth,t.height=e.videoHeight,t.getContext(`2d`).drawImage(e,0,0),this.closeCamera(),this.emit(t.toDataURL(`image/jpeg`,.9))}triggerFallback(){this.renderRoot.querySelector(`input[type=file]`)?.click()}render(){let e=this.value!=null&&this.value!==``;return w`
             <input type="file" accept="image/*" capture="environment" style="display: none;"
                    @change="${this.fileFallback}">
             ${this.cameraOpen?w`
@@ -8715,7 +8715,7 @@ ${i}
             font-size: var(--lumo-font-size-xs, 0.75rem);
             color: var(--lumo-secondary-text-color, rgba(0, 0, 0, 0.6));
         }
-    `}};O([v()],Ac.prototype,`fieldId`,void 0),O([v()],Ac.prototype,`value`,void 0),O([S()],Ac.prototype,`cameraOpen`,void 0),O([S()],Ac.prototype,`cameraError`,void 0),Ac=O([h(`mateu-camera-capture`)],Ac);var jc,Mc=(e,t)=>{if(!e)return;if(Array.isArray(e)){let n=e.find(e=>e.key==t);return n?.value==null?void 0:String(n.value)}let n=e[t];return n==null?void 0:String(n)},Nc=class extends y{static{jc=this}constructor(...e){super(...e),this.fieldId=``,this.editable=!0,this.filePicked=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>{let e=r.result,t=e.indexOf(`,`),i=e.substring(0,t).replace(`;base64`,`;name=${encodeURIComponent(n.name)};base64`);this.emit(i+e.substring(t))},r.readAsDataURL(n),t.value=``}}static fileName(e){if(!e)return``;if(e.startsWith(`data:`)){let t=e.indexOf(`,`),n=e.substring(5,t<0?e.length:t).split(`;`).find(e=>e.startsWith(`name=`));if(n)try{return decodeURIComponent(n.substring(5))}catch{return n.substring(5)}return`Attached file`}return e.split(`/`).pop()||e}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}triggerPick(){this.renderRoot.querySelector(`input[type=file]`)?.click()}render(){let e=this.value!=null&&this.value!==``,t=jc.fileName(this.value),n=e&&this.value.startsWith(`data:`),r=e?w`<span class="file" title="${t}">📄 ${n?w`<a href="${this.value}" download="${t}">${t}</a>`:w`<a href="${this.value}" target="_blank">${t}</a>`}</span>`:_;return this.editable?w`
+    `}};O([v()],Nc.prototype,`fieldId`,void 0),O([v()],Nc.prototype,`value`,void 0),O([S()],Nc.prototype,`cameraOpen`,void 0),O([S()],Nc.prototype,`cameraError`,void 0),Nc=O([h(`mateu-camera-capture`)],Nc);var Pc,Fc=(e,t)=>{if(!e)return;if(Array.isArray(e)){let n=e.find(e=>e.key==t);return n?.value==null?void 0:String(n.value)}let n=e[t];return n==null?void 0:String(n)},Ic=class extends y{static{Pc=this}constructor(...e){super(...e),this.fieldId=``,this.editable=!0,this.filePicked=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>{let e=r.result,t=e.indexOf(`,`),i=e.substring(0,t).replace(`;base64`,`;name=${encodeURIComponent(n.name)};base64`);this.emit(i+e.substring(t))},r.readAsDataURL(n),t.value=``}}static fileName(e){if(!e)return``;if(e.startsWith(`data:`)){let t=e.indexOf(`,`),n=e.substring(5,t<0?e.length:t).split(`;`).find(e=>e.startsWith(`name=`));if(n)try{return decodeURIComponent(n.substring(5))}catch{return n.substring(5)}return`Attached file`}return e.split(`/`).pop()||e}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}triggerPick(){this.renderRoot.querySelector(`input[type=file]`)?.click()}render(){let e=this.value!=null&&this.value!==``,t=Pc.fileName(this.value),n=e&&this.value.startsWith(`data:`),r=e?w`<span class="file" title="${t}">📄 ${n?w`<a href="${this.value}" download="${t}">${t}</a>`:w`<a href="${this.value}" target="_blank">${t}</a>`}</span>`:_;return this.editable?w`
             <input type="file" accept="${this.accept||_}" style="display: none;"
                    @change="${this.filePicked}">
             <div class="row">
@@ -8763,28 +8763,28 @@ ${i}
         .button--danger {
             color: var(--lumo-error-text-color, rgb(179, 49, 31));
         }
-    `}};O([v()],Nc.prototype,`fieldId`,void 0),O([v()],Nc.prototype,`value`,void 0),O([v()],Nc.prototype,`accept`,void 0),O([v({type:Boolean})],Nc.prototype,`editable`,void 0),Nc=jc=O([h(`mateu-file-upload`)],Nc);var Pc=e=>!!e&&typeof e==`object`&&`__mateuGroup`in e,Fc=e=>String(e??``),Ic=(e,t,n)=>{let r=e??[];if(!t||!n||n.length===0)return r;let i=[],a,o=!1;return r.forEach((e,s)=>{let c=Fc(e?.[t]);if(!o||c!==a){let e=n.find(e=>Fc(e.value)===c)??{value:c,count:r.filter(e=>Fc(e?.[t])===c).length,aggregates:{}};i.push({__mateuGroup:e,__mateuGroupBy:t,_rowNumber:`__mateuGroup:${s}:${c}`}),o=!0,a=c}i.push(e)}),i},Lc=(e,t)=>e==null?``:t.dataType===`money`||t.stereotype===`money`?new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e):t.aggregate===`count`?new Intl.NumberFormat(void 0,{maximumFractionDigits:0}).format(Math.round(e)):new Intl.NumberFormat(void 0,{maximumFractionDigits:2}).format(e),Rc=(e,t)=>e&&t.includes(e)?e:t.find(e=>!!e),zc=(e,t,n)=>{let r=e.__mateuGroup;return t.id===n?`${r.value} (${r.count})`:t.aggregate?Lc(r.aggregates?.[t.id],t):``},Bc=(e,t,n)=>{let r=t?.aggregates;if(!r||!e.some(e=>e.aggregate))return;let i={};e.forEach(e=>{e.aggregate&&r[e.id]!=null&&(i[e.id]=Lc(r[e.id],e))});let a=e[0];if(a&&i[a.id]===void 0){let e=t?.page?.totalElements;i[a.id]=n&&a.id===n&&e!=null?`Total (${e})`:`Total`}return i},Vc=(e,t,n)=>F(e[n.path]?`vaadin:check`:`vaadin:minus`,`height: 16px; width: 16px; color: var(--lumo-body-text-color);`),Hc=(e,t,n,r,i)=>{let a=e[n.path],o=a;return r==`money`&&a&&a.locale&&a.currency?o=new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(a.value):i==`money`&&(o=new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(a)),w`${o}`},Uc=(e,t,n)=>{e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:n},bubbles:!0,composed:!0}))},Wc=(e,t,n,r,i,a)=>{let o=n.xcolumn??a;if(o.text)return o.actionId?w`<a href="javascript: void(0);" @click="${t=>Uc(n,o,e)}">${o.text}</a>`:w`<a href="${e[n.path]}">${o.text}</a>`;if(r==`string`){if(o.actionId)return w`<a href="javascript: void(0);" @click="${t=>Uc(n,o,e)}">${e[n.path]}</a>`;let t=e[n.path];return w`<a href="${t}">${t}</a>`}let s=e[n.path];return w`<a href="${s.href}">${s.text}</a>`},Gc=(e,t,n,r,i)=>{let a=e[n.path];return r==`string`?a.split(`,`).map(e=>F(e,`width: 16px;`)):a.split(`,`).map(e=>F(e.icon,`width: 16px;`))},Kc=(e,t,n,r,i)=>{let a=e[n.path];return w`${g(a)}`},qc=(e,t,n,r,i,a)=>r==`string`?w`<img src="${e[n.path]}" style="${`max-height: 40px; `+(a.style??``)}">`:w`<img src="${e[n.path].src}" style="${a.style??``}">`,Jc=e=>{let t={_clickedRow:e.target.row};e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+e.detail.value.methodNameInCrud,parameters:t},bubbles:!0,composed:!0}))},Yc=e=>{let t={_clickedRow:e.target.row},n=e.target.action;e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+n.methodNameInCrud,parameters:t},bubbles:!0,composed:!0}))},Xc=e=>{let t=document.createElement(`vaadin-context-menu-item`),n=document.createElement(`vaadin-icon`);return n.style.color=`var(--lumo-secondary-text-color)`,n.style.marginInlineEnd=`var(--lumo-space-s)`,n.style.padding=`var(--lumo-space-xs)`,n.setAttribute(`icon`,e.icon),t.appendChild(n),e.label&&t.appendChild(document.createTextNode(e.label)),t.disabled=e.disabled,t},Zc=(e,t,n)=>{let r=e[n.path]?.actions?.map(e=>e.icon?{component:Xc(e),methodNameInCrud:e.methodNameInCrud}:{...e,text:e.label});return!r||r.length==0?w``:w`
+    `}};O([v()],Ic.prototype,`fieldId`,void 0),O([v()],Ic.prototype,`value`,void 0),O([v()],Ic.prototype,`accept`,void 0),O([v({type:Boolean})],Ic.prototype,`editable`,void 0),Ic=Pc=O([h(`mateu-file-upload`)],Ic);var Lc=e=>!!e&&typeof e==`object`&&`__mateuGroup`in e,Rc=e=>String(e??``),zc=(e,t,n)=>{let r=e??[];if(!t||!n||n.length===0)return r;let i=[],a,o=!1;return r.forEach((e,s)=>{let c=Rc(e?.[t]);if(!o||c!==a){let e=n.find(e=>Rc(e.value)===c)??{value:c,count:r.filter(e=>Rc(e?.[t])===c).length,aggregates:{}};i.push({__mateuGroup:e,__mateuGroupBy:t,_rowNumber:`__mateuGroup:${s}:${c}`}),o=!0,a=c}i.push(e)}),i},Bc=(e,t)=>e==null?``:t.dataType===`money`||t.stereotype===`money`?new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e):t.aggregate===`count`?new Intl.NumberFormat(void 0,{maximumFractionDigits:0}).format(Math.round(e)):new Intl.NumberFormat(void 0,{maximumFractionDigits:2}).format(e),Vc=(e,t)=>e&&t.includes(e)?e:t.find(e=>!!e),Hc=(e,t,n)=>{let r=e.__mateuGroup;return t.id===n?`${r.value} (${r.count})`:t.aggregate?Bc(r.aggregates?.[t.id],t):``},Uc=(e,t,n)=>{let r=t?.aggregates;if(!r||!e.some(e=>e.aggregate))return;let i={};e.forEach(e=>{e.aggregate&&r[e.id]!=null&&(i[e.id]=Bc(r[e.id],e))});let a=e[0];if(a&&i[a.id]===void 0){let e=t?.page?.totalElements;i[a.id]=n&&a.id===n&&e!=null?`Total (${e})`:`Total`}return i},Wc=(e,t,n)=>F(e[n.path]?`vaadin:check`:`vaadin:minus`,`height: 16px; width: 16px; color: var(--lumo-body-text-color);`),Gc=(e,t,n,r,i)=>{let a=e[n.path],o=a;return r==`money`&&a&&a.locale&&a.currency?o=new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(a.value):i==`money`&&(o=new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(a)),w`${o}`},Kc=(e,t,n)=>{e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:n},bubbles:!0,composed:!0}))},qc=(e,t,n,r,i,a)=>{let o=n.xcolumn??a;if(o.text)return o.actionId?w`<a href="javascript: void(0);" @click="${t=>Kc(n,o,e)}">${o.text}</a>`:w`<a href="${e[n.path]}">${o.text}</a>`;if(r==`string`){if(o.actionId)return w`<a href="javascript: void(0);" @click="${t=>Kc(n,o,e)}">${e[n.path]}</a>`;let t=e[n.path];return w`<a href="${t}">${t}</a>`}let s=e[n.path];return w`<a href="${s.href}">${s.text}</a>`},Jc=(e,t,n,r,i)=>{let a=e[n.path];return r==`string`?a.split(`,`).map(e=>F(e,`width: 16px;`)):a.split(`,`).map(e=>F(e.icon,`width: 16px;`))},Yc=(e,t,n,r,i)=>{let a=e[n.path];return w`${g(a)}`},Xc=(e,t,n,r,i,a)=>r==`string`?w`<img src="${e[n.path]}" style="${`max-height: 40px; `+(a.style??``)}">`:w`<img src="${e[n.path].src}" style="${a.style??``}">`,Zc=e=>{let t={_clickedRow:e.target.row};e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+e.detail.value.methodNameInCrud,parameters:t},bubbles:!0,composed:!0}))},Qc=e=>{let t={_clickedRow:e.target.row},n=e.target.action;e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+n.methodNameInCrud,parameters:t},bubbles:!0,composed:!0}))},$c=e=>{let t=document.createElement(`vaadin-context-menu-item`),n=document.createElement(`vaadin-icon`);return n.style.color=`var(--lumo-secondary-text-color)`,n.style.marginInlineEnd=`var(--lumo-space-s)`,n.style.padding=`var(--lumo-space-xs)`,n.setAttribute(`icon`,e.icon),t.appendChild(n),e.label&&t.appendChild(document.createTextNode(e.label)),t.disabled=e.disabled,t},el=(e,t,n)=>{let r=e[n.path]?.actions?.map(e=>e.icon?{component:$c(e),methodNameInCrud:e.methodNameInCrud}:{...e,text:e.label});return!r||r.length==0?w``:w`
                                      <vaadin-menu-bar
                                          .items=${[{text:`···`,children:r}]}
                                          theme="tertiary"
                                          .row="${e}"
                                          data-testid="menubar-${n.path}"
-                                         @item-selected="${Jc}"
+                                         @item-selected="${Zc}"
                                      ></vaadin-menu-bar>
-                                   `},Qc=(e,t,n)=>{if(n.path==`select`)return w`
-         <vaadin-button theme="tertiary" title="Select" @click="${Yc}" .row="${e}" .action="${{actionId:n.path,icon:``,label:`Select`,disabled:!1,methodNameInCrud:`select`}}">
+                                   `},tl=(e,t,n)=>{if(n.path==`select`)return w`
+         <vaadin-button theme="tertiary" title="Select" @click="${Qc}" .row="${e}" .action="${{actionId:n.path,icon:``,label:`Select`,disabled:!1,methodNameInCrud:`select`}}">
              Select
          </vaadin-button>
     `;let r=n.path&&e[n.path]?.methodNameInCrud?e[n.path]:e.action;return r?w`
-         <vaadin-button theme="tertiary${r.icon&&!r.label?` icon`:``}" title="${r.label||_}" @click="${Yc}" .row="${e}" .action="${r}">
+         <vaadin-button theme="tertiary${r.icon&&!r.label?` icon`:``}" title="${r.label||_}" @click="${Qc}" .row="${e}" .action="${r}">
              ${r.icon?w`<vaadin-icon icon="${r.icon}"></vaadin-icon>`:_}
              ${r.label?r.label:_}
          </vaadin-button>
-    `:w``},$c=(e,t,n)=>{e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:n},bubbles:!0,composed:!0}))},el=(e,t,n,r,i,a)=>{let o=n.xcolumn??a;if(o.actionId)return w`
-            <vaadin-button theme="tertiary" @click="${t=>$c(n,o,e)}" .row="${e}">
+    `:w``},nl=(e,t,n)=>{e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:n},bubbles:!0,composed:!0}))},rl=(e,t,n,r,i,a)=>{let o=n.xcolumn??a;if(o.actionId)return w`
+            <vaadin-button theme="tertiary" @click="${t=>nl(n,o,e)}" .row="${e}">
                 ${o.text||e[n.path]}
             </vaadin-button>
-        `;let s=e[n.path];return w`<a href="${s}">${o.text||s}</a>`},tl=(e,t,n,r,i,a,o,s,c)=>{let l=e[n.path];return P(r,l,i,a,o,s,c)},nl=new WeakMap,rl=(e,t)=>nl.get(e)?.[t],il=(e,t,n)=>{let r=nl.get(e);r||(r={},nl.set(e,r)),r[t]=n},al=e=>{if(e==null||e===``)return null;let t=Number(e);return Number.isNaN(t)?null:t},ol=(e,t,n,r)=>{let i=n?.field?.fieldId,a=a=>{if(e[t.id]===a||e[t.id]==null&&(a===``||a==null))return;if(e[t.id]=a,!i){n.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`update-row`,parameters:{_editedRow:{...e}}},bubbles:!0,composed:!0}));return}let o=(n?.state??r)[i];n.dispatchEvent(new CustomEvent(`value-changed`,{detail:{fieldId:i,value:Array.isArray(o)?[...o]:o},bubbles:!0,composed:!0}))},o=e[t.id],s=o==null?``:String(o);switch(t.editorType){case`boolean`:return w`<vaadin-checkbox ?checked=${!!o} @checked-changed=${e=>a(e.detail.value)}></vaadin-checkbox>`;case`integer`:return w`<vaadin-integer-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(al(e.target.value))}></vaadin-integer-field>`;case`number`:return w`<vaadin-number-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(al(e.target.value))}></vaadin-number-field>`;case`date`:return w`<vaadin-date-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-date-picker>`;case`time`:return w`<vaadin-time-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-time-picker>`;case`datetime`:return w`<vaadin-date-time-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-date-time-picker>`;case`select`:return w`<vaadin-combo-box
+        `;let s=e[n.path];return w`<a href="${s}">${o.text||s}</a>`},il=(e,t,n,r,i,a,o,s,c)=>{let l=e[n.path];return P(r,l,i,a,o,s,c)},al=new WeakMap,ol=(e,t)=>al.get(e)?.[t],sl=(e,t,n)=>{let r=al.get(e);r||(r={},al.set(e,r)),r[t]=n},cl=e=>{if(e==null||e===``)return null;let t=Number(e);return Number.isNaN(t)?null:t},ll=(e,t,n,r)=>{let i=n?.field?.fieldId,a=a=>{if(e[t.id]===a||e[t.id]==null&&(a===``||a==null))return;if(e[t.id]=a,!i){n.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`update-row`,parameters:{_editedRow:{...e}}},bubbles:!0,composed:!0}));return}let o=(n?.state??r)[i];n.dispatchEvent(new CustomEvent(`value-changed`,{detail:{fieldId:i,value:Array.isArray(o)?[...o]:o},bubbles:!0,composed:!0}))},o=e[t.id],s=o==null?``:String(o);switch(t.editorType){case`boolean`:return w`<vaadin-checkbox ?checked=${!!o} @checked-changed=${e=>a(e.detail.value)}></vaadin-checkbox>`;case`integer`:return w`<vaadin-integer-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(cl(e.target.value))}></vaadin-integer-field>`;case`number`:return w`<vaadin-number-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(cl(e.target.value))}></vaadin-number-field>`;case`date`:return w`<vaadin-date-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-date-picker>`;case`time`:return w`<vaadin-time-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-time-picker>`;case`datetime`:return w`<vaadin-date-time-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-date-time-picker>`;case`select`:return w`<vaadin-combo-box
                 theme="small" style="width:100%;"
                 .items=${(t.editorOptions??[]).map(e=>({label:e.label,value:String(e.value)}))}
                 item-label-path="label" item-value-path="value"
@@ -8793,12 +8793,12 @@ ${i}
                 theme="small" style="width:100%;"
                 item-label-path="label" item-id-path="value"
                 .dataProvider=${(e,t)=>{n.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:i,parameters:{searchText:e.filter,size:e.pageSize,page:e.page},callback:e=>{let n=e?.fragments?.[0]?.data?.[o];t(n?.content??[],n?.totalElements??0)},callbackonly:!0},bubbles:!0,composed:!0}))}}
-                .selectedItem=${(t.editorOptions??[]).find(e=>String(e.value)===s)??(s?{value:s,label:rl(e,t.id)??s}:void 0)}
-                @selected-item-changed=${n=>{let r=n.detail.value,i=r?r.value:null;String(i??``)!==s&&(r&&il(e,t.id,r.label),a(i))}}></vaadin-combo-box>`}default:return w`<vaadin-text-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(e.target.value)}></vaadin-text-field>`}},sl=e=>ee(()=>w`<span title="${e}" style="white-space:normal;overflow-wrap:break-word;">${e}</span>`,[e]),cl=e=>e===void 0?_:d(()=>w`<span style="font-weight: 600; white-space: nowrap;">${e}</span>`,[e]),ll=e=>{e.preventDefault(),e.stopPropagation(),e.currentTarget?.dispatchEvent(new CustomEvent(`sort-direction-changed`,{detail:{grid:e.currentTarget.parentElement},bubbles:!0,composed:!0}))},ul=(e,t,n,r,i,a,o,s)=>w`
+                .selectedItem=${(t.editorOptions??[]).find(e=>String(e.value)===s)??(s?{value:s,label:ol(e,t.id)??s}:void 0)}
+                @selected-item-changed=${n=>{let r=n.detail.value,i=r?r.value:null;String(i??``)!==s&&(r&&sl(e,t.id,r.label),a(i))}}></vaadin-combo-box>`}default:return w`<vaadin-text-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(e.target.value)}></vaadin-text-field>`}},ul=e=>ee(()=>w`<span title="${e}" style="white-space:normal;overflow-wrap:break-word;">${e}</span>`,[e]),dl=e=>e===void 0?_:d(()=>w`<span style="font-weight: 600; white-space: nowrap;">${e}</span>`,[e]),fl=e=>{e.preventDefault(),e.stopPropagation(),e.currentTarget?.dispatchEvent(new CustomEvent(`sort-direction-changed`,{detail:{grid:e.currentTarget.parentElement},bubbles:!0,composed:!0}))},pl=(e,t,n,r,i,a,o,s)=>w`
 <vaadin-grid-column-group header="${j(e.label,r,i)}">
-    ${e.columns.map(e=>fl(e.metadata,t,n,r,i,a,o,s?.[e.metadata?.id]))}
+    ${e.columns.map(e=>hl(e.metadata,t,n,r,i,a,o,s?.[e.metadata?.id]))}
 </vaadin-grid-column-group>
-`,dl=(e,t,n,r,i,a,o,s)=>A.GridGroupColumn==e.metadata?.type?ul(e.metadata,t,n,r,i,a,o,s):fl(e.metadata,t,n,r,i,a,o,s?.[e.metadata?.id]),fl=(e,n,r,i,a,o,s,c)=>{let l=j(e.label,i,a);return e.sortable?w`
+`,ml=(e,t,n,r,i,a,o,s)=>A.GridGroupColumn==e.metadata?.type?pl(e.metadata,t,n,r,i,a,o,s):hl(e.metadata,t,n,r,i,a,o,s?.[e.metadata?.id]),hl=(e,n,r,i,a,o,s,c)=>{let l=j(e.label,i,a);return e.sortable?w`
                         <vaadin-grid-sort-column
                                 path="${e.id}"
                                 text-align="${e.align??_}"
@@ -8808,12 +8808,12 @@ ${i}
                                 flex-grow="${e.flexGrow??_}"
                                 ?resizable="${e.resizable}"
                                 width="${e.width??_}"
-                                @direction-changed="${ll}"
+                                @direction-changed="${fl}"
                                 data-data-type="${e.dataType}"
                                 data-stereotype="${e.stereotype}"
-                                ${sl(l)}
-                                ${cl(c)}
-                                ${t((t,c,l)=>pl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
+                                ${ul(l)}
+                                ${dl(c)}
+                                ${t((t,c,l)=>gl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
                         ></vaadin-grid-sort-column>
                     `:e.filterable?w`
                         <vaadin-grid-filter-column
@@ -8827,9 +8827,9 @@ ${i}
                                 width="${e.width??_}"
                                 data-data-type="${e.dataType}"
                                 data-stereotype="${e.stereotype}"
-                                ${sl(l)}
-                                ${cl(c)}
-                                ${t((t,c,l)=>pl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
+                                ${ul(l)}
+                                ${dl(c)}
+                                ${t((t,c,l)=>gl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
                         ></vaadin-grid-filter-column>
                     `:w`
                         <vaadin-grid-column
@@ -8844,17 +8844,17 @@ ${i}
                                 data-data-type="${e.dataType}"
                                 data-stereotype="${e.stereotype}"
                                 .xcolumn="${e}"
-                                ${sl(l)}
-                                ${cl(c)}
-                                ${t((t,c,l)=>pl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
+                                ${ul(l)}
+                                ${dl(c)}
+                                ${t((t,c,l)=>gl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
                         ></vaadin-grid-column>
-                    `},pl=(e,t,n,r,i,a,o,s,c,l)=>{let u=n.dataset.dataType??``,d=n.dataset.stereotype??``;if(Pc(e)){let t=i?.metadata,n=(t?.columns??[]).flatMap(e=>e?.metadata?.type===A.GridGroupColumn?(e.metadata.columns??[]).map(e=>e?.metadata?.id):[e?.metadata?.id]),a=zc(e,r,Rc(e.__mateuGroupBy,n)),o=e.__mateuGroup.hiddenActions??[],s=r.id===n[n.length-1]?(t?.groupActions??[]).filter(e=>!o.includes(e.actionId??e.id)):[];return s.length?w`<span style="display: flex; align-items: center; justify-content: flex-end; gap: var(--lumo-space-s); overflow: hidden;">
+                    `},gl=(e,t,n,r,i,a,o,s,c,l)=>{let u=n.dataset.dataType??``,d=n.dataset.stereotype??``;if(Lc(e)){let t=i?.metadata,n=(t?.columns??[]).flatMap(e=>e?.metadata?.type===A.GridGroupColumn?(e.metadata.columns??[]).map(e=>e?.metadata?.id):[e?.metadata?.id]),a=Hc(e,r,Vc(e.__mateuGroupBy,n)),o=e.__mateuGroup.hiddenActions??[],s=r.id===n[n.length-1]?(t?.groupActions??[]).filter(e=>!o.includes(e.actionId??e.id)):[];return s.length?w`<span style="display: flex; align-items: center; justify-content: flex-end; gap: var(--lumo-space-s); overflow: hidden;">
                 ${a?w`<span style="font-weight: 600;">${a}</span>`:_}
                 ${s.map(t=>w`
                     <vaadin-button theme="tertiary small" style="flex-shrink: 0;"
                         @click="${n=>{n.stopPropagation(),n.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+(t.actionId??t.id),parameters:{_groupValue:e.__mateuGroup.value}},bubbles:!0,composed:!0}))}}">${t.label??t.caption??``}</vaadin-button>
                 `)}
-            </span>`:w`<span title="${a}" style="font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block;">${a}</span>`}if(r.editable)return ol(e,r,i,o);if(u==`status`)return la(e,t,n);if(u==`bool`)return Vc(e,t,n);if(u==`money`||d==`money`)return Hc(e,t,n,u,d);if(u==`link`||d==`link`)return Wc(e,t,n,u,d,r);if(u==`icon`||d==`icon`)return Gc(e,t,n,u,d);if(d==`html`)return Kc(e,t,n,u,d);if(d==`image`)return qc(e,t,n,u,d,r);if(u==`menu`)return Zc(e,t,n);if(u==`component`)return tl(e,t,n,i,a,o,s,c,l);if(u==`action`)return Qc(e,t,n);if(u==`actionGroup`)return Zc(e,t,n);if(d==`button`||r.actionId)return el(e,t,n,u,d,r);let f=e[n.path];return w`<span title="${f}" style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block;">${f}</span>`},ml=()=>{let e=document.activeElement;for(;e?.shadowRoot?.activeElement;)e=e.shadowRoot.activeElement;return e},hl=(e,t)=>{let n=t;for(;n;){if(n===e)return!0;n=n.assignedSlot??n.parentNode??n.host??null}return!1},gl=class extends et{constructor(...e){super(...e),this.state={},this.data={},this.appState={},this.appData={},this.detailsOpenedItems=[],this.hoveredItem=null,this.onGridHoverMove=e=>{let t=e.currentTarget,n=t.getEventContext(e)?.item??null;n!==this.hoveredItem&&(this.hoveredItem=n,t.generateCellPartNames())},this.onGridHoverLeave=e=>{this.hoveredItem!==null&&(this.hoveredItem=null,e.currentTarget.generateCellPartNames())},this.hoverCellPartNameGenerator=(e,t)=>t?.item!=null&&t.item===this.hoveredItem?`hovered-cell`:``,this._onRowKey=e=>{let t=this.field?.rowSelectionShortcut;if(!t||!this.field?.onItemSelectionActionId||!this._isRowShortcutRelevant()||!In(t,e))return;let n=/^(?:Digit|Numpad)([1-9])$/.exec(e.code);if(!n)return;let r=this.currentItems(),i=parseInt(n[1],10)-1;i>=r.length||(e.preventDefault(),this.selectRow(r[i]))},this.handleButtonClick=e=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))}}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._onRowKey)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`keydown`,this._onRowKey)}currentItems(){return this.field?.remoteCoordinates?this.data?.[this.id]?.content??[]:this.field?.fieldId&&this.state?this.state[this.field.fieldId]??[]:[]}selectRow(e){!e||!this.field?.onItemSelectionActionId||(this.selectedItems=[e],this.state[this.id+`_selected_items`]=[e],this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.field.onItemSelectionActionId,parameters:{_clickedRow:e}},bubbles:!0,composed:!0})))}_isRowShortcutRelevant(){if(this.offsetParent===null&&this.getClientRects().length===0)return!1;let e=ml();if(e&&e!==document.body&&!hl(this,e)){let t=e.tagName?.toLowerCase()??``;if(e.isContentEditable||/^(input|textarea|select)$/.test(t)||t.startsWith(`vaadin-`)&&/(field|combo|picker|area|select)/.test(t))return!1}return!0}handleItemToggle(e){let{item:t,selected:n,shiftKey:r}=e.detail;if(this.rangeStartItem??=t,r){let e=[];this.field?.fieldId&&this.state&&this.state[this.field.fieldId]&&(e=this.state[this.field.fieldId]);let[r,i]=[this.rangeStartItem,t].map(t=>e.indexOf(t)).sort((e,t)=>e-t),a=e.slice(r,i+1),o=new Set(this.selectedItems);a.forEach(e=>{n?o.add(e):o.delete(e)}),this.selectedItems=[...o],this.state[this.id+`_selected_items`]=this.selectedItems}this.rangeStartItem=t}render(){let e=[];this.field?.fieldId&&this.state&&this.state[this.field.fieldId]&&(e=this.state[this.field.fieldId]);let t=this.state[this.field?.fieldId+`_show_detail`]||this.state._show_detail&&this.state._show_detail[this.field.fieldId];if(this.field?.remoteCoordinates){let t=this.field.remoteCoordinates;this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements?e=this.data[this.id].content:this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}if(Array.isArray(e)&&e.forEach((e,t)=>{e&&typeof e==`object`&&e._rowNumber===void 0&&(e._rowNumber=t)}),this.field?.inlineEditing)return this.renderMaster(e);if(this.field?.formPosition&&this.field?.formPosition.startsWith(`modal`)){let n=this;return w`
+            </span>`:w`<span title="${a}" style="font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block;">${a}</span>`}if(r.editable)return ll(e,r,i,o);if(u==`status`)return da(e,t,n);if(u==`bool`)return Wc(e,t,n);if(u==`money`||d==`money`)return Gc(e,t,n,u,d);if(u==`link`||d==`link`)return qc(e,t,n,u,d,r);if(u==`icon`||d==`icon`)return Jc(e,t,n,u,d);if(d==`html`)return Yc(e,t,n,u,d);if(d==`image`)return Xc(e,t,n,u,d,r);if(u==`menu`)return el(e,t,n);if(u==`component`)return il(e,t,n,i,a,o,s,c,l);if(u==`action`)return tl(e,t,n);if(u==`actionGroup`)return el(e,t,n);if(d==`button`||r.actionId)return rl(e,t,n,u,d,r);let f=e[n.path];return w`<span title="${f}" style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block;">${f}</span>`},_l=()=>{let e=document.activeElement;for(;e?.shadowRoot?.activeElement;)e=e.shadowRoot.activeElement;return e},vl=(e,t)=>{let n=t;for(;n;){if(n===e)return!0;n=n.assignedSlot??n.parentNode??n.host??null}return!1},yl=class extends et{constructor(...e){super(...e),this.state={},this.data={},this.appState={},this.appData={},this.detailsOpenedItems=[],this.hoveredItem=null,this.onGridHoverMove=e=>{let t=e.currentTarget,n=t.getEventContext(e)?.item??null;n!==this.hoveredItem&&(this.hoveredItem=n,t.generateCellPartNames())},this.onGridHoverLeave=e=>{this.hoveredItem!==null&&(this.hoveredItem=null,e.currentTarget.generateCellPartNames())},this.hoverCellPartNameGenerator=(e,t)=>t?.item!=null&&t.item===this.hoveredItem?`hovered-cell`:``,this._onRowKey=e=>{let t=this.field?.rowSelectionShortcut;if(!t||!this.field?.onItemSelectionActionId||!this._isRowShortcutRelevant()||!Rn(t,e))return;let n=/^(?:Digit|Numpad)([1-9])$/.exec(e.code);if(!n)return;let r=this.currentItems(),i=parseInt(n[1],10)-1;i>=r.length||(e.preventDefault(),this.selectRow(r[i]))},this.handleButtonClick=e=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))}}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._onRowKey)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`keydown`,this._onRowKey)}currentItems(){return this.field?.remoteCoordinates?this.data?.[this.id]?.content??[]:this.field?.fieldId&&this.state?this.state[this.field.fieldId]??[]:[]}selectRow(e){!e||!this.field?.onItemSelectionActionId||(this.selectedItems=[e],this.state[this.id+`_selected_items`]=[e],this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.field.onItemSelectionActionId,parameters:{_clickedRow:e}},bubbles:!0,composed:!0})))}_isRowShortcutRelevant(){if(this.offsetParent===null&&this.getClientRects().length===0)return!1;let e=_l();if(e&&e!==document.body&&!vl(this,e)){let t=e.tagName?.toLowerCase()??``;if(e.isContentEditable||/^(input|textarea|select)$/.test(t)||t.startsWith(`vaadin-`)&&/(field|combo|picker|area|select)/.test(t))return!1}return!0}handleItemToggle(e){let{item:t,selected:n,shiftKey:r}=e.detail;if(this.rangeStartItem??=t,r){let e=[];this.field?.fieldId&&this.state&&this.state[this.field.fieldId]&&(e=this.state[this.field.fieldId]);let[r,i]=[this.rangeStartItem,t].map(t=>e.indexOf(t)).sort((e,t)=>e-t),a=e.slice(r,i+1),o=new Set(this.selectedItems);a.forEach(e=>{n?o.add(e):o.delete(e)}),this.selectedItems=[...o],this.state[this.id+`_selected_items`]=this.selectedItems}this.rangeStartItem=t}render(){let e=[];this.field?.fieldId&&this.state&&this.state[this.field.fieldId]&&(e=this.state[this.field.fieldId]);let t=this.state[this.field?.fieldId+`_show_detail`]||this.state._show_detail&&this.state._show_detail[this.field.fieldId];if(this.field?.remoteCoordinates){let t=this.field.remoteCoordinates;this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements?e=this.data[this.id].content:this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}if(Array.isArray(e)&&e.forEach((e,t)=>{e&&typeof e==`object`&&e._rowNumber===void 0&&(e._rowNumber=t)}),this.field?.inlineEditing)return this.renderMaster(e);if(this.field?.formPosition&&this.field?.formPosition.startsWith(`modal`)){let n=this;return w`
 
                 ${this.renderMaster(e)}
 
@@ -8909,7 +8909,7 @@ ${i}
                 ${this.field?.readOnly||this.field?.inlineEditing?_:w`
                     <vaadin-grid-selection-column drag-select></vaadin-grid-selection-column>
                 `}
-                ${this.field?.columns?.map(e=>dl(e,this,this.baseUrl,this.state,this.data,this.appState,this.appData))}
+                ${this.field?.columns?.map(e=>ml(e,this,this.baseUrl,this.state,this.data,this.appState,this.appData))}
 
                 ${this.field?.inlineEditing&&!this.field?.readOnly?w`
                     <vaadin-grid-column width="3.5rem" flex-grow="0" frozen-to-end
@@ -8966,7 +8966,7 @@ ${i}
             background-color: var(--lumo-primary-color-10pct);
             cursor: pointer;
         }
-    `}};O([v()],gl.prototype,`field`,void 0),O([v()],gl.prototype,`state`,void 0),O([v()],gl.prototype,`data`,void 0),O([v()],gl.prototype,`appState`,void 0),O([v()],gl.prototype,`appData`,void 0),O([v()],gl.prototype,`selectedItems`,void 0),O([S()],gl.prototype,`detailsOpenedItems`,void 0),gl=O([h(`mateu-grid`)],gl);var _l=class extends y{constructor(...e){super(...e),this.getNewValue=e=>{if(this.field?.dataType==`array`){if(!this.value)return[e];let t=this.value;return t.indexOf(e)>=0?t.filter(t=>t!==e):[...t,e]}return e}}render(){let e=this.field?.options;if(this.field?.remoteCoordinates){let t=this.field.remoteCoordinates;this.data?.[this.field.fieldId]&&this.data[this.field.fieldId].content&&this.data[this.field.fieldId].totalElements?e=this.data[this.field.fieldId].content:this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}return w`
+    `}};O([v()],yl.prototype,`field`,void 0),O([v()],yl.prototype,`state`,void 0),O([v()],yl.prototype,`data`,void 0),O([v()],yl.prototype,`appState`,void 0),O([v()],yl.prototype,`appData`,void 0),O([v()],yl.prototype,`selectedItems`,void 0),O([S()],yl.prototype,`detailsOpenedItems`,void 0),yl=O([h(`mateu-grid`)],yl);var bl=class extends y{constructor(...e){super(...e),this.getNewValue=e=>{if(this.field?.dataType==`array`){if(!this.value)return[e];let t=this.value;return t.indexOf(e)>=0?t.filter(t=>t!==e):[...t,e]}return e}}render(){let e=this.field?.options;if(this.field?.remoteCoordinates){let t=this.field.remoteCoordinates;this.data?.[this.field.fieldId]&&this.data[this.field.fieldId].content&&this.data[this.field.fieldId].totalElements?e=this.data[this.field.fieldId].content:this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}return w`
         <div style="display: flex; gap: 1rem; padding: 1rem; flex-wrap: wrap; ${this.field?.attributes?.divStyle}">
                                     ${e?.map(e=>w`
                             <div role="button" tabindex="0" 
@@ -9014,7 +9014,7 @@ ${i}
         }
   
         ${R}
-    `}};O([v()],_l.prototype,`field`,void 0),O([v()],_l.prototype,`baseUrl`,void 0),O([v()],_l.prototype,`state`,void 0),O([v()],_l.prototype,`data`,void 0),O([v()],_l.prototype,`value`,void 0),_l=O([h(`mateu-choice`)],_l);var vl=class extends y{constructor(...e){super(...e),this.currencyChanged=e=>{this.value||={value:0,currency:`EUR`,locale:`es-ES`},this.value.currency=e.detail.value,this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:{...this.value},fieldId:this.fieldId}}))},this.valueChanged=e=>{this.value||={value:0,currency:`EUR`,locale:`es-ES`},e.detail.value&&(this.value.value=e.detail.value?parseFloat(e.detail.value):0,this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:{...this.value},fieldId:this.fieldId}})))}}render(){return w`
+    `}};O([v()],bl.prototype,`field`,void 0),O([v()],bl.prototype,`baseUrl`,void 0),O([v()],bl.prototype,`state`,void 0),O([v()],bl.prototype,`data`,void 0),O([v()],bl.prototype,`value`,void 0),bl=O([h(`mateu-choice`)],bl);var xl=class extends y{constructor(...e){super(...e),this.currencyChanged=e=>{this.value||={value:0,currency:`EUR`,locale:`es-ES`},this.value.currency=e.detail.value,this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:{...this.value},fieldId:this.fieldId}}))},this.valueChanged=e=>{this.value||={value:0,currency:`EUR`,locale:`es-ES`},e.detail.value&&(this.value.value=e.detail.value?parseFloat(e.detail.value):0,this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:{...this.value},fieldId:this.fieldId}})))}}render(){return w`
             <vaadin-number-field
                     id="${this.fieldId}"
                     label="${this.label}"
@@ -9034,7 +9034,7 @@ ${i}
                     theme="small"
             ></vaadin-select></div></vaadin-number-field>
        `}static{this.styles=m`
-  `}};O([v()],vl.prototype,`fieldId`,void 0),O([v()],vl.prototype,`label`,void 0),O([v()],vl.prototype,`state`,void 0),O([v()],vl.prototype,`data`,void 0),O([v()],vl.prototype,`value`,void 0),O([v()],vl.prototype,`autoFocus`,void 0),O([v()],vl.prototype,`required`,void 0),O([v()],vl.prototype,`colspan`,void 0),O([v()],vl.prototype,`helperText`,void 0),vl=O([h(`mateu-money-field`)],vl);var yl=`vaadin:abacus.vaadin:absolute-position.vaadin:academy-cap.vaadin:accessibility.vaadin:accordion-menu.vaadin:add-dock.vaadin:adjust.vaadin:adobe-flash.vaadin:airplane.vaadin:alarm.vaadin:align-center.vaadin:align-justify.vaadin:align-left.vaadin:align-right.vaadin:alt-a.vaadin:alt.vaadin:ambulance.vaadin:anchor.vaadin:angle-double-down.vaadin:angle-double-left.vaadin:angle-double-right.vaadin:angle-double-up.vaadin:angle-down.vaadin:angle-left.vaadin:angle-right.vaadin:angle-up.vaadin:archive.vaadin:archives.vaadin:area-select.vaadin:arrow-backward.vaadin:arrow-circle-down-o.vaadin:arrow-circle-down.vaadin:arrow-circle-left-o.vaadin:arrow-circle-left.vaadin:arrow-circle-right-o.vaadin:arrow-circle-right.vaadin:arrow-circle-up-o.vaadin:arrow-circle-up.vaadin:arrow-down.vaadin:arrow-forward.vaadin:arrow-left.vaadin:arrow-long-down.vaadin:arrow-long-left.vaadin:arrow-right.vaadin:arrow-up.vaadin:arrows-cross.vaadin:arrows-long-h.vaadin:arrows-long-right.vaadin:arrows-long-up.vaadin:arrows-long-v.vaadin:arrows.vaadin:asterisk.vaadin:at.vaadin:automation.vaadin:backspace-a.vaadin:backspace.vaadin:backwards.vaadin:ban.vaadin:bar-chart-h.vaadin:bar-chart-v.vaadin:bar-chart.vaadin:barcode.vaadin:bed.vaadin:bell-o.vaadin:bell-slash-o.vaadin:bell-slash.vaadin:bell.vaadin:boat.vaadin:bold.vaadin:bolt.vaadin:bomb.vaadin:book-dollar.vaadin:book-percent.vaadin:book.vaadin:bookmark-o.vaadin:bookmark.vaadin:briefcase.vaadin:browser.vaadin:bug-o.vaadin:bug.vaadin:building-o.vaadin:building.vaadin:bullets.vaadin:bullseye.vaadin:bus.vaadin:buss.vaadin:button.vaadin:calc-book.vaadin:calc.vaadin:calendar-briefcase.vaadin:calendar-clock.vaadin:calendar-envelope.vaadin:calendar-o.vaadin:calendar-user.vaadin:calendar.vaadin:camera.vaadin:car.vaadin:caret-down.vaadin:caret-left.vaadin:caret-right.vaadin:caret-square-down-o.vaadin:caret-square-left-o.vaadin:caret-square-right-o.vaadin:caret-square-up-o.vaadin:caret-up.vaadin:cart-o.vaadin:cart.vaadin:cash.vaadin:chart-3d.vaadin:chart-grid.vaadin:chart-line.vaadin:chart-timeline.vaadin:chart.vaadin:chat.vaadin:check-circle-o.vaadin:check-circle.vaadin:check-square-o.vaadin:check-square.vaadin:check.vaadin:chevron-circle-down-o.vaadin:chevron-circle-down.vaadin:chevron-circle-left-o.vaadin:chevron-circle-left.vaadin:chevron-circle-right-o.vaadin:chevron-circle-right.vaadin:chevron-circle-up-o.vaadin:chevron-circle-up.vaadin:chevron-down-small.vaadin:chevron-down.vaadin:chevron-left-small.vaadin:chevron-left.vaadin:chevron-right-small.vaadin:chevron-right.vaadin:chevron-up-small.vaadin:chevron-up.vaadin:child.vaadin:circle-thin.vaadin:circle.vaadin:clipboard-check.vaadin:clipboard-cross.vaadin:clipboard-heart.vaadin:clipboard-pulse.vaadin:clipboard-text.vaadin:clipboard-user.vaadin:clipboard.vaadin:clock.vaadin:close-big.vaadin:close-circle-o.vaadin:close-circle.vaadin:close-small.vaadin:close.vaadin:cloud-download-o.vaadin:cloud-download.vaadin:cloud-o.vaadin:cloud-upload-o.vaadin:cloud-upload.vaadin:cloud.vaadin:cluster.vaadin:code.vaadin:coffee.vaadin:cog-o.vaadin:cog.vaadin:cogs.vaadin:coin-piles.vaadin:coins.vaadin:combobox.vaadin:comment-ellipsis-o.vaadin:comment-ellipsis.vaadin:comment-o.vaadin:comment.vaadin:comments-o.vaadin:comments.vaadin:compile.vaadin:compress-square.vaadin:compress.vaadin:connect-o.vaadin:connect.vaadin:controller.vaadin:copy-o.vaadin:copy.vaadin:copyright.vaadin:corner-lower-left.vaadin:corner-lower-right.vaadin:corner-upper-left.vaadin:corner-upper-right.vaadin:credit-card.vaadin:crop.vaadin:cross-cutlery.vaadin:crosshairs.vaadin:css.vaadin:ctrl-a.vaadin:ctrl.vaadin:cube.vaadin:cubes.vaadin:curly-brackets.vaadin:cursor-o.vaadin:cursor.vaadin:cutlery.vaadin:dashboard.vaadin:database.vaadin:date-input.vaadin:deindent.vaadin:del-a.vaadin:del.vaadin:dental-chair.vaadin:desktop.vaadin:diamond-o.vaadin:diamond.vaadin:diploma-scroll.vaadin:diploma.vaadin:disc.vaadin:doctor-briefcase.vaadin:doctor.vaadin:dollar.vaadin:dot-circle.vaadin:download-alt.vaadin:download.vaadin:drop.vaadin:edit.vaadin:eject.vaadin:elastic.vaadin:ellipsis-circle-o.vaadin:ellipsis-circle.vaadin:ellipsis-dots-h.vaadin:ellipsis-dots-v.vaadin:ellipsis-h.vaadin:ellipsis-v.vaadin:enter-arrow.vaadin:enter.vaadin:envelope-o.vaadin:envelope-open-o.vaadin:envelope-open.vaadin:envelope.vaadin:envelopes-o.vaadin:envelopes.vaadin:eraser.vaadin:esc-a.vaadin:esc.vaadin:euro.vaadin:exchange.vaadin:exclamation-circle-o.vaadin:exclamation-circle.vaadin:exclamation.vaadin:exit-o.vaadin:exit.vaadin:expand-full.vaadin:expand-square.vaadin:expand.vaadin:external-browser.vaadin:external-link.vaadin:eye-slash.vaadin:eye.vaadin:eyedropper.vaadin:facebook-square.vaadin:facebook.vaadin:factory.vaadin:family.vaadin:fast-backward.vaadin:fast-forward.vaadin:female.vaadin:file-add.vaadin:file-code.vaadin:file-font.vaadin:file-movie.vaadin:file-o.vaadin:file-picture.vaadin:file-presentation.vaadin:file-process.vaadin:file-refresh.vaadin:file-remove.vaadin:file-search.vaadin:file-sound.vaadin:file-start.vaadin:file-table.vaadin:file-text-o.vaadin:file-text.vaadin:file-tree-small.vaadin:file-tree-sub.vaadin:file-tree.vaadin:file-zip.vaadin:file.vaadin:fill.vaadin:film.vaadin:filter.vaadin:fire.vaadin:flag-checkered.vaadin:flag-o.vaadin:flag.vaadin:flash.vaadin:flask.vaadin:flight-landing.vaadin:flight-takeoff.vaadin:flip-h.vaadin:flip-v.vaadin:folder-add.vaadin:folder-o.vaadin:folder-open-o.vaadin:folder-open.vaadin:folder-remove.vaadin:folder-search.vaadin:folder.vaadin:font.vaadin:form.vaadin:forward.vaadin:frown-o.vaadin:funcion.vaadin:function.vaadin:funnel.vaadin:gamepad.vaadin:gavel.vaadin:gift.vaadin:glass.vaadin:glasses.vaadin:globe-wire.vaadin:globe.vaadin:golf.vaadin:google-plus-square.vaadin:google-plus.vaadin:grab.vaadin:grid-bevel.vaadin:grid-big-o.vaadin:grid-big.vaadin:grid-h.vaadin:grid-small-o.vaadin:grid-small.vaadin:grid-v.vaadin:grid.vaadin:group.vaadin:hammer.vaadin:hand.vaadin:handle-corner.vaadin:hands-up.vaadin:handshake.vaadin:harddrive-o.vaadin:harddrive.vaadin:hash.vaadin:header.vaadin:headphones.vaadin:headset.vaadin:health-card.vaadin:heart-o.vaadin:heart.vaadin:home-o.vaadin:home.vaadin:hospital.vaadin:hourglass-empty.vaadin:hourglass-end.vaadin:hourglass-start.vaadin:hourglass.vaadin:inbox.vaadin:indent.vaadin:info-circle-o.vaadin:info-circle.vaadin:info.vaadin:input.vaadin:insert.vaadin:institution.vaadin:invoice.vaadin:italic.vaadin:key-o.vaadin:key.vaadin:keyboard-o.vaadin:keyboard.vaadin:laptop.vaadin:layout.vaadin:level-down-bold.vaadin:level-down.vaadin:level-left-bold.vaadin:level-left.vaadin:level-right-bold.vaadin:level-right.vaadin:level-up-bold.vaadin:level-up.vaadin:lifebuoy.vaadin:lightbulb.vaadin:line-bar-chart.vaadin:line-chart.vaadin:line-h.vaadin:line-v.vaadin:lines-list.vaadin:lines.vaadin:link.vaadin:list-ol.vaadin:list-select.vaadin:list-ul.vaadin:list.vaadin:location-arrow-circle-o.vaadin:location-arrow-circle.vaadin:location-arrow.vaadin:lock.vaadin:magic.vaadin:magnet.vaadin:mailbox.vaadin:male.vaadin:map-marker.vaadin:margin-bottom.vaadin:margin-left.vaadin:margin-right.vaadin:margin-top.vaadin:margin.vaadin:medal.vaadin:megafone.vaadin:megaphone.vaadin:meh-o.vaadin:menu.vaadin:microphone.vaadin:minus-circle-o.vaadin:minus-circle.vaadin:minus-square-o.vaadin:minus.vaadin:mobile-browser.vaadin:mobile-retro.vaadin:mobile.vaadin:modal-list.vaadin:modal.vaadin:money-deposit.vaadin:money-exchange.vaadin:money-withdraw.vaadin:money.vaadin:moon-o.vaadin:moon.vaadin:morning.vaadin:movie.vaadin:music.vaadin:mute.vaadin:native-button.vaadin:newspaper.vaadin:notebook.vaadin:nurse.vaadin:office.vaadin:open-book.vaadin:option-a.vaadin:option.vaadin:options.vaadin:orientation.vaadin:out.vaadin:outbox.vaadin:package.vaadin:padding-bottom.vaadin:padding-left.vaadin:padding-right.vaadin:padding-top.vaadin:padding.vaadin:paint-roll.vaadin:paintbrush.vaadin:palete.vaadin:palette.vaadin:panel.vaadin:paperclip.vaadin:paperplane-o.vaadin:paperplane.vaadin:paragraph.vaadin:password.vaadin:paste.vaadin:pause.vaadin:pencil.vaadin:phone-landline.vaadin:phone.vaadin:picture.vaadin:pie-bar-chart.vaadin:pie-chart.vaadin:piggy-bank-coin.vaadin:piggy-bank.vaadin:pill.vaadin:pills.vaadin:pin-post.vaadin:pin.vaadin:play-circle-o.vaadin:play-circle.vaadin:play.vaadin:plug.vaadin:plus-circle-o.vaadin:plus-circle.vaadin:plus-minus.vaadin:plus-square-o.vaadin:plus.vaadin:pointer.vaadin:power-off.vaadin:presentation.vaadin:print.vaadin:progressbar.vaadin:puzzle-piece.vaadin:pyramid-chart.vaadin:qrcode.vaadin:question-circle-o.vaadin:question-circle.vaadin:question.vaadin:quote-left.vaadin:quote-right.vaadin:random.vaadin:raster-lower-left.vaadin:raster.vaadin:records.vaadin:recycle.vaadin:refresh.vaadin:reply-all.vaadin:reply.vaadin:resize-h.vaadin:resize-v.vaadin:retweet.vaadin:rhombus.vaadin:road-branch.vaadin:road-branches.vaadin:road-split.vaadin:road.vaadin:rocket.vaadin:rotate-left.vaadin:rotate-right.vaadin:rss-square.vaadin:rss.vaadin:safe-lock.vaadin:safe.vaadin:scale-unbalance.vaadin:scale.vaadin:scatter-chart.vaadin:scissors.vaadin:screwdriver.vaadin:search-minus.vaadin:search-plus.vaadin:search.vaadin:select.vaadin:server.vaadin:share-square.vaadin:share.vaadin:shield.vaadin:shift-arrow.vaadin:shift.vaadin:shop.vaadin:sign-in-alt.vaadin:sign-in.vaadin:sign-out-alt.vaadin:sign-out.vaadin:signal.vaadin:sitemap.vaadin:slider.vaadin:sliders.vaadin:smiley-o.vaadin:sort.vaadin:sound-disable.vaadin:spark-line.vaadin:specialist.vaadin:spinner-arc.vaadin:spinner-third.vaadin:spinner.vaadin:spline-area-chart.vaadin:spline-chart.vaadin:split-h.vaadin:split-v.vaadin:split.vaadin:spoon.vaadin:square-shadow.vaadin:star-half-left-o.vaadin:star-half-left.vaadin:star-half-right-o.vaadin:star-half-right.vaadin:star-o.vaadin:star.vaadin:start-cog.vaadin:step-backward.vaadin:step-forward.vaadin:stethoscope.vaadin:stock.vaadin:stop-cog.vaadin:stop.vaadin:stopwatch.vaadin:storage.vaadin:strikethrough.vaadin:subscript.vaadin:suitcase.vaadin:sun-down.vaadin:sun-o.vaadin:sun-rise.vaadin:superscript.vaadin:sword.vaadin:tab-a.vaadin:tab.vaadin:table.vaadin:tablet.vaadin:tabs.vaadin:tag.vaadin:tags.vaadin:tasks.vaadin:taxi.vaadin:teeth.vaadin:terminal.vaadin:text-height.vaadin:text-input.vaadin:text-label.vaadin:text-width.vaadin:thin-square.vaadin:thumbs-down-o.vaadin:thumbs-down.vaadin:thumbs-up-o.vaadin:thumbs-up.vaadin:ticket.vaadin:time-backward.vaadin:time-forward.vaadin:timer.vaadin:toolbox.vaadin:tools.vaadin:tooth.vaadin:touch.vaadin:train.vaadin:trash.vaadin:tree-table.vaadin:trendind-down.vaadin:trending-down.vaadin:trending-up.vaadin:trophy.vaadin:truck.vaadin:twin-col-select.vaadin:twitter-square.vaadin:twitter.vaadin:umbrella.vaadin:underline.vaadin:unlink.vaadin:unlock.vaadin:upload-alt.vaadin:upload.vaadin:user-card.vaadin:user-check.vaadin:user-clock.vaadin:user-heart.vaadin:user-star.vaadin:user.vaadin:users.vaadin:vaadin-h.vaadin:vaadin-v.vaadin:viewport.vaadin:vimeo-square.vaadin:vimeo.vaadin:volume-down.vaadin:volume-off.vaadin:volume-up.vaadin:volume.vaadin:wallet.vaadin:warning.vaadin:workplace.vaadin:wrench.vaadin:youtube-square.vaadin:youtube`.split(`.`),bl=null,xl=()=>(bl||=Promise.all([E(()=>import(`./vendor-ui5.js`).then(e=>e.n),__vite__mapDeps([5,1])),E(()=>import(`./vendor-ui5.js`).then(e=>e.t),__vite__mapDeps([5,1]))]),bl),Q=class extends y{constructor(...e){super(...e),this.ui5FieldComponentsReady=!1,this.component=void 0,this.field=void 0,this.baseUrl=void 0,this.state={},this.data={},this.appState={},this.appData={},this.colorPickerOpened=!1,this.colorPickerValue=void 0,this.comboData=[],this._comboFilter=``,this.rendered=!1,this.renderColorPicker=()=>{this.loadUi5FieldComponents();let e=this.field?.fieldId;return w`
+  `}};O([v()],xl.prototype,`fieldId`,void 0),O([v()],xl.prototype,`label`,void 0),O([v()],xl.prototype,`state`,void 0),O([v()],xl.prototype,`data`,void 0),O([v()],xl.prototype,`value`,void 0),O([v()],xl.prototype,`autoFocus`,void 0),O([v()],xl.prototype,`required`,void 0),O([v()],xl.prototype,`colspan`,void 0),O([v()],xl.prototype,`helperText`,void 0),xl=O([h(`mateu-money-field`)],xl);var Sl=`vaadin:abacus.vaadin:absolute-position.vaadin:academy-cap.vaadin:accessibility.vaadin:accordion-menu.vaadin:add-dock.vaadin:adjust.vaadin:adobe-flash.vaadin:airplane.vaadin:alarm.vaadin:align-center.vaadin:align-justify.vaadin:align-left.vaadin:align-right.vaadin:alt-a.vaadin:alt.vaadin:ambulance.vaadin:anchor.vaadin:angle-double-down.vaadin:angle-double-left.vaadin:angle-double-right.vaadin:angle-double-up.vaadin:angle-down.vaadin:angle-left.vaadin:angle-right.vaadin:angle-up.vaadin:archive.vaadin:archives.vaadin:area-select.vaadin:arrow-backward.vaadin:arrow-circle-down-o.vaadin:arrow-circle-down.vaadin:arrow-circle-left-o.vaadin:arrow-circle-left.vaadin:arrow-circle-right-o.vaadin:arrow-circle-right.vaadin:arrow-circle-up-o.vaadin:arrow-circle-up.vaadin:arrow-down.vaadin:arrow-forward.vaadin:arrow-left.vaadin:arrow-long-down.vaadin:arrow-long-left.vaadin:arrow-right.vaadin:arrow-up.vaadin:arrows-cross.vaadin:arrows-long-h.vaadin:arrows-long-right.vaadin:arrows-long-up.vaadin:arrows-long-v.vaadin:arrows.vaadin:asterisk.vaadin:at.vaadin:automation.vaadin:backspace-a.vaadin:backspace.vaadin:backwards.vaadin:ban.vaadin:bar-chart-h.vaadin:bar-chart-v.vaadin:bar-chart.vaadin:barcode.vaadin:bed.vaadin:bell-o.vaadin:bell-slash-o.vaadin:bell-slash.vaadin:bell.vaadin:boat.vaadin:bold.vaadin:bolt.vaadin:bomb.vaadin:book-dollar.vaadin:book-percent.vaadin:book.vaadin:bookmark-o.vaadin:bookmark.vaadin:briefcase.vaadin:browser.vaadin:bug-o.vaadin:bug.vaadin:building-o.vaadin:building.vaadin:bullets.vaadin:bullseye.vaadin:bus.vaadin:buss.vaadin:button.vaadin:calc-book.vaadin:calc.vaadin:calendar-briefcase.vaadin:calendar-clock.vaadin:calendar-envelope.vaadin:calendar-o.vaadin:calendar-user.vaadin:calendar.vaadin:camera.vaadin:car.vaadin:caret-down.vaadin:caret-left.vaadin:caret-right.vaadin:caret-square-down-o.vaadin:caret-square-left-o.vaadin:caret-square-right-o.vaadin:caret-square-up-o.vaadin:caret-up.vaadin:cart-o.vaadin:cart.vaadin:cash.vaadin:chart-3d.vaadin:chart-grid.vaadin:chart-line.vaadin:chart-timeline.vaadin:chart.vaadin:chat.vaadin:check-circle-o.vaadin:check-circle.vaadin:check-square-o.vaadin:check-square.vaadin:check.vaadin:chevron-circle-down-o.vaadin:chevron-circle-down.vaadin:chevron-circle-left-o.vaadin:chevron-circle-left.vaadin:chevron-circle-right-o.vaadin:chevron-circle-right.vaadin:chevron-circle-up-o.vaadin:chevron-circle-up.vaadin:chevron-down-small.vaadin:chevron-down.vaadin:chevron-left-small.vaadin:chevron-left.vaadin:chevron-right-small.vaadin:chevron-right.vaadin:chevron-up-small.vaadin:chevron-up.vaadin:child.vaadin:circle-thin.vaadin:circle.vaadin:clipboard-check.vaadin:clipboard-cross.vaadin:clipboard-heart.vaadin:clipboard-pulse.vaadin:clipboard-text.vaadin:clipboard-user.vaadin:clipboard.vaadin:clock.vaadin:close-big.vaadin:close-circle-o.vaadin:close-circle.vaadin:close-small.vaadin:close.vaadin:cloud-download-o.vaadin:cloud-download.vaadin:cloud-o.vaadin:cloud-upload-o.vaadin:cloud-upload.vaadin:cloud.vaadin:cluster.vaadin:code.vaadin:coffee.vaadin:cog-o.vaadin:cog.vaadin:cogs.vaadin:coin-piles.vaadin:coins.vaadin:combobox.vaadin:comment-ellipsis-o.vaadin:comment-ellipsis.vaadin:comment-o.vaadin:comment.vaadin:comments-o.vaadin:comments.vaadin:compile.vaadin:compress-square.vaadin:compress.vaadin:connect-o.vaadin:connect.vaadin:controller.vaadin:copy-o.vaadin:copy.vaadin:copyright.vaadin:corner-lower-left.vaadin:corner-lower-right.vaadin:corner-upper-left.vaadin:corner-upper-right.vaadin:credit-card.vaadin:crop.vaadin:cross-cutlery.vaadin:crosshairs.vaadin:css.vaadin:ctrl-a.vaadin:ctrl.vaadin:cube.vaadin:cubes.vaadin:curly-brackets.vaadin:cursor-o.vaadin:cursor.vaadin:cutlery.vaadin:dashboard.vaadin:database.vaadin:date-input.vaadin:deindent.vaadin:del-a.vaadin:del.vaadin:dental-chair.vaadin:desktop.vaadin:diamond-o.vaadin:diamond.vaadin:diploma-scroll.vaadin:diploma.vaadin:disc.vaadin:doctor-briefcase.vaadin:doctor.vaadin:dollar.vaadin:dot-circle.vaadin:download-alt.vaadin:download.vaadin:drop.vaadin:edit.vaadin:eject.vaadin:elastic.vaadin:ellipsis-circle-o.vaadin:ellipsis-circle.vaadin:ellipsis-dots-h.vaadin:ellipsis-dots-v.vaadin:ellipsis-h.vaadin:ellipsis-v.vaadin:enter-arrow.vaadin:enter.vaadin:envelope-o.vaadin:envelope-open-o.vaadin:envelope-open.vaadin:envelope.vaadin:envelopes-o.vaadin:envelopes.vaadin:eraser.vaadin:esc-a.vaadin:esc.vaadin:euro.vaadin:exchange.vaadin:exclamation-circle-o.vaadin:exclamation-circle.vaadin:exclamation.vaadin:exit-o.vaadin:exit.vaadin:expand-full.vaadin:expand-square.vaadin:expand.vaadin:external-browser.vaadin:external-link.vaadin:eye-slash.vaadin:eye.vaadin:eyedropper.vaadin:facebook-square.vaadin:facebook.vaadin:factory.vaadin:family.vaadin:fast-backward.vaadin:fast-forward.vaadin:female.vaadin:file-add.vaadin:file-code.vaadin:file-font.vaadin:file-movie.vaadin:file-o.vaadin:file-picture.vaadin:file-presentation.vaadin:file-process.vaadin:file-refresh.vaadin:file-remove.vaadin:file-search.vaadin:file-sound.vaadin:file-start.vaadin:file-table.vaadin:file-text-o.vaadin:file-text.vaadin:file-tree-small.vaadin:file-tree-sub.vaadin:file-tree.vaadin:file-zip.vaadin:file.vaadin:fill.vaadin:film.vaadin:filter.vaadin:fire.vaadin:flag-checkered.vaadin:flag-o.vaadin:flag.vaadin:flash.vaadin:flask.vaadin:flight-landing.vaadin:flight-takeoff.vaadin:flip-h.vaadin:flip-v.vaadin:folder-add.vaadin:folder-o.vaadin:folder-open-o.vaadin:folder-open.vaadin:folder-remove.vaadin:folder-search.vaadin:folder.vaadin:font.vaadin:form.vaadin:forward.vaadin:frown-o.vaadin:funcion.vaadin:function.vaadin:funnel.vaadin:gamepad.vaadin:gavel.vaadin:gift.vaadin:glass.vaadin:glasses.vaadin:globe-wire.vaadin:globe.vaadin:golf.vaadin:google-plus-square.vaadin:google-plus.vaadin:grab.vaadin:grid-bevel.vaadin:grid-big-o.vaadin:grid-big.vaadin:grid-h.vaadin:grid-small-o.vaadin:grid-small.vaadin:grid-v.vaadin:grid.vaadin:group.vaadin:hammer.vaadin:hand.vaadin:handle-corner.vaadin:hands-up.vaadin:handshake.vaadin:harddrive-o.vaadin:harddrive.vaadin:hash.vaadin:header.vaadin:headphones.vaadin:headset.vaadin:health-card.vaadin:heart-o.vaadin:heart.vaadin:home-o.vaadin:home.vaadin:hospital.vaadin:hourglass-empty.vaadin:hourglass-end.vaadin:hourglass-start.vaadin:hourglass.vaadin:inbox.vaadin:indent.vaadin:info-circle-o.vaadin:info-circle.vaadin:info.vaadin:input.vaadin:insert.vaadin:institution.vaadin:invoice.vaadin:italic.vaadin:key-o.vaadin:key.vaadin:keyboard-o.vaadin:keyboard.vaadin:laptop.vaadin:layout.vaadin:level-down-bold.vaadin:level-down.vaadin:level-left-bold.vaadin:level-left.vaadin:level-right-bold.vaadin:level-right.vaadin:level-up-bold.vaadin:level-up.vaadin:lifebuoy.vaadin:lightbulb.vaadin:line-bar-chart.vaadin:line-chart.vaadin:line-h.vaadin:line-v.vaadin:lines-list.vaadin:lines.vaadin:link.vaadin:list-ol.vaadin:list-select.vaadin:list-ul.vaadin:list.vaadin:location-arrow-circle-o.vaadin:location-arrow-circle.vaadin:location-arrow.vaadin:lock.vaadin:magic.vaadin:magnet.vaadin:mailbox.vaadin:male.vaadin:map-marker.vaadin:margin-bottom.vaadin:margin-left.vaadin:margin-right.vaadin:margin-top.vaadin:margin.vaadin:medal.vaadin:megafone.vaadin:megaphone.vaadin:meh-o.vaadin:menu.vaadin:microphone.vaadin:minus-circle-o.vaadin:minus-circle.vaadin:minus-square-o.vaadin:minus.vaadin:mobile-browser.vaadin:mobile-retro.vaadin:mobile.vaadin:modal-list.vaadin:modal.vaadin:money-deposit.vaadin:money-exchange.vaadin:money-withdraw.vaadin:money.vaadin:moon-o.vaadin:moon.vaadin:morning.vaadin:movie.vaadin:music.vaadin:mute.vaadin:native-button.vaadin:newspaper.vaadin:notebook.vaadin:nurse.vaadin:office.vaadin:open-book.vaadin:option-a.vaadin:option.vaadin:options.vaadin:orientation.vaadin:out.vaadin:outbox.vaadin:package.vaadin:padding-bottom.vaadin:padding-left.vaadin:padding-right.vaadin:padding-top.vaadin:padding.vaadin:paint-roll.vaadin:paintbrush.vaadin:palete.vaadin:palette.vaadin:panel.vaadin:paperclip.vaadin:paperplane-o.vaadin:paperplane.vaadin:paragraph.vaadin:password.vaadin:paste.vaadin:pause.vaadin:pencil.vaadin:phone-landline.vaadin:phone.vaadin:picture.vaadin:pie-bar-chart.vaadin:pie-chart.vaadin:piggy-bank-coin.vaadin:piggy-bank.vaadin:pill.vaadin:pills.vaadin:pin-post.vaadin:pin.vaadin:play-circle-o.vaadin:play-circle.vaadin:play.vaadin:plug.vaadin:plus-circle-o.vaadin:plus-circle.vaadin:plus-minus.vaadin:plus-square-o.vaadin:plus.vaadin:pointer.vaadin:power-off.vaadin:presentation.vaadin:print.vaadin:progressbar.vaadin:puzzle-piece.vaadin:pyramid-chart.vaadin:qrcode.vaadin:question-circle-o.vaadin:question-circle.vaadin:question.vaadin:quote-left.vaadin:quote-right.vaadin:random.vaadin:raster-lower-left.vaadin:raster.vaadin:records.vaadin:recycle.vaadin:refresh.vaadin:reply-all.vaadin:reply.vaadin:resize-h.vaadin:resize-v.vaadin:retweet.vaadin:rhombus.vaadin:road-branch.vaadin:road-branches.vaadin:road-split.vaadin:road.vaadin:rocket.vaadin:rotate-left.vaadin:rotate-right.vaadin:rss-square.vaadin:rss.vaadin:safe-lock.vaadin:safe.vaadin:scale-unbalance.vaadin:scale.vaadin:scatter-chart.vaadin:scissors.vaadin:screwdriver.vaadin:search-minus.vaadin:search-plus.vaadin:search.vaadin:select.vaadin:server.vaadin:share-square.vaadin:share.vaadin:shield.vaadin:shift-arrow.vaadin:shift.vaadin:shop.vaadin:sign-in-alt.vaadin:sign-in.vaadin:sign-out-alt.vaadin:sign-out.vaadin:signal.vaadin:sitemap.vaadin:slider.vaadin:sliders.vaadin:smiley-o.vaadin:sort.vaadin:sound-disable.vaadin:spark-line.vaadin:specialist.vaadin:spinner-arc.vaadin:spinner-third.vaadin:spinner.vaadin:spline-area-chart.vaadin:spline-chart.vaadin:split-h.vaadin:split-v.vaadin:split.vaadin:spoon.vaadin:square-shadow.vaadin:star-half-left-o.vaadin:star-half-left.vaadin:star-half-right-o.vaadin:star-half-right.vaadin:star-o.vaadin:star.vaadin:start-cog.vaadin:step-backward.vaadin:step-forward.vaadin:stethoscope.vaadin:stock.vaadin:stop-cog.vaadin:stop.vaadin:stopwatch.vaadin:storage.vaadin:strikethrough.vaadin:subscript.vaadin:suitcase.vaadin:sun-down.vaadin:sun-o.vaadin:sun-rise.vaadin:superscript.vaadin:sword.vaadin:tab-a.vaadin:tab.vaadin:table.vaadin:tablet.vaadin:tabs.vaadin:tag.vaadin:tags.vaadin:tasks.vaadin:taxi.vaadin:teeth.vaadin:terminal.vaadin:text-height.vaadin:text-input.vaadin:text-label.vaadin:text-width.vaadin:thin-square.vaadin:thumbs-down-o.vaadin:thumbs-down.vaadin:thumbs-up-o.vaadin:thumbs-up.vaadin:ticket.vaadin:time-backward.vaadin:time-forward.vaadin:timer.vaadin:toolbox.vaadin:tools.vaadin:tooth.vaadin:touch.vaadin:train.vaadin:trash.vaadin:tree-table.vaadin:trendind-down.vaadin:trending-down.vaadin:trending-up.vaadin:trophy.vaadin:truck.vaadin:twin-col-select.vaadin:twitter-square.vaadin:twitter.vaadin:umbrella.vaadin:underline.vaadin:unlink.vaadin:unlock.vaadin:upload-alt.vaadin:upload.vaadin:user-card.vaadin:user-check.vaadin:user-clock.vaadin:user-heart.vaadin:user-star.vaadin:user.vaadin:users.vaadin:vaadin-h.vaadin:vaadin-v.vaadin:viewport.vaadin:vimeo-square.vaadin:vimeo.vaadin:volume-down.vaadin:volume-off.vaadin:volume-up.vaadin:volume.vaadin:wallet.vaadin:warning.vaadin:workplace.vaadin:wrench.vaadin:youtube-square.vaadin:youtube`.split(`.`),Cl=null,wl=()=>(Cl||=Promise.all([E(()=>import(`./vendor-ui5.js`).then(e=>e.n),__vite__mapDeps([5,1])),E(()=>import(`./vendor-ui5.js`).then(e=>e.t),__vite__mapDeps([5,1]))]),Cl),Z=class extends y{constructor(...e){super(...e),this.ui5FieldComponentsReady=!1,this.component=void 0,this.field=void 0,this.baseUrl=void 0,this.state={},this.data={},this.appState={},this.appData={},this.colorPickerOpened=!1,this.colorPickerValue=void 0,this.comboData=[],this._comboFilter=``,this.rendered=!1,this.renderColorPicker=()=>{this.loadUi5FieldComponents();let e=this.field?.fieldId;return w`
             <ui5-color-picker value="${this.state&&e in this.state?this.state[e]:this.field?.initialValue}" @change="${e=>this.colorPickerValue=e.target.value}">Picker</ui5-color-picker>
         `},this.saveColor=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.colorPickerValue,fieldId:this.field.fieldId},bubbles:!0,composed:!0})),this.colorPickerOpened=!1},this.renderColorPickerFooter=()=>w`<vaadin-button @click="${()=>this.colorPickerOpened=!1}">Cancel</vaadin-button>
         <vaadin-button theme="primary" @click="${this.saveColor}">Save</vaadin-button>`,this.checked=e=>{let t=e.target;this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t.checked,fieldId:this.field.fieldId},bubbles:!0,composed:!0}))},this.convert=e=>this.field?.dataType==`integer`?parseInt(e):e,this.multiComboBoxValueChanged=e=>{if(this.rendered){let t=this.field?.fieldId,n=this.state&&t in this.state?this.state[t]:this.field?.initialValue,r;e.detail.value&&(r=e.detail.value.map(e=>e.value),r&&r.length>0&&(this.data[this.id]||(this.data[this.id]={}),this.data[this.id].content||(this.data[this.id].content=[]),this.data[this.id]&&this.data[this.id].content&&e.detail.value.forEach(e=>{this.data[this.id].content?.find(t=>e.value==t.value)||this.data[this.id].content.push(e)}))),this.compareArrays(r,n)||this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}},this.valueChanged=e=>{this.rendered&&e.detail.value!==void 0&&e.detail.value!=this.state[this.field.fieldId]&&this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.convert(e.detail.value),fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.selectedItems=e=>{if(e&&e.length>0)if(this.field?.remoteCoordinates){if(this.comboData&&this.comboData.length>0)return this.comboData?.filter(t=>e.indexOf(t.value)>=0);if(this.data[this.id]&&this.data[this.id].content&&this.data[this.id].content.length>0)return this.data[this.id].content.filter(t=>e.indexOf(t.value)>=0)}else return this.field?.options?.filter(t=>e.indexOf(t.value)>=0);return[]},this.selectedIndex=e=>{if(e)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content){let t=this.data[this.id].content.find(t=>t.value==e);if(t)return this.data[this.id].content.indexOf(t)}}else{let t=this.field?.options?.find(t=>t.value==e);if(t)return this.field?.options?.indexOf(t)}},this.selectedIndexes=e=>{if(e&&e.length>0)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content)return this.data[this.id].content.filter(t=>e.indexOf(t.value)>=0).map(e=>this.data[this.id].content.indexOf(e))}else return this.field?.options?.filter(t=>e.indexOf(t.value)>=0).map(e=>this.field?.options?.indexOf(e));return[]},this.compareArrays=(e,t)=>this.falsy(e)&&this.falsy(t)||e&&t&&e.length===t.length&&e.every((e,n)=>e===t[n]),this.falsy=e=>!e||e.length==0,this.listItemsSelected=e=>{let t=this.field?.fieldId,n=this.state&&t in this.state?this.state[t]:this.field?.initialValue,r;this.rendered&&(e.detail.value&&(this.field?.remoteCoordinates?this.data[this.id]&&this.data[this.id].content&&(r=e.detail.value.map(e=>this.data[this.id].content[e].value)):r=e.detail.value.map(e=>this.field.options[e].value)),this.compareArrays(r,n)||this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r,fieldId:this.field?.fieldId},bubbles:!0,composed:!0})))},this.listItemSelected=e=>{let t;if(e.detail.value||e.detail.value==0)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content){let n=this.data[this.id].content[e.detail.value];n&&(t=n.value)}}else{let n=this.field.options[e.detail.value];n&&(t=n.value)}this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.mapPosition=e=>{switch(e){case`topStretch`:return`top-stretch`;case`topStart`:return`top-start`;case`topCenter`:return`top-center`;case`topEnd`:return`top-end`;case`middle`:return`middle`;case`bottomStart`:return`bottom-start`;case`bottomEnd`:return`bottom-end`;case`bottomStretch`:return`bottom-stretch`;case`bottomCenter`:return`bottom-center`}return`bottom-end`},this.helperShownInControl=!1,this.lastAnnouncedError=``,this.controlOwnsValidity=!1,this.fileUploaded=e=>{let t=this.field?.fieldId??``,n=this.state[t];n.push({id:e.detail.xhr.responseText,name:e.detail.file.name}),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:n,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.fileChanged=e=>{let t=this.field?.fieldId??``,n=(e.detail.value??[]).filter(e=>e.id).map(e=>e.id),r=(this.state[t]??[]).map(e=>e.id);if(!this.compareArrays(r,n)){let t=(e.detail.value??[]).filter(e=>e.id).map(e=>({id:e.id,name:e.name}));this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}},this.triggerImageUpload=()=>{(this.renderRoot?.querySelector(`input[type="file"]`))?.click()},this.imageUpload=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r.result,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},r.readAsDataURL(n),t.value=``},this.imageDelete=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:``,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.iconComboboxRenderer=e=>w`
@@ -9075,7 +9075,7 @@ ${i}
 
             </vaadin-horizontal-layout>
                             `:e.label}
-`,this.filteredIcons=[],this.navLinkOffset=null,this.iconFilterChanged=e=>{this.filteredIcons=yl.filter(t=>!e.detail.value||t.indexOf(e.detail.value)>=0)}}loadUi5FieldComponents(){this.ui5FieldComponentsReady||xl().then(()=>{this.ui5FieldComponentsReady=!0})}remoteComboDataProvider(e){return(t,n)=>{let{filter:i,page:a,pageSize:o}=t,s=i??``;this._comboFilter=s,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{searchText:i,fieldId:this.field?.fieldId,size:o,page:a,sort:void 0},callback:e=>{if(s===this._comboFilter)if(e?.messages?.forEach(e=>{r.show(e.text,{position:e.position?this.mapPosition(e.position):void 0,theme:e.variant,duration:e.duration})}),!e.fragments||e.fragments.length==0)this.comboData=[],n([],0);else{let t=e.fragments[0].data?.[this.id];this.comboData=t?.content,n(t?.content,t?.totalElements)}},callbackonly:!0},bubbles:!0,composed:!0}))}}disconnectedCallback(){super.disconnectedCallback(),this.rendered=!1}renderNavLink(){let e=this.field?.link;if(!e?.href)return _;let t=j(e.href,this.state,this.data)??e.href,n=j(e.title,this.state,this.data)||t,r=e.icon||(t.startsWith(`http`)?`vaadin:external-link`:`vaadin:link`),i=this.navLinkOffset??`calc(var(--lumo-font-size-s) * 1.6 + (var(--lumo-size-m) - var(--lumo-icon-size-s)) / 2)`;return w`<a
+`,this.filteredIcons=[],this.navLinkOffset=null,this.iconFilterChanged=e=>{this.filteredIcons=Sl.filter(t=>!e.detail.value||t.indexOf(e.detail.value)>=0)}}loadUi5FieldComponents(){this.ui5FieldComponentsReady||wl().then(()=>{this.ui5FieldComponentsReady=!0})}remoteComboDataProvider(e){return(t,n)=>{let{filter:i,page:a,pageSize:o}=t,s=i??``;this._comboFilter=s,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{searchText:i,fieldId:this.field?.fieldId,size:o,page:a,sort:void 0},callback:e=>{if(s===this._comboFilter)if(e?.messages?.forEach(e=>{r.show(e.text,{position:e.position?this.mapPosition(e.position):void 0,theme:e.variant,duration:e.duration})}),!e.fragments||e.fragments.length==0)this.comboData=[],n([],0);else{let t=e.fragments[0].data?.[this.id];this.comboData=t?.content,n(t?.content,t?.totalElements)}},callbackonly:!0},bubbles:!0,composed:!0}))}}disconnectedCallback(){super.disconnectedCallback(),this.rendered=!1}renderNavLink(){let e=this.field?.link;if(!e?.href)return _;let t=j(e.href,this.state,this.data)??e.href,n=j(e.title,this.state,this.data)||t,r=e.icon||(t.startsWith(`http`)?`vaadin:external-link`:`vaadin:link`),i=this.navLinkOffset??`calc(var(--lumo-font-size-s) * 1.6 + (var(--lumo-size-m) - var(--lumo-icon-size-s)) / 2)`;return w`<a
                 data-navlink
                 href="${t}"
                 title="${n}"
@@ -9089,7 +9089,7 @@ ${i}
             ${i?w`
                 <div role="alert"><ul>${r.map(e=>w`<li>${e}</li>`)}</ul></div>
             `:_}
-        </div>`}async firstUpdated(){this.filteredIcons=yl}update(e){e.has(`component`)&&(this.rendered=!1),super.update(e)}updated(e){super.updated(e),this.positionNavLink(),this.applyValidationState(),this.controlOwnsValidity=!!this.validatableControl()}renderField(){let e=this.field?.fieldId??``,t=this.state&&e in this.state?this.state[e]:this.field?.initialValue,n=j(this.field?.label+``,this.state,this.data),r=this.labelAlreadyRendered||!n||n==`null`?_:n;return this.field?.propertyRow?this.renderPropertyRowField(e,t,r,n):this.field?.stereotype==`badge`?this.renderBadgeField(e,t,r,n):this.field?.stereotype==`plainText`?this.renderPlainTextField(e,t,r,n):this.field?.stereotype==`bulletedList`?this.renderBulletedListField(e,t,r,n):this.field?.readOnly&&this.field.stereotype!=`grid`&&this.field.dataType!=`status`&&this.field?.dataType!=`money`?this.renderReadOnlyField(e,t,r,n):this.field?.dataType==`file`?this.renderFileField(e,t,r,n):this.field?.dataType==`string`?this.renderStringField(e,t,r,n):this.field?.dataType==`number`?this.renderNumberField(e,t,r,n):this.field?.dataType==`integer`?this.renderIntegerField(e,t,r,n):this.field?.dataType==`bool`?this.renderBoolField(e,t,r,n):this.field?.dataType==`dateRange`?this.renderDateRangeField(e,t,r,n):this.field?.dataType==`date`?this.renderDateField(e,t,r,n):this.field?.dataType==`dateTime`?this.renderDateTimeField(e,t,r,n):this.field?.dataType==`time`?this.renderTimeField(e,t,r,n):this.field?.dataType==`array`?this.renderArrayField(e,t,r,n):this.field?.dataType==`money`?this.renderMoneyField(e,t,r,n):this.field?.dataType==`status`?this.renderStatusField(e,t,r,n):this.field?.dataType==`range`?this.renderRangeField(e,t,r,n):w`<p>Unknown field type ${this.field?.dataType} / ${this.field?.stereotype}</p>`}renderBadgeField(e,t,n,r){if(!this.field)return w``;let i=t===!0||t===`true`;return w`<vaadin-custom-field
+        </div>`}async firstUpdated(){this.filteredIcons=Sl}update(e){e.has(`component`)&&(this.rendered=!1),super.update(e)}updated(e){super.updated(e),this.positionNavLink(),this.applyValidationState(),this.controlOwnsValidity=!!this.validatableControl()}renderField(){let e=this.field?.fieldId??``,t=this.state&&e in this.state?this.state[e]:this.field?.initialValue,n=j(this.field?.label+``,this.state,this.data),r=this.labelAlreadyRendered||!n||n==`null`?_:n;return this.field?.propertyRow?this.renderPropertyRowField(e,t,r,n):this.field?.stereotype==`badge`?this.renderBadgeField(e,t,r,n):this.field?.stereotype==`plainText`?this.renderPlainTextField(e,t,r,n):this.field?.stereotype==`bulletedList`?this.renderBulletedListField(e,t,r,n):this.field?.readOnly&&this.field.stereotype!=`grid`&&this.field.dataType!=`status`&&this.field?.dataType!=`money`?this.renderReadOnlyField(e,t,r,n):this.field?.dataType==`file`?this.renderFileField(e,t,r,n):this.field?.dataType==`string`?this.renderStringField(e,t,r,n):this.field?.dataType==`number`?this.renderNumberField(e,t,r,n):this.field?.dataType==`integer`?this.renderIntegerField(e,t,r,n):this.field?.dataType==`bool`?this.renderBoolField(e,t,r,n):this.field?.dataType==`dateRange`?this.renderDateRangeField(e,t,r,n):this.field?.dataType==`date`?this.renderDateField(e,t,r,n):this.field?.dataType==`dateTime`?this.renderDateTimeField(e,t,r,n):this.field?.dataType==`time`?this.renderTimeField(e,t,r,n):this.field?.dataType==`array`?this.renderArrayField(e,t,r,n):this.field?.dataType==`money`?this.renderMoneyField(e,t,r,n):this.field?.dataType==`status`?this.renderStatusField(e,t,r,n):this.field?.dataType==`range`?this.renderRangeField(e,t,r,n):w`<p>Unknown field type ${this.field?.dataType} / ${this.field?.stereotype}</p>`}renderBadgeField(e,t,n,r){if(!this.field)return w``;let i=t===!0||t===`true`;return w`<vaadin-custom-field
                     id="${this.field.fieldId}"
                     .helperText="${this.helperText()}"
                     data-colspan="${this.field?.colspan}"
@@ -9174,7 +9174,7 @@ ${i}
                             <vaadin-button theme="icon" @click="${e=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`codesearch-`+this.field?.fieldId,parameters:{}},bubbles:!0,composed:!0}))}}"><vaadin-icon icon="lumo:search"></vaadin-icon></vaadin-button>
                         </vaadin-horizontal-layout>
                     </vaadin-custom-field>
-                `;if(this.field?.stereotype==`select`){if(this.field?.optionsSource){let e=this.field.optionsSource,r=j(e.url,this.state,this.data)??e.url;this.data[this.id]?.sourceSignature!==r&&(this.data[this.id]={content:this.data[this.id]?.content??[],sourceSignature:r},e.proxy?this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`__restfetch__`,parameters:{_sourceKind:`options`,_sourceId:this.field.fieldId},callback:t=>{let n=t?.appData?._restfetch,i=Wt(n,e.itemsPath,e.valuePath,e.labelPath);this.data[this.id]={content:i,totalElements:i.length,sourceSignature:r},this.requestUpdate()},callbackonly:!0},bubbles:!0,composed:!0})):qt(e,e=>j(e,this.state,this.data)).then(e=>{this.data[this.id]={content:e,totalElements:e.length,sourceSignature:r},this.requestUpdate()}).catch(e=>console.warn(`mateu: external options fetch failed`,e)));let i=t;return t&&t.value&&(i=t.value),w`
+                `;if(this.field?.stereotype==`select`){if(this.field?.optionsSource){let e=this.field.optionsSource,r=j(e.url,this.state,this.data)??e.url;this.data[this.id]?.sourceSignature!==r&&(this.data[this.id]={content:this.data[this.id]?.content??[],sourceSignature:r},e.proxy?this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`__restfetch__`,parameters:{_sourceKind:`options`,_sourceId:this.field.fieldId},callback:t=>{let n=t?.appData?._restfetch,i=Kt(n,e.itemsPath,e.valuePath,e.labelPath);this.data[this.id]={content:i,totalElements:i.length,sourceSignature:r},this.requestUpdate()},callbackonly:!0},bubbles:!0,composed:!0})):Yt(e,e=>j(e,this.state,this.data)).then(e=>{this.data[this.id]={content:e,totalElements:e.length,sourceSignature:r},this.requestUpdate()}).catch(e=>console.warn(`mateu: external options fetch failed`,e)));let i=t;return t&&t.value&&(i=t.value),w`
                     <vaadin-select
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9577,7 +9577,7 @@ ${i}
                     >
                         <mateu-camera-capture .fieldId="${this.field.fieldId}" .value="${t}"></mateu-camera-capture>
                     </vaadin-custom-field>
-                `;if(this.field?.stereotype==`fileUpload`){let e=Mc(this.field.attributes,`accept`);return w`
+                `;if(this.field?.stereotype==`fileUpload`){let e=Fc(this.field.attributes,`accept`);return w`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9929,7 +9929,7 @@ ${i}
                         .helperText="${this.helperText()}"
                         data-colspan="${this.field.colspan}"
                 >
-                    ${i?w`<span theme="badge pill ${ua(i.type)}">${i.message}</span>`:w``}                    
+                    ${i?w`<span theme="badge pill ${fa(i.type)}">${i.message}</span>`:w``}                    
                 </vaadin-custom-field>
             `}renderRangeField(e,t,n,r){if(!this.field)return w``;this.loadUi5FieldComponents();let i=t;return w`
                 <vaadin-custom-field
@@ -10027,7 +10027,7 @@ ${i}
             text-overflow: clip;
             height: auto;
         }
-  `}};O([S()],Q.prototype,`ui5FieldComponentsReady`,void 0),O([v()],Q.prototype,`component`,void 0),O([v()],Q.prototype,`field`,void 0),O([v()],Q.prototype,`baseUrl`,void 0),O([v()],Q.prototype,`state`,void 0),O([v()],Q.prototype,`data`,void 0),O([v()],Q.prototype,`appState`,void 0),O([v()],Q.prototype,`appData`,void 0),O([v()],Q.prototype,`labelAlreadyRendered`,void 0),O([S()],Q.prototype,`colorPickerOpened`,void 0),O([S()],Q.prototype,`colorPickerValue`,void 0),O([S()],Q.prototype,`controlOwnsValidity`,void 0),O([S()],Q.prototype,`filteredIcons`,void 0),O([S()],Q.prototype,`navLinkOffset`,void 0),Q=O([h(`mateu-field`)],Q);var Sl=(e,t,n,r,i,a,o,s)=>{let c=t.metadata;return w`
+  `}};O([S()],Z.prototype,`ui5FieldComponentsReady`,void 0),O([v()],Z.prototype,`component`,void 0),O([v()],Z.prototype,`field`,void 0),O([v()],Z.prototype,`baseUrl`,void 0),O([v()],Z.prototype,`state`,void 0),O([v()],Z.prototype,`data`,void 0),O([v()],Z.prototype,`appState`,void 0),O([v()],Z.prototype,`appData`,void 0),O([v()],Z.prototype,`labelAlreadyRendered`,void 0),O([S()],Z.prototype,`colorPickerOpened`,void 0),O([S()],Z.prototype,`colorPickerValue`,void 0),O([S()],Z.prototype,`controlOwnsValidity`,void 0),O([S()],Z.prototype,`filteredIcons`,void 0),O([S()],Z.prototype,`navLinkOffset`,void 0),Z=O([h(`mateu-field`)],Z);var Tl=(e,t,n,r,i,a,o,s)=>{let c=t.metadata;return w`
         <mateu-field
                 id="${t.id}"
                 .component="${t}"
@@ -10036,7 +10036,7 @@ ${i}
                 .data="${i}"
                 .appState="${a}"
                 .appdata="${o}"
-                style="${ia(t,i)}" class="${t.cssClasses}"
+                style="${oa(t,i)}" class="${t.cssClasses}"
                 slot="${t.slot??_}"
                 data-colspan="${c.colspan}"
                 colspan="${(c.colspan??1)>1?c.colspan:_}"
@@ -10044,7 +10044,7 @@ ${i}
         >
             ${t.children?.map(t=>P(e,t,n,r,i,a,o,s))}
         </mateu-field>
-    `},Cl=(e,n,r,i,a,o,s)=>{let c=n.metadata;if(c.tree)return w`
+    `},El=(e,n,r,i,a,o,s)=>{let c=n.metadata;if(c.tree)return w`
         <vaadin-grid style="${n.style}" class="${n.cssClasses}"
                      .itemHasChildrenPath="${`children`}" .dataProvider="${async(e,t)=>{let n=e.parentItem?e.parentItem.children:c.page.content;t(n,n.length)}}"
                      slot="${n.slot??_}"
@@ -10057,7 +10057,7 @@ ${i}
                                 flex-grow="${l?.flexGrow??_}"
                                 width="${l?.width??_}"
                                 .column="${n.metadata}"
-                                ${t((t,n,c)=>pl(t,n,c,l,e,r,i,a,o,s),[])}></vaadin-grid-column>
+                                ${t((t,n,c)=>gl(t,n,c,l,e,r,i,a,o,s),[])}></vaadin-grid-column>
 `:w`
             <vaadin-grid-tree-column path="${n.id}"
                                 header="${l?.label??_}"
@@ -10075,9 +10075,9 @@ ${i}
                 .items="${l}"
                 all-rows-visible
         >
-            ${c?.content?.map(t=>dl(t,e,r,i,a,o,s))}
+            ${c?.content?.map(t=>ml(t,e,r,i,a,o,s))}
         </vaadin-grid>
-    `},$=class extends y{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.detailsOpenedItems=[],this.pagesRequested=[],this.emptyArray=e=>!e||e.length==0,this.dataProvider=(e,t)=>{let n=this.data[this.id]?.page;if(this.metadata?.infiniteScrolling&&e.page>0){let r=!1;n&&n.content&&(n.content.length>=(e.page+1)*e.pageSize||n.content.length==n.totalElements)&&(t(n.content.slice(e.page*e.pageSize,(e.page+1)*e.pageSize),n.totalElements),r=!0,this.grid&&this.grid.recalculateColumnWidths()),r||this.pagesRequested.find(t=>t==e.page)||(this.pagesRequested.push(e.page),this.dispatchEvent(new CustomEvent(`fetch-more-elements`,{detail:{params:e,callback:()=>{this.data[this.id]?.page?.content&&(t(this.data[this.id].page.content.slice(e.page*e.pageSize,(e.page+1)*e.pageSize),this.data[this.id].page.totalElements),this.grid&&this.grid.recalculateColumnWidths())}},bubbles:!0,composed:!0})))}else{let e=this.metadata?.infiniteScrolling?n?.totalElements:n?.content?.length??0;t(n?.content??[],e),this.grid&&this.grid.recalculateColumnWidths()}},this._onActionRequested=e=>{let t=e.detail,n=this.identifierFieldName;if(!n||!t.parameters||t.actionId?.startsWith(`action-on-row-`))return;let r=t.parameters[n];r!==void 0&&(this.state._selectedId=String(r),this._applyCellPartNameGenerator(),this.grid?.requestContentUpdate())},this.tooltipGenerator=e=>{let t=``,{column:n,item:r}=e,i=this.metadata?.columns?.find(e=>e.metadata.id==n?.path);if(i?.metadata){let e=(i?.metadata).tooltipPath;e&&n&&r&&(t=r[e])}return t}}get identifierFieldName(){let e=this.metadata?.columns?.find(e=>e.metadata?.identifier);if(e)return e.metadata?.id;if(this.metadata?.columns?.find(e=>e.metadata?.id===`id`))return`id`}_applyCellPartNameGenerator(){if(!this.grid)return;let e=this.identifierFieldName,t=this.state?._selectedId??this.appState?._splitDetailId,n=!!this.metadata?.groupBy;e&&t!==void 0||n?this.grid.cellPartNameGenerator=(n,r)=>{let i=r.item;return Pc(i)?`mateu-group-row`:e&&t!==void 0&&String(i[e])===String(t)?`selected-row`:``}:this.grid.cellPartNameGenerator=null}connectedCallback(){super.connectedCallback(),this.addEventListener(`action-requested`,this._onActionRequested)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`action-requested`,this._onActionRequested)}updated(e){super.updated(e),this._applyCellPartNameGenerator(),this.grid?.clearCache(),this.grid?.requestContentUpdate(),this.grid?.recalculateColumnWidths(),this.pagesRequested=[]}render(){let e=this.data[this.id],r=e?.page,i=this.metadata?.groupBy,a=this.metadata?.infiniteScrolling?void 0:r?.content?Ic(r.content,i,e?.groups):r?.content,o=Bc((this.metadata?.columns??[]).flatMap(e=>e.metadata?.type===A.GridGroupColumn?(e.metadata.columns??[]).map(e=>e.metadata):[e.metadata]),e,i),s=``;return this.metadata?.wrapCellContent&&(s+=` wrap-cell-content`),this.metadata?.compact&&(s+=` compact`),this.metadata?.noBorder&&(s+=` no-border`),this.metadata?.noRowBorder&&(s+=` no-row-borders`),this.metadata?.columnBorders&&(s+=` column-borders`),this.metadata?.rowStripes&&(s+=` row-stripes`),w`
+    `},Q=class extends y{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.detailsOpenedItems=[],this.pagesRequested=[],this.emptyArray=e=>!e||e.length==0,this.dataProvider=(e,t)=>{let n=this.data[this.id]?.page;if(this.metadata?.infiniteScrolling&&e.page>0){let r=!1;n&&n.content&&(n.content.length>=(e.page+1)*e.pageSize||n.content.length==n.totalElements)&&(t(n.content.slice(e.page*e.pageSize,(e.page+1)*e.pageSize),n.totalElements),r=!0,this.grid&&this.grid.recalculateColumnWidths()),r||this.pagesRequested.find(t=>t==e.page)||(this.pagesRequested.push(e.page),this.dispatchEvent(new CustomEvent(`fetch-more-elements`,{detail:{params:e,callback:()=>{this.data[this.id]?.page?.content&&(t(this.data[this.id].page.content.slice(e.page*e.pageSize,(e.page+1)*e.pageSize),this.data[this.id].page.totalElements),this.grid&&this.grid.recalculateColumnWidths())}},bubbles:!0,composed:!0})))}else{let e=this.metadata?.infiniteScrolling?n?.totalElements:n?.content?.length??0;t(n?.content??[],e),this.grid&&this.grid.recalculateColumnWidths()}},this._onActionRequested=e=>{let t=e.detail,n=this.identifierFieldName;if(!n||!t.parameters||t.actionId?.startsWith(`action-on-row-`))return;let r=t.parameters[n];r!==void 0&&(this.state._selectedId=String(r),this._applyCellPartNameGenerator(),this.grid?.requestContentUpdate())},this.tooltipGenerator=e=>{let t=``,{column:n,item:r}=e,i=this.metadata?.columns?.find(e=>e.metadata.id==n?.path);if(i?.metadata){let e=(i?.metadata).tooltipPath;e&&n&&r&&(t=r[e])}return t}}get identifierFieldName(){let e=this.metadata?.columns?.find(e=>e.metadata?.identifier);if(e)return e.metadata?.id;if(this.metadata?.columns?.find(e=>e.metadata?.id===`id`))return`id`}_applyCellPartNameGenerator(){if(!this.grid)return;let e=this.identifierFieldName,t=this.state?._selectedId??this.appState?._splitDetailId,n=!!this.metadata?.groupBy;e&&t!==void 0||n?this.grid.cellPartNameGenerator=(n,r)=>{let i=r.item;return Lc(i)?`mateu-group-row`:e&&t!==void 0&&String(i[e])===String(t)?`selected-row`:``}:this.grid.cellPartNameGenerator=null}connectedCallback(){super.connectedCallback(),this.addEventListener(`action-requested`,this._onActionRequested)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`action-requested`,this._onActionRequested)}updated(e){super.updated(e),this._applyCellPartNameGenerator(),this.grid?.clearCache(),this.grid?.requestContentUpdate(),this.grid?.recalculateColumnWidths(),this.pagesRequested=[]}render(){let e=this.data[this.id],r=e?.page,i=this.metadata?.groupBy,a=this.metadata?.infiniteScrolling?void 0:r?.content?zc(r.content,i,e?.groups):r?.content,o=Uc((this.metadata?.columns??[]).flatMap(e=>e.metadata?.type===A.GridGroupColumn?(e.metadata.columns??[]).map(e=>e.metadata):[e.metadata]),e,i),s=``;return this.metadata?.wrapCellContent&&(s+=` wrap-cell-content`),this.metadata?.compact&&(s+=` compact`),this.metadata?.noBorder&&(s+=` no-border`),this.metadata?.noRowBorder&&(s+=` no-row-borders`),this.metadata?.columnBorders&&(s+=` column-borders`),this.metadata?.rowStripes&&(s+=` row-stripes`),w`
             <vaadin-grid
                     .items="${a}"
                     item-id-path="_rowNumber"
@@ -10089,8 +10089,8 @@ ${i}
                     .dataProvider="${this.metadata?.infiniteScrolling?this.dataProvider:void 0}"
                     page-size="${this.metadata?.pageSize}"
                     multi-sort-on-shift-click
-                    @selected-items-changed="${e=>{let t=(e.detail.value??[]).filter(e=>!Pc(e));this.emptyArray(this.state[this.id+`_selected_items`])&&this.emptyArray(t)||(this.state[this.id+`_selected_items`]=t,this.metadata?.onRowSelectionChangedActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.metadata?.onRowSelectionChangedActionId},bubbles:!0,composed:!0})))}}"
-                    @active-item-changed="${x(this.metadata?.detailPath&&!this.metadata?.useButtonForDetail?e=>{if(this.metadata?.detailPath){let t=e.detail.value;if(t&&Pc(t))return;t?this.detailsOpenedItems=[t]:this.detailsOpenedItems=[]}}:void 0)}"
+                    @selected-items-changed="${e=>{let t=(e.detail.value??[]).filter(e=>!Lc(e));this.emptyArray(this.state[this.id+`_selected_items`])&&this.emptyArray(t)||(this.state[this.id+`_selected_items`]=t,this.metadata?.onRowSelectionChangedActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.metadata?.onRowSelectionChangedActionId},bubbles:!0,composed:!0})))}}"
+                    @active-item-changed="${x(this.metadata?.detailPath&&!this.metadata?.useButtonForDetail?e=>{if(this.metadata?.detailPath){let t=e.detail.value;if(t&&Lc(t))return;t?this.detailsOpenedItems=[t]:this.detailsOpenedItems=[]}}:void 0)}"
                     .detailsOpenedItems="${this.detailsOpenedItems}"
                     ${x(this.metadata?.detailPath?n(e=>w`${P(this,e[this.metadata?.detailPath],this.baseUrl,this.state,this.data,this.appState,this.appData)}`):void 0)}
                     theme="${s}"
@@ -10099,7 +10099,7 @@ ${i}
                 ${this.metadata?.rowsSelectionEnabled?w`
                     <vaadin-grid-selection-column></vaadin-grid-selection-column>
                 `:_}
-                ${this.metadata?.columns?.map(e=>dl(e,this,this.baseUrl,this.state,this.data,this.appState,this.appData,o))}
+                ${this.metadata?.columns?.map(e=>ml(e,this,this.baseUrl,this.state,this.data,this.appState,this.appData,o))}
                 ${this.metadata?.useButtonForDetail?w`
                     <vaadin-grid-column
                             width="44px"
@@ -10138,7 +10138,7 @@ ${i}
             background-color: var(--lumo-contrast-5pct, rgba(0, 0, 0, 0.04));
             font-weight: 600;
         }
-  `}};O([v()],$.prototype,`id`,void 0),O([v()],$.prototype,`metadata`,void 0),O([v()],$.prototype,`baseUrl`,void 0),O([v()],$.prototype,`state`,void 0),O([v()],$.prototype,`data`,void 0),O([v()],$.prototype,`appState`,void 0),O([v()],$.prototype,`appData`,void 0),O([v()],$.prototype,`emptyStateMessage`,void 0),O([S()],$.prototype,`detailsOpenedItems`,void 0),O([b(`vaadin-grid`)],$.prototype,`grid`,void 0),$=O([h(`mateu-table`)],$);var wl=(e,t,n,r,i,a,o)=>w`
+  `}};O([v()],Q.prototype,`id`,void 0),O([v()],Q.prototype,`metadata`,void 0),O([v()],Q.prototype,`baseUrl`,void 0),O([v()],Q.prototype,`state`,void 0),O([v()],Q.prototype,`data`,void 0),O([v()],Q.prototype,`appState`,void 0),O([v()],Q.prototype,`appData`,void 0),O([v()],Q.prototype,`emptyStateMessage`,void 0),O([S()],Q.prototype,`detailsOpenedItems`,void 0),O([b(`vaadin-grid`)],Q.prototype,`grid`,void 0),Q=O([h(`mateu-table`)],Q);var Dl=(e,t,n,r,i,a,o)=>w`
     <mateu-table
             id="${t.id}"
             baseUrl="${n}"
@@ -10151,7 +10151,7 @@ ${i}
             slot="${t.slot??_}"
     >
         ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
-    </mateu-table>`,Tl=(e,t,n,r,i,a)=>w`
+    </mateu-table>`,Ol=(e,t,n,r,i,a)=>w`
     <mateu-table id="${e.id}"
                  .metadata="${t?.metadata}"
                  .data="${e.data}"
@@ -10162,7 +10162,7 @@ ${i}
                  @sort-direction-changed="${e.directionChanged}"
                  @fetch-more-elements="${e.fetchMoreElements}"
                  baseUrl="${n}"
-    ></mateu-table>`,El=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+    ></mateu-table>`,kl=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <div id="show-notifications" slot="${t.slot??_}">${P(e,s.wrapped,n,r,i,a,o)}</div>
         <vaadin-popover
                 for="show-notifications"
@@ -10174,14 +10174,14 @@ ${i}
                 ${te(()=>w`${P(e,s.content,n,r,i,a,o)}`,[])}
                 style="${t.style}" class="${t.cssClasses}"
         ></vaadin-popover>
-    `},Dl=(e,t,n)=>{let r=e;return w`
+    `},Al=(e,t,n)=>{let r=e;return w`
         <vaadin-button
                 data-action-id="${r.id}"
                 theme="${ht(e)||_}"
                 @click="${n}"
                 ?disabled="${r.disabled}"
         >${r.iconOnLeft?w`<vaadin-icon icon="${r.iconOnLeft}"></vaadin-icon>`:_}${t}${r.iconOnRight?w`<vaadin-icon icon="${r.iconOnRight}"></vaadin-icon>`:_}</vaadin-button>
-    `},Ol=e=>w`
+    `},jl=e=>w`
     <div style="display: flex; gap: var(--lumo-space-xs, .25rem); align-items: center;" class="peer-nav">
         <vaadin-button theme="tertiary icon" class="peer-nav-prev" title="${e.prevLabel??`Previous`}"
                 ?disabled="${!e.prevRoute}"
@@ -10193,30 +10193,30 @@ ${i}
                 @click="${()=>{e.nextRoute&&(window.location.href=e.nextRoute)}}">
             <vaadin-icon icon="vaadin:angle-right"></vaadin-icon>
         </vaadin-button>
-    </div>`,kl={"vaadin:wifi":`vaadin:connect`,"vaadin:pen":`vaadin:pencil`,"vaadin:automation":`vaadin:cogs`},Al=(e,t,n)=>w`<vaadin-icon icon="${kl[e]??e}" style="${t??_}" class="${n??_}"></vaadin-icon>`,jl=(e,t,n)=>{let r=e.metadata,i=j(r.label,t,n),a=``;return r.buttonStyle&&(a+=` `+r.buttonStyle),r.color&&r.color!==`none`&&r.color!==`normal`&&(a+=` `+r.color),r.size&&r.size!==`none`&&r.size!==`normal`&&(a+=` `+r.size),w`<vaadin-button
+    </div>`,Ml={"vaadin:wifi":`vaadin:connect`,"vaadin:pen":`vaadin:pencil`,"vaadin:automation":`vaadin:cogs`},Nl=(e,t,n)=>w`<vaadin-icon icon="${Ml[e]??e}" style="${t??_}" class="${n??_}"></vaadin-icon>`,Pl=(e,t,n)=>{let r=e.metadata,i=j(r.label,t,n),a=``;return r.buttonStyle&&(a+=` `+r.buttonStyle),r.color&&r.color!==`none`&&r.color!==`normal`&&(a+=` `+r.color),r.size&&r.size!==`none`&&r.size!==`normal`&&(a+=` `+r.size),w`<vaadin-button
             id="${e.id}"
             data-action-id="${r.actionId}"
-            @click="${e=>zn(e,r)}"
+            @click="${e=>Vn(e,r)}"
             style="${e.style}"
             class="${e.cssClasses}"
             theme="${a}"
             ?disabled="${r.disabled}"
-            title="${r.shortcut?`${i} (${Rn(r.shortcut)})`:_}"
+            title="${r.shortcut?`${i} (${Bn(r.shortcut)})`:_}"
             slot="${e.slot??_}"
-    >${r.iconOnLeft?w`<vaadin-icon icon="${r.iconOnLeft}"></vaadin-icon>`:_}${i}${r.iconOnRight?w`<vaadin-icon icon="${r.iconOnRight}"></vaadin-icon>`:_}</vaadin-button>`},Ml=e=>{let t=e.metadata;return w`
+    >${r.iconOnLeft?w`<vaadin-icon icon="${r.iconOnLeft}"></vaadin-icon>`:_}${i}${r.iconOnRight?w`<vaadin-icon icon="${r.iconOnRight}"></vaadin-icon>`:_}</vaadin-button>`},Fl=e=>{let t=e.metadata;return w`
         <vaadin-message-input
                 style="${e.style}" class="${e.cssClasses}"
                 slot="${e.slot??_}"
                 @submit="${e=>{let n=e.detail?.value??``;!t.actionId||!n.trim()||e.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:{message:n}},bubbles:!0,composed:!0}))}}"
         ></vaadin-message-input>
-    `},Nl=e=>{let t=(e.metadata.items??[]).map(e=>({text:e.text,time:e.time,userName:e.userName,userImg:e.userImg,userAbbr:e.userAbbr,userColorIndex:e.userColorIndex}));return w`
+    `},Il=e=>{let t=(e.metadata.items??[]).map(e=>({text:e.text,time:e.time,userName:e.userName,userImg:e.userImg,userAbbr:e.userAbbr,userColorIndex:e.userColorIndex}));return w`
         <vaadin-message-list
                 markdown
                 style="${e.style}" class="${e.cssClasses}"
                 slot="${e.slot??_}"
                 .items="${t}"
         ></vaadin-message-list>
-    `},Pl=(e,t)=>{e&&e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},Fl=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!1;if(s.openedCondition)try{c=at(s.openedCondition,r,i,a,o)}catch(e){console.error(`when evaluating `+s.openedCondition+` :`+e+`, where data is `+i+` and state is `+r)}return w`
+    `},Ll=(e,t)=>{e&&e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},Rl=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!1;if(s.openedCondition)try{c=at(s.openedCondition,r,i,a,o)}catch(e){console.error(`when evaluating `+s.openedCondition+` :`+e+`, where data is `+i+` and state is `+r)}return w`
         <vaadin-confirm-dialog
                 header="${s.header}"
                 ?cancel-button-visible="${s.canCancel}"
@@ -10224,15 +10224,15 @@ ${i}
                 reject-text="${s.rejectText}"
                 confirm-text="${s.confirmText}"
                 .opened="${c}"
-                @confirm="${e=>Pl(e.currentTarget,s.confirmActionId)}"
-                @reject="${e=>Pl(e.currentTarget,s.rejectActionId)}"
-                @cancel="${e=>Pl(e.currentTarget,s.cancelActionId)}"
+                @confirm="${e=>Ll(e.currentTarget,s.confirmActionId)}"
+                @reject="${e=>Ll(e.currentTarget,s.rejectActionId)}"
+                @cancel="${e=>Ll(e.currentTarget,s.cancelActionId)}"
                 style="${t.style}" class="${t.cssClasses}"
                 slot="${t.slot??_}"
         >
             ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </vaadin-confirm-dialog>
-    `},Il=class extends y{constructor(...e){super(...e),this.panels=[],this.headerTitle=``,this.badges=[],this.navigation=null,this.overviewEditActionId=``,this._raf=0,this._snapping=!1,this._less=!1,this._more=!1,this._onScroll=()=>{this._raf||=requestAnimationFrame(()=>{this._raf=0,this._syncPin()})},this._onScrollEnd=()=>{this._snapping||this._snapToNearest()},this._fit=()=>{let e=this.getBoundingClientRect().top;this.style.setProperty(`--mateu-foldout-fill`,`${Math.max(240,window.innerHeight-e)}px`),this._syncPin()},this._onKeydown=e=>{if(e.key!==`ArrowRight`&&e.key!==`ArrowLeft`||e.defaultPrevented||e.ctrlKey||e.metaKey||e.altKey||this._isEditingContext())return;let t=this._rail;!t||t.scrollWidth<=t.clientWidth||(e.preventDefault(),this._step(e.key===`ArrowRight`?1:-1))}}navAction(e){e&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{}},bubbles:!0,composed:!0}))}_stride(){let e=this.renderRoot.querySelectorAll(`.section`);return e.length>1?e[1].offsetLeft:this._rail?.clientWidth??0}_boundaries(){let e=this._rail;if(!e)return[];let t=e.scrollWidth-e.clientWidth,n=[...this.renderRoot.querySelectorAll(`.section`)].map(e=>Math.max(0,Math.min(e.offsetLeft,t)));return[...new Set(n)]}_snapToNearest(){let e=this._rail;if(!e)return;let t=this._boundaries();if(!t.length)return;let n=t.reduce((t,n)=>Math.abs(n-e.scrollLeft)<Math.abs(t-e.scrollLeft)?n:t);Math.abs(n-e.scrollLeft)<1||(this._snapping=!0,e.scrollTo({left:n,behavior:`smooth`}),window.setTimeout(()=>{this._snapping=!1},400))}_syncPin(){let e=this._rail,t=this._first;if(!e||!t)return;let n=this._stride(),r=Math.min(e.scrollLeft,n);t.style.transform=r?`translateX(${r}px)`:``,t.classList.toggle(`floating`,e.scrollLeft>0);let i=e.scrollWidth-e.clientWidth,a=i>32;this._less=a&&e.scrollLeft>2,this._more=a&&e.scrollLeft<i-2}_step(e){let t=this._rail;if(!t)return;let n=this._boundaries();if(!n.length)return;let r=n.reduce((e,r,i)=>Math.abs(r-t.scrollLeft)<Math.abs(n[e]-t.scrollLeft)?i:e,0),i=n[Math.max(0,Math.min(r+e,n.length-1))];this._snapping=!0,t.scrollTo({left:i,behavior:`smooth`}),window.setTimeout(()=>{this._snapping=!1},400)}_isEditingContext(){let e=document.activeElement;for(;e&&e.shadowRoot&&e.shadowRoot.activeElement;)e=e.shadowRoot.activeElement;if(!e)return!1;let t=e.tagName;return t===`INPUT`||t===`TEXTAREA`||t===`SELECT`||e.isContentEditable}_sectionFlex(e,t){if(!e.width)return _;let n=parseFloat(e.width)||1;return t===this.panels.length-1&&n<22?`flex: 22 1 var(--mateu-foldout-overview-width, 22rem);`:`flex: ${n} 1 ${e.width};`}firstUpdated(){this._fit(),this._resizeObserver=new ResizeObserver(()=>this._syncPin()),this._rail&&this._resizeObserver.observe(this._rail);for(let e of this.renderRoot.querySelectorAll(`.section`))this._resizeObserver.observe(e)}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._onKeydown),window.addEventListener(`resize`,this._fit)}disconnectedCallback(){document.removeEventListener(`keydown`,this._onKeydown),window.removeEventListener(`resize`,this._fit),this._resizeObserver?.disconnect(),this._resizeObserver=void 0,this._raf&&=(cancelAnimationFrame(this._raf),0),super.disconnectedCallback()}static{this.styles=m`
+    `},$=class extends y{constructor(...e){super(...e),this.panels=[],this.headerTitle=``,this.badges=[],this.navigation=null,this.overviewEditActionId=``,this._raf=0,this._snapping=!1,this._less=!1,this._more=!1,this._onScroll=()=>{this._raf||=requestAnimationFrame(()=>{this._raf=0,this._syncPin()})},this._onScrollEnd=()=>{this._snapping||this._snapToNearest()},this._fit=()=>{let e=this.getBoundingClientRect().top;this.style.setProperty(`--mateu-foldout-fill`,`${Math.max(240,window.innerHeight-e)}px`),this._syncPin()},this._onKeydown=e=>{if(e.key!==`ArrowRight`&&e.key!==`ArrowLeft`||e.defaultPrevented||e.ctrlKey||e.metaKey||e.altKey||this._isEditingContext())return;let t=this._rail;!t||t.scrollWidth<=t.clientWidth||(e.preventDefault(),this._step(e.key===`ArrowRight`?1:-1))}}navAction(e){e&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{}},bubbles:!0,composed:!0}))}_stride(){let e=this.renderRoot.querySelectorAll(`.section`);return e.length>1?e[1].offsetLeft:this._rail?.clientWidth??0}_boundaries(){let e=this._rail;if(!e)return[];let t=e.scrollWidth-e.clientWidth,n=[...this.renderRoot.querySelectorAll(`.section`)].map(e=>Math.max(0,Math.min(e.offsetLeft,t)));return[...new Set(n)]}_snapToNearest(){let e=this._rail;if(!e)return;let t=this._boundaries();if(!t.length)return;let n=t.reduce((t,n)=>Math.abs(n-e.scrollLeft)<Math.abs(t-e.scrollLeft)?n:t);Math.abs(n-e.scrollLeft)<1||(this._snapping=!0,e.scrollTo({left:n,behavior:`smooth`}),window.setTimeout(()=>{this._snapping=!1},400))}_syncPin(){let e=this._rail,t=this._first;if(!e||!t)return;let n=this._stride(),r=Math.min(e.scrollLeft,n);t.style.transform=r?`translateX(${r}px)`:``,t.classList.toggle(`floating`,e.scrollLeft>0);let i=e.scrollWidth-e.clientWidth,a=i>32;this._less=a&&e.scrollLeft>2,this._more=a&&e.scrollLeft<i-2}_step(e){let t=this._rail;if(!t)return;let n=this._boundaries();if(!n.length)return;let r=n.reduce((e,r,i)=>Math.abs(r-t.scrollLeft)<Math.abs(n[e]-t.scrollLeft)?i:e,0),i=n[Math.max(0,Math.min(r+e,n.length-1))];this._snapping=!0,t.scrollTo({left:i,behavior:`smooth`}),window.setTimeout(()=>{this._snapping=!1},400)}_isEditingContext(){let e=document.activeElement;for(;e&&e.shadowRoot&&e.shadowRoot.activeElement;)e=e.shadowRoot.activeElement;if(!e)return!1;let t=e.tagName;return t===`INPUT`||t===`TEXTAREA`||t===`SELECT`||e.isContentEditable}_sectionFlex(e,t){if(!e.width)return _;let n=parseFloat(e.width)||1;return t===this.panels.length-1&&n<22?`flex: 22 1 var(--mateu-foldout-overview-width, 22rem);`:`flex: ${n} 1 ${e.width};`}firstUpdated(){this._fit(),this._resizeObserver=new ResizeObserver(()=>this._syncPin()),this._rail&&this._resizeObserver.observe(this._rail);for(let e of this.renderRoot.querySelectorAll(`.section`))this._resizeObserver.observe(e)}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._onKeydown),window.addEventListener(`resize`,this._fit)}disconnectedCallback(){document.removeEventListener(`keydown`,this._onKeydown),window.removeEventListener(`resize`,this._fit),this._resizeObserver?.disconnect(),this._resizeObserver=void 0,this._raf&&=(cancelAnimationFrame(this._raf),0),super.disconnectedCallback()}static{this.styles=m`
         :host {
             position: relative;
             display: flex;
@@ -10493,7 +10493,7 @@ ${i}
                     </svg>
                 </button>
             `:_}
-        `}};O([v({type:Array})],Il.prototype,`panels`,void 0),O([v({type:String})],Il.prototype,`headerTitle`,void 0),O([v({type:Array})],Il.prototype,`badges`,void 0),O([v({attribute:!1})],Il.prototype,`navigation`,void 0),O([v({type:String})],Il.prototype,`overviewEditActionId`,void 0),O([b(`.rail`)],Il.prototype,`_rail`,void 0),O([b(`.section--first`)],Il.prototype,`_first`,void 0),O([S()],Il.prototype,`_less`,void 0),O([S()],Il.prototype,`_more`,void 0),Il=O([h(`mateu-vaadin-foldout`)],Il);var Ll=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
+        `}};O([v({type:Array})],$.prototype,`panels`,void 0),O([v({type:String})],$.prototype,`headerTitle`,void 0),O([v({type:Array})],$.prototype,`badges`,void 0),O([v({attribute:!1})],$.prototype,`navigation`,void 0),O([v({type:String})],$.prototype,`overviewEditActionId`,void 0),O([b(`.rail`)],$.prototype,`_rail`,void 0),O([b(`.section--first`)],$.prototype,`_first`,void 0),O([S()],$.prototype,`_less`,void 0),O([S()],$.prototype,`_more`,void 0),$=O([h(`mateu-vaadin-foldout`)],$);var zl=(e,t,n,r,i,a,o)=>{let s=t.metadata;return w`
         <mateu-vaadin-foldout
                 .panels="${s.panels??[]}"
                 .headerTitle="${s.headerTitle??``}"
@@ -10506,7 +10506,7 @@ ${i}
         >
             ${t.children?.map(t=>P(e,t,n,r,i,a,o))}
         </mateu-vaadin-foldout>
-    `},Rl=class extends y{constructor(...e){super(...e),this.rows=[],this.columns=[],this.navigable=!1,this.expandedItems=[],this._normalized=[],this.dataProvider=(e,t)=>{let n=e.parentItem?e.parentItem.children??[]:this.normalized;t(n,n.length)}}get normalized(){return this._src!==this.rows&&(this._src=this.rows,this._normalized=this.normalizeRows(this.rows??[])),this._normalized}normalizeRows(e){return(e??[]).map(e=>{let t=Array.isArray(e.children)&&e.children.length?this.normalizeRows(e.children):void 0;return{...e,children:t}})}collectGroups(e,t=[]){return e.forEach(e=>{e.children&&e.children.length&&(t.push(e),this.collectGroups(e.children,t))}),t}willUpdate(){this._expandedSrc!==this.rows&&(this._expandedSrc=this.rows,this.expandedItems=this.collectGroups(this.normalized))}updated(e){e.has(`rows`)&&this._grid?.clearCache?.()}dispatch(e,t){this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:t},bubbles:!0,composed:!0}))}render(){let e=this.columns??[],n=e[0],r=e.slice(1);return w`
+    `},Bl=class extends y{constructor(...e){super(...e),this.rows=[],this.columns=[],this.navigable=!1,this.expandedItems=[],this._normalized=[],this.dataProvider=(e,t)=>{let n=e.parentItem?e.parentItem.children??[]:this.normalized;t(n,n.length)}}get normalized(){return this._src!==this.rows&&(this._src=this.rows,this._normalized=this.normalizeRows(this.rows??[])),this._normalized}normalizeRows(e){return(e??[]).map(e=>{let t=Array.isArray(e.children)&&e.children.length?this.normalizeRows(e.children):void 0;return{...e,children:t}})}collectGroups(e,t=[]){return e.forEach(e=>{e.children&&e.children.length&&(t.push(e),this.collectGroups(e.children,t))}),t}willUpdate(){this._expandedSrc!==this.rows&&(this._expandedSrc=this.rows,this.expandedItems=this.collectGroups(this.normalized))}updated(e){e.has(`rows`)&&this._grid?.clearCache?.()}dispatch(e,t){this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:t},bubbles:!0,composed:!0}))}render(){let e=this.columns??[],n=e[0],r=e.slice(1);return w`
             <vaadin-grid
                     theme="compact no-row-borders"
                     all-rows-visible
@@ -10536,11 +10536,11 @@ ${i}
             max-height: min(60vh, 32rem);
             min-width: 22rem;
         }
-    `}};O([v({attribute:!1})],Rl.prototype,`rows`,void 0),O([v({attribute:!1})],Rl.prototype,`columns`,void 0),O([v()],Rl.prototype,`idField`,void 0),O([v({type:Boolean})],Rl.prototype,`navigable`,void 0),O([v()],Rl.prototype,`selectedId`,void 0),O([S()],Rl.prototype,`expandedItems`,void 0),O([b(`vaadin-grid`)],Rl.prototype,`_grid`,void 0),Rl=O([h(`mateu-vaadin-tree`)],Rl);var zl={[A.VirtualList]:(e,t,n,r,i,a,o)=>Qs(e,t,n,r,i,a,o),[A.Notification]:(e,t)=>$s(t),[A.ProgressBar]:(e,t,n,r)=>ec(t,r),[A.Details]:(e,t,n,r,i,a,o)=>tc(e,t,n,r,i,a,o),[A.Avatar]:(e,t,n,r,i)=>nc(t,r,i),[A.AvatarGroup]:(e,t)=>rc(t),[A.Card]:(e,t,n,r,i,a,o)=>ic(e,t,n,r,i,a,o),[A.Button]:(e,t,n,r,i)=>jl(t,r,i),[A.MessageInput]:(e,t)=>Ml(t),[A.MessageList]:(e,t)=>Nl(t),[A.ConfirmDialog]:(e,t,n,r,i,a,o)=>Fl(e,t,n,r,i,a,o),[A.FormLayout]:(e,t,n,r,i,a,o)=>sc(e,t,n,r,i,a,o),[A.HorizontalLayout]:(e,t,n,r,i,a,o)=>dc(e,t,n,r,i,a,o),[A.VerticalLayout]:(e,t,n,r,i,a,o)=>fc(e,t,n,r,i,a,o),[A.SplitLayout]:(e,t,n,r,i,a,o)=>pc(e,t,n,r,i,a,o),[A.MasterDetailLayout]:(e,t,n,r,i,a,o)=>mc(e,t,n,r,i,a,o),[A.TabLayout]:(e,t,n,r,i,a,o)=>hc(e,t,n,r,i,a,o),[A.AccordionLayout]:(e,t,n,r,i,a,o)=>_c(e,t,n,r,i,a,o),[A.BoardLayout]:(e,t,n,r,i,a,o)=>bc(e,t,n,r,i,a,o),[A.BoardLayoutRow]:(e,t,n,r,i,a,o)=>xc(e,t,n,r,i,a,o),[A.BoardLayoutItem]:(e,t,n,r,i,a,o)=>Sc(e,t,n,r,i,a,o),[A.Scroller]:(e,t,n,r,i,a,o)=>yc(e,t,n,r,i,a,o),[A.MenuBar]:(e,t,n,r,i)=>Tc(e,t,n,r,i),[A.ContextMenu]:(e,t,n,r,i,a,o)=>wc(e,t,n,r,i,a,o),[A.FormField]:(e,t,n,r,i,a,o,s)=>Sl(e,t,n,r,i,a,o,s),[A.Grid]:(e,t,n,r,i,a,o)=>Cl(e,t,n,r,i,a,o),[A.Table]:(e,t,n,r,i,a,o)=>wl(e,t,n,r,i,a,o),[A.Popover]:(e,t,n,r,i,a,o)=>El(e,t,n,r,i,a,o),[A.FoldoutLayout]:(e,t,n,r,i,a,o)=>Ll(e,t,n,r,i,a,o)},Bl=class extends Zs{rendererName(){return`vaadin`}renderClientSideComponent(e,t,n,r,i,a,o,s){let c=t?.metadata?.type,l=c?zl[c]:void 0;return l&&t?l(e,t,n,r,i,a,o,s):super.renderClientSideComponent(e,t,n,r,i,a,o,s)}renderTableComponent(e,t,n,r,i,a,o){return Tl(e,t,n,r,a,o)}renderTreeComponent(e,t){return w`
+    `}};O([v({attribute:!1})],Bl.prototype,`rows`,void 0),O([v({attribute:!1})],Bl.prototype,`columns`,void 0),O([v()],Bl.prototype,`idField`,void 0),O([v({type:Boolean})],Bl.prototype,`navigable`,void 0),O([v()],Bl.prototype,`selectedId`,void 0),O([S()],Bl.prototype,`expandedItems`,void 0),O([b(`vaadin-grid`)],Bl.prototype,`_grid`,void 0),Bl=O([h(`mateu-vaadin-tree`)],Bl);var Vl={[A.VirtualList]:(e,t,n,r,i,a,o)=>tc(e,t,n,r,i,a,o),[A.Notification]:(e,t)=>nc(t),[A.ProgressBar]:(e,t,n,r)=>rc(t,r),[A.Details]:(e,t,n,r,i,a,o)=>ic(e,t,n,r,i,a,o),[A.Avatar]:(e,t,n,r,i)=>ac(t,r,i),[A.AvatarGroup]:(e,t)=>oc(t),[A.Card]:(e,t,n,r,i,a,o)=>sc(e,t,n,r,i,a,o),[A.Button]:(e,t,n,r,i)=>Pl(t,r,i),[A.MessageInput]:(e,t)=>Fl(t),[A.MessageList]:(e,t)=>Il(t),[A.ConfirmDialog]:(e,t,n,r,i,a,o)=>Rl(e,t,n,r,i,a,o),[A.FormLayout]:(e,t,n,r,i,a,o)=>uc(e,t,n,r,i,a,o),[A.HorizontalLayout]:(e,t,n,r,i,a,o)=>mc(e,t,n,r,i,a,o),[A.VerticalLayout]:(e,t,n,r,i,a,o)=>hc(e,t,n,r,i,a,o),[A.SplitLayout]:(e,t,n,r,i,a,o)=>gc(e,t,n,r,i,a,o),[A.MasterDetailLayout]:(e,t,n,r,i,a,o)=>_c(e,t,n,r,i,a,o),[A.TabLayout]:(e,t,n,r,i,a,o)=>vc(e,t,n,r,i,a,o),[A.AccordionLayout]:(e,t,n,r,i,a,o)=>bc(e,t,n,r,i,a,o),[A.BoardLayout]:(e,t,n,r,i,a,o)=>Cc(e,t,n,r,i,a,o),[A.BoardLayoutRow]:(e,t,n,r,i,a,o)=>wc(e,t,n,r,i,a,o),[A.BoardLayoutItem]:(e,t,n,r,i,a,o)=>Tc(e,t,n,r,i,a,o),[A.Scroller]:(e,t,n,r,i,a,o)=>Sc(e,t,n,r,i,a,o),[A.MenuBar]:(e,t,n,r,i)=>Oc(e,t,n,r,i),[A.ContextMenu]:(e,t,n,r,i,a,o)=>Dc(e,t,n,r,i,a,o),[A.FormField]:(e,t,n,r,i,a,o,s)=>Tl(e,t,n,r,i,a,o,s),[A.Grid]:(e,t,n,r,i,a,o)=>El(e,t,n,r,i,a,o),[A.Table]:(e,t,n,r,i,a,o)=>Dl(e,t,n,r,i,a,o),[A.Popover]:(e,t,n,r,i,a,o)=>kl(e,t,n,r,i,a,o),[A.FoldoutLayout]:(e,t,n,r,i,a,o)=>zl(e,t,n,r,i,a,o)},Hl=class extends ec{rendererName(){return`vaadin`}renderClientSideComponent(e,t,n,r,i,a,o,s){let c=t?.metadata?.type,l=c?Vl[c]:void 0;return l&&t?l(e,t,n,r,i,a,o,s):super.renderClientSideComponent(e,t,n,r,i,a,o,s)}renderTableComponent(e,t,n,r,i,a,o){return Ol(e,t,n,r,a,o)}renderTreeComponent(e,t){return w`
             <mateu-vaadin-tree
                     .rows="${t.rows}"
                     .columns="${t.columns}"
                     .idField="${t.idField}"
                     .navigable="${t.navigable}"
                     .selectedId="${t.selectedId}"
-            ></mateu-vaadin-tree>`}renderToolbarButton(e,t,n){return Dl(e,t,n)}renderPeerNav(e){return Ol(e)}renderIcon(e,t,n){return Al(e,t,n)}renderTopNav(e,t,n){return Cc(e,t,n)}};function Vl(e){switch(e){case`topStretch`:return`top-stretch`;case`topStart`:return`top-start`;case`topCenter`:return`top-center`;case`topEnd`:return`top-end`;case`middle`:return`middle`;case`bottomStart`:return`bottom-start`;case`bottomEnd`:return`bottom-end`;case`bottomStretch`:return`bottom-stretch`;case`bottomCenter`:return`bottom-center`}return`bottom-end`}function Hl(e,t){if(e.onAction)return{label:e.actionLabel??`Retry`,run:e.onAction};if(e.undoActionId)return{label:e.undoLabel??`Undo`,run:()=>t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.undoActionId,parameters:e.undoParameters??{}},bubbles:!0,composed:!0}))}}function Ul(e,t){let n=new r;n.position=Vl(e.position),n.duration=e.duration??1e4,e.variant&&n.setAttribute(`theme`,e.variant),n.renderer=r=>{if(r.firstElementChild)return;let i=document.createElement(`span`);i.textContent=e.text;let a=Hl(e,t),o=document.createElement(`button`);o.textContent=a.label,o.style.cssText=`margin-left: 0.75rem; background: none; border: 1px solid currentColor; border-radius: var(--lumo-border-radius-s, 4px); color: inherit; cursor: pointer; padding: 0.15rem 0.6rem; font: inherit; font-weight: 600;`,o.addEventListener(`click`,()=>{a.run(),n.opened=!1}),r.append(i,o)},document.body.appendChild(n),n.opened=!0,n.addEventListener(`opened-changed`,e=>{e.detail.value||n.remove()})}N.set(new Bl),fa({show(e,t){if(Qe(e.text,{politeness:e.variant===`error`?`assertive`:`polite`}),e.undoActionId||e.onAction){Ul(e,t);return}r.show(e.text,{position:e.position?Vl(e.position):`bottom-end`,theme:e.variant,duration:e.duration})}});
+            ></mateu-vaadin-tree>`}renderToolbarButton(e,t,n){return Al(e,t,n)}renderPeerNav(e){return jl(e)}renderIcon(e,t,n){return Nl(e,t,n)}renderTopNav(e,t,n){return Ec(e,t,n)}};function Ul(e){switch(e){case`topStretch`:return`top-stretch`;case`topStart`:return`top-start`;case`topCenter`:return`top-center`;case`topEnd`:return`top-end`;case`middle`:return`middle`;case`bottomStart`:return`bottom-start`;case`bottomEnd`:return`bottom-end`;case`bottomStretch`:return`bottom-stretch`;case`bottomCenter`:return`bottom-center`}return`bottom-end`}function Wl(e,t){if(e.onAction)return{label:e.actionLabel??`Retry`,run:e.onAction};if(e.undoActionId)return{label:e.undoLabel??`Undo`,run:()=>t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.undoActionId,parameters:e.undoParameters??{}},bubbles:!0,composed:!0}))}}function Gl(e,t){let n=new r;n.position=Ul(e.position),n.duration=e.duration??1e4,e.variant&&n.setAttribute(`theme`,e.variant),n.renderer=r=>{if(r.firstElementChild)return;let i=document.createElement(`span`);i.textContent=e.text;let a=Wl(e,t),o=document.createElement(`button`);o.textContent=a.label,o.style.cssText=`margin-left: 0.75rem; background: none; border: 1px solid currentColor; border-radius: var(--lumo-border-radius-s, 4px); color: inherit; cursor: pointer; padding: 0.15rem 0.6rem; font: inherit; font-weight: 600;`,o.addEventListener(`click`,()=>{a.run(),n.opened=!1}),r.append(i,o)},document.body.appendChild(n),n.opened=!0,n.addEventListener(`opened-changed`,e=>{e.detail.value||n.remove()})}N.set(new Hl),ma({show(e,t){if(Qe(e.text,{politeness:e.variant===`error`?`assertive`:`polite`}),e.undoActionId||e.onAction){Gl(e,t);return}r.show(e.text,{position:e.position?Ul(e.position):`bottom-end`,theme:e.variant,duration:e.duration})}});

--- a/doc/src/content/docs/java-ui-definition/annotations/rest-options.md
+++ b/doc/src/content/docs/java-ui-definition/annotations/rest-options.md
@@ -105,6 +105,30 @@ public class VaultSecrets implements SecretsProvider {
 With no `SecretsProvider` registered, Mateu falls back to reading an **environment variable** of the
 same name (`${secret.COUNTRIES_TOKEN}` → `System.getenv("COUNTRIES_TOKEN")`).
 
+## Client-side auth for the direct path (`registerExternalAuthProvider`)
+
+Proxy mode keeps secrets on the **server**. If instead you keep the **direct** (client-side) fetch —
+the default — but still need to authenticate it (e.g. an OAuth token the SPA already holds), register
+a client-side auth provider. The renderer calls it right before every direct external fetch and
+merges the returned headers, so the token is added **at fetch time on the client** and never travels
+in the annotation or the Mateu wire:
+
+```ts
+// web (import from the `mateu` package, alongside registerNeutralNotifier)
+import { registerExternalAuthProvider } from 'mateu'
+
+registerExternalAuthProvider(({ url }) =>
+  url.startsWith('https://api.example.com')
+    ? { Authorization: `Bearer ${tokenStore.current()}` }
+    : {})
+```
+
+The provider may be async (e.g. refresh the token first), its headers win over any statically
+declared header of the same name, and a throwing provider is swallowed (it never breaks the fetch).
+It is **ignored on the proxy path** (there, secrets are injected server-side). The native renderers
+expose the same hook: React Native `registerExternalAuthProvider` (from `src/core/restFetch`) and the
+IntelliJ plugin `RestFetch.externalAuthProvider = { url, method -> … }`.
+
 ## Other backends
 
 Mateu.NET and the Python backend emit the same `optionsSource` descriptor, so any renderer fetches

--- a/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/state/AppContext.kt
+++ b/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/state/AppContext.kt
@@ -519,6 +519,8 @@ class AppContext(val session: AppSession) {
                     val body = source.get("body")?.asText("").orEmpty().let {
                         if (it.isBlank()) null else Expressions.interpolate(it, ctx)
                     }
+                    // A registered client-side auth provider supplies dynamic headers (merged last).
+                    headers.putAll(io.mateu.ijp.ui.RestFetch.authHeaders(url, method))
                     apiClient.fetchExternal(url, method, headers, body)
                 }
             },

--- a/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/ui/RestFetch.kt
+++ b/frontend/app/intellij-plugin/src/main/kotlin/io/mateu/ijp/ui/RestFetch.kt
@@ -13,6 +13,24 @@ import io.mateu.ijp.state.Expressions
  */
 object RestFetch {
 
+    /**
+     * Client-side secure auth for DIRECT (non-proxy) external REST fetches: a host registers a
+     * provider that supplies auth headers (e.g. a bearer token from a secure store) at fetch time,
+     * so the token stays on the client and never rides the Mateu wire — the client-direct
+     * counterpart of the server-side `proxy` mode. Its headers are merged LAST (they win over a
+     * declared header). Ignored on the proxy path (secrets injected server-side). Null = none.
+     */
+    @Volatile
+    var externalAuthProvider: ((url: String, method: String) -> Map<String, String>)? = null
+
+    /** Auth headers for a direct fetch — empty when no provider is set or it throws. */
+    fun authHeaders(url: String, method: String): Map<String, String> =
+        externalAuthProvider?.let {
+            runCatching { it(url, method) }.getOrElse {
+                println("[Mateu] external auth provider failed: ${it.message}"); emptyMap()
+            }
+        } ?: emptyMap()
+
     /** Navigate a dot path (`data.items`, `name.common`) into a JSON value; blank path is identity. */
     fun valueAtPath(node: JsonNode?, path: String?): JsonNode? {
         if (node == null) return null
@@ -29,6 +47,8 @@ object RestFetch {
         val headers = LinkedHashMap<String, String>()
         source.path("headers").fields().forEach { (k, v) -> headers[k] = Expressions.interpolate(v.asText(""), ctx) }
         val body = source.get("body")?.asText("").orEmpty().let { if (it.isBlank()) null else Expressions.interpolate(it, ctx) }
+        // A registered client-side auth provider supplies dynamic headers (merged last, so it wins).
+        headers.putAll(authHeaders(url, method))
         return apiClient.fetchExternal(url, method, headers, body)
     }
 }

--- a/frontend/app/react-native/src/core/MateuViewController.ts
+++ b/frontend/app/react-native/src/core/MateuViewController.ts
@@ -1,5 +1,6 @@
 import { evaluateExpression, interpolate } from './expressions';
 import { MateuSession, NavTarget } from './MateuSession';
+import { externalAuthHeaders } from './restFetch';
 import { announce } from '../a11y/a11y';
 
 type Json = Record<string, any>;
@@ -245,6 +246,8 @@ export class MateuViewController {
         const method = (str(source['method']) || 'GET').toUpperCase();
         const headers: Record<string, string> = {};
         for (const [k, v] of Object.entries((source['headers'] as Json) ?? {})) headers[k] = resolve(v);
+        // A registered client-side auth provider supplies dynamic headers (merged last, so it wins).
+        Object.assign(headers, await externalAuthHeaders({ url, method }));
         const init: RequestInit = { method, headers };
         if (method !== 'GET' && method !== 'HEAD' && source['body']) init.body = resolve(source['body']);
         const res = await fetch(url, init);

--- a/frontend/app/react-native/src/core/restFetch.ts
+++ b/frontend/app/react-native/src/core/restFetch.ts
@@ -5,6 +5,34 @@
 
 type Json = Record<string, any>;
 
+/** Client-side secure auth for DIRECT (non-proxy) external REST fetches: a host app registers a
+ *  provider that supplies auth headers (e.g. a bearer token from a secure store) at fetch time, so
+ *  the token stays on the device and never rides the Mateu wire — the client-direct counterpart of
+ *  the server-side `proxy` mode. Ignored on the proxy path (secrets are injected server-side). */
+export type ExternalAuthProvider = (ctx: {
+  url: string;
+  method: string;
+}) => Record<string, string> | undefined | Promise<Record<string, string> | undefined>;
+
+let authProvider: ExternalAuthProvider | undefined;
+
+/** Register (or clear, with `undefined`) the direct-fetch auth-header provider. Its headers are
+ *  merged LAST, so they win over any statically declared header of the same name. */
+export function registerExternalAuthProvider(p: ExternalAuthProvider | undefined): void {
+  authProvider = p;
+}
+
+/** Resolve the auth headers for a direct external fetch — `{}` with no provider / on error. */
+export async function externalAuthHeaders(ctx: { url: string; method: string }): Promise<Record<string, string>> {
+  if (!authProvider) return {};
+  try {
+    return (await authProvider(ctx)) ?? {};
+  } catch (e) {
+    console.warn('mateu: external auth provider failed', e);
+    return {};
+  }
+}
+
 /** Navigate a dot path (`data.items`, `name.common`) into a JSON value; an empty path is identity. */
 export function getByPath(obj: unknown, path?: string): unknown {
   if (!path) return obj;
@@ -58,6 +86,9 @@ export async function fetchExternalJson(source: Json, resolve: (t: unknown) => s
   const method = String(source['method'] ?? 'GET').toUpperCase();
   const headers: Record<string, string> = {};
   for (const [k, v] of Object.entries((source['headers'] as Json) ?? {})) headers[k] = resolve(v);
+  // A registered client-side auth provider supplies dynamic headers (e.g. a bearer token) — merged
+  // last so it wins over any declared header.
+  Object.assign(headers, await externalAuthHeaders({ url, method }));
   const init: RequestInit = { method, headers };
   if (method !== 'GET' && method !== 'HEAD' && source['body']) init.body = resolve(source['body']);
   const res = await fetch(url, init);

--- a/frontend/web/monorepo/libs/mateu/src/index.ts
+++ b/frontend/web/monorepo/libs/mateu/src/index.ts
@@ -1,2 +1,4 @@
 export { onSessionExpired } from './mateu/ui/infra/http/sessionGuard.ts'
 export type { SessionExpiredContext } from './mateu/ui/infra/http/sessionGuard.ts'
+export { registerExternalAuthProvider } from './mateu/ui/infra/http/externalAuth.ts'
+export type { ExternalAuthProvider, ExternalAuthContext } from './mateu/ui/infra/http/externalAuth.ts'

--- a/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/http/externalAuth.ts
+++ b/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/http/externalAuth.ts
@@ -1,0 +1,41 @@
+// Client-side secure auth for DIRECT (non-proxy) external REST fetches. A host app registers a
+// provider that supplies auth headers (e.g. an Authorization bearer token read from a secure
+// store) at fetch time; the renderer merges them into every direct @RestOptions/@RestListing/
+// @RestAction/@RestData request. The token stays on the client and never rides the Mateu wire —
+// the client-direct counterpart of the server-side `proxy` mode (which injects ${secret.X}
+// server-side). The proxy path never calls this (it fetches server-to-server).
+
+export interface ExternalAuthContext {
+    /** The interpolated endpoint URL about to be fetched. */
+    url: string
+    /** The HTTP method (uppercased). */
+    method: string
+}
+
+/** Supplies auth headers for a direct external fetch; may be async (e.g. refresh a token). */
+export type ExternalAuthProvider = (
+    ctx: ExternalAuthContext,
+) => Record<string, string> | undefined | Promise<Record<string, string> | undefined>
+
+let provider: ExternalAuthProvider | undefined
+
+/**
+ * Register (or clear, with `undefined`) the auth-header provider consulted before every DIRECT
+ * external REST fetch. Its headers are merged LAST, so they win over any statically declared
+ * header of the same name. Ignored on the proxy path (secrets are injected server-side there).
+ */
+export function registerExternalAuthProvider(p: ExternalAuthProvider | undefined): void {
+    provider = p
+}
+
+/** Resolve the auth headers for a direct external fetch — `{}` when no provider is registered or
+ *  the provider throws (a failing token lookup must not break the fetch outright). */
+export async function externalAuthHeaders(ctx: ExternalAuthContext): Promise<Record<string, string>> {
+    if (!provider) return {}
+    try {
+        return (await provider(ctx)) ?? {}
+    } catch (e) {
+        console.warn('mateu: external auth provider failed', e)
+        return {}
+    }
+}

--- a/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/http/externalOptions.test.ts
+++ b/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/http/externalOptions.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterEach } from 'vitest'
 import { getByPath, mapItemsToOptions, mapItemsToRows, fetchExternalOptions, fetchExternalRows, fetchExternalJson } from './externalOptions'
+import { registerExternalAuthProvider } from './externalAuth'
 import type RestDataSource from '@mateu/shared/apiClients/dtos/componentmetadata/RestDataSource.ts'
 
 describe('getByPath', () => {
@@ -90,6 +91,44 @@ describe('fetchExternalJson', () => {
         expect((seen.init?.headers as Record<string, string>).Authorization).toBe('Bearer abc')
         expect(seen.init?.body).toBe('{"z":"28001"}')
         expect(getByPath(json, 'address.city')).toBe('Madrid')
+    })
+})
+
+describe('client-side auth provider (direct path)', () => {
+    afterEach(() => registerExternalAuthProvider(undefined))
+
+    const capture = (): [typeof fetch, () => Record<string, string>] => {
+        let headers: Record<string, string> = {}
+        const fetchImpl = (async (_u: string, init: RequestInit) => {
+            headers = init.headers as Record<string, string>
+            return { ok: true, status: 200, json: async () => ({}) }
+        }) as unknown as typeof fetch
+        return [fetchImpl, () => headers]
+    }
+
+    it('merges provider headers into a direct fetch, winning over a declared header', async () => {
+        registerExternalAuthProvider(({ url, method }) => ({ Authorization: `Bearer secret-${method}`, 'X-Url': url }))
+        const [fetchImpl, headers] = capture()
+        await fetchExternalJson(
+            { url: 'https://api/x', headers: { Authorization: 'Bearer declared' } } as RestDataSource,
+            (t) => t,
+            fetchImpl,
+        )
+        expect(headers().Authorization).toBe('Bearer secret-GET') // provider wins over the declared header
+        expect(headers()['X-Url']).toBe('https://api/x')
+    })
+
+    it('adds nothing when no provider is registered', async () => {
+        const [fetchImpl, headers] = capture()
+        await fetchExternalJson({ url: 'https://api/x' } as RestDataSource, (t) => t, fetchImpl)
+        expect(headers().Authorization).toBeUndefined()
+    })
+
+    it('a throwing provider does not break the fetch', async () => {
+        registerExternalAuthProvider(() => { throw new Error('token store down') })
+        const [fetchImpl, headers] = capture()
+        await fetchExternalJson({ url: 'https://api/x' } as RestDataSource, (t) => t, fetchImpl)
+        expect(headers().Authorization).toBeUndefined()
     })
 })
 

--- a/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/http/externalOptions.ts
+++ b/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/http/externalOptions.ts
@@ -1,4 +1,5 @@
 import type RestDataSource from '@mateu/shared/apiClients/dtos/componentmetadata/RestDataSource.ts'
+import { externalAuthHeaders } from './externalAuth.ts'
 
 /**
  * Client-side consumption of an arbitrary (non-Mateu) REST endpoint for a field's select options —
@@ -76,6 +77,9 @@ export async function fetchExternalJson(
     const method = (source.method || 'GET').toUpperCase()
     const headers: Record<string, string> = {}
     for (const [k, v] of Object.entries(source.headers ?? {})) headers[k] = resolve(v) ?? v
+    // A registered client-side auth provider supplies dynamic headers (e.g. a bearer token from a
+    // secure store) for this DIRECT fetch — merged last so it wins over any declared header.
+    Object.assign(headers, await externalAuthHeaders({ url, method }))
     const init: RequestInit = { method, headers }
     if (method !== 'GET' && method !== 'HEAD' && source.body) init.body = resolve(source.body) ?? source.body
     const res = await fetchImpl(url, init)


### PR DESCRIPTION
Increment 5 (final) of the external-endpoints auth/CORS hardening — the **client-direct** counterpart of server-side proxy mode (#344–#348). Teams that keep the direct (client-side) fetch but still need to authenticate it register a client-side auth provider; the renderer merges its headers into every **direct** `@RestOptions`/`@RestListing`/`@RestAction`/`@RestData` request. The token is added **at fetch time on the client** and never rides the annotation or the Mateu wire. Ignored on the proxy path (secrets are server-side there).

### Web (`libs/mateu`)
- New `externalAuth.ts`: `registerExternalAuthProvider(fn)` + `externalAuthHeaders(ctx)`.
- `fetchExternalJson` merges the provider's headers **last** (they win over a declared header of the same name) — a single choke point covering all four direct surfaces (options/rows delegate to it; `handleRestAction` uses it directly).
- Exported from the package index next to `onSessionExpired`/`registerNeutralNotifier`.
- Async providers are awaited; a throwing provider is swallowed (never breaks the fetch).

### React Native (`src/core/restFetch.ts`)
Same `registerExternalAuthProvider` + `externalAuthHeaders`, merged in `fetchExternalJson` (options/rows) and `MateuViewController.handleRestAction` (action/data).

### IntelliJ (`RestFetch.externalAuthProvider`)
Merged in `RestFetch.fetch` (options/rows) and `AppContext.handleRestAction` (action/data).

### Verification
3 vitest (merges + wins over a declared header; no-op with no provider; a throwing provider is safe) — asserted **through the real `fetchExternalJson` path**, i.e. the header lands in the actual `fetch` `init.headers`. RN tsc-clean, IntelliJ compiles.

(A live browser check via the vaadin shell is currently blocked by a pre-existing framework bug — `RouteInstanceCreator.resolveAsApp` `NoClassDefFoundError: lombok/Lombok` on route-only page loads, which 500s the whole page and is unrelated to this feature; same blocker noted for the RN proxy verification in #348. The vitest exercises the exact runtime merge.)

Docs: `rest-options.md` → "Client-side auth for the direct path".

This closes the external-endpoints hardening line (proxy mode + client token provider, both selectable per source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)