### PR TITLE
feat(editor): semántica del delta de layout, la pieza que había que decidir

### DIFF
--- a/backend/shared/uidl/src/main/java/io/mateu/uidl/data/LayoutDelta.java
+++ b/backend/shared/uidl/src/main/java/io/mateu/uidl/data/LayoutDelta.java
@@ -1,0 +1,101 @@
+package io.mateu.uidl.data;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * What the visual editor changed about a screen's layout, expressed as a DELTA over the inferred
+ * one rather than as a snapshot of the result.
+ *
+ * <p><b>Why this exists.</b> Today the editor writes a full {@code layout:} tree, and an explicit
+ * layout takes a screen out of the inference regime for good — <i>explicit always wins</i>, by
+ * design. The consequence is quiet and permanent: the moment someone drags one field, that screen
+ * stops re-deriving. Add a field to the record and it does not appear; rename one and the layout
+ * points at a ghost. That is the divergence that actually matters now — not stale data, which the
+ * bundle already solved, but a layout that stopped following its model.
+ *
+ * <p><b>The shape of the fix.</b> A delta records the DECISIONS a human made — this field first,
+ * that one hidden, this one wider — anchored to <b>stable field ids</b> rather than to positions in
+ * a tree. Inference still runs on every request; the delta is re-applied on top. A field the model
+ * grows is simply one the delta says nothing about, so it appears in its inferred place. A field
+ * the model loses is a delta entry that no longer matches anything, and is ignored rather than
+ * breaking the page.
+ *
+ * <p><b>What it deliberately cannot express.</b> Arbitrary restructuring. A delta says "these
+ * fields, in this order, with these tweaks" — not "wrap these two in a card inside a tab".
+ * Anchoring to ids is exactly what makes it survive model change, and a delta that could rebuild
+ * the tree freely would be a snapshot wearing a different name.
+ */
+public record LayoutDelta(
+    List<String> order, List<String> hidden, Map<String, FieldOverride> overrides) {
+
+  /** Per-field tweaks a human made. Every member is optional; null means "leave as inferred". */
+  public record FieldOverride(String label, Integer colspan, String section) {}
+
+  public LayoutDelta {
+    order = order == null ? List.of() : List.copyOf(order);
+    hidden = hidden == null ? List.of() : List.copyOf(hidden);
+    overrides = overrides == null ? Map.of() : Map.copyOf(overrides);
+  }
+
+  public static LayoutDelta empty() {
+    return new LayoutDelta(List.of(), List.of(), Map.of());
+  }
+
+  public boolean isEmpty() {
+    return order.isEmpty() && hidden.isEmpty() && overrides.isEmpty();
+  }
+
+  /**
+   * The field ids to render, in order, given what inference produced.
+   *
+   * <p>The rule that makes this a delta and not a snapshot: <b>fields the delta does not mention
+   * keep their inferred position</b>. Listed ones come first in the order the human chose; the rest
+   * follow in the order inference gave them. So a field added to the model later appears — which is
+   * precisely what a stored snapshot cannot do.
+   */
+  public List<String> applyTo(List<String> inferred) {
+    var result = new ArrayList<String>();
+    for (var id : order) {
+      // A delta entry for a field the model no longer has is stale, not fatal: ignore it.
+      if (inferred.contains(id) && !hidden.contains(id) && !result.contains(id)) {
+        result.add(id);
+      }
+    }
+    for (var id : inferred) {
+      if (!hidden.contains(id) && !result.contains(id)) {
+        result.add(id);
+      }
+    }
+    return result;
+  }
+
+  /** The override for a field, or an empty one — so callers never branch on null. */
+  public FieldOverride overrideFor(String fieldId) {
+    return overrides.getOrDefault(fieldId, new FieldOverride(null, null, null));
+  }
+
+  /**
+   * The delta that turns {@code inferred} into {@code desired} — what the editor should SAVE after
+   * a human rearranges a screen, instead of the whole tree.
+   *
+   * <p>It records only what differs: a screen dragged into exactly its inferred order produces an
+   * empty delta, and therefore keeps re-deriving. That is the property to preserve — using the
+   * editor at all should not, by itself, freeze a screen.
+   */
+  public static LayoutDelta between(List<String> inferred, List<String> desired) {
+    var hidden = new ArrayList<String>();
+    for (var id : inferred) {
+      if (!desired.contains(id)) {
+        hidden.add(id);
+      }
+    }
+    var visibleInferred = new ArrayList<>(inferred);
+    visibleInferred.removeAll(hidden);
+    // Only record an order when it actually differs from what inference already gives.
+    var order = visibleInferred.equals(desired) ? List.<String>of() : List.copyOf(desired);
+    return new LayoutDelta(order, hidden, new LinkedHashMap<>());
+  }
+}

