### PR TITLE
feat(bundle): identidad del manifest y fallo opcional ante rutas no bundleadas

### DIFF
--- a/backend/mateu-bundle-maven-plugin/src/main/java/io/mateu/maven/bundle/BundleMojo.java
+++ b/backend/mateu-bundle-maven-plugin/src/main/java/io/mateu/maven/bundle/BundleMojo.java
@@ -73,6 +73,17 @@ public class BundleMojo extends AbstractMojo {
   @Parameter(property = "mateu.bundle.failOnEmpty", defaultValue = "false")
   private boolean failOnEmpty;
 
+  /**
+   * Fail the build when ANY route could not be bundled.
+   *
+   * <p>Off by default, because a healthy app usually has routes that legitimately stay
+   * backend-served (service-backed loads, screens gated on identity). Turn it on once your set of
+   * bundled routes is stable: a route dropping out of the bundle is otherwise a silent performance
+   * regression whose only trace is one line in a build log nobody reads.
+   */
+  @Parameter(property = "mateu.bundle.failOnSkipped", defaultValue = "false")
+  private boolean failOnSkipped;
+
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
     var appLoader = buildAppLoader();
@@ -135,6 +146,18 @@ public class BundleMojo extends AbstractMojo {
                     + outputDirectory);
         if (failOnEmpty && ok == 0) {
           throw new MojoFailureException("mateu-bundle: no routes rendered");
+        }
+        var skipped = manifest.entries().stream().filter(e -> !e.ok()).toList();
+        if (failOnSkipped && !skipped.isEmpty()) {
+          var detail =
+              skipped.stream()
+                  .map(e -> "  " + e.route() + " — " + e.skipReason())
+                  .collect(java.util.stream.Collectors.joining("\n"));
+          throw new MojoFailureException(
+              "mateu-bundle: "
+                  + skipped.size()
+                  + " route(s) could not be bundled (failOnSkipped):\n"
+                  + detail);
         }
       }
     } catch (MojoFailureException e) {

--- a/backend/shared/core/src/main/java/io/mateu/core/application/export/MateuBundleExporter.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/export/MateuBundleExporter.java
@@ -83,6 +83,40 @@ public final class MateuBundleExporter {
         String baseUrl, String generatedAt, boolean staticOnly, List<BundleEntry> entries) {
       this(baseUrl, generatedAt, staticOnly, entries, RouteTable.empty());
     }
+
+    /**
+     * A stable identity for what this bundle CONTAINS, independent of when it was built.
+     *
+     * <p>A bundle is derivation frozen in time: deployed to a CDN it can outlive the model it came
+     * from, and in a hybrid deploy a client can be answering loads from build N while posting
+     * actions to a backend at N+1 — with nothing anywhere saying so. {@code generatedAt} does not
+     * help: two builds of the same source differ, and a stale bundle looks as fresh as any other.
+     *
+     * <p>This makes the bundle a <em>cache</em> rather than a fork: two manifests with the same
+     * hash carry the same screens, and a mismatch against the backend's is something a client or a
+     * deploy check can act on.
+     */
+    public String structureHash() {
+      var material =
+          entries.stream()
+              .sorted(java.util.Comparator.comparing(e -> String.valueOf(e.route())))
+              .map(
+                  e ->
+                      e.route() + "\u0000" + e.ok() + "\u0000" + (e.json() == null ? "" : e.json()))
+              .collect(java.util.stream.Collectors.joining("\u0001"));
+      try {
+        var digest = java.security.MessageDigest.getInstance("SHA-256");
+        var bytes = digest.digest(material.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        var out = new StringBuilder(bytes.length * 2);
+        for (var b : bytes) {
+          out.append(Character.forDigit((b >> 4) & 0xF, 16))
+              .append(Character.forDigit(b & 0xF, 16));
+        }
+        return out.toString();
+      } catch (java.security.NoSuchAlgorithmException e) {
+        throw new IllegalStateException("SHA-256 is required by the JLS", e);
+      }
+    }
   }
 
   /** A {@code :name} route segment (the param marker). */

--- a/backend/shared/core/src/test/java/io/mateu/core/application/export/BundleStructureHashTest.java
+++ b/backend/shared/core/src/test/java/io/mateu/core/application/export/BundleStructureHashTest.java
@@ -1,0 +1,76 @@
+package io.mateu.core.application.export;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.mateu.core.application.export.MateuBundleExporter.BundleEntry;
+import io.mateu.core.application.export.MateuBundleExporter.BundleManifest;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The manifest's identity: what the bundle CONTAINS, independent of when it was built.
+ *
+ * <p>A bundle is derivation frozen in time — deployed to a CDN it can outlive the model it came
+ * from, and in a hybrid deploy a client can answer loads from build N while posting actions to a
+ * backend at N+1, with nothing saying so. The hash is what turns the bundle into a <em>cache</em>
+ * rather than a fork: same hash, same screens.
+ */
+class BundleStructureHashTest {
+
+  private static BundleManifest manifest(String generatedAt, List<BundleEntry> entries) {
+    return new BundleManifest("", generatedAt, true, entries);
+  }
+
+  private static BundleEntry ok(String route, String json) {
+    return new BundleEntry(route, route, json, true, null);
+  }
+
+  @Test
+  void twoBuildsOfTheSameScreensShareAHash() {
+    // The point of the hash: `generatedAt` differs on every build, so it cannot answer "is this the
+    // same bundle?". The content can.
+    var a = manifest("2026-08-12T09:00:00Z", List.of(ok("home", "{\"a\":1}")));
+    var b = manifest("2026-08-12T18:30:00Z", List.of(ok("home", "{\"a\":1}")));
+
+    assertThat(a.structureHash()).isEqualTo(b.structureHash());
+  }
+
+  @Test
+  void aChangedScreenChangesTheHash() {
+    var before = manifest("t", List.of(ok("home", "{\"a\":1}")));
+    var after = manifest("t", List.of(ok("home", "{\"a\":2}")));
+
+    assertThat(after.structureHash()).isNotEqualTo(before.structureHash());
+  }
+
+  @Test
+  void aRouteDroppingOutOfTheBundleChangesTheHash() {
+    // The silent regression this guards: a route that stops being bundled still leaves an entry,
+    // but a skipped one — and that must not look like the same bundle.
+    var bundled = manifest("t", List.of(ok("home", "{}"), ok("about", "{}")));
+    var skipped =
+        manifest(
+            "t",
+            List.of(
+                ok("home", "{}"), new BundleEntry("about", "about", null, false, "needs a DB")));
+
+    assertThat(skipped.structureHash()).isNotEqualTo(bundled.structureHash());
+  }
+
+  @Test
+  void theHashDoesNotDependOnEntryOrder() {
+    // Route discovery walks beans and indexes, so the order is not guaranteed between builds; a
+    // hash that changed with it would report drift that is not there and get ignored.
+    var one = manifest("t", List.of(ok("a", "{}"), ok("b", "{}")));
+    var other = manifest("t", List.of(ok("b", "{}"), ok("a", "{}")));
+
+    assertThat(one.structureHash()).isEqualTo(other.structureHash());
+  }
+
+  @Test
+  void theHashIsAHexDigest() {
+    assertThat(manifest("t", List.of(ok("home", "{}"))).structureHash())
+        .hasSize(64)
+        .matches("[0-9a-f]+");
+  }
+}

--- a/doc/src/content/docs/java-user-manual/build/static-bundle.md
+++ b/doc/src/content/docs/java-user-manual/build/static-bundle.md
@@ -82,6 +82,23 @@ not render (see the boundaries below) is logged and skipped — it stays backend
 | `assetsFrom` | vaadin-lit resources | directory holding `_index.html` + `assets/` |
 | `pageTitle` | `Mateu` | `<title>` of the static page |
 | `failOnEmpty` | `false` | fail the build if zero routes rendered |
+| `failOnSkipped` | `false` | fail the build if **any** route could not be bundled — turn it on once your bundled set is stable, so a route dropping out stops being a silent regression |
+
+### Knowing which bundle you are looking at
+
+The manifest carries a `structureHash`: a stable identity of **what the bundle contains**,
+independent of when it was built. `generatedAt` cannot answer "is this the same bundle?" — it
+differs on every build, and a stale bundle looks as fresh as any other.
+
+That matters because a bundle is derivation frozen in time. Deployed to a CDN it can outlive the
+model it came from, and in a hybrid deploy a client can be answering loads from build N while posting
+actions to a backend at N+1, with nothing anywhere saying so. Comparing hashes is what makes the
+bundle a **cache** rather than a fork — same hash, same screens — and gives a deploy check something
+to assert.
+
+The hash ignores entry order (route discovery walks beans and indexes, so the order is not stable
+between builds) and changes when a route stops being bundled, which is exactly the regression that
+otherwise leaves only a line in a build log.
 
 ## Serving the bundle at runtime (no build step)
 


### PR DESCRIPTION
Filas **9.3b** y **9.3a** del backlog: las dos formas en que un bundle se degrada en silencio.

## 9.3b — `structureHash`

Una identidad estable de **lo que el bundle contiene**, independiente de cuándo se construyó. `generatedAt` no puede responder *"¿es el mismo bundle?"*: cambia en cada build, y un bundle viejo parece tan fresco como cualquiera.

Importa porque **un bundle es derivación congelada**. En un CDN puede sobrevivir al modelo del que salió, y en despliegue híbrido un cliente puede estar respondiendo cargas del build N mientras postea acciones a un backend en N+1, sin que nada lo diga. Comparar hashes es lo que lo convierte en **caché y no en fork**.

Dos decisiones en el hash:
- **Ignora el orden de entradas** — el descubrimiento de rutas recorre beans e índices, así que el orden no es estable entre builds; un hash que cambiara con él reportaría deriva inexistente y acabaría ignorado.
- **Sí cambia cuando una ruta deja de bundlearse**, que es justo la regresión que hoy solo deja rastro en un log.

## 9.3a — `failOnSkipped`

Nuevo parámetro del goal, **apagado por defecto**: una app sana tiene rutas que legítimamente se quedan servidas por backend (cargas con DB, pantallas con `@EyesOnly`). Encendido una vez el conjunto es estable, convierte *"una ruta se cayó del bundle"* de una línea en un log que nadie lee a un build roto, con el detalle de cuál y por qué.

`core`: **844 tests verde**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)