### PR TITLE
refactor(core): remove @SneakyThrows across core, handle checked exceptions explicitly

### DIFF
--- a/backend/shared/core/src/main/java/io/mateu/core/application/runaction/ActionInstanceCreator.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/runaction/ActionInstanceCreator.java
@@ -160,7 +160,7 @@ public class ActionInstanceCreator {
                           : java.util.stream.Stream.concat(
                               java.util.stream.Stream.of(a), a.children().stream()))
               .anyMatch(a -> actionId.equals(a.actionId()));
-    } catch (ReflectiveOperationException | RuntimeException e) {
+    } catch (Exception e) {
       return false;
     }
   }

--- a/backend/shared/core/src/main/java/io/mateu/core/application/runaction/CrudNavigationAdjuster.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/runaction/CrudNavigationAdjuster.java
@@ -22,12 +22,9 @@ public class CrudNavigationAdjuster {
     if (command.serverSideType() == null || command.serverSideType().isEmpty()) {
       return new AdjustedCommand(command, false);
     }
-    Class<?> type;
-    try {
-      type = forName(command.serverSideType());
-    } catch (ClassNotFoundException e) {
-      throw new IllegalStateException("Unknown serverSideType " + command.serverSideType(), e);
-    }
+    // forName throws an unchecked IllegalStateException naming the class if it is genuinely
+    // missing.
+    var type = forName(command.serverSideType());
     if (!Crud.class.isAssignableFrom(type)) {
       return new AdjustedCommand(command, false);
     }

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/act/AppContextSearchActionRunner.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/act/AppContextSearchActionRunner.java
@@ -16,7 +16,6 @@ import jakarta.inject.Named;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import lombok.SneakyThrows;
 import reactor.core.publisher.Flux;
 
 /**
@@ -42,7 +41,6 @@ public class AppContextSearchActionRunner implements ActionRunner {
     return actionId != null && actionId.startsWith(ACTION_PREFIX);
   }
 
-  @SneakyThrows
   @Override
   public Flux<?> run(Object instance, RunActionCommand command) {
     var httpRequest = command.httpRequest();
@@ -63,7 +61,7 @@ public class AppContextSearchActionRunner implements ActionRunner {
   }
 
   private java.lang.reflect.Field findAppContextField(
-      Object instance, HttpRequest httpRequest, String fieldName) throws Exception {
+      Object instance, HttpRequest httpRequest, String fieldName) {
     for (Class<?> c = instance.getClass(); c != null && c != Object.class; c = c.getSuperclass()) {
       try {
         return c.getDeclaredField(fieldName);
@@ -73,12 +71,15 @@ public class AppContextSearchActionRunner implements ActionRunner {
     }
     var serverSideType = httpRequest.runActionRq().serverSideType();
     if (serverSideType != null && !serverSideType.isBlank()) {
-      return forName(serverSideType).getDeclaredField(fieldName);
+      try {
+        return forName(serverSideType).getDeclaredField(fieldName);
+      } catch (NoSuchFieldException ignored) {
+        // not on the declared app type either → run() reports it as a non-@AppContext field
+      }
     }
     return null;
   }
 
-  @SneakyThrows
   private Object searchOptions(
       java.lang.reflect.Field field, String searchText, HttpRequest httpRequest) {
     if (field.getType().isEnum()) {

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/act/AuditActionRunner.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/act/AuditActionRunner.java
@@ -15,7 +15,6 @@ import io.mateu.uidl.interfaces.HttpRequest;
 import jakarta.inject.Named;
 import java.util.List;
 import java.util.UUID;
-import lombok.SneakyThrows;
 import reactor.core.publisher.Flux;
 
 @Named
@@ -31,7 +30,6 @@ public class AuditActionRunner implements ActionRunner {
     return 50;
   }
 
-  @SneakyThrows
   @Override
   public Flux<?> run(Object instance, RunActionCommand command) {
     var listing = new AuditHistoryListing((Auditable) instance);

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/act/CodeFieldActionRunner.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/act/CodeFieldActionRunner.java
@@ -15,7 +15,6 @@ import jakarta.inject.Named;
 import java.lang.reflect.ParameterizedType;
 import java.util.List;
 import java.util.Map;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Flux;
 
@@ -33,7 +32,6 @@ public class CodeFieldActionRunner implements ActionRunner {
     return actionId != null && actionId.startsWith("code-");
   }
 
-  @SneakyThrows
   @Override
   public Flux<?> run(Object instance, RunActionCommand command) {
     var actionId = command.actionId();

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/act/CodeSearchFieldActionRunner.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/act/CodeSearchFieldActionRunner.java
@@ -22,7 +22,6 @@ import jakarta.inject.Named;
 import java.lang.reflect.ParameterizedType;
 import java.util.List;
 import java.util.UUID;
-import lombok.SneakyThrows;
 import reactor.core.publisher.Flux;
 
 @Named
@@ -38,7 +37,6 @@ public class CodeSearchFieldActionRunner implements ActionRunner {
     return actionId != null && actionId.startsWith("codesearch-");
   }
 
-  @SneakyThrows
   @Override
   public Flux<?> run(Object instance, RunActionCommand command) {
     var actionId = command.actionId();

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/act/ComponentTreeActionRunner.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/act/ComponentTreeActionRunner.java
@@ -10,7 +10,6 @@ import io.mateu.uidl.fluent.Form;
 import io.mateu.uidl.interfaces.ComponentTreeSupplier;
 import io.mateu.uidl.interfaces.HttpRequest;
 import jakarta.inject.Named;
-import lombok.SneakyThrows;
 import reactor.core.publisher.Flux;
 
 @Named
@@ -36,7 +35,6 @@ public class ComponentTreeActionRunner implements ActionRunner {
     return 100;
   }
 
-  @SneakyThrows
   @Override
   public Flux<?> run(Object instance, RunActionCommand command) {
     Button button =
@@ -47,7 +45,12 @@ public class ComponentTreeActionRunner implements ActionRunner {
         button.runnable().run();
       }
       if (button.callable() != null) {
-        result = button.callable().call();
+        try {
+          result = button.callable().call();
+        } catch (Exception e) {
+          // the button's Callable (user code) threw — surface its real failure, not a lombok mask
+          throw e instanceof RuntimeException re ? re : new RuntimeException(e);
+        }
       }
     }
     return asFlux(result, instance);

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/act/DefaultActionRunnerProvider.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/act/DefaultActionRunnerProvider.java
@@ -9,7 +9,6 @@ import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import java.util.Comparator;
 import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -20,7 +19,6 @@ public class DefaultActionRunnerProvider implements ActionRunnerProvider {
   private final BeanProvider beanProvider;
   private final InstanceFactoryProvider instanceFactoryProvider;
 
-  @SneakyThrows
   @Override
   public ActionRunner get(
       Object instance,
@@ -29,7 +27,7 @@ public class DefaultActionRunnerProvider implements ActionRunnerProvider {
       String route,
       HttpRequest httpRequest) {
     if (instance == null) {
-      throw new NoSuchMethodException("No method with name " + actionId + " on null");
+      throw new IllegalStateException("No method with name " + actionId + " on null");
     }
     if (actionId == null) {
       return new ActionRunner() {

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/act/ExportActionRunner.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/act/ExportActionRunner.java
@@ -17,7 +17,6 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
 import reactor.core.publisher.Flux;
 
 @Named
@@ -38,7 +37,6 @@ public class ExportActionRunner implements ActionRunner {
     return 50;
   }
 
-  @SneakyThrows
   @Override
   public Flux<?> run(Object instance, RunActionCommand command) {
     var actionId = command.actionId();
@@ -51,25 +49,31 @@ public class ExportActionRunner implements ActionRunner {
     String filename;
     String mimeType;
 
-    switch (actionId) {
-      case "export-excel" -> {
-        var exporter = beanProvider.getBean(ExcelExporter.class);
-        bytes = exporter.export(rows, columns, httpRequest);
-        filename = "export.xlsx";
-        mimeType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+    // the exporter interface declares `throws Exception` (IO/format failures) — surface it as
+    // itself
+    try {
+      switch (actionId) {
+        case "export-excel" -> {
+          var exporter = beanProvider.getBean(ExcelExporter.class);
+          bytes = exporter.export(rows, columns, httpRequest);
+          filename = "export.xlsx";
+          mimeType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+        }
+        case "export-pdf" -> {
+          var exporter = beanProvider.getBean(PdfExporter.class);
+          bytes = exporter.export(rows, columns, httpRequest);
+          filename = "export.pdf";
+          mimeType = "application/pdf";
+        }
+        default -> {
+          var exporter = beanProvider.getBean(CsvExporter.class);
+          bytes = exporter.export(rows, columns, httpRequest);
+          filename = "export.csv";
+          mimeType = "text/csv";
+        }
       }
-      case "export-pdf" -> {
-        var exporter = beanProvider.getBean(PdfExporter.class);
-        bytes = exporter.export(rows, columns, httpRequest);
-        filename = "export.pdf";
-        mimeType = "application/pdf";
-      }
-      default -> {
-        var exporter = beanProvider.getBean(CsvExporter.class);
-        bytes = exporter.export(rows, columns, httpRequest);
-        filename = "export.csv";
-        mimeType = "text/csv";
-      }
+    } catch (Exception e) {
+      throw e instanceof RuntimeException re ? re : new RuntimeException(e);
     }
 
     return Flux.just(

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/act/FieldCrudActionRunner.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/act/FieldCrudActionRunner.java
@@ -9,7 +9,6 @@ import io.mateu.core.infra.declarative.orchestrators.crud.Crud;
 import io.mateu.uidl.interfaces.HttpRequest;
 import jakarta.inject.Named;
 import java.util.List;
-import lombok.SneakyThrows;
 import reactor.core.publisher.Flux;
 
 @Named
@@ -71,7 +70,6 @@ public class FieldCrudActionRunner implements ActionRunner {
     return instance.getClass();
   }
 
-  @SneakyThrows
   @Override
   public Flux<?> run(Object instance, RunActionCommand command) {
     var actionId = command.actionId();

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/act/GlobalSearchActionRunner.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/act/GlobalSearchActionRunner.java
@@ -9,7 +9,6 @@ import io.mateu.uidl.interfaces.HttpRequest;
 import jakarta.inject.Named;
 import java.util.List;
 import java.util.Map;
-import lombok.SneakyThrows;
 import reactor.core.publisher.Flux;
 
 /**
@@ -33,7 +32,6 @@ public class GlobalSearchActionRunner implements ActionRunner {
     return ACTION_ID.equals(actionId);
   }
 
-  @SneakyThrows
   @Override
   public Flux<?> run(Object instance, RunActionCommand command) {
     var httpRequest = command.httpRequest();
@@ -54,7 +52,6 @@ public class GlobalSearchActionRunner implements ActionRunner {
   /**
    * The resolved instance may be the shell wrapper — the palette sends the app's serverSideType.
    */
-  @SneakyThrows
   private GlobalSearchSupplier findSupplier(Object instance, HttpRequest httpRequest) {
     if (instance instanceof GlobalSearchSupplier supplier) {
       return supplier;

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/act/ImportActionRunner.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/act/ImportActionRunner.java
@@ -6,7 +6,6 @@ import io.mateu.core.application.runaction.RunActionCommand;
 import io.mateu.uidl.interfaces.HttpRequest;
 import io.mateu.uidl.interfaces.UploadEnabled;
 import jakarta.inject.Named;
-import lombok.SneakyThrows;
 import reactor.core.publisher.Flux;
 
 @Named
@@ -22,7 +21,6 @@ public class ImportActionRunner implements ActionRunner {
     return 50;
   }
 
-  @SneakyThrows
   @Override
   public Flux<?> run(Object instance, RunActionCommand command) {
     var uploadEnabled = (UploadEnabled) instance;

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/act/ListingRowActionRunner.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/act/ListingRowActionRunner.java
@@ -8,7 +8,6 @@ import io.mateu.uidl.interfaces.HttpRequest;
 import io.mateu.uidl.interfaces.Listing;
 import jakarta.inject.Named;
 import java.lang.reflect.Method;
-import lombok.SneakyThrows;
 import reactor.core.publisher.Flux;
 
 /**
@@ -31,7 +30,6 @@ public class ListingRowActionRunner implements ActionRunner {
         && actionId.startsWith("action-on-row-");
   }
 
-  @SneakyThrows
   @Override
   public Flux<?> run(Object instance, RunActionCommand command) {
     var httpRequest = command.httpRequest();

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/act/NotificationsActionRunner.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/act/NotificationsActionRunner.java
@@ -9,7 +9,6 @@ import io.mateu.uidl.interfaces.NotificationsSupplier;
 import jakarta.inject.Named;
 import java.util.List;
 import java.util.Map;
-import lombok.SneakyThrows;
 import reactor.core.publisher.Flux;
 
 /**
@@ -40,7 +39,6 @@ public class NotificationsActionRunner implements ActionRunner {
     return actionId != null && actionId.startsWith(ACTION_PREFIX);
   }
 
-  @SneakyThrows
   @Override
   public Flux<?> run(Object instance, RunActionCommand command) {
     var httpRequest = command.httpRequest();
@@ -81,7 +79,6 @@ public class NotificationsActionRunner implements ActionRunner {
    * The resolved instance may be the app shell wrapper or the home content — walk to the app class
    * exactly like the app-context search does: the widget sends the app's serverSideType.
    */
-  @SneakyThrows
   private NotificationsSupplier findSupplier(Object instance, HttpRequest httpRequest) {
     if (instance instanceof NotificationsSupplier supplier) {
       return supplier;

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/act/SearchFieldActionRunner.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/act/SearchFieldActionRunner.java
@@ -15,7 +15,6 @@ import jakarta.inject.Named;
 import java.lang.reflect.ParameterizedType;
 import java.util.List;
 import java.util.Map;
-import lombok.SneakyThrows;
 import reactor.core.publisher.Flux;
 
 @Named
@@ -37,7 +36,6 @@ public class SearchFieldActionRunner implements ActionRunner {
     return actionId != null && actionId.startsWith("search-");
   }
 
-  @SneakyThrows
   @Override
   public Flux<?> run(Object instance, RunActionCommand command) {
     var actionId = command.actionId();

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/act/crudfieldhandlers/AddActionHandler.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/act/crudfieldhandlers/AddActionHandler.java
@@ -18,11 +18,9 @@ import io.mateu.uidl.interfaces.HttpRequest;
 import io.mateu.uidl.interfaces.MateuInstanceFactory;
 import java.lang.reflect.Field;
 import java.util.*;
-import lombok.SneakyThrows;
 
 public class AddActionHandler {
 
-  @SneakyThrows
   public static Object handleAdd(
       Object instance,
       String actionId,

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/act/crudfieldhandlers/CreateActionHandler.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/act/crudfieldhandlers/CreateActionHandler.java
@@ -17,11 +17,9 @@ import io.mateu.uidl.interfaces.MateuInstanceFactory;
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.util.*;
-import lombok.SneakyThrows;
 
 public class CreateActionHandler {
 
-  @SneakyThrows
   public static Object handleCreate(
       Object crudOrchestrator,
       String actionId,

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/act/crudfieldhandlers/SelectActionHandler.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/act/crudfieldhandlers/SelectActionHandler.java
@@ -16,11 +16,9 @@ import io.mateu.uidl.interfaces.MateuInstanceFactory;
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.util.*;
-import lombok.SneakyThrows;
 
 public class SelectActionHandler {
 
-  @SneakyThrows
   public static Object handleSelect(
       Object instance,
       String actionId,

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/out/componentmapper/AppWidgetExtractor.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/out/componentmapper/AppWidgetExtractor.java
@@ -11,7 +11,6 @@ import io.mateu.uidl.interfaces.HttpRequest;
 import io.mateu.uidl.interfaces.WidgetSupplier;
 import java.util.Collection;
 import java.util.Objects;
-import lombok.SneakyThrows;
 
 final class AppWidgetExtractor {
 
@@ -31,7 +30,6 @@ final class AppWidgetExtractor {
         .toList();
   }
 
-  @SneakyThrows
   private static Component mapWidget(
       java.lang.reflect.Field field,
       Object instance,

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/out/componentmapper/PageContentBuilder.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/out/componentmapper/PageContentBuilder.java
@@ -24,11 +24,9 @@ import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import lombok.SneakyThrows;
 
 final class PageContentBuilder {
 
-  @SneakyThrows
   static Collection<? extends Component> getContent(
       Object instanceOrType,
       String baseUrl,
@@ -38,7 +36,21 @@ final class PageContentBuilder {
       HttpRequest httpRequest) {
     Object instance;
     if (instanceOrType instanceof Class<?> type) {
-      instance = MateuBeanProvider.getBean(InstanceFactory.class).newInstance(type, httpRequest);
+      try {
+        instance = MateuBeanProvider.getBean(InstanceFactory.class).newInstance(type, httpRequest);
+      } catch (java.lang.reflect.InvocationTargetException e) {
+        // surface the constructor's real failure, not the reflective wrapper / lombok mask
+        var cause = e.getCause() != null ? e.getCause() : e;
+        if (cause instanceof RuntimeException re) {
+          throw re;
+        }
+        if (cause instanceof Error err) {
+          throw err;
+        }
+        throw new RuntimeException(cause);
+      } catch (ReflectiveOperationException e) {
+        throw new RuntimeException("Cannot instantiate " + type.getName(), e);
+      }
     } else {
       instance = instanceOrType;
     }

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/out/componentmapper/PageMetadataExtractor.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/out/componentmapper/PageMetadataExtractor.java
@@ -13,7 +13,6 @@ import io.mateu.uidl.data.PageBanner;
 import io.mateu.uidl.data.PeerNav;
 import io.mateu.uidl.interfaces.*;
 import java.util.List;
-import lombok.SneakyThrows;
 
 final class PageMetadataExtractor {
 
@@ -170,7 +169,6 @@ final class PageMetadataExtractor {
         .toList();
   }
 
-  @SneakyThrows
   static List<PageBanner> getBanners(Object instance, HttpRequest httpRequest) {
     if (instance instanceof BannerSupplier bannerSupplier) {
       return bannerSupplier.banners();
@@ -213,14 +211,19 @@ final class PageMetadataExtractor {
    * optional label prefix + the value's {@code toString()}). {@code null} when there is no such
    * field or its value is null.
    */
-  @SneakyThrows
   static String getTimestamp(Object instance) {
     for (var field : getAllFields(instance.getClass())) {
       if (!MetaAnnotations.isPresent(field, Timestamp.class)) {
         continue;
       }
       field.setAccessible(true);
-      Object value = field.get(instance);
+      Object value;
+      try {
+        value = field.get(instance);
+      } catch (IllegalAccessException e) {
+        throw new RuntimeException(
+            e); // field was just setAccessible(true) → effectively unreachable
+      }
       if (value == null) {
         return null;
       }

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/AppMappingUtils.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/AppMappingUtils.java
@@ -10,7 +10,6 @@ import io.mateu.uidl.interfaces.HttpRequest;
 import io.mateu.uidl.interfaces.RouteResolver;
 import java.util.List;
 import java.util.regex.Pattern;
-import lombok.SneakyThrows;
 
 public class AppMappingUtils {
 
@@ -26,7 +25,6 @@ public class AppMappingUtils {
     return total;
   }
 
-  @SneakyThrows
   public static String getRoute(
       Object componentSupplier,
       Object instance,

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/mappers/AppHomeRouteResolver.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/mappers/AppHomeRouteResolver.java
@@ -10,11 +10,9 @@ import io.mateu.uidl.interfaces.ComponentTreeSupplier;
 import io.mateu.uidl.interfaces.HttpRequest;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import lombok.SneakyThrows;
 
 final class AppHomeRouteResolver {
 
-  @SneakyThrows
   static String getHomeRoute(
       AppShell app,
       String route,

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/mappers/AppMapper.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/mappers/AppMapper.java
@@ -21,11 +21,9 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
-import lombok.SneakyThrows;
 
 public final class AppMapper {
 
-  @SneakyThrows
   public static ClientSideComponentDto mapAppToDto(
       ComponentTreeSupplier componentSupplier,
       AppShell app,
@@ -108,7 +106,6 @@ public final class AppMapper {
         null);
   }
 
-  @SneakyThrows
   private static List<FabDto> getAppFabs(AppShell app) {
     if (app.serverSideType() == null) return List.of();
     var appClass = forName(app.serverSideType());
@@ -140,7 +137,6 @@ public final class AppMapper {
    * (visibility follows server-side state). Each actionId dispatches like a {@code @Fab}: the app
    * class method with that name runs.
    */
-  @SneakyThrows
   private static List<AppHeaderActionDto> getContextActions(AppShell app, HttpRequest httpRequest) {
     if (app.serverSideType() == null) return List.of();
     var appClass = forName(app.serverSideType());
@@ -161,7 +157,6 @@ public final class AppMapper {
    * The bell renders when the app class implements {@link
    * io.mateu.uidl.interfaces.NotificationsSupplier}.
    */
-  @SneakyThrows
   private static boolean isNotificationsEnabled(AppShell app) {
     if (app.serverSideType() == null) {
       return false;
@@ -171,7 +166,6 @@ public final class AppMapper {
   }
 
   /** The ⌘K palette searches data too when the app class implements GlobalSearchSupplier. */
-  @SneakyThrows
   private static boolean isGlobalSearchEnabled(AppShell app) {
     if (app.serverSideType() == null) {
       return false;
@@ -198,7 +192,6 @@ public final class AppMapper {
    * with an empty text (first page). The selected value lives in the app state under the field's
    * name; see {@code HttpRequest.appContext(String)}.
    */
-  @SneakyThrows
   private static List<AppContextSelectorDto> getContextSelectors(
       AppShell app, HttpRequest httpRequest) {
     if (app.serverSideType() == null) return List.of();
@@ -223,7 +216,6 @@ public final class AppMapper {
     return selectors;
   }
 
-  @SneakyThrows
   private static List<OptionDto> getContextOptions(
       java.lang.reflect.Field field, HttpRequest httpRequest) {
     if (field.getType().isEnum()) {
@@ -264,7 +256,6 @@ public final class AppMapper {
     return List.of();
   }
 
-  @SneakyThrows
   private static boolean getThemeToggle(AppShell app) {
     if (app.serverSideType() == null) return false;
     var appClass = forName(app.serverSideType());
@@ -277,7 +268,6 @@ public final class AppMapper {
   /**
    * The command-center FAB shows when {@code @App(commandCenter=true)} — or implied by chromeless.
    */
-  @SneakyThrows
   private static boolean getCommandCenter(AppShell app) {
     if (app.serverSideType() == null) return false;
     var appClass = forName(app.serverSideType());
@@ -291,7 +281,6 @@ public final class AppMapper {
   /**
    * Chromeless drops the nav chrome; it implies the command center so navigation stays possible.
    */
-  @SneakyThrows
   private static boolean getChromeless(AppShell app) {
     if (app.serverSideType() == null) return false;
     var appClass = forName(app.serverSideType());
@@ -301,7 +290,6 @@ public final class AppMapper {
     return false;
   }
 
-  @SneakyThrows
   private static String getMcpUrl(AppShell app) {
     if (app.serverSideType() == null) return null;
     var appClass = forName(app.serverSideType());
@@ -312,7 +300,6 @@ public final class AppMapper {
     return null;
   }
 
-  @SneakyThrows
   private static String getUploadUrl(AppShell app) {
     if (app.serverSideType() == null) return null;
     var appClass = forName(app.serverSideType());
@@ -323,7 +310,6 @@ public final class AppMapper {
     return null;
   }
 
-  @SneakyThrows
   private static String getSseUrl(AppShell app) {
     if (app.serverSideType() == null) return null;
     var appClass = forName(app.serverSideType());

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/mappers/DataMapper.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/mappers/DataMapper.java
@@ -15,7 +15,6 @@ import io.mateu.uidl.fluent.Component;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.*;
-import lombok.SneakyThrows;
 
 public class DataMapper {
 
@@ -69,7 +68,6 @@ public class DataMapper {
     return map;
   }
 
-  @SneakyThrows
   public static Map<String, Object> mapPojo(Object item) {
     Map<String, Object> map = new HashMap<>();
     for (Field field : getAllFields(item.getClass())) {

--- a/backend/shared/core/src/main/java/io/mateu/core/infra/InputStreamReader.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/infra/InputStreamReader.java
@@ -1,9 +1,10 @@
 package io.mateu.core.infra;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.nio.charset.Charset;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
 /** Created by miguel on 13/9/16. */
@@ -22,17 +23,20 @@ public final class InputStreamReader {
     return readInputStream(inputStream);
   }
 
-  @SneakyThrows
   public static String readInputStream(InputStream is) {
 
     int count;
     byte[] data = new byte[BUFFER];
     ByteArrayOutputStream dest = new ByteArrayOutputStream();
-    while ((count = is.read(data, 0, BUFFER)) != -1) {
-      dest.write(data, 0, count);
+    try {
+      while ((count = is.read(data, 0, BUFFER)) != -1) {
+        dest.write(data, 0, count);
+      }
+      dest.flush();
+      dest.close();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
     }
-    dest.flush();
-    dest.close();
 
     return new String(dest.toByteArray(), Charset.defaultCharset());
   }

--- a/backend/shared/core/src/main/java/io/mateu/core/infra/JsonSerializer.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/infra/JsonSerializer.java
@@ -2,16 +2,17 @@ package io.mateu.core.infra;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.introspect.AnnotatedField;
 import com.fasterxml.jackson.databind.introspect.VisibilityChecker;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.io.UncheckedIOException;
 import java.lang.reflect.Modifier;
 import java.util.List;
 import java.util.Map;
-import lombok.SneakyThrows;
 
 public final class JsonSerializer {
 
@@ -46,9 +47,16 @@ public final class JsonSerializer {
 
   private JsonSerializer() {}
 
-  @SneakyThrows
+  // Jackson's checked JsonProcessingException (an IOException) is wrapped in UncheckedIOException
+  // so
+  // callers don't need @SneakyThrows — a malformed payload surfaces as itself, not as the
+  // NoClassDefFoundError: lombok/Lombok that @SneakyThrows produced when lombok is off runtime.
   public static String toJson(Object object) {
-    return mapper.writeValueAsString(object);
+    try {
+      return mapper.writeValueAsString(object);
+    } catch (JsonProcessingException e) {
+      throw new UncheckedIOException(e);
+    }
   }
 
   public static <T> T fromMap(Map<String, Object> map, Class<T> c) throws Exception {
@@ -59,21 +67,30 @@ public final class JsonSerializer {
     return pojoFromJson(json, c);
   }
 
-  @SneakyThrows
   public static <T> T pojoFromJson(String json, Class<T> c) {
     if (json == null || json.isEmpty()) json = "{}";
-    return mapper.readValue(json, c);
+    try {
+      return mapper.readValue(json, c);
+    } catch (JsonProcessingException e) {
+      throw new UncheckedIOException(e);
+    }
   }
 
-  @SneakyThrows
   public static <T> List<T> listFromJson(String json, Class<T> c) {
     if (json == null || json.isEmpty()) json = "[]";
-    return mapper.readerForListOf(c).readValue(json);
+    try {
+      return mapper.readerForListOf(c).readValue(json);
+    } catch (JsonProcessingException e) {
+      throw new UncheckedIOException(e);
+    }
   }
 
-  @SneakyThrows
   public static Map<String, Object> fromJson(String json) {
     if (json == null || "".equals(json)) json = "{}";
-    return mapper.readValue(json, Map.class);
+    try {
+      return mapper.readValue(json, Map.class);
+    } catch (JsonProcessingException e) {
+      throw new UncheckedIOException(e);
+    }
   }
 }

--- a/backend/shared/core/src/main/java/io/mateu/core/infra/StructureHashPostProcessor.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/infra/StructureHashPostProcessor.java
@@ -1,5 +1,6 @@
 package io.mateu.core.infra;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -8,10 +9,10 @@ import io.mateu.dtos.ServerSideComponentDto;
 import io.mateu.dtos.UIFragmentDto;
 import io.mateu.dtos.UIIncrementDto;
 import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.HexFormat;
 import java.util.List;
-import lombok.SneakyThrows;
 
 /**
  * Template-ref / ETag for screen structure (phase b of the client structure cache).
@@ -81,15 +82,18 @@ public final class StructureHashPostProcessor {
     return fragment.withComponent(component.withStructureHash(hash));
   }
 
-  @SneakyThrows
   private static String hashOf(ServerSideComponentDto component) {
     // Normalize away the two per-request fields before hashing so the SAME structure always hashes
     // the same: the top-level component id is a fresh UUID on every request (an instance id, not
     // structure), and the hash slot itself must not feed back into the hash. Nested/structural ids
     // (field ids, etc.) are kept — they ARE part of the structure. The client never computes this
     // hash, only echoes the server's, so nulling id here is symmetric across request and response.
-    byte[] json = CANONICAL.writeValueAsBytes(component.withId(null).withStructureHash(null));
-    byte[] digest = MessageDigest.getInstance("SHA-256").digest(json);
-    return HexFormat.of().formatHex(digest);
+    try {
+      byte[] json = CANONICAL.writeValueAsBytes(component.withId(null).withStructureHash(null));
+      byte[] digest = MessageDigest.getInstance("SHA-256").digest(json);
+      return HexFormat.of().formatHex(digest);
+    } catch (JsonProcessingException | NoSuchAlgorithmException e) {
+      throw new IllegalStateException("Cannot compute structure hash", e);
+    }
   }
 }

--- a/backend/shared/core/src/main/java/io/mateu/core/infra/declarative/orchestrators/crud/CrudAdapterHelper.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/infra/declarative/orchestrators/crud/CrudAdapterHelper.java
@@ -5,12 +5,12 @@ import static io.mateu.core.infra.reflection.read.AllFieldsProvider.getAllFields
 
 import io.mateu.uidl.interfaces.HttpRequest;
 import io.mateu.uidl.interfaces.MateuInstanceFactory;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import lombok.SneakyThrows;
 
 public class CrudAdapterHelper {
 
@@ -25,7 +25,6 @@ public class CrudAdapterHelper {
     return getInstance(map, viewClass, httpRequest);
   }
 
-  @SneakyThrows
   private static <T> T getInstance(
       Map<String, Object> data, Class<T> type, HttpRequest httpRequest) {
     T value = null;
@@ -34,9 +33,22 @@ public class CrudAdapterHelper {
     } catch (Exception e) {
     }
     if (value == null) {
-      var constructor = type.getDeclaredConstructor();
-      if (!Modifier.isPublic(constructor.getModifiers())) constructor.setAccessible(true);
-      return constructor.newInstance();
+      try {
+        var constructor = type.getDeclaredConstructor();
+        if (!Modifier.isPublic(constructor.getModifiers())) constructor.setAccessible(true);
+        return constructor.newInstance();
+      } catch (InvocationTargetException e) {
+        var cause = e.getCause() != null ? e.getCause() : e;
+        if (cause instanceof RuntimeException re) {
+          throw re;
+        }
+        if (cause instanceof Error err) {
+          throw err;
+        }
+        throw new RuntimeException(cause);
+      } catch (ReflectiveOperationException e) {
+        throw new RuntimeException("Cannot instantiate " + type.getName(), e);
+      }
     }
     return value;
   }

--- a/backend/shared/core/src/main/java/io/mateu/core/infra/declarative/orchestrators/crud/FilteredAutoCrud.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/infra/declarative/orchestrators/crud/FilteredAutoCrud.java
@@ -9,7 +9,6 @@ import io.mateu.uidl.di.MateuBeanProvider;
 import io.mateu.uidl.interfaces.*;
 import java.util.List;
 import java.util.Map;
-import lombok.SneakyThrows;
 
 public abstract class FilteredAutoCrud<Filters, T extends Identifiable>
     extends Crud<T, T, T, Filters, T, String> {
@@ -95,7 +94,6 @@ public abstract class FilteredAutoCrud<Filters, T extends Identifiable>
   }
 
   /** The entity backing the creation form. Override to return a pre-populated instance. */
-  @SneakyThrows
   @SuppressWarnings("unchecked")
   public T buildCreationForm(HttpRequest httpRequest) {
     Map<String, Object> data = Map.of();
@@ -110,7 +108,6 @@ public abstract class FilteredAutoCrud<Filters, T extends Identifiable>
             .newInstance(entityClass(), data, httpRequest);
   }
 
-  @SneakyThrows
   @SuppressWarnings("unchecked")
   T toEntity(HttpRequest httpRequest) {
     // parameters is nullable on the wire — without the guard a save with no parameters NPEd

--- a/backend/shared/core/src/main/java/io/mateu/core/infra/declarative/orchestrators/crud/LookupSupplierResolver.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/infra/declarative/orchestrators/crud/LookupSupplierResolver.java
@@ -8,11 +8,28 @@ import io.mateu.uidl.interfaces.LookupLabelSupplier;
 import io.mateu.uidl.interfaces.LookupOptionsSupplier;
 import io.mateu.uidl.interfaces.Selector;
 import java.lang.reflect.Field;
-import lombok.SneakyThrows;
+import java.lang.reflect.InvocationTargetException;
 
 final class LookupSupplierResolver {
 
-  @SneakyThrows
+  /** Instantiate a supplier via its no-arg constructor, surfacing the constructor's REAL cause. */
+  private static <S> S instantiate(Class<S> type) {
+    try {
+      return type.getConstructor().newInstance();
+    } catch (InvocationTargetException e) {
+      var cause = e.getCause() != null ? e.getCause() : e;
+      if (cause instanceof RuntimeException re) {
+        throw re;
+      }
+      if (cause instanceof Error err) {
+        throw err;
+      }
+      throw new RuntimeException(cause);
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException("Cannot instantiate " + type.getName(), e);
+    }
+  }
+
   static Selector getSelector(Object instance, Field field) {
     Class<? extends Selector> supplierType = null;
     if (MetaAnnotations.isPresent(field, Searchable.class)) {
@@ -27,12 +44,11 @@ final class LookupSupplierResolver {
     }
     var supplier = MateuBeanProvider.getBean(supplierType);
     if (supplier == null) {
-      return supplierType.getConstructor().newInstance();
+      return instantiate(supplierType);
     }
     return supplier;
   }
 
-  @SneakyThrows
   static LookupLabelSupplier getLookupLabelSupplier(Object instance, Field field) {
     Class<? extends LookupLabelSupplier> supplierType = null;
     if (MetaAnnotations.isPresent(field, Lookup.class)) {
@@ -51,12 +67,11 @@ final class LookupSupplierResolver {
     }
     var supplier = MateuBeanProvider.getBean(supplierType);
     if (supplier == null) {
-      return supplierType.getConstructor().newInstance();
+      return instantiate(supplierType);
     }
     return supplier;
   }
 
-  @SneakyThrows
   static LookupOptionsSupplier getLookupOptionsSupplier(Object instance, Field field) {
     if (field != null) {
       var lookup = MetaAnnotations.find(field, Lookup.class);
@@ -70,7 +85,7 @@ final class LookupSupplierResolver {
         var supplier =
             MateuBeanProvider.getBean(MetaAnnotations.find(field, Lookup.class).search());
         if (supplier == null) {
-          return MetaAnnotations.find(field, Lookup.class).search().getConstructor().newInstance();
+          return instantiate(MetaAnnotations.find(field, Lookup.class).search());
         }
         return supplier;
       }

--- a/backend/shared/core/src/main/java/io/mateu/core/infra/declarative/orchestrators/crud/OptimisticLock.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/infra/declarative/orchestrators/crud/OptimisticLock.java
@@ -5,7 +5,6 @@ import io.mateu.uidl.annotations.Version;
 import io.mateu.uidl.interfaces.HttpRequest;
 import java.lang.reflect.Field;
 import java.util.Optional;
-import lombok.SneakyThrows;
 
 /**
  * Optimistic locking over the entity's {@code @Version} field: {@link #check} compares the incoming
@@ -39,7 +38,6 @@ public final class OptimisticLock {
     return Optional.empty();
   }
 
-  @SneakyThrows
   public static <T> void check(T incoming, Optional<T> stored, HttpRequest httpRequest) {
     if (stored.isEmpty()) {
       return;
@@ -48,30 +46,39 @@ public final class OptimisticLock {
     if (field.isEmpty()) {
       return;
     }
-    if (forceOverwrite(httpRequest)) {
-      // the user chose to overwrite from the conflict dialog: adopt the STORED version so the
-      // bump below moves it forward instead of resurrecting the stale one
-      field.get().set(incoming, field.get().get(stored.get()));
-      return;
-    }
-    long incomingVersion = ((Number) field.get().get(incoming)).longValue();
-    long storedVersion = ((Number) field.get().get(stored.get())).longValue();
-    if (storedVersion > incomingVersion) {
-      throw new StaleEditException();
+    // the @Version field is setAccessible(true) in versionField, so IllegalAccessException is
+    // effectively unreachable — wrapped so callers don't need @SneakyThrows.
+    try {
+      if (forceOverwrite(httpRequest)) {
+        // the user chose to overwrite from the conflict dialog: adopt the STORED version so the
+        // bump below moves it forward instead of resurrecting the stale one
+        field.get().set(incoming, field.get().get(stored.get()));
+        return;
+      }
+      long incomingVersion = ((Number) field.get().get(incoming)).longValue();
+      long storedVersion = ((Number) field.get().get(stored.get())).longValue();
+      if (storedVersion > incomingVersion) {
+        throw new StaleEditException();
+      }
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(e);
     }
   }
 
-  @SneakyThrows
   public static <T> void bump(T entity) {
     var field = versionField(entity.getClass());
     if (field.isEmpty()) {
       return;
     }
-    long version = ((Number) field.get().get(entity)).longValue();
-    if (field.get().getType() == int.class || field.get().getType() == Integer.class) {
-      field.get().set(entity, (int) (version + 1));
-    } else {
-      field.get().set(entity, version + 1);
+    try {
+      long version = ((Number) field.get().get(entity)).longValue();
+      if (field.get().getType() == int.class || field.get().getType() == Integer.class) {
+        field.get().set(entity, (int) (version + 1));
+      } else {
+        field.get().set(entity, version + 1);
+      }
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(e);
     }
   }
 

--- a/backend/shared/core/src/main/java/io/mateu/core/infra/declarative/orchestrators/crud/actionhandlers/ActionOnRowActionHandler.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/infra/declarative/orchestrators/crud/actionhandlers/ActionOnRowActionHandler.java
@@ -8,7 +8,6 @@ import io.mateu.core.infra.declarative.orchestrators.crud.Crud;
 import io.mateu.core.infra.declarative.orchestrators.crud.CrudActionResult;
 import io.mateu.uidl.interfaces.HttpRequest;
 import java.lang.reflect.Method;
-import lombok.SneakyThrows;
 
 public class ActionOnRowActionHandler implements CrudOrchestratorActionHandler {
   @Override
@@ -16,7 +15,6 @@ public class ActionOnRowActionHandler implements CrudOrchestratorActionHandler {
     return actionId.startsWith("action-on-row-");
   }
 
-  @SneakyThrows
   @Override
   public Object handleAction(String actionId, HttpRequest httpRequest, Crud orchestrator) {
     String methodName = actionId.substring("action-on-row-".length());

--- a/backend/shared/core/src/main/java/io/mateu/core/infra/declarative/orchestrators/crud/actionhandlers/ActionOnViewActionHandler.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/infra/declarative/orchestrators/crud/actionhandlers/ActionOnViewActionHandler.java
@@ -7,7 +7,6 @@ import io.mateu.core.infra.declarative.orchestrators.crud.Crud;
 import io.mateu.core.infra.declarative.orchestrators.crud.CrudActionResult;
 import io.mateu.uidl.data.State;
 import io.mateu.uidl.interfaces.HttpRequest;
-import lombok.SneakyThrows;
 
 public class ActionOnViewActionHandler implements CrudOrchestratorActionHandler {
   @Override
@@ -15,13 +14,17 @@ public class ActionOnViewActionHandler implements CrudOrchestratorActionHandler 
     return actionId.startsWith("action-on-view-");
   }
 
-  @SneakyThrows
   @Override
   public Object handleAction(String actionId, HttpRequest httpRequest, Crud orchestrator) {
     String methodName = actionId.substring("action-on-view-".length());
     var item = toView(httpRequest, orchestrator.viewClass());
     var idField = orchestrator.getIdFieldForRow();
-    var savedId = getValue(idField, item);
+    Object savedId;
+    try {
+      savedId = getValue(idField, item);
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException(e);
+    }
 
     var result = CrudViewMethodInvoker.invoke(methodName, item, orchestrator, httpRequest);
     if (result != null) {

--- a/backend/shared/core/src/main/java/io/mateu/core/infra/declarative/orchestrators/crud/actionhandlers/CrudViewMethodInvoker.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/infra/declarative/orchestrators/crud/actionhandlers/CrudViewMethodInvoker.java
@@ -8,11 +8,9 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.SneakyThrows;
 
 final class CrudViewMethodInvoker {
 
-  @SneakyThrows
   static Object invoke(String methodName, Object item, Crud orchestrator, HttpRequest httpRequest) {
     for (Object subject : List.of(item, orchestrator.behaviourSource())) {
       for (Method method : getAllMethods(subject.getClass())) {
@@ -32,12 +30,18 @@ final class CrudViewMethodInvoker {
           }
           try {
             return method.invoke(subject, args.toArray());
-          } catch (Throwable e) {
-            if (e instanceof InvocationTargetException invocationTargetException
-                && invocationTargetException.getCause() != null) {
-              throw invocationTargetException.getCause();
+          } catch (InvocationTargetException e) {
+            // surface the user view-method's REAL cause, not the reflective wrapper / lombok mask
+            var cause = e.getCause() != null ? e.getCause() : e;
+            if (cause instanceof RuntimeException re) {
+              throw re;
             }
-            throw e;
+            if (cause instanceof Error err) {
+              throw err;
+            }
+            throw new RuntimeException(cause);
+          } catch (IllegalAccessException e) {
+            throw new RuntimeException("Cannot invoke " + method, e);
           }
         }
       }

--- a/backend/shared/core/src/main/java/io/mateu/core/infra/declarative/orchestrators/dashboard/DashboardComposer.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/infra/declarative/orchestrators/dashboard/DashboardComposer.java
@@ -13,7 +13,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.SneakyThrows;
 
 /**
  * The {@link Dashboard} composition, extracted so it works over ANY instance declaring the same
@@ -24,7 +23,6 @@ import lombok.SneakyThrows;
  */
 public final class DashboardComposer {
 
-  @SneakyThrows
   public static Component compose(Object host, String id, int columns) {
     List<Component> items = new ArrayList<>();
     List<MetricCard> pendingMetrics = new ArrayList<>();
@@ -33,7 +31,13 @@ public final class DashboardComposer {
         continue;
       }
       field.setAccessible(true);
-      Object value = field.get(host);
+      Object value;
+      try {
+        value = field.get(host);
+      } catch (IllegalAccessException e) {
+        throw new RuntimeException(
+            e); // field was just setAccessible(true) → effectively unreachable
+      }
       if (value instanceof MetricCard metricCard) {
         pendingMetrics.add(metricCard);
         continue;

--- a/backend/shared/core/src/main/java/io/mateu/core/infra/declarative/orchestrators/foldout/Foldout.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/infra/declarative/orchestrators/foldout/Foldout.java
@@ -22,7 +22,6 @@ import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.SneakyThrows;
 
 /**
  * Declarative Redwood-style foldout page: a fixed overview panel on the left plus lateral fold-out
@@ -107,7 +106,6 @@ public abstract class Foldout implements ComponentTreeSupplier, ActionSupplier, 
    * Chips shown under the header title (RDS "Label Value" pills). Defaults to the first {@code
    * List<Badge>} field found; override to compute them.
    */
-  @SneakyThrows
   public List<Badge> headerBadges() {
     for (Field field : getClass().getDeclaredFields()) {
       if (Modifier.isStatic(field.getModifiers())) {
@@ -118,7 +116,12 @@ public abstract class Foldout implements ComponentTreeSupplier, ActionSupplier, 
           && pt.getActualTypeArguments().length == 1
           && pt.getActualTypeArguments()[0] == Badge.class) {
         field.setAccessible(true);
-        Object value = field.get(this);
+        Object value;
+        try {
+          value = field.get(this);
+        } catch (IllegalAccessException e) {
+          throw new RuntimeException(e); // just setAccessible(true) → effectively unreachable
+        }
         if (value instanceof List<?> list) {
           List<Badge> badges = new ArrayList<>();
           for (Object item : list) {
@@ -143,7 +146,6 @@ public abstract class Foldout implements ComponentTreeSupplier, ActionSupplier, 
   }
 
   @Override
-  @SneakyThrows
   public Component component(HttpRequest httpRequest) {
     Component overview = null;
     List<FoldoutPanel> panels = new ArrayList<>();
@@ -152,7 +154,12 @@ public abstract class Foldout implements ComponentTreeSupplier, ActionSupplier, 
         continue;
       }
       field.setAccessible(true);
-      Object value = field.get(this);
+      Object value;
+      try {
+        value = field.get(this);
+      } catch (IllegalAccessException e) {
+        throw new RuntimeException(e); // just setAccessible(true) → effectively unreachable
+      }
       if (!(value instanceof Component component)) {
         continue;
       }

--- a/backend/shared/core/src/main/java/io/mateu/core/infra/declarative/orchestrators/importwizard/ImportRowAssembler.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/infra/declarative/orchestrators/importwizard/ImportRowAssembler.java
@@ -12,6 +12,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -19,7 +20,6 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.SneakyThrows;
 
 /**
  * Builds typed rows from parsed CSV records per the {@link ColumnMapping}s: coerces each cell into
@@ -59,7 +59,6 @@ final class ImportRowAssembler {
         || type.isEnum();
   }
 
-  @SneakyThrows
   static <Row> Preview<Row> assemble(
       Class<Row> rowClass, List<List<String>> records, List<ColumnMapping> mappings) {
     var validRows = new ArrayList<Row>();
@@ -73,7 +72,21 @@ final class ImportRowAssembler {
       int line = r + 1; // 1-based, counting the header line
       var record = records.get(r);
       var rowIssues = new ArrayList<RowIssue>();
-      Row row = rowClass.getDeclaredConstructor().newInstance();
+      Row row;
+      try {
+        row = rowClass.getDeclaredConstructor().newInstance();
+      } catch (InvocationTargetException e) {
+        var cause = e.getCause() != null ? e.getCause() : e;
+        if (cause instanceof RuntimeException re) {
+          throw re;
+        }
+        if (cause instanceof Error err) {
+          throw err;
+        }
+        throw new RuntimeException(cause);
+      } catch (ReflectiveOperationException e) {
+        throw new RuntimeException("Cannot instantiate " + rowClass.getName(), e);
+      }
       for (var mapping : mappings) {
         if (mapping.targetField == null || mapping.targetField.isBlank()) {
           continue;

--- a/backend/shared/core/src/main/java/io/mateu/core/infra/declarative/orchestrators/importwizard/MappingStep.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/infra/declarative/orchestrators/importwizard/MappingStep.java
@@ -48,7 +48,8 @@ public class MappingStep implements WizardStep, OptionsSupplier {
       ImportRowAssembler.assignableFields(rowClass)
           .forEach(field -> options.add(new Option(field.getName(), field.getName())));
       return options;
-    } catch (ClassNotFoundException e) {
+    } catch (RuntimeException e) {
+      // forName throws an unchecked IllegalStateException when the row class is missing
       return List.of();
     }
   }

--- a/backend/shared/core/src/main/java/io/mateu/core/infra/declarative/orchestrators/itemoverview/ItemOverview.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/infra/declarative/orchestrators/itemoverview/ItemOverview.java
@@ -16,7 +16,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.SneakyThrows;
 
 /**
  * Item overview page (Redwood item-overview template): the item's key information stays pinned in a
@@ -45,7 +44,6 @@ public abstract class ItemOverview implements ComponentTreeSupplier {
   }
 
   @Override
-  @SneakyThrows
   public Component component(HttpRequest httpRequest) {
     Component keyInfo = null;
     List<Tab> tabs = new ArrayList<>();
@@ -54,7 +52,13 @@ public abstract class ItemOverview implements ComponentTreeSupplier {
         continue;
       }
       field.setAccessible(true);
-      Object value = field.get(this);
+      Object value;
+      try {
+        value = field.get(this);
+      } catch (IllegalAccessException e) {
+        throw new RuntimeException(
+            e); // field was just setAccessible(true) → effectively unreachable
+      }
       if (!(value instanceof Component component)) {
         continue;
       }

--- a/backend/shared/core/src/main/java/io/mateu/core/infra/declarative/orchestrators/welcome/WelcomeComposer.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/infra/declarative/orchestrators/welcome/WelcomeComposer.java
@@ -15,7 +15,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.SneakyThrows;
 
 /**
  * The {@link Welcome} composition, extracted so it works over ANY instance declaring the same field
@@ -26,7 +25,6 @@ import lombok.SneakyThrows;
  */
 public final class WelcomeComposer {
 
-  @SneakyThrows
   public static Component compose(
       Object host, String id, String heroTitle, String heroSubtitle, String heroImage) {
     List<Component> ctas = new ArrayList<>();
@@ -36,7 +34,13 @@ public final class WelcomeComposer {
         continue;
       }
       field.setAccessible(true);
-      Object value = field.get(host);
+      Object value;
+      try {
+        value = field.get(host);
+      } catch (IllegalAccessException e) {
+        throw new RuntimeException(
+            e); // field was just setAccessible(true) → effectively unreachable
+      }
       if (value instanceof Button button) {
         ctas.add(button);
         continue;

--- a/backend/shared/core/src/main/java/io/mateu/core/infra/declarative/orchestrators/wizard/Wizard.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/infra/declarative/orchestrators/wizard/Wizard.java
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -57,7 +56,6 @@ public abstract class Wizard
     }
   }
 
-  @SneakyThrows
   @Override
   public Object handleAction(String actionId, HttpRequest httpRequest) {
     return WizardActionDispatcher.dispatch(actionId, this, httpRequest);

--- a/backend/shared/core/src/main/java/io/mateu/core/infra/declarative/orchestrators/wizard/WizardActionDispatcher.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/infra/declarative/orchestrators/wizard/WizardActionDispatcher.java
@@ -8,13 +8,32 @@ import io.mateu.uidl.annotations.WizardCompletionAction;
 import io.mateu.uidl.di.MateuBeanProvider;
 import io.mateu.uidl.interfaces.HttpRequest;
 import io.mateu.uidl.interfaces.InstanceFactory;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
-import lombok.SneakyThrows;
 
 final class WizardActionDispatcher {
 
-  @SneakyThrows
   static Object dispatch(String actionId, Wizard wizard, HttpRequest httpRequest) {
+    try {
+      return dispatchInner(actionId, wizard, httpRequest);
+    } catch (InvocationTargetException e) {
+      // the @WizardCompletionAction method (user code) threw — surface its REAL cause, not the
+      // reflective wrapper / the NoClassDefFoundError: lombok/Lombok that @SneakyThrows produced.
+      var cause = e.getCause() != null ? e.getCause() : e;
+      if (cause instanceof RuntimeException re) {
+        throw re;
+      }
+      if (cause instanceof Error err) {
+        throw err;
+      }
+      throw new RuntimeException(cause);
+    } catch (Exception e) {
+      throw e instanceof RuntimeException re ? re : new RuntimeException(e);
+    }
+  }
+
+  private static Object dispatchInner(String actionId, Wizard wizard, HttpRequest httpRequest)
+      throws Exception {
     if (actionId.startsWith("search-")) {
       return WizardLookupHandler.handleSearch(actionId, wizard, httpRequest);
     }

--- a/backend/shared/core/src/main/java/io/mateu/core/infra/declarative/orchestrators/wizard/WizardLookupHandler.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/infra/declarative/orchestrators/wizard/WizardLookupHandler.java
@@ -10,11 +10,9 @@ import io.mateu.uidl.di.MateuBeanProvider;
 import io.mateu.uidl.interfaces.HttpRequest;
 import io.mateu.uidl.interfaces.LookupOptionsSupplier;
 import java.util.Map;
-import lombok.SneakyThrows;
 
 final class WizardLookupHandler {
 
-  @SneakyThrows
   static Data handleSearch(String actionId, Wizard orchestrator, HttpRequest httpRequest) {
     String fieldName = actionId.substring(actionId.indexOf('-') + 1);
     LookupOptionsSupplier optionsSupplier;

--- a/backend/shared/core/src/main/java/io/mateu/core/infra/reflection/BuilderInstantiator.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/infra/reflection/BuilderInstantiator.java
@@ -3,14 +3,13 @@ package io.mateu.core.infra.reflection;
 import static io.mateu.uidl.reflection.GenericClassProvider.getGenericClass;
 
 import io.mateu.uidl.interfaces.HttpRequest;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Map;
-import lombok.SneakyThrows;
 
 final class BuilderInstantiator {
 
-  @SneakyThrows
   static <T> T tryInstantiate(
       Class<T> c,
       Map<String, Object> data,
@@ -23,25 +22,39 @@ final class BuilderInstantiator {
     }
     if (builderMethod == null) return null;
 
-    Object builder = c.getMethod("builder").invoke(null);
-    for (String key : data.keySet()) {
-      var found =
-          Arrays.stream(builder.getClass().getMethods())
-              .filter(m -> m.getName().equals(key))
-              .findFirst();
-      if (found.isPresent()) {
-        Method setter = found.get();
-        setter.invoke(
-            builder,
-            ReflectionTypeCoercer.coerce(
-                setter.getParameterTypes()[0],
-                data.get(key),
-                httpRequest,
-                getGenericClass(setter.getGenericParameterTypes()[0]),
-                factory));
+    try {
+      Object builder = c.getMethod("builder").invoke(null);
+      for (String key : data.keySet()) {
+        var found =
+            Arrays.stream(builder.getClass().getMethods())
+                .filter(m -> m.getName().equals(key))
+                .findFirst();
+        if (found.isPresent()) {
+          Method setter = found.get();
+          setter.invoke(
+              builder,
+              ReflectionTypeCoercer.coerce(
+                  setter.getParameterTypes()[0],
+                  data.get(key),
+                  httpRequest,
+                  getGenericClass(setter.getGenericParameterTypes()[0]),
+                  factory));
+        }
       }
+      return (T) builder.getClass().getMethod("build").invoke(builder);
+    } catch (InvocationTargetException e) {
+      // a builder/setter/build method (user code) threw — surface its real cause
+      var cause = e.getCause() != null ? e.getCause() : e;
+      if (cause instanceof RuntimeException re) {
+        throw re;
+      }
+      if (cause instanceof Error err) {
+        throw err;
+      }
+      throw new RuntimeException(cause);
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException("Cannot build " + c.getName(), e);
     }
-    return (T) builder.getClass().getMethod("build").invoke(builder);
   }
 
   private BuilderInstantiator() {}

--- a/backend/shared/core/src/main/java/io/mateu/core/infra/reflection/ClassLoaders.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/infra/reflection/ClassLoaders.java
@@ -8,11 +8,22 @@ package io.mateu.core.infra.reflection;
  */
 public class ClassLoaders {
 
-  public static Class<?> forName(String className) throws ClassNotFoundException {
+  /**
+   * Load a class by name. A genuinely missing class throws an UNCHECKED {@link
+   * IllegalStateException} naming it — so callers on the render/action path don't need
+   * {@code @SneakyThrows} (whose sneaky rethrow masked the real cause as {@code
+   * NoClassDefFoundError: lombok/Lombok} when lombok is off the runtime classpath), and the
+   * missing-class name actually surfaces.
+   */
+  public static Class<?> forName(String className) {
     try {
       return Class.forName(className);
     } catch (ClassNotFoundException e) {
-      return Thread.currentThread().getContextClassLoader().loadClass(className);
+      try {
+        return Thread.currentThread().getContextClassLoader().loadClass(className);
+      } catch (ClassNotFoundException e2) {
+        throw new IllegalStateException("Class not found: " + className, e2);
+      }
     }
   }
 }

--- a/backend/shared/core/src/main/java/io/mateu/core/infra/reflection/FragmentDataSerializer.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/infra/reflection/FragmentDataSerializer.java
@@ -12,7 +12,6 @@ import io.mateu.dtos.UIFragmentActionDto;
 import io.mateu.dtos.UIFragmentDto;
 import java.util.Collection;
 import java.util.Map;
-import lombok.SneakyThrows;
 
 final class FragmentDataSerializer {
 
@@ -35,7 +34,6 @@ final class FragmentDataSerializer {
             || ((ClientSideComponentDto) fragment.component()).metadata() instanceof DrawerDto);
   }
 
-  @SneakyThrows
   static Object toMap(Object data) {
     if (data == null) {
       return null;

--- a/backend/shared/core/src/main/java/io/mateu/core/infra/reflection/ReflectionInstanceFactory.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/infra/reflection/ReflectionInstanceFactory.java
@@ -2,7 +2,6 @@ package io.mateu.core.infra.reflection;
 
 import static io.mateu.core.infra.reflection.ClassLoaders.forName;
 import static io.mateu.core.infra.reflection.write.Hydrater.hydrate;
-import static java.lang.Thread.currentThread;
 
 import io.mateu.core.domain.ports.BeanProvider;
 import io.mateu.core.domain.ports.InstanceFactory;
@@ -16,7 +15,6 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.*;
 import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
 import reactor.core.publisher.Mono;
 
 @Singleton
@@ -31,7 +29,6 @@ public class ReflectionInstanceFactory implements InstanceFactory {
     return true;
   }
 
-  @SneakyThrows
   @Override
   public Mono<? extends Object> createInstance(
       String className, Map<String, Object> data, HttpRequest httpRequest) {
@@ -57,12 +54,10 @@ public class ReflectionInstanceFactory implements InstanceFactory {
         .map(uiInstance -> postHydrateIfNeeded(uiInstance, httpRequest));
   }
 
-  private Class<?> loadClass(String className) throws ClassNotFoundException {
-    try {
-      return forName(className);
-    } catch (ClassNotFoundException e) {
-      return currentThread().getContextClassLoader().loadClass(className);
-    }
+  private Class<?> loadClass(String className) {
+    // forName already falls back to the thread context classloader and throws an unchecked
+    // IllegalStateException naming the class if it is genuinely missing.
+    return forName(className);
   }
 
   private Object hydrateIfNeeded(Object uiInstance, HttpRequest httpRequest) {
@@ -87,8 +82,28 @@ public class ReflectionInstanceFactory implements InstanceFactory {
     return (T) newInstance(c, Map.of(), httpRequest);
   }
 
-  @SneakyThrows
   public <T> T newInstance(Class<T> c, Map<String, Object> data, HttpRequest httpRequest) {
+    try {
+      return newInstanceInner(c, data, httpRequest);
+    } catch (InvocationTargetException e) {
+      // a constructor (user code) threw — surface its real cause, not the reflective wrapper
+      var cause = e.getCause() != null ? e.getCause() : e;
+      if (cause instanceof RuntimeException re) {
+        throw re;
+      }
+      if (cause instanceof Error err) {
+        throw err;
+      }
+      throw new RuntimeException(cause);
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException("Cannot instantiate " + c.getName(), e);
+    } catch (Exception e) {
+      throw e instanceof RuntimeException re ? re : new RuntimeException(e);
+    }
+  }
+
+  private <T> T newInstanceInner(Class<T> c, Map<String, Object> data, HttpRequest httpRequest)
+      throws Exception {
     var o = beanProvider.getBean(c);
     if (o == null) { // not from spring
       if (c.getDeclaringClass() != null && !java.lang.reflect.Modifier.isStatic(c.getModifiers())) {

--- a/backend/shared/core/src/main/java/io/mateu/core/infra/reflection/ReflectionTypeCoercer.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/infra/reflection/ReflectionTypeCoercer.java
@@ -13,11 +13,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import lombok.SneakyThrows;
 
 final class ReflectionTypeCoercer {
 
-  @SneakyThrows
   static Object coerce(
       Class type,
       Object data,

--- a/backend/shared/core/src/main/java/io/mateu/core/infra/reflection/read/ValueProvider.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/infra/reflection/read/ValueProvider.java
@@ -12,41 +12,53 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Map;
 import java.util.concurrent.Callable;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class ValueProvider {
 
-  @SneakyThrows
   public static Object getValueOrNewInstance(BeanProvider beanProvider, Field f, Object o) {
     var value = getValue(f, o);
     if (value == null) {
       value = beanProvider.getBean(f.getType());
     }
     if (value == null) {
-      var constructor = f.getType().getDeclaredConstructor();
-      if (!Modifier.isPublic(constructor.getModifiers())) constructor.setAccessible(true);
-      return constructor.newInstance();
+      return newInstanceOf(f.getType());
     }
     return value;
   }
 
-  @SneakyThrows
   public static Object getValueOrNewInstance(Field f, Object o, HttpRequest httpRequest) {
     var value = getValue(f, o);
     if (value == null) {
       value = MateuInstanceFactory.newInstance(f.getType(), Map.of(), httpRequest);
     }
     if (value == null) {
-      var constructor = f.getType().getDeclaredConstructor();
-      if (!Modifier.isPublic(constructor.getModifiers())) constructor.setAccessible(true);
-      return constructor.newInstance();
+      return newInstanceOf(f.getType());
     }
     return value;
   }
 
-  @SneakyThrows
+  /** Instantiate via the no-arg constructor; a failing constructor surfaces its REAL cause. */
+  private static Object newInstanceOf(Class<?> type) {
+    try {
+      var constructor = type.getDeclaredConstructor();
+      if (!Modifier.isPublic(constructor.getModifiers())) constructor.setAccessible(true);
+      return constructor.newInstance();
+    } catch (InvocationTargetException e) {
+      var cause = e.getCause() != null ? e.getCause() : e;
+      if (cause instanceof RuntimeException re) {
+        throw re;
+      }
+      if (cause instanceof Error err) {
+        throw err;
+      }
+      throw new RuntimeException(cause);
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException("Cannot instantiate " + type.getName(), e);
+    }
+  }
+
   public static Object getValue(Field f, Object o) {
     if (o == null) return null;
     if (f == null) {
@@ -83,7 +95,12 @@ public class ValueProvider {
       log.error("when getting initialValue for field " + f.getName(), e);
     }
     if (v instanceof Callable callable) {
-      v = callable.call();
+      try {
+        v = callable.call();
+      } catch (Exception e) {
+        // a field-holder Callable (user lambda) — surface its real failure, not a lombok mask
+        throw e instanceof RuntimeException re ? re : new RuntimeException(e);
+      }
     }
     return v;
   }

--- a/backend/shared/core/src/main/java/io/mateu/core/infra/reflection/write/FallbackFieldSetter.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/infra/reflection/write/FallbackFieldSetter.java
@@ -7,11 +7,9 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Date;
-import lombok.SneakyThrows;
 
 final class FallbackFieldSetter {
 
-  @SneakyThrows
   static void set(Field field, Object target, Object value) {
     if (!java.lang.reflect.Modifier.isPublic(field.getModifiers())) {
       field.setAccessible(true);
@@ -20,7 +18,11 @@ final class FallbackFieldSetter {
       value = coerce(field, value);
       field.set(target, value);
     } catch (Exception ignored) {
-      field.set(target, null);
+      try {
+        field.set(target, null);
+      } catch (IllegalAccessException e) {
+        throw new RuntimeException(e); // field was setAccessible(true) → effectively unreachable
+      }
     }
   }
 

--- a/backend/shared/core/src/main/java/io/mateu/core/infra/reflection/write/ForeignKeyResolverActionRunner.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/infra/reflection/write/ForeignKeyResolverActionRunner.java
@@ -16,7 +16,6 @@ import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
 import reactor.core.publisher.Flux;
 
 @Named
@@ -36,7 +35,6 @@ public class ForeignKeyResolverActionRunner implements ActionRunner {
     return false;
   }
 
-  @SneakyThrows
   @Override
   public Flux<?> run(Object instance, RunActionCommand command) {
     var fieldName = command.actionId().substring("search-".length());

--- a/backend/shared/core/src/main/java/io/mateu/core/infra/reflection/write/RunMethodActionRunner.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/infra/reflection/write/RunMethodActionRunner.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -39,7 +38,6 @@ public class RunMethodActionRunner implements ActionRunner {
             || getFieldByName(instance.getClass(), actionId) != null);
   }
 
-  @SneakyThrows
   @Override
   public Flux<?> run(Object instance, RunActionCommand command) {
     var methodName = command.actionId();
@@ -85,7 +83,11 @@ public class RunMethodActionRunner implements ActionRunner {
                 .createInstance(f.getType().getName(), Map.of(), command.httpRequest());
       }
       if (result instanceof Callable<?> callable) {
-        result = callable.call();
+        try {
+          result = callable.call();
+        } catch (Exception e) {
+          throw e instanceof RuntimeException re ? re : new RuntimeException(e);
+        }
       }
       if (result instanceof Runnable runnable) {
         runnable.run();
@@ -102,12 +104,27 @@ public class RunMethodActionRunner implements ActionRunner {
     return Flux.empty();
   }
 
-  public static Object invoke(Method m, Object instance, RunActionCommand command)
-      throws InvocationTargetException, IllegalAccessException {
-    if (m.getParameterCount() > 0) {
-      return m.invoke(instance, createParameters(m, command));
-    } else {
-      return m.invoke(instance);
+  public static Object invoke(Method m, Object instance, RunActionCommand command) {
+    try {
+      if (m.getParameterCount() > 0) {
+        return m.invoke(instance, createParameters(m, command));
+      } else {
+        return m.invoke(instance);
+      }
+    } catch (InvocationTargetException e) {
+      // Surface the real exception the user method threw, not the reflective wrapper (and not the
+      // NoClassDefFoundError: lombok/Lombok that @SneakyThrows produced when lombok is off
+      // runtime).
+      var cause = e.getCause() != null ? e.getCause() : e;
+      if (cause instanceof RuntimeException re) {
+        throw re;
+      }
+      if (cause instanceof Error err) {
+        throw err;
+      }
+      throw new RuntimeException(cause);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException("Cannot invoke " + m, e);
     }
   }
 


### PR DESCRIPTION
Audit + fix of every remaining `@SneakyThrows` in core (**76 sites**, follow-up to #350/#351). They all share the same trap: `@SneakyThrows` rethrows a checked exception via `lombok.Lombok.sneakyThrow()`, which needs lombok on the **runtime** classpath — but a repackaged app excludes it, so any actual throw surfaces as an inscrutable `NoClassDefFoundError: lombok/Lombok` that masks the real cause. Removed all of them and handled the checked exceptions at the source.

### The audit (4 parallel sub-agents)
| Package | HIGH | MED | NONE |
|---|---|---|---|
| `domain/act` | 6 | 3 | 11 |
| `domain/out` | 15 | 4 | 1 |
| `orchestrators` | 5 | 8 | 7 |
| `infra/reflection` + `infra` | 10 | 5 | 1 |

The ~36 HIGH collapsed into 4 root causes, so most were fixed at the source rather than site-by-site.

### Source fixes that cascaded
- **`ClassLoaders.forName`** now throws an unchecked `IllegalStateException` naming the missing class (was `throws ClassNotFoundException`). This alone let **~20** forName-only callers — all 13 `AppMapper` app-metadata getters, the crud field handlers (`Select`/`Create`/`Add`), route/home resolvers — drop `@SneakyThrows` with no handling, and the missing-class name now surfaces.
- **`RunMethodActionRunner.invoke`** unwraps `InvocationTargetException` to the real cause (like `ComponentStateHelper.invoke` in #351).

### Per-site handling
- Reflective invoke/newInstance → unwrap `InvocationTargetException`: `CrudViewMethodInvoker`, `WizardActionDispatcher`, `BuilderInstantiator`, `ReflectionInstanceFactory`, `ValueProvider`, `CrudAdapterHelper`, `LookupSupplierResolver`, `ImportRowAssembler`, `PageContentBuilder`.
- Jackson read/write & InputStream IO → `UncheckedIOException`: `JsonSerializer`, `StructureHashPostProcessor`, `InputStreamReader`.
- `field.get/set` on already-`setAccessible` fields → `RuntimeException`: `Foldout`, `ItemOverview`, `WelcomeComposer`, `DashboardComposer`, `PageMetadataExtractor`, `OptimisticLock`, `FallbackFieldSetter`.
- `Callable.call()` → real cause: `ComponentTreeActionRunner`, `ValueProvider`, `RunMethodActionRunner`.
- Dead catches left by the forName change removed/broadened: `CrudNavigationAdjuster`, `ActionInstanceCreator`, `MappingStep`. `DefaultActionRunnerProvider`'s explicit checked throw → `IllegalStateException`.

### Verification
Full core suite green (**791**). Zero `@SneakyThrows` annotations and zero `lombok.SneakyThrows` imports remain in core. Verified live earlier in this line: a bogus `serverSideType` logs the real `IllegalStateException` with no lombok masking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)