### PR TITLE
fix(core,dtos): deep-link into a remote whose routes carry the menu path

### DIFF
--- a/backend/shared/core/src/main/java/io/mateu/core/application/runaction/RemoteMenuHandler.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/runaction/RemoteMenuHandler.java
@@ -51,18 +51,39 @@ public class RemoteMenuHandler {
       AppShell app,
       HttpRequest httpRequest,
       RunActionCommand command) {
-    var routeWithinApp = routeWithinApp(remoteMenu, route);
     return fetchRemoteAppDto(remoteMenu, httpRequest, command)
         .flatMap(
-            appDto ->
-                ownsRoute(appDto, routeWithinApp)
-                    ? Mono.just(
-                        app.withHomeRoute(routeWithinApp)
-                            .withHomeBaseUrl(remoteMenu.baseUrl())
-                            .withHomeServerSideType(appDto.homeServerSideType())
-                            .withHomeConsumedRoute(appDto.homeConsumedRoute())
-                            .withHomeUriPrefix(""))
-                    : Mono.empty());
+            appDto -> {
+              var claimed = claimedRoute(appDto, remoteMenu, route);
+              return claimed == null
+                  ? Mono.empty()
+                  : Mono.just(
+                      app.withHomeRoute(claimed)
+                          .withHomeBaseUrl(remoteMenu.baseUrl())
+                          .withHomeServerSideType(appDto.homeServerSideType())
+                          .withHomeConsumedRoute(appDto.homeConsumedRoute())
+                          .withHomeUriPrefix(""));
+            });
+  }
+
+  /**
+   * Which of the two candidate routes the remote actually claims, or null if neither: the route
+   * with the shell's menu path stripped ({@code /forms/tasks} → {@code /tasks}, the convention) or
+   * the route VERBATIM — a remote may declare its own routes already prefixed with the same path
+   * ({@code /forms/tasks} is literally what its menu says, which is also what the frontend sends
+   * when the user clicks that menu entry). Stripping by convention alone mounts a route the remote
+   * does not have, and the page renders "Not found" — the deep-link half of a screen that works
+   * fine through the menu.
+   */
+  private String claimedRoute(AppDto appDto, RemoteMenu remoteMenu, String route) {
+    if (route == null) {
+      return null;
+    }
+    var routeWithinApp = routeWithinApp(remoteMenu, route);
+    if (ownsRoute(appDto, routeWithinApp)) {
+      return routeWithinApp;
+    }
+    return ownsRoute(appDto, route) ? route : null;
   }
 
   /**
@@ -145,8 +166,11 @@ public class RemoteMenuHandler {
                 mountRoute = routeWithinApp;
                 mountConsumedRoute = remoteMenu.consumedRoute();
               } else {
-                // Page route: resolves within the app with the AppDto's home consumed route.
-                mountRoute = routeWithinApp;
+                // Page route: resolves within the app with the AppDto's home consumed route. Which
+                // route the remote actually claims is asked, not assumed — see claimedRoute; when
+                // it claims neither, the stripped one keeps the previous behaviour.
+                var claimed = claimedRoute(app, remoteMenu, command.route());
+                mountRoute = claimed != null ? claimed : routeWithinApp;
                 mountConsumedRoute = app.homeConsumedRoute();
               }
               return MicroFrontend.builder()

--- a/backend/shared/core/src/test/java/io/mateu/core/application/RemoteMenuPrefixedDeepLinkSyncTest.java
+++ b/backend/shared/core/src/test/java/io/mateu/core/application/RemoteMenuPrefixedDeepLinkSyncTest.java
@@ -1,0 +1,150 @@
+package io.mateu.core.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.mateu.core.application.out.MateuHttpClient;
+import io.mateu.core.testutil.TestMateu;
+import io.mateu.dtos.AppDto;
+import io.mateu.dtos.ClientSideComponentDto;
+import io.mateu.dtos.ComponentDto;
+import io.mateu.dtos.MenuOptionDto;
+import io.mateu.dtos.RunActionRqDto;
+import io.mateu.dtos.UIFragmentDto;
+import io.mateu.dtos.UIIncrementDto;
+import io.mateu.uidl.annotations.Menu;
+import io.mateu.uidl.annotations.Title;
+import io.mateu.uidl.annotations.UI;
+import io.mateu.uidl.data.RemoteMenu;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Deep-link into a remote whose menu routes are PREFIXED with the shell's menu path — the other
+ * half of {@link RemoteMenuRootDeepLinkSyncTest}, whose remote declares them unprefixed.
+ *
+ * <p>Real case: the EventConductor demo console. Its shell declares {@code @Menu RemoteMenu forms =
+ * new RemoteMenu("/_forms")} (menu path {@code /forms}, the field name) and the forms service
+ * declares its own routes as {@code /forms/tasks} — the SAME prefix, so stripping it by convention
+ * mounted {@code /tasks}, a route the remote does not have, and the page rendered "Not found."
+ * Clicking that entry in the menu worked all along: the menu option carries the remote's route
+ * verbatim and the browser calls the remote directly, so only the URL/deep-link path (resolved
+ * server-to-server by the shell) went through the stripping.
+ *
+ * <p>{@link TestMateu} runs the whole server side, so the mounted home asserted here is what the
+ * frontend receives.
+ */
+class RemoteMenuPrefixedDeepLinkSyncTest {
+
+  @SuppressWarnings("unused")
+  @UI("")
+  @Title("Demo Console")
+  public static class ShellRoot {
+    // No withPath(): the menu path defaults to the field name, "/forms" — which is also the prefix
+    // the remote uses for its own routes.
+    @Menu RemoteMenu forms = new RemoteMenu("/_forms");
+  }
+
+  /** A remote that declares its routes WITH the /forms prefix (like the demo's forms service). */
+  public static class FakeForms implements MateuHttpClient {
+    @Override
+    public CompletableFuture<UIIncrementDto> send(String baseUrl, RunActionRqDto request) {
+      return send(baseUrl, request, null);
+    }
+
+    @Override
+    public CompletableFuture<UIIncrementDto> send(
+        String baseUrl, RunActionRqDto request, String authorization) {
+      var appDto =
+          AppDto.builder()
+              .route("")
+              .title("Forms")
+              .homeRoute("_no_home_route")
+              .homeConsumedRoute("")
+              .homeServerSideType("io.mateu.workflow.infra.in.ui.FormsHome")
+              .menu(
+                  List.of(
+                      MenuOptionDto.builder()
+                          .label("Forms")
+                          .path("/forms")
+                          .route("/forms")
+                          .submenus(
+                              List.of(
+                                  MenuOptionDto.builder()
+                                      .label("Tasks")
+                                      .path("/forms/tasks")
+                                      .route("/forms/tasks")
+                                      .build()))
+                          .build()))
+              .build();
+      var component = new ClientSideComponentDto(appDto, "forms_app", List.of(), null, null, null);
+      var fragment = UIFragmentDto.builder().component(component).build();
+      return CompletableFuture.completedFuture(
+          UIIncrementDto.builder().fragments(List.of(fragment)).build());
+    }
+  }
+
+  static TestMateu mateu;
+
+  @BeforeEach
+  void boot() {
+    mateu = TestMateu.withUisAndBeans(List.of(new FakeForms()), ShellRoot.class);
+  }
+
+  @AfterEach
+  void shutdown() {
+    mateu.close();
+  }
+
+  private static AppDto shellApp(UIIncrementDto increment) {
+    for (var fragment : increment.fragments()) {
+      var found = findApp(fragment.component());
+      if (found != null) {
+        return found;
+      }
+    }
+    return null;
+  }
+
+  private static AppDto findApp(ComponentDto component) {
+    if (component instanceof ClientSideComponentDto cs) {
+      if (cs.metadata() instanceof AppDto app) {
+        return app;
+      }
+      for (var child : cs.children()) {
+        var found = findApp(child);
+        if (found != null) {
+          return found;
+        }
+      }
+    }
+    return null;
+  }
+
+  private UIIncrementDto viaUrl(String route) {
+    return mateu.run(
+        RunActionRqDto.builder().route(route).consumedRoute("_empty").actionId("").build());
+  }
+
+  @Test
+  void pageDeepLinkMountsTheRouteTheRemoteDeclares() {
+    var app = shellApp(viaUrl("/forms/tasks"));
+    assertThat(app).isNotNull();
+    assertThat(app.homeBaseUrl()).isEqualTo("/_forms");
+    // NOT "/tasks": the remote's menu says "/forms/tasks", and mounting the stripped route made the
+    // remote answer "Not found." while the very same screen opened fine from the menu.
+    assertThat(app.homeRoute()).isEqualTo("/forms/tasks");
+  }
+
+  @Test
+  void rootDeepLinkStillMountsTheMenuPathAsHomeContent() {
+    var app = shellApp(viaUrl("/forms"));
+    assertThat(app).isNotNull();
+    assertThat(app.homeBaseUrl()).isEqualTo("/_forms");
+    assertThat(app.homeRoute()).isNotIn("_no_home_route", "_page", "");
+    assertThat(app.homeRoute()).isEqualTo("/forms");
+    assertThat(app.homeConsumedRoute()).isEqualTo("/forms");
+  }
+}

