### PR TITLE
feat(bundle): serve GET /mateu/v3/bundle on all server adapters

### DIFF
--- a/backend/helidon-mp/helidon-mp-core/src/main/java/io/mateu/MateuBundleController.java
+++ b/backend/helidon-mp/helidon-mp-core/src/main/java/io/mateu/MateuBundleController.java
@@ -1,0 +1,52 @@
+package io.mateu;
+
+import io.mateu.core.application.MateuService;
+import io.mateu.core.application.export.MateuBundleExporter;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * Serves the static bundle at RUNTIME (no build step): {@code GET /mateu/v3/bundle} returns the
+ * same {@code manifest.json} the {@code mateu:bundle} Maven goal produces, rendered live from this
+ * app's bean graph. Cached after first compute. {@code @ApplicationScoped} so Jersey/Weld discover
+ * it from the adapter's bean archive (like the generated RouteResolver) and the cache survives
+ * across requests. Cross-origin access relies on the app's global CORS config (like the generated
+ * sync endpoint, which carries no per-endpoint CORS annotation on the JAX-RS adapters). Helidon MP
+ * counterpart of the MVC controller.
+ */
+@ApplicationScoped
+@Path("/mateu/v3/bundle")
+public class MateuBundleController {
+
+  private final MateuService service;
+  private volatile String cached;
+
+  @Inject
+  public MateuBundleController(MateuService service) {
+    this.service = service;
+  }
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response bundle() {
+    var out = cached;
+    if (out == null) {
+      var cl =
+          getClass().getClassLoader(); // app classloader (sees META-INF/mateu route index); TCCL is
+      // unreliable off the request thread
+      var manifest = new MateuBundleExporter(service).exportAll("", cl, true);
+      try {
+        out = MateuBundleExporter.defaultWireMapper().writeValueAsString(manifest);
+      } catch (Exception e) {
+        return Response.serverError().entity("{\"error\":\"" + e.getMessage() + "\"}").build();
+      }
+      cached = out;
+    }
+    return Response.ok(out, MediaType.APPLICATION_JSON).build();
+  }
+}

--- a/backend/micronaut/micronaut-core/src/main/java/io/mateu/MateuBundleController.java
+++ b/backend/micronaut/micronaut-core/src/main/java/io/mateu/MateuBundleController.java
@@ -1,0 +1,53 @@
+package io.mateu;
+
+import io.mateu.core.application.MateuService;
+import io.mateu.core.application.export.MateuBundleExporter;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Produces;
+import io.micronaut.scheduling.TaskExecutors;
+import io.micronaut.scheduling.annotation.ExecuteOn;
+import jakarta.inject.Inject;
+
+/**
+ * Serves the static bundle at RUNTIME (no build step): {@code GET /mateu/v3/bundle} returns the
+ * same {@code manifest.json} the {@code mateu:bundle} Maven goal produces, rendered live from this
+ * app's bean graph. Cached after first compute; runs on the blocking pool because the exporter
+ * {@code blockFirst()}s each route (must stay off the Netty event loop). Cross-origin access relies
+ * on the app's {@code micronaut.server.cors} config ({@code @CrossOrigin} is not processable in
+ * this module, and a manual header would double up when global CORS is enabled). Micronaut
+ * counterpart of the MVC controller.
+ */
+@Controller("/mateu/v3")
+public class MateuBundleController {
+
+  private final MateuService service;
+  private volatile String cached;
+
+  @Inject
+  public MateuBundleController(MateuService service) {
+    this.service = service;
+  }
+
+  @Get("/bundle")
+  @Produces(MediaType.APPLICATION_JSON)
+  @ExecuteOn(TaskExecutors.BLOCKING)
+  public HttpResponse<String> bundle() {
+    var out = cached;
+    if (out == null) {
+      var cl =
+          getClass().getClassLoader(); // app classloader (sees META-INF/mateu route index); TCCL is
+      // unreliable off the request thread
+      var manifest = new MateuBundleExporter(service).exportAll("", cl, true);
+      try {
+        out = MateuBundleExporter.defaultWireMapper().writeValueAsString(manifest);
+      } catch (Exception e) {
+        return HttpResponse.serverError("{\"error\":\"" + e.getMessage() + "\"}");
+      }
+      cached = out;
+    }
+    return HttpResponse.ok(out).contentType(MediaType.APPLICATION_JSON);
+  }
+}

