### PR TITLE
docs(rest): cross-reference proxy mode + client auth on all four REST surfaces

### DIFF
--- a/doc/src/content/docs/java-ui-definition/annotations/rest-action.md
+++ b/doc/src/content/docs/java-ui-definition/annotations/rest-action.md
@@ -59,6 +59,13 @@ interpolates the url/headers/body against the live state, `fetch`es the endpoint
 `resultPath` into the form state and shows the toast. A non-2xx response shows a failure toast. The
 endpoint must be reachable from the browser (CORS-friendly for cross-origin APIs).
 
+:::note[CORS & auth]
+`proxy = true` also works on `@RestAction`: the call goes through the Mateu server (no CORS) with
+`${secret.X}` auth injected server-side. To authenticate the direct call instead, register a
+client-side auth provider. Both are described under
+[`@RestOptions`](./rest-options#server-proxy-mode-proxy--true--cors--auth-hardening).
+:::
+
 ## Other backends
 
 Mateu.NET and the Python backend emit the same `restAction` descriptor:

--- a/doc/src/content/docs/java-ui-definition/annotations/rest-data.md
+++ b/doc/src/content/docs/java-ui-definition/annotations/rest-data.md
@@ -48,6 +48,13 @@ the trigger runs the action client-side — interpolating the url/headers/body a
 renderer that already runs OnLoad triggers and `@RestAction` gets it for free. The endpoint must be
 reachable from the browser (CORS-friendly for cross-origin APIs).
 
+:::note[CORS & auth]
+`proxy = true` also works on `@RestData`: the load goes through the Mateu server (no CORS) with
+`${secret.X}` auth injected server-side. To authenticate the direct load instead, register a
+client-side auth provider. Both are described under
+[`@RestOptions`](./rest-options#server-proxy-mode-proxy--true--cors--auth-hardening).
+:::
+
 `url` interpolation lets the request depend on a route parameter seeded into the state (e.g.
 `url = "https://api.example.com/users/${state.id}"`).
 

--- a/doc/src/content/docs/java-ui-definition/annotations/rest-listing.md
+++ b/doc/src/content/docs/java-ui-definition/annotations/rest-listing.md
@@ -59,10 +59,17 @@ column id.
 The endpoint must be reachable from the browser (CORS-friendly for cross-origin APIs; same-origin
 needs nothing). The listing is read-only.
 
+:::note[CORS & auth]
+`proxy = true` also works on `@RestListing`: the rows are fetched through the Mateu server (no CORS)
+with `${secret.X}` auth injected server-side. To authenticate the direct fetch instead, register a
+client-side auth provider. Both are described under
+[`@RestOptions`](./rest-options#server-proxy-mode-proxy--true--cors--auth-hardening).
+:::
+
 :::note
-Rows and [options](./rest-options) are the shipped surfaces of consuming external endpoints. Form/
-screen data load and endpoint button actions reuse the same `RestDataSource` descriptor and are on
-the roadmap.
+All four surfaces are shipped: [options](./rest-options), [listing rows](./rest-listing),
+[screen data](./rest-data) and [button actions](./rest-action) — each reusing the same
+`RestDataSource` descriptor.
 :::
 
 ## Other backends

--- a/doc/src/content/docs/java-ui-definition/annotations/rest-options.md
+++ b/doc/src/content/docs/java-ui-definition/annotations/rest-options.md
@@ -61,8 +61,9 @@ String city;
 ```
 
 :::note
-This is the **options** surface. Consuming external endpoints for listing rows, form data and
-button actions reuses the same `RestDataSource` descriptor and is on the roadmap.
+This is the **options** surface. The same `RestDataSource` descriptor also powers
+[listing rows](./rest-listing), [screen data](./rest-data) and [button actions](./rest-action) —
+all four are shipped.
 :::
 
 ## Server-proxy mode (`proxy = true`) — CORS & auth hardening


### PR DESCRIPTION
Proxy mode and the client-side auth provider were documented only under `@RestOptions`; `@RestListing`/`@RestAction`/`@RestData` read as client-direct-only. Added a "CORS & auth" cross-reference note to each, and fixed two stale "on the roadmap" notes (all four surfaces are shipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)