### PR TITLE
ci: a workflow to ask the Central Publisher API about a deployment

### DIFF
--- a/.github/workflows/central-deployment-status.yml
+++ b/.github/workflows/central-deployment-status.yml
@@ -1,0 +1,43 @@
+# Ask the Central Publisher API what happened to a deployment.
+#
+# The publish job uploads a signed bundle and returns as soon as Central reports it VALIDATED —
+# `waitUntil=published` is commented out in backend/pom.xml — so a green release run does not
+# prove the artifacts are downloadable. When they do not show up on repo1 (v3.0-alpha.293 sat
+# validated-but-not-published while every earlier release was live the second the run ended),
+# this is how to see the real state without guessing from the outside: the deployment is visible
+# only to the account that created it, which is the CI token, not a browser session.
+name: Central deployment status
+
+on:
+  workflow_dispatch:
+    inputs:
+      deployment_id:
+        description: 'deploymentId from the publish log ("Uploaded bundle successfully, deploymentId: …")'
+        required: true
+
+jobs:
+  status:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ask the Central Publisher API
+        env:
+          # Read through env, never interpolated into the shell command: a workflow input is
+          # untrusted text and `${{ }}` inside a run block is string substitution, not an argument.
+          ID: ${{ inputs.deployment_id }}
+          CENTRAL_USER: ${{ secrets.CENTRAL_TOKEN_USERNAME }}
+          CENTRAL_PASS: ${{ secrets.CENTRAL_TOKEN_PASSWORD }}
+        run: |
+          set -euo pipefail
+          # Only the response body is printed. It carries the deployment state and the validation
+          # errors — never the credentials, which travel in a header the log never sees.
+          auth=$(printf '%s:%s' "$CENTRAL_USER" "$CENTRAL_PASS" | base64 -w0)
+          code=$(curl -sS -o /tmp/status.json -w '%{http_code}' -X POST \
+            -H "Authorization: Bearer $auth" \
+            "https://central.sonatype.com/api/v1/publisher/status?id=$ID")
+          echo "HTTP $code"
+          if command -v jq >/dev/null && jq -e . /tmp/status.json >/dev/null 2>&1; then
+            jq . /tmp/status.json
+          else
+            head -c 4000 /tmp/status.json; echo
+          fi
+          test "$code" = "200"


### PR DESCRIPTION
`v3.0-alpha.293` was validated by Central at 09:14 and 45 minutes later `io.mateu:core:3.0-alpha.293` is still a 404 on repo1 — while `v3.0-alpha.291` was downloadable **five seconds before** its run even finished. So this is not sync lag; the deployment is parked.

From outside there is no way to tell: a deployment is visible only to the account that created it, which is the CI token, not a browser session (browsing the Portal with another account reports "no verified namespace" and lists nothing).

This adds a `workflow_dispatch` job that POSTs to `https://central.sonatype.com/api/v1/publisher/status?id=<deploymentId>` with the `CENTRAL_TOKEN_*` secrets already in the repo and prints the deployment state plus any validation errors. The token travels in a header and is never printed; the input is passed through `env` rather than interpolated into the shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)