### PR TITLE
feat(bundle): no pre-renderizar pantallas dependientes de identidad

### DIFF
--- a/backend/shared/core/src/main/java/io/mateu/core/application/export/MateuBundleExporter.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/export/MateuBundleExporter.java
@@ -7,6 +7,7 @@ import io.mateu.core.application.MateuService;
 import io.mateu.core.application.runaction.RouteRegistry;
 import io.mateu.core.infra.HeadlessHttpRequest;
 import io.mateu.dtos.RunActionRqDto;
+import io.mateu.uidl.annotations.EyesOnly;
 import io.mateu.uidl.annotations.HomeRoute;
 import io.mateu.uidl.annotations.Route;
 import io.mateu.uidl.annotations.Routes;
@@ -19,6 +20,7 @@ import io.mateu.uidl.interfaces.RoutedClassProvider;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
 
@@ -158,8 +160,25 @@ public final class MateuBundleExporter {
         .map(entry -> "/" + entry.route())
         .filter(r -> !onlyStatic || RouteRegistrations.isStatic(r))
         .forEach(routes::add);
+    // Which class answers each route, so an identity-dependent screen is recognised BEFORE it is
+    // rendered (see identityRestriction).
+    var classByRoute = new java.util.HashMap<String, String>(classesFromBeans());
+    for (var ref : RouteRegistrations.read(cl)) {
+      classByRoute.putIfAbsent(normalizedRoute(ref.route()), ref.className());
+    }
+    for (var entry : authored.routes()) {
+      if (entry.viewModel() != null && !entry.viewModel().isBlank()) {
+        classByRoute.put(normalizedRoute(entry.route()), entry.viewModel());
+      }
+    }
+
     var entries = new ArrayList<BundleEntry>();
     for (String route : routes) {
+      var restriction = identityRestriction(classByRoute.get(normalizedRoute(route)), cl);
+      if (restriction != null) {
+        entries.add(new BundleEntry(route, toSyncPath(route), null, false, restriction));
+        continue;
+      }
       entries.add(
           RouteRegistrations.isStatic(route)
               ? exportRoute(baseUrl, route)
@@ -174,6 +193,103 @@ public final class MateuBundleExporter {
    * (never throws) when no bean context is wired — e.g. the Maven goal's fresh context — so the
    * caller falls back to the index.
    */
+  private static String normalizedRoute(String route) {
+    return route == null ? "" : route.replaceAll("^/+", "").replaceAll("/+$", "");
+  }
+
+  /**
+   * Why a route must NOT be pre-rendered, or {@code null} when it is safe to bundle.
+   *
+   * <p><b>The policy.</b> A screen whose structure depends on WHO is asking cannot be baked into a
+   * static bundle, because a bundle is one file served to everyone. Export runs headless, with no
+   * Authorization header, and {@link io.mateu.core.domain.Authorizer} denies restricted content
+   * without a token — so the danger is NOT a leak (it fails closed) but a screen that is
+   * <em>permanently wrong</em>: the pre-rendered variant is the DENIED one, and an authorised user
+   * hitting a static host has no server left to re-render the version they are entitled to.
+   *
+   * <p>Skipping is the conservative half of that trade: the route stays backend-served, which is
+   * where a screen gated on identity belongs anyway. Baking it silently would be the kind of
+   * failure nobody notices until a privileged user reports "the button is missing".
+   *
+   * <p>{@code @Audience} is deliberately NOT treated this way: it is a UX projection, not access
+   * control (see {@code AudienceGate}), and with no audience selected the export renders the full,
+   * unprojected view — correct for everyone, merely not personalised.
+   */
+  private static String identityRestriction(String className, ClassLoader cl) {
+    if (className == null || className.isBlank()) {
+      return null;
+    }
+    try {
+      var loader = cl != null ? cl : MateuBundleExporter.class.getClassLoader();
+      var type = Class.forName(className, false, loader);
+      if (type.isAnnotationPresent(EyesOnly.class)) {
+        return "identity-dependent: the class declares @EyesOnly — kept backend-served";
+      }
+      for (var field : type.getDeclaredFields()) {
+        if (field.isAnnotationPresent(EyesOnly.class)) {
+          return "identity-dependent: field '"
+              + field.getName()
+              + "' declares @EyesOnly — kept backend-served";
+        }
+      }
+      for (var method : type.getDeclaredMethods()) {
+        if (method.isAnnotationPresent(EyesOnly.class)) {
+          return "identity-dependent: method '"
+              + method.getName()
+              + "' declares @EyesOnly — kept backend-served";
+        }
+      }
+      return null;
+    } catch (Throwable t) {
+      // Unloadable class: let the normal export path run and report its own reason.
+      return null;
+    }
+  }
+
+  /**
+   * Which class answers each route, as seen by the live beans. The index ( {@code *-registrations})
+   * covers the build-time path; this covers the runtime one, and is the only source in a
+   * single-module app or under the test harness — without it the identity policy would silently
+   * never fire where routes come from beans.
+   */
+  private Map<String, String> classesFromBeans() {
+    var byRoute = new java.util.HashMap<String, String>();
+    try {
+      var resolvers = MateuBeanProvider.getBeans(RouteResolver.class);
+      if (resolvers != null) {
+        for (RouteResolver rr : resolvers) {
+          for (var pattern : rr.supportedRoutesPatterns()) {
+            if (pattern.route() == null) continue;
+            // resolveRoute is the only way to get the class a pattern answers with; it is a pure
+            // lookup on the generated resolvers (it returns a Class, it does not instantiate), and
+            // any resolver that misbehaves is isolated by the surrounding catch.
+            try {
+              var owner = rr.resolveRoute(pattern.route(), "", null);
+              if (owner != null) {
+                byRoute.putIfAbsent(normalizedRoute(pattern.route()), owner.getName());
+              }
+            } catch (Throwable ignored) {
+              // this pattern simply contributes no class; the index may still supply one
+            }
+          }
+        }
+      }
+      var providers = MateuBeanProvider.getBeans(RoutedClassProvider.class);
+      if (providers != null) {
+        for (RoutedClassProvider p : providers) {
+          var owner = p.routedClass();
+          if (owner == null) continue;
+          for (String r : routesOf(owner)) {
+            if (r != null) byRoute.putIfAbsent(normalizedRoute(r), owner.getName());
+          }
+        }
+      }
+    } catch (Throwable t) {
+      log.debug("route→class discovery from beans failed: {}", t.toString());
+    }
+    return byRoute;
+  }
+
   private List<String> routesFromBeans(boolean staticOnly) {
     var out = new ArrayList<String>();
     try {

--- a/backend/shared/core/src/test/java/io/mateu/core/application/export/BundleIdentityPolicyTest.java
+++ b/backend/shared/core/src/test/java/io/mateu/core/application/export/BundleIdentityPolicyTest.java
@@ -1,0 +1,103 @@
+package io.mateu.core.application.export;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.mateu.core.testutil.TestMateu;
+import io.mateu.uidl.annotations.EyesOnly;
+import io.mateu.uidl.annotations.Title;
+import io.mateu.uidl.annotations.UI;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A screen whose structure depends on WHO is asking is not pre-rendered into the static bundle.
+ *
+ * <p>A bundle is one file served to everyone, and export runs headless: with no Authorization
+ * header the {@code Authorizer} denies restricted content, so the danger is not a leak — it fails
+ * closed — but a screen that is <em>permanently wrong</em>. The pre-rendered variant would be the
+ * DENIED one, and an authorised user on a static host has no server left to re-render what they are
+ * entitled to. So the route is skipped and stays backend-served.
+ */
+class BundleIdentityPolicyTest {
+
+  @SuppressWarnings("unused")
+  @UI("/plain-screen")
+  @Title("Plain")
+  public static class PlainScreen {
+    public String name = "Widget";
+  }
+
+  @SuppressWarnings("unused")
+  @UI("/restricted-screen")
+  @Title("Restricted")
+  @EyesOnly(roles = "admin")
+  public static class RestrictedScreen {
+    public String name = "Widget";
+  }
+
+  @SuppressWarnings("unused")
+  @UI("/partly-restricted")
+  @Title("Partly restricted")
+  public static class PartlyRestricted {
+    public String name = "Widget";
+
+    @EyesOnly(roles = "admin")
+    public String secret = "only for admins";
+  }
+
+  static TestMateu mateu;
+
+  @BeforeAll
+  static void boot() {
+    mateu = TestMateu.withUis(PlainScreen.class, RestrictedScreen.class, PartlyRestricted.class);
+  }
+
+  @AfterAll
+  static void shutdown() {
+    mateu.close();
+  }
+
+  private static MateuBundleExporter.BundleEntry entryFor(String route) {
+    var manifest =
+        new MateuBundleExporter(mateu.service())
+            .exportAll("", BundleIdentityPolicyTest.class.getClassLoader(), false, true);
+    return manifest.entries().stream()
+        .filter(e -> route.equals(e.route()))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("no bundle entry for " + route));
+  }
+
+  @Test
+  void aScreenGatedOnIdentityIsNotBundled() {
+    var entry = entryFor("/restricted-screen");
+    assertThat(entry.ok()).isFalse();
+    assertThat(entry.json()).isNull();
+    assertThat(entry.skipReason()).contains("identity-dependent").contains("@EyesOnly");
+  }
+
+  @Test
+  void aScreenWithOneRestrictedFieldIsNotBundledEither() {
+    // The whole screen is skipped, not just the field: what would be baked is the denied variant of
+    // the page, and a static host cannot re-render it for someone who may see the field.
+    var entry = entryFor("/partly-restricted");
+    assertThat(entry.ok()).isFalse();
+    assertThat(entry.skipReason()).contains("secret");
+  }
+
+  @Test
+  void anOrdinaryScreenIsStillBundled() {
+    var entry = entryFor("/plain-screen");
+    assertThat(entry.ok()).as("skipped because: %s", entry.skipReason()).isTrue();
+    assertThat(entry.json()).isNotBlank();
+  }
+
+  @Test
+  void theSkipReasonSaysWhereTheRestrictionIs() {
+    // The reason is what a developer reads in the build log when a route silently stops being
+    // bundled, so it names the member rather than just the rule.
+    assertThat(entryFor("/partly-restricted").skipReason())
+        .contains("field 'secret'")
+        .contains("backend-served");
+  }
+}

--- a/doc/src/content/docs/java-user-manual/build/static-bundle.md
+++ b/doc/src/content/docs/java-user-manual/build/static-bundle.md
@@ -157,6 +157,16 @@ skipped, exactly like a static view that needs a live backend. See `demo/demo-st
   client-side). A view that loads its entity server-side by id still needs a backend.
 - **Service-backed loads** — a ViewModel whose initial load needs a live DB / a bean the build can't
   construct is skipped at export time (logged) and stays backend-served.
+- **Screens gated on identity** — a route whose class, field or method declares `@EyesOnly` is
+  **skipped on purpose** and stays backend-served. A bundle is one file served to everyone, and
+  export runs headless: with no `Authorization` header the authorizer denies restricted content, so
+  nothing leaks — it fails closed. What would leak instead is *correctness*: the baked variant is the
+  **denied** one, and an authorised user hitting a static host has no server left to re-render the
+  version they are entitled to. The skip reason names the member, so the build log says which one.
+
+  `@Audience` is deliberately **not** treated this way: it is a UX projection, not access control, so
+  with no audience selected the export renders the full, unprojected view — correct for everyone,
+  merely not personalised.
 
 A **hybrid** deploy is the sweet spot: ship the bundle for instant, backend-free first paint, and
 point `baseUrl` at a real backend so actions and unbundled/param routes still work — the client uses


### PR DESCRIPTION
Fila **9.2** del backlog — una de las tres fronteras de seguridad. Una ruta cuya clase, campo o método declare `@EyesOnly` se **salta** del bundle estático y se queda servida por backend.

## El fundamento corrige lo que el propio backlog afirmaba

El backlog decía que el riesgo era *"en el peor caso, divulgación de capacidades"*. Verificándolo sobre `Authorizer`: **sin token, deniega**. El export headless no filtra nada — **falla cerrado**.

El riesgo real es otro, y es más silencioso: lo que se hornearía es la variante **denegada**, servida a todo el mundo *incluido quien sí tiene permiso*, y en un host estático no queda servidor que re-renderice la versión a la que tiene derecho. Se descubre cuando alguien reporta "me falta el botón".

Saltarla es la mitad conservadora del intercambio: la ruta se queda donde una pantalla con control de acceso debe estar de todos modos.

## `@Audience` no se trata así, a propósito

Es **proyección de UX, no control de acceso** — lo dice el javadoc de `AudienceGate`. Sin audiencia seleccionada el export renderiza la vista completa sin proyectar: correcta para todos, solo que no personalizada.

## Un detalle de implementación que costó encontrar

El mapa ruta→clase **no puede salir solo de los índices de los APs**: en una app de un módulo y en el harness de test las rutas vienen de **beans**, así que sin `classesFromBeans` la política no habría disparado nunca justo donde más se prueba. Los tres primeros tests fallaron por eso y fue lo que lo destapó.

El `skipReason` nombra el **miembro concreto**, no solo la regla — es lo que alguien lee en el log cuando una ruta deja de bundlearse.

## Verificación

- `BundleIdentityPolicyTest` — 4 tests
- `core` — **839 verde**
- Documentado en `static-bundle.md`, incluida la parte de que falla cerrado

🤖 Generated with [Claude Code](https://claude.com/claude-code)