--- a/backend/quarkus/quarkus-core/src/main/java/io/mateu/MateuBundleController.java
+++ b/backend/quarkus/quarkus-core/src/main/java/io/mateu/MateuBundleController.java
@@ -1,0 +1,53 @@
+package io.mateu;
+
+import io.mateu.core.application.MateuService;
+import io.mateu.core.application.export.MateuBundleExporter;
+import io.smallrye.common.annotation.Blocking;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * Serves the static bundle at RUNTIME (no build step): {@code GET /mateu/v3/bundle} returns the
+ * same {@code manifest.json} the {@code mateu:bundle} Maven goal produces, rendered live from this
+ * app's bean graph. Cached after first compute; {@code @Blocking} because the exporter {@code
+ * blockFirst()}s each route. Cross-origin access relies on the app's global CORS config (like the
+ * generated sync endpoint, which carries no per-endpoint CORS annotation on the JAX-RS adapters).
+ * Quarkus counterpart of the MVC controller.
+ */
+@ApplicationScoped
+@Path("/mateu/v3/bundle")
+public class MateuBundleController {
+
+  private final MateuService service;
+  private volatile String cached;
+
+  @Inject
+  public MateuBundleController(MateuService service) {
+    this.service = service;
+  }
+
+  @GET
+  @Blocking
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response bundle() {
+    var out = cached;
+    if (out == null) {
+      var cl =
+          getClass().getClassLoader(); // app classloader (sees META-INF/mateu route index); TCCL is
+      // unreliable off the request thread
+      var manifest = new MateuBundleExporter(service).exportAll("", cl, true);
+      try {
+        out = MateuBundleExporter.defaultWireMapper().writeValueAsString(manifest);
+      } catch (Exception e) {
+        return Response.serverError().entity("{\"error\":\"" + e.getMessage() + "\"}").build();
+      }
+      cached = out;
+    }
+    return Response.ok(out, MediaType.APPLICATION_JSON).build();
+  }
+}

--- a/backend/shared/core/src/main/java/io/mateu/core/application/export/MateuBundleExporter.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/export/MateuBundleExporter.java
@@ -6,8 +6,11 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.mateu.core.application.MateuService;
 import io.mateu.core.infra.HeadlessHttpRequest;
 import io.mateu.dtos.RunActionRqDto;
+import io.mateu.uidl.di.MateuBeanProvider;
 import io.mateu.uidl.interfaces.HttpRequest;
+import io.mateu.uidl.interfaces.RouteResolver;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
@@ -51,18 +54,52 @@ public final class MateuBundleExporter {
   }
 
   /**
-   * Render every declared route discovered from the classloader's route index (skipping {@code
-   * :param} routes when {@code staticOnly}). The one-call entry point shared by the build-time
-   * Maven goal and the runtime bundle endpoint.
+   * Render every declared route, discovered from BOTH sources so it works in any module layout:
+   *
+   * <ul>
+   *   <li>the live {@link RouteResolver} beans (via {@link MateuBeanProvider}) — the framework's
+   *       annotation processor always generates one per {@code @UI}, so this is the RUNTIME source
+   *       (the bundle endpoint) and covers single-module apps where {@code @UI} lives in the app;
+   *   <li>the classloader's compiled route index ({@code META-INF/mateu/*-registrations}) — written
+   *       only by the indexer AP (two-module setup), the BUILD-TIME source used by the Maven goal
+   *       from a fresh context with no live beans.
+   * </ul>
+   *
+   * {@code :param} routes are skipped when {@code staticOnly}. The one-call entry point shared by
+   * the build-time Maven goal and the runtime bundle endpoint.
    */
   public BundleManifest exportAll(String baseUrl, ClassLoader cl, boolean staticOnly) {
-    var routes =
-        RouteRegistrations.read(cl).stream()
-            .map(RouteRegistrations.RouteRef::route)
-            .filter(r -> !staticOnly || RouteRegistrations.isStatic(r))
-            .distinct()
-            .toList();
-    return export(baseUrl, routes);
+    var routes = new LinkedHashSet<>(routesFromBeans(staticOnly));
+    RouteRegistrations.read(cl).stream()
+        .map(RouteRegistrations.RouteRef::route)
+        .filter(r -> !staticOnly || RouteRegistrations.isStatic(r))
+        .forEach(routes::add);
+    return export(baseUrl, new ArrayList<>(routes));
+  }
+
+  /**
+   * Routes declared by the live {@link RouteResolver} beans. Empty (never throws) when no bean
+   * context is wired — e.g. the Maven goal's fresh context — so the caller falls back to the index.
+   */
+  private List<String> routesFromBeans(boolean staticOnly) {
+    var out = new ArrayList<String>();
+    try {
+      var resolvers = MateuBeanProvider.getBeans(RouteResolver.class);
+      if (resolvers == null) {
+        return out;
+      }
+      for (RouteResolver rr : resolvers) {
+        for (var pattern : rr.supportedRoutesPatterns()) {
+          var r = pattern.route();
+          if (r != null && !r.isBlank() && (!staticOnly || RouteRegistrations.isStatic(r))) {
+            out.add(r);
+          }
+        }
+      }
+    } catch (Throwable t) {
+      log.debug("route discovery from beans failed (falling back to the index): {}", t.toString());
+    }
+    return out;
   }
 
   /** Render every route; per-route failure is captured, never thrown. */

