### PR TITLE
fix(frontend): header toolbar overflow is fit-based, not a fixed count

### DIFF
--- a/demo/explorer/src/main/java/io/mateu/explorer/ui/ToolbarOverflow.java
+++ b/demo/explorer/src/main/java/io/mateu/explorer/ui/ToolbarOverflow.java
@@ -1,0 +1,25 @@
+package io.mateu.explorer.ui;
+
+import io.mateu.uidl.annotations.Title;
+import io.mateu.uidl.annotations.Toolbar;
+import io.mateu.uidl.annotations.UI;
+
+/**
+ * Several secondary toolbar buttons — they must stay inline while they FIT the header and only the
+ * trailing ones that don't fit collapse into the "…" menu (not all of them, and not at a fixed count).
+ * Resize the window to see the overflow adapt.
+ */
+@UI("/toolbar-overflow")
+@Title("Toolbar overflow")
+public class ToolbarOverflow {
+
+    String name = "Order 4711";
+
+    @Toolbar public void refresh() {}
+    @Toolbar public void duplicate() {}
+    @Toolbar public void export() {}
+    @Toolbar public void archive() {}
+    @Toolbar public void share() {}
+    @Toolbar public void print() {}
+    @Toolbar public void settings() {}
+}

--- a/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/mateu-content-header.ts
+++ b/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/mateu-content-header.ts
@@ -57,10 +57,16 @@ export class MateuContentHeader extends LitElement {
     @property()
     appData: ComponentData = {}
 
-    // "…" overflow for secondary actions (the VB/Redwood header grammar): primaries stay
-    // visible; two or more secondaries collapse into this menu.
+    // "…" overflow for secondary actions: primaries stay inline; secondaries stay inline as long
+    // as they FIT — only the ones that don't fit collapse into this menu (measured, not a count).
     @state()
     private _overflowOpen = false
+
+    // How many trailing secondary buttons are moved into the "…" menu (measured to fit the header).
+    @state()
+    private _overflowN = 0
+    private _secCount = 0
+    private _ro?: ResizeObserver
 
     private _onDocClick = (e: Event) => {
         if (!e.composedPath().includes(this)) {
@@ -71,11 +77,39 @@ export class MateuContentHeader extends LitElement {
     connectedCallback() {
         super.connectedCallback()
         document.addEventListener('click', this._onDocClick)
+        // Re-fit the toolbar whenever the header (or window) is resized. The ResizeObserver catches
+        // container-driven size changes; the window listener is a robust fallback.
+        this._ro = new ResizeObserver(() => this._resetOverflow())
+        this._ro.observe(this)
+        window.addEventListener('resize', this._resetOverflow)
     }
 
     disconnectedCallback() {
         document.removeEventListener('click', this._onDocClick)
+        window.removeEventListener('resize', this._resetOverflow)
+        this._ro?.disconnect()
+        this._ro = undefined
         super.disconnectedCallback()
+    }
+
+    /** Show everything inline again, then let updated() shrink to fit — the expand path on resize. */
+    private _resetOverflow = () => {
+        if (this._overflowN !== 0) this._overflowN = 0
+        else this.requestUpdate()
+    }
+
+    /** After each render, move one more secondary into the "…" menu while the action cluster still
+     *  overflows the header (wrapped to a new line or past the right edge). Monotonic → converges. */
+    protected updated(changed: Map<PropertyKey, unknown>) {
+        if (changed.has('metadata') || changed.has('data')) { this._resetOverflow(); return }
+        const cluster = this.renderRoot.querySelector('.actions-cluster') as HTMLElement | null
+        if (!cluster || this._secCount === 0) return
+        const row = cluster.closest('.form-header, .no-header-row') as HTMLElement | null
+        if (!row) return
+        const cr = cluster.getBoundingClientRect()
+        const rr = row.getBoundingClientRect()
+        const overflowing = cr.top - rr.top > 8 || cr.right > rr.right + 1
+        if (overflowing && this._overflowN < this._secCount) this._overflowN += 1
     }
 
     handleButtonClick = (actionId: string) => {
@@ -110,28 +144,35 @@ export class MateuContentHeader extends LitElement {
     `
     }
 
-    // Action cluster with the "…" overflow: primaries always inline; a SINGLE secondary
-    // stays inline too, two or more collapse into the menu (the VB/Redwood header grammar).
+    // Action cluster with the "…" overflow: primaries always inline; secondaries stay inline while
+    // they FIT the header and only the trailing ones that don't fit collapse into the menu. The
+    // split (_overflowN) is measured in updated(); here we just render it.
     renderActions = (actionButtons: Button[]) => {
         const visible = actionButtons.filter(b => !(this.data ?? {})[b.actionId + '.hidden'])
         const primaries = visible.filter(b => b.buttonStyle === 'primary')
         const secondaries = visible.filter(b => b.buttonStyle !== 'primary')
-        if (secondaries.length < 2) {
-            return html`${visible.map(this.renderBtn)}`
-        }
+        this._secCount = secondaries.length
+        const n = Math.max(0, Math.min(this._overflowN, secondaries.length))
+        const inline = secondaries.slice(0, secondaries.length - n)
+        const menu = secondaries.slice(secondaries.length - n)
         return html`
-            ${primaries.map(this.renderBtn)}
-            <div class="overflow-wrap">
-                <button class="mtb overflow-btn" title="Más acciones" aria-haspopup="true"
-                        aria-expanded="${this._overflowOpen}"
-                        @click="${(e: Event) => { e.stopPropagation(); this._overflowOpen = !this._overflowOpen }}">⋯</button>
-                ${this._overflowOpen ? html`
-                    <div class="overflow-menu">
-                        ${secondaries.map(b => html`
-                            <button class="overflow-item" ?disabled="${b.disabled}"
-                                    data-action-id="${b.actionId}"
-                                    @click="${() => this.handleButtonClick(b.actionId)}">${this.evalLabel(b.label)}</button>
-                        `)}
+            <div class="actions-cluster">
+                ${primaries.map(this.renderBtn)}
+                ${inline.map(this.renderBtn)}
+                ${menu.length ? html`
+                    <div class="overflow-wrap">
+                        <button class="mtb overflow-btn" title="Más acciones" aria-haspopup="true"
+                                aria-expanded="${this._overflowOpen}"
+                                @click="${(e: Event) => { e.stopPropagation(); this._overflowOpen = !this._overflowOpen }}">⋯</button>
+                        ${this._overflowOpen ? html`
+                            <div class="overflow-menu">
+                                ${menu.map(b => html`
+                                    <button class="overflow-item" ?disabled="${b.disabled}"
+                                            data-action-id="${b.actionId}"
+                                            @click="${() => this.handleButtonClick(b.actionId)}">${this.evalLabel(b.label)}</button>
+                                `)}
+                            </div>
+                        ` : nothing}
                     </div>
                 ` : nothing}
             </div>
@@ -190,7 +231,7 @@ export class MateuContentHeader extends LitElement {
                 </div>
             ` : nothing}
             ${metadata.noHeader ? html`
-                <div style="display: flex; gap: var(--lumo-space-m, 1rem); align-items: center;">
+                <div style="display: flex; gap: var(--lumo-space-m, 1rem); align-items: center;" class="no-header-row">
                     ${metadata?.header?.map((component: Component) => renderComponent(this, component, this.baseUrl, this.state ?? {}, this.data ?? {}, this.appState, this.appData))}
                     ${peerNav ? this.renderPeerNav(peerNav) : nothing}
                     ${navButtons.map(this.renderBtn)}
@@ -293,6 +334,15 @@ export class MateuContentHeader extends LitElement {
         }
         .kpi-value {
             font-weight: 600;
+        }
+
+        /* The action cluster stays on one line and moves/wraps as a unit; updated() measures it
+           against the header row to decide how many trailing secondaries overflow into the menu. */
+        .actions-cluster {
+            display: inline-flex;
+            align-items: center;
+            flex-wrap: nowrap;
+            gap: var(--lumo-space-xs, .25rem);
         }
 
         /* "…" overflow menu for secondary header actions */


### PR DESCRIPTION
The page header's secondary action buttons collapsed into the "…" menu as soon as there were **two** of them, and the menu then held **all** of them — regardless of how much room the header had.

Now the overflow is **measured**: primaries stay inline, secondaries stay inline **as long as they FIT** the header, and only the trailing ones that don't fit move into the "…" menu. `renderActions` renders the split; `updated()` measures the action cluster against the header row (wrapped to a new line / past the right edge) and moves one more into the menu while it overflows (monotonic → converges). A `ResizeObserver` + `window` resize listener re-fit on resize — expanding back when there's room.

Verified live: 7 secondary buttons render all inline at 1512px; at ~820px, 4 stay inline and only the 3 that don't fit go into the "…" menu.

Demo/regression page: `/toolbar-overflow` (explorer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)