### PR TITLE
feat(uidl,core): fragments — reusable UI usable anywhere a component is

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,7 @@ mdd-vaadin/src/main/webapp/VAADIN/themes/mateu/styles.css
 .mvn
 mvnw
 mvnw.*
-.dev/proyecto
+# Scratch clones of Oracle VB tooling, kept while reverse-engineering their page templates.
+# One of these once dragged 94k files into a commit; none of it is source.
+.dev/
 .DS_Store

--- a/backend/shared/core/src/main/java/io/mateu/core/application/runaction/FragmentRegistry.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/runaction/FragmentRegistry.java
@@ -1,0 +1,146 @@
+package io.mateu.core.application.runaction;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.mateu.uidl.fluent.Component;
+import io.mateu.uidl.interfaces.ComponentTreeSupplier;
+import io.mateu.uidl.interfaces.HttpRequest;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Resolves a {@link io.mateu.uidl.data.Fragment}'s {@code ref} into the components it stands for.
+ *
+ * <p>A fragment definition is authored the same way a page is, and this is where the two authoring
+ * paths meet:
+ *
+ * <ul>
+ *   <li><b>YAML</b> — {@code specs/ui/fragments/<ref>.yaml}, holding either a bare component
+ *       ({@code type: ...}) or a {@code content:} list of them. An explicit classpath path ending
+ *       in {@code .yaml} is honoured as-is, so a fragment can live next to the pages that use it.
+ *   <li><b>Java</b> — {@code ref} as a fully-qualified class name. A {@link ComponentTreeSupplier}
+ *       contributes its tree; a plain {@link Component} contributes itself.
+ * </ul>
+ *
+ * <p>A ref that resolves to nothing is <b>not</b> fatal. A missing fragment renders as no content
+ * and logs; a page is not worth taking down over one piece of it, and the alternative — a 500 on
+ * every request to every page that mentions the ref — turns a typo into an outage.
+ *
+ * <p>This is a static singleton rather than a bean because the mappers that need it are static and
+ * reached from several entry points. Nothing about it is per-request: definitions are files.
+ */
+@Slf4j
+public final class FragmentRegistry {
+
+  private static final FragmentRegistry INSTANCE = new FragmentRegistry();
+
+  public static FragmentRegistry instance() {
+    return INSTANCE;
+  }
+
+  /**
+   * Resolution misses are cached too — a page mentioning a bad ref would otherwise hit the
+   * classpath on every request forever.
+   */
+  private static final List<Component> NONE = List.of();
+
+  private final ObjectMapper mapper = YamlUidlMapperFactory.create();
+  private final ConcurrentHashMap<String, List<Component>> byRef = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, List<Component>> registered = new ConcurrentHashMap<>();
+
+  private FragmentRegistry() {}
+
+  /**
+   * Contribute a fragment programmatically. For tests, and for apps that build their shared pieces
+   * in code rather than in files. A registration wins over a file of the same name — the same
+   * precedence a route registration has over the {@code specs/ui/<route>.yaml} convention.
+   */
+  public void register(String ref, List<Component> content) {
+    registered.put(ref, List.copyOf(content));
+    byRef.remove(ref);
+  }
+
+  /** Forget everything registered programmatically, and every cached lookup. Tests. */
+  public void reset() {
+    registered.clear();
+    byRef.clear();
+  }
+
+  /** The components {@code ref} stands for; empty when it resolves to nothing. */
+  public List<Component> resolve(String ref, HttpRequest httpRequest) {
+    if (ref == null || ref.isBlank()) {
+      return NONE;
+    }
+    var fromCode = registered.get(ref);
+    if (fromCode != null) {
+      return fromCode;
+    }
+    // Class refs are resolved on every call: a ComponentTreeSupplier may legitimately return a
+    // different tree per request, which is the whole reason to author a fragment in Java.
+    var fromClass = fromClass(ref, httpRequest);
+    if (fromClass != null) {
+      return fromClass;
+    }
+    return byRef.computeIfAbsent(ref, this::fromYaml);
+  }
+
+  private List<Component> fromYaml(String ref) {
+    var path =
+        ref.endsWith(".yaml") || ref.endsWith(".yml") ? ref : "specs/ui/fragments/" + ref + ".yaml";
+    try (InputStream in =
+        Thread.currentThread().getContextClassLoader().getResourceAsStream(path)) {
+      if (in == null) {
+        log.warn("No fragment definition for ref '{}' (looked for classpath:{})", ref, path);
+        return NONE;
+      }
+      var root = mapper.readTree(in);
+      if (root == null || root.isNull()) {
+        return NONE;
+      }
+      if (root.has("content")) {
+        var content = new ArrayList<Component>();
+        for (var child : root.get("content")) {
+          var component = mapper.treeToValue(child, Component.class);
+          if (component != null) {
+            content.add(component);
+          }
+        }
+        return List.copyOf(content);
+      }
+      var single = mapper.treeToValue(root, Component.class);
+      return single == null ? NONE : List.of(single);
+    } catch (Exception e) {
+      log.error("Could not read fragment '{}' from classpath:{}", ref, path, e);
+      return NONE;
+    }
+  }
+
+  private List<Component> fromClass(String ref, HttpRequest httpRequest) {
+    if (ref.indexOf('.') < 0 || ref.endsWith(".yaml") || ref.endsWith(".yml")) {
+      return null;
+    }
+    try {
+      var type = Class.forName(ref, true, Thread.currentThread().getContextClassLoader());
+      var instance = type.getDeclaredConstructor().newInstance();
+      if (instance instanceof ComponentTreeSupplier supplier) {
+        var tree = supplier.component(httpRequest);
+        return tree == null ? NONE : List.of(tree);
+      }
+      if (instance instanceof Component component) {
+        return List.of(component);
+      }
+      log.warn(
+          "Fragment ref '{}' names a class that is neither a Component nor a ComponentTreeSupplier",
+          ref);
+      return NONE;
+    } catch (ClassNotFoundException e) {
+      // Not a class ref at all — a dotted YAML name is perfectly legal. Fall through to the file.
+      return null;
+    } catch (Exception e) {
+      log.error("Could not build fragment from class '{}'", ref, e);
+      return NONE;
+    }
+  }
+}

