### PR TITLE
feat(ci): medir cuántas anotaciones necesita una pantalla, y que no suban

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -21,6 +21,11 @@ jobs:
       - name: Bundles are not older than their source
         run: scripts/check-bundle-freshness.sh
 
+      # The framework's own thesis, measured: a screen should need few annotations, and that number
+      # should not creep up. Each new annotation is always justifiable alone; the sum is what drifts.
+      - name: Annotations per screen have not crept up
+        run: python3 scripts/annotation-density.py --check
+
   e2e:
     runs-on: ubuntu-latest
 

--- a/doc/src/content/docs/authoring-rule.md
+++ b/doc/src/content/docs/authoring-rule.md
@@ -65,6 +65,20 @@ screen work with no backend" is not a list of exceptions to memorise — it is
 **if you declared it with annotations, it can ship statically; if you used an interface, it needs a
 server.**
 
+## The surface is measured
+
+The rule above decides case by case. The risk it cannot catch is **accumulation**: every annotation
+is justifiable on its own, and the sum still drifts the framework away from the reason it exists.
+
+So it is counted. `scripts/annotation-density.py` measures how many Mateu annotations a screen needs
+across the demo and e2e corpus — **4.38 per screen over 444 screens** as of 2026-08-12 — and CI fails
+if the average creeps above a recorded ceiling.
+
+The ceiling carries deliberate headroom (~5%): pinned to the exact current value it would fail on the
+very next annotation added anywhere, and a check that fires on ordinary work gets raised by reflex
+until it means nothing. Raising it is allowed. Raising it *silently* is the thing the number exists
+to prevent.
+
 ## What Mateu will not infer
 
 Inference has a ceiling, and it is worth knowing where it is so you do not wait for a version that

--- a/scripts/annotation-density.json
+++ b/scripts/annotation-density.json
@@ -1,0 +1,6 @@
+{
+  "ceiling": 4.6,
+  "_baseline": "4.38 over 444 screens, measured 2026-08-12",
+  "_why_headroom": "A ceiling pinned to the exact current value fails on the very next annotation added anywhere, and a check that fires on ordinary work gets raised by reflex until it means nothing. ~5% of headroom means normal work passes and a TREND trips it — roughly 100 net new annotations across the corpus.",
+  "_when_it_fires": "Either infer it instead (doc/.../authoring-rule.md), or raise this deliberately and say why in the commit. Raising it is allowed; raising it silently is the thing to avoid."
+}