--- a/backend/webflux/webflux-core/src/main/java/io/mateu/MateuBundleController.java
+++ b/backend/webflux/webflux-core/src/main/java/io/mateu/MateuBundleController.java
@@ -7,14 +7,16 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 /**
  * Serves the static bundle at RUNTIME (no build step): {@code GET /mateu/v3/bundle} returns the
  * same {@code manifest.json} the {@code mateu:bundle} Maven goal produces, rendered live from this
- * app's bean graph — so it has full fidelity (real services/DB available) and needs no build. Point
- * a static shell's {@code <mateu-ui bundleUrl="…/mateu/v3/bundle">} at it, or curl it to snapshot
- * the bundle. The result is computed once and cached (screen structure is stable within a
- * deployment).
+ * app's bean graph — full fidelity (real services/DB), no build. Point a static shell's {@code
+ * <mateu-ui bundleUrl="…/mateu/v3/bundle">} at it, or curl it to snapshot the bundle. Cached after
+ * first compute. The exporter blocks (it {@code blockFirst()}s each route), so it runs on a
+ * bounded-elastic scheduler, off the event loop. WebFlux counterpart of the MVC controller.
  */
 @RestController
 @CrossOrigin
@@ -28,13 +30,16 @@ public class MateuBundleController {
   }
 
   @GetMapping(value = "/mateu/v3/bundle", produces = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity<String> bundle() {
+  public Mono<ResponseEntity<String>> bundle() {
+    return Mono.fromCallable(this::render).subscribeOn(Schedulers.boundedElastic());
+  }
+
+  private ResponseEntity<String> render() {
     var out = cached;
     if (out == null) {
       var cl =
-          getClass()
-              .getClassLoader(); // app classloader (sees META-INF/mateu route index); TCCL is
-                                 // unreliable off the request thread
+          getClass().getClassLoader(); // app classloader (sees META-INF/mateu route index); TCCL is
+      // unreliable on the bounded-elastic worker thread
       var manifest = new MateuBundleExporter(service).exportAll("", cl, true);
       try {
         out = MateuBundleExporter.defaultWireMapper().writeValueAsString(manifest);

--- a/doc/src/content/docs/java-user-manual/build/static-bundle.md
+++ b/doc/src/content/docs/java-user-manual/build/static-bundle.md
@@ -90,8 +90,15 @@ which returns the identical `manifest.json`, rendered from the app's real bean g
 - **Snapshot it** — `curl https://your-app/mateu/v3/bundle > manifest.json` to produce the bundle in
   CI without the Maven goal.
 
-The result is computed once and cached (structure is stable within a deployment). The endpoint is
-provided by the MVC adapter today.
+The result is computed once and cached (structure is stable within a deployment). The endpoint ships
+in **every server adapter** — Spring MVC, Spring WebFlux, Micronaut, Quarkus and Helidon MP — and
+discovers routes from the live `RouteResolver` beans, so it works whether your `@UI` classes live in
+the app module or in a separate UI module.
+
+**Cross-origin note:** the Spring adapters (MVC/WebFlux) send `Access-Control-Allow-Origin` via
+`@CrossOrigin`. On the other adapters the endpoint relies on the app's own CORS configuration
+(`micronaut.server.cors`, `quarkus.http.cors`, Helidon's CORS feature) — the same requirement as the
+main `/mateu/v3/sync` endpoint. Same-origin serving needs no CORS at all.
 
 ## What works without a backend
 


### PR DESCRIPTION
## What

Extends the runtime bundle endpoint (`GET /mateu/v3/bundle`, added in #359) from **MVC-only** to **all server adapters**: WebFlux, Micronaut, Quarkus and Helidon MP. Each gets a `MateuBundleController` in its `*-core` module using that framework's REST/DI idioms.

## Framework specifics

- **WebFlux** — reactive `@RestController`, runs on `Schedulers.boundedElastic()` (the exporter `blockFirst()`s each route → must stay off the event loop), `@CrossOrigin`.
- **Micronaut** — `@Controller` + `@ExecuteOn(BLOCKING)`; cross-origin via `micronaut.server.cors` (`@CrossOrigin` isn't processable in this module).
- **Quarkus** — JAX-RS `@ApplicationScoped` + `@Blocking`; cross-origin via `quarkus.http.cors`.
- **Helidon MP** — JAX-RS `@ApplicationScoped` (discovered from the adapter bean archive, like the generated `RouteResolver`); cross-origin via Helidon's CORS feature.

## Route discovery made module-layout-agnostic

`MateuBundleExporter.exportAll` now **unions two sources**:
- the live `RouteResolver` beans (the framework AP always generates one per `@UI` — the **runtime** source; covers single-module apps where `@UI` lives in the app);
- the compiled route index `META-INF/mateu/*-registrations` (the **build-time** source used by the Maven goal from a fresh context).

The index-only path only found routes in the two-module setup, so single-module demos discovered nothing. All controllers resolve the app classloader via `getClass().getClassLoader()` (TCCL is unreliable off the request/worker thread); MVC updated to match.

## Verification (live)

`GET /mateu/v3/bundle` returns a valid manifest on:
- demo-vaadin-webflux → 1 route
- demo-vaadin-quarkus → 2 routes (single CORS header)
- demo-vaadin-micronaut → 2 routes (discovered from beans)
- helidon-app1 SUT → **49/49**

`MateuBundleExporterTest` green (3/3). Docs updated (endpoint now in every adapter + cross-origin notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)