--- a/backend/shared/core/src/main/java/io/mateu/core/application/runaction/YamlUidlMapperFactory.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/runaction/YamlUidlMapperFactory.java
@@ -59,6 +59,7 @@ final class YamlUidlMapperFactory {
         new NamedType(Div.class, "Div"),
         new NamedType(Element.class, "Element"),
         new NamedType(FormEditor.class, "FormEditor"),
+        new NamedType(Fragment.class, "Fragment"),
         new NamedType(FormField.class, "FormField"),
         new NamedType(FormItem.class, "FormItem"),
         new NamedType(FormLayout.class, "FormLayout"),

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/FragmentExpander.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/FragmentExpander.java
@@ -1,0 +1,234 @@
+package io.mateu.core.domain.out.fragmentmapper;
+
+import io.mateu.core.application.runaction.FragmentRegistry;
+import io.mateu.uidl.data.Fragment;
+import io.mateu.uidl.data.VerticalLayout;
+import io.mateu.uidl.fluent.Component;
+import io.mateu.uidl.interfaces.HttpRequest;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.RecordComponent;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Inlines every {@link Fragment} in a component tree, before anything maps it to DTOs.
+ *
+ * <p>This is what makes a fragment "usable anywhere a component is" true rather than aspirational.
+ * The alternative — a fragment node on the wire that each renderer resolves — would mean the
+ * feature ships once per renderer, arrives late in the ones nobody maintains, and leaves a static
+ * bundle holding a reference it cannot follow. Resolving here means the wire never learns the
+ * concept exists, and neither does any renderer.
+ *
+ * <p>A fragment that stands for <b>several</b> components is spliced into its parent's content
+ * rather than wrapped, so putting one inside a {@code FormLayout} yields form fields — not a nested
+ * layout that quietly breaks the grid. That splice is why this walks the tree generically over
+ * record components instead of teaching each of the ~36 layout mappers about fragments: the rule
+ * belongs in one place, and a layout added next year gets it for free.
+ *
+ * <p>In the one position where splicing is impossible — a slot that holds a single component, like
+ * {@code Container.content} — a multi-component fragment is stacked in a bare {@link
+ * VerticalLayout}. Nothing else is available there, and silently dropping all but the first would
+ * be worse.
+ */
+@Slf4j
+public final class FragmentExpander {
+
+  /** A ref chain longer than this is a bug, not a design. Belt to the cycle detector's braces. */
+  private static final int MAX_DEPTH = 20;
+
+  private static final ConcurrentHashMap<Class<?>, Shape> SHAPES = new ConcurrentHashMap<>();
+
+  /**
+   * What a component record looks like to this walker, worked out once per class.
+   *
+   * @param all every record component, in canonical-constructor order
+   * @param walkable the indices worth descending into. Everything else — labels, ids, enums,
+   *     numbers — is skipped by static type, so a page of text costs a handful of index lookups
+   *     rather than a reflective read per field.
+   * @param canonical the constructor used to rebuild the record once a child has changed
+   */
+  private record Shape(RecordComponent[] all, int[] walkable, Constructor<?> canonical) {}
+
+  private FragmentExpander() {}
+
+  /**
+   * The tree with its fragments resolved. Returns the very same instance when there was nothing to
+   * resolve, which is the common case and costs one reflective pass with no allocation.
+   */
+  public static Component expand(Component root, HttpRequest httpRequest) {
+    if (root == null) {
+      return null;
+    }
+    try {
+      return single(root, httpRequest, new ArrayDeque<>());
+    } catch (Exception e) {
+      // A tree that renders slightly wrong beats a page that does not render. The refs that failed
+      // have already been logged by the registry.
+      log.error("Could not expand fragments; rendering the tree as authored", e);
+      return root;
+    }
+  }
+
+  /** What a component becomes in a slot that holds exactly one. */
+  private static Component single(Component component, HttpRequest request, Deque<String> chain) {
+    var expanded = inList(component, request, chain);
+    if (expanded.isEmpty()) {
+      return null;
+    }
+    if (expanded.size() == 1) {
+      return expanded.get(0);
+    }
+    return new VerticalLayout(expanded);
+  }
+
+  /** What a component becomes in a content list — where a fragment may contribute several. */
+  private static List<Component> inList(
+      Component component, HttpRequest request, Deque<String> chain) {
+    if (!(component instanceof Fragment fragment)) {
+      return List.of(rewrite(component, request, chain));
+    }
+    var ref = fragment.ref();
+    if (chain.contains(ref)) {
+      // A stack iterates newest-first; reversed, the message reads as the include chain a human
+      // would follow through the files.
+      var path = new ArrayList<>(chain);
+      java.util.Collections.reverse(path);
+      path.add(ref);
+      log.error("Fragment '{}' includes itself: {}", ref, String.join(" -> ", path));
+      return List.of();
+    }
+    if (chain.size() >= MAX_DEPTH) {
+      log.error("Fragment nesting deeper than {} at '{}'; stopping", MAX_DEPTH, ref);
+      return List.of();
+    }
+    chain.push(ref);
+    try {
+      var resolved = new ArrayList<Component>();
+      for (var child : FragmentRegistry.instance().resolve(ref, request)) {
+        resolved.addAll(inList(child, request, chain));
+      }
+      return resolved;
+    } finally {
+      chain.pop();
+    }
+  }
+
+  /** The same component with its children expanded — identical instance when nothing changed. */
+  private static Component rewrite(Component component, HttpRequest request, Deque<String> chain) {
+    if (component == null || !component.getClass().isRecord()) {
+      return component;
+    }
+    var shape = shapeOf(component.getClass());
+    if (shape == null || shape.walkable().length == 0) {
+      return component;
+    }
+    Object[] values = null;
+    for (var index : shape.walkable()) {
+      Object current;
+      try {
+        current = shape.all()[index].getAccessor().invoke(component);
+      } catch (Exception e) {
+        log.debug(
+            "Could not read {}.{}",
+            component.getClass().getSimpleName(),
+            shape.all()[index].getName(),
+            e);
+        continue;
+      }
+      var rewritten = rewriteValue(current, request, chain);
+      if (rewritten == current) {
+        continue;
+      }
+      if (values == null) {
+        values = read(component, shape.all());
+        if (values == null) {
+          return component;
+        }
+      }
+      values[index] = rewritten;
+    }
+    if (values == null) {
+      return component;
+    }
+    try {
+      return (Component) shape.canonical().newInstance(values);
+    } catch (Exception e) {
+      log.error("Could not rebuild {} with its fragments inlined", component.getClass(), e);
+      return component;
+    }
+  }
+
+  private static Object rewriteValue(Object value, HttpRequest request, Deque<String> chain) {
+    if (value instanceof Component child) {
+      var expanded = single(child, request, chain);
+      return expanded == child ? value : expanded;
+    }
+    if (value instanceof Collection<?> collection) {
+      if (collection.isEmpty() || !(collection.iterator().next() instanceof Component)) {
+        // Options, grid columns, flex grows — plenty of lists on a component hold no components.
+        return value;
+      }
+      var changed = false;
+      var rewritten = new ArrayList<Object>(collection.size());
+      for (var element : collection) {
+        if (!(element instanceof Component child)) {
+          rewritten.add(element);
+          continue;
+        }
+        var expanded = inList(child, request, chain);
+        changed |= expanded.size() != 1 || expanded.get(0) != child;
+        rewritten.addAll(expanded);
+      }
+      return changed ? List.copyOf(rewritten) : value;
+    }
+    return value;
+  }
+
+  /** Null when the record has no canonical constructor we can reach — then we leave it alone. */
+  private static Shape shapeOf(Class<?> type) {
+    return SHAPES.computeIfAbsent(
+        type,
+        t -> {
+          var all = t.getRecordComponents();
+          var walkable = new ArrayList<Integer>();
+          var types = new Class<?>[all.length];
+          for (var i = 0; i < all.length; i++) {
+            types[i] = all[i].getType();
+            if (Component.class.isAssignableFrom(types[i])
+                || Collection.class.isAssignableFrom(types[i])) {
+              walkable.add(i);
+            }
+          }
+          try {
+            var canonical = t.getDeclaredConstructor(types);
+            canonical.setAccessible(true);
+            var indices = new int[walkable.size()];
+            for (var i = 0; i < indices.length; i++) {
+              indices[i] = walkable.get(i);
+            }
+            return new Shape(all, indices, canonical);
+          } catch (Exception e) {
+            log.error("No reachable canonical constructor on {}", t, e);
+            return new Shape(all, new int[0], null);
+          }
+        });
+  }
+
+  private static Object[] read(Component component, RecordComponent[] all) {
+    var values = new Object[all.length];
+    for (var i = 0; i < all.length; i++) {
+      try {
+        values[i] = all[i].getAccessor().invoke(component);
+      } catch (Exception e) {
+        log.error("Could not read {}.{}", component.getClass(), all[i].getName(), e);
+        return null;
+      }
+    }
+    return values;
+  }
+}

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/UIFragmentAssembler.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/UIFragmentAssembler.java
@@ -27,6 +27,9 @@ public final class UIFragmentAssembler {
       String consumedRoute,
       String initiatorComponentId,
       HttpRequest httpRequest) {
+    // Fragments are an authoring concept: they are inlined here, once, so that nothing downstream
+    // — no mapper, no DTO, no renderer — ever has to know they existed.
+    component = FragmentExpander.expand(component, httpRequest);
     if (component instanceof State state) {
       return mapStateToDto(state, initiatorComponentId);
     }

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/mappers/ComponentTreeSupplierMapper.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/mappers/ComponentTreeSupplierMapper.java
@@ -6,6 +6,7 @@ import static io.mateu.core.domain.out.fragmentmapper.ComponentToFragmentDtoMapp
 import io.mateu.core.domain.out.componentmapper.PageTypeResolver;
 import io.mateu.core.domain.out.componentmapper.PageWidthResolver;
 import io.mateu.core.domain.out.componentmapper.StaticViewResolver;
+import io.mateu.core.domain.out.fragmentmapper.FragmentExpander;
 import io.mateu.dtos.ComponentDto;
 import io.mateu.dtos.ServerSideComponentDto;
 import io.mateu.uidl.interfaces.ComponentTreeSupplier;
@@ -29,7 +30,7 @@ public class ComponentTreeSupplierMapper {
         List.of(
             mapComponentToDto(
                 componentTreeSupplier,
-                componentTreeSupplier.component(httpRequest),
+                FragmentExpander.expand(componentTreeSupplier.component(httpRequest), httpRequest),
                 baseUrl,
                 route,
                 consumedRoute,

--- a/backend/shared/core/src/test/java/io/mateu/core/application/FragmentExpansionTest.java
+++ b/backend/shared/core/src/test/java/io/mateu/core/application/FragmentExpansionTest.java
@@ -1,0 +1,148 @@
+package io.mateu.core.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.mateu.core.application.runaction.FragmentRegistry;
+import io.mateu.core.application.runaction.RouteRegistry;
+import io.mateu.core.application.runaction.YamlUidlLoader;
+import io.mateu.core.domain.out.fragmentmapper.FragmentExpander;
+import io.mateu.uidl.data.Container;
+import io.mateu.uidl.data.FormField;
+import io.mateu.uidl.data.FormLayout;
+import io.mateu.uidl.data.Fragment;
+import io.mateu.uidl.data.Text;
+import io.mateu.uidl.data.VerticalLayout;
+import io.mateu.uidl.fluent.Component;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A fragment is a page-shaped thing with no route: one component, or a list of them, usable
+ * anywhere a component is.
+ *
+ * <p>These pin the two properties that decide whether that sentence is true. First, a fragment that
+ * stands for several components <b>splices</b> into its parent rather than wrapping — otherwise
+ * "anywhere a component is" quietly excludes forms and grids, the places reuse matters most.
+ * Second, fragments are gone by the time anything maps to DTOs, so no renderer has to learn the
+ * concept.
+ */
+class FragmentExpansionTest {
+
+  private final YamlUidlLoader loader = new YamlUidlLoader(new RouteRegistry());
+
+  @BeforeEach
+  void clean() {
+    FragmentRegistry.instance().reset();
+  }
+
+  private static List<Component> contentOf(Component component) {
+    return ((FormLayout) component).content();
+  }
+
+  @Test
+  void aMultiComponentFragmentSplicesIntoItsParentInsteadOfNesting() {
+    // THE test. Inside a FormLayout, a wrapper would put two fields in one grid cell. Splicing is
+    // what makes a fragment interchangeable with the components it stands for.
+    var page = loader.loadSpec("fragment-page").layout();
+
+    var expanded = FragmentExpander.expand(page, null);
+
+    assertThat(contentOf(expanded))
+        .extracting(c -> c instanceof FormField f ? f.id() : ((Text) c).text())
+        .containsExactly("name", "street", "city", "Prices include VAT.");
+  }
+
+  @Test
+  void fragmentsAreGoneAfterExpansion() {
+    var expanded = FragmentExpander.expand(loader.loadSpec("fragment-page").layout(), null);
+
+    assertThat(contentOf(expanded)).noneMatch(Fragment.class::isInstance);
+  }
+
+  @Test
+  void aFragmentFileThatIsJustAComponentNeedsNoEnvelope() {
+    var expanded = FragmentExpander.expand(new VerticalLayout(new Fragment("legal-notice")), null);
+
+    assertThat(((VerticalLayout) expanded).content())
+        .singleElement()
+        .isInstanceOf(Text.class)
+        .extracting(c -> ((Text) c).text())
+        .isEqualTo("Prices include VAT.");
+  }
+
+  @Test
+  void fragmentsCompose() {
+    var expanded = FragmentExpander.expand(new VerticalLayout(new Fragment("contact-card")), null);
+
+    assertThat(((VerticalLayout) expanded).content()).hasSize(3);
+  }
+
+  @Test
+  void aFragmentCanBeRegisteredInCodeAndWinsOverAFileOfTheSameName() {
+    FragmentRegistry.instance()
+        .register("legal-notice", List.of(new Text("Registered in code instead.")));
+
+    var expanded = FragmentExpander.expand(new VerticalLayout(new Fragment("legal-notice")), null);
+
+    assertThat(((Text) ((VerticalLayout) expanded).content().get(0)).text())
+        .isEqualTo("Registered in code instead.");
+  }
+
+  @Test
+  void aMissingRefCostsTheFragmentAndNotThePage() {
+    // A typo in one ref must not 500 every request to every page that mentions it.
+    var expanded =
+        FragmentExpander.expand(
+            new VerticalLayout(new Text("still here"), new Fragment("no-such-thing")), null);
+
+    assertThat(((VerticalLayout) expanded).content())
+        .singleElement()
+        .extracting(c -> ((Text) c).text())
+        .isEqualTo("still here");
+  }
+
+  @Test
+  void aFragmentCycleIsReportedRatherThanOverflowingTheStack() {
+    var expanded = FragmentExpander.expand(new VerticalLayout(new Fragment("loop-a")), null);
+
+    assertThat(((VerticalLayout) expanded).content()).isEmpty();
+  }
+
+  @Test
+  void aSingleComponentSlotStacksWhatItCannotSplice() {
+    // Container holds exactly one child. Dropping all but the first would be a silent wrong render.
+    var expanded = FragmentExpander.expand(new Container(new Fragment("address-block")), null);
+
+    var inner = ((Container) expanded).content();
+    assertThat(inner).isInstanceOf(VerticalLayout.class);
+    assertThat(((VerticalLayout) inner).content()).hasSize(2);
+  }
+
+  @Test
+  void aTreeWithoutFragmentsComesBackUntouched() {
+    // Identity, not just equality: expansion is on the render path of every page, and the common
+    // case must not rebuild the tree.
+    var tree =
+        new VerticalLayout(
+            new Text("hello"),
+            new FormLayout(
+                null,
+                List.of(new Text("nested")),
+                false,
+                false,
+                1,
+                null,
+                false,
+                false,
+                null,
+                null,
+                null,
+                null,
+                null,
+                "",
+                ""));
+
+    assertThat(FragmentExpander.expand(tree, null)).isSameAs(tree);
+  }
+}

--- a/backend/shared/core/src/test/java/io/mateu/core/application/FragmentWireSyncTest.java
+++ b/backend/shared/core/src/test/java/io/mateu/core/application/FragmentWireSyncTest.java
@@ -1,0 +1,84 @@
+package io.mateu.core.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.mateu.core.testutil.TestMateu;
+import io.mateu.dtos.ClientSideComponentDto;
+import io.mateu.dtos.RunActionRqDto;
+import io.mateu.uidl.annotations.Action;
+import io.mateu.uidl.annotations.UI;
+import io.mateu.uidl.data.FormField;
+import io.mateu.uidl.data.FormLayout;
+import io.mateu.uidl.data.Fragment;
+import io.mateu.uidl.fluent.Component;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The claim that costs nothing to state and everything to get wrong: <b>fragments do not exist on
+ * the wire</b>.
+ *
+ * <p>If one ever leaked into a {@code UIIncrementDto}, every renderer would need to learn to
+ * resolve it — Vaadin, Redwood, React Native, both IDE plugins — and a static bundle would carry a
+ * reference it has no server to follow. Resolving server-side is what makes the feature arrive
+ * everywhere at once; this test is what keeps that true.
+ */
+class FragmentWireSyncTest {
+
+  @SuppressWarnings("unused")
+  @UI("/fragment-host")
+  public static class FragmentHostForm {
+
+    String name = "n";
+
+    @Action
+    Component showAddress() {
+      return FormLayout.builder()
+          .content(
+              List.of(
+                  FormField.builder().id("name").label("Name").build(),
+                  new Fragment("address-block")))
+          .build();
+    }
+  }
+
+  static TestMateu mateu;
+
+  @BeforeAll
+  static void boot() {
+    mateu = TestMateu.withUis(FragmentHostForm.class);
+  }
+
+  @AfterAll
+  static void shutdown() {
+    mateu.close();
+  }
+
+  private static ClientSideComponentDto form() {
+    var increment =
+        mateu.run(
+            RunActionRqDto.builder()
+                .route("/fragment-host")
+                .actionId("showAddress")
+                .serverSideType(FragmentHostForm.class.getName())
+                .initiatorComponentId("cmp-1")
+                .componentState(Map.of("name", "n"))
+                .build());
+    return (ClientSideComponentDto) increment.fragments().get(0).component();
+  }
+
+  @Test
+  void theFragmentIsAlreadyResolvedByTheTimeTheClientSeesIt() {
+    assertThat(form().children()).hasSize(3);
+  }
+
+  @Test
+  void whatArrivesAreTheFragmentsFieldsSplicedInPlace() {
+    // Not a nested layout holding them: in a form grid that would be a visible, wrong render.
+    assertThat(form().children())
+        .allSatisfy(child -> assertThat(child).isInstanceOf(ClientSideComponentDto.class));
+  }
+}

--- a/backend/shared/core/src/test/resources/specs/ui/fragment-page.yaml
+++ b/backend/shared/core/src/test/resources/specs/ui/fragment-page.yaml
@@ -1,0 +1,11 @@
+layout:
+  type: FormLayout
+  content:
+    - type: FormField
+      id: name
+      label: Name
+      dataType: string
+    - type: Fragment
+      ref: address-block
+    - type: Fragment
+      ref: legal-notice

--- a/backend/shared/core/src/test/resources/specs/ui/fragments/address-block.yaml
+++ b/backend/shared/core/src/test/resources/specs/ui/fragments/address-block.yaml
@@ -1,0 +1,11 @@
+# A fragment that stands for SEVERAL components. Used inside a FormLayout it must splice, not nest,
+# or the form grid breaks.
+content:
+  - type: FormField
+    id: street
+    label: Street
+    dataType: string
+  - type: FormField
+    id: city
+    label: City
+    dataType: string

--- a/backend/shared/core/src/test/resources/specs/ui/fragments/contact-card.yaml
+++ b/backend/shared/core/src/test/resources/specs/ui/fragments/contact-card.yaml
@@ -1,0 +1,6 @@
+# Fragments compose: this one uses another.
+content:
+  - type: Text
+    text: "Contact"
+  - type: Fragment
+    ref: address-block

--- a/backend/shared/core/src/test/resources/specs/ui/fragments/legal-notice.yaml
+++ b/backend/shared/core/src/test/resources/specs/ui/fragments/legal-notice.yaml
@@ -1,0 +1,3 @@
+# A fragment that is just one component: the file is the component, no envelope needed.
+type: Text
+text: "Prices include VAT."

--- a/backend/shared/core/src/test/resources/specs/ui/fragments/loop-a.yaml
+++ b/backend/shared/core/src/test/resources/specs/ui/fragments/loop-a.yaml
@@ -1,0 +1,3 @@
+content:
+  - type: Fragment
+    ref: loop-b

--- a/backend/shared/core/src/test/resources/specs/ui/fragments/loop-b.yaml
+++ b/backend/shared/core/src/test/resources/specs/ui/fragments/loop-b.yaml
@@ -1,0 +1,3 @@
+content:
+  - type: Fragment
+    ref: loop-a

--- a/backend/shared/uidl/src/main/java/io/mateu/uidl/data/Fragment.java
+++ b/backend/shared/uidl/src/main/java/io/mateu/uidl/data/Fragment.java
@@ -1,0 +1,50 @@
+package io.mateu.uidl.data;
+
+import io.mateu.uidl.fluent.Component;
+import lombok.Builder;
+
+/**
+ * A reference to a reusable piece of UI, usable anywhere a component is.
+ *
+ * <p>A <b>fragment</b> is authored exactly like a page — a YAML file, or a Java class — except that
+ * it has no route and no page chrome: it is a component, or a list of components, and nothing else.
+ * Where a page answers "what does this URL show", a fragment answers "what does this <i>piece</i>
+ * look like, wherever it appears".
+ *
+ * <pre>{@code
+ * # specs/ui/fragments/address-block.yaml
+ * content:
+ *   - type: FormField
+ *     id: street
+ *     label: Street
+ *   - type: FormField
+ *     id: city
+ *     label: City
+ * }</pre>
+ *
+ * <pre>{@code
+ * # any page
+ * - type: Fragment
+ *   ref: address-block
+ * }</pre>
+ *
+ * <p><b>Fragments do not exist on the wire.</b> They are resolved and inlined server-side before
+ * the tree is mapped, so every renderer — Vaadin, Redwood, React Native, the IDE plugins — supports
+ * them without a line of renderer code, and a static bundle stays self-contained rather than
+ * carrying an unresolved reference to a CDN.
+ *
+ * <p>Because inlining happens before binding, a fragment's fields bind against <i>the page that
+ * used it</i>, by the same convention as everywhere else: a {@code FormField id="street"} inside a
+ * fragment binds to the hosting ModelView's {@code street} property. That is what makes a fragment
+ * useful without a parameter-passing mechanism of its own.
+ *
+ * <p>Note for readers of the codebase: this is unrelated to {@code UIFragmentDto}, which is the
+ * wire's name for an increment of UI sent in response to an action. This {@code Fragment} is an
+ * authoring-time concept and never reaches that layer.
+ *
+ * @param ref names the definition. Resolution order: {@code specs/ui/fragments/<ref>.yaml} on the
+ *     classpath; then {@code <ref>} itself when it already looks like a classpath path to a YAML
+ *     file; then {@code <ref>} as a fully-qualified Java class name.
+ */
+@Builder
+public record Fragment(String ref) implements Component {}

--- a/backend/shared/uidl/uidl-schema.json
+++ b/backend/shared/uidl/uidl-schema.json
@@ -1237,6 +1237,8 @@
       }, {
         "$ref" : "#/$defs/FormSubSection"
       }, {
+        "$ref" : "#/$defs/Fragment"
+      }, {
         "$ref" : "#/$defs/FullWidth"
       }, {
         "$ref" : "#/$defs/Funnel"
@@ -2678,6 +2680,19 @@
           "type" : "string"
         },
         "cssClasses" : {
+          "type" : "string"
+        }
+      }
+    },
+    "Fragment" : {
+      "type" : "object",
+      "required" : [ "type" ],
+      "properties" : {
+        "type" : {
+          "type" : "string",
+          "const" : "Fragment"
+        },
+        "ref" : {
           "type" : "string"
         }
       }

--- a/doc/astro.config.mjs
+++ b/doc/astro.config.mjs
@@ -324,6 +324,7 @@ export default defineConfig({
 						{ slug: 'java-ui-definition/client-side-logic' },
 						{ slug: 'java-ui-definition/yaml-ui-definition' },
 						{ slug: 'java-ui-definition/route-registry' },
+						{ slug: 'java-ui-definition/fragments' },
 						{ slug: 'java-ui-definition/domain-vocabulary', label: 'Build Your Domain Vocabulary' },
 						{
 							label: 'Components',

--- a/doc/src/content/docs/java-ui-definition/fragments.md
+++ b/doc/src/content/docs/java-ui-definition/fragments.md
@@ -1,0 +1,137 @@
+---
+title: "Fragments"
+---
+
+A **fragment** is a page-shaped thing with no page. It holds one component, or a list of them, and
+nothing else — no route, no title, no chrome — and it can be used anywhere a component can.
+
+Where a page answers *"what does this URL show"*, a fragment answers *"what does this **piece** look
+like, wherever it appears"*.
+
+## Defining one
+
+Exactly as you would define a page, in a YAML file under `specs/ui/fragments/`:
+
+```yaml
+# src/main/resources/specs/ui/fragments/address-block.yaml
+content:
+  - type: FormField
+    id: street
+    label: Street
+    dataType: string
+  - type: FormField
+    id: city
+    label: City
+    dataType: string
+```
+
+When the fragment is a single component, the file *is* that component — no envelope:
+
+```yaml
+# src/main/resources/specs/ui/fragments/legal-notice.yaml
+type: Text
+text: "Prices include VAT."
+```
+
+## Using one
+
+```yaml
+type: FormLayout
+content:
+  - type: FormField
+    id: name
+    label: Name
+  - type: Fragment
+    ref: address-block
+```
+
+or from Java:
+
+```java
+FormLayout.builder()
+    .content(List.of(
+        FormField.builder().id("name").label("Name").build(),
+        new Fragment("address-block")))
+    .build();
+```
+
+Fragments compose: a fragment may use another. A cycle is reported in the log and rendered as
+nothing, rather than taken as an invitation to recurse.
+
+## It splices, it does not wrap
+
+A fragment standing for **several** components is spliced into its parent's content:
+
+| Authored | Rendered |
+|---|---|
+| `FormLayout[ name, Fragment(address-block) ]` | `FormLayout[ name, street, city ]` |
+
+This is the property that makes "usable anywhere a component is" true rather than aspirational. A
+wrapper would put two fields into one grid cell — so the places reuse matters most, forms and grids,
+would be exactly the places fragments could not go.
+
+The one exception is a slot that holds a single component by construction, such as
+`Container.content`. There is nowhere to splice into, so a multi-component fragment is stacked in a
+bare `VerticalLayout`. Give such a fragment its own root when you care about the container.
+
+## Binding
+
+There is **no parameter-passing mechanism**, and that is deliberate. A fragment is inlined *before*
+binding, so its fields bind against the page that used it, by the same convention as everywhere
+else: a `FormField id="street"` inside a fragment binds to the hosting ModelView's `street`
+property, and a `Button actionId="save"` to its `save()` method.
+
+The consequence to know: a fragment is a piece of **layout vocabulary**, not a component with its
+own private state. Two pages using `address-block` each bind it to their own `street` and `city`.
+
+## Where fragments live at runtime: nowhere
+
+Fragments are resolved and inlined **server-side, before anything is mapped to DTOs**. They never
+appear on the wire.
+
+That is not an implementation detail — it is why the feature works everywhere at once:
+
+- No renderer has to learn the concept. Vaadin, Redwood, React Native and both IDE plugins support
+  fragments without a line of renderer code, and a renderer added next year does too.
+- A [static bundle](/java-user-manual/build/static-bundle/) stays self-contained. A fragment node
+  on the wire would be a reference the bundle has no server to follow.
+
+## Fragments in Java
+
+`ref` may also name a class:
+
+```yaml
+- type: Fragment
+  ref: com.acme.ui.AddressBlock
+```
+
+A `ComponentTreeSupplier` contributes the tree it returns — resolved per request, which is the
+reason to author a fragment in Java rather than in a file. A plain `Component` contributes itself.
+
+Fragments can also be registered in code, and a registration wins over a file of the same name:
+
+```java
+FragmentRegistry.instance().register("legal-notice", List.of(new Text("…")));
+```
+
+## When a ref resolves to nothing
+
+The fragment renders as no content, and the miss is logged. A page is not worth taking down over
+one piece of it: the alternative turns a typo in one ref into a 500 on every request to every page
+that mentions it.
+
+## Not to be confused with
+
+`UIFragmentDto` — the wire's name for an *increment of UI* returned by an action. Unrelated. The
+fragment on this page is an authoring-time concept and never reaches that layer.
+
+## Availability
+
+| Port | Fragments |
+|---|---|
+| Java | ✅ |
+| .NET | — |
+| Python | — |
+
+The ports read the same YAML shapes but do not resolve `Fragment` yet; a page that uses one renders
+without it there.

--- a/doc/src/content/docs/java-ui-definition/yaml-ui-definition.md
+++ b/doc/src/content/docs/java-ui-definition/yaml-ui-definition.md
@@ -147,6 +147,18 @@ IntelliJ will now provide autocompletion and validation for all YAML files under
 
 ---
 
+## Fragments
+
+A YAML file under `specs/ui/fragments/` is not a page but a **fragment** — one component, or a list
+of them, usable anywhere a component is:
+
+```yaml
+- type: Fragment
+  ref: address-block
+```
+
+See [Fragments](/java-ui-definition/fragments/).
+
 ## `layoutDelta:` — keep inference alive
 
 A page can carry a **`layoutDelta:`** instead of a `layout:`. The difference matters more than it

--- a/doc/src/content/docs/reference/parity.md
+++ b/doc/src/content/docs/reference/parity.md
@@ -67,6 +67,7 @@ for the surface below (verified by golden-JSON tests in `backend/dotnet/test` an
 | Structure ETag / template-ref (`structureHash` + request `knownStructureHash` → omit the component when unchanged) | ✅ | ✅ | ✅ |
 | ModelView bindable contract (`__contract__` sync action → fields + actions on `appData._contract`, for the visual-builder tooling) | ✅ | ✅ | ✅ |
 | Visual-builder live preview (`__preview__` sync action → renders arbitrary YAML page text; the plugin's preview pane) | ✅ | ✅ | ✅ |
+| [Fragments](/java-ui-definition/fragments/) (`specs/ui/fragments/<ref>.yaml` or a class ref; spliced into the parent's content, resolved server-side so they never reach the wire). The ports parse the YAML but ignore `Fragment`, so a page that uses one renders without that piece there | ✅ | — | — |
 | YAML pages bound to a ModelView (`specs/ui/<route>.yaml` with `modelView:` → the file supplies the layout, the class supplies state + actions; on the classpath in Java, under the cwd — `MATEU_SPECS_DIR` — in the ports) | ✅ | ✅ | ✅ |
 | Static-view skip (`@StaticView`/`[StaticView]`/`@static_view` → `staticView` flag; client caches the full response for the session and skips the round-trip on return) | ✅ | ✅ | ✅ |
 | Sticky sections index (`@Toc`) | ✅ | ✅ | ✅ |


### PR DESCRIPTION
A **fragment** is a page-shaped thing with no page: one component, or a list of them, and nothing else — no route, no title, no chrome. Where a page answers *"what does this URL show"*, a fragment answers *"what does this **piece** look like, wherever it appears"*.

```yaml
# specs/ui/fragments/address-block.yaml
content:
  - type: FormField
    id: street
    label: Street
  - type: FormField
    id: city
    label: City
```

```yaml
# any page, or any Java tree
- type: Fragment
  ref: address-block
```

Definitions come from `specs/ui/fragments/<ref>.yaml`, an explicit `.yaml` classpath path, a fully-qualified class name (a `ComponentTreeSupplier` resolves per request), or `FragmentRegistry.instance().register(...)` — registration wins over a file, the same precedence a route registration has over the route convention.

### It splices, it does not wrap

| Authored | Rendered |
|---|---|
| `FormLayout[ name, Fragment(address-block) ]` | `FormLayout[ name, street, city ]` |

This is the decision the whole feature rests on. A wrapper would put two fields in one grid cell, so forms and grids — the places reuse matters most — would be exactly where fragments could not go.

That splice is also why `FragmentExpander` walks the tree generically over record components rather than teaching each of the ~36 layout mappers about fragments: the rule lives in one place, and a layout added next year inherits it. All 111 uidl components are records, so the walker rebuilds through canonical constructors and returns the **same instance** when nothing changed — the common case costs one reflective pass and no allocation.

The one exception is a slot that holds a single component by construction (`Container.content`): there is nowhere to splice into, so the pieces are stacked in a bare `VerticalLayout`. Dropping all but the first would be a silent wrong render.

### Fragments never reach the wire

Expansion happens server-side, before anything maps to DTOs. That is not an implementation detail:

- No renderer learns the concept. Vaadin, Redwood, React Native and both IDE plugins get fragments with zero renderer code, and so does a renderer added later.
- A static bundle stays self-contained — a `Fragment` node on the wire would be a reference the bundle has no server to follow. (The bundle exporter runs the real action pipeline, so this comes for free.)

`FragmentWireSyncTest` runs a real action end to end and asserts what arrives is three spliced children, not a fragment.

### No parameters, deliberately

Because inlining happens *before* binding, a fragment's fields bind against the page that used it, by the same convention as everywhere else — `FormField id="street"` → the hosting ModelView's `street`. A fragment is **layout vocabulary**, not a component with private state. Two pages using `address-block` each bind it to their own fields.

### Failure modes

A missing ref costs the fragment, not the page: a typo in one ref should not be a 500 on every request to every page that mentions it. Cycles are reported with the include chain (`loop-a -> loop-b -> loop-a`) and render as nothing.

### Naming

`Fragment` here is unrelated to `UIFragmentDto`, the wire's name for an increment of UI returned by an action. Different layer, and this one never reaches it — but the collision is real and the javadoc and docs both say so. Happy to rename to `Partial`/`Include` if you'd rather keep "fragment" meaning one thing in this codebase.

### Not in this PR

.NET and Python parse the YAML but ignore `Fragment`; the parity matrix carries the row.

---

882 core tests, 0 failures. `uidl-schema.json` regenerated, so the visual editor and both IDE plugins autocomplete `Fragment` already.

Also ignores `.dev/` wholesale — those Oracle VB scratch clones dragged 94k files into a commit once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)