### PR TITLE
fix(routing): a broken RoutedClassProvider no longer 500s every route

### DIFF
--- a/backend/shared/core/src/main/java/io/mateu/core/application/DefaultRoutedClassResolver.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/DefaultRoutedClassResolver.java
@@ -9,7 +9,9 @@ import jakarta.inject.Singleton;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Named
 @Singleton
 @RequiredArgsConstructor(onConstructor_ = @Inject)
@@ -21,8 +23,9 @@ public class DefaultRoutedClassResolver implements RoutedClassResolver {
   public Optional<ResolvedRoute> resolveAbsolute(String route, RunActionCommand command) {
     var ui =
         providers.stream()
-            .filter(provider -> provider.routedClass().isAnnotationPresent(UI.class))
-            .map(provider -> matchesAbsolute(route, provider.routedClass(), command))
+            .filter(DefaultRoutedClassResolver::isUi)
+            .map(
+                provider -> safe(provider, route, command, RouteAnnotationMatcher::matchesAbsolute))
             .filter(Optional::isPresent)
             .map(Optional::get)
             .findFirst();
@@ -30,7 +33,7 @@ public class DefaultRoutedClassResolver implements RoutedClassResolver {
       return ui;
     }
     return providers.stream()
-        .map(provider -> matchesAbsolute(route, provider.routedClass(), command))
+        .map(provider -> safe(provider, route, command, RouteAnnotationMatcher::matchesAbsolute))
         .filter(Optional::isPresent)
         .map(Optional::get)
         .findFirst();
@@ -39,7 +42,7 @@ public class DefaultRoutedClassResolver implements RoutedClassResolver {
   @Override
   public Optional<ResolvedRoute> resolveApp(String route, RunActionCommand command) {
     return providers.stream()
-        .map(provider -> matchesApp(route, provider.routedClass(), command))
+        .map(provider -> safe(provider, route, command, RouteAnnotationMatcher::matchesApp))
         .filter(Optional::isPresent)
         .map(Optional::get)
         .findFirst();
@@ -48,23 +51,42 @@ public class DefaultRoutedClassResolver implements RoutedClassResolver {
   @Override
   public Optional<ResolvedRoute> resolve(String route, RunActionCommand command) {
     return providers.stream()
-        .map(provider -> matches(route, provider.routedClass(), command))
+        .map(provider -> safe(provider, route, command, RouteAnnotationMatcher::matches))
         .filter(Optional::isPresent)
         .map(Optional::get)
         .findFirst();
   }
 
-  private Optional<ResolvedRoute> matchesAbsolute(
-      String route, Class<?> aClass, RunActionCommand command) {
-    return RouteAnnotationMatcher.matchesAbsolute(route, aClass, command);
+  /**
+   * Evaluate one provider against the route, isolating any failure to THAT provider: a broken or
+   * stale generated {@code RoutedClassProvider} (e.g. one whose {@code routedClass()} references a
+   * class removed at runtime) is logged and skipped instead of aborting the whole resolution — one
+   * bad provider must not 500 every route. Catches {@link Throwable} because a missing class
+   * surfaces as {@link NoClassDefFoundError} (an Error, not an Exception).
+   */
+  private static Optional<ResolvedRoute> safe(
+      RoutedClassProvider provider, String route, RunActionCommand command, RouteMatcher matcher) {
+    try {
+      return matcher.match(route, provider.routedClass(), command);
+    } catch (Throwable t) {
+      log.warn(
+          "skipping route provider {}: its routed class could not be resolved ({})",
+          provider.getClass().getName(),
+          t.toString());
+      return Optional.empty();
+    }
   }
 
-  private Optional<ResolvedRoute> matchesApp(
-      String route, Class<?> aClass, RunActionCommand command) {
-    return RouteAnnotationMatcher.matchesApp(route, aClass, command);
+  private static boolean isUi(RoutedClassProvider provider) {
+    try {
+      return provider.routedClass().isAnnotationPresent(UI.class);
+    } catch (Throwable t) {
+      return false;
+    }
   }
 
-  private Optional<ResolvedRoute> matches(String route, Class<?> aClass, RunActionCommand command) {
-    return RouteAnnotationMatcher.matches(route, aClass, command);
+  @FunctionalInterface
+  private interface RouteMatcher {
+    Optional<ResolvedRoute> match(String route, Class<?> aClass, RunActionCommand command);
   }
 }

--- a/backend/shared/core/src/test/java/io/mateu/core/application/DefaultRoutedClassResolverTest.java
+++ b/backend/shared/core/src/test/java/io/mateu/core/application/DefaultRoutedClassResolverTest.java
@@ -1,0 +1,63 @@
+package io.mateu.core.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.mateu.core.application.runaction.RunActionCommand;
+import io.mateu.uidl.annotations.UI;
+import io.mateu.uidl.interfaces.RoutedClassProvider;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A single broken/stale {@link RoutedClassProvider} — e.g. a generated route resolver left in
+ * {@code target/classes} whose {@code routedClass()} references a class removed at runtime — must
+ * be skipped, not abort route resolution for every route. Reproduces the failure that a stale
+ * generated resolver caused (a {@link NoClassDefFoundError} from one provider 500'd every route; it
+ * was further masked by {@code @SneakyThrows} → {@code NoClassDefFoundError: lombok/Lombok} at
+ * runtime).
+ */
+class DefaultRoutedClassResolverTest {
+
+  @UI("/ok")
+  static class Ok {}
+
+  /**
+   * Its routed class cannot be loaded (the class it names was removed) — mirrors a stale resolver.
+   */
+  static class BrokenProvider implements RoutedClassProvider {
+    @Override
+    public Class<?> routedClass() {
+      throw new NoClassDefFoundError("io/example/Deleted");
+    }
+  }
+
+  static class OkProvider implements RoutedClassProvider {
+    @Override
+    public Class<?> routedClass() {
+      return Ok.class;
+    }
+  }
+
+  @Test
+  void aBrokenProviderIsSkippedInsteadOfFailingResolution() {
+    var resolver = new DefaultRoutedClassResolver(List.of(new BrokenProvider()));
+    // resolve() consults the (throwing) provider first, so command is never reached for it.
+    assertThatCode(() -> resolver.resolve("/anything", null)).doesNotThrowAnyException();
+    assertThat(resolver.resolve("/anything", null)).isEmpty();
+    assertThat(resolver.resolveApp("/anything", null)).isEmpty();
+    assertThat(resolver.resolveAbsolute("/anything", null)).isEmpty();
+  }
+
+  @Test
+  void aValidProviderStillResolvesAlongsideABrokenOne() {
+    var resolver = new DefaultRoutedClassResolver(List.of(new BrokenProvider(), new OkProvider()));
+    // matchesAbsolute matches command.baseUrl()+route() against the @UI value, so a minimal command
+    // (baseUrl "" + route "/ok") is enough — the broken provider must not stop it being found.
+    var command =
+        new RunActionCommand("", null, "/ok", null, null, null, null, null, null, null, null);
+    var resolved = resolver.resolveAbsolute("/ok", command);
+    assertThat(resolved).isPresent();
+    assertThat(resolved.get().resolvedClass()).isEqualTo(Ok.class);
+  }
+}


### PR DESCRIPTION
## The bug

Route resolution (`DefaultRoutedClassResolver`) iterated **every** `RoutedClassProvider` and called `provider.routedClass()` inline in a stream. A single broken/stale provider — e.g. a generated route resolver left in `target/classes` whose `routedClass()` references a class removed at runtime — threw `NoClassDefFoundError` and **aborted resolution for every route** (the whole app 500s).

Worse, the real cause was **masked**: the enclosing `RouteInstanceCreator.resolveAsApp`/`findRouteResolver` are `@SneakyThrows`, and lombok is (correctly) excluded from the app's runtime jar, so the generated `lombok.Lombok.sneakyThrow(...)` rethrow could not load `lombok.Lombok` → the error surfaced as an inscrutable `NoClassDefFoundError: lombok/Lombok` with the actual exception hidden entirely.

## How it was found

Diagnosing a "pre-existing lombok bug" that 500'd route-only page loads. Un-masking `resolveAsApp` revealed the true cause: a **stale generated resolver** (`FooUIRouteResolver`) from a deleted temp fixture — its `target/classes` `.class` outlived a non-clean rebuild — whose `routedClass()` NoClassDefFound'd on the deleted `Foo`.

## The fix

`DefaultRoutedClassResolver` now evaluates each provider through a `safe(...)` wrapper that catches `Throwable` (a missing class is a `NoClassDefFoundError`, an `Error` not an `Exception`), **logs which provider was skipped and why, and continues**. The `@UI` pre-filter in `resolveAbsolute` is guarded the same way. One bad provider can no longer take down the route table.

## Verification

- New `DefaultRoutedClassResolverTest`: a broken provider is skipped (not fatal) across `resolve`/`resolveApp`/`resolveAbsolute`; a valid provider still resolves alongside it.
- Full core suite green (**789**).
- **Live**: with a stale resolver planted on the classpath, `/rest-options` returns **200** and the skip is logged (`skipping route provider …StaleProbeUIRouteResolver … NoClassDefFoundError: …/StaleProbe`) — zero lombok masking (before: 500 on every route).

Note: the broader `@SneakyThrows`-masks-as-lombok effect (55 sites, only bites when a `@SneakyThrows` method throws AND lombok is excluded from runtime) is left as-is; this fix removes the most common trigger (a throwing provider) and makes resolution resilient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)