### PR TITLE
chore(ap): drop orphaned lombok.SneakyThrows import from generated controllers

### DIFF
--- a/backend/helidon-mp/annotation-processor-helidon-mp/src/main/resources/templates/index.ftl
+++ b/backend/helidon-mp/annotation-processor-helidon-mp/src/main/resources/templates/index.ftl
@@ -6,7 +6,6 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashMap;

--- a/backend/mvc/annotation-processor-mvc/src/main/resources/templates/index.ftl
+++ b/backend/mvc/annotation-processor-mvc/src/main/resources/templates/index.ftl
@@ -1,6 +1,5 @@
 package ${pkgName};
 
-import lombok.SneakyThrows;
 import org.springframework.http.HttpStatus;
 import org.springframework.beans.factory.annotation.Value;
 import io.mateu.core.infra.InputStreamReader;

--- a/backend/quarkus/annotation-processor-quarkus/src/main/resources/templates/index.ftl
+++ b/backend/quarkus/annotation-processor-quarkus/src/main/resources/templates/index.ftl
@@ -7,7 +7,6 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.jboss.resteasy.reactive.RestResponse;
 


### PR DESCRIPTION
Audit of `@SneakyThrows` in the framework adapters (**mvc / webflux / micronaut / quarkus / helidon-mp**), completing the core sweep (#351/#352).

### Result: adapters are clean
Their Java sources use `@SneakyThrows` **zero** times — no masking risk. In particular the generated `*UIRouteResolver` (the class that caused #350) has no `@SneakyThrows`, so a missing routed class surfaces as a plain `NoClassDefFoundError` that `DefaultRoutedClassResolver.safe()` now catches — not the `lombok/Lombok` mask.

### The only finding
The `mvc` / `quarkus` / `helidon-mp` `index.ftl` controller templates `import lombok.SneakyThrows` but **never use the annotation**, so every generated `*Controller` in consumer apps carried a dead import (`webflux`/`micronaut` don't import it — it was also inconsistent between adapters). Removed it.

### Verification
`mvc-app1` regenerates its controllers from the updated template and compiles clean; **0** generated controllers import `SneakyThrows` anymore.

Note: one AP-core **test** resource template still contains a real `@SneakyThrows` — left as-is (test fixture, not shipped, no production masking risk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)