### PR TITLE
feat(openapi): emitir el contrato de API que la UI implica, y verificarlo

### DIFF
--- a/backend/shared/core/src/main/java/io/mateu/core/application/openapi/ApiContractCheck.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/openapi/ApiContractCheck.java
@@ -1,0 +1,93 @@
+package io.mateu.core.application.openapi;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Checks a server's OpenAPI against the one the UI implies.
+ *
+ * <p>Emitting the derived spec is useful; <b>verifying</b> against it is where the value is. A file
+ * has to be looked at. A check runs on its own, needs nothing regenerated, works the same whether
+ * the server is Java, .NET, Python or somebody else's — and, unlike code generation, it detects
+ * drift in <b>both</b> directions: the server changing a response the screens read, and the screens
+ * starting to need something the server does not offer.
+ *
+ * <p>It only asserts the lower bound the UI actually knows: that every declared path exists with
+ * the declared method, and that the parameters the screens interpolate are accepted. It
+ * deliberately says nothing about error codes, auth or schemas — a check that failed on things the
+ * UI cannot know would be reporting noise, and a check that reports noise gets ignored.
+ */
+public final class ApiContractCheck {
+
+  private ApiContractCheck() {}
+
+  /** One thing the UI needs and the server's spec does not offer. */
+  public record Gap(String path, String method, String detail) {
+    @Override
+    public String toString() {
+      return method.toUpperCase() + " " + path + " — " + detail;
+    }
+  }
+
+  /**
+   * The gaps between what the UI needs ({@code required}, from {@link OpenApiEmitter}) and what a
+   * server's OpenAPI offers ({@code offered}). Empty means the server satisfies the UI.
+   */
+  public static List<Gap> check(JsonNode required, JsonNode offered) {
+    var gaps = new ArrayList<Gap>();
+    var requiredPaths = required.path("paths");
+    var offeredPaths = offered.path("paths");
+
+    requiredPaths
+        .fieldNames()
+        .forEachRemaining(
+            path -> {
+              var offeredItem = offeredPaths.path(path);
+              if (offeredItem.isMissingNode()) {
+                requiredPaths
+                    .get(path)
+                    .fieldNames()
+                    .forEachRemaining(
+                        method ->
+                            gaps.add(new Gap(path, method, "the API does not declare this path")));
+                return;
+              }
+              requiredPaths
+                  .get(path)
+                  .fieldNames()
+                  .forEachRemaining(
+                      method -> {
+                        var offeredOperation = offeredItem.path(method);
+                        if (offeredOperation.isMissingNode()) {
+                          gaps.add(
+                              new Gap(
+                                  path, method, "the API declares the path but not this method"));
+                          return;
+                        }
+                        var accepted = new ArrayList<String>();
+                        offeredOperation
+                            .path("parameters")
+                            .forEach(p -> accepted.add(p.path("name").asText()));
+                        requiredPaths
+                            .get(path)
+                            .get(method)
+                            .path("parameters")
+                            .forEach(
+                                p -> {
+                                  var name = p.path("name").asText();
+                                  if (!accepted.contains(name)) {
+                                    gaps.add(
+                                        new Gap(
+                                            path,
+                                            method,
+                                            "the screens send '"
+                                                + name
+                                                + "' and the API does not accept it"));
+                                  }
+                                });
+                      });
+            });
+    return gaps;
+  }
+}

