### PR TITLE
docs: give the data-authored half of the model its own altitude

### DIFF
--- a/doc/astro.config.mjs
+++ b/doc/astro.config.mjs
@@ -162,9 +162,11 @@ export default defineConfig({
 						{ slug: 'mateu-about/what-is-mateu' },
 						{ slug: 'mateu-about/why-mateu', label: 'Why Mateu' },
 						{ slug: 'mateu-about/how-mateu-works', label: 'How Mateu Works' },
+						{ slug: 'mateu-about/the-model', label: 'The Model' },
 						{ slug: 'mateu-about/architecture', label: 'Technical Architecture' },
 						{ slug: 'mateu-about/system-architecture' },
 						{ slug: 'mateu-about/comparison' },
+						{ slug: 'mateu-about/comparison-low-code', label: 'Mateu vs Visual Builders' },
 						{ slug: 'mateu-about/mateu-and-ai', label: 'Mateu and AI' },
 						{ slug: 'mateu-about/disclaimer' },
 						{
@@ -324,6 +326,7 @@ export default defineConfig({
 						{ slug: 'java-ui-definition/client-side-logic' },
 						{ slug: 'java-ui-definition/yaml-ui-definition' },
 						{ slug: 'java-ui-definition/route-registry' },
+						{ slug: 'java-ui-definition/yaml-app-shell', label: 'App Shell as Data' },
 						{ slug: 'java-ui-definition/partials' },
 						{ slug: 'java-ui-definition/domain-vocabulary', label: 'Build Your Domain Vocabulary' },
 						{

--- a/doc/src/content/docs/index.mdx
+++ b/doc/src/content/docs/index.mdx
@@ -57,6 +57,32 @@ public class Orders extends AutoCrud<Order> {}
 
 Wondering how this differs from a React SPA, Vaadin, or a CRUD generator? See [Mateu vs the traditional stack →](/mateu-about/comparison/).
 
+## Or say the same thing as data
+
+The Java class is one authoring surface. The same screen can be written as YAML — a page definition,
+a route registry and an app shell — and a whole application authored that way needs no Mateu Java at
+all:
+
+```yaml
+# specs/ui/routes.yaml
+app:
+  title: Back office
+  menu:
+    - type: RouteLink
+      label: Orders
+      route: orders
+routes:
+  - route: orders
+    definition: orders.yaml
+```
+
+Both halves meet in the same component model, share the same published JSON Schema (so your editor
+autocompletes them), and can be mixed on one screen — layout from YAML, behaviour from Java. There
+is a [visual editor](/java-ui-definition/yaml-ui-definition/) that writes those files, and the files
+live in your repository, in your build, under review.
+
+[The model →](/mateu-about/the-model/) · [Mateu vs visual builders →](/mateu-about/comparison-low-code/)
+
 ## What you can build
 
 <CardGrid>
@@ -84,6 +110,7 @@ Mateu's UI travels as a wire protocol, not as framework code. That means:
 
 - **Polyglot servers** — write your UI in [Java](/java-user-manual/start-here/quickstart/), [Kotlin](/kotlin-user-manual/), [C#](/csharp-user-manual/) or [Python](/python-user-manual/) (C# and Python are early-stage); they all emit the same UI model.
 - **Multi-frontend** — the same backend renders on [two web design systems](/design-systems/) (Vaadin and Oracle Redwood) and on [native desktop and mobile](/native/) (the IntelliJ plugin on the desktop, React Native on iOS/Android), without touching your code.
+- **Several ways in, one model** — annotations, YAML, the visual editor and [Figma](/design-systems/figma/) all produce [the same model](/mateu-about/the-model/), with a generated schema and written-down precedence rules keeping them in step.
 
 ## Recommended path
 

--- a/doc/src/content/docs/java-ui-definition/yaml-app-shell.md
+++ b/doc/src/content/docs/java-ui-definition/yaml-app-shell.md
@@ -1,0 +1,105 @@
+---
+title: "App shell as data (app:)"
+description: "Declare a mount's chrome — title, menu, variant, widgets — in the app: block of routes.yaml, the data-driven counterpart of an @App class."
+---
+
+**Status:** ✅ Implemented (Java server; Spring MVC auto-configures the HTTP surface)
+
+A **mount** is a UI application served at a base path. `@UI("/back-office")` declares one, and the
+annotated class carries the chrome around it: title, logo, menu, variant.
+
+The `app:` block of [`specs/ui/routes.yaml`](/java-ui-definition/route-registry/) declares that same
+chrome **as data**. The chrome lives in the same file as the routes it wraps because both are
+properties of the same mount — `routes:` says what is inside, `app:` says what surrounds it.
+
+```yaml
+app:
+  title: Back office
+  subtitle: Authored entirely in YAML
+  variant: MENU_ON_TOP
+  menu:
+    - type: RouteLink
+      label: Orders
+      route: orders
+      icon: vaadin:cart
+    - type: RouteLink
+      label: Users
+      route: users
+      icon: vaadin:users
+
+routes:
+  - route: orders
+    definition: orders.yaml
+  - route: users
+    definition: users.yaml
+```
+
+With those two blocks and the page definitions they point at, the mount needs **no Mateu Java at
+all** — see `demo/demo-app-definition` (port 8099), whose only Java file is the Spring Boot entry
+point.
+
+## What the block accepts
+
+| Key | Meaning |
+|---|---|
+| `title`, `subtitle`, `pageTitle` | header texts |
+| `logo`, `favicon` | assets |
+| `variant` | `AppVariant` — `AUTO`, `MENU_ON_TOP`, `HAMBURGUER_MENU`, `TABS`, `TILES` |
+| `layout` | `AppLayout` — `SINGLE_SLOT` (default) or `SPLIT` |
+| `drawerClosed` | start with the drawer collapsed |
+| `style`, `cssClasses` | styling hooks |
+| `route` | the mount's own route |
+| `menu` | a list of navigation items |
+| `widgets` | a list of components rendered in the header |
+| `homeRoute` | what the mount loads at its root |
+
+`menu:` and `widgets:` deserialize through the **same `type:` discriminator as page layouts**, so
+every navigation type (`RouteLink`, `Menu`, `RemoteMenu`, …) and every component of the catalog is
+available with no extra wiring, and the same [JSON Schema IntelliSense](/java-ui-definition/yaml-ui-definition/#intellisense-setup)
+applies while you edit.
+
+### `homeRoute` matters
+
+A YAML mount has no class to carry `@HomeRoute`, so the home defaults to the **first navigable menu
+item**. Declare `homeRoute:` explicitly to point somewhere else. Do not leave a mount with neither:
+the shell would load its own root route, which is the shell again.
+
+## Serving it
+
+For **Spring MVC**, `mvc-core` auto-configures the HTTP surface (the SPA at `/` and sync at
+`/mateu/v3/**`) when the classpath has a `specs/ui/routes.yaml` **with an `app:` block** — the work
+the annotation processor normally does per `@UI` class, which cannot happen when there is no class.
+It stands down as soon as a generated controller exists, so adding an `@UI` class later changes
+nothing.
+
+Your application is then a Spring Boot entry point plus resources:
+
+```text
+src/main/
+├── java/…/AppDefinitionDemoApplication.java   ← @SpringBootApplication, nothing else
+└── resources/specs/ui/
+    ├── routes.yaml        ← app: + routes:
+    ├── orders.yaml
+    └── users.yaml
+```
+
+## The visual editor edits this
+
+Open `routes.yaml` in the visual editor and it presents the mount as two tabs: **Routes**, a table
+over the route registry, and **App**, a form over this block with a link/group/separator menu tree.
+Each tab preserves the other's block verbatim, so editing one never rewrites the other.
+
+## Limits
+
+Not carried by the block yet — these are read reflectively off an `@App` class and still need one:
+theme toggle, command center / chromeless, SSE / MCP / upload URLs, `@AppContext` selectors,
+notifications, global search and FABs.
+
+A broken or unparseable descriptor never takes the application down: it is treated as "no app
+block", exactly like the route registry.
+
+## Next
+
+- [Route registry](/java-ui-definition/route-registry/) — the `routes:` half of the same file
+- [YAML UI definition](/java-ui-definition/yaml-ui-definition/) — the page definitions it points at
+- [The model](/mateu-about/the-model/) — how this fits with the annotated half

--- a/doc/src/content/docs/mateu-about/comparison-low-code.md
+++ b/doc/src/content/docs/mateu-about/comparison-low-code.md
@@ -1,0 +1,99 @@
+---
+title: "Mateu vs visual builders"
+description: "How Mateu differs from low-code and internal-tool platforms — by where the model lives, who decides at runtime, and what happens when you outgrow the tool."
+---
+
+Mateu now has a component catalog with a published schema, screens authored as YAML and a visual
+editor. That puts it in the same conversation as Oracle Visual Builder, OutSystems, Mendix, Retool,
+Appsmith and Budibase — so it is worth being precise about where the overlap actually is.
+
+The overlap is the **authoring surface**. The difference is everything around it: where the model
+lives, who decides what happens at runtime, and what it costs you to leave.
+
+This is deliberately not a feature matrix. Feature lists change every quarter; the differences below
+are structural.
+
+## Where the model lives
+
+A visual builder keeps your application in its own store — a project in its cloud, a proprietary
+file, a database only the platform reads. The tool is the way in and usually the only way in.
+
+A Mateu model is **files in your repository**: `.java` classes and `.yaml` definitions, next to the
+code they drive. They go through your pull requests, your code review, your branches, your CI, your
+release. The visual editor is one way to write those files; a text editor is another; both produce
+the same lines in the same commit.
+
+That single difference is what the rest of this page is downstream of.
+
+## Who decides at runtime
+
+| | Visual builders | Mateu |
+|---|---|---|
+| Data access | connectors and bindings configured in the tool | your repositories, your use cases, your transactions |
+| Business rules | expressions and flows in the platform's runtime | your domain code, in your language |
+| Auth | the platform's model, mapped to yours | your framework's security, already in the request |
+| Where integration happens | the browser, per page | the server: one endpoint, one protocol |
+
+Mateu's runtime spine is a wire protocol between your backend and a renderer. The screen is derived
+from your model, but *what happens when the user presses the button* is a method you wrote, in the
+application you already had.
+
+## When you outgrow it
+
+Every model-driven tool meets the same wall: one screen in forty needs to be something the templates
+do not cover. What matters is not whether it can be done, but **what you keep when you drop down** —
+if the answer is "rewrite it outside the tool", the savings on the other thirty-nine stop counting.
+
+In Mateu that screen builds its own component tree by hand and keeps its state, its actions, its
+validation, its routing and the surrounding app chrome. Those guarantees are pinned by a test on
+purpose, because a promise nothing checks erodes quietly.
+
+## Leaving
+
+- The model is already in your repo — there is nothing to export.
+- `mateu:bundle` renders the declared screens into a static bundle a CDN serves.
+- `mateu:openapi` exports the same declarations as an OpenAPI document.
+- The wire protocol is documented and the renderer contract is public, so a renderer you write
+  yourself is a supported path, not a hack.
+
+## Backend language
+
+Visual builders are largely indifferent to what your backend is written in — you integrate with it
+over HTTP like any other client. Mateu goes the other way: the UI is defined **in** the backend, in
+Java, Kotlin, C# or Python, sharing its model and its validation. If you have no backend to speak
+of, that is not an advantage; if you have one and it owns the business rules, it removes an entire
+translation layer.
+
+## What visual builders do better
+
+Plainly, because it matters when choosing:
+
+- **Non-developers can build screens.** Mateu's authoring surface is friendlier than it was, but its
+  audience is still a team with a repository and a build.
+- **Batteries included** — hosting, user management, connectors to hundreds of SaaS products,
+  environments and audit trails, all in the box.
+- **Free-form visual layout.** A WYSIWYG canvas positions anything anywhere. Mateu derives layout
+  from the model and lets you adjust it; it is not a design tool.
+- **Governance for a large citizen-developer population** is a product feature there, and not
+  something Mateu attempts.
+
+## Choosing
+
+| Pick a visual builder when | Pick Mateu when |
+|---|---|
+| the builders are not developers | the builders own a backend |
+| the app is mostly connectors over SaaS data | the logic lives in your domain code |
+| you want hosting and governance in the box | you want the UI in the same repo, review and release as the code |
+| the screens are bespoke by design | the screens are forms, listings and workflows over your model |
+
+## A note on Oracle Visual Builder
+
+VB is also a **target**, not only a competitor: one of Mateu's renderers is a Visual Builder
+application, so a Mateu backend can be served through the Redwood/VB runtime and its design system.
+See [Oracle Redwood](/design-systems/oracle-redwood/).
+
+## Next
+
+- [The model](/mateu-about/the-model/) — what is actually being authored, and the rules that keep it honest
+- [Mateu vs the traditional stack](/mateu-about/comparison/) — the comparison with a hand-written SPA
+- [When to use Mateu](/when-to-use-mateu/)

--- a/doc/src/content/docs/mateu-about/comparison.md
+++ b/doc/src/content/docs/mateu-about/comparison.md
@@ -30,7 +30,7 @@ One step. One file.
 
 | Concern | Traditional stack | Mateu |
 |---|---|---|
-| UI definition | frontend components (JSX / templates) | Java ViewModel class |
+| UI definition | frontend components (JSX / templates) | Java ViewModel class — or the same model [authored as YAML](/java-ui-definition/yaml-ui-definition/) |
 | Validation | frontend library (Zod, Yup, etc.) + backend | Bean Validation, once |
 | Routing | frontend router (React Router, etc.) | `@UI` + `@Route` annotations |
 | Navigation | frontend nav config | `@Menu` annotations |
@@ -47,6 +47,13 @@ One step. One file.
 Consumer-facing products with complex animations, highly custom interactions, and brand-specific visual design benefit from a dedicated frontend application. Frontend frameworks give experienced teams precise control over the user experience.
 
 Mateu does not try to compete with this. The target is the class of applications where the frontend split is cost without commensurate benefit.
+
+## The other comparison
+
+Screens can also be authored as data and edited visually, which puts Mateu next to a different set
+of tools — Oracle Visual Builder, OutSystems, Retool and friends. That comparison turns on where the
+model lives and what happens when you outgrow the tool: see
+[Mateu vs visual builders](/mateu-about/comparison-low-code/).
 
 ## When to choose Mateu
 

--- a/doc/src/content/docs/mateu-about/the-model.md
+++ b/doc/src/content/docs/mateu-about/the-model.md
@@ -1,0 +1,121 @@
+---
+title: "The model"
+description: "One UI model, several ways to author it and several things that consume it — plus the rules that keep them from drifting apart."
+---
+
+A Mateu screen is not the Java class you happened to write it in. The class is **one way of saying
+it**. What travels on the wire, what the renderers paint, what the visual editor edits and what the
+static bundle exports is always the same thing:
+
+```text
+a component tree  +  the routes that reach it  +  the shell around them
+```
+
+That is the model. Everything else in this page follows from it being a real model — something with
+a schema, several producers, several consumers and written-down rules — rather than a convenient
+shape for one library's API.
+
+## Several ways to say the same thing
+
+| You author in | What it looks like |
+|---|---|
+| **Java / Kotlin** | `@UI` classes, annotations, fluent components |
+| **C# / Python** | attributes / decorators over the same catalog ([parity matrix](/reference/parity/)) |
+| **YAML** | [pages](/java-ui-definition/yaml-ui-definition/), a [route registry](/java-ui-definition/route-registry/), an [app shell](/java-ui-definition/yaml-app-shell/) |
+| **Visually** | the visual editor, which writes YAML back into your repo |
+| **Design** | Figma, through the published `contract.json` ([design pipeline](/design-systems/figma/)) |
+
+The same screen, twice. In Java:
+
+```java
+@UI("/orders")
+@Title("Orders")
+public class Orders extends AutoCrud<Order> {}
+```
+
+As data — a page definition plus the entry that routes to it:
+
+```yaml
+# specs/ui/orders.yaml
+type: VerticalLayout
+content:
+  - type: Text
+    text: Orders
+    size: xl
+```
+
+```yaml
+# specs/ui/routes.yaml
+routes:
+  - route: orders
+    definition: orders.yaml
+```
+
+Neither is the "real" one. They meet in the same model, and a screen can mix them: `@UISpec` takes
+its layout from YAML and its behaviour from Java, and a `layoutDelta:` records what a human
+rearranged on top of a layout the framework still infers on every request.
+
+## Several things consume it
+
+- **Three server runtimes** — Java/Kotlin, C# and Python emit the same wire model.
+- **Every renderer** — two web design systems (Vaadin, Oracle Redwood), React Native on mobile, the
+  IntelliJ plugin on the desktop. None of them knows how the screen was authored.
+- **The [static bundle](/java-user-manual/build/static-bundle/)** — `mateu:bundle` renders your
+  declared screens at build time into a `manifest.json` a CDN can serve.
+- **The [visual editor](/java-ui-definition/yaml-ui-definition/#the-visual-editor-writes-these)** —
+  reads the catalog straight from the generated schema, so it offers every component without anyone
+  maintaining a second list.
+- **External tooling** — the Figma contract ships inside the `io.mateu:uidl` jar at
+  `META-INF/mateu/contract.json`, so generators and importers read it from the artifact instead of
+  keeping a copy that drifts.
+- **`mateu:openapi`** — the same declarations exported as an OpenAPI document.
+
+## What makes it a model and not a config format
+
+A format is a way to write things down. A model has to survive being written down by several people
+and read by several tools, which takes rules:
+
+**The catalog has a published schema, generated from the source of truth.**
+`uidl-schema.json` and `routes-schema.json` are generated from the records themselves and pinned by
+a test, so adding a component without regenerating fails the build instead of shipping a schema that
+does not know about it. Editors point their YAML IntelliSense at them.
+
+**Precedence is written down: authored wins.** The annotation processor's index and the authored
+`routes.yaml` are two producers of one route table. The authored half replaces the derived entry
+outright — and the same order applies on the server, in the browser and in the ports, because route
+resolution runs in more than one place.
+
+**Human decisions are stored as deltas, not snapshots.** A `layoutDelta:` anchors to field ids and
+is re-applied to a freshly inferred tree on every request, so a field the model grows later still
+lands in its inferred place. A `layout:` is a snapshot that takes the screen out of inference for
+good — and the editor shows which of the two a page is on, so the moment a screen leaves inference
+is visible rather than silent.
+
+**Inference cannot flip in silence.** `PageFingerprint` produces a stable per-class signature meant
+for golden tests, so a change to the inference rules shows up as a failing diff instead of a screen
+that quietly became a different template.
+
+## Where the model stops
+
+Worth knowing before you plan around it:
+
+- **Rendering still goes through a server.** There is no client-side YAML renderer: a page authored
+  as data is served through the ordinary sync path. The static bundle covers the **initial load of
+  static routes**, precomputed at build time — live data comes from external endpoints and
+  **actions still need a backend**.
+- **`layoutDelta:` is served by the Java server.** The C# and Python ports parse the key and decline
+  the page rather than rendering it wrongly.
+- **The YAML app shell does not carry everything yet** — the flags read reflectively off an `@App`
+  class (theme toggle, command center, `@AppContext` selectors, notifications, global search, FABs)
+  still need that class. See [App shell as data](/java-ui-definition/yaml-app-shell/).
+- **The model is not meant to say everything.** When a screen needs to be something no template
+  covers, you drop to a component tree and build it by hand — and what you keep when you drop down
+  (state, actions, validation, routing, the surrounding chrome) is pinned by a test, because a
+  promise nothing checks degrades.
+
+## Next
+
+- [Mateu vs visual builders](/mateu-about/comparison-low-code/) — how this differs from a low-code platform
+- [Mateu vs the traditional stack](/mateu-about/comparison/) — how it differs from a SPA
+- [YAML UI definition](/java-ui-definition/yaml-ui-definition/) — authoring pages as data
+- [Route registry](/java-ui-definition/route-registry/) — routes as data

--- a/doc/src/content/docs/mateu-about/what-is-mateu.md
+++ b/doc/src/content/docs/mateu-about/what-is-mateu.md
@@ -52,8 +52,12 @@ Mateu is not:
 
 - a frontend framework or a React alternative
 - a stateful server-side rendering framework (like JSF or Wicket)
-- a low-code platform detached from your codebase
 - a code generator you run once and abandon
+
+There is a visual editor and screens can be authored as YAML, so the comparison with a low-code
+platform comes up — the difference is that a Mateu UI is **files in your repository**, going through
+your pull requests, your build and your release, never a project in someone's cloud. See
+[Mateu vs visual builders](/mateu-about/comparison-low-code/).
 
 Mateu is closer to an **inbound adapter** for your backend — the same way a REST controller exposes your application logic over HTTP, Mateu exposes it as a browser UI.
 
@@ -71,6 +75,18 @@ public record Product(
 ```
 
 From this model, Mateu can infer fields, forms, list columns, validation, and navigation. You create explicit view models only when the defaults are not enough.
+
+### Java is one way to say it
+
+The Java class is an authoring surface, not the model itself. The same screen can be authored as
+data — a [YAML page definition](/java-ui-definition/yaml-ui-definition/), a
+[route registry](/java-ui-definition/route-registry/) and an
+[app shell](/java-ui-definition/yaml-app-shell/) — and a mount authored entirely that way needs no
+Mateu Java at all. Both halves meet in the same component model, share the same published schema,
+and can be mixed on the same screen: layout from YAML, behaviour from Java.
+
+See [The model](/mateu-about/the-model/) for what is being authored, what consumes it, and the rules
+that keep the two halves from drifting.
 
 ## Two levels of control
 
@@ -124,6 +140,7 @@ Mateu is especially useful for:
 ## Next
 
 - [The Mateu Way](/the-mateu-way) — the golden path: six families, one starting class each
+- [The model](/mateu-about/the-model) — one model, several ways to author it, several things that consume it
 - [Why Mateu](/mateu-about/why-mateu) — the problem it solves and what you gain
 - [How Mateu works](/mateu-about/how-mateu-works) — mental model, building blocks, and the stateless cycle
 - [Build a full backoffice in 10 minutes](/build-a-full-backoffice-in-10-minutes)


### PR DESCRIPTION
Mateu's model can now be authored as data — YAML pages, a route registry, an `app:` shell block, a visual editor that writes those files, a Figma contract. All of it was **documented only at reference altitude**: every page that answers *what is Mateu* still described a Java-class-only framework, so a reader landing on the home page could not learn any of it existed. And `app.yaml`, the newest piece (#399), was documented **nowhere**.

## New pages

**`mateu-about/the-model`** — the page that was missing. One model; several ways to author it (Java/Kotlin, C#/Python, YAML, the editor, Figma); several things that consume it (three runtimes, the renderers, the static bundle, external tooling reading the packaged contract). Then the rules that keep those from drifting — schema generated from the records and pinned by a test, *authored wins*, `layoutDelta` instead of snapshots, `PageFingerprint` — and a **"where the model stops"** section: rendering still goes through a server, the bundle covers the initial load of static routes only, `layoutDelta` is Java-only, and the escape hatch for the screen no template covers.

**`mateu-about/comparison-low-code`** — the comparison people will make now that there is a visual editor (Oracle VB, OutSystems, Retool…). Framed on structural axes, **not** a feature matrix: where the model lives, who decides at runtime, what you keep when you outgrow it, leaving, backend language. Includes an honest *what visual builders do better* section, and notes that Oracle Visual Builder is also a render **target**, not only a competitor.

**`java-ui-definition/yaml-app-shell`** — `app.yaml` documented: the keys it accepts, why `homeRoute` matters (without it the shell loads itself), how `mvc-core` auto-configures a mount with no `@UI` class, the visual editor's two-tab view, and the flags the block does not carry yet.

## Edits

- `index.mdx` — an "Or say the same thing as data" section after the Java example, plus a bullet in *One protocol, many stacks*.
- `what-is-mateu` — the *"not a low-code platform detached from your codebase"* bullet became the positive claim it was hiding: the model is files in your repo, under review, in your build. Plus a *Java is one way to say it* subsection.
- `comparison` — the "UI definition" row now mentions YAML, and a pointer to the new comparison.
- `astro.config.mjs` — sidebar entries.

Docs site builds (331 pages); the new pages and every link they add resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)