### PR TITLE
ci: cache the playwright browsers in the e2e job

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -97,6 +97,20 @@ jobs:
       - name: Install npm dependencies
         run: cd e2e && npm ci
 
+      # The browser download is the one step of this job that reaches outside GitHub and npm, and
+      # it has no timeout of its own: on 2026-08-19 it hung a release run and a PR run for ~50
+      # minutes each without ever failing, blocking the publish to Maven Central. The binaries
+      # only change when @playwright/test does, so key the cache on the lockfile that pins it.
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('e2e/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-playwright-
+
+      # Kept unconditional on purpose: --with-deps also installs SYSTEM packages, which live
+      # outside the cached directory and are needed on every run. On a cache hit this is the apt
+      # part only — the ~150 MB download is what the cache saves.
       - name: Install Playwright browsers
         run: cd e2e && npx playwright install --with-deps chromium
 


### PR DESCRIPTION
## Why

The browser download is the one step of the e2e job that reaches outside GitHub and npm, and it has no timeout of its own. Today it **hung a release run and a PR run for ~50 minutes each without ever failing** (both stuck on `Install Playwright browsers`, GitHub status all-operational, the Playwright CDN reachable from outside). The release never got to publish `v3.0-alpha.292` to Maven Central; both runs had to be cancelled and re-run by hand.

## What

`actions/cache@v4` over `~/.cache/ms-playwright`, keyed on `e2e/package-lock.json` — the file that pins `@playwright/test` (1.62.0), which is what decides the browser build.

The install step stays **unconditional**: `--with-deps` also installs system packages, which live outside the cached directory and are needed on every run. On a cache hit it is the apt part only, without the ~150 MB download.

This PR's own e2e run is the first exercise of it (cache miss → populates; the next run hits).

Not included, say the word if you want it: a `timeout-minutes` on that step so a future hang fails fast instead of sitting there — the cache removes the download on the common path, but a version bump still downloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)