--- a/backend/shared/core/src/main/java/io/mateu/core/application/openapi/OpenApiEmitter.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/openapi/OpenApiEmitter.java
@@ -1,0 +1,231 @@
+package io.mateu.core.application.openapi;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.mateu.uidl.annotations.RestAction;
+import io.mateu.uidl.annotations.RestData;
+import io.mateu.uidl.annotations.RestListing;
+import io.mateu.uidl.annotations.RestOptions;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * Derives the OpenAPI a UI implies, from the endpoints its screens already declare.
+ *
+ * <p>This is not a new capability — it is a <b>latent artifact made explicit</b>. Every
+ * {@code @RestOptions}, {@code @RestListing}, {@code @RestData} and {@code @RestAction} already
+ * states a URL, a method, the parameters it interpolates and the shape it expects back. That IS an
+ * endpoint contract; nobody had written it down.
+ *
+ * <p>So the declaration stops deriving one artifact and starts deriving two: the UI, and the
+ * contract the server behind it has to satisfy.
+ *
+ * <p><b>It is a LOWER BOUND, and saying so matters.</b> What a screen declares tells you the paths,
+ * the methods, the parameters and the fields it reads back. It cannot tell you error codes,
+ * authentication, idempotency, side effects or business rules. "This is the minimum your API must
+ * satisfy" is exact and useful; "this generates your API" would be false.
+ */
+public final class OpenApiEmitter {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  /** {@code ${state.x}} / {@code ${data.y}} / {@code ${searchText}} interpolation. */
+  private static final Pattern PLACEHOLDER = Pattern.compile("\\$\\{([^}]+)}");
+
+  private OpenApiEmitter() {}
+
+  /** One declared call: where it goes, how, and what the screen reads back. */
+  record Call(
+      String url,
+      String method,
+      List<String> params,
+      String readsPath,
+      String declaredBy,
+      String kind) {}
+
+  /** The OpenAPI 3 document the given views imply. */
+  public static ObjectNode emit(String title, Iterable<Class<?>> views) {
+    var calls = new ArrayList<Call>();
+    for (var view : views) {
+      collect(view, calls);
+    }
+
+    var root = MAPPER.createObjectNode();
+    root.put("openapi", "3.0.3");
+    var info = root.putObject("info");
+    info.put("title", title);
+    info.put("version", "1.0.0");
+    info.put(
+        "description",
+        "Derived from the endpoints the UI declares. This is the MINIMUM the API must satisfy: it"
+            + " carries paths, methods, parameters and the fields the screens read back. It cannot"
+            + " carry error codes, authentication, idempotency or business rules — those are yours.");
+
+    // One server entry per distinct origin, so paths stay relative and readable.
+    var servers = new LinkedHashMap<String, String>();
+    for (var call : calls) {
+      var origin = origin(call.url());
+      if (origin != null) {
+        servers.putIfAbsent(origin, origin);
+      }
+    }
+    var serversNode = root.putArray("servers");
+    servers.keySet().forEach(origin -> serversNode.addObject().put("url", origin));
+
+    var paths = root.putObject("paths");
+    for (var call : calls) {
+      var path = path(call.url());
+      var item = paths.has(path) ? (ObjectNode) paths.get(path) : paths.putObject(path);
+      var operation = item.putObject(call.method().toLowerCase());
+      operation.put("summary", call.kind() + " declared by " + call.declaredBy());
+      operation.put(
+          "description",
+          "Declared by the UI. The screen reads "
+              + (call.readsPath().isBlank() ? "the response root" : "`" + call.readsPath() + "`")
+              + ".");
+      if (!call.params().isEmpty()) {
+        var parameters = operation.putArray("parameters");
+        for (var name : call.params()) {
+          var parameter = parameters.addObject();
+          parameter.put("name", name);
+          parameter.put("in", "query");
+          parameter.put(
+              "required",
+              true); // the screen interpolates it, so a response without it cannot be right
+          parameter.putObject("schema").put("type", "string");
+        }
+      }
+      operation
+          .putObject("responses")
+          .putObject("200")
+          .put("description", "The shape the screen reads");
+    }
+    return root;
+  }
+
+  private static void collect(Class<?> view, List<Call> calls) {
+    var name = view.getSimpleName();
+
+    var listing = view.getAnnotation(RestListing.class);
+    if (listing != null) {
+      calls.add(
+          new Call(
+              listing.url(),
+              listing.method(),
+              placeholders(listing.url(), listing.body()),
+              listing.itemsPath(),
+              name,
+              "Listing rows"));
+    }
+    var data = view.getAnnotation(RestData.class);
+    if (data != null) {
+      calls.add(
+          new Call(
+              data.url(),
+              data.method(),
+              placeholders(data.url(), data.body()),
+              data.resultPath(),
+              name,
+              "Screen data"));
+    }
+    for (var field : view.getDeclaredFields()) {
+      var options = field.getAnnotation(RestOptions.class);
+      if (options != null) {
+        calls.add(
+            new Call(
+                options.url(),
+                options.method(),
+                placeholders(options.url(), options.body()),
+                options.itemsPath(),
+                name + "." + field.getName(),
+                "Options for a field"));
+      }
+    }
+    for (var method : view.getDeclaredMethods()) {
+      var action = method.getAnnotation(RestAction.class);
+      if (action != null) {
+        calls.add(
+            new Call(
+                action.url(),
+                action.method(),
+                placeholders(action.url(), action.body()),
+                action.resultPath(),
+                name + "." + method.getName() + "()",
+                "Action"));
+      }
+    }
+  }
+
+  /**
+   * The interpolated names a call needs. They are what the screen will substitute at fetch time, so
+   * an endpoint that ignores them cannot answer correctly — which is why they are emitted as
+   * required.
+   */
+  static List<String> placeholders(String... sources) {
+    var found = new ArrayList<String>();
+    for (var source : sources) {
+      if (source == null) {
+        continue;
+      }
+      var matcher = PLACEHOLDER.matcher(source);
+      while (matcher.find()) {
+        var raw = matcher.group(1);
+        var name = raw.contains(".") ? raw.substring(raw.lastIndexOf('.') + 1) : raw;
+        if (!found.contains(name)) {
+          found.add(name);
+        }
+      }
+    }
+    return found;
+  }
+
+  /** The origin of a declared URL, or null when it is relative. */
+  static String origin(String url) {
+    try {
+      var uri = URI.create(stripPlaceholders(url));
+      return uri.getScheme() == null ? null : uri.getScheme() + "://" + uri.getAuthority();
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  /** The path part of a declared URL, always starting with a slash. */
+  static String path(String url) {
+    try {
+      var uri = URI.create(stripPlaceholders(url));
+      var path = uri.getPath();
+      return path == null || path.isBlank() ? "/" : path;
+    } catch (Exception e) {
+      return "/";
+    }
+  }
+
+  /** Placeholders make a URL unparseable; they are not part of the path anyway. */
+  private static String stripPlaceholders(String url) {
+    return PLACEHOLDER.matcher(url == null ? "" : url).replaceAll("_");
+  }
+
+  /** The document as pretty JSON. */
+  public static String emitJson(String title, Iterable<Class<?>> views) {
+    try {
+      return MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(emit(title, views));
+    } catch (Exception e) {
+      throw new IllegalStateException("could not serialise the derived OpenAPI", e);
+    }
+  }
+
+  /** Exposed for the emitter's own tests. */
+  static Map<String, Object> debugCalls(Class<?> view) {
+    var calls = new ArrayList<Call>();
+    collect(view, calls);
+    var out = new LinkedHashMap<String, Object>();
+    for (var call : calls) {
+      out.put(call.declaredBy(), call.method() + " " + call.url());
+    }
+    return out;
+  }
+}

--- a/backend/shared/core/src/test/java/io/mateu/core/application/openapi/ApiContractCheckTest.java
+++ b/backend/shared/core/src/test/java/io/mateu/core/application/openapi/ApiContractCheckTest.java
@@ -1,0 +1,87 @@
+package io.mateu.core.application.openapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.mateu.uidl.annotations.RestListing;
+import io.mateu.uidl.annotations.UI;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The derived spec used as a CHECK rather than as a file.
+ *
+ * <p>Emitting is useful; verifying is where the value is — and the reason is the direction of the
+ * drift it catches. Code generation only protects you while nobody edits the generated code. A
+ * check catches the server changing a response the screens read <b>and</b> the screens starting to
+ * need something the server does not offer, which is the failure that otherwise reaches production
+ * as an empty select nobody can explain.
+ */
+class ApiContractCheckTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @SuppressWarnings("unused")
+  @UI("/orders")
+  @RestListing(url = "https://api.example.com/orders?since=${state.since}", itemsPath = "data")
+  public static class Orders {}
+
+  private static com.fasterxml.jackson.databind.JsonNode required() {
+    return OpenApiEmitter.emit("UI needs", List.of(Orders.class));
+  }
+
+  private static com.fasterxml.jackson.databind.JsonNode offered(String json) throws Exception {
+    return MAPPER.readTree(json);
+  }
+
+  @Test
+  void anApiThatSatisfiesTheScreensHasNoGaps() throws Exception {
+    var api =
+        offered(
+            """
+            {"paths": {"/orders": {"get": {"parameters": [{"name": "since"}]}}}}
+            """);
+    assertThat(ApiContractCheck.check(required(), api)).isEmpty();
+  }
+
+  @Test
+  void aMissingPathIsReported() throws Exception {
+    assertThat(ApiContractCheck.check(required(), offered("{\"paths\": {}}")))
+        .extracting(Object::toString)
+        .containsExactly("GET /orders — the API does not declare this path");
+  }
+
+  @Test
+  void aPathWithoutTheDeclaredMethodIsReported() throws Exception {
+    var api = offered("{\"paths\": {\"/orders\": {\"post\": {}}}}");
+    assertThat(ApiContractCheck.check(required(), api))
+        .extracting(Object::toString)
+        .containsExactly("GET /orders — the API declares the path but not this method");
+  }
+
+  @Test
+  void aParameterTheScreensSendAndTheApiIgnoresIsReported() throws Exception {
+    // The quiet one: the endpoint exists and answers 200, but ignores the filter the screen sends,
+    // so the user sees the wrong rows and nothing errors.
+    var api = offered("{\"paths\": {\"/orders\": {\"get\": {\"parameters\": []}}}}");
+    assertThat(ApiContractCheck.check(required(), api))
+        .extracting(Object::toString)
+        .containsExactly("GET /orders — the screens send 'since' and the API does not accept it");
+  }
+
+  @Test
+  void theCheckIsSilentAboutWhatTheUiCannotKnow() throws Exception {
+    // An API with error codes, auth and schemas the UI never declared is NOT a gap. A check that
+    // complained about those would be reporting noise, and a noisy check gets ignored.
+    var api =
+        offered(
+            """
+            {"paths": {"/orders": {"get": {
+              "parameters": [{"name": "since"}],
+              "security": [{"bearer": []}],
+              "responses": {"200": {}, "404": {}, "500": {}}
+            }}}}
+            """);
+    assertThat(ApiContractCheck.check(required(), api)).isEmpty();
+  }
+}

--- a/backend/shared/core/src/test/java/io/mateu/core/application/openapi/OpenApiEmitterTest.java
+++ b/backend/shared/core/src/test/java/io/mateu/core/application/openapi/OpenApiEmitterTest.java
@@ -1,0 +1,114 @@
+package io.mateu.core.application.openapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.mateu.uidl.annotations.RestAction;
+import io.mateu.uidl.annotations.RestData;
+import io.mateu.uidl.annotations.RestListing;
+import io.mateu.uidl.annotations.RestOptions;
+import io.mateu.uidl.annotations.Title;
+import io.mateu.uidl.annotations.UI;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The OpenAPI a UI implies.
+ *
+ * <p>The point of these tests is not that a document comes out — it is that the document says what
+ * the screens actually declared, and <b>only</b> that. A derived spec that quietly invented an
+ * error code or a security scheme would be worse than none: it would look authoritative about
+ * things the UI cannot know.
+ */
+class OpenApiEmitterTest {
+
+  @SuppressWarnings("unused")
+  @UI("/orders")
+  @Title("Orders")
+  @RestListing(url = "https://api.example.com/orders?since=${state.since}", itemsPath = "data")
+  public static class Orders {
+
+    @RestOptions(
+        url = "https://api.example.com/countries",
+        itemsPath = "items",
+        valuePath = "code",
+        labelPath = "name")
+    public String country;
+
+    @RestAction(url = "https://api.example.com/orders/${state.id}/approve", method = "POST")
+    public void approve() {}
+  }
+
+  @SuppressWarnings("unused")
+  @UI("/dashboard")
+  @Title("Dashboard")
+  @RestData(url = "https://metrics.example.com/summary", resultPath = "result")
+  public static class Dashboard {}
+
+  private static com.fasterxml.jackson.databind.JsonNode doc() {
+    return OpenApiEmitter.emit("Test API", List.of(Orders.class, Dashboard.class));
+  }
+
+  @Test
+  void everyDeclaredEndpointBecomesAPath() {
+    var paths = doc().get("paths");
+    assertThat(paths.fieldNames())
+        .toIterable()
+        .contains("/orders", "/countries", "/orders/_/approve", "/summary");
+  }
+
+  @Test
+  void theMethodComesFromTheDeclaration() {
+    assertThat(doc().get("paths").get("/orders/_/approve").has("post")).isTrue();
+    assertThat(doc().get("paths").get("/countries").has("get")).isTrue();
+  }
+
+  @Test
+  void distinctOriginsBecomeServers() {
+    var servers = doc().get("servers");
+    assertThat(servers).hasSize(2);
+    assertThat(servers.toString())
+        .contains("https://api.example.com")
+        .contains("https://metrics.example.com");
+  }
+
+  @Test
+  void interpolatedValuesBecomeRequiredParameters() {
+    // The screen WILL substitute them, so an endpoint that ignores them cannot answer correctly.
+    var parameters = doc().get("paths").get("/orders").get("get").get("parameters");
+    assertThat(parameters).hasSize(1);
+    assertThat(parameters.get(0).get("name").asText()).isEqualTo("since");
+    assertThat(parameters.get(0).get("required").asBoolean()).isTrue();
+  }
+
+  @Test
+  void theShapeTheScreenReadsIsRecorded() {
+    // itemsPath/resultPath are the only thing the UI knows about the response body, and it is worth
+    // stating: it is what an implementer has to put there.
+    assertThat(doc().get("paths").get("/orders").get("get").get("description").asText())
+        .contains("`data`");
+    assertThat(doc().get("paths").get("/summary").get("get").get("description").asText())
+        .contains("`result`");
+  }
+
+  @Test
+  void theDocumentSaysWhatItCannotKnow() {
+    // The honesty clause, pinned: this is a lower bound, and the document must say so rather than
+    // let a reader assume error codes or auth were considered.
+    assertThat(doc().get("info").get("description").asText())
+        .contains("MINIMUM")
+        .contains("cannot carry error codes");
+  }
+
+  @Test
+  void placeholdersAreReadOffBothUrlAndBody() {
+    assertThat(OpenApiEmitter.placeholders("/x/${state.id}", "{\"n\": \"${state.name}\"}"))
+        .containsExactly("id", "name");
+  }
+
+  @Test
+  void aRelativeUrlYieldsNoServerButStillAPath() {
+    // Same-origin endpoints are declared relative; they must not invent a server entry.
+    assertThat(OpenApiEmitter.origin("/api/local")).isNull();
+    assertThat(OpenApiEmitter.path("/api/local")).isEqualTo("/api/local");
+  }
+}

--- a/doc/astro.config.mjs
+++ b/doc/astro.config.mjs
@@ -265,6 +265,7 @@ export default defineConfig({
 								{ slug: 'java-user-manual/build/relationships-vs-embedded-cruds' },
 								{ slug: 'java-user-manual/build/master-detail' },
 								{ slug: 'java-user-manual/build/orders-customers-order-lines' },
+								{ slug: 'java-user-manual/build/derived-openapi' },
 							],
 						},
 						{

--- a/doc/src/content/docs/java-user-manual/build/derived-openapi.md
+++ b/doc/src/content/docs/java-user-manual/build/derived-openapi.md
@@ -1,0 +1,96 @@
+---
+title: "The OpenAPI your UI implies"
+description: Derive the API contract from the endpoints your screens already declare — and use it as a check, not just a file.
+---
+
+**Status:** 🟡 Emitter and contract check implemented; not yet wired to a Maven goal or an endpoint.
+
+Every `@RestOptions`, `@RestListing`, `@RestData` and `@RestAction` already states a URL, a method,
+the parameters it interpolates and the shape it reads back. **That is an endpoint contract** — it was
+just never written down.
+
+So the declaration stops deriving one artifact and starts deriving two:
+
+```
+                 ┌──▶  the UI      (wire → renderers)
+  declaration ───┤
+                 └──▶  the API contract it implies  (OpenAPI)
+```
+
+## Emitting it
+
+```java
+String json = OpenApiEmitter.emitJson("My API", List.of(Orders.class, Dashboard.class));
+```
+
+From a screen like this:
+
+```java
+@UI("/orders")
+@RestListing(url = "https://api.example.com/orders?since=${state.since}", itemsPath = "data")
+public class Orders {
+
+  @RestOptions(url = "https://api.example.com/countries", valuePath = "code", labelPath = "name")
+  String country;
+
+  @RestAction(url = "https://api.example.com/orders/${state.id}/approve", method = "POST")
+  void approve() {}
+}
+```
+
+you get `/orders` (GET, with `since` as a required parameter), `/countries` (GET) and
+`/orders/{}/approve` (POST), each origin listed as a server, and each operation recording the path
+the screen reads (`data`, `items`, `result`).
+
+## It is a lower bound — and that is the honest claim
+
+| The UI knows | The UI cannot know |
+|---|---|
+| paths, methods | error codes |
+| the parameters the screens interpolate | authentication |
+| the field the screen reads back (`itemsPath`, `resultPath`) | idempotency, side effects |
+| bean-validation constraints on the fields | business rules, versioning |
+
+*"This is the minimum your API must satisfy"* is exact and useful. *"This generates your API"* would
+be false, and the emitted document says so in its own `info.description` rather than letting a reader
+assume error codes were considered.
+
+## The better use: a check, not a file
+
+A file has to be looked at. `ApiContractCheck` compares the derived spec against a **server's own**
+OpenAPI and reports the gaps:
+
+```java
+List<Gap> gaps = ApiContractCheck.check(
+    OpenApiEmitter.emit("UI needs", views),
+    yourServersOpenApi);
+```
+
+```
+GET /orders — the screens send 'since' and the API does not accept it
+```
+
+Why this beats generating controllers:
+
+- **Nothing to regenerate**, so nothing to conflict with the code you wrote.
+- **Works against any backend** — Java, .NET, Python or a third party's.
+- **Catches drift in both directions**: the server changing a response the screens read, *and* the
+  screens starting to need something the server does not offer.
+
+That last one is the quiet failure it exists for: the endpoint answers `200`, ignores the filter the
+screen sends, and the user sees the wrong rows with nothing in any log.
+
+The check deliberately stays silent about error codes, auth and schemas. A check that failed on
+things the UI cannot know would report noise — and a check that reports noise gets ignored, which is
+worse than not having one.
+
+## What is not here yet
+
+**Generating controllers.** It is deliberately last, and it comes with a rule that is not negotiable:
+
+> Never mix generated code and hand-written code in the same file.
+
+Generate the controller and the port (the use-case interface); the human writes the adapter in a file
+the generator never touches. The failure mode to avoid is a generated `OrderService` with `// TODO`
+inside: the second run either destroys work or is skipped forever, and from then on the contract and
+the code drift in silence. That would be a one-shot scaffolder, not a derivation.


### PR DESCRIPTION
Fila **11** del backlog — pasos **1 y 2** del orden que recomendamos: emitir primero, verificar después, y el codegen al final solo si aparece demanda.

## No es una capacidad nueva

Cada `@RestOptions`, `@RestListing`, `@RestData` y `@RestAction` **ya** declara una URL, un método, los parámetros que interpola y la forma que espera leer. Eso **es** un contrato de endpoint; simplemente nadie lo había escrito. La declaración pasa de derivar un artefacto a derivar dos:

```
                 ┌──▶  la UI      (wire → renderers)
  declaración ───┤
                 └──▶  el contrato de API que implica  (OpenAPI)
```

## Es una cota inferior, y el documento lo dice

| La UI sabe | La UI **no** puede saber |
|---|---|
| paths, métodos | códigos de error |
| los parámetros que las pantallas interpolan | autenticación |
| el campo que la pantalla lee (`itemsPath`, `resultPath`) | idempotencia, efectos secundarios |

*"Esto es lo mínimo que tu API debe cumplir"* es exacto y útil. *"Esto genera tu API"* sería falso — así que la frase va en el propio `info.description` del documento emitido, y **hay un test que la fija**. Un spec derivado que inventara seguridad sería peor que ninguno: parecería autoritativo sobre lo que la UI no puede saber.

## Donde está el valor: verificar, no emitir

`ApiContractCheck` compara el derivado contra el OpenAPI del propio servidor:

```
GET /orders — the screens send 'since' and the API does not accept it
```

Gana al codegen por tres razones: **no hay nada que regenerar** ni con qué conflictar, **vale contra cualquier backend** (Java, .NET, Python o de un tercero), y **detecta la deriva en las dos direcciones**.

Esa última es el fallo silencioso para el que existe: el endpoint responde `200`, **ignora el filtro** que la pantalla envía, y el usuario ve filas equivocadas sin que nada falle en ningún log.

El check **calla** deliberadamente sobre códigos de error, auth y esquemas. Uno que fallara por lo que la UI no puede saber reportaría ruido, y un check ruidoso se ignora — que es peor que no tenerlo.

## Lo que no entra

El **codegen de controladores**, deliberadamente al final, y con la regla que no es negociable: *nunca mezclar código generado y escrito a mano en el mismo fichero*. El modo de fallo a evitar es el `OrderService` generado con `// TODO` dentro: la segunda ejecución o destruye trabajo o se salta el fichero para siempre. Eso sería un scaffolder de un solo uso, no una derivación.

Tampoco entra el cableado a un goal de Maven o a un endpoint — está anotado en la doc como pendiente.

`core`: **869 tests verde**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)