### PR TITLE
fix(vaadin): @MasterDetail row Edit opens the detail editor (was selecting the row)

### DIFF
--- a/demo/demo-vaadin-mvc/src/main/java/com/example/demo/infra/in/ui/pages/tests/EditableList.java
+++ b/demo/demo-vaadin-mvc/src/main/java/com/example/demo/infra/in/ui/pages/tests/EditableList.java
@@ -1,20 +1,16 @@
 package com.example.demo.infra.in.ui.pages.tests;
 
 import io.mateu.uidl.StyleConstants;
-import io.mateu.uidl.annotations.Hidden;
+import io.mateu.uidl.annotations.MasterDetail;
 import io.mateu.uidl.annotations.Route;
 import io.mateu.uidl.annotations.Style;
 import io.mateu.uidl.annotations.Toolbar;
-import io.mateu.uidl.fluent.Action;
-import io.mateu.uidl.fluent.ActionSupplier;
 import io.mateu.uidl.interfaces.ActionHandler;
 import io.mateu.uidl.interfaces.HttpRequest;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 record Row(String name, String email) {}
 
@@ -23,19 +19,20 @@ record Row(String name, String email) {}
 @Style(StyleConstants.CONTAINER)
 public class EditableList implements ActionHandler {
 
-    List<Row> rows = new ArrayList<>();
+    // A master-detail editable list: the table shows an "Edit" button per row that must open the
+    // row's detail editor (regression guard for the edit-button-selects-row bug).
+    @MasterDetail(minHeightWhenDetailVisible = "16rem")
+    List<Row> rows = new ArrayList<>(List.of(
+            new Row("Ada Lovelace", "ada@example.com"),
+            new Row("Alan Turing", "alan@example.com")));
 
     @Toolbar
     void test() {
-
     }
-
 
     @Override
     public Object handleAction(String actionId, HttpRequest httpRequest) {
-
         log.info("action " + actionId);
-
         return this;
     }
 }

--- a/frontend/web/monorepo/apps/vaadin/src/fields/mateu-grid.ts
+++ b/frontend/web/monorepo/apps/vaadin/src/fields/mateu-grid.ts
@@ -295,23 +295,25 @@ export class MateuGrid extends MetadataDrivenElement {
             `
 
         } else {
-            const orientation = (this.field?.formPosition == 'left' || this.field?.formPosition == 'right')?'horizontal':'vertical'
-
+            // Master + inline detail editor. A plain flex layout instead of vaadin-master-detail-layout:
+            // that component renders the slotted detail as an off-screen overlay in the current Vaadin
+            // version (the detail form never became visible), so the row's "Edit" appeared to do nothing.
+            // Column by default (detail below the grid); row when @DetailPosition is left/right.
+            const side = this.field?.formPosition
+            const horizontal = side === 'left' || side === 'right'
+            // The detail container must stay in the DOM even when hidden (applyFragment targets it by
+            // id), so we toggle visibility rather than presence.
             return html`
-            <vaadin-master-detail-layout
-                    style="overflow: unset; width: 100%; ${showDetail && this.field?.minHeightWhenDetailVisible?'min-height: '+this.field?.minHeightWhenDetailVisible+';':''}"
-                    orientation="${orientation}"
-                    .forceOverlay="${true}"
-            >
-                ${this.renderMaster(items)}
-                <div slot="${showDetail?'detail':'detail-hidden'}" style="${this.field?.formStyle??'display: contents;'}">
-                    <div id="container" style="padding-left: 2rem; padding-right: 2rem; padding-bottom: 2rem; background-color: var(--lumo-base-color);">
+            <div style="display: flex; flex-direction: ${horizontal ? 'row' : 'column'}; gap: var(--lumo-space-m, 1rem); width: 100%; ${showDetail && this.field?.minHeightWhenDetailVisible ? 'min-height: ' + this.field?.minHeightWhenDetailVisible + ';' : ''}">
+                <div style="${horizontal ? 'flex: 1; min-width: 0;' : 'width: 100%;'}${side === 'left' ? ' order: 2;' : ''}">
+                    ${this.renderMaster(items)}
+                </div>
+                <div style="${showDetail ? '' : 'display: none;'}${horizontal ? 'flex: 1; min-width: 0;' : 'width: 100%;'}${side === 'left' ? ' order: 1;' : ''}${this.field?.formStyle ?? ''}">
+                    <div id="container" style="padding: 0 2rem 2rem; background-color: var(--lumo-base-color);">
                         <mateu-component id="${this.field?.fieldId}-container"></mateu-component>
                     </div>
                 </div>
-                
-                
-            </vaadin-master-detail-layout>`
+            </div>`
         }
 
     }
@@ -338,6 +340,14 @@ export class MateuGrid extends MetadataDrivenElement {
                     }}"
                     @item-toggle="${this.handleItemToggle}"
                     @click="${ifDefined(this.field?.onItemSelectionActionId ? (e: MouseEvent) => {
+            // A click on an in-row control (the "Edit" button, an action/link cell, a checkbox…)
+            // must NOT also fire row selection: clicking Edit dispatches `<field>_select` (opens the
+            // detail editor) AND, without this guard, `<field>_selected` — whose response rebuilds
+            // the state with the pre-click `_show_detail=false`, immediately closing the editor. So
+            // the row only appeared selected. Skip selection when the click originates from a control.
+            if (e.composedPath().some((el) => el instanceof HTMLElement &&
+                (el.localName === 'vaadin-button' || el.localName === 'button' || el.localName === 'a' ||
+                 el.localName === 'vaadin-checkbox' || el.getAttribute?.('role') === 'button'))) return
             // Row-click selection: Vaadin's active-item is not reliably set by a click on a
             // read-only grid, so resolve the clicked row from the grid event context instead.
             const grid = e.currentTarget as unknown as { getEventContext: (ev: Event) => { item?: unknown } }


### PR DESCRIPTION
Clicking the per-row **Edit** button on a `@MasterDetail` list only highlighted the row; the detail editor never appeared. Two causes in `apps/vaadin/src/fields/mateu-grid.ts`, both fixed:

1. **Double dispatch.** The grid's row-click selection handler fired on ANY click inside the grid, so clicking Edit dispatched both `<field>_select` (open editor) AND `<field>_selected` (row selection). The `_selected` response rebuilds state with the pre-click `_show_detail=false`, immediately closing the editor `_select` just opened. Guard the click handler to ignore clicks originating from an in-row control (vaadin-button/button/anchor/checkbox/role=button).

2. **Invisible detail.** The detail form was rendered into a `<vaadin-master-detail-layout>` detail slot, which the current Vaadin version places as an off-screen overlay — the editor was in the DOM (with height) but never visible. Replaced with a plain flex layout (detail below the grid by default, beside it for a left/right form position); the detail container stays in the DOM (hidden) so `applyFragment` can target it by id.

Regression demo: `/editable-list` (demo-vaadin-mvc) now uses `@MasterDetail` with seeded rows. Verified live: clicking Edit opens the "Update Row" editor with the row's fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)