--- a/backend/shared/uidl/src/test/java/io/mateu/uidl/data/LayoutDeltaTest.java
+++ b/backend/shared/uidl/src/test/java/io/mateu/uidl/data/LayoutDeltaTest.java
@@ -1,0 +1,99 @@
+package io.mateu.uidl.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The property that separates a delta from a snapshot.
+ *
+ * <p>A stored snapshot answers "what did the screen look like when someone last touched it". A
+ * delta answers "what did that person DECIDE" — and the difference only shows up later, when the
+ * model changes underneath. These tests are that later.
+ */
+class LayoutDeltaTest {
+
+  private static final List<String> INFERRED = List.of("name", "email", "age");
+
+  @Test
+  void aFieldTheModelGrowsLaterStillAppears() {
+    // THE test. A human reordered two fields months ago; today someone adds `phone` to the record.
+    // With a snapshot, `phone` is invisible and nobody knows why. With a delta, it simply is not
+    // mentioned, so it lands in its inferred place.
+    var delta = new LayoutDelta(List.of("email", "name"), List.of(), Map.of());
+
+    var withNewField = List.of("name", "email", "age", "phone");
+
+    assertThat(delta.applyTo(withNewField)).containsExactly("email", "name", "age", "phone");
+  }
+
+  @Test
+  void aFieldTheModelLosesIsIgnoredRatherThanFatal() {
+    // The mirror case: the delta still names a field that no longer exists. A snapshot would render
+    // a ghost; the delta drops it and the page keeps working.
+    var delta = new LayoutDelta(List.of("email", "removed", "name"), List.of(), Map.of());
+
+    assertThat(delta.applyTo(INFERRED)).containsExactly("email", "name", "age");
+  }
+
+  @Test
+  void unmentionedFieldsKeepTheirInferredOrder() {
+    var delta = new LayoutDelta(List.of("age"), List.of(), Map.of());
+    assertThat(delta.applyTo(INFERRED)).containsExactly("age", "name", "email");
+  }
+
+  @Test
+  void hidingIsExplicitAndSurvivesReordering() {
+    var delta = new LayoutDelta(List.of("age"), List.of("email"), Map.of());
+    assertThat(delta.applyTo(INFERRED)).containsExactly("age", "name");
+  }
+
+  @Test
+  void anEmptyDeltaChangesNothing() {
+    assertThat(LayoutDelta.empty().applyTo(INFERRED)).isEqualTo(INFERRED);
+    assertThat(LayoutDelta.empty().isEmpty()).isTrue();
+  }
+
+  @Test
+  void openingAScreenInTheEditorAndChangingNothingDoesNotFreezeIt() {
+    // The trap to avoid: if merely touching a screen produced a delta, the editor would still take
+    // it out of inference — the same failure with extra steps. Dragging nothing must record
+    // nothing.
+    var delta = LayoutDelta.between(INFERRED, INFERRED);
+
+    assertThat(delta.isEmpty()).isTrue();
+  }
+
+  @Test
+  void theEditorRecordsOnlyWhatTheHumanActuallyChanged() {
+    var delta = LayoutDelta.between(INFERRED, List.of("email", "name"));
+
+    assertThat(delta.order()).containsExactly("email", "name");
+    assertThat(delta.hidden()).containsExactly("age");
+  }
+
+  @Test
+  void aRecordedDeltaReproducesWhatTheHumanArranged() {
+    // Round trip: what `between` records must be what `applyTo` gives back, or the editor would
+    // save one thing and the server render another.
+    var desired = List.of("email", "name");
+    var delta = LayoutDelta.between(INFERRED, desired);
+
+    assertThat(delta.applyTo(INFERRED)).isEqualTo(desired);
+  }
+
+  @Test
+  void overridesAreLookedUpWithoutBranchingOnNull() {
+    var delta =
+        new LayoutDelta(
+            List.of(),
+            List.of(),
+            Map.of("name", new LayoutDelta.FieldOverride("Full name", 2, null)));
+
+    assertThat(delta.overrideFor("name").label()).isEqualTo("Full name");
+    assertThat(delta.overrideFor("name").colspan()).isEqualTo(2);
+    assertThat(delta.overrideFor("absent").label()).isNull();
+  }
+}

