### PR TITLE
fix(frontend): a bubbled action posts the originator's state as componentState

### DIFF
--- a/backend/shared/core/src/test/java/io/mateu/core/application/ViewToolbarButtonComponentStateContractTest.java
+++ b/backend/shared/core/src/test/java/io/mateu/core/application/ViewToolbarButtonComponentStateContractTest.java
@@ -1,0 +1,147 @@
+package io.mateu.core.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.mateu.core.infra.declarative.orchestrators.crud.AutoCrud;
+import io.mateu.core.testutil.TestMateu;
+import io.mateu.dtos.RunActionRqDto;
+import io.mateu.uidl.annotations.Action;
+import io.mateu.uidl.annotations.Title;
+import io.mateu.uidl.annotations.UI;
+import io.mateu.uidl.annotations.ViewToolbarButton;
+import io.mateu.uidl.interfaces.CrudStore;
+import io.mateu.uidl.interfaces.HttpRequest;
+import io.mateu.uidl.interfaces.Identifiable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the server-side contract behind the "@ViewToolbarButton on an AutoCrud sees a null id" bug:
+ * {@code httpRequest.getComponentState(EntityType.class)} reconstructs the entity from the
+ * run-action request's {@code componentState} map ONLY — so the selected/viewed row is resolved
+ * exactly when its own fields (notably {@code id}) travel at the top level of {@code
+ * componentState}.
+ *
+ * <p>The regression was on the client: a {@code @ViewToolbarButton}'s action is declared on the
+ * crud host, not on the form, so it bubbles up carrying the form (with its id) in {@code
+ * parameters.initiatorState}, while the crud host used to POST its OWN state (the list —
+ * filters/paging, no id) as {@code componentState}. The fix ({@code resolveComponentState} in the
+ * web client) makes a bubbled action POST its originator's state as {@code componentState}. These
+ * tests lock the backend half of that contract so it can't silently drift.
+ */
+class ViewToolbarButtonComponentStateContractTest {
+
+  public static class Form implements Identifiable {
+    String id;
+    String name;
+
+    public Form() {}
+
+    public Form(String id, String name) {
+      this.id = id;
+      this.name = name;
+    }
+
+    @Override
+    public String id() {
+      return id;
+    }
+  }
+
+  static final List<Form> FORMS = new ArrayList<>(List.of(new Form("42", "My form")));
+
+  @UI("/forms")
+  @Title("Forms")
+  @Action(id = "action-on-view-graphEditor")
+  public static class Forms extends AutoCrud<Form> {
+
+    static volatile String seenId = "UNSET";
+
+    @ViewToolbarButton
+    public String graphEditor(HttpRequest httpRequest) {
+      var f = httpRequest.getComponentState(Form.class);
+      seenId = f == null ? "NULL_FORM" : String.valueOf(f.id());
+      return "opened " + seenId;
+    }
+
+    @Override
+    public Object handleAction(String actionId, HttpRequest httpRequest) {
+      if ("action-on-view-graphEditor".equals(actionId)) {
+        return graphEditor(httpRequest);
+      }
+      return super.handleAction(actionId, httpRequest);
+    }
+
+    @Override
+    public CrudStore<Form> store() {
+      return new CrudStore<>() {
+        @Override
+        public Optional<Form> findById(String id) {
+          return FORMS.stream().filter(f -> f.id().equals(id)).findFirst();
+        }
+
+        @Override
+        public String save(Form entity) {
+          return entity.id();
+        }
+
+        @Override
+        public List<Form> findAll() {
+          return FORMS;
+        }
+
+        @Override
+        public void deleteAllById(List<String> selectedIds) {}
+      };
+    }
+  }
+
+  static TestMateu mateu;
+
+  @BeforeAll
+  static void boot() {
+    mateu = TestMateu.withUis(Forms.class);
+  }
+
+  @AfterAll
+  static void shutdown() {
+    mateu.close();
+  }
+
+  private String runWith(Map<String, Object> componentState, Map<String, Object> parameters) {
+    Forms.seenId = "UNSET";
+    mateu.run(
+        RunActionRqDto.builder()
+            .route("/forms/42")
+            .consumedRoute("/forms")
+            .serverSideType(Forms.class.getName())
+            .actionId("action-on-view-graphEditor")
+            .initiatorComponentId("c1_app")
+            .componentState(componentState)
+            .parameters(parameters)
+            .build());
+    return Forms.seenId;
+  }
+
+  @Test
+  void componentStateCarryingTheRowResolvesTheEntity() {
+    // This is what the fixed client sends for a @ViewToolbarButton: the originating form (with id)
+    // as componentState. getComponentState(Form.class).id() must be the selected row's id.
+    assertThat(runWith(Map.of("id", "42"), Map.of())).isEqualTo("42");
+  }
+
+  @Test
+  void aComponentStateWithoutTheEntityFieldsResolvesANullId() {
+    // The pre-fix client POSTed the crud host's own (list) state, which has no id — the reported
+    // bug: getComponentState builds a Form with a null id ("null"), so the app's findById(null)
+    // blows up. Neither an empty componentState nor the id only riding in parameters.initiatorState
+    // resolves the entity, because getComponentState reads componentState exclusively.
+    assertThat(runWith(Map.of(), Map.of())).isEqualTo("null");
+    assertThat(runWith(Map.of(), Map.of("initiatorState", Map.of("id", "42")))).isEqualTo("null");
+  }
+}

