### PR TITLE
fix(crud): honor @Label on the detail-view toolbar buttons

### DIFF
--- a/backend/shared/core/src/main/java/io/mateu/core/infra/declarative/orchestrators/crud/routeresolvers/ViewToolbarBuilder.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/infra/declarative/orchestrators/crud/routeresolvers/ViewToolbarBuilder.java
@@ -1,7 +1,7 @@
 package io.mateu.core.infra.declarative.orchestrators.crud.routeresolvers;
 
+import static io.mateu.core.domain.out.componentmapper.FieldMetadataExtractor.getLabel;
 import static io.mateu.core.infra.reflection.read.AllMethodsProvider.getAllMethods;
-import static io.mateu.uidl.Humanizer.toUpperCaseFirst;
 
 import io.mateu.core.infra.declarative.orchestrators.crud.Crud;
 import io.mateu.core.infra.reflection.MetaAnnotations;
@@ -30,9 +30,7 @@ final class ViewToolbarBuilder {
         .filter(method -> MetaAnnotations.isPresent(method, ViewToolbarButton.class))
         .forEach(
             method ->
-                toolbar.add(
-                    new Button(
-                        toUpperCaseFirst(method.getName()), "action-on-view-" + method.getName())));
+                toolbar.add(new Button(getLabel(method), "action-on-view-" + method.getName())));
     final var finalEntity = item;
     getAllMethods(finalEntity.getClass()).stream()
         .filter(method -> MetaAnnotations.isPresent(method, Toolbar.class))
