### PR TITLE
Fix the shared frontend library's build, and make CI notice it

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,4 +1,7 @@
-name: E2E Tests
+# Named for what it does rather than for the one job it started as: it now also guards the
+# committed bundles, the annotation density and the shared frontend library. Renaming the WORKFLOW
+# is safe for branch protection, which names JOBS (`e2e`) and not workflows.
+name: Tests
 
 on:
   pull_request:
@@ -25,6 +28,40 @@ jobs:
       # should not creep up. Each new annotation is always justifiable alone; the sum is what drifts.
       - name: Annotations per screen have not crept up
         run: python3 scripts/annotation-density.py --check
+
+  # The shared frontend library is where the renderers' logic actually lives, and nothing in CI
+  # compiled or ran it: `run_tests.yml` builds the backend from the COMMITTED bundle, and the
+  # release workflow's `apps/vaadin && npm run copy` typechecks against the APP's tsconfig, which
+  # excludes the library's test files. So a `tsc` error in libs/mateu sat on master while every
+  # check stayed green, and its 304 unit tests only ran on whoever remembered to run them.
+  #
+  # The typecheck comes first in the same job on purpose: the tests run through vitest's own
+  # transform, which strips types without checking them, so they pass over exactly the errors
+  # this step exists to catch — running them first would report success from a tree that does
+  # not compile.
+  frontend-lib:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: frontend/web/monorepo/package-lock.json
+
+      # Scoped to the one workspace: a plain `npm ci` at the monorepo root also installs
+      # apps/redwood's Oracle tooling, part of which comes from static.oracle.com rather than the
+      # npm registry — an external host this job has no reason to depend on.
+      - name: Install the library's dependencies
+        run: cd frontend/web/monorepo && npm ci --workspace mateu --include-workspace-root
+
+      - name: Typecheck and build the library
+        run: cd frontend/web/monorepo/libs/mateu && npm run build
+
+      - name: Unit tests
+        run: cd frontend/web/monorepo/libs/mateu && npm test
 
   e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -53,9 +53,12 @@ jobs:
 
       # Scoped to the one workspace: a plain `npm ci` at the monorepo root also installs
       # apps/redwood's Oracle tooling, part of which comes from static.oracle.com rather than the
-      # npm registry — an external host this job has no reason to depend on.
+      # npm registry — an external host this job has no reason to depend on. `--ignore-scripts`
+      # keeps the dependency tree's install hooks from running arbitrary code on the runner; the
+      # platform binaries this build needs (esbuild's) arrive as optional dependencies rather than
+      # from a postinstall, so the build and the suite were verified to pass without them.
       - name: Install the library's dependencies
-        run: cd frontend/web/monorepo && npm ci --workspace mateu --include-workspace-root
+        run: cd frontend/web/monorepo && npm ci --workspace mateu --include-workspace-root --ignore-scripts
 
       - name: Typecheck and build the library
         run: cd frontend/web/monorepo/libs/mateu && npm run build

--- a/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/applyFragment.test.ts
+++ b/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/applyFragment.test.ts
@@ -104,12 +104,20 @@ describe('willUpdate data preservation', () => {
     // re-binds our .data with a fresh EMPTY object. That empty re-bind must not wipe the rows.
     // A plain stand-in (like componentElement above): .data is a normal field, so assigning it does
     // not run Lit's reactive setter. willUpdate keeps its super binding to LitElement's no-op.
+    // `willUpdate` is Lit's protected lifecycle hook and stays protected on ComponentElement:
+    // widening a framework base class's public surface so a test can reach it is the wrong way
+    // round. This test-only subclass is the single place that reaches it, and it hands the method
+    // out with its REAL type (a structural cast here would keep compiling if the signature moved).
+    class WillUpdateProbe extends ComponentElement {
+        static readonly hook = WillUpdateProbe.prototype.willUpdate
+    }
+
     const withProto = (over: Record<string, any>) => ({
         data: {} as Record<string, any>,
         _lastFragmentData: undefined as Record<string, any> | undefined,
         _lastViewKey: undefined as string | undefined,
         component: undefined as ServerSideComponent | undefined,
-        willUpdate: ComponentElement.prototype.willUpdate,
+        willUpdate: WillUpdateProbe.hook,
         ...over,
     })
 


### PR DESCRIPTION
Two findings on master: a broken build, and the reason nobody noticed.

## 1. `libs/mateu` did not compile

`cd frontend/web/monorepo/libs/mateu && npm run build` (= `tsc && vite build`) failed:

```
applyFragment.test.ts(112,48): error TS2445:
  Property 'willUpdate' is protected and only accessible within class 'ComponentElement'
```

The suite borrows `ComponentElement.prototype.willUpdate` onto a plain stand-in object so it
can run the hook without Lit's reactive machinery — a reasonable thing for it to want, but
`willUpdate` is protected.

**Kept it protected.** It is Lit's own lifecycle hook, and widening a framework base class's
public surface so a test can reach it is the wrong way round; the concession belongs in the
test. A test-only subclass hands the method out. That is preferred over a cast at the borrow
site because the cast would restate the signature and keep compiling if the real one moved,
while the subclass carries the actual type.

No new test: the build failing *is* the reproduction. It fails before and passes after, with
the 316 unit tests green.

## 2. Nothing in CI typechecked or ran the library

The e2e job builds the backend from the **committed bundle**, and the release workflow's
`apps/vaadin && npm run copy` typechecks against the *app's* tsconfig, which excludes the
library's test files — so it compiled cleanly while the library's own build failed. The 316
unit tests ran only on whoever remembered to run them.

New `frontend-lib` job in `run_tests.yml`:

- **Typecheck before tests, one job.** vitest strips types without checking them, so tests
  first would report success from a tree that does not compile.
- **Install scoped to the one workspace** (`npm ci --workspace mateu --include-workspace-root`).
  A plain root `npm ci` also pulls apps/redwood's Oracle tooling, part of it from
  `static.oracle.com` — an external host this job has no reason to depend on. Verified on a
  clean tree: no `@oracle` in the resulting `node_modules`.
- **The release path gets it too**, since `buid-and-publish.yml` calls this whole workflow and
  the bundle it publishes is built from this library.
- **Workflow renamed** "E2E Tests" → "Tests" (it already guarded the bundles and the annotation
  density). Branch protection names JOBS, and `e2e` is the only required one, so no rule moves —
  which also means `frontend-lib` reports on every PR but does not block until you add it to the
  protection rule.
- **Left the `buid-and-publish.yml` filename typo alone.** Nothing but one doc line references
  it, but renaming detaches the release workflow's run history in the Actions UI — a separate
  call from these two fixes.

Note: `Cloudflare Pages` fails on this PR as it does on #406–#409; it is not from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)