--- a/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/common.test.ts
+++ b/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/common.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { parseOverrides } from './common'
+import { parseOverrides, resolveComponentState } from './common'
 
 describe('parseOverrides', () => {
     it('parses a JSON object', () => {
@@ -13,5 +13,37 @@ describe('parseOverrides', () => {
     it('returns an empty object for undefined or empty input', () => {
         expect(parseOverrides(undefined)).toEqual({})
         expect(parseOverrides('')).toEqual({})
+    })
+})
+
+describe('resolveComponentState', () => {
+    it('uses the acting component own state for a direct (non-bubbled) action', () => {
+        const own = { searchText: 'ma', page: 0 }
+        expect(resolveComponentState(own, {})).toEqual(own)
+        expect(resolveComponentState(own, undefined)).toEqual(own)
+    })
+
+    it('prefers parameters.initiatorState when a descendant bubbled the action up', () => {
+        // A @ViewToolbarButton on a crud detail view: the crud host catches the bubbled action;
+        // its own state is the list (no id), but the form the button lives on rode up in
+        // initiatorState WITH its id. That is what getComponentState(EntityType.class) must see.
+        const crudHostState = { _route: 'list', page: 0 }
+        const parameters = { initiatorState: { id: '42', name: 'My form' } }
+        expect(resolveComponentState(crudHostState, parameters)).toEqual({ id: '42', name: 'My form' })
+    })
+
+    it('returns a fresh copy, not the original references', () => {
+        const own = { a: 1 }
+        const out = resolveComponentState(own, {})
+        expect(out).not.toBe(own)
+        const initiator = { id: '7' }
+        const out2 = resolveComponentState({}, { initiatorState: initiator })
+        expect(out2).not.toBe(initiator)
+    })
+
+    it('falls back to own state when initiatorState is not an object', () => {
+        const own = { a: 1 }
+        expect(resolveComponentState(own, { initiatorState: 'nope' })).toEqual(own)
+        expect(resolveComponentState(own, { initiatorState: null })).toEqual(own)
     })
 })

--- a/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/common.ts
+++ b/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/common.ts
@@ -1,3 +1,25 @@
+/**
+ * The componentState to POST for an action, given the acting component's own state and the action's
+ * parameters. When a descendant originated the action and bubbled it up (e.g. a @ViewToolbarButton
+ * on a crud's detail view, whose action is declared on the crud host, not on the form), it carries
+ * its OWN state in parameters.initiatorState. That originating state — the form the button lives on,
+ * WITH its id — is what the server's getComponentState(EntityType.class) must see; the ancestor's
+ * own state (the crud list: filters/paging, no id) is not. So prefer the initiatorState when
+ * present. Mirrors what the CSS-renderer shell (MateuRendererApp.handleUnhandledAction) already
+ * does, making every renderer consistent. A direct (non-bubbled) action has no initiatorState, so
+ * its own state is used unchanged.
+ */
+export const resolveComponentState = (
+    ownState: Record<string, unknown> | undefined,
+    parameters: Record<string, unknown> | undefined,
+): Record<string, unknown> => {
+    const initiatorState = parameters?.['initiatorState']
+    if (initiatorState && typeof initiatorState === 'object') {
+        return { ...(initiatorState as Record<string, unknown>) }
+    }
+    return { ...(ownState ?? {}) }
+}
+
 export const parseOverrides = (overrides: string | undefined) => {
     if (overrides) {
         try {

--- a/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/mateu-component.ts
+++ b/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/mateu-component.ts
@@ -31,6 +31,7 @@ import './mateu-workflow'
 import './mateu-form-editor'
 import './mateu-debug-overlay'
 import { shortcutMatchesEvent } from './shortcuts'
+import { resolveComponentState } from './common'
 import { notify as showToast } from "@application/Notifier.ts";
 import {componentRenderer} from "@infra/ui/renderers/ComponentRenderer.ts";
 import {RuleAction} from "@mateu/shared/apiClients/dtos/componentmetadata/RuleAction.ts";
@@ -688,11 +689,19 @@ export class MateuComponent extends ComponentElement {
             markPending(control)
         }
 
+        // A bubbled action (e.g. a @ViewToolbarButton on a crud's detail view, whose action is
+        // declared on the crud host rather than on the form) carries its originator's state in
+        // parameters.initiatorState — the form the button lives on, WITH its id. That is what the
+        // server's getComponentState(EntityType.class) must see, not this ancestor's own state (the
+        // crud list: filters/paging, no id). resolveComponentState prefers it when present; a direct
+        // action has no initiatorState and keeps its own state.
+        const componentState = resolveComponentState(this.state, detail.parameters)
+
         this.dispatchEvent(new CustomEvent('server-side-action-requested', {
             detail: {
                 route: this.route,
                 consumedRoute: this.consumedRoute,
-                componentState: {...this.state},
+                componentState,
                 parameters: detail.parameters ?? {},
                 actionId: detail.actionId,
                 serverSideType: serverSideComponent.serverSideType,


### PR DESCRIPTION
## The bug
A `@ViewToolbarButton` on an `AutoCrud` (e.g. a button acting on the selected row) received a **null id** in `getComponentState(EntityType.class)`, so a handler doing `findById(id)` failed and the action never opened its view. It used to work.

## Root cause (frontend)
The button's `action-requested` bubbles from the form's `mateu-component` — which sets `parameters.initiatorState = this.state` (the selected row, **with its id**) — up to the crud host, which matches the class-level `@Action` and dispatches. The dispatch in `requestActionCallToServer` used `componentState: {...this.state}` — the **crud host's own state** (list filters/paging, no id) — **discarding the initiator's state**. So `getComponentState(Form.class).id()` was null.

The CSS renderer's `handleUnhandledAction` already resolved this correctly (`componentState = parameters.initiatorState`); the default/Vaadin path was inconsistent.

## Fix
`resolveComponentState(ownState, parameters)` posts `parameters.initiatorState` when a descendant bubbled the action up, else the component's own state — mirroring the CSS renderer and the framework's existing treatment of `initiatorState` as authoritative. Wired into the single dispatch path `requestActionCallToServer`.

## Tests
- Frontend: 4 new `resolveComponentState` cases; full vitest green (289).
- Backend: new `ViewToolbarButtonComponentStateContractTest`; full `shared/core` green (797).

## ⚠️ For review
`requestActionCallToServer` is the single dispatch path for all server actions, so every *bubbled + matched* action now posts the originator's state as `componentState`. Consistent with existing entity resolution and all tests pass — but worth a sanity check that no **mediator** handler relies on receiving its own state while a child has bubbled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)