### PR TITLE
docs(readme): posicionar Mateu como derivación frente a generación

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,30 +2,47 @@
 
 [![Discord](https://img.shields.io/badge/Discord-Join%20us-5865F2?logo=discord&logoColor=white)](https://discord.gg/YFb9utDMYK)
 
-Mateu is a **model-driven UI framework for Java** that lets you build **business web applications** at very high speed.
-
-Define your UI once in Java.  
-Mateu generates forms, navigation, CRUD screens and application structure automatically.
+Mateu is a **model-driven UI framework** for building **business applications**: you declare what a
+screen contains, and Mateu derives the UI. Java is the reference implementation; .NET and Python
+speak the same wire.
 
 ---
 
 ## Why Mateu
 
-Traditional business applications usually require:
+An LLM will write you a React admin panel in a minute. So "less code" is no longer the point.
 
-- backend logic
-- frontend app
-- API layer
-- duplicated models
-- duplicated validation
-- a lot of glue code
+The point is what happens **on day 200**.
 
-Mateu takes a different approach:
+Generated code **derives** from your model and then **diverges** from it: the moment someone edits
+it, it is theirs to maintain, and it drifts. Mateu does not generate the UI — it **derives** it, so
+it cannot drift. Change the model and the screen is already correct.
 
-- one application model
-- one source of truth
-- less code
-- fewer moving parts
+That is one distinction, and it is the whole framework:
+
+> **Source of truth vs artifact.** You maintain the declaration. Everything downstream — the UI, the
+> API contract it implies, a static bundle — is derived, and nobody edits it.
+
+### Start from whatever you already have
+
+|  |  |
+|---|---|
+| A domain model? | Declare `@UI` classes — inside-out |
+| A design or a mockup? | Draw it in the visual editor — outside-in |
+| An existing REST API? | Point the screens at it |
+
+All three land on the same declaration. Code-first tools cannot start from a design; design-first
+low-code tools cannot start from your domain model.
+
+### And the UI travels with the domain
+
+Each service ships its own screens **inside its own jar** — the UI module needs one dependency and
+no framework coupling — and they aggregate into one shell, or embed into an IDE, a mobile app or
+another product's page. Eight teams can own, version and deploy their slice of the same back office
+independently.
+
+That is micro-frontends without the micro-frontend tax: what federates is a **declaration**, not a
+JS bundle, so there is one framework version, no runtime composition and no CSS collisions.
 
 ---
 
@@ -64,6 +81,9 @@ becomes:
 - menus from your object model
 - full CRUD with minimal code
 - responsive UI out of the box
+- the same screens on the web, on mobile (React Native) and inside an IDE — no renderer work
+- an optional [static bundle](https://mateu.io/java-user-manual/build/static-bundle/): the same app
+  served from a CDN with no backend running
 
 ---
 
@@ -81,6 +101,9 @@ Mateu is **not designed for**:
 - marketing websites
 - highly custom visual experiences
 - frontend-heavy products
+
+When one screen out of forty does need to be special, you drop to a custom component for that one
+and keep routing, state, validation, i18n and the rest of the app.
 
 ---
 
@@ -101,4 +124,4 @@ Have questions, ideas or feedback?
 
 ## One-sentence summary
 
-Mateu turns backend Java models into real business UIs with almost no frontend code.
+Mateu derives real business UIs from a declaration you keep — so they cannot drift away from it.


### PR DESCRIPTION
Fila 8 de la tabla de ataque de `design/framework-design-backlog.md`.

## Por qué

El argumento histórico del README —*escribes menos código*— **lo ha ganado la IA**: un LLM escribe un panel de admin en React en un minuto. Lo que no da es lo que pasa el día 200.

La oposición útil no es *derivación vs generación* sino **fuente de verdad vs artefacto** (sección 15.1): generar no es el problema, el problema es **qué se edita**. El código generado pasa a ser tuyo y diverge; una UI derivada no puede divergir.

## Qué cambia

- **"Why Mateu"** reescrito alrededor de esa distinción.
- **"Empieza por donde ya tengas algo"** — modelo de dominio, diseño o API REST. Las herramientas code-first no pueden arrancar de un diseño; las design-first no pueden arrancar de tu modelo de dominio. Ninguna de las dos puede decir esto.
- **"La UI viaja con el dominio"** — cada servicio embarca sus pantallas en su jar y se agregan en una shell: micro-frontends sin el impuesto, porque lo que se federa es una declaración y no un bundle JS.
- **Matiza el "no está diseñado para"**: cuando una pantalla de cuarenta sí necesita ser especial, se baja a un componente custom para esa y se conserva routing, estado, validación e i18n.
- Añade a "what you get" el multi-renderer y el bundle estático, que el README callaba.

Solo documentación: no toca código.

🤖 Generated with [Claude Code](https://claude.com/claude-code)