### PR TITLE
chore(ap-core): drop the last @SneakyThrows (test index template)

### DIFF
--- a/backend/shared/annotation-processor-core/src/test/resources/templates/index.ftl
+++ b/backend/shared/annotation-processor-core/src/test/resources/templates/index.ftl
@@ -4,7 +4,6 @@ import io.mateu.core.domain.model.outbound.modelToDtoMappers.UIMapper;
 import io.mateu.core.domain.model.reflection.ReflectionService;
 import io.mateu.core.domain.model.util.SerializerService;
 import io.mateu.uidl.interfaces.ReflectionHelper;
-import lombok.SneakyThrows;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.beans.factory.annotation.Value;
@@ -126,7 +125,6 @@ public class ${simpleClassName}Controller {
         return html;
     }
 
-    @SneakyThrows
     private String getContextData(ServerHttpRequest request) {
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.putAll(request.getQueryParams());


### PR DESCRIPTION
The final `@SneakyThrows` in the backend. `annotation-processor-core`'s **test** resource template (`getContextData`) carried `@SneakyThrows` + the import. The AP-core tests string-compare generated **route-resolver** output — they never compile the index template nor assert on it — so removing both is safe.

With this, the **entire backend** — core, all five adapters (mvc/webflux/micronaut/quarkus/helidon-mp), the annotation-processor templates, main **and** test — has **zero** `@SneakyThrows`. Nothing can mask a thrown checked exception as `NoClassDefFoundError: lombok/Lombok` anymore.

Verified: AP-core tests green (45).

🤖 Generated with [Claude Code](https://claude.com/claude-code)