### PR TITLE
fix(vaadin): menu-on-top nav matches the header color (light & dark)

### DIFF
--- a/backend/shared/frontend/vaadin-lit/src/main/resources/META-INF/resources/assets/mateu-vaadin.js
+++ b/backend/shared/frontend/vaadin-lit/src/main/resources/META-INF/resources/assets/mateu-vaadin.js
@@ -8483,6 +8483,7 @@ ${i}
                </div>
             `},Fc=(e,t,n)=>T`
     <vaadin-menu-bar
+        theme="tertiary"
         .items=${e}
         class="${n??v}"
         @item-selected=${e=>t(e.detail.value)}>

--- a/backend/shared/frontend/vaadin-lit/src/main/resources/static/assets/mateu-vaadin.js
+++ b/backend/shared/frontend/vaadin-lit/src/main/resources/static/assets/mateu-vaadin.js
@@ -8483,6 +8483,7 @@ ${i}
                </div>
             `},Fc=(e,t,n)=>T`
     <vaadin-menu-bar
+        theme="tertiary"
         .items=${e}
         class="${n??v}"
         @item-selected=${e=>t(e.detail.value)}>

--- a/demo/sites/vaadin/assets/mateu-vaadin.js
+++ b/demo/sites/vaadin/assets/mateu-vaadin.js
@@ -8483,6 +8483,7 @@ ${i}
                </div>
             `},Fc=(e,t,n)=>T`
     <vaadin-menu-bar
+        theme="tertiary"
         .items=${e}
         class="${n??v}"
         @item-selected=${e=>t(e.detail.value)}>

--- a/frontend/web/monorepo/apps/vaadin/src/renderers/renderMenu.ts
+++ b/frontend/web/monorepo/apps/vaadin/src/renderers/renderMenu.ts
@@ -18,6 +18,7 @@ import "@vaadin/context-menu";
 // click (native <details> did neither). onSelect is the shell's existing itemSelected handler.
 export const renderTopNav = (items: AppMenuBarItem[], onSelect: (item: AppMenuBarItem) => void, cls?: string) => html`
     <vaadin-menu-bar
+        theme="tertiary"
         .items=${items as unknown as MenuBarItem[]}
         class="${cls ?? nothing}"
         @item-selected=${(e: CustomEvent) => onSelect((e.detail as { value: AppMenuBarItem }).value)}>


### PR DESCRIPTION
## What

In the Vaadin **MENU_ON_TOP** app shell, the top nav (a `<vaadin-menu-bar>`) rendered each item with Lumo's default light-gray button background — a gray strip inside the header (which is `--lumo-base-color`), in both light and dark mode.

## Fix

Render the top-nav menu-bar with `theme="tertiary"` → items are transparent/borderless, so the header color shows through and adapts to dark mode; hover keeps a subtle contrast for feedback. Scoped to `renderTopNav` (the menu-on-top nav only).

## Verification

Explorer `/shell-menu` (`@App(MENU_ON_TOP, themeToggle=true)`) — before: gray button strip; after: transparent nav on the header base-color, verified in **light and dark**.

| Light | Dark |
|---|---|
| header-white nav, no gray strip | header-dark nav, no gray strip |

🤖 Generated with [Claude Code](https://claude.com/claude-code)