### PR TITLE
refactor(routing): drop @SneakyThrows from the hot reactive route path

### DIFF
--- a/backend/shared/core/src/main/java/io/mateu/core/application/runaction/ActionInstanceCreator.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/runaction/ActionInstanceCreator.java
@@ -11,7 +11,6 @@ import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 
@@ -27,7 +26,6 @@ public class ActionInstanceCreator {
   private final AppMenuResolver appMenuResolver;
   private final YamlUidlLoader yamlUidlLoader;
 
-  @SneakyThrows
   Mono<?> createInstance(RunActionCommand command) {
     log.info("createInstance {}", command);
 

--- a/backend/shared/core/src/main/java/io/mateu/core/application/runaction/AppMenuResolver.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/runaction/AppMenuResolver.java
@@ -22,7 +22,6 @@ import jakarta.inject.Singleton;
 import java.util.List;
 import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 
@@ -238,7 +237,6 @@ public class AppMenuResolver {
         .build();
   }
 
-  @SneakyThrows
   AppShell toApp(
       Object potentialApp,
       String baseUrl,

--- a/backend/shared/core/src/main/java/io/mateu/core/application/runaction/ComponentStateHelper.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/runaction/ComponentStateHelper.java
@@ -19,9 +19,9 @@ import io.mateu.uidl.annotations.UI;
 import io.mateu.uidl.fluent.Component;
 import io.mateu.uidl.interfaces.HttpRequest;
 import io.mateu.uidl.interfaces.StateSupplier;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.*;
-import lombok.SneakyThrows;
 
 /** Static helpers for building ServerSideComponentDto and extracting component/state metadata. */
 public class ComponentStateHelper {
@@ -115,8 +115,22 @@ public class ComponentStateHelper {
     return "";
   }
 
-  @SneakyThrows
   public static Object invoke(Method method, Object instance) {
-    return method.invoke(instance);
+    try {
+      return method.invoke(instance);
+    } catch (InvocationTargetException e) {
+      // Surface the real exception the method threw, not the reflective wrapper (this is exactly
+      // what @SneakyThrows hid behind NoClassDefFoundError: lombok/Lombok when it rethrew).
+      var cause = e.getCause() != null ? e.getCause() : e;
+      if (cause instanceof RuntimeException re) {
+        throw re;
+      }
+      if (cause instanceof Error err) {
+        throw err;
+      }
+      throw new RuntimeException(cause);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException("Cannot invoke " + method, e);
+    }
   }
 }

--- a/backend/shared/core/src/main/java/io/mateu/core/application/runaction/CrudNavigationAdjuster.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/runaction/CrudNavigationAdjuster.java
@@ -5,7 +5,6 @@ import static io.mateu.core.infra.reflection.ClassLoaders.forName;
 import io.mateu.core.infra.declarative.orchestrators.crud.Crud;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
-import lombok.SneakyThrows;
 
 /** Adjusts a {@link RunActionCommand} before route resolution for CRUD navigation actions. */
 @Named
@@ -19,12 +18,16 @@ public class CrudNavigationAdjuster {
    * pre-adjusted so the correct sub-route resolves. Returns routeFirst=true to signal that route
    * resolution should be attempted before falling back to the known serverSideType.
    */
-  @SneakyThrows
   AdjustedCommand adjust(RunActionCommand command) {
     if (command.serverSideType() == null || command.serverSideType().isEmpty()) {
       return new AdjustedCommand(command, false);
     }
-    var type = forName(command.serverSideType());
+    Class<?> type;
+    try {
+      type = forName(command.serverSideType());
+    } catch (ClassNotFoundException e) {
+      throw new IllegalStateException("Unknown serverSideType " + command.serverSideType(), e);
+    }
     if (!Crud.class.isAssignableFrom(type)) {
       return new AdjustedCommand(command, false);
     }

--- a/backend/shared/core/src/main/java/io/mateu/core/application/runaction/DirectClassResolver.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/runaction/DirectClassResolver.java
@@ -13,20 +13,36 @@ import io.mateu.uidl.RouteConstants;
 import io.mateu.uidl.interfaces.RouteResolver;
 import java.util.List;
 import java.util.Optional;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 
 @Slf4j
 final class DirectClassResolver {
 
-  @SneakyThrows
   static Mono<?> resolve(
       String rawRoute,
       RunActionCommand command,
       RoutedClassResolver routedClassResolver,
       InstanceFactoryProvider instanceFactoryProvider,
       List<RouteResolver> routeResolvers) {
+    // A missing class (forName → ClassNotFoundException) or a failing RouteResolver becomes a
+    // reactive error signal, so it surfaces as itself instead of the NoClassDefFoundError:
+    // lombok/Lombok that @SneakyThrows produced when lombok is off the runtime classpath.
+    try {
+      return resolveInner(
+          rawRoute, command, routedClassResolver, instanceFactoryProvider, routeResolvers);
+    } catch (Exception e) {
+      return Mono.error(e);
+    }
+  }
+
+  private static Mono<?> resolveInner(
+      String rawRoute,
+      RunActionCommand command,
+      RoutedClassResolver routedClassResolver,
+      InstanceFactoryProvider instanceFactoryProvider,
+      List<RouteResolver> routeResolvers)
+      throws ClassNotFoundException {
     if ("".equals(rawRoute)) {
       rawRoute = command.baseUrl();
     }

--- a/backend/shared/core/src/main/java/io/mateu/core/application/runaction/RouteInstanceCreator.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/runaction/RouteInstanceCreator.java
@@ -18,7 +18,6 @@ import jakarta.inject.Singleton;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -40,7 +39,6 @@ public class RouteInstanceCreator {
    * (shortest-first so the broadest enclosing app wins), then fall back to direct class matches
    * (longest-first so the most-specific route wins).
    */
-  @SneakyThrows
   public Mono<?> findRouteResolver(RunActionCommand command) {
     List<String> segments = createRoutes(command);
     log.info("findRouteResolver segments={}", segments);
@@ -68,8 +66,19 @@ public class RouteInstanceCreator {
    * #findRouteResolver}). Returns the instantiated app after remote-menu resolution so the UI can
    * use it as the next serverSideType.
    */
-  @SneakyThrows
   private Mono<?> resolveAsApp(String rawRoute, RunActionCommand command) {
+    // A missing class (forName → ClassNotFoundException) becomes a reactive error signal, so it
+    // surfaces as itself instead of the NoClassDefFoundError: lombok/Lombok that @SneakyThrows
+    // produced when lombok is off the runtime classpath.
+    try {
+      return resolveAsAppInner(rawRoute, command);
+    } catch (Exception e) {
+      return Mono.error(e);
+    }
+  }
+
+  private Mono<?> resolveAsAppInner(String rawRoute, RunActionCommand command)
+      throws ClassNotFoundException {
     var route = removeQueryParamsFromRoute(rawRoute);
     var routedClass = routedClassResolver.resolve(route, command);
     if (routedClass.isPresent()) {

--- a/backend/shared/core/src/test/java/io/mateu/core/application/runaction/ComponentStateHelperTest.java
+++ b/backend/shared/core/src/test/java/io/mateu/core/application/runaction/ComponentStateHelperTest.java
@@ -1,0 +1,43 @@
+package io.mateu.core.application.runaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link ComponentStateHelper#invoke} used to be {@code @SneakyThrows}, which rethrew the
+ * reflective {@code InvocationTargetException} as-is (hiding the real cause) and — because lombok
+ * is off the app's runtime classpath — could surface as {@code NoClassDefFoundError: lombok/Lombok}
+ * instead of the actual error. It now unwraps the real exception the invoked method threw.
+ */
+class ComponentStateHelperTest {
+
+  static class Fixture {
+    public String ok() {
+      return "hi";
+    }
+
+    public void boom() {
+      throw new IllegalArgumentException("kaboom");
+    }
+  }
+
+  private static Method method(String name) throws NoSuchMethodException {
+    return Fixture.class.getMethod(name);
+  }
+
+  @Test
+  void invokeReturnsTheResult() throws Exception {
+    assertThat(ComponentStateHelper.invoke(method("ok"), new Fixture())).isEqualTo("hi");
+  }
+
+  @Test
+  void invokeSurfacesTheRealCauseNotTheReflectiveWrapper() throws Exception {
+    // the caller sees the business exception the method threw, not InvocationTargetException
+    assertThatThrownBy(() -> ComponentStateHelper.invoke(method("boom"), new Fixture()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("kaboom");
+  }
+}


### PR DESCRIPTION
Follow-up to #350. `@SneakyThrows` on the route-resolution / run-action path rethrew checked exceptions via `lombok.Lombok.sneakyThrow()`, which needs lombok on the **runtime** classpath — but consumer apps exclude lombok from their runtime jar, so any such throw surfaced as an inscrutable `NoClassDefFoundError: lombok/Lombok`, hiding the real cause. That masking is what made a stale route resolver so hard to diagnose in #350.

Removed all **7** `@SneakyThrows` in `application/runaction` and handled the checked exceptions explicitly:

- **`ComponentStateHelper.invoke`** — unwraps `InvocationTargetException` to the real cause (rethrows a `RuntimeException`/`Error` as-is, else wraps) and wraps `IllegalAccessException`. A reflective action failure now surfaces the business exception, not the reflective wrapper.
- **`CrudNavigationAdjuster.adjust`** — `forName`'s `ClassNotFoundException` → `IllegalStateException("Unknown serverSideType …")`.
- **`DirectClassResolver.resolve`** / **`RouteInstanceCreator.resolveAsApp`** — the reactive `Mono` methods catch and return `Mono.error(e)` (extracted an `*Inner` that declares `throws`), so a missing class flows through the reactive error channel as itself.
- **`findRouteResolver`**, **`ActionInstanceCreator.createInstance`**, **`AppMenuResolver.toApp`** — the annotation was unnecessary (nothing on those bodies throws checked) — removed.

### Verification
- **Live**: a bogus `serverSideType` now logs `IllegalStateException: Unknown serverSideType …` (the real cause) with **zero** `lombok/Lombok` masking; normal routes still **200**.
- Tests: new `ComponentStateHelperTest` (result + real-cause unwrap). Full core suite green (**789**).

The remaining 48 `@SneakyThrows` elsewhere in core are outside the hot route path and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)