--- a/scripts/annotation-density.py
+++ b/scripts/annotation-density.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""How many Mateu annotations a typical screen needs — and whether that number is going up.
+
+The framework exists to make you declare information and have the UX inferred. Every annotation is
+either information only the developer has (legitimate) or a decision Mateu could have taken by
+looking at the model (debt) — see doc/.../authoring-rule.md. Individually, each new annotation is
+always justifiable. Collectively they can drift the framework away from the reason it exists, and
+nobody notices, because nobody is counting.
+
+So: count. A number published every release disciplines more than a document of principles, and it
+is cheap — the corpus already exists as the demo and e2e screens.
+
+Usage:
+  scripts/annotation-density.py            # report
+  scripts/annotation-density.py --check    # also fail if the average exceeds the recorded ceiling
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+CEILING_FILE = ROOT / "scripts" / "annotation-density.json"
+
+# The corpus: screens written the way a user writes them. Framework internals are excluded on
+# purpose — they are not "a typical screen" and would drown the signal.
+CORPUS = [
+    ROOT / "e2e" / "sut",
+    ROOT / "demo",
+]
+
+# A screen is a class carrying @UI or @Route.
+SCREEN = re.compile(r"^\s*@(UI|Route)\b", re.M)
+# Annotations that come from Mateu. Bean-validation (@NotNull…) and Lombok are NOT counted: they are
+# not Mateu's declarative surface, and counting them would blame the framework for other people's.
+ANNOTATION = re.compile(r"^\s*@([A-Z]\w+)", re.M)
+NOT_MATEU = {
+    "Override", "Autowired", "Inject", "Component", "Service", "Repository", "Bean",
+    "Builder", "With", "Data", "Getter", "Setter", "Slf4j", "AllArgsConstructor",
+    "NoArgsConstructor", "RequiredArgsConstructor", "Entity", "Id", "GeneratedValue",
+    "Column", "Table", "ManyToOne", "OneToMany", "NotNull", "NotEmpty", "NotBlank",
+    "Min", "Max", "Size", "Pattern", "Email", "Valid", "SuppressWarnings", "Test",
+    "BeforeAll", "AfterAll", "Nested", "Deprecated", "FunctionalInterface", "SafeVarargs",
+}
+
+
+def screens() -> list[tuple[pathlib.Path, int]]:
+    found = []
+    for base in CORPUS:
+        if not base.exists():
+            continue
+        for path in base.rglob("*.java"):
+            if "/target/" in str(path) or "/generated-sources/" in str(path):
+                continue
+            text = path.read_text(errors="ignore")
+            if not SCREEN.search(text):
+                continue
+            count = sum(1 for m in ANNOTATION.finditer(text) if m.group(1) not in NOT_MATEU)
+            found.append((path.relative_to(ROOT), count))
+    return sorted(found, key=lambda p: -p[1])
+
+
+def main() -> int:
+    found = screens()
+    if not found:
+        print("no screens found — is the corpus still where this script expects it?")
+        return 1
+
+    total = sum(c for _, c in found)
+    average = total / len(found)
+
+    print(f"screens: {len(found)}   annotations: {total}   average per screen: {average:.2f}")
+    print("\nthe ten most annotated screens (where the surface is being spent):")
+    for path, count in found[:10]:
+        print(f"  {count:3d}  {path}")
+
+    if "--check" not in sys.argv:
+        print(f"\n(record this as the ceiling with: scripts/annotation-density.py --write)")
+        if "--write" in sys.argv:
+            CEILING_FILE.write_text(json.dumps({"ceiling": round(average, 2)}, indent=2) + "\n")
+            print(f"wrote ceiling {average:.2f} to {CEILING_FILE.name}")
+        return 0
+
+    if not CEILING_FILE.exists():
+        print("\nno ceiling recorded yet — run with --write")
+        return 1
+    ceiling = json.loads(CEILING_FILE.read_text())["ceiling"]
+    if average > ceiling:
+        print(
+            f"\nFAIL  the average rose to {average:.2f}, above the recorded ceiling {ceiling}."
+            "\n      Every annotation is justifiable on its own; the point of the number is that"
+            "\n      the sum is not. Either infer it instead (see doc/.../authoring-rule.md), or"
+            "\n      raise the ceiling deliberately with --write and say why in the commit."
+        )
+        return 1
+    print(f"\nOK  average {average:.2f} is at or below the ceiling {ceiling}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Fila **6.3** del backlog.

## Por qué un número

La [regla de autoría](https://mateu.io/authoring-rule/) decide caso a caso. Lo que no puede cazar es la **acumulación**: cada anotación es justificable por separado y la suma aleja igualmente al framework de la razón por la que existe. Nadie se entera porque nadie cuenta.

## La línea base

**4,38 anotaciones por pantalla, sobre 444 pantallas** del corpus de demos y e2e — pantallas escritas como las escribe un usuario. La cola son los demos de front-office (37, 36, 30), que son ricos a propósito.

Dos exclusiones deliberadas:
- **Bean validation y Lombok** no cuentan: no son superficie declarativa de Mateu, y contarlas culparía al framework de decisiones ajenas.
- **Las clases internas del framework** tampoco: no son "una pantalla típica" y ahogarían la señal.

## El techo, y por qué tiene holgura

Fijado en **4,6**. Un techo clavado al valor actual fallaría con la siguiente anotación añadida en cualquier sitio, y **un check que salta con el trabajo normal se sube por reflejo hasta no significar nada** — el mismo modo de fallo que acabamos de vivir con el `e2e` en rojo. Un 5% de holgura deja pasar el trabajo normal y hace saltar una *tendencia*.

Subirlo está permitido. Subirlo **en silencio** es lo que el número existe para evitar, y el propio fichero lo dice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)