--- a/design/framework-design-backlog.md
+++ b/design/framework-design-backlog.md
@@ -540,6 +540,22 @@ Y **esta es la divergencia que de verdad importa ahora**: no la de datos (resuel
 lleva datos de negocio), sino **layout que dejó de seguir al modelo**. Añades un campo al record y
 la pantalla no lo muestra; renombras uno y el layout apunta a un fantasma.
 
+> **Semántica decidida y probada (2026-08-12).** `LayoutDelta` (uidl.data) fija qué es un delta y por
+> qué sobrevive a un cambio de modelo: se ancla a **ids de campo estables**, no a posiciones en un
+> árbol. Los campos que el delta no menciona conservan su posición inferida, así que **un campo que el
+> modelo gane después aparece** — que es exactamente lo que un snapshot no puede hacer; uno que el
+> modelo pierda se ignora en vez de romper la página. Y `between(inferido, deseado)` registra solo lo
+> que difiere, de modo que **abrir una pantalla en el editor y no tocar nada no la congela** — la
+> trampa que convertiría el arreglo en el mismo fallo con pasos extra.
+>
+> Lo que el delta deliberadamente NO puede expresar es reestructuración arbitraria ("envuelve estos
+> dos en un card dentro de un tab"). Anclar a ids es justo lo que le da la supervivencia, y un delta
+> capaz de reconstruir el árbol sería un snapshot con otro nombre.
+>
+> **Pendiente:** que el editor escriba `layoutDelta:` en vez de `layout:`, que el mapper lo consulte
+> donde hoy consulta la inferencia, y migrar los YAML existentes. La semántica es la parte que había
+> que decidir; el cableado es trabajo, no diseño.
+
 **Dirección a explorar:** que el YAML guarde el **delta sobre el layout inferido, no una foto del
 layout completo**. Un parche en vez de un snapshot. Un cambio de modelo sigue re-derivando y el
 delta se reaplica encima — o falla ruidosamente, que también sirve. Es más caro de implementar,


### PR DESCRIPTION
Fila **10.2** — la única que dijimos desde el principio que **no era de una tarde**.

**Este PR no la cierra.** Fija y prueba su *semántica*, que es la parte de diseño; el cableado queda pendiente y lo digo sin adornos abajo.

## El problema

Hoy el editor escribe un `layout:` completo, y un layout explícito saca la pantalla del régimen de inferencia **para siempre** — *explicit always wins*, por diseño.

La consecuencia es silenciosa y permanente: en cuanto alguien arrastra un campo, esa pantalla deja de re-derivarse. Añades un campo al record y **no aparece**; renombras uno y el layout apunta a un fantasma. Esa es la divergencia que importa ahora — no la de datos, que el bundle ya resolvió, sino **un layout que dejó de seguir a su modelo**.

## La semántica

`LayoutDelta` se ancla a **ids de campo estables**, no a posiciones en un árbol.

| Situación | Snapshot (hoy) | Delta |
|---|---|---|
| El modelo gana un campo | invisible, y nadie sabe por qué | **aparece** en su sitio inferido |
| El modelo pierde un campo | fantasma en el layout | la entrada se ignora |
| Abres el editor y no tocas nada | la pantalla queda congelada | **delta vacío: sigue derivando** |

Ese último es el que más me importa: un delta que se generase por el mero hecho de abrir el editor sería **el mismo fallo con pasos extra**. `between(inferido, deseado)` registra solo lo que difiere.

## Lo que deliberadamente no puede expresar

Reestructuración arbitraria — *"envuelve estos dos en un card dentro de un tab"*. Anclar a ids es justo lo que le da la supervivencia, y **un delta capaz de reconstruir el árbol libremente sería un snapshot con otro nombre**.

## Lo que falta

- Que el editor escriba `layoutDelta:` en vez de `layout:`.
- Que el mapper lo consulte donde hoy consulta la inferencia.
- Migrar los YAML existentes.

Anotado también en el backlog de diseño. La semántica era la parte que había que decidir; lo demás es trabajo, no diseño.

`uidl`: **60 tests verde**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)