### PR TITLE
fix(frontend): RDS content width — FULL_WIDTH gutters + Markdown reading measure

### DIFF
--- a/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/mateu-ux.ts
+++ b/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/mateu-ux.ts
@@ -544,13 +544,18 @@ export class MateuUx extends ConnectedElement {
 
         /* Anatomía de anchos RDS (data-page-width — el valor RESUELTO fixed|full|edge que
            applyFragment estampa en el host): fixed = columna de contenido con tope RDS
-           (1408px) centrada; full = fluido sin tope (el comportamiento por defecto del
-           host); edge = a sangre — los gutters del shell caen por el hook no-padding
-           (compact-changed) y el header de mateu-page conserva el suyo. Solo aplica al
-           mateu-ux de CONTENIDO: el ux raíz del app shell resuelve 'edge'. */
+           (1408px) centrada; full = fluido sin tope pero CON gutter de 24px siempre (el
+           contenido posee el gutter — así una página SUELTA sin app-shell no queda a sangre
+           por accidente; dentro de un app-shell el shell ya aporta su propio padding); edge =
+           a sangre — los gutters del shell caen por el hook no-padding (compact-changed) y el
+           header de mateu-page conserva el suyo. Solo aplica al mateu-ux de CONTENIDO. */
         :host([data-page-width='fixed']) {
             max-width: min(1408px, 100%);
             margin-inline: auto;
+        }
+        :host([data-page-width='full']) {
+            box-sizing: border-box;
+            padding-inline: 24px;
         }
 
         /* Loading placeholder for a route with nothing on screen yet. */

--- a/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/renderers/markdownRenderer.ts
+++ b/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/renderers/markdownRenderer.ts
@@ -5,9 +5,13 @@ import { html, nothing } from "lit";
 export const renderMarkdown = (component: ClientSideComponent) => {
     const metadata = component.metadata as Markdown
 
+    // Cap prose to a comfortable reading measure (~72ch ≈ 700-800px, within the 45-75 chars/line
+    // guideline) so long-form text doesn't stretch the full page width and hurt legibility. It's a
+    // DEFAULT: a developer's @Style (component.style) comes last and can override (e.g. max-width:none
+    // for full-bleed markdown). max-width alone leaves narrow screens at container width.
     return html`
         <mateu-markdown .content=${metadata.markdown}
-                        style="${component.style}" class="${component.cssClasses}"
+                        style="display:block; max-width: 72ch; ${component.style ?? ''}" class="${component.cssClasses}"
                         slot="${component.slot??nothing}"></mateu-markdown>
             `
 }


### PR DESCRIPTION
Two small RDS content-width / legibility fixes to the shared `libs/mateu` renderer.

### 1. `@PageWidth(FULL_WIDTH)` keeps its 24px side gutters on a standalone page
`fullWidth` relied on the app-shell's content padding for its gutter, so a routed page with **no `@App` shell** (e.g. the `/width-full` explorer demo, where `mateu-ux` sits directly under `mateu-ui`) rendered edge-to-edge like `EDGE_TO_EDGE`. Now `data-page-width='full'` owns a 24px `padding-inline` in `mateu-ux`, so the content keeps the RDS gutter regardless of host. `fixed`/`edge` unchanged.

### 2. Markdown capped to a ~72ch reading measure
Long-form Markdown stretched the full page width (~1360px on a fixed page), well past the 45–75 chars/line legibility guideline. `mateu-markdown` now defaults to `display:block; max-width:72ch` (~700–800px); a developer's `@Style` comes last and can override (e.g. `max-width:none`). Forms/tables/cards are unaffected.

Verified live against the explorer demo (`/width-full`, `/width-fixed`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)