### PR TITLE
feat(uidl,core): proxy mode for views that build their REST sources at runtime

### DIFF
--- a/backend/shared/core/src/main/java/io/mateu/core/application/runaction/RestSourceResolver.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/runaction/RestSourceResolver.java
@@ -6,6 +6,8 @@ import io.mateu.uidl.annotations.RestData;
 import io.mateu.uidl.annotations.RestListing;
 import io.mateu.uidl.annotations.RestOptions;
 import io.mateu.uidl.data.RestDataSource;
+import io.mateu.uidl.data.RestSourceKind;
+import io.mateu.uidl.interfaces.RestSourceSupplier;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.LinkedHashMap;
@@ -14,14 +16,19 @@ import java.util.Map;
 /**
  * Resolves the DECLARED {@link RestDataSource} of a view for a proxy fetch — from the annotation on
  * the field ({@code @RestOptions}), the class ({@code @RestListing}/{@code @RestData}) or the
- * method ({@code @RestAction}), never from a client-supplied url (so the proxy can't be turned into
- * an open SSRF/secret-exfiltration relay). Used by {@code __restfetch__}.
+ * method ({@code @RestAction}), or from what a {@link RestSourceSupplier} view declares at runtime,
+ * never from a client-supplied url (so the proxy can't be turned into an open SSRF/secret-
+ * exfiltration relay). Used by {@code __restfetch__}.
  */
 final class RestSourceResolver {
 
   private RestSourceResolver() {}
 
   static RestDataSource resolve(Object instance, String kind, String id) {
+    var declared = declaredBySupplier(instance, kind, id);
+    if (declared != null) {
+      return declared;
+    }
     var cls = instance.getClass();
     switch (kind == null ? "" : kind) {
       case "options" -> {
@@ -82,6 +89,37 @@ final class RestSourceResolver {
         return null;
       }
     }
+  }
+
+  /**
+   * What a {@link RestSourceSupplier} view says it declared for this kind and id, or null when the
+   * view is not one or declares nothing matching. Asked first: a view that builds its sources at
+   * runtime has no annotation for the reflective lookups below to find.
+   */
+  private static RestDataSource declaredBySupplier(Object instance, String kind, String id) {
+    if (!(instance instanceof RestSourceSupplier supplier)) {
+      return null;
+    }
+    var wanted = RestSourceKind.fromWire(kind);
+    if (wanted == null) {
+      return null;
+    }
+    var declarations = supplier.declaredRestSources();
+    if (declarations == null) {
+      return null;
+    }
+    var wantedId = id == null ? "" : id;
+    return declarations.stream()
+        .filter(d -> d != null && d.source() != null && wanted.equals(d.kind()))
+        // ROWS and DATA have one per view, so an id is not part of what identifies them.
+        .filter(
+            d ->
+                wanted == RestSourceKind.ROWS
+                    || wanted == RestSourceKind.DATA
+                    || wantedId.equals(d.id()))
+        .map(io.mateu.uidl.data.DeclaredRestSource::source)
+        .findFirst()
+        .orElse(null);
   }
 
   private static Map<String, String> parseHeaders(String[] headers) {

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/mappers/RestDataSupport.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/mappers/RestDataSupport.java
@@ -29,12 +29,21 @@ final class RestDataSupport {
   private RestDataSupport() {}
 
   /**
-   * True when the view declares at least one proxy-mode REST source ({@code proxy = true} on a
-   * field {@code @RestOptions}, a method {@code @RestAction}, or the class
-   * {@code @RestListing}/{@code @RestData}). Gates advertising the {@code __restfetch__} action so
-   * only proxy views carry it.
+   * True when the view declares at least one proxy-mode REST source: {@code proxy = true} on a
+   * field {@code @RestOptions}, a method {@code @RestAction}, the class
+   * {@code @RestListing}/{@code @RestData}, or on anything a {@link
+   * io.mateu.uidl.interfaces.RestSourceSupplier} view declares at runtime. Gates advertising the
+   * {@code __restfetch__} action so only proxy views carry it.
    */
   static boolean hasProxySource(Object instance) {
+    if (instance instanceof io.mateu.uidl.interfaces.RestSourceSupplier supplier) {
+      var declarations = supplier.declaredRestSources();
+      if (declarations != null
+          && declarations.stream()
+              .anyMatch(d -> d != null && d.source() != null && d.source().proxy())) {
+        return true;
+      }
+    }
     var cls = instance.getClass();
     var listing = MetaAnnotations.find(cls, RestListing.class);
     if (listing != null && listing.proxy()) {

--- a/backend/shared/core/src/test/java/io/mateu/core/application/RestSourceSupplierProxyTest.java
+++ b/backend/shared/core/src/test/java/io/mateu/core/application/RestSourceSupplierProxyTest.java
@@ -1,0 +1,90 @@
+package io.mateu.core.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.mateu.core.testutil.TestMateu;
+import io.mateu.dtos.ServerSideComponentDto;
+import io.mateu.uidl.annotations.Title;
+import io.mateu.uidl.annotations.UI;
+import io.mateu.uidl.data.DeclaredRestSource;
+import io.mateu.uidl.data.RestDataSource;
+import io.mateu.uidl.data.RestSourceKind;
+import io.mateu.uidl.interfaces.RestSourceSupplier;
+import java.util.List;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Proxy mode for a view that builds its sources at runtime: a form assembled from a stored
+ * definition has no annotation to read, so it says what it declared through {@link
+ * RestSourceSupplier} and gets the same __restfetch__ treatment an annotated one gets.
+ */
+class RestSourceSupplierProxyTest {
+
+  @SuppressWarnings("unused")
+  @UI("/suppliedproxy")
+  @Title("Supplied proxy")
+  public static class SuppliedProxyForm implements RestSourceSupplier {
+    String country;
+
+    @Override
+    public List<DeclaredRestSource> declaredRestSources() {
+      return List.of(
+          new DeclaredRestSource(
+              RestSourceKind.OPTIONS,
+              "country",
+              RestDataSource.builder()
+                  .url("https://api.example.com/countries?t=${secret.TOKEN}")
+                  .valuePath("code")
+                  .labelPath("name")
+                  .proxy(true)
+                  .build()));
+    }
+  }
+
+  @SuppressWarnings("unused")
+  @UI("/supplieddirect")
+  @Title("Supplied direct")
+  public static class SuppliedDirectForm implements RestSourceSupplier {
+    String country;
+
+    @Override
+    public List<DeclaredRestSource> declaredRestSources() {
+      return List.of(
+          new DeclaredRestSource(
+              RestSourceKind.OPTIONS,
+              "country",
+              RestDataSource.builder().url("https://public.example.com/countries").build()));
+    }
+  }
+
+  static TestMateu mateu;
+
+  @BeforeAll
+  static void boot() {
+    mateu = TestMateu.withUis(SuppliedProxyForm.class, SuppliedDirectForm.class);
+  }
+
+  @AfterAll
+  static void shutdown() {
+    mateu.close();
+  }
+
+  @Test
+  void aViewThatDeclaresAProxySourceAtRuntimeAdvertisesTheRestfetchAction() {
+    var component =
+        (ServerSideComponentDto) mateu.sync("/suppliedproxy").fragments().get(0).component();
+
+    assertThat(component.actions().stream().anyMatch(a -> "__restfetch__".equals(a.id()))).isTrue();
+  }
+
+  @Test
+  void declaringOnlyDirectSourcesStillDoesNotAdvertiseIt() {
+    var component =
+        (ServerSideComponentDto) mateu.sync("/supplieddirect").fragments().get(0).component();
+
+    assertThat(component.actions().stream().anyMatch(a -> "__restfetch__".equals(a.id())))
+        .isFalse();
+  }
+}

--- a/backend/shared/core/src/test/java/io/mateu/core/application/runaction/RestSourceResolverTest.java
+++ b/backend/shared/core/src/test/java/io/mateu/core/application/runaction/RestSourceResolverTest.java
@@ -1,0 +1,78 @@
+package io.mateu.core.application.runaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.mateu.uidl.annotations.RestOptions;
+import io.mateu.uidl.data.DeclaredRestSource;
+import io.mateu.uidl.data.RestDataSource;
+import io.mateu.uidl.data.RestSourceKind;
+import io.mateu.uidl.interfaces.RestSourceSupplier;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * What a proxy fetch is allowed to resolve to: what the view declared, whether it declared it as an
+ * annotation or at runtime — and nothing the client asked for.
+ */
+class RestSourceResolverTest {
+
+  @SuppressWarnings("unused")
+  static class Annotated {
+    @RestOptions(url = "https://annotated.example.com/x", proxy = true)
+    String country;
+  }
+
+  static class Supplied implements RestSourceSupplier {
+    @Override
+    public List<DeclaredRestSource> declaredRestSources() {
+      return List.of(
+          new DeclaredRestSource(
+              RestSourceKind.OPTIONS,
+              "country",
+              RestDataSource.builder().url("https://supplied.example.com/x").proxy(true).build()),
+          new DeclaredRestSource(
+              RestSourceKind.DATA,
+              RestDataSource.builder().url("https://supplied.example.com/me").proxy(true).build()));
+    }
+  }
+
+  /** Declares nothing, so nothing resolves — the shape of a view that is not in on this at all. */
+  static class Silent implements RestSourceSupplier {
+    @Override
+    public List<DeclaredRestSource> declaredRestSources() {
+      return List.of();
+    }
+  }
+
+  @Test
+  void resolvesWhatTheViewDeclaredAtRuntime() {
+    var source = RestSourceResolver.resolve(new Supplied(), "options", "country");
+
+    assertThat(source).isNotNull();
+    assertThat(source.url()).isEqualTo("https://supplied.example.com/x");
+  }
+
+  @Test
+  void aKindWithOneSourcePerViewNeedsNoId() {
+    var source = RestSourceResolver.resolve(new Supplied(), "data", "");
+
+    assertThat(source).isNotNull();
+    assertThat(source.url()).isEqualTo("https://supplied.example.com/me");
+  }
+
+  @Test
+  void anUndeclaredFieldResolvesToNothing() {
+    assertThat(RestSourceResolver.resolve(new Supplied(), "options", "other")).isNull();
+    assertThat(RestSourceResolver.resolve(new Silent(), "options", "country")).isNull();
+    assertThat(RestSourceResolver.resolve(new Supplied(), "rows", "")).isNull();
+  }
+
+  @Test
+  void theAnnotationPathIsUntouched() {
+    var source = RestSourceResolver.resolve(new Annotated(), "options", "country");
+
+    assertThat(source).isNotNull();
+    assertThat(source.url()).isEqualTo("https://annotated.example.com/x");
+    assertThat(source.proxy()).isTrue();
+  }
+}

--- a/backend/shared/uidl/src/main/java/io/mateu/uidl/data/DeclaredRestSource.java
+++ b/backend/shared/uidl/src/main/java/io/mateu/uidl/data/DeclaredRestSource.java
@@ -1,0 +1,23 @@
+package io.mateu.uidl.data;
+
+/**
+ * One REST source a view declares programmatically, for the surfaces that are not written as
+ * annotations. See {@link io.mateu.uidl.interfaces.RestSourceSupplier}.
+ *
+ * @param kind which surface it feeds
+ * @param id what it feeds within that surface: the field id for {@link RestSourceKind#OPTIONS}, the
+ *     action id for {@link RestSourceKind#ACTION}, and ignored (use {@code ""}) for {@link
+ *     RestSourceKind#ROWS} and {@link RestSourceKind#DATA}, of which a view has at most one
+ * @param source the descriptor, exactly as it travels to the renderer
+ */
+public record DeclaredRestSource(RestSourceKind kind, String id, RestDataSource source) {
+
+  public DeclaredRestSource {
+    id = id == null ? "" : id;
+  }
+
+  /** The view's single source of a kind that has only one. */
+  public DeclaredRestSource(RestSourceKind kind, RestDataSource source) {
+    this(kind, "", source);
+  }
+}

--- a/backend/shared/uidl/src/main/java/io/mateu/uidl/data/RestSourceKind.java
+++ b/backend/shared/uidl/src/main/java/io/mateu/uidl/data/RestSourceKind.java
@@ -1,0 +1,40 @@
+package io.mateu.uidl.data;
+
+/**
+ * Which surface a {@link RestDataSource} feeds, and so which of a view's declarations a proxy fetch
+ * is asking for. The wire name is what the renderer sends as {@code _sourceKind}.
+ */
+public enum RestSourceKind {
+
+  /** A field's select options ({@code @RestOptions} / {@code FormField.optionsSource}). */
+  OPTIONS("options"),
+  /** A listing's rows ({@code @RestListing} / {@code Crudl.rowsSource}). */
+  ROWS("rows"),
+  /** A button's call ({@code @RestAction} / {@code Action.restAction}). */
+  ACTION("action"),
+  /** A screen's initial data ({@code @RestData}). */
+  DATA("data");
+
+  private final String wireName;
+
+  RestSourceKind(String wireName) {
+    this.wireName = wireName;
+  }
+
+  public String wireName() {
+    return wireName;
+  }
+
+  /** The kind the renderer named, or null when it named none of them. */
+  public static RestSourceKind fromWire(String wireName) {
+    if (wireName == null) {
+      return null;
+    }
+    for (var kind : values()) {
+      if (kind.wireName.equals(wireName)) {
+        return kind;
+      }
+    }
+    return null;
+  }
+}

--- a/backend/shared/uidl/src/main/java/io/mateu/uidl/interfaces/RestSourceSupplier.java
+++ b/backend/shared/uidl/src/main/java/io/mateu/uidl/interfaces/RestSourceSupplier.java
@@ -1,0 +1,31 @@
+package io.mateu.uidl.interfaces;
+
+import io.mateu.uidl.data.DeclaredRestSource;
+import java.util.List;
+
+/**
+ * Implemented by a view that builds its REST sources at runtime rather than declaring them as
+ * annotations, so that they too can be fetched in proxy mode.
+ *
+ * <p>Proxy mode — the fetch that goes through the Mateu server instead of the browser, resolving
+ * CORS and injecting {@code ${secret.X}} server-side — needs the server to know what the view
+ * declared, and it deliberately will not take the endpoint from the request: a proxy that fetched
+ * whatever url the client asked for would be an open SSRF and secret-exfiltration relay. Until now
+ * the only thing it would read was an annotation, which a view assembled from data — a form built
+ * from a stored definition, a screen composed at runtime — does not have, so proxy mode was closed
+ * to exactly the views that most need it. This is how such a view says the same thing.
+ *
+ * <p>The declarations are read on the server, from server-side state. <strong>An implementation
+ * must build them from what the server holds — a stored definition, configuration, a catalogue —
+ * and never from the request or the component state.</strong> That is the invariant the whole
+ * feature rests on; supplying a url the client chose hands the relay back.
+ *
+ * <p>The descriptor a surface carries to the renderer and the one declared here are the same
+ * source; a view that puts one on a {@code FormField.optionsSource} declares it here too, under
+ * {@link io.mateu.uidl.data.RestSourceKind#OPTIONS} and the field's id.
+ */
+public interface RestSourceSupplier {
+
+  /** Every REST source this view declares. Empty when it declares none. */
+  List<DeclaredRestSource> declaredRestSources();
+}

--- a/doc/src/content/docs/java-ui-definition/annotations/rest-options.md
+++ b/doc/src/content/docs/java-ui-definition/annotations/rest-options.md
@@ -113,9 +113,42 @@ String country;
   on the server by a `SecretsProvider` (see below), so the token **never reaches the browser**. Only
   the placeholder (`${secret.COUNTRIES_TOKEN}`) travels on the wire, never its value.
 
-The server resolves the endpoint from the **declared** annotation (by field/action/class), never
-from a url supplied by the client, so the proxy can't be turned into an open relay. `${state.x}`
-interpolation works the same as in direct mode (resolved from the component state).
+The server resolves the endpoint from what the view **declared**, never from a url supplied by the
+client, so the proxy can't be turned into an open relay. `${state.x}` interpolation works the same
+as in direct mode (resolved from the component state).
+
+#### Views with no annotation to read — `RestSourceSupplier`
+
+Reading the annotation is enough for a view written as a Java class. A view **assembled at
+runtime** — a form built from a stored definition, a screen composed from configuration — has no
+annotated field for that lookup to find, and proxy mode was closed to exactly the views that most
+need it. Such a view implements `io.mateu.uidl.interfaces.RestSourceSupplier` to say the same thing
+programmatically:
+
+```java
+public class TaskForm implements RestSourceSupplier {
+
+  @Override
+  public List<DeclaredRestSource> declaredRestSources() {
+    return definition.fields().stream()                       // ← server-side state
+        .filter(f -> f.optionsSource() != null)
+        .map(f -> new DeclaredRestSource(RestSourceKind.OPTIONS, f.id(), sourceOf(f)))
+        .toList();
+  }
+}
+```
+
+The declarations are read on the server and gate `__restfetch__` exactly as the annotations do:
+a view declaring at least one `proxy = true` source advertises the reserved action, and a fetch for
+`kind` + `id` resolves to the source declared under them (`OPTIONS` by field id, `ACTION` by action
+id; `ROWS` and `DATA` have one per view, so their id is ignored).
+
+:::danger[Build them from server-side state, never from the request]
+The invariant the proxy rests on is that the endpoint is the server's choice, not the client's. An
+implementation must derive its declarations from something the server holds — a stored definition,
+configuration, a catalogue — and never from the request or the component state. Supplying a url the
+client chose hands back the open relay the annotation lookup exists to prevent.
+:::
 
 ### Supplying secrets — `SecretsProvider`
 

--- a/doc/src/content/docs/reference/parity.md
+++ b/doc/src/content/docs/reference/parity.md
@@ -54,6 +54,7 @@ for the surface below (verified by golden-JSON tests in `backend/dotnet/test` an
 | External REST button action (`@RestAction`/`[RestAction]`/`@rest_action` on a button → calls an arbitrary endpoint client-side via `Action.restAction`; response toast + merge into form state) | ✅ | ✅ | ✅ |
 | External REST screen data (`@RestData`/`[RestData]`/`@rest_data` on a view → initial data fetched client-side on load and merged into the form state; reuses the `restAction` machinery via a synthetic `__restdata__` action + OnLoad trigger) | ✅ | ✅ | ✅ |
 | — Proxy mode (`proxy = true` on any of the four → the fetch is routed through the Mateu server via the reserved `__restfetch__` action: no CORS, and `${secret.X}` auth injected server-side from a secrets provider / env var; the server resolves the DECLARED source only) | ✅ | ✅ | ✅ |
+| — Proxy mode for views with no annotation to read (`RestSourceSupplier`: a view assembled at runtime declares its sources programmatically, and they gate `__restfetch__` and resolve a proxy fetch exactly as annotations do) | ✅ | ❌ | ❌ |
 | Editable grids / inline CRUD editing (`@InlineEditing` + update-row) | ✅ | ✅ | ✅ |
 | Bulk list actions (`@ListToolbarButton` + typed selection) | ✅ | ✅ | ✅ |
 | Listing aggregates & grouping (`@Aggregate`/`@GroupBy` + summaries) | ✅ | ✅ | ✅ |


### PR DESCRIPTION
Proxy mode (`proxy = true` on `@RestOptions`/`@RestListing`/`@RestAction`/`@RestData`) resolves the endpoint from what the view **declared**, never from the request — a proxy that fetched whatever url the client asked for would be an open SSRF and secret-exfiltration relay. The only declaration it could read was an annotation, so a view **assembled at runtime** — a form built from a stored definition, a screen composed from configuration — had none for that lookup to find, and proxy mode was closed to exactly the views that most need it: the ones whose endpoints are not known at compile time.

## What this adds

`io.mateu.uidl.interfaces.RestSourceSupplier` — how such a view says the same thing in code:

```java
public class TaskForm implements RestSourceSupplier {
  @Override
  public List<DeclaredRestSource> declaredRestSources() {
    return definition.fields().stream()                       // ← server-side state
        .filter(f -> f.optionsSource() != null)
        .map(f -> new DeclaredRestSource(RestSourceKind.OPTIONS, f.id(), sourceOf(f)))
        .toList();
  }
}
```

- `DeclaredRestSource(kind, id, source)` and `RestSourceKind {OPTIONS, ROWS, ACTION, DATA}` — the enum also gives the four wire names a home, instead of the string literals the resolver's switch spelled out.
- `RestSourceResolver` asks the supplier first (OPTIONS by field id, ACTION by action id; ROWS and DATA are one per view, so their id is ignored), then falls back to the reflective annotation scan, which is untouched.
- `RestDataSupport.hasProxySource` does the same, so a view declaring a proxy source at runtime advertises the reserved `__restfetch__` action exactly as an annotated one does.

## The invariant moves, it does not weaken

The source is still the server's choice. What changes is where the server reads it from — an annotation, or code on the view. That puts the responsibility on the implementer, so the interface javadoc and the docs say it in the strongest terms available: **declarations must be built from server-side state (a stored definition, configuration, a catalogue) and never from the request or the component state.** Supplying a url the client chose hands back the relay the annotation lookup exists to prevent.

## Tests

- `RestSourceResolverTest` — runtime declarations resolve; a kind with one source per view resolves without an id; undeclared resolves to nothing; the annotation path is unchanged.
- `RestSourceSupplierProxyTest` — a view declaring a proxy source at runtime advertises `__restfetch__`; one declaring only direct sources still does not.

uidl 62 and core 909 green, `UidlSchemaTest` included (no new components in the authoring catalog).

Not covered, and it was not before either: the proxy fetch itself (`RunActionUseCase.handleRestFetch`) does real HTTP through a static client, so there is no test upstream of it. This covers resolution and advertisement.

## Docs

`rest-options.md` gains a *"Views with no annotation to read"* section with the example and the danger note; `parity.md` gains a row (Java ✅, .NET ❌, Python ❌ — the ports have no equivalent and are untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)