### PR TITLE
test(bundle): endpoint IT + committed demo; discover routes from RoutedClassProvider

### DIFF
--- a/backend/mateu-bundle-maven-plugin/src/main/java/io/mateu/maven/bundle/BundleMojo.java
+++ b/backend/mateu-bundle-maven-plugin/src/main/java/io/mateu/maven/bundle/BundleMojo.java
@@ -107,7 +107,13 @@ public class BundleMojo extends AbstractMojo {
 
       try (var boot = new BootContext(appLoader, uiClasses, packages)) {
         var exporter = new MateuBundleExporter(boot.service);
-        var manifest = exporter.export(baseUrl, toExport);
+        // With an explicit allowlist, export exactly those routes. Otherwise let the exporter
+        // discover every route from the booted bean graph (RouteResolver + RoutedClassProvider) AND
+        // the compiled index — so single-module apps (no index files) still bundle.
+        var manifest =
+            (routes != null && !routes.isEmpty())
+                ? exporter.export(baseUrl, toExport)
+                : exporter.exportAll(baseUrl, appLoader, skipParamRoutes);
 
         BundleWriter.write(
             outputDirectory.toPath(), manifest, assetsFrom, appLoader, baseUrl, pageTitle);

--- a/backend/shared/core/src/main/java/io/mateu/core/application/export/MateuBundleExporter.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/export/MateuBundleExporter.java
@@ -6,9 +6,14 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.mateu.core.application.MateuService;
 import io.mateu.core.infra.HeadlessHttpRequest;
 import io.mateu.dtos.RunActionRqDto;
+import io.mateu.uidl.annotations.HomeRoute;
+import io.mateu.uidl.annotations.Route;
+import io.mateu.uidl.annotations.Routes;
+import io.mateu.uidl.annotations.UI;
 import io.mateu.uidl.di.MateuBeanProvider;
 import io.mateu.uidl.interfaces.HttpRequest;
 import io.mateu.uidl.interfaces.RouteResolver;
+import io.mateu.uidl.interfaces.RoutedClassProvider;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -57,9 +62,12 @@ public final class MateuBundleExporter {
    * Render every declared route, discovered from BOTH sources so it works in any module layout:
    *
    * <ul>
-   *   <li>the live {@link RouteResolver} beans (via {@link MateuBeanProvider}) — the framework's
-   *       annotation processor always generates one per {@code @UI}, so this is the RUNTIME source
-   *       (the bundle endpoint) and covers single-module apps where {@code @UI} lives in the app;
+   *   <li>the live {@link RouteResolver} and {@link RoutedClassProvider} beans (via {@link
+   *       MateuBeanProvider}) — the framework's annotation processor generates a {@code
+   *       RouteResolver} for a pathed {@code @UI("/x")} (route in its patterns) and a {@code
+   *       RoutedClassProvider} for a root {@code @UI("")}/{@code @Route}/{@code @HomeRoute} (route
+   *       read off the class's routing annotations). This is the RUNTIME source (the bundle
+   *       endpoint) and covers single-module apps where {@code @UI} lives in the app;
    *   <li>the classloader's compiled route index ({@code META-INF/mateu/*-registrations}) — written
    *       only by the indexer AP (two-module setup), the BUILD-TIME source used by the Maven goal
    *       from a fresh context with no live beans.
@@ -78,21 +86,29 @@ public final class MateuBundleExporter {
   }
 
   /**
-   * Routes declared by the live {@link RouteResolver} beans. Empty (never throws) when no bean
-   * context is wired — e.g. the Maven goal's fresh context — so the caller falls back to the index.
+   * Routes declared by the live {@link RouteResolver} and {@link RoutedClassProvider} beans. Empty
+   * (never throws) when no bean context is wired — e.g. the Maven goal's fresh context — so the
+   * caller falls back to the index.
    */
   private List<String> routesFromBeans(boolean staticOnly) {
     var out = new ArrayList<String>();
     try {
+      // Pathed @UI("/x") → a RouteResolver carrying the route in its compiled patterns.
       var resolvers = MateuBeanProvider.getBeans(RouteResolver.class);
-      if (resolvers == null) {
-        return out;
+      if (resolvers != null) {
+        for (RouteResolver rr : resolvers) {
+          for (var pattern : rr.supportedRoutesPatterns()) {
+            addRoute(out, pattern.route(), staticOnly);
+          }
+        }
       }
-      for (RouteResolver rr : resolvers) {
-        for (var pattern : rr.supportedRoutesPatterns()) {
-          var r = pattern.route();
-          if (r != null && !r.isBlank() && (!staticOnly || RouteRegistrations.isStatic(r))) {
-            out.add(r);
+      // Root @UI("") / @Route / @HomeRoute → a RoutedClassProvider; the route lives on the class's
+      // routing annotations (a blank @UI("") is the valid root route).
+      var providers = MateuBeanProvider.getBeans(RoutedClassProvider.class);
+      if (providers != null) {
+        for (RoutedClassProvider p : providers) {
+          for (String r : routesOf(p.routedClass())) {
+            addRoute(out, r, staticOnly);
           }
         }
       }
@@ -100,6 +116,40 @@ public final class MateuBundleExporter {
       log.debug("route discovery from beans failed (falling back to the index): {}", t.toString());
     }
     return out;
+  }
+
+  private static void addRoute(List<String> out, String r, boolean staticOnly) {
+    // route "" (root) is valid and kept; a null route is not
+    if (r != null && (!staticOnly || RouteRegistrations.isStatic(r))) {
+      out.add(r);
+    }
+  }
+
+  /**
+   * The route(s) declared by a routed class's routing annotations ({@code @UI}, {@code @Route},
+   * {@code @Routes}, {@code @HomeRoute}). Read directly (routing annotations are NOT
+   * meta-annotation composable — the AP resolves them at compile time).
+   */
+  private static List<String> routesOf(Class<?> c) {
+    var routes = new ArrayList<String>();
+    var ui = c.getAnnotation(UI.class);
+    if (ui != null) {
+      routes.add(ui.value());
+    }
+    var route = c.getAnnotation(Route.class);
+    if (route != null) {
+      routes.add(route.value());
+    }
+    var routesAnn = c.getAnnotation(Routes.class);
+    if (routesAnn != null) {
+      for (Route r : routesAnn.value()) {
+        routes.add(r.value());
+      }
+    }
+    if (c.getAnnotation(HomeRoute.class) != null) {
+      routes.add("");
+    }
+    return routes;
   }
 
   /** Render every route; per-route failure is captured, never thrown. */

--- a/backend/shared/integration-tests/src/main/java/io/mateu/integrationtests/BundleEndpointITFoundation.java
+++ b/backend/shared/integration-tests/src/main/java/io/mateu/integrationtests/BundleEndpointITFoundation.java
@@ -1,0 +1,33 @@
+package io.mateu.integrationtests;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.notNullValue;
+
+import io.restassured.http.ContentType;
+
+/**
+ * Verifies the runtime static-bundle endpoint {@code GET /mateu/v3/bundle}: it must return the
+ * bundle manifest (the same shape the {@code mateu:bundle} Maven goal writes), rendered live from
+ * the app's bean graph. Routes are discovered from the live {@code RouteResolver} beans, so a
+ * static {@code @UI} route (here {@code /hello}) must come back pre-rendered and {@code ok}. Reused
+ * by every server adapter's IT so the endpoint is CI-guarded on each framework.
+ */
+public class BundleEndpointITFoundation {
+
+  public void servesBundleManifest() {
+    given()
+        .accept(ContentType.JSON)
+        .when()
+        .get("/mateu/v3/bundle")
+        .then()
+        .statusCode(200)
+        .body("entries", notNullValue())
+        .body("entries.size()", greaterThan(0))
+        // the /hello screen is a plain form → it renders and is bundled ok
+        .body("entries.find { it.syncPath == 'hello' }", notNullValue())
+        .body("entries.find { it.syncPath == 'hello' }.ok", equalTo(true))
+        .body("entries.find { it.syncPath == 'hello' }.json", notNullValue());
+  }
+}

--- a/backend/webflux/webflux-core/src/test/java/io/mateu/integrationtests/BundleEndpointIT.java
+++ b/backend/webflux/webflux-core/src/test/java/io/mateu/integrationtests/BundleEndpointIT.java
@@ -1,0 +1,26 @@
+package io.mateu.integrationtests;
+
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+import com.example.FakeApplication;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@SpringBootTest(webEnvironment = RANDOM_PORT, classes = FakeApplication.class)
+class BundleEndpointIT {
+
+  @LocalServerPort private Integer port;
+
+  @BeforeEach
+  void setUp() {
+    RestAssured.port = port;
+  }
+
+  @Test
+  void servesBundleManifest() {
+    new BundleEndpointITFoundation().servesBundleManifest();
+  }
+}

--- a/demo/demo-static-bundle/pom.xml
+++ b/demo/demo-static-bundle/pom.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.5</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>io.mateu.demo</groupId>
+    <artifactId>demo-static-bundle</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <name>demo-static-bundle</name>
+    <description>Minimal demo of Mateu's static bundle: the runtime GET /mateu/v3/bundle endpoint and
+        the build-time mateu:bundle Maven goal (see README.md).</description>
+
+    <properties>
+        <java.version>21</java.version>
+        <mateu.version>0.0.1-MATEU</mateu.version>
+    </properties>
+
+    <dependencies>
+        <!-- Mateu MVC runtime -->
+        <dependency>
+            <groupId>io.mateu</groupId>
+            <artifactId>mvc-core</artifactId>
+            <version>${mateu.version}</version>
+        </dependency>
+
+        <!-- Frontend web components (Vaadin renderer) -->
+        <dependency>
+            <groupId>io.mateu</groupId>
+            <artifactId>vaadin-lit</artifactId>
+            <version>${mateu.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </path>
+                        <path>
+                            <groupId>io.mateu</groupId>
+                            <artifactId>annotation-processor-mvc</artifactId>
+                            <version>${mateu.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <!-- mvn -Pbundle package  →  target/mateu-bundle/ (a static site: index.html + manifest.json
+             + assets/). Serve it from any static host with NO backend. The same manifest is also
+             available at runtime from a running app at GET /mateu/v3/bundle (no build step). -->
+        <profile>
+            <id>bundle</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.mateu</groupId>
+                        <artifactId>mateu-bundle-maven-plugin</artifactId>
+                        <version>${mateu.version}</version>
+                        <configuration>
+                            <!-- vaadin-lit assets, exploded in-repo (a jar can't be listed) -->
+                            <assetsFrom>${project.basedir}/../../backend/shared/frontend/vaadin-lit/src/main/resources/static</assetsFrom>
+                            <basePackages>io.mateu.demo.staticbundle</basePackages>
+                            <pageTitle>Mateu static bundle demo</pageTitle>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>bundle</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/demo/demo-static-bundle/src/main/java/io/mateu/demo/staticbundle/About.java
+++ b/demo/demo-static-bundle/src/main/java/io/mateu/demo/staticbundle/About.java
@@ -1,0 +1,20 @@
+package io.mateu.demo.staticbundle;
+
+import io.mateu.uidl.annotations.Route;
+import io.mateu.uidl.annotations.Text;
+import io.mateu.uidl.annotations.Title;
+import lombok.Getter;
+
+/**
+ * A second static screen (route {@code /about}). Purely presentational, so it bundles cleanly and
+ * renders with no backend.
+ */
+@Route("/about")
+@Title("About")
+@Getter
+public class About {
+
+  @Text
+  private final String intro =
+      "This screen was served from a static bundle — no Mateu backend was contacted to render it.";
+}

--- a/demo/demo-static-bundle/src/main/java/io/mateu/demo/staticbundle/Home.java
+++ b/demo/demo-static-bundle/src/main/java/io/mateu/demo/staticbundle/Home.java
@@ -1,0 +1,27 @@
+package io.mateu.demo.staticbundle;
+
+import io.mateu.uidl.annotations.RestOptions;
+import io.mateu.uidl.annotations.Title;
+import io.mateu.uidl.annotations.UI;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Home screen (route {@code /}). A plain form: its structure is fully pre-renderable into the bundle,
+ * and the {@code assignedTo} select fetches its options CLIENT-SIDE from a public REST API — so this
+ * screen shows live data even when served from a static host with NO Mateu backend.
+ */
+@UI("")
+@Title("Static bundle demo")
+@Getter
+@Setter
+public class Home {
+
+  private String name;
+
+  private String notes;
+
+  // Options fetched directly by the browser from a public, CORS-open API — no Mateu backend needed.
+  @RestOptions(url = "https://jsonplaceholder.typicode.com/users", valuePath = "id", labelPath = "name")
+  private String assignedTo;
+}

--- a/demo/demo-static-bundle/src/main/java/io/mateu/demo/staticbundle/StaticBundleDemoApplication.java
+++ b/demo/demo-static-bundle/src/main/java/io/mateu/demo/staticbundle/StaticBundleDemoApplication.java
@@ -1,0 +1,17 @@
+package io.mateu.demo.staticbundle;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Minimal Mateu app that demonstrates the static bundle. Once running it exposes {@code GET
+ * /mateu/v3/bundle} (the runtime endpoint, no build step); {@code mvn -Pbundle package} produces the
+ * same bundle as a static site under {@code target/mateu-bundle/}. See README.md.
+ */
+@SpringBootApplication(scanBasePackages = "io.mateu")
+public class StaticBundleDemoApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(StaticBundleDemoApplication.class, args);
+  }
+}

--- a/demo/demo-static-bundle/src/main/resources/application.properties
+++ b/demo/demo-static-bundle/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+spring.application.name=demo-static-bundle
+server.port=8097

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -30,6 +30,7 @@
     <module>demo-front-office-evolution</module>
     <module>demo-redwood-showcase</module>
     <module>demo-vb</module>
+    <module>demo-static-bundle</module>
     <module>explorer</module>
   </modules>
 

--- a/doc/src/content/docs/java-user-manual/build/static-bundle.md
+++ b/doc/src/content/docs/java-user-manual/build/static-bundle.md
@@ -11,6 +11,17 @@ backend running**. The renderer boots, reads the bundle, and paints each screen 
 still flows from [external endpoints](../../java-ui-definition/annotations/rest-options), and screens
 that need server logic keep working when a backend is present.
 
+## Runnable demo
+
+`demo/demo-static-bundle` is a minimal, self-contained example (two static `@UI` screens, one with a
+live `@RestOptions` select). Two ways to see the bundle:
+
+```bash
+cd demo/demo-static-bundle
+mvn spring-boot:run            # then GET http://localhost:8097/mateu/v3/bundle  (runtime, no build)
+mvn -Pbundle package           # then serve target/mateu-bundle/ from any static host (no backend)
+```
+
 ## How it works
 
 Two halves, both shipped:


### PR DESCRIPTION
## What

Two follow-ups to the static-bundle endpoint, plus a route-discovery fix they surfaced.

### Endpoint IT (CI-guarded)
- `BundleEndpointITFoundation` (integration-tests): asserts `GET /mateu/v3/bundle` returns the manifest with the static `/hello` route pre-rendered `ok`.
- `BundleEndpointIT` in webflux-core (Spring Boot `RANDOM_PORT` + RestAssured — the only adapter core with IT infra).

### Committed demo
- `demo/demo-static-bundle` — a minimal single-module app: two static `@UI` screens, one with a live `@RestOptions` select.
  - `mvn spring-boot:run` → runtime endpoint at `:8097/mateu/v3/bundle`.
  - `mvn -Pbundle package` → `target/mateu-bundle/` served from any static host with no backend.
- Added to the demo aggregator.

### Route-discovery fix (found via the demo)
A root `@UI("")` / `@Route` / `@HomeRoute` compiles to a **`RoutedClassProvider`** (no route string), not a `RouteResolver` — so single-module apps discovered **0 routes**. Now `MateuBundleExporter.routesFromBeans` also reads `RoutedClassProvider` beans and derives the route from the class's routing annotations (`@UI`/`@Route`/`@Routes`/`@HomeRoute`), unioned with `RouteResolver` beans and the compiled index. `BundleMojo` delegates to `exportAll` (bean+index union) when no explicit allowlist is given, so the build-time goal bundles single-module apps too.

## Verification

- demo runtime endpoint → **2/2 ok**; `mvn -Pbundle package` → **2/2 rendered**; the static bundle renders `/about` with **zero** `/mateu/v3/sync` POSTs.
- `BundleEndpointIT` green (1/1); `MateuBundleExporterTest` green (3/3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)