### PR TITLE
feat(federation): reportar colisiones de ruta y declarar los dos contratos

### DIFF
--- a/backend/shared/core/src/main/java/io/mateu/core/application/export/RouteRegistrations.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/export/RouteRegistrations.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Reads the routes an app declares from the framework's compiled indexes ({@code
@@ -17,6 +18,7 @@ import java.util.Map;
  * value|parentRoute|uis}, entries joined by {@code ;}). De-duped by route, first wins. Reused by
  * the static-bundle exporter (build-time Maven goal AND the runtime bundle endpoint).
  */
+@Slf4j
 public final class RouteRegistrations {
 
   /** A declared route and the class it resolves to. */
@@ -32,6 +34,34 @@ public final class RouteRegistrations {
   /** Whether a route can be pre-rendered without a runtime value (no {@code :param} segment). */
   public static boolean isStatic(String route) {
     return route != null && !route.contains(":");
+  }
+
+  /**
+   * Claims a route for a class, reporting a real COLLISION instead of resolving it silently.
+   *
+   * <p>First-wins is kept — changing it now would move which class answers a route in apps that
+   * already work — but "first" depends on classpath order, which is not stable between builds or
+   * between a dev machine and CI. So two jars claiming the same route is a bug that used to resolve
+   * differently on different days, with nothing said. Now it is named, with both classes, so it can
+   * be fixed rather than discovered.
+   *
+   * <p>Re-declaring the same route for the same class is not a collision: an app can end up reading
+   * the same index twice (a jar present in two classloaders), and that is harmless.
+   */
+  private static void claim(Map<String, RouteRef> out, String route, String className) {
+    var existing = out.get(route);
+    if (existing == null) {
+      out.put(route, new RouteRef(route, className));
+      return;
+    }
+    if (!existing.className().equals(className)) {
+      log.warn(
+          "route collision: '{}' is claimed by {} and by {}. Classpath order decides which one"
+              + " answers, and that order is not stable — give one of them a different route.",
+          route,
+          existing.className(),
+          className);
+    }
   }
 
   private static void readResource(
@@ -53,7 +83,7 @@ public final class RouteRegistrations {
           if (ui) {
             var p = kv.get("path");
             if (p != null && !p.isBlank()) {
-              out.putIfAbsent(p, new RouteRef(p, cls));
+              claim(out, p, cls);
             }
           } else {
             var routes = kv.get("routes");
@@ -61,7 +91,7 @@ public final class RouteRegistrations {
               for (String entry : routes.split(";")) {
                 var value = entry.split("\\|", -1)[0];
                 if (value != null && !value.isBlank()) {
-                  out.putIfAbsent(value, new RouteRef(value, cls));
+                  claim(out, value, cls);
                 }
               }
             }

--- a/doc/src/content/docs/mateu-about/ui-federation.md
+++ b/doc/src/content/docs/mateu-about/ui-federation.md
@@ -29,3 +29,63 @@ The shell can also centralize concerns such as:
 - shared widgets
 
 This makes it possible to compose a distributed UI while still keeping a consistent application shell.
+
+## The two contracts a federated shell needs
+
+Federation works because what travels between a domain and the shell is a **declaration**, not a JS
+bundle: one renderer, one framework version, no CSS collisions. But two things then have to be
+agreed, and leaving them implicit is what turns a federated UI into a distributed mess.
+
+### 1. Route ownership
+
+Routes declared inside a mount are **relative to it**, so two domains can each have an `orders`
+screen without colliding — uniqueness only has to hold *within* a mount, and between mount base
+paths (two `@UI` classes claiming the same base path already fail at startup).
+
+Within a mount, two classes claiming the same route is a bug. Mateu keeps **first-wins** — changing
+it would move which class answers a route in apps that already work — but "first" depends on
+classpath order, which is **not stable** between builds, or between a developer's machine and CI. So
+a collision is now **reported with both class names** at startup:
+
+```
+route collision: 'orders' is claimed by com.acme.billing.Orders and by com.acme.sales.Orders.
+Classpath order decides which one answers, and that order is not stable — give one of them a
+different route.
+```
+
+Re-declaring the same route for the *same* class is not a collision (an index can legitimately be
+read twice) and stays silent.
+
+### 2. Version compatibility
+
+A federated deployment mixes jars: domain A may have been built against one Mateu version and domain
+B against another, while the shell runs a third.
+
+**The policy: all the jars in one shell must be built against the same Mateu MINOR version.** Patch
+differences are fine; minor differences are not supported, and nothing checks it for you today.
+
+That is not caution for its own sake — it follows from where the coupling actually is. A domain jar
+carries `@UI` classes compiled against `io.mateu:uidl` and an index written by that version's
+annotation processor; the shell's core reads both. Anything that changes the wire DTOs or the index
+format therefore has to be uniform, and Mateu is still `3.0-alpha`, where the wire is explicitly
+allowed to move.
+
+In practice: **bump Mateu across all your domain modules in one go.** If you cannot, keep the
+straggler behind its own mount and a separate deployment rather than mixing it into a shared shell.
+
+### Embedding outside a browser shell
+
+The same declaration also renders inside a host that is not a Mateu shell — an IDE webview, a mobile
+app, another product's page. Five things the host has to settle, and it is worth settling them
+explicitly rather than per host:
+
+| | |
+|---|---|
+| **Size and layout** | the host decides the viewport; the embedded UI must not assume a full page |
+| **Theming** | do **not** assume the host's design tokens are present. A component that reaches for `--lumo-*` renders unstyled in an IDE webview — use your own tokens with fallbacks |
+| **Authentication** | the host holds the session; the embedded UI has to be told, not discover it |
+| **URL and history** | decide who owns them. Inside a webview the embedded UI usually must **not** touch browser history |
+| **Events** | which events may escape to the host, and which stay inside |
+
+Mateu does not enforce these; they are the contract you agree with the host. Getting theming wrong is
+the one that bites first and looks like "the UI is broken" rather than "a variable is missing".


### PR DESCRIPTION
Filas **13.4a**, **13.3** y **13.4b** del backlog.

## 13.4a — las colisiones de ruta dejan de ser silenciosas

`RouteRegistrations` resolvía dos jars que reclaman la misma ruta con *"el primero gana"*, sin decir nada.

Se **mantiene** ese comportamiento —cambiarlo movería qué clase responde en apps que ya funcionan— pero ahora la colisión se **reporta con los dos nombres de clase**. El motivo: *"el primero"* depende del orden del classpath, que **no es estable** entre builds ni entre una máquina de desarrollo y CI. Era un bug que se resolvía distinto según el día.

Redeclarar la misma ruta para la **misma** clase no es colisión y sigue callado: un índice puede leerse dos veces legítimamente.

## 13.3 — política de compatibilidad (no existía)

> Todos los jars de una shell deben construirse contra la misma versión **menor** de Mateu.

No es cautela porque sí. Un jar de dominio lleva clases compiladas contra `uidl` **y** un índice escrito por el AP de esa versión, y el core de la shell lee ambos: lo que mueva los DTOs del wire o el formato del índice tiene que ser uniforme. Y Mateu sigue en `3.0-alpha`, donde el wire puede moverse.

Con la salida práctica: si no puedes bumpear todos a la vez, deja al rezagado tras su propio mount y su propio despliegue en vez de mezclarlo en una shell compartida.

## 13.4b — contrato de embedding

Las cinco cosas que un anfitrión que **no** es una shell de Mateu tiene que acordar: tamaño y layout, **theming**, autenticación, quién es dueño de la URL y del historial, y qué eventos escapan.

El theming es el que muerde primero, y se manifiesta como *"la UI está rota"* en vez de *"falta una variable CSS"* — un componente que busca `--lumo-*` sale sin estilo en un webview de IDE.

`core`: **839 tests verde**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)