@@ -52,7 +50,7 @@ final class ViewToolbarBuilder {
               var buttonSize = ann.buttonSize() != ButtonSize.none ? ann.buttonSize() : null;
               toolbar.add(
                   Button.builder()
-                      .label(toUpperCaseFirst(method.getName()))
+                      .label(getLabel(method))
                       .actionId(method.getName())
                       .buttonStyle(buttonStyle)
                       .color(buttonColor)

--- a/backend/shared/core/src/test/java/io/mateu/core/application/ViewToolbarLabelSyncTest.java
+++ b/backend/shared/core/src/test/java/io/mateu/core/application/ViewToolbarLabelSyncTest.java
@@ -1,0 +1,165 @@
+package io.mateu.core.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.mateu.core.infra.declarative.orchestrators.crud.AutoCrud;
+import io.mateu.core.testutil.TestMateu;
+import io.mateu.dtos.ButtonDto;
+import io.mateu.dtos.RunActionRqDto;
+import io.mateu.dtos.ServerSideComponentDto;
+import io.mateu.dtos.UIIncrementDto;
+import io.mateu.uidl.annotations.Label;
+import io.mateu.uidl.annotations.ReadOnly;
+import io.mateu.uidl.annotations.Title;
+import io.mateu.uidl.annotations.Toolbar;
+import io.mateu.uidl.annotations.UI;
+import io.mateu.uidl.annotations.ViewToolbarButton;
+import io.mateu.uidl.interfaces.CrudStore;
+import io.mateu.uidl.interfaces.Identifiable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The detail view of a crud builds its toolbar with {@code ViewToolbarBuilder}, a different path
+ * from the page-level {@code PageButtonsBuilder}. It used to label every button by humanizing the
+ * method name, silently dropping {@code @Label} — so an action declared as "Retry from failure"
+ * appeared as "Retry process" and read to operators as a missing button.
+ */
+class ViewToolbarLabelSyncTest {
+
+  public static class Job implements Identifiable {
+    String id;
+    String name;
+
+    public Job() {}
+
+    public Job(String id, String name) {
+      this.id = id;
+      this.name = name;
+    }
+
+    @Override
+    public String id() {
+      return id;
+    }
+
+    @Toolbar
+    @Label("Retry from failure")
+    public void retryProcess() {}
+
+    /** No {@code @Label}: still humanized from the method name. */
+    @Toolbar
+    public void pauseProcess() {}
+  }
+
+  static final List<Job> JOBS = new ArrayList<>(List.of(new Job("1", "Nightly import")));
+
+  @UI("/jobs")
+  @Title("Jobs")
+  @ReadOnly
+  public static class JobsCrud extends AutoCrud<Job> {
+
+    @ViewToolbarButton
+    @Label("Export to Excel")
+    public void exportRows() {}
+
+    @Override
+    public CrudStore<Job> store() {
+      return new CrudStore<>() {
+        @Override
+        public Optional<Job> findById(String id) {
+          return JOBS.stream().filter(job -> job.id().equals(id)).findFirst();
+        }
+
+        @Override
+        public String save(Job entity) {
+          return entity.id();
+        }
+
+        @Override
+        public List<Job> findAll() {
+          return JOBS;
+        }
+
+        @Override
+        public void deleteAllById(List<String> selectedIds) {}
+      };
+    }
+  }
+
+  static TestMateu mateu;
+
+  @BeforeAll
+  static void boot() {
+    mateu = TestMateu.withUis(JobsCrud.class);
+  }
+
+  @AfterAll
+  static void shutdown() {
+    mateu.close();
+  }
+
+  private List<ButtonDto> viewToolbar() {
+    UIIncrementDto increment =
+        mateu.run(
+            RunActionRqDto.builder()
+                .route("/jobs/1")
+                .consumedRoute("/jobs")
+                .serverSideType(JobsCrud.class.getName())
+                .actionId("")
+                .initiatorComponentId("c1_app")
+                .componentState(Map.of())
+                .build());
+    var component = (ServerSideComponentDto) increment.fragments().get(0).component();
+    var buttons = new ArrayList<ButtonDto>();
+    collectButtons(component, buttons);
+    return buttons;
+  }
+
+  private static void collectButtons(Object node, List<ButtonDto> out) {
+    if (node instanceof ButtonDto button) {
+      out.add(button);
+      return;
+    }
+    if (node instanceof io.mateu.dtos.ComponentDto component) {
+      if (component instanceof io.mateu.dtos.ClientSideComponentDto clientSide) {
+        collectButtons(clientSide.metadata(), out);
+      }
+      if (component instanceof ServerSideComponentDto serverSide) {
+        serverSide.children().forEach(child -> collectButtons(child, out));
+      }
+    }
+    if (node instanceof io.mateu.dtos.PageDto page) {
+      page.toolbar().forEach(trigger -> collectButtons(trigger, out));
+    }
+    if (node instanceof io.mateu.dtos.ClientSideComponentDto clientSide) {
+      clientSide.children().forEach(child -> collectButtons(child, out));
+    }
+  }
+
+  @Test
+  void toolbarButtonsOnTheViewedEntityUseTheirDeclaredLabel() {
+    assertThat(viewToolbar())
+        .extracting(ButtonDto::label)
+        .contains("Retry from failure")
+        .doesNotContain("Retry process");
+  }
+
+  @Test
+  void aToolbarMethodWithoutALabelIsStillHumanizedFromItsName() {
+    assertThat(viewToolbar()).extracting(ButtonDto::label).contains("Pause process");
+  }
+
+  @Test
+  void viewToolbarButtonsOnTheCrudAlsoUseTheirDeclaredLabel() {
+    assertThat(viewToolbar())
+        .extracting(ButtonDto::label)
+        .contains("Export to Excel")
+        .doesNotContain("Export rows");
+  }
+}


### PR DESCRIPTION
## What

The CRUD **detail view** builds its toolbar via `ViewToolbarBuilder` — a different path from the page-level `PageButtonsBuilder` — which labeled every button by humanizing the method name and **silently ignored `@Label`**:

- `@Toolbar @Label("Retry from failure") retryProcess()` → showed **"Retry process"**
- `@ViewToolbarButton @Label("Export to Excel") exportRows()` → showed **"Export rows"**

To an operator that reads as a missing/wrong button, and it's inconsistent with the rest of the framework (the page path respects `@Label`).

## Fix

Both branches now label via `FieldMetadataExtractor.getLabel` — the same helper the page path uses: `@Label` when present, humanized method name otherwise.

## Tests

`ViewToolbarLabelSyncTest` (3 cases): the declared label wins on both `@Toolbar` and `@ViewToolbarButton`, and a method without `@Label` is still humanized. Green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)