--- a/backend/shared/core/src/test/java/io/mateu/core/application/WireRequestCompatibilityTest.java
+++ b/backend/shared/core/src/test/java/io/mateu/core/application/WireRequestCompatibilityTest.java
@@ -1,0 +1,48 @@
+package io.mateu.core.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.mateu.dtos.RunActionRqDto;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Forward compatibility of the inbound wire request across a federated deployment: a shell built
+ * against a NEWER Mateu talks server-to-server to a remote built against an older one, so the
+ * remote receives fields it has never heard of. Rejecting them answers HTTP 400 to the shell's
+ * deep-link resolution while the same screen keeps working through the menu (there the browser
+ * calls the remote directly, with the request shape that remote's own frontend produces) — a
+ * failure mode that only shows up by URL. Seen for real with {@code knownStructureHash} against a
+ * 3.0-alpha.275 service.
+ */
+class WireRequestCompatibilityTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  void anUnknownFieldFromANewerShellDoesNotBreakTheRequest() {
+    var json =
+        """
+        {"componentState":{},"appState":{},"parameters":null,"initiatorComponentId":"_ux",\
+        "consumedRoute":"_empty","actionId":"","route":"/forms/tasks","serverSideType":"",\
+        "serverSideComponentRoute":null,"knownStructureHash":null,\
+        "aFieldAddedInSomeFutureRelease":"whatever"}
+        """;
+
+    assertThatCode(() -> objectMapper.readValue(json, RunActionRqDto.class))
+        .doesNotThrowAnyException();
+
+    var request = readRequest(json);
+    assertThat(request.route()).isEqualTo("/forms/tasks");
+    assertThat(request.consumedRoute()).isEqualTo("_empty");
+  }
+
+  private RunActionRqDto readRequest(String json) {
+    try {
+      return objectMapper.readValue(json, RunActionRqDto.class);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/backend/shared/dtos/src/main/java/io/mateu/dtos/RunActionRqDto.java
+++ b/backend/shared/dtos/src/main/java/io/mateu/dtos/RunActionRqDto.java
@@ -1,9 +1,19 @@
 package io.mateu.dtos;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.Collections;
 import java.util.Map;
 import lombok.Builder;
 
+/**
+ * The inbound wire request. Unknown properties are IGNORED because federation puts two independent
+ * deployments on this contract: a shell built against a newer Mateu sends fields (the last one
+ * added was {@code knownStructureHash}) that an older service has never heard of. Rejecting them
+ * makes the remote answer HTTP 400 to the shell's server-to-server call — which is exactly the
+ * deep-link path, so the screen works through the menu (the browser talks to the remote directly,
+ * with its own older-shaped request) and fails by URL.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
 @Builder
 public record RunActionRqDto(
     Map<String, Object> componentState,


### PR DESCRIPTION
A screen served by a federated remote opened fine from the menu and rendered **"Not found"** when the same URL was entered or reloaded. Found while checking the EventConductor demo console (shell aggregating forms/workflow/booking through `@Menu RemoteMenu`).

## Why the two paths differ

A menu option carries `baseUrl` + `route`, so the **browser** calls the remote directly. A URL lands on the **shell**, which has to resolve it server-to-server through `RemoteMenuHandler` — and only that path went through the menu-path stripping.

## The fix

**`RemoteMenuHandler`** stripped the shell's menu path by convention (`/forms/tasks` → `/tasks`). A remote may declare its own routes *already prefixed* with that same path — the demo console's forms service literally says `/forms/tasks` in its menu — so the shell mounted a route the remote does not have. New `claimedRoute(...)` asks the remote's descriptor which of the two it claims instead of assuming: the stripped route wins when owned (previous behaviour, so remotes with unprefixed routes are untouched), the verbatim route otherwise. `tryResolveRoute` takes the same decision, so a deep link that matches no local menu resolves identically. The root deep-link case (`/forms`) is unchanged.

**`RunActionRqDto`** now ignores unknown properties. Federation puts two independent deployments on this contract: a shell built against a newer Mateu sends fields an older service has never heard of (`knownStructureHash` against a 3.0-alpha.275 service → HTTP 400) — again only on the server-to-server call, so again only by URL.

## Tests

- `RemoteMenuPrefixedDeepLinkSyncTest` (new) — remote with prefixed routes, modelled on the demo's real `AppDto`. Verified it **fails without the fix**: `expected "/forms/tasks" but was "/tasks"`.
- `WireRequestCompatibilityTest` (new) — an unknown field does not break deserialization.
- `RemoteMenuRootDeepLinkSyncTest` (existing, unprefixed remote) still green — the real regression risk here.
- Full core suite: **901 tests, 0 failures**.

## Verified end to end

Built the demo shell against this branch and redeployed it in the local stack: `http://localhost:8191/forms/tasks` typed in the address bar now renders the Tasks screen, same as via the menu.

Out of scope (local-stack config, not framework): the shell derives the remote's absolute URL from the browser's `Origin` header, so inside a container `localhost:8191` points at itself. A configurable internal base URL for server-to-server federation would be a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)