### PR TITLE
docs: escribir la regla de autoría y el techo de la inferencia

### DIFF
--- a/doc/astro.config.mjs
+++ b/doc/astro.config.mjs
@@ -58,6 +58,7 @@ export default defineConfig({
 			],
 			sidebar: [
 				{ slug: 'the-mateu-way', label: 'The Mateu Way' },
+				{ slug: 'authoring-rule', label: 'The authoring rule' },
 				{
 					label: 'Use with AI',
 					items: [

--- a/doc/src/content/docs/authoring-rule.md
+++ b/doc/src/content/docs/authoring-rule.md
@@ -1,0 +1,71 @@
+---
+title: "The authoring rule"
+description: "When something is an annotation, an interface, or something Mateu infers for you — and the criterion that decides."
+---
+
+Mateu has a large declarative surface. It has stayed learnable because of one rule that has governed
+it from the start — and this page writes it down, because a rule nobody can read is a rule only the
+maintainer can apply.
+
+If you are extending Mateu, this decides where your new capability belongs. If you are only using
+it, it explains why the API looks the way it does, and lets you guess right about parts you have not
+read yet.
+
+## Two questions
+
+The first splits by **when the answer is known**:
+
+> **Annotation** — purely declarative: known at compile time, no decision to make.
+> **Interface (supplier / abstract method)** — there is a decision, and it is taken at runtime.
+
+That is why a page's subtitle is `@Subtitle("…")` *and* `SubtitleSupplier.subtitle()`: one is a
+constant, the other is computed. The same pair appears for the title, the overline, the title
+placeholder, peer navigation, page width. **When both are present, the supplier wins** — a runtime
+value outranks a declared one.
+
+The second question splits by **who decides**:
+
+|  | **you decide** | **Mateu decides** |
+|---|---|---|
+| **compile time** | annotation | inference from the shape of your model |
+| **runtime** | interface / abstract method | inference + composition |
+
+The left-hand column is the rule above. The right-hand column is
+[layout inference](/ux-patterns/layout-inference/) and page inference: Mateu reading the
+information you declared and choosing the presentation you did not.
+
+This is why `@AutoPage` feels unlike every other annotation: **its content is not information, it is
+permission** — "decide this for me". It is not a declaration, it is a change of column.
+
+## The criterion
+
+From those two axes comes the rule that decides where a new capability goes:
+
+> **An annotation is legitimate when it carries information that only you have.**
+> **It is debt when it carries a decision Mateu could take by looking at the model.**
+
+A `@Timestamp` field marks *which* of your fields is the last-updated one — Mateu cannot know that;
+information only you have. A two-column layout for a form of six short fields is *not* information:
+it is a decision derivable from the fields, so it is inferred, and the annotation exists only to
+override.
+
+Applied consistently, the surface shrinks as inference improves instead of accumulating.
+
+## It also decides where your screen runs
+
+The same partition governs delivery, which is why it is worth getting right:
+
+| Authoring | Delivery |
+|---|---|
+| **annotation** — compile time, no decision | can be pre-rendered into a [static bundle](/java-user-manual/build/static-bundle/) and served from a CDN |
+| **interface** — decision at runtime | needs the server |
+
+Both ask the same thing: *can this be known without the request?* So the rule of thumb for "will this
+screen work with no backend" is not a list of exceptions to memorise — it is
+**if you declared it with annotations, it can ship statically; if you used an interface, it needs a
+server.**
+
+## What Mateu will not infer
+
+Inference has a ceiling, and it is worth knowing where it is so you do not wait for a version that
+lifts it. See [the limits of inference](/ux-patterns/layout-inference/#the-limits-of-inference).

--- a/doc/src/content/docs/ux-patterns/layout-inference.md
+++ b/doc/src/content/docs/ux-patterns/layout-inference.md
@@ -195,6 +195,35 @@ Inference does not just pick a widget — it tells the renderer **what the group
 - `groupRelationship` — the semantic relation between the groups: `alternative` (the user looks at one group at a time — what tabs express), `sequential` (steps), or `simultaneous` (side by side). Developer-declared tabs and inferred section-tabs both emit `alternative`.
 - `adaptable` — `true` when the class is under `@AutoLayout`: the developer delegated the presentation, so a renderer **may degrade the tabs to an accordion** on a narrow viewport without losing the disclosure semantics. Tabs declared on a class *without* `@AutoLayout` still carry their `groupRelationship`, but are marked `adaptable: false` — the developer asked for tabs, so tabs they get.
 
+## The limits of inference
+
+Inference has a ceiling, and it is **not an implementation gap that a future version will close** —
+it is a limit on what your model contains. Knowing where it sits saves you waiting for something
+that cannot arrive.
+
+Mateu infers **presentation from shape**. It can do that because shape and presentation are tightly
+correlated: six short optional fields *are* a foldable group; a class of `MetricCard` fields *is* a
+dashboard.
+
+Page **family**, though, comes from a different place. The Redwood decision model that the six
+families come from starts at the **user's goal**:
+
+```
+user goal → category → data density → template → fixed anatomy
+```
+
+Mateu starts at the **data model**. That distance is the ceiling. A list of records could be a
+table, a calendar, a kanban, a planning board or a triage queue — **the same shape, five different
+user goals**. No amount of inference separates them, because the information is not in the model.
+
+So Mateu only composes the families that are **fully derivable** from what you declared
+(`MetricCard` fields → Dashboard; a page of `Button` calls-to-action → Welcome). For everything else
+it can at most *hint* — the advisor logs "this looks like a CollectionDetail" — and **you** pick,
+which is exactly what [The Mateu Way](/the-mateu-way/) asks you to do first.
+
+That is not a limitation to work around. It is the one decision the framework needs from you, and it
+takes one annotation.
+
 ## Notes
 
 - The decision table lives in `LayoutInference` (core, `componentmapper`), and it is the **reference implementation**: the C# and Python backends port the exact same rules and thresholds, so the wire JSON is identical whichever server emits it.


### PR DESCRIPTION
Filas **6.1** y **6.2** de la tabla de ataque de `design/framework-design-backlog.md`. Las dos son reglas que llevan años gobernando el diseño y que **solo existían en la cabeza del mantenedor** — el problema que la sección 0.2 identifica desde que el proyecto es un producto con terceros.

## `authoring-rule` (página nueva, junto a *The Mateu Way*)

- **La regla de la etapa 1**, que nunca se escribió: *anotación* cuando es puramente declarativo (compile time, sin decisión); *interfaz* cuando hay decisión y se toma en runtime. Y que **el supplier gana a la anotación** cuando están los dos.
- **El segundo eje**, el que abrió la inferencia: *quién* decide. De ahí que `@AutoPage` se sienta distinta a todas las demás — su contenido no es información, es **permiso**.
- **El criterio que faltaba**: una anotación es legítima cuando transporta información que solo tú tienes; es deuda cuando transporta una decisión que Mateu podría tomar mirando el modelo.
- Y que **la misma partición decide dónde corre la pantalla**: si lo declaraste con anotaciones puede servirse desde un CDN, si usaste una interfaz necesita servidor. Las dos preguntan lo mismo: *¿se puede saber sin la petición?* Eso convierte "¿funcionará sin backend?" de una lista de excepciones a memorizar en algo razonable de cabeza.

## `layout-inference` → *The limits of inference*

El techo **no es un hueco de implementación** que una versión futura cierre: es un límite de lo que el modelo contiene. La cadena de decisión de Redwood arranca en el **objetivo de usuario** y Mateu arranca en el **modelo de datos**. Una lista de registros puede ser tabla, calendario, kanban, planning board o cola de triaje: misma forma, cinco objetivos distintos.

Por eso solo se componen las familias plenamente derivables y del resto se avisa — y decirlo evita que alguien espere una versión que no puede llegar.

Solo documentación: no toca código.

🤖 Generated with [Claude Code](https://claude.com/claude-code)