### PR TITLE
docs: el trato del modo sin servidor y el invariante del código de cliente

### DIFF
--- a/doc/src/content/docs/java-ui-definition/annotations/rest-options.md
+++ b/doc/src/content/docs/java-ui-definition/annotations/rest-options.md
@@ -66,6 +66,31 @@ This is the **options** surface. The same `RestDataSource` descriptor also power
 all four are shipped.
 :::
 
+## Serving with no Mateu server — what you are signing up for
+
+A [statically deployed](/java-user-manual/build/static-bundle/) mount has no Mateu server behind it,
+which is the point — and it has a consequence worth stating plainly rather than discovering:
+
+:::caution[The deal]
+With no Mateu server, **your endpoints are exposed directly to the browser**. They must accept CORS
+from your static host, and the only authentication available is one a browser can hold.
+
+And `proxy = true` — the mode that fixes exactly that — **is unavailable there**, because it works by
+routing the fetch through the Mateu server. It is missing precisely where you would most want it.
+:::
+
+So the choice is real, not a detail:
+
+| | direct (no server) | `proxy = true` (server) |
+|---|---|---|
+| Who fetches | the browser | the Mateu server |
+| CORS | your endpoint must allow the static host | not involved |
+| Secrets | whatever the browser can hold | `${secret.X}` injected server-side |
+| Works statically | yes | no |
+
+A public or read-only API is a fine fit for the direct mode. An API that needs a real credential is
+not — and a screen that talks to one should stay backend-served.
+
 ## Server-proxy mode (`proxy = true`) — CORS & auth hardening
 
 By default the **browser** fetches the endpoint directly, so the endpoint must be CORS-friendly and

--- a/doc/src/content/docs/java-ui-definition/client-side-logic.md
+++ b/doc/src/content/docs/java-ui-definition/client-side-logic.md
@@ -33,6 +33,31 @@ Rules are evaluated in the browser and can:
 - **triggers** define when actions run
 - **rules** define how the UI changes dynamically in the browser
 
+## The line: client logic moves state, it does not build UI
+
+`@Rule` can already run JavaScript, and shipping whole modules to the browser — a bundle built from
+a TypeScript project, or Java transpiled with TeaVM — is a direction worth taking. Before any of it,
+the boundary is worth stating, because it is what keeps the framework's central promise intact:
+
+:::note[The invariant]
+Client-side code may **read and write state, trigger actions and navigate**. It may **not construct
+UI**.
+:::
+
+Building UI stays derivation. The moment client code can paint, a screen can diverge from the
+declaration it came from, and "the UI cannot drift away from your model" stops being true — the one
+claim the whole framework rests on.
+
+That is not a restriction on what you can build, it is a restriction on *where*: a custom widget is
+still a first-class extension point ([component adapters](/design-systems/bring-your-own-design-system/)),
+declared like everything else. What the invariant rules out is UI appearing from imperative code
+nobody declared.
+
+There is a second reason, less philosophical: any API given to client code has to speak the language
+of the **declared model** — components by id, state, actions, routes — and never the DOM. An API that
+exposed the DOM would work on one renderer and break on the others, and "one declaration, many
+renderers" would quietly stop being true.
+
 ## Why this matters
 
 This gives you dynamic behavior without introducing a separate frontend application layer.


### PR DESCRIPTION
Filas **10.3** y **14.3** del backlog. Las dos son fronteras que ya estaban decididas pero sin escribir.

## 10.3 — el trato del modo sin servidor

`rest-options` gana un cuadro de *"esto es lo que estás firmando"*:

> Sin servidor Mateu, tus endpoints quedan **expuestos directamente al navegador**: CORS abierto, y la única autenticación posible es la que un navegador puede sostener.

Y lo que más importa: **`proxy = true` no está disponible ahí**, porque funciona enrutando el fetch por el servidor. Falta precisamente donde más haría falta. Va con una tabla directo-vs-proxy para que la elección se vea, y con la conclusión práctica — una API que necesita una credencial de verdad no encaja en el modo estático, y una pantalla que hable con ella debe quedarse servida por backend.

## 14.3 — el invariante del código de cliente

`client-side-logic` gana la línea que conviene fijar **antes** de mandar módulos al navegador (un bundle TS, o Java transpilado con TeaVM):

> El código de cliente puede **leer y escribir estado, disparar acciones y navegar**. **No puede construir UI.**

Construir UI sigue siendo derivación. En cuanto el cliente pueda pintar, una pantalla puede divergir de la declaración de la que salió, y *"la UI no puede alejarse de tu modelo"* deja de ser cierto — que es lo único sobre lo que descansa el framework entero.

Con la aclaración de que no limita **qué** puedes construir sino **dónde**: un widget custom sigue siendo punto de extensión de primera clase, declarado. Y la razón menos filosófica: una API que expusiera el DOM funcionaría en un renderer y rompería en los demás.

Solo documentación.

🤖 Generated with [Claude Code](https://claude.com/claude-code)