### PR TITLE
A listing that is still loading says so, instead of "nothing here"

### DIFF
--- a/backend/shared/frontend/vaadin-lit/src/main/resources/META-INF/resources/assets/mateu-vaadin.js
+++ b/backend/shared/frontend/vaadin-lit/src/main/resources/META-INF/resources/assets/mateu-vaadin.js
@@ -139,17 +139,17 @@ ${i}
             width: 100%;
             height: 100%;
         }
-    `}};k([y()],he.prototype,`position`,void 0),k([y()],he.prototype,`zoom`,void 0),k([x(`#map`)],he.prototype,`mapElement`,void 0),he=k([g(`mateu-map`)],he);var ge=typeof HTMLElement<`u`?HTMLElement:class{},_e=class extends ge{static get observedAttributes(){return[`content`]}#e;#t=0;get content(){return this.#e}set content(e){this.#e=e,this.#n()}attributeChangedCallback(e,t,n){this.content=n??void 0}connectedCallback(){this.style.display=`block`,this.#n()}async#n(){if(!this.isConnected)return;let e=this.#e??``,t=++this.#t,[{marked:n},{default:r}]=await Promise.all([D(()=>import(`./vendor.js`).then(e=>e.n),__vite__mapDeps([2,1])),D(()=>import(`./vendor.js`).then(e=>e.a),__vite__mapDeps([2,1]))]);t===this.#t&&(this.innerHTML=r.sanitize(await n.parse(e),{USE_PROFILES:{html:!0,svg:!0,svgFilters:!0},CUSTOM_ELEMENT_HANDLING:{tagNameCheck:e=>!0}}))}};typeof customElements<`u`&&!customElements.get(`mateu-markdown`)&&customElements.define(`mateu-markdown`,_e);var A=function(e){return e.ServerSide=`ServerSide`,e.ClientSide=`ClientSide`,e}({}),j=function(e){return e.Page=`Page`,e.Div=`Div`,e.Element=`Element`,e.MicroFrontend=`MicroFrontend`,e.Form=`Form`,e.Crud=`Crud`,e.Result=`Result`,e.Card=`Card`,e.Directory=`Directory`,e.Stepper=`Stepper`,e.HorizontalLayout=`HorizontalLayout`,e.VerticalLayout=`VerticalLayout`,e.SplitLayout=`SplitLayout`,e.MasterDetailLayout=`MasterDetailLayout`,e.TabLayout=`TabLayout`,e.AccordionLayout=`AccordionLayout`,e.FormLayout=`FormLayout`,e.FormRow=`FormRow`,e.FormItem=`FormItem`,e.BoardLayout=`BoardLayout`,e.BoardLayoutRow=`BoardLayoutRow`,e.BoardLayoutItem=`BoardLayoutItem`,e.Scroller=`Scroller`,e.FullWidth=`FullWidth`,e.Container=`Container`,e.FormField=`FormField`,e.Table=`Table`,e.App=`App`,e.Text=`Text`,e.Avatar=`Avatar`,e.Chat=`Chat`,e.AvatarGroup=`AvatarGroup`,e.Badge=`Badge`,e.Breadcrumbs=`Breadcrumbs`,e.Anchor=`Anchor`,e.Button=`Button`,e.Chart=`Chart`,e.Icon=`Icon`,e.ConfirmDialog=`ConfirmDialog`,e.ContextMenu=`ContextMenu`,e.CookieConsent=`CookieConsent`,e.Details=`Details`,e.Dialog=`Dialog`,e.Drawer=`Drawer`,e.Image=`Image`,e.Map=`Map`,e.Markdown=`Markdown`,e.Notification=`Notification`,e.ProgressBar=`ProgressBar`,e.Popover=`Popover`,e.CarouselLayout=`CarouselLayout`,e.Tooltip=`Tooltip`,e.MessageInput=`MessageInput`,e.MessageList=`MessageList`,e.CustomField=`CustomField`,e.MenuBar=`MenuBar`,e.Grid=`Grid`,e.GridColumn=`GridColumn`,e.GridGroupColumn=`GridGroupColumn`,e.VirtualList=`VirtualList`,e.FormSection=`FormSection`,e.FormSubSection=`FormSubSection`,e.Bpmn=`Bpmn`,e.Workflow=`Workflow`,e.FormEditor=`FormEditor`,e.MetricCard=`MetricCard`,e.Scoreboard=`Scoreboard`,e.DashboardPanel=`DashboardPanel`,e.DashboardLayout=`DashboardLayout`,e.FoldoutLayout=`FoldoutLayout`,e.ContentLayout=`ContentLayout`,e.HeroSection=`HeroSection`,e.EmptyState=`EmptyState`,e.Skeleton=`Skeleton`,e.Gantt=`Gantt`,e.PlanningBoard=`PlanningBoard`,e.Kanban=`Kanban`,e.Timeline=`Timeline`,e.ProgressSteps=`ProgressSteps`,e.Stat=`Stat`,e.Calendar=`Calendar`,e.PricingTable=`PricingTable`,e.OrgChart=`OrgChart`,e.Heatmap=`Heatmap`,e.Funnel=`Funnel`,e.TrendChart=`TrendChart`,e.FeatureGrid=`FeatureGrid`,e.Testimonials=`Testimonials`,e.Faq=`Faq`,e.CalloutCard=`CalloutCard`,e.CommentThread=`CommentThread`,e.FileList=`FileList`,e.Checklist=`Checklist`,e.ComparisonCard=`ComparisonCard`,e.EntityHeader=`EntityHeader`,e.Meter=`Meter`,e.TaskProgress=`TaskProgress`,e.StatusList=`StatusList`,e.BulletedList=`BulletedList`,e.Separator=`Separator`,e.Notice=`Notice`,e.TaskQueue=`TaskQueue`,e.ResourceGrid=`ResourceGrid`,e.OfferCard=`OfferCard`,e.AddOnPicker=`AddOnPicker`,e.Ledger=`Ledger`,e.PaymentPicker=`PaymentPicker`,e.ProcessMonitor=`ProcessMonitor`,e}({}),ve=`mateu-app-context`,ye=`mateu-app-context-labels`,be=e=>{try{return JSON.parse(localStorage.getItem(e)??`{}`)}catch{return{}}},xe=(e,t)=>{try{localStorage.setItem(e,JSON.stringify(t))}catch{}},Se=()=>be(ve),Ce=()=>be(ye),we=(e,t,n)=>{let r=Se(),i=Ce();t==null||t===``?(delete r[e],delete i[e]):(r[e]=t,n!==void 0&&(i[e]=n)),xe(ve,r),xe(ye,i)},Te=!1,Ee=()=>{Te||(Te=!0,window.addEventListener(`storage`,e=>{e.key===ve&&e.newValue!==e.oldValue&&window.location.reload()}))},De,Oe=(e,t)=>new Promise((n,r)=>{let i=!1,a={retry:()=>{i||(i=!0,t().then(n,r))},giveUp:()=>{i||(i=!0,r(e))}};if(De){De(a);return}let o=new CustomEvent(`mateu-session-expired`,{detail:a,cancelable:!0,bubbles:!1});typeof document<`u`&&!document.dispatchEvent(o)||a.giveUp()}),ke=(e,t)=>e.includes(`json`)?!0:typeof t==`object`&&!!t,Ae=(e,t)=>{let n=e.finalUrl;if(!n)return;let r=t??(typeof window<`u`?window.location.href:void 0),i;try{i=new URL(e.requestedUrl,r).href}catch{return}if(i!==n&&!ke(e.contentType??``,e.data))return n},je=new class{constructor(){this.windowMs=4e3,this.threshold=12,this.events=[],this.reported=new Set}check(e,t=Date.now()){this.events.push({sig:e,t});let n=t-this.windowMs;this.events=this.events.filter(e=>e.t>=n);let r=0;for(let t of this.events)t.sig===e&&r++;if(r>=this.threshold){let t=!this.reported.has(e);return this.reported.add(e),{blocked:!0,firstTrip:t}}return this.reported.delete(e),{blocked:!1,firstTrip:!1}}reset(){this.events=[],this.reported.clear()}configure(e){e.windowMs!==void 0&&(this.windowMs=e.windowMs),e.threshold!==void 0&&(this.threshold=e.threshold)}},Me=[],Ne=e=>{Me=Array.isArray(e)?e:[]},Pe=e=>e?Me.find(t=>t.name===e):void 0,Fe=e=>e==null||e===``,Ie=e=>{if(!e?.ref)return e;let t=Pe(e.ref);if(!t?.source)return console.warn(`mateu: no REST source named "${e.ref}" in the app's catalogue`),e;let n=t.source;return{...e,url:Fe(e.url)?n.url:e.url,method:Fe(e.method)?n.method:e.method,headers:e.headers&&Object.keys(e.headers).length>0?e.headers:n.headers,body:Fe(e.body)?n.body:e.body,itemsPath:Fe(e.itemsPath)?n.itemsPath:e.itemsPath,valuePath:Fe(e.valuePath)?n.valuePath:e.valuePath,labelPath:Fe(e.labelPath)?n.labelPath:e.labelPath,proxy:e.proxy||n.proxy}},Le=(e,t)=>{let n=Pe(e?.ref)?.fields?.[t];return n&&n!==``?n:t},Re,ze=[],Be,Ve=[],He=e=>e.split(`/`).filter(e=>e.startsWith(`:`)&&e.length>1).map(e=>e.substring(1)),Ue=e=>{let t=e=>e.replace(/^\/+/,``).replace(/\/+$/,``),n=t(e===`_no_route`?``:e),r=n===``?[]:n.split(`/`),i;for(let e of Ve){let n=t(e.route??``),a=n===``?[]:n.split(`/`);if(a.length!==r.length)continue;let o={},s=!0;for(let e=0;e<a.length;e++){let t=a[e];if(t.startsWith(`:`)&&t.length>1)o[t.substring(1)]=r[e];else if(t!==r[e]){s=!1;break}}if(!s)continue;let c={entry:e,pathParams:o};(!i||He(n).length<He(t(i.entry.route??``)).length)&&(i=c)}return i},We=(e,t)=>{let n=Ue(e);if(!n)return t;let{entry:r,pathParams:i}=n,a=r.defaultParams??{},o=r.fixedParams??{};return!Object.keys(a).length&&!Object.keys(o).length&&!Object.keys(i).length?t:{...t,fragments:(t.fragments??[]).map(e=>({...e,state:{...a,...e.state??{},...i,...o},data:{...a,...e.data??{},...i,...o}}))}},Ge=e=>{let t=e&&e.startsWith(`/`)?e.substring(1):e??``;return t===``?`_no_route`:t};function Ke(e,t=fetch){return Be=(async()=>{try{let n=await t(e);if(!n.ok)return;let r=await n.json(),i=new Map,a=[];for(let e of r.entries??[])if(!(!e.ok||!e.json))try{let t=JSON.parse(e.json);e.routePattern?a.push({regex:new RegExp(e.routePattern),paramNames:e.paramNames??[],increment:t}):i.set(e.syncPath,t)}catch(t){console.warn(`mateu: bundle entry parse failed for`,e.syncPath,t)}Re=i,ze=a,Ve=r.routes?.routes??[],Ne(r.sources?.sources)}catch(e){console.warn(`mateu: bundle manifest load failed`,e)}})(),Be}var qe=()=>Be??Promise.resolve(),Je=()=>Re!==void 0&&Re.size>0||ze.length>0,Ye=e=>{let t=Re?.get(e);return t===void 0?void 0:We(e,t)},Xe=e=>{for(let t of ze){let n=t.regex.exec(e);if(!n)continue;let r={};return t.paramNames.forEach((e,t)=>{r[e]=n[t+1]}),We(e,{...t.increment,fragments:(t.increment.fragments??[]).map(e=>({...e,state:{...e.state??{},...r},data:{...e.data??{},...r}}))})}},Ze={offline:()=>`No connection. Your changes have not been sent — check your network and try again.`,timeout:()=>`The server is taking too long to answer. Your changes may not have been saved.`,server:e=>`The server could not complete the request${e?` (error ${e})`:``}. Please try again.`,unauthorized:()=>`Your session is no longer valid. Please sign in again.`,notFound:()=>`This is no longer available. It may have been moved or deleted.`,client:e=>`The request was rejected${e?` (error ${e})`:``}.`,cancelled:()=>``,unknown:()=>`Something went wrong. Please try again.`},Qe=new Set([`offline`,`timeout`,`server`]),$e=(e,t={})=>{let n=e??{},r=n.response?.status,i=n.code,a=t.online??(typeof navigator<`u`&&typeof navigator.onLine==`boolean`?navigator.onLine:!0),o=e=>({kind:e,message:Ze[e](r),retryable:Qe.has(e),status:r});return i===`ERR_CANCELED`?o(`cancelled`):i===`ECONNABORTED`||i===`ETIMEDOUT`||/timeout/i.test(n.message??``)?o(`timeout`):r===void 0?!a||i===`ERR_NETWORK`||/network error/i.test(n.message??``)?o(`offline`):o(`unknown`):o(r===401||r===403?`unauthorized`:r===404||r===410?`notFound`:r===408||r===429?`timeout`:r>=500?`server`:r>=400?`client`:`unknown`)},et=new Set([``,`__load__`,`search`,`_globalsearch`,`_notifications-list`]),tt=[`_appcontext-search-`,`search-`],nt=(e,t)=>t===!0?!0:e==null?!1:et.has(e)?!0:tt.some(t=>e.startsWith(t)),rt=(e,t=Math.random)=>{let n=300*3**Math.max(0,e-1);return Math.round(n*(.75+t()*.5))},it=(e,t,n)=>!n.idempotent||t>2||!e.retryable?!1:e.kind===`timeout`||e.kind===`server`,at=new class{constructor(){this.linkUp=!0,this.listeners=new Set,this.waiters=new Set,this.started=!1}start(){this.started||typeof window>`u`||(this.started=!0,this.linkUp=typeof navigator<`u`&&typeof navigator.onLine==`boolean`?navigator.onLine:!0,window.addEventListener(`online`,()=>{this.linkUp=!0,this.reachable=void 0,this.changed(),this.releaseWaiters()}),window.addEventListener(`offline`,()=>{this.linkUp=!1,this.changed()}))}isOnline(){return this.linkUp?this.reachable!==!1:!1}noteReachable(){let e=this.isOnline();this.reachable=!0,e||(this.changed(),this.releaseWaiters())}noteUnreachable(){let e=this.isOnline();this.reachable=!1,e&&this.changed()}subscribe(e){return this.listeners.add(e),()=>this.listeners.delete(e)}whenBack(e){return this.isOnline()?(e(),()=>{}):(this.waiters.add(e),()=>this.waiters.delete(e))}reset(){this.linkUp=!0,this.reachable=void 0,this.waiters.clear()}changed(){let e=this.isOnline();this.listeners.forEach(t=>t(e))}releaseWaiters(){let e=Array.from(this.waiters);this.waiters.clear(),e.forEach(e=>e())}};at.start();var ot=[],st=6e4,ct=e=>new Promise(t=>setTimeout(t,e)),lt=new class{constructor(){this.axiosInstance=ae.create({timeout:st}),this.axiosInstance.interceptors.request.use(e=>(this.addAuthToken(e),this.addSessionId(e),e)),this.axiosInstance.interceptors.response.use(e=>{let t=Ae({requestedUrl:this.axiosInstance.getUri(e.config),finalUrl:e.request?.responseURL,contentType:String(e.headers?.[`content-type`]??``),data:e.data});if(t)throw window.location.assign(t),Object.assign(Error(`session lost — redirecting to `+t),{code:`ERR_CANCELED`});return e},e=>{let t=e;if(t?.response?.status===401&&t.config&&!t.config.__mateuRetried){let n=t.config;return n.__mateuRetried=!0,Oe(e,()=>this.axiosInstance.request(n))}throw e})}addSessionId(e){let t=sessionStorage.getItem(`__mateu_sesion_id`);t||(t=E(),sessionStorage.setItem(`__mateu_sesion_id`,t)),e.headers[`X-Session-Id`]=t}addAuthToken(e){let t=localStorage.getItem(`__mateu_auth_token`);t&&(e.headers.Authorization=`Bearer `+t)}async wrap(e,t,n,r,i){return n||t.dispatchEvent(new CustomEvent(`backend-called-event`,{bubbles:!0,composed:!0,detail:{}})),e().then(e=>(t.dispatchEvent(new CustomEvent(`backend-succeeded-event`,{bubbles:!0,composed:!0,detail:{actionId:r}})),e)).catch(e=>{let n=$e(e,{online:at.isOnline()});throw n.kind==`cancelled`?t.dispatchEvent(new CustomEvent(`backend-cancelled-event`,{bubbles:!0,composed:!0,detail:{actionId:r}})):(e&&typeof e==`object`&&(e.__mateuReported=!0),t.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:r,reason:this.serialize(e),failure:n,retry:i}}))),e})}async sendWithRetry(e,t){let n=0;for(;;)try{let t=await e();return at.noteReachable(),t}catch(e){let r=$e(e,{online:at.isOnline()});if(r.kind==`offline`&&at.noteUnreachable(),n++,!it(r,n,{idempotent:t}))throw e;await ct(rt(n))}}serialize(e){return e?.message?e:JSON.stringify(e)}release(e){ot=ot.filter(t=>t!==e)}async get(e){let t=new AbortController;return ot=[...ot,t],this.axiosInstance.get(e,{signal:t.signal}).finally(()=>this.release(t))}async post(e,t,n){let r=new AbortController;return ot=[...ot,r],this.axiosInstance.post(e,t,{signal:r.signal,...n&&n>0?{timeout:n}:{}}).finally(()=>this.release(r))}async abortAll(){ot.forEach(e=>e.abort()),ot=[]}async runAction(e,t,n,r,i,a,o,s,c,l,u,d={}){if(t&&t.startsWith(`/`)&&(t=t.substring(1)),r===``&&(await qe(),Je())){let e=Ye(Ge(t))??Xe(Ge(t));if(e){let t={...e,fragments:(e.fragments??[]).map(e=>e.targetComponentId?e:{...e,targetComponentId:i})};return await this.wrap(()=>Promise.resolve(t),l,u,r,d.retry)}}let f=[e,t,n,o??``,r,i].join(``),p=je.check(f);if(p.blocked)return await this.abortAll(),p.firstTrip&&console.error(`[mateu] request loop detected — aborting repeated request`,f),{messages:p.firstTrip?[{title:``,text:`A repeating request was detected and stopped to protect the server. Reload the page or navigate elsewhere.`,position:`bottom-end`,variant:`error`,duration:6e3}]:[],commands:[],fragments:[],banners:[],appendBanners:!1,appData:void 0,appState:void 0};a={...Se(),...a};let ee=e+`/mateu/v3/sync/`+(t&&t!=``?t:`_no_route`),m={serverSideType:o,appState:a,componentState:s,parameters:c,initiatorComponentId:i,consumedRoute:n,route:t&&t!=``?`/`+t:``,actionId:r,knownStructureHash:d.knownStructureHash},te=nt(r,d.idempotent),ne=()=>this.post(ee,m,d.timeoutMillis).then(e=>e.data);return await this.wrap(()=>this.sendWithRetry(ne,te),l,u,r,d.retry)}},ut=function(e){return e.Add=`Add`,e.Replace=`Replace`,e.ReplaceKeepData=`ReplaceKeepData`,e}({}),dt=function(e){return e.HAMBURGUER_MENU=`HAMBURGUER_MENU`,e.MENU_ON_LEFT=`MENU_ON_LEFT`,e.MENU_ON_TOP=`MENU_ON_TOP`,e.TABS=`TABS`,e.TILES=`TILES`,e.RAIL=`RAIL`,e.AUTO=`AUTO`,e.MEDIATOR=`MEDIATOR`,e}({}),ft=new Map,pt=[`position:absolute`,`width:1px`,`height:1px`,`margin:-1px`,`padding:0`,`overflow:hidden`,`clip:rect(0 0 0 0)`,`clip-path:inset(50%)`,`white-space:nowrap`,`border:0`].join(`;`),mt=e=>{if(typeof document>`u`||!document.body)return;let t=ft.get(e);return t?.isConnected?t:(t=document.createElement(`div`),t.setAttribute(`aria-live`,e),t.setAttribute(`aria-atomic`,`true`),t.setAttribute(`role`,e===`assertive`?`alert`:`status`),t.setAttribute(`data-mateu-live-region`,e),t.style.cssText=pt,document.body.appendChild(t),ft.set(e,t),t)},ht=()=>{if(!(typeof document>`u`)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>ht(),{once:!0});return}mt(`polite`),mt(`assertive`)}},gt=(e,t={})=>{let n=(e??``).trim();if(!n)return;let r=mt(t.politeness??`polite`);if(r){if(r.textContent===n){r.textContent=``,setTimeout(()=>{r.textContent=n},60);return}r.textContent=n}},_t=class extends b{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.callbackToken=``,this.createElement=e=>{let t=e.data,n=document.createElement(t.name);for(let e in t.attributes)n.setAttribute(e,t.attributes[e]);for(let e in t.on)n.addEventListener(e,n=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.on[e],parameters:{event:n}},bubbles:!0,composed:!0}))});return n},this.closeModal=()=>{let e=(this.shadowRoot??this).querySelectorAll(`mateu-dialog, mateu-drawer`);if(e&&e.length>0){e[e.length-1].close();return}this.dispatchEvent(new CustomEvent(`close-modal-requested`,{bubbles:!0,composed:!0}))},this.changeFavicon=e=>{let t=document.querySelector(`link[rel="icon"]`);t===null?(t=document.createElement(`link`),t.setAttribute(`rel`,`icon`),t.setAttribute(`href`,e),document.head.appendChild(t)):t.setAttribute(`href`,e)}}connectedCallback(){super.connectedCallback(),this.upstreamSubscription=le.subscribe(e=>{if(e.command){let t=e.command;this.id==t.targetComponentId&&this.applyCommand(t)}if((!e.callbackToken||!this.callbackToken||e.callbackToken===this.callbackToken)&&e.fragment){let t=e.fragment;this.id==t.targetComponentId&&(this.applyFragment(t),this.completeMenu(t))}})}completeMenu(e){if(e.component&&e.component.type==A.ClientSide){let t=e.component,n=t.metadata;if(n?.type==j.App){let e=n,r=this.getRemoteMenus(e.menu);if(r.length>0){let n=r.map(e=>lt.runAction(e.baseUrl,e.route,`_empty`,``,e.baseUrl+`#`+e.route,void 0,void 0,void 0,e.params,this,!0));Promise.all(n).then(n=>{e.menu=this.updateMenu(e.menu,n.map(e=>e.fragments).filter(e=>e).map(e=>e).flat()),e.variant=dt.MENU_ON_TOP,le.next({fragment:{component:t,data:void 0,state:void 0,action:ut.Replace,targetComponentId:this.id,containerId:void 0},callbackToken:this.callbackToken})})}}}}updateMenu(e,t){let n=[];return e.forEach(e=>{if(e.remote){let r=t.find(t=>t.targetComponentId==e.baseUrl+`#`+e.route);if(r&&r.component?.type==A.ClientSide){let t=r.component;if(t.metadata?.type==j.App){let r=t.metadata,i=e.serverSideType&&e.serverSideType!=``?e.serverSideType:r.serverSideType;this.changeBaseUrl(r.menu,e.baseUrl,i,e.route,r.route),n.push(...r.menu)}}}else n.push(e)}),n}changeBaseUrl(e,t,n,r,i){e.forEach(e=>{e.baseUrl||(e.submenus&&e.submenus.length>0?this.changeBaseUrl(e.submenus,t,n,r,i):(e.consumedRoute=i??``,e.baseUrl=t,e.serverSideType=n,e.uriPrefix=r))})}getRemoteMenus(e){let t=[];return e.forEach(e=>{e.remote&&t.push(e)}),t}disconnectedCallback(){super.disconnectedCallback(),this.upstreamSubscription?.unsubscribe()}applyCommand(e){if(e.type==`SetWindowTitle`&&(document.title=e.data,gt(document.title)),e.type==`SetFavicon`&&this.changeFavicon(e.data),e.type==`DispatchEvent`&&this.dispatchNamedEvent(e.data),e.type==`NavigateTo`){let t=e.data;t&&(t.startsWith(`http:`)||t.startsWith(`https:`)?window.open(e.data,`_blank`):window.location.href=e.data)}if(e.type==`PushStateToHistory`){let t=e.data;t!==void 0&&this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0}))}if(e.type==`RunAction`){let t=e.data;if(t&&t.actionId)if(t.targetComponentId){let e={command:{type:`RunAction`,data:{actionId:t.actionId},targetComponentId:t.targetComponentId},fragment:void 0,ui:void 0,error:void 0,callbackToken:``};setTimeout(()=>le.next(e))}else this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:{}},bubbles:!0,composed:!0}))}if(e.type==`MarkAsDirty`&&this.dispatchEvent(new CustomEvent(`dirty`,{detail:{},bubbles:!0,composed:!0})),e.type==`MarkAsClean`&&this.dispatchEvent(new CustomEvent(`clean`,{detail:{},bubbles:!0,composed:!0})),e.type==`DownloadFile`){let t=e.data;if(t&&t.base64Content){let e=atob(t.base64Content),n=new Uint8Array(e.length);for(let t=0;t<e.length;t++)n[t]=e.charCodeAt(t);let r=new Blob([n],{type:t.mimeType}),i=URL.createObjectURL(r),a=document.createElement(`a`);a.href=i,a.download=t.filename??`export`,a.click(),URL.revokeObjectURL(i)}}if(e.type==`CloseModal`&&(this.closeModal(),this.dispatchNamedEvent(e.data)),e.type==`AddContentToHead`){let t=e.data;if(t&&t.name){if(t.attributes&&t.attributes.id&&document.getElementById(t.attributes.id))return;document.head.appendChild(this.createElement(e))}}if(e.type==`AddContentToBody`){let t=e.data;if(t&&t.name){if(t.attributes&&t.attributes.id&&document.getElementById(t.attributes.id))return;document.body.appendChild(this.createElement(e))}}}dispatchNamedEvent(e){if(e&&e.eventName){let t=this.component,n=t?.emitsName??t?.serverSideType,r=e.payload??e.detail;n&&r&&typeof r==`object`&&(r={...r,__source:n}),this.dispatchEvent(new CustomEvent(e.eventName,{detail:r,bubbles:!0,composed:!0}))}}};k([y()],_t.prototype,`id`,void 0),k([y()],_t.prototype,`baseUrl`,void 0);var vt=class extends _t{applyFragment(e){}manageActionRequestedEvent(e){}};k([y()],vt.prototype,`component`,void 0);var yt=(e,t)=>Function(...Object.keys(t),"return `"+e+"`")(...Object.values(t)),bt=(e,t,n)=>({state:e??{},data:t??{},...n});function M(e,t,n,r){if(!e?.includes("${"))return e;try{return yt(e,bt(t,n,r))}catch(t){return console.warn(`Mateu: could not interpolate "${e}":`,t),e}}var N=(e,t,n)=>{if(e&&e.indexOf("${")>=0)try{return yt(e,bt(t,n))}catch(e){return e.message}return e},xt=(e,t,n,r,i)=>{if(!e)return e;let a=bt(t,n,{appState:r??{},appData:i??{}}),o=e;try{if(o=yt(e,a),o.includes("${"))try{o=yt(o,a)}catch(a){o=`when evaluating nested `+e+` :`+a+`, where data is `+n+` and state is `+t+` and app state is `+r+` and app data is `+i,console.error(a,o,t,n,r,i)}}catch(a){o=`when evaluating `+e+` :`+a+`, where data is `+n+` and state is `+t+` and app state is `+r+` and app data is `+i,console.error(a,o,t,n,r,i)}return o},St=(e,t,n,r,i,a)=>{let o=bt(t,n,{appState:r??{},appData:i??{},...a}),s=yt(e,o);return Function(...Object.keys(o),`return (${s})`)(...Object.values(o))},Ct=(e,t,n,r)=>{let i=bt(t,n,r);return Function(...Object.keys(i),`return (${e})`)(...Object.values(i))},wt=(e,t,n,r)=>yt(e,bt(t,n,r)),Tt=`display:inline-flex; align-items:center; justify-content:center; width:2rem; height:2rem; border-radius:50%; background:var(--lumo-contrast-10pct,#e0e0e0); color:var(--lumo-secondary-text-color,#555); font-size:.8rem; font-weight:600; overflow:hidden; flex:none;`,Et=(e,t)=>t||(typeof e==`string`&&e?e.trim().split(/\s+/).map(e=>e[0]).slice(0,2).join(``).toUpperCase():``),Dt=(e,t,n)=>{let r=e.metadata,i=P(r.name,t,n);return T`<span style="${Tt}${e.style}" class="${e.cssClasses}"
+    `}};k([y()],he.prototype,`position`,void 0),k([y()],he.prototype,`zoom`,void 0),k([x(`#map`)],he.prototype,`mapElement`,void 0),he=k([g(`mateu-map`)],he);var ge=typeof HTMLElement<`u`?HTMLElement:class{},_e=class extends ge{static get observedAttributes(){return[`content`]}#e;#t=0;get content(){return this.#e}set content(e){this.#e=e,this.#n()}attributeChangedCallback(e,t,n){this.content=n??void 0}connectedCallback(){this.style.display=`block`,this.#n()}async#n(){if(!this.isConnected)return;let e=this.#e??``,t=++this.#t,[{marked:n},{default:r}]=await Promise.all([D(()=>import(`./vendor.js`).then(e=>e.n),__vite__mapDeps([2,1])),D(()=>import(`./vendor.js`).then(e=>e.a),__vite__mapDeps([2,1]))]);t===this.#t&&(this.innerHTML=r.sanitize(await n.parse(e),{USE_PROFILES:{html:!0,svg:!0,svgFilters:!0},CUSTOM_ELEMENT_HANDLING:{tagNameCheck:e=>!0}}))}};typeof customElements<`u`&&!customElements.get(`mateu-markdown`)&&customElements.define(`mateu-markdown`,_e);var A=function(e){return e.ServerSide=`ServerSide`,e.ClientSide=`ClientSide`,e}({}),j=function(e){return e.Page=`Page`,e.Div=`Div`,e.Element=`Element`,e.MicroFrontend=`MicroFrontend`,e.Form=`Form`,e.Crud=`Crud`,e.Result=`Result`,e.Card=`Card`,e.Directory=`Directory`,e.Stepper=`Stepper`,e.HorizontalLayout=`HorizontalLayout`,e.VerticalLayout=`VerticalLayout`,e.SplitLayout=`SplitLayout`,e.MasterDetailLayout=`MasterDetailLayout`,e.TabLayout=`TabLayout`,e.AccordionLayout=`AccordionLayout`,e.FormLayout=`FormLayout`,e.FormRow=`FormRow`,e.FormItem=`FormItem`,e.BoardLayout=`BoardLayout`,e.BoardLayoutRow=`BoardLayoutRow`,e.BoardLayoutItem=`BoardLayoutItem`,e.Scroller=`Scroller`,e.FullWidth=`FullWidth`,e.Container=`Container`,e.FormField=`FormField`,e.Table=`Table`,e.App=`App`,e.Text=`Text`,e.Avatar=`Avatar`,e.Chat=`Chat`,e.AvatarGroup=`AvatarGroup`,e.Badge=`Badge`,e.Breadcrumbs=`Breadcrumbs`,e.Anchor=`Anchor`,e.Button=`Button`,e.Chart=`Chart`,e.Icon=`Icon`,e.ConfirmDialog=`ConfirmDialog`,e.ContextMenu=`ContextMenu`,e.CookieConsent=`CookieConsent`,e.Details=`Details`,e.Dialog=`Dialog`,e.Drawer=`Drawer`,e.Image=`Image`,e.Map=`Map`,e.Markdown=`Markdown`,e.Notification=`Notification`,e.ProgressBar=`ProgressBar`,e.Popover=`Popover`,e.CarouselLayout=`CarouselLayout`,e.Tooltip=`Tooltip`,e.MessageInput=`MessageInput`,e.MessageList=`MessageList`,e.CustomField=`CustomField`,e.MenuBar=`MenuBar`,e.Grid=`Grid`,e.GridColumn=`GridColumn`,e.GridGroupColumn=`GridGroupColumn`,e.VirtualList=`VirtualList`,e.FormSection=`FormSection`,e.FormSubSection=`FormSubSection`,e.Bpmn=`Bpmn`,e.Workflow=`Workflow`,e.FormEditor=`FormEditor`,e.MetricCard=`MetricCard`,e.Scoreboard=`Scoreboard`,e.DashboardPanel=`DashboardPanel`,e.DashboardLayout=`DashboardLayout`,e.FoldoutLayout=`FoldoutLayout`,e.ContentLayout=`ContentLayout`,e.HeroSection=`HeroSection`,e.EmptyState=`EmptyState`,e.Skeleton=`Skeleton`,e.Gantt=`Gantt`,e.PlanningBoard=`PlanningBoard`,e.Kanban=`Kanban`,e.Timeline=`Timeline`,e.ProgressSteps=`ProgressSteps`,e.Stat=`Stat`,e.Calendar=`Calendar`,e.PricingTable=`PricingTable`,e.OrgChart=`OrgChart`,e.Heatmap=`Heatmap`,e.Funnel=`Funnel`,e.TrendChart=`TrendChart`,e.FeatureGrid=`FeatureGrid`,e.Testimonials=`Testimonials`,e.Faq=`Faq`,e.CalloutCard=`CalloutCard`,e.CommentThread=`CommentThread`,e.FileList=`FileList`,e.Checklist=`Checklist`,e.ComparisonCard=`ComparisonCard`,e.EntityHeader=`EntityHeader`,e.Meter=`Meter`,e.TaskProgress=`TaskProgress`,e.StatusList=`StatusList`,e.BulletedList=`BulletedList`,e.Separator=`Separator`,e.Notice=`Notice`,e.TaskQueue=`TaskQueue`,e.ResourceGrid=`ResourceGrid`,e.OfferCard=`OfferCard`,e.AddOnPicker=`AddOnPicker`,e.Ledger=`Ledger`,e.PaymentPicker=`PaymentPicker`,e.ProcessMonitor=`ProcessMonitor`,e}({}),ve=`mateu-app-context`,ye=`mateu-app-context-labels`,be=e=>{try{return JSON.parse(localStorage.getItem(e)??`{}`)}catch{return{}}},xe=(e,t)=>{try{localStorage.setItem(e,JSON.stringify(t))}catch{}},Se=()=>be(ve),Ce=()=>be(ye),we=(e,t,n)=>{let r=Se(),i=Ce();t==null||t===``?(delete r[e],delete i[e]):(r[e]=t,n!==void 0&&(i[e]=n)),xe(ve,r),xe(ye,i)},Te=!1,Ee=()=>{Te||(Te=!0,window.addEventListener(`storage`,e=>{e.key===ve&&e.newValue!==e.oldValue&&window.location.reload()}))},De,Oe=(e,t)=>new Promise((n,r)=>{let i=!1,a={retry:()=>{i||(i=!0,t().then(n,r))},giveUp:()=>{i||(i=!0,r(e))}};if(De){De(a);return}let o=new CustomEvent(`mateu-session-expired`,{detail:a,cancelable:!0,bubbles:!1});typeof document<`u`&&!document.dispatchEvent(o)||a.giveUp()}),ke=(e,t)=>e.includes(`json`)?!0:typeof t==`object`&&!!t,Ae=(e,t)=>{let n=e.finalUrl;if(!n)return;let r=t??(typeof window<`u`?window.location.href:void 0),i;try{i=new URL(e.requestedUrl,r).href}catch{return}if(i!==n&&!ke(e.contentType??``,e.data))return n},je=new class{constructor(){this.windowMs=4e3,this.threshold=12,this.events=[],this.reported=new Set}check(e,t=Date.now()){this.events.push({sig:e,t});let n=t-this.windowMs;this.events=this.events.filter(e=>e.t>=n);let r=0;for(let t of this.events)t.sig===e&&r++;if(r>=this.threshold){let t=!this.reported.has(e);return this.reported.add(e),{blocked:!0,firstTrip:t}}return this.reported.delete(e),{blocked:!1,firstTrip:!1}}reset(){this.events=[],this.reported.clear()}configure(e){e.windowMs!==void 0&&(this.windowMs=e.windowMs),e.threshold!==void 0&&(this.threshold=e.threshold)}},Me=[],Ne=e=>{Me=Array.isArray(e)?e:[]},Pe=e=>e?Me.find(t=>t.name===e):void 0,Fe=e=>e==null||e===``,Ie=e=>{if(!e?.ref)return e;let t=Pe(e.ref);if(!t?.source)return console.warn(`mateu: no REST source named "${e.ref}" in the app's catalogue`),e;let n=t.source;return{...e,url:Fe(e.url)?n.url:e.url,method:Fe(e.method)?n.method:e.method,headers:e.headers&&Object.keys(e.headers).length>0?e.headers:n.headers,body:Fe(e.body)?n.body:e.body,itemsPath:Fe(e.itemsPath)?n.itemsPath:e.itemsPath,valuePath:Fe(e.valuePath)?n.valuePath:e.valuePath,labelPath:Fe(e.labelPath)?n.labelPath:e.labelPath,proxy:e.proxy||n.proxy}},Le=(e,t)=>{let n=Pe(e?.ref)?.fields?.[t];return n&&n!==``?n:t},Re,ze=[],Be,Ve=[],He=e=>e.split(`/`).filter(e=>e.startsWith(`:`)&&e.length>1).map(e=>e.substring(1)),Ue=e=>{let t=e=>e.replace(/^\/+/,``).replace(/\/+$/,``),n=t(e===`_no_route`?``:e),r=n===``?[]:n.split(`/`),i;for(let e of Ve){let n=t(e.route??``),a=n===``?[]:n.split(`/`);if(a.length!==r.length)continue;let o={},s=!0;for(let e=0;e<a.length;e++){let t=a[e];if(t.startsWith(`:`)&&t.length>1)o[t.substring(1)]=r[e];else if(t!==r[e]){s=!1;break}}if(!s)continue;let c={entry:e,pathParams:o};(!i||He(n).length<He(t(i.entry.route??``)).length)&&(i=c)}return i},We=(e,t)=>{let n=Ue(e);if(!n)return t;let{entry:r,pathParams:i}=n,a=r.defaultParams??{},o=r.fixedParams??{};return!Object.keys(a).length&&!Object.keys(o).length&&!Object.keys(i).length?t:{...t,fragments:(t.fragments??[]).map(e=>({...e,state:{...a,...e.state??{},...i,...o},data:{...a,...e.data??{},...i,...o}}))}},Ge=e=>{let t=e&&e.startsWith(`/`)?e.substring(1):e??``;return t===``?`_no_route`:t};function Ke(e,t=fetch){return Be=(async()=>{try{let n=await t(e);if(!n.ok)return;let r=await n.json(),i=new Map,a=[];for(let e of r.entries??[])if(!(!e.ok||!e.json))try{let t=JSON.parse(e.json);e.routePattern?a.push({regex:new RegExp(e.routePattern),paramNames:e.paramNames??[],increment:t}):i.set(e.syncPath,t)}catch(t){console.warn(`mateu: bundle entry parse failed for`,e.syncPath,t)}Re=i,ze=a,Ve=r.routes?.routes??[],Ne(r.sources?.sources)}catch(e){console.warn(`mateu: bundle manifest load failed`,e)}})(),Be}var qe=()=>Be??Promise.resolve(),Je=()=>Re!==void 0&&Re.size>0||ze.length>0,Ye=e=>{let t=Re?.get(e);return t===void 0?void 0:We(e,t)},Xe=e=>{for(let t of ze){let n=t.regex.exec(e);if(!n)continue;let r={};return t.paramNames.forEach((e,t)=>{r[e]=n[t+1]}),We(e,{...t.increment,fragments:(t.increment.fragments??[]).map(e=>({...e,state:{...e.state??{},...r},data:{...e.data??{},...r}}))})}},Ze={offline:()=>`No connection. Your changes have not been sent — check your network and try again.`,timeout:()=>`The server is taking too long to answer. Your changes may not have been saved.`,server:e=>`The server could not complete the request${e?` (error ${e})`:``}. Please try again.`,unauthorized:()=>`Your session is no longer valid. Please sign in again.`,notFound:()=>`This is no longer available. It may have been moved or deleted.`,client:e=>`The request was rejected${e?` (error ${e})`:``}.`,cancelled:()=>``,unknown:()=>`Something went wrong. Please try again.`},Qe=new Set([`offline`,`timeout`,`server`]),$e=(e,t={})=>{let n=e??{},r=n.response?.status,i=n.code,a=t.online??(typeof navigator<`u`&&typeof navigator.onLine==`boolean`?navigator.onLine:!0),o=e=>({kind:e,message:Ze[e](r),retryable:Qe.has(e),status:r});return i===`ERR_CANCELED`?o(`cancelled`):i===`ECONNABORTED`||i===`ETIMEDOUT`||/timeout/i.test(n.message??``)?o(`timeout`):r===void 0?!a||i===`ERR_NETWORK`||/network error/i.test(n.message??``)?o(`offline`):o(`unknown`):o(r===401||r===403?`unauthorized`:r===404||r===410?`notFound`:r===408||r===429?`timeout`:r>=500?`server`:r>=400?`client`:`unknown`)},et=new Set([``,`__load__`,`search`,`_globalsearch`,`_notifications-list`]),tt=[`_appcontext-search-`,`search-`],nt=(e,t)=>t===!0?!0:e==null?!1:et.has(e)?!0:tt.some(t=>e.startsWith(t)),rt=(e,t=Math.random)=>{let n=300*3**Math.max(0,e-1);return Math.round(n*(.75+t()*.5))},it=(e,t,n)=>!n.idempotent||t>2||!e.retryable?!1:e.kind===`timeout`||e.kind===`server`,at=new class{constructor(){this.linkUp=!0,this.listeners=new Set,this.waiters=new Set,this.started=!1}start(){this.started||typeof window>`u`||(this.started=!0,this.linkUp=typeof navigator<`u`&&typeof navigator.onLine==`boolean`?navigator.onLine:!0,window.addEventListener(`online`,()=>{this.linkUp=!0,this.reachable=void 0,this.changed(),this.releaseWaiters()}),window.addEventListener(`offline`,()=>{this.linkUp=!1,this.changed()}))}isOnline(){return this.linkUp?this.reachable!==!1:!1}noteReachable(){let e=this.isOnline();this.reachable=!0,e||(this.changed(),this.releaseWaiters())}noteUnreachable(){let e=this.isOnline();this.reachable=!1,e&&this.changed()}subscribe(e){return this.listeners.add(e),()=>this.listeners.delete(e)}whenBack(e){return this.isOnline()?(e(),()=>{}):(this.waiters.add(e),()=>this.waiters.delete(e))}reset(){this.linkUp=!0,this.reachable=void 0,this.waiters.clear()}changed(){let e=this.isOnline();this.listeners.forEach(t=>t(e))}releaseWaiters(){let e=Array.from(this.waiters);this.waiters.clear(),e.forEach(e=>e())}};at.start();var ot=[],st=6e4,ct=e=>new Promise(t=>setTimeout(t,e)),lt=new class{constructor(){this.axiosInstance=ae.create({timeout:st}),this.axiosInstance.interceptors.request.use(e=>(this.addAuthToken(e),this.addSessionId(e),e)),this.axiosInstance.interceptors.response.use(e=>{let t=Ae({requestedUrl:this.axiosInstance.getUri(e.config),finalUrl:e.request?.responseURL,contentType:String(e.headers?.[`content-type`]??``),data:e.data});if(t)throw window.location.assign(t),Object.assign(Error(`session lost — redirecting to `+t),{code:`ERR_CANCELED`});return e},e=>{let t=e;if(t?.response?.status===401&&t.config&&!t.config.__mateuRetried){let n=t.config;return n.__mateuRetried=!0,Oe(e,()=>this.axiosInstance.request(n))}throw e})}addSessionId(e){let t=sessionStorage.getItem(`__mateu_sesion_id`);t||(t=E(),sessionStorage.setItem(`__mateu_sesion_id`,t)),e.headers[`X-Session-Id`]=t}addAuthToken(e){let t=localStorage.getItem(`__mateu_auth_token`);t&&(e.headers.Authorization=`Bearer `+t)}async wrap(e,t,n,r,i){return n||t.dispatchEvent(new CustomEvent(`backend-called-event`,{bubbles:!0,composed:!0,detail:{}})),e().then(e=>(t.dispatchEvent(new CustomEvent(`backend-succeeded-event`,{bubbles:!0,composed:!0,detail:{actionId:r}})),e)).catch(e=>{let n=$e(e,{online:at.isOnline()});throw n.kind==`cancelled`?t.dispatchEvent(new CustomEvent(`backend-cancelled-event`,{bubbles:!0,composed:!0,detail:{actionId:r}})):(e&&typeof e==`object`&&(e.__mateuReported=!0),t.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:r,reason:this.serialize(e),failure:n,retry:i}}))),e})}async sendWithRetry(e,t){let n=0;for(;;)try{let t=await e();return at.noteReachable(),t}catch(e){let r=$e(e,{online:at.isOnline()});if(r.kind==`offline`&&at.noteUnreachable(),n++,!it(r,n,{idempotent:t}))throw e;await ct(rt(n))}}serialize(e){return e?.message?e:JSON.stringify(e)}release(e){ot=ot.filter(t=>t!==e)}async get(e){let t=new AbortController;return ot=[...ot,t],this.axiosInstance.get(e,{signal:t.signal}).finally(()=>this.release(t))}async post(e,t,n){let r=new AbortController;return ot=[...ot,r],this.axiosInstance.post(e,t,{signal:r.signal,...n&&n>0?{timeout:n}:{}}).finally(()=>this.release(r))}async abortAll(){ot.forEach(e=>e.abort()),ot=[]}async runAction(e,t,n,r,i,a,o,s,c,l,u,d={}){if(t&&t.startsWith(`/`)&&(t=t.substring(1)),r===``&&(await qe(),Je())){let e=Ye(Ge(t))??Xe(Ge(t));if(e){let t={...e,fragments:(e.fragments??[]).map(e=>e.targetComponentId?e:{...e,targetComponentId:i})};return await this.wrap(()=>Promise.resolve(t),l,u,r,d.retry)}}let f=[e,t,n,o??``,r,i].join(``),p=je.check(f);if(p.blocked)return await this.abortAll(),p.firstTrip&&console.error(`[mateu] request loop detected — aborting repeated request`,f),{messages:p.firstTrip?[{title:``,text:`A repeating request was detected and stopped to protect the server. Reload the page or navigate elsewhere.`,position:`bottom-end`,variant:`error`,duration:6e3}]:[],commands:[],fragments:[],banners:[],appendBanners:!1,appData:void 0,appState:void 0};a={...Se(),...a};let ee=e+`/mateu/v3/sync/`+(t&&t!=``?t:`_no_route`),m={serverSideType:o,appState:a,componentState:s,parameters:c,initiatorComponentId:i,consumedRoute:n,route:t&&t!=``?`/`+t:``,actionId:r,knownStructureHash:d.knownStructureHash},te=nt(r,d.idempotent),ne=()=>this.post(ee,m,d.timeoutMillis).then(e=>e.data);return await this.wrap(()=>this.sendWithRetry(ne,te),l,u,r,d.retry)}},ut=function(e){return e.Add=`Add`,e.Replace=`Replace`,e.ReplaceKeepData=`ReplaceKeepData`,e}({}),dt=function(e){return e.HAMBURGUER_MENU=`HAMBURGUER_MENU`,e.MENU_ON_LEFT=`MENU_ON_LEFT`,e.MENU_ON_TOP=`MENU_ON_TOP`,e.TABS=`TABS`,e.TILES=`TILES`,e.RAIL=`RAIL`,e.AUTO=`AUTO`,e.MEDIATOR=`MEDIATOR`,e}({}),ft=new Map,pt=[`position:absolute`,`width:1px`,`height:1px`,`margin:-1px`,`padding:0`,`overflow:hidden`,`clip:rect(0 0 0 0)`,`clip-path:inset(50%)`,`white-space:nowrap`,`border:0`].join(`;`),mt=e=>{if(typeof document>`u`||!document.body)return;let t=ft.get(e);return t?.isConnected?t:(t=document.createElement(`div`),t.setAttribute(`aria-live`,e),t.setAttribute(`aria-atomic`,`true`),t.setAttribute(`role`,e===`assertive`?`alert`:`status`),t.setAttribute(`data-mateu-live-region`,e),t.style.cssText=pt,document.body.appendChild(t),ft.set(e,t),t)},ht=()=>{if(!(typeof document>`u`)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>ht(),{once:!0});return}mt(`polite`),mt(`assertive`)}},gt=(e,t={})=>{let n=(e??``).trim();if(!n)return;let r=mt(t.politeness??`polite`);if(r){if(r.textContent===n){r.textContent=``,setTimeout(()=>{r.textContent=n},60);return}r.textContent=n}},_t=class extends b{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.callbackToken=``,this.createElement=e=>{let t=e.data,n=document.createElement(t.name);for(let e in t.attributes)n.setAttribute(e,t.attributes[e]);for(let e in t.on)n.addEventListener(e,n=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.on[e],parameters:{event:n}},bubbles:!0,composed:!0}))});return n},this.closeModal=()=>{let e=(this.shadowRoot??this).querySelectorAll(`mateu-dialog, mateu-drawer`);if(e&&e.length>0){e[e.length-1].close();return}this.dispatchEvent(new CustomEvent(`close-modal-requested`,{bubbles:!0,composed:!0}))},this.changeFavicon=e=>{let t=document.querySelector(`link[rel="icon"]`);t===null?(t=document.createElement(`link`),t.setAttribute(`rel`,`icon`),t.setAttribute(`href`,e),document.head.appendChild(t)):t.setAttribute(`href`,e)}}connectedCallback(){super.connectedCallback(),this.upstreamSubscription=le.subscribe(e=>{if(e.command){let t=e.command;this.id==t.targetComponentId&&this.applyCommand(t)}if((!e.callbackToken||!this.callbackToken||e.callbackToken===this.callbackToken)&&e.fragment){let t=e.fragment;this.id==t.targetComponentId&&(this.applyFragment(t),this.completeMenu(t))}})}completeMenu(e){if(e.component&&e.component.type==A.ClientSide){let t=e.component,n=t.metadata;if(n?.type==j.App){let e=n,r=this.getRemoteMenus(e.menu);if(r.length>0){let n=r.map(e=>lt.runAction(e.baseUrl,e.route,`_empty`,``,e.baseUrl+`#`+e.route,void 0,void 0,void 0,e.params,this,!0));Promise.all(n).then(n=>{e.menu=this.updateMenu(e.menu,n.map(e=>e.fragments).filter(e=>e).map(e=>e).flat()),e.variant=dt.MENU_ON_TOP,le.next({fragment:{component:t,data:void 0,state:void 0,action:ut.Replace,targetComponentId:this.id,containerId:void 0},callbackToken:this.callbackToken})})}}}}updateMenu(e,t){let n=[];return e.forEach(e=>{if(e.remote){let r=t.find(t=>t.targetComponentId==e.baseUrl+`#`+e.route);if(r&&r.component?.type==A.ClientSide){let t=r.component;if(t.metadata?.type==j.App){let r=t.metadata,i=e.serverSideType&&e.serverSideType!=``?e.serverSideType:r.serverSideType;this.changeBaseUrl(r.menu,e.baseUrl,i,e.route,r.route),n.push(...r.menu)}}}else n.push(e)}),n}changeBaseUrl(e,t,n,r,i){e.forEach(e=>{e.baseUrl||(e.submenus&&e.submenus.length>0?this.changeBaseUrl(e.submenus,t,n,r,i):(e.consumedRoute=i??``,e.baseUrl=t,e.serverSideType=n,e.uriPrefix=r))})}getRemoteMenus(e){let t=[];return e.forEach(e=>{e.remote&&t.push(e)}),t}disconnectedCallback(){super.disconnectedCallback(),this.upstreamSubscription?.unsubscribe()}applyCommand(e){if(e.type==`SetWindowTitle`&&(document.title=e.data,gt(document.title)),e.type==`SetFavicon`&&this.changeFavicon(e.data),e.type==`DispatchEvent`&&this.dispatchNamedEvent(e.data),e.type==`NavigateTo`){let t=e.data;t&&(t.startsWith(`http:`)||t.startsWith(`https:`)?window.open(e.data,`_blank`):window.location.href=e.data)}if(e.type==`PushStateToHistory`){let t=e.data;t!==void 0&&this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0}))}if(e.type==`RunAction`){let t=e.data;if(t&&t.actionId)if(t.targetComponentId){let e={command:{type:`RunAction`,data:{actionId:t.actionId},targetComponentId:t.targetComponentId},fragment:void 0,ui:void 0,error:void 0,callbackToken:``};setTimeout(()=>le.next(e))}else this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:{}},bubbles:!0,composed:!0}))}if(e.type==`MarkAsDirty`&&this.dispatchEvent(new CustomEvent(`dirty`,{detail:{},bubbles:!0,composed:!0})),e.type==`MarkAsClean`&&this.dispatchEvent(new CustomEvent(`clean`,{detail:{},bubbles:!0,composed:!0})),e.type==`DownloadFile`){let t=e.data;if(t&&t.base64Content){let e=atob(t.base64Content),n=new Uint8Array(e.length);for(let t=0;t<e.length;t++)n[t]=e.charCodeAt(t);let r=new Blob([n],{type:t.mimeType}),i=URL.createObjectURL(r),a=document.createElement(`a`);a.href=i,a.download=t.filename??`export`,a.click(),URL.revokeObjectURL(i)}}if(e.type==`CloseModal`&&(this.closeModal(),this.dispatchNamedEvent(e.data)),e.type==`AddContentToHead`){let t=e.data;if(t&&t.name){if(t.attributes&&t.attributes.id&&document.getElementById(t.attributes.id))return;document.head.appendChild(this.createElement(e))}}if(e.type==`AddContentToBody`){let t=e.data;if(t&&t.name){if(t.attributes&&t.attributes.id&&document.getElementById(t.attributes.id))return;document.body.appendChild(this.createElement(e))}}}dispatchNamedEvent(e){if(e&&e.eventName){let t=this.component,n=t?.emitsName??t?.serverSideType,r=e.payload??e.detail;n&&r&&typeof r==`object`&&(r={...r,__source:n}),this.dispatchEvent(new CustomEvent(e.eventName,{detail:r,bubbles:!0,composed:!0}))}}};k([y()],_t.prototype,`id`,void 0),k([y()],_t.prototype,`baseUrl`,void 0);var vt=class extends _t{applyFragment(e){}manageActionRequestedEvent(e){}};k([y()],vt.prototype,`component`,void 0);var yt=(e,t)=>Function(...Object.keys(t),"return `"+e+"`")(...Object.values(t)),bt=(e,t,n)=>({state:e??{},data:t??{},...n});function M(e,t,n,r){if(!e?.includes("${"))return e;try{return yt(e,bt(t,n,r))}catch(t){return console.warn(`Mateu: could not interpolate "${e}":`,t),e}}var N=(e,t,n)=>{if(e&&e.indexOf("${")>=0)try{return yt(e,bt(t,n))}catch(e){return e.message}return e},xt=(e,t,n,r,i)=>{if(!e)return e;let a=bt(t,n,{appState:r??{},appData:i??{}}),o=e;try{if(o=yt(e,a),o.includes("${"))try{o=yt(o,a)}catch(a){o=`when evaluating nested `+e+` :`+a+`, where data is `+n+` and state is `+t+` and app state is `+r+` and app data is `+i,console.error(a,o,t,n,r,i)}}catch(a){o=`when evaluating `+e+` :`+a+`, where data is `+n+` and state is `+t+` and app state is `+r+` and app data is `+i,console.error(a,o,t,n,r,i)}return o},St=(e,t,n,r,i,a)=>{let o=bt(t,n,{appState:r??{},appData:i??{},...a}),s=yt(e,o);return Function(...Object.keys(o),`return (${s})`)(...Object.values(o))},Ct=(e,t,n,r)=>{let i=bt(t,n,r);return Function(...Object.keys(i),`return (${e})`)(...Object.values(i))},wt=(e,t,n,r)=>yt(e,bt(t,n,r)),Tt=`display:inline-flex; align-items:center; justify-content:center; width:2rem; height:2rem; border-radius:50%; background:var(--lumo-contrast-10pct,#e0e0e0); color:var(--lumo-secondary-text-color,#555); font-size:.8rem; font-weight:600; overflow:hidden; flex:none;`,Et=(e,t)=>t||(typeof e==`string`&&e?e.trim().split(/\s+/).map(e=>e[0]).slice(0,2).join(``).toUpperCase():``),Dt=(e,t,n)=>{let r=e.metadata,i=Ot(r.name,t,n);return T`<span style="${Tt}${e.style}" class="${e.cssClasses}"
                       title="${i||v}" slot="${e.slot??v}">
         ${r.image?T`<img src="${r.image}" alt="${i}" style="width:100%;height:100%;object-fit:cover;">`:Et(i,r.abbreviation)}
-    </span>`},P=(e,t,n)=>typeof e==`string`&&e.includes("${")?M(e,t,n):e,Ot=e=>{let t=e.metadata,n=t.avatars??[],r=t.maxItemsVisible&&t.maxItemsVisible>0?t.maxItemsVisible:n.length,i=n.slice(0,r),a=n.length-i.length,o=`margin-left:-0.4rem; border:2px solid var(--lumo-base-color,#fff);`;return T`<span style="display:inline-flex; ${e.style}" class="${e.cssClasses}" slot="${e.slot??v}">
+    </span>`},Ot=(e,t,n)=>typeof e==`string`&&e.includes("${")?M(e,t,n):e,kt=e=>{let t=e.metadata,n=t.avatars??[],r=t.maxItemsVisible&&t.maxItemsVisible>0?t.maxItemsVisible:n.length,i=n.slice(0,r),a=n.length-i.length,o=`margin-left:-0.4rem; border:2px solid var(--lumo-base-color,#fff);`;return T`<span style="display:inline-flex; ${e.style}" class="${e.cssClasses}" slot="${e.slot??v}">
         ${i.map(e=>T`<span style="${Tt}${o}" title="${e.name||v}">
             ${e.img?T`<img src="${e.img}" style="width:100%;height:100%;object-fit:cover;">`:Et(e.name??``,e.abbr)}
         </span>`)}
         ${a>0?T`<span style="${Tt}${o}">+${a}</span>`:v}
-    </span>`},kt=(e,t,n)=>{let r=e.metadata;return T`<span theme="badge ${r.color} ${r.pill?`pill`:``} ${r.small?`small`:``} ${r.primary?`primary`:``}"
+    </span>`},At=(e,t,n)=>{let r=e.metadata;return T`<span theme="badge ${r.color} ${r.pill?`pill`:``} ${r.small?`small`:``} ${r.primary?`primary`:``}"
                       style="${e.style}" class="${e.cssClasses}"
-                      slot="${e.slot??v}">${P(r.text,t,n)}</span>`},At=(e,t,n)=>{let r=P(e.text,t,n);if(!r)return v;let i=P(e.color,t,n);return i==`SUCCESS`&&(i=`success`),i==`ERROR`&&(i=`error`),i==`DANGER`&&(i=`error`),i==`WARNING`&&(i=`warning`),i==`INFO`&&(i=`info`),i==`PRIMARY`&&(i=`primary`),i==`SECONDARY`&&(i=`secondary`),i==`TERTIARY`&&(i=`tertiary`),i==`QUATERNARY`&&(i=`quaternary`),i==`LIGHT`&&(i=`light`),i==`DARK`&&(i=`dark`),T`<span theme="badge ${i} ${e.pill?`pill`:``} ${e.small?`small`:``} ${e.primary?`primary`:``}">${r}</span>`},F=new class{constructor(){this.afterRenderHook=void 0,this.useShadowRoot=!0,this.componentRenderer=void 0}set(e){if(this.componentRenderer=e,typeof window<`u`){let t=e.supportedClientSideTypes?.();window.__mateuRendererInfo={name:e.rendererName?.()??e.constructor?.name??`unknown`,supportedTypes:t?[...t].sort():null}}}get(){return this.componentRenderer}setUseShadowRoot(e){this.useShadowRoot=e}mustUseShadowRoot(){return this.useShadowRoot}setAfterRenderHook(e){this.afterRenderHook=e}getAfterRenderHook(){return this.afterRenderHook}},jt=(e,t,n,r,i,a,o,s,c)=>(t.slot=s,I(e,t,n,r,i,a,o,c)),I=(e,t,n,r,i,a,o,s)=>{if(!t)return T``;if(t.type==A.ClientSide)return F.get().renderClientSideComponent(e,t,n,r,i,a,o,s);let c=e.route,l=e.consumedRoute;return T`
+                      slot="${e.slot??v}">${Ot(r.text,t,n)}</span>`},jt=(e,t,n)=>{let r=Ot(e.text,t,n);if(!r)return v;let i=Ot(e.color,t,n);return i==`SUCCESS`&&(i=`success`),i==`ERROR`&&(i=`error`),i==`DANGER`&&(i=`error`),i==`WARNING`&&(i=`warning`),i==`INFO`&&(i=`info`),i==`PRIMARY`&&(i=`primary`),i==`SECONDARY`&&(i=`secondary`),i==`TERTIARY`&&(i=`tertiary`),i==`QUATERNARY`&&(i=`quaternary`),i==`LIGHT`&&(i=`light`),i==`DARK`&&(i=`dark`),T`<span theme="badge ${i} ${e.pill?`pill`:``} ${e.small?`small`:``} ${e.primary?`primary`:``}">${r}</span>`},P=new class{constructor(){this.afterRenderHook=void 0,this.useShadowRoot=!0,this.componentRenderer=void 0}set(e){if(this.componentRenderer=e,typeof window<`u`){let t=e.supportedClientSideTypes?.();window.__mateuRendererInfo={name:e.rendererName?.()??e.constructor?.name??`unknown`,supportedTypes:t?[...t].sort():null}}}get(){return this.componentRenderer}setUseShadowRoot(e){this.useShadowRoot=e}mustUseShadowRoot(){return this.useShadowRoot}setAfterRenderHook(e){this.afterRenderHook=e}getAfterRenderHook(){return this.afterRenderHook}},Mt=(e,t,n,r,i,a,o,s,c)=>(t.slot=s,F(e,t,n,r,i,a,o,c)),F=(e,t,n,r,i,a,o,s)=>{if(!t)return T``;if(t.type==A.ClientSide)return P.get().renderClientSideComponent(e,t,n,r,i,a,o,s);let c=e.route,l=e.consumedRoute;return T`
         <mateu-component id="${t.id}"
                          .component="${t}"
                         route="${c}"
@@ -163,8 +163,8 @@ ${i}
                          .appState="${a}"
                          .appData="${o}"
         >
-       </mateu-component>`},Mt=e=>{let t=[];return e.color&&e.color!==`normal`&&e.color!==`none`&&t.push(e.color),e.buttonStyle&&t.push(e.buttonStyle===`tertiaryInline`?`tertiary-inline`:e.buttonStyle),e.size&&e.size!==`none`&&e.size!==`normal`&&t.push(e.size),t.length?t.join(` `):void 0},Nt=e=>{let t=Mt(e)??``,n=[];return t.includes(`primary`)&&n.push(`primary`),t.includes(`tertiary`)&&n.push(`tertiary`),(t.includes(`error`)||e.color===`error`)&&n.push(`danger`),n.join(` `)},Pt=e=>e===`back`||e===`backToList`||!!e&&e.startsWith(`cancel`),Ft=class extends b{constructor(...e){super(...e),this.appState={},this.appData={},this._overflowOpen=!1,this._overflowN=0,this._secCount=0,this._onDocClick=e=>{e.composedPath().includes(this)||(this._overflowOpen=!1)},this._resetOverflow=()=>{this._overflowN===0?this.requestUpdate():this._overflowN=0},this.handleButtonClick=e=>{this._overflowOpen=!1,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.evalLabel=e=>M(e,this.state,this.data),this.renderBtn=e=>{if((this.data??{})[e.actionId+`.hidden`])return v;let t=this.evalLabel(e.label);return F.get()?.renderToolbarButton?.(e,t,()=>this.handleButtonClick(e.actionId))||T`
-        <button class="mtb ${Nt(e)}"
+       </mateu-component>`},Nt=e=>{let t=[];return e.color&&e.color!==`normal`&&e.color!==`none`&&t.push(e.color),e.buttonStyle&&t.push(e.buttonStyle===`tertiaryInline`?`tertiary-inline`:e.buttonStyle),e.size&&e.size!==`none`&&e.size!==`normal`&&t.push(e.size),t.length?t.join(` `):void 0},Pt=e=>{let t=Nt(e)??``,n=[];return t.includes(`primary`)&&n.push(`primary`),t.includes(`tertiary`)&&n.push(`tertiary`),(t.includes(`error`)||e.color===`error`)&&n.push(`danger`),n.join(` `)},Ft=e=>e===`back`||e===`backToList`||!!e&&e.startsWith(`cancel`),It=class extends b{constructor(...e){super(...e),this.appState={},this.appData={},this._overflowOpen=!1,this._overflowN=0,this._secCount=0,this._onDocClick=e=>{e.composedPath().includes(this)||(this._overflowOpen=!1)},this._resetOverflow=()=>{this._overflowN===0?this.requestUpdate():this._overflowN=0},this.handleButtonClick=e=>{this._overflowOpen=!1,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.evalLabel=e=>M(e,this.state,this.data),this.renderBtn=e=>{if((this.data??{})[e.actionId+`.hidden`])return v;let t=this.evalLabel(e.label);return P.get()?.renderToolbarButton?.(e,t,()=>this.handleButtonClick(e.actionId))||T`
+        <button class="mtb ${Pt(e)}"
                 data-action-id="${e.id}"
                 @click="${()=>this.handleButtonClick(e.actionId)}"
                 ?disabled="${e.disabled}"
@@ -190,7 +190,7 @@ ${i}
                     </div>
                 `:v}
             </div>
-        `},this.renderPeerNav=e=>F.get()?.renderPeerNav?.(e)||T`
+        `},this.renderPeerNav=e=>P.get()?.renderPeerNav?.(e)||T`
             <div style="display: flex; gap: var(--lumo-space-xs, .25rem); align-items: center;" class="peer-nav">
                 <button class="mtb tertiary peer-nav-prev"
                         title="${e.prevLabel??`Previous`}"
@@ -201,7 +201,7 @@ ${i}
                         ?disabled="${!e.nextRoute}"
                         @click="${()=>{e.nextRoute&&(window.location.href=e.nextRoute)}}">›</button>
             </div>
-        `}connectedCallback(){super.connectedCallback(),document.addEventListener(`click`,this._onDocClick),this._ro=new ResizeObserver(()=>this._resetOverflow()),this._ro.observe(this),window.addEventListener(`resize`,this._resetOverflow)}disconnectedCallback(){document.removeEventListener(`click`,this._onDocClick),window.removeEventListener(`resize`,this._resetOverflow),this._ro?.disconnect(),this._ro=void 0,super.disconnectedCallback()}updated(e){if(e.has(`metadata`)||e.has(`data`)){this._resetOverflow();return}let t=this.renderRoot.querySelector(`.actions-cluster`);if(!t||this._secCount===0)return;let n=t.closest(`.form-header, .no-header-row`);if(!n)return;let r=t.getBoundingClientRect(),i=n.getBoundingClientRect();(r.top-i.top>8||r.right>i.right+1)&&this._overflowN<this._secCount&&(this._overflowN+=1)}render(){let e=this.metadata;if(!e)return T``;let t=e.peerNav&&(e.peerNav.prevRoute||e.peerNav.nextRoute)?e.peerNav:void 0,n=e.toolbar??[],r=n.filter(e=>Pt(e.actionId)),i=n.filter(e=>!Pt(e.actionId)),a=r.length>0&&i.length>0?T`<span class="toolbar-divider"></span>`:v,o=e.overline,s=e.title?void 0:e.titlePlaceholder,c=e.avatar||e.title||e.subtitle||o||s||e.kpis?.length>0||e.header?.length>0||n.length>0||!!t,l=e.level??0;return l>0?this.setAttribute(`data-nested`,``):this.removeAttribute(`data-nested`),T`
+        `}connectedCallback(){super.connectedCallback(),document.addEventListener(`click`,this._onDocClick),this._ro=new ResizeObserver(()=>this._resetOverflow()),this._ro.observe(this),window.addEventListener(`resize`,this._resetOverflow)}disconnectedCallback(){document.removeEventListener(`click`,this._onDocClick),window.removeEventListener(`resize`,this._resetOverflow),this._ro?.disconnect(),this._ro=void 0,super.disconnectedCallback()}updated(e){if(e.has(`metadata`)||e.has(`data`)){this._resetOverflow();return}let t=this.renderRoot.querySelector(`.actions-cluster`);if(!t||this._secCount===0)return;let n=t.closest(`.form-header, .no-header-row`);if(!n)return;let r=t.getBoundingClientRect(),i=n.getBoundingClientRect();(r.top-i.top>8||r.right>i.right+1)&&this._overflowN<this._secCount&&(this._overflowN+=1)}render(){let e=this.metadata;if(!e)return T``;let t=e.peerNav&&(e.peerNav.prevRoute||e.peerNav.nextRoute)?e.peerNav:void 0,n=e.toolbar??[],r=n.filter(e=>Ft(e.actionId)),i=n.filter(e=>!Ft(e.actionId)),a=r.length>0&&i.length>0?T`<span class="toolbar-divider"></span>`:v,o=e.overline,s=e.title?void 0:e.titlePlaceholder,c=e.avatar||e.title||e.subtitle||o||s||e.kpis?.length>0||e.header?.length>0||n.length>0||!!t,l=e.level??0;return l>0?this.setAttribute(`data-nested`,``):this.removeAttribute(`data-nested`),T`
             ${e.breadcrumbs&&e.breadcrumbs.length>0?T`
                 <div style="display: flex; gap: var(--lumo-space-m, 1rem); width: 100%; align-items: center;" class="breadcrumbs-bar">
                     ${e.breadcrumbs.map((e,t)=>T`
@@ -212,7 +212,7 @@ ${i}
             `:v}
             ${e.noHeader?T`
                 <div style="display: flex; gap: var(--lumo-space-m, 1rem); align-items: center;" class="no-header-row">
-                    ${e?.header?.map(e=>I(this,e,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData))}
+                    ${e?.header?.map(e=>F(this,e,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData))}
                     ${t?this.renderPeerNav(t):v}
                     ${r.map(this.renderBtn)}
                     ${a}
@@ -220,13 +220,13 @@ ${i}
                 </div>
             `:c?T`
                 <div style="display: flex; gap: var(--lumo-space-m, 1rem); width: 100%; align-items: center; flex-wrap: wrap;" class="form-header">
-                    ${e.avatar?I(this,e.avatar,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData):v}
+                    ${e.avatar?F(this,e.avatar,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData):v}
                     <div style="flex: 1; min-width: min(22rem, 100%); overflow: hidden;">
                         ${o?T`<div class="page-overline">${_(N(o,this.state??{},this.data??{}))}</div>`:v}
                         ${(e?.title||s)&&l==0?T`
                             <div style="display: flex; align-items: center; gap: var(--lumo-space-s, .5rem); min-width: 0;">
                                 <h2 style="margin: 0; margin-block-end: 0px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">${e?.title?_(N(e?.title,this.state??{},this.data??{})):T`<span class="page-title-placeholder">${_(N(s,this.state??{},this.data??{}))}</span>`}</h2>
-                                ${e.kpisBelow&&e.badges?.length?e.badges.map(e=>At(e,this.state??{},this.data??{})):v}
+                                ${e.kpisBelow&&e.badges?.length?e.badges.map(e=>jt(e,this.state??{},this.data??{})):v}
                             </div>`:v}
                         ${e?.title&&l==1?T`<h3 style="margin: 0; margin-block-end: 0px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; width: 100%;">${_(N(e?.title,this.state??{},this.data??{}))}</h3>`:v}
                         ${e?.title&&l==2?T`<h4 style="margin: 0; margin-block-end: 0px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; width: 100%;">${_(N(e?.title,this.state??{},this.data??{}))}</h4>`:v}
@@ -243,7 +243,7 @@ ${i}
                                 <div>${_(N(e.text,this.state??{},this.data??{}))}</div>
                             </div>
                         `)}
-                        ${e?.header?.map(e=>I(this,e,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData))}
+                        ${e?.header?.map(e=>F(this,e,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData))}
                         ${t?this.renderPeerNav(t):v}
                         ${r.map(this.renderBtn)}
                         ${a}
@@ -263,7 +263,7 @@ ${i}
             `:v}
             ${e.badges&&e.badges.length>0&&!e.kpisBelow?T`
                 <div style="display: flex; gap: var(--lumo-space-s, .5rem); padding-bottom: var(--lumo-space-s, .5rem);">
-                    ${e.badges.map(e=>At(e,this.state??{},this.data??{}))}
+                    ${e.badges.map(e=>jt(e,this.state??{},this.data??{}))}
                 </div>
             `:v}
         `}static{this.styles=h`
@@ -408,7 +408,7 @@ ${i}
         .mtb.danger.primary { background: var(--lumo-error-color, #c0392b); color: #fff; border-color: transparent; }
 
         ${de}
-    `}};k([y()],Ft.prototype,`metadata`,void 0),k([y()],Ft.prototype,`baseUrl`,void 0),k([y()],Ft.prototype,`state`,void 0),k([y()],Ft.prototype,`data`,void 0),k([y()],Ft.prototype,`appState`,void 0),k([y()],Ft.prototype,`appData`,void 0),k([C()],Ft.prototype,`_overflowOpen`,void 0),k([C()],Ft.prototype,`_overflowN`,void 0),Ft=k([g(`mateu-content-header`)],Ft);var It=class extends vt{constructor(...e){super(...e),this.state={},this.data={},this.appState={},this.appData={}}render(){let e=this.component?.metadata;return T`
+    `}};k([y()],It.prototype,`metadata`,void 0),k([y()],It.prototype,`baseUrl`,void 0),k([y()],It.prototype,`state`,void 0),k([y()],It.prototype,`data`,void 0),k([y()],It.prototype,`appState`,void 0),k([y()],It.prototype,`appData`,void 0),k([C()],It.prototype,`_overflowOpen`,void 0),k([C()],It.prototype,`_overflowN`,void 0),It=k([g(`mateu-content-header`)],It);var Lt=class extends vt{constructor(...e){super(...e),this.state={},this.data={},this.appState={},this.appData={}}render(){let e=this.component?.metadata;return T`
             <div class="mateu-vlayout ${this.component?.cssClasses??``}">
                 <mateu-content-header
                     .metadata="${e}"
@@ -454,7 +454,7 @@ ${i}
         .form-content {
             padding-bottom: 3rem;
         }
-    `}};k([y()],It.prototype,`state`,void 0),k([y()],It.prototype,`data`,void 0),k([y()],It.prototype,`appState`,void 0),k([y()],It.prototype,`appData`,void 0),It=k([g(`mateu-form`)],It);var Lt=class extends b{constructor(...e){super(...e),this.variant=`text`,this.count=3}static{this.styles=h`
+    `}};k([y()],Lt.prototype,`state`,void 0),k([y()],Lt.prototype,`data`,void 0),k([y()],Lt.prototype,`appState`,void 0),k([y()],Lt.prototype,`appData`,void 0),Lt=k([g(`mateu-form`)],Lt);var Rt=class extends b{constructor(...e){super(...e),this.variant=`text`,this.count=3}static{this.styles=h`
         :host {
             display: block;
             flex: 1 1 0;
@@ -488,7 +488,7 @@ ${i}
                     <div class="bone label"></div>
                     <div class="bone field"></div>
                 </div>
-            `)}`:T`${e.map(()=>T`<div class="bone line"></div>`)}`}};k([y()],Lt.prototype,`variant`,void 0),k([y({type:Number})],Lt.prototype,`count`,void 0),Lt=k([g(`mateu-skeleton`)],Lt);var Rt=(e,t)=>{t&&e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},zt=(e,t,n,r,i,a)=>T`
+            `)}`:T`${e.map(()=>T`<div class="bone line"></div>`)}`}};k([y()],Rt.prototype,`variant`,void 0),k([y({type:Number})],Rt.prototype,`count`,void 0),Rt=k([g(`mateu-skeleton`)],Rt);var zt=(e,t)=>{t&&e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},Bt=(e,t,n,r,i,a)=>T`
         <div class="mateu-empty-state"
              style="display: flex; flex-direction: column; align-items: center; justify-content: center; gap: .35rem; padding: var(--lumo-space-l, 1.5rem); text-align: center; color: var(--lumo-secondary-text-color, #666);">
             <span style="font-size: 1.8rem; line-height: 1; opacity: .6;">${t??`🗂`}</span>
@@ -496,14 +496,14 @@ ${i}
             <span style="font-size: var(--lumo-font-size-s, .875rem);">${r??e??`Nothing here yet.`}</span>
             ${i&&a?T`
                 <button style="margin-top: .25rem; font: inherit; font-weight: 500; cursor: pointer; padding: .4rem .9rem; border: none; border-radius: var(--lumo-border-radius-m, 6px); background: transparent; color: var(--lumo-primary-text-color, #3b5bdb);"
-                        @click="${e=>Rt(e,i)}">${a}</button>
+                        @click="${e=>zt(e,i)}">${a}</button>
             `:v}
         </div>
-    `,Bt=e=>{let t=e.metadata;return T`
+    `,Vt=e=>{let t=e.metadata;return T`
         <div style="${e.style??v}" class="${e.cssClasses??v}" slot="${e.slot??v}">
-            ${zt(void 0,t.icon,t.title,t.description,t.actionId,t.actionLabel)}
+            ${Bt(void 0,t.icon,t.title,t.description,t.actionId,t.actionLabel)}
         </div>
-    `},Vt=e=>{let t=e.metadata;return T`
+    `},Ht=e=>{let t=e.metadata;return T`
         <mateu-skeleton
                 variant="${t.variant??`text`}"
                 count="${t.count&&t.count>0?t.count:3}"
@@ -511,8 +511,8 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-skeleton>
-    `},L=(e,t,n,r)=>{if(!e)return T``;let i=F.get()?.renderIcon;if(i){let a=i.call(F.get(),e,t,n);return r?T`<span slot="${r}">${a}</span>`:a}return T`<span class="mateu-icon ${n??``}" data-icon="${e}" aria-hidden="true"
-                      style="display:inline-block; width:1em; height:1em; ${t??``}" slot="${r??v}"></span>`},Ht=`mateu-saved-views`,Ut=()=>{try{return JSON.parse(localStorage.getItem(Ht)??`{}`)}catch{return{}}},Wt=e=>{try{localStorage.setItem(Ht,JSON.stringify(e))}catch{}},Gt=e=>Ut()[e]??[],Kt=(e,t)=>{let n=t.name?.trim();if(!n||Object.keys(t.values??{}).length===0)return;let r=Ut(),i=(r[e]??[]).filter(e=>e.name!==n);i.push({...t,name:n}),r[e]=i,Wt(r)},qt=(e,t)=>{let n=Ut(),r=(n[e]??[]).filter(e=>e.name!==t);r.length===0?delete n[e]:n[e]=r,Wt(n)},Jt=(e,t)=>{let n=Ut();n[e]=(n[e]??[]).map(e=>({...e,isDefault:e.name===t&&!e.isDefault})),Wt(n)},Yt=e=>Gt(e).find(e=>e.isDefault),R=class extends b{constructor(...e){super(...e),this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.searchOnly=!1,this.panelOpened=!1,this.viewsOpened=!1,this.draftText=``,this.openPanel=()=>{this.panelOpened||this.filters.length===0||(this.panelOpened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick))},this.closePanel=()=>{this.detachOutsideClick(),this.panelOpened=!1,this.activeFilter=void 0},this.clearAllFilters=()=>{let e=this.filters.flatMap(e=>this.isRangeFilter(e)?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId]),t={searchText:void 0};e.forEach(e=>{t[e]=void 0}),this.state={...this.state,...t},this.dispatchEvent(new CustomEvent(`filter-reset-requested`,{detail:{fieldIds:e},bubbles:!0,composed:!0})),this.requestSearch()},this.keepFocus=e=>e.preventDefault()}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}get filters(){return this.metadata?.filters??[]}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}requestSearch(){this.closePanel(),this.dispatchEvent(new CustomEvent(`search-requested`,{detail:{},bubbles:!0,composed:!0}))}emitValueChanged(e,t){this.state={...this.state,[e]:t},this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:e},bubbles:!0,composed:!0}))}applyFilter(e,t){this.emitValueChanged(e,t),this.requestSearch()}removeChip(e){let t=this.filters.find(t=>t.fieldId===e);t&&this.isRangeFilter(t)?(this.emitValueChanged(`${e}_from`,void 0),this.emitValueChanged(`${e}_to`,void 0)):this.emitValueChanged(e,e===`searchText`?``:void 0),this.requestSearch()}commitText(e){this.emitValueChanged(`searchText`,e.value),this.draftText=``,e.value=``,this.requestSearch()}get viewsScope(){return window.location.pathname}allFilterKeys(){return[`searchText`,...this.filters.flatMap(e=>this.isRangeFilter(e)?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId])]}snapshotValues(){let e={};return this.state.searchText&&(e.searchText=this.state.searchText),this.filters.forEach(t=>{if(this.isSet(t))if(this.isRangeFilter(t)){let n=this.rangeBound(t,`from`),r=this.rangeBound(t,`to`);n&&(e[`${t.fieldId}_from`]=n),r&&(e[`${t.fieldId}_to`]=r)}else this.isMultiFilter(t)?e[t.fieldId]=this.multiValues(t):e[t.fieldId]=this.state[t.fieldId]}),e}applyView(e){let t=this.allFilterKeys(),n={};t.forEach(e=>{n[e]=void 0}),this.state={...this.state,...n},this.dispatchEvent(new CustomEvent(`filter-reset-requested`,{detail:{fieldIds:t},bubbles:!0,composed:!0})),Object.entries(e.values).forEach(([e,t])=>this.emitValueChanged(e,t)),this.viewsOpened=!1,this.detachOutsideClick(),this.requestSearch()}saveCurrentView(e){let t=e.value.trim();t&&(Kt(this.viewsScope,{name:t,values:this.snapshotValues()}),e.value=``,this.requestUpdate())}firstUpdated(){if(window.location.search)return;let e=Yt(this.viewsScope);e&&setTimeout(()=>{this.state.searchText||this.filters.some(e=>this.isSet(e))||this.applyView(e)},0)}isBooleanFilter(e){return e.dataType===`boolean`||e.dataType===`bool`||e.stereotype===`checkbox`||e.stereotype===`toggle`}isNumericFilter(e){return[`integer`,`decimal`,`number`,`money`].includes(e.dataType??``)}isRangeFilter(e){return e.stereotype===`dateRange`||e.stereotype===`numberRange`}isMultiFilter(e){return e.stereotype===`multiSelect`}hasOptions(e){return(e.options?.length??0)>0}multiValues(e){let t=this.state[e.fieldId];return Array.isArray(t)?t.map(String):typeof t==`string`&&t!==``?t.split(`,`).map(e=>e.trim()).filter(e=>e):[]}rangeBound(e,t){let n=this.state[`${e.fieldId}_${t}`];return n==null?``:String(n)}isSet(e){if(this.isRangeFilter(e))return this.rangeBound(e,`from`)!==``||this.rangeBound(e,`to`)!==``;if(this.isMultiFilter(e))return this.multiValues(e).length>0;let t=this.state[e.fieldId];return t!=null&&t!==``&&!Number.isNaN(t)}getFilterDisplayValue(e,t){if(e.options?.length){let n=e.options.find(e=>e.value===String(t));if(n)return n.label??n.value}return typeof t==`boolean`?t?`Yes`:`No`:String(t)}conditionDisplay(e){if(this.isRangeFilter(e)){let t=this.rangeBound(e,`from`),n=this.rangeBound(e,`to`);return t&&n?`${t} – ${n}`:t?`≥ ${t}`:`≤ ${n}`}return this.isMultiFilter(e)?this.multiValues(e).map(t=>this.getFilterDisplayValue(e,t)).join(`, `):this.getFilterDisplayValue(e,this.state[e.fieldId])}labelOf(e){return M(e.label,this.state,this.data)||e.fieldId}panelRow(e,t,n=`panel-row`){return T`
+    `},I=(e,t,n,r)=>{if(!e)return T``;let i=P.get()?.renderIcon;if(i){let a=i.call(P.get(),e,t,n);return r?T`<span slot="${r}">${a}</span>`:a}return T`<span class="mateu-icon ${n??``}" data-icon="${e}" aria-hidden="true"
+                      style="display:inline-block; width:1em; height:1em; ${t??``}" slot="${r??v}"></span>`},Ut=`mateu-saved-views`,Wt=()=>{try{return JSON.parse(localStorage.getItem(Ut)??`{}`)}catch{return{}}},Gt=e=>{try{localStorage.setItem(Ut,JSON.stringify(e))}catch{}},Kt=e=>Wt()[e]??[],qt=(e,t)=>{let n=t.name?.trim();if(!n||Object.keys(t.values??{}).length===0)return;let r=Wt(),i=(r[e]??[]).filter(e=>e.name!==n);i.push({...t,name:n}),r[e]=i,Gt(r)},Jt=(e,t)=>{let n=Wt(),r=(n[e]??[]).filter(e=>e.name!==t);r.length===0?delete n[e]:n[e]=r,Gt(n)},Yt=(e,t)=>{let n=Wt();n[e]=(n[e]??[]).map(e=>({...e,isDefault:e.name===t&&!e.isDefault})),Gt(n)},Xt=e=>Kt(e).find(e=>e.isDefault),L=class extends b{constructor(...e){super(...e),this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.searchOnly=!1,this.panelOpened=!1,this.viewsOpened=!1,this.draftText=``,this.openPanel=()=>{this.panelOpened||this.filters.length===0||(this.panelOpened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick))},this.closePanel=()=>{this.detachOutsideClick(),this.panelOpened=!1,this.activeFilter=void 0},this.clearAllFilters=()=>{let e=this.filters.flatMap(e=>this.isRangeFilter(e)?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId]),t={searchText:void 0};e.forEach(e=>{t[e]=void 0}),this.state={...this.state,...t},this.dispatchEvent(new CustomEvent(`filter-reset-requested`,{detail:{fieldIds:e},bubbles:!0,composed:!0})),this.requestSearch()},this.keepFocus=e=>e.preventDefault()}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}get filters(){return this.metadata?.filters??[]}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}requestSearch(){this.closePanel(),this.dispatchEvent(new CustomEvent(`search-requested`,{detail:{},bubbles:!0,composed:!0}))}emitValueChanged(e,t){this.state={...this.state,[e]:t},this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:e},bubbles:!0,composed:!0}))}applyFilter(e,t){this.emitValueChanged(e,t),this.requestSearch()}removeChip(e){let t=this.filters.find(t=>t.fieldId===e);t&&this.isRangeFilter(t)?(this.emitValueChanged(`${e}_from`,void 0),this.emitValueChanged(`${e}_to`,void 0)):this.emitValueChanged(e,e===`searchText`?``:void 0),this.requestSearch()}commitText(e){this.emitValueChanged(`searchText`,e.value),this.draftText=``,e.value=``,this.requestSearch()}get viewsScope(){return window.location.pathname}allFilterKeys(){return[`searchText`,...this.filters.flatMap(e=>this.isRangeFilter(e)?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId])]}snapshotValues(){let e={};return this.state.searchText&&(e.searchText=this.state.searchText),this.filters.forEach(t=>{if(this.isSet(t))if(this.isRangeFilter(t)){let n=this.rangeBound(t,`from`),r=this.rangeBound(t,`to`);n&&(e[`${t.fieldId}_from`]=n),r&&(e[`${t.fieldId}_to`]=r)}else this.isMultiFilter(t)?e[t.fieldId]=this.multiValues(t):e[t.fieldId]=this.state[t.fieldId]}),e}applyView(e){let t=this.allFilterKeys(),n={};t.forEach(e=>{n[e]=void 0}),this.state={...this.state,...n},this.dispatchEvent(new CustomEvent(`filter-reset-requested`,{detail:{fieldIds:t},bubbles:!0,composed:!0})),Object.entries(e.values).forEach(([e,t])=>this.emitValueChanged(e,t)),this.viewsOpened=!1,this.detachOutsideClick(),this.requestSearch()}saveCurrentView(e){let t=e.value.trim();t&&(qt(this.viewsScope,{name:t,values:this.snapshotValues()}),e.value=``,this.requestUpdate())}firstUpdated(){if(window.location.search)return;let e=Xt(this.viewsScope);e&&setTimeout(()=>{this.state.searchText||this.filters.some(e=>this.isSet(e))||this.applyView(e)},0)}isBooleanFilter(e){return e.dataType===`boolean`||e.dataType===`bool`||e.stereotype===`checkbox`||e.stereotype===`toggle`}isNumericFilter(e){return[`integer`,`decimal`,`number`,`money`].includes(e.dataType??``)}isRangeFilter(e){return e.stereotype===`dateRange`||e.stereotype===`numberRange`}isMultiFilter(e){return e.stereotype===`multiSelect`}hasOptions(e){return(e.options?.length??0)>0}multiValues(e){let t=this.state[e.fieldId];return Array.isArray(t)?t.map(String):typeof t==`string`&&t!==``?t.split(`,`).map(e=>e.trim()).filter(e=>e):[]}rangeBound(e,t){let n=this.state[`${e.fieldId}_${t}`];return n==null?``:String(n)}isSet(e){if(this.isRangeFilter(e))return this.rangeBound(e,`from`)!==``||this.rangeBound(e,`to`)!==``;if(this.isMultiFilter(e))return this.multiValues(e).length>0;let t=this.state[e.fieldId];return t!=null&&t!==``&&!Number.isNaN(t)}getFilterDisplayValue(e,t){if(e.options?.length){let n=e.options.find(e=>e.value===String(t));if(n)return n.label??n.value}return typeof t==`boolean`?t?`Yes`:`No`:String(t)}conditionDisplay(e){if(this.isRangeFilter(e)){let t=this.rangeBound(e,`from`),n=this.rangeBound(e,`to`);return t&&n?`${t} – ${n}`:t?`≥ ${t}`:`≤ ${n}`}return this.isMultiFilter(e)?this.multiValues(e).map(t=>this.getFilterDisplayValue(e,t)).join(`, `):this.getFilterDisplayValue(e,this.state[e.fieldId])}labelOf(e){return M(e.label,this.state,this.data)||e.fieldId}panelRow(e,t,n=`panel-row`){return T`
             <div class="${n}" @mousedown="${this.keepFocus}" @click="${t}">${e}</div>`}renderRangeWidget(e){let t=e.stereotype===`numberRange`?`number`:e.dataType===`dateTime`?`datetime-local`:e.dataType===`time`?`time`:`date`,n=t=>{let n=t.closest(`.panel-input-row`),r=n.querySelector(`input.range-from`).value,i=n.querySelector(`input.range-to`).value;this.emitValueChanged(`${e.fieldId}_from`,r===``?void 0:r),this.emitValueChanged(`${e.fieldId}_to`,i===``?void 0:i),this.requestSearch()},r=e=>{e.key===`Enter`&&n(e.target),e.key===`Escape`&&this.closePanel()};return T`
             <div class="panel-input-row">
                 <input class="range-from" type="${t}" placeholder="From"
@@ -542,7 +542,7 @@ ${i}
                 <button class="apply-button"
                         @mousedown="${this.keepFocus}"
                         @click="${e=>n(e.target.previousElementSibling)}">Apply</button>
-            </div>`}renderViewsPanel(){if(!this.viewsOpened)return v;let e=Gt(this.viewsScope),t=!!this.state.searchText||this.filters.some(e=>this.isSet(e));return T`
+            </div>`}renderViewsPanel(){if(!this.viewsOpened)return v;let e=Kt(this.viewsScope),t=!!this.state.searchText||this.filters.some(e=>this.isSet(e));return T`
             <div class="panel views-panel">
                 <div class="panel-caption">Saved views</div>
                 ${e.length===0?T`
@@ -552,9 +552,9 @@ ${i}
                         <span class="view-name" @click="${()=>this.applyView(e)}">${e.name}</span>
                         <button class="view-star ${e.isDefault?`view-star--on`:``}"
                                 title="${e.isDefault?`Unset as default`:`Open this listing with this view`}"
-                                @click="${()=>{Jt(this.viewsScope,e.name),this.requestUpdate()}}">★</button>
+                                @click="${()=>{Yt(this.viewsScope,e.name),this.requestUpdate()}}">★</button>
                         <button class="chip-remove" aria-label="Delete view ${e.name}"
-                                @click="${()=>{qt(this.viewsScope,e.name),this.requestUpdate()}}">✕</button>
+                                @click="${()=>{Jt(this.viewsScope,e.name),this.requestUpdate()}}">✕</button>
                     </div>`)}
                 ${t?T`
                     <div class="panel-input-row" @mousedown="${e=>e.stopPropagation()}">
@@ -811,7 +811,7 @@ ${i}
             padding: 0.35rem 0.75rem;
             cursor: pointer;
         }
-    `}};k([y()],R.prototype,`metadata`,void 0),k([y()],R.prototype,`baseUrl`,void 0),k([C()],R.prototype,`state`,void 0),k([C()],R.prototype,`data`,void 0),k([y()],R.prototype,`appState`,void 0),k([y()],R.prototype,`appData`,void 0),k([y({type:Boolean})],R.prototype,`searchOnly`,void 0),k([C()],R.prototype,`panelOpened`,void 0),k([C()],R.prototype,`viewsOpened`,void 0),k([C()],R.prototype,`activeFilter`,void 0),k([C()],R.prototype,`draftText`,void 0),R=k([g(`mateu-filter-bar`)],R);var Xt=`mateu-column-prefs`,Zt=()=>{try{let e=JSON.parse(localStorage.getItem(Xt)??`{}`);return e&&typeof e==`object`&&!Array.isArray(e)?e:{}}catch{return{}}},Qt=e=>{try{localStorage.setItem(Xt,JSON.stringify(e))}catch{}},$t=e=>{if(!e||typeof e!=`object`)return;let t=e=>Array.isArray(e)?e.filter(e=>typeof e==`string`):[];return{hidden:t(e.hidden),order:t(e.order)}},en=e=>$t(Zt()[e]),tn=(e,t)=>{let n=Zt(),r=$t(t);r.hidden.length===0&&r.order.length===0?delete n[e]:n[e]=r,Qt(n)},nn=e=>{let t=Zt();delete t[e],Qt(t)},rn=e=>e?!!e.identifier||e.dataType===`action`||e.dataType===`actionGroup`||e.dataType===`menu`||e.id===`select`||e.id===`menu`:!1,an=(e,t,n=e=>e)=>{let r=$t(t);if(!r||r.hidden.length===0&&r.order.length===0)return e;let i=e=>n(e)?.id??e.id,a=new Set(r.hidden),o=e.filter(e=>{let t=i(e);return!t||!a.has(t)||rn(n(e))});if(r.order.length===0)return o.length===e.length?e:o;let s=new Map;o.forEach(e=>{let t=i(e);t&&!s.has(t)&&s.set(t,e)});let c=[],l=new Set;return r.order.forEach(e=>{let t=s.get(e);t&&!l.has(t)&&(c.push(t),l.add(t))}),o.forEach(e=>{l.has(e)||(c.push(e),l.add(e))}),c.length===e.length&&c.every((t,n)=>t===e[n])?e:c},on=class extends b{constructor(...e){super(...e),this.columns=[],this.scope=``,this.panelOpened=!1,this.revision=0,this.togglePanel=()=>{if(this.panelOpened){this.closePanel();return}this.panelOpened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick)},this.closePanel=()=>{this.detachOutsideClick(),this.panelOpened=!1},this.reset=()=>{nn(this.scope),this.revision++,this.dispatchEvent(new CustomEvent(`column-prefs-changed`,{bubbles:!0,composed:!0}))}}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}get prefs(){return en(this.scope)??{hidden:[],order:[]}}effectiveEntries(e){return an(this.columns,{hidden:[],order:e.order})}commit(e){tn(this.scope,e),this.revision++,this.dispatchEvent(new CustomEvent(`column-prefs-changed`,{bubbles:!0,composed:!0}))}toggleVisibility(e){let t=this.prefs,n=t.hidden.includes(e)?t.hidden.filter(t=>t!==e):[...t.hidden,e];this.commit({...t,hidden:n})}move(e,t){let n=this.prefs,r=[...this.effectiveEntries(n)],i=r.findIndex(t=>t.id===e);if(i<0)return;let a=i+t;for(;a>=0&&a<r.length&&r[a].protected;)a+=t;if(a<0||a>=r.length)return;let o=r[i];r[i]=r[a],r[a]=o,this.commit({...n,order:r.map(e=>e.id)})}render(){this.revision;let e=this.prefs,t=this.effectiveEntries(e).filter(e=>!e.protected);if(t.length===0)return T``;let n=e.hidden.length>0||e.order.length>0;return T`
+    `}};k([y()],L.prototype,`metadata`,void 0),k([y()],L.prototype,`baseUrl`,void 0),k([C()],L.prototype,`state`,void 0),k([C()],L.prototype,`data`,void 0),k([y()],L.prototype,`appState`,void 0),k([y()],L.prototype,`appData`,void 0),k([y({type:Boolean})],L.prototype,`searchOnly`,void 0),k([C()],L.prototype,`panelOpened`,void 0),k([C()],L.prototype,`viewsOpened`,void 0),k([C()],L.prototype,`activeFilter`,void 0),k([C()],L.prototype,`draftText`,void 0),L=k([g(`mateu-filter-bar`)],L);var Zt=`mateu-column-prefs`,Qt=()=>{try{let e=JSON.parse(localStorage.getItem(Zt)??`{}`);return e&&typeof e==`object`&&!Array.isArray(e)?e:{}}catch{return{}}},$t=e=>{try{localStorage.setItem(Zt,JSON.stringify(e))}catch{}},en=e=>{if(!e||typeof e!=`object`)return;let t=e=>Array.isArray(e)?e.filter(e=>typeof e==`string`):[];return{hidden:t(e.hidden),order:t(e.order)}},tn=e=>en(Qt()[e]),nn=(e,t)=>{let n=Qt(),r=en(t);r.hidden.length===0&&r.order.length===0?delete n[e]:n[e]=r,$t(n)},rn=e=>{let t=Qt();delete t[e],$t(t)},an=e=>e?!!e.identifier||e.dataType===`action`||e.dataType===`actionGroup`||e.dataType===`menu`||e.id===`select`||e.id===`menu`:!1,on=(e,t,n=e=>e)=>{let r=en(t);if(!r||r.hidden.length===0&&r.order.length===0)return e;let i=e=>n(e)?.id??e.id,a=new Set(r.hidden),o=e.filter(e=>{let t=i(e);return!t||!a.has(t)||an(n(e))});if(r.order.length===0)return o.length===e.length?e:o;let s=new Map;o.forEach(e=>{let t=i(e);t&&!s.has(t)&&s.set(t,e)});let c=[],l=new Set;return r.order.forEach(e=>{let t=s.get(e);t&&!l.has(t)&&(c.push(t),l.add(t))}),o.forEach(e=>{l.has(e)||(c.push(e),l.add(e))}),c.length===e.length&&c.every((t,n)=>t===e[n])?e:c},sn=class extends b{constructor(...e){super(...e),this.columns=[],this.scope=``,this.panelOpened=!1,this.revision=0,this.togglePanel=()=>{if(this.panelOpened){this.closePanel();return}this.panelOpened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick)},this.closePanel=()=>{this.detachOutsideClick(),this.panelOpened=!1},this.reset=()=>{rn(this.scope),this.revision++,this.dispatchEvent(new CustomEvent(`column-prefs-changed`,{bubbles:!0,composed:!0}))}}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}get prefs(){return tn(this.scope)??{hidden:[],order:[]}}effectiveEntries(e){return on(this.columns,{hidden:[],order:e.order})}commit(e){nn(this.scope,e),this.revision++,this.dispatchEvent(new CustomEvent(`column-prefs-changed`,{bubbles:!0,composed:!0}))}toggleVisibility(e){let t=this.prefs,n=t.hidden.includes(e)?t.hidden.filter(t=>t!==e):[...t.hidden,e];this.commit({...t,hidden:n})}move(e,t){let n=this.prefs,r=[...this.effectiveEntries(n)],i=r.findIndex(t=>t.id===e);if(i<0)return;let a=i+t;for(;a>=0&&a<r.length&&r[a].protected;)a+=t;if(a<0||a>=r.length)return;let o=r[i];r[i]=r[a],r[a]=o,this.commit({...n,order:r.map(e=>e.id)})}render(){this.revision;let e=this.prefs,t=this.effectiveEntries(e).filter(e=>!e.protected);if(t.length===0)return T``;let n=e.hidden.length>0||e.order.length>0;return T`
             <div class="chooser">
                 <button
                     class="trigger ${n?`active`:``}"
@@ -968,7 +968,7 @@ ${i}
             opacity: 0.4;
             cursor: default;
         }
-    `}};k([y()],on.prototype,`columns`,void 0),k([y()],on.prototype,`scope`,void 0),k([C()],on.prototype,`panelOpened`,void 0),k([C()],on.prototype,`revision`,void 0),on=k([g(`mateu-column-chooser`)],on);var sn;async function cn(e){if(!sn)return{};try{return await sn(e)??{}}catch(e){return console.warn(`mateu: external auth provider failed`,e),{}}}function ln(e,t){return t?t.split(`.`).reduce((e,t)=>typeof e==`object`&&e?e[t]:void 0,e):e}function un(e,t,n=`value`,r=`label`){let i=ln(e,t);return Array.isArray(i)?i.map(e=>{if(typeof e==`object`&&e){let t=ln(e,n),i=ln(e,r);return{value:t??i,label:String(i??t??``)}}return{value:e,label:String(e)}}):[]}function dn(e,t,n,r=e=>e){let i=ln(e,t);return Array.isArray(i)?i.map(e=>{let t={};for(let i of n)t[i]=ln(e,r(i));return t}):[]}async function fn(e,t=e=>e,n=fetch){let r=Ie(e);if(!r.url)throw Error(`External REST fetch has no url${e.ref?` (unknown source "${e.ref}")`:``}`);let i=t(r.url)??r.url,a=(r.method||`GET`).toUpperCase(),o={};for(let[e,n]of Object.entries(r.headers??{}))o[e]=t(n)??n;Object.assign(o,await cn({url:i,method:a}));let s={method:a,headers:o};a!==`GET`&&a!==`HEAD`&&r.body&&(s.body=t(r.body)??r.body);let c=await n(i,s);if(!c.ok)throw Error(`External REST fetch failed: ${c.status}`);return c.json()}async function pn(e,t=e=>e,n=fetch){let r=await fn(e,t,n),i=Ie(e);return un(r,i.itemsPath,i.valuePath,i.labelPath)}async function mn(e,t,n=e=>e,r=fetch){return dn(await fn(e,n,r),Ie(e).itemsPath,t,t=>Le(e,t))}var hn=class extends b{constructor(...e){super(...e),this.totalElements=0,this.pageSize=100,this.pageNumber=0,this.totalPages=0}updated(e){super.updated(e),(e.has(`totalElements`)||e.has(`pageSize`))&&(this.totalPages=Math.ceil(this.totalElements/this.pageSize))}dispatch(e){this.dispatchEvent(new CustomEvent(`page-changed`,{bubbles:!0,composed:!0,detail:{page:e}}))}render(){if(!this.totalElements)return v;let e=this.totalPages>1,t=this.pageNumber,n=t===0,r=t>=this.totalPages-1;return T`
+    `}};k([y()],sn.prototype,`columns`,void 0),k([y()],sn.prototype,`scope`,void 0),k([C()],sn.prototype,`panelOpened`,void 0),k([C()],sn.prototype,`revision`,void 0),sn=k([g(`mateu-column-chooser`)],sn);var cn;async function ln(e){if(!cn)return{};try{return await cn(e)??{}}catch(e){return console.warn(`mateu: external auth provider failed`,e),{}}}function un(e,t){return t?t.split(`.`).reduce((e,t)=>typeof e==`object`&&e?e[t]:void 0,e):e}function dn(e,t,n=`value`,r=`label`){let i=un(e,t);return Array.isArray(i)?i.map(e=>{if(typeof e==`object`&&e){let t=un(e,n),i=un(e,r);return{value:t??i,label:String(i??t??``)}}return{value:e,label:String(e)}}):[]}function fn(e,t,n,r=e=>e){let i=un(e,t);return Array.isArray(i)?i.map(e=>{let t={};for(let i of n)t[i]=un(e,r(i));return t}):[]}async function pn(e,t=e=>e,n=fetch){let r=Ie(e);if(!r.url)throw Error(`External REST fetch has no url${e.ref?` (unknown source "${e.ref}")`:``}`);let i=t(r.url)??r.url,a=(r.method||`GET`).toUpperCase(),o={};for(let[e,n]of Object.entries(r.headers??{}))o[e]=t(n)??n;Object.assign(o,await ln({url:i,method:a}));let s={method:a,headers:o};a!==`GET`&&a!==`HEAD`&&r.body&&(s.body=t(r.body)??r.body);let c=await n(i,s);if(!c.ok)throw Error(`External REST fetch failed: ${c.status}`);return c.json()}async function mn(e,t=e=>e,n=fetch){let r=await pn(e,t,n),i=Ie(e);return dn(r,i.itemsPath,i.valuePath,i.labelPath)}async function hn(e,t,n=e=>e,r=fetch){return fn(await pn(e,n,r),Ie(e).itemsPath,t,t=>Le(e,t))}var gn=class extends b{constructor(...e){super(...e),this.totalElements=0,this.pageSize=100,this.pageNumber=0,this.totalPages=0}updated(e){super.updated(e),(e.has(`totalElements`)||e.has(`pageSize`))&&(this.totalPages=Math.ceil(this.totalElements/this.pageSize))}dispatch(e){this.dispatchEvent(new CustomEvent(`page-changed`,{bubbles:!0,composed:!0,detail:{page:e}}))}render(){if(!this.totalElements)return v;let e=this.totalPages>1,t=this.pageNumber,n=t===0,r=t>=this.totalPages-1;return T`
             <div class="bar">
                 ${e?T`
                     <button class="nav" title="First page" ?disabled="${n}"
@@ -1032,97 +1032,97 @@ ${i}
             align-self: center;
             margin: 0 4px;
         }
-    `}};k([y()],hn.prototype,`totalElements`,void 0),k([y()],hn.prototype,`pageSize`,void 0),k([y()],hn.prototype,`pageNumber`,void 0),k([C()],hn.prototype,`totalPages`,void 0),hn=k([g(`mateu-pagination`)],hn);var gn=`var(--lumo-space-m, 1rem)`,_n=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.columnWidth||`13rem`,l=`display: grid; grid-template-columns: ${s.maxColumns&&s.maxColumns>0?`repeat(${s.maxColumns}, minmax(0, 1fr))`:`repeat(auto-fill, minmax(min(100%, ${c}), 1fr))`}; gap: ${gn} var(--lumo-space-l, 1.5rem); align-items: start;`;return s.labelsAside&&(l+=` --mateu-label-width: 10rem;`),s.fullWidth&&(l+=` width: 100%;`),l+=t.style??``,T`
+    `}};k([y()],gn.prototype,`totalElements`,void 0),k([y()],gn.prototype,`pageSize`,void 0),k([y()],gn.prototype,`pageNumber`,void 0),k([C()],gn.prototype,`totalPages`,void 0),gn=k([g(`mateu-pagination`)],gn);var _n=`var(--lumo-space-m, 1rem)`,vn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.columnWidth||`13rem`,l=`display: grid; grid-template-columns: ${s.maxColumns&&s.maxColumns>0?`repeat(${s.maxColumns}, minmax(0, 1fr))`:`repeat(auto-fill, minmax(min(100%, ${c}), 1fr))`}; gap: ${_n} var(--lumo-space-l, 1.5rem); align-items: start;`;return s.labelsAside&&(l+=` --mateu-label-width: 10rem;`),s.fullWidth&&(l+=` width: 100%;`),l+=t.style??``,T`
         <div id="${t.id??v}" style="${l}" class="${t.cssClasses}" slot="${t.slot||v}">
-            ${t.children?.map(t=>vn(s,e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>yn(s,e,t,n,r,i,a,o))}
         </div>
-    `},vn=(e,t,n,r,i,a,o,s)=>n.type==A.ClientSide&&n.metadata?.type==j.FormRow?xn(e,t,n,r,i,a,o,s):T`<div style="grid-column: span ${yn(n)}; min-width: 0;">${e.labelsAside?bn(t,n,r,i,a,o,s):I(t,n,r,i,a,o,s)}</div>`,yn=e=>{if(e.type==A.ClientSide){let t=e.metadata;if(t?.type==j.FormField)return t.colspan||1}return 1},bn=(e,t,n,r,i,a,o)=>{if(t.type==A.ClientSide&&t.metadata?.type==j.FormField&&t.metadata.label){let s=t.metadata;return T`
-            <div style="display: flex; gap: ${gn}; align-items: baseline;">
+    `},yn=(e,t,n,r,i,a,o,s)=>n.type==A.ClientSide&&n.metadata?.type==j.FormRow?Sn(e,t,n,r,i,a,o,s):T`<div style="grid-column: span ${bn(n)}; min-width: 0;">${e.labelsAside?xn(t,n,r,i,a,o,s):F(t,n,r,i,a,o,s)}</div>`,bn=e=>{if(e.type==A.ClientSide){let t=e.metadata;if(t?.type==j.FormField)return t.colspan||1}return 1},xn=(e,t,n,r,i,a,o)=>{if(t.type==A.ClientSide&&t.metadata?.type==j.FormField&&t.metadata.label){let s=t.metadata;return T`
+            <div style="display: flex; gap: ${_n}; align-items: baseline;">
                 <label style="flex: 0 0 var(--mateu-label-width, 10rem); color: var(--lumo-secondary-text-color, #667);">${s.label?.includes("${")?e._evalTemplate(s.label):s.label}</label>
-                <div style="flex: 1; min-width: 0;">${I(e,t,n,r,i,a,o,!0)}</div>
+                <div style="flex: 1; min-width: 0;">${F(e,t,n,r,i,a,o,!0)}</div>
             </div>
-        `}return I(e,t,n,r,i,a,o)},xn=(e,t,n,r,i,a,o,s)=>T`
-        <div style="grid-column: 1 / -1; display: flex; gap: ${gn}; flex-wrap: wrap;">
-            ${n.children?.map(c=>T`<div style="flex: 1 1 ${100/Math.max(1,n.children.length)}%; min-width: min(100%, 13rem);">${vn(e,t,c,r,i,a,o,s)}</div>`)}
+        `}return F(e,t,n,r,i,a,o)},Sn=(e,t,n,r,i,a,o,s)=>T`
+        <div style="grid-column: 1 / -1; display: flex; gap: ${_n}; flex-wrap: wrap;">
+            ${n.children?.map(c=>T`<div style="flex: 1 1 ${100/Math.max(1,n.children.length)}%; min-width: min(100%, 13rem);">${yn(e,t,c,r,i,a,o,s)}</div>`)}
         </div>
-    `,Sn=(e,t,n,r,i,a,o,s)=>{let c=n.metadata,l=`display: flex; flex-direction: ${e};`;c.spacing&&(l+=` gap: ${gn};`),c.padding&&(l+=` padding: var(--lumo-space-m, 1rem);`),c.wrap&&(l+=` flex-wrap: wrap;`),c.fullWidth&&(l+=` width: 100%;`),c.justification&&(l+=` justify-content: ${c.justification};`);let u=e===`row`?c.verticalAlignment:c.horizontalAlignment;return u&&(l+=` align-items: ${u};`),l+=n.style??``,T`
+    `,Cn=(e,t,n,r,i,a,o,s)=>{let c=n.metadata,l=`display: flex; flex-direction: ${e};`;c.spacing&&(l+=` gap: ${_n};`),c.padding&&(l+=` padding: var(--lumo-space-m, 1rem);`),c.wrap&&(l+=` flex-wrap: wrap;`),c.fullWidth&&(l+=` width: 100%;`),c.justification&&(l+=` justify-content: ${c.justification};`);let u=e===`row`?c.verticalAlignment:c.horizontalAlignment;return u&&(l+=` align-items: ${u};`),l+=n.style??``,T`
         <div id="${n.id??v}" style="${l}" class="${n.cssClasses}" slot="${n.slot??v}">
-            ${n.children?.map(e=>I(t,e,r,i,a,o,s))}
+            ${n.children?.map(e=>F(t,e,r,i,a,o,s))}
         </div>
-    `},Cn=(e,t,n,r,i,a,o)=>Sn(`row`,e,t,n,r,i,a,o),wn=(e,t,n,r,i,a,o)=>Sn(`column`,e,t,n,r,i,a,o),Tn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=`display: flex; flex-direction: ${s.orientation===`vertical`?`column`:`row`}; gap: var(--lumo-space-s, 0.5rem);`;return s.fullWidth&&(c+=` width: 100%;`),c+=t.style??``,T`
+    `},wn=(e,t,n,r,i,a,o)=>Cn(`row`,e,t,n,r,i,a,o),Tn=(e,t,n,r,i,a,o)=>Cn(`column`,e,t,n,r,i,a,o),En=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=`display: flex; flex-direction: ${s.orientation===`vertical`?`column`:`row`}; gap: var(--lumo-space-s, 0.5rem);`;return s.fullWidth&&(c+=` width: 100%;`),c+=t.style??``,T`
         <div id="${t.id??v}" style="${c}" class="${t.cssClasses}" slot="${t.slot??v}">
-            <div style="flex: 1; min-width: 0; min-height: 0;">${I(e,t.children[0],n,r,i,a,o)}</div>
-            <div style="flex: 1; min-width: 0; min-height: 0;">${I(e,t.children[1],n,r,i,a,o)}</div>
+            <div style="flex: 1; min-width: 0; min-height: 0;">${F(e,t.children[0],n,r,i,a,o)}</div>
+            <div style="flex: 1; min-width: 0; min-height: 0;">${F(e,t.children[1],n,r,i,a,o)}</div>
         </div>
-    `},En=(e,t,n,r,i,a,o)=>{let s=t.children&&t.children.length>1?t.children[1]:null,c=i?.detailComponent??null,l=!!i?.hasDetail||!!s,u=c??s;return T`
+    `},Dn=(e,t,n,r,i,a,o)=>{let s=t.children&&t.children.length>1?t.children[1]:null,c=i?.detailComponent??null,l=!!i?.hasDetail||!!s,u=c??s;return T`
         <div id="${t.id??v}" style="display: flex; gap: var(--lumo-space-m, 1rem); ${t.style??``}" class="${t.cssClasses}" slot="${t.slot??v}">
-            <div style="flex: 1; min-width: 0;">${I(e,t.children[0],n,r,i,a,o)}</div>
-            ${l&&u?T`<div style="flex: 1; min-width: 0;">${I(e,u,n,r,i,a,o)}</div>`:T`<div style="flex: 1; display: flex; align-items: center; justify-content: center; color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-s, .875rem);">Select an item to view details</div>`}
+            <div style="flex: 1; min-width: 0;">${F(e,t.children[0],n,r,i,a,o)}</div>
+            ${l&&u?T`<div style="flex: 1; min-width: 0;">${F(e,u,n,r,i,a,o)}</div>`:T`<div style="flex: 1; display: flex; align-items: center; justify-content: center; color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-s, .875rem);">Select an item to view details</div>`}
         </div>
-    `},Dn=(e,t,n,r,i,a,o)=>{let s=t.style??``;t.metadata.fullWidth&&(s+=` width: 100%;`);let c=Math.max(0,(t.children??[]).findIndex(e=>e.metadata.active));return T`
+    `},On=(e,t,n,r,i,a,o)=>{let s=t.style??``;t.metadata.fullWidth&&(s+=` width: 100%;`);let c=Math.max(0,(t.children??[]).findIndex(e=>e.metadata.active));return T`
         <div id="${t.id??v}" style="${s}" class="${t.cssClasses}" slot="${t.slot??v}">
             ${t.children?.map((t,s)=>{let l=t,u=l.metadata.label,d=u?.includes("${")?e._evalTemplate(u):u;return T`
                     <details ?open="${s===c}" style="border-bottom: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));">
                         <summary style="cursor: pointer; padding: var(--lumo-space-s, .5rem) 0; font-weight: 600;">${d}</summary>
                         <div style="padding: var(--lumo-space-m, 1rem) 0;">
-                            ${l.children?.map(t=>I(e,t,n,r,i,a,o))}
+                            ${l.children?.map(t=>F(e,t,n,r,i,a,o))}
                         </div>
                     </details>
                 `})}
         </div>
-    `},On=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style??``;return s.fullWidth&&(c+=` width: 100%;`),T`
+    `},kn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style??``;return s.fullWidth&&(c+=` width: 100%;`),T`
         <div style="${c}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${t.children?.map(t=>kn(e,t,n,r,i,a,o,s.variant))}
+            ${t.children?.map(t=>An(e,t,n,r,i,a,o,s.variant))}
         </div>
-    `},kn=(e,t,n,r,i,a,o,s)=>{let c=t.metadata,l=c.label?.includes("${")?e._evalTemplate(c.label):c.label;return T`
+    `},An=(e,t,n,r,i,a,o,s)=>{let c=t.metadata,l=c.label?.includes("${")?e._evalTemplate(c.label):c.label;return T`
         <details ?open="${c.active}" style="border-bottom: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1)); ${t.style??``}" class="${t.cssClasses}">
             <summary style="cursor: pointer; padding: var(--lumo-space-s, .5rem) 0; font-weight: 600; ${c.disabled?`pointer-events: none; opacity: .5;`:``}">${l}</summary>
             <div style="padding: var(--lumo-space-s, .5rem) 0;">
-                ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+                ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
             </div>
         </details>
-    `},An=(e,t,n,r,i,a,o)=>T`
+    `},jn=(e,t,n,r,i,a,o)=>T`
         <div style="overflow: auto; ${t.style??``}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
-        </div>
-    `,jn=(e,t,n,r,i,a,o)=>T`
-        <div style="width: 100%; ${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
         </div>
     `,Mn=(e,t,n,r,i,a,o)=>T`
-        <div style="max-width: min(100%, 1200px); margin: auto; ${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+        <div style="width: 100%; ${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
         </div>
     `,Nn=(e,t,n,r,i,a,o)=>T`
-        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr)); gap: ${gn}; ${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+        <div style="max-width: min(100%, 1200px); margin: auto; ${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
         </div>
     `,Pn=(e,t,n,r,i,a,o)=>T`
-        <div style="display: flex; gap: ${gn}; flex-wrap: wrap; ${t.style}" class="${t.cssClasses}">
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr)); gap: ${_n}; ${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
         </div>
     `,Fn=(e,t,n,r,i,a,o)=>T`
-        <div style="flex: ${t.metadata.boardCols??1} 1 0; min-width: min(100%, 12rem); ${t.style}" class="${t.cssClasses}">
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+        <div style="display: flex; gap: ${_n}; flex-wrap: wrap; ${t.style}" class="${t.cssClasses}">
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
         </div>
-    `,In=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+    `,In=(e,t,n,r,i,a,o)=>T`
+        <div style="flex: ${t.metadata.boardCols??1} 1 0; min-width: min(100%, 12rem); ${t.style}" class="${t.cssClasses}">
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+        </div>
+    `,Ln=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
         <div
                 style="display: flex; flex-direction: column; overflow: auto; ${t.style}"
                 class="${t.cssClasses}"
                 slot="${t.slot??v}"
         >
-            ${s.page.content.map(t=>I(e,t,n,r,i,a,o))}
+            ${s.page.content.map(t=>F(e,t,n,r,i,a,o))}
         </div>
-    `},Ln=e=>{let t=e.metadata;return(t?.content??t?.columns??[]).filter(e=>e&&e.metadata).map(e=>{let t=e.metadata;return{id:e.id??``,label:t?.label??e.id??``,autoWidth:t?.autoWidth,width:t?.width}})},Rn=(e,t)=>{let n=e?.[t];return n==null?``:typeof n==`object`?n.text??n.label??n.value??``:String(n)},zn=(e,t,n)=>{let r=Ln(e);return T`
+    `},Rn=e=>{let t=e.metadata;return(t?.content??t?.columns??[]).filter(e=>e&&e.metadata).map(e=>{let t=e.metadata;return{id:e.id??``,label:t?.label??e.id??``,autoWidth:t?.autoWidth,width:t?.width}})},zn=(e,t)=>{let n=e?.[t];return n==null?``:typeof n==`object`?n.text??n.label??n.value??``:String(n)},Bn=(e,t,n)=>{let r=Rn(e);return T`
         <div style="overflow:auto; width:100%; ${e.style}" class="${e.cssClasses}" slot="${e.slot??v}">
             <table style="border-collapse:collapse; width:100%; font-size: var(--lumo-font-size-s,.875rem);">
                 <thead><tr>${r.map(e=>T`<th style="${`text-align:left; padding:.45rem .6rem; border-bottom:2px solid var(--lumo-contrast-20pct,rgba(0,0,0,.2)); font-weight:600; white-space:nowrap; color: var(--lumo-secondary-text-color,#556);`}">${e.label}</th>`)}</tr></thead>
                 <tbody>
-                    ${(t??[]).length===0?T`<tr><td colspan="${Math.max(1,r.length)}" style="padding:1.5rem; text-align:center; color: var(--lumo-secondary-text-color,#888);">${n??`No data.`}</td></tr>`:t.map(e=>T`<tr>${r.map(t=>T`<td style="${`padding:.4rem .6rem; border-bottom:1px solid var(--lumo-contrast-10pct,rgba(0,0,0,.08)); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:24rem;`}" title="${Rn(e,t.id)}">${Rn(e,t.id)}</td>`)}</tr>`)}
+                    ${(t??[]).length===0?T`<tr><td colspan="${Math.max(1,r.length)}" style="padding:1.5rem; text-align:center; color: var(--lumo-secondary-text-color,#888);">${n??`No data.`}</td></tr>`:t.map(e=>T`<tr>${r.map(t=>T`<td style="${`padding:.4rem .6rem; border-bottom:1px solid var(--lumo-contrast-10pct,rgba(0,0,0,.08)); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:24rem;`}" title="${zn(e,t.id)}">${zn(e,t.id)}</td>`)}</tr>`)}
                 </tbody>
             </table>
         </div>
-    `},Bn=(e,t)=>{let n=e.metadata;return e.id&&t&&t[e.id]?t[e.id]:n?.page?.content??[]},Vn=e=>{let t=e.metadata.items??[];return T`
+    `},Vn=(e,t)=>{let n=e.metadata;return e.id&&t&&t[e.id]?t[e.id]:n?.page?.content??[]},Hn=e=>{let t=e.metadata.items??[];return T`
         <div class="mateu-message-list ${e.cssClasses??``}"
              style="display:flex; flex-direction:column; gap:.75rem; ${e.style??``}"
              slot="${e.slot??v}">
@@ -1141,15 +1141,15 @@ ${i}
                 </div>
             `)}
         </div>
-    `},Hn=(e,t,n,r,i,a,o)=>t.separator?T`<span style="align-self: stretch; width: 1px; background: var(--lumo-contrast-20pct, rgba(0,0,0,.2));"></span>`:t.submenus?T`
+    `},Un=(e,t,n,r,i,a,o)=>t.separator?T`<span style="align-self: stretch; width: 1px; background: var(--lumo-contrast-20pct, rgba(0,0,0,.2));"></span>`:t.submenus?T`
             <details style="position: relative;">
                 <summary style="cursor: pointer; list-style: none; padding: .35rem .7rem; border-radius: var(--lumo-border-radius-m, 6px);">
-                    ${t.component?I(e,t.component,n,r,i,a,o):t.label} ▾
+                    ${t.component?F(e,t.component,n,r,i,a,o):t.label} ▾
                 </summary>
                 <div style="display: flex; flex-direction: column; gap: .1rem; padding: .3rem; min-width: 10rem;
                             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1)); border-radius: var(--lumo-border-radius-m, 6px);
                             background: var(--lumo-base-color, #fff); box-shadow: var(--lumo-box-shadow-s, 0 2px 8px rgba(0,0,0,.15));">
-                    ${t.submenus.map(t=>Hn(e,t,n,r,i,a,o))}
+                    ${t.submenus.map(t=>Un(e,t,n,r,i,a,o))}
                 </div>
             </details>
         `:T`
@@ -1157,27 +1157,27 @@ ${i}
               style="cursor: ${t.disabled?`default`:`pointer`}; opacity: ${t.disabled?.5:1};
                      padding: .35rem .7rem; border-radius: var(--lumo-border-radius-m, 6px);
                      ${t.selected?`background: var(--lumo-primary-color-10pct, rgba(26,115,232,.12));`:``}">
-            ${t.component?I(e,t.component,n,r,i,a,o):t.label}
+            ${t.component?F(e,t.component,n,r,i,a,o):t.label}
         </span>
-    `,Un=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+    `,Wn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
         <div style="display: flex; flex-wrap: wrap; gap: .25rem; align-items: center; ${t.style}"
              class="${t.cssClasses}" slot="${t.slot??v}">
-            ${s.options?.map(t=>Hn(e,t,n,r,i,a??{},o??{}))}
+            ${s.options?.map(t=>Un(e,t,n,r,i,a??{},o??{}))}
         </div>
-    `},Wn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+    `},Gn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
         <div style="${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${I(e,s.wrapped,n,r,i,a,o)}
+            ${F(e,s.wrapped,n,r,i,a,o)}
         </div>
-    `},Gn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.content?.metadata,l=c?.type==j.Notice&&c.fullWidth===!0;return T`
+    `},Kn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.content?.metadata,l=c?.type==j.Notice&&c.fullWidth===!0;return T`
         <div style="display:flex; flex-direction:column; ${l?`width: 100%; `:``}${t.style}"
              class="${t.cssClasses}"
              slot="${t.slot??v}"
              data-colspan="${s.colspan||(l?99:v)}"
         >
             ${s.label?T`<label style="font-size: var(--lumo-font-size-s,.875rem); color: var(--lumo-secondary-text-color,#667); margin-bottom:.15rem;">${s.label}</label>`:v}
-            ${I(e,s.content,n,r,i,a,o)}
+            ${F(e,s.content,n,r,i,a,o)}
         </div>
-            `},Kn=e=>{let t=e.metadata,n=e=>{let n=e.closest(`.mateu-message-input`)?.querySelector(`input`),r=n?.value??``;!t.actionId||!r.trim()||(e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:{message:r}},bubbles:!0,composed:!0})),n&&(n.value=``))};return T`
+            `},qn=e=>{let t=e.metadata,n=e=>{let n=e.closest(`.mateu-message-input`)?.querySelector(`input`),r=n?.value??``;!t.actionId||!r.trim()||(e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:{message:r}},bubbles:!0,composed:!0})),n&&(n.value=``))};return T`
         <div class="mateu-message-input ${e.cssClasses??``}"
              style="display:flex; gap:.5rem; align-items:center; ${e.style??``}"
              slot="${e.slot??v}">
@@ -1187,62 +1187,62 @@ ${i}
             <button style="font:inherit; font-weight:500; cursor:pointer; padding:.5rem 1rem; border:none; border-radius:var(--lumo-border-radius-m,6px); background:var(--lumo-primary-color,#3b5bdb); color:var(--lumo-primary-contrast-color,#fff);"
                     @click="${e=>n(e.currentTarget)}">Send</button>
         </div>
-    `},qn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`<span title="${s.text}" style="${t.style}" class="${t.cssClasses}" slot="${t.slot??v}"
-        >${I(e,s.wrapped,n,r,i,a,o)}</span>`},Jn=e=>{if(e instanceof CustomEvent)return e.detail;let t={};for(let n in e){let r=e[n];[`number`,`string`,`boolean`].indexOf(typeof r)>=0&&(t[n]=e[n])}return t},Yn=(e,t,n,r,i)=>{let a={appState:r??{},appData:i??{}},o={};for(let r in e.attributes)o[r]=M(e.attributes[r],t,n,a);return{attributes:o,content:M(e.content,t,n,a)}},Xn=(e,t,n,r)=>{for(let t in r.attributes)e.setAttribute(t,r.attributes[t]);n.style&&e.setAttribute(`style`,n.style),n.cssClasses&&e.setAttribute(`class`,n.cssClasses),n.slot&&e.setAttribute(`slot`,n.slot),r.content&&(t.html?e.innerHTML=r.content:e.append(r.content))},Zn=e=>{let t=e.name,n=e.attributes?e.attributes.import:void 0;n&&t.includes(`-`)&&!customElements.get(t)&&D(()=>import(n),[])},Qn=(e,t,n,r,i,a,o)=>{Zn(t);let s=Yn(t,r,i,a,o),c=t.name;s.attributes.id&&(c=`#`+s.attributes.id);let l=n.id?`.element-container[data-element-id="${n.id}"]`:`.element-container`;return setTimeout(()=>{let r=e.shadowRoot?.querySelector(l),i=r?.querySelector(c);if(i){for(;i.firstChild;)i.removeChild(i.lastChild);Xn(i,t,n,s)}else{let i=document.createElement(t.name);Xn(i,t,n,s);for(let n in t.on)i.addEventListener(n,r=>{let i=Jn(r);e.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.on[n],parameters:{event:i}},bubbles:!0,composed:!0}))});r?.appendChild(i)}}),T`<div class="element-container" data-element-id="${S(n.id)}"></div>`},$n=function(e){return e.div=`div`,e.p=`p`,e.h1=`h1`,e.h2=`h2`,e.h3=`h3`,e.h4=`h4`,e.h5=`h5`,e.h6=`h6`,e.span=`span`,e}({}),er=(e,t,n,r,i)=>{let a=e.metadata,o=a.attributes?.[`data-colspan`],s=xt(a.text,t,n,r,i),c={xl:`var(--lumo-font-size-xl, 1.375rem)`,l:`var(--lumo-font-size-l, 1.125rem)`,s:`var(--lumo-font-size-s, .875rem)`,xs:`var(--lumo-font-size-xs, .8125rem)`},l=(a.size&&c[a.size]?`font-size: ${c[a.size]}; `:``)+(a.noMargins?`margin-block-start: 0; margin-block-end: 0; `:``);return $n.h1==a.container?T`
+    `},Jn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`<span title="${s.text}" style="${t.style}" class="${t.cssClasses}" slot="${t.slot??v}"
+        >${F(e,s.wrapped,n,r,i,a,o)}</span>`},Yn=e=>{if(e instanceof CustomEvent)return e.detail;let t={};for(let n in e){let r=e[n];[`number`,`string`,`boolean`].indexOf(typeof r)>=0&&(t[n]=e[n])}return t},Xn=(e,t,n,r,i)=>{let a={appState:r??{},appData:i??{}},o={};for(let r in e.attributes)o[r]=M(e.attributes[r],t,n,a);return{attributes:o,content:M(e.content,t,n,a)}},Zn=(e,t,n,r)=>{for(let t in r.attributes)e.setAttribute(t,r.attributes[t]);n.style&&e.setAttribute(`style`,n.style),n.cssClasses&&e.setAttribute(`class`,n.cssClasses),n.slot&&e.setAttribute(`slot`,n.slot),r.content&&(t.html?e.innerHTML=r.content:e.append(r.content))},Qn=e=>{let t=e.name,n=e.attributes?e.attributes.import:void 0;n&&t.includes(`-`)&&!customElements.get(t)&&D(()=>import(n),[])},$n=(e,t,n,r,i,a,o)=>{Qn(t);let s=Xn(t,r,i,a,o),c=t.name;s.attributes.id&&(c=`#`+s.attributes.id);let l=n.id?`.element-container[data-element-id="${n.id}"]`:`.element-container`;return setTimeout(()=>{let r=e.shadowRoot?.querySelector(l),i=r?.querySelector(c);if(i){for(;i.firstChild;)i.removeChild(i.lastChild);Zn(i,t,n,s)}else{let i=document.createElement(t.name);Zn(i,t,n,s);for(let n in t.on)i.addEventListener(n,r=>{let i=Yn(r);e.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.on[n],parameters:{event:i}},bubbles:!0,composed:!0}))});r?.appendChild(i)}}),T`<div class="element-container" data-element-id="${S(n.id)}"></div>`},er=function(e){return e.div=`div`,e.p=`p`,e.h1=`h1`,e.h2=`h2`,e.h3=`h3`,e.h4=`h4`,e.h5=`h5`,e.h6=`h6`,e.span=`span`,e}({}),tr=(e,t,n,r,i)=>{let a=e.metadata,o=a.attributes?.[`data-colspan`],s=xt(a.text,t,n,r,i),c={xl:`var(--lumo-font-size-xl, 1.375rem)`,l:`var(--lumo-font-size-l, 1.125rem)`,s:`var(--lumo-font-size-s, .875rem)`,xs:`var(--lumo-font-size-xs, .8125rem)`},l=(a.size&&c[a.size]?`font-size: ${c[a.size]}; `:``)+(a.noMargins?`margin-block-start: 0; margin-block-end: 0; `:``);return er.h1==a.container?T`
             <h1 style="${l}${e.style}" class="${e.cssClasses}"
                 id="${S(e.id)}"
                 data-colspan="${S(o)}"
                 slot="${e.slot??v}">
                 ${s??v}
             </h1>
-        `:$n.h2==a.container?T`
+        `:er.h2==a.container?T`
             <h2 style="${l}${e.style}" class="${e.cssClasses}"
                 id="${S(e.id)}"
                 data-colspan="${S(o)}"
                 slot="${e.slot??v}">
                 ${s??v}
             </h2>
-        `:$n.h3==a.container?T`
+        `:er.h3==a.container?T`
             <h3 style="${l}${e.style}" class="${e.cssClasses}"
                 id="${S(e.id)}"
                 data-colspan="${S(o)}"
                 slot="${e.slot??v}">
                 ${s??v}
             </h3>
-        `:$n.h4==a.container?T`
+        `:er.h4==a.container?T`
             <h4 style="${l}${e.style}" class="${e.cssClasses}"
                 id="${S(e.id)}"
                 data-colspan="${S(o)}"
                 slot="${e.slot??v}">
                 ${s??v}
             </h4>
-        `:$n.h5==a.container?T`
+        `:er.h5==a.container?T`
             <h5 style="${l}${e.style}" class="${e.cssClasses}"
                 id="${S(e.id)}"
                 data-colspan="${S(o)}"
                 slot="${e.slot??v}">
                 ${s??v}
             </h5>
-        `:$n.h6==a.container?T`
+        `:er.h6==a.container?T`
             <h6 style="${l}${e.style}" class="${e.cssClasses}"
                 id="${S(e.id)}"
                 data-colspan="${S(o)}"
                 slot="${e.slot??v}">
                 ${s??v}
             </h6>
-        `:$n.p==a.container?T`
+        `:er.p==a.container?T`
                <p style="${l}${e.style}" class="${e.cssClasses}"
                   id="${S(e.id)}"
                   data-colspan="${S(o)}"
                   slot="${e.slot??v}">
                    ${s??v}
                </p>
-            `:$n.div==a.container?T`
+            `:er.div==a.container?T`
                <div style="${l}${e.style}" class="${e.cssClasses}"
                     id="${S(e.id)}"
                     data-colspan="${S(o)}"
                     slot="${e.slot??v}">${s?_(s):v}</div>
-            `:$n.span==a.container?T`
+            `:er.span==a.container?T`
                <span style="${l}${e.style}" class="${e.cssClasses}"
                      id="${S(e.id)}"
                      data-colspan="${S(o)}"
@@ -1254,20 +1254,20 @@ ${i}
                        slot="${e.slot??v}">
                    Unknown text container: ${a.container} 
                </p>
-            `},tr=e=>{let t=e.metadata;return T`<a href="${t.url}" target="${t.target??v}"
+            `},nr=e=>{let t=e.metadata;return T`<a href="${t.url}" target="${t.target??v}"
                    rel="${t.target===`_blank`?`noopener`:v}"
                    style="${e.style}" class="${e.cssClasses}"
-                   slot="${e.slot??v}">${t.text}</a>`},nr=(e,t)=>{let n=e.toLowerCase().split(`+`);return t.ctrlKey===n.includes(`ctrl`)&&t.altKey===n.includes(`alt`)&&t.shiftKey===n.includes(`shift`)&&t.metaKey===n.includes(`meta`)},rr=(e,t)=>{if(!nr(e,t))return!1;let n=e.toLowerCase().split(`+`),r=n[n.length-1];return!!(t.key.toLowerCase()===r||/^[a-z]$/.test(r)&&t.code===`Key`+r.toUpperCase()||/^[0-9]$/.test(r)&&(t.code===`Digit`+r||t.code===`Numpad`+r))},ir=e=>e?e.split(`+`).map(e=>e.length<=1?e.toUpperCase():e.charAt(0).toUpperCase()+e.slice(1)).join(`+`):void 0,ar=(e,t)=>{let n=e.currentTarget.dataset.actionId;e.currentTarget?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:n,parameters:t.parameters},bubbles:!0,composed:!0}))},or=`display:inline-flex; align-items:center; justify-content:center; gap:.4em; box-sizing:border-box; font:inherit; font-weight:500; cursor:pointer; border-radius:var(--lumo-border-radius-m,6px); border:1px solid transparent; line-height:1; white-space:nowrap;`,sr=e=>{let t=e.buttonStyle??``,n=e.color&&e.color!==`none`&&e.color!==`normal`?e.color:``,r=e.size,i=n===`success`?`var(--lumo-success-color,#1a7f37)`:n===`error`?`var(--lumo-error-color,#c5221f)`:n===`contrast`?`var(--lumo-contrast,#161513)`:`var(--lumo-primary-color,#3b5bdb)`,a=n===`success`?`var(--lumo-success-contrast-color,#fff)`:n===`error`?`var(--lumo-error-contrast-color,#fff)`:n===`contrast`?`var(--lumo-base-color,#fff)`:`var(--lumo-primary-contrast-color,#fff)`,o=n===`success`?`var(--lumo-success-text-color,#1a7f37)`:n===`error`?`var(--lumo-error-text-color,#c5221f)`:n===`contrast`?`var(--lumo-body-text-color,#161513)`:`var(--lumo-primary-text-color,#3b5bdb)`,s;return s=t===`primary`?`background:${i}; color:${a};`:t===`tertiary`||t===`tertiaryInline`?`background:transparent; color:${o};`:`background:var(--lumo-contrast-5pct,rgba(0,0,0,.04)); color:${o}; border-color:var(--lumo-contrast-20pct,rgba(0,0,0,.16));`,`${or}${s}${r===`small`?`padding:.25rem .6rem; font-size:var(--lumo-font-size-s,.875rem);`:r===`large`?`padding:.65rem 1.4rem; font-size:var(--lumo-font-size-l,1.125rem);`:`padding:.45rem 1rem; font-size:var(--lumo-font-size-m,1rem);`}`},cr=(e,t,n)=>{let r=e.metadata,i=M(r.label,t,n);return T`<button
+                   slot="${e.slot??v}">${t.text}</a>`},rr=(e,t)=>{let n=e.toLowerCase().split(`+`);return t.ctrlKey===n.includes(`ctrl`)&&t.altKey===n.includes(`alt`)&&t.shiftKey===n.includes(`shift`)&&t.metaKey===n.includes(`meta`)},ir=(e,t)=>{if(!rr(e,t))return!1;let n=e.toLowerCase().split(`+`),r=n[n.length-1];return!!(t.key.toLowerCase()===r||/^[a-z]$/.test(r)&&t.code===`Key`+r.toUpperCase()||/^[0-9]$/.test(r)&&(t.code===`Digit`+r||t.code===`Numpad`+r))},ar=e=>e?e.split(`+`).map(e=>e.length<=1?e.toUpperCase():e.charAt(0).toUpperCase()+e.slice(1)).join(`+`):void 0,or=(e,t)=>{let n=e.currentTarget.dataset.actionId;e.currentTarget?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:n,parameters:t.parameters},bubbles:!0,composed:!0}))},sr=`display:inline-flex; align-items:center; justify-content:center; gap:.4em; box-sizing:border-box; font:inherit; font-weight:500; cursor:pointer; border-radius:var(--lumo-border-radius-m,6px); border:1px solid transparent; line-height:1; white-space:nowrap;`,cr=e=>{let t=e.buttonStyle??``,n=e.color&&e.color!==`none`&&e.color!==`normal`?e.color:``,r=e.size,i=n===`success`?`var(--lumo-success-color,#1a7f37)`:n===`error`?`var(--lumo-error-color,#c5221f)`:n===`contrast`?`var(--lumo-contrast,#161513)`:`var(--lumo-primary-color,#3b5bdb)`,a=n===`success`?`var(--lumo-success-contrast-color,#fff)`:n===`error`?`var(--lumo-error-contrast-color,#fff)`:n===`contrast`?`var(--lumo-base-color,#fff)`:`var(--lumo-primary-contrast-color,#fff)`,o=n===`success`?`var(--lumo-success-text-color,#1a7f37)`:n===`error`?`var(--lumo-error-text-color,#c5221f)`:n===`contrast`?`var(--lumo-body-text-color,#161513)`:`var(--lumo-primary-text-color,#3b5bdb)`,s;return s=t===`primary`?`background:${i}; color:${a};`:t===`tertiary`||t===`tertiaryInline`?`background:transparent; color:${o};`:`background:var(--lumo-contrast-5pct,rgba(0,0,0,.04)); color:${o}; border-color:var(--lumo-contrast-20pct,rgba(0,0,0,.16));`,`${sr}${s}${r===`small`?`padding:.25rem .6rem; font-size:var(--lumo-font-size-s,.875rem);`:r===`large`?`padding:.65rem 1.4rem; font-size:var(--lumo-font-size-l,1.125rem);`:`padding:.45rem 1rem; font-size:var(--lumo-font-size-m,1rem);`}`},lr=(e,t,n)=>{let r=e.metadata,i=M(r.label,t,n);return T`<button
             id="${e.id}"
             data-action-id="${r.actionId}"
-            @click="${e=>ar(e,r)}"
-            style="${sr(r)}${e.style}"
+            @click="${e=>or(e,r)}"
+            style="${cr(r)}${e.style}"
             class="${e.cssClasses}"
             ?disabled="${r.disabled}"
-            title="${r.shortcut?`${i} (${ir(r.shortcut)})`:v}"
+            title="${r.shortcut?`${i} (${ar(r.shortcut)})`:v}"
             slot="${e.slot??v}"
-    >${r.iconOnLeft?L(r.iconOnLeft):v}${i}${r.iconOnRight?L(r.iconOnRight):v}</button>`},lr=`display:block; box-sizing:border-box; background:var(--lumo-base-color,#fff); border:1px solid var(--lumo-contrast-10pct,rgba(0,0,0,.1)); border-radius:var(--lumo-border-radius-l,12px); box-shadow:var(--lumo-box-shadow-xs,0 1px 3px rgba(0,0,0,.08)); overflow:hidden;`,ur=(e,t,n,r,i,a,o)=>{let s=t.metadata;if(!s)return T``;let c=t=>t?I(e,t,n,r,i,a,o,!1):v,l=s.header||s.headerPrefix||s.headerSuffix||s.title||s.subtitle;return T`
-        <div id="${t.id??v}" style="${lr}${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
+    >${r.iconOnLeft?I(r.iconOnLeft):v}${i}${r.iconOnRight?I(r.iconOnRight):v}</button>`},ur=`display:block; box-sizing:border-box; background:var(--lumo-base-color,#fff); border:1px solid var(--lumo-contrast-10pct,rgba(0,0,0,.1)); border-radius:var(--lumo-border-radius-l,12px); box-shadow:var(--lumo-box-shadow-xs,0 1px 3px rgba(0,0,0,.08)); overflow:hidden;`,dr=(e,t,n,r,i,a,o)=>{let s=t.metadata;if(!s)return T``;let c=t=>t?F(e,t,n,r,i,a,o,!1):v,l=s.header||s.headerPrefix||s.headerSuffix||s.title||s.subtitle;return T`
+        <div id="${t.id??v}" style="${ur}${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
             ${s.media?c(s.media):v}
             ${l?T`<div style="display:flex; align-items:flex-start; gap:.75rem; padding:1rem 1.25rem ${s.content||s.footer?`0`:`1rem`};">
                 ${s.headerPrefix?c(s.headerPrefix):v}
@@ -1281,7 +1281,7 @@ ${i}
             ${s.content?T`<div style="padding:1rem 1.25rem;">${c(s.content)}</div>`:v}
             ${s.footer?T`<div style="padding:0 1.25rem 1rem;">${c(s.footer)}</div>`:v}
         </div>
-    `},dr=e=>{let t=e.metadata;return T`
+    `},fr=e=>{let t=e.metadata;return T`
         <mateu-chart 
                 style="${e.style}" 
                 class="${e.cssClasses}"
@@ -1291,21 +1291,21 @@ ${i}
                 .options="${t.chartOptions}"
         >
         </mateu-chart>
-    `},fr=e=>{let t=e.metadata;return L(t.icon,e.style,e.cssClasses,e.slot)},pr=(e,t)=>{e&&e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},mr=`font:inherit; font-weight:500; cursor:pointer; padding:.45rem 1rem; border-radius:var(--lumo-border-radius-m,6px);`,hr=`${mr} background:var(--lumo-contrast-5pct,rgba(0,0,0,.04)); color:var(--lumo-body-text-color,#161513); border:1px solid var(--lumo-contrast-20pct,rgba(0,0,0,.16));`,gr=`${mr} background:var(--lumo-primary-color,#3b5bdb); color:var(--lumo-primary-contrast-color,#fff); border:1px solid transparent;`,_r=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!1;if(s.openedCondition)try{c=St(s.openedCondition,r,i,a,o)}catch(e){console.error(`when evaluating `+s.openedCondition+` :`+e+`, where data is `+i+` and state is `+r)}return c?T`
+    `},pr=e=>{let t=e.metadata;return I(t.icon,e.style,e.cssClasses,e.slot)},mr=(e,t)=>{e&&e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},hr=`font:inherit; font-weight:500; cursor:pointer; padding:.45rem 1rem; border-radius:var(--lumo-border-radius-m,6px);`,gr=`${hr} background:var(--lumo-contrast-5pct,rgba(0,0,0,.04)); color:var(--lumo-body-text-color,#161513); border:1px solid var(--lumo-contrast-20pct,rgba(0,0,0,.16));`,_r=`${hr} background:var(--lumo-primary-color,#3b5bdb); color:var(--lumo-primary-contrast-color,#fff); border:1px solid transparent;`,vr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!1;if(s.openedCondition)try{c=St(s.openedCondition,r,i,a,o)}catch(e){console.error(`when evaluating `+s.openedCondition+` :`+e+`, where data is `+i+` and state is `+r)}return c?T`
         <div class="mateu-confirm-dialog ${t.cssClasses??``}"
              style="position:fixed; inset:0; z-index:1000; display:flex; align-items:center; justify-content:center; background:rgba(0,0,0,.4); ${t.style??``}"
              slot="${t.slot??v}">
             <div style="background:var(--lumo-base-color,#fff); color:var(--lumo-body-text-color,#161513); border-radius:var(--lumo-border-radius-l,12px); box-shadow:var(--lumo-box-shadow-l,0 8px 24px rgba(0,0,0,.2)); width:100%; max-width:min(90vw,32rem); padding:1.5rem; box-sizing:border-box;">
                 ${s.header?T`<h3 style="margin:0 0 .75rem; font-size:1.15rem;">${s.header}</h3>`:v}
-                <div>${t.children?.map(t=>I(e,t,n,r,i,a,o))}</div>
+                <div>${t.children?.map(t=>F(e,t,n,r,i,a,o))}</div>
                 <div style="display:flex; gap:.5rem; justify-content:flex-end; margin-top:1.25rem;">
-                    ${s.canCancel?T`<button style="${hr}" @click="${e=>pr(e.currentTarget,s.cancelActionId)}">${s.rejectText&&!s.canReject?s.rejectText:`Cancel`}</button>`:v}
-                    ${s.canReject?T`<button style="${hr}" @click="${e=>pr(e.currentTarget,s.rejectActionId)}">${s.rejectText||`No`}</button>`:v}
-                    <button style="${gr}" @click="${e=>pr(e.currentTarget,s.confirmActionId)}">${s.confirmText||`OK`}</button>
+                    ${s.canCancel?T`<button style="${gr}" @click="${e=>mr(e.currentTarget,s.cancelActionId)}">${s.rejectText&&!s.canReject?s.rejectText:`Cancel`}</button>`:v}
+                    ${s.canReject?T`<button style="${gr}" @click="${e=>mr(e.currentTarget,s.rejectActionId)}">${s.rejectText||`No`}</button>`:v}
+                    <button style="${_r}" @click="${e=>mr(e.currentTarget,s.confirmActionId)}">${s.confirmText||`OK`}</button>
                 </div>
             </div>
         </div>
-    `:T``},vr=e=>{let t=e.metadata,n;return t.position&&(n={Top:`top`,Bottom:`bottom`,TopLeft:`top-left`,TopRight:`top-right`,BottomLeft:`bottom-left`,BottomRight:`bottom-right`}[t.position]),T`
+    `:T``},yr=e=>{let t=e.metadata,n;return t.position&&(n={Top:`top`,Bottom:`bottom`,TopLeft:`top-left`,TopRight:`top-right`,BottomLeft:`bottom-left`,BottomRight:`bottom-right`}[t.position]),T`
         <mateu-cookie-consent style="${e.style}" class="${e.cssClasses}"
                                slot="${e.slot??v}"
                                position="${n??v}"
@@ -1316,17 +1316,17 @@ ${i}
                                .learnMoreLink="${t.learnMoreLink??v}"
                                .dismiss="${t.dismiss??v}"
         ></mateu-cookie-consent>
-    `},yr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+    `},br=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
         <details
                 ?open="${s.opened}"
                 style="${t.style}"
                 class="${t.cssClasses}"
                 slot="${t.slot??v}"
         >
-            <summary>${I(e,s.summary,n,r,i,a,o)}</summary>
-            ${I(e,s.content,n,r,i,a,o)}
+            <summary>${F(e,s.summary,n,r,i,a,o)}</summary>
+            ${F(e,s.content,n,r,i,a,o)}
         </details>
-            `},br=(e,t,n,r,i,a)=>T`
+            `},xr=(e,t,n,r,i,a)=>T`
         <mateu-dialog
                 id="${e.metadata.id}"
             .component="${e}"
@@ -1336,7 +1336,7 @@ ${i}
             .appState="${i}"
             .appdata="${a}"
         ></mateu-dialog>
-            `,xr=(e,t,n,r,i,a)=>T`
+            `,Sr=(e,t,n,r,i,a)=>T`
         <mateu-drawer
                 id="${e.metadata.id}"
             .component="${e}"
@@ -1346,7 +1346,7 @@ ${i}
             .appState="${i}"
             .appdata="${a}"
         ></mateu-drawer>
-            `,Sr=e=>{let t=e.metadata;return T`
+            `,Cr=e=>{let t=e.metadata;return T`
         <mateu-api-caller>
         <mateu-ux baseUrl="${t.baseUrl}"  
                   route="${t.route}" 
@@ -1358,11 +1358,11 @@ ${i}
                   slot="${e.slot??v}"
         ></mateu-ux>
         </mateu-api-caller>
-            `},Cr=e=>T`
+            `},wr=e=>T`
         <mateu-markdown .content=${e.metadata.markdown}
                         style="display:block; max-width: 72ch; ${e.style??``}" class="${e.cssClasses}"
                         slot="${e.slot??v}"></mateu-markdown>
-            `,wr=e=>{let t=e.metadata;return T`
+            `,Tr=e=>{let t=e.metadata;return T`
         <div
             role="status"
             slot="${e.slot??v}"
@@ -1375,7 +1375,7 @@ ${i}
             ${t.title?T`<strong>${t.title}</strong>`:v}
             ${t.text?T`<span>${t.text}</span>`:v}
         </div>
-    `},Tr=(e,t={})=>{let n=e.metadata,r=n.valueKey?t[n.valueKey]:n.value,i=n.max&&n.max!=0?n.max:1,a=!n.indeterminate&&r!=null;return T`
+    `},Er=(e,t={})=>{let n=e.metadata,r=n.valueKey?t[n.valueKey]:n.value,i=n.max&&n.max!=0?n.max:1,a=!n.indeterminate&&r!=null;return T`
         <div style="${e.style}" class="${e.cssClasses}" slot="${e.slot??v}">
             <progress
                     style="width:100%;"
@@ -1386,29 +1386,29 @@ ${i}
     ${n.text}
   </span>`:v}
         </div>
-    `},Er=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+    `},Dr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
         <details style="position: relative; ${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
-            <summary style="list-style: none; cursor: pointer;">${I(e,s.wrapped,n,r,i,a,o)}</summary>
+            <summary style="list-style: none; cursor: pointer;">${F(e,s.wrapped,n,r,i,a,o)}</summary>
             <div style="position: absolute; z-index: 100; min-width: 300px; margin-top: .25rem; padding: .6rem .8rem;
                         border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1)); border-radius: var(--lumo-border-radius-m, 8px);
                         background: var(--lumo-base-color, #fff); box-shadow: var(--lumo-box-shadow-m, 0 4px 16px rgba(0,0,0,.2));">
-                ${I(e,s.content,n,r,i,a,o)}
+                ${F(e,s.content,n,r,i,a,o)}
             </div>
         </details>
-    `},Dr=e=>{let t=e.metadata;return T`
+    `},Or=e=>{let t=e.metadata;return T`
         <mateu-map position="${t.position}" zoom="${t.zoom}"
                    style="${e.style}" class="${e.cssClasses}"
                    slot="${e.slot??v}"></mateu-map>
-            `},Or=e=>T`
+            `},kr=e=>T`
         <img src="${e.metadata.src}" style="${e.style}" class="${e.cssClasses}"
              slot="${e.slot??v}">
-            `,kr=e=>{let t=e.metadata;return T`<div style="display:flex; align-items:center; gap:0.5rem;" slot="${e.slot??v}">
+            `,Ar=e=>{let t=e.metadata;return T`<div style="display:flex; align-items:center; gap:0.5rem;" slot="${e.slot??v}">
         ${t.breadcrumbs.map(e=>T`
             <a href="${e.link}">${e.text}</a>
             <span>/</span>
         `)}
         <span style="${e.style}" class="${e.cssClasses}">${t.currentItemText}</span>
-    </div>`},Ar=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+    </div>`},jr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
         <skeleton-carousel 
                 id="${t.id}"
                 ?dots = "${s.dots}" 
@@ -1417,54 +1417,54 @@ ${i}
                 style="${t.style}"
                 css="${t.cssClasses}"
         >
-            ${t.children?.map(t=>T`<div>${I(e,t,n,r,i,a,o)}</div>`)}
+            ${t.children?.map(t=>T`<div>${F(e,t,n,r,i,a,o)}</div>`)}
         </skeleton-carousel>
-    `},jr=(e,t,n,r)=>{let i=e.metadata;return T`
+    `},Mr=(e,t,n,r)=>{let i=e.metadata;return T`
         <div style="display: flex; gap: 3rem; ${e.style}" class="${e.cssClasses}" slot="${e.slot??v}">
-            ${i.menu.map(e=>Mr(e))}
+            ${i.menu.map(e=>Nr(e))}
         </div>
-            `},Mr=e=>T`
+            `},Nr=e=>T`
         ${e.submenus?T`
                 <details open>
                     <summary>${e.label}</summary>
                     <div style="display:flex; flex-direction:column; gap:0.25rem; padding-left:0.5rem;">
-                        ${e.submenus.map(e=>Mr(e))}
+                        ${e.submenus.map(e=>Nr(e))}
                     </div>
                 </details>
             `:T`
                 <a href="${e.path}">${e.label}</a>
         `}
-        `,Nr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`<div
+        `,Pr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`<div
                 slot="${t.slot??v}"
                 style="${t.style}" class="${t.cssClasses}"
-        >${s.content?_(s.content):v}${t.children?.map(t=>I(e,t,n,r,i,a,o))}</div>
-    `},Pr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.title?.includes("${")?e._evalTemplate(s.title):s.title;return T`<div
+        >${s.content?_(s.content):v}${t.children?.map(t=>F(e,t,n,r,i,a,o))}</div>
+    `},Fr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.title?.includes("${")?e._evalTemplate(s.title):s.title;return T`<div
                 id="${t.id??v}"
                 slot="${t.slot??v}"
                 style="width: 100%; margin-bottom: var(--lumo-space-m); ${t.style}"
                 class="${t.cssClasses}"
         >
         ${c?T`<div style="font-size: var(--lumo-font-size-l); font-weight: 600; color: var(--lumo-header-text-color); margin-bottom: var(--lumo-space-s);">${c}</div>`:v}
-        ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+        ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
     </div>
-    `},Fr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.title?.includes("${")?e._evalTemplate(s.title):s.title;return T`
+    `},Ir=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.title?.includes("${")?e._evalTemplate(s.title):s.title;return T`
         <div
                 slot="${t.slot??v}"
                 style="${t.style}" class="${t.cssClasses}"
         >
         <h4>${c}</h4>
-        ${t.children?.map(t=>I(e,t,n,r,i,a,o))}</div>
-    `},Ir=(e,t,n)=>{n.dispatchEvent(new CustomEvent(`value-changed`,{detail:{fieldId:e,value:t},bubbles:!0,composed:!0}))},Lr=e=>t=>{let n=t.target,r=n.type===`checkbox`?n.checked:n.value;Ir(e.fieldId,r,n)},Rr=(e,t)=>{let n=e.metadata,r=t?.[n.fieldId]??``,i=n,a=i.dataType,o=i.stereotype,s=!!i.readOnly,c=!!i.disabled,l=i.options,u=n.label?T`<label style="display:block; font-size: var(--lumo-font-size-s,.875rem); color: var(--lumo-secondary-text-color,#667); margin-bottom:.15rem;">${n.label}</label>`:v,d=`width:100%; box-sizing:border-box; padding:.4rem .6rem; border:1px solid var(--lumo-contrast-30pct,rgba(0,0,0,.3)); border-radius: var(--lumo-border-radius-m,6px); font:inherit; background: var(--lumo-base-color,#fff); color: var(--lumo-body-text-color,#1a1a1a);`,f;return f=s||o===`plainText`?T`<div style="padding:.4rem 0;">${String(r??``)}</div>`:a===`boolean`||o===`checkbox`||o===`badge`?T`<input type="checkbox" ?checked="${!!r}" ?disabled="${c}" @change="${Lr(n)}">`:l&&l.length?T`
-            <select style="${d}" ?disabled="${c}" @change="${Lr(n)}">
+        ${t.children?.map(t=>F(e,t,n,r,i,a,o))}</div>
+    `},Lr=(e,t,n)=>{n.dispatchEvent(new CustomEvent(`value-changed`,{detail:{fieldId:e,value:t},bubbles:!0,composed:!0}))},Rr=e=>t=>{let n=t.target,r=n.type===`checkbox`?n.checked:n.value;Lr(e.fieldId,r,n)},zr=(e,t)=>{let n=e.metadata,r=t?.[n.fieldId]??``,i=n,a=i.dataType,o=i.stereotype,s=!!i.readOnly,c=!!i.disabled,l=i.options,u=n.label?T`<label style="display:block; font-size: var(--lumo-font-size-s,.875rem); color: var(--lumo-secondary-text-color,#667); margin-bottom:.15rem;">${n.label}</label>`:v,d=`width:100%; box-sizing:border-box; padding:.4rem .6rem; border:1px solid var(--lumo-contrast-30pct,rgba(0,0,0,.3)); border-radius: var(--lumo-border-radius-m,6px); font:inherit; background: var(--lumo-base-color,#fff); color: var(--lumo-body-text-color,#1a1a1a);`,f;return f=s||o===`plainText`?T`<div style="padding:.4rem 0;">${String(r??``)}</div>`:a===`boolean`||o===`checkbox`||o===`badge`?T`<input type="checkbox" ?checked="${!!r}" ?disabled="${c}" @change="${Rr(n)}">`:l&&l.length?T`
+            <select style="${d}" ?disabled="${c}" @change="${Rr(n)}">
                 <option value="">—</option>
                 ${l.map(e=>T`<option value="${e.value}" ?selected="${e.value===r}">${e.label}</option>`)}
-            </select>`:o===`textarea`||o===`richText`||o===`html`?T`<textarea style="${d}" rows="3" ?disabled="${c}" @input="${Lr(n)}">${String(r??``)}</textarea>`:T`<input type="${a===`integer`||a===`number`||a===`double`||a===`money`?`number`:a===`date`?`date`:a===`datetime`?`datetime-local`:a===`time`?`time`:o===`password`?`password`:a===`email`?`email`:`text`}" style="${d}" .value="${String(r??``)}"
-                              placeholder="${i.placeholder??v}" ?disabled="${c}" @input="${Lr(n)}">`,T`
+            </select>`:o===`textarea`||o===`richText`||o===`html`?T`<textarea style="${d}" rows="3" ?disabled="${c}" @input="${Rr(n)}">${String(r??``)}</textarea>`:T`<input type="${a===`integer`||a===`number`||a===`double`||a===`money`?`number`:a===`date`?`date`:a===`datetime`?`datetime-local`:a===`time`?`time`:o===`password`?`password`:a===`email`?`email`:`text`}" style="${d}" .value="${String(r??``)}"
+                              placeholder="${i.placeholder??v}" ?disabled="${c}" @input="${Rr(n)}">`,T`
         <div id="${e.id??v}" style="${e.style}" class="${e.cssClasses}" slot="${e.slot??v}">
             ${u}
             ${f}
         </div>
-    `},zr=e=>{let t=e.metadata;if((t?.level??0)>0)return e;let n=e=>{if(e?.metadata?.type===j.EntityHeader)return e;let t=e?.metadata?.content,r=[...e?.children??[],...Array.isArray(t)?t:t?[t]:[]];for(let e of r){let t=n(e);if(t)return t}},r;for(let t of e.children??[])if(r=n(t),r)break;if(!r)return e;let i=r.metadata;r.__hoistedToPageHeader=!0;let a=[...(i.facts??[]).filter(e=>e.label||e.value).map(e=>({title:e.label??``,text:e.value??``})),...i.metricLabel?[{title:i.metricLabel,text:i.metricValue??``}]:[]],o=(i.badges??[]).filter(e=>e.label).map(e=>({text:e.label,color:e.color})),s={...t,title:i.title||t.title,subtitle:i.subtitle??t.subtitle,kpis:[...t.kpis??[],...a],kpisBelow:!0,badges:[...t.badges??[],...o]};return{...e,metadata:s}},Br=(e,t,n,r,i,a,o,s)=>{let c=zr(t),l=c.metadata,u=l?.fabs??[];return T`<mateu-page
+    `},Br=e=>{let t=e.metadata;if((t?.level??0)>0)return e;let n=e=>{if(e?.metadata?.type===j.EntityHeader)return e;let t=e?.metadata?.content,r=[...e?.children??[],...Array.isArray(t)?t:t?[t]:[]];for(let e of r){let t=n(e);if(t)return t}},r;for(let t of e.children??[])if(r=n(t),r)break;if(!r)return e;let i=r.metadata;r.__hoistedToPageHeader=!0;let a=[...(i.facts??[]).filter(e=>e.label||e.value).map(e=>({title:e.label??``,text:e.value??``})),...i.metricLabel?[{title:i.metricLabel,text:i.metricValue??``}]:[]],o=(i.badges??[]).filter(e=>e.label).map(e=>({text:e.label,color:e.color})),s={...t,title:i.title||t.title,subtitle:i.subtitle??t.subtitle,kpis:[...t.kpis??[],...a],kpisBelow:!0,badges:[...t.badges??[],...o]};return{...e,metadata:s}},Vr=(e,t,n,r,i,a,o,s)=>{let c=Br(t),l=c.metadata,u=l?.fabs??[];return T`<mateu-page
             .component="${c}"
             baseUrl="${n}"
             .state="${r}"
@@ -1476,19 +1476,19 @@ ${i}
             class="${c.cssClasses}"
             ?standalone="${s??!1}"
     >
-        ${c.children?.map(t=>I(e,t,n,r,i,a,o))}
+        ${c.children?.map(t=>F(e,t,n,r,i,a,o))}
         ${l?.buttons?.map(t=>T`
-                   ${I(e,{id:t.actionId,metadata:t,type:A.ClientSide,slot:`buttons`},void 0,r,i,a,o)}
+                   ${F(e,{id:t.actionId,metadata:t,type:A.ClientSide,slot:`buttons`},void 0,r,i,a,o)}
 `)}
         ${u.map((t,n)=>T`
             <button class="page-fab" style="position: fixed; bottom: ${1.5+n*4}rem; right: 5.5rem;"
                 @click="${()=>e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))}"
                 title="${t.label}">
-                ${L(t.icon)}
+                ${I(t.icon)}
             </button>
         `)}
 </mateu-page>
-    `},Vr=(e,t,n,r,i,a,o,s)=>T`<mateu-table-crud
+    `},Hr=(e,t,n,r,i,a,o,s)=>T`<mateu-table-crud
             id="${t.id}"
             baseUrl="${n}"
             .component="${t}"
@@ -1502,8 +1502,8 @@ ${i}
             slot="${t.slot??v}"
             ?standalone="${s??!1}"
     >
-        ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
-    </mateu-table-crud>`,Hr=e=>{let t=e.metadata;return T`
+        ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+    </mateu-table-crud>`,Ur=e=>{let t=e.metadata;return T`
         <mateu-bpmn
                 style="${e.style}"
                 class="${e.cssClasses}"
@@ -1511,64 +1511,64 @@ ${i}
                 xml="${t.xml}"
         >
         </mateu-bpmn>
-    `},Ur=(e,t,n)=>T`<mateu-chat sseUrl="${e.metadata.sseUrl}"
+    `},Wr=(e,t,n)=>T`<mateu-chat sseUrl="${e.metadata.sseUrl}"
                             style="${e.style}" 
                             class="${e.cssClasses}" 
-                            slot="${e.slot??v}"></mateu-chat>`,Wr=e=>{let t=e.metadata;return T`
+                            slot="${e.slot??v}"></mateu-chat>`,Gr=e=>{let t=e.metadata;return T`
         <mateu-workflow
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
                 value="${t.value??`{"name":"New Workflow","steps":[]}`}"
         ></mateu-workflow>
-    `},Gr=e=>{let t=e.metadata;return T`
+    `},Kr=e=>{let t=e.metadata;return T`
         <mateu-form-editor
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
                 value="${t.value??`{"name":"New Form","fields":[]}`}"
         ></mateu-form-editor>
-    `},Kr=`
+    `},qr=`
     background: var(--lumo-base-color, #fff);
     border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.08));
     border-radius: var(--lumo-border-radius-l, 12px);
     padding: var(--lumo-space-m, 1rem);
     box-sizing: border-box;
-`,qr=e=>e==`up`?`var(--lumo-success-text-color, #1a7f37)`:e==`down`?`var(--lumo-error-text-color, #c5221f)`:`var(--lumo-secondary-text-color, #666)`,Jr=e=>e==`up`?`▲`:e==`down`?`▼`:``,Yr=(e,t)=>{t.actionId&&e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))},Xr=e=>{let t=e.metadata,n=!!t.actionId;return T`
+`,Jr=e=>e==`up`?`var(--lumo-success-text-color, #1a7f37)`:e==`down`?`var(--lumo-error-text-color, #c5221f)`:`var(--lumo-secondary-text-color, #666)`,Yr=e=>e==`up`?`▲`:e==`down`?`▼`:``,Xr=(e,t)=>{t.actionId&&e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))},Zr=e=>{let t=e.metadata,n=!!t.actionId;return T`
         <div class="mateu-metric-card ${e.cssClasses??``}"
-             style="${Kr} display: flex; flex-direction: column; gap: .25rem; min-width: 11rem; flex: 1; ${n?`cursor: pointer;`:``} ${e.style??``}"
+             style="${qr} display: flex; flex-direction: column; gap: .25rem; min-width: 11rem; flex: 1; ${n?`cursor: pointer;`:``} ${e.style??``}"
              slot="${e.slot??v}"
              role="${n?`button`:v}"
-             @click="${e=>Yr(e,t)}"
+             @click="${e=>Xr(e,t)}"
         >
             <div style="display: flex; align-items: center; justify-content: space-between; gap: .5rem;">
                 <span style="font-size: var(--lumo-font-size-s, .875rem); color: var(--lumo-secondary-text-color, #666);">${t.title}</span>
-                ${t.icon?L(t.icon,`color: var(--lumo-tertiary-text-color, #999); width: 1.1em; height: 1.1em;`):v}
+                ${t.icon?I(t.icon,`color: var(--lumo-tertiary-text-color, #999); width: 1.1em; height: 1.1em;`):v}
             </div>
             <div style="display: flex; align-items: baseline; gap: .35rem;">
                 <span style="font-size: var(--lumo-font-size-xxxl, 2rem); font-weight: 600; line-height: 1.1;">${t.value}</span>
                 ${t.unit?T`<span style="font-size: var(--lumo-font-size-m, 1rem); color: var(--lumo-secondary-text-color, #666);">${t.unit}</span>`:v}
             </div>
             ${t.trend||t.trendLabel?T`
-                <span style="font-size: var(--lumo-font-size-s, .875rem); color: ${qr(t.trend)};">
-                    ${Jr(t.trend)} ${t.trendLabel??v}
+                <span style="font-size: var(--lumo-font-size-s, .875rem); color: ${Jr(t.trend)};">
+                    ${Yr(t.trend)} ${t.trendLabel??v}
                 </span>
             `:v}
             ${t.description?T`<span style="font-size: var(--lumo-font-size-xs, .8rem); color: var(--lumo-tertiary-text-color, #999);">${t.description}</span>`:v}
         </div>
-    `},Zr=(e,t,n,r,i,a,o)=>T`
+    `},Qr=(e,t,n,r,i,a,o)=>T`
         <div class="mateu-scoreboard ${t.cssClasses??``}"
              style="display: flex; flex-wrap: wrap; gap: var(--lumo-space-m, 1rem); grid-column: 1 / -1; ${t.style??``}"
              slot="${t.slot??v}"
         >
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
         </div>
-    `,Qr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.colSpan&&s.colSpan>1?`grid-column: span ${s.colSpan};`:``,l=s.rowSpan&&s.rowSpan>1?`grid-row: span ${s.rowSpan};`:``,u=t.children??[];return u.length===1&&u[0].metadata?.type===`MetricCard`?T`
+    `,$r=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.colSpan&&s.colSpan>1?`grid-column: span ${s.colSpan};`:``,l=s.rowSpan&&s.rowSpan>1?`grid-row: span ${s.rowSpan};`:``,u=t.children??[];return u.length===1&&u[0].metadata?.type===`MetricCard`?T`
             <div style="min-width: 0; ${c} ${l} ${t.style??``}" slot="${t.slot??v}">
-                ${I(e,u[0],n,r,i,a,o)}
+                ${F(e,u[0],n,r,i,a,o)}
             </div>`:T`
         <div class="mateu-dashboard-panel ${t.cssClasses??``}"
-             style="${Kr} display: flex; flex-direction: column; gap: .5rem; min-width: 0; ${c} ${l} ${t.style??``}"
+             style="${qr} display: flex; flex-direction: column; gap: .5rem; min-width: 0; ${c} ${l} ${t.style??``}"
              slot="${t.slot??v}"
         >
             ${s.title?T`
@@ -1578,17 +1578,17 @@ ${i}
                 </div>
             `:v}
             <div style="flex: 1; min-height: 0;">
-                ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+                ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
             </div>
         </div>
-    `},$r=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.columns&&s.columns>0?`repeat(${s.columns}, minmax(0, 1fr))`:`repeat(auto-fit, minmax(20rem, 1fr))`;return T`
+    `},ei=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.columns&&s.columns>0?`repeat(${s.columns}, minmax(0, 1fr))`:`repeat(auto-fit, minmax(20rem, 1fr))`;return T`
         <div class="mateu-dashboard ${t.cssClasses??``}"
              style="display: grid; grid-template-columns: ${c}; gap: var(--lumo-space-m, 1rem); align-items: stretch; ${t.style??``}"
              slot="${t.slot??v}"
         >
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
         </div>
-    `},ei=class extends b{constructor(...e){super(...e),this.panels=[],this.headerTitle=``,this.badges=[],this.orientation=`vertical`,this.navigation=null,this.overviewEditActionId=``,this.openPanels=new Set,this.expandedPanel=null,this._onPopState=()=>{let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(e.startsWith(`expand=`)){let t=e.slice(7),n=this.panels.findIndex((e,n)=>this.panelAnchor(e,n)===t);this.expandedPanel=n>=0?n:null}else this.expandedPanel=null},this.initialized=!1}navAction(e){e&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{}},bubbles:!0,composed:!0}))}connectedCallback(){super.connectedCallback(),window.addEventListener(`popstate`,this._onPopState)}disconnectedCallback(){window.removeEventListener(`popstate`,this._onPopState),super.disconnectedCallback()}willUpdate(){if(!this.initialized&&this.panels.length){this.openPanels=new Set(this.panels.map((e,t)=>e.open?t:-1).filter(e=>e>=0));let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(e.startsWith(`expand=`)){let t=e.slice(7),n=this.panels.findIndex((e,n)=>this.panelAnchor(e,n)===t);n>=0&&(this.expandedPanel=n)}else if(e){let t=this.panels.findIndex((t,n)=>this.panelAnchor(t,n)===e);t>=0&&this.openPanels.add(t)}this.initialized=!0}}firstUpdated(){let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(!e)return;let t=this.renderRoot.querySelector(`[data-anchor="${CSS.escape(e)}"]`);t&&t.scrollIntoView({block:`nearest`})}panelAnchor(e,t){return(e.title??``).toLowerCase().replace(/[^a-z0-9]+/g,`-`).replace(/^-|-$/g,``)||`panel-${t}`}bookmarkPanel(e){let t=this.panelAnchor(this.panels[e],e);try{history.replaceState(history.state,``,`#`+t)}catch{}}clearBookmark(e){let t=this.panelAnchor(this.panels[e],e);if(decodeURIComponent((location.hash||``).replace(/^#/,``))===t)try{history.replaceState(history.state,``,location.pathname+location.search)}catch{}}expandPanel(e,t){t?.stopPropagation(),this.expandedPanel=e;let n=this.panelAnchor(this.panels[e],e);try{history.pushState(history.state,``,`#expand=`+n)}catch{}}collapsePanel(){try{history.back()}catch{this.expandedPanel=null}}toggle(e){let t=new Set(this.openPanels);t.has(e)?(t.delete(e),this.clearBookmark(e)):(t.add(e),this.bookmarkPanel(e)),this.openPanels=t}static{this.styles=h`
+    `},ti=class extends b{constructor(...e){super(...e),this.panels=[],this.headerTitle=``,this.badges=[],this.orientation=`vertical`,this.navigation=null,this.overviewEditActionId=``,this.openPanels=new Set,this.expandedPanel=null,this._onPopState=()=>{let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(e.startsWith(`expand=`)){let t=e.slice(7),n=this.panels.findIndex((e,n)=>this.panelAnchor(e,n)===t);this.expandedPanel=n>=0?n:null}else this.expandedPanel=null},this.initialized=!1}navAction(e){e&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{}},bubbles:!0,composed:!0}))}connectedCallback(){super.connectedCallback(),window.addEventListener(`popstate`,this._onPopState)}disconnectedCallback(){window.removeEventListener(`popstate`,this._onPopState),super.disconnectedCallback()}willUpdate(){if(!this.initialized&&this.panels.length){this.openPanels=new Set(this.panels.map((e,t)=>e.open?t:-1).filter(e=>e>=0));let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(e.startsWith(`expand=`)){let t=e.slice(7),n=this.panels.findIndex((e,n)=>this.panelAnchor(e,n)===t);n>=0&&(this.expandedPanel=n)}else if(e){let t=this.panels.findIndex((t,n)=>this.panelAnchor(t,n)===e);t>=0&&this.openPanels.add(t)}this.initialized=!0}}firstUpdated(){let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(!e)return;let t=this.renderRoot.querySelector(`[data-anchor="${CSS.escape(e)}"]`);t&&t.scrollIntoView({block:`nearest`})}panelAnchor(e,t){return(e.title??``).toLowerCase().replace(/[^a-z0-9]+/g,`-`).replace(/^-|-$/g,``)||`panel-${t}`}bookmarkPanel(e){let t=this.panelAnchor(this.panels[e],e);try{history.replaceState(history.state,``,`#`+t)}catch{}}clearBookmark(e){let t=this.panelAnchor(this.panels[e],e);if(decodeURIComponent((location.hash||``).replace(/^#/,``))===t)try{history.replaceState(history.state,``,location.pathname+location.search)}catch{}}expandPanel(e,t){t?.stopPropagation(),this.expandedPanel=e;let n=this.panelAnchor(this.panels[e],e);try{history.pushState(history.state,``,`#expand=`+n)}catch{}}collapsePanel(){try{history.back()}catch{this.expandedPanel=null}}toggle(e){let t=new Set(this.openPanels);t.has(e)?(t.delete(e),this.clearBookmark(e)):(t.add(e),this.bookmarkPanel(e)),this.openPanels=t}static{this.styles=h`
         :host {
             display: flex;
             flex-direction: column;
@@ -1974,7 +1974,7 @@ ${i}
                     `)}
                 </div>
             </div>
-        `}};k([y({type:Array})],ei.prototype,`panels`,void 0),k([y({type:String})],ei.prototype,`headerTitle`,void 0),k([y({type:Array})],ei.prototype,`badges`,void 0),k([y({type:String,reflect:!0})],ei.prototype,`orientation`,void 0),k([y({attribute:!1})],ei.prototype,`navigation`,void 0),k([y({type:String})],ei.prototype,`overviewEditActionId`,void 0),k([C()],ei.prototype,`openPanels`,void 0),k([C()],ei.prototype,`expandedPanel`,void 0),ei=k([g(`mateu-foldout`)],ei);var ti=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+        `}};k([y({type:Array})],ti.prototype,`panels`,void 0),k([y({type:String})],ti.prototype,`headerTitle`,void 0),k([y({type:Array})],ti.prototype,`badges`,void 0),k([y({type:String,reflect:!0})],ti.prototype,`orientation`,void 0),k([y({attribute:!1})],ti.prototype,`navigation`,void 0),k([y({type:String})],ti.prototype,`overviewEditActionId`,void 0),k([C()],ti.prototype,`openPanels`,void 0),k([C()],ti.prototype,`expandedPanel`,void 0),ti=k([g(`mateu-foldout`)],ti);var ni=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
         <mateu-foldout
                 .panels="${s.panels??[]}"
                 .headerTitle="${s.headerTitle??``}"
@@ -1986,9 +1986,9 @@ ${i}
                 class="${t.cssClasses}"
                 slot="${t.slot??v}"
         >
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
         </mateu-foldout>
-    `},ni=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.children??[],l=e=>c.filter(t=>(t.slot??``).startsWith(e)),u=l(`main-`),d=l(`aside-`),f=l(`footer-`),p=s.asideWidth&&s.asideWidth.trim()?s.asideWidth:`32%`,ee=s.asidePosition===`start`,m=s.asideSticky!==!1,te=t=>t.map(t=>I(e,t,n,r,i,a,o)),ne=T`
+    `},ri=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.children??[],l=e=>c.filter(t=>(t.slot??``).startsWith(e)),u=l(`main-`),d=l(`aside-`),f=l(`footer-`),p=s.asideWidth&&s.asideWidth.trim()?s.asideWidth:`32%`,ee=s.asidePosition===`start`,m=s.asideSticky!==!1,te=t=>t.map(t=>F(e,t,n,r,i,a,o)),ne=T`
         <div class="mateu-content-main"
              style="flex: 1 1 0; min-width: min(20rem, 100%); box-sizing: border-box;">
             ${te(u)}
@@ -2009,7 +2009,7 @@ ${i}
                     ${te(f)}
                 </div>`:v}
         </div>
-    `},ri=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!!s.image,l=c?`background-image: linear-gradient(rgba(0,0,0,.35), rgba(0,0,0,.35)), url('${s.image}'); background-size: cover; background-position: center; color: #fff;`:``,u=s.centered===!1?`flex-start`:`center`,d=s.centered===!1?`left`:`center`;return T`
+    `},ii=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!!s.image,l=c?`background-image: linear-gradient(rgba(0,0,0,.35), rgba(0,0,0,.35)), url('${s.image}'); background-size: cover; background-position: center; color: #fff;`:``,u=s.centered===!1?`flex-start`:`center`,d=s.centered===!1?`left`:`center`;return T`
         <div class="mateu-hero ${t.cssClasses??``}"
              style="display: flex; flex-direction: column; align-items: ${u}; justify-content: center; gap: var(--lumo-space-m, 1rem); text-align: ${d}; padding: var(--lumo-space-xl, 2.5rem) var(--lumo-space-l, 1.5rem); border-radius: var(--lumo-border-radius-l, 12px); min-height: ${s.height??`12rem`}; box-sizing: border-box; ${l} ${t.style??``}"
              slot="${t.slot??v}"
@@ -2018,11 +2018,11 @@ ${i}
             ${s.subtitle?T`<p style="margin: 0; font-size: var(--lumo-font-size-l, 1.125rem); ${c?``:`color: var(--lumo-secondary-text-color, #666);`} max-width: 40rem;">${s.subtitle}</p>`:v}
             ${t.children?.length?T`
                 <div style="display: flex; gap: var(--lumo-space-s, .5rem); flex-wrap: wrap; justify-content: ${u}; width: 100%; max-width: 40rem;">
-                    ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+                    ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
                 </div>
             `:v}
         </div>
-    `},z=e=>t=>{if(t.key===`Enter`){e(t);return}(t.key===` `||t.key===`Spacebar`)&&(t.preventDefault(),e(t))},B=h`
+    `},R=e=>t=>{if(t.key===`Enter`){e(t);return}(t.key===` `||t.key===`Spacebar`)&&(t.preventDefault(),e(t))},z=h`
     [role="button"]:focus-visible,
     [role="option"]:focus-visible,
     [role="treeitem"]:focus-visible,
@@ -2033,7 +2033,7 @@ ${i}
         outline-offset: 2px;
         border-radius: var(--lumo-border-radius-s, 4px);
     }
-`,ii=1440*60*1e3,ai=class extends b{constructor(...e){super(...e),this.tasks=[],this.onTaskSelectionActionId=``}selectTask(e){this.onTaskSelectionActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.onTaskSelectionActionId,parameters:{_clickedTaskId:e.id}},bubbles:!0,composed:!0}))}static{this.styles=h`
+`,ai=1440*60*1e3,oi=class extends b{constructor(...e){super(...e),this.tasks=[],this.onTaskSelectionActionId=``}selectTask(e){this.onTaskSelectionActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.onTaskSelectionActionId,parameters:{_clickedTaskId:e.id}},bubbles:!0,composed:!0}))}static{this.styles=h`
         :host {
             display: block;
             width: 100%;
@@ -2108,8 +2108,8 @@ ${i}
             opacity: .55;
         }
     
-        ${B}
-    `}range(){let e=this.tasks.flatMap(e=>[e.start,e.end]).filter(e=>!!e).map(e=>new Date(e+`T00:00:00`).getTime());return e.length?{min:Math.min(...e)-ii,max:Math.max(...e)+2*ii}:null}months(e,t){let n=[],r=new Date(e);for(r.setDate(1);r.getTime()<=t;){let i=Math.max(r.getTime(),e),a=new Date(r.getFullYear(),r.getMonth()+1,1),o=Math.min(a.getTime(),t);n.push({label:r.toLocaleDateString(void 0,{month:`short`,year:`2-digit`}),from:i,to:o}),r.setMonth(r.getMonth()+1)}return n}render(){let e=this.range();if(!e)return T``;let t=e.max-e.min,n=n=>(n-e.min)/t*100,r=Date.now();return T`
+        ${z}
+    `}range(){let e=this.tasks.flatMap(e=>[e.start,e.end]).filter(e=>!!e).map(e=>new Date(e+`T00:00:00`).getTime());return e.length?{min:Math.min(...e)-ai,max:Math.max(...e)+2*ai}:null}months(e,t){let n=[],r=new Date(e);for(r.setDate(1);r.getTime()<=t;){let i=Math.max(r.getTime(),e),a=new Date(r.getFullYear(),r.getMonth()+1,1),o=Math.min(a.getTime(),t);n.push({label:r.toLocaleDateString(void 0,{month:`short`,year:`2-digit`}),from:i,to:o}),r.setMonth(r.getMonth()+1)}return n}render(){let e=this.range();if(!e)return T``;let t=e.max-e.min,n=n=>(n-e.min)/t*100,r=Date.now();return T`
             <div class="frame">
                 <div class="head">Task</div>
                 <div class="head months">
@@ -2117,7 +2117,7 @@ ${i}
                         <div class="month" style="width: ${(e.to-e.from)/t*100}%;">${e.label}</div>
                     `)}
                 </div>
-                ${this.tasks.map(i=>{let a=new Date(i.start+`T00:00:00`).getTime(),o=new Date(i.end+`T00:00:00`).getTime()+ii;return T`
+                ${this.tasks.map(i=>{let a=new Date(i.start+`T00:00:00`).getTime(),o=new Date(i.end+`T00:00:00`).getTime()+ai;return T`
                         <div class="label" title="${i.title}">${i.title}</div>
                         <div class="lane">
                             ${r>=e.min&&r<=e.max?T`<div class="today" style="left: ${n(r)}%;"></div>`:v}
@@ -2125,14 +2125,14 @@ ${i}
                                  aria-label="${i.title}, ${i.start} to ${i.end}${i.progress?`, ${i.progress}% complete`:``}"
                                  class="bar ${this.onTaskSelectionActionId?`clickable`:``}"
                                  title="${i.title} · ${i.start} → ${i.end}${i.progress?` · ${i.progress}%`:``}"
-                                 @click="${()=>this.selectTask(i)}" @keydown="${z(()=>this.selectTask(i))}"
+                                 @click="${()=>this.selectTask(i)}" @keydown="${R(()=>this.selectTask(i))}"
                                  style="left: ${n(a)}%; width: ${(o-a)/t*100}%; ${i.color?`--mateu-gantt-fill: ${i.color};`:``}">
                                 <div class="fill" style="width: ${i.progress??0}%;"></div>
                             </div>
                         </div>
                     `})}
             </div>
-        `}};k([y({type:Array})],ai.prototype,`tasks`,void 0),k([y()],ai.prototype,`onTaskSelectionActionId`,void 0),ai=k([g(`mateu-gantt`)],ai);var oi=e=>{let t=e.metadata;return T`
+        `}};k([y({type:Array})],oi.prototype,`tasks`,void 0),k([y()],oi.prototype,`onTaskSelectionActionId`,void 0),oi=k([g(`mateu-gantt`)],oi);var si=e=>{let t=e.metadata;return T`
         <mateu-gantt
                 .tasks="${t.tasks??[]}"
                 .onTaskSelectionActionId="${t.onTaskSelectionActionId??``}"
@@ -2140,7 +2140,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-gantt>
-    `},V,si=class extends b{static{V=this}constructor(...e){super(...e),this.resources=[],this.blocks=[],this.drag=null,this.dragStartX=0,this.dragStartY=0,this.laneRects=[],this.onDragKeydown=e=>{e.key===`Escape`&&this.drag&&(e.stopPropagation(),this.endDrag())}}static{this.styles=h`
+    `},B,ci=class extends b{static{B=this}constructor(...e){super(...e),this.resources=[],this.blocks=[],this.drag=null,this.dragStartX=0,this.dragStartY=0,this.laneRects=[],this.onDragKeydown=e=>{e.key===`Escape`&&this.drag&&(e.stopPropagation(),this.endDrag())}}static{this.styles=h`
         :host {
             display: block;
             width: 100%;
@@ -2282,7 +2282,7 @@ ${i}
             pointer-events: none;
             z-index: 2;
         }
-    `}static parse(e){return new Date(e+`T00:00:00`)}static iso(e){let t=e=>String(e).padStart(2,`0`);return`${e.getFullYear()}-${t(e.getMonth()+1)}-${t(e.getDate())}`}static addDays(e,t){return new Date(e.getFullYear(),e.getMonth(),e.getDate()+t)}static daysBetween(e,t){return Math.round((t.getTime()-e.getTime())/864e5)}window(){if(this.from&&this.to){let e=V.parse(this.from),t=V.daysBetween(e,V.parse(this.to))+1;return t>0?{from:e,days:t}:null}let e=this.blocks.flatMap(e=>[e.start,e.end]).filter(e=>!!e).map(e=>V.parse(e));if(!e.length)return null;let t=new Date(Math.min(...e.map(e=>e.getTime()))),n=new Date(Math.max(...e.map(e=>e.getTime())));return{from:t,days:V.daysBetween(t,n)+1}}onBlockPointerDown(e,t,n){if(!this.moveActionId&&!this.selectActionId||(e.preventDefault(),e.currentTarget.setPointerCapture(e.pointerId),this.dragStartX=e.clientX,this.dragStartY=e.clientY,!this.window()))return;let r=V.parse(t.start),i=V.parse(t.end),a=Math.max(1,V.daysBetween(r,i)+1);this.laneRects=[...this.renderRoot.querySelectorAll(`.lane[data-resource-id]`)].map(e=>({resourceId:e.dataset.resourceId,rect:e.getBoundingClientRect()}));let o=this.dayAt(t.resourceId,e.clientX)??n;this.drag={blockId:t.id,duration:a,grabOffsetDays:o-n,originResourceId:t.resourceId,originStartIdx:n,targetResourceId:t.resourceId,targetStartIdx:n,moved:!1},window.addEventListener(`keydown`,this.onDragKeydown)}dayAt(e,t){let n=this.laneRects.find(t=>t.resourceId===e),r=this.window();if(!n||!r||n.rect.width===0)return null;let i=Math.floor((t-n.rect.left)/n.rect.width*r.days);return Math.max(0,Math.min(r.days-1,i))}onBlockPointerMove(e){if(!this.drag||!this.drag.moved&&Math.abs(e.clientX-this.dragStartX)<4&&Math.abs(e.clientY-this.dragStartY)<4||!this.moveActionId)return;let t=this.window();if(!t)return;let n=this.laneRects.find(t=>e.clientY>=t.rect.top&&e.clientY<=t.rect.bottom)??this.laneRects.find(e=>e.resourceId===this.drag.targetResourceId);if(!n)return;let r=this.dayAt(n.resourceId,e.clientX);if(r==null)return;let i=Math.max(0,Math.min(t.days-this.drag.duration,r-this.drag.grabOffsetDays));this.drag={...this.drag,moved:!0,targetResourceId:n.resourceId,targetStartIdx:i}}onBlockPointerUp(e){let t=this.drag;if(this.endDrag(),!t)return;if(!t.moved){this.selectActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.selectActionId,parameters:{_blockId:e.id}},bubbles:!0,composed:!0}));return}if(!this.moveActionId||t.targetResourceId===t.originResourceId&&t.targetStartIdx===t.originStartIdx)return;let n=this.window();if(!n)return;let r=V.addDays(n.from,t.targetStartIdx),i=V.addDays(r,t.duration-1);this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.moveActionId,parameters:{_blockId:t.blockId,_resourceId:t.targetResourceId,_start:V.iso(r),_end:V.iso(i)}},bubbles:!0,composed:!0}))}endDrag(){this.drag=null,window.removeEventListener(`keydown`,this.onDragKeydown)}disconnectedCallback(){super.disconnectedCallback(),window.removeEventListener(`keydown`,this.onDragKeydown)}render(){let e=this.window();if(!e||!this.resources.length)return T``;let t=[...Array(e.days).keys()].map(t=>V.addDays(e.from,t)),n=new Date,r=V.daysBetween(e.from,new Date(n.getFullYear(),n.getMonth(),n.getDate())),i=r>=0&&r<e.days,a=[],o;return this.resources.forEach(n=>{n.group&&n.group!==o&&a.push(T`<div class="group">${n.group}</div>`),o=n.group,a.push(this.renderRow(n,e,t,i?r:null))}),T`
+    `}static parse(e){return new Date(e+`T00:00:00`)}static iso(e){let t=e=>String(e).padStart(2,`0`);return`${e.getFullYear()}-${t(e.getMonth()+1)}-${t(e.getDate())}`}static addDays(e,t){return new Date(e.getFullYear(),e.getMonth(),e.getDate()+t)}static daysBetween(e,t){return Math.round((t.getTime()-e.getTime())/864e5)}window(){if(this.from&&this.to){let e=B.parse(this.from),t=B.daysBetween(e,B.parse(this.to))+1;return t>0?{from:e,days:t}:null}let e=this.blocks.flatMap(e=>[e.start,e.end]).filter(e=>!!e).map(e=>B.parse(e));if(!e.length)return null;let t=new Date(Math.min(...e.map(e=>e.getTime()))),n=new Date(Math.max(...e.map(e=>e.getTime())));return{from:t,days:B.daysBetween(t,n)+1}}onBlockPointerDown(e,t,n){if(!this.moveActionId&&!this.selectActionId||(e.preventDefault(),e.currentTarget.setPointerCapture(e.pointerId),this.dragStartX=e.clientX,this.dragStartY=e.clientY,!this.window()))return;let r=B.parse(t.start),i=B.parse(t.end),a=Math.max(1,B.daysBetween(r,i)+1);this.laneRects=[...this.renderRoot.querySelectorAll(`.lane[data-resource-id]`)].map(e=>({resourceId:e.dataset.resourceId,rect:e.getBoundingClientRect()}));let o=this.dayAt(t.resourceId,e.clientX)??n;this.drag={blockId:t.id,duration:a,grabOffsetDays:o-n,originResourceId:t.resourceId,originStartIdx:n,targetResourceId:t.resourceId,targetStartIdx:n,moved:!1},window.addEventListener(`keydown`,this.onDragKeydown)}dayAt(e,t){let n=this.laneRects.find(t=>t.resourceId===e),r=this.window();if(!n||!r||n.rect.width===0)return null;let i=Math.floor((t-n.rect.left)/n.rect.width*r.days);return Math.max(0,Math.min(r.days-1,i))}onBlockPointerMove(e){if(!this.drag||!this.drag.moved&&Math.abs(e.clientX-this.dragStartX)<4&&Math.abs(e.clientY-this.dragStartY)<4||!this.moveActionId)return;let t=this.window();if(!t)return;let n=this.laneRects.find(t=>e.clientY>=t.rect.top&&e.clientY<=t.rect.bottom)??this.laneRects.find(e=>e.resourceId===this.drag.targetResourceId);if(!n)return;let r=this.dayAt(n.resourceId,e.clientX);if(r==null)return;let i=Math.max(0,Math.min(t.days-this.drag.duration,r-this.drag.grabOffsetDays));this.drag={...this.drag,moved:!0,targetResourceId:n.resourceId,targetStartIdx:i}}onBlockPointerUp(e){let t=this.drag;if(this.endDrag(),!t)return;if(!t.moved){this.selectActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.selectActionId,parameters:{_blockId:e.id}},bubbles:!0,composed:!0}));return}if(!this.moveActionId||t.targetResourceId===t.originResourceId&&t.targetStartIdx===t.originStartIdx)return;let n=this.window();if(!n)return;let r=B.addDays(n.from,t.targetStartIdx),i=B.addDays(r,t.duration-1);this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.moveActionId,parameters:{_blockId:t.blockId,_resourceId:t.targetResourceId,_start:B.iso(r),_end:B.iso(i)}},bubbles:!0,composed:!0}))}endDrag(){this.drag=null,window.removeEventListener(`keydown`,this.onDragKeydown)}disconnectedCallback(){super.disconnectedCallback(),window.removeEventListener(`keydown`,this.onDragKeydown)}render(){let e=this.window();if(!e||!this.resources.length)return T``;let t=[...Array(e.days).keys()].map(t=>B.addDays(e.from,t)),n=new Date,r=B.daysBetween(e.from,new Date(n.getFullYear(),n.getMonth(),n.getDate())),i=r>=0&&r<e.days,a=[],o;return this.resources.forEach(n=>{n.group&&n.group!==o&&a.push(T`<div class="group">${n.group}</div>`),o=n.group,a.push(this.renderRow(n,e,t,i?r:null))}),T`
             <div class="frame" style="grid-template-columns: minmax(8rem, 12rem) repeat(${e.days}, minmax(2.2rem, 1fr));">
                 <div class="corner">Resource</div>
                 ${t.map((e,t)=>T`
@@ -2300,7 +2300,7 @@ ${i}
                     ${n.map(e=>T`<div class="cell ${this.isWeekend(e)?`weekend`:``}"></div>`)}
                 </div>
                 ${r==null?v:T`<div class="today-line" style="left: ${(r+.5)*i}%;"></div>`}
-                ${a.map(e=>{let n=V.daysBetween(t.from,V.parse(e.start)),r=V.daysBetween(t.from,V.parse(e.end));if(r<0||n>=t.days)return v;let a=Math.max(0,n),o=Math.min(t.days-1,r),s=this.drag?.moved&&this.drag.blockId===e.id;return T`
+                ${a.map(e=>{let n=B.daysBetween(t.from,B.parse(e.start)),r=B.daysBetween(t.from,B.parse(e.end));if(r<0||n>=t.days)return v;let a=Math.max(0,n),o=Math.min(t.days-1,r),s=this.drag?.moved&&this.drag.blockId===e.id;return T`
                         <div class="block ${this.selectActionId?`clickable`:``} ${this.moveActionId?`draggable`:``} ${s?`dragging`:``}"
                              title="${e.label??``} · ${e.start} → ${e.end}${e.status?` · ${e.status}`:``}"
                              style="left: ${a*i}%; width: ${(o-a+1)*i}%; ${e.color?`--mateu-planning-block: ${e.color};`:``}"
@@ -2315,7 +2315,7 @@ ${i}
                          style="left: ${o.targetStartIdx*i}%; width: ${Math.min(o.duration,t.days-o.targetStartIdx)*i}%;"></div>
                 `:v}
             </div>
-        `}};k([y({type:Array})],si.prototype,`resources`,void 0),k([y({type:Array})],si.prototype,`blocks`,void 0),k([y()],si.prototype,`from`,void 0),k([y()],si.prototype,`to`,void 0),k([y()],si.prototype,`moveActionId`,void 0),k([y()],si.prototype,`selectActionId`,void 0),k([C()],si.prototype,`drag`,void 0),si=V=k([g(`mateu-planning-board`)],si);var ci=e=>{let t=e.metadata;return T`
+        `}};k([y({type:Array})],ci.prototype,`resources`,void 0),k([y({type:Array})],ci.prototype,`blocks`,void 0),k([y()],ci.prototype,`from`,void 0),k([y()],ci.prototype,`to`,void 0),k([y()],ci.prototype,`moveActionId`,void 0),k([y()],ci.prototype,`selectActionId`,void 0),k([C()],ci.prototype,`drag`,void 0),ci=B=k([g(`mateu-planning-board`)],ci);var li=e=>{let t=e.metadata;return T`
         <mateu-planning-board
                 .resources="${t.resources??[]}"
                 .blocks="${t.blocks??[]}"
@@ -2327,7 +2327,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-planning-board>
-    `},li=class extends b{constructor(...e){super(...e),this.columns=[]}static{this.styles=h`
+    `},ui=class extends b{constructor(...e){super(...e),this.columns=[]}static{this.styles=h`
         :host {
             display: block;
             width: 100%;
@@ -2410,7 +2410,7 @@ ${i}
             .card { background: var(--lumo-contrast-5pct, #2a2a2a); }
         }
     
-        ${B}
+        ${z}
     `}clickCard(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_clickedCard:e}},bubbles:!0,composed:!0}))}render(){return T`
             <div class="board">
                 ${this.columns.map(e=>T`
@@ -2422,7 +2422,7 @@ ${i}
                         ${(e.cards??[]).map(e=>T`
                             <div role="button" tabindex="0" class="card ${e.actionId?`clickable`:``}"
                                  style="${e.color?`--mateu-kanban-card-accent: ${e.color};`:``}"
-                                 @click="${()=>this.clickCard(e)}" @keydown="${z(()=>this.clickCard(e))}">
+                                 @click="${()=>this.clickCard(e)}" @keydown="${R(()=>this.clickCard(e))}">
                                 <span class="card-title">${e.title}</span>
                                 ${e.description?T`<span class="card-desc">${e.description}</span>`:v}
                                 ${e.badge?T`<span class="badge">${e.badge}</span>`:v}
@@ -2431,14 +2431,14 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};k([y({type:Array})],li.prototype,`columns`,void 0),li=k([g(`mateu-kanban`)],li);var ui=e=>T`
+        `}};k([y({type:Array})],ui.prototype,`columns`,void 0),ui=k([g(`mateu-kanban`)],ui);var di=e=>T`
         <mateu-kanban
                 .columns="${e.metadata.columns??[]}"
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-kanban>
-    `,di=class extends b{constructor(...e){super(...e),this.items=[]}static{this.styles=h`
+    `,fi=class extends b{constructor(...e){super(...e),this.items=[]}static{this.styles=h`
         :host {
             display: block;
             width: 100%;
@@ -2510,7 +2510,7 @@ ${i}
             margin-top: .15rem;
         }
     
-        ${B}
+        ${z}
     `}clickItem(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_clickedItem:e}},bubbles:!0,composed:!0}))}render(){return T`
             <div class="feed">
                 ${this.items.map(e=>T`
@@ -2519,7 +2519,7 @@ ${i}
                             <div class="dot" style="${e.color?`--mateu-timeline-dot: ${e.color};`:``}">${e.icon??``}</div>
                             <div class="line"></div>
                         </div>
-                        <div role="button" tabindex="0" class="body" @click="${()=>this.clickItem(e)}" @keydown="${z(()=>this.clickItem(e))}">
+                        <div role="button" tabindex="0" class="body" @click="${()=>this.clickItem(e)}" @keydown="${R(()=>this.clickItem(e))}">
                             <div class="head">
                                 <span class="title">${e.title}</span>
                                 ${e.timestamp?T`<span class="time">${e.timestamp}</span>`:v}
@@ -2529,14 +2529,14 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};k([y({type:Array})],di.prototype,`items`,void 0),di=k([g(`mateu-timeline`)],di);var fi=e=>T`
+        `}};k([y({type:Array})],fi.prototype,`items`,void 0),fi=k([g(`mateu-timeline`)],fi);var pi=e=>T`
         <mateu-timeline
                 .items="${e.metadata.items??[]}"
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-timeline>
-    `,pi=class extends b{constructor(...e){super(...e),this.steps=[],this.vertical=!1}static{this.styles=h`
+    `,mi=class extends b{constructor(...e){super(...e),this.steps=[],this.vertical=!1}static{this.styles=h`
         :host {
             display: block;
             width: 100%;
@@ -2650,7 +2650,7 @@ ${i}
                         </div>
                     `})}
             </div>
-        `}};k([y({type:Array})],pi.prototype,`steps`,void 0),k([y({type:Boolean,reflect:!0})],pi.prototype,`vertical`,void 0),pi=k([g(`mateu-progress-steps`)],pi);var mi=e=>{let t=e.metadata;return T`
+        `}};k([y({type:Array})],mi.prototype,`steps`,void 0),k([y({type:Boolean,reflect:!0})],mi.prototype,`vertical`,void 0),mi=k([g(`mateu-progress-steps`)],mi);var hi=e=>{let t=e.metadata;return T`
         <mateu-progress-steps
                 .steps="${t.steps??[]}"
                 ?vertical="${t.vertical??!1}"
@@ -2658,7 +2658,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-progress-steps>
-    `},hi=class extends b{constructor(...e){super(...e),this.spark=[]}static{this.styles=h`
+    `},gi=class extends b{constructor(...e){super(...e),this.spark=[]}static{this.styles=h`
         :host {
             display: block;
         }
@@ -2713,7 +2713,7 @@ ${i}
             .tile { background: var(--lumo-contrast-5pct, #2a2a2a); }
         }
     
-        ${B}
+        ${z}
     `}sparkline(){let e=this.spark;if(!e||e.length<2)return v;let t=Math.min(...e),n=Math.max(...e)-t||1,r=80/(e.length-1),i=e.map((e,i)=>[2+i*r,2+26*(1-(e-t)/n)]),a=i.map(([e,t],n)=>`${n===0?`M`:`L`}${e.toFixed(1)} ${t.toFixed(1)}`).join(` `),o=`${a} L${i[i.length-1][0].toFixed(1)} 30 L${i[0][0].toFixed(1)} 30 Z`,s=this.trend===`down`?`var(--lumo-error-color, #e11d48)`:this.trend===`flat`?`var(--lumo-secondary-text-color, #888)`:`var(--lumo-success-color, #12b76a)`;return w`
             <svg width="${84}" height="${30}" viewBox="0 0 ${84} ${30}">
                 <path d="${o}" fill="${s}" opacity="0.12"></path>
@@ -2721,7 +2721,7 @@ ${i}
                       stroke-linejoin="round" stroke-linecap="round"></path>
             </svg>
         `}dispatchAction(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId},bubbles:!0,composed:!0}))}render(){let e=this.trend??`up`;return T`
-            <div role="button" tabindex="0" class="tile ${this.actionId?`clickable`:``}" @click="${()=>this.dispatchAction()}" @keydown="${z(()=>this.dispatchAction())}">
+            <div role="button" tabindex="0" class="tile ${this.actionId?`clickable`:``}" @click="${()=>this.dispatchAction()}" @keydown="${R(()=>this.dispatchAction())}">
                 ${this.label?T`<span class="label">${this.label}</span>`:v}
                 <span class="value">${this.value}${this.unit?T`<span class="unit">${this.unit}</span>`:v}</span>
                 <div class="foot">
@@ -2729,7 +2729,7 @@ ${i}
                     ${this.sparkline()}
                 </div>
             </div>
-        `}};k([y()],hi.prototype,`label`,void 0),k([y()],hi.prototype,`value`,void 0),k([y()],hi.prototype,`unit`,void 0),k([y()],hi.prototype,`delta`,void 0),k([y()],hi.prototype,`trend`,void 0),k([y({type:Array})],hi.prototype,`spark`,void 0),k([y()],hi.prototype,`actionId`,void 0),hi=k([g(`mateu-stat`)],hi);var gi=e=>{let t=e.metadata;return T`
+        `}};k([y()],gi.prototype,`label`,void 0),k([y()],gi.prototype,`value`,void 0),k([y()],gi.prototype,`unit`,void 0),k([y()],gi.prototype,`delta`,void 0),k([y()],gi.prototype,`trend`,void 0),k([y({type:Array})],gi.prototype,`spark`,void 0),k([y()],gi.prototype,`actionId`,void 0),gi=k([g(`mateu-stat`)],gi);var _i=e=>{let t=e.metadata;return T`
         <mateu-stat
                 label="${t.label??v}"
                 value="${t.value??v}"
@@ -2742,7 +2742,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-stat>
-    `},_i=class extends b{constructor(...e){super(...e),this.events=[]}static{this.styles=h`
+    `},vi=class extends b{constructor(...e){super(...e),this.events=[]}static{this.styles=h`
         :host {
             display: block;
             width: 100%;
@@ -2816,7 +2816,7 @@ ${i}
             .dow { background: var(--lumo-contrast-10pct, #333); }
         }
     
-        ${B}
+        ${z}
     `}clickEvent(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_clickedEvent:e}},bubbles:!0,composed:!0}))}render(){let e=this.month?new Date(this.month+`T00:00:00`):new Date,t=e.getFullYear(),n=e.getMonth(),r=new Date(t,n,1),i=(r.getDay()+6)%7,a=new Date(t,n+1,0).getDate(),o=new Date,s=e=>o.getFullYear()===t&&o.getMonth()===n&&o.getDate()===e,c={};for(let e of this.events){if(!e.date)continue;let r=new Date(e.date+`T00:00:00`);r.getFullYear()===t&&r.getMonth()===n&&(c[r.getDate()]??=[]).push(e)}let l=[`Mon`,`Tue`,`Wed`,`Thu`,`Fri`,`Sat`,`Sun`],u=[];for(let e=0;e<i;e++)u.push(T`<div class="cell blank"></div>`);for(let e=1;e<=a;e++)u.push(T`
                 <div class="cell ${s(e)?`today`:``}">
                     <span class="num">${e}</span>
@@ -2824,7 +2824,7 @@ ${i}
                         <span role="button" tabindex="0" class="chip ${e.actionId?`clickable`:``}"
                               style="${e.color?`--mateu-cal-accent: ${e.color};`:``}"
                               title="${e.title??``}"
-                              @click="${()=>this.clickEvent(e)}" @keydown="${z(()=>this.clickEvent(e))}">${e.title}</span>
+                              @click="${()=>this.clickEvent(e)}" @keydown="${R(()=>this.clickEvent(e))}">${e.title}</span>
                     `)}
                 </div>
             `);return T`
@@ -2833,7 +2833,7 @@ ${i}
                 ${l.map(e=>T`<div class="dow">${e}</div>`)}
                 ${u}
             </div>
-        `}};k([y()],_i.prototype,`month`,void 0),k([y({type:Array})],_i.prototype,`events`,void 0),_i=k([g(`mateu-calendar`)],_i);var vi=e=>{let t=e.metadata;return T`
+        `}};k([y()],vi.prototype,`month`,void 0),k([y({type:Array})],vi.prototype,`events`,void 0),vi=k([g(`mateu-calendar`)],vi);var yi=e=>{let t=e.metadata;return T`
         <mateu-calendar
                 month="${t.month??v}"
                 .events="${t.events??[]}"
@@ -2841,7 +2841,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-calendar>
-    `},yi=class extends b{constructor(...e){super(...e),this.plans=[]}static{this.styles=h`
+    `},bi=class extends b{constructor(...e){super(...e),this.plans=[]}static{this.styles=h`
         :host {
             display: block;
             width: 100%;
@@ -2953,14 +2953,14 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};k([y({type:Array})],yi.prototype,`plans`,void 0),yi=k([g(`mateu-pricing-table`)],yi);var bi=e=>T`
+        `}};k([y({type:Array})],bi.prototype,`plans`,void 0),bi=k([g(`mateu-pricing-table`)],bi);var xi=e=>T`
         <mateu-pricing-table
                 .plans="${e.metadata.plans??[]}"
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-pricing-table>
-    `,xi=class extends b{static{this.styles=h`
+    `,Si=class extends b{static{this.styles=h`
         :host {
             display: block;
             width: 100%;
@@ -3056,26 +3056,26 @@ ${i}
             .node { background: var(--lumo-contrast-5pct, #2a2a2a); }
         }
     
-        ${B}
+        ${z}
     `}clickNode(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_clickedNode:e}},bubbles:!0,composed:!0}))}renderNode(e){let t=e.avatar,n=t&&(t.startsWith(`http`)||t.startsWith(`data:`));return T`
             <li>
                 <div role="button" tabindex="0" class="node ${e.actionId?`clickable`:``}"
                      style="${e.color?`--mateu-org-accent: ${e.color};`:``}"
-                     @click="${()=>this.clickNode(e)}" @keydown="${z(()=>this.clickNode(e))}">
+                     @click="${()=>this.clickNode(e)}" @keydown="${R(()=>this.clickNode(e))}">
                     ${t?T`<span class="avatar">${n?T`<img src="${t}" alt="">`:t}</span>`:v}
                     <span class="title">${e.title}</span>
                     ${e.subtitle?T`<span class="subtitle">${e.subtitle}</span>`:v}
                 </div>
                 ${e.children&&e.children.length?T`<ul>${e.children.map(e=>this.renderNode(e))}</ul>`:v}
             </li>
-        `}render(){return this.root?T`<div class="tree"><ul>${this.renderNode(this.root)}</ul></div>`:T``}};k([y({attribute:!1})],xi.prototype,`root`,void 0),xi=k([g(`mateu-org-chart`)],xi);var Si=e=>T`
+        `}render(){return this.root?T`<div class="tree"><ul>${this.renderNode(this.root)}</ul></div>`:T``}};k([y({attribute:!1})],Si.prototype,`root`,void 0),Si=k([g(`mateu-org-chart`)],Si);var Ci=e=>T`
         <mateu-org-chart
                 .root="${e.metadata.root}"
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-org-chart>
-    `,Ci=1440*60*1e3,wi=class extends b{constructor(...e){super(...e),this.cells=[]}static{this.styles=h`
+    `,wi=1440*60*1e3,Ti=class extends b{constructor(...e){super(...e),this.cells=[]}static{this.styles=h`
         :host {
             display: block;
             width: 100%;
@@ -3099,7 +3099,7 @@ ${i}
             margin-top: .15rem;
         }
         .legend .cell { width: 10px; height: 10px; }
-    `}color(e,t){if(e<=0||t<=0)return`var(--lumo-contrast-10pct, #ebedf0)`;let n=e/t;return`color-mix(in srgb, var(--lumo-primary-color, #1a73e8) ${Math.round((n>.75?1:n>.5?.75:n>.25?.5:.3)*100)}%, transparent)`}render(){let e=this.cells.filter(e=>!!e.date);if(!e.length)return T``;let t=e.map(e=>new Date(e.date+`T00:00:00`).getTime()),n=Math.min(...t),r=Math.max(...t),i=new Date(n);i.setDate(i.getDate()-(i.getDay()+6)%7);let a={};for(let t of e)a[t.date]=t;let o=Math.max(...e.map(e=>e.value??0),1),s=[];for(let e=i.getTime();e<=r;e+=Ci){let t=new Date(e),n=t.toISOString().slice(0,10),r=a[n],i=r?.value??0,c=(t.getDay()+6)%7+1,l=r?.label??`${n}: ${i}`;s.push(T`
+    `}color(e,t){if(e<=0||t<=0)return`var(--lumo-contrast-10pct, #ebedf0)`;let n=e/t;return`color-mix(in srgb, var(--lumo-primary-color, #1a73e8) ${Math.round((n>.75?1:n>.5?.75:n>.25?.5:.3)*100)}%, transparent)`}render(){let e=this.cells.filter(e=>!!e.date);if(!e.length)return T``;let t=e.map(e=>new Date(e.date+`T00:00:00`).getTime()),n=Math.min(...t),r=Math.max(...t),i=new Date(n);i.setDate(i.getDate()-(i.getDay()+6)%7);let a={};for(let t of e)a[t.date]=t;let o=Math.max(...e.map(e=>e.value??0),1),s=[];for(let e=i.getTime();e<=r;e+=wi){let t=new Date(e),n=t.toISOString().slice(0,10),r=a[n],i=r?.value??0,c=(t.getDay()+6)%7+1,l=r?.label??`${n}: ${i}`;s.push(T`
                 <div class="cell" style="grid-row: ${c}; --cell: ${this.color(i,o)};" title="${l}"></div>
             `)}return T`
             <div class="wrap">
@@ -3114,14 +3114,14 @@ ${i}
                     <span>More</span>
                 </div>
             </div>
-        `}};k([y({type:Array})],wi.prototype,`cells`,void 0),wi=k([g(`mateu-heatmap`)],wi);var Ti=e=>T`
+        `}};k([y({type:Array})],Ti.prototype,`cells`,void 0),Ti=k([g(`mateu-heatmap`)],Ti);var Ei=e=>T`
         <mateu-heatmap
                 .cells="${e.metadata.cells??[]}"
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-heatmap>
-    `,Ei=class extends b{constructor(...e){super(...e),this.stages=[]}static{this.styles=h`
+    `,Di=class extends b{constructor(...e){super(...e),this.stages=[]}static{this.styles=h`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .funnel { display: flex; flex-direction: column; gap: .35rem; }
         .stage { display: flex; flex-direction: column; align-items: center; gap: .1rem; }
@@ -3154,14 +3154,14 @@ ${i}
                         </div>
                     `})}
             </div>
-        `}};k([y({type:Array})],Ei.prototype,`stages`,void 0),Ei=k([g(`mateu-funnel`)],Ei);var Di=e=>T`
+        `}};k([y({type:Array})],Di.prototype,`stages`,void 0),Di=k([g(`mateu-funnel`)],Di);var Oi=e=>T`
         <mateu-funnel
                 .stages="${e.metadata.stages??[]}"
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-funnel>
-    `,Oi=class extends b{constructor(...e){super(...e),this.values=[],this.labels=[],this.area=!1}static{this.styles=h`
+    `,ki=class extends b{constructor(...e){super(...e),this.values=[],this.labels=[],this.area=!1}static{this.styles=h`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .title { font-weight: 600; margin-bottom: .35rem; color: var(--lumo-body-text-color, #222); }
         svg { display: block; width: 100%; height: auto; overflow: visible; }
@@ -3174,7 +3174,7 @@ ${i}
                 ${a.map((t,n)=>n===l||n===u?w`<circle cx="${t[0]}" cy="${t[1]}" r="3.2" fill="${c}"><title>${this.labels[n]??``}: ${e[n]}</title></circle>`:w`<circle cx="${t[0]}" cy="${t[1]}" r="6" fill="transparent"><title>${this.labels[n]??``}: ${e[n]}</title></circle>`)}
             </svg>
             ${this.labels&&this.labels.length?T`<div class="labels"><span>${this.labels[0]}</span><span>${this.labels[this.labels.length-1]}</span></div>`:v}
-        `}};k([y()],Oi.prototype,`heading`,void 0),k([y({type:Array})],Oi.prototype,`values`,void 0),k([y({type:Array})],Oi.prototype,`labels`,void 0),k([y()],Oi.prototype,`color`,void 0),k([y({type:Boolean})],Oi.prototype,`area`,void 0),Oi=k([g(`mateu-trend-chart`)],Oi);var ki=e=>{let t=e.metadata;return T`
+        `}};k([y()],ki.prototype,`heading`,void 0),k([y({type:Array})],ki.prototype,`values`,void 0),k([y({type:Array})],ki.prototype,`labels`,void 0),k([y()],ki.prototype,`color`,void 0),k([y({type:Boolean})],ki.prototype,`area`,void 0),ki=k([g(`mateu-trend-chart`)],ki);var Ai=e=>{let t=e.metadata;return T`
         <mateu-trend-chart
                 heading="${t.title??v}"
                 color="${t.color??v}"
@@ -3185,7 +3185,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-trend-chart>
-    `},Ai=class extends b{constructor(...e){super(...e),this.features=[],this.columns=0}static{this.styles=h`
+    `},ji=class extends b{constructor(...e){super(...e),this.features=[],this.columns=0}static{this.styles=h`
         :host { display: block; width: 100%; }
         .grid {
             display: grid;
@@ -3215,18 +3215,18 @@ ${i}
             .card { background: var(--lumo-contrast-5pct, #2a2a2a); }
         }
     
-        ${B}
+        ${z}
     `}clickFeature(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))}render(){return T`
             <div class="grid" style="grid-template-columns: ${this.columns&&this.columns>0?`repeat(${this.columns}, minmax(0, 1fr))`:`repeat(auto-fit, minmax(15rem, 1fr))`};">
                 ${this.features.map(e=>T`
-                    <div role="button" tabindex="0" class="card ${e.actionId?`clickable`:``}" @click="${()=>this.clickFeature(e)}" @keydown="${z(()=>this.clickFeature(e))}">
+                    <div role="button" tabindex="0" class="card ${e.actionId?`clickable`:``}" @click="${()=>this.clickFeature(e)}" @keydown="${R(()=>this.clickFeature(e))}">
                         ${e.icon?T`<span class="icon">${e.icon}</span>`:v}
                         <span class="title">${e.title}</span>
                         ${e.description?T`<span class="desc">${e.description}</span>`:v}
                     </div>
                 `)}
             </div>
-        `}};k([y({type:Array})],Ai.prototype,`features`,void 0),k([y({type:Number})],Ai.prototype,`columns`,void 0),Ai=k([g(`mateu-feature-grid`)],Ai);var ji=e=>{let t=e.metadata;return T`
+        `}};k([y({type:Array})],ji.prototype,`features`,void 0),k([y({type:Number})],ji.prototype,`columns`,void 0),ji=k([g(`mateu-feature-grid`)],ji);var Mi=e=>{let t=e.metadata;return T`
         <mateu-feature-grid
                 .features="${t.features??[]}"
                 .columns="${t.columns??0}"
@@ -3234,7 +3234,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-feature-grid>
-    `},Mi=class extends b{constructor(...e){super(...e),this.items=[]}static{this.styles=h`
+    `},Ni=class extends b{constructor(...e){super(...e),this.items=[]}static{this.styles=h`
         :host { display: block; width: 100%; }
         .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr)); gap: var(--lumo-space-m, 1rem); }
         .card {
@@ -3274,14 +3274,14 @@ ${i}
                         </div>
                     `})}
             </div>
-        `}};k([y({type:Array})],Mi.prototype,`items`,void 0),Mi=k([g(`mateu-testimonials`)],Mi);var Ni=e=>T`
+        `}};k([y({type:Array})],Ni.prototype,`items`,void 0),Ni=k([g(`mateu-testimonials`)],Ni);var Pi=e=>T`
         <mateu-testimonials
                 .items="${e.metadata.items??[]}"
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-testimonials>
-    `,Pi=class extends b{constructor(...e){super(...e),this.items=[],this.openSet=new Set,this.seeded=!1}static{this.styles=h`
+    `,Fi=class extends b{constructor(...e){super(...e),this.items=[],this.openSet=new Set,this.seeded=!1}static{this.styles=h`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-m, 1rem); }
         .list {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -3305,12 +3305,12 @@ ${i}
         }
         @media (prefers-color-scheme: dark) { .q { background: var(--lumo-contrast-5pct, #2a2a2a); } }
     
-        ${B}
+        ${z}
     `}seed(){this.seeded||(this.seeded=!0,this.items.forEach((e,t)=>{e.open&&this.openSet.add(t)}))}toggle(e){this.openSet.has(e)?this.openSet.delete(e):this.openSet.add(e),this.requestUpdate()}render(){return this.seed(),T`
             <div class="list">
                 ${this.items.map((e,t)=>{let n=this.openSet.has(t);return T`
                         <div class="item ${n?`open`:``}">
-                            <div role="button" tabindex="0" aria-expanded="${n}" class="q" @click="${()=>this.toggle(t)}" @keydown="${z(()=>this.toggle(t))}">
+                            <div role="button" tabindex="0" aria-expanded="${n}" class="q" @click="${()=>this.toggle(t)}" @keydown="${R(()=>this.toggle(t))}">
                                 <span>${e.question}</span>
                                 <span class="chevron">›</span>
                             </div>
@@ -3318,14 +3318,14 @@ ${i}
                         </div>
                     `})}
             </div>
-        `}};k([y({type:Array})],Pi.prototype,`items`,void 0),k([C()],Pi.prototype,`openSet`,void 0),Pi=k([g(`mateu-faq`)],Pi);var Fi=e=>T`
+        `}};k([y({type:Array})],Fi.prototype,`items`,void 0),k([C()],Fi.prototype,`openSet`,void 0),Fi=k([g(`mateu-faq`)],Fi);var Ii=e=>T`
         <mateu-faq
                 .items="${e.metadata.items??[]}"
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-faq>
-    `,Ii=class extends b{static{this.styles=h`
+    `,Li=class extends b{static{this.styles=h`
         :host { display: block; width: 100%; }
         .callout {
             display: flex; gap: 1rem; align-items: flex-start;
@@ -3354,7 +3354,7 @@ ${i}
                     ${this.ctaLabel?T`<button class="cta" @click="${()=>this.cta()}">${this.ctaLabel}</button>`:v}
                 </div>
             </div>
-        `}};k([y()],Ii.prototype,`heading`,void 0),k([y()],Ii.prototype,`description`,void 0),k([y()],Ii.prototype,`icon`,void 0),k([y()],Ii.prototype,`ctaLabel`,void 0),k([y()],Ii.prototype,`actionId`,void 0),k([y()],Ii.prototype,`theme`,void 0),Ii=k([g(`mateu-callout-card`)],Ii);var Li=e=>{let t=e.metadata;return T`
+        `}};k([y()],Li.prototype,`heading`,void 0),k([y()],Li.prototype,`description`,void 0),k([y()],Li.prototype,`icon`,void 0),k([y()],Li.prototype,`ctaLabel`,void 0),k([y()],Li.prototype,`actionId`,void 0),k([y()],Li.prototype,`theme`,void 0),Li=k([g(`mateu-callout-card`)],Li);var Ri=e=>{let t=e.metadata;return T`
         <mateu-callout-card
                 heading="${t.title??v}"
                 description="${t.description??v}"
@@ -3366,7 +3366,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-callout-card>
-    `},Ri=class extends b{constructor(...e){super(...e),this.comments=[]}static{this.styles=h`
+    `},zi=class extends b{constructor(...e){super(...e),this.comments=[]}static{this.styles=h`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .thread { display: flex; flex-direction: column; gap: 1rem; }
         .replies {
@@ -3398,14 +3398,14 @@ ${i}
                     ${e.replies&&e.replies.length?T`<div class="replies">${e.replies.map(e=>this.renderComment(e))}</div>`:v}
                 </div>
             </div>
-        `}render(){return T`<div class="thread">${this.comments.map(e=>this.renderComment(e))}</div>`}};k([y({type:Array})],Ri.prototype,`comments`,void 0),Ri=k([g(`mateu-comment-thread`)],Ri);var zi=e=>T`
+        `}render(){return T`<div class="thread">${this.comments.map(e=>this.renderComment(e))}</div>`}};k([y({type:Array})],zi.prototype,`comments`,void 0),zi=k([g(`mateu-comment-thread`)],zi);var Bi=e=>T`
         <mateu-comment-thread
                 .comments="${e.metadata.comments??[]}"
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-comment-thread>
-    `,Bi={pdf:`📕`,image:`🖼️`,img:`🖼️`,doc:`📘`,docx:`📘`,word:`📘`,xls:`📗`,xlsx:`📗`,excel:`📗`,sheet:`📗`,zip:`🗜️`,archive:`🗜️`,video:`🎬`,audio:`🎵`,code:`💻`,csv:`📄`,txt:`📄`},Vi=class extends b{constructor(...e){super(...e),this.files=[]}static{this.styles=h`
+    `,Vi={pdf:`📕`,image:`🖼️`,img:`🖼️`,doc:`📘`,docx:`📘`,word:`📘`,xls:`📗`,xlsx:`📗`,excel:`📗`,sheet:`📗`,zip:`🗜️`,archive:`🗜️`,video:`🎬`,audio:`🎵`,code:`💻`,csv:`📄`,txt:`📄`},Hi=class extends b{constructor(...e){super(...e),this.files=[]}static{this.styles=h`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .list {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -3421,24 +3421,24 @@ ${i}
         .size { color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-xs, .75rem); flex: 0 0 auto; }
         .dl { color: var(--lumo-primary-color, #1a73e8); flex: 0 0 auto; }
     
-        ${B}
-    `}icon(e){return e&&Bi[e.toLowerCase()]||`📄`}clickFile(e,t){e.url||e.actionId&&(t.preventDefault(),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_file:e}},bubbles:!0,composed:!0})))}render(){return T`
+        ${z}
+    `}icon(e){return e&&Vi[e.toLowerCase()]||`📄`}clickFile(e,t){e.url||e.actionId&&(t.preventDefault(),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_file:e}},bubbles:!0,composed:!0})))}render(){return T`
             <div class="list">
                 ${this.files.map(e=>{let t=!!e.url||!!e.actionId,n=T`
                         <span class="icon">${this.icon(e.type)}</span>
                         <span class="name">${e.name}</span>
                         ${e.size?T`<span class="size">${e.size}</span>`:v}
                         ${e.url?T`<span class="dl">⬇</span>`:v}
-                    `;return e.url?T`<a class="file clickable" href="${e.url}" download target="_blank" rel="noopener">${n}</a>`:T`<div role="button" tabindex="0" class="file ${t?`clickable`:``}" @click="${t=>this.clickFile(e,t)}" @keydown="${z(t=>this.clickFile(e,t))}">${n}</div>`})}
+                    `;return e.url?T`<a class="file clickable" href="${e.url}" download target="_blank" rel="noopener">${n}</a>`:T`<div role="button" tabindex="0" class="file ${t?`clickable`:``}" @click="${t=>this.clickFile(e,t)}" @keydown="${R(t=>this.clickFile(e,t))}">${n}</div>`})}
             </div>
-        `}};k([y({type:Array})],Vi.prototype,`files`,void 0),Vi=k([g(`mateu-file-list`)],Vi);var Hi=e=>T`
+        `}};k([y({type:Array})],Hi.prototype,`files`,void 0),Hi=k([g(`mateu-file-list`)],Hi);var Ui=e=>T`
         <mateu-file-list
                 .files="${e.metadata.files??[]}"
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-file-list>
-    `,Ui=class extends b{constructor(...e){super(...e),this.items=[],this.localDone=new Map}static{this.styles=h`
+    `,Wi=class extends b{constructor(...e){super(...e),this.items=[],this.localDone=new Map}static{this.styles=h`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .head { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: .5rem; }
         .title { font-weight: 700; color: var(--lumo-body-text-color, #222); }
@@ -3455,7 +3455,7 @@ ${i}
         .label { color: var(--lumo-body-text-color, #333); }
         .item.done .label { color: var(--lumo-secondary-text-color, #999); text-decoration: line-through; }
     
-        ${B}
+        ${z}
     `}isDone(e,t){return this.localDone.has(t)?!!this.localDone.get(t):!!e.done}toggle(e,t){let n=!this.isDone(e,t);this.localDone.set(t,n),this.requestUpdate(),e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_item:e,_done:n}},bubbles:!0,composed:!0}))}render(){let e=this.items.length,t=this.items.filter((e,t)=>this.isDone(e,t)).length,n=e>0?Math.round(t/e*100):0;return T`
             <div class="head">
                 ${this.heading?T`<span class="title">${this.heading}</span>`:T`<span></span>`}
@@ -3463,12 +3463,12 @@ ${i}
             </div>
             <div class="bar"><div class="fill" style="width: ${n}%;"></div></div>
             ${this.items.map((e,t)=>{let n=this.isDone(e,t);return T`
-                    <div role="button" tabindex="0" class="item ${n?`done`:``}" @click="${()=>this.toggle(e,t)}" @keydown="${z(()=>this.toggle(e,t))}">
+                    <div role="button" tabindex="0" class="item ${n?`done`:``}" @click="${()=>this.toggle(e,t)}" @keydown="${R(()=>this.toggle(e,t))}">
                         <span class="box">${n?`✓`:v}</span>
                         <span class="label">${e.label}</span>
                     </div>
                 `})}
-        `}};k([y()],Ui.prototype,`heading`,void 0),k([y({type:Array})],Ui.prototype,`items`,void 0),k([C()],Ui.prototype,`localDone`,void 0),Ui=k([g(`mateu-checklist`)],Ui);var Wi=e=>{let t=e.metadata;return T`
+        `}};k([y()],Wi.prototype,`heading`,void 0),k([y({type:Array})],Wi.prototype,`items`,void 0),k([C()],Wi.prototype,`localDone`,void 0),Wi=k([g(`mateu-checklist`)],Wi);var Gi=e=>{let t=e.metadata;return T`
         <mateu-checklist
                 heading="${t.title??v}"
                 .items="${t.items??[]}"
@@ -3476,7 +3476,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-checklist>
-    `},Gi=class extends b{static{this.styles=h`
+    `},Ki=class extends b{static{this.styles=h`
         :host { display: block; width: 100%; }
         .card {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -3516,7 +3516,7 @@ ${i}
                     </div>
                 </div>
             </div>
-        `}};k([y()],Gi.prototype,`heading`,void 0),k([y()],Gi.prototype,`leftLabel`,void 0),k([y()],Gi.prototype,`leftValue`,void 0),k([y()],Gi.prototype,`rightLabel`,void 0),k([y()],Gi.prototype,`rightValue`,void 0),k([y()],Gi.prototype,`delta`,void 0),k([y()],Gi.prototype,`trend`,void 0),Gi=k([g(`mateu-comparison-card`)],Gi);var Ki=e=>{let t=e.metadata;return T`
+        `}};k([y()],Ki.prototype,`heading`,void 0),k([y()],Ki.prototype,`leftLabel`,void 0),k([y()],Ki.prototype,`leftValue`,void 0),k([y()],Ki.prototype,`rightLabel`,void 0),k([y()],Ki.prototype,`rightValue`,void 0),k([y()],Ki.prototype,`delta`,void 0),k([y()],Ki.prototype,`trend`,void 0),Ki=k([g(`mateu-comparison-card`)],Ki);var qi=e=>{let t=e.metadata;return T`
         <mateu-comparison-card
                 heading="${t.title??v}"
                 leftLabel="${t.leftLabel??v}"
@@ -3529,7 +3529,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-comparison-card>
-    `},qi=h`
+    `},Ji=h`
     .chip {
         display: inline-flex;
         align-items: center;
@@ -3559,7 +3559,7 @@ ${i}
         color: var(--lumo-contrast-80pct, #333);
         background: var(--lumo-contrast-10pct, rgba(0, 0, 0, .08));
     }
-`,Ji=new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}),Yi=e=>Number.isFinite(e)?Ji.format(e):``,Xi=(e,t)=>{let n=e<0?`-`:``,r=Yi(Math.abs(e));return t?`${n}${t} ${r}`:`${n}${r}`},Zi=(e,t)=>t?`${Yi(e)} ${t}`:Yi(e),Qi=class extends b{constructor(...e){super(...e),this.title=``,this.badges=[],this.facts=[]}static{this.styles=[qi,h`
+`,Yi=new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}),Xi=e=>Number.isFinite(e)?Yi.format(e):``,Zi=(e,t)=>{let n=e<0?`-`:``,r=Xi(Math.abs(e));return t?`${n}${t} ${r}`:`${n}${r}`},Qi=(e,t)=>t?`${Xi(e)} ${t}`:Xi(e),$i=class extends b{constructor(...e){super(...e),this.title=``,this.badges=[],this.facts=[]}static{this.styles=[Ji,h`
         :host { display: block; width: 100%; }
         .card {
             display: flex;
@@ -3642,7 +3642,7 @@ ${i}
                     </div>
                 `:v}
             </div>
-        `}};k([y()],Qi.prototype,`title`,void 0),k([y({type:Array})],Qi.prototype,`badges`,void 0),k([y()],Qi.prototype,`subtitle`,void 0),k([y({type:Array})],Qi.prototype,`facts`,void 0),k([y()],Qi.prototype,`metricLabel`,void 0),k([y()],Qi.prototype,`metricValue`,void 0),k([y()],Qi.prototype,`metricCaption`,void 0),Qi=k([g(`mateu-entity-header`)],Qi);var $i=e=>{if(e.__hoistedToPageHeader)return T``;let t=e.metadata;return T`
+        `}};k([y()],$i.prototype,`title`,void 0),k([y({type:Array})],$i.prototype,`badges`,void 0),k([y()],$i.prototype,`subtitle`,void 0),k([y({type:Array})],$i.prototype,`facts`,void 0),k([y()],$i.prototype,`metricLabel`,void 0),k([y()],$i.prototype,`metricValue`,void 0),k([y()],$i.prototype,`metricCaption`,void 0),$i=k([g(`mateu-entity-header`)],$i);var ea=e=>{if(e.__hoistedToPageHeader)return T``;let t=e.metadata;return T`
         <mateu-entity-header
                 .title="${t.title??``}"
                 .badges="${t.badges??[]}"
@@ -3655,7 +3655,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-entity-header>
-    `},ea=class extends b{constructor(...e){super(...e),this.value=0,this.max=0}static{this.styles=h`
+    `},ta=class extends b{constructor(...e){super(...e),this.value=0,this.max=0}static{this.styles=h`
         :host { display: block; width: 100%; }
         .meter { display: flex; flex-direction: column; gap: .35rem; }
         .label {
@@ -3680,13 +3680,13 @@ ${i}
     `}fillColor(){return this.dangerAt!=null&&this.value>=this.dangerAt?`error`:this.warnAt!=null&&this.value>=this.warnAt?`warning`:this.warnAt!=null||this.dangerAt!=null?`success`:`primary`}render(){let e=this.max>0?Math.min(Math.max(this.value/this.max,0),1):0,t=Math.round(e*100);return T`
             <div class="meter">
                 ${this.label?T`<span class="label">${this.label}</span>`:v}
-                <span class="value">${Zi(this.value,this.unit)}</span>
+                <span class="value">${Qi(this.value,this.unit)}</span>
                 <div class="track">
                     <div class="fill ${this.fillColor()}" style="width: ${t}%"></div>
                 </div>
                 <span class="caption">${this.caption?this.caption:`${t}%`}</span>
             </div>
-        `}};k([y()],ea.prototype,`label`,void 0),k([y({type:Number})],ea.prototype,`value`,void 0),k([y({type:Number})],ea.prototype,`max`,void 0),k([y()],ea.prototype,`unit`,void 0),k([y()],ea.prototype,`caption`,void 0),k([y({type:Number})],ea.prototype,`warnAt`,void 0),k([y({type:Number})],ea.prototype,`dangerAt`,void 0),ea=k([g(`mateu-meter`)],ea);var ta=e=>{let t=e.metadata;return T`
+        `}};k([y()],ta.prototype,`label`,void 0),k([y({type:Number})],ta.prototype,`value`,void 0),k([y({type:Number})],ta.prototype,`max`,void 0),k([y()],ta.prototype,`unit`,void 0),k([y()],ta.prototype,`caption`,void 0),k([y({type:Number})],ta.prototype,`warnAt`,void 0),k([y({type:Number})],ta.prototype,`dangerAt`,void 0),ta=k([g(`mateu-meter`)],ta);var na=e=>{let t=e.metadata;return T`
         <mateu-meter
                 .label="${t.label}"
                 .value="${t.value??0}"
@@ -3699,7 +3699,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-meter>
-    `},na=class extends b{constructor(...e){super(...e),this.total=0,this.done=0}static{this.styles=h`
+    `},ra=class extends b{constructor(...e){super(...e),this.total=0,this.done=0}static{this.styles=h`
         :host { display: block; width: 100%; }
         .banner {
             display: flex; align-items: center; gap: .8rem; flex-wrap: wrap;
@@ -3754,7 +3754,7 @@ ${i}
                 <span class="spacer"></span>
                 ${t?T`<button @click="${()=>this.runAction()}">${this.actionLabel} →</button>`:v}
             </div>
-        `}};k([y()],na.prototype,`label`,void 0),k([y({type:Number})],na.prototype,`total`,void 0),k([y({type:Number})],na.prototype,`done`,void 0),k([y()],na.prototype,`actionLabel`,void 0),k([y()],na.prototype,`actionId`,void 0),na=k([g(`mateu-task-progress`)],na);var ra=e=>{let t=e.metadata;return T`
+        `}};k([y()],ra.prototype,`label`,void 0),k([y({type:Number})],ra.prototype,`total`,void 0),k([y({type:Number})],ra.prototype,`done`,void 0),k([y()],ra.prototype,`actionLabel`,void 0),k([y()],ra.prototype,`actionId`,void 0),ra=k([g(`mateu-task-progress`)],ra);var ia=e=>{let t=e.metadata;return T`
         <mateu-task-progress
                 .label="${t.label}"
                 .total="${t.total??0}"
@@ -3765,7 +3765,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-task-progress>
-    `},ia=class extends b{constructor(...e){super(...e),this.items=[],this.compact=!1,this.frameless=!1,this.columns=0,this.itemHeadingLevel=3}static{this.styles=[qi,B,h`
+    `},aa=class extends b{constructor(...e){super(...e),this.items=[],this.compact=!1,this.frameless=!1,this.columns=0,this.itemHeadingLevel=3}static{this.styles=[Ji,z,h`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .list {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -3870,7 +3870,7 @@ ${i}
     `]}runAction(e,t){t&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_item:e.id}},bubbles:!0,composed:!0}))}rowClicked(e){this.rowActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.rowActionId,parameters:{_item:e.id}},bubbles:!0,composed:!0}))}renderItemAction(e,t,n,r){return!t||!n?v:r?T`
                 <button class="icon-action" title="${t}" aria-label="${t}"
                     @click="${t=>{t.stopPropagation(),this.runAction(e,n)}}">
-                    ${L(r)}
+                    ${I(r)}
                 </button>`:T`
             <button class="row-action" title="${t}"
                 @click="${t=>{t.stopPropagation(),this.runAction(e,n)}}">${t}</button>`}render(){let e=this.columns>1||this.items.some(e=>e.actionId||e.actionId2||e.actionId3||(e.lines?.length??0)>0),t=this.itemHeadingLevel===4?`h4`:`h3`;return e?T`
@@ -3878,7 +3878,7 @@ ${i}
                      style="${this.columns>1?`grid-template-columns: repeat(auto-fit, minmax(min(18rem, calc(100% / ${this.columns} - 1.5rem)), 1fr));`:``}">
                     ${this.items.map(e=>T`
                         <div role="button" tabindex="0" class="cell ${(e.lines?.length??0)>0?`with-lines`:``} ${this.rowActionId?`clickable`:``}"
-                             @click="${()=>this.rowClicked(e)}" @keydown="${z(()=>this.rowClicked(e))}">
+                             @click="${()=>this.rowClicked(e)}" @keydown="${R(()=>this.rowClicked(e))}">
                             <div class="cell-title-row">
                                 ${t===`h4`?T`<h4 class="cell-title">${e.title}</h4>`:T`<h3 class="cell-title">${e.title}</h3>`}
                                 ${e.status?T`<span class="chip ${e.statusColor??``}">${e.status}</span>`:v}
@@ -3898,7 +3898,7 @@ ${i}
             <div class="list ${this.compact?`compact`:``} ${this.frameless?`frameless`:``}">
                 ${this.items.map(e=>T`
                     <div role="button" tabindex="0" class="row ${this.rowActionId?`clickable`:``}"
-                         @click="${()=>this.rowClicked(e)}" @keydown="${z(()=>this.rowClicked(e))}">
+                         @click="${()=>this.rowClicked(e)}" @keydown="${R(()=>this.rowClicked(e))}">
                         ${e.avatar?T`<span class="avatar">${e.avatar}</span>`:e.icon?T`<span class="icon">${e.icon}</span>`:v}
                         <div class="body">
                             <span class="title">${e.title}</span>
@@ -3908,7 +3908,7 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};k([y({type:Array})],ia.prototype,`items`,void 0),k([y({type:Boolean})],ia.prototype,`compact`,void 0),k([y({type:Boolean})],ia.prototype,`frameless`,void 0),k([y()],ia.prototype,`rowActionId`,void 0),k([y({type:Number})],ia.prototype,`columns`,void 0),k([y({type:Number})],ia.prototype,`itemHeadingLevel`,void 0),ia=k([g(`mateu-status-list`)],ia);var aa=e=>{let t=e.metadata;return T`
+        `}};k([y({type:Array})],aa.prototype,`items`,void 0),k([y({type:Boolean})],aa.prototype,`compact`,void 0),k([y({type:Boolean})],aa.prototype,`frameless`,void 0),k([y()],aa.prototype,`rowActionId`,void 0),k([y({type:Number})],aa.prototype,`columns`,void 0),k([y({type:Number})],aa.prototype,`itemHeadingLevel`,void 0),aa=k([g(`mateu-status-list`)],aa);var oa=e=>{let t=e.metadata;return T`
         <mateu-status-list
                 .items="${t.items??[]}"
                 ?compact="${t.compact??!1}"
@@ -3920,7 +3920,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-status-list>
-    `},oa=class extends b{constructor(...e){super(...e),this.items=[]}static{this.styles=h`
+    `},sa=class extends b{constructor(...e){super(...e),this.items=[]}static{this.styles=h`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         ul {
             margin: 0; padding-inline-start: 1.2rem;
@@ -3935,20 +3935,20 @@ ${i}
             <ul>
                 ${this.items.map(e=>T`<li>${e}</li>`)}
             </ul>
-        `}};k([y({type:Array})],oa.prototype,`items`,void 0),oa=k([g(`mateu-bulleted-list`)],oa);var sa=e=>T`
+        `}};k([y({type:Array})],sa.prototype,`items`,void 0),sa=k([g(`mateu-bulleted-list`)],sa);var ca=e=>T`
         <mateu-bulleted-list
                 .items="${e.metadata.items??[]}"
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-bulleted-list>
-    `,ca=e=>{let t=e.metadata.attributes?.[`data-colspan`];return T`
+    `,la=e=>{let t=e.metadata.attributes?.[`data-colspan`];return T`
         <hr style="border: none; border-top: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1)); width: 100%; margin: var(--lumo-space-s, .5rem) 0; ${e.style??``}"
             class="${e.cssClasses??v}"
             id="${S(e.id??void 0)}"
             data-colspan="${S(t)}"
             slot="${e.slot??v}"/>
-    `},la={info:`ℹ`,success:`✓`,warning:`!`,danger:`!`},H=class extends b{constructor(...e){super(...e),this.text=``,this.theme=`info`,this.noIcon=!1,this.slim=!1,this.fullWidth=!1,this.hasContent=!1,this.inlineContent=!1}static{this.styles=h`
+    `},ua={info:`ℹ`,success:`✓`,warning:`!`,danger:`!`},V=class extends b{constructor(...e){super(...e),this.text=``,this.theme=`info`,this.noIcon=!1,this.slim=!1,this.fullWidth=!1,this.hasContent=!1,this.inlineContent=!1}static{this.styles=h`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .notice {
             display: flex;
@@ -4013,14 +4013,14 @@ ${i}
         .danger  .icon  { background: #b25b3d; }
     `}runAction(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId},bubbles:!0,composed:!0}))}render(){let e=!!this.text&&!!this.text.trim();if(!e&&!this.hasContent)return T``;let t=[`info`,`success`,`warning`,`danger`].includes(this.theme)?this.theme:`info`;return T`
             <div class="notice ${t} ${this.slim?`slim`:``}">
-                ${this.noIcon?v:T`<span class="icon ${this.icon?`custom`:``}">${this.icon||la[t]}</span>`}
+                ${this.noIcon?v:T`<span class="icon ${this.icon?`custom`:``}">${this.icon||ua[t]}</span>`}
                 <div class="body ${this.inlineContent?`inline`:``}">
                     ${e?T`<span class="text">${this.text}</span>`:v}
                     ${this.hasContent?T`<div class="content"><slot></slot></div>`:v}
                 </div>
                 ${this.actionLabel&&this.actionId?T`<button class="notice-action" @click="${()=>this.runAction()}">${this.actionLabel}</button>`:this.status?T`<span class="status">${this.status}</span>`:v}
             </div>
-        `}};k([y()],H.prototype,`text`,void 0),k([y()],H.prototype,`theme`,void 0),k([y()],H.prototype,`icon`,void 0),k([y({type:Boolean})],H.prototype,`noIcon`,void 0),k([y()],H.prototype,`actionLabel`,void 0),k([y()],H.prototype,`actionId`,void 0),k([y()],H.prototype,`status`,void 0),k([y({type:Boolean})],H.prototype,`slim`,void 0),k([y({type:Boolean})],H.prototype,`fullWidth`,void 0),k([y({type:Boolean})],H.prototype,`hasContent`,void 0),k([y({type:Boolean})],H.prototype,`inlineContent`,void 0),H=k([g(`mateu-notice`)],H);var ua=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=xt(s.text??``,r,i,a,o)??``,l=t.children??[];return T`
+        `}};k([y()],V.prototype,`text`,void 0),k([y()],V.prototype,`theme`,void 0),k([y()],V.prototype,`icon`,void 0),k([y({type:Boolean})],V.prototype,`noIcon`,void 0),k([y()],V.prototype,`actionLabel`,void 0),k([y()],V.prototype,`actionId`,void 0),k([y()],V.prototype,`status`,void 0),k([y({type:Boolean})],V.prototype,`slim`,void 0),k([y({type:Boolean})],V.prototype,`fullWidth`,void 0),k([y({type:Boolean})],V.prototype,`hasContent`,void 0),k([y({type:Boolean})],V.prototype,`inlineContent`,void 0),V=k([g(`mateu-notice`)],V);var da=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=xt(s.text??``,r,i,a,o)??``,l=t.children??[];return T`
         <mateu-notice
                 text="${c}"
                 theme="${s.theme??`info`}"
@@ -4037,8 +4037,8 @@ ${i}
                 style="${t.style??v}"
                 class="${t.cssClasses??v}"
                 slot="${t.slot??v}"
-        >${l.map(t=>I(e,t,n,r,i,a,o))}</mateu-notice>
-    `},da=class extends b{constructor(...e){super(...e),this.groups=[]}static{this.styles=[qi,B,h`
+        >${l.map(t=>F(e,t,n,r,i,a,o))}</mateu-notice>
+    `},fa=class extends b{constructor(...e){super(...e),this.groups=[]}static{this.styles=[Ji,z,h`
         :host { display: block; width: 100%; }
         .rail { display: flex; flex-direction: column; gap: var(--lumo-space-m, 1rem); }
         .group { display: flex; flex-direction: column; gap: .45rem; }
@@ -4086,7 +4086,7 @@ ${i}
                         ${e.label?T`<span class="group-label">${e.label}</span>`:v}
                         ${(e.items??[]).map(e=>T`
                             <div role="option" tabindex="0" aria-selected="${e.id===this.selectedId}" class="card ${e.id===this.selectedId?`selected`:``}"
-                                 @click="${()=>this.select(e.id)}" @keydown="${z(()=>this.select(e.id))}">
+                                 @click="${()=>this.select(e.id)}" @keydown="${R(()=>this.select(e.id))}">
                                 <span class="title">${e.title}</span>
                                 <div class="meta">
                                     ${e.caption?T`<span class="caption">${e.caption}</span>`:v}
@@ -4101,7 +4101,7 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};k([y()],da.prototype,`actionId`,void 0),k([y({type:Array})],da.prototype,`groups`,void 0),k([C()],da.prototype,`selectedId`,void 0),da=k([g(`mateu-task-queue`)],da);var fa=e=>{let t=e.metadata;return T`
+        `}};k([y()],fa.prototype,`actionId`,void 0),k([y({type:Array})],fa.prototype,`groups`,void 0),k([C()],fa.prototype,`selectedId`,void 0),fa=k([g(`mateu-task-queue`)],fa);var pa=e=>{let t=e.metadata;return T`
         <mateu-task-queue
                 .actionId="${t.actionId}"
                 .groups="${t.groups??[]}"
@@ -4109,7 +4109,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-task-queue>
-    `},pa=class extends b{constructor(...e){super(...e),this.columns=0,this.items=[]}static{this.styles=[qi,B,h`
+    `},ma=class extends b{constructor(...e){super(...e),this.columns=0,this.items=[]}static{this.styles=[Ji,z,h`
         /* explicit line-height: inside a form field wrapper the inherited one is the 44px
            field height, which blows up every text row */
         :host { display: block; width: 100%; line-height: var(--lumo-line-height-m, 1.4); }
@@ -4164,7 +4164,7 @@ ${i}
             <div class="grid" style="${this.columns>0?`grid-template-columns: repeat(${this.columns}, minmax(0, 1fr));`:`grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));`}">
                 ${this.items.map(e=>T`
                     <div role="button" tabindex="0" class="cell ${e.disabled?`disabled`:``} ${e.recommended?`recommended`:``} ${e.id===this.selectedId?`selected`:``}"
-                         @click="${()=>this.select(e)}" @keydown="${z(()=>this.select(e))}">
+                         @click="${()=>this.select(e)}" @keydown="${R(()=>this.select(e))}">
                         ${e.recommended?T`<span class="tag">${this.recommendedLabel||`Recommended`}</span>`:v}
                         <span class="title">${e.title}</span>
                         ${e.subtitle?T`<span class="subtitle">${e.subtitle}</span>`:v}
@@ -4173,7 +4173,7 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};k([y()],pa.prototype,`actionId`,void 0),k([y({type:Number})],pa.prototype,`columns`,void 0),k([y()],pa.prototype,`recommendedLabel`,void 0),k([y({type:Array})],pa.prototype,`items`,void 0),k([C()],pa.prototype,`selectedId`,void 0),pa=k([g(`mateu-resource-grid`)],pa);var ma=e=>{let t=e.metadata;return T`
+        `}};k([y()],ma.prototype,`actionId`,void 0),k([y({type:Number})],ma.prototype,`columns`,void 0),k([y()],ma.prototype,`recommendedLabel`,void 0),k([y({type:Array})],ma.prototype,`items`,void 0),k([C()],ma.prototype,`selectedId`,void 0),ma=k([g(`mateu-resource-grid`)],ma);var ha=e=>{let t=e.metadata;return T`
         <mateu-resource-grid
                 .actionId="${t.actionId}"
                 .columns="${t.columns??0}"
@@ -4183,7 +4183,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-resource-grid>
-    `},U=class extends b{constructor(...e){super(...e),this.title=``,this.features=[],this.current=!1,this.added=!1}static{this.styles=h`
+    `},H=class extends b{constructor(...e){super(...e),this.title=``,this.features=[],this.current=!1,this.added=!1}static{this.styles=h`
         /* explicit line-height: inside a form field wrapper the inherited one is the 44px
            field height, which blows up every text row */
         :host { display: block; width: 100%; line-height: var(--lumo-line-height-m, 1.4); }
@@ -4271,7 +4271,7 @@ ${i}
                         `:v}
                 </div>
             </div>
-        `}};k([y()],U.prototype,`tag`,void 0),k([y()],U.prototype,`title`,void 0),k([y()],U.prototype,`subtitle`,void 0),k([y()],U.prototype,`image`,void 0),k([y({type:Array})],U.prototype,`features`,void 0),k([y()],U.prototype,`priceLabel`,void 0),k([y()],U.prototype,`actionLabel`,void 0),k([y()],U.prototype,`actionId`,void 0),k([y({type:Boolean})],U.prototype,`current`,void 0),k([y()],U.prototype,`currentLabel`,void 0),k([y({type:Boolean})],U.prototype,`added`,void 0),k([y()],U.prototype,`addedLabel`,void 0),U=k([g(`mateu-offer-card`)],U);var ha=e=>{let t=e.metadata;return T`
+        `}};k([y()],H.prototype,`tag`,void 0),k([y()],H.prototype,`title`,void 0),k([y()],H.prototype,`subtitle`,void 0),k([y()],H.prototype,`image`,void 0),k([y({type:Array})],H.prototype,`features`,void 0),k([y()],H.prototype,`priceLabel`,void 0),k([y()],H.prototype,`actionLabel`,void 0),k([y()],H.prototype,`actionId`,void 0),k([y({type:Boolean})],H.prototype,`current`,void 0),k([y()],H.prototype,`currentLabel`,void 0),k([y({type:Boolean})],H.prototype,`added`,void 0),k([y()],H.prototype,`addedLabel`,void 0),H=k([g(`mateu-offer-card`)],H);var ga=e=>{let t=e.metadata;return T`
         <mateu-offer-card
                 .tag="${t.tag}"
                 .title="${t.title??``}"
@@ -4289,7 +4289,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-offer-card>
-    `},ga=class extends b{constructor(...e){super(...e),this.items=[],this.added=new Set}static{this.styles=h`
+    `},_a=class extends b{constructor(...e){super(...e),this.items=[],this.added=new Set}static{this.styles=h`
         :host { display: block; width: 100%; }
         .header { display: flex; align-items: baseline; justify-content: flex-end; gap: .4rem; margin-bottom: .6rem; }
         .total-label { font-size: var(--lumo-font-size-s, .875rem); color: var(--lumo-secondary-text-color, #888); }
@@ -4357,7 +4357,7 @@ ${i}
     `}willUpdate(e){e.has(`items`)&&(this.added=new Set(this.items.filter(e=>e.added).map(e=>e.id)))}total(){return this.items.filter(e=>e.id!=null&&this.added.has(e.id)).reduce((e,t)=>e+(t.price??0),0)}toggle(e){if(e.id==null)return;let t=new Set(this.added),n=!t.has(e.id);n?t.add(e.id):t.delete(e.id),this.added=t,this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{_item:e.id,_added:n,_total:this.total()}},bubbles:!0,composed:!0}))}render(){return T`
             <div class="header">
                 ${this.totalLabel?T`<span class="total-label">${this.totalLabel}:</span>`:v}
-                <span class="total">${Xi(this.total(),this.currency)}</span>
+                <span class="total">${Zi(this.total(),this.currency)}</span>
             </div>
             <div class="grid">
                 ${this.items.map(e=>{let t=e.id!=null&&this.added.has(e.id);return T`
@@ -4367,7 +4367,7 @@ ${i}
                             ${e.description?T`<span class="description">${e.description}</span>`:v}
                             ${e.includedLabel?T`<span class="included">${e.includedLabel}</span>`:T`
                                     ${e.price==null?v:T`
-                                        <span class="price">${Xi(e.price,this.currency)}${e.unit?` / ${e.unit}`:``}</span>
+                                        <span class="price">${Zi(e.price,this.currency)}${e.unit?` / ${e.unit}`:``}</span>
                                     `}
                                     <button class="toggle ${t?`on`:``}" @click="${()=>this.toggle(e)}"
                                             aria-pressed="${t}">${t?`✓`:`+`}</button>
@@ -4375,7 +4375,7 @@ ${i}
                         </div>
                     `})}
             </div>
-        `}};k([y()],ga.prototype,`totalLabel`,void 0),k([y()],ga.prototype,`currency`,void 0),k([y()],ga.prototype,`actionId`,void 0),k([y({type:Array})],ga.prototype,`items`,void 0),k([C()],ga.prototype,`added`,void 0),ga=k([g(`mateu-addon-picker`)],ga);var _a=e=>{let t=e.metadata;return T`
+        `}};k([y()],_a.prototype,`totalLabel`,void 0),k([y()],_a.prototype,`currency`,void 0),k([y()],_a.prototype,`actionId`,void 0),k([y({type:Array})],_a.prototype,`items`,void 0),k([C()],_a.prototype,`added`,void 0),_a=k([g(`mateu-addon-picker`)],_a);var va=e=>{let t=e.metadata;return T`
         <mateu-addon-picker
                 .totalLabel="${t.totalLabel}"
                 .currency="${t.currency}"
@@ -4385,7 +4385,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-addon-picker>
-    `},va=class extends b{constructor(...e){super(...e),this.lines=[]}static{this.styles=h`
+    `},ya=class extends b{constructor(...e){super(...e),this.lines=[]}static{this.styles=h`
         :host {
             display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem);
             /* an ancestor (e.g. a form-layout row) may set an inherited line-height like 44px —
@@ -4427,14 +4427,14 @@ ${i}
                 <div class="row">
                     <span class="dot"></span>
                     <span class="concept">${e.concept}</span>
-                    ${e.included?T`<span class="included-label">${e.includedLabel||`Included`}</span>`:T`<span class="amount ${(e.amount??0)<0?`negative`:``}">${Xi(e.amount??0,this.currency)}</span>`}
+                    ${e.included?T`<span class="included-label">${e.includedLabel||`Included`}</span>`:T`<span class="amount ${(e.amount??0)<0?`negative`:``}">${Zi(e.amount??0,this.currency)}</span>`}
                 </div>
             `)}
             <div class="total-row">
                 <span class="total-label">${this.totalLabel||`Total`}</span>
-                <span class="total">${Xi(this.computedTotal(),this.currency)}</span>
+                <span class="total">${Zi(this.computedTotal(),this.currency)}</span>
             </div>
-        `}};k([y()],va.prototype,`currency`,void 0),k([y()],va.prototype,`totalLabel`,void 0),k([y({type:Array})],va.prototype,`lines`,void 0),k([y({type:Number})],va.prototype,`total`,void 0),va=k([g(`mateu-ledger`)],va);var ya=e=>{let t=e.metadata;return T`
+        `}};k([y()],ya.prototype,`currency`,void 0),k([y()],ya.prototype,`totalLabel`,void 0),k([y({type:Array})],ya.prototype,`lines`,void 0),k([y({type:Number})],ya.prototype,`total`,void 0),ya=k([g(`mateu-ledger`)],ya);var ba=e=>{let t=e.metadata;return T`
         <mateu-ledger
                 .currency="${t.currency}"
                 .totalLabel="${t.totalLabel}"
@@ -4444,7 +4444,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-ledger>
-    `},ba=class extends b{constructor(...e){super(...e),this.methods=[]}static{this.styles=h`
+    `},xa=class extends b{constructor(...e){super(...e),this.methods=[]}static{this.styles=h`
         :host { display: block; width: 100%; }
         .bar { display: flex; align-items: stretch; gap: .6rem; flex-wrap: wrap; }
         .methods { display: flex; gap: .4rem; flex-wrap: wrap; }
@@ -4506,7 +4506,7 @@ ${i}
                 <span class="spacer"></span>
                 ${this.confirmLabel&&this.actionId?T`<button class="confirm" @click="${()=>this.confirm()}">${this.confirmLabel}</button>`:v}
             </div>
-        `}};k([y()],ba.prototype,`actionId`,void 0),k([y()],ba.prototype,`methodActionId`,void 0),k([y({type:Array})],ba.prototype,`methods`,void 0),k([y()],ba.prototype,`selected`,void 0),k([y()],ba.prototype,`contextLabel`,void 0),k([y()],ba.prototype,`contextValue`,void 0),k([y()],ba.prototype,`confirmLabel`,void 0),k([C()],ba.prototype,`selectedId`,void 0),ba=k([g(`mateu-payment-picker`)],ba);var xa=e=>{let t=e.metadata;return T`
+        `}};k([y()],xa.prototype,`actionId`,void 0),k([y()],xa.prototype,`methodActionId`,void 0),k([y({type:Array})],xa.prototype,`methods`,void 0),k([y()],xa.prototype,`selected`,void 0),k([y()],xa.prototype,`contextLabel`,void 0),k([y()],xa.prototype,`contextValue`,void 0),k([y()],xa.prototype,`confirmLabel`,void 0),k([C()],xa.prototype,`selectedId`,void 0),xa=k([g(`mateu-payment-picker`)],xa);var Sa=e=>{let t=e.metadata;return T`
         <mateu-payment-picker
                 .actionId="${t.actionId}"
                 .methodActionId="${t.methodActionId}"
@@ -4519,7 +4519,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-payment-picker>
-    `},Sa=class extends b{constructor(...e){super(...e),this.items=[]}static{this.styles=h`
+    `},Ca=class extends b{constructor(...e){super(...e),this.items=[]}static{this.styles=h`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .list {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -4573,14 +4573,14 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};k([y({type:Array})],Sa.prototype,`items`,void 0),Sa=k([g(`mateu-process-monitor`)],Sa);var Ca=e=>T`
+        `}};k([y({type:Array})],Ca.prototype,`items`,void 0),Ca=k([g(`mateu-process-monitor`)],Ca);var wa=e=>T`
         <mateu-process-monitor
                 .items="${e.metadata.items??[]}"
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-process-monitor>
-    `,wa=(e,t)=>{let n=e.style;return e.id&&(n&&!n.endsWith(`;`)&&(n+=`;`),n??=``,t[e.id+`.hidden`]==1&&(n+=`display: none;`)),n},Ta=(e,t)=>{let n={...e.metadata};if(e.id&&n){if(n.type==j.Button){let r=n;t[e.id+`.disabled`]==1&&(r.disabled=!0)}if(n.type==j.FormField){let r=n;t[e.id+`.disabled`]==1&&(r.disabled=!0)}}return n},W=e=>t=>e(t.container,t.component,t.baseUrl,t.state,t.data,t.appState,t.appData),Ea={[j.Bpmn]:({component:e})=>Hr(e),[j.Workflow]:({component:e})=>Wr(e),[j.FormEditor]:({component:e})=>Gr(e),[j.Page]:W(Br),[j.Div]:W(Nr),[j.Directory]:({component:e,baseUrl:t,state:n,data:r})=>jr(e,t,n,r),[j.FormLayout]:W(_n),[j.HorizontalLayout]:W(Cn),[j.VerticalLayout]:W(wn),[j.SplitLayout]:W(Tn),[j.MasterDetailLayout]:W(En),[j.TabLayout]:W(Dn),[j.AccordionLayout]:W(On),[j.BoardLayout]:W(Nn),[j.BoardLayoutRow]:W(Pn),[j.BoardLayoutItem]:W(Fn),[j.Scroller]:W(An),[j.FullWidth]:W(jn),[j.Container]:W(Mn),[j.Form]:({container:e,component:t,baseUrl:n,state:r,data:i,appState:a,appData:o})=>{let s=t.metadata;return T`<mateu-form
+    `,Ta=(e,t)=>{let n=e.style;return e.id&&(n&&!n.endsWith(`;`)&&(n+=`;`),n??=``,t[e.id+`.hidden`]==1&&(n+=`display: none;`)),n},Ea=(e,t)=>{let n={...e.metadata};if(e.id&&n){if(n.type==j.Button){let r=n;t[e.id+`.disabled`]==1&&(r.disabled=!0)}if(n.type==j.FormField){let r=n;t[e.id+`.disabled`]==1&&(r.disabled=!0)}}return n},U=e=>t=>e(t.container,t.component,t.baseUrl,t.state,t.data,t.appState,t.appData),Da={[j.Bpmn]:({component:e})=>Ur(e),[j.Workflow]:({component:e})=>Gr(e),[j.FormEditor]:({component:e})=>Kr(e),[j.Page]:U(Vr),[j.Div]:U(Pr),[j.Directory]:({component:e,baseUrl:t,state:n,data:r})=>Mr(e,t,n,r),[j.FormLayout]:U(vn),[j.HorizontalLayout]:U(wn),[j.VerticalLayout]:U(Tn),[j.SplitLayout]:U(En),[j.MasterDetailLayout]:U(Dn),[j.TabLayout]:U(On),[j.AccordionLayout]:U(kn),[j.BoardLayout]:U(Pn),[j.BoardLayoutRow]:U(Fn),[j.BoardLayoutItem]:U(In),[j.Scroller]:U(jn),[j.FullWidth]:U(Mn),[j.Container]:U(Nn),[j.Form]:({container:e,component:t,baseUrl:n,state:r,data:i,appState:a,appData:o})=>{let s=t.metadata;return T`<mateu-form
             id="${t.id}"
         baseUrl="${n}"
             .component="${t}"
@@ -4593,12 +4593,12 @@ ${i}
             class="${t.cssClasses}"
             slot="${t.slot??v}"
             >
-                ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+                ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
             ${s?.buttons?.map(t=>T`
-               ${I(e,{id:t.actionId,metadata:t,type:A.ClientSide,slot:`buttons`},void 0,r,i,a,o)}
+               ${F(e,{id:t.actionId,metadata:t,type:A.ClientSide,slot:`buttons`},void 0,r,i,a,o)}
 `)}
 
-            </mateu-form>`},[j.Table]:({component:e,state:t,data:n})=>zn(e,(e.id?n?.[e.id]:void 0)?.page?.content??Bn(e,t)),[j.Crud]:W(Vr),[j.App]:({container:e,component:t,baseUrl:n,state:r,data:i,appState:a,appData:o})=>T`
+            </mateu-form>`},[j.Table]:({component:e,state:t,data:n})=>Bn(e,(e.id?n?.[e.id]:void 0)?.page?.content??Vn(e,t)),[j.Crud]:U(Hr),[j.App]:({container:e,component:t,baseUrl:n,state:r,data:i,appState:a,appData:o})=>T`
             <mateu-app
                         id="${t.id}"
                         baseUrl="${n}"
@@ -4610,20 +4610,20 @@ ${i}
                         .appState="${a}"
                         .appData="${o}"
             >
-             ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
-         </mateu-app>`,[j.Element]:({container:e,component:t,state:n,data:r,appState:i,appData:a})=>Qn(e,t.metadata,t,n,r,i,a),[j.FormField]:({component:e,state:t})=>Rr(e,t),[j.Text]:({component:e,state:t,data:n,appState:r,appData:i})=>er(e,t,n,r,i),[j.Avatar]:({component:e,state:t,data:n})=>Dt(e,t,n),[j.Chat]:({component:e,state:t,data:n})=>Ur(e,t,n),[j.AvatarGroup]:({component:e})=>Ot(e),[j.Badge]:({component:e,state:t,data:n})=>kt(e,t,n),[j.Breadcrumbs]:({component:e})=>kr(e),[j.Anchor]:({component:e})=>tr(e),[j.Button]:({component:e,state:t,data:n})=>cr(e,t,n),[j.Card]:W(ur),[j.Chart]:({component:e})=>dr(e),[j.Icon]:({component:e})=>fr(e),[j.ConfirmDialog]:W(_r),[j.ContextMenu]:W(Wn),[j.CookieConsent]:({component:e})=>vr(e),[j.Details]:W(yr),[j.Dialog]:({component:e,baseUrl:t,state:n,data:r,appState:i,appData:a})=>br(e,t,n,r,i,a),[j.Drawer]:({component:e,baseUrl:t,state:n,data:r,appState:i,appData:a})=>xr(e,t,n,r,i,a),[j.Image]:({component:e})=>Or(e),[j.Map]:({component:e})=>Dr(e),[j.Markdown]:({component:e})=>Cr(e),[j.MicroFrontend]:({component:e})=>Sr(e),[j.Notification]:({component:e})=>wr(e),[j.ProgressBar]:({component:e,state:t})=>Tr(e,t),[j.Popover]:W(Er),[j.CarouselLayout]:W(Ar),[j.Tooltip]:W(qn),[j.MessageInput]:({component:e})=>Kn(e),[j.MessageList]:({component:e})=>Vn(e),[j.CustomField]:W(Gn),[j.MenuBar]:({container:e,component:t,baseUrl:n,state:r,data:i})=>Un(e,t,n,r,i),[j.Grid]:({component:e,state:t})=>zn(e,Bn(e,t)),[j.VirtualList]:W(In),[j.FormSection]:W(Pr),[j.FormSubSection]:W(Fr),[j.MetricCard]:({component:e})=>Xr(e),[j.Scoreboard]:W(Zr),[j.DashboardPanel]:W(Qr),[j.DashboardLayout]:W($r),[j.FoldoutLayout]:W(ti),[j.ContentLayout]:W(ni),[j.HeroSection]:W(ri),[j.EmptyState]:({component:e})=>Bt(e),[j.Skeleton]:({component:e})=>Vt(e),[j.Gantt]:({component:e})=>oi(e),[j.PlanningBoard]:({component:e})=>ci(e),[j.Kanban]:({component:e})=>ui(e),[j.Timeline]:({component:e})=>fi(e),[j.ProgressSteps]:({component:e})=>mi(e),[j.Stat]:({component:e})=>gi(e),[j.Calendar]:({component:e})=>vi(e),[j.PricingTable]:({component:e})=>bi(e),[j.OrgChart]:({component:e})=>Si(e),[j.Heatmap]:({component:e})=>Ti(e),[j.Funnel]:({component:e})=>Di(e),[j.TrendChart]:({component:e})=>ki(e),[j.FeatureGrid]:({component:e})=>ji(e),[j.Testimonials]:({component:e})=>Ni(e),[j.Faq]:({component:e})=>Fi(e),[j.CalloutCard]:({component:e})=>Li(e),[j.CommentThread]:({component:e})=>zi(e),[j.FileList]:({component:e})=>Hi(e),[j.Checklist]:({component:e})=>Wi(e),[j.ComparisonCard]:({component:e})=>Ki(e),[j.EntityHeader]:({component:e})=>$i(e),[j.Meter]:({component:e})=>ta(e),[j.TaskProgress]:({component:e})=>ra(e),[j.StatusList]:({component:e})=>aa(e),[j.BulletedList]:({component:e})=>sa(e),[j.Separator]:({component:e})=>ca(e),[j.Notice]:W(ua),[j.TaskQueue]:({component:e})=>fa(e),[j.ResourceGrid]:({component:e})=>ma(e),[j.OfferCard]:({component:e})=>ha(e),[j.AddOnPicker]:({component:e})=>_a(e),[j.Ledger]:({component:e})=>ya(e),[j.PaymentPicker]:({component:e})=>xa(e),[j.ProcessMonitor]:({component:e})=>Ca(e)},Da=(e,t,n,r,i,a,o,s)=>{if(!t?.metadata)return t==null?(console.warn(`No metadata for component`,t),T`<p>No metadata for component</p>`):Da(e,{id:E(),metadata:t,type:A.ClientSide},n,r,i,a,o,s);let c=t.metadata.type,l={...t,style:wa(t,i),metadata:Ta(t,i)},u=Ea[c];return u?u({container:e,component:l,baseUrl:n,state:r,data:i,appState:a,appData:o,labelAlreadyRendered:s}):T`<p ${l?.slot??v}>Unknown metadata type ${c} for component ${l?.id}</p>`},Oa=function(e){return e.NONE=`NONE`,e.INFO=`INFO`,e.SUCCESS=`SUCCESS`,e.WARNING=`WARNING`,e.DANGER=`DANGER`,e}({}),ka=(e,t,n)=>{let r=e[n.path];return r?T`<span theme="badge pill ${Aa(r.type)}">${r.message}</span>`:T``},Aa=e=>{switch(e){case Oa.SUCCESS:return`success`;case Oa.WARNING:return`warning`;case Oa.DANGER:return`error`;case Oa.NONE:return`contrast`}return``},G=class extends b{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.respondToVisibility=(e,t)=>{var n={root:document.documentElement};new IntersectionObserver(e=>{e.forEach(e=>{t(e.intersectionRatio>0)})},n).observe(e)},this.keepAsking=!1,this.askToUpper=()=>{let e=this.data[this.id]?.page,t=e?.content?.length/e?.pageSize;this.dispatchEvent(new CustomEvent(`fetch-more-elements`,{detail:{params:{page:t,pageSize:this.metadata?.pageSize},callback:()=>{this.keepAsking&&this.askToUpper()}},bubbles:!0,composed:!0}))},this.renderItem=e=>e.card?Da(this,e.card,this.baseUrl,this.state,this.data,this.appState,this.appData,!1):e.title?T`<div class="neutral-card">
+             ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+         </mateu-app>`,[j.Element]:({container:e,component:t,state:n,data:r,appState:i,appData:a})=>$n(e,t.metadata,t,n,r,i,a),[j.FormField]:({component:e,state:t})=>zr(e,t),[j.Text]:({component:e,state:t,data:n,appState:r,appData:i})=>tr(e,t,n,r,i),[j.Avatar]:({component:e,state:t,data:n})=>Dt(e,t,n),[j.Chat]:({component:e,state:t,data:n})=>Wr(e,t,n),[j.AvatarGroup]:({component:e})=>kt(e),[j.Badge]:({component:e,state:t,data:n})=>At(e,t,n),[j.Breadcrumbs]:({component:e})=>Ar(e),[j.Anchor]:({component:e})=>nr(e),[j.Button]:({component:e,state:t,data:n})=>lr(e,t,n),[j.Card]:U(dr),[j.Chart]:({component:e})=>fr(e),[j.Icon]:({component:e})=>pr(e),[j.ConfirmDialog]:U(vr),[j.ContextMenu]:U(Gn),[j.CookieConsent]:({component:e})=>yr(e),[j.Details]:U(br),[j.Dialog]:({component:e,baseUrl:t,state:n,data:r,appState:i,appData:a})=>xr(e,t,n,r,i,a),[j.Drawer]:({component:e,baseUrl:t,state:n,data:r,appState:i,appData:a})=>Sr(e,t,n,r,i,a),[j.Image]:({component:e})=>kr(e),[j.Map]:({component:e})=>Or(e),[j.Markdown]:({component:e})=>wr(e),[j.MicroFrontend]:({component:e})=>Cr(e),[j.Notification]:({component:e})=>Tr(e),[j.ProgressBar]:({component:e,state:t})=>Er(e,t),[j.Popover]:U(Dr),[j.CarouselLayout]:U(jr),[j.Tooltip]:U(Jn),[j.MessageInput]:({component:e})=>qn(e),[j.MessageList]:({component:e})=>Hn(e),[j.CustomField]:U(Kn),[j.MenuBar]:({container:e,component:t,baseUrl:n,state:r,data:i})=>Wn(e,t,n,r,i),[j.Grid]:({component:e,state:t})=>Bn(e,Vn(e,t)),[j.VirtualList]:U(Ln),[j.FormSection]:U(Fr),[j.FormSubSection]:U(Ir),[j.MetricCard]:({component:e})=>Zr(e),[j.Scoreboard]:U(Qr),[j.DashboardPanel]:U($r),[j.DashboardLayout]:U(ei),[j.FoldoutLayout]:U(ni),[j.ContentLayout]:U(ri),[j.HeroSection]:U(ii),[j.EmptyState]:({component:e})=>Vt(e),[j.Skeleton]:({component:e})=>Ht(e),[j.Gantt]:({component:e})=>si(e),[j.PlanningBoard]:({component:e})=>li(e),[j.Kanban]:({component:e})=>di(e),[j.Timeline]:({component:e})=>pi(e),[j.ProgressSteps]:({component:e})=>hi(e),[j.Stat]:({component:e})=>_i(e),[j.Calendar]:({component:e})=>yi(e),[j.PricingTable]:({component:e})=>xi(e),[j.OrgChart]:({component:e})=>Ci(e),[j.Heatmap]:({component:e})=>Ei(e),[j.Funnel]:({component:e})=>Oi(e),[j.TrendChart]:({component:e})=>Ai(e),[j.FeatureGrid]:({component:e})=>Mi(e),[j.Testimonials]:({component:e})=>Pi(e),[j.Faq]:({component:e})=>Ii(e),[j.CalloutCard]:({component:e})=>Ri(e),[j.CommentThread]:({component:e})=>Bi(e),[j.FileList]:({component:e})=>Ui(e),[j.Checklist]:({component:e})=>Gi(e),[j.ComparisonCard]:({component:e})=>qi(e),[j.EntityHeader]:({component:e})=>ea(e),[j.Meter]:({component:e})=>na(e),[j.TaskProgress]:({component:e})=>ia(e),[j.StatusList]:({component:e})=>oa(e),[j.BulletedList]:({component:e})=>ca(e),[j.Separator]:({component:e})=>la(e),[j.Notice]:U(da),[j.TaskQueue]:({component:e})=>pa(e),[j.ResourceGrid]:({component:e})=>ha(e),[j.OfferCard]:({component:e})=>ga(e),[j.AddOnPicker]:({component:e})=>va(e),[j.Ledger]:({component:e})=>ba(e),[j.PaymentPicker]:({component:e})=>Sa(e),[j.ProcessMonitor]:({component:e})=>wa(e)},Oa=(e,t,n,r,i,a,o,s)=>{if(!t?.metadata)return t==null?(console.warn(`No metadata for component`,t),T`<p>No metadata for component</p>`):Oa(e,{id:E(),metadata:t,type:A.ClientSide},n,r,i,a,o,s);let c=t.metadata.type,l={...t,style:Ta(t,i),metadata:Ea(t,i)},u=Da[c];return u?u({container:e,component:l,baseUrl:n,state:r,data:i,appState:a,appData:o,labelAlreadyRendered:s}):T`<p ${l?.slot??v}>Unknown metadata type ${c} for component ${l?.id}</p>`},ka=function(e){return e.NONE=`NONE`,e.INFO=`INFO`,e.SUCCESS=`SUCCESS`,e.WARNING=`WARNING`,e.DANGER=`DANGER`,e}({}),Aa=(e,t,n)=>{let r=e[n.path];return r?T`<span theme="badge pill ${ja(r.type)}">${r.message}</span>`:T``},ja=e=>{switch(e){case ka.SUCCESS:return`success`;case ka.WARNING:return`warning`;case ka.DANGER:return`error`;case ka.NONE:return`contrast`}return``},W=class extends b{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.respondToVisibility=(e,t)=>{var n={root:document.documentElement};new IntersectionObserver(e=>{e.forEach(e=>{t(e.intersectionRatio>0)})},n).observe(e)},this.keepAsking=!1,this.askToUpper=()=>{let e=this.data[this.id]?.page,t=e?.content?.length/e?.pageSize;this.dispatchEvent(new CustomEvent(`fetch-more-elements`,{detail:{params:{page:t,pageSize:this.metadata?.pageSize},callback:()=>{this.keepAsking&&this.askToUpper()}},bubbles:!0,composed:!0}))},this.renderItem=e=>e.card?Oa(this,e.card,this.baseUrl,this.state,this.data,this.appState,this.appData,!1):e.title?T`<div class="neutral-card">
                 ${e.image?T`<img class="card-media" src="${e.image}" alt="" />`:v}
                 <div class="card-body">
                     <div class="card-head">
                         ${e.title?T`<span class="card-title">${e.title}</span>`:v}
-                        ${e.status?T`<span theme="badge ${Aa(e.status.type)}">${e.status.message}</span>`:v}
+                        ${e.status?T`<span theme="badge ${ja(e.status.type)}">${e.status.message}</span>`:v}
                     </div>
                     ${e.subtitle?T`<div class="card-subtitle">${e.subtitle}</div>`:v}
                     ${e.content?T`<div>${e.content}</div>`:v}
                 </div>
         </div>`:T`${e}`,this.hasMore=!1,this.clickedOnCard=e=>{this.state[this.id+`_selected_items`]=[e],this.metadata?.onRowSelectionChangedActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.metadata?.onRowSelectionChangedActionId},bubbles:!0,composed:!0}))}}updated(e){super.updated(e);let t=this.data[this.id]?.page;this.hasMore=t?.content?.length<t?.totalElements}firstUpdated(e){super.firstUpdated(e),this.respondToVisibility(this.askForMore,e=>{this.keepAsking=e,e&&this.askToUpper()})}render(){return T`
             <div class="card-container">
-                ${(this.data[this.id]?.page)?.content?.map(e=>T`<div role="button" tabindex="0" @click="${()=>this.clickedOnCard(e)}" @keydown="${z(()=>this.clickedOnCard(e))}" class="car-container">${this.renderItem(e)}</div>`)}
+                ${(this.data[this.id]?.page)?.content?.map(e=>T`<div role="button" tabindex="0" @click="${()=>this.clickedOnCard(e)}" @keydown="${R(()=>this.clickedOnCard(e))}" class="car-container">${this.renderItem(e)}</div>`)}
                 <div id="ask-for-more" style="display: ${this.hasMore?`flex`:`none`}; width: 100%; justify-content: center; padding: var(--lumo-space-m); color: var(--lumo-secondary-text-color); font-size: var(--lumo-font-size-s);">Loading more…</div>
             </div>
 
@@ -4653,39 +4653,39 @@ ${i}
         .neutral-card .card-title { font-weight: 600; }
         .neutral-card .card-subtitle { color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-s, .875rem); }
     
-        ${B}
-    `}};k([y()],G.prototype,`id`,void 0),k([y()],G.prototype,`metadata`,void 0),k([y()],G.prototype,`baseUrl`,void 0),k([y()],G.prototype,`state`,void 0),k([y()],G.prototype,`data`,void 0),k([y()],G.prototype,`appState`,void 0),k([y()],G.prototype,`appData`,void 0),k([y()],G.prototype,`emptyStateMessage`,void 0),k([C()],G.prototype,`keepAsking`,void 0),k([x(`#ask-for-more`)],G.prototype,`askForMore`,void 0),k([C()],G.prototype,`hasMore`,void 0),G=k([g(`mateu-card-list`)],G);var ja={show:e=>console.debug(`[mateu] no notifier registered, dropping toast:`,e.text)};function Ma(e){ja=e}function Na(e,t){ja.show(e,t)}var Pa=function(e){return e.none=`none`,e.success=`success`,e.error=`error`,e.warning=`warning`,e.contrast=`contrast`,e.normal=`normal`,e}({}),Fa=function(e){return e.primary=`primary`,e.secondary=`secondary`,e.tertiary=`tertiary`,e.tertiaryInline=`tertiaryInline`,e}({});function Ia(e){if(e.weight!=null)return e.weight;let t=e.stereotype??``;if(t===`icon`)return 1;if(t===`image`)return 4;if(t===`html`||t===`richText`||t===`markdown`||t===`textarea`)return 5;if(t===`link`)return 2.5;if(t===`combobox`||t===`select`)return 2;let n=e.dataType??``;return n===`bool`?1:n===`status`||n===`integer`?1.5:n===`number`||n===`date`||n===`money`?2:n===`dateTime`||n===`dateRange`?2.5:3}function La(e,t){if(e.length===0)return`table`;let n=e.reduce((e,t)=>e+Ia(t),0)/(t/76);if(n<=1.1)return`table`;if(n>1.6||e.length>10)return`masterDetail`;let r=e.filter(e=>e.identifier||(e.priority??2**53-1)<=2),i=r.reduce((e,t)=>e+Ia(t),0);return r.length>0&&i<=8?`list`:e.some(e=>e.stereotype===`image`||e.stereotype===`html`)||r.length===0&&e.length>=4&&e.length<=8?`cards`:`masterDetail`}function Ra(e){return e.filter(e=>e.identifier||(e.priority??2**53-1)<=2).sort((e,t)=>(e.priority??2**53-1)-(t.priority??2**53-1))}function za(e){let t=Ra(e);return t.length>0?t:e.slice(0,3)}var Ba,Va={asc:`ascending`,desc:`descending`},K=class extends b{static{Ba=this}constructor(...e){super(...e),this.component=void 0,this.standalone=!1,this.state={},this.data={},this.appState={},this.appData={},this.showImportDialog=!1,this.availableWidthPx=1024,this.selectedItem=null,this._columnPrefsRevision=0,this._prefsRevisionApplied=-1,this.pendingMeasure=!0,this.corrections=0,this.windowResizeListener=()=>this.scheduleMeasure(),this.search=()=>{let e=this.component.metadata;this.state={...this.state,size:e.pageSize,page:0,crud_selected_items:[]},this._syncStateToUrl(e),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`search`,parameters:{crudId:this.id,_searchState:{...this.state}}},bubbles:!0,composed:!0}))},this.notify=e=>{Na({text:e,position:`bottomEnd`,variant:`error`,duration:3e3},this)},this.handleSearchRequested=e=>{this.state={...this.state,crud_selected_items:[]};let t=this.component.metadata;if(this._syncStateToUrl(t),t.rowsSource){this._fetchRowsFromRest(t,e);return}!t.infiniteScrolling&&this.data?.[this.id]?.page&&(this.data[this.id].page.content=[]),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`search`,parameters:{crudId:this.id,_searchState:{...this.state}},callback:e},bubbles:!0,composed:!0}))},this._fetchRowsFromRest=(e,t)=>{let n=this.cols.map(e=>e.id).filter(Boolean),r=e.rowsSource;(r.proxy?new Promise(e=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`__restfetch__`,parameters:{_sourceKind:`rows`,_sourceId:this.id},callback:t=>e(dn(t?.appData?._restfetch,r.itemsPath,n)),callbackonly:!0},bubbles:!0,composed:!0}))}):mn(r,n,e=>M(e,this.state,this.data))).then(r=>{let i=String(this.state?.searchText??``).trim().toLowerCase(),a=i?r.filter(e=>n.some(t=>String(e[t]??``).toLowerCase().includes(i))):r,o=e.pageSize&&e.pageSize>0?e.pageSize:a.length||1,s=Number(this.state?.page??0),c=a.slice(s*o,s*o+o);this.data={...this.data,[this.id]:{page:{totalElements:a.length,pageSize:o,pageNumber:s,content:c}}},this.requestUpdate(),t?.()}).catch(e=>{console.warn(`mateu: external rows fetch failed`,e),t?.()})},this.fetchMoreElements=e=>{let{params:t,callback:n}=e.detail;this.state={...this.state,size:t.pageSize,page:t.page},this.handleSearchRequested(n)},this.directionChanged=e=>{let t=e.detail.grid._sorters;this.state={...this.state,sort:t.map(e=>({fieldId:e.__data.path,direction:e.__data.direction?Va[e.__data.direction]:void 0}))},this.handleSearchRequested(void 0)},this._initializedForComponentId=void 0,this.evalLabel=e=>M(e,this.state,this.data),this.handleToolbarButtonClick=e=>{if(e===`import`){this.showImportDialog=!0;return}this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.handleImportUploadSuccess=e=>{let t=e.detail.xhr.responseText;this.showImportDialog=!1,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`process-import`,parameters:{fileId:t}},bubbles:!0,composed:!0}))}}get columnPrefsScope(){return window.location.pathname}get effectiveComponent(){let e=this.component,t=e?.metadata;if(!e||!t?.columns)return e;if(this._prefsSource===e&&this._prefsRevisionApplied===this._columnPrefsRevision)return this._prefsApplied;let n=en(this.columnPrefsScope),r=an(t.columns,n,e=>e.metadata??{});return this._prefsApplied=r===t.columns?e:{...e,metadata:{...t,columns:r}},this._prefsSource=e,this._prefsRevisionApplied=this._columnPrefsRevision,this._prefsApplied}get columnChooserEntries(){return(this.component?.metadata?.columns??[]).map(e=>{let t=e.metadata??{},n=t.id??e.id;return n?{id:n,label:t.label??n,protected:rn(t)}:void 0}).filter(e=>!!e)}renderColumnChooser(){let e=this.columnChooserEntries;return e.filter(e=>!e.protected).length===0?v:T`
+        ${z}
+    `}};k([y()],W.prototype,`id`,void 0),k([y()],W.prototype,`metadata`,void 0),k([y()],W.prototype,`baseUrl`,void 0),k([y()],W.prototype,`state`,void 0),k([y()],W.prototype,`data`,void 0),k([y()],W.prototype,`appState`,void 0),k([y()],W.prototype,`appData`,void 0),k([y()],W.prototype,`emptyStateMessage`,void 0),k([C()],W.prototype,`keepAsking`,void 0),k([x(`#ask-for-more`)],W.prototype,`askForMore`,void 0),k([C()],W.prototype,`hasMore`,void 0),W=k([g(`mateu-card-list`)],W);var Ma={show:e=>console.debug(`[mateu] no notifier registered, dropping toast:`,e.text)};function Na(e){Ma=e}function Pa(e,t){Ma.show(e,t)}var Fa=function(e){return e.none=`none`,e.success=`success`,e.error=`error`,e.warning=`warning`,e.contrast=`contrast`,e.normal=`normal`,e}({}),Ia=function(e){return e.primary=`primary`,e.secondary=`secondary`,e.tertiary=`tertiary`,e.tertiaryInline=`tertiaryInline`,e}({});function La(e){if(e.weight!=null)return e.weight;let t=e.stereotype??``;if(t===`icon`)return 1;if(t===`image`)return 4;if(t===`html`||t===`richText`||t===`markdown`||t===`textarea`)return 5;if(t===`link`)return 2.5;if(t===`combobox`||t===`select`)return 2;let n=e.dataType??``;return n===`bool`?1:n===`status`||n===`integer`?1.5:n===`number`||n===`date`||n===`money`?2:n===`dateTime`||n===`dateRange`?2.5:3}function Ra(e,t){if(e.length===0)return`table`;let n=e.reduce((e,t)=>e+La(t),0)/(t/76);if(n<=1.1)return`table`;if(n>1.6||e.length>10)return`masterDetail`;let r=e.filter(e=>e.identifier||(e.priority??2**53-1)<=2),i=r.reduce((e,t)=>e+La(t),0);return r.length>0&&i<=8?`list`:e.some(e=>e.stereotype===`image`||e.stereotype===`html`)||r.length===0&&e.length>=4&&e.length<=8?`cards`:`masterDetail`}function za(e){return e.filter(e=>e.identifier||(e.priority??2**53-1)<=2).sort((e,t)=>(e.priority??2**53-1)-(t.priority??2**53-1))}function Ba(e){let t=za(e);return t.length>0?t:e.slice(0,3)}var Va,Ha={asc:`ascending`,desc:`descending`},G=class extends b{static{Va=this}constructor(...e){super(...e),this.component=void 0,this.standalone=!1,this.state={},this.data={},this.appState={},this.appData={},this.showImportDialog=!1,this.availableWidthPx=1024,this.selectedItem=null,this._columnPrefsRevision=0,this._prefsRevisionApplied=-1,this.pendingMeasure=!0,this.corrections=0,this.windowResizeListener=()=>this.scheduleMeasure(),this.search=()=>{this.beginLoading();let e=this.component.metadata;this.state={...this.state,size:e.pageSize,page:0,crud_selected_items:[]},this._syncStateToUrl(e),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`search`,parameters:{crudId:this.id,_searchState:{...this.state}}},bubbles:!0,composed:!0}))},this.notify=e=>{Pa({text:e,position:`bottomEnd`,variant:`error`,duration:3e3},this)},this.handleSearchRequested=e=>{this.state={...this.state,crud_selected_items:[]};let t=this.component.metadata;if(this._syncStateToUrl(t),t.rowsSource){this._fetchRowsFromRest(t,e);return}!t.infiniteScrolling&&this.data?.[this.id]?.page&&(this.data[this.id].page.content=[]),this.beginLoading(),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`search`,parameters:{crudId:this.id,_searchState:{...this.state}},callback:e},bubbles:!0,composed:!0}))},this._fetchRowsFromRest=(e,t)=>{let n=this.cols.map(e=>e.id).filter(Boolean),r=e.rowsSource;(r.proxy?new Promise(e=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`__restfetch__`,parameters:{_sourceKind:`rows`,_sourceId:this.id},callback:t=>e(fn(t?.appData?._restfetch,r.itemsPath,n)),callbackonly:!0},bubbles:!0,composed:!0}))}):hn(r,n,e=>M(e,this.state,this.data))).then(r=>{let i=String(this.state?.searchText??``).trim().toLowerCase(),a=i?r.filter(e=>n.some(t=>String(e[t]??``).toLowerCase().includes(i))):r,o=e.pageSize&&e.pageSize>0?e.pageSize:a.length||1,s=Number(this.state?.page??0),c=a.slice(s*o,s*o+o);this.data={...this.data,[this.id]:{page:{totalElements:a.length,pageSize:o,pageNumber:s,content:c}}},this.requestUpdate(),t?.()}).catch(e=>{console.warn(`mateu: external rows fetch failed`,e),t?.()})},this.fetchMoreElements=e=>{let{params:t,callback:n}=e.detail;this.state={...this.state,size:t.pageSize,page:t.page},this.handleSearchRequested(n)},this.directionChanged=e=>{let t=e.detail.grid._sorters;this.state={...this.state,sort:t.map(e=>({fieldId:e.__data.path,direction:e.__data.direction?Ha[e.__data.direction]:void 0}))},this.handleSearchRequested(void 0)},this._initializedForComponentId=void 0,this.evalLabel=e=>M(e,this.state,this.data),this.handleToolbarButtonClick=e=>{if(e===`import`){this.showImportDialog=!0;return}this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.handleImportUploadSuccess=e=>{let t=e.detail.xhr.responseText;this.showImportDialog=!1,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`process-import`,parameters:{fileId:t}},bubbles:!0,composed:!0}))}}get columnPrefsScope(){return window.location.pathname}get effectiveComponent(){let e=this.component,t=e?.metadata;if(!e||!t?.columns)return e;if(this._prefsSource===e&&this._prefsRevisionApplied===this._columnPrefsRevision)return this._prefsApplied;let n=tn(this.columnPrefsScope),r=on(t.columns,n,e=>e.metadata??{});return this._prefsApplied=r===t.columns?e:{...e,metadata:{...t,columns:r}},this._prefsSource=e,this._prefsRevisionApplied=this._columnPrefsRevision,this._prefsApplied}get columnChooserEntries(){return(this.component?.metadata?.columns??[]).map(e=>{let t=e.metadata??{},n=t.id??e.id;return n?{id:n,label:t.label??n,protected:an(t)}:void 0}).filter(e=>!!e)}renderColumnChooser(){let e=this.columnChooserEntries;return e.filter(e=>!e.protected).length===0?v:T`
             <mateu-column-chooser
                 .columns="${e}"
                 .scope="${this.columnPrefsScope}"
                 @column-prefs-changed="${e=>{e.stopPropagation(),this._columnPrefsRevision++}}"
             ></mateu-column-chooser>
-        `}get cols(){return(this.effectiveComponent?.metadata)?.columns?.map(e=>e.metadata)??[]}get identifierFieldName(){let e=this.cols.find(e=>e.identifier);return e?e.id:this.cols.find(e=>e.id===`id`)?.id}get effectiveGridLayout(){let e=this.component?.metadata,t=e?.gridLayout??`auto`;return t===`auto`?e?.crudlType===`card`?`cards`:La(this.cols,this.availableWidthPx):t}scheduleMeasure(){this.pendingMeasure=!0,this.corrections=0,this.fillHeightPx==null?this.requestUpdate():this.fillHeightPx=void 0}measureFill(){if(!this.pendingMeasure||this.fillHeightPx!=null)return;let e=this.renderRoot?.querySelector?.(`[data-crud-box]`);if(!e)return;if(this.closest?.(`mateu-dialog, mateu-drawer`)){this.pendingMeasure=!1;return}let t=e.getBoundingClientRect().top,n=Math.round(window.innerHeight-t-this.measureBottomInset(e)-Ba.BOTTOM_GUTTER_PX);this.pendingMeasure=!1,n>=Ba.MIN_FILL_PX&&(this.fillHeightPx=n)}trimOverflow(){if(this.fillHeightPx==null||this.pendingMeasure||this.corrections>=Ba.MAX_CORRECTIONS)return;let e=document.documentElement.scrollHeight-window.innerHeight;e<=1||e>Ba.MAX_SLIVER_PX||(this.corrections++,this.fillHeightPx=Math.max(Ba.MIN_FILL_PX,this.fillHeightPx-e))}measureBottomInset(e){let t=e,n=0;for(let e=0;t&&e<20;e++){n+=parseFloat(getComputedStyle(t).marginBottom)||0;let e=t.getRootNode(),r=t.assignedSlot??t.parentElement??e.host??null;if(!r||r===document.documentElement||r===document.body)break;let i=getComputedStyle(r);n+=(parseFloat(i.paddingBottom)||0)+(parseFloat(i.borderBottomWidth)||0);let a=parseFloat(i.rowGap)||0;for(let e=t.nextElementSibling;e;e=e.nextElementSibling){let t=getComputedStyle(e);n+=e.getBoundingClientRect().height+(parseFloat(t.marginTop)||0)+(parseFloat(t.marginBottom)||0)+a}t=r}return Math.round(n)}static{this.BOTTOM_GUTTER_PX=16}static{this.MAX_SLIVER_PX=64}static{this.MAX_CORRECTIONS=3}static{this.MIN_FILL_PX=320}boxStyle(){let e=`border: var(--mateu-section-border, none); background: var(--mateu-section-bg, transparent); overflow: hidden; padding: var(--mateu-section-padding, 0); display: flex; flex-direction: column;`;return this.fillHeightPx==null?`${e} max-height: calc(100dvh - 12rem);`:`${e} height: ${this.fillHeightPx}px;`}connectedCallback(){super.connectedCallback(),window.addEventListener(`resize`,this.windowResizeListener),this.resizeObserver=new ResizeObserver(e=>{let t=e[0]?.contentRect.width;t&&Math.abs(t-this.availableWidthPx)>10&&(this.availableWidthPx=t)}),this.resizeObserver.observe(this)}disconnectedCallback(){super.disconnectedCallback(),window.removeEventListener(`resize`,this.windowResizeListener),this.resizeObserver?.disconnect()}_filterIds(e){return new Set([`searchText`,...(e.filters??[]).flatMap(e=>e.stereotype===`dateRange`||e.stereotype===`numberRange`?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId])])}_syncStateToUrl(e){let t=this._filterIds(e),n=new URLSearchParams(window.location.search);t.forEach(e=>n.delete(e)),n.delete(`page`),n.delete(`sort`),t.forEach(e=>{let t=this.state[e];t!=null&&t!==``&&n.set(e,String(t))});let r=this.state.page;r&&r>0&&n.set(`page`,String(r));let i=this.state.sort;if(i&&i.length>0){let e=i.filter(e=>e.fieldId&&e.direction).map(e=>`${e.fieldId}:${e.direction}`).join(`,`);e&&n.set(`sort`,e)}let a=n.toString(),o=a?`${window.location.pathname}?${a}`:window.location.pathname;window.location.pathname+window.location.search!==o&&history.replaceState(null,``,o)}_initStateFromUrl(e,t){let n=new URLSearchParams(window.location.search),r=this._filterIds(e),i={...t};n.forEach((e,t)=>{r.has(t)&&(i[t]=e)});let a=n.get(`page`);if(a!==null){let e=parseInt(a,10);!isNaN(e)&&e>0&&(i.page=e)}let o=n.get(`sort`);if(o){let e=o.split(`,`).map(e=>{let[t,n]=e.split(`:`);return t&&n?{fieldId:t,direction:n}:null}).filter(Boolean);e.length>0&&(i.sort=e)}return i}pageChanged(e){this.state={...this.state,page:e.detail.page},this.handleSearchRequested(void 0)}updated(e){if(super.updated(e),e.has(`component`)&&(this.pendingMeasure=!0),this.measureFill(),this.trimOverflow(),e.has(`component`)){let e=this.component?.id;if(e!==this._initializedForComponentId){this._initializedForComponentId=e;let t=this.component?.metadata,n=t.initialPage&&t.initialPage>0?t.initialPage:0;this.state=this._initStateFromUrl(t,{...this.state,size:t.pageSize,page:n,sort:[]}),(this.state.page!==n||this.state.sort?.length>0||[...this._filterIds(t)].some(e=>this.state[e]!=null)||t.rowsSource)&&this.handleSearchRequested(void 0)}}}render(){let e=e=>{let t=[];return e.color&&e.color!==Pa.normal&&t.push(e.color),e.buttonStyle&&t.push(e.buttonStyle===Fa.tertiaryInline?`tertiary-inline`:e.buttonStyle),t.length?t.join(` `):void 0},t=e=>e===`back`||e===`backToList`||!!e&&e.startsWith(`cancel`),n=t=>F.get()?.renderToolbarButton?.(t,this.evalLabel(t.label),()=>this.handleToolbarButtonClick(t.actionId))||T`
+        `}get cols(){return(this.effectiveComponent?.metadata)?.columns?.map(e=>e.metadata)??[]}get identifierFieldName(){let e=this.cols.find(e=>e.identifier);return e?e.id:this.cols.find(e=>e.id===`id`)?.id}get effectiveGridLayout(){let e=this.component?.metadata,t=e?.gridLayout??`auto`;return t===`auto`?e?.crudlType===`card`?`cards`:Ra(this.cols,this.availableWidthPx):t}scheduleMeasure(){this.pendingMeasure=!0,this.corrections=0,this.fillHeightPx==null?this.requestUpdate():this.fillHeightPx=void 0}measureFill(){if(!this.pendingMeasure||this.fillHeightPx!=null)return;let e=this.renderRoot?.querySelector?.(`[data-crud-box]`);if(!e)return;if(this.closest?.(`mateu-dialog, mateu-drawer`)){this.pendingMeasure=!1;return}let t=e.getBoundingClientRect().top,n=Math.round(window.innerHeight-t-this.measureBottomInset(e)-Va.BOTTOM_GUTTER_PX);this.pendingMeasure=!1,n>=Va.MIN_FILL_PX&&(this.fillHeightPx=n)}trimOverflow(){if(this.fillHeightPx==null||this.pendingMeasure||this.corrections>=Va.MAX_CORRECTIONS)return;let e=document.documentElement.scrollHeight-window.innerHeight;e<=1||e>Va.MAX_SLIVER_PX||(this.corrections++,this.fillHeightPx=Math.max(Va.MIN_FILL_PX,this.fillHeightPx-e))}measureBottomInset(e){let t=e,n=0;for(let e=0;t&&e<20;e++){n+=parseFloat(getComputedStyle(t).marginBottom)||0;let e=t.getRootNode(),r=t.assignedSlot??t.parentElement??e.host??null;if(!r||r===document.documentElement||r===document.body)break;let i=getComputedStyle(r);n+=(parseFloat(i.paddingBottom)||0)+(parseFloat(i.borderBottomWidth)||0);let a=parseFloat(i.rowGap)||0;for(let e=t.nextElementSibling;e;e=e.nextElementSibling){let t=getComputedStyle(e);n+=e.getBoundingClientRect().height+(parseFloat(t.marginTop)||0)+(parseFloat(t.marginBottom)||0)+a}t=r}return Math.round(n)}static{this.BOTTOM_GUTTER_PX=16}static{this.MAX_SLIVER_PX=64}static{this.MAX_CORRECTIONS=3}static{this.MIN_FILL_PX=320}boxStyle(){let e=`border: var(--mateu-section-border, none); background: var(--mateu-section-bg, transparent); overflow: hidden; padding: var(--mateu-section-padding, 0); display: flex; flex-direction: column;`;return this.fillHeightPx==null?`${e} max-height: calc(100dvh - 12rem);`:`${e} height: ${this.fillHeightPx}px;`}connectedCallback(){super.connectedCallback(),window.addEventListener(`resize`,this.windowResizeListener),this.resizeObserver=new ResizeObserver(e=>{let t=e[0]?.contentRect.width;t&&Math.abs(t-this.availableWidthPx)>10&&(this.availableWidthPx=t)}),this.resizeObserver.observe(this)}disconnectedCallback(){super.disconnectedCallback(),clearTimeout(this.loadingTimer),window.removeEventListener(`resize`,this.windowResizeListener),this.resizeObserver?.disconnect()}static{this.LOADING_VALVE_MS=15e3}get awaitingRows(){return this.loadingSince!=null&&Date.now()-this.loadingSince<Va.LOADING_VALVE_MS}beginLoading(){this.loadingSince=Date.now(),clearTimeout(this.loadingTimer),this.loadingTimer=setTimeout(()=>this.requestUpdate(),Va.LOADING_VALVE_MS)}endLoading(){this.loadingSince=void 0,clearTimeout(this.loadingTimer)}_filterIds(e){return new Set([`searchText`,...(e.filters??[]).flatMap(e=>e.stereotype===`dateRange`||e.stereotype===`numberRange`?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId])])}_syncStateToUrl(e){let t=this._filterIds(e),n=new URLSearchParams(window.location.search);t.forEach(e=>n.delete(e)),n.delete(`page`),n.delete(`sort`),t.forEach(e=>{let t=this.state[e];t!=null&&t!==``&&n.set(e,String(t))});let r=this.state.page;r&&r>0&&n.set(`page`,String(r));let i=this.state.sort;if(i&&i.length>0){let e=i.filter(e=>e.fieldId&&e.direction).map(e=>`${e.fieldId}:${e.direction}`).join(`,`);e&&n.set(`sort`,e)}let a=n.toString(),o=a?`${window.location.pathname}?${a}`:window.location.pathname;window.location.pathname+window.location.search!==o&&history.replaceState(null,``,o)}_initStateFromUrl(e,t){let n=new URLSearchParams(window.location.search),r=this._filterIds(e),i={...t};n.forEach((e,t)=>{r.has(t)&&(i[t]=e)});let a=n.get(`page`);if(a!==null){let e=parseInt(a,10);!isNaN(e)&&e>0&&(i.page=e)}let o=n.get(`sort`);if(o){let e=o.split(`,`).map(e=>{let[t,n]=e.split(`:`);return t&&n?{fieldId:t,direction:n}:null}).filter(Boolean);e.length>0&&(i.sort=e)}return i}pageChanged(e){this.state={...this.state,page:e.detail.page},this.handleSearchRequested(void 0)}updated(e){if(super.updated(e),e.has(`component`)&&(this.pendingMeasure=!0),this.measureFill(),this.trimOverflow(),this.data?.[this.id]==null?this.loadingSince==null&&this._initializedForComponentId!=null&&!this.awaitingRows&&this.beginLoading():this.endLoading(),e.has(`component`)){let e=this.component?.id;if(e!==this._initializedForComponentId){this._initializedForComponentId=e;let t=this.component?.metadata,n=t.initialPage&&t.initialPage>0?t.initialPage:0;this.state=this._initStateFromUrl(t,{...this.state,size:t.pageSize,page:n,sort:[]}),(this.state.page!==n||this.state.sort?.length>0||[...this._filterIds(t)].some(e=>this.state[e]!=null)||t.rowsSource)&&this.handleSearchRequested(void 0)}}}render(){let e=e=>{let t=[];return e.color&&e.color!==Fa.normal&&t.push(e.color),e.buttonStyle&&t.push(e.buttonStyle===Ia.tertiaryInline?`tertiary-inline`:e.buttonStyle),t.length?t.join(` `):void 0},t=e=>e===`back`||e===`backToList`||!!e&&e.startsWith(`cancel`),n=t=>P.get()?.renderToolbarButton?.(t,this.evalLabel(t.label),()=>this.handleToolbarButtonClick(t.actionId))||T`
                 <button class="crud-btn"
                         data-action-id="${t.id}"
                         theme="${e(t)||v}"
                         @click="${()=>this.handleToolbarButtonClick(t.actionId)}"
                 >${this.evalLabel(t.label)}</button>
-            `;if(!this.component)return T`no component`;let r=this.effectiveComponent,i=r.metadata;i.serverSideOrdering=!0;let a=(()=>{let e=this;for(;e;){let t=e;if(t.tagName===`MATEU-PAGE`)return(t.component?.metadata?.toolbar?.length??0)>0;e=t.parentElement??(t.getRootNode?.()instanceof ShadowRoot?t.getRootNode().host:null)}return!1})()?[]:i?.toolbar??[],o=a.filter(e=>t(e.actionId)),s=a.filter(e=>!t(e.actionId)),c=o.length>0&&s.length>0,l=!!i?.title||!!i?.subtitle||a.length>0,u=this.effectiveGridLayout,d=this.cols,f=Ra(d),p=this.data[this.id]?.page?.content??[],ee=this.state[this.component?.id]?.emptyStateMessage,m=(e,t)=>{let n=t[e.id];return n==null?T``:e.dataType===`status`?T`<span theme="badge pill ${Aa(n.type)}">${n.message}</span>`:e.dataType===`bool`?T`${n?`✓`:`✗`}`:typeof n==`object`?T`${n.label??n.name??n.message??``}`:T`${n}`},te=()=>{let e=this.identifierFieldName,t=this.state._selectedId??this.appState?._splitDetailId,n=f.find(e=>e.identifier)??f[0],r=e=>e.dataType===`action`||e.dataType===`actionGroup`||e.dataType===`menu`||e.stereotype===`button`,i=f.filter(e=>e!==n&&!r(e)),a=d.filter(e=>r(e)),o=(e,t,n)=>{e.stopPropagation(),e.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_clickedRow:n}},bubbles:!0,composed:!0}))},s=e=>{let t=[];for(let n of a){let r=e[n.id];if(n.dataType===`action`){let i=r?.methodNameInCrud?r:e.action?.methodNameInCrud?e.action:{methodNameInCrud:n.id,label:n.label,icon:null,disabled:!1};t.push(T`
+            `;if(!this.component)return T`no component`;let r=this.effectiveComponent,i=r.metadata;i.serverSideOrdering=!0;let a=(()=>{let e=this;for(;e;){let t=e;if(t.tagName===`MATEU-PAGE`)return(t.component?.metadata?.toolbar?.length??0)>0;e=t.parentElement??(t.getRootNode?.()instanceof ShadowRoot?t.getRootNode().host:null)}return!1})()?[]:i?.toolbar??[],o=a.filter(e=>t(e.actionId)),s=a.filter(e=>!t(e.actionId)),c=o.length>0&&s.length>0,l=!!i?.title||!!i?.subtitle||a.length>0,u=this.effectiveGridLayout,d=this.cols,f=za(d),p=this.data[this.id]?.page?.content??[],ee=this.state[this.component?.id]?.emptyStateMessage,m=(e,t)=>{let n=t[e.id];return n==null?T``:e.dataType===`status`?T`<span theme="badge pill ${ja(n.type)}">${n.message}</span>`:e.dataType===`bool`?T`${n?`✓`:`✗`}`:typeof n==`object`?T`${n.label??n.name??n.message??``}`:T`${n}`},te=()=>{let e=this.identifierFieldName,t=this.state._selectedId??this.appState?._splitDetailId,n=f.find(e=>e.identifier)??f[0],r=e=>e.dataType===`action`||e.dataType===`actionGroup`||e.dataType===`menu`||e.stereotype===`button`,i=f.filter(e=>e!==n&&!r(e)),a=d.filter(e=>r(e)),o=(e,t,n)=>{e.stopPropagation(),e.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_clickedRow:n}},bubbles:!0,composed:!0}))},s=e=>{let t=[];for(let n of a){let r=e[n.id];if(n.dataType===`action`){let i=r?.methodNameInCrud?r:e.action?.methodNameInCrud?e.action:{methodNameInCrud:n.id,label:n.label,icon:null,disabled:!1};t.push(T`
                             <button class="crud-btn" theme="tertiary small" title="${i.label||v}"
                                 @click="${t=>o(t,`action-on-row-`+i.methodNameInCrud,e)}">
-                                ${i.icon?L(i.icon):v}
+                                ${i.icon?I(i.icon):v}
                                 ${i.label??v}
                             </button>`)}else(n.dataType===`actionGroup`||n.dataType===`menu`)&&(r?.actions??[]).forEach(n=>t.push(T`
                             <button class="crud-btn" theme="tertiary small" title="${n.label||v}"
                                 @click="${t=>o(t,`action-on-row-`+n.methodNameInCrud,e)}">
-                                ${n.icon?L(n.icon):v}
+                                ${n.icon?I(n.icon):v}
                                 ${n.label??v}
                             </button>`))}return t.length?T`
                     <div style="display: flex; flex-wrap: wrap; gap: var(--lumo-space-xs); margin-top: var(--lumo-space-xs);">
                         ${t}
                     </div>`:v};return T`
                 <div class="m-listbox" style="width: 100%;">
-                    ${p.length===0?T`<div class="m-item" disabled>${zt(ee)}</div>`:v}
+                    ${p.length===0?T`<div class="m-item" disabled>${Bt(ee)}</div>`:v}
                     ${p.map(r=>T`
                         <div role="button" tabindex="0" class="m-item"
                             ?selected="${e&&t!==void 0&&String(r[e])===String(t)}"
-                            @click="${()=>{e&&r[e]!==void 0&&(this.state={...this.state,_selectedId:String(r[e])}),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`view`,parameters:r},bubbles:!0,composed:!0}))}}" @keydown="${z(()=>{e&&r[e]!==void 0&&(this.state={...this.state,_selectedId:String(r[e])}),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`view`,parameters:r},bubbles:!0,composed:!0}))})}"
+                            @click="${()=>{e&&r[e]!==void 0&&(this.state={...this.state,_selectedId:String(r[e])}),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`view`,parameters:r},bubbles:!0,composed:!0}))}}" @keydown="${R(()=>{e&&r[e]!==void 0&&(this.state={...this.state,_selectedId:String(r[e])}),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`view`,parameters:r},bubbles:!0,composed:!0}))})}"
                             style="cursor: pointer;"
                         >
                             <div style="font-weight: 600;">${n?r[n.id]??``:``}</div>
@@ -4698,24 +4698,24 @@ ${i}
                 </div>`},ne=(e,t,n)=>{let r=this.identifierFieldName;r&&n[r]!==void 0&&(this.state={...this.state,_selectedId:String(n[r])}),e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:n},bubbles:!0,composed:!0}))},h=()=>{let e=this.identifierFieldName,t=this.state._selectedId??this.appState?._splitDetailId,n=e=>!!e.actionId,r=e=>e.dataType===`action`||e.dataType===`actionGroup`||e.dataType===`menu`||e.stereotype===`button`,i=[...d.slice(0,6),...d.slice(6).filter(e=>r(e)||e.dataType===`status`)],a=i.filter(e=>e.stereotype===`image`),o=i.find(e=>e.identifier)??i[0],s=i.find(e=>e.id===`select`&&e.dataType===`action`),c=!!s,l=i.filter(e=>e!==o&&!a.includes(e)&&!n(e)&&!r(e)),u=i.filter(e=>r(e)&&!(c&&e===s)),f=(e,t,n)=>{e.stopPropagation(),e.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_clickedRow:n}},bubbles:!0,composed:!0}))},te=e=>{let t=[];for(let n of u){let r=e[n.id];if(n.dataType===`action`){let i=r?.methodNameInCrud?r:e.action?.methodNameInCrud?e.action:{methodNameInCrud:n.id,label:n.label,icon:null,disabled:!1};t.push(T`
                             <button class="crud-btn" theme="tertiary" title="${i.label||v}"
                                 @click="${t=>f(t,`action-on-row-`+i.methodNameInCrud,e)}">
-                                ${i.icon?L(i.icon):v}
+                                ${i.icon?I(i.icon):v}
                                 ${i.label??v}
                             </button>`)}else(n.dataType===`actionGroup`||n.dataType===`menu`)&&(r?.actions??[]).forEach(n=>t.push(T`
                             <button class="crud-btn" theme="tertiary" title="${n.label||v}"
                                 @click="${t=>f(t,`action-on-row-`+n.methodNameInCrud,e)}">
-                                ${n.icon?L(n.icon):v}
+                                ${n.icon?I(n.icon):v}
                                 ${n.label??v}
                             </button>`))}return t.length?T`
                     <div style="display: flex; flex-wrap: wrap; gap: var(--lumo-space-xs); padding-top: var(--lumo-space-s); border-top: 1px solid var(--lumo-contrast-10pct);">
                         ${t}
                     </div>`:v};return T`
                 <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: var(--lumo-space-m); padding: var(--lumo-space-s) 0;">
-                    ${p.length===0?T`<div style="grid-column: 1 / -1;">${zt(ee)}</div>`:v}
+                    ${p.length===0?T`<div style="grid-column: 1 / -1;">${Bt(ee)}</div>`:v}
                     ${p.map(n=>T`
                         <div role="button" tabindex="0" class="crud-card"
                             ?data-selected="${e&&t!==void 0&&String(n[e])===String(t)}"
                             style="cursor: pointer;"
-                            @click="${e=>c?f(e,`action-on-row-select`,n):ne(e.target,`view`,n)}" @keydown="${z(e=>c?f(e,`action-on-row-select`,n):ne(e.target,`view`,n))}"
+                            @click="${e=>c?f(e,`action-on-row-select`,n):ne(e.target,`view`,n)}" @keydown="${R(e=>c?f(e,`action-on-row-select`,n):ne(e.target,`view`,n))}"
                         >
                             ${a.length?T`<img src="${n[a[0].id]??``}" alt="" style="width: 100%; max-height: 160px; object-fit: cover; border-radius: var(--lumo-border-radius-m, 8px);" />`:v}
                             ${o?T`<div class="crud-card-title">${n[o.id]??``}</div>`:v}
@@ -4730,15 +4730,15 @@ ${i}
                             ${te(n)}
                         </div>
                     `)}
-                </div>`},g=()=>{let e=za(d),t=e.find(e=>e.identifier)??e[0],n=e.filter(e=>e!==t);return T`
+                </div>`},g=()=>{let e=Ba(d),t=e.find(e=>e.identifier)??e[0],n=e.filter(e=>e!==t);return T`
                 <div style="display: flex; height: 100%; min-height: 400px; gap: 0;">
                     <div style="width: 260px; flex-shrink: 0; border-right: 1px solid var(--lumo-contrast-20pct); overflow-y: auto;">
                         <div class="m-listbox" style="width: 100%;">
-                            ${p.length===0?T`<div class="m-item" disabled>${zt(ee)}</div>`:v}
+                            ${p.length===0?T`<div class="m-item" disabled>${Bt(ee)}</div>`:v}
                             ${p.map(e=>T`
                                 <div role="button" tabindex="0" class="m-item"
                                     ?selected="${this.selectedItem===e}"
-                                    @click="${()=>{this.selectedItem=e}}" @keydown="${z(()=>{this.selectedItem=e})}"
+                                    @click="${()=>{this.selectedItem=e}}" @keydown="${R(()=>{this.selectedItem=e})}"
                                     style="cursor: pointer;"
                                 >
                                     <div style="font-weight: 600;">${t?e[t.id]??``:``}</div>
@@ -4779,10 +4779,18 @@ ${i}
                         ${i?T`<th></th>`:v}
                     </tr></thead>
                     <tbody>
-                        ${o.length===0?T`<tr><td colspan="99" style="padding: 1.5rem; text-align: center; color: var(--lumo-secondary-text-color, #888);">${zt(ee)}</td></tr>`:v}
+                        ${o.length===0?T`<tr><td colspan="99" style="padding: 1.5rem; text-align: center; color: var(--lumo-secondary-text-color, #888);">${Bt(ee)}</td></tr>`:v}
                         ${o.map(e=>c(e,0))}
                     </tbody>
-                </table>`},re=F.get()?.rendersCrudLayouts?.()===!0,y=T`
+                </table>`},re=P.get()?.rendersCrudLayouts?.()===!0,y=p.length===0&&this.awaitingRows?T`
+            <div role="status" aria-live="polite" aria-busy="true"
+                 style="padding: var(--lumo-space-m, 1rem); width: 100%; box-sizing: border-box;">
+                <span style="position: absolute; width: 1px; height: 1px; overflow: hidden;
+                             clip: rect(0 0 0 0); clip-path: inset(50%); white-space: nowrap;"
+                >Loading…</span>
+                <mateu-skeleton variant="grid" count="6"></mateu-skeleton>
+            </div>
+        `:T`
             ${i.infiniteScrolling?T`
                 <div>${this.data[this.id]?.page?.totalElements} items found.</div>
             `:v}
@@ -4790,10 +4798,10 @@ ${i}
                 <div class="m-scroll" style="width: 100%; height: ${i.contentHeight};">
                     ${h()}
                 </div>
-            `:h():!re&&u===`masterDetail`?g():!re&&u===`tree`?(()=>{let e=F.get();return e?.renderTreeComponent?e.renderTreeComponent(this,{rows:p,columns:d.map(e=>({id:e.id,label:e.label})),idField:this.identifierFieldName,navigable:!!d[0]?.actionId,selectedId:this.state._selectedId??this.appState?._splitDetailId}):_()})():F.get()?.renderTableComponent(this,r,this.baseUrl,this.state,this.data,this.appState,this.appData)}
+            `:h():!re&&u===`masterDetail`?g():!re&&u===`tree`?(()=>{let e=P.get();return e?.renderTreeComponent?e.renderTreeComponent(this,{rows:p,columns:d.map(e=>({id:e.id,label:e.label})),idField:this.identifierFieldName,navigable:!!d[0]?.actionId,selectedId:this.state._selectedId??this.appState?._splitDetailId}):_()})():P.get()?.renderTableComponent(this,r,this.baseUrl,this.state,this.data,this.appState,this.appData)}
             <slot></slot>
-        `,b=i.infiniteScrolling?v:F.get()?.renderPagination(this,this.component),x=this.showImportDialog?T`
-            <div role="button" tabindex="0" class="crud-modal-backdrop" @click="${e=>{e.target===e.currentTarget&&(this.showImportDialog=!1)}}" @keydown="${z(e=>{e.target===e.currentTarget&&(this.showImportDialog=!1)})}">
+        `,b=i.infiniteScrolling?v:P.get()?.renderPagination(this,this.component),x=this.showImportDialog?T`
+            <div role="button" tabindex="0" class="crud-modal-backdrop" @click="${e=>{e.target===e.currentTarget&&(this.showImportDialog=!1)}}" @keydown="${R(e=>{e.target===e.currentTarget&&(this.showImportDialog=!1)})}">
                 <div class="crud-modal">
                     <h3 style="margin: 0 0 .75rem;">Import</h3>
                     <input type="file" @change="${e=>{let t=e.target.files?.[0];if(t){let e=new FormData;e.append(`file`,t),fetch(`/upload`,{method:`POST`,body:e}).then(e=>e.json()).then(e=>this.handleImportUploadSuccess({detail:e})).catch(()=>this.notify(`Import failed`))}}}">
@@ -4823,7 +4831,7 @@ ${i}
                         ></mateu-content-header>
                     </div>
                     <div style="flex-shrink: 0; display: flex; align-items: center; gap: var(--lumo-space-s, 0.5rem);">
-                        <div style="flex: 1; min-width: 0;">${F.get()?.renderFilterBar(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData,!0)}</div>
+                        <div style="flex: 1; min-width: 0;">${P.get()?.renderFilterBar(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData,!0)}</div>
                         ${this.renderColumnChooser()}
                     </div>
                     <div data-crud-area style="flex: 1; overflow-y: auto; min-height: 0; display: flex; flex-direction: column;">${y}</div>
@@ -4856,13 +4864,13 @@ ${i}
                 </style>
             <div data-crud-box style="${this.boxStyle()}">
                 <div style="flex-shrink: 0; display: flex; align-items: center; gap: var(--lumo-space-s, 0.5rem);">
-                    <div style="flex: 1; min-width: 0;">${F.get()?.renderFilterBar(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData)}</div>
+                    <div style="flex: 1; min-width: 0;">${P.get()?.renderFilterBar(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData)}</div>
                     ${this.renderColumnChooser()}
                 </div>
                 <div data-crud-area style="flex: 1; overflow-y: auto; min-height: 0; display: flex; flex-direction: column;">${y}</div>
                 <div style="flex-shrink: 0;">${b}</div>
             </div>
-        `}createRenderRoot(){return F.mustUseShadowRoot()?super.createRenderRoot():this}static{this.styles=h`
+        `}createRenderRoot(){return P.mustUseShadowRoot()?super.createRenderRoot():this}static{this.styles=h`
         ${de}
         /* DS-neutral crud widgets (replace vaadin-button/card/grid/list-box/form-layout/dialog). */
         .crud-btn {
@@ -4916,8 +4924,8 @@ ${i}
             outline-offset: -2px;
         }
     
-        ${B}
-    `}};k([y()],K.prototype,`component`,void 0),k([y()],K.prototype,`baseUrl`,void 0),k([y({type:Boolean})],K.prototype,`standalone`,void 0),k([y()],K.prototype,`state`,void 0),k([y()],K.prototype,`data`,void 0),k([y()],K.prototype,`appState`,void 0),k([y()],K.prototype,`appData`,void 0),k([C()],K.prototype,`showImportDialog`,void 0),k([C()],K.prototype,`availableWidthPx`,void 0),k([C()],K.prototype,`selectedItem`,void 0),k([C()],K.prototype,`_columnPrefsRevision`,void 0),k([C()],K.prototype,`fillHeightPx`,void 0),K=Ba=k([g(`mateu-table-crud`)],K);var Ha=function(e){return e.OnLoad=`OnLoad`,e.OnSuccess=`OnSuccess`,e.OnError=`OnError`,e.OnValueChange=`OnValueChange`,e.OnCustomEvent=`OnCustomEvent`,e.AutoSave=`AutoSave`,e}({}),Ua=class extends vt{constructor(...e){super(...e),this.state={},this.data={},this.appData={},this.appState={},this.triggerOnLoad=()=>{let e=this.component;this.registerCustomEventListeners(),e.triggers?.filter(e=>e.type==Ha.OnLoad).forEach(e=>{if((!e.condition||this._evalExpr(e.condition))&&!e.triggered){let n=e;n.triggered=!0;var t=n.times-1;n.timeoutMillis>0?this.scheduleOnload(n,t,this.id):this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.actionId},bubbles:!0,composed:!0}))}})},this.scheduleOnload=(e,t,n)=>{if(n!=this.component?.id)return;let r=this.callbackToken;setTimeout(()=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,callbackToken:r},bubbles:!0,composed:!0}))},e.timeoutMillis)},this._registeredCustomEventListeners=[],this.customEventManager=e=>{if(!(e instanceof CustomEvent))return;let t=e,n=(this.component.triggers??[]).filter(e=>e.type==Ha.OnCustomEvent).filter(e=>e.eventName==t.type).filter(e=>e.source!==`COMPONENT`||t.detail?.__source===e.from);n.length!==0&&(n.some(e=>!e.source||e.source===`SELF`)&&(e.stopPropagation(),e.preventDefault()),n.forEach(e=>{(!e.condition||this._evalExpr(e.condition))&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:t.detail},bubbles:!0,composed:!0}))}))}}_interpolationExtra(){return{appState:this.appState??{},appData:this.appData??{},component:this.component}}_evalExpr(e){return Ct(e,this.state??{},this.data??{},this._interpolationExtra())}_evalTemplate(e){return wt(e,this.state??{},this.data??{},this._interpolationExtra())}isOverlayChild(e){let t=e?.metadata?.type;return t==j.Drawer||t==j.Dialog}removeSelfFromOwnerChildren(){let e=this.component;if(!e)return!1;let t=t=>{if(t===e)return!0;let n=t;return e.id!=null&&n?.id==e.id&&this.isOverlayChild(n)},n=this.parentNode;for(;n;){let e=n instanceof ShadowRoot?n.host:n,r=e.component?.children;if(Array.isArray(r)){let n=r.findIndex(t);if(n>=0)return r.splice(n,1),e.requestUpdate?.(),!0}n=n instanceof ShadowRoot?e:n.parentNode}return!1}applyFragment(e){if(this.id==e.targetComponentId){if(e.component)if(ut.Add==e.action){if(this.component){let t=this.component.children??(this.component.children=[]),n=e.component.id?t.findIndex(t=>t.id==e.component.id&&this.isOverlayChild(t)):-1;n>=0?(t[n]=e.component,this.component={...this.component}):t.push(e.component)}}else{this.callbackToken=E();let t=!1;if(e.component?.type==A.ServerSide)if(this.component){let n=this.component,r=e.component;t=n.serverSideType==r.serverSideType;let i=t?(n.children??[]).filter(e=>this.isOverlayChild(e)):[];n.actions=r.actions,n.type=r.type,n.rules=r.rules,n.triggers=r.triggers,n.serverSideType=r.serverSideType,n.route=r.route,n.initialData=r.initialData,n.validations=r.validations,n.cssClasses=r.cssClasses,n.slot=r.slot,n.style=r.style,n.children=i.length?[...r.children??[],...i]:r.children,(n.serverSideType!=r.serverSideType||n.id!=r.id)&&setTimeout(()=>this.triggerOnLoad())}else this.component=e.component,setTimeout(()=>this.triggerOnLoad());else{let t=[e.component];this.component&&(this.component.children=t)}e.action!==ut.ReplaceKeepData&&!t&&(this.state={},this.data={})}if(e.state&&(this.state={...this.state,...e.state}),e.data){for(let t in e.data){let n=e.data[t]?.page;n?.pageNumber>0&&this.data[t]&&this.data[t].page.content&&(n.content?n.content=[...this.data[t].page.content,...n.content]:n.content=[...this.data[t].page.content])}this.data={...this.data,...e.data}}this._lastFragmentData=this.data,this.registerCustomEventListeners();let t=F.getAfterRenderHook();t&&setTimeout(()=>t(this)),this.requestUpdate()}}willUpdate(e){super.willUpdate(e);let t=this.component?.serverSideType,n=t!=null&&this._lastViewKey!=null&&t!==this._lastViewKey;if(t!=null&&(this._lastViewKey=t),!e.has(`data`)||this.data===this._lastFragmentData||n)return;let r=this.data,i=e.get(`data`);r&&Object.keys(r).length===0&&i&&Object.keys(i).length>0&&(this.data=i)}registerCustomEventListeners(){this._registeredCustomEventListeners.forEach(({target:e,name:t})=>e.removeEventListener(t,this.customEventManager)),this._registeredCustomEventListeners=[],this.component?.triggers?.filter(e=>e.type==Ha.OnCustomEvent).forEach(e=>{let t=e.source===`DOCUMENT`||e.source===`COMPONENT`?document:this;t.addEventListener(e.eventName,this.customEventManager),this._registeredCustomEventListeners.push({target:t,name:e.eventName})})}disconnectedCallback(){this._registeredCustomEventListeners.forEach(({target:e,name:t})=>e.removeEventListener(t,this.customEventManager)),this._registeredCustomEventListeners=[],super.disconnectedCallback()}connectedCallback(){super.connectedCallback(),this.component&&this.registerCustomEventListeners()}};k([y()],Ua.prototype,`state`,void 0),k([y()],Ua.prototype,`data`,void 0),k([y()],Ua.prototype,`appData`,void 0),k([y()],Ua.prototype,`appState`,void 0);var Wa=`mateu-recent-routes`,Ga=8;function Ka(){try{return JSON.parse(localStorage.getItem(Wa)??`{}`)}catch{return{}}}function qa(e){try{localStorage.setItem(Wa,JSON.stringify(e))}catch{}}function Ja(e){return Ka()[e||`_`]??[]}function Ya(e,t){if(!t?.route||!t.label)return;let n=e||`_`,r=Ka(),i=(r[n]??[]).filter(e=>e.route!==t.route);i.unshift({route:t.route,label:t.label}),r[n]=i.slice(0,Ga),qa(r)}var Xa=class extends b{constructor(...e){super(...e),this.baseUrl=``,this.open=!1,this.queryText=``,this.dataHits=[],this.loading=!1,this.selectedIndex=0,this.fabOffset=0,this.keydownHandler=null}connectedCallback(){super.connectedCallback(),this.keydownHandler=e=>{(e.metaKey||e.ctrlKey)&&(e.key===`k`||e.key===`K`)?(e.preventDefault(),this.toggle()):e.key===`Escape`&&this.open&&this.close()},document.addEventListener(`keydown`,this.keydownHandler),this.setupFabObserver()}disconnectedCallback(){super.disconnectedCallback(),this.keydownHandler&&document.removeEventListener(`keydown`,this.keydownHandler),clearTimeout(this.searchTimer),this.fabObserver?.disconnect(),this.fabObserver=void 0}setupFabObserver(){let e=this.getRootNode(),t=e instanceof ShadowRoot?e:document.body;this.measureFabStack(),this.fabObserver?.disconnect(),this.fabObserver=new MutationObserver(()=>this.measureFabStack()),this.fabObserver.observe(t,{childList:!0,subtree:!0})}measureFabStack(){let e=(this.getRootNode().querySelectorAll?.(`.ai-fab, .app-fab, .page-fab`).length??0)*4;e!==this.fabOffset&&(this.fabOffset=e)}updated(e){e.has(`open`)&&this.open&&requestAnimationFrame(()=>this.inputEl?.focus())}toggle(){this.open?this.close():this.openCenter()}openCenter(){this.open=!0,this.queryText=``,this.dataHits=[],this.selectedIndex=0}close(){this.open=!1,this.queryText=``,this.dataHits=[],clearTimeout(this.searchTimer)}flattenMenu(e,t){let n=[];for(let r of e??[])if(!r.separator)if(r.submenus&&r.submenus.length>0){let e=t?`${t} › ${r.label}`:r.label;n.push(...this.flattenMenu(r.submenus,e))}else r.route!==void 0&&r.route!==null&&n.push({label:r.label,breadcrumb:t,route:r.route});return n}onInput(e){this.queryText=e,this.selectedIndex=0;let t=e.trim();if(clearTimeout(this.searchTimer),!t||!this.app?.globalSearchEnabled){this.dataHits=[],this.loading=!1;return}this.loading=!0,this.searchTimer=setTimeout(()=>this.fetchGlobalSearch(t),250)}async fetchGlobalSearch(e){let t=this.app;if(!t?.globalSearchEnabled){this.loading=!1;return}try{let n=(await lt.runAction(this.baseUrl??``,t.rootRoute??``,``,`_globalsearch`,`command-center`,void 0,t.serverSideType,{},{searchText:e},this,!0))?.fragments?.map(e=>e.data).find(e=>e&&e._globalsearch);this.dataHits=n?._globalsearch??[]}catch{this.dataHits=[]}finally{this.loading=!1}}navigateTo(e,t){Ya(this.app?.serverSideType??``,{route:e,label:t}),this.close();for(let t of[`route-changed`,`navigate-to-requested`])this.dispatchEvent(new CustomEvent(t,{detail:{route:e},bubbles:!0,composed:!0}))}askAi(){let e=this.queryText.trim();this.close(),this.dispatchEvent(new CustomEvent(`mateu-open-ai`,{detail:{query:e},bubbles:!0,composed:!0}))}visibleTargets(e){if(!this.queryText.trim()){let e=this.flattenMenu(this.app?.menu,``).map(e=>({route:e.route,label:e.label})),t=Ja(this.app?.serverSideType??``);return[...e,...t]}return[...e.map(e=>({route:e.route,label:e.label})),...this.dataHits.map(e=>({route:e.route,label:e.label}))]}onKeydown(e,t){if(e.key===`ArrowDown`)e.preventDefault(),this.selectedIndex=Math.min(this.selectedIndex+1,t.length-1);else if(e.key===`ArrowUp`)e.preventDefault(),this.selectedIndex=Math.max(this.selectedIndex-1,0);else if(e.key===`Enter`){let e=t[this.selectedIndex];e&&this.navigateTo(e.route,e.label)}}render(){return T`
+        ${z}
+    `}};k([y()],G.prototype,`component`,void 0),k([y()],G.prototype,`baseUrl`,void 0),k([y({type:Boolean})],G.prototype,`standalone`,void 0),k([y()],G.prototype,`state`,void 0),k([y()],G.prototype,`data`,void 0),k([y()],G.prototype,`appState`,void 0),k([y()],G.prototype,`appData`,void 0),k([C()],G.prototype,`showImportDialog`,void 0),k([C()],G.prototype,`availableWidthPx`,void 0),k([C()],G.prototype,`selectedItem`,void 0),k([C()],G.prototype,`_columnPrefsRevision`,void 0),k([C()],G.prototype,`fillHeightPx`,void 0),k([C()],G.prototype,`loadingSince`,void 0),G=Va=k([g(`mateu-table-crud`)],G);var Ua=function(e){return e.OnLoad=`OnLoad`,e.OnSuccess=`OnSuccess`,e.OnError=`OnError`,e.OnValueChange=`OnValueChange`,e.OnCustomEvent=`OnCustomEvent`,e.AutoSave=`AutoSave`,e}({}),Wa=class extends vt{constructor(...e){super(...e),this.state={},this.data={},this.appData={},this.appState={},this.triggerOnLoad=()=>{let e=this.component;this.registerCustomEventListeners(),e.triggers?.filter(e=>e.type==Ua.OnLoad).forEach(e=>{if((!e.condition||this._evalExpr(e.condition))&&!e.triggered){let n=e;n.triggered=!0;var t=n.times-1;n.timeoutMillis>0?this.scheduleOnload(n,t,this.id):this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.actionId},bubbles:!0,composed:!0}))}})},this.scheduleOnload=(e,t,n)=>{if(n!=this.component?.id)return;let r=this.callbackToken;setTimeout(()=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,callbackToken:r},bubbles:!0,composed:!0}))},e.timeoutMillis)},this._registeredCustomEventListeners=[],this.customEventManager=e=>{if(!(e instanceof CustomEvent))return;let t=e,n=(this.component.triggers??[]).filter(e=>e.type==Ua.OnCustomEvent).filter(e=>e.eventName==t.type).filter(e=>e.source!==`COMPONENT`||t.detail?.__source===e.from);n.length!==0&&(n.some(e=>!e.source||e.source===`SELF`)&&(e.stopPropagation(),e.preventDefault()),n.forEach(e=>{(!e.condition||this._evalExpr(e.condition))&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:t.detail},bubbles:!0,composed:!0}))}))}}_interpolationExtra(){return{appState:this.appState??{},appData:this.appData??{},component:this.component}}_evalExpr(e){return Ct(e,this.state??{},this.data??{},this._interpolationExtra())}_evalTemplate(e){return wt(e,this.state??{},this.data??{},this._interpolationExtra())}isOverlayChild(e){let t=e?.metadata?.type;return t==j.Drawer||t==j.Dialog}removeSelfFromOwnerChildren(){let e=this.component;if(!e)return!1;let t=t=>{if(t===e)return!0;let n=t;return e.id!=null&&n?.id==e.id&&this.isOverlayChild(n)},n=this.parentNode;for(;n;){let e=n instanceof ShadowRoot?n.host:n,r=e.component?.children;if(Array.isArray(r)){let n=r.findIndex(t);if(n>=0)return r.splice(n,1),e.requestUpdate?.(),!0}n=n instanceof ShadowRoot?e:n.parentNode}return!1}applyFragment(e){if(this.id==e.targetComponentId){if(e.component)if(ut.Add==e.action){if(this.component){let t=this.component.children??(this.component.children=[]),n=e.component.id?t.findIndex(t=>t.id==e.component.id&&this.isOverlayChild(t)):-1;n>=0?(t[n]=e.component,this.component={...this.component}):t.push(e.component)}}else{this.callbackToken=E();let t=!1;if(e.component?.type==A.ServerSide)if(this.component){let n=this.component,r=e.component;t=n.serverSideType==r.serverSideType;let i=t?(n.children??[]).filter(e=>this.isOverlayChild(e)):[];n.actions=r.actions,n.type=r.type,n.rules=r.rules,n.triggers=r.triggers,n.serverSideType=r.serverSideType,n.route=r.route,n.initialData=r.initialData,n.validations=r.validations,n.cssClasses=r.cssClasses,n.slot=r.slot,n.style=r.style,n.children=i.length?[...r.children??[],...i]:r.children,(n.serverSideType!=r.serverSideType||n.id!=r.id)&&setTimeout(()=>this.triggerOnLoad())}else this.component=e.component,setTimeout(()=>this.triggerOnLoad());else{let t=[e.component];this.component&&(this.component.children=t)}e.action!==ut.ReplaceKeepData&&!t&&(this.state={},this.data={})}if(e.state&&(this.state={...this.state,...e.state}),e.data){for(let t in e.data){let n=e.data[t]?.page;n?.pageNumber>0&&this.data[t]&&this.data[t].page.content&&(n.content?n.content=[...this.data[t].page.content,...n.content]:n.content=[...this.data[t].page.content])}this.data={...this.data,...e.data}}this._lastFragmentData=this.data,this.registerCustomEventListeners();let t=P.getAfterRenderHook();t&&setTimeout(()=>t(this)),this.requestUpdate()}}willUpdate(e){super.willUpdate(e);let t=this.component?.serverSideType,n=t!=null&&this._lastViewKey!=null&&t!==this._lastViewKey;if(t!=null&&(this._lastViewKey=t),!e.has(`data`)||this.data===this._lastFragmentData||n)return;let r=this.data,i=e.get(`data`);r&&Object.keys(r).length===0&&i&&Object.keys(i).length>0&&(this.data=i)}registerCustomEventListeners(){this._registeredCustomEventListeners.forEach(({target:e,name:t})=>e.removeEventListener(t,this.customEventManager)),this._registeredCustomEventListeners=[],this.component?.triggers?.filter(e=>e.type==Ua.OnCustomEvent).forEach(e=>{let t=e.source===`DOCUMENT`||e.source===`COMPONENT`?document:this;t.addEventListener(e.eventName,this.customEventManager),this._registeredCustomEventListeners.push({target:t,name:e.eventName})})}disconnectedCallback(){this._registeredCustomEventListeners.forEach(({target:e,name:t})=>e.removeEventListener(t,this.customEventManager)),this._registeredCustomEventListeners=[],super.disconnectedCallback()}connectedCallback(){super.connectedCallback(),this.component&&this.registerCustomEventListeners()}};k([y()],Wa.prototype,`state`,void 0),k([y()],Wa.prototype,`data`,void 0),k([y()],Wa.prototype,`appData`,void 0),k([y()],Wa.prototype,`appState`,void 0);var Ga=`mateu-recent-routes`,Ka=8;function qa(){try{return JSON.parse(localStorage.getItem(Ga)??`{}`)}catch{return{}}}function Ja(e){try{localStorage.setItem(Ga,JSON.stringify(e))}catch{}}function Ya(e){return qa()[e||`_`]??[]}function Xa(e,t){if(!t?.route||!t.label)return;let n=e||`_`,r=qa(),i=(r[n]??[]).filter(e=>e.route!==t.route);i.unshift({route:t.route,label:t.label}),r[n]=i.slice(0,Ka),Ja(r)}var Za=class extends b{constructor(...e){super(...e),this.baseUrl=``,this.open=!1,this.queryText=``,this.dataHits=[],this.loading=!1,this.selectedIndex=0,this.fabOffset=0,this.keydownHandler=null}connectedCallback(){super.connectedCallback(),this.keydownHandler=e=>{(e.metaKey||e.ctrlKey)&&(e.key===`k`||e.key===`K`)?(e.preventDefault(),this.toggle()):e.key===`Escape`&&this.open&&this.close()},document.addEventListener(`keydown`,this.keydownHandler),this.setupFabObserver()}disconnectedCallback(){super.disconnectedCallback(),this.keydownHandler&&document.removeEventListener(`keydown`,this.keydownHandler),clearTimeout(this.searchTimer),this.fabObserver?.disconnect(),this.fabObserver=void 0}setupFabObserver(){let e=this.getRootNode(),t=e instanceof ShadowRoot?e:document.body;this.measureFabStack(),this.fabObserver?.disconnect(),this.fabObserver=new MutationObserver(()=>this.measureFabStack()),this.fabObserver.observe(t,{childList:!0,subtree:!0})}measureFabStack(){let e=(this.getRootNode().querySelectorAll?.(`.ai-fab, .app-fab, .page-fab`).length??0)*4;e!==this.fabOffset&&(this.fabOffset=e)}updated(e){e.has(`open`)&&this.open&&requestAnimationFrame(()=>this.inputEl?.focus())}toggle(){this.open?this.close():this.openCenter()}openCenter(){this.open=!0,this.queryText=``,this.dataHits=[],this.selectedIndex=0}close(){this.open=!1,this.queryText=``,this.dataHits=[],clearTimeout(this.searchTimer)}flattenMenu(e,t){let n=[];for(let r of e??[])if(!r.separator)if(r.submenus&&r.submenus.length>0){let e=t?`${t} › ${r.label}`:r.label;n.push(...this.flattenMenu(r.submenus,e))}else r.route!==void 0&&r.route!==null&&n.push({label:r.label,breadcrumb:t,route:r.route});return n}onInput(e){this.queryText=e,this.selectedIndex=0;let t=e.trim();if(clearTimeout(this.searchTimer),!t||!this.app?.globalSearchEnabled){this.dataHits=[],this.loading=!1;return}this.loading=!0,this.searchTimer=setTimeout(()=>this.fetchGlobalSearch(t),250)}async fetchGlobalSearch(e){let t=this.app;if(!t?.globalSearchEnabled){this.loading=!1;return}try{let n=(await lt.runAction(this.baseUrl??``,t.rootRoute??``,``,`_globalsearch`,`command-center`,void 0,t.serverSideType,{},{searchText:e},this,!0))?.fragments?.map(e=>e.data).find(e=>e&&e._globalsearch);this.dataHits=n?._globalsearch??[]}catch{this.dataHits=[]}finally{this.loading=!1}}navigateTo(e,t){Xa(this.app?.serverSideType??``,{route:e,label:t}),this.close();for(let t of[`route-changed`,`navigate-to-requested`])this.dispatchEvent(new CustomEvent(t,{detail:{route:e},bubbles:!0,composed:!0}))}askAi(){let e=this.queryText.trim();this.close(),this.dispatchEvent(new CustomEvent(`mateu-open-ai`,{detail:{query:e},bubbles:!0,composed:!0}))}visibleTargets(e){if(!this.queryText.trim()){let e=this.flattenMenu(this.app?.menu,``).map(e=>({route:e.route,label:e.label})),t=Ya(this.app?.serverSideType??``);return[...e,...t]}return[...e.map(e=>({route:e.route,label:e.label})),...this.dataHits.map(e=>({route:e.route,label:e.label}))]}onKeydown(e,t){if(e.key===`ArrowDown`)e.preventDefault(),this.selectedIndex=Math.min(this.selectedIndex+1,t.length-1);else if(e.key===`ArrowUp`)e.preventDefault(),this.selectedIndex=Math.max(this.selectedIndex-1,0);else if(e.key===`Enter`){let e=t[this.selectedIndex];e&&this.navigateTo(e.route,e.label)}}render(){return T`
             <button class="cc-fab" style="bottom: ${1.5+this.fabOffset}rem;"
                 @click=${()=>this.openCenter()} title="Buscar y navegar (⌘K)" aria-label="Command center">
                 ${this.fabIcon()}
@@ -4943,7 +4951,7 @@ ${i}
                 </div>
                 <button class="cc-close" @click=${()=>this.close()} title="Cerrar">${this.clearIcon()}</button>
             </div>
-        `}renderDefault(){let e=this.flattenMenu(this.app?.menu,``),t=Ja(this.app?.serverSideType??``),n=-1;return T`
+        `}renderDefault(){let e=this.flattenMenu(this.app?.menu,``),t=Ya(this.app?.serverSideType??``),n=-1;return T`
             <div class="cc-columns">
                 <div class="cc-col">
                     <div class="cc-section-title">Ir a</div>
@@ -5078,7 +5086,7 @@ ${i}
             display: flex; align-items: center; justify-content: center; cursor: pointer; z-index: 1110;
         }
         .cc-close:hover { background: rgba(0,0,0,0.75); }
-    `}};k([y({attribute:!1})],Xa.prototype,`app`,void 0),k([y()],Xa.prototype,`baseUrl`,void 0),k([C()],Xa.prototype,`open`,void 0),k([C()],Xa.prototype,`queryText`,void 0),k([C()],Xa.prototype,`dataHits`,void 0),k([C()],Xa.prototype,`loading`,void 0),k([C()],Xa.prototype,`selectedIndex`,void 0),k([C()],Xa.prototype,`fabOffset`,void 0),k([x(`.cc-input`)],Xa.prototype,`inputEl`,void 0),Xa=k([g(`mateu-command-center`)],Xa);var Za=null;function Qa(e){let t=e.component?.metadata;t&&(t.commandCenterEnabled||t.chromeless)&&t.variant!==`MEDIATOR`?((!Za||!Za.isConnected)&&(Za=document.createElement(`mateu-command-center`),e.renderRoot.appendChild(Za)),Za.app=t,Za.baseUrl=e.baseUrl??``):Za&&e.renderRoot.contains(Za)&&(Za.remove(),Za=null)}var $a=class extends b{constructor(...e){super(...e),this.fetchStarted=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!0},this.fetchFinished=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!1},this.fetchFailed=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!1;let t=e.detail??{},n=t.failure??$e(t.reason,{online:at.isOnline()});if(n.kind===`cancelled`)return;let r=t.retry;Na({text:n.message,variant:`error`,duration:r?8e3:5e3,position:`bottomEnd`,...r?{actionLabel:`Retry`,onAction:r}:{}},this)}}connectedCallback(){super.connectedCallback(),this.addEventListener(`backend-called-event`,this.fetchStarted),this.addEventListener(`backend-succeeded-event`,this.fetchFinished),this.addEventListener(`backend-cancelled-event`,this.fetchFinished),this.addEventListener(`backend-failed-event`,this.fetchFailed)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`backend-called-event`,this.fetchStarted),this.removeEventListener(`backend-succeeded-event`,this.fetchFinished),this.removeEventListener(`backend-cancelled-event`,this.fetchFinished),this.removeEventListener(`backend-failed-event`,this.fetchFailed)}render(){return T`<div class="loader-container">
+    `}};k([y({attribute:!1})],Za.prototype,`app`,void 0),k([y()],Za.prototype,`baseUrl`,void 0),k([C()],Za.prototype,`open`,void 0),k([C()],Za.prototype,`queryText`,void 0),k([C()],Za.prototype,`dataHits`,void 0),k([C()],Za.prototype,`loading`,void 0),k([C()],Za.prototype,`selectedIndex`,void 0),k([C()],Za.prototype,`fabOffset`,void 0),k([x(`.cc-input`)],Za.prototype,`inputEl`,void 0),Za=k([g(`mateu-command-center`)],Za);var Qa=null;function $a(e){let t=e.component?.metadata;t&&(t.commandCenterEnabled||t.chromeless)&&t.variant!==`MEDIATOR`?((!Qa||!Qa.isConnected)&&(Qa=document.createElement(`mateu-command-center`),e.renderRoot.appendChild(Qa)),Qa.app=t,Qa.baseUrl=e.baseUrl??``):Qa&&e.renderRoot.contains(Qa)&&(Qa.remove(),Qa=null)}var eo=class extends b{constructor(...e){super(...e),this.fetchStarted=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!0},this.fetchFinished=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!1},this.fetchFailed=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!1;let t=e.detail??{},n=t.failure??$e(t.reason,{online:at.isOnline()});if(n.kind===`cancelled`)return;let r=t.retry;Pa({text:n.message,variant:`error`,duration:r?8e3:5e3,position:`bottomEnd`,...r?{actionLabel:`Retry`,onAction:r}:{}},this)}}connectedCallback(){super.connectedCallback(),this.addEventListener(`backend-called-event`,this.fetchStarted),this.addEventListener(`backend-succeeded-event`,this.fetchFinished),this.addEventListener(`backend-cancelled-event`,this.fetchFinished),this.addEventListener(`backend-failed-event`,this.fetchFailed)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`backend-called-event`,this.fetchStarted),this.removeEventListener(`backend-succeeded-event`,this.fetchFinished),this.removeEventListener(`backend-cancelled-event`,this.fetchFinished),this.removeEventListener(`backend-failed-event`,this.fetchFailed)}render(){return T`<div class="loader-container">
             <div style="display: flex; flex-direction: column;">
                 <slot></slot>
                 <div class="loader-frame ${this.loading?`delayed-show`:``}" style="${this.loading?`pointer-events: all;`:`display: none;`}"><div class="loader"></div></div>
@@ -5146,11 +5154,11 @@ ${i}
             animation: l5 1s infinite;
         }
         @keyframes l5 {to{transform: rotate(.5turn)}}
-  `}};k([C()],$a.prototype,`loading`,void 0),$a=k([g(`mateu-api-caller`)],$a);var eo=new class{constructor(){this._dirty=!1,this._installed=!1,this.message=`You have unsaved changes. Are you sure you want to leave this page?`,this._onDirty=()=>{this._dirty=!0},this._onClean=()=>{this._dirty=!1},this._onBeforeUnload=e=>{this._dirty&&(e.preventDefault(),e.returnValue=``)}}install(){this._installed||(this._installed=!0,document.addEventListener(`dirty`,this._onDirty),document.addEventListener(`clean`,this._onClean),window.addEventListener(`beforeunload`,this._onBeforeUnload))}get dirty(){return this._dirty}markDirty(){this._dirty=!0}markClean(){this._dirty=!1}confirmLeave(){if(!this._dirty)return!0;let e=window.confirm(this.message);return e&&(this._dirty=!1),e}},to,q=class extends Ua{static{to=this}constructor(...e){super(...e),this.filter=``,this.instant=void 0,this.selectedConsumedRoute=void 0,this.selectedRoute=void 0,this.selectedUriPrefix=void 0,this.selectedBaseUrl=void 0,this.selectedServerSideType=void 0,this.selectedParams=void 0,this.tilesMenuOption=null,this.railOpenOption=null,this.commandPaletteOpen=!1,this.commandPaletteQuery=``,this.commandPaletteSelectedIndex=0,this.commandPaletteDataHits=[],this.openDataHit=e=>{eo.confirmLeave()&&(this.commandPaletteOpen=!1,this.commandPaletteQuery=``,this.commandPaletteDataHits=[],this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:e.route},bubbles:!0,composed:!0})),this.dispatchEvent(new CustomEvent(`navigate-to-requested`,{detail:{route:e.route},bubbles:!0,composed:!0})))},this._commandPaletteHandler=null,this.pageCompact=!1,this._compactHandler=e=>{this.pageCompact=e.detail?.compact??!1},this._openAiHandler=()=>{this.chatOpen||this.showHideIa()},this.isDark=document.documentElement.getAttribute(`theme`)===`dark`,this.chatOpen=!1,this.toggleTheme=()=>{this.isDark=!this.isDark;let e=this.isDark?`dark`:`light`;document.documentElement.setAttribute(`theme`,e),localStorage.setItem(`mateu-theme`,e)},this.showHideIa=()=>{this.chat&&(this.chatOpen=!this.chatOpen,this.chat.slot=this.chatOpen?`detail`:`detail-hidden`)},this.runAction=e=>{let t=this.renderRoot.querySelector?.(`mateu-component`);t&&t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.getSelectedOption=e=>{if(e)for(let t=0;t<e.length;t++){let n=e[t];if(this.selectedRoute?this.isActiveOption(n):n.selected)return n;let r=this.getSelectedOption(n.submenus);if(r)return r}return null},this.itemSelected=e=>{let t=e.detail.value;this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix)},this.itemSelectedTiles=e=>{let t=e.detail.value._menuOption;t.submenus&&t.submenus.length>0?this.tilesMenuOption=t:(this.tilesMenuOption=null,this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix))},this.mapItemsForTiles=e=>e.map(e=>({text:e.label,consumedRoute:e.consumedRoute,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:e.selected,_menuOption:e})),this.flattenMenuForPalette=(e,t)=>{let n=[];for(let r of e)if(!r.separator)if(r.submenus&&r.submenus.length>0){let e=t?`${t} › ${r.label}`:r.label;n.push(...this.flattenMenuForPalette(r.submenus,e))}else n.push({label:r.label,breadcrumb:t,consumedRoute:r.consumedRoute,route:r.route,actionId:r.actionId,baseUrl:r.baseUrl,serverSideType:r.serverSideType,uriPrefix:r.uriPrefix});return n},this.handleCommandPaletteKeydown=(e,t)=>{let n=Math.min(t.length,10),r=n+Math.min(this.commandPaletteDataHits.length,8);if(e.key===`ArrowDown`)e.preventDefault(),this.commandPaletteSelectedIndex=Math.min(this.commandPaletteSelectedIndex+1,r-1);else if(e.key===`ArrowUp`)e.preventDefault(),this.commandPaletteSelectedIndex=Math.max(this.commandPaletteSelectedIndex-1,0);else if(e.key===`Enter`){if(this.commandPaletteSelectedIndex>=n){let e=this.commandPaletteDataHits[this.commandPaletteSelectedIndex-n];e&&this.openDataHit(e);return}let e=t[this.commandPaletteSelectedIndex];e&&(this.selectRoute(e.consumedRoute,e.route,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix),this.commandPaletteOpen=!1,this.commandPaletteQuery=``)}},this.renderCommandPalette=()=>{if(!this.commandPaletteOpen)return v;let e=this.component?.metadata;if(e?.commandCenterEnabled||!e?.menu)return v;let t=this.flattenMenuForPalette(e.menu,``),n=this.commandPaletteQuery.toLowerCase(),r=n?t.filter(e=>e.label.toLowerCase().includes(n)||e.breadcrumb.toLowerCase().includes(n)):t;return T`
+  `}};k([C()],eo.prototype,`loading`,void 0),eo=k([g(`mateu-api-caller`)],eo);var to=new class{constructor(){this._dirty=!1,this._installed=!1,this.message=`You have unsaved changes. Are you sure you want to leave this page?`,this._onDirty=()=>{this._dirty=!0},this._onClean=()=>{this._dirty=!1},this._onBeforeUnload=e=>{this._dirty&&(e.preventDefault(),e.returnValue=``)}}install(){this._installed||(this._installed=!0,document.addEventListener(`dirty`,this._onDirty),document.addEventListener(`clean`,this._onClean),window.addEventListener(`beforeunload`,this._onBeforeUnload))}get dirty(){return this._dirty}markDirty(){this._dirty=!0}markClean(){this._dirty=!1}confirmLeave(){if(!this._dirty)return!0;let e=window.confirm(this.message);return e&&(this._dirty=!1),e}},no,K=class extends Wa{static{no=this}constructor(...e){super(...e),this.filter=``,this.instant=void 0,this.selectedConsumedRoute=void 0,this.selectedRoute=void 0,this.selectedUriPrefix=void 0,this.selectedBaseUrl=void 0,this.selectedServerSideType=void 0,this.selectedParams=void 0,this.tilesMenuOption=null,this.railOpenOption=null,this.commandPaletteOpen=!1,this.commandPaletteQuery=``,this.commandPaletteSelectedIndex=0,this.commandPaletteDataHits=[],this.openDataHit=e=>{to.confirmLeave()&&(this.commandPaletteOpen=!1,this.commandPaletteQuery=``,this.commandPaletteDataHits=[],this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:e.route},bubbles:!0,composed:!0})),this.dispatchEvent(new CustomEvent(`navigate-to-requested`,{detail:{route:e.route},bubbles:!0,composed:!0})))},this._commandPaletteHandler=null,this.pageCompact=!1,this._compactHandler=e=>{this.pageCompact=e.detail?.compact??!1},this._openAiHandler=()=>{this.chatOpen||this.showHideIa()},this.isDark=document.documentElement.getAttribute(`theme`)===`dark`,this.chatOpen=!1,this.toggleTheme=()=>{this.isDark=!this.isDark;let e=this.isDark?`dark`:`light`;document.documentElement.setAttribute(`theme`,e),localStorage.setItem(`mateu-theme`,e)},this.showHideIa=()=>{this.chat&&(this.chatOpen=!this.chatOpen,this.chat.slot=this.chatOpen?`detail`:`detail-hidden`)},this.runAction=e=>{let t=this.renderRoot.querySelector?.(`mateu-component`);t&&t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.getSelectedOption=e=>{if(e)for(let t=0;t<e.length;t++){let n=e[t];if(this.selectedRoute?this.isActiveOption(n):n.selected)return n;let r=this.getSelectedOption(n.submenus);if(r)return r}return null},this.itemSelected=e=>{let t=e.detail.value;this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix)},this.itemSelectedTiles=e=>{let t=e.detail.value._menuOption;t.submenus&&t.submenus.length>0?this.tilesMenuOption=t:(this.tilesMenuOption=null,this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix))},this.mapItemsForTiles=e=>e.map(e=>({text:e.label,consumedRoute:e.consumedRoute,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:e.selected,_menuOption:e})),this.flattenMenuForPalette=(e,t)=>{let n=[];for(let r of e)if(!r.separator)if(r.submenus&&r.submenus.length>0){let e=t?`${t} › ${r.label}`:r.label;n.push(...this.flattenMenuForPalette(r.submenus,e))}else n.push({label:r.label,breadcrumb:t,consumedRoute:r.consumedRoute,route:r.route,actionId:r.actionId,baseUrl:r.baseUrl,serverSideType:r.serverSideType,uriPrefix:r.uriPrefix});return n},this.handleCommandPaletteKeydown=(e,t)=>{let n=Math.min(t.length,10),r=n+Math.min(this.commandPaletteDataHits.length,8);if(e.key===`ArrowDown`)e.preventDefault(),this.commandPaletteSelectedIndex=Math.min(this.commandPaletteSelectedIndex+1,r-1);else if(e.key===`ArrowUp`)e.preventDefault(),this.commandPaletteSelectedIndex=Math.max(this.commandPaletteSelectedIndex-1,0);else if(e.key===`Enter`){if(this.commandPaletteSelectedIndex>=n){let e=this.commandPaletteDataHits[this.commandPaletteSelectedIndex-n];e&&this.openDataHit(e);return}let e=t[this.commandPaletteSelectedIndex];e&&(this.selectRoute(e.consumedRoute,e.route,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix),this.commandPaletteOpen=!1,this.commandPaletteQuery=``)}},this.renderCommandPalette=()=>{if(!this.commandPaletteOpen)return v;let e=this.component?.metadata;if(e?.commandCenterEnabled||!e?.menu)return v;let t=this.flattenMenuForPalette(e.menu,``),n=this.commandPaletteQuery.toLowerCase(),r=n?t.filter(e=>e.label.toLowerCase().includes(n)||e.breadcrumb.toLowerCase().includes(n)):t;return T`
             <div class="cmd-backdrop" @click=${()=>{this.commandPaletteOpen=!1,this.commandPaletteQuery=``}}>
                 <div class="cmd-palette" @click=${e=>e.stopPropagation()}>
                     <div class="cmd-search-wrapper">
-                        ${L(`vaadin:search`,void 0,`cmd-search-icon`)}
+                        ${I(`vaadin:search`,void 0,`cmd-search-icon`)}
                         <input
                             class="cmd-input"
                             placeholder="Go to…"
@@ -5192,7 +5200,7 @@ ${i}
             <div class="rail-item ${(e.submenus?.length>0?this.railOpenOption?.label===e.label:e.selected)?`rail-item--active`:``}"
                 @click=${()=>{e.submenus&&e.submenus.length>0?this.railOpenOption=this.railOpenOption?.label===e.label?null:e:(this.railOpenOption=null,this.selectRoute(e.consumedRoute,e.route,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix))}}
             >
-                ${e.icon?L(e.icon,void 0,`rail-icon`):T`<div class="rail-icon-placeholder">${e.label.charAt(0).toUpperCase()}</div>`}
+                ${e.icon?I(e.icon,void 0,`rail-icon`):T`<div class="rail-icon-placeholder">${e.label.charAt(0).toUpperCase()}</div>`}
                 <span class="rail-label">${e.label}</span>
             </div>
         `,this.renderRailSubPanel=e=>T`
@@ -5212,14 +5220,14 @@ ${i}
                         <div class="nav-tile"
                             @click=${()=>{e.submenus&&e.submenus.length>0?this.tilesMenuOption=e:(this.tilesMenuOption=null,this.selectRoute(e.consumedRoute,e.route,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix))}}
                         >
-                            ${e.icon?L(e.icon,`font-size: 2rem; color: var(--lumo-primary-color); display: block; margin-bottom: 0.75rem;`):v}
+                            ${e.icon?I(e.icon,`font-size: 2rem; color: var(--lumo-primary-color); display: block; margin-bottom: 0.75rem;`):v}
                             <div class="nav-tile-title">${e.label}</div>
                             ${e.description?T`<div class="nav-tile-desc">${e.description}</div>`:v}
                         </div>
                     `)}
                 </div>
             </div>
-        `,this.goHome=()=>{eo.confirmLeave()&&(window.history.pushState(null,``,`/`),window.dispatchEvent(new PopStateEvent(`popstate`,{state:null})))},this.selectRoute=(e,t,n,r,i,a)=>{eo.confirmLeave()&&this._selectRoute(e,t,n,r,i,a)},this._selectRoute=(e,t,n,r,i,a)=>{{this.selectedConsumedRoute=e,this.selectedBaseUrl=r,this.selectedRoute=t,this.selectedServerSideType=i,this.selectedUriPrefix=a,this.instant=E(),this.state&&this.state._route!=null&&(this.state._route=void 0);let n=this.baseUrl??``;n.indexOf(`://`)<0&&(n.startsWith(`/`)||(n=`/`+n),n=window.location.origin+n),n.endsWith(`/`)&&(t??``).startsWith(`/`)&&(t=(t??``).substring(1));let o=new URL(n+t);if(e&&o.pathname.startsWith(e)){let t=o.pathname.substring(e.length);o=new URL(o.origin+(t||`/`))}if((window.location.pathname||o.pathname)&&window.location.pathname!=o.pathname){let e=o.pathname;o.search&&(e+=o.search),e&&!e.startsWith(`/`)&&(e=`/`+e),this.baseUrl&&e.startsWith(this.baseUrl)&&(e=e.substring(this.baseUrl.length));let t=e;this.selectedUriPrefix&&(t=t.startsWith(`/`)&&this.selectedUriPrefix.endsWith(`/`)?this.selectedUriPrefix+t.substring(1):!t.startsWith(`/`)&&!this.selectedUriPrefix.endsWith(`/`)?this.selectedUriPrefix+`/`+t:this.selectedUriPrefix+t),t==`/_page`&&(t=``),this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0}))}}},this.isActiveOption=e=>this.selectedRoute?!!e.route&&(this.selectedRoute==e.route||this.selectedRoute.startsWith(e.route+`/`)):!!e.selected,this.mapItems=(e,t)=>e.map(e=>{if(e.submenus&&e.submenus.length>0){let n=this.mapItems(e.submenus,t);return t&&e.label.toLowerCase().includes(t)&&(n=this.mapItems(e.submenus,``)),n&&n.length>0?{consumedRoute:e.consumedRoute,text:e.label,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:t||this.isActiveOption(e),children:n}:void 0}if(e.separator)return t?void 0:{component:`hr`};if(!t||e.label.toLowerCase().includes(t))return{consumedRoute:e.consumedRoute,text:e.label,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:t||this.isActiveOption(e)}}).filter(e=>e!=null),this.getSelectedIndex=e=>{if(!e)return NaN;let t=e=>{let t=(e??``).trim();return t.length>1&&t.endsWith(`/`)&&(t=t.slice(0,-1)),t},n=t(this.selectedRoute??window.location.pathname),r=NaN,i=-1;for(let a=0;a<e.length;a++){let o=t(e[a].route);o!==``&&(n===o||n.startsWith(o+`/`))&&o.length>i&&(i=o.length,r=a)}if(!Number.isNaN(r))return r;let a=this.getSelectedOption(e);return a?e.indexOf(a):NaN},this.renderOptionOnLeftMenu=e=>e.submenus&&e.submenus.length>0?T`
+        `,this.goHome=()=>{to.confirmLeave()&&(window.history.pushState(null,``,`/`),window.dispatchEvent(new PopStateEvent(`popstate`,{state:null})))},this.selectRoute=(e,t,n,r,i,a)=>{to.confirmLeave()&&this._selectRoute(e,t,n,r,i,a)},this._selectRoute=(e,t,n,r,i,a)=>{{this.selectedConsumedRoute=e,this.selectedBaseUrl=r,this.selectedRoute=t,this.selectedServerSideType=i,this.selectedUriPrefix=a,this.instant=E(),this.state&&this.state._route!=null&&(this.state._route=void 0);let n=this.baseUrl??``;n.indexOf(`://`)<0&&(n.startsWith(`/`)||(n=`/`+n),n=window.location.origin+n),n.endsWith(`/`)&&(t??``).startsWith(`/`)&&(t=(t??``).substring(1));let o=new URL(n+t);if(e&&o.pathname.startsWith(e)){let t=o.pathname.substring(e.length);o=new URL(o.origin+(t||`/`))}if((window.location.pathname||o.pathname)&&window.location.pathname!=o.pathname){let e=o.pathname;o.search&&(e+=o.search),e&&!e.startsWith(`/`)&&(e=`/`+e),this.baseUrl&&e.startsWith(this.baseUrl)&&(e=e.substring(this.baseUrl.length));let t=e;this.selectedUriPrefix&&(t=t.startsWith(`/`)&&this.selectedUriPrefix.endsWith(`/`)?this.selectedUriPrefix+t.substring(1):!t.startsWith(`/`)&&!this.selectedUriPrefix.endsWith(`/`)?this.selectedUriPrefix+`/`+t:this.selectedUriPrefix+t),t==`/_page`&&(t=``),this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0}))}}},this.isActiveOption=e=>this.selectedRoute?!!e.route&&(this.selectedRoute==e.route||this.selectedRoute.startsWith(e.route+`/`)):!!e.selected,this.mapItems=(e,t)=>e.map(e=>{if(e.submenus&&e.submenus.length>0){let n=this.mapItems(e.submenus,t);return t&&e.label.toLowerCase().includes(t)&&(n=this.mapItems(e.submenus,``)),n&&n.length>0?{consumedRoute:e.consumedRoute,text:e.label,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:t||this.isActiveOption(e),children:n}:void 0}if(e.separator)return t?void 0:{component:`hr`};if(!t||e.label.toLowerCase().includes(t))return{consumedRoute:e.consumedRoute,text:e.label,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:t||this.isActiveOption(e)}}).filter(e=>e!=null),this.getSelectedIndex=e=>{if(!e)return NaN;let t=e=>{let t=(e??``).trim();return t.length>1&&t.endsWith(`/`)&&(t=t.slice(0,-1)),t},n=t(this.selectedRoute??window.location.pathname),r=NaN,i=-1;for(let a=0;a<e.length;a++){let o=t(e[a].route);o!==``&&(n===o||n.startsWith(o+`/`))&&o.length>i&&(i=o.length,r=a)}if(!Number.isNaN(r))return r;let a=this.getSelectedOption(e);return a?e.indexOf(a):NaN},this.renderOptionOnLeftMenu=e=>e.submenus&&e.submenus.length>0?T`
                 <details open class="left-menu-group">
                     <summary>${e.label}</summary>
                     <div class="left-menu-children">
@@ -5235,14 +5243,14 @@ ${i}
                                 <div class="side-nav-item ${t.selected?`side-nav-item--active`:``}">
                                     <button class="side-nav-link"
                                             @click="${()=>{t.route&&!t.children&&this.selectRoute(void 0,t.route,void 0,this.baseUrl,void 0,void 0)}}">
-                                        ${t.icon?L(`vaadin:dashboard`,`margin-right:.5rem;`):v}${t.text}
+                                        ${t.icon?I(`vaadin:dashboard`,`margin-right:.5rem;`):v}${t.text}
                                     </button>
                                     ${t.children?T`<div class="side-nav-children">${this.renderSideNav(t.children,`children`)}</div>`:v}
                                 </div>
                         `}
 
-                            `})}`:v,this.updateRoute=e=>{e.preventDefault(),e.stopPropagation();var t=e.detail;this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix)}}createRenderRoot(){return F.mustUseShadowRoot()?super.createRenderRoot():(to.injectLightDomStyles(),this)}static{this.lightDomStylesInjected=!1}static injectLightDomStyles(){if(to.lightDomStylesInjected||typeof document>`u`||(to.lightDomStylesInjected=!0,document.getElementById(`mateu-app-light-styles`)))return;let e=to.styles,t=Array.isArray(e)?e.map(e=>e?.cssText??``).join(`
-`):e?.cssText??``;if(!t)return;let n=document.createElement(`style`);n.id=`mateu-app-light-styles`,n.textContent=t,document.head.appendChild(n)}fetchGlobalSearch(e){let t=this.component?.metadata;if(t?.globalSearchEnabled){if(clearTimeout(this._globalSearchTimer),!e){this.commandPaletteDataHits=[];return}this._globalSearchTimer=setTimeout(async()=>{try{let n=(await lt.runAction(this.baseUrl??``,t.rootRoute??``,``,`_globalsearch`,`cmd-palette`,void 0,t.serverSideType,{},{searchText:e},this,!0))?.fragments?.map(e=>e.data).find(e=>e&&e._globalsearch);this.commandPaletteDataHits=n?._globalsearch??[]}catch{this.commandPaletteDataHits=[]}},250)}}connectedCallback(){super.connectedCallback(),this.isDark=document.documentElement.getAttribute(`theme`)===`dark`,this._commandPaletteHandler=e=>{this.component?.metadata?.commandCenterEnabled||((e.metaKey||e.ctrlKey)&&e.key===`k`&&(e.preventDefault(),this.commandPaletteOpen=!this.commandPaletteOpen,this.commandPaletteQuery=``,this.commandPaletteSelectedIndex=0),e.key===`Escape`&&this.commandPaletteOpen&&(this.commandPaletteOpen=!1,this.commandPaletteQuery=``))},document.addEventListener(`keydown`,this._commandPaletteHandler),eo.install(),this.addEventListener(`compact-changed`,this._compactHandler),this.addEventListener(`mateu-open-ai`,this._openAiHandler)}disconnectedCallback(){super.disconnectedCallback(),this._commandPaletteHandler&&document.removeEventListener(`keydown`,this._commandPaletteHandler),this.removeEventListener(`compact-changed`,this._compactHandler),this.removeEventListener(`mateu-open-ai`,this._openAiHandler)}updated(e){if(super.updated(e),Qa(this),this.component){let t=this.component.metadata;if(t){let n=t;if(Ne(n.restSources),n.favicon){let e=document.querySelector(`link[rel~='icon']`);e||(e=document.createElement(`link`),e.rel=`icon`,document.head.appendChild(e)),e.href=n.favicon}e.has(`component`)&&(this.selectedRoute=n.homeRoute,this.selectedConsumedRoute=n.homeConsumedRoute,this.selectedServerSideType=n.homeServerSideType,this.selectedBaseUrl=n.homeBaseUrl,this.selectedUriPrefix=n.homeUriPrefix)}}e.has(`commandPaletteOpen`)&&this.commandPaletteOpen&&setTimeout(()=>{this.renderRoot.querySelector(`.cmd-input`)?.focus()},0)}render(){return F.get()?.renderAppComponent(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData)}static{this.styles=h`
+                            `})}`:v,this.updateRoute=e=>{e.preventDefault(),e.stopPropagation();var t=e.detail;this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix)}}createRenderRoot(){return P.mustUseShadowRoot()?super.createRenderRoot():(no.injectLightDomStyles(),this)}static{this.lightDomStylesInjected=!1}static injectLightDomStyles(){if(no.lightDomStylesInjected||typeof document>`u`||(no.lightDomStylesInjected=!0,document.getElementById(`mateu-app-light-styles`)))return;let e=no.styles,t=Array.isArray(e)?e.map(e=>e?.cssText??``).join(`
+`):e?.cssText??``;if(!t)return;let n=document.createElement(`style`);n.id=`mateu-app-light-styles`,n.textContent=t,document.head.appendChild(n)}fetchGlobalSearch(e){let t=this.component?.metadata;if(t?.globalSearchEnabled){if(clearTimeout(this._globalSearchTimer),!e){this.commandPaletteDataHits=[];return}this._globalSearchTimer=setTimeout(async()=>{try{let n=(await lt.runAction(this.baseUrl??``,t.rootRoute??``,``,`_globalsearch`,`cmd-palette`,void 0,t.serverSideType,{},{searchText:e},this,!0))?.fragments?.map(e=>e.data).find(e=>e&&e._globalsearch);this.commandPaletteDataHits=n?._globalsearch??[]}catch{this.commandPaletteDataHits=[]}},250)}}connectedCallback(){super.connectedCallback(),this.isDark=document.documentElement.getAttribute(`theme`)===`dark`,this._commandPaletteHandler=e=>{this.component?.metadata?.commandCenterEnabled||((e.metaKey||e.ctrlKey)&&e.key===`k`&&(e.preventDefault(),this.commandPaletteOpen=!this.commandPaletteOpen,this.commandPaletteQuery=``,this.commandPaletteSelectedIndex=0),e.key===`Escape`&&this.commandPaletteOpen&&(this.commandPaletteOpen=!1,this.commandPaletteQuery=``))},document.addEventListener(`keydown`,this._commandPaletteHandler),to.install(),this.addEventListener(`compact-changed`,this._compactHandler),this.addEventListener(`mateu-open-ai`,this._openAiHandler)}disconnectedCallback(){super.disconnectedCallback(),this._commandPaletteHandler&&document.removeEventListener(`keydown`,this._commandPaletteHandler),this.removeEventListener(`compact-changed`,this._compactHandler),this.removeEventListener(`mateu-open-ai`,this._openAiHandler)}updated(e){if(super.updated(e),$a(this),this.component){let t=this.component.metadata;if(t){let n=t;if(Ne(n.restSources),n.favicon){let e=document.querySelector(`link[rel~='icon']`);e||(e=document.createElement(`link`),e.rel=`icon`,document.head.appendChild(e)),e.href=n.favicon}e.has(`component`)&&(this.selectedRoute=n.homeRoute,this.selectedConsumedRoute=n.homeConsumedRoute,this.selectedServerSideType=n.homeServerSideType,this.selectedBaseUrl=n.homeBaseUrl,this.selectedUriPrefix=n.homeUriPrefix)}}e.has(`commandPaletteOpen`)&&this.commandPaletteOpen&&setTimeout(()=>{this.renderRoot.querySelector(`.cmd-input`)?.focus()},0)}render(){return P.get()?.renderAppComponent(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData)}static{this.styles=h`
         /* DS-neutral app chrome (replaces vaadin-app-layout / menu-bar / tabs / side-nav). */
         .m-hl { display: flex; flex-direction: row; }
         .m-vl { display: flex; flex-direction: column; }
@@ -5592,14 +5600,14 @@ ${i}
             transform: scale(1.08);
         }
 
-  `}};k([C()],q.prototype,`filter`,void 0),k([C()],q.prototype,`instant`,void 0),k([C()],q.prototype,`selectedConsumedRoute`,void 0),k([C()],q.prototype,`selectedRoute`,void 0),k([C()],q.prototype,`selectedUriPrefix`,void 0),k([C()],q.prototype,`selectedBaseUrl`,void 0),k([C()],q.prototype,`selectedServerSideType`,void 0),k([C()],q.prototype,`selectedParams`,void 0),k([C()],q.prototype,`tilesMenuOption`,void 0),k([C()],q.prototype,`railOpenOption`,void 0),k([C()],q.prototype,`commandPaletteOpen`,void 0),k([C()],q.prototype,`commandPaletteQuery`,void 0),k([C()],q.prototype,`commandPaletteSelectedIndex`,void 0),k([C()],q.prototype,`commandPaletteDataHits`,void 0),k([C()],q.prototype,`pageCompact`,void 0),k([x(`mateu-chat`)],q.prototype,`chat`,void 0),k([C()],q.prototype,`isDark`,void 0),k([C()],q.prototype,`chatOpen`,void 0),k([x(`.mateu-app-layout`)],q.prototype,`vaadinAppLayout`,void 0),q=to=k([g(`mateu-app`)],q);var no=class extends b{constructor(...e){super(...e),this.message=`This website uses cookies.`,this.dismiss=`Ok. Thanks :).`,this.learnMore=`Learn more`,this.learnMoreLink=`https://cookiesandyou.com/`,this.showLearnMore=!0,this.position=`top`,this.cookieName=`mateu-cookieconsent`}updated(e){super.updated(e)}connectedCallback(){super.connectedCallback(),this._css=document.createElement(`style`),this._css.innerText=`.cc-window{opacity:1;transition:opacity 1s ease}.cc-window.cc-invisible{opacity:0}.cc-animate.cc-revoke{transition:transform 1s ease}.cc-animate.cc-revoke.cc-top{transform:translateY(-2em)}.cc-animate.cc-revoke.cc-bottom{transform:translateY(2em)}.cc-animate.cc-revoke.cc-active.cc-bottom,.cc-animate.cc-revoke.cc-active.cc-top,.cc-revoke:hover{transform:translateY(0)}.cc-grower{max-height:0;overflow:hidden;transition:max-height 1s}.cc-link,.cc-revoke:hover{text-decoration:underline}.cc-revoke,.cc-window{position:fixed;overflow:hidden;box-sizing:border-box;font-family:Helvetica,Calibri,Arial,sans-serif;font-size:16px;line-height:1.5em;display:flex;flex-wrap:nowrap;z-index:9999}.cc-window.cc-static{position:static}.cc-window.cc-floating{padding:2em;max-width:24em;flex-direction:column}.cc-window.cc-banner{padding:1em 1.8em;width:100%;flex-direction:row}.cc-revoke{padding:.5em}.cc-header{font-size:18px;font-weight:700}.cc-btn,.cc-close,.cc-link,.cc-revoke{cursor:pointer}.cc-link{opacity:.8;display:inline-block;padding:.2em}.cc-link:hover{opacity:1}.cc-link:active,.cc-link:visited{color:initial}.cc-btn{display:block;padding:.4em .8em;font-size:.9em;font-weight:700;border-width:2px;border-style:solid;text-align:center;white-space:nowrap}.cc-banner .cc-btn:last-child{min-width:140px}.cc-highlight .cc-btn:first-child{background-color:transparent;border-color:transparent}.cc-highlight .cc-btn:first-child:focus,.cc-highlight .cc-btn:first-child:hover{background-color:transparent;text-decoration:underline}.cc-close{display:block;position:absolute;top:.5em;right:.5em;font-size:1.6em;opacity:.9;line-height:.75}.cc-close:focus,.cc-close:hover{opacity:1}.cc-revoke.cc-top{top:0;left:3em;border-bottom-left-radius:.5em;border-bottom-right-radius:.5em}.cc-revoke.cc-bottom{bottom:0;left:3em;border-top-left-radius:.5em;border-top-right-radius:.5em}.cc-revoke.cc-left{left:3em;right:unset}.cc-revoke.cc-right{right:3em;left:unset}.cc-top{top:1em}.cc-left{left:1em}.cc-right{right:1em}.cc-bottom{bottom:1em}.cc-floating>.cc-link{margin-bottom:1em}.cc-floating .cc-message{display:block;margin-bottom:1em}.cc-window.cc-floating .cc-compliance{flex:1 0 auto}.cc-window.cc-banner{align-items:center}.cc-banner.cc-top{left:0;right:0;top:0}.cc-banner.cc-bottom{left:0;right:0;bottom:0}.cc-banner .cc-message{flex:1}.cc-compliance{display:flex;align-items:center;align-content:space-between}.cc-compliance>.cc-btn{flex:1}.cc-btn+.cc-btn{margin-left:.5em}@media print{.cc-revoke,.cc-window{display:none}}@media screen and (max-width:900px){.cc-btn{white-space:normal}}@media screen and (max-width:414px) and (orientation:portrait),screen and (max-width:736px) and (orientation:landscape){.cc-window.cc-top{top:0}.cc-window.cc-bottom{bottom:0}.cc-window.cc-banner,.cc-window.cc-left,.cc-window.cc-right{left:0;right:0}.cc-window.cc-banner{flex-direction:column}.cc-window.cc-banner .cc-compliance{flex:1}.cc-window.cc-floating{max-width:none}.cc-window .cc-message{margin-bottom:1em}.cc-window.cc-banner{align-items:unset}}.cc-floating.cc-theme-classic{padding:1.2em;border-radius:5px}.cc-floating.cc-type-info.cc-theme-classic .cc-compliance{text-align:center;display:inline;flex:none}.cc-theme-classic .cc-btn{border-radius:5px}.cc-theme-classic .cc-btn:last-child{min-width:140px}.cc-floating.cc-type-info.cc-theme-classic .cc-btn{display:inline-block}.cc-theme-edgeless.cc-window{padding:0}.cc-floating.cc-theme-edgeless .cc-message{margin:2em 2em 1.5em}.cc-banner.cc-theme-edgeless .cc-btn{margin:0;padding:.8em 1.8em;height:100%}.cc-banner.cc-theme-edgeless .cc-message{margin-left:1em}.cc-floating.cc-theme-edgeless .cc-btn+.cc-btn{margin-left:0}`,document.head.appendChild(this._css),this.__updatePopup()}disconnectedCallback(){super.disconnectedCallback(),this.__closePopup(),this._css.isConnected&&this._css.remove()}__closePopup(){let e=this.popup;e&&e.parentNode?.removeChild(e)}_show(){let e=this.popup;e&&(e.classList.remove(`cc-invisible`),e.style.display=``)}__updatePopup(){this.__closePopup(),window.cookieconsent.initialise({palette:{popup:{background:`#000`},button:{background:`rgba(22, 118, 243, 0.95)`,hover:`rgba(22, 118, 243, 1)`}},showLink:this.showLearnMore,content:{message:this.message,dismiss:this.dismiss,link:this.learnMore,href:this.learnMoreLink},cookie:{name:this.cookieName},position:this.position,elements:{messagelink:`<span id="cookieconsent:desc" class="cc-message">${this.message} <a tabindex="0" class="cc-link" href="${this.learnMoreLink}" target="_blank" rel="noopener noreferrer nofollow">${this.learnMore}</a></span>`,dismiss:`<a tabindex="0" class="cc-btn cc-dismiss">${this.dismiss}</a>`}});let e=this.popup;if(e){e.setAttribute(`role`,`alert`);let t=e.querySelector(`a.cc-btn`);t?.addEventListener(`keydown`,e=>{let n=e.keyCode||e.which;(n===32||n===13)&&t.click()})}}render(){return T`
+  `}};k([C()],K.prototype,`filter`,void 0),k([C()],K.prototype,`instant`,void 0),k([C()],K.prototype,`selectedConsumedRoute`,void 0),k([C()],K.prototype,`selectedRoute`,void 0),k([C()],K.prototype,`selectedUriPrefix`,void 0),k([C()],K.prototype,`selectedBaseUrl`,void 0),k([C()],K.prototype,`selectedServerSideType`,void 0),k([C()],K.prototype,`selectedParams`,void 0),k([C()],K.prototype,`tilesMenuOption`,void 0),k([C()],K.prototype,`railOpenOption`,void 0),k([C()],K.prototype,`commandPaletteOpen`,void 0),k([C()],K.prototype,`commandPaletteQuery`,void 0),k([C()],K.prototype,`commandPaletteSelectedIndex`,void 0),k([C()],K.prototype,`commandPaletteDataHits`,void 0),k([C()],K.prototype,`pageCompact`,void 0),k([x(`mateu-chat`)],K.prototype,`chat`,void 0),k([C()],K.prototype,`isDark`,void 0),k([C()],K.prototype,`chatOpen`,void 0),k([x(`.mateu-app-layout`)],K.prototype,`vaadinAppLayout`,void 0),K=no=k([g(`mateu-app`)],K);var ro=class extends b{constructor(...e){super(...e),this.message=`This website uses cookies.`,this.dismiss=`Ok. Thanks :).`,this.learnMore=`Learn more`,this.learnMoreLink=`https://cookiesandyou.com/`,this.showLearnMore=!0,this.position=`top`,this.cookieName=`mateu-cookieconsent`}updated(e){super.updated(e)}connectedCallback(){super.connectedCallback(),this._css=document.createElement(`style`),this._css.innerText=`.cc-window{opacity:1;transition:opacity 1s ease}.cc-window.cc-invisible{opacity:0}.cc-animate.cc-revoke{transition:transform 1s ease}.cc-animate.cc-revoke.cc-top{transform:translateY(-2em)}.cc-animate.cc-revoke.cc-bottom{transform:translateY(2em)}.cc-animate.cc-revoke.cc-active.cc-bottom,.cc-animate.cc-revoke.cc-active.cc-top,.cc-revoke:hover{transform:translateY(0)}.cc-grower{max-height:0;overflow:hidden;transition:max-height 1s}.cc-link,.cc-revoke:hover{text-decoration:underline}.cc-revoke,.cc-window{position:fixed;overflow:hidden;box-sizing:border-box;font-family:Helvetica,Calibri,Arial,sans-serif;font-size:16px;line-height:1.5em;display:flex;flex-wrap:nowrap;z-index:9999}.cc-window.cc-static{position:static}.cc-window.cc-floating{padding:2em;max-width:24em;flex-direction:column}.cc-window.cc-banner{padding:1em 1.8em;width:100%;flex-direction:row}.cc-revoke{padding:.5em}.cc-header{font-size:18px;font-weight:700}.cc-btn,.cc-close,.cc-link,.cc-revoke{cursor:pointer}.cc-link{opacity:.8;display:inline-block;padding:.2em}.cc-link:hover{opacity:1}.cc-link:active,.cc-link:visited{color:initial}.cc-btn{display:block;padding:.4em .8em;font-size:.9em;font-weight:700;border-width:2px;border-style:solid;text-align:center;white-space:nowrap}.cc-banner .cc-btn:last-child{min-width:140px}.cc-highlight .cc-btn:first-child{background-color:transparent;border-color:transparent}.cc-highlight .cc-btn:first-child:focus,.cc-highlight .cc-btn:first-child:hover{background-color:transparent;text-decoration:underline}.cc-close{display:block;position:absolute;top:.5em;right:.5em;font-size:1.6em;opacity:.9;line-height:.75}.cc-close:focus,.cc-close:hover{opacity:1}.cc-revoke.cc-top{top:0;left:3em;border-bottom-left-radius:.5em;border-bottom-right-radius:.5em}.cc-revoke.cc-bottom{bottom:0;left:3em;border-top-left-radius:.5em;border-top-right-radius:.5em}.cc-revoke.cc-left{left:3em;right:unset}.cc-revoke.cc-right{right:3em;left:unset}.cc-top{top:1em}.cc-left{left:1em}.cc-right{right:1em}.cc-bottom{bottom:1em}.cc-floating>.cc-link{margin-bottom:1em}.cc-floating .cc-message{display:block;margin-bottom:1em}.cc-window.cc-floating .cc-compliance{flex:1 0 auto}.cc-window.cc-banner{align-items:center}.cc-banner.cc-top{left:0;right:0;top:0}.cc-banner.cc-bottom{left:0;right:0;bottom:0}.cc-banner .cc-message{flex:1}.cc-compliance{display:flex;align-items:center;align-content:space-between}.cc-compliance>.cc-btn{flex:1}.cc-btn+.cc-btn{margin-left:.5em}@media print{.cc-revoke,.cc-window{display:none}}@media screen and (max-width:900px){.cc-btn{white-space:normal}}@media screen and (max-width:414px) and (orientation:portrait),screen and (max-width:736px) and (orientation:landscape){.cc-window.cc-top{top:0}.cc-window.cc-bottom{bottom:0}.cc-window.cc-banner,.cc-window.cc-left,.cc-window.cc-right{left:0;right:0}.cc-window.cc-banner{flex-direction:column}.cc-window.cc-banner .cc-compliance{flex:1}.cc-window.cc-floating{max-width:none}.cc-window .cc-message{margin-bottom:1em}.cc-window.cc-banner{align-items:unset}}.cc-floating.cc-theme-classic{padding:1.2em;border-radius:5px}.cc-floating.cc-type-info.cc-theme-classic .cc-compliance{text-align:center;display:inline;flex:none}.cc-theme-classic .cc-btn{border-radius:5px}.cc-theme-classic .cc-btn:last-child{min-width:140px}.cc-floating.cc-type-info.cc-theme-classic .cc-btn{display:inline-block}.cc-theme-edgeless.cc-window{padding:0}.cc-floating.cc-theme-edgeless .cc-message{margin:2em 2em 1.5em}.cc-banner.cc-theme-edgeless .cc-btn{margin:0;padding:.8em 1.8em;height:100%}.cc-banner.cc-theme-edgeless .cc-message{margin-left:1em}.cc-floating.cc-theme-edgeless .cc-btn+.cc-btn{margin-left:0}`,document.head.appendChild(this._css),this.__updatePopup()}disconnectedCallback(){super.disconnectedCallback(),this.__closePopup(),this._css.isConnected&&this._css.remove()}__closePopup(){let e=this.popup;e&&e.parentNode?.removeChild(e)}_show(){let e=this.popup;e&&(e.classList.remove(`cc-invisible`),e.style.display=``)}__updatePopup(){this.__closePopup(),window.cookieconsent.initialise({palette:{popup:{background:`#000`},button:{background:`rgba(22, 118, 243, 0.95)`,hover:`rgba(22, 118, 243, 1)`}},showLink:this.showLearnMore,content:{message:this.message,dismiss:this.dismiss,link:this.learnMore,href:this.learnMoreLink},cookie:{name:this.cookieName},position:this.position,elements:{messagelink:`<span id="cookieconsent:desc" class="cc-message">${this.message} <a tabindex="0" class="cc-link" href="${this.learnMoreLink}" target="_blank" rel="noopener noreferrer nofollow">${this.learnMore}</a></span>`,dismiss:`<a tabindex="0" class="cc-btn cc-dismiss">${this.dismiss}</a>`}});let e=this.popup;if(e){e.setAttribute(`role`,`alert`);let t=e.querySelector(`a.cc-btn`);t?.addEventListener(`keydown`,e=>{let n=e.keyCode||e.which;(n===32||n===13)&&t.click()})}}render(){return T`
        `}static{this.styles=h`
-  `}};k([y()],no.prototype,`message`,void 0),k([y()],no.prototype,`dismiss`,void 0),k([y()],no.prototype,`learnMore`,void 0),k([y()],no.prototype,`learnMoreLink`,void 0),k([y()],no.prototype,`showLearnMore`,void 0),k([y()],no.prototype,`position`,void 0),k([y()],no.prototype,`cookieName`,void 0),k([C()],no.prototype,`_css`,void 0),k([x(`[aria-label="cookieconsent"]`)],no.prototype,`popup`,void 0),no=k([g(`mateu-cookie-consent`)],no);var ro=class extends b{constructor(...e){super(...e),this.redispatchEvent=e=>{e instanceof CustomEvent&&(e.stopPropagation(),e.preventDefault(),this.target?.dispatchEvent(new CustomEvent(e.type,{detail:e.detail,bubbles:!0,composed:!0})))}}connectedCallback(){super.connectedCallback(),this.addEventListener(`value-changed`,this.redispatchEvent),this.addEventListener(`data-changed`,this.redispatchEvent),this.addEventListener(`action-requested`,this.redispatchEvent),this.addEventListener(`server-side-action-requested`,this.redispatchEvent),this.addEventListener(`route-changed`,this.redispatchEvent),this.addEventListener(`close-modal-requested`,this.redispatchEvent)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`value-changed`,this.redispatchEvent),this.removeEventListener(`data-changed`,this.redispatchEvent),this.removeEventListener(`action-requested`,this.redispatchEvent),this.removeEventListener(`server-side-action-requested`,this.redispatchEvent),this.removeEventListener(`route-changed`,this.redispatchEvent)}render(){return T`<slot></slot>`}static{this.styles=h`
+  `}};k([y()],ro.prototype,`message`,void 0),k([y()],ro.prototype,`dismiss`,void 0),k([y()],ro.prototype,`learnMore`,void 0),k([y()],ro.prototype,`learnMoreLink`,void 0),k([y()],ro.prototype,`showLearnMore`,void 0),k([y()],ro.prototype,`position`,void 0),k([y()],ro.prototype,`cookieName`,void 0),k([C()],ro.prototype,`_css`,void 0),k([x(`[aria-label="cookieconsent"]`)],ro.prototype,`popup`,void 0),ro=k([g(`mateu-cookie-consent`)],ro);var io=class extends b{constructor(...e){super(...e),this.redispatchEvent=e=>{e instanceof CustomEvent&&(e.stopPropagation(),e.preventDefault(),this.target?.dispatchEvent(new CustomEvent(e.type,{detail:e.detail,bubbles:!0,composed:!0})))}}connectedCallback(){super.connectedCallback(),this.addEventListener(`value-changed`,this.redispatchEvent),this.addEventListener(`data-changed`,this.redispatchEvent),this.addEventListener(`action-requested`,this.redispatchEvent),this.addEventListener(`server-side-action-requested`,this.redispatchEvent),this.addEventListener(`route-changed`,this.redispatchEvent),this.addEventListener(`close-modal-requested`,this.redispatchEvent)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`value-changed`,this.redispatchEvent),this.removeEventListener(`data-changed`,this.redispatchEvent),this.removeEventListener(`action-requested`,this.redispatchEvent),this.removeEventListener(`server-side-action-requested`,this.redispatchEvent),this.removeEventListener(`route-changed`,this.redispatchEvent)}render(){return T`<slot></slot>`}static{this.styles=h`
         :host {
             /* width: 100%; */
             display: inline-block;
         }
-  `}};k([y()],ro.prototype,`target`,void 0),ro=k([g(`mateu-event-interceptor`)],ro);var io=[`a[href]`,`button`,`input`,`select`,`textarea`,`[tabindex]`,`vaadin-button`,`vaadin-text-field`,`vaadin-combo-box`,`vaadin-select`,`vaadin-checkbox`,`vaadin-date-picker`,`ui5-button`,`oj-c-button`].join(`,`),ao=e=>{let t=e;return t.hidden||t.hasAttribute(`disabled`)||t.getAttribute(`aria-hidden`)===`true`||t.getAttribute(`tabindex`)===`-1`?!1:!!(t.offsetParent||t.getClientRects().length)},oo=e=>{let t=[],n=e=>{e.querySelectorAll(`*`).forEach(e=>{e.matches(io)&&ao(e)&&t.push(e),e.shadowRoot&&n(e.shadowRoot),e instanceof HTMLSlotElement&&e.assignedElements().forEach(e=>{e.matches(io)&&ao(e)&&t.push(e),n(e)})})};return n(e),t.filter((e,n)=>t.indexOf(e)===n)},so=(e,t={})=>{let n=co(),r=[],i=()=>{r=oo(e)},a=t=>{if(t.key!==`Tab`)return;if(i(),r.length===0){t.preventDefault(),e.focus();return}let n=r[0],a=r[r.length-1],o=co();t.shiftKey&&(o===n||!o||!lo(o,e))?(t.preventDefault(),a.focus()):!t.shiftKey&&o===a&&(t.preventDefault(),n.focus())};return e.addEventListener(`keydown`,a),requestAnimationFrame(()=>{i();let n=t.initialFocus?.()??r[0];n?n.focus():(e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus())}),{refresh:i,release(){e.removeEventListener(`keydown`,a);let t=co();(!t||t===document.body||lo(t,e))&&n?.focus?.()}}},co=()=>{let e=document.activeElement;for(;e?.shadowRoot?.activeElement;)e=e.shadowRoot.activeElement;return e},lo=(e,t)=>{let n=e;for(;n;){if(n===t)return!0;n=n.parentNode??n.host??null}return!1},uo=class extends Ua{constructor(...e){super(...e),this.opened=!0,this.close=()=>{this.opened=!1,this.releaseFocusTrap(),setTimeout(()=>{this.removeSelfFromOwnerChildren()||this.parentElement?.removeChild(this)},500)},this.onKeydown=e=>{e.key===`Escape`&&this.opened&&(e.stopPropagation(),this.close())}}connectedCallback(){super.connectedCallback(),this.addEventListener(`keydown`,this.onKeydown)}disconnectedCallback(){super.disconnectedCallback(),this.releaseFocusTrap()}releaseFocusTrap(){this.focusTrap?.release(),this.focusTrap=void 0}applyFragment(e){super.applyFragment(e);let t=e.state?._closeAfterMillis;t&&setTimeout(()=>this.close(),t)}updated(e){if(super.updated(e),e.has(`component`)&&this.component){let e=this.component.metadata;this.state=e.initialData}let t=this.renderRoot.querySelector(`[role="dialog"]`),n=this.component?.metadata?.modeless;this.opened&&t&&!this.focusTrap&&!n?this.focusTrap=so(t):this.focusTrap&&this.opened&&this.focusTrap.refresh()}render(){if(!this.opened)return T``;let e=this.component.metadata,t=xt(e.headerTitle,this.state,this.data,this.appState,this.appData),n=!!(t||e.header||e.closeButtonOnHeader),r=[e.width?`width:${e.width};`:`min-width:min(90vw,28rem);`,e.height?`height:${e.height};`:``,e.top?`margin-top:${e.top};`:``].join(``);return T`
+  `}};k([y()],io.prototype,`target`,void 0),io=k([g(`mateu-event-interceptor`)],io);var ao=[`a[href]`,`button`,`input`,`select`,`textarea`,`[tabindex]`,`vaadin-button`,`vaadin-text-field`,`vaadin-combo-box`,`vaadin-select`,`vaadin-checkbox`,`vaadin-date-picker`,`ui5-button`,`oj-c-button`].join(`,`),oo=e=>{let t=e;return t.hidden||t.hasAttribute(`disabled`)||t.getAttribute(`aria-hidden`)===`true`||t.getAttribute(`tabindex`)===`-1`?!1:!!(t.offsetParent||t.getClientRects().length)},so=e=>{let t=[],n=e=>{e.querySelectorAll(`*`).forEach(e=>{e.matches(ao)&&oo(e)&&t.push(e),e.shadowRoot&&n(e.shadowRoot),e instanceof HTMLSlotElement&&e.assignedElements().forEach(e=>{e.matches(ao)&&oo(e)&&t.push(e),n(e)})})};return n(e),t.filter((e,n)=>t.indexOf(e)===n)},co=(e,t={})=>{let n=lo(),r=[],i=()=>{r=so(e)},a=t=>{if(t.key!==`Tab`)return;if(i(),r.length===0){t.preventDefault(),e.focus();return}let n=r[0],a=r[r.length-1],o=lo();t.shiftKey&&(o===n||!o||!uo(o,e))?(t.preventDefault(),a.focus()):!t.shiftKey&&o===a&&(t.preventDefault(),n.focus())};return e.addEventListener(`keydown`,a),requestAnimationFrame(()=>{i();let n=t.initialFocus?.()??r[0];n?n.focus():(e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus())}),{refresh:i,release(){e.removeEventListener(`keydown`,a);let t=lo();(!t||t===document.body||uo(t,e))&&n?.focus?.()}}},lo=()=>{let e=document.activeElement;for(;e?.shadowRoot?.activeElement;)e=e.shadowRoot.activeElement;return e},uo=(e,t)=>{let n=e;for(;n;){if(n===t)return!0;n=n.parentNode??n.host??null}return!1},fo=class extends Wa{constructor(...e){super(...e),this.opened=!0,this.close=()=>{this.opened=!1,this.releaseFocusTrap(),setTimeout(()=>{this.removeSelfFromOwnerChildren()||this.parentElement?.removeChild(this)},500)},this.onKeydown=e=>{e.key===`Escape`&&this.opened&&(e.stopPropagation(),this.close())}}connectedCallback(){super.connectedCallback(),this.addEventListener(`keydown`,this.onKeydown)}disconnectedCallback(){super.disconnectedCallback(),this.releaseFocusTrap()}releaseFocusTrap(){this.focusTrap?.release(),this.focusTrap=void 0}applyFragment(e){super.applyFragment(e);let t=e.state?._closeAfterMillis;t&&setTimeout(()=>this.close(),t)}updated(e){if(super.updated(e),e.has(`component`)&&this.component){let e=this.component.metadata;this.state=e.initialData}let t=this.renderRoot.querySelector(`[role="dialog"]`),n=this.component?.metadata?.modeless;this.opened&&t&&!this.focusTrap&&!n?this.focusTrap=co(t):this.focusTrap&&this.opened&&this.focusTrap.refresh()}render(){if(!this.opened)return T``;let e=this.component.metadata,t=xt(e.headerTitle,this.state,this.data,this.appState,this.appData),n=!!(t||e.header||e.closeButtonOnHeader),r=[e.width?`width:${e.width};`:`min-width:min(90vw,28rem);`,e.height?`height:${e.height};`:``,e.top?`margin-top:${e.top};`:``].join(``);return T`
             <div class="backdrop ${e.modeless?`modeless`:``}"
                  @click="${t=>{!e.modeless&&t.target===t.currentTarget&&this.close()}}">
                 <div class="dialog ${e.noPadding?`no-padding`:``} ${this.component?.cssClasses??``}"
@@ -5611,20 +5619,20 @@ ${i}
                         <div class="dialog-header">
                             <mateu-event-interceptor .target="${this}" style="flex:1; min-width:0;">
                                 ${t?T`<span class="dialog-title">${t}</span>`:v}
-                                ${e.header?I(this,e.header,this.baseUrl,this.state,this.data,this.appState,this.appData):v}
+                                ${e.header?F(this,e.header,this.baseUrl,this.state,this.data,this.appState,this.appData):v}
                             </mateu-event-interceptor>
                             ${e.closeButtonOnHeader?T`<button class="dialog-close" @click="${this.close}" aria-label="Close">✕</button>`:v}
                         </div>`:v}
                     ${e.content?T`
                         <div class="dialog-body">
                             <mateu-event-interceptor .target="${this}" style="--mateu-section-border: none; width:100%;">
-                                ${I(this,e.content,this.baseUrl,this.state,this.data,this.appState,this.appData)}
+                                ${F(this,e.content,this.baseUrl,this.state,this.data,this.appState,this.appData)}
                             </mateu-event-interceptor>
                         </div>`:v}
                     ${e.footer?T`
                         <div class="dialog-footer">
                             <mateu-event-interceptor .target="${this}" style="width:100%;">
-                                ${I(this,e.footer,this.baseUrl,this.state,this.data,this.appState,this.appData)}
+                                ${F(this,e.footer,this.baseUrl,this.state,this.data,this.appState,this.appData)}
                             </mateu-event-interceptor>
                         </div>`:v}
                 </div>
@@ -5654,7 +5662,7 @@ ${i}
         .dialog-body { padding: .5rem 1.2rem; flex: 1; }
         .dialog.no-padding .dialog-body { padding: 0; }
         .dialog-footer { padding: .5rem 1.2rem 1rem; display: flex; justify-content: flex-end; gap: .5rem; }
-    `}};k([C()],uo.prototype,`opened`,void 0),uo=k([g(`mateu-dialog`)],uo);var fo,po=class extends Ua{static{fo=this}constructor(...e){super(...e),this.opened=!1,this.maximizeSteps=0,this.collapsed=!1,this.pagerMenuOpen=!1,this.onGuidedProgress=e=>{let t=e.detail;t&&t.total>0&&(this.guidedProgress=t)},this.close=()=>{this.opened=!1,this.releaseLayoutInset(),this.releaseFocusTrap(),setTimeout(()=>{this.removeSelfFromOwnerChildren()||this.parentElement?.removeChild(this)},300)},this._escListener=e=>{if(e.key!==`Escape`)return;let t=this.getRootNode().querySelectorAll(`mateu-drawer, mateu-dialog`);t[t.length-1]===this&&(e.stopPropagation(),this.close())}}jumpToStep(e){this.pagerMenuOpen=!1,e&&(this.renderRoot.querySelector(`.content mateu-component`)??this.renderRoot.querySelector(`mateu-component`))?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`goToStep`,parameters:{_stepId:e}},bubbles:!0,composed:!0}))}static{this.SIZE_LADDER=[`s`,`m`,`l`,`xl`]}static{this.SIZE_WIDTHS={s:`464px`,m:`648px`,l:`968px`,xl:`90vw`}}effectiveWidth(e){if(e.width)return e.width;if(!e.size)return;let t=fo.SIZE_LADDER,n=Math.max(0,t.indexOf(e.size)),r=Math.min(t.length-1,n+this.maximizeSteps);return fo.SIZE_WIDTHS[t[r]]}canMaximize(e){if(!e.maximizable)return!1;let t=fo.SIZE_LADDER;return Math.max(0,t.indexOf(e.size??`m`))+this.maximizeSteps<t.length-1}firstUpdated(){requestAnimationFrame(()=>this.opened=!0),this.addEventListener(`mateu-guided-progress`,this.onGuidedProgress);let e=this.component?.metadata;e&&requestAnimationFrame(()=>this.applyLayoutInset(e))}releaseFocusTrap(){this.focusTrap?.release(),this.focusTrap=void 0}applyLayoutInset(e){if(!e.layout)return;let t=document.querySelector(`mateu-ui`);if(!t)return;let n=e.position??`end`,r=n===`bottom`?`var(--mateu-drawer-height, 50vh)`:this.effectiveWidth(e)??`648px`;this._insetProp=n===`start`?`paddingLeft`:n===`bottom`?`paddingBottom`:`paddingRight`,t.style.transition=`padding .25s ease`,t.style[this._insetProp]=r}releaseLayoutInset(){if(!this._insetProp)return;let e=document.querySelector(`mateu-ui`);e&&(e.style[this._insetProp]=``),this._insetProp=void 0}applyFragment(e){super.applyFragment(e);let t=e.state?._closeAfterMillis;t&&setTimeout(()=>this.close(),t)}updated(e){if(super.updated(e),e.has(`component`)&&this.component){let e=this.component.metadata;this.state=e.initialData}let t=this.component?.metadata,n=this.renderRoot.querySelector(`[role="dialog"]`);this.opened&&n&&!t?.modeless&&!t?.layout&&!this.focusTrap?this.focusTrap=so(n):this.focusTrap&&this.opened&&this.focusTrap.refresh()}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._escListener)}disconnectedCallback(){document.removeEventListener(`keydown`,this._escListener),this.releaseLayoutInset(),this.releaseFocusTrap(),super.disconnectedCallback()}render(){let e=this.component.metadata,t=e.position??`end`,n=xt(e.headerTitle,this.state,this.data,this.appState,this.appData),r=xt(e.subtitle,this.state,this.data,this.appState,this.appData),i=this.effectiveWidth(e),a=e.peerNav&&(e.peerNav.prevRoute||e.peerNav.nextRoute)?e.peerNav:void 0;return T`
+    `}};k([C()],fo.prototype,`opened`,void 0),fo=k([g(`mateu-dialog`)],fo);var po,mo=class extends Wa{static{po=this}constructor(...e){super(...e),this.opened=!1,this.maximizeSteps=0,this.collapsed=!1,this.pagerMenuOpen=!1,this.onGuidedProgress=e=>{let t=e.detail;t&&t.total>0&&(this.guidedProgress=t)},this.close=()=>{this.opened=!1,this.releaseLayoutInset(),this.releaseFocusTrap(),setTimeout(()=>{this.removeSelfFromOwnerChildren()||this.parentElement?.removeChild(this)},300)},this._escListener=e=>{if(e.key!==`Escape`)return;let t=this.getRootNode().querySelectorAll(`mateu-drawer, mateu-dialog`);t[t.length-1]===this&&(e.stopPropagation(),this.close())}}jumpToStep(e){this.pagerMenuOpen=!1,e&&(this.renderRoot.querySelector(`.content mateu-component`)??this.renderRoot.querySelector(`mateu-component`))?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`goToStep`,parameters:{_stepId:e}},bubbles:!0,composed:!0}))}static{this.SIZE_LADDER=[`s`,`m`,`l`,`xl`]}static{this.SIZE_WIDTHS={s:`464px`,m:`648px`,l:`968px`,xl:`90vw`}}effectiveWidth(e){if(e.width)return e.width;if(!e.size)return;let t=po.SIZE_LADDER,n=Math.max(0,t.indexOf(e.size)),r=Math.min(t.length-1,n+this.maximizeSteps);return po.SIZE_WIDTHS[t[r]]}canMaximize(e){if(!e.maximizable)return!1;let t=po.SIZE_LADDER;return Math.max(0,t.indexOf(e.size??`m`))+this.maximizeSteps<t.length-1}firstUpdated(){requestAnimationFrame(()=>this.opened=!0),this.addEventListener(`mateu-guided-progress`,this.onGuidedProgress);let e=this.component?.metadata;e&&requestAnimationFrame(()=>this.applyLayoutInset(e))}releaseFocusTrap(){this.focusTrap?.release(),this.focusTrap=void 0}applyLayoutInset(e){if(!e.layout)return;let t=document.querySelector(`mateu-ui`);if(!t)return;let n=e.position??`end`,r=n===`bottom`?`var(--mateu-drawer-height, 50vh)`:this.effectiveWidth(e)??`648px`;this._insetProp=n===`start`?`paddingLeft`:n===`bottom`?`paddingBottom`:`paddingRight`,t.style.transition=`padding .25s ease`,t.style[this._insetProp]=r}releaseLayoutInset(){if(!this._insetProp)return;let e=document.querySelector(`mateu-ui`);e&&(e.style[this._insetProp]=``),this._insetProp=void 0}applyFragment(e){super.applyFragment(e);let t=e.state?._closeAfterMillis;t&&setTimeout(()=>this.close(),t)}updated(e){if(super.updated(e),e.has(`component`)&&this.component){let e=this.component.metadata;this.state=e.initialData}let t=this.component?.metadata,n=this.renderRoot.querySelector(`[role="dialog"]`);this.opened&&n&&!t?.modeless&&!t?.layout&&!this.focusTrap?this.focusTrap=co(n):this.focusTrap&&this.opened&&this.focusTrap.refresh()}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._escListener)}disconnectedCallback(){document.removeEventListener(`keydown`,this._escListener),this.releaseLayoutInset(),this.releaseFocusTrap(),super.disconnectedCallback()}render(){let e=this.component.metadata,t=e.position??`end`,n=xt(e.headerTitle,this.state,this.data,this.appState,this.appData),r=xt(e.subtitle,this.state,this.data,this.appState,this.appData),i=this.effectiveWidth(e),a=e.peerNav&&(e.peerNav.prevRoute||e.peerNav.nextRoute)?e.peerNav:void 0;return T`
         ${e.modeless||e.layout?v:T`
             <div class="backdrop ${this.opened?`open`:``}" @click="${this.close}"></div>
         `}
@@ -5683,7 +5691,7 @@ ${i}
                     </div>
                 `:v}
                 ${e.header?T`
-                    <mateu-event-interceptor .target="${this}">${I(this,e.header,this.baseUrl,this.state,this.data,this.appState,this.appData)}</mateu-event-interceptor>
+                    <mateu-event-interceptor .target="${this}">${F(this,e.header,this.baseUrl,this.state,this.data,this.appState,this.appData)}</mateu-event-interceptor>
                 `:v}
                 ${a?T`
                     <button class="drawer-icon" aria-label="${a.prevLabel??`Previous`}" title="${a.prevLabel??`Previous`}"
@@ -5703,12 +5711,12 @@ ${i}
             ${this.collapsed?v:T`
             <div class="content ${e.noPadding?`no-padding`:``}">
                 ${e.content?T`
-                    <mateu-event-interceptor .target="${this}" style="--mateu-section-border: none; width: 100%;">${I(this,e.content,this.baseUrl,this.state,this.data,this.appState,this.appData)}</mateu-event-interceptor>
+                    <mateu-event-interceptor .target="${this}" style="--mateu-section-border: none; width: 100%;">${F(this,e.content,this.baseUrl,this.state,this.data,this.appState,this.appData)}</mateu-event-interceptor>
                 `:v}
             </div>
             ${e.footer?T`
                 <footer>
-                    <mateu-event-interceptor .target="${this}" style="width: 100%;">${I(this,e.footer,this.baseUrl,this.state,this.data,this.appState,this.appData)}</mateu-event-interceptor>
+                    <mateu-event-interceptor .target="${this}" style="width: 100%;">${F(this,e.footer,this.baseUrl,this.state,this.data,this.appState,this.appData)}</mateu-event-interceptor>
                 </footer>
             `:v}
             `}
@@ -5932,7 +5940,7 @@ ${i}
             display: flex;
             justify-content: flex-end;
         }
-  `}};k([C()],po.prototype,`opened`,void 0),k([C()],po.prototype,`maximizeSteps`,void 0),k([C()],po.prototype,`collapsed`,void 0),k([C()],po.prototype,`guidedProgress`,void 0),k([C()],po.prototype,`pagerMenuOpen`,void 0),po=fo=k([g(`mateu-drawer`)],po);function mo(e){if(e.parentElement)return e.parentElement;let t=e.getRootNode();return t instanceof ShadowRoot?t.host:null}var J=class extends b{constructor(...e){super(...e),this.appState={},this.appData={},this.standalone=!1,this.actionBanners=[],this.dismissedStaticBannerIndices=new Set,this._tocEntries=[],this._activeToc=0,this._tocVisible=!1,this._tocRebuildScheduled=!1,this._headerH=0,this._onResize=()=>this._layoutStickyTops(),this._tocLocked=!1,this._unlockToc=e=>{if(e&&e.type===`keydown`){let t=e;if(t.ctrlKey&&t.altKey&&!t.shiftKey&&!t.metaKey&&/^(?:Digit|Numpad)[1-9]$/.test(t.code))return}this._tocLocked=!1},this._actionBannerTimers=[],this._staticBannerTimers=[],this._bannersHandler=e=>{let t=e.detail,n=t.banners??[],r=t.append??!1;r?this.actionBanners=[...this.actionBanners,...n]:(this._clearActionBannerTimers(),this.actionBanners=n);let i=r?this.actionBanners.length-n.length:0;n.forEach((e,t)=>{if(e.timeoutSeconds&&e.timeoutSeconds>0){let n=i+t;this._actionBannerTimers.push(setTimeout(()=>{this.actionBanners=this.actionBanners.filter((e,t)=>t!==n)},e.timeoutSeconds*1e3))}})},this._onTocKey=e=>{if(!this._tocVisible||!e.ctrlKey||!e.altKey||e.shiftKey||e.metaKey)return;let t=/^(?:Digit|Numpad)([1-9])$/.exec(e.code);if(!t)return;let n=parseInt(t[1],10)-1;n>=this._tocEntries.length||(e.preventDefault(),this._scrollToSection(n))},this._onScrollSpy=()=>{if(this._tocLocked)return;let e=this._sectionCards();if(!e.length)return;let t=this.shadowRoot?.querySelector(`mateu-content-header`),n=t?t.getBoundingClientRect().bottom:0;for(let t of e){if(!t.classList.contains(`mateu-section--sticky`))continue;let e=t.getBoundingClientRect();e.top<=n+12+2&&(n=Math.max(n,e.bottom))}let r=n+12+4,i=0;this._tocEntries.forEach((e,t)=>{e.el.getBoundingClientRect().top<=r&&(i=t)}),this._activeToc=i}}connectedCallback(){super.connectedCallback(),document.addEventListener(`page-banners-received`,this._bannersHandler),window.addEventListener(`resize`,this._onResize),document.addEventListener(`keydown`,this._onTocKey)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`page-banners-received`,this._bannersHandler),window.removeEventListener(`resize`,this._onResize),document.removeEventListener(`keydown`,this._onTocKey),this._clearAllTimers(),this._teardownScrollSpy()}updated(e){if(super.updated(e),e.has(`component`)&&e.get(`component`)!==void 0&&(this._clearAllTimers(),this.actionBanners=[],this.dismissedStaticBannerIndices=new Set),e.has(`component`)){let e=this.component?.metadata?.level??0;this.toggleAttribute(`data-nested`,e>0),this._scheduleStaticBannerTimeouts();let t=this.component?.metadata?.pageWidth===`edgeToEdge`;this.toggleAttribute(`data-edge`,t),this.dispatchEvent(new CustomEvent(`compact-changed`,{detail:{compact:!!this.component?.style?.includes(`--mateu-compact:1`)||t},bubbles:!0,composed:!0})),this._scheduleTocRebuild()}}_scheduleStaticBannerTimeouts(){this._staticBannerTimers.forEach(e=>clearTimeout(e)),this._staticBannerTimers=[],(this.component?.metadata?.banners??[]).forEach((e,t)=>{e.timeoutSeconds&&e.timeoutSeconds>0&&this._staticBannerTimers.push(setTimeout(()=>{this.dismissedStaticBannerIndices=new Set([...this.dismissedStaticBannerIndices,t])},e.timeoutSeconds*1e3))})}_clearActionBannerTimers(){this._actionBannerTimers.forEach(e=>clearTimeout(e)),this._actionBannerTimers=[]}_clearAllTimers(){this._clearActionBannerTimers(),this._staticBannerTimers.forEach(e=>clearTimeout(e)),this._staticBannerTimers=[]}_dismissActionBanner(e){this.actionBanners=this.actionBanners.filter((t,n)=>n!==e)}_dismissStaticBanner(e){this.dismissedStaticBannerIndices=new Set([...this.dismissedStaticBannerIndices,e])}bannerThemeClass(e){let t=e.theme?.toLowerCase()??`info`;return t===`none`?``:t}_evalBannerText(e){return M(e,this.state,this.data)}_renderBanner(e,t){let n=this._evalBannerText(e.title),r=this._evalBannerText(e.description);return T`
+  `}};k([C()],mo.prototype,`opened`,void 0),k([C()],mo.prototype,`maximizeSteps`,void 0),k([C()],mo.prototype,`collapsed`,void 0),k([C()],mo.prototype,`guidedProgress`,void 0),k([C()],mo.prototype,`pagerMenuOpen`,void 0),mo=po=k([g(`mateu-drawer`)],mo);function ho(e){if(e.parentElement)return e.parentElement;let t=e.getRootNode();return t instanceof ShadowRoot?t.host:null}var q=class extends b{constructor(...e){super(...e),this.appState={},this.appData={},this.standalone=!1,this.actionBanners=[],this.dismissedStaticBannerIndices=new Set,this._tocEntries=[],this._activeToc=0,this._tocVisible=!1,this._tocRebuildScheduled=!1,this._headerH=0,this._onResize=()=>this._layoutStickyTops(),this._tocLocked=!1,this._unlockToc=e=>{if(e&&e.type===`keydown`){let t=e;if(t.ctrlKey&&t.altKey&&!t.shiftKey&&!t.metaKey&&/^(?:Digit|Numpad)[1-9]$/.test(t.code))return}this._tocLocked=!1},this._actionBannerTimers=[],this._staticBannerTimers=[],this._bannersHandler=e=>{let t=e.detail,n=t.banners??[],r=t.append??!1;r?this.actionBanners=[...this.actionBanners,...n]:(this._clearActionBannerTimers(),this.actionBanners=n);let i=r?this.actionBanners.length-n.length:0;n.forEach((e,t)=>{if(e.timeoutSeconds&&e.timeoutSeconds>0){let n=i+t;this._actionBannerTimers.push(setTimeout(()=>{this.actionBanners=this.actionBanners.filter((e,t)=>t!==n)},e.timeoutSeconds*1e3))}})},this._onTocKey=e=>{if(!this._tocVisible||!e.ctrlKey||!e.altKey||e.shiftKey||e.metaKey)return;let t=/^(?:Digit|Numpad)([1-9])$/.exec(e.code);if(!t)return;let n=parseInt(t[1],10)-1;n>=this._tocEntries.length||(e.preventDefault(),this._scrollToSection(n))},this._onScrollSpy=()=>{if(this._tocLocked)return;let e=this._sectionCards();if(!e.length)return;let t=this.shadowRoot?.querySelector(`mateu-content-header`),n=t?t.getBoundingClientRect().bottom:0;for(let t of e){if(!t.classList.contains(`mateu-section--sticky`))continue;let e=t.getBoundingClientRect();e.top<=n+12+2&&(n=Math.max(n,e.bottom))}let r=n+12+4,i=0;this._tocEntries.forEach((e,t)=>{e.el.getBoundingClientRect().top<=r&&(i=t)}),this._activeToc=i}}connectedCallback(){super.connectedCallback(),document.addEventListener(`page-banners-received`,this._bannersHandler),window.addEventListener(`resize`,this._onResize),document.addEventListener(`keydown`,this._onTocKey)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`page-banners-received`,this._bannersHandler),window.removeEventListener(`resize`,this._onResize),document.removeEventListener(`keydown`,this._onTocKey),this._clearAllTimers(),this._teardownScrollSpy()}updated(e){if(super.updated(e),e.has(`component`)&&e.get(`component`)!==void 0&&(this._clearAllTimers(),this.actionBanners=[],this.dismissedStaticBannerIndices=new Set),e.has(`component`)){let e=this.component?.metadata?.level??0;this.toggleAttribute(`data-nested`,e>0),this._scheduleStaticBannerTimeouts();let t=this.component?.metadata?.pageWidth===`edgeToEdge`;this.toggleAttribute(`data-edge`,t),this.dispatchEvent(new CustomEvent(`compact-changed`,{detail:{compact:!!this.component?.style?.includes(`--mateu-compact:1`)||t},bubbles:!0,composed:!0})),this._scheduleTocRebuild()}}_scheduleStaticBannerTimeouts(){this._staticBannerTimers.forEach(e=>clearTimeout(e)),this._staticBannerTimers=[],(this.component?.metadata?.banners??[]).forEach((e,t)=>{e.timeoutSeconds&&e.timeoutSeconds>0&&this._staticBannerTimers.push(setTimeout(()=>{this.dismissedStaticBannerIndices=new Set([...this.dismissedStaticBannerIndices,t])},e.timeoutSeconds*1e3))})}_clearActionBannerTimers(){this._actionBannerTimers.forEach(e=>clearTimeout(e)),this._actionBannerTimers=[]}_clearAllTimers(){this._clearActionBannerTimers(),this._staticBannerTimers.forEach(e=>clearTimeout(e)),this._staticBannerTimers=[]}_dismissActionBanner(e){this.actionBanners=this.actionBanners.filter((t,n)=>n!==e)}_dismissStaticBanner(e){this.dismissedStaticBannerIndices=new Set([...this.dismissedStaticBannerIndices,e])}bannerThemeClass(e){let t=e.theme?.toLowerCase()??`info`;return t===`none`?``:t}_evalBannerText(e){return M(e,this.state,this.data)}_renderBanner(e,t){let n=this._evalBannerText(e.title),r=this._evalBannerText(e.description);return T`
             <div class="page-banner page-banner--${this.bannerThemeClass(e)}">
                 ${n||e.hasCloseButton?T`
                     <div style="display: flex; align-items: center; justify-content: space-between; color: #1a1a1a; width: 100%;">
@@ -5944,7 +5952,7 @@ ${i}
                 `:v}
                 ${r?T`<p>${r}</p>`:v}
             </div>
-        `}_onSlotChange(){this._scheduleTocRebuild()}_scheduleTocRebuild(){this._tocRebuildScheduled||(this._tocRebuildScheduled=!0,requestAnimationFrame(()=>{this._tocRebuildScheduled=!1,this._rebuildToc()}))}_sectionCards(){return Array.from(this.querySelectorAll(`.mateu-section`))}_sectionTitle(e){return e.querySelector(`[slot="title"]`)?.textContent?.trim()||e.querySelector(`h1,h2,h3,h4,h5,h6`)?.textContent?.trim()||void 0}_rebuildToc(){let e=this._sectionCards(),t=e.map(e=>({title:this._sectionTitle(e),el:e})).filter(e=>!!e.title),n=this.component?.metadata?.toc,r=t.length>4&&e.every(e=>!e.closest(`vaadin-horizontal-layout`)),i=(n===!0||n!==!1&&r)&&t.length>0;this._tocEntries=t,this._tocVisible=i,this._activeToc>=t.length&&(this._activeToc=0),this._teardownScrollSpy(),i?requestAnimationFrame(()=>{this._layoutStickyTops(),this._setupScrollSpy()}):this._layoutStickyTops()}_layoutStickyTops(){let e=this.shadowRoot?.querySelector(`mateu-content-header`);this._headerH=this._tocVisible&&e?e.offsetHeight:0,this.style.setProperty(`--mateu-header-h`,this._headerH+`px`);let t=this._headerH+12;for(let e of this._sectionCards())e.classList.contains(`mateu-section--sticky`)&&(e.style.top=t+`px`,t+=e.offsetHeight+12)}_scrollContainer(){let e=mo(this);for(;e;){let t=getComputedStyle(e).overflowY;if((t===`auto`||t===`scroll`)&&e.scrollHeight>e.clientHeight)return e;e=mo(e)}return null}_setupScrollSpy(){this._tocEntries.length&&(this._spyTarget=this._scrollContainer()??window,this._spyTarget.addEventListener(`scroll`,this._onScrollSpy,{passive:!0}),window.addEventListener(`wheel`,this._unlockToc,{passive:!0}),window.addEventListener(`touchstart`,this._unlockToc,{passive:!0}),window.addEventListener(`keydown`,this._unlockToc),this._onScrollSpy())}_teardownScrollSpy(){this._spyTarget?.removeEventListener(`scroll`,this._onScrollSpy),window.removeEventListener(`wheel`,this._unlockToc),window.removeEventListener(`touchstart`,this._unlockToc),window.removeEventListener(`keydown`,this._unlockToc),this._spyTarget=void 0}_scrollToSection(e){let t=this._tocEntries[e];if(!t)return;this._activeToc=e,this._tocLocked=!0;let n=this._headerH+12;for(let e of this._sectionCards()){if(e===t.el)break;e.classList.contains(`mateu-section--sticky`)&&(n+=e.offsetHeight+12)}let r=this._scrollContainer(),i=r?r.getBoundingClientRect().top:0,a=t.el.getBoundingClientRect().top-i-n;(r??window).scrollBy({top:a,behavior:`smooth`})}_showHeaderBand(){let e=this.component?.metadata,t=!!(e?.title||e?.subtitle||e?.overline||e?.titlePlaceholder||e?.toolbar?.length),n=!!this.component?.children?.some(e=>e.metadata?.type===j.Crud);return t&&!n&&!this._hasWelcomeBanner()}_hasWelcomeBanner(){let e=t=>t?.metadata?.type===j.HeroSection||(t?.children??[]).some(e);return(this.component?.children??[]).some(e)}render(){let e=this.component?.metadata,t=[...(e?.banners??[]).map((e,t)=>({banner:e,index:t})).filter(({index:e})=>!this.dismissedStaticBannerIndices.has(e)).map(({banner:e,index:t})=>({banner:e,onDismiss:()=>this._dismissStaticBanner(t)})),...this.actionBanners.map((e,t)=>({banner:e,onDismiss:()=>this._dismissActionBanner(t)}))];return T`<div style="display: flex; flex-direction: column; width: 100%;">${T`
+        `}_onSlotChange(){this._scheduleTocRebuild()}_scheduleTocRebuild(){this._tocRebuildScheduled||(this._tocRebuildScheduled=!0,requestAnimationFrame(()=>{this._tocRebuildScheduled=!1,this._rebuildToc()}))}_sectionCards(){return Array.from(this.querySelectorAll(`.mateu-section`))}_sectionTitle(e){return e.querySelector(`[slot="title"]`)?.textContent?.trim()||e.querySelector(`h1,h2,h3,h4,h5,h6`)?.textContent?.trim()||void 0}_rebuildToc(){let e=this._sectionCards(),t=e.map(e=>({title:this._sectionTitle(e),el:e})).filter(e=>!!e.title),n=this.component?.metadata?.toc,r=t.length>4&&e.every(e=>!e.closest(`vaadin-horizontal-layout`)),i=(n===!0||n!==!1&&r)&&t.length>0;this._tocEntries=t,this._tocVisible=i,this._activeToc>=t.length&&(this._activeToc=0),this._teardownScrollSpy(),i?requestAnimationFrame(()=>{this._layoutStickyTops(),this._setupScrollSpy()}):this._layoutStickyTops()}_layoutStickyTops(){let e=this.shadowRoot?.querySelector(`mateu-content-header`);this._headerH=this._tocVisible&&e?e.offsetHeight:0,this.style.setProperty(`--mateu-header-h`,this._headerH+`px`);let t=this._headerH+12;for(let e of this._sectionCards())e.classList.contains(`mateu-section--sticky`)&&(e.style.top=t+`px`,t+=e.offsetHeight+12)}_scrollContainer(){let e=ho(this);for(;e;){let t=getComputedStyle(e).overflowY;if((t===`auto`||t===`scroll`)&&e.scrollHeight>e.clientHeight)return e;e=ho(e)}return null}_setupScrollSpy(){this._tocEntries.length&&(this._spyTarget=this._scrollContainer()??window,this._spyTarget.addEventListener(`scroll`,this._onScrollSpy,{passive:!0}),window.addEventListener(`wheel`,this._unlockToc,{passive:!0}),window.addEventListener(`touchstart`,this._unlockToc,{passive:!0}),window.addEventListener(`keydown`,this._unlockToc),this._onScrollSpy())}_teardownScrollSpy(){this._spyTarget?.removeEventListener(`scroll`,this._onScrollSpy),window.removeEventListener(`wheel`,this._unlockToc),window.removeEventListener(`touchstart`,this._unlockToc),window.removeEventListener(`keydown`,this._unlockToc),this._spyTarget=void 0}_scrollToSection(e){let t=this._tocEntries[e];if(!t)return;this._activeToc=e,this._tocLocked=!0;let n=this._headerH+12;for(let e of this._sectionCards()){if(e===t.el)break;e.classList.contains(`mateu-section--sticky`)&&(n+=e.offsetHeight+12)}let r=this._scrollContainer(),i=r?r.getBoundingClientRect().top:0,a=t.el.getBoundingClientRect().top-i-n;(r??window).scrollBy({top:a,behavior:`smooth`})}_showHeaderBand(){let e=this.component?.metadata,t=!!(e?.title||e?.subtitle||e?.overline||e?.titlePlaceholder||e?.toolbar?.length),n=!!this.component?.children?.some(e=>e.metadata?.type===j.Crud);return t&&!n&&!this._hasWelcomeBanner()}_hasWelcomeBanner(){let e=t=>t?.metadata?.type===j.HeroSection||(t?.children??[]).some(e);return(this.component?.children??[]).some(e)}render(){let e=this.component?.metadata,t=[...(e?.banners??[]).map((e,t)=>({banner:e,index:t})).filter(({index:e})=>!this.dismissedStaticBannerIndices.has(e)).map(({banner:e,index:t})=>({banner:e,onDismiss:()=>this._dismissStaticBanner(t)})),...this.actionBanners.map((e,t)=>({banner:e,onDismiss:()=>this._dismissActionBanner(t)}))];return T`<div style="display: flex; flex-direction: column; width: 100%;">${T`
             <div class="page-header-wrap">
                 <mateu-content-header
                     class="${this._tocVisible?`sticky-header`:``}"
@@ -5987,7 +5995,7 @@ ${i}
                 `:v}
             </div>
             <div class="form-footer">
-                ${e?.footer?.map(e=>I(this,e,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData))}
+                ${e?.footer?.map(e=>F(this,e,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData))}
             </div>
         `}</div>`}static{this.styles=h`
         /* Design-system hook: background behind the page header (the RDS "Header + Background"
@@ -6188,7 +6196,7 @@ ${i}
             background: #fdf2f2;
             border-leftx: 4px solid var(--lumo-error-color);
         }
-    `}};k([y()],J.prototype,`component`,void 0),k([y()],J.prototype,`baseUrl`,void 0),k([y()],J.prototype,`state`,void 0),k([y()],J.prototype,`data`,void 0),k([y()],J.prototype,`appState`,void 0),k([y()],J.prototype,`appData`,void 0),k([y()],J.prototype,`value`,void 0),k([y({type:Boolean})],J.prototype,`standalone`,void 0),k([C()],J.prototype,`actionBanners`,void 0),k([C()],J.prototype,`dismissedStaticBannerIndices`,void 0),k([C()],J.prototype,`_tocEntries`,void 0),k([C()],J.prototype,`_activeToc`,void 0),k([C()],J.prototype,`_tocVisible`,void 0),J=k([g(`mateu-page`)],J);var ho=h`
+    `}};k([y()],q.prototype,`component`,void 0),k([y()],q.prototype,`baseUrl`,void 0),k([y()],q.prototype,`state`,void 0),k([y()],q.prototype,`data`,void 0),k([y()],q.prototype,`appState`,void 0),k([y()],q.prototype,`appData`,void 0),k([y()],q.prototype,`value`,void 0),k([y({type:Boolean})],q.prototype,`standalone`,void 0),k([C()],q.prototype,`actionBanners`,void 0),k([C()],q.prototype,`dismissedStaticBannerIndices`,void 0),k([C()],q.prototype,`_tocEntries`,void 0),k([C()],q.prototype,`_activeToc`,void 0),k([C()],q.prototype,`_tocVisible`,void 0),q=k([g(`mateu-page`)],q);var go=h`
     .nbtn {
         display: inline-flex;
         align-items: center;
@@ -6217,25 +6225,25 @@ ${i}
     }
     .nbtn.primary:hover { background: var(--lumo-primary-color, #1676f3); filter: brightness(1.08); }
     .nbtn svg { width: 1em; height: 1em; flex-shrink: 0; }
-`,go=e=>w`
+`,_o=e=>w`
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-         stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${e}</svg>`,_o=go(w`
+         stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${e}</svg>`,vo=_o(w`
     <circle cx="12" cy="12" r="3"></circle>
-    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path>`),vo=go(w`
+    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path>`),yo=_o(w`
     <line x1="12" y1="5" x2="12" y2="19"></line>
-    <line x1="5" y1="12" x2="19" y2="12"></line>`),yo=go(w`
+    <line x1="5" y1="12" x2="19" y2="12"></line>`),bo=_o(w`
     <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
     <polyline points="7 10 12 15 17 10"></polyline>
-    <line x1="12" y1="15" x2="12" y2="3"></line>`);go(w`
+    <line x1="12" y1="15" x2="12" y2="3"></line>`);_o(w`
     <rect x="9" y="2" width="6" height="5" rx="1"></rect>
     <rect x="2" y="17" width="6" height="5" rx="1"></rect>
     <rect x="16" y="17" width="6" height="5" rx="1"></rect>
-    <path d="M12 7v4M5 17v-3h14v3M12 11v3"></path>`);var bo=go(w`
+    <path d="M12 7v4M5 17v-3h14v3M12 11v3"></path>`);var xo=_o(w`
     <rect x="9" y="2" width="6" height="12" rx="3"></rect>
     <path d="M5 10v1a7 7 0 0 0 14 0v-1"></path>
-    <line x1="12" y1="18" x2="12" y2="22"></line>`),xo=go(w`
+    <line x1="12" y1="18" x2="12" y2="22"></line>`),So=_o(w`
     <line x1="18" y1="6" x2="6" y2="18"></line>
-    <line x1="6" y1="6" x2="18" y2="18"></line>`),So=[`#e91e63`,`#1676f3`,`#10b981`,`#8b5cf6`,`#f59e0b`,`#ef4444`],Co=e=>So[Math.abs(e??0)%So.length],wo=e=>(e??`?`).split(/\s+/).filter(e=>e).map(e=>e[0]).slice(0,2).join(``).toUpperCase()||`?`,Y=class extends b{constructor(...e){super(...e),this.localAgentUrl=`http://127.0.0.1:8776`,this.localAgentAlive=!1,this.menu=[],this.chatSessionId=E(),this.menuContextSent=!1,this.attachments=[],this.uploading=!1,this.expanded=!1,this.toggleExpanded=()=>{this.expanded=!this.expanded},this.items=[],this.listening=!1,this.recognitionAvailable=!1,this.loading=!1,this.elapsedSeconds=0,this.startListening=()=>{this.recognition&&(this.listening?(this.recognition.stop(),this.listening=!1):(this.recognition.start(),this.listening=!0))},this.onSpeechResult=e=>{if(this.recognition){let t=e,n=t.results[t.results[0].length-1][0].transcript;this.messageInputElement&&(this.messageInputElement.value=n,this.send(new CustomEvent(`submit`,{detail:{value:n},bubbles:!0,composed:!0})))}},this.probeLocalAgent=async()=>{if(this.localAgentUrl)try{let e=new AbortController,t=setTimeout(()=>e.abort(),1200),n=await fetch(this.localAgentUrl+`/health`,{signal:e.signal});clearTimeout(t),this.localAgentAlive=n.ok}catch{this.localAgentAlive=!1}},this.pickFiles=()=>this.fileInputElement?.click(),this.onFilesPicked=async e=>{let t=e.target,n=Array.from(t.files??[]);if(t.value=``,!(!n.length||!this.uploadUrl)){this.uploading=!0;try{let e=new FormData;e.append(`sessionId`,this.chatSessionId);for(let t of n)e.append(`files`,t,t.name);let t={},r=localStorage.getItem(`__mateu_auth_token`);r&&(t.Authorization=`Bearer `+r);let i=sessionStorage.getItem(`__mateu_sesion_id`);i&&(t[`X-Session-Id`]=i);let a=await fetch(this.uploadUrl,{method:`POST`,headers:t,body:e});if(!a.ok)throw Error(`Upload failed: ${a.status}`);let o=((await a.json()).files??[]).filter(e=>e&&e.path);this.attachments=[...this.attachments,...o]}catch(e){this.addMessage(`⚠️ No se pudieron subir los ficheros: ${e instanceof Error?e.message:e}`,`agent`)}finally{this.uploading=!1}}},this.removeAttachment=e=>{this.attachments=this.attachments.filter(t=>t.path!==e)},this.send=async e=>{this.messageInputElement?.setAttribute(`disabled`,`disabled`);let t=e.detail.value.trim(),n=this.localAgentAlive?this.localAgentUrl+`/mateu/agent/stream`:this.sseUrl,r=this.attachments;if(!t&&r.length===0||!n)return;let i=r.length?`${t}${t?`
+    <line x1="6" y1="6" x2="18" y2="18"></line>`),Co=[`#e91e63`,`#1676f3`,`#10b981`,`#8b5cf6`,`#f59e0b`,`#ef4444`],wo=e=>Co[Math.abs(e??0)%Co.length],To=e=>(e??`?`).split(/\s+/).filter(e=>e).map(e=>e[0]).slice(0,2).join(``).toUpperCase()||`?`,J=class extends b{constructor(...e){super(...e),this.localAgentUrl=`http://127.0.0.1:8776`,this.localAgentAlive=!1,this.menu=[],this.chatSessionId=E(),this.menuContextSent=!1,this.attachments=[],this.uploading=!1,this.expanded=!1,this.toggleExpanded=()=>{this.expanded=!this.expanded},this.items=[],this.listening=!1,this.recognitionAvailable=!1,this.loading=!1,this.elapsedSeconds=0,this.startListening=()=>{this.recognition&&(this.listening?(this.recognition.stop(),this.listening=!1):(this.recognition.start(),this.listening=!0))},this.onSpeechResult=e=>{if(this.recognition){let t=e,n=t.results[t.results[0].length-1][0].transcript;this.messageInputElement&&(this.messageInputElement.value=n,this.send(new CustomEvent(`submit`,{detail:{value:n},bubbles:!0,composed:!0})))}},this.probeLocalAgent=async()=>{if(this.localAgentUrl)try{let e=new AbortController,t=setTimeout(()=>e.abort(),1200),n=await fetch(this.localAgentUrl+`/health`,{signal:e.signal});clearTimeout(t),this.localAgentAlive=n.ok}catch{this.localAgentAlive=!1}},this.pickFiles=()=>this.fileInputElement?.click(),this.onFilesPicked=async e=>{let t=e.target,n=Array.from(t.files??[]);if(t.value=``,!(!n.length||!this.uploadUrl)){this.uploading=!0;try{let e=new FormData;e.append(`sessionId`,this.chatSessionId);for(let t of n)e.append(`files`,t,t.name);let t={},r=localStorage.getItem(`__mateu_auth_token`);r&&(t.Authorization=`Bearer `+r);let i=sessionStorage.getItem(`__mateu_sesion_id`);i&&(t[`X-Session-Id`]=i);let a=await fetch(this.uploadUrl,{method:`POST`,headers:t,body:e});if(!a.ok)throw Error(`Upload failed: ${a.status}`);let o=((await a.json()).files??[]).filter(e=>e&&e.path);this.attachments=[...this.attachments,...o]}catch(e){this.addMessage(`⚠️ No se pudieron subir los ficheros: ${e instanceof Error?e.message:e}`,`agent`)}finally{this.uploading=!1}}},this.removeAttachment=e=>{this.attachments=this.attachments.filter(t=>t.path!==e)},this.send=async e=>{this.messageInputElement?.setAttribute(`disabled`,`disabled`);let t=e.detail.value.trim(),n=this.localAgentAlive?this.localAgentUrl+`/mateu/agent/stream`:this.sseUrl,r=this.attachments;if(!t&&r.length===0||!n)return;let i=r.length?`${t}${t?`
 
 `:``}📎 ${r.map(e=>e.name).join(`, `)}`:t;this.addMessage(i,`user`),this.attachments=[];let a=this.addMessage(``,`agent`);this.startLoading();let o=``;try{let e={Accept:`text/event-stream`,"Content-Type":`application/json`},i=localStorage.getItem(`__mateu_auth_token`);i&&(e.Authorization=`Bearer `+i);let s=sessionStorage.getItem(`__mateu_sesion_id`);s&&(e[`X-Session-Id`]=s);let c=this.contextProvider?.(),l=JSON.stringify({message:t,sessionId:this.chatSessionId,...r.length&&{attachments:r},...c!=null&&{context:c},...this.mcpUrl&&{mcpUrl:new URL(this.mcpUrl,window.location.origin).href},...!this.menuContextSent&&{menuContext:this.buildMenuContext(this.menu)}});this.menuContextSent=!0;let u=await fetch(n,{method:`POST`,headers:e,body:l});if(!u.ok){let e=await u.text();throw Error(`Servidor respondió ${u.status}: ${e}`)}let d=u.body?.getReader();if(!d)throw Error(`No se pudo obtener el reader del stream.`);let f=new TextDecoder,p=``;for(;;){let{done:e,value:t}=await d.read();if(e){if(p.trim().startsWith(`data:`)){let e=p.trim().slice(5).trim(),t=this.tryParseTokenUsage(e),n=!t&&this.tryParseCustomEvent(e);t?this.tokenUsage={...this.tokenUsage,...t}:n?n.event===`agent-error`?(o=`⚠️ `+(n.detail?.message??`Error desconocido del agente`),this.updateMessage(a,o)):this.dispatchEvent(new CustomEvent(n.event,{detail:n.detail,bubbles:!0,composed:!0})):(o+=e,this.updateMessage(a,o))}break}let n=f.decode(t,{stream:!0});p+=n;let r=p.split(`
 `);p=r.pop()||``;let i=!1;for(let e of r)if(e.trim().startsWith(`data:`)){let t=e.trim().slice(5).trim(),n=this.tryParseTokenUsage(t),r=!n&&this.tryParseCustomEvent(t);n?this.tokenUsage={...this.tokenUsage,...n}:r?r.event===`agent-error`?(o=`⚠️ `+(r.detail?.message??`Error desconocido del agente`),this.updateMessage(a,o)):this.dispatchEvent(new CustomEvent(r.event,{detail:r.detail,bubbles:!0,composed:!0})):(o+=t+`
@@ -6250,14 +6258,14 @@ ${i}
                         ${this.expanded?`⤡`:`⤢`}
                     </button>
                     <button class="chat-close" @click="${this.closeChat}" title="Cerrar">
-                        ${xo}
+                        ${So}
                     </button>
                 </div>
                 <div class="scroll-container">
                     <div class="message-list" role="list">
                         ${this.items.map(e=>T`
                             <div class="message" role="listitem">
-                                <div class="avatar" style="background: ${Co(e.userColorIndex)};">${wo(e.userName)}</div>
+                                <div class="avatar" style="background: ${wo(e.userColorIndex)};">${To(e.userName)}</div>
                                 <div class="message-body">
                                     <div class="message-meta">
                                         <span class="message-name">${e.userName}</span>
@@ -6305,7 +6313,7 @@ ${i}
                             style="color: ${this.listening?`red`:`var(--lumo-contrast-50pct, #767676)`};"
                             @click="${this.startListening}"
                             ?disabled="${!this.recognitionAvailable}"
-                    >${bo}</button>
+                    >${xo}</button>
                     <input class="msg-input"
                            placeholder="Message"
                            aria-label="Message"
@@ -6313,7 +6321,7 @@ ${i}
                     <button class="nbtn primary" ?disabled="${this.loading}" @click="${this.submitFromInput}">Send</button>
                 </div>
             </div>
-        `}static{this.styles=[ho,h`
+        `}static{this.styles=[go,h`
         :host {
             display: block;
             height: 100%;
@@ -6638,7 +6646,7 @@ ${i}
         @keyframes spin {
             to { transform: rotate(360deg); }
         }
-    `]}};k([y({attribute:!1})],Y.prototype,`contextProvider`,void 0),k([y()],Y.prototype,`localAgentUrl`,void 0),k([y({attribute:!1})],Y.prototype,`mcpUrl`,void 0),k([C()],Y.prototype,`localAgentAlive`,void 0),k([y()],Y.prototype,`sseUrl`,void 0),k([y()],Y.prototype,`uploadUrl`,void 0),k([y({attribute:!1})],Y.prototype,`menu`,void 0),k([C()],Y.prototype,`attachments`,void 0),k([C()],Y.prototype,`uploading`,void 0),k([x(`.file-input`)],Y.prototype,`fileInputElement`,void 0),k([y({type:Boolean,reflect:!0})],Y.prototype,`expanded`,void 0),k([y()],Y.prototype,`items`,void 0),k([x(`.scroll-container`)],Y.prototype,`scrollContainer`,void 0),k([x(`.msg-input`)],Y.prototype,`messageInputElement`,void 0),k([C()],Y.prototype,`recognition`,void 0),k([C()],Y.prototype,`listening`,void 0),k([C()],Y.prototype,`recognitionAvailable`,void 0),k([C()],Y.prototype,`loading`,void 0),k([C()],Y.prototype,`elapsedSeconds`,void 0),k([C()],Y.prototype,`tokenUsage`,void 0),Y=k([g(`mateu-chat`)],Y);var To=class extends b{updated(e){super.updated(e),this.chart&&=(this.chart.destroy(),void 0),this.data&&this.createChart(this.data)}async createChart(e){let[{default:t}]=await Promise.all([D(()=>import(`./vendor-chartjs.js`).then(e=>e.n),__vite__mapDeps([3,1])),D(()=>import(`./vendor-chartjs.js`).then(e=>e.t),__vite__mapDeps([3,1]))]);if(e!==this.data)return;this.chart&&this.chart.destroy();let n={type:this.type,data:this.data,options:this.options};this.chart=new t(this.chartElement,n)}handleSlotChange(){}render(){return T`
+    `]}};k([y({attribute:!1})],J.prototype,`contextProvider`,void 0),k([y()],J.prototype,`localAgentUrl`,void 0),k([y({attribute:!1})],J.prototype,`mcpUrl`,void 0),k([C()],J.prototype,`localAgentAlive`,void 0),k([y()],J.prototype,`sseUrl`,void 0),k([y()],J.prototype,`uploadUrl`,void 0),k([y({attribute:!1})],J.prototype,`menu`,void 0),k([C()],J.prototype,`attachments`,void 0),k([C()],J.prototype,`uploading`,void 0),k([x(`.file-input`)],J.prototype,`fileInputElement`,void 0),k([y({type:Boolean,reflect:!0})],J.prototype,`expanded`,void 0),k([y()],J.prototype,`items`,void 0),k([x(`.scroll-container`)],J.prototype,`scrollContainer`,void 0),k([x(`.msg-input`)],J.prototype,`messageInputElement`,void 0),k([C()],J.prototype,`recognition`,void 0),k([C()],J.prototype,`listening`,void 0),k([C()],J.prototype,`recognitionAvailable`,void 0),k([C()],J.prototype,`loading`,void 0),k([C()],J.prototype,`elapsedSeconds`,void 0),k([C()],J.prototype,`tokenUsage`,void 0),J=k([g(`mateu-chat`)],J);var Eo=class extends b{updated(e){super.updated(e),this.chart&&=(this.chart.destroy(),void 0),this.data&&this.createChart(this.data)}async createChart(e){let[{default:t}]=await Promise.all([D(()=>import(`./vendor-chartjs.js`).then(e=>e.n),__vite__mapDeps([3,1])),D(()=>import(`./vendor-chartjs.js`).then(e=>e.t),__vite__mapDeps([3,1]))]);if(e!==this.data)return;this.chart&&this.chart.destroy();let n={type:this.type,data:this.data,options:this.options};this.chart=new t(this.chartElement,n)}handleSlotChange(){}render(){return T`
             <div class="container">
                 <canvas id="chart"></canvas>
             </div>
@@ -6655,7 +6663,7 @@ ${i}
         height: 100%;
         position: relative;
     }
-  `}};k([y()],To.prototype,`type`,void 0),k([y()],To.prototype,`data`,void 0),k([y()],To.prototype,`options`,void 0),k([x(`#chart`)],To.prototype,`chartElement`,void 0),To=k([g(`mateu-chart`)],To);var Eo=class extends b{updated(e){super.updated(e),this.chart&&=(this.chart.destroy(),void 0),this.xml&&this.createViewer(this.xml)}async createViewer(e){let{default:t}=await D(async()=>{let{default:e}=await import(`./vendor-diagrams.js`).then(e=>e.t);return{default:e}},__vite__mapDeps([4,1,2]));if(e!==this.xml)return;this.chart&&this.chart.destroy();let n={container:this.divElement};this.chart=new t(n),this.chart.importXML(e)}handleSlotChange(){}render(){return T`
+  `}};k([y()],Eo.prototype,`type`,void 0),k([y()],Eo.prototype,`data`,void 0),k([y()],Eo.prototype,`options`,void 0),k([x(`#chart`)],Eo.prototype,`chartElement`,void 0),Eo=k([g(`mateu-chart`)],Eo);var Do=class extends b{updated(e){super.updated(e),this.chart&&=(this.chart.destroy(),void 0),this.xml&&this.createViewer(this.xml)}async createViewer(e){let{default:t}=await D(async()=>{let{default:e}=await import(`./vendor-diagrams.js`).then(e=>e.t);return{default:e}},__vite__mapDeps([4,1,2]));if(e!==this.xml)return;this.chart&&this.chart.destroy();let n={container:this.divElement};this.chart=new t(n),this.chart.importXML(e)}handleSlotChange(){}render(){return T`
             <div class="container" style="width: 20rem; height: 15rem; overflow: auto;">
                 <!-- BPMN diagram container -->
                 <div id="canvas" style="width: 60rem; height: 30rem; zoom: 0.5;"></div>
@@ -6664,7 +6672,7 @@ ${i}
                 <slot @slotchange=${this.handleSlotChange}></slot>
             </div>
        `}static{this.styles=h`
-  `}};k([y()],Eo.prototype,`xml`,void 0),k([x(`#canvas`)],Eo.prototype,`divElement`,void 0),Eo=k([g(`mateu-bpmn`)],Eo);var Do=160,Oo=56,ko=220,Ao=110,jo=60,Mo={ACTION:`#3B82F6`,JOIN:`#8B5CF6`,FORK:`#F59E0B`,END:`#EF4444`,USER_TASK:`#10B981`,PROCESS:`#6366F1`},No={ACTION:`▶`,JOIN:`⟨`,FORK:`⟩`,END:`◼`,USER_TASK:`👤`,PROCESS:`⚙`},Po=[`ACTION`,`JOIN`,`FORK`,`END`,`USER_TASK`,`PROCESS`];function Fo(){return`step-`+Math.random().toString(36).slice(2,8)}var Io=class extends b{constructor(...e){super(...e),this.value=`{"name":"New Workflow","steps":[]}`,this.wf={name:`New Workflow`,steps:[]},this.positions={},this.selectedId=null,this.showMeta=!1,this.draggingId=null,this.dragOffset={x:0,y:0},this.svgEl=null,this.onMouseMove=e=>{if(!this.draggingId||!this.svgEl)return;let t=this.toSvgPoint(e);this.positions={...this.positions,[this.draggingId]:{x:Math.max(0,t.x-this.dragOffset.x),y:Math.max(0,t.y-this.dragOffset.y)}}},this.onMouseUp=()=>{this.draggingId=null,window.removeEventListener(`mousemove`,this.onMouseMove),window.removeEventListener(`mouseup`,this.onMouseUp)}}updated(e){if(e.has(`value`)){try{this.wf=JSON.parse(this.value)}catch{}this.autoLayout()}}autoLayout(){let e=this.wf.steps??[],t={};e.forEach(e=>{t[e.id]=0});let n=!0;for(;n;)n=!1,e.forEach(e=>{if(e.preconditionStepId!=null&&t[e.preconditionStepId]!==void 0){let r=t[e.preconditionStepId]+1;r>t[e.id]&&(t[e.id]=r,n=!0)}});let r={};e.forEach(e=>{let n=t[e.id]??0;(r[n]??=[]).push(e.id)});let i={...this.positions},a=!1;Object.entries(r).forEach(([e,t])=>{let n=Number(e);t.forEach((e,t)=>{i[e]||(i[e]={x:jo+n*ko,y:jo+t*Ao},a=!0)})}),a&&(this.positions=i)}emit(){let e=JSON.stringify(this.wf,null,2);this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e},bubbles:!0,composed:!0}))}updateWf(e){this.wf={...this.wf,...e},this.emit()}updateStep(e,t){this.wf={...this.wf,steps:this.wf.steps.map(n=>n.id===e?{...n,...t}:n)},this.emit()}addStep(){let e=Fo(),t={id:e,type:`ACTION`,name:`New Step`};this.wf={...this.wf,steps:[...this.wf.steps??[],t]};let n=Object.values(this.positions).map(e=>e.y),r=n.length?Math.max(...n)+Ao:jo;this.positions={...this.positions,[e]:{x:jo,y:r}},this.selectedId=e,this.emit()}deleteStep(e){this.wf={...this.wf,steps:this.wf.steps.filter(t=>t.id!==e).map(t=>t.preconditionStepId===e?{...t,preconditionStepId:void 0}:t)};let{[e]:t,...n}=this.positions;this.positions=n,this.selectedId===e&&(this.selectedId=null),this.emit()}onNodeMouseDown(e,t){e.preventDefault(),this.draggingId=t;let n=this.positions[t]??{x:0,y:0},r=this.toSvgPoint(e);this.dragOffset={x:r.x-n.x,y:r.y-n.y},this.svgEl=e.currentTarget.closest(`svg`),window.addEventListener(`mousemove`,this.onMouseMove),window.addEventListener(`mouseup`,this.onMouseUp)}toSvgPoint(e){if(!this.svgEl)return{x:0,y:0};let t=this.svgEl.getBoundingClientRect();return{x:e.clientX-t.left,y:e.clientY-t.top}}canvasSize(){let e=Object.values(this.positions),t=e.length?Math.max(...e.map(e=>e.x))+Do+jo:600,n=e.length?Math.max(...e.map(e=>e.y))+Oo+jo:400;return{w:Math.max(t,600),h:Math.max(n,400)}}render(){let{w:e,h:t}=this.canvasSize(),n=this.wf.steps??[];return T`
+  `}};k([y()],Do.prototype,`xml`,void 0),k([x(`#canvas`)],Do.prototype,`divElement`,void 0),Do=k([g(`mateu-bpmn`)],Do);var Oo=160,ko=56,Ao=220,jo=110,Mo=60,No={ACTION:`#3B82F6`,JOIN:`#8B5CF6`,FORK:`#F59E0B`,END:`#EF4444`,USER_TASK:`#10B981`,PROCESS:`#6366F1`},Po={ACTION:`▶`,JOIN:`⟨`,FORK:`⟩`,END:`◼`,USER_TASK:`👤`,PROCESS:`⚙`},Fo=[`ACTION`,`JOIN`,`FORK`,`END`,`USER_TASK`,`PROCESS`];function Io(){return`step-`+Math.random().toString(36).slice(2,8)}var Lo=class extends b{constructor(...e){super(...e),this.value=`{"name":"New Workflow","steps":[]}`,this.wf={name:`New Workflow`,steps:[]},this.positions={},this.selectedId=null,this.showMeta=!1,this.draggingId=null,this.dragOffset={x:0,y:0},this.svgEl=null,this.onMouseMove=e=>{if(!this.draggingId||!this.svgEl)return;let t=this.toSvgPoint(e);this.positions={...this.positions,[this.draggingId]:{x:Math.max(0,t.x-this.dragOffset.x),y:Math.max(0,t.y-this.dragOffset.y)}}},this.onMouseUp=()=>{this.draggingId=null,window.removeEventListener(`mousemove`,this.onMouseMove),window.removeEventListener(`mouseup`,this.onMouseUp)}}updated(e){if(e.has(`value`)){try{this.wf=JSON.parse(this.value)}catch{}this.autoLayout()}}autoLayout(){let e=this.wf.steps??[],t={};e.forEach(e=>{t[e.id]=0});let n=!0;for(;n;)n=!1,e.forEach(e=>{if(e.preconditionStepId!=null&&t[e.preconditionStepId]!==void 0){let r=t[e.preconditionStepId]+1;r>t[e.id]&&(t[e.id]=r,n=!0)}});let r={};e.forEach(e=>{let n=t[e.id]??0;(r[n]??=[]).push(e.id)});let i={...this.positions},a=!1;Object.entries(r).forEach(([e,t])=>{let n=Number(e);t.forEach((e,t)=>{i[e]||(i[e]={x:Mo+n*Ao,y:Mo+t*jo},a=!0)})}),a&&(this.positions=i)}emit(){let e=JSON.stringify(this.wf,null,2);this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e},bubbles:!0,composed:!0}))}updateWf(e){this.wf={...this.wf,...e},this.emit()}updateStep(e,t){this.wf={...this.wf,steps:this.wf.steps.map(n=>n.id===e?{...n,...t}:n)},this.emit()}addStep(){let e=Io(),t={id:e,type:`ACTION`,name:`New Step`};this.wf={...this.wf,steps:[...this.wf.steps??[],t]};let n=Object.values(this.positions).map(e=>e.y),r=n.length?Math.max(...n)+jo:Mo;this.positions={...this.positions,[e]:{x:Mo,y:r}},this.selectedId=e,this.emit()}deleteStep(e){this.wf={...this.wf,steps:this.wf.steps.filter(t=>t.id!==e).map(t=>t.preconditionStepId===e?{...t,preconditionStepId:void 0}:t)};let{[e]:t,...n}=this.positions;this.positions=n,this.selectedId===e&&(this.selectedId=null),this.emit()}onNodeMouseDown(e,t){e.preventDefault(),this.draggingId=t;let n=this.positions[t]??{x:0,y:0},r=this.toSvgPoint(e);this.dragOffset={x:r.x-n.x,y:r.y-n.y},this.svgEl=e.currentTarget.closest(`svg`),window.addEventListener(`mousemove`,this.onMouseMove),window.addEventListener(`mouseup`,this.onMouseUp)}toSvgPoint(e){if(!this.svgEl)return{x:0,y:0};let t=this.svgEl.getBoundingClientRect();return{x:e.clientX-t.left,y:e.clientY-t.top}}canvasSize(){let e=Object.values(this.positions),t=e.length?Math.max(...e.map(e=>e.x))+Oo+Mo:600,n=e.length?Math.max(...e.map(e=>e.y))+ko+Mo:400;return{w:Math.max(t,600),h:Math.max(n,400)}}render(){let{w:e,h:t}=this.canvasSize(),n=this.wf.steps??[];return T`
             <div class="root">
                 ${this.renderToolbar()}
                 ${this.showMeta?this.renderMeta():``}
@@ -6691,15 +6699,15 @@ ${i}
                 <span class="badge badge-${e.toLowerCase()}">${e}</span>
                 <div style="flex:1"></div>
                 <button class="nbtn" @click="${()=>this.showMeta=!this.showMeta}">
-                    ${_o}
+                    ${vo}
                     Settings
                 </button>
                 <button class="nbtn primary" @click="${()=>this.addStep()}">
-                    ${vo}
+                    ${yo}
                     Add Step
                 </button>
                 <button class="nbtn" @click="${()=>this.exportJson()}">
-                    ${yo}
+                    ${bo}
                     Export
                 </button>
             </div>
@@ -6728,27 +6736,27 @@ ${i}
                     `:``}
                 </div>
             </div>
-        `}renderArrow(e){if(!e.preconditionStepId)return w``;let t=this.positions[e.preconditionStepId],n=this.positions[e.id];if(!t||!n)return w``;let r=t.x+Do,i=t.y+Oo/2,a=n.x,o=n.y+Oo/2,s=(r+a)/2;return w`
+        `}renderArrow(e){if(!e.preconditionStepId)return w``;let t=this.positions[e.preconditionStepId],n=this.positions[e.id];if(!t||!n)return w``;let r=t.x+Oo,i=t.y+ko/2,a=n.x,o=n.y+ko/2,s=(r+a)/2;return w`
             <path d="M${r},${i} C${s},${i} ${s},${o} ${a},${o}"
                   fill="none" stroke="#94a3b8" stroke-width="2"
                   marker-end="url(#arrow)"/>
-        `}renderNode(e){let t=this.positions[e.id]??{x:jo,y:jo},n=Mo[e.type]??`#64748b`,r=No[e.type]??`•`,i=this.selectedId===e.id;return w`
+        `}renderNode(e){let t=this.positions[e.id]??{x:Mo,y:Mo},n=No[e.type]??`#64748b`,r=Po[e.type]??`•`,i=this.selectedId===e.id;return w`
             <g transform="translate(${t.x},${t.y})"
                style="cursor:grab"
                @mousedown="${t=>this.onNodeMouseDown(t,e.id)}"
                @click="${t=>{t.stopPropagation(),this.selectedId=e.id}}">
-                <rect width="${Do}" height="${Oo}" rx="8"
+                <rect width="${Oo}" height="${ko}" rx="8"
                       fill="white"
                       stroke="${i?n:`#e2e8f0`}"
                       stroke-width="${i?2.5:1.5}"
                       filter="url(#shadow)"/>
                 <!-- type badge -->
-                <rect x="0" y="0" width="32" height="${Oo}" rx="8" fill="${n}" clip-path="inset(0 -8px 0 0 round 8px)"/>
-                <rect x="24" y="0" width="8" height="${Oo}" fill="${n}"/>
+                <rect x="0" y="0" width="32" height="${ko}" rx="8" fill="${n}" clip-path="inset(0 -8px 0 0 round 8px)"/>
+                <rect x="24" y="0" width="8" height="${ko}" fill="${n}"/>
                 <text x="16" y="${33}" text-anchor="middle"
                       font-size="14" fill="white">${r}</text>
                 <!-- name -->
-                <text x="44" y="${Oo/2-6}" font-size="11" fill="#1e293b" font-weight="600">
+                <text x="44" y="${ko/2-6}" font-size="11" fill="#1e293b" font-weight="600">
                     ${e.name.length>16?e.name.slice(0,15)+`…`:e.name}
                 </text>
                 <text x="44" y="${36}" font-size="9" fill="#94a3b8">${e.id}</text>
@@ -6773,7 +6781,7 @@ ${i}
                         @change="${t=>this.updateStep(e.id,{name:t.target.value})}"/>`)}
                     ${n(`Type`,T`
                         <select class="inp" @change="${t=>this.updateStep(e.id,{type:t.target.value})}">
-                            ${Po.map(t=>T`<option value="${t}" ?selected="${e.type===t}">${t}</option>`)}
+                            ${Fo.map(t=>T`<option value="${t}" ?selected="${e.type===t}">${t}</option>`)}
                         </select>`)}
                     ${n(`Description`,T`<textarea class="inp" rows="2"
                         @change="${t=>this.updateStep(e.id,{description:t.target.value})}">${e.description??``}</textarea>`)}
@@ -6818,7 +6826,7 @@ ${i}
                         @change="${t=>this.updateStep(e.id,{childWorkflowDefinitionId:t.target.value||void 0})}"/>`):``}
                 </div>
             </div>
-        `}exportJson(){let e=JSON.stringify(this.wf,null,2),t=new Blob([e],{type:`application/json`}),n=URL.createObjectURL(t),r=document.createElement(`a`);r.href=n,r.download=(this.wf.name??`workflow`).replace(/\s+/g,`-`).toLowerCase()+`.json`,r.click(),URL.revokeObjectURL(n)}static{this.styles=[ho,h`
+        `}exportJson(){let e=JSON.stringify(this.wf,null,2),t=new Blob([e],{type:`application/json`}),n=URL.createObjectURL(t),r=document.createElement(`a`);r.href=n,r.download=(this.wf.name??`workflow`).replace(/\s+/g,`-`).toLowerCase()+`.json`,r.click(),URL.revokeObjectURL(n)}static{this.styles=[go,h`
         :host { display: block; height: 100%; font-family: var(--lumo-font-family, sans-serif); }
 
         .root { display: flex; flex-direction: column; height: 100%; background: var(--lumo-base-color, #fff); }
@@ -6896,7 +6904,7 @@ ${i}
         .inp:focus { border-color: #3B82F6; }
         textarea.inp { resize: vertical; }
         input[readonly].inp { background: #f8fafc; color: #94a3b8; }
-    `]}};k([y()],Io.prototype,`value`,void 0),k([C()],Io.prototype,`wf`,void 0),k([C()],Io.prototype,`positions`,void 0),k([C()],Io.prototype,`selectedId`,void 0),k([C()],Io.prototype,`showMeta`,void 0),Io=k([g(`mateu-workflow`)],Io);var Lo=[`string`,`integer`,`number`,`bool`,`date`,`time`,`dateTime`,`dateRange`,`money`,`file`,`array`,`status`,`component`,`menu`,`range`,`action`,`actionGroup`],Ro=[`regular`,`radio`,`checkbox`,`textarea`,`toggle`,`combobox`,`select`,`email`,`password`,`richText`,`listBox`,`html`,`markdown`,`image`,`icon`,`link`,`money`,`grid`,`color`,`choice`,`popover`,`slider`,`button`,`stars`],zo={string:`#3B82F6`,integer:`#8B5CF6`,number:`#6366F1`,bool:`#10B981`,date:`#F59E0B`,time:`#F59E0B`,dateTime:`#F59E0B`,dateRange:`#F59E0B`,money:`#EF4444`,file:`#64748B`,array:`#0EA5E9`,status:`#EC4899`,component:`#14B8A6`,menu:`#94A3B8`,range:`#A855F7`,action:`#F97316`,actionGroup:`#FB923C`};function Bo(){return`field-`+Math.random().toString(36).slice(2,8)}var Vo=class extends b{constructor(...e){super(...e),this.value=`{"name":"New Form","fields":[]}`,this.form={name:`New Form`,fields:[]},this.selectedId=null,this.showMeta=!1,this.sortable=null,this.listEl=null}updated(e){if(e.has(`value`))try{this.form=JSON.parse(this.value)}catch{}this.attachSortable()}disconnectedCallback(){super.disconnectedCallback(),this.sortable?.destroy(),this.sortable=null}attachSortable(){let e=this.shadowRoot?.querySelector(`.field-list`);!e||e===this.listEl||(this.listEl=e,this.sortable?.destroy(),this.sortable=se.create(e,{animation:150,handle:`.drag-handle`,ghostClass:`sortable-ghost`,onEnd:e=>{let{oldIndex:t,newIndex:n}=e;if(t===void 0||n===void 0||t===n)return;let r=[...this.form.fields],[i]=r.splice(t,1);r.splice(n,0,i),this.form={...this.form,fields:r},this.emit()}}))}emit(){let e=JSON.stringify(this.form,null,2);this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e},bubbles:!0,composed:!0}))}updateForm(e){this.form={...this.form,...e},this.emit()}updateField(e,t){this.form={...this.form,fields:this.form.fields.map(n=>n.id===e?{...n,...t}:n)},this.emit()}addField(){let e=Bo(),t={id:e,label:`New Field`,dataType:`string`};this.form={...this.form,fields:[...this.form.fields,t]},this.selectedId=e,this.emit()}deleteField(e){this.form={...this.form,fields:this.form.fields.filter(t=>t.id!==e)},this.selectedId===e&&(this.selectedId=null),this.emit()}duplicateField(e){let t=this.form.fields.find(t=>t.id===e);if(!t)return;let n={...t,id:Bo(),label:t.label+` (copy)`},r=this.form.fields.findIndex(t=>t.id===e),i=[...this.form.fields];i.splice(r+1,0,n),this.form={...this.form,fields:i},this.selectedId=n.id,this.emit()}render(){return T`
+    `]}};k([y()],Lo.prototype,`value`,void 0),k([C()],Lo.prototype,`wf`,void 0),k([C()],Lo.prototype,`positions`,void 0),k([C()],Lo.prototype,`selectedId`,void 0),k([C()],Lo.prototype,`showMeta`,void 0),Lo=k([g(`mateu-workflow`)],Lo);var Ro=[`string`,`integer`,`number`,`bool`,`date`,`time`,`dateTime`,`dateRange`,`money`,`file`,`array`,`status`,`component`,`menu`,`range`,`action`,`actionGroup`],zo=[`regular`,`radio`,`checkbox`,`textarea`,`toggle`,`combobox`,`select`,`email`,`password`,`richText`,`listBox`,`html`,`markdown`,`image`,`icon`,`link`,`money`,`grid`,`color`,`choice`,`popover`,`slider`,`button`,`stars`],Bo={string:`#3B82F6`,integer:`#8B5CF6`,number:`#6366F1`,bool:`#10B981`,date:`#F59E0B`,time:`#F59E0B`,dateTime:`#F59E0B`,dateRange:`#F59E0B`,money:`#EF4444`,file:`#64748B`,array:`#0EA5E9`,status:`#EC4899`,component:`#14B8A6`,menu:`#94A3B8`,range:`#A855F7`,action:`#F97316`,actionGroup:`#FB923C`};function Vo(){return`field-`+Math.random().toString(36).slice(2,8)}var Ho=class extends b{constructor(...e){super(...e),this.value=`{"name":"New Form","fields":[]}`,this.form={name:`New Form`,fields:[]},this.selectedId=null,this.showMeta=!1,this.sortable=null,this.listEl=null}updated(e){if(e.has(`value`))try{this.form=JSON.parse(this.value)}catch{}this.attachSortable()}disconnectedCallback(){super.disconnectedCallback(),this.sortable?.destroy(),this.sortable=null}attachSortable(){let e=this.shadowRoot?.querySelector(`.field-list`);!e||e===this.listEl||(this.listEl=e,this.sortable?.destroy(),this.sortable=se.create(e,{animation:150,handle:`.drag-handle`,ghostClass:`sortable-ghost`,onEnd:e=>{let{oldIndex:t,newIndex:n}=e;if(t===void 0||n===void 0||t===n)return;let r=[...this.form.fields],[i]=r.splice(t,1);r.splice(n,0,i),this.form={...this.form,fields:r},this.emit()}}))}emit(){let e=JSON.stringify(this.form,null,2);this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e},bubbles:!0,composed:!0}))}updateForm(e){this.form={...this.form,...e},this.emit()}updateField(e,t){this.form={...this.form,fields:this.form.fields.map(n=>n.id===e?{...n,...t}:n)},this.emit()}addField(){let e=Vo(),t={id:e,label:`New Field`,dataType:`string`};this.form={...this.form,fields:[...this.form.fields,t]},this.selectedId=e,this.emit()}deleteField(e){this.form={...this.form,fields:this.form.fields.filter(t=>t.id!==e)},this.selectedId===e&&(this.selectedId=null),this.emit()}duplicateField(e){let t=this.form.fields.find(t=>t.id===e);if(!t)return;let n={...t,id:Vo(),label:t.label+` (copy)`},r=this.form.fields.findIndex(t=>t.id===e),i=[...this.form.fields];i.splice(r+1,0,n),this.form={...this.form,fields:i},this.selectedId=n.id,this.emit()}render(){return T`
             <div class="root">
                 ${this.renderToolbar()}
                 ${this.showMeta?this.renderMeta():v}
@@ -6910,15 +6918,15 @@ ${i}
                 <span class="form-name">${this.form.name}</span>
                 <div style="flex:1"></div>
                 <button class="nbtn" @click="${()=>this.showMeta=!this.showMeta}">
-                    ${_o}
+                    ${vo}
                     Settings
                 </button>
                 <button class="nbtn primary" @click="${()=>this.addField()}">
-                    ${vo}
+                    ${yo}
                     Add Field
                 </button>
                 <button class="nbtn" @click="${()=>this.exportJson()}">
-                    ${yo}
+                    ${bo}
                     Export
                 </button>
             </div>
@@ -6943,10 +6951,10 @@ ${i}
                     ${e.map(e=>this.renderRow(e))}
                 </div>
             </div>
-        `}renderRow(e){let t=zo[e.dataType]??`#64748b`;return T`
+        `}renderRow(e){let t=Bo[e.dataType]??`#64748b`;return T`
             <div role="button" tabindex="0" class="field-row ${this.selectedId===e.id?`selected`:``}"
                  data-id="${e.id}"
-                 @click="${()=>this.selectedId=this.selectedId===e.id?null:e.id}" @keydown="${z(()=>this.selectedId=this.selectedId===e.id?null:e.id)}">
+                 @click="${()=>this.selectedId=this.selectedId===e.id?null:e.id}" @keydown="${R(()=>this.selectedId=this.selectedId===e.id?null:e.id)}">
                 <span class="drag-handle" title="Drag to reorder">⠿</span>
                 <span class="type-badge" style="background:${t}">${e.dataType}</span>
                 <span class="field-label-text">${e.label}</span>
@@ -6978,13 +6986,13 @@ ${i}
                     ${t(`Data type`,T`
                         <select class="inp"
                                 @change="${t=>this.updateField(e.id,{dataType:t.target.value})}">
-                            ${Lo.map(t=>T`
+                            ${Ro.map(t=>T`
                                 <option value="${t}" ?selected="${e.dataType===t}">${t}</option>`)}
                         </select>`)}
                     ${t(`Stereotype`,T`
                         <select class="inp"
                                 @change="${t=>this.updateField(e.id,{stereotype:t.target.value||void 0})}">
-                            ${Ro.map(t=>T`
+                            ${zo.map(t=>T`
                                 <option value="${t}" ?selected="${(e.stereotype??`regular`)===t}">${t}</option>`)}
                         </select>`)}
                     <div class="prop-field row">
@@ -6997,7 +7005,7 @@ ${i}
                                   @change="${t=>this.updateField(e.id,{description:t.target.value||void 0})}">${e.description??``}</textarea>`)}
                 </div>
             </div>
-        `}exportJson(){let e=JSON.stringify(this.form,null,2),t=new Blob([e],{type:`application/json`}),n=URL.createObjectURL(t),r=document.createElement(`a`);r.href=n,r.download=(this.form.name??`form`).replace(/\s+/g,`-`).toLowerCase()+`.json`,r.click(),URL.revokeObjectURL(n)}static{this.styles=[ho,B,h`
+        `}exportJson(){let e=JSON.stringify(this.form,null,2),t=new Blob([e],{type:`application/json`}),n=URL.createObjectURL(t),r=document.createElement(`a`);r.href=n,r.download=(this.form.name??`form`).replace(/\s+/g,`-`).toLowerCase()+`.json`,r.click(),URL.revokeObjectURL(n)}static{this.styles=[go,z,h`
         :host { display: block; height: 100%; font-family: var(--lumo-font-family, sans-serif); }
 
         .root { display: flex; flex-direction: column; height: 100%; background: var(--lumo-base-color, #fff); }
@@ -7112,7 +7120,7 @@ ${i}
         .inp:focus { border-color: #3B82F6; }
         textarea.inp { resize: vertical; }
         input[readonly].inp { background: #f8fafc; color: #94a3b8; }
-    `]}};k([y()],Vo.prototype,`value`,void 0),k([C()],Vo.prototype,`form`,void 0),k([C()],Vo.prototype,`selectedId`,void 0),k([C()],Vo.prototype,`showMeta`,void 0),Vo=k([g(`mateu-form-editor`)],Vo);var Ho=class extends b{constructor(...e){super(...e),this.appState={},this.appData={},this.open=!1,this.activeTab=`appstate`,this.hoveredTag=``,this.hoveredId=``,this.hoveredState=null,this.hoveredData=null,this.hoveredMeta=null,this._prevTarget=null,this._onMouseover=e=>{let t=e.target;for(;t&&!(t.tagName?.toLowerCase().startsWith(`mateu-`)&&t!==this);)t=t.parentElement;if(t===this||t===null){t===null&&this._prevTarget&&(this._prevTarget.style.outline=``,this._prevTarget.style.outlineOffset=``,this._prevTarget=null,this.hoveredTag=``,this.hoveredId=``,this.hoveredState=null,this.hoveredData=null,this.hoveredMeta=null);return}t!==this._prevTarget&&(this._prevTarget&&(this._prevTarget.style.outline=``,this._prevTarget.style.outlineOffset=``),this._prevTarget=t,t.style.outline=`2px solid #0070f3`,t.style.outlineOffset=`-2px`,this.hoveredTag=t.tagName.toLowerCase(),this.hoveredId=t.id||``,this.hoveredState=t.state,this.hoveredData=t.data,this.hoveredMeta=t.component?.metadata)}}connectedCallback(){super.connectedCallback(),document.addEventListener(`mouseover`,this._onMouseover,!0)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`mouseover`,this._onMouseover,!0),this._prevTarget&&=(this._prevTarget.style.outline=``,null)}_fmt(e){try{return JSON.stringify(e,null,2)??`null`}catch{return String(e)}}_renderTab(e,t){return T`
+    `]}};k([y()],Ho.prototype,`value`,void 0),k([C()],Ho.prototype,`form`,void 0),k([C()],Ho.prototype,`selectedId`,void 0),k([C()],Ho.prototype,`showMeta`,void 0),Ho=k([g(`mateu-form-editor`)],Ho);var Uo=class extends b{constructor(...e){super(...e),this.appState={},this.appData={},this.open=!1,this.activeTab=`appstate`,this.hoveredTag=``,this.hoveredId=``,this.hoveredState=null,this.hoveredData=null,this.hoveredMeta=null,this._prevTarget=null,this._onMouseover=e=>{let t=e.target;for(;t&&!(t.tagName?.toLowerCase().startsWith(`mateu-`)&&t!==this);)t=t.parentElement;if(t===this||t===null){t===null&&this._prevTarget&&(this._prevTarget.style.outline=``,this._prevTarget.style.outlineOffset=``,this._prevTarget=null,this.hoveredTag=``,this.hoveredId=``,this.hoveredState=null,this.hoveredData=null,this.hoveredMeta=null);return}t!==this._prevTarget&&(this._prevTarget&&(this._prevTarget.style.outline=``,this._prevTarget.style.outlineOffset=``),this._prevTarget=t,t.style.outline=`2px solid #0070f3`,t.style.outlineOffset=`-2px`,this.hoveredTag=t.tagName.toLowerCase(),this.hoveredId=t.id||``,this.hoveredState=t.state,this.hoveredData=t.data,this.hoveredMeta=t.component?.metadata)}}connectedCallback(){super.connectedCallback(),document.addEventListener(`mouseover`,this._onMouseover,!0)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`mouseover`,this._onMouseover,!0),this._prevTarget&&=(this._prevTarget.style.outline=``,null)}_fmt(e){try{return JSON.stringify(e,null,2)??`null`}catch{return String(e)}}_renderTab(e,t){return T`
             <button class="tab ${this.activeTab===e?`tab--active`:``}"
                 @click=${()=>{this.activeTab=e}}>
                 ${t}
@@ -7285,7 +7293,7 @@ ${i}
             border-bottom: 1px solid #2a2a3a;
         }
         .section-label:first-of-type { margin-top: 0; }
-    `}};k([y()],Ho.prototype,`appState`,void 0),k([y()],Ho.prototype,`appData`,void 0),k([C()],Ho.prototype,`open`,void 0),k([C()],Ho.prototype,`activeTab`,void 0),k([C()],Ho.prototype,`hoveredTag`,void 0),k([C()],Ho.prototype,`hoveredId`,void 0),k([C()],Ho.prototype,`hoveredState`,void 0),k([C()],Ho.prototype,`hoveredData`,void 0),k([C()],Ho.prototype,`hoveredMeta`,void 0),Ho=k([g(`mateu-debug-overlay`)],Ho);var Uo=(e,t)=>{let n=t?.initiatorState;return n&&typeof n==`object`?{...n}:{...e??{}}},Wo=e=>{if(e)try{return JSON.parse(e)}catch{return{value:e}}else return{}},Go=function(e){return e.SetAppDataValue=`SetAppDataValue`,e.SetAppStateValue=`SetAppStateValue`,e.SetDataValue=`SetDataValue`,e.RunAction=`RunAction`,e.RunJS=`RunJS`,e.SetAttributeValue=`SetAttributeValue`,e.SetStateValue=`SetStateValue`,e.SetCssClass=`SetCssClass`,e.SetStyle=`SetStyle`,e}({}),Ko=function(e){return e.required=`required`,e.disabled=`disabled`,e.hidden=`hidden`,e.pattern=`pattern`,e.minValue=`minValue`,e.maxValue=`maxValue`,e.minLength=`minLength`,e.maxLength=`maxLength`,e.css=`css`,e.style=`style`,e.theme=`theme`,e.errorMessage=`errorMessage`,e.description=`description`,e.none=`none`,e}({}),qo=function(e){return e.Continue=`Continue`,e.Stop=`Stop`,e}({}),Jo=12e4,Yo=(e,t)=>`${e??`_`}::${t}`,Xo=new class{constructor(){this.started=new Map,this.listeners=new Set}begin(e,t=Date.now()){let n=this.started.get(e);return n!==void 0&&t-n<Jo?!1:(this.started.set(e,t),this.emit(),!0)}end(e){this.started.delete(e)&&this.emit()}isPending(e,t=Date.now()){let n=this.started.get(e);return n!==void 0&&t-n<Jo}snapshot(){return new Set(this.started.keys())}subscribe(e){return this.listeners.add(e),()=>this.listeners.delete(e)}reset(){this.started.clear(),this.emit()}emit(){let e=this.snapshot();this.listeners.forEach(t=>t(e))}},Zo=`data-mateu-pending-styles`,Qo=`
+    `}};k([y()],Uo.prototype,`appState`,void 0),k([y()],Uo.prototype,`appData`,void 0),k([C()],Uo.prototype,`open`,void 0),k([C()],Uo.prototype,`activeTab`,void 0),k([C()],Uo.prototype,`hoveredTag`,void 0),k([C()],Uo.prototype,`hoveredId`,void 0),k([C()],Uo.prototype,`hoveredState`,void 0),k([C()],Uo.prototype,`hoveredData`,void 0),k([C()],Uo.prototype,`hoveredMeta`,void 0),Uo=k([g(`mateu-debug-overlay`)],Uo);var Wo=(e,t)=>{let n=t?.initiatorState;return n&&typeof n==`object`?{...n}:{...e??{}}},Go=e=>{if(e)try{return JSON.parse(e)}catch{return{value:e}}else return{}},Ko=function(e){return e.SetAppDataValue=`SetAppDataValue`,e.SetAppStateValue=`SetAppStateValue`,e.SetDataValue=`SetDataValue`,e.RunAction=`RunAction`,e.RunJS=`RunJS`,e.SetAttributeValue=`SetAttributeValue`,e.SetStateValue=`SetStateValue`,e.SetCssClass=`SetCssClass`,e.SetStyle=`SetStyle`,e}({}),qo=function(e){return e.required=`required`,e.disabled=`disabled`,e.hidden=`hidden`,e.pattern=`pattern`,e.minValue=`minValue`,e.maxValue=`maxValue`,e.minLength=`minLength`,e.maxLength=`maxLength`,e.css=`css`,e.style=`style`,e.theme=`theme`,e.errorMessage=`errorMessage`,e.description=`description`,e.none=`none`,e}({}),Jo=function(e){return e.Continue=`Continue`,e.Stop=`Stop`,e}({}),Yo=12e4,Xo=(e,t)=>`${e??`_`}::${t}`,Zo=new class{constructor(){this.started=new Map,this.listeners=new Set}begin(e,t=Date.now()){let n=this.started.get(e);return n!==void 0&&t-n<Yo?!1:(this.started.set(e,t),this.emit(),!0)}end(e){this.started.delete(e)&&this.emit()}isPending(e,t=Date.now()){let n=this.started.get(e);return n!==void 0&&t-n<Yo}snapshot(){return new Set(this.started.keys())}subscribe(e){return this.listeners.add(e),()=>this.listeners.delete(e)}reset(){this.started.clear(),this.emit()}emit(){let e=this.snapshot();this.listeners.forEach(t=>t(e))}},Qo=`data-mateu-pending-styles`,$o=`
 [data-mateu-pending] {
     pointer-events: none;
     cursor: progress;
@@ -7299,9 +7307,9 @@ ${i}
     0%, 100% { opacity: .45; }
     50% { opacity: .85; }
 }
-`,$o=new WeakSet,es=e=>{if($o.has(e))return;$o.add(e);let t=e;if(typeof CSSStyleSheet<`u`&&Array.isArray(t.adoptedStyleSheets))try{let e=new CSSStyleSheet;e.replaceSync(Qo),t.adoptedStyleSheets=[...t.adoptedStyleSheets,e];return}catch{}let n=e instanceof Document?e.head:e;if(!n)return;let r=document.createElement(`style`);r.setAttribute(Zo,``),r.textContent=Qo,n.appendChild(r)},ts=e=>{let t=e.getRootNode();if(t instanceof ShadowRoot||t instanceof Document)return t},ns=e=>{if(!e||e.hasAttribute(`data-mateu-pending`))return;let t=ts(e);t&&es(t),e.setAttribute(`data-mateu-pending`,``),e.setAttribute(`aria-busy`,`true`)},rs=e=>{e&&(e.removeAttribute(`data-mateu-pending`),e.removeAttribute(`aria-busy`))},is=e=>{let t=(typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target;return t instanceof Element?t:void 0},as=[`button`,`a[href]`,`[role="button"]`,`[role="menuitem"]`,`input[type="button"]`,`input[type="submit"]`,`vaadin-button`,`vaadin-menu-bar-button`,`ui5-button`,`oj-c-button`,`oj-button`].join(`, `),os=e=>{if(!(!e||typeof e.closest!=`function`))return e.closest(as)??void 0},ss=null,cs=class extends Ua{constructor(...e){super(...e),this.baseUrl=``,this.route=``,this.consumedRoute=``,this.formerState={},this.applyRules=()=>{let e=this.component.rules;if(e&&e.length>0){let t=this.state,n=this.data,r=this.appState,i=this.appData,a=this.component,o=e=>Ct(e,t,n,{appState:r,appData:i,component:a}),s=e=>St(e,t,n,r,i,{component:a}),c=[`state`,`data`,`appState`,`appData`,`component`],l=[t,n,r,i,a],u={...this.state},d={...this.data},f=!1,p=!1;for(let t=0;t<e.length;t++){let n=e[t];try{if(o(n.filter)){if(Go.SetStateValue==n.action||Go.SetDataValue==n.action){let e=Go.SetStateValue==n.action?u:d,t=n.fieldName.split(`,`);for(let r=0;r<t.length;r++){let i=t[r];if(!e[i]||e[i]!=n.value){let t=n.expression?s(n.expression):n.value,r=Ko.none==n.fieldAttribute?i:i+`.`+n.fieldAttribute;t!=e[r]&&(e[r]=t,Go.SetStateValue==n.action&&(f=!0),Go.SetDataValue==n.action&&(p=!0))}}}if(Go.RunAction==n.action&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.actionId},bubbles:!0,composed:!0})),Go.RunJS==n.action&&Function(...c,n.value)(...l),Go.SetAttributeValue==n.action){let e=n.expression?o(n.expression):n.value;if(n.fieldAttribute==`disabled`){e?this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(n.fieldAttribute,`disabled`):this.shadowRoot?.getElementById(n.fieldName)?.removeAttribute(n.fieldAttribute);continue}this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(n.fieldAttribute,e)}if(Go.SetCssClass==n.action&&this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(`class`,n.value),Go.SetStyle==n.action&&this.shadowRoot?.getElementById(n.fieldName)?.style.setProperty(n.expression,n.value),qo.Stop==n.result)break}}catch(e){console.error(`rule failed`,n,e)}}f&&(this.state=u),p&&(this.data=d),f&&this.checkValidations()}},this.skipValidation=(e,t)=>e&&t.fieldId&&!e.includes(t.fieldId)||!e&&t.fieldId&&t.fieldId.includes(`-`),this.checkValidations=e=>{let t=e?e.split(`,`):void 0,n=this.component.validations,r=!0,i=!1,a=this.data??{},o={...this.data??{},errors:{}};if(n){for(let e=0;e<n.length;e++){let r=n[e];if(this.skipValidation(t,r))continue;let i=(r.fieldId??`_component`).split(`,`);for(let e=0;e<i.length;e++){let t=i[e];o.errors[t]=[]}}for(let e=0;e<n.length;e++){let i=n[e];if(!this.skipValidation(t,i))try{let e=i.condition&&i.condition.includes("${")?this._evalTemplate(i.condition):this._evalExpr(i.condition);if(i.condition&&!e){r=!1;let e=(i.fieldId??`_component`).split(`,`);for(let t=0;t<e.length;t++){let n=e[t],r=o.errors[n];if(r||(o.errors[n]=[]),r=o.errors[n],!a[n]){let e=i.message;try{e=this._evalTemplate(i.message)}catch{}r.push(e)}}}}catch(e){console.error(`validation failed`,i,e)}}for(let e=0;e<n.length;e++){let r=n[e];if(this.skipValidation(t,r))continue;let s=(r.fieldId??`_component`).split(`,`);for(let e=0;e<s.length;e++){let t=s[e];if((a.errors||o.errors==``)&&[t].join(`,`)){i=!0;break}}}(a.errors||o.errors==``)&&[`_component`].join(`,`)&&(i=!0)}o._valid=r,o._valid!=a._valid&&(i=!0),i&&(this.data=o)},this._autoSaveTimers=new Map,this.onChange=()=>{this.applyRules()},this.closeModalRequestedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.closeModal()},this.resetFilters=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail,n={};t.fieldIds.forEach(e=>{n[e]=void 0}),n.searchText=void 0,this.state={...this.state,...n}}},this.dataChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail,n={};n[t.key]=t.value,e.type==`data-changed`&&(this.data={...this.data,...n})}},this.valueChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail;if(e.type==`value-changed`){let n={...this.state};n[t.fieldId]=t.value,this.state=n,(this.state[t.fieldId]||this.formerState[t.fieldId])&&this.state[t.fieldId]!=this.formerState[t.fieldId]&&this.component?.confirmOnNavigationIfDirty&&this.dispatchEvent(new CustomEvent(`dirty`,{detail:e.detail,bubbles:!0,composed:!0}));let r=this.component;r.triggers?.filter(e=>e.type==Ha.OnValueChange).filter(e=>!e.propertyName||t.fieldId==e.propertyName).forEach(e=>{(!e.condition||this._evalExpr(e.condition))&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))}),r.triggers?.filter(e=>e.type==Ha.AutoSave).forEach(e=>{let t=e.actionId,n=this._autoSaveTimers.get(t);n!==void 0&&clearTimeout(n),this._autoSaveTimers.set(t,setTimeout(()=>{this._autoSaveTimers.delete(t),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))},e.debounceMillis??800))})}}},this.actionRequestedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.manageActionRequestedEvent(e)},this.manageActionRequestedEvent=e=>{let t=e.detail,n=t?._originElement??is(e);if(e.type==`action-requested`){e.preventDefault(),e.stopPropagation();let r=this.component,i=r.actions?.find(e=>e.id==t.actionId)??r.actions?.find(e=>e.id.endsWith(`*`)&&t.actionId.startsWith(e.id.replace(`*`,``)));if(i){if(i&&i.rowsSelectedRequired&&(!this.state.crud_selected_items||this.state.crud_selected_items.length==0)){this.notify(`You first need to select some rows`);return}if(i&&i.validationRequired){let e=ss??this;if(ss=null,e.checkValidations(i.fieldsToValidate),!e.data._valid){e.notifyValidationErrors();return}}ss=null;let e={...t,initiatorComponentId:this.id};i&&i.confirmationRequired?this.callAfterConfirmation(i,()=>this.requestActionCallToServerOrBubble(e,r,i,n)):this.requestActionCallToServerOrBubble(e,r,i,n)}else{let r={...t.parameters};r.initiatorState||=this.state,ss||=this,this.dispatchEvent(new CustomEvent(e.type,{detail:{...e.detail,_originElement:n,parameters:r},bubbles:!0,composed:!0}))}}},this.buildFieldLabelMap=()=>{let e={},t=n=>{if(n)for(let r of n){let n=r.metadata;if(n?.type===j.FormField){let t=n;t.fieldId&&t.label&&(e[t.fieldId]=t.label)}t(r.children)}};return t(this.component?.children),e},this.notifyValidationErrors=()=>{let e=this.data?.errors??{},t=this.buildFieldLabelMap(),n=[];if(Object.entries(e).forEach(([e,r])=>{if(!Array.isArray(r))return;let i=e===`_component`?void 0:t[e]??e;r.forEach(e=>{e&&!n.some(t=>t.label===i&&t.msg===e)&&n.push({label:i,msg:e})})}),n.length===0){this.notify(`There are validation errors`);return}Na({text:`There are validation errors
+`,es=new WeakSet,ts=e=>{if(es.has(e))return;es.add(e);let t=e;if(typeof CSSStyleSheet<`u`&&Array.isArray(t.adoptedStyleSheets))try{let e=new CSSStyleSheet;e.replaceSync($o),t.adoptedStyleSheets=[...t.adoptedStyleSheets,e];return}catch{}let n=e instanceof Document?e.head:e;if(!n)return;let r=document.createElement(`style`);r.setAttribute(Qo,``),r.textContent=$o,n.appendChild(r)},ns=e=>{let t=e.getRootNode();if(t instanceof ShadowRoot||t instanceof Document)return t},rs=e=>{if(!e||e.hasAttribute(`data-mateu-pending`))return;let t=ns(e);t&&ts(t),e.setAttribute(`data-mateu-pending`,``),e.setAttribute(`aria-busy`,`true`)},is=e=>{e&&(e.removeAttribute(`data-mateu-pending`),e.removeAttribute(`aria-busy`))},as=e=>{let t=(typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target;return t instanceof Element?t:void 0},os=[`button`,`a[href]`,`[role="button"]`,`[role="menuitem"]`,`input[type="button"]`,`input[type="submit"]`,`vaadin-button`,`vaadin-menu-bar-button`,`ui5-button`,`oj-c-button`,`oj-button`].join(`, `),ss=e=>{if(!(!e||typeof e.closest!=`function`))return e.closest(os)??void 0},cs=null,ls=class extends Wa{constructor(...e){super(...e),this.baseUrl=``,this.route=``,this.consumedRoute=``,this.formerState={},this.applyRules=()=>{let e=this.component.rules;if(e&&e.length>0){let t=this.state,n=this.data,r=this.appState,i=this.appData,a=this.component,o=e=>Ct(e,t,n,{appState:r,appData:i,component:a}),s=e=>St(e,t,n,r,i,{component:a}),c=[`state`,`data`,`appState`,`appData`,`component`],l=[t,n,r,i,a],u={...this.state},d={...this.data},f=!1,p=!1;for(let t=0;t<e.length;t++){let n=e[t];try{if(o(n.filter)){if(Ko.SetStateValue==n.action||Ko.SetDataValue==n.action){let e=Ko.SetStateValue==n.action?u:d,t=n.fieldName.split(`,`);for(let r=0;r<t.length;r++){let i=t[r];if(!e[i]||e[i]!=n.value){let t=n.expression?s(n.expression):n.value,r=qo.none==n.fieldAttribute?i:i+`.`+n.fieldAttribute;t!=e[r]&&(e[r]=t,Ko.SetStateValue==n.action&&(f=!0),Ko.SetDataValue==n.action&&(p=!0))}}}if(Ko.RunAction==n.action&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.actionId},bubbles:!0,composed:!0})),Ko.RunJS==n.action&&Function(...c,n.value)(...l),Ko.SetAttributeValue==n.action){let e=n.expression?o(n.expression):n.value;if(n.fieldAttribute==`disabled`){e?this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(n.fieldAttribute,`disabled`):this.shadowRoot?.getElementById(n.fieldName)?.removeAttribute(n.fieldAttribute);continue}this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(n.fieldAttribute,e)}if(Ko.SetCssClass==n.action&&this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(`class`,n.value),Ko.SetStyle==n.action&&this.shadowRoot?.getElementById(n.fieldName)?.style.setProperty(n.expression,n.value),Jo.Stop==n.result)break}}catch(e){console.error(`rule failed`,n,e)}}f&&(this.state=u),p&&(this.data=d),f&&this.checkValidations()}},this.skipValidation=(e,t)=>e&&t.fieldId&&!e.includes(t.fieldId)||!e&&t.fieldId&&t.fieldId.includes(`-`),this.checkValidations=e=>{let t=e?e.split(`,`):void 0,n=this.component.validations,r=!0,i=!1,a=this.data??{},o={...this.data??{},errors:{}};if(n){for(let e=0;e<n.length;e++){let r=n[e];if(this.skipValidation(t,r))continue;let i=(r.fieldId??`_component`).split(`,`);for(let e=0;e<i.length;e++){let t=i[e];o.errors[t]=[]}}for(let e=0;e<n.length;e++){let i=n[e];if(!this.skipValidation(t,i))try{let e=i.condition&&i.condition.includes("${")?this._evalTemplate(i.condition):this._evalExpr(i.condition);if(i.condition&&!e){r=!1;let e=(i.fieldId??`_component`).split(`,`);for(let t=0;t<e.length;t++){let n=e[t],r=o.errors[n];if(r||(o.errors[n]=[]),r=o.errors[n],!a[n]){let e=i.message;try{e=this._evalTemplate(i.message)}catch{}r.push(e)}}}}catch(e){console.error(`validation failed`,i,e)}}for(let e=0;e<n.length;e++){let r=n[e];if(this.skipValidation(t,r))continue;let s=(r.fieldId??`_component`).split(`,`);for(let e=0;e<s.length;e++){let t=s[e];if((a.errors||o.errors==``)&&[t].join(`,`)){i=!0;break}}}(a.errors||o.errors==``)&&[`_component`].join(`,`)&&(i=!0)}o._valid=r,o._valid!=a._valid&&(i=!0),i&&(this.data=o)},this._autoSaveTimers=new Map,this.onChange=()=>{this.applyRules()},this.closeModalRequestedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.closeModal()},this.resetFilters=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail,n={};t.fieldIds.forEach(e=>{n[e]=void 0}),n.searchText=void 0,this.state={...this.state,...n}}},this.dataChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail,n={};n[t.key]=t.value,e.type==`data-changed`&&(this.data={...this.data,...n})}},this.valueChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail;if(e.type==`value-changed`){let n={...this.state};n[t.fieldId]=t.value,this.state=n,(this.state[t.fieldId]||this.formerState[t.fieldId])&&this.state[t.fieldId]!=this.formerState[t.fieldId]&&this.component?.confirmOnNavigationIfDirty&&this.dispatchEvent(new CustomEvent(`dirty`,{detail:e.detail,bubbles:!0,composed:!0}));let r=this.component;r.triggers?.filter(e=>e.type==Ua.OnValueChange).filter(e=>!e.propertyName||t.fieldId==e.propertyName).forEach(e=>{(!e.condition||this._evalExpr(e.condition))&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))}),r.triggers?.filter(e=>e.type==Ua.AutoSave).forEach(e=>{let t=e.actionId,n=this._autoSaveTimers.get(t);n!==void 0&&clearTimeout(n),this._autoSaveTimers.set(t,setTimeout(()=>{this._autoSaveTimers.delete(t),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))},e.debounceMillis??800))})}}},this.actionRequestedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.manageActionRequestedEvent(e)},this.manageActionRequestedEvent=e=>{let t=e.detail,n=t?._originElement??as(e);if(e.type==`action-requested`){e.preventDefault(),e.stopPropagation();let r=this.component,i=r.actions?.find(e=>e.id==t.actionId)??r.actions?.find(e=>e.id.endsWith(`*`)&&t.actionId.startsWith(e.id.replace(`*`,``)));if(i){if(i&&i.rowsSelectedRequired&&(!this.state.crud_selected_items||this.state.crud_selected_items.length==0)){this.notify(`You first need to select some rows`);return}if(i&&i.validationRequired){let e=cs??this;if(cs=null,e.checkValidations(i.fieldsToValidate),!e.data._valid){e.notifyValidationErrors();return}}cs=null;let e={...t,initiatorComponentId:this.id};i&&i.confirmationRequired?this.callAfterConfirmation(i,()=>this.requestActionCallToServerOrBubble(e,r,i,n)):this.requestActionCallToServerOrBubble(e,r,i,n)}else{let r={...t.parameters};r.initiatorState||=this.state,cs||=this,this.dispatchEvent(new CustomEvent(e.type,{detail:{...e.detail,_originElement:n,parameters:r},bubbles:!0,composed:!0}))}}},this.buildFieldLabelMap=()=>{let e={},t=n=>{if(n)for(let r of n){let n=r.metadata;if(n?.type===j.FormField){let t=n;t.fieldId&&t.label&&(e[t.fieldId]=t.label)}t(r.children)}};return t(this.component?.children),e},this.notifyValidationErrors=()=>{let e=this.data?.errors??{},t=this.buildFieldLabelMap(),n=[];if(Object.entries(e).forEach(([e,r])=>{if(!Array.isArray(r))return;let i=e===`_component`?void 0:t[e]??e;r.forEach(e=>{e&&!n.some(t=>t.label===i&&t.msg===e)&&n.push({label:i,msg:e})})}),n.length===0){this.notify(`There are validation errors`);return}Pa({text:`There are validation errors
 `+n.map(({label:e,msg:t})=>e?`• ${e}: ${t}`:`• ${t}`).join(`
-`),variant:`error`,position:`bottomEnd`,duration:Math.max(3e3,1500+n.length*1e3)},this),this.focusFirstInvalidField()},this.notify=e=>{Na({text:e,variant:`error`,position:`bottomEnd`,duration:3e3},this)},this.handleRestAction=(e,t)=>{let n=t=>{if(e.resultPath!=null){let n=ln(t,e.resultPath);n&&typeof n==`object`&&(this.state={...this.state,...n})}let n=M(e.successMessage,this.state,this.data);n&&Na({text:n,variant:`success`,position:`bottomEnd`,duration:3e3},this)};if(e.source?.proxy){let e=t===`__restdata__`?`data`:`action`;this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:`__restfetch__`,parameters:{_sourceKind:e,_sourceId:t},callback:e=>n(e?.appData?._restfetch),callbackonly:!0},bubbles:!0,composed:!0}));return}fn(e.source,e=>M(e,this.state,this.data)).then(n).catch(e=>{console.warn(`mateu: rest action failed`,e),Na({text:`Request failed`,variant:`error`,position:`bottomEnd`,duration:3e3},this)})},this.callAfterConfirmation=(e,t)=>{let n=`One moment, please`,r=`Are you sure?`,i=`Yes`,a=`No`;e.confirmationTexts&&(n=e.confirmationTexts.title,r=e.confirmationTexts.message,i=e.confirmationTexts.confirmationText,a=e.confirmationTexts.denialText);let o=document.createElement(`div`);o.style.cssText=`position:fixed;inset:0;z-index:1100;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.35);padding:1rem;`;let s=document.createElement(`div`);s.style.cssText=`background:var(--lumo-base-color,#fff);color:var(--lumo-body-text-color,#1a1a1a);border-radius:var(--lumo-border-radius-l,12px);box-shadow:var(--lumo-box-shadow-xl,0 12px 40px rgba(0,0,0,.3));padding:1.2rem;max-width:min(90vw,26rem);`;let c=()=>{o.parentElement&&document.body.removeChild(o)},l=`font:inherit;font-weight:600;padding:.45rem 1rem;border-radius:var(--lumo-border-radius-m,6px);cursor:pointer;`;re(T`
+`),variant:`error`,position:`bottomEnd`,duration:Math.max(3e3,1500+n.length*1e3)},this),this.focusFirstInvalidField()},this.notify=e=>{Pa({text:e,variant:`error`,position:`bottomEnd`,duration:3e3},this)},this.handleRestAction=(e,t)=>{let n=t=>{if(e.resultPath!=null){let n=un(t,e.resultPath);n&&typeof n==`object`&&(this.state={...this.state,...n})}let n=M(e.successMessage,this.state,this.data);n&&Pa({text:n,variant:`success`,position:`bottomEnd`,duration:3e3},this)};if(e.source?.proxy){let e=t===`__restdata__`?`data`:`action`;this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:`__restfetch__`,parameters:{_sourceKind:e,_sourceId:t},callback:e=>n(e?.appData?._restfetch),callbackonly:!0},bubbles:!0,composed:!0}));return}pn(e.source,e=>M(e,this.state,this.data)).then(n).catch(e=>{console.warn(`mateu: rest action failed`,e),Pa({text:`Request failed`,variant:`error`,position:`bottomEnd`,duration:3e3},this)})},this.callAfterConfirmation=(e,t)=>{let n=`One moment, please`,r=`Are you sure?`,i=`Yes`,a=`No`;e.confirmationTexts&&(n=e.confirmationTexts.title,r=e.confirmationTexts.message,i=e.confirmationTexts.confirmationText,a=e.confirmationTexts.denialText);let o=document.createElement(`div`);o.style.cssText=`position:fixed;inset:0;z-index:1100;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.35);padding:1rem;`;let s=document.createElement(`div`);s.style.cssText=`background:var(--lumo-base-color,#fff);color:var(--lumo-body-text-color,#1a1a1a);border-radius:var(--lumo-border-radius-l,12px);box-shadow:var(--lumo-box-shadow-xl,0 12px 40px rgba(0,0,0,.3));padding:1.2rem;max-width:min(90vw,26rem);`;let c=()=>{o.parentElement&&document.body.removeChild(o)},l=`font:inherit;font-weight:600;padding:.45rem 1rem;border-radius:var(--lumo-border-radius-m,6px);cursor:pointer;`;re(T`
             <h3 style="margin:0 0 .5rem;">${n}</h3>
             <div style="margin-bottom:1.2rem;">${r}</div>
             <div style="display:flex;justify-content:flex-end;gap:.5rem;">
@@ -7310,18 +7318,18 @@ ${i}
                 <button style="${l}border:none;background:var(--lumo-primary-color,#1676f3);color:var(--lumo-primary-contrast-color,#fff);"
                         @click="${()=>{c(),t()}}">${i}</button>
             </div>
-        `,s),o.appendChild(s),o.addEventListener(`click`,e=>{e.target===o&&c()}),document.body.appendChild(o)},this.requestActionCallToServerOrBubble=(e,t,n,r)=>{if(n&&n.bubble){let t={...e.parameters};t.initiatorState||=this.state,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{...e,_originElement:r,parameters:t},bubbles:!0,composed:!0}))}else this.requestActionCallToServer(e,t,n,r)},this.requestActionCallToServer=(e,t,n,r)=>{if(n&&n.href){window.location.href=n.href;return}if(n&&n.js)try{Function(`state`,`data`,`appState`,`appData`,`component`,n.js).call(this,this.state??{},this.data??{},this.appState??{},this.appData??{},this.component),this.state={...this.state},this.data={...this.data}}catch(e){console.error(`when evaluating `+n.js,e,this.component,this.state,this.data)}if(n&&n.customEvent&&this.dispatchEvent(new CustomEvent(n.customEvent.name,{detail:n.customEvent.detail,bubbles:!0,composed:!0})),n&&(n.js||n.customEvent))return;if(n&&n.restAction){this.handleRestAction(n.restAction,n.id);return}if(e.actionId==`search`){let t=e.parameters?._searchState;t?this.state={...this.state,...t}:this.state.size||(this.state={...this.state,size:10,page:0,sort:[]})}if(!n?.background){if(!nt(e.actionId,n?.idempotent)&&!Xo.begin(Yo(this.id,e.actionId)))return;let t=os(r);this._pendingOrigins.set(e.actionId,t),ns(t)}let i=Uo(this.state,e.parameters);this.dispatchEvent(new CustomEvent(`server-side-action-requested`,{detail:{route:this.route,consumedRoute:this.consumedRoute,componentState:i,parameters:e.parameters??{},actionId:e.actionId,serverSideType:t.serverSideType,serverSideComponentRoute:t.route,initiatorComponentId:e.initiatorComponentId??t.id,initiator:this,background:n?.background,sse:n?.sse,timeoutMillis:n?.timeoutMillis,idempotent:n?.idempotent,callback:e.callback,callbackonly:e.callbackonly,callbackToken:e.callbackToken??this.callbackToken},bubbles:!0,composed:!0}))},this.handleBackendSucceeded=e=>{e.detail.actionId&&this.component.triggers?.filter(e=>e.type==Ha.OnSuccess).filter(t=>e.detail.actionId==t.calledActionId).forEach(t=>{if(!t.condition||this._evalExpr(t.condition))if(e.preventDefault(),e.stopPropagation(),t.timeoutMillis>0){let e=this.callbackToken;setTimeout(()=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,callbackToken:e},bubbles:!0,composed:!0}))},t.timeoutMillis)}else this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))})},this.handleBackendFailed=e=>{e.detail.actionId&&this.component.triggers?.filter(e=>e.type==Ha.OnError).filter(t=>e.detail.actionId==t.calledActionId).forEach(t=>{(!t.condition||this._evalExpr(t.condition))&&(e.preventDefault(),e.stopPropagation(),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0})))})},this._pendingOrigins=new Map,this._backendSettledListener=e=>{((typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target)===this&&this._releasePending(e.detail?.actionId)},this._keydownListener=e=>{if(this._handleTabShortcut(e))return;let t=this.component;if(t)for(let n of t.actions??[]){let t=n.shortcut||(n.runOnEnter?`enter`:null);if(t&&this._shortcutMatchesEvent(t,e)){e.preventDefault(),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.id},bubbles:!0,composed:!0}));return}}}}createRenderRoot(){return F.mustUseShadowRoot()?super.createRenderRoot():this}updated(e){super.updated(e),e.has(`state`)&&this.state&&JSON.stringify(this.state)!=JSON.stringify({})&&this.onChange(),e.has(`component`)&&(this.formerState={...this.state},this.component?.confirmOnNavigationIfDirty&&this.dispatchEvent(new CustomEvent(`clean`,{detail:{},bubbles:!0,composed:!0})),setTimeout(()=>this.triggerOnLoad()))}focusFirstInvalidField(){let e=t=>requestAnimationFrame(()=>{let n=this.findFirstInvalid(this.renderRoot);if(n){n.focus?.(),n.scrollIntoView?.({block:`center`,behavior:`smooth`});return}t>0&&e(t-1)});e(3)}findFirstInvalid(e){if(!e?.querySelectorAll)return null;for(let t of Array.from(e.querySelectorAll(`*`))){if(t.invalid===!0)return t;if(t.shadowRoot){let e=this.findFirstInvalid(t.shadowRoot);if(e)return e}}return null}_releasePending(e){(e===void 0?Array.from(this._pendingOrigins.keys()):[e]).forEach(e=>{Xo.end(Yo(this.id,e)),rs(this._pendingOrigins.get(e)),this._pendingOrigins.delete(e)})}_shortcutMatchesEvent(e,t){return rr(e,t)}_collectShortcutTabs(){let e=this.renderRoot;if(!e)return[];let t=Array.from(e.querySelectorAll(`vaadin-tab[data-shortcut]`));return e.querySelectorAll(`mateu-drawer, mateu-dialog`).forEach(e=>{let n=e.shadowRoot;n&&t.push(...Array.from(n.querySelectorAll(`vaadin-tab[data-shortcut]`)))}),t}_handleTabShortcut(e){let t=this._collectShortcutTabs();if(t.length===0)return!1;for(let n of Array.from(t)){let t=n.dataset.shortcut;if(!t||!this._shortcutMatchesEvent(t,e))continue;let r=n.closest(`vaadin-tabs`);if(!r)continue;let i=Array.from(r.querySelectorAll(`vaadin-tab`)).indexOf(n);if(!(i<0))return e.preventDefault(),r.selected=i,!0}return!1}connectedCallback(){super.connectedCallback(),this.addEventListener(`backend-call-succeeded`,this.handleBackendSucceeded),this.addEventListener(`backend-call-failed`,this.handleBackendFailed),this.addEventListener(`backend-succeeded-event`,this._backendSettledListener),this.addEventListener(`backend-failed-event`,this._backendSettledListener),this.addEventListener(`backend-cancelled-event`,this._backendSettledListener),document.addEventListener(`keydown`,this._keydownListener)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`backend-call-succeeded`,this.handleBackendSucceeded),this.removeEventListener(`backend-call-failed`,this.handleBackendFailed),this.removeEventListener(`backend-succeeded-event`,this._backendSettledListener),this.removeEventListener(`backend-failed-event`,this._backendSettledListener),this.removeEventListener(`backend-cancelled-event`,this._backendSettledListener),document.removeEventListener(`keydown`,this._keydownListener),this._releasePending()}render(){return T`<div>
+        `,s),o.appendChild(s),o.addEventListener(`click`,e=>{e.target===o&&c()}),document.body.appendChild(o)},this.requestActionCallToServerOrBubble=(e,t,n,r)=>{if(n&&n.bubble){let t={...e.parameters};t.initiatorState||=this.state,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{...e,_originElement:r,parameters:t},bubbles:!0,composed:!0}))}else this.requestActionCallToServer(e,t,n,r)},this.requestActionCallToServer=(e,t,n,r)=>{if(n&&n.href){window.location.href=n.href;return}if(n&&n.js)try{Function(`state`,`data`,`appState`,`appData`,`component`,n.js).call(this,this.state??{},this.data??{},this.appState??{},this.appData??{},this.component),this.state={...this.state},this.data={...this.data}}catch(e){console.error(`when evaluating `+n.js,e,this.component,this.state,this.data)}if(n&&n.customEvent&&this.dispatchEvent(new CustomEvent(n.customEvent.name,{detail:n.customEvent.detail,bubbles:!0,composed:!0})),n&&(n.js||n.customEvent))return;if(n&&n.restAction){this.handleRestAction(n.restAction,n.id);return}if(e.actionId==`search`){let t=e.parameters?._searchState;t?this.state={...this.state,...t}:this.state.size||(this.state={...this.state,size:10,page:0,sort:[]})}if(!n?.background){if(!nt(e.actionId,n?.idempotent)&&!Zo.begin(Xo(this.id,e.actionId)))return;let t=ss(r);this._pendingOrigins.set(e.actionId,t),rs(t)}let i=Wo(this.state,e.parameters);this.dispatchEvent(new CustomEvent(`server-side-action-requested`,{detail:{route:this.route,consumedRoute:this.consumedRoute,componentState:i,parameters:e.parameters??{},actionId:e.actionId,serverSideType:t.serverSideType,serverSideComponentRoute:t.route,initiatorComponentId:e.initiatorComponentId??t.id,initiator:this,background:n?.background,sse:n?.sse,timeoutMillis:n?.timeoutMillis,idempotent:n?.idempotent,callback:e.callback,callbackonly:e.callbackonly,callbackToken:e.callbackToken??this.callbackToken},bubbles:!0,composed:!0}))},this.handleBackendSucceeded=e=>{e.detail.actionId&&this.component.triggers?.filter(e=>e.type==Ua.OnSuccess).filter(t=>e.detail.actionId==t.calledActionId).forEach(t=>{if(!t.condition||this._evalExpr(t.condition))if(e.preventDefault(),e.stopPropagation(),t.timeoutMillis>0){let e=this.callbackToken;setTimeout(()=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,callbackToken:e},bubbles:!0,composed:!0}))},t.timeoutMillis)}else this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))})},this.handleBackendFailed=e=>{e.detail.actionId&&this.component.triggers?.filter(e=>e.type==Ua.OnError).filter(t=>e.detail.actionId==t.calledActionId).forEach(t=>{(!t.condition||this._evalExpr(t.condition))&&(e.preventDefault(),e.stopPropagation(),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0})))})},this._pendingOrigins=new Map,this._backendSettledListener=e=>{((typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target)===this&&this._releasePending(e.detail?.actionId)},this._keydownListener=e=>{if(this._handleTabShortcut(e))return;let t=this.component;if(t)for(let n of t.actions??[]){let t=n.shortcut||(n.runOnEnter?`enter`:null);if(t&&this._shortcutMatchesEvent(t,e)){e.preventDefault(),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.id},bubbles:!0,composed:!0}));return}}}}createRenderRoot(){return P.mustUseShadowRoot()?super.createRenderRoot():this}updated(e){super.updated(e),e.has(`state`)&&this.state&&JSON.stringify(this.state)!=JSON.stringify({})&&this.onChange(),e.has(`component`)&&(this.formerState={...this.state},this.component?.confirmOnNavigationIfDirty&&this.dispatchEvent(new CustomEvent(`clean`,{detail:{},bubbles:!0,composed:!0})),setTimeout(()=>this.triggerOnLoad()))}focusFirstInvalidField(){let e=t=>requestAnimationFrame(()=>{let n=this.findFirstInvalid(this.renderRoot);if(n){n.focus?.(),n.scrollIntoView?.({block:`center`,behavior:`smooth`});return}t>0&&e(t-1)});e(3)}findFirstInvalid(e){if(!e?.querySelectorAll)return null;for(let t of Array.from(e.querySelectorAll(`*`))){if(t.invalid===!0)return t;if(t.shadowRoot){let e=this.findFirstInvalid(t.shadowRoot);if(e)return e}}return null}_releasePending(e){(e===void 0?Array.from(this._pendingOrigins.keys()):[e]).forEach(e=>{Zo.end(Xo(this.id,e)),is(this._pendingOrigins.get(e)),this._pendingOrigins.delete(e)})}_shortcutMatchesEvent(e,t){return ir(e,t)}_collectShortcutTabs(){let e=this.renderRoot;if(!e)return[];let t=Array.from(e.querySelectorAll(`vaadin-tab[data-shortcut]`));return e.querySelectorAll(`mateu-drawer, mateu-dialog`).forEach(e=>{let n=e.shadowRoot;n&&t.push(...Array.from(n.querySelectorAll(`vaadin-tab[data-shortcut]`)))}),t}_handleTabShortcut(e){let t=this._collectShortcutTabs();if(t.length===0)return!1;for(let n of Array.from(t)){let t=n.dataset.shortcut;if(!t||!this._shortcutMatchesEvent(t,e))continue;let r=n.closest(`vaadin-tabs`);if(!r)continue;let i=Array.from(r.querySelectorAll(`vaadin-tab`)).indexOf(n);if(!(i<0))return e.preventDefault(),r.selected=i,!0}return!1}connectedCallback(){super.connectedCallback(),this.addEventListener(`backend-call-succeeded`,this.handleBackendSucceeded),this.addEventListener(`backend-call-failed`,this.handleBackendFailed),this.addEventListener(`backend-succeeded-event`,this._backendSettledListener),this.addEventListener(`backend-failed-event`,this._backendSettledListener),this.addEventListener(`backend-cancelled-event`,this._backendSettledListener),document.addEventListener(`keydown`,this._keydownListener)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`backend-call-succeeded`,this.handleBackendSucceeded),this.removeEventListener(`backend-call-failed`,this.handleBackendFailed),this.removeEventListener(`backend-succeeded-event`,this._backendSettledListener),this.removeEventListener(`backend-failed-event`,this._backendSettledListener),this.removeEventListener(`backend-cancelled-event`,this._backendSettledListener),document.removeEventListener(`keydown`,this._keydownListener),this._releasePending()}render(){return T`<div>
             <div>${this._render()}</div>
             ${this.data&&this.data.errors&&this.data.errors._component&&this.data.errors._component.length>0?T`
                 <div><ul>${this.data.errors._component.map(e=>T`<li>${e}</li>`)}</ul></div>
-            `:v}</div>`}_render(){if(this.component?.type==A.ClientSide){let e=this.component;return e.metadata?.type==j.Page?Br(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!0):e.metadata?.type==j.Crud?Vr(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!0):F.get()?.renderClientSideComponent(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!1)}return T`
+            `:v}</div>`}_render(){if(this.component?.type==A.ClientSide){let e=this.component;return e.metadata?.type==j.Page?Vr(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!0):e.metadata?.type==j.Crud?Hr(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!0):P.get()?.renderClientSideComponent(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!1)}return T`
             <mateu-api-caller 
                     @value-changed="${this.valueChangedListener}"
                     @data-changed="${this.dataChangedListener}"
                     @close-modal-requested="${this.closeModalRequestedListener}"
                     @filter-reset-requested="${this.resetFilters}"
                     @action-requested="${this.actionRequestedListener}">
-            ${this.component?.children?.map(e=>{if(e.type==A.ClientSide){let t=e;if(t.metadata?.type==j.Page)return Br(this,t,this.baseUrl,this.state,this.data,this.appState,this.appData,!0);if(t.metadata?.type==j.Crud)return Vr(this,t,this.baseUrl,this.state,this.data,this.appState,this.appData,!0)}return I(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData)})}
+            ${this.component?.children?.map(e=>{if(e.type==A.ClientSide){let t=e;if(t.metadata?.type==j.Page)return Vr(this,t,this.baseUrl,this.state,this.data,this.appState,this.appData,!0);if(t.metadata?.type==j.Crud)return Hr(this,t,this.baseUrl,this.state,this.data,this.appState,this.appData,!0)}return F(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData)})}
             </mateu-api-caller>
         `}static{this.styles=h`
         :host {
@@ -7358,15 +7366,15 @@ ${i}
             padding-block: var(--lumo-space-xs);
             box-shadow: 0 1px 0 0 var(--lumo-contrast-10pct, rgba(0, 0, 0, 0.1));
         }
-  `}};k([y()],cs.prototype,`baseUrl`,void 0),k([y()],cs.prototype,`route`,void 0),k([y()],cs.prototype,`consumedRoute`,void 0),cs=k([g(`mateu-component`)],cs);var ls=new class{async handle(e,t){return await e.runAction(t.baseUrl,t.route,t.consumedRoute,t.actionId,t.initiatorComponentId,t.appState,t.serverSideType,t.componentState,t.parameters,t.initiator,t.background,t.options)}},us=new class{constructor(){this.handleUIIncrement=(e,t,n)=>{if(e?.fragments?.forEach(e=>{le.next({command:void 0,fragment:e,ui:void 0,error:void 0,callbackToken:n})}),e?.appState&&(O.value={...e.appState},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))),e?.appData){let n=e?.appData;ue.value={...e.appData,...n},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))}e?.messages?.forEach(e=>{Na({text:e.text,position:e.position,variant:e.variant,duration:e.duration,undoLabel:e.undoLabel,undoActionId:e.undoActionId,undoParameters:e.undoParameters},t)}),e?.banners&&e.banners.length>0&&document.dispatchEvent(new CustomEvent(`page-banners-received`,{detail:{banners:e.banners,append:e.appendBanners??!1},bubbles:!1,composed:!1})),e?.commands?.forEach(e=>{le.next({command:e,fragment:void 0,ui:void 0,error:void 0,callbackToken:n})})}}async runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,m={}){let te=()=>{this.runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,m)};try{let o=await ls.handle(e,{baseUrl:t,route:n,consumedRoute:r,actionId:i,appState:O.value,initiatorComponentId:a,componentState:c,parameters:l,serverSideType:s,initiator:u,background:d,options:{...m,retry:te}});f&&f(o),p||this.handleUIIncrement(o,u,ee),o.messages&&o.messages.length==1&&o.messages[0].variant==`error`&&u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-succeeded`,{detail:{actionId:i,evevntId:E()},bubbles:!0,composed:!0}))}catch(e){console.warn(`Action request failed`,e),e?.__mateuReported||u.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:i,reason:this.serialize(e),retry:te}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))}}serialize(e){return e?.message?e:JSON.stringify(e)}},ds=new class{constructor(){this.handleUIIncrement=(e,t,n)=>{if(e?.messages?.forEach(e=>{Na({text:e.text,position:e.position,variant:e.variant,duration:e.duration,undoLabel:e.undoLabel,undoActionId:e.undoActionId,undoParameters:e.undoParameters},t)}),e?.banners&&e.banners.length>0&&document.dispatchEvent(new CustomEvent(`page-banners-received`,{detail:{banners:e.banners,append:e.appendBanners??!1},bubbles:!1,composed:!1})),e?.commands?.forEach(e=>{le.next({command:e,fragment:void 0,ui:void 0,error:void 0,callbackToken:n})}),e?.fragments?.forEach(e=>{le.next({command:void 0,fragment:e,ui:void 0,error:void 0,callbackToken:n})}),e?.appState&&(O.value={...e.appState},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))),e?.appData){let n=e?.appData;ue.value={...e.appData,...n},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))}}}async runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,m={}){let te=()=>{this.runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,m)};if(n){n||=`_no_route`,n&&n.startsWith(`/`)&&(n=n.substring(1));let e={serverSideType:s,appState:O.value,componentState:c,parameters:l,initiatorComponentId:a,consumedRoute:r,route:`/`+n,actionId:i};d||u.dispatchEvent(new CustomEvent(`backend-called-event`,{bubbles:!0,composed:!0,detail:{}}));let o={Accept:`text/event-stream`,"Content-Type":`application/json`},m=localStorage.getItem(`__mateu_auth_token`);m&&(o.Authorization=`Bearer `+m);let ne=sessionStorage.getItem(`__mateu_sesion_id`);ne&&(o[`X-Session-Id`]=ne),fetch(t+`/mateu/v3/sse/`+n,{method:`POST`,headers:o,body:JSON.stringify(e)}).then(async e=>{let t=e.body?.pipeThrough(new TextDecoderStream).getReader();if(t){let e=``;for(;;){let{value:n,done:r}=await t.read();if(r)break;e+=n;let a=e.split(`
+  `}};k([y()],ls.prototype,`baseUrl`,void 0),k([y()],ls.prototype,`route`,void 0),k([y()],ls.prototype,`consumedRoute`,void 0),ls=k([g(`mateu-component`)],ls);var us=new class{async handle(e,t){return await e.runAction(t.baseUrl,t.route,t.consumedRoute,t.actionId,t.initiatorComponentId,t.appState,t.serverSideType,t.componentState,t.parameters,t.initiator,t.background,t.options)}},ds=new class{constructor(){this.handleUIIncrement=(e,t,n)=>{if(e?.fragments?.forEach(e=>{le.next({command:void 0,fragment:e,ui:void 0,error:void 0,callbackToken:n})}),e?.appState&&(O.value={...e.appState},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))),e?.appData){let n=e?.appData;ue.value={...e.appData,...n},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))}e?.messages?.forEach(e=>{Pa({text:e.text,position:e.position,variant:e.variant,duration:e.duration,undoLabel:e.undoLabel,undoActionId:e.undoActionId,undoParameters:e.undoParameters},t)}),e?.banners&&e.banners.length>0&&document.dispatchEvent(new CustomEvent(`page-banners-received`,{detail:{banners:e.banners,append:e.appendBanners??!1},bubbles:!1,composed:!1})),e?.commands?.forEach(e=>{le.next({command:e,fragment:void 0,ui:void 0,error:void 0,callbackToken:n})})}}async runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,m={}){let te=()=>{this.runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,m)};try{let o=await us.handle(e,{baseUrl:t,route:n,consumedRoute:r,actionId:i,appState:O.value,initiatorComponentId:a,componentState:c,parameters:l,serverSideType:s,initiator:u,background:d,options:{...m,retry:te}});f&&f(o),p||this.handleUIIncrement(o,u,ee),o.messages&&o.messages.length==1&&o.messages[0].variant==`error`&&u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-succeeded`,{detail:{actionId:i,evevntId:E()},bubbles:!0,composed:!0}))}catch(e){console.warn(`Action request failed`,e),e?.__mateuReported||u.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:i,reason:this.serialize(e),retry:te}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))}}serialize(e){return e?.message?e:JSON.stringify(e)}},fs=new class{constructor(){this.handleUIIncrement=(e,t,n)=>{if(e?.messages?.forEach(e=>{Pa({text:e.text,position:e.position,variant:e.variant,duration:e.duration,undoLabel:e.undoLabel,undoActionId:e.undoActionId,undoParameters:e.undoParameters},t)}),e?.banners&&e.banners.length>0&&document.dispatchEvent(new CustomEvent(`page-banners-received`,{detail:{banners:e.banners,append:e.appendBanners??!1},bubbles:!1,composed:!1})),e?.commands?.forEach(e=>{le.next({command:e,fragment:void 0,ui:void 0,error:void 0,callbackToken:n})}),e?.fragments?.forEach(e=>{le.next({command:void 0,fragment:e,ui:void 0,error:void 0,callbackToken:n})}),e?.appState&&(O.value={...e.appState},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))),e?.appData){let n=e?.appData;ue.value={...e.appData,...n},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))}}}async runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,m={}){let te=()=>{this.runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,m)};if(n){n||=`_no_route`,n&&n.startsWith(`/`)&&(n=n.substring(1));let e={serverSideType:s,appState:O.value,componentState:c,parameters:l,initiatorComponentId:a,consumedRoute:r,route:`/`+n,actionId:i};d||u.dispatchEvent(new CustomEvent(`backend-called-event`,{bubbles:!0,composed:!0,detail:{}}));let o={Accept:`text/event-stream`,"Content-Type":`application/json`},m=localStorage.getItem(`__mateu_auth_token`);m&&(o.Authorization=`Bearer `+m);let ne=sessionStorage.getItem(`__mateu_sesion_id`);ne&&(o[`X-Session-Id`]=ne),fetch(t+`/mateu/v3/sse/`+n,{method:`POST`,headers:o,body:JSON.stringify(e)}).then(async e=>{let t=e.body?.pipeThrough(new TextDecoderStream).getReader();if(t){let e=``;for(;;){let{value:n,done:r}=await t.read();if(r)break;e+=n;let a=e.split(`
 
-`);e=a.pop()??``;for(let e of a){let t=e.trim();if(t)if(t.startsWith(`data:`)){let e=JSON.parse(t.substring(5).trim());f&&f(e),p||this.handleUIIncrement(e,u,ee),e.messages&&e.messages.length==1&&e.messages[0].variant==`error`&&u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))}else{let e=t;try{let n=JSON.parse(t);e=n.message,n._embedded?.errors?.length>0&&n._embedded.errors[0].message&&(e=n._embedded.errors[0].message)}catch{}throw Error(e)}}}}d||u.dispatchEvent(new CustomEvent(`backend-succeeded-event`,{bubbles:!0,composed:!0,detail:{actionId:i}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-succeeded`,{detail:{actionId:i},bubbles:!0,composed:!0}))}).catch(e=>{u.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:i,reason:this.serialize(e),retry:te}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))})}}serialize(e){return e?.message?e:JSON.stringify(e)}},fs={fixed:`fixed`,fullWidth:`full`,edgeToEdge:`edge`},ps=new Set([j.Gantt,j.PlanningBoard,j.Kanban,j.Bpmn,j.Workflow,j.Map]),ms={landing:`fixed`,form:`fixed`,process:`fixed`},hs=e=>e?fs[e]:void 0,gs=e=>e.type==A.ClientSide?e.metadata:void 0,_s=e=>{let t=gs(e);if(t?.type==j.Page){let e=hs(t.pageWidth);if(e)return e}for(let t of e.children??[]){let e=_s(t);if(e)return e}},vs=e=>{let t=e.pageType;if(t)return t;let n=e=>{let t=gs(e);if(t?.type==j.Page&&t.pageType)return t.pageType;for(let t of e.children??[]){let e=n(t);if(e)return e}};return n(e)},ys=e=>{let t=gs(e);if(t?.type!=j.Crud)return!1;let n=t;return n.compact?!0:(n.columns??[]).some(e=>e.metadata?.editable)},bs=(e,t)=>t(e)||(e.children??[]).some(e=>bs(e,t)),xs=e=>!!e&&bs(e,e=>gs(e)?.type==j.HeroSection),Ss=e=>gs(e)?.type==j.App||(e.children??[]).some(e=>gs(e)?.type==j.App),Cs=(e,t)=>e?(hs(e.pageWidth)??_s(e))||(t?.top&&Ss(e)?`edge`:ms[vs(e)??``]||(bs(e,e=>{let t=gs(e)?.type;return t!=null&&ps.has(t)})?`edge`:bs(e,ys)?`full`:`fixed`)):`fixed`,ws=`mateu-route-structure-cache`,Ts=1,Es=50,Ds=(()=>{try{return localStorage.getItem(`mateu-route-structure-cache-off`)!==`1`}catch{return!0}})(),Os=()=>{try{return JSON.parse(localStorage.getItem(ws)??`{}`)}catch{return{}}},ks=e=>{try{localStorage.setItem(ws,JSON.stringify(e))}catch{try{let t=Object.entries(e).sort((e,t)=>t[1].t-e[1].t).slice(0,Math.floor(Es/2));localStorage.setItem(ws,JSON.stringify(Object.fromEntries(t)))}catch{}}},As=e=>{let t=e.initialState&&Object.keys(e.initialState).length?`#`+Ns(JSON.stringify(e.initialState)):``;return[e.baseUrl,e.consumedRoute??``,e.route??``,e.serverSideType??``].join(`|`)+t},js=e=>{if(!Ds)return;let t=Os()[e];if(!(!t||t.v!==Ts))return{component:t.component,hash:t.hash}},Ms=(e,t,n)=>{if(!Ds)return;let r=Os();r[e]={v:Ts,t:Date.now(),component:t,hash:n};let i=Object.keys(r);if(i.length>Es){let e=i.sort((e,t)=>r[e].t-r[t].t).slice(0,i.length-Es);for(let t of e)delete r[t]}ks(r)},Ns=e=>{let t=2166136261;for(let n=0;n<e.length;n++)t^=e.charCodeAt(n),t=Math.imul(t,16777619);return(t>>>0).toString(36)},Ps=30,Fs=new Map,Is=!0,Ls=e=>{if(Is)return Fs.get(e)},Rs=(e,t)=>{if(Is&&(Fs.delete(e),Fs.set(e,t),Fs.size>Ps)){let e=Fs.keys().next().value;e!==void 0&&Fs.delete(e)}},zs,X=class extends _t{static{zs=this}constructor(...e){super(...e),this.consumedRoute=``,this.serverSideType=void 0,this.uriPrefix=void 0,this.overrides=void 0,this.homeRoute=void 0,this.route=void 0,this.top=void 0,this.appState={},this.appData={},this.preventNavigation=!1,this.overridesParsed={},this.fragment=void 0,this.showSkeleton=!1,this.pendingRouteFocus=!1,this.hasRenderedContent=!1,this.loadLifecycleListener=e=>{if(((typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target)===this)if(clearTimeout(this.skeletonTimer),e.type===`backend-called-event`){if(this.fragment?.component)return;this.skeletonTimer=setTimeout(()=>{this.showSkeleton=!0},zs.SKELETON_DELAY_MS)}else this.showSkeleton=!1},this.actionRequestedListener=e=>{e instanceof CustomEvent&&(e.preventDefault(),e.stopPropagation(),this.manageActionEvent(e))},this.historyPushed=e=>{e instanceof CustomEvent&&(e.preventDefault(),e.stopPropagation(),this.preventNavigation=!0,this.route=e.detail.route)},this.routeChangedListener=e=>{if(e instanceof CustomEvent){e.preventDefault(),e.stopPropagation();let t=e.detail.route;typeof t==`string`&&(t===``||t.startsWith(`/`))&&this.consumedRoute&&this.consumedRoute!==`_empty`&&this.consumedRoute.startsWith(`/`)&&!t.startsWith(this.consumedRoute)&&(t=this.consumedRoute+t),this.uriPrefix&&(t=t.startsWith(`/`)&&this.uriPrefix.endsWith(`/`)?this.uriPrefix+t.substring(1):!t.startsWith(`/`)&&!this.uriPrefix.endsWith(`/`)?this.uriPrefix+`/`+t:this.uriPrefix+t),this.dispatchEvent(new CustomEvent(`url-update-requested`,{detail:{route:t},bubbles:!0,composed:!0}))}},this.backendFailedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&e.detail.actionId==``&&(this.fragment={targetComponentId:this.id,data:{},state:{},component:{type:A.ClientSide,metadata:{type:j.Element,name:`div`,content:`Not found`},id:`fieldId`},action:ut.Replace,containerId:void 0})},this.detail1=void 0,this.manageActionEvent=e=>{e.preventDefault(),e.stopPropagation(),this.detail1=e.detail;let t=this.detail1;if(e.type==`server-side-action-requested`){let e=us;t.sse&&(e=ds),e.runAction(lt,this.baseUrl,t.route??``,t.consumedRoute,t.actionId,t.initiatorComponentId,this.getCustomisedAppState(),t.serverSideType,t.componentState,t.parameters,t.initiator,t.background,t.callback,t.callbackonly,t.callbackToken,{timeoutMillis:t.timeoutMillis,idempotent:t.idempotent,knownStructureHash:t.knownStructureHash})}},this.getCustomisedAppState=()=>{let e={...O.value};if(this.overrides){let t=Wo(this.overrides);e={...e,...t}}return e}}manageActionRequestedEvent(e){throw Error(`Method not implemented.`)}createRenderRoot(){return F.mustUseShadowRoot()?super.createRenderRoot():this}structureCacheKey(){return As({baseUrl:this.baseUrl,consumedRoute:this.consumedRoute,route:this.route,serverSideType:this.serverSideType,initialState:this.initialState})}focusNewContent(){requestAnimationFrame(()=>{let e=this.renderRoot?.querySelector?.(`h1, h2, [role="heading"]`)??this;e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus?.({preventScroll:!0})})}static{this.SKELETON_DELAY_MS=400}connectedCallback(){super.connectedCallback(),this.overridesParsed=Wo(this.overrides),this.addEventListener(`server-side-action-requested`,this.actionRequestedListener),this.addEventListener(`backend-call-failed`,this.backendFailedListener),this.addEventListener(`history-pushed`,this.historyPushed),this.addEventListener(`route-changed`,this.routeChangedListener),this.addEventListener(`backend-called-event`,this.loadLifecycleListener),this.addEventListener(`backend-succeeded-event`,this.loadLifecycleListener),this.addEventListener(`backend-failed-event`,this.loadLifecycleListener),this.addEventListener(`backend-cancelled-event`,this.loadLifecycleListener)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`server-side-action-requested`,this.actionRequestedListener),this.removeEventListener(`backend-call-failed`,this.backendFailedListener),this.removeEventListener(`history-pushed`,this.historyPushed),this.removeEventListener(`route-changed`,this.routeChangedListener),this.removeEventListener(`backend-called-event`,this.loadLifecycleListener),this.removeEventListener(`backend-succeeded-event`,this.loadLifecycleListener),this.removeEventListener(`backend-failed-event`,this.loadLifecycleListener),this.removeEventListener(`backend-cancelled-event`,this.loadLifecycleListener),clearTimeout(this.skeletonTimer)}shouldUpdate(e){if(this.fragment?.component&&[...e.keys()].every(e=>e===`appState`||e===`appData`)){let t=this.renderRoot.querySelector(`mateu-component`);if(t)return e.has(`appState`)&&(t.appState=this.appState),e.has(`appData`)&&(t.appData=this.appData),!1}return!0}updated(e){if((e.has(`id`)||e.has(`baseurl`)||e.has(`route`)||e.has(`consumedRoute`)||e.has(`instant`))&&!this.preventNavigation){this.callbackToken=this.instant||E();let e=this.structureCacheKey(),t=e===this.lastAuthoritativeKey?void 0:Ls(e);if(t)queueMicrotask(()=>this.applyFragment(t));else{if(e!==this.lastAuthoritativeKey){let t=js(e);this.currentStructureHash=t?.hash,t&&(this.fragment={targetComponentId:this.id,component:t.component,state:{},data:{},action:ut.Replace,containerId:void 0})}this.manageActionEvent(new CustomEvent(`server-side-action-requested`,{detail:{route:this.route,consumedRoute:this.consumedRoute,userData:void 0,actionId:``,serverSideType:this.serverSideType,initiatorComponentId:this.id,initiator:this,componentState:this.initialState,knownStructureHash:this.currentStructureHash,callbackToken:this.callbackToken},bubbles:!0,composed:!0}))}}e.has(`route`)&&this.top&&(this.preventNavigation||(this.pendingRouteFocus=!0),this.preventNavigation||this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:this.route},bubbles:!0,composed:!0}))),this.preventNavigation&&=!1}applyFragment(e){if(!e.component&&this.fragment?.component){this.fragment={...this.fragment,state:{...this.fragment.state??{},...e.state??{}},data:{...this.fragment.data??{},...e.data??{}}};return}if(this.fragment=e,e.component){if(e.action!==ut.Add){let t=this.structureCacheKey(),n=e.component.structureHash;Ms(t,e.component,n),this.lastAuthoritativeKey=t,this.currentStructureHash=n,e.component.staticView&&Rs(t,e)}this.pendingRouteFocus&&this.hasRenderedContent&&this.focusNewContent(),this.pendingRouteFocus=!1,this.hasRenderedContent=!0}e.component&&(this.dataset.pageWidth=Cs(e.component,{top:this.top}),this.dataset.pageType=vs(e.component)??``,this.dataset.hasWelcomeBanner=String(xs(e.component)))}render(){return!this.fragment?.component&&this.showSkeleton?T`
+`);e=a.pop()??``;for(let e of a){let t=e.trim();if(t)if(t.startsWith(`data:`)){let e=JSON.parse(t.substring(5).trim());f&&f(e),p||this.handleUIIncrement(e,u,ee),e.messages&&e.messages.length==1&&e.messages[0].variant==`error`&&u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))}else{let e=t;try{let n=JSON.parse(t);e=n.message,n._embedded?.errors?.length>0&&n._embedded.errors[0].message&&(e=n._embedded.errors[0].message)}catch{}throw Error(e)}}}}d||u.dispatchEvent(new CustomEvent(`backend-succeeded-event`,{bubbles:!0,composed:!0,detail:{actionId:i}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-succeeded`,{detail:{actionId:i},bubbles:!0,composed:!0}))}).catch(e=>{u.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:i,reason:this.serialize(e),retry:te}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))})}}serialize(e){return e?.message?e:JSON.stringify(e)}},ps={fixed:`fixed`,fullWidth:`full`,edgeToEdge:`edge`},ms=new Set([j.Gantt,j.PlanningBoard,j.Kanban,j.Bpmn,j.Workflow,j.Map]),hs={landing:`fixed`,form:`fixed`,process:`fixed`},gs=e=>e?ps[e]:void 0,_s=e=>e.type==A.ClientSide?e.metadata:void 0,vs=e=>{let t=_s(e);if(t?.type==j.Page){let e=gs(t.pageWidth);if(e)return e}for(let t of e.children??[]){let e=vs(t);if(e)return e}},ys=e=>{let t=e.pageType;if(t)return t;let n=e=>{let t=_s(e);if(t?.type==j.Page&&t.pageType)return t.pageType;for(let t of e.children??[]){let e=n(t);if(e)return e}};return n(e)},bs=e=>{let t=_s(e);if(t?.type!=j.Crud)return!1;let n=t;return n.compact?!0:(n.columns??[]).some(e=>e.metadata?.editable)},xs=(e,t)=>t(e)||(e.children??[]).some(e=>xs(e,t)),Ss=e=>!!e&&xs(e,e=>_s(e)?.type==j.HeroSection),Cs=e=>_s(e)?.type==j.App||(e.children??[]).some(e=>_s(e)?.type==j.App),ws=(e,t)=>e?(gs(e.pageWidth)??vs(e))||(t?.top&&Cs(e)?`edge`:hs[ys(e)??``]||(xs(e,e=>{let t=_s(e)?.type;return t!=null&&ms.has(t)})?`edge`:xs(e,bs)?`full`:`fixed`)):`fixed`,Ts=`mateu-route-structure-cache`,Es=1,Ds=50,Os=(()=>{try{return localStorage.getItem(`mateu-route-structure-cache-off`)!==`1`}catch{return!0}})(),ks=()=>{try{return JSON.parse(localStorage.getItem(Ts)??`{}`)}catch{return{}}},As=e=>{try{localStorage.setItem(Ts,JSON.stringify(e))}catch{try{let t=Object.entries(e).sort((e,t)=>t[1].t-e[1].t).slice(0,Math.floor(Ds/2));localStorage.setItem(Ts,JSON.stringify(Object.fromEntries(t)))}catch{}}},js=e=>{let t=e.initialState&&Object.keys(e.initialState).length?`#`+Ps(JSON.stringify(e.initialState)):``;return[e.baseUrl,e.consumedRoute??``,e.route??``,e.serverSideType??``].join(`|`)+t},Ms=e=>{if(!Os)return;let t=ks()[e];if(!(!t||t.v!==Es))return{component:t.component,hash:t.hash}},Ns=(e,t,n)=>{if(!Os)return;let r=ks();r[e]={v:Es,t:Date.now(),component:t,hash:n};let i=Object.keys(r);if(i.length>Ds){let e=i.sort((e,t)=>r[e].t-r[t].t).slice(0,i.length-Ds);for(let t of e)delete r[t]}As(r)},Ps=e=>{let t=2166136261;for(let n=0;n<e.length;n++)t^=e.charCodeAt(n),t=Math.imul(t,16777619);return(t>>>0).toString(36)},Fs=30,Is=new Map,Ls=!0,Rs=e=>{if(Ls)return Is.get(e)},zs=(e,t)=>{if(Ls&&(Is.delete(e),Is.set(e,t),Is.size>Fs)){let e=Is.keys().next().value;e!==void 0&&Is.delete(e)}},Bs,Y=class extends _t{static{Bs=this}constructor(...e){super(...e),this.consumedRoute=``,this.serverSideType=void 0,this.uriPrefix=void 0,this.overrides=void 0,this.homeRoute=void 0,this.route=void 0,this.top=void 0,this.appState={},this.appData={},this.preventNavigation=!1,this.overridesParsed={},this.fragment=void 0,this.showSkeleton=!1,this.pendingRouteFocus=!1,this.hasRenderedContent=!1,this.loadLifecycleListener=e=>{if(((typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target)===this)if(clearTimeout(this.skeletonTimer),e.type===`backend-called-event`){if(this.fragment?.component)return;this.skeletonTimer=setTimeout(()=>{this.showSkeleton=!0},Bs.SKELETON_DELAY_MS)}else this.showSkeleton=!1},this.actionRequestedListener=e=>{e instanceof CustomEvent&&(e.preventDefault(),e.stopPropagation(),this.manageActionEvent(e))},this.historyPushed=e=>{e instanceof CustomEvent&&(e.preventDefault(),e.stopPropagation(),this.preventNavigation=!0,this.route=e.detail.route)},this.routeChangedListener=e=>{if(e instanceof CustomEvent){e.preventDefault(),e.stopPropagation();let t=e.detail.route;typeof t==`string`&&(t===``||t.startsWith(`/`))&&this.consumedRoute&&this.consumedRoute!==`_empty`&&this.consumedRoute.startsWith(`/`)&&!t.startsWith(this.consumedRoute)&&(t=this.consumedRoute+t),this.uriPrefix&&(t=t.startsWith(`/`)&&this.uriPrefix.endsWith(`/`)?this.uriPrefix+t.substring(1):!t.startsWith(`/`)&&!this.uriPrefix.endsWith(`/`)?this.uriPrefix+`/`+t:this.uriPrefix+t),this.dispatchEvent(new CustomEvent(`url-update-requested`,{detail:{route:t},bubbles:!0,composed:!0}))}},this.backendFailedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&e.detail.actionId==``&&(this.fragment={targetComponentId:this.id,data:{},state:{},component:{type:A.ClientSide,metadata:{type:j.Element,name:`div`,content:`Not found`},id:`fieldId`},action:ut.Replace,containerId:void 0})},this.detail1=void 0,this.manageActionEvent=e=>{e.preventDefault(),e.stopPropagation(),this.detail1=e.detail;let t=this.detail1;if(e.type==`server-side-action-requested`){let e=ds;t.sse&&(e=fs),e.runAction(lt,this.baseUrl,t.route??``,t.consumedRoute,t.actionId,t.initiatorComponentId,this.getCustomisedAppState(),t.serverSideType,t.componentState,t.parameters,t.initiator,t.background,t.callback,t.callbackonly,t.callbackToken,{timeoutMillis:t.timeoutMillis,idempotent:t.idempotent,knownStructureHash:t.knownStructureHash})}},this.getCustomisedAppState=()=>{let e={...O.value};if(this.overrides){let t=Go(this.overrides);e={...e,...t}}return e}}manageActionRequestedEvent(e){throw Error(`Method not implemented.`)}createRenderRoot(){return P.mustUseShadowRoot()?super.createRenderRoot():this}structureCacheKey(){return js({baseUrl:this.baseUrl,consumedRoute:this.consumedRoute,route:this.route,serverSideType:this.serverSideType,initialState:this.initialState})}focusNewContent(){requestAnimationFrame(()=>{let e=this.renderRoot?.querySelector?.(`h1, h2, [role="heading"]`)??this;e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus?.({preventScroll:!0})})}static{this.SKELETON_DELAY_MS=400}connectedCallback(){super.connectedCallback(),this.overridesParsed=Go(this.overrides),this.addEventListener(`server-side-action-requested`,this.actionRequestedListener),this.addEventListener(`backend-call-failed`,this.backendFailedListener),this.addEventListener(`history-pushed`,this.historyPushed),this.addEventListener(`route-changed`,this.routeChangedListener),this.addEventListener(`backend-called-event`,this.loadLifecycleListener),this.addEventListener(`backend-succeeded-event`,this.loadLifecycleListener),this.addEventListener(`backend-failed-event`,this.loadLifecycleListener),this.addEventListener(`backend-cancelled-event`,this.loadLifecycleListener)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`server-side-action-requested`,this.actionRequestedListener),this.removeEventListener(`backend-call-failed`,this.backendFailedListener),this.removeEventListener(`history-pushed`,this.historyPushed),this.removeEventListener(`route-changed`,this.routeChangedListener),this.removeEventListener(`backend-called-event`,this.loadLifecycleListener),this.removeEventListener(`backend-succeeded-event`,this.loadLifecycleListener),this.removeEventListener(`backend-failed-event`,this.loadLifecycleListener),this.removeEventListener(`backend-cancelled-event`,this.loadLifecycleListener),clearTimeout(this.skeletonTimer)}shouldUpdate(e){if(this.fragment?.component&&[...e.keys()].every(e=>e===`appState`||e===`appData`)){let t=this.renderRoot.querySelector(`mateu-component`);if(t)return e.has(`appState`)&&(t.appState=this.appState),e.has(`appData`)&&(t.appData=this.appData),!1}return!0}updated(e){if((e.has(`id`)||e.has(`baseurl`)||e.has(`route`)||e.has(`consumedRoute`)||e.has(`instant`))&&!this.preventNavigation){this.callbackToken=this.instant||E();let e=this.structureCacheKey(),t=e===this.lastAuthoritativeKey?void 0:Rs(e);if(t)queueMicrotask(()=>this.applyFragment(t));else{if(e!==this.lastAuthoritativeKey){let t=Ms(e);this.currentStructureHash=t?.hash,t&&(this.fragment={targetComponentId:this.id,component:t.component,state:{},data:{},action:ut.Replace,containerId:void 0})}this.manageActionEvent(new CustomEvent(`server-side-action-requested`,{detail:{route:this.route,consumedRoute:this.consumedRoute,userData:void 0,actionId:``,serverSideType:this.serverSideType,initiatorComponentId:this.id,initiator:this,componentState:this.initialState,knownStructureHash:this.currentStructureHash,callbackToken:this.callbackToken},bubbles:!0,composed:!0}))}}e.has(`route`)&&this.top&&(this.preventNavigation||(this.pendingRouteFocus=!0),this.preventNavigation||this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:this.route},bubbles:!0,composed:!0}))),this.preventNavigation&&=!1}applyFragment(e){if(!e.component&&this.fragment?.component){this.fragment={...this.fragment,state:{...this.fragment.state??{},...e.state??{}},data:{...this.fragment.data??{},...e.data??{}}};return}if(this.fragment=e,e.component){if(e.action!==ut.Add){let t=this.structureCacheKey(),n=e.component.structureHash;Ns(t,e.component,n),this.lastAuthoritativeKey=t,this.currentStructureHash=n,e.component.staticView&&zs(t,e)}this.pendingRouteFocus&&this.hasRenderedContent&&this.focusNewContent(),this.pendingRouteFocus=!1,this.hasRenderedContent=!0}e.component&&(this.dataset.pageWidth=ws(e.component,{top:this.top}),this.dataset.pageType=ys(e.component)??``,this.dataset.hasWelcomeBanner=String(Ss(e.component)))}render(){return!this.fragment?.component&&this.showSkeleton?T`
                 <div class="route-skeleton" aria-busy="true" aria-live="polite">
                     <mateu-skeleton variant="text" count="1"></mateu-skeleton>
                     <mateu-skeleton variant="form" count="4"></mateu-skeleton>
                 </div>
             `:T`
-           ${this.fragment?.component?I(this,this.fragment?.component,this.baseUrl,this.fragment?.state??{},this.fragment?.data??{},this.appState,this.appData):v}
+           ${this.fragment?.component?F(this,this.fragment?.component,this.baseUrl,this.fragment?.state??{},this.fragment?.data??{},this.appState,this.appData):v}
        `}static{this.styles=h`
         :host {
             display: block;
@@ -7405,7 +7413,7 @@ ${i}
             max-width: 16rem;
             margin-block-end: var(--lumo-space-l, 1.5rem);
         }
-  `}};k([y()],X.prototype,`consumedRoute`,void 0),k([y()],X.prototype,`serverSideType`,void 0),k([y()],X.prototype,`uriPrefix`,void 0),k([y()],X.prototype,`overrides`,void 0),k([y()],X.prototype,`homeRoute`,void 0),k([y()],X.prototype,`route`,void 0),k([y()],X.prototype,`top`,void 0),k([y()],X.prototype,`instant`,void 0),k([y()],X.prototype,`initialState`,void 0),k([y()],X.prototype,`appState`,void 0),k([y()],X.prototype,`appData`,void 0),k([C()],X.prototype,`fragment`,void 0),k([C()],X.prototype,`showSkeleton`,void 0),X=zs=k([g(`mateu-ux`)],X);function Bs(e){let t=`var(--lumo-space-m, 1rem)`,n={left:`50%`,transform:`translateX(-50%)`};switch(e){case`topStart`:return{top:t,left:t};case`topCenter`:return{top:t,...n};case`topEnd`:return{top:t,right:t};case`topStretch`:return{top:t,left:t,right:t};case`middle`:return{top:`50%`,left:`50%`,transform:`translate(-50%, -50%)`};case`bottomStart`:return{bottom:t,left:t};case`bottomCenter`:return{bottom:t,...n};case`bottomStretch`:return{bottom:t,left:t,right:t};default:return{bottom:t,right:t}}}function Vs(e){switch(e){case`success`:return{bg:`var(--lumo-success-color, #2e7d32)`,fg:`#fff`};case`error`:return{bg:`var(--lumo-error-color, #c62828)`,fg:`#fff`};case`warning`:return{bg:`var(--lumo-warning-color, #f9a825)`,fg:`#1a1a1a`};case`contrast`:return{bg:`var(--lumo-contrast-90pct, #1a1a1a)`,fg:`#fff`};default:return{bg:`var(--lumo-base-color, #fff)`,fg:`var(--lumo-body-text-color, #1a1a1a)`}}}var Hs={show(e,t){let{bg:n,fg:r}=Vs(e.variant),i=Bs(e.position),a=document.createElement(`div`),o=e.variant===`error`;a.setAttribute(`role`,o?`alert`:`status`),a.setAttribute(`aria-live`,o?`assertive`:`polite`),a.setAttribute(`aria-atomic`,`true`),Object.assign(a.style,{position:`fixed`,zIndex:`2000`,display:`flex`,alignItems:`center`,gap:`0.75rem`,maxWidth:`min(90vw, 28rem)`,padding:`0.7rem 1rem`,borderRadius:`var(--lumo-border-radius-m, 8px)`,boxShadow:`var(--lumo-box-shadow-m, 0 4px 16px rgba(0,0,0,0.2))`,background:n,color:r,font:`inherit`,fontSize:`var(--lumo-font-size-s, 0.875rem)`,opacity:`0`,transition:`opacity 0.2s ease`,...i});let s=document.createElement(`span`);s.textContent=e.text,a.appendChild(s);let c=()=>{a.style.opacity=`0`,setTimeout(()=>a.remove(),200)},l=e.onAction?{label:e.actionLabel??`Retry`,run:e.onAction}:e.undoActionId?{label:e.undoLabel??`Undo`,run:()=>t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.undoActionId,parameters:e.undoParameters??{}},bubbles:!0,composed:!0}))}:void 0;if(l){let e=document.createElement(`button`);e.textContent=l.label,e.style.cssText=`margin-left: 0.25rem; background: none; border: 1px solid currentColor; border-radius: var(--lumo-border-radius-s, 4px); color: inherit; cursor: pointer; padding: 0.15rem 0.6rem; font: inherit; font-weight: 600;`,e.addEventListener(`click`,()=>{l.run(),c()}),a.appendChild(e)}document.body.appendChild(a),requestAnimationFrame(()=>{a.style.opacity=`1`});let u=e.duration??(l?1e4:5e3);u>0&&setTimeout(c,u)}};function Us(){Ma(Hs)}var Ws=class extends b{constructor(...e){super(...e),this.online=!0,this.recovered=!1}connectedCallback(){super.connectedCallback(),this.online=at.isOnline(),this.unsubscribe=at.subscribe(e=>{let t=!this.online;this.online=e,e&&t&&(this.recovered=!0,clearTimeout(this.recoveredTimer),this.recoveredTimer=setTimeout(()=>{this.recovered=!1},4e3))})}disconnectedCallback(){super.disconnectedCallback(),this.unsubscribe?.(),clearTimeout(this.recoveredTimer),this.releaseSpace()}updated(){let e=this.renderRoot.querySelector(`.bar`);if(!e){this.releaseSpace();return}document.body.style.setProperty(`padding-block-start`,`${e.offsetHeight}px`)}releaseSpace(){typeof document<`u`&&document.body?.style.removeProperty(`padding-block-start`)}render(){if(this.online&&!this.recovered)return v;let e=!this.online;return T`<div class="bar ${e?`offline`:`back`}" role="status" aria-live="polite">
+  `}};k([y()],Y.prototype,`consumedRoute`,void 0),k([y()],Y.prototype,`serverSideType`,void 0),k([y()],Y.prototype,`uriPrefix`,void 0),k([y()],Y.prototype,`overrides`,void 0),k([y()],Y.prototype,`homeRoute`,void 0),k([y()],Y.prototype,`route`,void 0),k([y()],Y.prototype,`top`,void 0),k([y()],Y.prototype,`instant`,void 0),k([y()],Y.prototype,`initialState`,void 0),k([y()],Y.prototype,`appState`,void 0),k([y()],Y.prototype,`appData`,void 0),k([C()],Y.prototype,`fragment`,void 0),k([C()],Y.prototype,`showSkeleton`,void 0),Y=Bs=k([g(`mateu-ux`)],Y);function Vs(e){let t=`var(--lumo-space-m, 1rem)`,n={left:`50%`,transform:`translateX(-50%)`};switch(e){case`topStart`:return{top:t,left:t};case`topCenter`:return{top:t,...n};case`topEnd`:return{top:t,right:t};case`topStretch`:return{top:t,left:t,right:t};case`middle`:return{top:`50%`,left:`50%`,transform:`translate(-50%, -50%)`};case`bottomStart`:return{bottom:t,left:t};case`bottomCenter`:return{bottom:t,...n};case`bottomStretch`:return{bottom:t,left:t,right:t};default:return{bottom:t,right:t}}}function Hs(e){switch(e){case`success`:return{bg:`var(--lumo-success-color, #2e7d32)`,fg:`#fff`};case`error`:return{bg:`var(--lumo-error-color, #c62828)`,fg:`#fff`};case`warning`:return{bg:`var(--lumo-warning-color, #f9a825)`,fg:`#1a1a1a`};case`contrast`:return{bg:`var(--lumo-contrast-90pct, #1a1a1a)`,fg:`#fff`};default:return{bg:`var(--lumo-base-color, #fff)`,fg:`var(--lumo-body-text-color, #1a1a1a)`}}}var Us={show(e,t){let{bg:n,fg:r}=Hs(e.variant),i=Vs(e.position),a=document.createElement(`div`),o=e.variant===`error`;a.setAttribute(`role`,o?`alert`:`status`),a.setAttribute(`aria-live`,o?`assertive`:`polite`),a.setAttribute(`aria-atomic`,`true`),Object.assign(a.style,{position:`fixed`,zIndex:`2000`,display:`flex`,alignItems:`center`,gap:`0.75rem`,maxWidth:`min(90vw, 28rem)`,padding:`0.7rem 1rem`,borderRadius:`var(--lumo-border-radius-m, 8px)`,boxShadow:`var(--lumo-box-shadow-m, 0 4px 16px rgba(0,0,0,0.2))`,background:n,color:r,font:`inherit`,fontSize:`var(--lumo-font-size-s, 0.875rem)`,opacity:`0`,transition:`opacity 0.2s ease`,...i});let s=document.createElement(`span`);s.textContent=e.text,a.appendChild(s);let c=()=>{a.style.opacity=`0`,setTimeout(()=>a.remove(),200)},l=e.onAction?{label:e.actionLabel??`Retry`,run:e.onAction}:e.undoActionId?{label:e.undoLabel??`Undo`,run:()=>t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.undoActionId,parameters:e.undoParameters??{}},bubbles:!0,composed:!0}))}:void 0;if(l){let e=document.createElement(`button`);e.textContent=l.label,e.style.cssText=`margin-left: 0.25rem; background: none; border: 1px solid currentColor; border-radius: var(--lumo-border-radius-s, 4px); color: inherit; cursor: pointer; padding: 0.15rem 0.6rem; font: inherit; font-weight: 600;`,e.addEventListener(`click`,()=>{l.run(),c()}),a.appendChild(e)}document.body.appendChild(a),requestAnimationFrame(()=>{a.style.opacity=`1`});let u=e.duration??(l?1e4:5e3);u>0&&setTimeout(c,u)}};function Ws(){Na(Us)}var Gs=class extends b{constructor(...e){super(...e),this.online=!0,this.recovered=!1}connectedCallback(){super.connectedCallback(),this.online=at.isOnline(),this.unsubscribe=at.subscribe(e=>{let t=!this.online;this.online=e,e&&t&&(this.recovered=!0,clearTimeout(this.recoveredTimer),this.recoveredTimer=setTimeout(()=>{this.recovered=!1},4e3))})}disconnectedCallback(){super.disconnectedCallback(),this.unsubscribe?.(),clearTimeout(this.recoveredTimer),this.releaseSpace()}updated(){let e=this.renderRoot.querySelector(`.bar`);if(!e){this.releaseSpace();return}document.body.style.setProperty(`padding-block-start`,`${e.offsetHeight}px`)}releaseSpace(){typeof document<`u`&&document.body?.style.removeProperty(`padding-block-start`)}render(){if(this.online&&!this.recovered)return v;let e=!this.online;return T`<div class="bar ${e?`offline`:`back`}" role="status" aria-live="polite">
             <span class="dot"></span>
             <span>${e?`No connection — changes you make now will not be saved.`:`Connection restored.`}</span>
         </div>`}static{this.styles=h`
@@ -7447,7 +7455,7 @@ ${i}
         @media (prefers-reduced-motion: reduce) {
             .bar, .bar.offline .dot { animation: none; }
         }
-    `}};k([C()],Ws.prototype,`online`,void 0),k([C()],Ws.prototype,`recovered`,void 0),Ws=k([g(`mateu-connectivity-banner`)],Ws);var Gs=null;function Ks(){if(!(typeof document>`u`)&&!(Gs&&Gs.isConnected)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>Ks(),{once:!0});return}Gs=document.createElement(`mateu-connectivity-banner`),document.body.appendChild(Gs)}}var qs,Js=class extends b{static{qs=this}constructor(...e){super(...e),this.skip=()=>{let e=this.findContent();e&&(e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus(),e.scrollIntoView({block:`start`}))}}static{this.TARGETS=[`.app-content`,`mateu-page`,`mateu-ux`,`mateu-component`]}findContent(){let e=new Set,t=n=>{if(e.has(n))return null;e.add(n);for(let e of qs.TARGETS){let t=n.querySelector?.(e);if(t&&t!==this)return t}for(let e of Array.from(n.querySelectorAll?.(`*`)??[]))if(e.shadowRoot){let n=t(e.shadowRoot);if(n)return n}return null};return t(document)}render(){return T`<button class="skip" @click="${this.skip}">Skip to content</button>`}static{this.styles=h`
+    `}};k([C()],Gs.prototype,`online`,void 0),k([C()],Gs.prototype,`recovered`,void 0),Gs=k([g(`mateu-connectivity-banner`)],Gs);var Ks=null;function qs(){if(!(typeof document>`u`)&&!(Ks&&Ks.isConnected)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>qs(),{once:!0});return}Ks=document.createElement(`mateu-connectivity-banner`),document.body.appendChild(Ks)}}var Js,Ys=class extends b{static{Js=this}constructor(...e){super(...e),this.skip=()=>{let e=this.findContent();e&&(e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus(),e.scrollIntoView({block:`start`}))}}static{this.TARGETS=[`.app-content`,`mateu-page`,`mateu-ux`,`mateu-component`]}findContent(){let e=new Set,t=n=>{if(e.has(n))return null;e.add(n);for(let e of Js.TARGETS){let t=n.querySelector?.(e);if(t&&t!==this)return t}for(let e of Array.from(n.querySelectorAll?.(`*`)??[]))if(e.shadowRoot){let n=t(e.shadowRoot);if(n)return n}return null};return t(document)}render(){return T`<button class="skip" @click="${this.skip}">Skip to content</button>`}static{this.styles=h`
         :host {
             position: fixed;
             inset-block-start: 0;
@@ -7480,7 +7488,7 @@ ${i}
             outline: 2px solid var(--lumo-body-text-color, #161513);
             outline-offset: 2px;
         }
-    `}};Js=qs=k([g(`mateu-skip-link`)],Js);var Ys=null;function Xs(){if(!(typeof document>`u`)&&!(Ys&&Ys.isConnected)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>Xs(),{once:!0});return}Ys=document.createElement(`mateu-skip-link`),document.body.insertBefore(Ys,document.body.firstChild)}}Us(),Ks(),ht(),Xs();var Zs=class extends b{constructor(...e){super(...e),this.baseUrl=``,this.route=void 0,this.consumedRoute=`_empty`,this.config=void 0,this.top=`true`,this.pathPrefix=void 0,this.bundleUrl=void 0,this.debug=!1,this._lastUrl=``,this.routeChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.top==`true`){let t=e.detail.route,n=this.baseUrl??``;!t||t.startsWith(`/`)?n=window.location.origin+(this.pathPrefix??``):(t=(this.pathPrefix??``)+t,n.indexOf(`://`)<0&&(n.startsWith(`/`)||(n=`/`+n),n=window.location.origin+n)),t.startsWith(this.pathPrefix+`/`)&&(t=t.substring(this.pathPrefix?.length)),n.endsWith(`/`)&&t.startsWith(`/`)&&(t=t.substring(1));let r=new URL(n+t);if((window.location.pathname||r.pathname)&&window.location.pathname!=r.pathname){let e=r.pathname;r.search&&(e+=r.search),e&&!e.startsWith(`/`)&&(e=`/`+e),window.history.pushState({},``,e),this._lastUrl=window.location.href}}},this.navigateToRequestedListener=e=>{if(e.preventDefault(),e.stopPropagation(),eo.markClean(),e instanceof CustomEvent){let t=e.detail.route,n=this.renderRoot.querySelector(`mateu-ux`);n&&(n.setAttribute(`route`,t),n.setAttribute(`instant`,E()))}}}createRenderRoot(){return F.mustUseShadowRoot()?super.createRenderRoot():this}connectedCallback(){if(super.connectedCallback(),eo.install(),this._lastUrl=window.location.href,window.onpopstate=e=>{if(!eo.confirmLeave()){window.history.pushState({},``,this._lastUrl);return}let t=e.target;this.loadUrl(t)},this.top==`true`?(this.bundleUrl&&Ke(this.bundleUrl),this.loadUrl(window)):this.route&&(this.consumedRoute=``),this.config)try{let e=JSON.parse(this.config);O.value={...O.value,...e}}catch{O.value={...O.value,config:this.config}}this.addEventListener(`url-update-requested`,this.routeChangedListener),this.addEventListener(`navigate-to-requested`,this.navigateToRequestedListener)}disconnectedCallback(){super.disconnectedCallback(),this.upstreamSubscription?.unsubscribe(),this.removeEventListener(`url-update-requested`,this.routeChangedListener),this.removeEventListener(`navigate-to-requested`,this.navigateToRequestedListener)}loadUrl(e){if(this.route=this.extractRouteFromUrl(e),this.setAttribute(`route`,this.route),this.instant=E(),this._lastUrl=e.location.href,e.location.search){let t=new URLSearchParams(e.location.search).get(`overrides`);if(t&&(this.config=t,this.config))try{let e=JSON.parse(this.config);O.value={...O.value,...e}}catch{O.value={...O.value,config:this.config}}}}extractRouteFromUrl(e){return this.addQueryParams(this.extractRouteWithoutParamsFromUrl(e),e.location)}extractRouteWithoutParamsFromUrl(e){let t=this.extractGrossRouteFromUrl(e);return this.pathPrefix&&t.startsWith(this.pathPrefix)?t.substring(this.pathPrefix.length):t==`/`?``:t}addQueryParams(e,t){return e+(t.search?``+t.search:``)}extractGrossRouteFromUrl(e){let t=e.location.pathname,n=this.baseUrl&&(this.baseUrl.startsWith(`http://`)||this.baseUrl.startsWith(`https://`))?this.baseUrl.substring(this.getContextPathStartingIndex(this.baseUrl)):this.baseUrl;return t.startsWith(n)?t.substring(n.length):t}getContextPathStartingIndex(e){return e.startsWith(`http:`)?e.indexOf(`/`,7):e.startsWith(`https:`)?e.indexOf(`/`,8):0}render(){return T`
+    `}};Ys=Js=k([g(`mateu-skip-link`)],Ys);var Xs=null;function Zs(){if(!(typeof document>`u`)&&!(Xs&&Xs.isConnected)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>Zs(),{once:!0});return}Xs=document.createElement(`mateu-skip-link`),document.body.insertBefore(Xs,document.body.firstChild)}}Ws(),qs(),ht(),Zs();var Qs=class extends b{constructor(...e){super(...e),this.baseUrl=``,this.route=void 0,this.consumedRoute=`_empty`,this.config=void 0,this.top=`true`,this.pathPrefix=void 0,this.bundleUrl=void 0,this.debug=!1,this._lastUrl=``,this.routeChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.top==`true`){let t=e.detail.route,n=this.baseUrl??``;!t||t.startsWith(`/`)?n=window.location.origin+(this.pathPrefix??``):(t=(this.pathPrefix??``)+t,n.indexOf(`://`)<0&&(n.startsWith(`/`)||(n=`/`+n),n=window.location.origin+n)),t.startsWith(this.pathPrefix+`/`)&&(t=t.substring(this.pathPrefix?.length)),n.endsWith(`/`)&&t.startsWith(`/`)&&(t=t.substring(1));let r=new URL(n+t);if((window.location.pathname||r.pathname)&&window.location.pathname!=r.pathname){let e=r.pathname;r.search&&(e+=r.search),e&&!e.startsWith(`/`)&&(e=`/`+e),window.history.pushState({},``,e),this._lastUrl=window.location.href}}},this.navigateToRequestedListener=e=>{if(e.preventDefault(),e.stopPropagation(),to.markClean(),e instanceof CustomEvent){let t=e.detail.route,n=this.renderRoot.querySelector(`mateu-ux`);n&&(n.setAttribute(`route`,t),n.setAttribute(`instant`,E()))}}}createRenderRoot(){return P.mustUseShadowRoot()?super.createRenderRoot():this}connectedCallback(){if(super.connectedCallback(),to.install(),this._lastUrl=window.location.href,window.onpopstate=e=>{if(!to.confirmLeave()){window.history.pushState({},``,this._lastUrl);return}let t=e.target;this.loadUrl(t)},this.top==`true`?(this.bundleUrl&&Ke(this.bundleUrl),this.loadUrl(window)):this.route&&(this.consumedRoute=``),this.config)try{let e=JSON.parse(this.config);O.value={...O.value,...e}}catch{O.value={...O.value,config:this.config}}this.addEventListener(`url-update-requested`,this.routeChangedListener),this.addEventListener(`navigate-to-requested`,this.navigateToRequestedListener)}disconnectedCallback(){super.disconnectedCallback(),this.upstreamSubscription?.unsubscribe(),this.removeEventListener(`url-update-requested`,this.routeChangedListener),this.removeEventListener(`navigate-to-requested`,this.navigateToRequestedListener)}loadUrl(e){if(this.route=this.extractRouteFromUrl(e),this.setAttribute(`route`,this.route),this.instant=E(),this._lastUrl=e.location.href,e.location.search){let t=new URLSearchParams(e.location.search).get(`overrides`);if(t&&(this.config=t,this.config))try{let e=JSON.parse(this.config);O.value={...O.value,...e}}catch{O.value={...O.value,config:this.config}}}}extractRouteFromUrl(e){return this.addQueryParams(this.extractRouteWithoutParamsFromUrl(e),e.location)}extractRouteWithoutParamsFromUrl(e){let t=this.extractGrossRouteFromUrl(e);return this.pathPrefix&&t.startsWith(this.pathPrefix)?t.substring(this.pathPrefix.length):t==`/`?``:t}addQueryParams(e,t){return e+(t.search?``+t.search:``)}extractGrossRouteFromUrl(e){let t=e.location.pathname,n=this.baseUrl&&(this.baseUrl.startsWith(`http://`)||this.baseUrl.startsWith(`https://`))?this.baseUrl.substring(this.getContextPathStartingIndex(this.baseUrl)):this.baseUrl;return t.startsWith(n)?t.substring(n.length):t}getContextPathStartingIndex(e){return e.startsWith(`http:`)?e.indexOf(`/`,7):e.startsWith(`https:`)?e.indexOf(`/`,8):0}render(){return T`
            <mateu-api-caller>
                 <mateu-ux id="_ux"
                           baseurl="${this.baseUrl}"
@@ -7504,9 +7512,9 @@ ${i}
         :host {
             --lumo-clickable-cursor: pointer;
         }
-  `}};k([y()],Zs.prototype,`baseUrl`,void 0),k([y()],Zs.prototype,`route`,void 0),k([y()],Zs.prototype,`consumedRoute`,void 0),k([y()],Zs.prototype,`config`,void 0),k([y()],Zs.prototype,`top`,void 0),k([y()],Zs.prototype,`pathPrefix`,void 0),k([y()],Zs.prototype,`bundleUrl`,void 0),k([C()],Zs.prototype,`instant`,void 0),k([y({type:Boolean})],Zs.prototype,`debug`,void 0),Zs=k([g(`mateu-ui`)],Zs);var Qs,$s=class extends b{static{Qs=this}constructor(...e){super(...e),this.baseUrl=``,this.opened=!1,this.searchText=``}static{this.SEARCHABLE_THRESHOLD=7}connectedCallback(){super.connectedCallback(),Ee()}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick(),this.searchTimer&&clearTimeout(this.searchTimer)}currentValue(){return String(Se()[this.selector.fieldName]??``)}currentLabel(){let e=this.currentValue();if(!e)return`—`;let t=(this.searchedOptions??this.selector.options)?.find(t=>String(t.value)===e);if(t)return t.label;let n=Ce()[this.selector.fieldName];return n===void 0?e:String(n)}pick(e,t){we(this.selector.fieldName,e,t),window.location.reload()}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}openPanel(){this.opened||(this.opened=!0,this.searchText=``,this.searchedOptions=void 0,this.remoteSearch(),this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick),this.updateComplete.then(()=>this.renderRoot.querySelector(`input.picker-search`)?.focus()))}closePanel(){this.detachOutsideClick(),this.opened=!1}onSearchInput(e){this.searchText=e.target.value,this.searchTimer&&clearTimeout(this.searchTimer),this.searchTimer=setTimeout(()=>this.remoteSearch(),300)}async remoteSearch(){let e=this.app;if(e?.serverSideType)try{let t=await lt.runAction(this.baseUrl??``,e.rootRoute??e.initialRoute??``,``,`_appcontext-search-${this.selector.fieldName}`,`appcontext-${this.selector.fieldName}`,void 0,e.serverSideType,{},{searchText:this.searchText},this,!0);for(let e of t?.fragments??[]){let t=e.data?.[`_appcontext_${this.selector.fieldName}`]?.content;if(Array.isArray(t)){this.searchedOptions=t.map(e=>({value:e.value,label:e.label??String(e.value)}));return}}}catch{}}visibleOptions(){let e=this.searchedOptions??this.selector.options??[],t=this.searchText.trim().toLowerCase();return t?e.filter(e=>e.label.toLowerCase().includes(t)):e}renderPanel(){let e=this.currentValue(),t=this.visibleOptions();return T`
+  `}};k([y()],Qs.prototype,`baseUrl`,void 0),k([y()],Qs.prototype,`route`,void 0),k([y()],Qs.prototype,`consumedRoute`,void 0),k([y()],Qs.prototype,`config`,void 0),k([y()],Qs.prototype,`top`,void 0),k([y()],Qs.prototype,`pathPrefix`,void 0),k([y()],Qs.prototype,`bundleUrl`,void 0),k([C()],Qs.prototype,`instant`,void 0),k([y({type:Boolean})],Qs.prototype,`debug`,void 0),Qs=k([g(`mateu-ui`)],Qs);var $s,ec=class extends b{static{$s=this}constructor(...e){super(...e),this.baseUrl=``,this.opened=!1,this.searchText=``}static{this.SEARCHABLE_THRESHOLD=7}connectedCallback(){super.connectedCallback(),Ee()}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick(),this.searchTimer&&clearTimeout(this.searchTimer)}currentValue(){return String(Se()[this.selector.fieldName]??``)}currentLabel(){let e=this.currentValue();if(!e)return`—`;let t=(this.searchedOptions??this.selector.options)?.find(t=>String(t.value)===e);if(t)return t.label;let n=Ce()[this.selector.fieldName];return n===void 0?e:String(n)}pick(e,t){we(this.selector.fieldName,e,t),window.location.reload()}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}openPanel(){this.opened||(this.opened=!0,this.searchText=``,this.searchedOptions=void 0,this.remoteSearch(),this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick),this.updateComplete.then(()=>this.renderRoot.querySelector(`input.picker-search`)?.focus()))}closePanel(){this.detachOutsideClick(),this.opened=!1}onSearchInput(e){this.searchText=e.target.value,this.searchTimer&&clearTimeout(this.searchTimer),this.searchTimer=setTimeout(()=>this.remoteSearch(),300)}async remoteSearch(){let e=this.app;if(e?.serverSideType)try{let t=await lt.runAction(this.baseUrl??``,e.rootRoute??e.initialRoute??``,``,`_appcontext-search-${this.selector.fieldName}`,`appcontext-${this.selector.fieldName}`,void 0,e.serverSideType,{},{searchText:this.searchText},this,!0);for(let e of t?.fragments??[]){let t=e.data?.[`_appcontext_${this.selector.fieldName}`]?.content;if(Array.isArray(t)){this.searchedOptions=t.map(e=>({value:e.value,label:e.label??String(e.value)}));return}}}catch{}}visibleOptions(){let e=this.searchedOptions??this.selector.options??[],t=this.searchText.trim().toLowerCase();return t?e.filter(e=>e.label.toLowerCase().includes(t)):e}renderPanel(){let e=this.currentValue(),t=this.visibleOptions();return T`
             <div class="panel">
-                ${this.searchText!==``||t.length>Qs.SEARCHABLE_THRESHOLD?T`
+                ${this.searchText!==``||t.length>$s.SEARCHABLE_THRESHOLD?T`
                     <input class="picker-search" type="text" placeholder="Search"
                            .value="${this.searchText}"
                            @input="${this.onSearchInput}"
@@ -7598,9 +7606,9 @@ ${i}
         .option--clear {
             color: var(--lumo-secondary-text-color, rgba(0, 0, 0, 0.55));
         }
-    `}};k([y()],$s.prototype,`selector`,void 0),k([y()],$s.prototype,`app`,void 0),k([y()],$s.prototype,`baseUrl`,void 0),k([C()],$s.prototype,`opened`,void 0),k([C()],$s.prototype,`searchText`,void 0),k([C()],$s.prototype,`searchedOptions`,void 0),$s=Qs=k([g(`mateu-app-context-picker`)],$s);var ec=class extends b{constructor(...e){super(...e),this.baseUrl=``,this.opened=!1,this.notifications=[],this.fetched=!1}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}updated(){!this.fetched&&this.app?.serverSideType&&(this.fetched=!0,this.refresh())}unreadCount(){return this.notifications.filter(e=>e.unread).length}async runNotificationsAction(e,t){let n=this.app;if(n?.serverSideType)try{let r=await lt.runAction(this.baseUrl??``,n.rootRoute??n.initialRoute??``,``,e,`notification-bell`,void 0,n.serverSideType,{},t,this,!0);for(let e of r?.fragments??[]){let t=e.data?._notifications;if(Array.isArray(t)){this.notifications=t;return}}}catch{}}refresh(){return this.runNotificationsAction(`_notifications-list`,{})}markRead(e){return this.runNotificationsAction(`_notifications-read`,{ids:e})}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}openPanel(){this.opened||(this.opened=!0,this.refresh(),this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick))}closePanel(){this.detachOutsideClick(),this.opened=!1}async entryClicked(e){e.unread&&await this.markRead([e.id]);let t=e.route;if(t){if(!eo.confirmLeave())return;this.closePanel(),this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0})),this.dispatchEvent(new CustomEvent(`navigate-to-requested`,{detail:{route:t},bubbles:!0,composed:!0}))}}renderEntry(e){return T`
+    `}};k([y()],ec.prototype,`selector`,void 0),k([y()],ec.prototype,`app`,void 0),k([y()],ec.prototype,`baseUrl`,void 0),k([C()],ec.prototype,`opened`,void 0),k([C()],ec.prototype,`searchText`,void 0),k([C()],ec.prototype,`searchedOptions`,void 0),ec=$s=k([g(`mateu-app-context-picker`)],ec);var tc=class extends b{constructor(...e){super(...e),this.baseUrl=``,this.opened=!1,this.notifications=[],this.fetched=!1}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}updated(){!this.fetched&&this.app?.serverSideType&&(this.fetched=!0,this.refresh())}unreadCount(){return this.notifications.filter(e=>e.unread).length}async runNotificationsAction(e,t){let n=this.app;if(n?.serverSideType)try{let r=await lt.runAction(this.baseUrl??``,n.rootRoute??n.initialRoute??``,``,e,`notification-bell`,void 0,n.serverSideType,{},t,this,!0);for(let e of r?.fragments??[]){let t=e.data?._notifications;if(Array.isArray(t)){this.notifications=t;return}}}catch{}}refresh(){return this.runNotificationsAction(`_notifications-list`,{})}markRead(e){return this.runNotificationsAction(`_notifications-read`,{ids:e})}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}openPanel(){this.opened||(this.opened=!0,this.refresh(),this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick))}closePanel(){this.detachOutsideClick(),this.opened=!1}async entryClicked(e){e.unread&&await this.markRead([e.id]);let t=e.route;if(t){if(!to.confirmLeave())return;this.closePanel(),this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0})),this.dispatchEvent(new CustomEvent(`navigate-to-requested`,{detail:{route:t},bubbles:!0,composed:!0}))}}renderEntry(e){return T`
             <div role="button" tabindex="0" class="entry ${e.unread?`entry--unread`:``}"
-                 @click="${()=>this.entryClicked(e)}" @keydown="${z(()=>this.entryClicked(e))}">
+                 @click="${()=>this.entryClicked(e)}" @keydown="${R(()=>this.entryClicked(e))}">
                 <span class="unread-dot" aria-hidden="true"></span>
                 <div class="entry-body">
                     <div class="entry-top">
@@ -7785,48 +7793,48 @@ ${i}
             cursor: default;
         }
     
-        ${B}
-    `}};k([y()],ec.prototype,`app`,void 0),k([y()],ec.prototype,`baseUrl`,void 0),k([C()],ec.prototype,`opened`,void 0),k([C()],ec.prototype,`notifications`,void 0),ec=k([g(`mateu-notification-bell`)],ec);var tc=e=>{if(!e||!(`querySelectorAll`in e))return null;for(let t of e.querySelectorAll(`*`)){if(t.tagName?.toLowerCase()===`mateu-component`)return t;let e=tc(t.shadowRoot);if(e)return e}return null},nc=async(e,t,n)=>{let r=tc(t.renderRoot??t);await ds.runAction(lt,t.baseUrl??``,e.rootRoute||`_no_route`,``,n,r?.id??`app-header-action`,{},e.serverSideType??``,{},{},r??t,!0,void 0,!1,``)},rc=async(e,t,n)=>{try{await nc(e,t,n)}catch(e){Na({text:`La acción falló: `+e,position:`bottomStart`,duration:6e3,variant:`error`},t)}},ic=(e,t)=>{let n=e.contextSelectors??[],r=e.contextActions??[];return n.length===0&&r.length===0&&!e.notificationsEnabled?v:T`${e.notificationsEnabled?T`
+        ${z}
+    `}};k([y()],tc.prototype,`app`,void 0),k([y()],tc.prototype,`baseUrl`,void 0),k([C()],tc.prototype,`opened`,void 0),k([C()],tc.prototype,`notifications`,void 0),tc=k([g(`mateu-notification-bell`)],tc);var nc=e=>{if(!e||!(`querySelectorAll`in e))return null;for(let t of e.querySelectorAll(`*`)){if(t.tagName?.toLowerCase()===`mateu-component`)return t;let e=nc(t.shadowRoot);if(e)return e}return null},rc=async(e,t,n)=>{let r=nc(t.renderRoot??t);await fs.runAction(lt,t.baseUrl??``,e.rootRoute||`_no_route`,``,n,r?.id??`app-header-action`,{},e.serverSideType??``,{},{},r??t,!0,void 0,!1,``)},ic=async(e,t,n)=>{try{await rc(e,t,n)}catch(e){Pa({text:`La acción falló: `+e,position:`bottomStart`,duration:6e3,variant:`error`},t)}},ac=(e,t)=>{let n=e.contextSelectors??[],r=e.contextActions??[];return n.length===0&&r.length===0&&!e.notificationsEnabled?v:T`${e.notificationsEnabled?T`
         <mateu-notification-bell .app="${e}" .baseUrl="${t.baseUrl??``}"></mateu-notification-bell>`:v}${n.map(n=>T`
         <mateu-app-context-picker .selector="${n}" .app="${e}" .baseUrl="${t.baseUrl??``}"></mateu-app-context-picker>`)}${r.map(n=>(n.children?.length??0)>0?T`
         <details class="mateu-nav-group" style="margin-left: 0.5rem; flex-shrink: 0;">
             <summary class="app-header-action-btn">${n.label} ▾</summary>
             <div class="mateu-nav-panel" style="right: 0; left: auto;">
                 ${n.children.map(n=>T`
-                    <button class="mateu-nav-item" @click="${()=>n.actionId&&rc(e,t,n.actionId)}">${n.label}</button>`)}
+                    <button class="mateu-nav-item" @click="${()=>n.actionId&&ic(e,t,n.actionId)}">${n.label}</button>`)}
             </div>
         </details>`:T`
         <button class="app-header-action-btn" style="margin-left: 0.5rem; flex-shrink: 0;"
-            @click="${()=>n.actionId&&rc(e,t,n.actionId)}" title="${n.label}">${n.icon?L(n.icon):v}${n.label}</button>`)}`},ac=(e,t)=>T`
+            @click="${()=>n.actionId&&ic(e,t,n.actionId)}" title="${n.label}">${n.icon?I(n.icon):v}${n.label}</button>`)}`},oc=(e,t)=>T`
     <button class="mateu-nav-item ${e.selected?`mateu-nav-item--active`:``}"
             ?disabled="${e.disabled}"
-            @click="${()=>t(e)}">${e.text}</button>`,oc=(e,t,n=``)=>T`
+            @click="${()=>t(e)}">${e.text}</button>`,sc=(e,t,n=``)=>T`
     <nav class="mateu-nav ${n}">
         ${e.map(e=>(e.children?.length??0)>0?T`<details class="mateu-nav-group">
                        <summary class="mateu-nav-item">${e.text} ▾</summary>
                        <div class="mateu-nav-panel">
-                           ${e.children.map(e=>ac(e,t))}
+                           ${e.children.map(e=>oc(e,t))}
                        </div>
-                   </details>`:ac(e,t))}
-    </nav>`,sc=(e,t)=>n=>t.call(e,{detail:{value:n}}),cc=(e,t)=>e.themeToggle?T`
+                   </details>`:oc(e,t))}
+    </nav>`,cc=(e,t)=>n=>t.call(e,{detail:{value:n}}),lc=(e,t)=>e.themeToggle?T`
         <button class="app-chrome-icon-btn" @click="${t.toggleTheme}"
             title="${t.isDark?`Switch to light mode`:`Switch to dark mode`}"
             style="margin-left: 0.5rem; margin-right: 0.5rem; flex-shrink: 0;">
-            ${L(t.isDark?`vaadin:sun-o`:`vaadin:moon`,`color: var(--lumo-body-text-color);`)}
+            ${I(t.isDark?`vaadin:sun-o`:`vaadin:moon`,`color: var(--lumo-body-text-color);`)}
         </button>
-    `:v,lc=(e,t)=>{t.filter!=e.detail.value&&(t.filter=e.detail.value)},uc=(e,t,n)=>{let r=dc(e,t,n),i=Z(t,n);return r==`list`||r==i?`new`:r},dc=(e,t,n)=>{let r=e?._route;if(r!=null&&(r===``||r.startsWith(`/`))){let e=n.homeRoute??``,i=e.indexOf(`?`),a=i>=0?e.substring(i+1):``,o=Z(t,n)+r;return a?o+(o.indexOf(`?`)>=0?`&`:`?`)+a:o}return t.selectedRoute?t.selectedRoute:n.homeRoute},Z=(e,t)=>e.selectedRoute?e.selectedConsumedRoute??t.route:t.homeConsumedRoute,fc=(e,t)=>e.selectedRoute?e.selectedBaseUrl??e.baseUrl:t.homeBaseUrl,pc=(e,t)=>e.selectedRoute?e.selectedServerSideType??t.serverSideType:t.homeServerSideType,mc=(e,t)=>e.selectedRoute?e.selectedUriPrefix:t.homeUriPrefix,hc=(e,t)=>`ux_`+((Z(e,t)||`root`)+`|`+(pc(e,t)??``)).replace(/[^a-zA-Z0-9]/g,`_`),gc=(e,t,n,r,i,a,o)=>{let s=hc(e,t);if(t.chromeless)return T`
+    `:v,uc=(e,t)=>{t.filter!=e.detail.value&&(t.filter=e.detail.value)},dc=(e,t,n)=>{let r=fc(e,t,n),i=X(t,n);return r==`list`||r==i?`new`:r},fc=(e,t,n)=>{let r=e?._route;if(r!=null&&(r===``||r.startsWith(`/`))){let e=n.homeRoute??``,i=e.indexOf(`?`),a=i>=0?e.substring(i+1):``,o=X(t,n)+r;return a?o+(o.indexOf(`?`)>=0?`&`:`?`)+a:o}return t.selectedRoute?t.selectedRoute:n.homeRoute},X=(e,t)=>e.selectedRoute?e.selectedConsumedRoute??t.route:t.homeConsumedRoute,pc=(e,t)=>e.selectedRoute?e.selectedBaseUrl??e.baseUrl:t.homeBaseUrl,mc=(e,t)=>e.selectedRoute?e.selectedServerSideType??t.serverSideType:t.homeServerSideType,hc=(e,t)=>e.selectedRoute?e.selectedUriPrefix:t.homeUriPrefix,gc=(e,t)=>`ux_`+((X(e,t)||`root`)+`|`+(mc(e,t)??``)).replace(/[^a-zA-Z0-9]/g,`_`),_c=(e,t,n,r,i,a,o)=>{let s=gc(e,t);if(t.chromeless)return T`
             <div class="app chromeless">
                 <div role="main" class="${`app-content`+(e.pageCompact?` no-padding`:``)}" style="height: 100%;">
                     <div class="m-md">
                         <div class="m-scroll" style="height: 100%;">
                             <mateu-api-caller>
                                 <mateu-ux
-                                        route="${dc(r,e,t)}"
+                                        route="${fc(r,e,t)}"
                                         id="${s}"
-                                        baseUrl="${fc(e,t)}"
-                                        consumedRoute="${Z(e,t)}"
-                                        serverSideType="${pc(e,t)}"
-                                        uriPrefix="${mc(e,t)}"
+                                        baseUrl="${pc(e,t)}"
+                                        consumedRoute="${X(e,t)}"
+                                        serverSideType="${mc(e,t)}"
+                                        uriPrefix="${hc(e,t)}"
                                         style="width: 100%;"
                                         .appState="${a}"
                                         .appData="${o}"
@@ -7840,7 +7848,7 @@ ${i}
                 </div>
                 <slot></slot>
             </div>
-        `;let c=e.mapItems(t.menu,e.filter?.toLowerCase()??``),l=Z(e,t),u=uc(r,e,t),d=u&&u!==`new`&&u.startsWith(l+`/`)?u.substring(l.length+1).split(`/`)[0]:void 0;return T`
+        `;let c=e.mapItems(t.menu,e.filter?.toLowerCase()??``),l=X(e,t),u=dc(r,e,t),d=u&&u!==`new`&&u.startsWith(l+`/`)?u.substring(l.length+1).split(`/`)[0]:void 0;return T`
                     ${t.variant==dt.MEDIATOR?T`
 
                         ${t.layout==`SPLIT`?T`
@@ -7848,12 +7856,12 @@ ${i}
                                 <mateu-api-caller>
                                     <div style="display: block; width: calc(100% - 1rem);">
                                     <mateu-ux
-                                            route="${Z(e,t)}"
+                                            route="${X(e,t)}"
                                             id="${s}"
-                                            baseUrl="${fc(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${pc(e,t)}"
-                                            uriPrefix="${mc(e,t)}"
+                                            baseUrl="${pc(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${mc(e,t)}"
+                                            uriPrefix="${hc(e,t)}"
                                             style="width: 100%;"
                                             .appState="${{...a,_splitDetailId:d}}"
                                             .appData="${o}"
@@ -7865,12 +7873,12 @@ ${i}
                                 <mateu-api-caller slot="detail">
                                     <div style="padding-left: 1rem; width: calc(100% - 1rem);">
                                     <mateu-ux
-                                            route="${uc(r,e,t)}"
+                                            route="${dc(r,e,t)}"
                                             id="${s}_detail"
-                                            baseUrl="${fc(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${pc(e,t)}"
-                                            uriPrefix="${mc(e,t)}"
+                                            baseUrl="${pc(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${mc(e,t)}"
+                                            uriPrefix="${hc(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -7884,12 +7892,12 @@ ${i}
                         `:T`
                             <mateu-api-caller>
                                 <mateu-ux
-                                        route="${dc(r,e,t)}"
+                                        route="${fc(r,e,t)}"
                                         id="${s}"
-                                        baseUrl="${fc(e,t)}"
-                                        consumedRoute="${Z(e,t)}"
-                                        serverSideType="${pc(e,t)}"
-                                        uriPrefix="${mc(e,t)}"
+                                        baseUrl="${pc(e,t)}"
+                                        consumedRoute="${X(e,t)}"
+                                        serverSideType="${mc(e,t)}"
+                                        uriPrefix="${hc(e,t)}"
                                         style="width: 100%;"
                                         .appState="${a}"
                                         .appData="${o}"
@@ -7906,12 +7914,12 @@ ${i}
                     <header class="app-navbar">
                         <button class="drawer-toggle" title="Menu"
                                 @click="${e=>e.currentTarget.closest(`.m-app-layout`)?.classList.toggle(`drawer-open`)}">
-                            ${L(`vaadin:menu`)}
+                            ${I(`vaadin:menu`)}
                         </button>
                         <h2 style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; margin: 0 .5rem;">${t.title}</h2><p style="margin: 0;">${t.subtitle}</p>
                         <div class="m-hl" style="margin-left: auto; align-items: center;">
                             <slot name="widgets"></slot>
-                            ${ic(t,e)}${cc(t,e)}
+                            ${ac(t,e)}${lc(t,e)}
                         </div>
                     </header>
                     <div class="app-body">
@@ -7919,7 +7927,7 @@ ${i}
                             ${t.menu&&t.totalMenuOptions>10?T`
                                 <div style="position: sticky; top: 0; z-index: 2; background: var(--lumo-base-color); padding: .25rem 0 .5rem;">
                                     <input class="drawer-search" placeholder="Search…" style="width: calc(100% - 20px); margin: 0 10px;"
-                                           @input="${t=>lc({detail:{value:t.target.value}},e)}">
+                                           @input="${t=>uc({detail:{value:t.target.value}},e)}">
                                 </div>
                                 `:v}
                             <nav class="side-nav">
@@ -7931,12 +7939,12 @@ ${i}
                                 <div class="m-scroll" style="height: 100%;">
                                     <mateu-api-caller>
                                         <mateu-ux
-                                                route="${dc(r,e,t)}"
+                                                route="${fc(r,e,t)}"
                                                 id="${s}"
-                                                baseUrl="${fc(e,t)}"
-                                                consumedRoute="${Z(e,t)}"
-                                                serverSideType="${pc(e,t)}"
-                                                uriPrefix="${mc(e,t)}"
+                                                baseUrl="${pc(e,t)}"
+                                                consumedRoute="${X(e,t)}"
+                                                serverSideType="${mc(e,t)}"
+                                                uriPrefix="${hc(e,t)}"
                                                 style="width: 100%;"
                                                 .appState="${a}"
                                                 .appData="${o}"
@@ -7965,10 +7973,10 @@ ${i}
                             ${t.title?T`<h2 style="margin: 0 var(--lumo-space-l, 1.5rem) 0 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;">${t.title}</h2>`:v}
                         </div>
                         </a>
-                        ${(()=>{let t=sc(e,e.itemSelected);return F.get()?.renderTopNav?.(c,t,`menu-on-top`)??oc(c,t,`menu-on-top`)})()}
+                        ${(()=>{let t=cc(e,e.itemSelected);return P.get()?.renderTopNav?.(c,t,`menu-on-top`)??sc(c,t,`menu-on-top`)})()}
                         <div class="m-hl" style="margin-left: auto; flex-shrink: 0; align-items: center;">
                             <slot name="widgets"></slot>
-                            ${ic(t,e)}${cc(t,e)}
+                            ${ac(t,e)}${lc(t,e)}
                         </div>
                     </div>
                     <div style="flex: 1; min-height: 0; overflow-y: auto; overflow-x: hidden; box-sizing: border-box; width: 100%;">
@@ -7976,12 +7984,12 @@ ${i}
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${dc(r,e,t)}"
+                                            route="${fc(r,e,t)}"
                                             id="${s}"
-                                            baseUrl="${fc(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${pc(e,t)}"
-                                            uriPrefix="${mc(e,t)}"
+                                            baseUrl="${pc(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${mc(e,t)}"
+                                            uriPrefix="${hc(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -8009,10 +8017,10 @@ ${i}
                             ${t.title?T`<h2 style="margin: 0 var(--lumo-space-l, 1.5rem) 0 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;">${t.title}</h2>`:v}
                         </div>
                         </a>
-                        ${oc(e.mapItemsForTiles(t.menu),sc(e,e.itemSelectedTiles),`menu-on-top`)}
+                        ${sc(e.mapItemsForTiles(t.menu),cc(e,e.itemSelectedTiles),`menu-on-top`)}
                         <div class="m-hl" style="margin-left: auto; flex-shrink: 0; align-items: center;">
                             <slot name="widgets"></slot>
-                            ${ic(t,e)}${cc(t,e)}
+                            ${ac(t,e)}${lc(t,e)}
                         </div>
                     </div>
                     <div style="flex: 1; min-height: 0; overflow-y: auto; overflow-x: hidden; box-sizing: border-box; width: 100%;">
@@ -8021,12 +8029,12 @@ ${i}
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${dc(r,e,t)}"
+                                            route="${fc(r,e,t)}"
                                             id="${s}"
-                                            baseUrl="${fc(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${pc(e,t)}"
-                                            uriPrefix="${mc(e,t)}"
+                                            baseUrl="${pc(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${mc(e,t)}"
+                                            uriPrefix="${hc(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -8051,12 +8059,12 @@ ${i}
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${dc(r,e,t)}"
+                                            route="${fc(r,e,t)}"
                                             id="${s}"
-                                            baseUrl="${fc(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${pc(e,t)}"
-                                            uriPrefix="${mc(e,t)}"
+                                            baseUrl="${pc(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${mc(e,t)}"
+                                            uriPrefix="${hc(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -8078,7 +8086,7 @@ ${i}
                         <div class="m-vl"
                                 @navigation-requested="${e.updateRoute}">
                             ${t.menu.map(t=>e.renderOptionOnLeftMenu(t))}
-                            ${ic(t,e)}${cc(t,e)}
+                            ${ac(t,e)}${lc(t,e)}
                         </div>
                     </div>
                     <div role="main" class="${`app-content`+(e.pageCompact?` no-padding`:``)}">
@@ -8086,12 +8094,12 @@ ${i}
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${dc(r,e,t)}"
+                                            route="${fc(r,e,t)}"
                                             id="${s}"
-                                            baseUrl="${fc(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${pc(e,t)}"
-                                            uriPrefix="${mc(e,t)}"
+                                            baseUrl="${pc(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${mc(e,t)}"
+                                            uriPrefix="${hc(e,t)}"
                                             style="width: 100%; padding: 1em;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -8135,7 +8143,7 @@ ${i}
                             </nav>
                             <div class="m-hl" style="flex-shrink: 0; align-items: center;">
                                 <slot name="widgets"></slot>
-                                ${ic(t,e)}${cc(t,e)}
+                                ${ac(t,e)}${lc(t,e)}
                             </div>
                         </div>
                     </div>
@@ -8144,12 +8152,12 @@ ${i}
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${dc(r,e,t)}"
+                                            route="${fc(r,e,t)}"
                                             id="${s}"
-                                            baseUrl="${fc(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${pc(e,t)}"
-                                            uriPrefix="${mc(e,t)}"
+                                            baseUrl="${pc(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${mc(e,t)}"
+                                            uriPrefix="${hc(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -8169,17 +8177,17 @@ ${i}
                 <button class="app-fab" style="bottom: ${(t.sseUrl?5.5:1.5)+r*4}rem; right: 1.5rem;"
                     @click="${()=>e.runAction(n.actionId)}"
                     title="${n.label}">
-                    ${L(n.icon)}
+                    ${I(n.icon)}
                 </button>
             `)}
             ${t.sseUrl&&!e.chatOpen?T`
                 <button class="ai-fab" @click="${e.showHideIa}" title="Asistente IA">
-                    ${L(`vaadin:comments-o`)}
+                    ${I(`vaadin:comments-o`)}
                 </button>
             `:v}
             ${e.renderCommandPalette()}
             <slot></slot>
-       `},_c=(e,t)=>t!=null&&e!=null&&!e.has(t),vc=typeof HTMLElement<`u`?HTMLElement:class{},yc=class extends vc{static get observedAttributes(){return[`type`,`renderer`]}connectedCallback(){this.render()}attributeChangedCallback(){this.render()}render(){let e=this.getAttribute(`type`)??`unknown`,t=this.getAttribute(`renderer`)??`unknown`;this.shadowRoot||this.attachShadow({mode:`open`}),this.shadowRoot.innerHTML=`
+       `},vc=(e,t)=>t!=null&&e!=null&&!e.has(t),yc=typeof HTMLElement<`u`?HTMLElement:class{},bc=class extends yc{static get observedAttributes(){return[`type`,`renderer`]}connectedCallback(){this.render()}attributeChangedCallback(){this.render()}render(){let e=this.getAttribute(`type`)??`unknown`,t=this.getAttribute(`renderer`)??`unknown`;this.shadowRoot||this.attachShadow({mode:`open`}),this.shadowRoot.innerHTML=`
             <style>
                 :host { display: block; }
                 .mateu-unsupported {
@@ -8198,12 +8206,12 @@ ${i}
             <div class="mateu-unsupported" role="note">
                 ⚠ Component “${e}” is not supported by the “${t}” renderer yet.
             </div>
-        `}};typeof customElements<`u`&&!customElements.get(`mateu-unsupported`)&&customElements.define(`mateu-unsupported`,yc);var bc=new Set,xc=(e,t,n)=>{let r=`${n}/${t}`;return bc.has(r)||(bc.add(r),console.warn(`[mateu] Component type "${t}" is not supported by the "${n}" renderer — rendering <mateu-unsupported> placeholder.`)),T`<mateu-unsupported
+        `}};typeof customElements<`u`&&!customElements.get(`mateu-unsupported`)&&customElements.define(`mateu-unsupported`,bc);var xc=new Set,Sc=(e,t,n)=>{let r=`${n}/${t}`;return xc.has(r)||(xc.add(r),console.warn(`[mateu] Component type "${t}" is not supported by the "${n}" renderer — rendering <mateu-unsupported> placeholder.`)),T`<mateu-unsupported
             type="${t}"
             renderer="${n}"
             data-component-id="${e?.id??v}"
             slot="${e?.slot??v}"
-    ></mateu-unsupported>`},Sc=class{renderFilterBar(e,t,n,r,i,a,o,s){let c=t?.metadata;return T`
+    ></mateu-unsupported>`},Cc=class{renderFilterBar(e,t,n,r,i,a,o,s){let c=t?.metadata;return T`
             <mateu-filter-bar
                 .metadata="${c}"
                 @search-requested="${e.search}"
@@ -8215,7 +8223,7 @@ ${i}
                 .appData="${o}"
                 ?searchOnly="${s??!1}"
             >
-                ${c?.header?.map(t=>I(e,t,n,r,i,a,o))}
+                ${c?.header?.map(t=>F(e,t,n,r,i,a,o))}
             </mateu-filter-bar>
         `}renderPagination(e,t){return T`
         <mateu-pagination
@@ -8226,14 +8234,14 @@ ${i}
                 data-testid="pagination"
                 .pageNumber="${e.data[t?.id]?.page?.pageNumber??0}"
         ></mateu-pagination>
-        `}renderTableComponent(e,t,n,r,i,a,o){return zn(t,(e.data?.[e.id])?.page?.content??[],r[t?.id]?.emptyStateMessage)}rendererName(){return this.constructor?.name??`unknown`}supportedClientSideTypes(){}renderClientSideComponent(e,t,n,r,i,a,o,s){let c=t?.metadata?.type??t?.type,l=Object.values(j).includes(c)?c:void 0;return _c(this.supportedClientSideTypes(),l)?xc(t,l,this.rendererName()):Da(e,t,n,r,i,a,o,s)}renderAppComponent(e,t,n,r,i,a,o){return gc(e,t?.metadata,n,r,i,a,o)}},Cc=(e,t,n,r,i,a,o)=>T`
+        `}renderTableComponent(e,t,n,r,i,a,o){return Bn(t,(e.data?.[e.id])?.page?.content??[],r[t?.id]?.emptyStateMessage)}rendererName(){return this.constructor?.name??`unknown`}supportedClientSideTypes(){}renderClientSideComponent(e,t,n,r,i,a,o,s){let c=t?.metadata?.type??t?.type,l=Object.values(j).includes(c)?c:void 0;return vc(this.supportedClientSideTypes(),l)?Sc(t,l,this.rendererName()):Oa(e,t,n,r,i,a,o,s)}renderAppComponent(e,t,n,r,i,a,o){return _c(e,t?.metadata,n,r,i,a,o)}},wc=(e,t,n,r,i,a,o)=>T`
         <vaadin-virtual-list
                 .items="${t.metadata.page.content}"
-                ${te(t=>T`${I(e,t,n,r,i,a,o)}`,[])}
+                ${te(t=>T`${F(e,t,n,r,i,a,o)}`,[])}
                 style="${t.style}" class="${t.cssClasses}"
                 slot="${t.slot??v}"
         ></vaadin-virtual-list>
-    `,wc=e=>{let t=e.metadata;return T`
+    `,Tc=e=>{let t=e.metadata;return T`
         <vaadin-notification
                 .opened="${!0}"
                 slot="${e.slot??v}"
@@ -8246,7 +8254,7 @@ ${i}
                     </vaadin-horizontal-layout>
                 `,[])}
         ></vaadin-notification>
-    `},Tc=(e,t={})=>{let n=e.metadata,r=n.valueKey?t[n.valueKey]:n.value;return T`
+    `},Ec=(e,t={})=>{let n=e.metadata,r=n.valueKey?t[n.valueKey]:n.value;return T`
         <div style="${e.style}">
         <vaadin-progress-bar
                 ?indeterminate="${n.indeterminate}"
@@ -8261,7 +8269,7 @@ ${i}
     ${n.text}
   </span>`:v}
         </div>
-    `},Ec=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+    `},Dc=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
         <vaadin-details
                 ?opened="${s.opened}"
                 style="${t.style}"
@@ -8269,37 +8277,37 @@ ${i}
                 slot="${t.slot??v}"
         >
             <vaadin-details-summary slot="summary">
-            ${I(e,s.summary,n,r,i,a,o)}
+            ${F(e,s.summary,n,r,i,a,o)}
             </vaadin-details-summary>
-            ${I(e,s.content,n,r,i,a,o)}
+            ${F(e,s.content,n,r,i,a,o)}
         </vaadin-details>
-            `},Dc=(e,t,n)=>{let r=e.metadata;return T`<vaadin-avatar
+            `},Oc=(e,t,n)=>{let r=e.metadata;return T`<vaadin-avatar
             img="${r.image}"
-            name="${P(r.name,t,n)}"
+            name="${Ot(r.name,t,n)}"
             abbr="${r.abbreviation}"
             style="${e.style}" class="${e.cssClasses}"
             slot="${e.slot??v}"
-    ></vaadin-avatar>`},Oc=e=>{let t=e.metadata;return T`<vaadin-avatar-group max-items-visible="${t.maxItemsVisible}"
+    ></vaadin-avatar>`},kc=e=>{let t=e.metadata;return T`<vaadin-avatar-group max-items-visible="${t.maxItemsVisible}"
                                      .items="${t.avatars}"
                                      style="${e.style}" class="${e.cssClasses}"
                                      slot="${e.slot??v}">
-    </vaadin-avatar-group>`},kc=(e,t,n,r,i,a,o)=>{let s=t.metadata;if(!s)return T``;let c=``;return s.variants?.map(e=>e==`stretchMedia`?`stretch-media`:e==`coverMedia`?`cover-media`:e).forEach(e=>c+=` `+e),c=c.trim(),T`
+    </vaadin-avatar-group>`},Ac=(e,t,n,r,i,a,o)=>{let s=t.metadata;if(!s)return T``;let c=``;return s.variants?.map(e=>e==`stretchMedia`?`stretch-media`:e==`coverMedia`?`cover-media`:e).forEach(e=>c+=` `+e),c=c.trim(),T`
         <vaadin-card
                 style="${t.style}"
                 class="${t.cssClasses}"
                 theme="${c}"
                 slot="${t.slot??v}"
         >
-            ${s.media?jt(e,s.media,n,r,i,a,o,`media`,!1):v}
-            ${s.title?jt(e,s.title,n,r,i,a,o,`title`,!1):v}
-            ${s.subtitle?jt(e,s.subtitle,n,r,i,a,o,`subtitle`,!1):v}
-            ${s.header?jt(e,s.header,n,r,i,a,o,`header`,!1):v}
-            ${s.headerPrefix?jt(e,s.headerPrefix,n,r,i,a,o,`header-prefix`,!1):v}
-            ${s.headerSuffix?jt(e,s.headerSuffix,n,r,i,a,o,`header-suffix`,!1):v}
-            ${s.footer?jt(e,s.footer,n,r,i,a,o,`footer`,!1):v}
-            ${s.content?I(e,s.content,n,r,i,a,o,!1):v}
+            ${s.media?Mt(e,s.media,n,r,i,a,o,`media`,!1):v}
+            ${s.title?Mt(e,s.title,n,r,i,a,o,`title`,!1):v}
+            ${s.subtitle?Mt(e,s.subtitle,n,r,i,a,o,`subtitle`,!1):v}
+            ${s.header?Mt(e,s.header,n,r,i,a,o,`header`,!1):v}
+            ${s.headerPrefix?Mt(e,s.headerPrefix,n,r,i,a,o,`header-prefix`,!1):v}
+            ${s.headerSuffix?Mt(e,s.headerSuffix,n,r,i,a,o,`header-suffix`,!1):v}
+            ${s.footer?Mt(e,s.footer,n,r,i,a,o,`footer`,!1):v}
+            ${s.content?F(e,s.content,n,r,i,a,o,!1):v}
         </vaadin-card>
-    `},Ac=e=>e>0&&e<640?`accordion`:`tabs`,jc=class extends b{constructor(...e){super(...e),this.tabLabels=[],this.mode=`tabs`,this.selected=0,this.selectedChangedListener=e=>{let t=e.detail?.value;typeof t==`number`&&t>=0&&(this.selected=t)}}connectedCallback(){super.connectedCallback(),this.resizeObserver=new ResizeObserver(e=>{for(let t of e)this.mode=Ac(t.contentRect.width)}),this.resizeObserver.observe(this)}disconnectedCallback(){super.disconnectedCallback(),this.resizeObserver?.disconnect(),this.resizeObserver=void 0,this.detachTabsListener()}detachTabsListener(){this.slottedTabs?.removeEventListener(`selected-changed`,this.selectedChangedListener),this.slottedTabs=void 0}tabsSlotChanged(e){this.detachTabsListener();let t=e.target.assignedElements().find(e=>`selected`in e);t&&(this.slottedTabs=t,t.addEventListener(`selected-changed`,this.selectedChangedListener),t.selected=this.selected)}select(e){this.selected=e,this.slottedTabs&&(this.slottedTabs.selected=e)}updated(){this.slottedTabs&&this.slottedTabs.selected!=this.selected&&(this.slottedTabs.selected=this.selected)}static{this.styles=h`
+    `},jc=e=>e>0&&e<640?`accordion`:`tabs`,Mc=class extends b{constructor(...e){super(...e),this.tabLabels=[],this.mode=`tabs`,this.selected=0,this.selectedChangedListener=e=>{let t=e.detail?.value;typeof t==`number`&&t>=0&&(this.selected=t)}}connectedCallback(){super.connectedCallback(),this.resizeObserver=new ResizeObserver(e=>{for(let t of e)this.mode=jc(t.contentRect.width)}),this.resizeObserver.observe(this)}disconnectedCallback(){super.disconnectedCallback(),this.resizeObserver?.disconnect(),this.resizeObserver=void 0,this.detachTabsListener()}detachTabsListener(){this.slottedTabs?.removeEventListener(`selected-changed`,this.selectedChangedListener),this.slottedTabs=void 0}tabsSlotChanged(e){this.detachTabsListener();let t=e.target.assignedElements().find(e=>`selected`in e);t&&(this.slottedTabs=t,t.addEventListener(`selected-changed`,this.selectedChangedListener),t.selected=this.selected)}select(e){this.selected=e,this.slottedTabs&&(this.slottedTabs.selected=e)}updated(){this.slottedTabs&&this.slottedTabs.selected!=this.selected&&(this.slottedTabs.selected=this.selected)}static{this.styles=h`
         :host {
             display: block;
         }
@@ -8383,7 +8391,7 @@ ${i}
                     `)}
                 </div>
             `}
-        `}};k([y({type:Array})],jc.prototype,`tabLabels`,void 0),k([C()],jc.prototype,`mode`,void 0),k([C()],jc.prototype,`selected`,void 0),jc=k([g(`mateu-adaptive-tabs`)],jc);var Mc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;c??=``,s.columnSpacing&&(c+=`--vaadin-form-layout-column-spacing: `+s.columnSpacing+`;`);let l=s.itemRowSpacing&&s.itemRowSpacing!==`0`?s.itemRowSpacing:`var(--lumo-space-m)`;return c+=`--vaadin-form-layout-row-spacing: `+l+`;`,s.itemLabelSpacing&&(c+=`--vaadin-form-layout-label-spacing: `+s.itemLabelSpacing+`;`),s.labelsAside&&(c+=`--vaadin-form-item-label-width: 10rem;`),s.fullWidth&&(c+=`width: 100%;`),T`
+        `}};k([y({type:Array})],Mc.prototype,`tabLabels`,void 0),k([C()],Mc.prototype,`mode`,void 0),k([C()],Mc.prototype,`selected`,void 0),Mc=k([g(`mateu-adaptive-tabs`)],Mc);var Nc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;c??=``,s.columnSpacing&&(c+=`--vaadin-form-layout-column-spacing: `+s.columnSpacing+`;`);let l=s.itemRowSpacing&&s.itemRowSpacing!==`0`?s.itemRowSpacing:`var(--lumo-space-m)`;return c+=`--vaadin-form-layout-row-spacing: `+l+`;`,s.itemLabelSpacing&&(c+=`--vaadin-form-layout-label-spacing: `+s.itemLabelSpacing+`;`),s.labelsAside&&(c+=`--vaadin-form-item-label-width: 10rem;`),s.fullWidth&&(c+=`width: 100%;`),T`
                <vaadin-form-layout 
                        .responsiveSteps="${s.responsiveSteps||v}"  
                        style="${c||v}" 
@@ -8396,36 +8404,36 @@ ${i}
                        labels-aside="${s.labelsAside||v}"
                        slot="${t.slot||v}"
                >
-                   ${t.children?.map(t=>Nc(s,e,t,n,r,i,a,o))}
+                   ${t.children?.map(t=>Pc(s,e,t,n,r,i,a,o))}
                </vaadin-form-layout>
-            `},Nc=(e,t,n,r,i,a,o,s)=>n.type==A.ClientSide&&n.metadata?.type==j.FormRow?Fc(e,t,n,r,i,a,o,s):e.labelsAside?Pc(t,n,r,i,a,o,s):I(t,n,r,i,a,o,s),Pc=(e,t,n,r,i,a,o)=>{if(t.type==A.ClientSide&&t.metadata?.type==j.FormField&&t.metadata.label){let s=t.metadata,c=s.label?.includes("${")?e._evalTemplate(s.label):s.label;return T`
+            `},Pc=(e,t,n,r,i,a,o,s)=>n.type==A.ClientSide&&n.metadata?.type==j.FormRow?Ic(e,t,n,r,i,a,o,s):e.labelsAside?Fc(t,n,r,i,a,o,s):F(t,n,r,i,a,o,s),Fc=(e,t,n,r,i,a,o)=>{if(t.type==A.ClientSide&&t.metadata?.type==j.FormField&&t.metadata.label){let s=t.metadata,c=s.label?.includes("${")?e._evalTemplate(s.label):s.label;return T`
                        <vaadin-form-item data-colspan="${s.colspan}">
                            <label slot="label">${c}</label>
-                           ${I(e,t,n,r,i,a,o,!0)}
+                           ${F(e,t,n,r,i,a,o,!0)}
                        </vaadin-form-item>
-                   `}return I(e,t,n,r,i,a,o)},Fc=(e,t,n,r,i,a,o,s)=>T`
+                   `}return F(e,t,n,r,i,a,o)},Ic=(e,t,n,r,i,a,o,s)=>T`
         <vaadin-form-row>
-            ${n.children?.map(n=>Nc(e,t,n,r,i,a,o,s))}
+            ${n.children?.map(n=>Pc(e,t,n,r,i,a,o,s))}
         </vaadin-form-row>
-            `,Ic=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=(s.padding?` padding`:``)+(s.spacing?` spacing`:``)+(s.spacingVariant?` spacing-`+s.spacingVariant:``)+(s.wrap?` wrap`:``),l=t.style;return s.fullWidth&&(l=l?`width: 100%;`+l:`width: 100%;`),s.justification&&(l=l?`justify-content: `+s.justification+`;`+l:`justify-content: `+s.justification+`;`),s.verticalAlignment&&(l=l?`align-items: `+s.verticalAlignment+`;`+l:`align-items: `+s.verticalAlignment+`;`),T`
+            `,Lc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=(s.padding?` padding`:``)+(s.spacing?` spacing`:``)+(s.spacingVariant?` spacing-`+s.spacingVariant:``)+(s.wrap?` wrap`:``),l=t.style;return s.fullWidth&&(l=l?`width: 100%;`+l:`width: 100%;`),s.justification&&(l=l?`justify-content: `+s.justification+`;`+l:`justify-content: `+s.justification+`;`),s.verticalAlignment&&(l=l?`align-items: `+s.verticalAlignment+`;`+l:`align-items: `+s.verticalAlignment+`;`),T`
                <vaadin-horizontal-layout 
                        style="${l}" 
                        class="${t.cssClasses}"
                        theme="${c}"
                        slot="${t.slot??v}"
                >
-                   ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+                   ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
                </vaadin-horizontal-layout>
-            `},Lc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=(s.padding?` padding`:``)+(s.spacing?` spacing`:``)+(s.spacingVariant?` spacing-`+s.spacingVariant:``)+(s.wrap?` wrap`:``),l=t.style;return s.fullWidth&&(l=l?`width: 100%;`+l:`width: 100%;`),s.justification&&(l=l?`justify-content: `+s.justification+`;`+l:`justify-content: `+s.justification+`;`),s.horizontalAlignment&&(l=l?`align-items: `+s.horizontalAlignment+`;`+l:`align-items: `+s.horizontalAlignment+`;`),T`
+            `},Rc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=(s.padding?` padding`:``)+(s.spacing?` spacing`:``)+(s.spacingVariant?` spacing-`+s.spacingVariant:``)+(s.wrap?` wrap`:``),l=t.style;return s.fullWidth&&(l=l?`width: 100%;`+l:`width: 100%;`),s.justification&&(l=l?`justify-content: `+s.justification+`;`+l:`justify-content: `+s.justification+`;`),s.horizontalAlignment&&(l=l?`align-items: `+s.horizontalAlignment+`;`+l:`align-items: `+s.horizontalAlignment+`;`),T`
         <vaadin-vertical-layout
                 style="${l}"
                 class="${t.cssClasses}"
                 theme="${c}"
                 slot="${t.slot??v}"
         >
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
         </vaadin-vertical-layout>
-    `},Rc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;return s.fullWidth&&(c=c?`width: 100%;`+c:`width: 100%;`),T`
+    `},zc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;return s.fullWidth&&(c=c?`width: 100%;`+c:`width: 100%;`),T`
                <vaadin-split-layout 
                        style="${c}" 
                        class="${t.cssClasses}"
@@ -8433,18 +8441,18 @@ ${i}
                        theme="${s.variant??v}"
                        slot="${t.slot??v}"
                >
-                   <master-content>${I(e,t.children[0],n,r,i,a,o)}</master-content>
-                   <detail-content>${I(e,t.children[1],n,r,i,a,o)}</detail-content>
+                   <master-content>${F(e,t.children[0],n,r,i,a,o)}</master-content>
+                   <detail-content>${F(e,t.children[1],n,r,i,a,o)}</detail-content>
                </vaadin-split-layout>
-            `},zc=(e,t,n,r,i,a,o)=>{let s=t.children&&t.children.length>1?t.children[1]:null,c=i?.detailComponent??null,l=!!i?.hasDetail||!!s,u=c??s;return T`
+            `},Bc=(e,t,n,r,i,a,o)=>{let s=t.children&&t.children.length>1?t.children[1]:null,c=i?.detailComponent??null,l=!!i?.hasDetail||!!s,u=c??s;return T`
                <vaadin-master-detail-layout ?has-detail="${l}"
                                             style="${t.style}"
                                             class="${t.cssClasses}"
                                             slot="${t.slot??v}">
-                   <div>${I(e,t.children[0],n,r,i,a,o)}</div>
-                   ${l&&u?T`<div slot="detail">${I(e,u,n,r,i,a,o)}</div>`:T`<div slot="detail" style="display: flex; align-items: center; justify-content: center; height: 100%; color: var(--lumo-secondary-text-color); font-size: var(--lumo-font-size-s);">Select an item to view details</div>`}
+                   <div>${F(e,t.children[0],n,r,i,a,o)}</div>
+                   ${l&&u?T`<div slot="detail">${F(e,u,n,r,i,a,o)}</div>`:T`<div slot="detail" style="display: flex; align-items: center; justify-content: center; height: 100%; color: var(--lumo-secondary-text-color); font-size: var(--lumo-font-size-s);">Select an item to view details</div>`}
                </vaadin-master-detail-layout>
-            `},Bc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;c??=``,s.fullWidth&&(c+=`width: 100%;`);let l=s.variant;l==`equalWidth`&&(l=`equal-width-tabs`);let u=Math.max(0,(t.children??[]).findIndex(e=>e.metadata.active)),d=e=>{e.target.selected=u};if(s.adaptable){let u=(t.children??[]).map(t=>{let n=t.metadata.label;return n?.includes("${")?e._evalTemplate(n):n});return T`
+            `},Vc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;c??=``,s.fullWidth&&(c+=`width: 100%;`);let l=s.variant;l==`equalWidth`&&(l=`equal-width-tabs`);let u=Math.max(0,(t.children??[]).findIndex(e=>e.metadata.active)),d=e=>{e.target.selected=u};if(s.adaptable){let u=(t.children??[]).map(t=>{let n=t.metadata.label;return n?.includes("${")?e._evalTemplate(n):n});return T`
             <mateu-adaptive-tabs
                     .tabLabels="${u}"
                     style="${c}"
@@ -8466,7 +8474,7 @@ ${i}
 
                 ${t.children?.map((t,s)=>T`
                     <div slot="panel-${s}" style="padding: var(--lumo-space-m) 0;">
-                        ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+                        ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
                     </div>`)}
             </mateu-adaptive-tabs>
                 `}return T`
@@ -8489,73 +8497,73 @@ ${i}
                     >${r}</vaadin-tab>`})}
             </vaadin-tabs>
 
-            ${t.children?.map(t=>Vc(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>Hc(e,t,n,r,i,a,o))}
         </vaadin-tabsheet>
-            `},Vc=(e,t,n,r,i,a,o)=>{let s=t.metadata.label;return T`
+            `},Hc=(e,t,n,r,i,a,o)=>{let s=t.metadata.label;return T`
         <div tab="${s?.includes("${")?e._evalTemplate(s):s}" style="padding: var(--lumo-space-m) 0;">
-                   ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+                   ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
                </div>
-            `},Hc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;s.fullWidth&&(c=c?`width: 100%;`+c:`width: 100%;`);let l=0;if(t.children){for(let e=0;e<t.children.length;e++)if(t.children[e].metadata?.active){l=e;break}}return T`
+            `},Uc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;s.fullWidth&&(c=c?`width: 100%;`+c:`width: 100%;`);let l=0;if(t.children){for(let e=0;e<t.children.length;e++)if(t.children[e].metadata?.active){l=e;break}}return T`
                <vaadin-accordion
                        style="${t.style}"
                        class="${t.cssClasses}"
                        opened="${l}"
                        slot="${t.slot??v}"
                >
-                   ${t.children?.map(t=>Uc(e,t,n,r,i,a,o,s.variant))}
+                   ${t.children?.map(t=>Wc(e,t,n,r,i,a,o,s.variant))}
                </vaadin-accordion>
-            `},Uc=(e,t,n,r,i,a,o,s)=>{let c=t.metadata,l=c.label?.includes("${")?e._evalTemplate(c.label):c.label;return T`
+            `},Wc=(e,t,n,r,i,a,o,s)=>{let c=t.metadata,l=c.label?.includes("${")?e._evalTemplate(c.label):c.label;return T`
         <vaadin-accordion-panel style="${t.style}"
                                 class="${t.cssClasses}"
                                 theme="${s??v}"
                                 ?opened="${c.active}"
                                 ?disabled="${c.disabled}">
             <vaadin-accordion-heading slot="summary">${l}</vaadin-accordion-heading>
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
         </vaadin-accordion-panel>
-            `},Wc=(e,t,n,r,i,a,o)=>T`
+            `},Gc=(e,t,n,r,i,a,o)=>T`
                <vaadin-scroller style="${t.style}" 
                                 class="${t.cssClasses}"
                                 slot="${t.slot??v}">
-                   ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+                   ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
                </vaadin-scroller>
-            `,Gc=(e,t,n,r,i,a,o)=>T`
+            `,Kc=(e,t,n,r,i,a,o)=>T`
         <vaadin-board style="${t.style}" 
                       class="${t.cssClasses}"
                       slot="${t.slot??v}">
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
         </vaadin-board>
-            `,Kc=(e,t,n,r,i,a,o)=>T`
+            `,qc=(e,t,n,r,i,a,o)=>T`
         <vaadin-board-row style="${t.style}" class="${t.cssClasses}">
-                   ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+                   ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
                </vaadin-board-row>
-            `,qc=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+            `,Jc=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
         <div style="${t.style}" 
              class="${t.cssClasses}"
              board-cols="${s.boardCols??v}"
         >
-                   ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+                   ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
                </div>
-            `},Jc=(e,t,n)=>T`
+            `},Yc=(e,t,n)=>T`
     <vaadin-menu-bar
         theme="tertiary"
         .items=${e}
         class="${n??v}"
         @item-selected=${e=>t(e.detail.value)}>
-    </vaadin-menu-bar>`,Yc=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
-        <vaadin-context-menu .items=${Qc(e,s.menu,n,r,i,a,o)} 
+    </vaadin-menu-bar>`,Xc=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+        <vaadin-context-menu .items=${$c(e,s.menu,n,r,i,a,o)} 
                              style="${t.style}" 
                              class="${t.cssClasses}"
                              open-on="${s.activateOnLeftClick?`click`:v}"
                              slot="${t.slot??v}">
-            ${I(e,s.wrapped,n,r,i,a,o)}
+            ${F(e,s.wrapped,n,r,i,a,o)}
         </vaadin-context-menu>
-            `},Xc=(e,t,n,r,i)=>{let a=t.metadata;return T`
-        <vaadin-menu-bar .items=${Qc(e,a.options,n,r,i,O,ue)}
+            `},Zc=(e,t,n,r,i)=>{let a=t.metadata;return T`
+        <vaadin-menu-bar .items=${$c(e,a.options,n,r,i,O,ue)}
                          style="${t.style}" class="${t.cssClasses}"
                          slot="${t.slot??v}">
         </vaadin-menu-bar>
-            `},Zc=(e,t,n,r,i,a,o)=>{let s=document.createElement(`vaadin-context-menu-item`);return re(I(e,t,n,r,i,a,o),s),s},Qc=(e,t,n,r,i,a,o)=>t.map(t=>t.submenus?{text:t.component?void 0:t.label,route:t.path,checked:t.selected,disabled:t.disabled,className:t.className,component:t.component?Zc(e,t.component,n,r,i,a,o):void 0,children:Qc(e,t.submenus,n,r,i,a,o)}:t.separator?{component:`hr`}:{text:t.component?void 0:t.label,route:t.path,checked:t.selected,disabled:t.disabled,className:t.className,component:t.component?Zc(e,t.component,n,r,i,a,o):void 0}),$c=class extends b{constructor(...e){super(...e),this.fieldId=``,this.signing=!1,this.hasStrokes=!1,this.drawing=!1,this.startStroke=e=>{let t=e.target;this.ensureCanvasSize(t),t.setPointerCapture(e.pointerId),this.drawing=!0;let n=t.getContext(`2d`);n.lineWidth=2,n.lineCap=`round`,n.lineJoin=`round`,n.strokeStyle=getComputedStyle(this).getPropertyValue(`--lumo-body-text-color`)||`#1a1a1a`;let[r,i]=this.pointerPosition(e);n.beginPath(),n.moveTo(r,i),e.preventDefault()},this.stroke=e=>{if(!this.drawing)return;let t=e.target.getContext(`2d`),[n,r]=this.pointerPosition(e);t.lineTo(n,r),t.stroke(),this.hasStrokes=!0,e.preventDefault()},this.endStroke=e=>{this.drawing=!1,e.target.releasePointerCapture(e.pointerId)}}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}canvas(){return this.renderRoot.querySelector(`canvas`)}pointerPosition(e){let t=e.target.getBoundingClientRect();return[e.clientX-t.left,e.clientY-t.top]}ensureCanvasSize(e){let t=e.getBoundingClientRect();(e.width!==Math.round(t.width)||e.height!==Math.round(t.height))&&(e.width=Math.round(t.width),e.height=Math.round(t.height))}clear(){let e=this.canvas();e&&e.getContext(`2d`).clearRect(0,0,e.width,e.height),this.hasStrokes=!1}accept(){let e=this.canvas();!e||!this.hasStrokes||(this.signing=!1,this.emit(e.toDataURL(`image/png`)))}renderPad(){return T`
+            `},Qc=(e,t,n,r,i,a,o)=>{let s=document.createElement(`vaadin-context-menu-item`);return re(F(e,t,n,r,i,a,o),s),s},$c=(e,t,n,r,i,a,o)=>t.map(t=>t.submenus?{text:t.component?void 0:t.label,route:t.path,checked:t.selected,disabled:t.disabled,className:t.className,component:t.component?Qc(e,t.component,n,r,i,a,o):void 0,children:$c(e,t.submenus,n,r,i,a,o)}:t.separator?{component:`hr`}:{text:t.component?void 0:t.label,route:t.path,checked:t.selected,disabled:t.disabled,className:t.className,component:t.component?Qc(e,t.component,n,r,i,a,o):void 0}),el=class extends b{constructor(...e){super(...e),this.fieldId=``,this.signing=!1,this.hasStrokes=!1,this.drawing=!1,this.startStroke=e=>{let t=e.target;this.ensureCanvasSize(t),t.setPointerCapture(e.pointerId),this.drawing=!0;let n=t.getContext(`2d`);n.lineWidth=2,n.lineCap=`round`,n.lineJoin=`round`,n.strokeStyle=getComputedStyle(this).getPropertyValue(`--lumo-body-text-color`)||`#1a1a1a`;let[r,i]=this.pointerPosition(e);n.beginPath(),n.moveTo(r,i),e.preventDefault()},this.stroke=e=>{if(!this.drawing)return;let t=e.target.getContext(`2d`),[n,r]=this.pointerPosition(e);t.lineTo(n,r),t.stroke(),this.hasStrokes=!0,e.preventDefault()},this.endStroke=e=>{this.drawing=!1,e.target.releasePointerCapture(e.pointerId)}}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}canvas(){return this.renderRoot.querySelector(`canvas`)}pointerPosition(e){let t=e.target.getBoundingClientRect();return[e.clientX-t.left,e.clientY-t.top]}ensureCanvasSize(e){let t=e.getBoundingClientRect();(e.width!==Math.round(t.width)||e.height!==Math.round(t.height))&&(e.width=Math.round(t.width),e.height=Math.round(t.height))}clear(){let e=this.canvas();e&&e.getContext(`2d`).clearRect(0,0,e.width,e.height),this.hasStrokes=!1}accept(){let e=this.canvas();!e||!this.hasStrokes||(this.signing=!1,this.emit(e.toDataURL(`image/png`)))}renderPad(){return T`
             <canvas class="pad"
                     @pointerdown="${this.startStroke}"
                     @pointermove="${this.stroke}"
@@ -8622,7 +8630,7 @@ ${i}
         .button--danger {
             color: var(--lumo-error-text-color, rgb(179, 49, 31));
         }
-    `}};k([y()],$c.prototype,`fieldId`,void 0),k([y()],$c.prototype,`value`,void 0),k([C()],$c.prototype,`signing`,void 0),k([C()],$c.prototype,`hasStrokes`,void 0),$c=k([g(`mateu-signature-pad`)],$c);var el=class extends b{constructor(...e){super(...e),this.fieldId=``,this.options=[],this.leavesOnly=!1,this.opened=!1,this.expandedItems=[],this._normalized=[],this.dataProvider=(e,t)=>{let n=e.parentItem?e.parentItem.children??[]:this.normalized;t(n,n.length)}}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}get normalized(){return this._optsSource!==this.options&&(this._optsSource=this.options,this._normalized=this.normalizeOptions(this.options??[])),this._normalized}normalizeOptions(e){return e.map(e=>{let t=e.children&&e.children.length?this.normalizeOptions(e.children):void 0;return{...e,children:t}})}ancestorsOf(e,t){for(let n of t){if(String(n.value)===e)return[];let t=n.children?this.ancestorsOf(e,n.children):null;if(t!=null)return[n,...t]}return null}labelOf(e,t){for(let n of t){if(String(n.value)===e)return n.label;let t=n.children?this.labelOf(e,n.children):null;if(t!=null)return t}return null}open(){this.opened||(this.expandedItems=this.value==null?[]:this.ancestorsOf(String(this.value),this.normalized)??[],this.opened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.close()},document.addEventListener(`mousedown`,this.outsideClick))}close(){this.detachOutsideClick(),this.opened=!1}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}pick(e){this.close(),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e.value,fieldId:this.fieldId},bubbles:!0,composed:!0}))}clear(){this.close(),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:void 0,fieldId:this.fieldId},bubbles:!0,composed:!0}))}onActiveItemChanged(e){let t=e.detail.value;if(t){if((t.children?.length??0)>0&&this.leavesOnly){this.expandedItems=this.expandedItems.includes(t)?this.expandedItems.filter(e=>e!==t):[...this.expandedItems,t],e.target.activeItem=null;return}this.pick(t)}}render(){let e=this.value!=null&&this.value!==``?this.labelOf(String(this.value),this.normalized)??String(this.value):``;return T`
+    `}};k([y()],el.prototype,`fieldId`,void 0),k([y()],el.prototype,`value`,void 0),k([C()],el.prototype,`signing`,void 0),k([C()],el.prototype,`hasStrokes`,void 0),el=k([g(`mateu-signature-pad`)],el);var tl=class extends b{constructor(...e){super(...e),this.fieldId=``,this.options=[],this.leavesOnly=!1,this.opened=!1,this.expandedItems=[],this._normalized=[],this.dataProvider=(e,t)=>{let n=e.parentItem?e.parentItem.children??[]:this.normalized;t(n,n.length)}}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}get normalized(){return this._optsSource!==this.options&&(this._optsSource=this.options,this._normalized=this.normalizeOptions(this.options??[])),this._normalized}normalizeOptions(e){return e.map(e=>{let t=e.children&&e.children.length?this.normalizeOptions(e.children):void 0;return{...e,children:t}})}ancestorsOf(e,t){for(let n of t){if(String(n.value)===e)return[];let t=n.children?this.ancestorsOf(e,n.children):null;if(t!=null)return[n,...t]}return null}labelOf(e,t){for(let n of t){if(String(n.value)===e)return n.label;let t=n.children?this.labelOf(e,n.children):null;if(t!=null)return t}return null}open(){this.opened||(this.expandedItems=this.value==null?[]:this.ancestorsOf(String(this.value),this.normalized)??[],this.opened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.close()},document.addEventListener(`mousedown`,this.outsideClick))}close(){this.detachOutsideClick(),this.opened=!1}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}pick(e){this.close(),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e.value,fieldId:this.fieldId},bubbles:!0,composed:!0}))}clear(){this.close(),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:void 0,fieldId:this.fieldId},bubbles:!0,composed:!0}))}onActiveItemChanged(e){let t=e.detail.value;if(t){if((t.children?.length??0)>0&&this.leavesOnly){this.expandedItems=this.expandedItems.includes(t)?this.expandedItems.filter(e=>e!==t):[...this.expandedItems,t],e.target.activeItem=null;return}this.pick(t)}}render(){let e=this.value!=null&&this.value!==``?this.labelOf(String(this.value),this.normalized)??String(this.value):``;return T`
             <div class="root">
                 <vaadin-button class="control" theme="tertiary"
                                @click="${()=>this.opened?this.close():this.open()}">
@@ -8693,7 +8701,7 @@ ${i}
             min-width: 16rem;
             max-height: 18rem;
         }
-    `}};k([y()],el.prototype,`fieldId`,void 0),k([y()],el.prototype,`value`,void 0),k([y()],el.prototype,`options`,void 0),k([y({type:Boolean})],el.prototype,`leavesOnly`,void 0),k([C()],el.prototype,`opened`,void 0),k([C()],el.prototype,`expandedItems`,void 0),el=k([g(`mateu-vaadin-tree-select`)],el);var tl=class extends b{constructor(...e){super(...e),this.fieldId=``,this.cameraOpen=!1,this.cameraError=!1,this.fileFallback=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>this.emit(r.result),r.readAsDataURL(n),t.value=``}}disconnectedCallback(){super.disconnectedCallback(),this.stopStream()}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}stopStream(){this.stream?.getTracks().forEach(e=>e.stop()),this.stream=void 0}async openCamera(){this.cameraError=!1;try{this.stream=await navigator.mediaDevices.getUserMedia({video:{facingMode:`environment`},audio:!1}),this.cameraOpen=!0,await this.updateComplete;let e=this.renderRoot.querySelector(`video`);e&&(e.srcObject=this.stream,await e.play())}catch{this.stopStream(),this.cameraOpen=!1,this.cameraError=!0}}closeCamera(){this.stopStream(),this.cameraOpen=!1}shoot(){let e=this.renderRoot.querySelector(`video`);if(!e||e.videoWidth===0)return;let t=document.createElement(`canvas`);t.width=e.videoWidth,t.height=e.videoHeight,t.getContext(`2d`).drawImage(e,0,0),this.closeCamera(),this.emit(t.toDataURL(`image/jpeg`,.9))}triggerFallback(){this.renderRoot.querySelector(`input[type=file]`)?.click()}render(){let e=this.value!=null&&this.value!==``;return T`
+    `}};k([y()],tl.prototype,`fieldId`,void 0),k([y()],tl.prototype,`value`,void 0),k([y()],tl.prototype,`options`,void 0),k([y({type:Boolean})],tl.prototype,`leavesOnly`,void 0),k([C()],tl.prototype,`opened`,void 0),k([C()],tl.prototype,`expandedItems`,void 0),tl=k([g(`mateu-vaadin-tree-select`)],tl);var nl=class extends b{constructor(...e){super(...e),this.fieldId=``,this.cameraOpen=!1,this.cameraError=!1,this.fileFallback=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>this.emit(r.result),r.readAsDataURL(n),t.value=``}}disconnectedCallback(){super.disconnectedCallback(),this.stopStream()}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}stopStream(){this.stream?.getTracks().forEach(e=>e.stop()),this.stream=void 0}async openCamera(){this.cameraError=!1;try{this.stream=await navigator.mediaDevices.getUserMedia({video:{facingMode:`environment`},audio:!1}),this.cameraOpen=!0,await this.updateComplete;let e=this.renderRoot.querySelector(`video`);e&&(e.srcObject=this.stream,await e.play())}catch{this.stopStream(),this.cameraOpen=!1,this.cameraError=!0}}closeCamera(){this.stopStream(),this.cameraOpen=!1}shoot(){let e=this.renderRoot.querySelector(`video`);if(!e||e.videoWidth===0)return;let t=document.createElement(`canvas`);t.width=e.videoWidth,t.height=e.videoHeight,t.getContext(`2d`).drawImage(e,0,0),this.closeCamera(),this.emit(t.toDataURL(`image/jpeg`,.9))}triggerFallback(){this.renderRoot.querySelector(`input[type=file]`)?.click()}render(){let e=this.value!=null&&this.value!==``;return T`
             <input type="file" accept="image/*" capture="environment" style="display: none;"
                    @change="${this.fileFallback}">
             ${this.cameraOpen?T`
@@ -8771,7 +8779,7 @@ ${i}
             font-size: var(--lumo-font-size-xs, 0.75rem);
             color: var(--lumo-secondary-text-color, rgba(0, 0, 0, 0.6));
         }
-    `}};k([y()],tl.prototype,`fieldId`,void 0),k([y()],tl.prototype,`value`,void 0),k([C()],tl.prototype,`cameraOpen`,void 0),k([C()],tl.prototype,`cameraError`,void 0),tl=k([g(`mateu-camera-capture`)],tl);var nl,rl=(e,t)=>{if(!e)return;if(Array.isArray(e)){let n=e.find(e=>e.key==t);return n?.value==null?void 0:String(n.value)}let n=e[t];return n==null?void 0:String(n)},il=class extends b{static{nl=this}constructor(...e){super(...e),this.fieldId=``,this.editable=!0,this.filePicked=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>{let e=r.result,t=e.indexOf(`,`),i=e.substring(0,t).replace(`;base64`,`;name=${encodeURIComponent(n.name)};base64`);this.emit(i+e.substring(t))},r.readAsDataURL(n),t.value=``}}static fileName(e){if(!e)return``;if(e.startsWith(`data:`)){let t=e.indexOf(`,`),n=e.substring(5,t<0?e.length:t).split(`;`).find(e=>e.startsWith(`name=`));if(n)try{return decodeURIComponent(n.substring(5))}catch{return n.substring(5)}return`Attached file`}return e.split(`/`).pop()||e}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}triggerPick(){this.renderRoot.querySelector(`input[type=file]`)?.click()}render(){let e=this.value!=null&&this.value!==``,t=nl.fileName(this.value),n=e&&this.value.startsWith(`data:`),r=e?T`<span class="file" title="${t}">📄 ${n?T`<a href="${this.value}" download="${t}">${t}</a>`:T`<a href="${this.value}" target="_blank">${t}</a>`}</span>`:v;return this.editable?T`
+    `}};k([y()],nl.prototype,`fieldId`,void 0),k([y()],nl.prototype,`value`,void 0),k([C()],nl.prototype,`cameraOpen`,void 0),k([C()],nl.prototype,`cameraError`,void 0),nl=k([g(`mateu-camera-capture`)],nl);var rl,il=(e,t)=>{if(!e)return;if(Array.isArray(e)){let n=e.find(e=>e.key==t);return n?.value==null?void 0:String(n.value)}let n=e[t];return n==null?void 0:String(n)},al=class extends b{static{rl=this}constructor(...e){super(...e),this.fieldId=``,this.editable=!0,this.filePicked=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>{let e=r.result,t=e.indexOf(`,`),i=e.substring(0,t).replace(`;base64`,`;name=${encodeURIComponent(n.name)};base64`);this.emit(i+e.substring(t))},r.readAsDataURL(n),t.value=``}}static fileName(e){if(!e)return``;if(e.startsWith(`data:`)){let t=e.indexOf(`,`),n=e.substring(5,t<0?e.length:t).split(`;`).find(e=>e.startsWith(`name=`));if(n)try{return decodeURIComponent(n.substring(5))}catch{return n.substring(5)}return`Attached file`}return e.split(`/`).pop()||e}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}triggerPick(){this.renderRoot.querySelector(`input[type=file]`)?.click()}render(){let e=this.value!=null&&this.value!==``,t=rl.fileName(this.value),n=e&&this.value.startsWith(`data:`),r=e?T`<span class="file" title="${t}">📄 ${n?T`<a href="${this.value}" download="${t}">${t}</a>`:T`<a href="${this.value}" target="_blank">${t}</a>`}</span>`:v;return this.editable?T`
             <input type="file" accept="${this.accept||v}" style="display: none;"
                    @change="${this.filePicked}">
             <div class="row">
@@ -8819,28 +8827,28 @@ ${i}
         .button--danger {
             color: var(--lumo-error-text-color, rgb(179, 49, 31));
         }
-    `}};k([y()],il.prototype,`fieldId`,void 0),k([y()],il.prototype,`value`,void 0),k([y()],il.prototype,`accept`,void 0),k([y({type:Boolean})],il.prototype,`editable`,void 0),il=nl=k([g(`mateu-file-upload`)],il);var al=e=>e==null||typeof e==`string`&&e.trim()===``,ol=(e,t)=>{if(al(e))return null;let n=t?parseInt(String(e),10):Number(e);return Number.isNaN(n)?null:n},sl=(e,t)=>al(e)&&al(t)?!0:e==t,cl=e=>!!e&&typeof e==`object`&&`__mateuGroup`in e,ll=e=>String(e??``),ul=(e,t,n)=>{let r=e??[];if(!t||!n||n.length===0)return r;let i=[],a,o=!1;return r.forEach((e,s)=>{let c=ll(e?.[t]);if(!o||c!==a){let e=n.find(e=>ll(e.value)===c)??{value:c,count:r.filter(e=>ll(e?.[t])===c).length,aggregates:{}};i.push({__mateuGroup:e,__mateuGroupBy:t,_rowNumber:`__mateuGroup:${s}:${c}`}),o=!0,a=c}i.push(e)}),i},dl=(e,t)=>e==null?``:t.dataType===`money`||t.stereotype===`money`?new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e):t.aggregate===`count`?new Intl.NumberFormat(void 0,{maximumFractionDigits:0}).format(Math.round(e)):new Intl.NumberFormat(void 0,{maximumFractionDigits:2}).format(e),fl=(e,t)=>e&&t.includes(e)?e:t.find(e=>!!e),pl=(e,t,n)=>{let r=e.__mateuGroup;return t.id===n?`${r.value} (${r.count})`:t.aggregate?dl(r.aggregates?.[t.id],t):``},ml=(e,t,n)=>{let r=t?.aggregates;if(!r||!e.some(e=>e.aggregate))return;let i={};e.forEach(e=>{e.aggregate&&r[e.id]!=null&&(i[e.id]=dl(r[e.id],e))});let a=e[0];if(a&&i[a.id]===void 0){let e=t?.page?.totalElements;i[a.id]=n&&a.id===n&&e!=null?`Total (${e})`:`Total`}return i},hl=(e,t,n)=>L(e[n.path]?`vaadin:check`:`vaadin:minus`,`height: 16px; width: 16px; color: var(--lumo-body-text-color);`),gl=(e,t,n,r,i)=>{let a=e[n.path],o=a;return r==`money`&&a&&a.locale&&a.currency?o=new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(a.value):i==`money`&&(o=new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(a)),T`${o}`},_l=(e,t,n)=>{e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:n},bubbles:!0,composed:!0}))},vl=(e,t,n,r,i,a)=>{let o=n.xcolumn??a;if(o.text)return o.actionId?T`<a href="javascript: void(0);" @click="${t=>_l(n,o,e)}">${o.text}</a>`:T`<a href="${e[n.path]}">${o.text}</a>`;if(r==`string`){if(o.actionId)return T`<a href="javascript: void(0);" @click="${t=>_l(n,o,e)}">${e[n.path]}</a>`;let t=e[n.path];return T`<a href="${t}">${t}</a>`}let s=e[n.path];return T`<a href="${s.href}">${s.text}</a>`},yl=(e,t,n,r,i)=>{let a=e[n.path];return r==`string`?a.split(`,`).map(e=>L(e,`width: 16px;`)):a.split(`,`).map(e=>L(e.icon,`width: 16px;`))},bl=(e,t,n,r,i)=>{let a=e[n.path];return T`${_(a)}`},xl=(e,t,n,r,i,a)=>r==`string`?T`<img src="${e[n.path]}" style="${`max-height: 40px; `+(a.style??``)}">`:T`<img src="${e[n.path].src}" style="${a.style??``}">`,Sl=e=>{let t={_clickedRow:e.target.row};e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+e.detail.value.methodNameInCrud,parameters:t},bubbles:!0,composed:!0}))},Cl=e=>{let t={_clickedRow:e.target.row},n=e.target.action;e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+n.methodNameInCrud,parameters:t},bubbles:!0,composed:!0}))},wl=e=>{let t=document.createElement(`vaadin-context-menu-item`),n=document.createElement(`vaadin-icon`);return n.style.color=`var(--lumo-secondary-text-color)`,n.style.marginInlineEnd=`var(--lumo-space-s)`,n.style.padding=`var(--lumo-space-xs)`,n.setAttribute(`icon`,e.icon),t.appendChild(n),e.label&&t.appendChild(document.createTextNode(e.label)),t.disabled=e.disabled,t},Tl=(e,t,n)=>{let r=e[n.path]?.actions?.map(e=>e.icon?{component:wl(e),methodNameInCrud:e.methodNameInCrud}:{...e,text:e.label});return!r||r.length==0?T``:T`
+    `}};k([y()],al.prototype,`fieldId`,void 0),k([y()],al.prototype,`value`,void 0),k([y()],al.prototype,`accept`,void 0),k([y({type:Boolean})],al.prototype,`editable`,void 0),al=rl=k([g(`mateu-file-upload`)],al);var ol=e=>e==null||typeof e==`string`&&e.trim()===``,sl=(e,t)=>{if(ol(e))return null;let n=t?parseInt(String(e),10):Number(e);return Number.isNaN(n)?null:n},cl=(e,t)=>ol(e)&&ol(t)?!0:e==t,ll=e=>!!e&&typeof e==`object`&&`__mateuGroup`in e,ul=e=>String(e??``),dl=(e,t,n)=>{let r=e??[];if(!t||!n||n.length===0)return r;let i=[],a,o=!1;return r.forEach((e,s)=>{let c=ul(e?.[t]);if(!o||c!==a){let e=n.find(e=>ul(e.value)===c)??{value:c,count:r.filter(e=>ul(e?.[t])===c).length,aggregates:{}};i.push({__mateuGroup:e,__mateuGroupBy:t,_rowNumber:`__mateuGroup:${s}:${c}`}),o=!0,a=c}i.push(e)}),i},fl=(e,t)=>e==null?``:t.dataType===`money`||t.stereotype===`money`?new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e):t.aggregate===`count`?new Intl.NumberFormat(void 0,{maximumFractionDigits:0}).format(Math.round(e)):new Intl.NumberFormat(void 0,{maximumFractionDigits:2}).format(e),pl=(e,t)=>e&&t.includes(e)?e:t.find(e=>!!e),ml=(e,t,n)=>{let r=e.__mateuGroup;return t.id===n?`${r.value} (${r.count})`:t.aggregate?fl(r.aggregates?.[t.id],t):``},hl=(e,t,n)=>{let r=t?.aggregates;if(!r||!e.some(e=>e.aggregate))return;let i={};e.forEach(e=>{e.aggregate&&r[e.id]!=null&&(i[e.id]=fl(r[e.id],e))});let a=e[0];if(a&&i[a.id]===void 0){let e=t?.page?.totalElements;i[a.id]=n&&a.id===n&&e!=null?`Total (${e})`:`Total`}return i},gl=(e,t,n)=>I(e[n.path]?`vaadin:check`:`vaadin:minus`,`height: 16px; width: 16px; color: var(--lumo-body-text-color);`),_l=(e,t,n,r,i)=>{let a=e[n.path],o=a;return r==`money`&&a&&a.locale&&a.currency?o=new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(a.value):i==`money`&&(o=new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(a)),T`${o}`},vl=(e,t,n)=>{e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:n},bubbles:!0,composed:!0}))},yl=(e,t,n,r,i,a)=>{let o=n.xcolumn??a;if(o.text)return o.actionId?T`<a href="javascript: void(0);" @click="${t=>vl(n,o,e)}">${o.text}</a>`:T`<a href="${e[n.path]}">${o.text}</a>`;if(r==`string`){if(o.actionId)return T`<a href="javascript: void(0);" @click="${t=>vl(n,o,e)}">${e[n.path]}</a>`;let t=e[n.path];return T`<a href="${t}">${t}</a>`}let s=e[n.path];return T`<a href="${s.href}">${s.text}</a>`},bl=(e,t,n,r,i)=>{let a=e[n.path];return r==`string`?a.split(`,`).map(e=>I(e,`width: 16px;`)):a.split(`,`).map(e=>I(e.icon,`width: 16px;`))},xl=(e,t,n,r,i)=>{let a=e[n.path];return T`${_(a)}`},Sl=(e,t,n,r,i,a)=>r==`string`?T`<img src="${e[n.path]}" style="${`max-height: 40px; `+(a.style??``)}">`:T`<img src="${e[n.path].src}" style="${a.style??``}">`,Cl=e=>{let t={_clickedRow:e.target.row};e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+e.detail.value.methodNameInCrud,parameters:t},bubbles:!0,composed:!0}))},wl=e=>{let t={_clickedRow:e.target.row},n=e.target.action;e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+n.methodNameInCrud,parameters:t},bubbles:!0,composed:!0}))},Tl=e=>{let t=document.createElement(`vaadin-context-menu-item`),n=document.createElement(`vaadin-icon`);return n.style.color=`var(--lumo-secondary-text-color)`,n.style.marginInlineEnd=`var(--lumo-space-s)`,n.style.padding=`var(--lumo-space-xs)`,n.setAttribute(`icon`,e.icon),t.appendChild(n),e.label&&t.appendChild(document.createTextNode(e.label)),t.disabled=e.disabled,t},El=(e,t,n)=>{let r=e[n.path]?.actions?.map(e=>e.icon?{component:Tl(e),methodNameInCrud:e.methodNameInCrud}:{...e,text:e.label});return!r||r.length==0?T``:T`
                                      <vaadin-menu-bar
                                          .items=${[{text:`···`,children:r}]}
                                          theme="tertiary"
                                          .row="${e}"
                                          data-testid="menubar-${n.path}"
-                                         @item-selected="${Sl}"
+                                         @item-selected="${Cl}"
                                      ></vaadin-menu-bar>
-                                   `},El=(e,t,n)=>{if(n.path==`select`)return T`
-         <vaadin-button theme="tertiary" title="Select" @click="${Cl}" .row="${e}" .action="${{actionId:n.path,icon:``,label:`Select`,disabled:!1,methodNameInCrud:`select`}}">
+                                   `},Dl=(e,t,n)=>{if(n.path==`select`)return T`
+         <vaadin-button theme="tertiary" title="Select" @click="${wl}" .row="${e}" .action="${{actionId:n.path,icon:``,label:`Select`,disabled:!1,methodNameInCrud:`select`}}">
              Select
          </vaadin-button>
     `;let r=n.path&&e[n.path]?.methodNameInCrud?e[n.path]:e.action;return r?T`
-         <vaadin-button theme="tertiary${r.icon&&!r.label?` icon`:``}" title="${r.label||v}" @click="${Cl}" .row="${e}" .action="${r}">
+         <vaadin-button theme="tertiary${r.icon&&!r.label?` icon`:``}" title="${r.label||v}" @click="${wl}" .row="${e}" .action="${r}">
              ${r.icon?T`<vaadin-icon icon="${r.icon}"></vaadin-icon>`:v}
              ${r.label?r.label:v}
          </vaadin-button>
-    `:T``},Dl=(e,t,n)=>{e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:n},bubbles:!0,composed:!0}))},Ol=(e,t,n,r,i,a)=>{let o=n.xcolumn??a;if(o.actionId)return T`
-            <vaadin-button theme="tertiary" @click="${t=>Dl(n,o,e)}" .row="${e}">
+    `:T``},Ol=(e,t,n)=>{e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:n},bubbles:!0,composed:!0}))},kl=(e,t,n,r,i,a)=>{let o=n.xcolumn??a;if(o.actionId)return T`
+            <vaadin-button theme="tertiary" @click="${t=>Ol(n,o,e)}" .row="${e}">
                 ${o.text||e[n.path]}
             </vaadin-button>
-        `;let s=e[n.path];return T`<a href="${s}">${o.text||s}</a>`},kl=(e,t,n,r,i,a,o,s,c)=>{let l=e[n.path];return I(r,l,i,a,o,s,c)},Al=new WeakMap,jl=(e,t)=>Al.get(e)?.[t],Ml=(e,t,n)=>{let r=Al.get(e);r||(r={},Al.set(e,r)),r[t]=n},Nl=(e,t=!1)=>ol(e,t),Pl=(e,t,n,r)=>{let i=n?.field?.fieldId,a=a=>{if(e[t.id]===a||e[t.id]==null&&(a===``||a==null))return;if(e[t.id]=a,!i){n.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`update-row`,parameters:{_editedRow:{...e}}},bubbles:!0,composed:!0}));return}let o=(n?.state??r)[i];n.dispatchEvent(new CustomEvent(`value-changed`,{detail:{fieldId:i,value:Array.isArray(o)?[...o]:o},bubbles:!0,composed:!0}))},o=e[t.id],s=o==null?``:String(o);switch(t.editorType){case`boolean`:return T`<vaadin-checkbox ?checked=${!!o} @checked-changed=${e=>a(e.detail.value)}></vaadin-checkbox>`;case`integer`:return T`<vaadin-integer-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(Nl(e.target.value,!0))}></vaadin-integer-field>`;case`number`:return T`<vaadin-number-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(Nl(e.target.value))}></vaadin-number-field>`;case`date`:return T`<vaadin-date-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-date-picker>`;case`time`:return T`<vaadin-time-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-time-picker>`;case`datetime`:return T`<vaadin-date-time-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-date-time-picker>`;case`select`:return T`<vaadin-combo-box
+        `;let s=e[n.path];return T`<a href="${s}">${o.text||s}</a>`},Al=(e,t,n,r,i,a,o,s,c)=>{let l=e[n.path];return F(r,l,i,a,o,s,c)},jl=new WeakMap,Ml=(e,t)=>jl.get(e)?.[t],Nl=(e,t,n)=>{let r=jl.get(e);r||(r={},jl.set(e,r)),r[t]=n},Pl=(e,t=!1)=>sl(e,t),Fl=(e,t,n,r)=>{let i=n?.field?.fieldId,a=a=>{if(e[t.id]===a||e[t.id]==null&&(a===``||a==null))return;if(e[t.id]=a,!i){n.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`update-row`,parameters:{_editedRow:{...e}}},bubbles:!0,composed:!0}));return}let o=(n?.state??r)[i];n.dispatchEvent(new CustomEvent(`value-changed`,{detail:{fieldId:i,value:Array.isArray(o)?[...o]:o},bubbles:!0,composed:!0}))},o=e[t.id],s=o==null?``:String(o);switch(t.editorType){case`boolean`:return T`<vaadin-checkbox ?checked=${!!o} @checked-changed=${e=>a(e.detail.value)}></vaadin-checkbox>`;case`integer`:return T`<vaadin-integer-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(Pl(e.target.value,!0))}></vaadin-integer-field>`;case`number`:return T`<vaadin-number-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(Pl(e.target.value))}></vaadin-number-field>`;case`date`:return T`<vaadin-date-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-date-picker>`;case`time`:return T`<vaadin-time-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-time-picker>`;case`datetime`:return T`<vaadin-date-time-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-date-time-picker>`;case`select`:return T`<vaadin-combo-box
                 theme="small" style="width:100%;"
                 .items=${(t.editorOptions??[]).map(e=>({label:e.label,value:String(e.value)}))}
                 item-label-path="label" item-value-path="value"
@@ -8849,12 +8857,12 @@ ${i}
                 theme="small" style="width:100%;"
                 item-label-path="label" item-id-path="value"
                 .dataProvider=${(e,t)=>{n.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:i,parameters:{searchText:e.filter,size:e.pageSize,page:e.page},callback:e=>{let n=e?.fragments?.[0]?.data?.[o];t(n?.content??[],n?.totalElements??0)},callbackonly:!0},bubbles:!0,composed:!0}))}}
-                .selectedItem=${(t.editorOptions??[]).find(e=>String(e.value)===s)??(s?{value:s,label:jl(e,t.id)??s}:void 0)}
-                @selected-item-changed=${n=>{let r=n.detail.value,i=r?r.value:null;String(i??``)!==s&&(r&&Ml(e,t.id,r.label),a(i))}}></vaadin-combo-box>`}default:return T`<vaadin-text-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(e.target.value)}></vaadin-text-field>`}},Fl=e=>ee(()=>T`<span title="${e}" style="white-space:normal;overflow-wrap:break-word;">${e}</span>`,[e]),Il=e=>e===void 0?v:d(()=>T`<span style="font-weight: 600; white-space: nowrap;">${e}</span>`,[e]),Ll=e=>{e.preventDefault(),e.stopPropagation(),e.currentTarget?.dispatchEvent(new CustomEvent(`sort-direction-changed`,{detail:{grid:e.currentTarget.parentElement},bubbles:!0,composed:!0}))},Rl=(e,t,n,r,i,a,o,s)=>T`
+                .selectedItem=${(t.editorOptions??[]).find(e=>String(e.value)===s)??(s?{value:s,label:Ml(e,t.id)??s}:void 0)}
+                @selected-item-changed=${n=>{let r=n.detail.value,i=r?r.value:null;String(i??``)!==s&&(r&&Nl(e,t.id,r.label),a(i))}}></vaadin-combo-box>`}default:return T`<vaadin-text-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(e.target.value)}></vaadin-text-field>`}},Il=e=>ee(()=>T`<span title="${e}" style="white-space:normal;overflow-wrap:break-word;">${e}</span>`,[e]),Ll=e=>e===void 0?v:d(()=>T`<span style="font-weight: 600; white-space: nowrap;">${e}</span>`,[e]),Rl=e=>{e.preventDefault(),e.stopPropagation(),e.currentTarget?.dispatchEvent(new CustomEvent(`sort-direction-changed`,{detail:{grid:e.currentTarget.parentElement},bubbles:!0,composed:!0}))},zl=(e,t,n,r,i,a,o,s)=>T`
 <vaadin-grid-column-group header="${M(e.label,r,i)}">
-    ${e.columns.map(e=>Bl(e.metadata,t,n,r,i,a,o,s?.[e.metadata?.id]))}
+    ${e.columns.map(e=>Vl(e.metadata,t,n,r,i,a,o,s?.[e.metadata?.id]))}
 </vaadin-grid-column-group>
-`,zl=(e,t,n,r,i,a,o,s)=>j.GridGroupColumn==e.metadata?.type?Rl(e.metadata,t,n,r,i,a,o,s):Bl(e.metadata,t,n,r,i,a,o,s?.[e.metadata?.id]),Bl=(e,n,r,i,a,o,s,c)=>{let l=M(e.label,i,a);return e.sortable?T`
+`,Bl=(e,t,n,r,i,a,o,s)=>j.GridGroupColumn==e.metadata?.type?zl(e.metadata,t,n,r,i,a,o,s):Vl(e.metadata,t,n,r,i,a,o,s?.[e.metadata?.id]),Vl=(e,n,r,i,a,o,s,c)=>{let l=M(e.label,i,a);return e.sortable?T`
                         <vaadin-grid-sort-column
                                 path="${e.id}"
                                 text-align="${e.align??v}"
@@ -8864,12 +8872,12 @@ ${i}
                                 flex-grow="${e.flexGrow??v}"
                                 ?resizable="${e.resizable}"
                                 width="${e.width??v}"
-                                @direction-changed="${Ll}"
+                                @direction-changed="${Rl}"
                                 data-data-type="${e.dataType}"
                                 data-stereotype="${e.stereotype}"
-                                ${Fl(l)}
-                                ${Il(c)}
-                                ${t((t,c,l)=>Vl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
+                                ${Il(l)}
+                                ${Ll(c)}
+                                ${t((t,c,l)=>Hl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
                         ></vaadin-grid-sort-column>
                     `:e.filterable?T`
                         <vaadin-grid-filter-column
@@ -8883,9 +8891,9 @@ ${i}
                                 width="${e.width??v}"
                                 data-data-type="${e.dataType}"
                                 data-stereotype="${e.stereotype}"
-                                ${Fl(l)}
-                                ${Il(c)}
-                                ${t((t,c,l)=>Vl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
+                                ${Il(l)}
+                                ${Ll(c)}
+                                ${t((t,c,l)=>Hl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
                         ></vaadin-grid-filter-column>
                     `:T`
                         <vaadin-grid-column
@@ -8900,17 +8908,17 @@ ${i}
                                 data-data-type="${e.dataType}"
                                 data-stereotype="${e.stereotype}"
                                 .xcolumn="${e}"
-                                ${Fl(l)}
-                                ${Il(c)}
-                                ${t((t,c,l)=>Vl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
+                                ${Il(l)}
+                                ${Ll(c)}
+                                ${t((t,c,l)=>Hl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
                         ></vaadin-grid-column>
-                    `},Vl=(e,t,n,r,i,a,o,s,c,l)=>{let u=n.dataset.dataType??``,d=n.dataset.stereotype??``;if(cl(e)){let t=i?.metadata,n=(t?.columns??[]).flatMap(e=>e?.metadata?.type===j.GridGroupColumn?(e.metadata.columns??[]).map(e=>e?.metadata?.id):[e?.metadata?.id]),a=pl(e,r,fl(e.__mateuGroupBy,n)),o=e.__mateuGroup.hiddenActions??[],s=r.id===n[n.length-1]?(t?.groupActions??[]).filter(e=>!o.includes(e.actionId??e.id)):[];return s.length?T`<span style="display: flex; align-items: center; justify-content: flex-end; gap: var(--lumo-space-s); overflow: hidden;">
+                    `},Hl=(e,t,n,r,i,a,o,s,c,l)=>{let u=n.dataset.dataType??``,d=n.dataset.stereotype??``;if(ll(e)){let t=i?.metadata,n=(t?.columns??[]).flatMap(e=>e?.metadata?.type===j.GridGroupColumn?(e.metadata.columns??[]).map(e=>e?.metadata?.id):[e?.metadata?.id]),a=ml(e,r,pl(e.__mateuGroupBy,n)),o=e.__mateuGroup.hiddenActions??[],s=r.id===n[n.length-1]?(t?.groupActions??[]).filter(e=>!o.includes(e.actionId??e.id)):[];return s.length?T`<span style="display: flex; align-items: center; justify-content: flex-end; gap: var(--lumo-space-s); overflow: hidden;">
                 ${a?T`<span style="font-weight: 600;">${a}</span>`:v}
                 ${s.map(t=>T`
                     <vaadin-button theme="tertiary small" style="flex-shrink: 0;"
                         @click="${n=>{n.stopPropagation(),n.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+(t.actionId??t.id),parameters:{_groupValue:e.__mateuGroup.value}},bubbles:!0,composed:!0}))}}">${t.label??t.caption??``}</vaadin-button>
                 `)}
-            </span>`:T`<span title="${a}" style="font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block;">${a}</span>`}if(r.editable)return Pl(e,r,i,o);if(u==`status`)return ka(e,t,n);if(u==`bool`)return hl(e,t,n);if(u==`money`||d==`money`)return gl(e,t,n,u,d);if(u==`link`||d==`link`)return vl(e,t,n,u,d,r);if(u==`icon`||d==`icon`)return yl(e,t,n,u,d);if(d==`html`)return bl(e,t,n,u,d);if(d==`image`)return xl(e,t,n,u,d,r);if(u==`menu`)return Tl(e,t,n);if(u==`component`)return kl(e,t,n,i,a,o,s,c,l);if(u==`action`)return El(e,t,n);if(u==`actionGroup`)return Tl(e,t,n);if(d==`button`||r.actionId)return Ol(e,t,n,u,d,r);let f=e[n.path];return T`<span title="${f}" style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block;">${f}</span>`},Hl=()=>{let e=document.activeElement;for(;e?.shadowRoot?.activeElement;)e=e.shadowRoot.activeElement;return e},Ul=(e,t)=>{let n=t;for(;n;){if(n===e)return!0;n=n.assignedSlot??n.parentNode??n.host??null}return!1},Wl=class extends vt{constructor(...e){super(...e),this.state={},this.data={},this.appState={},this.appData={},this.detailsOpenedItems=[],this.hoveredItem=null,this.onGridHoverMove=e=>{let t=e.currentTarget,n=t.getEventContext(e)?.item??null;n!==this.hoveredItem&&(this.hoveredItem=n,t.generateCellPartNames())},this.onGridHoverLeave=e=>{this.hoveredItem!==null&&(this.hoveredItem=null,e.currentTarget.generateCellPartNames())},this.hoverCellPartNameGenerator=(e,t)=>t?.item!=null&&t.item===this.hoveredItem?`hovered-cell`:``,this._onRowKey=e=>{let t=this.field?.rowSelectionShortcut;if(!t||!this.field?.onItemSelectionActionId||!this._isRowShortcutRelevant()||!nr(t,e))return;let n=/^(?:Digit|Numpad)([1-9])$/.exec(e.code);if(!n)return;let r=this.currentItems(),i=parseInt(n[1],10)-1;i>=r.length||(e.preventDefault(),this.selectRow(r[i]))},this.handleButtonClick=e=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))}}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._onRowKey)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`keydown`,this._onRowKey)}currentItems(){return this.field?.remoteCoordinates?this.data?.[this.id]?.content??[]:this.field?.fieldId&&this.state?this.state[this.field.fieldId]??[]:[]}selectRow(e){!e||!this.field?.onItemSelectionActionId||(this.selectedItems=[e],this.state[this.id+`_selected_items`]=[e],this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.field.onItemSelectionActionId,parameters:{_clickedRow:e}},bubbles:!0,composed:!0})))}_isRowShortcutRelevant(){if(this.offsetParent===null&&this.getClientRects().length===0)return!1;let e=Hl();if(e&&e!==document.body&&!Ul(this,e)){let t=e.tagName?.toLowerCase()??``;if(e.isContentEditable||/^(input|textarea|select)$/.test(t)||t.startsWith(`vaadin-`)&&/(field|combo|picker|area|select)/.test(t))return!1}return!0}handleItemToggle(e){let{item:t,selected:n,shiftKey:r}=e.detail;if(this.rangeStartItem??=t,r){let e=[];this.field?.fieldId&&this.state&&this.state[this.field.fieldId]&&(e=this.state[this.field.fieldId]);let[r,i]=[this.rangeStartItem,t].map(t=>e.indexOf(t)).sort((e,t)=>e-t),a=e.slice(r,i+1),o=new Set(this.selectedItems);a.forEach(e=>{n?o.add(e):o.delete(e)}),this.selectedItems=[...o],this.state[this.id+`_selected_items`]=this.selectedItems}this.rangeStartItem=t}render(){let e=[];this.field?.fieldId&&this.state&&this.state[this.field.fieldId]&&(e=this.state[this.field.fieldId]);let t=this.state[this.field?.fieldId+`_show_detail`]||this.state._show_detail&&this.state._show_detail[this.field.fieldId];if(this.field?.remoteCoordinates){let t=this.field.remoteCoordinates;this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements?e=this.data[this.id].content:this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}if(Array.isArray(e)&&e.forEach((e,t)=>{e&&typeof e==`object`&&e._rowNumber===void 0&&(e._rowNumber=t)}),this.field?.inlineEditing)return this.renderMaster(e);if(this.field?.formPosition&&this.field?.formPosition.startsWith(`modal`)){let n=this;return T`
+            </span>`:T`<span title="${a}" style="font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block;">${a}</span>`}if(r.editable)return Fl(e,r,i,o);if(u==`status`)return Aa(e,t,n);if(u==`bool`)return gl(e,t,n);if(u==`money`||d==`money`)return _l(e,t,n,u,d);if(u==`link`||d==`link`)return yl(e,t,n,u,d,r);if(u==`icon`||d==`icon`)return bl(e,t,n,u,d);if(d==`html`)return xl(e,t,n,u,d);if(d==`image`)return Sl(e,t,n,u,d,r);if(u==`menu`)return El(e,t,n);if(u==`component`)return Al(e,t,n,i,a,o,s,c,l);if(u==`action`)return Dl(e,t,n);if(u==`actionGroup`)return El(e,t,n);if(d==`button`||r.actionId)return kl(e,t,n,u,d,r);let f=e[n.path];return T`<span title="${f}" style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block;">${f}</span>`},Ul=()=>{let e=document.activeElement;for(;e?.shadowRoot?.activeElement;)e=e.shadowRoot.activeElement;return e},Wl=(e,t)=>{let n=t;for(;n;){if(n===e)return!0;n=n.assignedSlot??n.parentNode??n.host??null}return!1},Gl=class extends vt{constructor(...e){super(...e),this.state={},this.data={},this.appState={},this.appData={},this.detailsOpenedItems=[],this.hoveredItem=null,this.onGridHoverMove=e=>{let t=e.currentTarget,n=t.getEventContext(e)?.item??null;n!==this.hoveredItem&&(this.hoveredItem=n,t.generateCellPartNames())},this.onGridHoverLeave=e=>{this.hoveredItem!==null&&(this.hoveredItem=null,e.currentTarget.generateCellPartNames())},this.hoverCellPartNameGenerator=(e,t)=>t?.item!=null&&t.item===this.hoveredItem?`hovered-cell`:``,this._onRowKey=e=>{let t=this.field?.rowSelectionShortcut;if(!t||!this.field?.onItemSelectionActionId||!this._isRowShortcutRelevant()||!rr(t,e))return;let n=/^(?:Digit|Numpad)([1-9])$/.exec(e.code);if(!n)return;let r=this.currentItems(),i=parseInt(n[1],10)-1;i>=r.length||(e.preventDefault(),this.selectRow(r[i]))},this.handleButtonClick=e=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))}}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._onRowKey)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`keydown`,this._onRowKey)}currentItems(){return this.field?.remoteCoordinates?this.data?.[this.id]?.content??[]:this.field?.fieldId&&this.state?this.state[this.field.fieldId]??[]:[]}selectRow(e){!e||!this.field?.onItemSelectionActionId||(this.selectedItems=[e],this.state[this.id+`_selected_items`]=[e],this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.field.onItemSelectionActionId,parameters:{_clickedRow:e}},bubbles:!0,composed:!0})))}_isRowShortcutRelevant(){if(this.offsetParent===null&&this.getClientRects().length===0)return!1;let e=Ul();if(e&&e!==document.body&&!Wl(this,e)){let t=e.tagName?.toLowerCase()??``;if(e.isContentEditable||/^(input|textarea|select)$/.test(t)||t.startsWith(`vaadin-`)&&/(field|combo|picker|area|select)/.test(t))return!1}return!0}handleItemToggle(e){let{item:t,selected:n,shiftKey:r}=e.detail;if(this.rangeStartItem??=t,r){let e=[];this.field?.fieldId&&this.state&&this.state[this.field.fieldId]&&(e=this.state[this.field.fieldId]);let[r,i]=[this.rangeStartItem,t].map(t=>e.indexOf(t)).sort((e,t)=>e-t),a=e.slice(r,i+1),o=new Set(this.selectedItems);a.forEach(e=>{n?o.add(e):o.delete(e)}),this.selectedItems=[...o],this.state[this.id+`_selected_items`]=this.selectedItems}this.rangeStartItem=t}render(){let e=[];this.field?.fieldId&&this.state&&this.state[this.field.fieldId]&&(e=this.state[this.field.fieldId]);let t=this.state[this.field?.fieldId+`_show_detail`]||this.state._show_detail&&this.state._show_detail[this.field.fieldId];if(this.field?.remoteCoordinates){let t=this.field.remoteCoordinates;this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements?e=this.data[this.id].content:this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}if(Array.isArray(e)&&e.forEach((e,t)=>{e&&typeof e==`object`&&e._rowNumber===void 0&&(e._rowNumber=t)}),this.field?.inlineEditing)return this.renderMaster(e);if(this.field?.formPosition&&this.field?.formPosition.startsWith(`modal`)){let n=this;return T`
 
                 ${this.renderMaster(e)}
 
@@ -8954,14 +8962,14 @@ ${i}
                     @click="${S(this.field?.onItemSelectionActionId?e=>{if(e.composedPath().some(e=>e instanceof HTMLElement&&(e.localName===`vaadin-button`||e.localName===`button`||e.localName===`a`||e.localName===`vaadin-checkbox`||e.getAttribute?.(`role`)===`button`)))return;let t=e.currentTarget.getEventContext(e)?.item;t&&this.selectRow(t)}:void 0)}"
                     @active-item-changed="${S(this.field?.detailPath&&!this.field?.useButtonForDetail?e=>{if(this.field?.detailPath){let t=e.detail.value;t?this.detailsOpenedItems=[t]:this.detailsOpenedItems=[]}}:void 0)}"
                     .detailsOpenedItems="${this.detailsOpenedItems}"
-                    ${S(this.field?.detailPath?n(e=>T`${I(this,e[this.field?.detailPath],this.baseUrl,this.state,this.data,this.appState,this.appData)}`):void 0)}
+                    ${S(this.field?.detailPath?n(e=>T`${F(this,e[this.field?.detailPath],this.baseUrl,this.state,this.data,this.appState,this.appData)}`):void 0)}
                     ?all-rows-visible=${e?.length<10}
             >
                 <span slot="empty-state">${this.field?.label?`No ${this.field.label.toLowerCase()} added yet.`:`No items added yet.`}</span>
                 ${this.field?.readOnly||this.field?.inlineEditing?v:T`
                     <vaadin-grid-selection-column drag-select></vaadin-grid-selection-column>
                 `}
-                ${this.field?.columns?.map(e=>zl(e,this,this.baseUrl,this.state,this.data,this.appState,this.appData))}
+                ${this.field?.columns?.map(e=>Bl(e,this,this.baseUrl,this.state,this.data,this.appState,this.appData))}
 
                 ${this.field?.inlineEditing&&!this.field?.readOnly?T`
                     <vaadin-grid-column width="3.5rem" flex-grow="0" frozen-to-end
@@ -9018,12 +9026,12 @@ ${i}
             background-color: var(--lumo-primary-color-10pct);
             cursor: pointer;
         }
-    `}};k([y()],Wl.prototype,`field`,void 0),k([y()],Wl.prototype,`state`,void 0),k([y()],Wl.prototype,`data`,void 0),k([y()],Wl.prototype,`appState`,void 0),k([y()],Wl.prototype,`appData`,void 0),k([y()],Wl.prototype,`selectedItems`,void 0),k([C()],Wl.prototype,`detailsOpenedItems`,void 0),Wl=k([g(`mateu-grid`)],Wl);var Gl=class extends b{constructor(...e){super(...e),this.getNewValue=e=>{if(this.field?.dataType==`array`){if(!this.value)return[e];let t=this.value;return t.indexOf(e)>=0?t.filter(t=>t!==e):[...t,e]}return e}}render(){let e=this.field?.options;if(this.field?.remoteCoordinates){let t=this.field.remoteCoordinates;this.data?.[this.field.fieldId]&&this.data[this.field.fieldId].content&&this.data[this.field.fieldId].totalElements?e=this.data[this.field.fieldId].content:this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}return T`
+    `}};k([y()],Gl.prototype,`field`,void 0),k([y()],Gl.prototype,`state`,void 0),k([y()],Gl.prototype,`data`,void 0),k([y()],Gl.prototype,`appState`,void 0),k([y()],Gl.prototype,`appData`,void 0),k([y()],Gl.prototype,`selectedItems`,void 0),k([C()],Gl.prototype,`detailsOpenedItems`,void 0),Gl=k([g(`mateu-grid`)],Gl);var Kl=class extends b{constructor(...e){super(...e),this.getNewValue=e=>{if(this.field?.dataType==`array`){if(!this.value)return[e];let t=this.value;return t.indexOf(e)>=0?t.filter(t=>t!==e):[...t,e]}return e}}render(){let e=this.field?.options;if(this.field?.remoteCoordinates){let t=this.field.remoteCoordinates;this.data?.[this.field.fieldId]&&this.data[this.field.fieldId].content&&this.data[this.field.fieldId].totalElements?e=this.data[this.field.fieldId].content:this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}return T`
         <div style="display: flex; gap: 1rem; padding: 1rem; flex-wrap: wrap; ${this.field?.attributes?.divStyle}">
                                     ${e?.map(e=>T`
                             <div role="button" tabindex="0" 
                                     class="choice ${this.value==e.value||Array.isArray(this.value)&&this.value.includes(e.value)?`selected`:``}"
-                                    @click="${()=>this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.getNewValue(e.value),fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}" @keydown="${z(()=>this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.getNewValue(e.value),fieldId:this.field?.fieldId},bubbles:!0,composed:!0})))}"
+                                    @click="${()=>this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.getNewValue(e.value),fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}" @keydown="${R(()=>this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.getNewValue(e.value),fieldId:this.field?.fieldId},bubbles:!0,composed:!0})))}"
                             >${e.description||e.image?T`
                                 <div style="display: flex; align-items: center; gap: var(--lumo-space-m, 1rem);">
                                     ${e.image?T`
@@ -9065,8 +9073,8 @@ ${i}
             border: 1px solid var(--lumo-shade-20pct);
         }
   
-        ${B}
-    `}};k([y()],Gl.prototype,`field`,void 0),k([y()],Gl.prototype,`baseUrl`,void 0),k([y()],Gl.prototype,`state`,void 0),k([y()],Gl.prototype,`data`,void 0),k([y()],Gl.prototype,`value`,void 0),Gl=k([g(`mateu-choice`)],Gl);var Kl,ql=class extends b{static{Kl=this}constructor(...e){super(...e),this.commit=e=>{this.value=e,this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:{...e},fieldId:this.fieldId}}))},this.currencyChanged=e=>{let t=this.value??Kl.EMPTY;!e.detail.value||e.detail.value===t.currency||this.commit({...t,currency:e.detail.value})},this.valueChanged=e=>{let t=this.value??Kl.EMPTY,n=ol(e.detail.value,!1)??0;n!==t.value&&this.commit({...t,value:n})}}static{this.EMPTY={value:0,currency:`EUR`,locale:`es-ES`}}render(){return T`
+        ${z}
+    `}};k([y()],Kl.prototype,`field`,void 0),k([y()],Kl.prototype,`baseUrl`,void 0),k([y()],Kl.prototype,`state`,void 0),k([y()],Kl.prototype,`data`,void 0),k([y()],Kl.prototype,`value`,void 0),Kl=k([g(`mateu-choice`)],Kl);var ql,Jl=class extends b{static{ql=this}constructor(...e){super(...e),this.commit=e=>{this.value=e,this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:{...e},fieldId:this.fieldId}}))},this.currencyChanged=e=>{let t=this.value??ql.EMPTY;!e.detail.value||e.detail.value===t.currency||this.commit({...t,currency:e.detail.value})},this.valueChanged=e=>{let t=this.value??ql.EMPTY,n=sl(e.detail.value,!1)??0;n!==t.value&&this.commit({...t,value:n})}}static{this.EMPTY={value:0,currency:`EUR`,locale:`es-ES`}}render(){return T`
             <vaadin-number-field
                     id="${this.fieldId}"
                     label="${this.label}"
@@ -9086,10 +9094,10 @@ ${i}
                     theme="small"
             ></vaadin-select></div></vaadin-number-field>
        `}static{this.styles=h`
-  `}};k([y()],ql.prototype,`fieldId`,void 0),k([y()],ql.prototype,`label`,void 0),k([y()],ql.prototype,`state`,void 0),k([y()],ql.prototype,`data`,void 0),k([y()],ql.prototype,`value`,void 0),k([y()],ql.prototype,`autoFocus`,void 0),k([y()],ql.prototype,`required`,void 0),k([y()],ql.prototype,`colspan`,void 0),k([y()],ql.prototype,`helperText`,void 0),ql=Kl=k([g(`mateu-money-field`)],ql);var Jl=`vaadin:abacus.vaadin:absolute-position.vaadin:academy-cap.vaadin:accessibility.vaadin:accordion-menu.vaadin:add-dock.vaadin:adjust.vaadin:adobe-flash.vaadin:airplane.vaadin:alarm.vaadin:align-center.vaadin:align-justify.vaadin:align-left.vaadin:align-right.vaadin:alt-a.vaadin:alt.vaadin:ambulance.vaadin:anchor.vaadin:angle-double-down.vaadin:angle-double-left.vaadin:angle-double-right.vaadin:angle-double-up.vaadin:angle-down.vaadin:angle-left.vaadin:angle-right.vaadin:angle-up.vaadin:archive.vaadin:archives.vaadin:area-select.vaadin:arrow-backward.vaadin:arrow-circle-down-o.vaadin:arrow-circle-down.vaadin:arrow-circle-left-o.vaadin:arrow-circle-left.vaadin:arrow-circle-right-o.vaadin:arrow-circle-right.vaadin:arrow-circle-up-o.vaadin:arrow-circle-up.vaadin:arrow-down.vaadin:arrow-forward.vaadin:arrow-left.vaadin:arrow-long-down.vaadin:arrow-long-left.vaadin:arrow-right.vaadin:arrow-up.vaadin:arrows-cross.vaadin:arrows-long-h.vaadin:arrows-long-right.vaadin:arrows-long-up.vaadin:arrows-long-v.vaadin:arrows.vaadin:asterisk.vaadin:at.vaadin:automation.vaadin:backspace-a.vaadin:backspace.vaadin:backwards.vaadin:ban.vaadin:bar-chart-h.vaadin:bar-chart-v.vaadin:bar-chart.vaadin:barcode.vaadin:bed.vaadin:bell-o.vaadin:bell-slash-o.vaadin:bell-slash.vaadin:bell.vaadin:boat.vaadin:bold.vaadin:bolt.vaadin:bomb.vaadin:book-dollar.vaadin:book-percent.vaadin:book.vaadin:bookmark-o.vaadin:bookmark.vaadin:briefcase.vaadin:browser.vaadin:bug-o.vaadin:bug.vaadin:building-o.vaadin:building.vaadin:bullets.vaadin:bullseye.vaadin:bus.vaadin:buss.vaadin:button.vaadin:calc-book.vaadin:calc.vaadin:calendar-briefcase.vaadin:calendar-clock.vaadin:calendar-envelope.vaadin:calendar-o.vaadin:calendar-user.vaadin:calendar.vaadin:camera.vaadin:car.vaadin:caret-down.vaadin:caret-left.vaadin:caret-right.vaadin:caret-square-down-o.vaadin:caret-square-left-o.vaadin:caret-square-right-o.vaadin:caret-square-up-o.vaadin:caret-up.vaadin:cart-o.vaadin:cart.vaadin:cash.vaadin:chart-3d.vaadin:chart-grid.vaadin:chart-line.vaadin:chart-timeline.vaadin:chart.vaadin:chat.vaadin:check-circle-o.vaadin:check-circle.vaadin:check-square-o.vaadin:check-square.vaadin:check.vaadin:chevron-circle-down-o.vaadin:chevron-circle-down.vaadin:chevron-circle-left-o.vaadin:chevron-circle-left.vaadin:chevron-circle-right-o.vaadin:chevron-circle-right.vaadin:chevron-circle-up-o.vaadin:chevron-circle-up.vaadin:chevron-down-small.vaadin:chevron-down.vaadin:chevron-left-small.vaadin:chevron-left.vaadin:chevron-right-small.vaadin:chevron-right.vaadin:chevron-up-small.vaadin:chevron-up.vaadin:child.vaadin:circle-thin.vaadin:circle.vaadin:clipboard-check.vaadin:clipboard-cross.vaadin:clipboard-heart.vaadin:clipboard-pulse.vaadin:clipboard-text.vaadin:clipboard-user.vaadin:clipboard.vaadin:clock.vaadin:close-big.vaadin:close-circle-o.vaadin:close-circle.vaadin:close-small.vaadin:close.vaadin:cloud-download-o.vaadin:cloud-download.vaadin:cloud-o.vaadin:cloud-upload-o.vaadin:cloud-upload.vaadin:cloud.vaadin:cluster.vaadin:code.vaadin:coffee.vaadin:cog-o.vaadin:cog.vaadin:cogs.vaadin:coin-piles.vaadin:coins.vaadin:combobox.vaadin:comment-ellipsis-o.vaadin:comment-ellipsis.vaadin:comment-o.vaadin:comment.vaadin:comments-o.vaadin:comments.vaadin:compile.vaadin:compress-square.vaadin:compress.vaadin:connect-o.vaadin:connect.vaadin:controller.vaadin:copy-o.vaadin:copy.vaadin:copyright.vaadin:corner-lower-left.vaadin:corner-lower-right.vaadin:corner-upper-left.vaadin:corner-upper-right.vaadin:credit-card.vaadin:crop.vaadin:cross-cutlery.vaadin:crosshairs.vaadin:css.vaadin:ctrl-a.vaadin:ctrl.vaadin:cube.vaadin:cubes.vaadin:curly-brackets.vaadin:cursor-o.vaadin:cursor.vaadin:cutlery.vaadin:dashboard.vaadin:database.vaadin:date-input.vaadin:deindent.vaadin:del-a.vaadin:del.vaadin:dental-chair.vaadin:desktop.vaadin:diamond-o.vaadin:diamond.vaadin:diploma-scroll.vaadin:diploma.vaadin:disc.vaadin:doctor-briefcase.vaadin:doctor.vaadin:dollar.vaadin:dot-circle.vaadin:download-alt.vaadin:download.vaadin:drop.vaadin:edit.vaadin:eject.vaadin:elastic.vaadin:ellipsis-circle-o.vaadin:ellipsis-circle.vaadin:ellipsis-dots-h.vaadin:ellipsis-dots-v.vaadin:ellipsis-h.vaadin:ellipsis-v.vaadin:enter-arrow.vaadin:enter.vaadin:envelope-o.vaadin:envelope-open-o.vaadin:envelope-open.vaadin:envelope.vaadin:envelopes-o.vaadin:envelopes.vaadin:eraser.vaadin:esc-a.vaadin:esc.vaadin:euro.vaadin:exchange.vaadin:exclamation-circle-o.vaadin:exclamation-circle.vaadin:exclamation.vaadin:exit-o.vaadin:exit.vaadin:expand-full.vaadin:expand-square.vaadin:expand.vaadin:external-browser.vaadin:external-link.vaadin:eye-slash.vaadin:eye.vaadin:eyedropper.vaadin:facebook-square.vaadin:facebook.vaadin:factory.vaadin:family.vaadin:fast-backward.vaadin:fast-forward.vaadin:female.vaadin:file-add.vaadin:file-code.vaadin:file-font.vaadin:file-movie.vaadin:file-o.vaadin:file-picture.vaadin:file-presentation.vaadin:file-process.vaadin:file-refresh.vaadin:file-remove.vaadin:file-search.vaadin:file-sound.vaadin:file-start.vaadin:file-table.vaadin:file-text-o.vaadin:file-text.vaadin:file-tree-small.vaadin:file-tree-sub.vaadin:file-tree.vaadin:file-zip.vaadin:file.vaadin:fill.vaadin:film.vaadin:filter.vaadin:fire.vaadin:flag-checkered.vaadin:flag-o.vaadin:flag.vaadin:flash.vaadin:flask.vaadin:flight-landing.vaadin:flight-takeoff.vaadin:flip-h.vaadin:flip-v.vaadin:folder-add.vaadin:folder-o.vaadin:folder-open-o.vaadin:folder-open.vaadin:folder-remove.vaadin:folder-search.vaadin:folder.vaadin:font.vaadin:form.vaadin:forward.vaadin:frown-o.vaadin:funcion.vaadin:function.vaadin:funnel.vaadin:gamepad.vaadin:gavel.vaadin:gift.vaadin:glass.vaadin:glasses.vaadin:globe-wire.vaadin:globe.vaadin:golf.vaadin:google-plus-square.vaadin:google-plus.vaadin:grab.vaadin:grid-bevel.vaadin:grid-big-o.vaadin:grid-big.vaadin:grid-h.vaadin:grid-small-o.vaadin:grid-small.vaadin:grid-v.vaadin:grid.vaadin:group.vaadin:hammer.vaadin:hand.vaadin:handle-corner.vaadin:hands-up.vaadin:handshake.vaadin:harddrive-o.vaadin:harddrive.vaadin:hash.vaadin:header.vaadin:headphones.vaadin:headset.vaadin:health-card.vaadin:heart-o.vaadin:heart.vaadin:home-o.vaadin:home.vaadin:hospital.vaadin:hourglass-empty.vaadin:hourglass-end.vaadin:hourglass-start.vaadin:hourglass.vaadin:inbox.vaadin:indent.vaadin:info-circle-o.vaadin:info-circle.vaadin:info.vaadin:input.vaadin:insert.vaadin:institution.vaadin:invoice.vaadin:italic.vaadin:key-o.vaadin:key.vaadin:keyboard-o.vaadin:keyboard.vaadin:laptop.vaadin:layout.vaadin:level-down-bold.vaadin:level-down.vaadin:level-left-bold.vaadin:level-left.vaadin:level-right-bold.vaadin:level-right.vaadin:level-up-bold.vaadin:level-up.vaadin:lifebuoy.vaadin:lightbulb.vaadin:line-bar-chart.vaadin:line-chart.vaadin:line-h.vaadin:line-v.vaadin:lines-list.vaadin:lines.vaadin:link.vaadin:list-ol.vaadin:list-select.vaadin:list-ul.vaadin:list.vaadin:location-arrow-circle-o.vaadin:location-arrow-circle.vaadin:location-arrow.vaadin:lock.vaadin:magic.vaadin:magnet.vaadin:mailbox.vaadin:male.vaadin:map-marker.vaadin:margin-bottom.vaadin:margin-left.vaadin:margin-right.vaadin:margin-top.vaadin:margin.vaadin:medal.vaadin:megafone.vaadin:megaphone.vaadin:meh-o.vaadin:menu.vaadin:microphone.vaadin:minus-circle-o.vaadin:minus-circle.vaadin:minus-square-o.vaadin:minus.vaadin:mobile-browser.vaadin:mobile-retro.vaadin:mobile.vaadin:modal-list.vaadin:modal.vaadin:money-deposit.vaadin:money-exchange.vaadin:money-withdraw.vaadin:money.vaadin:moon-o.vaadin:moon.vaadin:morning.vaadin:movie.vaadin:music.vaadin:mute.vaadin:native-button.vaadin:newspaper.vaadin:notebook.vaadin:nurse.vaadin:office.vaadin:open-book.vaadin:option-a.vaadin:option.vaadin:options.vaadin:orientation.vaadin:out.vaadin:outbox.vaadin:package.vaadin:padding-bottom.vaadin:padding-left.vaadin:padding-right.vaadin:padding-top.vaadin:padding.vaadin:paint-roll.vaadin:paintbrush.vaadin:palete.vaadin:palette.vaadin:panel.vaadin:paperclip.vaadin:paperplane-o.vaadin:paperplane.vaadin:paragraph.vaadin:password.vaadin:paste.vaadin:pause.vaadin:pencil.vaadin:phone-landline.vaadin:phone.vaadin:picture.vaadin:pie-bar-chart.vaadin:pie-chart.vaadin:piggy-bank-coin.vaadin:piggy-bank.vaadin:pill.vaadin:pills.vaadin:pin-post.vaadin:pin.vaadin:play-circle-o.vaadin:play-circle.vaadin:play.vaadin:plug.vaadin:plus-circle-o.vaadin:plus-circle.vaadin:plus-minus.vaadin:plus-square-o.vaadin:plus.vaadin:pointer.vaadin:power-off.vaadin:presentation.vaadin:print.vaadin:progressbar.vaadin:puzzle-piece.vaadin:pyramid-chart.vaadin:qrcode.vaadin:question-circle-o.vaadin:question-circle.vaadin:question.vaadin:quote-left.vaadin:quote-right.vaadin:random.vaadin:raster-lower-left.vaadin:raster.vaadin:records.vaadin:recycle.vaadin:refresh.vaadin:reply-all.vaadin:reply.vaadin:resize-h.vaadin:resize-v.vaadin:retweet.vaadin:rhombus.vaadin:road-branch.vaadin:road-branches.vaadin:road-split.vaadin:road.vaadin:rocket.vaadin:rotate-left.vaadin:rotate-right.vaadin:rss-square.vaadin:rss.vaadin:safe-lock.vaadin:safe.vaadin:scale-unbalance.vaadin:scale.vaadin:scatter-chart.vaadin:scissors.vaadin:screwdriver.vaadin:search-minus.vaadin:search-plus.vaadin:search.vaadin:select.vaadin:server.vaadin:share-square.vaadin:share.vaadin:shield.vaadin:shift-arrow.vaadin:shift.vaadin:shop.vaadin:sign-in-alt.vaadin:sign-in.vaadin:sign-out-alt.vaadin:sign-out.vaadin:signal.vaadin:sitemap.vaadin:slider.vaadin:sliders.vaadin:smiley-o.vaadin:sort.vaadin:sound-disable.vaadin:spark-line.vaadin:specialist.vaadin:spinner-arc.vaadin:spinner-third.vaadin:spinner.vaadin:spline-area-chart.vaadin:spline-chart.vaadin:split-h.vaadin:split-v.vaadin:split.vaadin:spoon.vaadin:square-shadow.vaadin:star-half-left-o.vaadin:star-half-left.vaadin:star-half-right-o.vaadin:star-half-right.vaadin:star-o.vaadin:star.vaadin:start-cog.vaadin:step-backward.vaadin:step-forward.vaadin:stethoscope.vaadin:stock.vaadin:stop-cog.vaadin:stop.vaadin:stopwatch.vaadin:storage.vaadin:strikethrough.vaadin:subscript.vaadin:suitcase.vaadin:sun-down.vaadin:sun-o.vaadin:sun-rise.vaadin:superscript.vaadin:sword.vaadin:tab-a.vaadin:tab.vaadin:table.vaadin:tablet.vaadin:tabs.vaadin:tag.vaadin:tags.vaadin:tasks.vaadin:taxi.vaadin:teeth.vaadin:terminal.vaadin:text-height.vaadin:text-input.vaadin:text-label.vaadin:text-width.vaadin:thin-square.vaadin:thumbs-down-o.vaadin:thumbs-down.vaadin:thumbs-up-o.vaadin:thumbs-up.vaadin:ticket.vaadin:time-backward.vaadin:time-forward.vaadin:timer.vaadin:toolbox.vaadin:tools.vaadin:tooth.vaadin:touch.vaadin:train.vaadin:trash.vaadin:tree-table.vaadin:trendind-down.vaadin:trending-down.vaadin:trending-up.vaadin:trophy.vaadin:truck.vaadin:twin-col-select.vaadin:twitter-square.vaadin:twitter.vaadin:umbrella.vaadin:underline.vaadin:unlink.vaadin:unlock.vaadin:upload-alt.vaadin:upload.vaadin:user-card.vaadin:user-check.vaadin:user-clock.vaadin:user-heart.vaadin:user-star.vaadin:user.vaadin:users.vaadin:vaadin-h.vaadin:vaadin-v.vaadin:viewport.vaadin:vimeo-square.vaadin:vimeo.vaadin:volume-down.vaadin:volume-off.vaadin:volume-up.vaadin:volume.vaadin:wallet.vaadin:warning.vaadin:workplace.vaadin:wrench.vaadin:youtube-square.vaadin:youtube`.split(`.`),Yl=null,Xl=()=>(Yl||=Promise.all([D(()=>import(`./vendor-ui5.js`).then(e=>e.n),__vite__mapDeps([5,1])),D(()=>import(`./vendor-ui5.js`).then(e=>e.t),__vite__mapDeps([5,1]))]),Yl),Q=class extends b{constructor(...e){super(...e),this.ui5FieldComponentsReady=!1,this.component=void 0,this.field=void 0,this.baseUrl=void 0,this.state={},this.data={},this.appState={},this.appData={},this.colorPickerOpened=!1,this.colorPickerValue=void 0,this.comboData=[],this._comboFilter=``,this.rendered=!1,this.renderColorPicker=()=>{this.loadUi5FieldComponents();let e=this.field?.fieldId;return T`
+  `}};k([y()],Jl.prototype,`fieldId`,void 0),k([y()],Jl.prototype,`label`,void 0),k([y()],Jl.prototype,`state`,void 0),k([y()],Jl.prototype,`data`,void 0),k([y()],Jl.prototype,`value`,void 0),k([y()],Jl.prototype,`autoFocus`,void 0),k([y()],Jl.prototype,`required`,void 0),k([y()],Jl.prototype,`colspan`,void 0),k([y()],Jl.prototype,`helperText`,void 0),Jl=ql=k([g(`mateu-money-field`)],Jl);var Yl=`vaadin:abacus.vaadin:absolute-position.vaadin:academy-cap.vaadin:accessibility.vaadin:accordion-menu.vaadin:add-dock.vaadin:adjust.vaadin:adobe-flash.vaadin:airplane.vaadin:alarm.vaadin:align-center.vaadin:align-justify.vaadin:align-left.vaadin:align-right.vaadin:alt-a.vaadin:alt.vaadin:ambulance.vaadin:anchor.vaadin:angle-double-down.vaadin:angle-double-left.vaadin:angle-double-right.vaadin:angle-double-up.vaadin:angle-down.vaadin:angle-left.vaadin:angle-right.vaadin:angle-up.vaadin:archive.vaadin:archives.vaadin:area-select.vaadin:arrow-backward.vaadin:arrow-circle-down-o.vaadin:arrow-circle-down.vaadin:arrow-circle-left-o.vaadin:arrow-circle-left.vaadin:arrow-circle-right-o.vaadin:arrow-circle-right.vaadin:arrow-circle-up-o.vaadin:arrow-circle-up.vaadin:arrow-down.vaadin:arrow-forward.vaadin:arrow-left.vaadin:arrow-long-down.vaadin:arrow-long-left.vaadin:arrow-right.vaadin:arrow-up.vaadin:arrows-cross.vaadin:arrows-long-h.vaadin:arrows-long-right.vaadin:arrows-long-up.vaadin:arrows-long-v.vaadin:arrows.vaadin:asterisk.vaadin:at.vaadin:automation.vaadin:backspace-a.vaadin:backspace.vaadin:backwards.vaadin:ban.vaadin:bar-chart-h.vaadin:bar-chart-v.vaadin:bar-chart.vaadin:barcode.vaadin:bed.vaadin:bell-o.vaadin:bell-slash-o.vaadin:bell-slash.vaadin:bell.vaadin:boat.vaadin:bold.vaadin:bolt.vaadin:bomb.vaadin:book-dollar.vaadin:book-percent.vaadin:book.vaadin:bookmark-o.vaadin:bookmark.vaadin:briefcase.vaadin:browser.vaadin:bug-o.vaadin:bug.vaadin:building-o.vaadin:building.vaadin:bullets.vaadin:bullseye.vaadin:bus.vaadin:buss.vaadin:button.vaadin:calc-book.vaadin:calc.vaadin:calendar-briefcase.vaadin:calendar-clock.vaadin:calendar-envelope.vaadin:calendar-o.vaadin:calendar-user.vaadin:calendar.vaadin:camera.vaadin:car.vaadin:caret-down.vaadin:caret-left.vaadin:caret-right.vaadin:caret-square-down-o.vaadin:caret-square-left-o.vaadin:caret-square-right-o.vaadin:caret-square-up-o.vaadin:caret-up.vaadin:cart-o.vaadin:cart.vaadin:cash.vaadin:chart-3d.vaadin:chart-grid.vaadin:chart-line.vaadin:chart-timeline.vaadin:chart.vaadin:chat.vaadin:check-circle-o.vaadin:check-circle.vaadin:check-square-o.vaadin:check-square.vaadin:check.vaadin:chevron-circle-down-o.vaadin:chevron-circle-down.vaadin:chevron-circle-left-o.vaadin:chevron-circle-left.vaadin:chevron-circle-right-o.vaadin:chevron-circle-right.vaadin:chevron-circle-up-o.vaadin:chevron-circle-up.vaadin:chevron-down-small.vaadin:chevron-down.vaadin:chevron-left-small.vaadin:chevron-left.vaadin:chevron-right-small.vaadin:chevron-right.vaadin:chevron-up-small.vaadin:chevron-up.vaadin:child.vaadin:circle-thin.vaadin:circle.vaadin:clipboard-check.vaadin:clipboard-cross.vaadin:clipboard-heart.vaadin:clipboard-pulse.vaadin:clipboard-text.vaadin:clipboard-user.vaadin:clipboard.vaadin:clock.vaadin:close-big.vaadin:close-circle-o.vaadin:close-circle.vaadin:close-small.vaadin:close.vaadin:cloud-download-o.vaadin:cloud-download.vaadin:cloud-o.vaadin:cloud-upload-o.vaadin:cloud-upload.vaadin:cloud.vaadin:cluster.vaadin:code.vaadin:coffee.vaadin:cog-o.vaadin:cog.vaadin:cogs.vaadin:coin-piles.vaadin:coins.vaadin:combobox.vaadin:comment-ellipsis-o.vaadin:comment-ellipsis.vaadin:comment-o.vaadin:comment.vaadin:comments-o.vaadin:comments.vaadin:compile.vaadin:compress-square.vaadin:compress.vaadin:connect-o.vaadin:connect.vaadin:controller.vaadin:copy-o.vaadin:copy.vaadin:copyright.vaadin:corner-lower-left.vaadin:corner-lower-right.vaadin:corner-upper-left.vaadin:corner-upper-right.vaadin:credit-card.vaadin:crop.vaadin:cross-cutlery.vaadin:crosshairs.vaadin:css.vaadin:ctrl-a.vaadin:ctrl.vaadin:cube.vaadin:cubes.vaadin:curly-brackets.vaadin:cursor-o.vaadin:cursor.vaadin:cutlery.vaadin:dashboard.vaadin:database.vaadin:date-input.vaadin:deindent.vaadin:del-a.vaadin:del.vaadin:dental-chair.vaadin:desktop.vaadin:diamond-o.vaadin:diamond.vaadin:diploma-scroll.vaadin:diploma.vaadin:disc.vaadin:doctor-briefcase.vaadin:doctor.vaadin:dollar.vaadin:dot-circle.vaadin:download-alt.vaadin:download.vaadin:drop.vaadin:edit.vaadin:eject.vaadin:elastic.vaadin:ellipsis-circle-o.vaadin:ellipsis-circle.vaadin:ellipsis-dots-h.vaadin:ellipsis-dots-v.vaadin:ellipsis-h.vaadin:ellipsis-v.vaadin:enter-arrow.vaadin:enter.vaadin:envelope-o.vaadin:envelope-open-o.vaadin:envelope-open.vaadin:envelope.vaadin:envelopes-o.vaadin:envelopes.vaadin:eraser.vaadin:esc-a.vaadin:esc.vaadin:euro.vaadin:exchange.vaadin:exclamation-circle-o.vaadin:exclamation-circle.vaadin:exclamation.vaadin:exit-o.vaadin:exit.vaadin:expand-full.vaadin:expand-square.vaadin:expand.vaadin:external-browser.vaadin:external-link.vaadin:eye-slash.vaadin:eye.vaadin:eyedropper.vaadin:facebook-square.vaadin:facebook.vaadin:factory.vaadin:family.vaadin:fast-backward.vaadin:fast-forward.vaadin:female.vaadin:file-add.vaadin:file-code.vaadin:file-font.vaadin:file-movie.vaadin:file-o.vaadin:file-picture.vaadin:file-presentation.vaadin:file-process.vaadin:file-refresh.vaadin:file-remove.vaadin:file-search.vaadin:file-sound.vaadin:file-start.vaadin:file-table.vaadin:file-text-o.vaadin:file-text.vaadin:file-tree-small.vaadin:file-tree-sub.vaadin:file-tree.vaadin:file-zip.vaadin:file.vaadin:fill.vaadin:film.vaadin:filter.vaadin:fire.vaadin:flag-checkered.vaadin:flag-o.vaadin:flag.vaadin:flash.vaadin:flask.vaadin:flight-landing.vaadin:flight-takeoff.vaadin:flip-h.vaadin:flip-v.vaadin:folder-add.vaadin:folder-o.vaadin:folder-open-o.vaadin:folder-open.vaadin:folder-remove.vaadin:folder-search.vaadin:folder.vaadin:font.vaadin:form.vaadin:forward.vaadin:frown-o.vaadin:funcion.vaadin:function.vaadin:funnel.vaadin:gamepad.vaadin:gavel.vaadin:gift.vaadin:glass.vaadin:glasses.vaadin:globe-wire.vaadin:globe.vaadin:golf.vaadin:google-plus-square.vaadin:google-plus.vaadin:grab.vaadin:grid-bevel.vaadin:grid-big-o.vaadin:grid-big.vaadin:grid-h.vaadin:grid-small-o.vaadin:grid-small.vaadin:grid-v.vaadin:grid.vaadin:group.vaadin:hammer.vaadin:hand.vaadin:handle-corner.vaadin:hands-up.vaadin:handshake.vaadin:harddrive-o.vaadin:harddrive.vaadin:hash.vaadin:header.vaadin:headphones.vaadin:headset.vaadin:health-card.vaadin:heart-o.vaadin:heart.vaadin:home-o.vaadin:home.vaadin:hospital.vaadin:hourglass-empty.vaadin:hourglass-end.vaadin:hourglass-start.vaadin:hourglass.vaadin:inbox.vaadin:indent.vaadin:info-circle-o.vaadin:info-circle.vaadin:info.vaadin:input.vaadin:insert.vaadin:institution.vaadin:invoice.vaadin:italic.vaadin:key-o.vaadin:key.vaadin:keyboard-o.vaadin:keyboard.vaadin:laptop.vaadin:layout.vaadin:level-down-bold.vaadin:level-down.vaadin:level-left-bold.vaadin:level-left.vaadin:level-right-bold.vaadin:level-right.vaadin:level-up-bold.vaadin:level-up.vaadin:lifebuoy.vaadin:lightbulb.vaadin:line-bar-chart.vaadin:line-chart.vaadin:line-h.vaadin:line-v.vaadin:lines-list.vaadin:lines.vaadin:link.vaadin:list-ol.vaadin:list-select.vaadin:list-ul.vaadin:list.vaadin:location-arrow-circle-o.vaadin:location-arrow-circle.vaadin:location-arrow.vaadin:lock.vaadin:magic.vaadin:magnet.vaadin:mailbox.vaadin:male.vaadin:map-marker.vaadin:margin-bottom.vaadin:margin-left.vaadin:margin-right.vaadin:margin-top.vaadin:margin.vaadin:medal.vaadin:megafone.vaadin:megaphone.vaadin:meh-o.vaadin:menu.vaadin:microphone.vaadin:minus-circle-o.vaadin:minus-circle.vaadin:minus-square-o.vaadin:minus.vaadin:mobile-browser.vaadin:mobile-retro.vaadin:mobile.vaadin:modal-list.vaadin:modal.vaadin:money-deposit.vaadin:money-exchange.vaadin:money-withdraw.vaadin:money.vaadin:moon-o.vaadin:moon.vaadin:morning.vaadin:movie.vaadin:music.vaadin:mute.vaadin:native-button.vaadin:newspaper.vaadin:notebook.vaadin:nurse.vaadin:office.vaadin:open-book.vaadin:option-a.vaadin:option.vaadin:options.vaadin:orientation.vaadin:out.vaadin:outbox.vaadin:package.vaadin:padding-bottom.vaadin:padding-left.vaadin:padding-right.vaadin:padding-top.vaadin:padding.vaadin:paint-roll.vaadin:paintbrush.vaadin:palete.vaadin:palette.vaadin:panel.vaadin:paperclip.vaadin:paperplane-o.vaadin:paperplane.vaadin:paragraph.vaadin:password.vaadin:paste.vaadin:pause.vaadin:pencil.vaadin:phone-landline.vaadin:phone.vaadin:picture.vaadin:pie-bar-chart.vaadin:pie-chart.vaadin:piggy-bank-coin.vaadin:piggy-bank.vaadin:pill.vaadin:pills.vaadin:pin-post.vaadin:pin.vaadin:play-circle-o.vaadin:play-circle.vaadin:play.vaadin:plug.vaadin:plus-circle-o.vaadin:plus-circle.vaadin:plus-minus.vaadin:plus-square-o.vaadin:plus.vaadin:pointer.vaadin:power-off.vaadin:presentation.vaadin:print.vaadin:progressbar.vaadin:puzzle-piece.vaadin:pyramid-chart.vaadin:qrcode.vaadin:question-circle-o.vaadin:question-circle.vaadin:question.vaadin:quote-left.vaadin:quote-right.vaadin:random.vaadin:raster-lower-left.vaadin:raster.vaadin:records.vaadin:recycle.vaadin:refresh.vaadin:reply-all.vaadin:reply.vaadin:resize-h.vaadin:resize-v.vaadin:retweet.vaadin:rhombus.vaadin:road-branch.vaadin:road-branches.vaadin:road-split.vaadin:road.vaadin:rocket.vaadin:rotate-left.vaadin:rotate-right.vaadin:rss-square.vaadin:rss.vaadin:safe-lock.vaadin:safe.vaadin:scale-unbalance.vaadin:scale.vaadin:scatter-chart.vaadin:scissors.vaadin:screwdriver.vaadin:search-minus.vaadin:search-plus.vaadin:search.vaadin:select.vaadin:server.vaadin:share-square.vaadin:share.vaadin:shield.vaadin:shift-arrow.vaadin:shift.vaadin:shop.vaadin:sign-in-alt.vaadin:sign-in.vaadin:sign-out-alt.vaadin:sign-out.vaadin:signal.vaadin:sitemap.vaadin:slider.vaadin:sliders.vaadin:smiley-o.vaadin:sort.vaadin:sound-disable.vaadin:spark-line.vaadin:specialist.vaadin:spinner-arc.vaadin:spinner-third.vaadin:spinner.vaadin:spline-area-chart.vaadin:spline-chart.vaadin:split-h.vaadin:split-v.vaadin:split.vaadin:spoon.vaadin:square-shadow.vaadin:star-half-left-o.vaadin:star-half-left.vaadin:star-half-right-o.vaadin:star-half-right.vaadin:star-o.vaadin:star.vaadin:start-cog.vaadin:step-backward.vaadin:step-forward.vaadin:stethoscope.vaadin:stock.vaadin:stop-cog.vaadin:stop.vaadin:stopwatch.vaadin:storage.vaadin:strikethrough.vaadin:subscript.vaadin:suitcase.vaadin:sun-down.vaadin:sun-o.vaadin:sun-rise.vaadin:superscript.vaadin:sword.vaadin:tab-a.vaadin:tab.vaadin:table.vaadin:tablet.vaadin:tabs.vaadin:tag.vaadin:tags.vaadin:tasks.vaadin:taxi.vaadin:teeth.vaadin:terminal.vaadin:text-height.vaadin:text-input.vaadin:text-label.vaadin:text-width.vaadin:thin-square.vaadin:thumbs-down-o.vaadin:thumbs-down.vaadin:thumbs-up-o.vaadin:thumbs-up.vaadin:ticket.vaadin:time-backward.vaadin:time-forward.vaadin:timer.vaadin:toolbox.vaadin:tools.vaadin:tooth.vaadin:touch.vaadin:train.vaadin:trash.vaadin:tree-table.vaadin:trendind-down.vaadin:trending-down.vaadin:trending-up.vaadin:trophy.vaadin:truck.vaadin:twin-col-select.vaadin:twitter-square.vaadin:twitter.vaadin:umbrella.vaadin:underline.vaadin:unlink.vaadin:unlock.vaadin:upload-alt.vaadin:upload.vaadin:user-card.vaadin:user-check.vaadin:user-clock.vaadin:user-heart.vaadin:user-star.vaadin:user.vaadin:users.vaadin:vaadin-h.vaadin:vaadin-v.vaadin:viewport.vaadin:vimeo-square.vaadin:vimeo.vaadin:volume-down.vaadin:volume-off.vaadin:volume-up.vaadin:volume.vaadin:wallet.vaadin:warning.vaadin:workplace.vaadin:wrench.vaadin:youtube-square.vaadin:youtube`.split(`.`),Xl=null,Zl=()=>(Xl||=Promise.all([D(()=>import(`./vendor-ui5.js`).then(e=>e.n),__vite__mapDeps([5,1])),D(()=>import(`./vendor-ui5.js`).then(e=>e.t),__vite__mapDeps([5,1]))]),Xl),Z=class extends b{constructor(...e){super(...e),this.ui5FieldComponentsReady=!1,this.component=void 0,this.field=void 0,this.baseUrl=void 0,this.state={},this.data={},this.appState={},this.appData={},this.colorPickerOpened=!1,this.colorPickerValue=void 0,this.comboData=[],this._comboFilter=``,this.rendered=!1,this.renderColorPicker=()=>{this.loadUi5FieldComponents();let e=this.field?.fieldId;return T`
             <ui5-color-picker value="${this.state&&e in this.state?this.state[e]:this.field?.initialValue}" @change="${e=>this.colorPickerValue=e.target.value}">Picker</ui5-color-picker>
         `},this.saveColor=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.colorPickerValue,fieldId:this.field.fieldId},bubbles:!0,composed:!0})),this.colorPickerOpened=!1},this.renderColorPickerFooter=()=>T`<vaadin-button @click="${()=>this.colorPickerOpened=!1}">Cancel</vaadin-button>
-        <vaadin-button theme="primary" @click="${this.saveColor}">Save</vaadin-button>`,this.checked=e=>{let t=e.target;this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t.checked,fieldId:this.field.fieldId},bubbles:!0,composed:!0}))},this.convert=e=>this.field?.dataType==`integer`?ol(e,!0):e,this.multiComboBoxValueChanged=e=>{if(this.rendered){let t=this.field?.fieldId,n=this.state&&t in this.state?this.state[t]:this.field?.initialValue,r;e.detail.value&&(r=e.detail.value.map(e=>e.value),r&&r.length>0&&(this.data[this.id]||(this.data[this.id]={}),this.data[this.id].content||(this.data[this.id].content=[]),this.data[this.id]&&this.data[this.id].content&&e.detail.value.forEach(e=>{this.data[this.id].content?.find(t=>e.value==t.value)||this.data[this.id].content.push(e)}))),this.compareArrays(r,n)||this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}},this.valueChanged=e=>{this.rendered&&e.detail.value!==void 0&&!sl(e.detail.value,this.state[this.field.fieldId])&&this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.convert(e.detail.value),fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.selectedItems=e=>{if(e&&e.length>0)if(this.field?.remoteCoordinates){if(this.comboData&&this.comboData.length>0)return this.comboData?.filter(t=>e.indexOf(t.value)>=0);if(this.data[this.id]&&this.data[this.id].content&&this.data[this.id].content.length>0)return this.data[this.id].content.filter(t=>e.indexOf(t.value)>=0)}else return this.field?.options?.filter(t=>e.indexOf(t.value)>=0);return[]},this.selectedIndex=e=>{if(e)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content){let t=this.data[this.id].content.find(t=>t.value==e);if(t)return this.data[this.id].content.indexOf(t)}}else{let t=this.field?.options?.find(t=>t.value==e);if(t)return this.field?.options?.indexOf(t)}},this.selectedIndexes=e=>{if(e&&e.length>0)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content)return this.data[this.id].content.filter(t=>e.indexOf(t.value)>=0).map(e=>this.data[this.id].content.indexOf(e))}else return this.field?.options?.filter(t=>e.indexOf(t.value)>=0).map(e=>this.field?.options?.indexOf(e));return[]},this.compareArrays=(e,t)=>this.falsy(e)&&this.falsy(t)||e&&t&&e.length===t.length&&e.every((e,n)=>e===t[n]),this.falsy=e=>!e||e.length==0,this.listItemsSelected=e=>{let t=this.field?.fieldId,n=this.state&&t in this.state?this.state[t]:this.field?.initialValue,r;this.rendered&&(e.detail.value&&(this.field?.remoteCoordinates?this.data[this.id]&&this.data[this.id].content&&(r=e.detail.value.map(e=>this.data[this.id].content[e].value)):r=e.detail.value.map(e=>this.field.options[e].value)),this.compareArrays(r,n)||this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r,fieldId:this.field?.fieldId},bubbles:!0,composed:!0})))},this.listItemSelected=e=>{let t;if(e.detail.value||e.detail.value==0)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content){let n=this.data[this.id].content[e.detail.value];n&&(t=n.value)}}else{let n=this.field.options[e.detail.value];n&&(t=n.value)}this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.mapPosition=e=>{switch(e){case`topStretch`:return`top-stretch`;case`topStart`:return`top-start`;case`topCenter`:return`top-center`;case`topEnd`:return`top-end`;case`middle`:return`middle`;case`bottomStart`:return`bottom-start`;case`bottomEnd`:return`bottom-end`;case`bottomStretch`:return`bottom-stretch`;case`bottomCenter`:return`bottom-center`}return`bottom-end`},this.helperShownInControl=!1,this.lastAnnouncedError=``,this.controlOwnsValidity=!1,this.fileUploaded=e=>{let t=this.field?.fieldId??``,n=this.state[t];n.push({id:e.detail.xhr.responseText,name:e.detail.file.name}),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:n,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.fileChanged=e=>{let t=this.field?.fieldId??``,n=(e.detail.value??[]).filter(e=>e.id).map(e=>e.id),r=(this.state[t]??[]).map(e=>e.id);if(!this.compareArrays(r,n)){let t=(e.detail.value??[]).filter(e=>e.id).map(e=>({id:e.id,name:e.name}));this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}},this.triggerImageUpload=()=>{(this.renderRoot?.querySelector(`input[type="file"]`))?.click()},this.imageUpload=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r.result,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},r.readAsDataURL(n),t.value=``},this.imageDelete=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:``,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.iconComboboxRenderer=e=>T`
+        <vaadin-button theme="primary" @click="${this.saveColor}">Save</vaadin-button>`,this.checked=e=>{let t=e.target;this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t.checked,fieldId:this.field.fieldId},bubbles:!0,composed:!0}))},this.convert=e=>this.field?.dataType==`integer`?sl(e,!0):e,this.multiComboBoxValueChanged=e=>{if(this.rendered){let t=this.field?.fieldId,n=this.state&&t in this.state?this.state[t]:this.field?.initialValue,r;e.detail.value&&(r=e.detail.value.map(e=>e.value),r&&r.length>0&&(this.data[this.id]||(this.data[this.id]={}),this.data[this.id].content||(this.data[this.id].content=[]),this.data[this.id]&&this.data[this.id].content&&e.detail.value.forEach(e=>{this.data[this.id].content?.find(t=>e.value==t.value)||this.data[this.id].content.push(e)}))),this.compareArrays(r,n)||this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}},this.valueChanged=e=>{this.rendered&&e.detail.value!==void 0&&!cl(e.detail.value,this.state[this.field.fieldId])&&this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.convert(e.detail.value),fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.selectedItems=e=>{if(e&&e.length>0)if(this.field?.remoteCoordinates){if(this.comboData&&this.comboData.length>0)return this.comboData?.filter(t=>e.indexOf(t.value)>=0);if(this.data[this.id]&&this.data[this.id].content&&this.data[this.id].content.length>0)return this.data[this.id].content.filter(t=>e.indexOf(t.value)>=0)}else return this.field?.options?.filter(t=>e.indexOf(t.value)>=0);return[]},this.selectedIndex=e=>{if(e)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content){let t=this.data[this.id].content.find(t=>t.value==e);if(t)return this.data[this.id].content.indexOf(t)}}else{let t=this.field?.options?.find(t=>t.value==e);if(t)return this.field?.options?.indexOf(t)}},this.selectedIndexes=e=>{if(e&&e.length>0)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content)return this.data[this.id].content.filter(t=>e.indexOf(t.value)>=0).map(e=>this.data[this.id].content.indexOf(e))}else return this.field?.options?.filter(t=>e.indexOf(t.value)>=0).map(e=>this.field?.options?.indexOf(e));return[]},this.compareArrays=(e,t)=>this.falsy(e)&&this.falsy(t)||e&&t&&e.length===t.length&&e.every((e,n)=>e===t[n]),this.falsy=e=>!e||e.length==0,this.listItemsSelected=e=>{let t=this.field?.fieldId,n=this.state&&t in this.state?this.state[t]:this.field?.initialValue,r;this.rendered&&(e.detail.value&&(this.field?.remoteCoordinates?this.data[this.id]&&this.data[this.id].content&&(r=e.detail.value.map(e=>this.data[this.id].content[e].value)):r=e.detail.value.map(e=>this.field.options[e].value)),this.compareArrays(r,n)||this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r,fieldId:this.field?.fieldId},bubbles:!0,composed:!0})))},this.listItemSelected=e=>{let t;if(e.detail.value||e.detail.value==0)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content){let n=this.data[this.id].content[e.detail.value];n&&(t=n.value)}}else{let n=this.field.options[e.detail.value];n&&(t=n.value)}this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.mapPosition=e=>{switch(e){case`topStretch`:return`top-stretch`;case`topStart`:return`top-start`;case`topCenter`:return`top-center`;case`topEnd`:return`top-end`;case`middle`:return`middle`;case`bottomStart`:return`bottom-start`;case`bottomEnd`:return`bottom-end`;case`bottomStretch`:return`bottom-stretch`;case`bottomCenter`:return`bottom-center`}return`bottom-end`},this.helperShownInControl=!1,this.lastAnnouncedError=``,this.controlOwnsValidity=!1,this.fileUploaded=e=>{let t=this.field?.fieldId??``,n=this.state[t];n.push({id:e.detail.xhr.responseText,name:e.detail.file.name}),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:n,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.fileChanged=e=>{let t=this.field?.fieldId??``,n=(e.detail.value??[]).filter(e=>e.id).map(e=>e.id),r=(this.state[t]??[]).map(e=>e.id);if(!this.compareArrays(r,n)){let t=(e.detail.value??[]).filter(e=>e.id).map(e=>({id:e.id,name:e.name}));this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}},this.triggerImageUpload=()=>{(this.renderRoot?.querySelector(`input[type="file"]`))?.click()},this.imageUpload=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r.result,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},r.readAsDataURL(n),t.value=``},this.imageDelete=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:``,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.iconComboboxRenderer=e=>T`
   <div style="display: flex;">
       <vaadin-icon
               icon="${e}"
@@ -9127,13 +9135,13 @@ ${i}
 
             </vaadin-horizontal-layout>
                             `:e.label}
-`,this.filteredIcons=[],this.navLinkOffset=null,this.iconFilterChanged=e=>{this.filteredIcons=Jl.filter(t=>!e.detail.value||t.indexOf(e.detail.value)>=0)}}loadUi5FieldComponents(){this.ui5FieldComponentsReady||Xl().then(()=>{this.ui5FieldComponentsReady=!0})}remoteComboDataProvider(e){return(t,n)=>{let{filter:i,page:a,pageSize:o}=t,s=i??``;this._comboFilter=s,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{searchText:i,fieldId:this.field?.fieldId,size:o,page:a,sort:void 0},callback:e=>{if(s===this._comboFilter)if(e?.messages?.forEach(e=>{r.show(e.text,{position:e.position?this.mapPosition(e.position):void 0,theme:e.variant,duration:e.duration})}),!e.fragments||e.fragments.length==0)this.comboData=[],n([],0);else{let t=e.fragments[0].data?.[this.id];this.comboData=t?.content,n(t?.content,t?.totalElements)}},callbackonly:!0},bubbles:!0,composed:!0}))}}disconnectedCallback(){super.disconnectedCallback(),this.rendered=!1}renderNavLink(){let e=this.field?.link;if(!e?.href)return v;let t=M(e.href,this.state,this.data)??e.href,n=M(e.title,this.state,this.data)||t,r=e.icon||(t.startsWith(`http`)?`vaadin:external-link`:`vaadin:link`),i=this.navLinkOffset??`calc(var(--lumo-font-size-s) * 1.6 + (var(--lumo-size-m) - var(--lumo-icon-size-s)) / 2)`;return T`<a
+`,this.filteredIcons=[],this.navLinkOffset=null,this.iconFilterChanged=e=>{this.filteredIcons=Yl.filter(t=>!e.detail.value||t.indexOf(e.detail.value)>=0)}}loadUi5FieldComponents(){this.ui5FieldComponentsReady||Zl().then(()=>{this.ui5FieldComponentsReady=!0})}remoteComboDataProvider(e){return(t,n)=>{let{filter:i,page:a,pageSize:o}=t,s=i??``;this._comboFilter=s,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{searchText:i,fieldId:this.field?.fieldId,size:o,page:a,sort:void 0},callback:e=>{if(s===this._comboFilter)if(e?.messages?.forEach(e=>{r.show(e.text,{position:e.position?this.mapPosition(e.position):void 0,theme:e.variant,duration:e.duration})}),!e.fragments||e.fragments.length==0)this.comboData=[],n([],0);else{let t=e.fragments[0].data?.[this.id];this.comboData=t?.content,n(t?.content,t?.totalElements)}},callbackonly:!0},bubbles:!0,composed:!0}))}}disconnectedCallback(){super.disconnectedCallback(),this.rendered=!1}renderNavLink(){let e=this.field?.link;if(!e?.href)return v;let t=M(e.href,this.state,this.data)??e.href,n=M(e.title,this.state,this.data)||t,r=e.icon||(t.startsWith(`http`)?`vaadin:external-link`:`vaadin:link`),i=this.navLinkOffset??`calc(var(--lumo-font-size-s) * 1.6 + (var(--lumo-size-m) - var(--lumo-icon-size-s)) / 2)`;return T`<a
                 data-navlink
                 href="${t}"
                 title="${n}"
                 target="${S(e.target||void 0)}"
                 style="display: flex; align-items: center; color: var(--lumo-secondary-text-color); align-self: flex-start; margin-top: ${i};"
-        ><vaadin-icon icon="${r}" style="width: var(--lumo-icon-size-s); height: var(--lumo-icon-size-s);"></vaadin-icon></a>`}positionNavLink(){let e=this.renderRoot?.querySelector(`a[data-navlink]`);e&&setTimeout(()=>{let t=e.parentElement,n=t?.firstElementChild?.firstElementChild;if(!t||!n)return;let r=(n.shadowRoot?.querySelector(`[part="input-field"]`)??n).getBoundingClientRect();if(r.height===0)return;let i=Math.max(0,r.top+r.height/2-e.offsetHeight/2-t.getBoundingClientRect().top),a=`${Math.round(i)}px`;this.navLinkOffset!==a&&(this.navLinkOffset=a)})}helperText(){return this.helperShownInControl=!0,P(this.field?.description??``,this.state,this.data)??``}fieldErrors(){let e=this.field?.fieldId??``,t=this.data?.errors?.[e];return Array.isArray(t)?t.filter(e=>!!e):[]}validatableControl(){let e=this.renderRoot.querySelectorAll(`*`);for(let t of e)if(`invalid`in t&&`errorMessage`in t)return t;return null}applyValidationState(){let e=this.fieldErrors(),t=this.validatableControl();if(!t){this.lastAnnouncedError=e.join(`. `);return}let n=e.join(`. `);if(t.errorMessage=n,t.invalid=e.length>0,n&&n!==this.lastAnnouncedError){let e=(this.field?.label??``).toString().trim();gt(e?`${e}: ${n}`:n,{politeness:`assertive`})}this.lastAnnouncedError=n}render(){this.rendered=!0;let e=this.renderNavLink();this.helperShownInControl=!1;let t=this.renderField(),n=this.field?.description&&!this.helperShownInControl?P(this.field.description,this.state,this.data):void 0,r=this.fieldErrors(),i=r.length>0&&!this.controlOwnsValidity;return T`<div style="display: block;">
+        ><vaadin-icon icon="${r}" style="width: var(--lumo-icon-size-s); height: var(--lumo-icon-size-s);"></vaadin-icon></a>`}positionNavLink(){let e=this.renderRoot?.querySelector(`a[data-navlink]`);e&&setTimeout(()=>{let t=e.parentElement,n=t?.firstElementChild?.firstElementChild;if(!t||!n)return;let r=(n.shadowRoot?.querySelector(`[part="input-field"]`)??n).getBoundingClientRect();if(r.height===0)return;let i=Math.max(0,r.top+r.height/2-e.offsetHeight/2-t.getBoundingClientRect().top),a=`${Math.round(i)}px`;this.navLinkOffset!==a&&(this.navLinkOffset=a)})}helperText(){return this.helperShownInControl=!0,Ot(this.field?.description??``,this.state,this.data)??``}fieldErrors(){let e=this.field?.fieldId??``,t=this.data?.errors?.[e];return Array.isArray(t)?t.filter(e=>!!e):[]}validatableControl(){let e=this.renderRoot.querySelectorAll(`*`);for(let t of e)if(`invalid`in t&&`errorMessage`in t)return t;return null}applyValidationState(){let e=this.fieldErrors(),t=this.validatableControl();if(!t){this.lastAnnouncedError=e.join(`. `);return}let n=e.join(`. `);if(t.errorMessage=n,t.invalid=e.length>0,n&&n!==this.lastAnnouncedError){let e=(this.field?.label??``).toString().trim();gt(e?`${e}: ${n}`:n,{politeness:`assertive`})}this.lastAnnouncedError=n}render(){this.rendered=!0;let e=this.renderNavLink();this.helperShownInControl=!1;let t=this.renderField(),n=this.field?.description&&!this.helperShownInControl?Ot(this.field.description,this.state,this.data):void 0,r=this.fieldErrors(),i=r.length>0&&!this.controlOwnsValidity;return T`<div style="display: block;">
             <div style="${e===v?``:`display: flex; gap: var(--lumo-space-xs);`}"><div style="flex: 1; min-width: 0;">${t}</div>${e}</div>
             ${n?T`
                 <div style="font-size: var(--lumo-font-size-xs); color: var(--lumo-secondary-text-color); margin-top: var(--lumo-space-xs);">${n}</div>
@@ -9141,29 +9149,29 @@ ${i}
             ${i?T`
                 <div role="alert"><ul>${r.map(e=>T`<li>${e}</li>`)}</ul></div>
             `:v}
-        </div>`}async firstUpdated(){this.filteredIcons=Jl}update(e){e.has(`component`)&&(this.rendered=!1),super.update(e)}updated(e){super.updated(e),this.positionNavLink(),this.applyValidationState(),this.controlOwnsValidity=!!this.validatableControl()}renderField(){let e=this.field?.fieldId??``,t=this.state&&e in this.state?this.state[e]:this.field?.initialValue,n=M(this.field?.label+``,this.state,this.data),r=this.labelAlreadyRendered||!n||n==`null`?v:n;return this.field?.propertyRow?this.renderPropertyRowField(e,t,r,n):this.field?.stereotype==`badge`?this.renderBadgeField(e,t,r,n):this.field?.stereotype==`plainText`?this.renderPlainTextField(e,t,r,n):this.field?.stereotype==`bulletedList`?this.renderBulletedListField(e,t,r,n):this.field?.readOnly&&this.field.stereotype!=`grid`&&this.field.dataType!=`status`&&this.field?.dataType!=`money`?this.renderReadOnlyField(e,t,r,n):this.field?.dataType==`file`?this.renderFileField(e,t,r,n):this.field?.dataType==`string`?this.renderStringField(e,t,r,n):this.field?.dataType==`number`?this.renderNumberField(e,t,r,n):this.field?.dataType==`integer`?this.renderIntegerField(e,t,r,n):this.field?.dataType==`bool`?this.renderBoolField(e,t,r,n):this.field?.dataType==`dateRange`?this.renderDateRangeField(e,t,r,n):this.field?.dataType==`date`?this.renderDateField(e,t,r,n):this.field?.dataType==`dateTime`?this.renderDateTimeField(e,t,r,n):this.field?.dataType==`time`?this.renderTimeField(e,t,r,n):this.field?.dataType==`array`?this.renderArrayField(e,t,r,n):this.field?.dataType==`money`?this.renderMoneyField(e,t,r,n):this.field?.dataType==`status`?this.renderStatusField(e,t,r,n):this.field?.dataType==`range`?this.renderRangeField(e,t,r,n):T`<p>Unknown field type ${this.field?.dataType} / ${this.field?.stereotype}</p>`}renderBadgeField(e,t,n,r){if(!this.field)return T``;let i=t===!0||t===`true`;return T`<vaadin-custom-field
+        </div>`}async firstUpdated(){this.filteredIcons=Yl}update(e){e.has(`component`)&&(this.rendered=!1),super.update(e)}updated(e){super.updated(e),this.positionNavLink(),this.applyValidationState(),this.controlOwnsValidity=!!this.validatableControl()}renderField(){let e=this.field?.fieldId??``,t=this.state&&e in this.state?this.state[e]:this.field?.initialValue,n=M(this.field?.label+``,this.state,this.data),r=this.labelAlreadyRendered||!n||n==`null`?v:n;return this.field?.propertyRow?this.renderPropertyRowField(e,t,r,n):this.field?.stereotype==`badge`?this.renderBadgeField(e,t,r,n):this.field?.stereotype==`plainText`?this.renderPlainTextField(e,t,r,n):this.field?.stereotype==`bulletedList`?this.renderBulletedListField(e,t,r,n):this.field?.readOnly&&this.field.stereotype!=`grid`&&this.field.dataType!=`status`&&this.field?.dataType!=`money`?this.renderReadOnlyField(e,t,r,n):this.field?.dataType==`file`?this.renderFileField(e,t,r,n):this.field?.dataType==`string`?this.renderStringField(e,t,r,n):this.field?.dataType==`number`?this.renderNumberField(e,t,r,n):this.field?.dataType==`integer`?this.renderIntegerField(e,t,r,n):this.field?.dataType==`bool`?this.renderBoolField(e,t,r,n):this.field?.dataType==`dateRange`?this.renderDateRangeField(e,t,r,n):this.field?.dataType==`date`?this.renderDateField(e,t,r,n):this.field?.dataType==`dateTime`?this.renderDateTimeField(e,t,r,n):this.field?.dataType==`time`?this.renderTimeField(e,t,r,n):this.field?.dataType==`array`?this.renderArrayField(e,t,r,n):this.field?.dataType==`money`?this.renderMoneyField(e,t,r,n):this.field?.dataType==`status`?this.renderStatusField(e,t,r,n):this.field?.dataType==`range`?this.renderRangeField(e,t,r,n):T`<p>Unknown field type ${this.field?.dataType} / ${this.field?.stereotype}</p>`}renderBadgeField(e,t,n,r){if(!this.field)return T``;let i=t===!0||t===`true`;return T`<vaadin-custom-field
                     id="${this.field.fieldId}"
                     .helperText="${this.helperText()}"
                     data-colspan="${this.field?.colspan}"
                     style="${this.field?.style}"
             ><span theme="badge ${i?`success`:``} pill" style="${i?``:`opacity: 0.4;`}">${r}</span>
-            </vaadin-custom-field>`}renderPropertyRowField(e,t,n,r){if(!this.field)return T``;let i=P(t,this.state,this.data),a=i&&typeof i==`object`&&`value`in i?i:null;i&&i.value&&(i=i.value);let o=this.field?.dataType==`bool`||i===!0||i===!1,s=this.field?.dataType==`money`,c=i!=null&&i!==``,l=c?String(i):`—`;if(s&&c){let e=typeof i==`number`?i:parseFloat(String(i));isNaN(e)||(l=a&&a.locale&&a.currency?new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(e):new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e))}let u=o?T`<vaadin-icon icon="${i===!0||i===`true`?`vaadin:check`:`vaadin:minus`}" style="height: 16px; width: 16px;"></vaadin-icon>`:T`<span style="font-weight: 500; text-align: right; word-break: break-word; margin-left: auto;${s?` font-variant-numeric: tabular-nums;`:``}">${l}</span>`,d=r&&r!=`null`;return T`<div
+            </vaadin-custom-field>`}renderPropertyRowField(e,t,n,r){if(!this.field)return T``;let i=Ot(t,this.state,this.data),a=i&&typeof i==`object`&&`value`in i?i:null;i&&i.value&&(i=i.value);let o=this.field?.dataType==`bool`||i===!0||i===!1,s=this.field?.dataType==`money`,c=i!=null&&i!==``,l=c?String(i):`—`;if(s&&c){let e=typeof i==`number`?i:parseFloat(String(i));isNaN(e)||(l=a&&a.locale&&a.currency?new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(e):new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e))}let u=o?T`<vaadin-icon icon="${i===!0||i===`true`?`vaadin:check`:`vaadin:minus`}" style="height: 16px; width: 16px;"></vaadin-icon>`:T`<span style="font-weight: 500; text-align: right; word-break: break-word; margin-left: auto;${s?` font-variant-numeric: tabular-nums;`:``}">${l}</span>`,d=r&&r!=`null`;return T`<div
                     id="${this.field.fieldId}"
                     data-colspan="${this.field?.colspan}"
                     style="display: flex; justify-content: space-between; align-items: baseline; gap: 1rem; width: 100%; padding: 0.4rem 0; border-bottom: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.08)); font-size: var(--lumo-font-size-s, .875rem); ${this.field?.style}"
-            >${d?T`<span style="color: var(--lumo-secondary-text-color, #888); white-space: nowrap;">${r}</span>`:v}${u}</div>`}renderBulletedListField(e,t,n,r){if(!this.field)return T``;let i=P(t,this.state,this.data),a=Array.isArray(i)?i.map(e=>String(e)):i!=null&&i!==``?[String(i)]:[];return T`<vaadin-custom-field
+            >${d?T`<span style="color: var(--lumo-secondary-text-color, #888); white-space: nowrap;">${r}</span>`:v}${u}</div>`}renderBulletedListField(e,t,n,r){if(!this.field)return T``;let i=Ot(t,this.state,this.data),a=Array.isArray(i)?i.map(e=>String(e)):i!=null&&i!==``?[String(i)]:[];return T`<vaadin-custom-field
                     id="${this.field.fieldId}"
                     label="${n}"
                     .helperText="${this.helperText()}"
                     data-colspan="${this.field?.colspan}"
                     style="${this.field?.style}"
             ><mateu-bulleted-list .items="${a}"></mateu-bulleted-list>
-            </vaadin-custom-field>`}renderPlainTextField(e,t,n,r){if(!this.field)return T``;let i=P(t,this.state,this.data),a=i&&typeof i==`object`&&`value`in i?i:null;i&&i.value&&(i=i.value);let o=this.field?.dataType==`bool`||i===!0||i===!1,s=this.field?.dataType==`money`,c=i!=null&&i!==``,l=c?String(i):`—`;if(s&&c){let e=typeof i==`number`?i:parseFloat(String(i));isNaN(e)||(l=a&&a.locale&&a.currency?new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(e):new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e))}let u=o?T`<vaadin-icon icon="${i===!0||i===`true`?`vaadin:check`:`vaadin:minus`}" style="height: 16px; width: 16px;"></vaadin-icon>`:this.field?.multiline?T`<span style="font-weight: 500; white-space: pre-wrap; word-break: break-word;">${l}</span>`:T`<span style="font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;${s?` font-variant-numeric: tabular-nums;`:``}">${l}</span>`;return T`<vaadin-custom-field
+            </vaadin-custom-field>`}renderPlainTextField(e,t,n,r){if(!this.field)return T``;let i=Ot(t,this.state,this.data),a=i&&typeof i==`object`&&`value`in i?i:null;i&&i.value&&(i=i.value);let o=this.field?.dataType==`bool`||i===!0||i===!1,s=this.field?.dataType==`money`,c=i!=null&&i!==``,l=c?String(i):`—`;if(s&&c){let e=typeof i==`number`?i:parseFloat(String(i));isNaN(e)||(l=a&&a.locale&&a.currency?new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(e):new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e))}let u=o?T`<vaadin-icon icon="${i===!0||i===`true`?`vaadin:check`:`vaadin:minus`}" style="height: 16px; width: 16px;"></vaadin-icon>`:this.field?.multiline?T`<span style="font-weight: 500; white-space: pre-wrap; word-break: break-word;">${l}</span>`:T`<span style="font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;${s?` font-variant-numeric: tabular-nums;`:``}">${l}</span>`;return T`<vaadin-custom-field
                     id="${this.field.fieldId}"
                     label="${n}"
                     data-colspan="${this.field?.colspan}"
                     style="${s?`text-align: right; `:``}${this.field?.style}"
-            >${u}</vaadin-custom-field>`}renderReadOnlyField(e,t,n,r){if(!this.field)return T``;let i=P(t,this.state,this.data)||this.data[e];if(i&&i.value&&(i=i.value),this.field.stereotype==`fileUpload`)return T`<vaadin-custom-field
+            >${u}</vaadin-custom-field>`}renderReadOnlyField(e,t,n,r){if(!this.field)return T``;let i=Ot(t,this.state,this.data)||this.data[e];if(i&&i.value&&(i=i.value),this.field.stereotype==`fileUpload`)return T`<vaadin-custom-field
                         id="${this.field.fieldId}"
                         label="${n}"
                         .helperText="${this.helperText()}"
@@ -9226,7 +9234,7 @@ ${i}
                             <vaadin-button theme="icon" @click="${e=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`codesearch-`+this.field?.fieldId,parameters:{}},bubbles:!0,composed:!0}))}}"><vaadin-icon icon="lumo:search"></vaadin-icon></vaadin-button>
                         </vaadin-horizontal-layout>
                     </vaadin-custom-field>
-                `;if(this.field?.stereotype==`select`){if(this.field?.optionsSource){let e=this.field.optionsSource,r=M(e.url,this.state,this.data)??e.url;this.data[this.id]?.sourceSignature!==r&&(this.data[this.id]={content:this.data[this.id]?.content??[],sourceSignature:r},e.proxy?this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`__restfetch__`,parameters:{_sourceKind:`options`,_sourceId:this.field.fieldId},callback:t=>{let n=t?.appData?._restfetch,i=un(n,e.itemsPath,e.valuePath,e.labelPath);this.data[this.id]={content:i,totalElements:i.length,sourceSignature:r},this.requestUpdate()},callbackonly:!0},bubbles:!0,composed:!0})):pn(e,e=>M(e,this.state,this.data)).then(e=>{this.data[this.id]={content:e,totalElements:e.length,sourceSignature:r},this.requestUpdate()}).catch(e=>console.warn(`mateu: external options fetch failed`,e)));let i=t;return t&&t.value&&(i=t.value),T`
+                `;if(this.field?.stereotype==`select`){if(this.field?.optionsSource){let e=this.field.optionsSource,r=M(e.url,this.state,this.data)??e.url;this.data[this.id]?.sourceSignature!==r&&(this.data[this.id]={content:this.data[this.id]?.content??[],sourceSignature:r},e.proxy?this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`__restfetch__`,parameters:{_sourceKind:`options`,_sourceId:this.field.fieldId},callback:t=>{let n=t?.appData?._restfetch,i=dn(n,e.itemsPath,e.valuePath,e.labelPath);this.data[this.id]={content:i,totalElements:i.length,sourceSignature:r},this.requestUpdate()},callbackonly:!0},bubbles:!0,composed:!0})):mn(e,e=>M(e,this.state,this.data)).then(e=>{this.data[this.id]={content:e,totalElements:e.length,sourceSignature:r},this.requestUpdate()}).catch(e=>console.warn(`mateu: external options fetch failed`,e)));let i=t;return t&&t.value&&(i=t.value),T`
                     <vaadin-select
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9629,7 +9637,7 @@ ${i}
                     >
                         <mateu-camera-capture .fieldId="${this.field.fieldId}" .value="${t}"></mateu-camera-capture>
                     </vaadin-custom-field>
-                `;if(this.field?.stereotype==`fileUpload`){let e=rl(this.field.attributes,`accept`);return T`
+                `;if(this.field?.stereotype==`fileUpload`){let e=il(this.field.attributes,`accept`);return T`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9981,7 +9989,7 @@ ${i}
                         .helperText="${this.helperText()}"
                         data-colspan="${this.field.colspan}"
                 >
-                    ${i?T`<span theme="badge pill ${Aa(i.type)}">${i.message}</span>`:T``}                    
+                    ${i?T`<span theme="badge pill ${ja(i.type)}">${i.message}</span>`:T``}                    
                 </vaadin-custom-field>
             `}renderRangeField(e,t,n,r){if(!this.field)return T``;this.loadUi5FieldComponents();let i=t;return T`
                 <vaadin-custom-field
@@ -10079,7 +10087,7 @@ ${i}
             text-overflow: clip;
             height: auto;
         }
-  `}};k([C()],Q.prototype,`ui5FieldComponentsReady`,void 0),k([y()],Q.prototype,`component`,void 0),k([y()],Q.prototype,`field`,void 0),k([y()],Q.prototype,`baseUrl`,void 0),k([y()],Q.prototype,`state`,void 0),k([y()],Q.prototype,`data`,void 0),k([y()],Q.prototype,`appState`,void 0),k([y()],Q.prototype,`appData`,void 0),k([y()],Q.prototype,`labelAlreadyRendered`,void 0),k([C()],Q.prototype,`colorPickerOpened`,void 0),k([C()],Q.prototype,`colorPickerValue`,void 0),k([C()],Q.prototype,`controlOwnsValidity`,void 0),k([C()],Q.prototype,`filteredIcons`,void 0),k([C()],Q.prototype,`navLinkOffset`,void 0),Q=k([g(`mateu-field`)],Q);var Zl=(e,t,n,r,i,a,o,s)=>{let c=t.metadata;return T`
+  `}};k([C()],Z.prototype,`ui5FieldComponentsReady`,void 0),k([y()],Z.prototype,`component`,void 0),k([y()],Z.prototype,`field`,void 0),k([y()],Z.prototype,`baseUrl`,void 0),k([y()],Z.prototype,`state`,void 0),k([y()],Z.prototype,`data`,void 0),k([y()],Z.prototype,`appState`,void 0),k([y()],Z.prototype,`appData`,void 0),k([y()],Z.prototype,`labelAlreadyRendered`,void 0),k([C()],Z.prototype,`colorPickerOpened`,void 0),k([C()],Z.prototype,`colorPickerValue`,void 0),k([C()],Z.prototype,`controlOwnsValidity`,void 0),k([C()],Z.prototype,`filteredIcons`,void 0),k([C()],Z.prototype,`navLinkOffset`,void 0),Z=k([g(`mateu-field`)],Z);var Ql=(e,t,n,r,i,a,o,s)=>{let c=t.metadata;return T`
         <mateu-field
                 id="${t.id}"
                 .component="${t}"
@@ -10088,15 +10096,15 @@ ${i}
                 .data="${i}"
                 .appState="${a}"
                 .appdata="${o}"
-                style="${wa(t,i)}" class="${t.cssClasses}"
+                style="${Ta(t,i)}" class="${t.cssClasses}"
                 slot="${t.slot??v}"
                 data-colspan="${c.colspan}"
                 colspan="${(c.colspan??1)>1?c.colspan:v}"
                 .labelAlreadyRendered="${s}"
         >
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o,s))}
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o,s))}
         </mateu-field>
-    `},Ql=(e,n,r,i,a,o,s)=>{let c=n.metadata;if(c.tree)return T`
+    `},$l=(e,n,r,i,a,o,s)=>{let c=n.metadata;if(c.tree)return T`
         <vaadin-grid style="${n.style}" class="${n.cssClasses}"
                      .itemHasChildrenPath="${`children`}" .dataProvider="${async(e,t)=>{let n=e.parentItem?e.parentItem.children:c.page.content;t(n,n.length)}}"
                      slot="${n.slot??v}"
@@ -10109,7 +10117,7 @@ ${i}
                                 flex-grow="${l?.flexGrow??v}"
                                 width="${l?.width??v}"
                                 .column="${n.metadata}"
-                                ${t((t,n,c)=>Vl(t,n,c,l,e,r,i,a,o,s),[])}></vaadin-grid-column>
+                                ${t((t,n,c)=>Hl(t,n,c,l,e,r,i,a,o,s),[])}></vaadin-grid-column>
 `:T`
             <vaadin-grid-tree-column path="${n.id}"
                                 header="${l?.label??v}"
@@ -10118,7 +10126,7 @@ ${i}
                                 width="${l?.width??v}"
             ></vaadin-grid-tree-column>
 `})}
-            <span slot="empty-state">${zt()}</span>
+            <span slot="empty-state">${Bt()}</span>
         </vaadin-grid>
     `;let l=c.page?.content;return n.id&&i&&i[n.id]&&(l=i[n.id]),l||=[],T`
         <vaadin-grid 
@@ -10127,9 +10135,9 @@ ${i}
                 .items="${l}"
                 all-rows-visible
         >
-            ${c?.content?.map(t=>zl(t,e,r,i,a,o,s))}
+            ${c?.content?.map(t=>Bl(t,e,r,i,a,o,s))}
         </vaadin-grid>
-    `},$=class extends b{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.detailsOpenedItems=[],this.pagesRequested=[],this._lastGridHeight=0,this.emptyArray=e=>!e||e.length==0,this.dataProvider=(e,t)=>{let n=this.data[this.id]?.page;if(this.metadata?.infiniteScrolling&&e.page>0){let r=!1;n&&n.content&&(n.content.length>=(e.page+1)*e.pageSize||n.content.length==n.totalElements)&&(t(n.content.slice(e.page*e.pageSize,(e.page+1)*e.pageSize),n.totalElements),r=!0,this.grid&&this.grid.recalculateColumnWidths()),r||this.pagesRequested.find(t=>t==e.page)||(this.pagesRequested.push(e.page),this.dispatchEvent(new CustomEvent(`fetch-more-elements`,{detail:{params:e,callback:()=>{this.data[this.id]?.page?.content&&(t(this.data[this.id].page.content.slice(e.page*e.pageSize,(e.page+1)*e.pageSize),this.data[this.id].page.totalElements),this.grid&&this.grid.recalculateColumnWidths())}},bubbles:!0,composed:!0})))}else{let e=this.metadata?.infiniteScrolling?n?.totalElements:n?.content?.length??0;t(n?.content??[],e),this.grid&&this.grid.recalculateColumnWidths()}},this._onActionRequested=e=>{let t=e.detail,n=this.identifierFieldName;if(!n||!t.parameters||t.actionId?.startsWith(`action-on-row-`))return;let r=t.parameters[n];r!==void 0&&(this.state._selectedId=String(r),this._applyCellPartNameGenerator(),this.grid?.requestContentUpdate())},this.tooltipGenerator=e=>{let t=``,{column:n,item:r}=e,i=this.metadata?.columns?.find(e=>e.metadata.id==n?.path);if(i?.metadata){let e=(i?.metadata).tooltipPath;e&&n&&r&&(t=r[e])}return t}}get identifierFieldName(){let e=this.metadata?.columns?.find(e=>e.metadata?.identifier);if(e)return e.metadata?.id;if(this.metadata?.columns?.find(e=>e.metadata?.id===`id`))return`id`}_applyCellPartNameGenerator(){if(!this.grid)return;let e=this.identifierFieldName,t=this.state?._selectedId??this.appState?._splitDetailId,n=!!this.metadata?.groupBy;e&&t!==void 0||n?this.grid.cellPartNameGenerator=(n,r)=>{let i=r.item;return cl(i)?`mateu-group-row`:e&&t!==void 0&&String(i[e])===String(t)?`selected-row`:``}:this.grid.cellPartNameGenerator=null}connectedCallback(){super.connectedCallback(),this.addEventListener(`action-requested`,this._onActionRequested)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`action-requested`,this._onActionRequested),this._resizeObserver?.disconnect(),this._resizeObserver=void 0}firstUpdated(){let e=this.grid;!e||this._resizeObserver||(this._resizeObserver=new ResizeObserver(()=>{let t=e.offsetHeight;t>0&&this._lastGridHeight===0&&requestAnimationFrame(()=>{e.recalculateColumnWidths(),e.requestContentUpdate(),e.notifyResize?.()}),this._lastGridHeight=t}),this._resizeObserver.observe(e))}updated(e){super.updated(e),this._applyCellPartNameGenerator(),this.grid?.clearCache(),this.grid?.requestContentUpdate(),this.grid?.recalculateColumnWidths(),this.pagesRequested=[]}render(){let e=this.data[this.id],r=e?.page,i=this.metadata?.groupBy,a=this.metadata?.infiniteScrolling?void 0:r?.content?ul(r.content,i,e?.groups):r?.content,o=ml((this.metadata?.columns??[]).flatMap(e=>e.metadata?.type===j.GridGroupColumn?(e.metadata.columns??[]).map(e=>e.metadata):[e.metadata]),e,i),s=``;return this.metadata?.wrapCellContent&&(s+=` wrap-cell-content`),this.metadata?.compact&&(s+=` compact`),this.metadata?.noBorder&&(s+=` no-border`),this.metadata?.noRowBorder&&(s+=` no-row-borders`),this.metadata?.columnBorders&&(s+=` column-borders`),this.metadata?.rowStripes&&(s+=` row-stripes`),T`
+    `},Q=class extends b{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.detailsOpenedItems=[],this.pagesRequested=[],this._lastGridHeight=0,this.emptyArray=e=>!e||e.length==0,this.dataProvider=(e,t)=>{let n=this.data[this.id]?.page;if(this.metadata?.infiniteScrolling&&e.page>0){let r=!1;n&&n.content&&(n.content.length>=(e.page+1)*e.pageSize||n.content.length==n.totalElements)&&(t(n.content.slice(e.page*e.pageSize,(e.page+1)*e.pageSize),n.totalElements),r=!0,this.grid&&this.grid.recalculateColumnWidths()),r||this.pagesRequested.find(t=>t==e.page)||(this.pagesRequested.push(e.page),this.dispatchEvent(new CustomEvent(`fetch-more-elements`,{detail:{params:e,callback:()=>{this.data[this.id]?.page?.content&&(t(this.data[this.id].page.content.slice(e.page*e.pageSize,(e.page+1)*e.pageSize),this.data[this.id].page.totalElements),this.grid&&this.grid.recalculateColumnWidths())}},bubbles:!0,composed:!0})))}else{let e=this.metadata?.infiniteScrolling?n?.totalElements:n?.content?.length??0;t(n?.content??[],e),this.grid&&this.grid.recalculateColumnWidths()}},this._onActionRequested=e=>{let t=e.detail,n=this.identifierFieldName;if(!n||!t.parameters||t.actionId?.startsWith(`action-on-row-`))return;let r=t.parameters[n];r!==void 0&&(this.state._selectedId=String(r),this._applyCellPartNameGenerator(),this.grid?.requestContentUpdate())},this.tooltipGenerator=e=>{let t=``,{column:n,item:r}=e,i=this.metadata?.columns?.find(e=>e.metadata.id==n?.path);if(i?.metadata){let e=(i?.metadata).tooltipPath;e&&n&&r&&(t=r[e])}return t}}get identifierFieldName(){let e=this.metadata?.columns?.find(e=>e.metadata?.identifier);if(e)return e.metadata?.id;if(this.metadata?.columns?.find(e=>e.metadata?.id===`id`))return`id`}_applyCellPartNameGenerator(){if(!this.grid)return;let e=this.identifierFieldName,t=this.state?._selectedId??this.appState?._splitDetailId,n=!!this.metadata?.groupBy;e&&t!==void 0||n?this.grid.cellPartNameGenerator=(n,r)=>{let i=r.item;return ll(i)?`mateu-group-row`:e&&t!==void 0&&String(i[e])===String(t)?`selected-row`:``}:this.grid.cellPartNameGenerator=null}connectedCallback(){super.connectedCallback(),this.addEventListener(`action-requested`,this._onActionRequested)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`action-requested`,this._onActionRequested),this._resizeObserver?.disconnect(),this._resizeObserver=void 0}firstUpdated(){let e=this.grid;!e||this._resizeObserver||(this._resizeObserver=new ResizeObserver(()=>{let t=e.offsetHeight;t>0&&this._lastGridHeight===0&&requestAnimationFrame(()=>{e.recalculateColumnWidths(),e.requestContentUpdate(),e.notifyResize?.()}),this._lastGridHeight=t}),this._resizeObserver.observe(e))}updated(e){super.updated(e),this._applyCellPartNameGenerator(),this.grid?.clearCache(),this.grid?.requestContentUpdate(),this.grid?.recalculateColumnWidths(),this.pagesRequested=[]}render(){let e=this.data[this.id],r=e?.page,i=this.metadata?.groupBy,a=this.metadata?.infiniteScrolling?void 0:r?.content?dl(r.content,i,e?.groups):r?.content,o=hl((this.metadata?.columns??[]).flatMap(e=>e.metadata?.type===j.GridGroupColumn?(e.metadata.columns??[]).map(e=>e.metadata):[e.metadata]),e,i),s=``;return this.metadata?.wrapCellContent&&(s+=` wrap-cell-content`),this.metadata?.compact&&(s+=` compact`),this.metadata?.noBorder&&(s+=` no-border`),this.metadata?.noRowBorder&&(s+=` no-row-borders`),this.metadata?.columnBorders&&(s+=` column-borders`),this.metadata?.rowStripes&&(s+=` row-stripes`),T`
             <vaadin-grid
                     .items="${a}"
                     item-id-path="_rowNumber"
@@ -10141,17 +10149,17 @@ ${i}
                     .dataProvider="${this.metadata?.infiniteScrolling?this.dataProvider:void 0}"
                     page-size="${this.metadata?.pageSize}"
                     multi-sort-on-shift-click
-                    @selected-items-changed="${e=>{let t=(e.detail.value??[]).filter(e=>!cl(e));this.emptyArray(this.state[this.id+`_selected_items`])&&this.emptyArray(t)||(this.state[this.id+`_selected_items`]=t,this.metadata?.onRowSelectionChangedActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.metadata?.onRowSelectionChangedActionId},bubbles:!0,composed:!0})))}}"
-                    @active-item-changed="${S(this.metadata?.detailPath&&!this.metadata?.useButtonForDetail?e=>{if(this.metadata?.detailPath){let t=e.detail.value;if(t&&cl(t))return;t?this.detailsOpenedItems=[t]:this.detailsOpenedItems=[]}}:void 0)}"
+                    @selected-items-changed="${e=>{let t=(e.detail.value??[]).filter(e=>!ll(e));this.emptyArray(this.state[this.id+`_selected_items`])&&this.emptyArray(t)||(this.state[this.id+`_selected_items`]=t,this.metadata?.onRowSelectionChangedActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.metadata?.onRowSelectionChangedActionId},bubbles:!0,composed:!0})))}}"
+                    @active-item-changed="${S(this.metadata?.detailPath&&!this.metadata?.useButtonForDetail?e=>{if(this.metadata?.detailPath){let t=e.detail.value;if(t&&ll(t))return;t?this.detailsOpenedItems=[t]:this.detailsOpenedItems=[]}}:void 0)}"
                     .detailsOpenedItems="${this.detailsOpenedItems}"
-                    ${S(this.metadata?.detailPath?n(e=>T`${I(this,e[this.metadata?.detailPath],this.baseUrl,this.state,this.data,this.appState,this.appData)}`):void 0)}
+                    ${S(this.metadata?.detailPath?n(e=>T`${F(this,e[this.metadata?.detailPath],this.baseUrl,this.state,this.data,this.appState,this.appData)}`):void 0)}
                     theme="${s}"
                     style="${this.metadata?.gridStyle}"
             >
                 ${this.metadata?.rowsSelectionEnabled?T`
                     <vaadin-grid-selection-column></vaadin-grid-selection-column>
                 `:v}
-                ${this.metadata?.columns?.map(e=>zl(e,this,this.baseUrl,this.state,this.data,this.appState,this.appData,o))}
+                ${this.metadata?.columns?.map(e=>Bl(e,this,this.baseUrl,this.state,this.data,this.appState,this.appData,o))}
                 ${this.metadata?.useButtonForDetail?T`
                     <vaadin-grid-column
                             width="44px"
@@ -10171,7 +10179,7 @@ ${i}
             `,[])}
                     ></vaadin-grid-column>
                 `:v}
-                <span slot="empty-state">${zt(this.emptyStateMessage??this.metadata?.emptyStateMessage)}</span>
+                <span slot="empty-state">${Bt(this.emptyStateMessage??this.metadata?.emptyStateMessage)}</span>
                 ${this.metadata?.columns?.find(e=>e.metadata.tooltipPath)?T`<vaadin-tooltip slot="tooltip" .generator="${this.tooltipGenerator}"></vaadin-tooltip>`:v}
             </vaadin-grid>
             <slot></slot>
@@ -10190,7 +10198,7 @@ ${i}
             background-color: var(--lumo-contrast-5pct, rgba(0, 0, 0, 0.04));
             font-weight: 600;
         }
-  `}};k([y()],$.prototype,`id`,void 0),k([y()],$.prototype,`metadata`,void 0),k([y()],$.prototype,`baseUrl`,void 0),k([y()],$.prototype,`state`,void 0),k([y()],$.prototype,`data`,void 0),k([y()],$.prototype,`appState`,void 0),k([y()],$.prototype,`appData`,void 0),k([y()],$.prototype,`emptyStateMessage`,void 0),k([C()],$.prototype,`detailsOpenedItems`,void 0),k([x(`vaadin-grid`)],$.prototype,`grid`,void 0),$=k([g(`mateu-table`)],$);var $l=(e,t,n,r,i,a,o)=>T`
+  `}};k([y()],Q.prototype,`id`,void 0),k([y()],Q.prototype,`metadata`,void 0),k([y()],Q.prototype,`baseUrl`,void 0),k([y()],Q.prototype,`state`,void 0),k([y()],Q.prototype,`data`,void 0),k([y()],Q.prototype,`appState`,void 0),k([y()],Q.prototype,`appData`,void 0),k([y()],Q.prototype,`emptyStateMessage`,void 0),k([C()],Q.prototype,`detailsOpenedItems`,void 0),k([x(`vaadin-grid`)],Q.prototype,`grid`,void 0),Q=k([g(`mateu-table`)],Q);var eu=(e,t,n,r,i,a,o)=>T`
     <mateu-table
             id="${t.id}"
             baseUrl="${n}"
@@ -10202,8 +10210,8 @@ ${i}
             style="${t.style}" class="${t.cssClasses}"
             slot="${t.slot??v}"
     >
-        ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
-    </mateu-table>`,eu=(e,t,n,r,i,a)=>T`
+        ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+    </mateu-table>`,tu=(e,t,n,r,i,a)=>T`
     <mateu-table id="${e.id}"
                  .metadata="${t?.metadata}"
                  .data="${e.data}"
@@ -10214,8 +10222,8 @@ ${i}
                  @sort-direction-changed="${e.directionChanged}"
                  @fetch-more-elements="${e.fetchMoreElements}"
                  baseUrl="${n}"
-    ></mateu-table>`,tu=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
-        <div id="show-notifications" slot="${t.slot??v}">${I(e,s.wrapped,n,r,i,a,o)}</div>
+    ></mateu-table>`,nu=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+        <div id="show-notifications" slot="${t.slot??v}">${F(e,s.wrapped,n,r,i,a,o)}</div>
         <vaadin-popover
                 for="show-notifications"
                 theme="arrow no-padding"
@@ -10223,17 +10231,17 @@ ${i}
                 accessible-name-ref="notifications-heading"
                 content-width="300px"
                 position="bottom"
-                ${m(()=>T`${I(e,s.content,n,r,i,a,o)}`,[])}
+                ${m(()=>T`${F(e,s.content,n,r,i,a,o)}`,[])}
                 style="${t.style}" class="${t.cssClasses}"
         ></vaadin-popover>
-    `},nu=(e,t,n)=>{let r=e;return T`
+    `},ru=(e,t,n)=>{let r=e;return T`
         <vaadin-button
                 data-action-id="${r.id}"
-                theme="${Mt(e)||v}"
+                theme="${Nt(e)||v}"
                 @click="${n}"
                 ?disabled="${r.disabled}"
         >${r.iconOnLeft?T`<vaadin-icon icon="${r.iconOnLeft}"></vaadin-icon>`:v}${t}${r.iconOnRight?T`<vaadin-icon icon="${r.iconOnRight}"></vaadin-icon>`:v}</vaadin-button>
-    `},ru=e=>T`
+    `},iu=e=>T`
     <div style="display: flex; gap: var(--lumo-space-xs, .25rem); align-items: center;" class="peer-nav">
         <vaadin-button theme="tertiary icon" class="peer-nav-prev" title="${e.prevLabel??`Previous`}"
                 ?disabled="${!e.prevRoute}"
@@ -10245,30 +10253,30 @@ ${i}
                 @click="${()=>{e.nextRoute&&(window.location.href=e.nextRoute)}}">
             <vaadin-icon icon="vaadin:angle-right"></vaadin-icon>
         </vaadin-button>
-    </div>`,iu={"vaadin:wifi":`vaadin:connect`,"vaadin:pen":`vaadin:pencil`,"vaadin:automation":`vaadin:cogs`},au=(e,t,n)=>T`<vaadin-icon icon="${iu[e]??e}" style="${t??v}" class="${n??v}"></vaadin-icon>`,ou=(e,t,n)=>{let r=e.metadata,i=M(r.label,t,n),a=``;return r.buttonStyle&&(a+=` `+r.buttonStyle),r.color&&r.color!==`none`&&r.color!==`normal`&&(a+=` `+r.color),r.size&&r.size!==`none`&&r.size!==`normal`&&(a+=` `+r.size),T`<vaadin-button
+    </div>`,au={"vaadin:wifi":`vaadin:connect`,"vaadin:pen":`vaadin:pencil`,"vaadin:automation":`vaadin:cogs`},ou=(e,t,n)=>T`<vaadin-icon icon="${au[e]??e}" style="${t??v}" class="${n??v}"></vaadin-icon>`,su=(e,t,n)=>{let r=e.metadata,i=M(r.label,t,n),a=``;return r.buttonStyle&&(a+=` `+r.buttonStyle),r.color&&r.color!==`none`&&r.color!==`normal`&&(a+=` `+r.color),r.size&&r.size!==`none`&&r.size!==`normal`&&(a+=` `+r.size),T`<vaadin-button
             id="${e.id}"
             data-action-id="${r.actionId}"
-            @click="${e=>ar(e,r)}"
+            @click="${e=>or(e,r)}"
             style="${e.style}"
             class="${e.cssClasses}"
             theme="${a}"
             ?disabled="${r.disabled}"
-            title="${r.shortcut?`${i} (${ir(r.shortcut)})`:v}"
+            title="${r.shortcut?`${i} (${ar(r.shortcut)})`:v}"
             slot="${e.slot??v}"
-    >${r.iconOnLeft?T`<vaadin-icon icon="${r.iconOnLeft}"></vaadin-icon>`:v}${i}${r.iconOnRight?T`<vaadin-icon icon="${r.iconOnRight}"></vaadin-icon>`:v}</vaadin-button>`},su=e=>{let t=e.metadata;return T`
+    >${r.iconOnLeft?T`<vaadin-icon icon="${r.iconOnLeft}"></vaadin-icon>`:v}${i}${r.iconOnRight?T`<vaadin-icon icon="${r.iconOnRight}"></vaadin-icon>`:v}</vaadin-button>`},cu=e=>{let t=e.metadata;return T`
         <vaadin-message-input
                 style="${e.style}" class="${e.cssClasses}"
                 slot="${e.slot??v}"
                 @submit="${e=>{let n=e.detail?.value??``;!t.actionId||!n.trim()||e.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:{message:n}},bubbles:!0,composed:!0}))}}"
         ></vaadin-message-input>
-    `},cu=e=>{let t=(e.metadata.items??[]).map(e=>({text:e.text,time:e.time,userName:e.userName,userImg:e.userImg,userAbbr:e.userAbbr,userColorIndex:e.userColorIndex}));return T`
+    `},lu=e=>{let t=(e.metadata.items??[]).map(e=>({text:e.text,time:e.time,userName:e.userName,userImg:e.userImg,userAbbr:e.userAbbr,userColorIndex:e.userColorIndex}));return T`
         <vaadin-message-list
                 markdown
                 style="${e.style}" class="${e.cssClasses}"
                 slot="${e.slot??v}"
                 .items="${t}"
         ></vaadin-message-list>
-    `},lu=(e,t)=>{e&&e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},uu=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!1;if(s.openedCondition)try{c=St(s.openedCondition,r,i,a,o)}catch(e){console.error(`when evaluating `+s.openedCondition+` :`+e+`, where data is `+i+` and state is `+r)}return T`
+    `},uu=(e,t)=>{e&&e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},du=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!1;if(s.openedCondition)try{c=St(s.openedCondition,r,i,a,o)}catch(e){console.error(`when evaluating `+s.openedCondition+` :`+e+`, where data is `+i+` and state is `+r)}return T`
         <vaadin-confirm-dialog
                 header="${s.header}"
                 ?cancel-button-visible="${s.canCancel}"
@@ -10276,15 +10284,15 @@ ${i}
                 reject-text="${s.rejectText}"
                 confirm-text="${s.confirmText}"
                 .opened="${c}"
-                @confirm="${e=>lu(e.currentTarget,s.confirmActionId)}"
-                @reject="${e=>lu(e.currentTarget,s.rejectActionId)}"
-                @cancel="${e=>lu(e.currentTarget,s.cancelActionId)}"
+                @confirm="${e=>uu(e.currentTarget,s.confirmActionId)}"
+                @reject="${e=>uu(e.currentTarget,s.rejectActionId)}"
+                @cancel="${e=>uu(e.currentTarget,s.cancelActionId)}"
                 style="${t.style}" class="${t.cssClasses}"
                 slot="${t.slot??v}"
         >
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
         </vaadin-confirm-dialog>
-    `},du=class extends b{constructor(...e){super(...e),this.panels=[],this.headerTitle=``,this.badges=[],this.navigation=null,this.overviewEditActionId=``,this._raf=0,this._snapping=!1,this._less=!1,this._more=!1,this._onScroll=()=>{this._raf||=requestAnimationFrame(()=>{this._raf=0,this._syncPin()})},this._onScrollEnd=()=>{this._snapping||this._snapToNearest()},this._fit=()=>{let e=this.getBoundingClientRect().top;this.style.setProperty(`--mateu-foldout-fill`,`${Math.max(240,window.innerHeight-e)}px`),this._syncPin()},this._onKeydown=e=>{if(e.key!==`ArrowRight`&&e.key!==`ArrowLeft`||e.defaultPrevented||e.ctrlKey||e.metaKey||e.altKey||this._isEditingContext())return;let t=this._rail;!t||t.scrollWidth<=t.clientWidth||(e.preventDefault(),this._step(e.key===`ArrowRight`?1:-1))}}navAction(e){e&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{}},bubbles:!0,composed:!0}))}_stride(){let e=this.renderRoot.querySelectorAll(`.section`);return e.length>1?e[1].offsetLeft:this._rail?.clientWidth??0}_boundaries(){let e=this._rail;if(!e)return[];let t=e.scrollWidth-e.clientWidth,n=[...this.renderRoot.querySelectorAll(`.section`)].map(e=>Math.max(0,Math.min(e.offsetLeft,t)));return[...new Set(n)]}_snapToNearest(){let e=this._rail;if(!e)return;let t=this._boundaries();if(!t.length)return;let n=t.reduce((t,n)=>Math.abs(n-e.scrollLeft)<Math.abs(t-e.scrollLeft)?n:t);Math.abs(n-e.scrollLeft)<1||(this._snapping=!0,e.scrollTo({left:n,behavior:`smooth`}),window.setTimeout(()=>{this._snapping=!1},400))}_syncPin(){let e=this._rail,t=this._first;if(!e||!t)return;let n=this._stride(),r=Math.min(e.scrollLeft,n);t.style.transform=r?`translateX(${r}px)`:``,t.classList.toggle(`floating`,e.scrollLeft>0);let i=e.scrollWidth-e.clientWidth,a=i>32;this._less=a&&e.scrollLeft>2,this._more=a&&e.scrollLeft<i-2}_step(e){let t=this._rail;if(!t)return;let n=this._boundaries();if(!n.length)return;let r=n.reduce((e,r,i)=>Math.abs(r-t.scrollLeft)<Math.abs(n[e]-t.scrollLeft)?i:e,0),i=n[Math.max(0,Math.min(r+e,n.length-1))];this._snapping=!0,t.scrollTo({left:i,behavior:`smooth`}),window.setTimeout(()=>{this._snapping=!1},400)}_isEditingContext(){let e=document.activeElement;for(;e&&e.shadowRoot&&e.shadowRoot.activeElement;)e=e.shadowRoot.activeElement;if(!e)return!1;let t=e.tagName;return t===`INPUT`||t===`TEXTAREA`||t===`SELECT`||e.isContentEditable}_sectionFlex(e,t){if(!e.width)return v;let n=parseFloat(e.width)||1;return t===this.panels.length-1&&n<22?`flex: 22 1 var(--mateu-foldout-overview-width, 22rem);`:`flex: ${n} 1 ${e.width};`}firstUpdated(){this._fit(),this._resizeObserver=new ResizeObserver(()=>this._syncPin()),this._rail&&this._resizeObserver.observe(this._rail);for(let e of this.renderRoot.querySelectorAll(`.section`))this._resizeObserver.observe(e)}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._onKeydown),window.addEventListener(`resize`,this._fit)}disconnectedCallback(){document.removeEventListener(`keydown`,this._onKeydown),window.removeEventListener(`resize`,this._fit),this._resizeObserver?.disconnect(),this._resizeObserver=void 0,this._raf&&=(cancelAnimationFrame(this._raf),0),super.disconnectedCallback()}static{this.styles=h`
+    `},$=class extends b{constructor(...e){super(...e),this.panels=[],this.headerTitle=``,this.badges=[],this.navigation=null,this.overviewEditActionId=``,this._raf=0,this._snapping=!1,this._less=!1,this._more=!1,this._onScroll=()=>{this._raf||=requestAnimationFrame(()=>{this._raf=0,this._syncPin()})},this._onScrollEnd=()=>{this._snapping||this._snapToNearest()},this._fit=()=>{let e=this.getBoundingClientRect().top;this.style.setProperty(`--mateu-foldout-fill`,`${Math.max(240,window.innerHeight-e)}px`),this._syncPin()},this._onKeydown=e=>{if(e.key!==`ArrowRight`&&e.key!==`ArrowLeft`||e.defaultPrevented||e.ctrlKey||e.metaKey||e.altKey||this._isEditingContext())return;let t=this._rail;!t||t.scrollWidth<=t.clientWidth||(e.preventDefault(),this._step(e.key===`ArrowRight`?1:-1))}}navAction(e){e&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{}},bubbles:!0,composed:!0}))}_stride(){let e=this.renderRoot.querySelectorAll(`.section`);return e.length>1?e[1].offsetLeft:this._rail?.clientWidth??0}_boundaries(){let e=this._rail;if(!e)return[];let t=e.scrollWidth-e.clientWidth,n=[...this.renderRoot.querySelectorAll(`.section`)].map(e=>Math.max(0,Math.min(e.offsetLeft,t)));return[...new Set(n)]}_snapToNearest(){let e=this._rail;if(!e)return;let t=this._boundaries();if(!t.length)return;let n=t.reduce((t,n)=>Math.abs(n-e.scrollLeft)<Math.abs(t-e.scrollLeft)?n:t);Math.abs(n-e.scrollLeft)<1||(this._snapping=!0,e.scrollTo({left:n,behavior:`smooth`}),window.setTimeout(()=>{this._snapping=!1},400))}_syncPin(){let e=this._rail,t=this._first;if(!e||!t)return;let n=this._stride(),r=Math.min(e.scrollLeft,n);t.style.transform=r?`translateX(${r}px)`:``,t.classList.toggle(`floating`,e.scrollLeft>0);let i=e.scrollWidth-e.clientWidth,a=i>32;this._less=a&&e.scrollLeft>2,this._more=a&&e.scrollLeft<i-2}_step(e){let t=this._rail;if(!t)return;let n=this._boundaries();if(!n.length)return;let r=n.reduce((e,r,i)=>Math.abs(r-t.scrollLeft)<Math.abs(n[e]-t.scrollLeft)?i:e,0),i=n[Math.max(0,Math.min(r+e,n.length-1))];this._snapping=!0,t.scrollTo({left:i,behavior:`smooth`}),window.setTimeout(()=>{this._snapping=!1},400)}_isEditingContext(){let e=document.activeElement;for(;e&&e.shadowRoot&&e.shadowRoot.activeElement;)e=e.shadowRoot.activeElement;if(!e)return!1;let t=e.tagName;return t===`INPUT`||t===`TEXTAREA`||t===`SELECT`||e.isContentEditable}_sectionFlex(e,t){if(!e.width)return v;let n=parseFloat(e.width)||1;return t===this.panels.length-1&&n<22?`flex: 22 1 var(--mateu-foldout-overview-width, 22rem);`:`flex: ${n} 1 ${e.width};`}firstUpdated(){this._fit(),this._resizeObserver=new ResizeObserver(()=>this._syncPin()),this._rail&&this._resizeObserver.observe(this._rail);for(let e of this.renderRoot.querySelectorAll(`.section`))this._resizeObserver.observe(e)}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._onKeydown),window.addEventListener(`resize`,this._fit)}disconnectedCallback(){document.removeEventListener(`keydown`,this._onKeydown),window.removeEventListener(`resize`,this._fit),this._resizeObserver?.disconnect(),this._resizeObserver=void 0,this._raf&&=(cancelAnimationFrame(this._raf),0),super.disconnectedCallback()}static{this.styles=h`
         :host {
             position: relative;
             display: flex;
@@ -10545,7 +10553,7 @@ ${i}
                     </svg>
                 </button>
             `:v}
-        `}};k([y({type:Array})],du.prototype,`panels`,void 0),k([y({type:String})],du.prototype,`headerTitle`,void 0),k([y({type:Array})],du.prototype,`badges`,void 0),k([y({attribute:!1})],du.prototype,`navigation`,void 0),k([y({type:String})],du.prototype,`overviewEditActionId`,void 0),k([x(`.rail`)],du.prototype,`_rail`,void 0),k([x(`.section--first`)],du.prototype,`_first`,void 0),k([C()],du.prototype,`_less`,void 0),k([C()],du.prototype,`_more`,void 0),du=k([g(`mateu-vaadin-foldout`)],du);var fu=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+        `}};k([y({type:Array})],$.prototype,`panels`,void 0),k([y({type:String})],$.prototype,`headerTitle`,void 0),k([y({type:Array})],$.prototype,`badges`,void 0),k([y({attribute:!1})],$.prototype,`navigation`,void 0),k([y({type:String})],$.prototype,`overviewEditActionId`,void 0),k([x(`.rail`)],$.prototype,`_rail`,void 0),k([x(`.section--first`)],$.prototype,`_first`,void 0),k([C()],$.prototype,`_less`,void 0),k([C()],$.prototype,`_more`,void 0),$=k([g(`mateu-vaadin-foldout`)],$);var fu=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
         <mateu-vaadin-foldout
                 .panels="${s.panels??[]}"
                 .headerTitle="${s.headerTitle??``}"
@@ -10556,7 +10564,7 @@ ${i}
                 class="${t.cssClasses}"
                 slot="${t.slot??v}"
         >
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
         </mateu-vaadin-foldout>
     `},pu=class extends b{constructor(...e){super(...e),this.rows=[],this.columns=[],this.navigable=!1,this.expandedItems=[],this._normalized=[],this.dataProvider=(e,t)=>{let n=e.parentItem?e.parentItem.children??[]:this.normalized;t(n,n.length)}}get normalized(){return this._src!==this.rows&&(this._src=this.rows,this._normalized=this.normalizeRows(this.rows??[])),this._normalized}normalizeRows(e){return(e??[]).map(e=>{let t=Array.isArray(e.children)&&e.children.length?this.normalizeRows(e.children):void 0;return{...e,children:t}})}collectGroups(e,t=[]){return e.forEach(e=>{e.children&&e.children.length&&(t.push(e),this.collectGroups(e.children,t))}),t}willUpdate(){this._expandedSrc!==this.rows&&(this._expandedSrc=this.rows,this.expandedItems=this.collectGroups(this.normalized))}updated(e){e.has(`rows`)&&this._grid?.clearCache?.()}dispatch(e,t){this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:t},bubbles:!0,composed:!0}))}render(){let e=this.columns??[],n=e[0],r=e.slice(1);return T`
             <vaadin-grid
@@ -10588,11 +10596,11 @@ ${i}
             max-height: min(60vh, 32rem);
             min-width: 22rem;
         }
-    `}};k([y({attribute:!1})],pu.prototype,`rows`,void 0),k([y({attribute:!1})],pu.prototype,`columns`,void 0),k([y()],pu.prototype,`idField`,void 0),k([y({type:Boolean})],pu.prototype,`navigable`,void 0),k([y()],pu.prototype,`selectedId`,void 0),k([C()],pu.prototype,`expandedItems`,void 0),k([x(`vaadin-grid`)],pu.prototype,`_grid`,void 0),pu=k([g(`mateu-vaadin-tree`)],pu);var mu={[j.VirtualList]:(e,t,n,r,i,a,o)=>Cc(e,t,n,r,i,a,o),[j.Notification]:(e,t)=>wc(t),[j.ProgressBar]:(e,t,n,r)=>Tc(t,r),[j.Details]:(e,t,n,r,i,a,o)=>Ec(e,t,n,r,i,a,o),[j.Avatar]:(e,t,n,r,i)=>Dc(t,r,i),[j.AvatarGroup]:(e,t)=>Oc(t),[j.Card]:(e,t,n,r,i,a,o)=>kc(e,t,n,r,i,a,o),[j.Button]:(e,t,n,r,i)=>ou(t,r,i),[j.MessageInput]:(e,t)=>su(t),[j.MessageList]:(e,t)=>cu(t),[j.ConfirmDialog]:(e,t,n,r,i,a,o)=>uu(e,t,n,r,i,a,o),[j.FormLayout]:(e,t,n,r,i,a,o)=>Mc(e,t,n,r,i,a,o),[j.HorizontalLayout]:(e,t,n,r,i,a,o)=>Ic(e,t,n,r,i,a,o),[j.VerticalLayout]:(e,t,n,r,i,a,o)=>Lc(e,t,n,r,i,a,o),[j.SplitLayout]:(e,t,n,r,i,a,o)=>Rc(e,t,n,r,i,a,o),[j.MasterDetailLayout]:(e,t,n,r,i,a,o)=>zc(e,t,n,r,i,a,o),[j.TabLayout]:(e,t,n,r,i,a,o)=>Bc(e,t,n,r,i,a,o),[j.AccordionLayout]:(e,t,n,r,i,a,o)=>Hc(e,t,n,r,i,a,o),[j.BoardLayout]:(e,t,n,r,i,a,o)=>Gc(e,t,n,r,i,a,o),[j.BoardLayoutRow]:(e,t,n,r,i,a,o)=>Kc(e,t,n,r,i,a,o),[j.BoardLayoutItem]:(e,t,n,r,i,a,o)=>qc(e,t,n,r,i,a,o),[j.Scroller]:(e,t,n,r,i,a,o)=>Wc(e,t,n,r,i,a,o),[j.MenuBar]:(e,t,n,r,i)=>Xc(e,t,n,r,i),[j.ContextMenu]:(e,t,n,r,i,a,o)=>Yc(e,t,n,r,i,a,o),[j.FormField]:(e,t,n,r,i,a,o,s)=>Zl(e,t,n,r,i,a,o,s),[j.Grid]:(e,t,n,r,i,a,o)=>Ql(e,t,n,r,i,a,o),[j.Table]:(e,t,n,r,i,a,o)=>$l(e,t,n,r,i,a,o),[j.Popover]:(e,t,n,r,i,a,o)=>tu(e,t,n,r,i,a,o),[j.FoldoutLayout]:(e,t,n,r,i,a,o)=>fu(e,t,n,r,i,a,o)},hu=class extends Sc{rendererName(){return`vaadin`}renderClientSideComponent(e,t,n,r,i,a,o,s){let c=t?.metadata?.type,l=c?mu[c]:void 0;return l&&t?l(e,t,n,r,i,a,o,s):super.renderClientSideComponent(e,t,n,r,i,a,o,s)}renderTableComponent(e,t,n,r,i,a,o){return eu(e,t,n,r,a,o)}renderTreeComponent(e,t){return T`
+    `}};k([y({attribute:!1})],pu.prototype,`rows`,void 0),k([y({attribute:!1})],pu.prototype,`columns`,void 0),k([y()],pu.prototype,`idField`,void 0),k([y({type:Boolean})],pu.prototype,`navigable`,void 0),k([y()],pu.prototype,`selectedId`,void 0),k([C()],pu.prototype,`expandedItems`,void 0),k([x(`vaadin-grid`)],pu.prototype,`_grid`,void 0),pu=k([g(`mateu-vaadin-tree`)],pu);var mu={[j.VirtualList]:(e,t,n,r,i,a,o)=>wc(e,t,n,r,i,a,o),[j.Notification]:(e,t)=>Tc(t),[j.ProgressBar]:(e,t,n,r)=>Ec(t,r),[j.Details]:(e,t,n,r,i,a,o)=>Dc(e,t,n,r,i,a,o),[j.Avatar]:(e,t,n,r,i)=>Oc(t,r,i),[j.AvatarGroup]:(e,t)=>kc(t),[j.Card]:(e,t,n,r,i,a,o)=>Ac(e,t,n,r,i,a,o),[j.Button]:(e,t,n,r,i)=>su(t,r,i),[j.MessageInput]:(e,t)=>cu(t),[j.MessageList]:(e,t)=>lu(t),[j.ConfirmDialog]:(e,t,n,r,i,a,o)=>du(e,t,n,r,i,a,o),[j.FormLayout]:(e,t,n,r,i,a,o)=>Nc(e,t,n,r,i,a,o),[j.HorizontalLayout]:(e,t,n,r,i,a,o)=>Lc(e,t,n,r,i,a,o),[j.VerticalLayout]:(e,t,n,r,i,a,o)=>Rc(e,t,n,r,i,a,o),[j.SplitLayout]:(e,t,n,r,i,a,o)=>zc(e,t,n,r,i,a,o),[j.MasterDetailLayout]:(e,t,n,r,i,a,o)=>Bc(e,t,n,r,i,a,o),[j.TabLayout]:(e,t,n,r,i,a,o)=>Vc(e,t,n,r,i,a,o),[j.AccordionLayout]:(e,t,n,r,i,a,o)=>Uc(e,t,n,r,i,a,o),[j.BoardLayout]:(e,t,n,r,i,a,o)=>Kc(e,t,n,r,i,a,o),[j.BoardLayoutRow]:(e,t,n,r,i,a,o)=>qc(e,t,n,r,i,a,o),[j.BoardLayoutItem]:(e,t,n,r,i,a,o)=>Jc(e,t,n,r,i,a,o),[j.Scroller]:(e,t,n,r,i,a,o)=>Gc(e,t,n,r,i,a,o),[j.MenuBar]:(e,t,n,r,i)=>Zc(e,t,n,r,i),[j.ContextMenu]:(e,t,n,r,i,a,o)=>Xc(e,t,n,r,i,a,o),[j.FormField]:(e,t,n,r,i,a,o,s)=>Ql(e,t,n,r,i,a,o,s),[j.Grid]:(e,t,n,r,i,a,o)=>$l(e,t,n,r,i,a,o),[j.Table]:(e,t,n,r,i,a,o)=>eu(e,t,n,r,i,a,o),[j.Popover]:(e,t,n,r,i,a,o)=>nu(e,t,n,r,i,a,o),[j.FoldoutLayout]:(e,t,n,r,i,a,o)=>fu(e,t,n,r,i,a,o)},hu=class extends Cc{rendererName(){return`vaadin`}renderClientSideComponent(e,t,n,r,i,a,o,s){let c=t?.metadata?.type,l=c?mu[c]:void 0;return l&&t?l(e,t,n,r,i,a,o,s):super.renderClientSideComponent(e,t,n,r,i,a,o,s)}renderTableComponent(e,t,n,r,i,a,o){return tu(e,t,n,r,a,o)}renderTreeComponent(e,t){return T`
             <mateu-vaadin-tree
                     .rows="${t.rows}"
                     .columns="${t.columns}"
                     .idField="${t.idField}"
                     .navigable="${t.navigable}"
                     .selectedId="${t.selectedId}"
-            ></mateu-vaadin-tree>`}renderToolbarButton(e,t,n){return nu(e,t,n)}renderPeerNav(e){return ru(e)}renderIcon(e,t,n){return au(e,t,n)}renderTopNav(e,t,n){return Jc(e,t,n)}};function gu(e){switch(e){case`topStretch`:return`top-stretch`;case`topStart`:return`top-start`;case`topCenter`:return`top-center`;case`topEnd`:return`top-end`;case`middle`:return`middle`;case`bottomStart`:return`bottom-start`;case`bottomEnd`:return`bottom-end`;case`bottomStretch`:return`bottom-stretch`;case`bottomCenter`:return`bottom-center`}return`bottom-end`}function _u(e,t){if(e.onAction)return{label:e.actionLabel??`Retry`,run:e.onAction};if(e.undoActionId)return{label:e.undoLabel??`Undo`,run:()=>t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.undoActionId,parameters:e.undoParameters??{}},bubbles:!0,composed:!0}))}}function vu(e,t){let n=new r;n.position=gu(e.position),n.duration=e.duration??1e4,e.variant&&n.setAttribute(`theme`,e.variant),n.renderer=r=>{if(r.firstElementChild)return;let i=document.createElement(`span`);i.textContent=e.text;let a=_u(e,t),o=document.createElement(`button`);o.textContent=a.label,o.style.cssText=`margin-left: 0.75rem; background: none; border: 1px solid currentColor; border-radius: var(--lumo-border-radius-s, 4px); color: inherit; cursor: pointer; padding: 0.15rem 0.6rem; font: inherit; font-weight: 600;`,o.addEventListener(`click`,()=>{a.run(),n.opened=!1}),r.append(i,o)},document.body.appendChild(n),n.opened=!0,n.addEventListener(`opened-changed`,e=>{e.detail.value||n.remove()})}F.set(new hu),Ma({show(e,t){if(gt(e.text,{politeness:e.variant===`error`?`assertive`:`polite`}),e.undoActionId||e.onAction){vu(e,t);return}r.show(e.text,{position:e.position?gu(e.position):`bottom-end`,theme:e.variant,duration:e.duration})}});
+            ></mateu-vaadin-tree>`}renderToolbarButton(e,t,n){return ru(e,t,n)}renderPeerNav(e){return iu(e)}renderIcon(e,t,n){return ou(e,t,n)}renderTopNav(e,t,n){return Yc(e,t,n)}};function gu(e){switch(e){case`topStretch`:return`top-stretch`;case`topStart`:return`top-start`;case`topCenter`:return`top-center`;case`topEnd`:return`top-end`;case`middle`:return`middle`;case`bottomStart`:return`bottom-start`;case`bottomEnd`:return`bottom-end`;case`bottomStretch`:return`bottom-stretch`;case`bottomCenter`:return`bottom-center`}return`bottom-end`}function _u(e,t){if(e.onAction)return{label:e.actionLabel??`Retry`,run:e.onAction};if(e.undoActionId)return{label:e.undoLabel??`Undo`,run:()=>t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.undoActionId,parameters:e.undoParameters??{}},bubbles:!0,composed:!0}))}}function vu(e,t){let n=new r;n.position=gu(e.position),n.duration=e.duration??1e4,e.variant&&n.setAttribute(`theme`,e.variant),n.renderer=r=>{if(r.firstElementChild)return;let i=document.createElement(`span`);i.textContent=e.text;let a=_u(e,t),o=document.createElement(`button`);o.textContent=a.label,o.style.cssText=`margin-left: 0.75rem; background: none; border: 1px solid currentColor; border-radius: var(--lumo-border-radius-s, 4px); color: inherit; cursor: pointer; padding: 0.15rem 0.6rem; font: inherit; font-weight: 600;`,o.addEventListener(`click`,()=>{a.run(),n.opened=!1}),r.append(i,o)},document.body.appendChild(n),n.opened=!0,n.addEventListener(`opened-changed`,e=>{e.detail.value||n.remove()})}P.set(new hu),Na({show(e,t){if(gt(e.text,{politeness:e.variant===`error`?`assertive`:`polite`}),e.undoActionId||e.onAction){vu(e,t);return}r.show(e.text,{position:e.position?gu(e.position):`bottom-end`,theme:e.variant,duration:e.duration})}});

--- a/backend/shared/frontend/vaadin-lit/src/main/resources/static/assets/mateu-vaadin.js
+++ b/backend/shared/frontend/vaadin-lit/src/main/resources/static/assets/mateu-vaadin.js
@@ -139,17 +139,17 @@ ${i}
             width: 100%;
             height: 100%;
         }
-    `}};k([y()],he.prototype,`position`,void 0),k([y()],he.prototype,`zoom`,void 0),k([x(`#map`)],he.prototype,`mapElement`,void 0),he=k([g(`mateu-map`)],he);var ge=typeof HTMLElement<`u`?HTMLElement:class{},_e=class extends ge{static get observedAttributes(){return[`content`]}#e;#t=0;get content(){return this.#e}set content(e){this.#e=e,this.#n()}attributeChangedCallback(e,t,n){this.content=n??void 0}connectedCallback(){this.style.display=`block`,this.#n()}async#n(){if(!this.isConnected)return;let e=this.#e??``,t=++this.#t,[{marked:n},{default:r}]=await Promise.all([D(()=>import(`./vendor.js`).then(e=>e.n),__vite__mapDeps([2,1])),D(()=>import(`./vendor.js`).then(e=>e.a),__vite__mapDeps([2,1]))]);t===this.#t&&(this.innerHTML=r.sanitize(await n.parse(e),{USE_PROFILES:{html:!0,svg:!0,svgFilters:!0},CUSTOM_ELEMENT_HANDLING:{tagNameCheck:e=>!0}}))}};typeof customElements<`u`&&!customElements.get(`mateu-markdown`)&&customElements.define(`mateu-markdown`,_e);var A=function(e){return e.ServerSide=`ServerSide`,e.ClientSide=`ClientSide`,e}({}),j=function(e){return e.Page=`Page`,e.Div=`Div`,e.Element=`Element`,e.MicroFrontend=`MicroFrontend`,e.Form=`Form`,e.Crud=`Crud`,e.Result=`Result`,e.Card=`Card`,e.Directory=`Directory`,e.Stepper=`Stepper`,e.HorizontalLayout=`HorizontalLayout`,e.VerticalLayout=`VerticalLayout`,e.SplitLayout=`SplitLayout`,e.MasterDetailLayout=`MasterDetailLayout`,e.TabLayout=`TabLayout`,e.AccordionLayout=`AccordionLayout`,e.FormLayout=`FormLayout`,e.FormRow=`FormRow`,e.FormItem=`FormItem`,e.BoardLayout=`BoardLayout`,e.BoardLayoutRow=`BoardLayoutRow`,e.BoardLayoutItem=`BoardLayoutItem`,e.Scroller=`Scroller`,e.FullWidth=`FullWidth`,e.Container=`Container`,e.FormField=`FormField`,e.Table=`Table`,e.App=`App`,e.Text=`Text`,e.Avatar=`Avatar`,e.Chat=`Chat`,e.AvatarGroup=`AvatarGroup`,e.Badge=`Badge`,e.Breadcrumbs=`Breadcrumbs`,e.Anchor=`Anchor`,e.Button=`Button`,e.Chart=`Chart`,e.Icon=`Icon`,e.ConfirmDialog=`ConfirmDialog`,e.ContextMenu=`ContextMenu`,e.CookieConsent=`CookieConsent`,e.Details=`Details`,e.Dialog=`Dialog`,e.Drawer=`Drawer`,e.Image=`Image`,e.Map=`Map`,e.Markdown=`Markdown`,e.Notification=`Notification`,e.ProgressBar=`ProgressBar`,e.Popover=`Popover`,e.CarouselLayout=`CarouselLayout`,e.Tooltip=`Tooltip`,e.MessageInput=`MessageInput`,e.MessageList=`MessageList`,e.CustomField=`CustomField`,e.MenuBar=`MenuBar`,e.Grid=`Grid`,e.GridColumn=`GridColumn`,e.GridGroupColumn=`GridGroupColumn`,e.VirtualList=`VirtualList`,e.FormSection=`FormSection`,e.FormSubSection=`FormSubSection`,e.Bpmn=`Bpmn`,e.Workflow=`Workflow`,e.FormEditor=`FormEditor`,e.MetricCard=`MetricCard`,e.Scoreboard=`Scoreboard`,e.DashboardPanel=`DashboardPanel`,e.DashboardLayout=`DashboardLayout`,e.FoldoutLayout=`FoldoutLayout`,e.ContentLayout=`ContentLayout`,e.HeroSection=`HeroSection`,e.EmptyState=`EmptyState`,e.Skeleton=`Skeleton`,e.Gantt=`Gantt`,e.PlanningBoard=`PlanningBoard`,e.Kanban=`Kanban`,e.Timeline=`Timeline`,e.ProgressSteps=`ProgressSteps`,e.Stat=`Stat`,e.Calendar=`Calendar`,e.PricingTable=`PricingTable`,e.OrgChart=`OrgChart`,e.Heatmap=`Heatmap`,e.Funnel=`Funnel`,e.TrendChart=`TrendChart`,e.FeatureGrid=`FeatureGrid`,e.Testimonials=`Testimonials`,e.Faq=`Faq`,e.CalloutCard=`CalloutCard`,e.CommentThread=`CommentThread`,e.FileList=`FileList`,e.Checklist=`Checklist`,e.ComparisonCard=`ComparisonCard`,e.EntityHeader=`EntityHeader`,e.Meter=`Meter`,e.TaskProgress=`TaskProgress`,e.StatusList=`StatusList`,e.BulletedList=`BulletedList`,e.Separator=`Separator`,e.Notice=`Notice`,e.TaskQueue=`TaskQueue`,e.ResourceGrid=`ResourceGrid`,e.OfferCard=`OfferCard`,e.AddOnPicker=`AddOnPicker`,e.Ledger=`Ledger`,e.PaymentPicker=`PaymentPicker`,e.ProcessMonitor=`ProcessMonitor`,e}({}),ve=`mateu-app-context`,ye=`mateu-app-context-labels`,be=e=>{try{return JSON.parse(localStorage.getItem(e)??`{}`)}catch{return{}}},xe=(e,t)=>{try{localStorage.setItem(e,JSON.stringify(t))}catch{}},Se=()=>be(ve),Ce=()=>be(ye),we=(e,t,n)=>{let r=Se(),i=Ce();t==null||t===``?(delete r[e],delete i[e]):(r[e]=t,n!==void 0&&(i[e]=n)),xe(ve,r),xe(ye,i)},Te=!1,Ee=()=>{Te||(Te=!0,window.addEventListener(`storage`,e=>{e.key===ve&&e.newValue!==e.oldValue&&window.location.reload()}))},De,Oe=(e,t)=>new Promise((n,r)=>{let i=!1,a={retry:()=>{i||(i=!0,t().then(n,r))},giveUp:()=>{i||(i=!0,r(e))}};if(De){De(a);return}let o=new CustomEvent(`mateu-session-expired`,{detail:a,cancelable:!0,bubbles:!1});typeof document<`u`&&!document.dispatchEvent(o)||a.giveUp()}),ke=(e,t)=>e.includes(`json`)?!0:typeof t==`object`&&!!t,Ae=(e,t)=>{let n=e.finalUrl;if(!n)return;let r=t??(typeof window<`u`?window.location.href:void 0),i;try{i=new URL(e.requestedUrl,r).href}catch{return}if(i!==n&&!ke(e.contentType??``,e.data))return n},je=new class{constructor(){this.windowMs=4e3,this.threshold=12,this.events=[],this.reported=new Set}check(e,t=Date.now()){this.events.push({sig:e,t});let n=t-this.windowMs;this.events=this.events.filter(e=>e.t>=n);let r=0;for(let t of this.events)t.sig===e&&r++;if(r>=this.threshold){let t=!this.reported.has(e);return this.reported.add(e),{blocked:!0,firstTrip:t}}return this.reported.delete(e),{blocked:!1,firstTrip:!1}}reset(){this.events=[],this.reported.clear()}configure(e){e.windowMs!==void 0&&(this.windowMs=e.windowMs),e.threshold!==void 0&&(this.threshold=e.threshold)}},Me=[],Ne=e=>{Me=Array.isArray(e)?e:[]},Pe=e=>e?Me.find(t=>t.name===e):void 0,Fe=e=>e==null||e===``,Ie=e=>{if(!e?.ref)return e;let t=Pe(e.ref);if(!t?.source)return console.warn(`mateu: no REST source named "${e.ref}" in the app's catalogue`),e;let n=t.source;return{...e,url:Fe(e.url)?n.url:e.url,method:Fe(e.method)?n.method:e.method,headers:e.headers&&Object.keys(e.headers).length>0?e.headers:n.headers,body:Fe(e.body)?n.body:e.body,itemsPath:Fe(e.itemsPath)?n.itemsPath:e.itemsPath,valuePath:Fe(e.valuePath)?n.valuePath:e.valuePath,labelPath:Fe(e.labelPath)?n.labelPath:e.labelPath,proxy:e.proxy||n.proxy}},Le=(e,t)=>{let n=Pe(e?.ref)?.fields?.[t];return n&&n!==``?n:t},Re,ze=[],Be,Ve=[],He=e=>e.split(`/`).filter(e=>e.startsWith(`:`)&&e.length>1).map(e=>e.substring(1)),Ue=e=>{let t=e=>e.replace(/^\/+/,``).replace(/\/+$/,``),n=t(e===`_no_route`?``:e),r=n===``?[]:n.split(`/`),i;for(let e of Ve){let n=t(e.route??``),a=n===``?[]:n.split(`/`);if(a.length!==r.length)continue;let o={},s=!0;for(let e=0;e<a.length;e++){let t=a[e];if(t.startsWith(`:`)&&t.length>1)o[t.substring(1)]=r[e];else if(t!==r[e]){s=!1;break}}if(!s)continue;let c={entry:e,pathParams:o};(!i||He(n).length<He(t(i.entry.route??``)).length)&&(i=c)}return i},We=(e,t)=>{let n=Ue(e);if(!n)return t;let{entry:r,pathParams:i}=n,a=r.defaultParams??{},o=r.fixedParams??{};return!Object.keys(a).length&&!Object.keys(o).length&&!Object.keys(i).length?t:{...t,fragments:(t.fragments??[]).map(e=>({...e,state:{...a,...e.state??{},...i,...o},data:{...a,...e.data??{},...i,...o}}))}},Ge=e=>{let t=e&&e.startsWith(`/`)?e.substring(1):e??``;return t===``?`_no_route`:t};function Ke(e,t=fetch){return Be=(async()=>{try{let n=await t(e);if(!n.ok)return;let r=await n.json(),i=new Map,a=[];for(let e of r.entries??[])if(!(!e.ok||!e.json))try{let t=JSON.parse(e.json);e.routePattern?a.push({regex:new RegExp(e.routePattern),paramNames:e.paramNames??[],increment:t}):i.set(e.syncPath,t)}catch(t){console.warn(`mateu: bundle entry parse failed for`,e.syncPath,t)}Re=i,ze=a,Ve=r.routes?.routes??[],Ne(r.sources?.sources)}catch(e){console.warn(`mateu: bundle manifest load failed`,e)}})(),Be}var qe=()=>Be??Promise.resolve(),Je=()=>Re!==void 0&&Re.size>0||ze.length>0,Ye=e=>{let t=Re?.get(e);return t===void 0?void 0:We(e,t)},Xe=e=>{for(let t of ze){let n=t.regex.exec(e);if(!n)continue;let r={};return t.paramNames.forEach((e,t)=>{r[e]=n[t+1]}),We(e,{...t.increment,fragments:(t.increment.fragments??[]).map(e=>({...e,state:{...e.state??{},...r},data:{...e.data??{},...r}}))})}},Ze={offline:()=>`No connection. Your changes have not been sent — check your network and try again.`,timeout:()=>`The server is taking too long to answer. Your changes may not have been saved.`,server:e=>`The server could not complete the request${e?` (error ${e})`:``}. Please try again.`,unauthorized:()=>`Your session is no longer valid. Please sign in again.`,notFound:()=>`This is no longer available. It may have been moved or deleted.`,client:e=>`The request was rejected${e?` (error ${e})`:``}.`,cancelled:()=>``,unknown:()=>`Something went wrong. Please try again.`},Qe=new Set([`offline`,`timeout`,`server`]),$e=(e,t={})=>{let n=e??{},r=n.response?.status,i=n.code,a=t.online??(typeof navigator<`u`&&typeof navigator.onLine==`boolean`?navigator.onLine:!0),o=e=>({kind:e,message:Ze[e](r),retryable:Qe.has(e),status:r});return i===`ERR_CANCELED`?o(`cancelled`):i===`ECONNABORTED`||i===`ETIMEDOUT`||/timeout/i.test(n.message??``)?o(`timeout`):r===void 0?!a||i===`ERR_NETWORK`||/network error/i.test(n.message??``)?o(`offline`):o(`unknown`):o(r===401||r===403?`unauthorized`:r===404||r===410?`notFound`:r===408||r===429?`timeout`:r>=500?`server`:r>=400?`client`:`unknown`)},et=new Set([``,`__load__`,`search`,`_globalsearch`,`_notifications-list`]),tt=[`_appcontext-search-`,`search-`],nt=(e,t)=>t===!0?!0:e==null?!1:et.has(e)?!0:tt.some(t=>e.startsWith(t)),rt=(e,t=Math.random)=>{let n=300*3**Math.max(0,e-1);return Math.round(n*(.75+t()*.5))},it=(e,t,n)=>!n.idempotent||t>2||!e.retryable?!1:e.kind===`timeout`||e.kind===`server`,at=new class{constructor(){this.linkUp=!0,this.listeners=new Set,this.waiters=new Set,this.started=!1}start(){this.started||typeof window>`u`||(this.started=!0,this.linkUp=typeof navigator<`u`&&typeof navigator.onLine==`boolean`?navigator.onLine:!0,window.addEventListener(`online`,()=>{this.linkUp=!0,this.reachable=void 0,this.changed(),this.releaseWaiters()}),window.addEventListener(`offline`,()=>{this.linkUp=!1,this.changed()}))}isOnline(){return this.linkUp?this.reachable!==!1:!1}noteReachable(){let e=this.isOnline();this.reachable=!0,e||(this.changed(),this.releaseWaiters())}noteUnreachable(){let e=this.isOnline();this.reachable=!1,e&&this.changed()}subscribe(e){return this.listeners.add(e),()=>this.listeners.delete(e)}whenBack(e){return this.isOnline()?(e(),()=>{}):(this.waiters.add(e),()=>this.waiters.delete(e))}reset(){this.linkUp=!0,this.reachable=void 0,this.waiters.clear()}changed(){let e=this.isOnline();this.listeners.forEach(t=>t(e))}releaseWaiters(){let e=Array.from(this.waiters);this.waiters.clear(),e.forEach(e=>e())}};at.start();var ot=[],st=6e4,ct=e=>new Promise(t=>setTimeout(t,e)),lt=new class{constructor(){this.axiosInstance=ae.create({timeout:st}),this.axiosInstance.interceptors.request.use(e=>(this.addAuthToken(e),this.addSessionId(e),e)),this.axiosInstance.interceptors.response.use(e=>{let t=Ae({requestedUrl:this.axiosInstance.getUri(e.config),finalUrl:e.request?.responseURL,contentType:String(e.headers?.[`content-type`]??``),data:e.data});if(t)throw window.location.assign(t),Object.assign(Error(`session lost — redirecting to `+t),{code:`ERR_CANCELED`});return e},e=>{let t=e;if(t?.response?.status===401&&t.config&&!t.config.__mateuRetried){let n=t.config;return n.__mateuRetried=!0,Oe(e,()=>this.axiosInstance.request(n))}throw e})}addSessionId(e){let t=sessionStorage.getItem(`__mateu_sesion_id`);t||(t=E(),sessionStorage.setItem(`__mateu_sesion_id`,t)),e.headers[`X-Session-Id`]=t}addAuthToken(e){let t=localStorage.getItem(`__mateu_auth_token`);t&&(e.headers.Authorization=`Bearer `+t)}async wrap(e,t,n,r,i){return n||t.dispatchEvent(new CustomEvent(`backend-called-event`,{bubbles:!0,composed:!0,detail:{}})),e().then(e=>(t.dispatchEvent(new CustomEvent(`backend-succeeded-event`,{bubbles:!0,composed:!0,detail:{actionId:r}})),e)).catch(e=>{let n=$e(e,{online:at.isOnline()});throw n.kind==`cancelled`?t.dispatchEvent(new CustomEvent(`backend-cancelled-event`,{bubbles:!0,composed:!0,detail:{actionId:r}})):(e&&typeof e==`object`&&(e.__mateuReported=!0),t.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:r,reason:this.serialize(e),failure:n,retry:i}}))),e})}async sendWithRetry(e,t){let n=0;for(;;)try{let t=await e();return at.noteReachable(),t}catch(e){let r=$e(e,{online:at.isOnline()});if(r.kind==`offline`&&at.noteUnreachable(),n++,!it(r,n,{idempotent:t}))throw e;await ct(rt(n))}}serialize(e){return e?.message?e:JSON.stringify(e)}release(e){ot=ot.filter(t=>t!==e)}async get(e){let t=new AbortController;return ot=[...ot,t],this.axiosInstance.get(e,{signal:t.signal}).finally(()=>this.release(t))}async post(e,t,n){let r=new AbortController;return ot=[...ot,r],this.axiosInstance.post(e,t,{signal:r.signal,...n&&n>0?{timeout:n}:{}}).finally(()=>this.release(r))}async abortAll(){ot.forEach(e=>e.abort()),ot=[]}async runAction(e,t,n,r,i,a,o,s,c,l,u,d={}){if(t&&t.startsWith(`/`)&&(t=t.substring(1)),r===``&&(await qe(),Je())){let e=Ye(Ge(t))??Xe(Ge(t));if(e){let t={...e,fragments:(e.fragments??[]).map(e=>e.targetComponentId?e:{...e,targetComponentId:i})};return await this.wrap(()=>Promise.resolve(t),l,u,r,d.retry)}}let f=[e,t,n,o??``,r,i].join(``),p=je.check(f);if(p.blocked)return await this.abortAll(),p.firstTrip&&console.error(`[mateu] request loop detected — aborting repeated request`,f),{messages:p.firstTrip?[{title:``,text:`A repeating request was detected and stopped to protect the server. Reload the page or navigate elsewhere.`,position:`bottom-end`,variant:`error`,duration:6e3}]:[],commands:[],fragments:[],banners:[],appendBanners:!1,appData:void 0,appState:void 0};a={...Se(),...a};let ee=e+`/mateu/v3/sync/`+(t&&t!=``?t:`_no_route`),m={serverSideType:o,appState:a,componentState:s,parameters:c,initiatorComponentId:i,consumedRoute:n,route:t&&t!=``?`/`+t:``,actionId:r,knownStructureHash:d.knownStructureHash},te=nt(r,d.idempotent),ne=()=>this.post(ee,m,d.timeoutMillis).then(e=>e.data);return await this.wrap(()=>this.sendWithRetry(ne,te),l,u,r,d.retry)}},ut=function(e){return e.Add=`Add`,e.Replace=`Replace`,e.ReplaceKeepData=`ReplaceKeepData`,e}({}),dt=function(e){return e.HAMBURGUER_MENU=`HAMBURGUER_MENU`,e.MENU_ON_LEFT=`MENU_ON_LEFT`,e.MENU_ON_TOP=`MENU_ON_TOP`,e.TABS=`TABS`,e.TILES=`TILES`,e.RAIL=`RAIL`,e.AUTO=`AUTO`,e.MEDIATOR=`MEDIATOR`,e}({}),ft=new Map,pt=[`position:absolute`,`width:1px`,`height:1px`,`margin:-1px`,`padding:0`,`overflow:hidden`,`clip:rect(0 0 0 0)`,`clip-path:inset(50%)`,`white-space:nowrap`,`border:0`].join(`;`),mt=e=>{if(typeof document>`u`||!document.body)return;let t=ft.get(e);return t?.isConnected?t:(t=document.createElement(`div`),t.setAttribute(`aria-live`,e),t.setAttribute(`aria-atomic`,`true`),t.setAttribute(`role`,e===`assertive`?`alert`:`status`),t.setAttribute(`data-mateu-live-region`,e),t.style.cssText=pt,document.body.appendChild(t),ft.set(e,t),t)},ht=()=>{if(!(typeof document>`u`)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>ht(),{once:!0});return}mt(`polite`),mt(`assertive`)}},gt=(e,t={})=>{let n=(e??``).trim();if(!n)return;let r=mt(t.politeness??`polite`);if(r){if(r.textContent===n){r.textContent=``,setTimeout(()=>{r.textContent=n},60);return}r.textContent=n}},_t=class extends b{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.callbackToken=``,this.createElement=e=>{let t=e.data,n=document.createElement(t.name);for(let e in t.attributes)n.setAttribute(e,t.attributes[e]);for(let e in t.on)n.addEventListener(e,n=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.on[e],parameters:{event:n}},bubbles:!0,composed:!0}))});return n},this.closeModal=()=>{let e=(this.shadowRoot??this).querySelectorAll(`mateu-dialog, mateu-drawer`);if(e&&e.length>0){e[e.length-1].close();return}this.dispatchEvent(new CustomEvent(`close-modal-requested`,{bubbles:!0,composed:!0}))},this.changeFavicon=e=>{let t=document.querySelector(`link[rel="icon"]`);t===null?(t=document.createElement(`link`),t.setAttribute(`rel`,`icon`),t.setAttribute(`href`,e),document.head.appendChild(t)):t.setAttribute(`href`,e)}}connectedCallback(){super.connectedCallback(),this.upstreamSubscription=le.subscribe(e=>{if(e.command){let t=e.command;this.id==t.targetComponentId&&this.applyCommand(t)}if((!e.callbackToken||!this.callbackToken||e.callbackToken===this.callbackToken)&&e.fragment){let t=e.fragment;this.id==t.targetComponentId&&(this.applyFragment(t),this.completeMenu(t))}})}completeMenu(e){if(e.component&&e.component.type==A.ClientSide){let t=e.component,n=t.metadata;if(n?.type==j.App){let e=n,r=this.getRemoteMenus(e.menu);if(r.length>0){let n=r.map(e=>lt.runAction(e.baseUrl,e.route,`_empty`,``,e.baseUrl+`#`+e.route,void 0,void 0,void 0,e.params,this,!0));Promise.all(n).then(n=>{e.menu=this.updateMenu(e.menu,n.map(e=>e.fragments).filter(e=>e).map(e=>e).flat()),e.variant=dt.MENU_ON_TOP,le.next({fragment:{component:t,data:void 0,state:void 0,action:ut.Replace,targetComponentId:this.id,containerId:void 0},callbackToken:this.callbackToken})})}}}}updateMenu(e,t){let n=[];return e.forEach(e=>{if(e.remote){let r=t.find(t=>t.targetComponentId==e.baseUrl+`#`+e.route);if(r&&r.component?.type==A.ClientSide){let t=r.component;if(t.metadata?.type==j.App){let r=t.metadata,i=e.serverSideType&&e.serverSideType!=``?e.serverSideType:r.serverSideType;this.changeBaseUrl(r.menu,e.baseUrl,i,e.route,r.route),n.push(...r.menu)}}}else n.push(e)}),n}changeBaseUrl(e,t,n,r,i){e.forEach(e=>{e.baseUrl||(e.submenus&&e.submenus.length>0?this.changeBaseUrl(e.submenus,t,n,r,i):(e.consumedRoute=i??``,e.baseUrl=t,e.serverSideType=n,e.uriPrefix=r))})}getRemoteMenus(e){let t=[];return e.forEach(e=>{e.remote&&t.push(e)}),t}disconnectedCallback(){super.disconnectedCallback(),this.upstreamSubscription?.unsubscribe()}applyCommand(e){if(e.type==`SetWindowTitle`&&(document.title=e.data,gt(document.title)),e.type==`SetFavicon`&&this.changeFavicon(e.data),e.type==`DispatchEvent`&&this.dispatchNamedEvent(e.data),e.type==`NavigateTo`){let t=e.data;t&&(t.startsWith(`http:`)||t.startsWith(`https:`)?window.open(e.data,`_blank`):window.location.href=e.data)}if(e.type==`PushStateToHistory`){let t=e.data;t!==void 0&&this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0}))}if(e.type==`RunAction`){let t=e.data;if(t&&t.actionId)if(t.targetComponentId){let e={command:{type:`RunAction`,data:{actionId:t.actionId},targetComponentId:t.targetComponentId},fragment:void 0,ui:void 0,error:void 0,callbackToken:``};setTimeout(()=>le.next(e))}else this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:{}},bubbles:!0,composed:!0}))}if(e.type==`MarkAsDirty`&&this.dispatchEvent(new CustomEvent(`dirty`,{detail:{},bubbles:!0,composed:!0})),e.type==`MarkAsClean`&&this.dispatchEvent(new CustomEvent(`clean`,{detail:{},bubbles:!0,composed:!0})),e.type==`DownloadFile`){let t=e.data;if(t&&t.base64Content){let e=atob(t.base64Content),n=new Uint8Array(e.length);for(let t=0;t<e.length;t++)n[t]=e.charCodeAt(t);let r=new Blob([n],{type:t.mimeType}),i=URL.createObjectURL(r),a=document.createElement(`a`);a.href=i,a.download=t.filename??`export`,a.click(),URL.revokeObjectURL(i)}}if(e.type==`CloseModal`&&(this.closeModal(),this.dispatchNamedEvent(e.data)),e.type==`AddContentToHead`){let t=e.data;if(t&&t.name){if(t.attributes&&t.attributes.id&&document.getElementById(t.attributes.id))return;document.head.appendChild(this.createElement(e))}}if(e.type==`AddContentToBody`){let t=e.data;if(t&&t.name){if(t.attributes&&t.attributes.id&&document.getElementById(t.attributes.id))return;document.body.appendChild(this.createElement(e))}}}dispatchNamedEvent(e){if(e&&e.eventName){let t=this.component,n=t?.emitsName??t?.serverSideType,r=e.payload??e.detail;n&&r&&typeof r==`object`&&(r={...r,__source:n}),this.dispatchEvent(new CustomEvent(e.eventName,{detail:r,bubbles:!0,composed:!0}))}}};k([y()],_t.prototype,`id`,void 0),k([y()],_t.prototype,`baseUrl`,void 0);var vt=class extends _t{applyFragment(e){}manageActionRequestedEvent(e){}};k([y()],vt.prototype,`component`,void 0);var yt=(e,t)=>Function(...Object.keys(t),"return `"+e+"`")(...Object.values(t)),bt=(e,t,n)=>({state:e??{},data:t??{},...n});function M(e,t,n,r){if(!e?.includes("${"))return e;try{return yt(e,bt(t,n,r))}catch(t){return console.warn(`Mateu: could not interpolate "${e}":`,t),e}}var N=(e,t,n)=>{if(e&&e.indexOf("${")>=0)try{return yt(e,bt(t,n))}catch(e){return e.message}return e},xt=(e,t,n,r,i)=>{if(!e)return e;let a=bt(t,n,{appState:r??{},appData:i??{}}),o=e;try{if(o=yt(e,a),o.includes("${"))try{o=yt(o,a)}catch(a){o=`when evaluating nested `+e+` :`+a+`, where data is `+n+` and state is `+t+` and app state is `+r+` and app data is `+i,console.error(a,o,t,n,r,i)}}catch(a){o=`when evaluating `+e+` :`+a+`, where data is `+n+` and state is `+t+` and app state is `+r+` and app data is `+i,console.error(a,o,t,n,r,i)}return o},St=(e,t,n,r,i,a)=>{let o=bt(t,n,{appState:r??{},appData:i??{},...a}),s=yt(e,o);return Function(...Object.keys(o),`return (${s})`)(...Object.values(o))},Ct=(e,t,n,r)=>{let i=bt(t,n,r);return Function(...Object.keys(i),`return (${e})`)(...Object.values(i))},wt=(e,t,n,r)=>yt(e,bt(t,n,r)),Tt=`display:inline-flex; align-items:center; justify-content:center; width:2rem; height:2rem; border-radius:50%; background:var(--lumo-contrast-10pct,#e0e0e0); color:var(--lumo-secondary-text-color,#555); font-size:.8rem; font-weight:600; overflow:hidden; flex:none;`,Et=(e,t)=>t||(typeof e==`string`&&e?e.trim().split(/\s+/).map(e=>e[0]).slice(0,2).join(``).toUpperCase():``),Dt=(e,t,n)=>{let r=e.metadata,i=P(r.name,t,n);return T`<span style="${Tt}${e.style}" class="${e.cssClasses}"
+    `}};k([y()],he.prototype,`position`,void 0),k([y()],he.prototype,`zoom`,void 0),k([x(`#map`)],he.prototype,`mapElement`,void 0),he=k([g(`mateu-map`)],he);var ge=typeof HTMLElement<`u`?HTMLElement:class{},_e=class extends ge{static get observedAttributes(){return[`content`]}#e;#t=0;get content(){return this.#e}set content(e){this.#e=e,this.#n()}attributeChangedCallback(e,t,n){this.content=n??void 0}connectedCallback(){this.style.display=`block`,this.#n()}async#n(){if(!this.isConnected)return;let e=this.#e??``,t=++this.#t,[{marked:n},{default:r}]=await Promise.all([D(()=>import(`./vendor.js`).then(e=>e.n),__vite__mapDeps([2,1])),D(()=>import(`./vendor.js`).then(e=>e.a),__vite__mapDeps([2,1]))]);t===this.#t&&(this.innerHTML=r.sanitize(await n.parse(e),{USE_PROFILES:{html:!0,svg:!0,svgFilters:!0},CUSTOM_ELEMENT_HANDLING:{tagNameCheck:e=>!0}}))}};typeof customElements<`u`&&!customElements.get(`mateu-markdown`)&&customElements.define(`mateu-markdown`,_e);var A=function(e){return e.ServerSide=`ServerSide`,e.ClientSide=`ClientSide`,e}({}),j=function(e){return e.Page=`Page`,e.Div=`Div`,e.Element=`Element`,e.MicroFrontend=`MicroFrontend`,e.Form=`Form`,e.Crud=`Crud`,e.Result=`Result`,e.Card=`Card`,e.Directory=`Directory`,e.Stepper=`Stepper`,e.HorizontalLayout=`HorizontalLayout`,e.VerticalLayout=`VerticalLayout`,e.SplitLayout=`SplitLayout`,e.MasterDetailLayout=`MasterDetailLayout`,e.TabLayout=`TabLayout`,e.AccordionLayout=`AccordionLayout`,e.FormLayout=`FormLayout`,e.FormRow=`FormRow`,e.FormItem=`FormItem`,e.BoardLayout=`BoardLayout`,e.BoardLayoutRow=`BoardLayoutRow`,e.BoardLayoutItem=`BoardLayoutItem`,e.Scroller=`Scroller`,e.FullWidth=`FullWidth`,e.Container=`Container`,e.FormField=`FormField`,e.Table=`Table`,e.App=`App`,e.Text=`Text`,e.Avatar=`Avatar`,e.Chat=`Chat`,e.AvatarGroup=`AvatarGroup`,e.Badge=`Badge`,e.Breadcrumbs=`Breadcrumbs`,e.Anchor=`Anchor`,e.Button=`Button`,e.Chart=`Chart`,e.Icon=`Icon`,e.ConfirmDialog=`ConfirmDialog`,e.ContextMenu=`ContextMenu`,e.CookieConsent=`CookieConsent`,e.Details=`Details`,e.Dialog=`Dialog`,e.Drawer=`Drawer`,e.Image=`Image`,e.Map=`Map`,e.Markdown=`Markdown`,e.Notification=`Notification`,e.ProgressBar=`ProgressBar`,e.Popover=`Popover`,e.CarouselLayout=`CarouselLayout`,e.Tooltip=`Tooltip`,e.MessageInput=`MessageInput`,e.MessageList=`MessageList`,e.CustomField=`CustomField`,e.MenuBar=`MenuBar`,e.Grid=`Grid`,e.GridColumn=`GridColumn`,e.GridGroupColumn=`GridGroupColumn`,e.VirtualList=`VirtualList`,e.FormSection=`FormSection`,e.FormSubSection=`FormSubSection`,e.Bpmn=`Bpmn`,e.Workflow=`Workflow`,e.FormEditor=`FormEditor`,e.MetricCard=`MetricCard`,e.Scoreboard=`Scoreboard`,e.DashboardPanel=`DashboardPanel`,e.DashboardLayout=`DashboardLayout`,e.FoldoutLayout=`FoldoutLayout`,e.ContentLayout=`ContentLayout`,e.HeroSection=`HeroSection`,e.EmptyState=`EmptyState`,e.Skeleton=`Skeleton`,e.Gantt=`Gantt`,e.PlanningBoard=`PlanningBoard`,e.Kanban=`Kanban`,e.Timeline=`Timeline`,e.ProgressSteps=`ProgressSteps`,e.Stat=`Stat`,e.Calendar=`Calendar`,e.PricingTable=`PricingTable`,e.OrgChart=`OrgChart`,e.Heatmap=`Heatmap`,e.Funnel=`Funnel`,e.TrendChart=`TrendChart`,e.FeatureGrid=`FeatureGrid`,e.Testimonials=`Testimonials`,e.Faq=`Faq`,e.CalloutCard=`CalloutCard`,e.CommentThread=`CommentThread`,e.FileList=`FileList`,e.Checklist=`Checklist`,e.ComparisonCard=`ComparisonCard`,e.EntityHeader=`EntityHeader`,e.Meter=`Meter`,e.TaskProgress=`TaskProgress`,e.StatusList=`StatusList`,e.BulletedList=`BulletedList`,e.Separator=`Separator`,e.Notice=`Notice`,e.TaskQueue=`TaskQueue`,e.ResourceGrid=`ResourceGrid`,e.OfferCard=`OfferCard`,e.AddOnPicker=`AddOnPicker`,e.Ledger=`Ledger`,e.PaymentPicker=`PaymentPicker`,e.ProcessMonitor=`ProcessMonitor`,e}({}),ve=`mateu-app-context`,ye=`mateu-app-context-labels`,be=e=>{try{return JSON.parse(localStorage.getItem(e)??`{}`)}catch{return{}}},xe=(e,t)=>{try{localStorage.setItem(e,JSON.stringify(t))}catch{}},Se=()=>be(ve),Ce=()=>be(ye),we=(e,t,n)=>{let r=Se(),i=Ce();t==null||t===``?(delete r[e],delete i[e]):(r[e]=t,n!==void 0&&(i[e]=n)),xe(ve,r),xe(ye,i)},Te=!1,Ee=()=>{Te||(Te=!0,window.addEventListener(`storage`,e=>{e.key===ve&&e.newValue!==e.oldValue&&window.location.reload()}))},De,Oe=(e,t)=>new Promise((n,r)=>{let i=!1,a={retry:()=>{i||(i=!0,t().then(n,r))},giveUp:()=>{i||(i=!0,r(e))}};if(De){De(a);return}let o=new CustomEvent(`mateu-session-expired`,{detail:a,cancelable:!0,bubbles:!1});typeof document<`u`&&!document.dispatchEvent(o)||a.giveUp()}),ke=(e,t)=>e.includes(`json`)?!0:typeof t==`object`&&!!t,Ae=(e,t)=>{let n=e.finalUrl;if(!n)return;let r=t??(typeof window<`u`?window.location.href:void 0),i;try{i=new URL(e.requestedUrl,r).href}catch{return}if(i!==n&&!ke(e.contentType??``,e.data))return n},je=new class{constructor(){this.windowMs=4e3,this.threshold=12,this.events=[],this.reported=new Set}check(e,t=Date.now()){this.events.push({sig:e,t});let n=t-this.windowMs;this.events=this.events.filter(e=>e.t>=n);let r=0;for(let t of this.events)t.sig===e&&r++;if(r>=this.threshold){let t=!this.reported.has(e);return this.reported.add(e),{blocked:!0,firstTrip:t}}return this.reported.delete(e),{blocked:!1,firstTrip:!1}}reset(){this.events=[],this.reported.clear()}configure(e){e.windowMs!==void 0&&(this.windowMs=e.windowMs),e.threshold!==void 0&&(this.threshold=e.threshold)}},Me=[],Ne=e=>{Me=Array.isArray(e)?e:[]},Pe=e=>e?Me.find(t=>t.name===e):void 0,Fe=e=>e==null||e===``,Ie=e=>{if(!e?.ref)return e;let t=Pe(e.ref);if(!t?.source)return console.warn(`mateu: no REST source named "${e.ref}" in the app's catalogue`),e;let n=t.source;return{...e,url:Fe(e.url)?n.url:e.url,method:Fe(e.method)?n.method:e.method,headers:e.headers&&Object.keys(e.headers).length>0?e.headers:n.headers,body:Fe(e.body)?n.body:e.body,itemsPath:Fe(e.itemsPath)?n.itemsPath:e.itemsPath,valuePath:Fe(e.valuePath)?n.valuePath:e.valuePath,labelPath:Fe(e.labelPath)?n.labelPath:e.labelPath,proxy:e.proxy||n.proxy}},Le=(e,t)=>{let n=Pe(e?.ref)?.fields?.[t];return n&&n!==``?n:t},Re,ze=[],Be,Ve=[],He=e=>e.split(`/`).filter(e=>e.startsWith(`:`)&&e.length>1).map(e=>e.substring(1)),Ue=e=>{let t=e=>e.replace(/^\/+/,``).replace(/\/+$/,``),n=t(e===`_no_route`?``:e),r=n===``?[]:n.split(`/`),i;for(let e of Ve){let n=t(e.route??``),a=n===``?[]:n.split(`/`);if(a.length!==r.length)continue;let o={},s=!0;for(let e=0;e<a.length;e++){let t=a[e];if(t.startsWith(`:`)&&t.length>1)o[t.substring(1)]=r[e];else if(t!==r[e]){s=!1;break}}if(!s)continue;let c={entry:e,pathParams:o};(!i||He(n).length<He(t(i.entry.route??``)).length)&&(i=c)}return i},We=(e,t)=>{let n=Ue(e);if(!n)return t;let{entry:r,pathParams:i}=n,a=r.defaultParams??{},o=r.fixedParams??{};return!Object.keys(a).length&&!Object.keys(o).length&&!Object.keys(i).length?t:{...t,fragments:(t.fragments??[]).map(e=>({...e,state:{...a,...e.state??{},...i,...o},data:{...a,...e.data??{},...i,...o}}))}},Ge=e=>{let t=e&&e.startsWith(`/`)?e.substring(1):e??``;return t===``?`_no_route`:t};function Ke(e,t=fetch){return Be=(async()=>{try{let n=await t(e);if(!n.ok)return;let r=await n.json(),i=new Map,a=[];for(let e of r.entries??[])if(!(!e.ok||!e.json))try{let t=JSON.parse(e.json);e.routePattern?a.push({regex:new RegExp(e.routePattern),paramNames:e.paramNames??[],increment:t}):i.set(e.syncPath,t)}catch(t){console.warn(`mateu: bundle entry parse failed for`,e.syncPath,t)}Re=i,ze=a,Ve=r.routes?.routes??[],Ne(r.sources?.sources)}catch(e){console.warn(`mateu: bundle manifest load failed`,e)}})(),Be}var qe=()=>Be??Promise.resolve(),Je=()=>Re!==void 0&&Re.size>0||ze.length>0,Ye=e=>{let t=Re?.get(e);return t===void 0?void 0:We(e,t)},Xe=e=>{for(let t of ze){let n=t.regex.exec(e);if(!n)continue;let r={};return t.paramNames.forEach((e,t)=>{r[e]=n[t+1]}),We(e,{...t.increment,fragments:(t.increment.fragments??[]).map(e=>({...e,state:{...e.state??{},...r},data:{...e.data??{},...r}}))})}},Ze={offline:()=>`No connection. Your changes have not been sent — check your network and try again.`,timeout:()=>`The server is taking too long to answer. Your changes may not have been saved.`,server:e=>`The server could not complete the request${e?` (error ${e})`:``}. Please try again.`,unauthorized:()=>`Your session is no longer valid. Please sign in again.`,notFound:()=>`This is no longer available. It may have been moved or deleted.`,client:e=>`The request was rejected${e?` (error ${e})`:``}.`,cancelled:()=>``,unknown:()=>`Something went wrong. Please try again.`},Qe=new Set([`offline`,`timeout`,`server`]),$e=(e,t={})=>{let n=e??{},r=n.response?.status,i=n.code,a=t.online??(typeof navigator<`u`&&typeof navigator.onLine==`boolean`?navigator.onLine:!0),o=e=>({kind:e,message:Ze[e](r),retryable:Qe.has(e),status:r});return i===`ERR_CANCELED`?o(`cancelled`):i===`ECONNABORTED`||i===`ETIMEDOUT`||/timeout/i.test(n.message??``)?o(`timeout`):r===void 0?!a||i===`ERR_NETWORK`||/network error/i.test(n.message??``)?o(`offline`):o(`unknown`):o(r===401||r===403?`unauthorized`:r===404||r===410?`notFound`:r===408||r===429?`timeout`:r>=500?`server`:r>=400?`client`:`unknown`)},et=new Set([``,`__load__`,`search`,`_globalsearch`,`_notifications-list`]),tt=[`_appcontext-search-`,`search-`],nt=(e,t)=>t===!0?!0:e==null?!1:et.has(e)?!0:tt.some(t=>e.startsWith(t)),rt=(e,t=Math.random)=>{let n=300*3**Math.max(0,e-1);return Math.round(n*(.75+t()*.5))},it=(e,t,n)=>!n.idempotent||t>2||!e.retryable?!1:e.kind===`timeout`||e.kind===`server`,at=new class{constructor(){this.linkUp=!0,this.listeners=new Set,this.waiters=new Set,this.started=!1}start(){this.started||typeof window>`u`||(this.started=!0,this.linkUp=typeof navigator<`u`&&typeof navigator.onLine==`boolean`?navigator.onLine:!0,window.addEventListener(`online`,()=>{this.linkUp=!0,this.reachable=void 0,this.changed(),this.releaseWaiters()}),window.addEventListener(`offline`,()=>{this.linkUp=!1,this.changed()}))}isOnline(){return this.linkUp?this.reachable!==!1:!1}noteReachable(){let e=this.isOnline();this.reachable=!0,e||(this.changed(),this.releaseWaiters())}noteUnreachable(){let e=this.isOnline();this.reachable=!1,e&&this.changed()}subscribe(e){return this.listeners.add(e),()=>this.listeners.delete(e)}whenBack(e){return this.isOnline()?(e(),()=>{}):(this.waiters.add(e),()=>this.waiters.delete(e))}reset(){this.linkUp=!0,this.reachable=void 0,this.waiters.clear()}changed(){let e=this.isOnline();this.listeners.forEach(t=>t(e))}releaseWaiters(){let e=Array.from(this.waiters);this.waiters.clear(),e.forEach(e=>e())}};at.start();var ot=[],st=6e4,ct=e=>new Promise(t=>setTimeout(t,e)),lt=new class{constructor(){this.axiosInstance=ae.create({timeout:st}),this.axiosInstance.interceptors.request.use(e=>(this.addAuthToken(e),this.addSessionId(e),e)),this.axiosInstance.interceptors.response.use(e=>{let t=Ae({requestedUrl:this.axiosInstance.getUri(e.config),finalUrl:e.request?.responseURL,contentType:String(e.headers?.[`content-type`]??``),data:e.data});if(t)throw window.location.assign(t),Object.assign(Error(`session lost — redirecting to `+t),{code:`ERR_CANCELED`});return e},e=>{let t=e;if(t?.response?.status===401&&t.config&&!t.config.__mateuRetried){let n=t.config;return n.__mateuRetried=!0,Oe(e,()=>this.axiosInstance.request(n))}throw e})}addSessionId(e){let t=sessionStorage.getItem(`__mateu_sesion_id`);t||(t=E(),sessionStorage.setItem(`__mateu_sesion_id`,t)),e.headers[`X-Session-Id`]=t}addAuthToken(e){let t=localStorage.getItem(`__mateu_auth_token`);t&&(e.headers.Authorization=`Bearer `+t)}async wrap(e,t,n,r,i){return n||t.dispatchEvent(new CustomEvent(`backend-called-event`,{bubbles:!0,composed:!0,detail:{}})),e().then(e=>(t.dispatchEvent(new CustomEvent(`backend-succeeded-event`,{bubbles:!0,composed:!0,detail:{actionId:r}})),e)).catch(e=>{let n=$e(e,{online:at.isOnline()});throw n.kind==`cancelled`?t.dispatchEvent(new CustomEvent(`backend-cancelled-event`,{bubbles:!0,composed:!0,detail:{actionId:r}})):(e&&typeof e==`object`&&(e.__mateuReported=!0),t.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:r,reason:this.serialize(e),failure:n,retry:i}}))),e})}async sendWithRetry(e,t){let n=0;for(;;)try{let t=await e();return at.noteReachable(),t}catch(e){let r=$e(e,{online:at.isOnline()});if(r.kind==`offline`&&at.noteUnreachable(),n++,!it(r,n,{idempotent:t}))throw e;await ct(rt(n))}}serialize(e){return e?.message?e:JSON.stringify(e)}release(e){ot=ot.filter(t=>t!==e)}async get(e){let t=new AbortController;return ot=[...ot,t],this.axiosInstance.get(e,{signal:t.signal}).finally(()=>this.release(t))}async post(e,t,n){let r=new AbortController;return ot=[...ot,r],this.axiosInstance.post(e,t,{signal:r.signal,...n&&n>0?{timeout:n}:{}}).finally(()=>this.release(r))}async abortAll(){ot.forEach(e=>e.abort()),ot=[]}async runAction(e,t,n,r,i,a,o,s,c,l,u,d={}){if(t&&t.startsWith(`/`)&&(t=t.substring(1)),r===``&&(await qe(),Je())){let e=Ye(Ge(t))??Xe(Ge(t));if(e){let t={...e,fragments:(e.fragments??[]).map(e=>e.targetComponentId?e:{...e,targetComponentId:i})};return await this.wrap(()=>Promise.resolve(t),l,u,r,d.retry)}}let f=[e,t,n,o??``,r,i].join(``),p=je.check(f);if(p.blocked)return await this.abortAll(),p.firstTrip&&console.error(`[mateu] request loop detected — aborting repeated request`,f),{messages:p.firstTrip?[{title:``,text:`A repeating request was detected and stopped to protect the server. Reload the page or navigate elsewhere.`,position:`bottom-end`,variant:`error`,duration:6e3}]:[],commands:[],fragments:[],banners:[],appendBanners:!1,appData:void 0,appState:void 0};a={...Se(),...a};let ee=e+`/mateu/v3/sync/`+(t&&t!=``?t:`_no_route`),m={serverSideType:o,appState:a,componentState:s,parameters:c,initiatorComponentId:i,consumedRoute:n,route:t&&t!=``?`/`+t:``,actionId:r,knownStructureHash:d.knownStructureHash},te=nt(r,d.idempotent),ne=()=>this.post(ee,m,d.timeoutMillis).then(e=>e.data);return await this.wrap(()=>this.sendWithRetry(ne,te),l,u,r,d.retry)}},ut=function(e){return e.Add=`Add`,e.Replace=`Replace`,e.ReplaceKeepData=`ReplaceKeepData`,e}({}),dt=function(e){return e.HAMBURGUER_MENU=`HAMBURGUER_MENU`,e.MENU_ON_LEFT=`MENU_ON_LEFT`,e.MENU_ON_TOP=`MENU_ON_TOP`,e.TABS=`TABS`,e.TILES=`TILES`,e.RAIL=`RAIL`,e.AUTO=`AUTO`,e.MEDIATOR=`MEDIATOR`,e}({}),ft=new Map,pt=[`position:absolute`,`width:1px`,`height:1px`,`margin:-1px`,`padding:0`,`overflow:hidden`,`clip:rect(0 0 0 0)`,`clip-path:inset(50%)`,`white-space:nowrap`,`border:0`].join(`;`),mt=e=>{if(typeof document>`u`||!document.body)return;let t=ft.get(e);return t?.isConnected?t:(t=document.createElement(`div`),t.setAttribute(`aria-live`,e),t.setAttribute(`aria-atomic`,`true`),t.setAttribute(`role`,e===`assertive`?`alert`:`status`),t.setAttribute(`data-mateu-live-region`,e),t.style.cssText=pt,document.body.appendChild(t),ft.set(e,t),t)},ht=()=>{if(!(typeof document>`u`)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>ht(),{once:!0});return}mt(`polite`),mt(`assertive`)}},gt=(e,t={})=>{let n=(e??``).trim();if(!n)return;let r=mt(t.politeness??`polite`);if(r){if(r.textContent===n){r.textContent=``,setTimeout(()=>{r.textContent=n},60);return}r.textContent=n}},_t=class extends b{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.callbackToken=``,this.createElement=e=>{let t=e.data,n=document.createElement(t.name);for(let e in t.attributes)n.setAttribute(e,t.attributes[e]);for(let e in t.on)n.addEventListener(e,n=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.on[e],parameters:{event:n}},bubbles:!0,composed:!0}))});return n},this.closeModal=()=>{let e=(this.shadowRoot??this).querySelectorAll(`mateu-dialog, mateu-drawer`);if(e&&e.length>0){e[e.length-1].close();return}this.dispatchEvent(new CustomEvent(`close-modal-requested`,{bubbles:!0,composed:!0}))},this.changeFavicon=e=>{let t=document.querySelector(`link[rel="icon"]`);t===null?(t=document.createElement(`link`),t.setAttribute(`rel`,`icon`),t.setAttribute(`href`,e),document.head.appendChild(t)):t.setAttribute(`href`,e)}}connectedCallback(){super.connectedCallback(),this.upstreamSubscription=le.subscribe(e=>{if(e.command){let t=e.command;this.id==t.targetComponentId&&this.applyCommand(t)}if((!e.callbackToken||!this.callbackToken||e.callbackToken===this.callbackToken)&&e.fragment){let t=e.fragment;this.id==t.targetComponentId&&(this.applyFragment(t),this.completeMenu(t))}})}completeMenu(e){if(e.component&&e.component.type==A.ClientSide){let t=e.component,n=t.metadata;if(n?.type==j.App){let e=n,r=this.getRemoteMenus(e.menu);if(r.length>0){let n=r.map(e=>lt.runAction(e.baseUrl,e.route,`_empty`,``,e.baseUrl+`#`+e.route,void 0,void 0,void 0,e.params,this,!0));Promise.all(n).then(n=>{e.menu=this.updateMenu(e.menu,n.map(e=>e.fragments).filter(e=>e).map(e=>e).flat()),e.variant=dt.MENU_ON_TOP,le.next({fragment:{component:t,data:void 0,state:void 0,action:ut.Replace,targetComponentId:this.id,containerId:void 0},callbackToken:this.callbackToken})})}}}}updateMenu(e,t){let n=[];return e.forEach(e=>{if(e.remote){let r=t.find(t=>t.targetComponentId==e.baseUrl+`#`+e.route);if(r&&r.component?.type==A.ClientSide){let t=r.component;if(t.metadata?.type==j.App){let r=t.metadata,i=e.serverSideType&&e.serverSideType!=``?e.serverSideType:r.serverSideType;this.changeBaseUrl(r.menu,e.baseUrl,i,e.route,r.route),n.push(...r.menu)}}}else n.push(e)}),n}changeBaseUrl(e,t,n,r,i){e.forEach(e=>{e.baseUrl||(e.submenus&&e.submenus.length>0?this.changeBaseUrl(e.submenus,t,n,r,i):(e.consumedRoute=i??``,e.baseUrl=t,e.serverSideType=n,e.uriPrefix=r))})}getRemoteMenus(e){let t=[];return e.forEach(e=>{e.remote&&t.push(e)}),t}disconnectedCallback(){super.disconnectedCallback(),this.upstreamSubscription?.unsubscribe()}applyCommand(e){if(e.type==`SetWindowTitle`&&(document.title=e.data,gt(document.title)),e.type==`SetFavicon`&&this.changeFavicon(e.data),e.type==`DispatchEvent`&&this.dispatchNamedEvent(e.data),e.type==`NavigateTo`){let t=e.data;t&&(t.startsWith(`http:`)||t.startsWith(`https:`)?window.open(e.data,`_blank`):window.location.href=e.data)}if(e.type==`PushStateToHistory`){let t=e.data;t!==void 0&&this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0}))}if(e.type==`RunAction`){let t=e.data;if(t&&t.actionId)if(t.targetComponentId){let e={command:{type:`RunAction`,data:{actionId:t.actionId},targetComponentId:t.targetComponentId},fragment:void 0,ui:void 0,error:void 0,callbackToken:``};setTimeout(()=>le.next(e))}else this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:{}},bubbles:!0,composed:!0}))}if(e.type==`MarkAsDirty`&&this.dispatchEvent(new CustomEvent(`dirty`,{detail:{},bubbles:!0,composed:!0})),e.type==`MarkAsClean`&&this.dispatchEvent(new CustomEvent(`clean`,{detail:{},bubbles:!0,composed:!0})),e.type==`DownloadFile`){let t=e.data;if(t&&t.base64Content){let e=atob(t.base64Content),n=new Uint8Array(e.length);for(let t=0;t<e.length;t++)n[t]=e.charCodeAt(t);let r=new Blob([n],{type:t.mimeType}),i=URL.createObjectURL(r),a=document.createElement(`a`);a.href=i,a.download=t.filename??`export`,a.click(),URL.revokeObjectURL(i)}}if(e.type==`CloseModal`&&(this.closeModal(),this.dispatchNamedEvent(e.data)),e.type==`AddContentToHead`){let t=e.data;if(t&&t.name){if(t.attributes&&t.attributes.id&&document.getElementById(t.attributes.id))return;document.head.appendChild(this.createElement(e))}}if(e.type==`AddContentToBody`){let t=e.data;if(t&&t.name){if(t.attributes&&t.attributes.id&&document.getElementById(t.attributes.id))return;document.body.appendChild(this.createElement(e))}}}dispatchNamedEvent(e){if(e&&e.eventName){let t=this.component,n=t?.emitsName??t?.serverSideType,r=e.payload??e.detail;n&&r&&typeof r==`object`&&(r={...r,__source:n}),this.dispatchEvent(new CustomEvent(e.eventName,{detail:r,bubbles:!0,composed:!0}))}}};k([y()],_t.prototype,`id`,void 0),k([y()],_t.prototype,`baseUrl`,void 0);var vt=class extends _t{applyFragment(e){}manageActionRequestedEvent(e){}};k([y()],vt.prototype,`component`,void 0);var yt=(e,t)=>Function(...Object.keys(t),"return `"+e+"`")(...Object.values(t)),bt=(e,t,n)=>({state:e??{},data:t??{},...n});function M(e,t,n,r){if(!e?.includes("${"))return e;try{return yt(e,bt(t,n,r))}catch(t){return console.warn(`Mateu: could not interpolate "${e}":`,t),e}}var N=(e,t,n)=>{if(e&&e.indexOf("${")>=0)try{return yt(e,bt(t,n))}catch(e){return e.message}return e},xt=(e,t,n,r,i)=>{if(!e)return e;let a=bt(t,n,{appState:r??{},appData:i??{}}),o=e;try{if(o=yt(e,a),o.includes("${"))try{o=yt(o,a)}catch(a){o=`when evaluating nested `+e+` :`+a+`, where data is `+n+` and state is `+t+` and app state is `+r+` and app data is `+i,console.error(a,o,t,n,r,i)}}catch(a){o=`when evaluating `+e+` :`+a+`, where data is `+n+` and state is `+t+` and app state is `+r+` and app data is `+i,console.error(a,o,t,n,r,i)}return o},St=(e,t,n,r,i,a)=>{let o=bt(t,n,{appState:r??{},appData:i??{},...a}),s=yt(e,o);return Function(...Object.keys(o),`return (${s})`)(...Object.values(o))},Ct=(e,t,n,r)=>{let i=bt(t,n,r);return Function(...Object.keys(i),`return (${e})`)(...Object.values(i))},wt=(e,t,n,r)=>yt(e,bt(t,n,r)),Tt=`display:inline-flex; align-items:center; justify-content:center; width:2rem; height:2rem; border-radius:50%; background:var(--lumo-contrast-10pct,#e0e0e0); color:var(--lumo-secondary-text-color,#555); font-size:.8rem; font-weight:600; overflow:hidden; flex:none;`,Et=(e,t)=>t||(typeof e==`string`&&e?e.trim().split(/\s+/).map(e=>e[0]).slice(0,2).join(``).toUpperCase():``),Dt=(e,t,n)=>{let r=e.metadata,i=Ot(r.name,t,n);return T`<span style="${Tt}${e.style}" class="${e.cssClasses}"
                       title="${i||v}" slot="${e.slot??v}">
         ${r.image?T`<img src="${r.image}" alt="${i}" style="width:100%;height:100%;object-fit:cover;">`:Et(i,r.abbreviation)}
-    </span>`},P=(e,t,n)=>typeof e==`string`&&e.includes("${")?M(e,t,n):e,Ot=e=>{let t=e.metadata,n=t.avatars??[],r=t.maxItemsVisible&&t.maxItemsVisible>0?t.maxItemsVisible:n.length,i=n.slice(0,r),a=n.length-i.length,o=`margin-left:-0.4rem; border:2px solid var(--lumo-base-color,#fff);`;return T`<span style="display:inline-flex; ${e.style}" class="${e.cssClasses}" slot="${e.slot??v}">
+    </span>`},Ot=(e,t,n)=>typeof e==`string`&&e.includes("${")?M(e,t,n):e,kt=e=>{let t=e.metadata,n=t.avatars??[],r=t.maxItemsVisible&&t.maxItemsVisible>0?t.maxItemsVisible:n.length,i=n.slice(0,r),a=n.length-i.length,o=`margin-left:-0.4rem; border:2px solid var(--lumo-base-color,#fff);`;return T`<span style="display:inline-flex; ${e.style}" class="${e.cssClasses}" slot="${e.slot??v}">
         ${i.map(e=>T`<span style="${Tt}${o}" title="${e.name||v}">
             ${e.img?T`<img src="${e.img}" style="width:100%;height:100%;object-fit:cover;">`:Et(e.name??``,e.abbr)}
         </span>`)}
         ${a>0?T`<span style="${Tt}${o}">+${a}</span>`:v}
-    </span>`},kt=(e,t,n)=>{let r=e.metadata;return T`<span theme="badge ${r.color} ${r.pill?`pill`:``} ${r.small?`small`:``} ${r.primary?`primary`:``}"
+    </span>`},At=(e,t,n)=>{let r=e.metadata;return T`<span theme="badge ${r.color} ${r.pill?`pill`:``} ${r.small?`small`:``} ${r.primary?`primary`:``}"
                       style="${e.style}" class="${e.cssClasses}"
-                      slot="${e.slot??v}">${P(r.text,t,n)}</span>`},At=(e,t,n)=>{let r=P(e.text,t,n);if(!r)return v;let i=P(e.color,t,n);return i==`SUCCESS`&&(i=`success`),i==`ERROR`&&(i=`error`),i==`DANGER`&&(i=`error`),i==`WARNING`&&(i=`warning`),i==`INFO`&&(i=`info`),i==`PRIMARY`&&(i=`primary`),i==`SECONDARY`&&(i=`secondary`),i==`TERTIARY`&&(i=`tertiary`),i==`QUATERNARY`&&(i=`quaternary`),i==`LIGHT`&&(i=`light`),i==`DARK`&&(i=`dark`),T`<span theme="badge ${i} ${e.pill?`pill`:``} ${e.small?`small`:``} ${e.primary?`primary`:``}">${r}</span>`},F=new class{constructor(){this.afterRenderHook=void 0,this.useShadowRoot=!0,this.componentRenderer=void 0}set(e){if(this.componentRenderer=e,typeof window<`u`){let t=e.supportedClientSideTypes?.();window.__mateuRendererInfo={name:e.rendererName?.()??e.constructor?.name??`unknown`,supportedTypes:t?[...t].sort():null}}}get(){return this.componentRenderer}setUseShadowRoot(e){this.useShadowRoot=e}mustUseShadowRoot(){return this.useShadowRoot}setAfterRenderHook(e){this.afterRenderHook=e}getAfterRenderHook(){return this.afterRenderHook}},jt=(e,t,n,r,i,a,o,s,c)=>(t.slot=s,I(e,t,n,r,i,a,o,c)),I=(e,t,n,r,i,a,o,s)=>{if(!t)return T``;if(t.type==A.ClientSide)return F.get().renderClientSideComponent(e,t,n,r,i,a,o,s);let c=e.route,l=e.consumedRoute;return T`
+                      slot="${e.slot??v}">${Ot(r.text,t,n)}</span>`},jt=(e,t,n)=>{let r=Ot(e.text,t,n);if(!r)return v;let i=Ot(e.color,t,n);return i==`SUCCESS`&&(i=`success`),i==`ERROR`&&(i=`error`),i==`DANGER`&&(i=`error`),i==`WARNING`&&(i=`warning`),i==`INFO`&&(i=`info`),i==`PRIMARY`&&(i=`primary`),i==`SECONDARY`&&(i=`secondary`),i==`TERTIARY`&&(i=`tertiary`),i==`QUATERNARY`&&(i=`quaternary`),i==`LIGHT`&&(i=`light`),i==`DARK`&&(i=`dark`),T`<span theme="badge ${i} ${e.pill?`pill`:``} ${e.small?`small`:``} ${e.primary?`primary`:``}">${r}</span>`},P=new class{constructor(){this.afterRenderHook=void 0,this.useShadowRoot=!0,this.componentRenderer=void 0}set(e){if(this.componentRenderer=e,typeof window<`u`){let t=e.supportedClientSideTypes?.();window.__mateuRendererInfo={name:e.rendererName?.()??e.constructor?.name??`unknown`,supportedTypes:t?[...t].sort():null}}}get(){return this.componentRenderer}setUseShadowRoot(e){this.useShadowRoot=e}mustUseShadowRoot(){return this.useShadowRoot}setAfterRenderHook(e){this.afterRenderHook=e}getAfterRenderHook(){return this.afterRenderHook}},Mt=(e,t,n,r,i,a,o,s,c)=>(t.slot=s,F(e,t,n,r,i,a,o,c)),F=(e,t,n,r,i,a,o,s)=>{if(!t)return T``;if(t.type==A.ClientSide)return P.get().renderClientSideComponent(e,t,n,r,i,a,o,s);let c=e.route,l=e.consumedRoute;return T`
         <mateu-component id="${t.id}"
                          .component="${t}"
                         route="${c}"
@@ -163,8 +163,8 @@ ${i}
                          .appState="${a}"
                          .appData="${o}"
         >
-       </mateu-component>`},Mt=e=>{let t=[];return e.color&&e.color!==`normal`&&e.color!==`none`&&t.push(e.color),e.buttonStyle&&t.push(e.buttonStyle===`tertiaryInline`?`tertiary-inline`:e.buttonStyle),e.size&&e.size!==`none`&&e.size!==`normal`&&t.push(e.size),t.length?t.join(` `):void 0},Nt=e=>{let t=Mt(e)??``,n=[];return t.includes(`primary`)&&n.push(`primary`),t.includes(`tertiary`)&&n.push(`tertiary`),(t.includes(`error`)||e.color===`error`)&&n.push(`danger`),n.join(` `)},Pt=e=>e===`back`||e===`backToList`||!!e&&e.startsWith(`cancel`),Ft=class extends b{constructor(...e){super(...e),this.appState={},this.appData={},this._overflowOpen=!1,this._overflowN=0,this._secCount=0,this._onDocClick=e=>{e.composedPath().includes(this)||(this._overflowOpen=!1)},this._resetOverflow=()=>{this._overflowN===0?this.requestUpdate():this._overflowN=0},this.handleButtonClick=e=>{this._overflowOpen=!1,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.evalLabel=e=>M(e,this.state,this.data),this.renderBtn=e=>{if((this.data??{})[e.actionId+`.hidden`])return v;let t=this.evalLabel(e.label);return F.get()?.renderToolbarButton?.(e,t,()=>this.handleButtonClick(e.actionId))||T`
-        <button class="mtb ${Nt(e)}"
+       </mateu-component>`},Nt=e=>{let t=[];return e.color&&e.color!==`normal`&&e.color!==`none`&&t.push(e.color),e.buttonStyle&&t.push(e.buttonStyle===`tertiaryInline`?`tertiary-inline`:e.buttonStyle),e.size&&e.size!==`none`&&e.size!==`normal`&&t.push(e.size),t.length?t.join(` `):void 0},Pt=e=>{let t=Nt(e)??``,n=[];return t.includes(`primary`)&&n.push(`primary`),t.includes(`tertiary`)&&n.push(`tertiary`),(t.includes(`error`)||e.color===`error`)&&n.push(`danger`),n.join(` `)},Ft=e=>e===`back`||e===`backToList`||!!e&&e.startsWith(`cancel`),It=class extends b{constructor(...e){super(...e),this.appState={},this.appData={},this._overflowOpen=!1,this._overflowN=0,this._secCount=0,this._onDocClick=e=>{e.composedPath().includes(this)||(this._overflowOpen=!1)},this._resetOverflow=()=>{this._overflowN===0?this.requestUpdate():this._overflowN=0},this.handleButtonClick=e=>{this._overflowOpen=!1,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.evalLabel=e=>M(e,this.state,this.data),this.renderBtn=e=>{if((this.data??{})[e.actionId+`.hidden`])return v;let t=this.evalLabel(e.label);return P.get()?.renderToolbarButton?.(e,t,()=>this.handleButtonClick(e.actionId))||T`
+        <button class="mtb ${Pt(e)}"
                 data-action-id="${e.id}"
                 @click="${()=>this.handleButtonClick(e.actionId)}"
                 ?disabled="${e.disabled}"
@@ -190,7 +190,7 @@ ${i}
                     </div>
                 `:v}
             </div>
-        `},this.renderPeerNav=e=>F.get()?.renderPeerNav?.(e)||T`
+        `},this.renderPeerNav=e=>P.get()?.renderPeerNav?.(e)||T`
             <div style="display: flex; gap: var(--lumo-space-xs, .25rem); align-items: center;" class="peer-nav">
                 <button class="mtb tertiary peer-nav-prev"
                         title="${e.prevLabel??`Previous`}"
@@ -201,7 +201,7 @@ ${i}
                         ?disabled="${!e.nextRoute}"
                         @click="${()=>{e.nextRoute&&(window.location.href=e.nextRoute)}}">›</button>
             </div>
-        `}connectedCallback(){super.connectedCallback(),document.addEventListener(`click`,this._onDocClick),this._ro=new ResizeObserver(()=>this._resetOverflow()),this._ro.observe(this),window.addEventListener(`resize`,this._resetOverflow)}disconnectedCallback(){document.removeEventListener(`click`,this._onDocClick),window.removeEventListener(`resize`,this._resetOverflow),this._ro?.disconnect(),this._ro=void 0,super.disconnectedCallback()}updated(e){if(e.has(`metadata`)||e.has(`data`)){this._resetOverflow();return}let t=this.renderRoot.querySelector(`.actions-cluster`);if(!t||this._secCount===0)return;let n=t.closest(`.form-header, .no-header-row`);if(!n)return;let r=t.getBoundingClientRect(),i=n.getBoundingClientRect();(r.top-i.top>8||r.right>i.right+1)&&this._overflowN<this._secCount&&(this._overflowN+=1)}render(){let e=this.metadata;if(!e)return T``;let t=e.peerNav&&(e.peerNav.prevRoute||e.peerNav.nextRoute)?e.peerNav:void 0,n=e.toolbar??[],r=n.filter(e=>Pt(e.actionId)),i=n.filter(e=>!Pt(e.actionId)),a=r.length>0&&i.length>0?T`<span class="toolbar-divider"></span>`:v,o=e.overline,s=e.title?void 0:e.titlePlaceholder,c=e.avatar||e.title||e.subtitle||o||s||e.kpis?.length>0||e.header?.length>0||n.length>0||!!t,l=e.level??0;return l>0?this.setAttribute(`data-nested`,``):this.removeAttribute(`data-nested`),T`
+        `}connectedCallback(){super.connectedCallback(),document.addEventListener(`click`,this._onDocClick),this._ro=new ResizeObserver(()=>this._resetOverflow()),this._ro.observe(this),window.addEventListener(`resize`,this._resetOverflow)}disconnectedCallback(){document.removeEventListener(`click`,this._onDocClick),window.removeEventListener(`resize`,this._resetOverflow),this._ro?.disconnect(),this._ro=void 0,super.disconnectedCallback()}updated(e){if(e.has(`metadata`)||e.has(`data`)){this._resetOverflow();return}let t=this.renderRoot.querySelector(`.actions-cluster`);if(!t||this._secCount===0)return;let n=t.closest(`.form-header, .no-header-row`);if(!n)return;let r=t.getBoundingClientRect(),i=n.getBoundingClientRect();(r.top-i.top>8||r.right>i.right+1)&&this._overflowN<this._secCount&&(this._overflowN+=1)}render(){let e=this.metadata;if(!e)return T``;let t=e.peerNav&&(e.peerNav.prevRoute||e.peerNav.nextRoute)?e.peerNav:void 0,n=e.toolbar??[],r=n.filter(e=>Ft(e.actionId)),i=n.filter(e=>!Ft(e.actionId)),a=r.length>0&&i.length>0?T`<span class="toolbar-divider"></span>`:v,o=e.overline,s=e.title?void 0:e.titlePlaceholder,c=e.avatar||e.title||e.subtitle||o||s||e.kpis?.length>0||e.header?.length>0||n.length>0||!!t,l=e.level??0;return l>0?this.setAttribute(`data-nested`,``):this.removeAttribute(`data-nested`),T`
             ${e.breadcrumbs&&e.breadcrumbs.length>0?T`
                 <div style="display: flex; gap: var(--lumo-space-m, 1rem); width: 100%; align-items: center;" class="breadcrumbs-bar">
                     ${e.breadcrumbs.map((e,t)=>T`
@@ -212,7 +212,7 @@ ${i}
             `:v}
             ${e.noHeader?T`
                 <div style="display: flex; gap: var(--lumo-space-m, 1rem); align-items: center;" class="no-header-row">
-                    ${e?.header?.map(e=>I(this,e,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData))}
+                    ${e?.header?.map(e=>F(this,e,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData))}
                     ${t?this.renderPeerNav(t):v}
                     ${r.map(this.renderBtn)}
                     ${a}
@@ -220,13 +220,13 @@ ${i}
                 </div>
             `:c?T`
                 <div style="display: flex; gap: var(--lumo-space-m, 1rem); width: 100%; align-items: center; flex-wrap: wrap;" class="form-header">
-                    ${e.avatar?I(this,e.avatar,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData):v}
+                    ${e.avatar?F(this,e.avatar,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData):v}
                     <div style="flex: 1; min-width: min(22rem, 100%); overflow: hidden;">
                         ${o?T`<div class="page-overline">${_(N(o,this.state??{},this.data??{}))}</div>`:v}
                         ${(e?.title||s)&&l==0?T`
                             <div style="display: flex; align-items: center; gap: var(--lumo-space-s, .5rem); min-width: 0;">
                                 <h2 style="margin: 0; margin-block-end: 0px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">${e?.title?_(N(e?.title,this.state??{},this.data??{})):T`<span class="page-title-placeholder">${_(N(s,this.state??{},this.data??{}))}</span>`}</h2>
-                                ${e.kpisBelow&&e.badges?.length?e.badges.map(e=>At(e,this.state??{},this.data??{})):v}
+                                ${e.kpisBelow&&e.badges?.length?e.badges.map(e=>jt(e,this.state??{},this.data??{})):v}
                             </div>`:v}
                         ${e?.title&&l==1?T`<h3 style="margin: 0; margin-block-end: 0px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; width: 100%;">${_(N(e?.title,this.state??{},this.data??{}))}</h3>`:v}
                         ${e?.title&&l==2?T`<h4 style="margin: 0; margin-block-end: 0px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; width: 100%;">${_(N(e?.title,this.state??{},this.data??{}))}</h4>`:v}
@@ -243,7 +243,7 @@ ${i}
                                 <div>${_(N(e.text,this.state??{},this.data??{}))}</div>
                             </div>
                         `)}
-                        ${e?.header?.map(e=>I(this,e,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData))}
+                        ${e?.header?.map(e=>F(this,e,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData))}
                         ${t?this.renderPeerNav(t):v}
                         ${r.map(this.renderBtn)}
                         ${a}
@@ -263,7 +263,7 @@ ${i}
             `:v}
             ${e.badges&&e.badges.length>0&&!e.kpisBelow?T`
                 <div style="display: flex; gap: var(--lumo-space-s, .5rem); padding-bottom: var(--lumo-space-s, .5rem);">
-                    ${e.badges.map(e=>At(e,this.state??{},this.data??{}))}
+                    ${e.badges.map(e=>jt(e,this.state??{},this.data??{}))}
                 </div>
             `:v}
         `}static{this.styles=h`
@@ -408,7 +408,7 @@ ${i}
         .mtb.danger.primary { background: var(--lumo-error-color, #c0392b); color: #fff; border-color: transparent; }
 
         ${de}
-    `}};k([y()],Ft.prototype,`metadata`,void 0),k([y()],Ft.prototype,`baseUrl`,void 0),k([y()],Ft.prototype,`state`,void 0),k([y()],Ft.prototype,`data`,void 0),k([y()],Ft.prototype,`appState`,void 0),k([y()],Ft.prototype,`appData`,void 0),k([C()],Ft.prototype,`_overflowOpen`,void 0),k([C()],Ft.prototype,`_overflowN`,void 0),Ft=k([g(`mateu-content-header`)],Ft);var It=class extends vt{constructor(...e){super(...e),this.state={},this.data={},this.appState={},this.appData={}}render(){let e=this.component?.metadata;return T`
+    `}};k([y()],It.prototype,`metadata`,void 0),k([y()],It.prototype,`baseUrl`,void 0),k([y()],It.prototype,`state`,void 0),k([y()],It.prototype,`data`,void 0),k([y()],It.prototype,`appState`,void 0),k([y()],It.prototype,`appData`,void 0),k([C()],It.prototype,`_overflowOpen`,void 0),k([C()],It.prototype,`_overflowN`,void 0),It=k([g(`mateu-content-header`)],It);var Lt=class extends vt{constructor(...e){super(...e),this.state={},this.data={},this.appState={},this.appData={}}render(){let e=this.component?.metadata;return T`
             <div class="mateu-vlayout ${this.component?.cssClasses??``}">
                 <mateu-content-header
                     .metadata="${e}"
@@ -454,7 +454,7 @@ ${i}
         .form-content {
             padding-bottom: 3rem;
         }
-    `}};k([y()],It.prototype,`state`,void 0),k([y()],It.prototype,`data`,void 0),k([y()],It.prototype,`appState`,void 0),k([y()],It.prototype,`appData`,void 0),It=k([g(`mateu-form`)],It);var Lt=class extends b{constructor(...e){super(...e),this.variant=`text`,this.count=3}static{this.styles=h`
+    `}};k([y()],Lt.prototype,`state`,void 0),k([y()],Lt.prototype,`data`,void 0),k([y()],Lt.prototype,`appState`,void 0),k([y()],Lt.prototype,`appData`,void 0),Lt=k([g(`mateu-form`)],Lt);var Rt=class extends b{constructor(...e){super(...e),this.variant=`text`,this.count=3}static{this.styles=h`
         :host {
             display: block;
             flex: 1 1 0;
@@ -488,7 +488,7 @@ ${i}
                     <div class="bone label"></div>
                     <div class="bone field"></div>
                 </div>
-            `)}`:T`${e.map(()=>T`<div class="bone line"></div>`)}`}};k([y()],Lt.prototype,`variant`,void 0),k([y({type:Number})],Lt.prototype,`count`,void 0),Lt=k([g(`mateu-skeleton`)],Lt);var Rt=(e,t)=>{t&&e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},zt=(e,t,n,r,i,a)=>T`
+            `)}`:T`${e.map(()=>T`<div class="bone line"></div>`)}`}};k([y()],Rt.prototype,`variant`,void 0),k([y({type:Number})],Rt.prototype,`count`,void 0),Rt=k([g(`mateu-skeleton`)],Rt);var zt=(e,t)=>{t&&e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},Bt=(e,t,n,r,i,a)=>T`
         <div class="mateu-empty-state"
              style="display: flex; flex-direction: column; align-items: center; justify-content: center; gap: .35rem; padding: var(--lumo-space-l, 1.5rem); text-align: center; color: var(--lumo-secondary-text-color, #666);">
             <span style="font-size: 1.8rem; line-height: 1; opacity: .6;">${t??`🗂`}</span>
@@ -496,14 +496,14 @@ ${i}
             <span style="font-size: var(--lumo-font-size-s, .875rem);">${r??e??`Nothing here yet.`}</span>
             ${i&&a?T`
                 <button style="margin-top: .25rem; font: inherit; font-weight: 500; cursor: pointer; padding: .4rem .9rem; border: none; border-radius: var(--lumo-border-radius-m, 6px); background: transparent; color: var(--lumo-primary-text-color, #3b5bdb);"
-                        @click="${e=>Rt(e,i)}">${a}</button>
+                        @click="${e=>zt(e,i)}">${a}</button>
             `:v}
         </div>
-    `,Bt=e=>{let t=e.metadata;return T`
+    `,Vt=e=>{let t=e.metadata;return T`
         <div style="${e.style??v}" class="${e.cssClasses??v}" slot="${e.slot??v}">
-            ${zt(void 0,t.icon,t.title,t.description,t.actionId,t.actionLabel)}
+            ${Bt(void 0,t.icon,t.title,t.description,t.actionId,t.actionLabel)}
         </div>
-    `},Vt=e=>{let t=e.metadata;return T`
+    `},Ht=e=>{let t=e.metadata;return T`
         <mateu-skeleton
                 variant="${t.variant??`text`}"
                 count="${t.count&&t.count>0?t.count:3}"
@@ -511,8 +511,8 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-skeleton>
-    `},L=(e,t,n,r)=>{if(!e)return T``;let i=F.get()?.renderIcon;if(i){let a=i.call(F.get(),e,t,n);return r?T`<span slot="${r}">${a}</span>`:a}return T`<span class="mateu-icon ${n??``}" data-icon="${e}" aria-hidden="true"
-                      style="display:inline-block; width:1em; height:1em; ${t??``}" slot="${r??v}"></span>`},Ht=`mateu-saved-views`,Ut=()=>{try{return JSON.parse(localStorage.getItem(Ht)??`{}`)}catch{return{}}},Wt=e=>{try{localStorage.setItem(Ht,JSON.stringify(e))}catch{}},Gt=e=>Ut()[e]??[],Kt=(e,t)=>{let n=t.name?.trim();if(!n||Object.keys(t.values??{}).length===0)return;let r=Ut(),i=(r[e]??[]).filter(e=>e.name!==n);i.push({...t,name:n}),r[e]=i,Wt(r)},qt=(e,t)=>{let n=Ut(),r=(n[e]??[]).filter(e=>e.name!==t);r.length===0?delete n[e]:n[e]=r,Wt(n)},Jt=(e,t)=>{let n=Ut();n[e]=(n[e]??[]).map(e=>({...e,isDefault:e.name===t&&!e.isDefault})),Wt(n)},Yt=e=>Gt(e).find(e=>e.isDefault),R=class extends b{constructor(...e){super(...e),this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.searchOnly=!1,this.panelOpened=!1,this.viewsOpened=!1,this.draftText=``,this.openPanel=()=>{this.panelOpened||this.filters.length===0||(this.panelOpened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick))},this.closePanel=()=>{this.detachOutsideClick(),this.panelOpened=!1,this.activeFilter=void 0},this.clearAllFilters=()=>{let e=this.filters.flatMap(e=>this.isRangeFilter(e)?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId]),t={searchText:void 0};e.forEach(e=>{t[e]=void 0}),this.state={...this.state,...t},this.dispatchEvent(new CustomEvent(`filter-reset-requested`,{detail:{fieldIds:e},bubbles:!0,composed:!0})),this.requestSearch()},this.keepFocus=e=>e.preventDefault()}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}get filters(){return this.metadata?.filters??[]}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}requestSearch(){this.closePanel(),this.dispatchEvent(new CustomEvent(`search-requested`,{detail:{},bubbles:!0,composed:!0}))}emitValueChanged(e,t){this.state={...this.state,[e]:t},this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:e},bubbles:!0,composed:!0}))}applyFilter(e,t){this.emitValueChanged(e,t),this.requestSearch()}removeChip(e){let t=this.filters.find(t=>t.fieldId===e);t&&this.isRangeFilter(t)?(this.emitValueChanged(`${e}_from`,void 0),this.emitValueChanged(`${e}_to`,void 0)):this.emitValueChanged(e,e===`searchText`?``:void 0),this.requestSearch()}commitText(e){this.emitValueChanged(`searchText`,e.value),this.draftText=``,e.value=``,this.requestSearch()}get viewsScope(){return window.location.pathname}allFilterKeys(){return[`searchText`,...this.filters.flatMap(e=>this.isRangeFilter(e)?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId])]}snapshotValues(){let e={};return this.state.searchText&&(e.searchText=this.state.searchText),this.filters.forEach(t=>{if(this.isSet(t))if(this.isRangeFilter(t)){let n=this.rangeBound(t,`from`),r=this.rangeBound(t,`to`);n&&(e[`${t.fieldId}_from`]=n),r&&(e[`${t.fieldId}_to`]=r)}else this.isMultiFilter(t)?e[t.fieldId]=this.multiValues(t):e[t.fieldId]=this.state[t.fieldId]}),e}applyView(e){let t=this.allFilterKeys(),n={};t.forEach(e=>{n[e]=void 0}),this.state={...this.state,...n},this.dispatchEvent(new CustomEvent(`filter-reset-requested`,{detail:{fieldIds:t},bubbles:!0,composed:!0})),Object.entries(e.values).forEach(([e,t])=>this.emitValueChanged(e,t)),this.viewsOpened=!1,this.detachOutsideClick(),this.requestSearch()}saveCurrentView(e){let t=e.value.trim();t&&(Kt(this.viewsScope,{name:t,values:this.snapshotValues()}),e.value=``,this.requestUpdate())}firstUpdated(){if(window.location.search)return;let e=Yt(this.viewsScope);e&&setTimeout(()=>{this.state.searchText||this.filters.some(e=>this.isSet(e))||this.applyView(e)},0)}isBooleanFilter(e){return e.dataType===`boolean`||e.dataType===`bool`||e.stereotype===`checkbox`||e.stereotype===`toggle`}isNumericFilter(e){return[`integer`,`decimal`,`number`,`money`].includes(e.dataType??``)}isRangeFilter(e){return e.stereotype===`dateRange`||e.stereotype===`numberRange`}isMultiFilter(e){return e.stereotype===`multiSelect`}hasOptions(e){return(e.options?.length??0)>0}multiValues(e){let t=this.state[e.fieldId];return Array.isArray(t)?t.map(String):typeof t==`string`&&t!==``?t.split(`,`).map(e=>e.trim()).filter(e=>e):[]}rangeBound(e,t){let n=this.state[`${e.fieldId}_${t}`];return n==null?``:String(n)}isSet(e){if(this.isRangeFilter(e))return this.rangeBound(e,`from`)!==``||this.rangeBound(e,`to`)!==``;if(this.isMultiFilter(e))return this.multiValues(e).length>0;let t=this.state[e.fieldId];return t!=null&&t!==``&&!Number.isNaN(t)}getFilterDisplayValue(e,t){if(e.options?.length){let n=e.options.find(e=>e.value===String(t));if(n)return n.label??n.value}return typeof t==`boolean`?t?`Yes`:`No`:String(t)}conditionDisplay(e){if(this.isRangeFilter(e)){let t=this.rangeBound(e,`from`),n=this.rangeBound(e,`to`);return t&&n?`${t} – ${n}`:t?`≥ ${t}`:`≤ ${n}`}return this.isMultiFilter(e)?this.multiValues(e).map(t=>this.getFilterDisplayValue(e,t)).join(`, `):this.getFilterDisplayValue(e,this.state[e.fieldId])}labelOf(e){return M(e.label,this.state,this.data)||e.fieldId}panelRow(e,t,n=`panel-row`){return T`
+    `},I=(e,t,n,r)=>{if(!e)return T``;let i=P.get()?.renderIcon;if(i){let a=i.call(P.get(),e,t,n);return r?T`<span slot="${r}">${a}</span>`:a}return T`<span class="mateu-icon ${n??``}" data-icon="${e}" aria-hidden="true"
+                      style="display:inline-block; width:1em; height:1em; ${t??``}" slot="${r??v}"></span>`},Ut=`mateu-saved-views`,Wt=()=>{try{return JSON.parse(localStorage.getItem(Ut)??`{}`)}catch{return{}}},Gt=e=>{try{localStorage.setItem(Ut,JSON.stringify(e))}catch{}},Kt=e=>Wt()[e]??[],qt=(e,t)=>{let n=t.name?.trim();if(!n||Object.keys(t.values??{}).length===0)return;let r=Wt(),i=(r[e]??[]).filter(e=>e.name!==n);i.push({...t,name:n}),r[e]=i,Gt(r)},Jt=(e,t)=>{let n=Wt(),r=(n[e]??[]).filter(e=>e.name!==t);r.length===0?delete n[e]:n[e]=r,Gt(n)},Yt=(e,t)=>{let n=Wt();n[e]=(n[e]??[]).map(e=>({...e,isDefault:e.name===t&&!e.isDefault})),Gt(n)},Xt=e=>Kt(e).find(e=>e.isDefault),L=class extends b{constructor(...e){super(...e),this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.searchOnly=!1,this.panelOpened=!1,this.viewsOpened=!1,this.draftText=``,this.openPanel=()=>{this.panelOpened||this.filters.length===0||(this.panelOpened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick))},this.closePanel=()=>{this.detachOutsideClick(),this.panelOpened=!1,this.activeFilter=void 0},this.clearAllFilters=()=>{let e=this.filters.flatMap(e=>this.isRangeFilter(e)?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId]),t={searchText:void 0};e.forEach(e=>{t[e]=void 0}),this.state={...this.state,...t},this.dispatchEvent(new CustomEvent(`filter-reset-requested`,{detail:{fieldIds:e},bubbles:!0,composed:!0})),this.requestSearch()},this.keepFocus=e=>e.preventDefault()}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}get filters(){return this.metadata?.filters??[]}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}requestSearch(){this.closePanel(),this.dispatchEvent(new CustomEvent(`search-requested`,{detail:{},bubbles:!0,composed:!0}))}emitValueChanged(e,t){this.state={...this.state,[e]:t},this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:e},bubbles:!0,composed:!0}))}applyFilter(e,t){this.emitValueChanged(e,t),this.requestSearch()}removeChip(e){let t=this.filters.find(t=>t.fieldId===e);t&&this.isRangeFilter(t)?(this.emitValueChanged(`${e}_from`,void 0),this.emitValueChanged(`${e}_to`,void 0)):this.emitValueChanged(e,e===`searchText`?``:void 0),this.requestSearch()}commitText(e){this.emitValueChanged(`searchText`,e.value),this.draftText=``,e.value=``,this.requestSearch()}get viewsScope(){return window.location.pathname}allFilterKeys(){return[`searchText`,...this.filters.flatMap(e=>this.isRangeFilter(e)?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId])]}snapshotValues(){let e={};return this.state.searchText&&(e.searchText=this.state.searchText),this.filters.forEach(t=>{if(this.isSet(t))if(this.isRangeFilter(t)){let n=this.rangeBound(t,`from`),r=this.rangeBound(t,`to`);n&&(e[`${t.fieldId}_from`]=n),r&&(e[`${t.fieldId}_to`]=r)}else this.isMultiFilter(t)?e[t.fieldId]=this.multiValues(t):e[t.fieldId]=this.state[t.fieldId]}),e}applyView(e){let t=this.allFilterKeys(),n={};t.forEach(e=>{n[e]=void 0}),this.state={...this.state,...n},this.dispatchEvent(new CustomEvent(`filter-reset-requested`,{detail:{fieldIds:t},bubbles:!0,composed:!0})),Object.entries(e.values).forEach(([e,t])=>this.emitValueChanged(e,t)),this.viewsOpened=!1,this.detachOutsideClick(),this.requestSearch()}saveCurrentView(e){let t=e.value.trim();t&&(qt(this.viewsScope,{name:t,values:this.snapshotValues()}),e.value=``,this.requestUpdate())}firstUpdated(){if(window.location.search)return;let e=Xt(this.viewsScope);e&&setTimeout(()=>{this.state.searchText||this.filters.some(e=>this.isSet(e))||this.applyView(e)},0)}isBooleanFilter(e){return e.dataType===`boolean`||e.dataType===`bool`||e.stereotype===`checkbox`||e.stereotype===`toggle`}isNumericFilter(e){return[`integer`,`decimal`,`number`,`money`].includes(e.dataType??``)}isRangeFilter(e){return e.stereotype===`dateRange`||e.stereotype===`numberRange`}isMultiFilter(e){return e.stereotype===`multiSelect`}hasOptions(e){return(e.options?.length??0)>0}multiValues(e){let t=this.state[e.fieldId];return Array.isArray(t)?t.map(String):typeof t==`string`&&t!==``?t.split(`,`).map(e=>e.trim()).filter(e=>e):[]}rangeBound(e,t){let n=this.state[`${e.fieldId}_${t}`];return n==null?``:String(n)}isSet(e){if(this.isRangeFilter(e))return this.rangeBound(e,`from`)!==``||this.rangeBound(e,`to`)!==``;if(this.isMultiFilter(e))return this.multiValues(e).length>0;let t=this.state[e.fieldId];return t!=null&&t!==``&&!Number.isNaN(t)}getFilterDisplayValue(e,t){if(e.options?.length){let n=e.options.find(e=>e.value===String(t));if(n)return n.label??n.value}return typeof t==`boolean`?t?`Yes`:`No`:String(t)}conditionDisplay(e){if(this.isRangeFilter(e)){let t=this.rangeBound(e,`from`),n=this.rangeBound(e,`to`);return t&&n?`${t} – ${n}`:t?`≥ ${t}`:`≤ ${n}`}return this.isMultiFilter(e)?this.multiValues(e).map(t=>this.getFilterDisplayValue(e,t)).join(`, `):this.getFilterDisplayValue(e,this.state[e.fieldId])}labelOf(e){return M(e.label,this.state,this.data)||e.fieldId}panelRow(e,t,n=`panel-row`){return T`
             <div class="${n}" @mousedown="${this.keepFocus}" @click="${t}">${e}</div>`}renderRangeWidget(e){let t=e.stereotype===`numberRange`?`number`:e.dataType===`dateTime`?`datetime-local`:e.dataType===`time`?`time`:`date`,n=t=>{let n=t.closest(`.panel-input-row`),r=n.querySelector(`input.range-from`).value,i=n.querySelector(`input.range-to`).value;this.emitValueChanged(`${e.fieldId}_from`,r===``?void 0:r),this.emitValueChanged(`${e.fieldId}_to`,i===``?void 0:i),this.requestSearch()},r=e=>{e.key===`Enter`&&n(e.target),e.key===`Escape`&&this.closePanel()};return T`
             <div class="panel-input-row">
                 <input class="range-from" type="${t}" placeholder="From"
@@ -542,7 +542,7 @@ ${i}
                 <button class="apply-button"
                         @mousedown="${this.keepFocus}"
                         @click="${e=>n(e.target.previousElementSibling)}">Apply</button>
-            </div>`}renderViewsPanel(){if(!this.viewsOpened)return v;let e=Gt(this.viewsScope),t=!!this.state.searchText||this.filters.some(e=>this.isSet(e));return T`
+            </div>`}renderViewsPanel(){if(!this.viewsOpened)return v;let e=Kt(this.viewsScope),t=!!this.state.searchText||this.filters.some(e=>this.isSet(e));return T`
             <div class="panel views-panel">
                 <div class="panel-caption">Saved views</div>
                 ${e.length===0?T`
@@ -552,9 +552,9 @@ ${i}
                         <span class="view-name" @click="${()=>this.applyView(e)}">${e.name}</span>
                         <button class="view-star ${e.isDefault?`view-star--on`:``}"
                                 title="${e.isDefault?`Unset as default`:`Open this listing with this view`}"
-                                @click="${()=>{Jt(this.viewsScope,e.name),this.requestUpdate()}}">★</button>
+                                @click="${()=>{Yt(this.viewsScope,e.name),this.requestUpdate()}}">★</button>
                         <button class="chip-remove" aria-label="Delete view ${e.name}"
-                                @click="${()=>{qt(this.viewsScope,e.name),this.requestUpdate()}}">✕</button>
+                                @click="${()=>{Jt(this.viewsScope,e.name),this.requestUpdate()}}">✕</button>
                     </div>`)}
                 ${t?T`
                     <div class="panel-input-row" @mousedown="${e=>e.stopPropagation()}">
@@ -811,7 +811,7 @@ ${i}
             padding: 0.35rem 0.75rem;
             cursor: pointer;
         }
-    `}};k([y()],R.prototype,`metadata`,void 0),k([y()],R.prototype,`baseUrl`,void 0),k([C()],R.prototype,`state`,void 0),k([C()],R.prototype,`data`,void 0),k([y()],R.prototype,`appState`,void 0),k([y()],R.prototype,`appData`,void 0),k([y({type:Boolean})],R.prototype,`searchOnly`,void 0),k([C()],R.prototype,`panelOpened`,void 0),k([C()],R.prototype,`viewsOpened`,void 0),k([C()],R.prototype,`activeFilter`,void 0),k([C()],R.prototype,`draftText`,void 0),R=k([g(`mateu-filter-bar`)],R);var Xt=`mateu-column-prefs`,Zt=()=>{try{let e=JSON.parse(localStorage.getItem(Xt)??`{}`);return e&&typeof e==`object`&&!Array.isArray(e)?e:{}}catch{return{}}},Qt=e=>{try{localStorage.setItem(Xt,JSON.stringify(e))}catch{}},$t=e=>{if(!e||typeof e!=`object`)return;let t=e=>Array.isArray(e)?e.filter(e=>typeof e==`string`):[];return{hidden:t(e.hidden),order:t(e.order)}},en=e=>$t(Zt()[e]),tn=(e,t)=>{let n=Zt(),r=$t(t);r.hidden.length===0&&r.order.length===0?delete n[e]:n[e]=r,Qt(n)},nn=e=>{let t=Zt();delete t[e],Qt(t)},rn=e=>e?!!e.identifier||e.dataType===`action`||e.dataType===`actionGroup`||e.dataType===`menu`||e.id===`select`||e.id===`menu`:!1,an=(e,t,n=e=>e)=>{let r=$t(t);if(!r||r.hidden.length===0&&r.order.length===0)return e;let i=e=>n(e)?.id??e.id,a=new Set(r.hidden),o=e.filter(e=>{let t=i(e);return!t||!a.has(t)||rn(n(e))});if(r.order.length===0)return o.length===e.length?e:o;let s=new Map;o.forEach(e=>{let t=i(e);t&&!s.has(t)&&s.set(t,e)});let c=[],l=new Set;return r.order.forEach(e=>{let t=s.get(e);t&&!l.has(t)&&(c.push(t),l.add(t))}),o.forEach(e=>{l.has(e)||(c.push(e),l.add(e))}),c.length===e.length&&c.every((t,n)=>t===e[n])?e:c},on=class extends b{constructor(...e){super(...e),this.columns=[],this.scope=``,this.panelOpened=!1,this.revision=0,this.togglePanel=()=>{if(this.panelOpened){this.closePanel();return}this.panelOpened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick)},this.closePanel=()=>{this.detachOutsideClick(),this.panelOpened=!1},this.reset=()=>{nn(this.scope),this.revision++,this.dispatchEvent(new CustomEvent(`column-prefs-changed`,{bubbles:!0,composed:!0}))}}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}get prefs(){return en(this.scope)??{hidden:[],order:[]}}effectiveEntries(e){return an(this.columns,{hidden:[],order:e.order})}commit(e){tn(this.scope,e),this.revision++,this.dispatchEvent(new CustomEvent(`column-prefs-changed`,{bubbles:!0,composed:!0}))}toggleVisibility(e){let t=this.prefs,n=t.hidden.includes(e)?t.hidden.filter(t=>t!==e):[...t.hidden,e];this.commit({...t,hidden:n})}move(e,t){let n=this.prefs,r=[...this.effectiveEntries(n)],i=r.findIndex(t=>t.id===e);if(i<0)return;let a=i+t;for(;a>=0&&a<r.length&&r[a].protected;)a+=t;if(a<0||a>=r.length)return;let o=r[i];r[i]=r[a],r[a]=o,this.commit({...n,order:r.map(e=>e.id)})}render(){this.revision;let e=this.prefs,t=this.effectiveEntries(e).filter(e=>!e.protected);if(t.length===0)return T``;let n=e.hidden.length>0||e.order.length>0;return T`
+    `}};k([y()],L.prototype,`metadata`,void 0),k([y()],L.prototype,`baseUrl`,void 0),k([C()],L.prototype,`state`,void 0),k([C()],L.prototype,`data`,void 0),k([y()],L.prototype,`appState`,void 0),k([y()],L.prototype,`appData`,void 0),k([y({type:Boolean})],L.prototype,`searchOnly`,void 0),k([C()],L.prototype,`panelOpened`,void 0),k([C()],L.prototype,`viewsOpened`,void 0),k([C()],L.prototype,`activeFilter`,void 0),k([C()],L.prototype,`draftText`,void 0),L=k([g(`mateu-filter-bar`)],L);var Zt=`mateu-column-prefs`,Qt=()=>{try{let e=JSON.parse(localStorage.getItem(Zt)??`{}`);return e&&typeof e==`object`&&!Array.isArray(e)?e:{}}catch{return{}}},$t=e=>{try{localStorage.setItem(Zt,JSON.stringify(e))}catch{}},en=e=>{if(!e||typeof e!=`object`)return;let t=e=>Array.isArray(e)?e.filter(e=>typeof e==`string`):[];return{hidden:t(e.hidden),order:t(e.order)}},tn=e=>en(Qt()[e]),nn=(e,t)=>{let n=Qt(),r=en(t);r.hidden.length===0&&r.order.length===0?delete n[e]:n[e]=r,$t(n)},rn=e=>{let t=Qt();delete t[e],$t(t)},an=e=>e?!!e.identifier||e.dataType===`action`||e.dataType===`actionGroup`||e.dataType===`menu`||e.id===`select`||e.id===`menu`:!1,on=(e,t,n=e=>e)=>{let r=en(t);if(!r||r.hidden.length===0&&r.order.length===0)return e;let i=e=>n(e)?.id??e.id,a=new Set(r.hidden),o=e.filter(e=>{let t=i(e);return!t||!a.has(t)||an(n(e))});if(r.order.length===0)return o.length===e.length?e:o;let s=new Map;o.forEach(e=>{let t=i(e);t&&!s.has(t)&&s.set(t,e)});let c=[],l=new Set;return r.order.forEach(e=>{let t=s.get(e);t&&!l.has(t)&&(c.push(t),l.add(t))}),o.forEach(e=>{l.has(e)||(c.push(e),l.add(e))}),c.length===e.length&&c.every((t,n)=>t===e[n])?e:c},sn=class extends b{constructor(...e){super(...e),this.columns=[],this.scope=``,this.panelOpened=!1,this.revision=0,this.togglePanel=()=>{if(this.panelOpened){this.closePanel();return}this.panelOpened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick)},this.closePanel=()=>{this.detachOutsideClick(),this.panelOpened=!1},this.reset=()=>{rn(this.scope),this.revision++,this.dispatchEvent(new CustomEvent(`column-prefs-changed`,{bubbles:!0,composed:!0}))}}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}get prefs(){return tn(this.scope)??{hidden:[],order:[]}}effectiveEntries(e){return on(this.columns,{hidden:[],order:e.order})}commit(e){nn(this.scope,e),this.revision++,this.dispatchEvent(new CustomEvent(`column-prefs-changed`,{bubbles:!0,composed:!0}))}toggleVisibility(e){let t=this.prefs,n=t.hidden.includes(e)?t.hidden.filter(t=>t!==e):[...t.hidden,e];this.commit({...t,hidden:n})}move(e,t){let n=this.prefs,r=[...this.effectiveEntries(n)],i=r.findIndex(t=>t.id===e);if(i<0)return;let a=i+t;for(;a>=0&&a<r.length&&r[a].protected;)a+=t;if(a<0||a>=r.length)return;let o=r[i];r[i]=r[a],r[a]=o,this.commit({...n,order:r.map(e=>e.id)})}render(){this.revision;let e=this.prefs,t=this.effectiveEntries(e).filter(e=>!e.protected);if(t.length===0)return T``;let n=e.hidden.length>0||e.order.length>0;return T`
             <div class="chooser">
                 <button
                     class="trigger ${n?`active`:``}"
@@ -968,7 +968,7 @@ ${i}
             opacity: 0.4;
             cursor: default;
         }
-    `}};k([y()],on.prototype,`columns`,void 0),k([y()],on.prototype,`scope`,void 0),k([C()],on.prototype,`panelOpened`,void 0),k([C()],on.prototype,`revision`,void 0),on=k([g(`mateu-column-chooser`)],on);var sn;async function cn(e){if(!sn)return{};try{return await sn(e)??{}}catch(e){return console.warn(`mateu: external auth provider failed`,e),{}}}function ln(e,t){return t?t.split(`.`).reduce((e,t)=>typeof e==`object`&&e?e[t]:void 0,e):e}function un(e,t,n=`value`,r=`label`){let i=ln(e,t);return Array.isArray(i)?i.map(e=>{if(typeof e==`object`&&e){let t=ln(e,n),i=ln(e,r);return{value:t??i,label:String(i??t??``)}}return{value:e,label:String(e)}}):[]}function dn(e,t,n,r=e=>e){let i=ln(e,t);return Array.isArray(i)?i.map(e=>{let t={};for(let i of n)t[i]=ln(e,r(i));return t}):[]}async function fn(e,t=e=>e,n=fetch){let r=Ie(e);if(!r.url)throw Error(`External REST fetch has no url${e.ref?` (unknown source "${e.ref}")`:``}`);let i=t(r.url)??r.url,a=(r.method||`GET`).toUpperCase(),o={};for(let[e,n]of Object.entries(r.headers??{}))o[e]=t(n)??n;Object.assign(o,await cn({url:i,method:a}));let s={method:a,headers:o};a!==`GET`&&a!==`HEAD`&&r.body&&(s.body=t(r.body)??r.body);let c=await n(i,s);if(!c.ok)throw Error(`External REST fetch failed: ${c.status}`);return c.json()}async function pn(e,t=e=>e,n=fetch){let r=await fn(e,t,n),i=Ie(e);return un(r,i.itemsPath,i.valuePath,i.labelPath)}async function mn(e,t,n=e=>e,r=fetch){return dn(await fn(e,n,r),Ie(e).itemsPath,t,t=>Le(e,t))}var hn=class extends b{constructor(...e){super(...e),this.totalElements=0,this.pageSize=100,this.pageNumber=0,this.totalPages=0}updated(e){super.updated(e),(e.has(`totalElements`)||e.has(`pageSize`))&&(this.totalPages=Math.ceil(this.totalElements/this.pageSize))}dispatch(e){this.dispatchEvent(new CustomEvent(`page-changed`,{bubbles:!0,composed:!0,detail:{page:e}}))}render(){if(!this.totalElements)return v;let e=this.totalPages>1,t=this.pageNumber,n=t===0,r=t>=this.totalPages-1;return T`
+    `}};k([y()],sn.prototype,`columns`,void 0),k([y()],sn.prototype,`scope`,void 0),k([C()],sn.prototype,`panelOpened`,void 0),k([C()],sn.prototype,`revision`,void 0),sn=k([g(`mateu-column-chooser`)],sn);var cn;async function ln(e){if(!cn)return{};try{return await cn(e)??{}}catch(e){return console.warn(`mateu: external auth provider failed`,e),{}}}function un(e,t){return t?t.split(`.`).reduce((e,t)=>typeof e==`object`&&e?e[t]:void 0,e):e}function dn(e,t,n=`value`,r=`label`){let i=un(e,t);return Array.isArray(i)?i.map(e=>{if(typeof e==`object`&&e){let t=un(e,n),i=un(e,r);return{value:t??i,label:String(i??t??``)}}return{value:e,label:String(e)}}):[]}function fn(e,t,n,r=e=>e){let i=un(e,t);return Array.isArray(i)?i.map(e=>{let t={};for(let i of n)t[i]=un(e,r(i));return t}):[]}async function pn(e,t=e=>e,n=fetch){let r=Ie(e);if(!r.url)throw Error(`External REST fetch has no url${e.ref?` (unknown source "${e.ref}")`:``}`);let i=t(r.url)??r.url,a=(r.method||`GET`).toUpperCase(),o={};for(let[e,n]of Object.entries(r.headers??{}))o[e]=t(n)??n;Object.assign(o,await ln({url:i,method:a}));let s={method:a,headers:o};a!==`GET`&&a!==`HEAD`&&r.body&&(s.body=t(r.body)??r.body);let c=await n(i,s);if(!c.ok)throw Error(`External REST fetch failed: ${c.status}`);return c.json()}async function mn(e,t=e=>e,n=fetch){let r=await pn(e,t,n),i=Ie(e);return dn(r,i.itemsPath,i.valuePath,i.labelPath)}async function hn(e,t,n=e=>e,r=fetch){return fn(await pn(e,n,r),Ie(e).itemsPath,t,t=>Le(e,t))}var gn=class extends b{constructor(...e){super(...e),this.totalElements=0,this.pageSize=100,this.pageNumber=0,this.totalPages=0}updated(e){super.updated(e),(e.has(`totalElements`)||e.has(`pageSize`))&&(this.totalPages=Math.ceil(this.totalElements/this.pageSize))}dispatch(e){this.dispatchEvent(new CustomEvent(`page-changed`,{bubbles:!0,composed:!0,detail:{page:e}}))}render(){if(!this.totalElements)return v;let e=this.totalPages>1,t=this.pageNumber,n=t===0,r=t>=this.totalPages-1;return T`
             <div class="bar">
                 ${e?T`
                     <button class="nav" title="First page" ?disabled="${n}"
@@ -1032,97 +1032,97 @@ ${i}
             align-self: center;
             margin: 0 4px;
         }
-    `}};k([y()],hn.prototype,`totalElements`,void 0),k([y()],hn.prototype,`pageSize`,void 0),k([y()],hn.prototype,`pageNumber`,void 0),k([C()],hn.prototype,`totalPages`,void 0),hn=k([g(`mateu-pagination`)],hn);var gn=`var(--lumo-space-m, 1rem)`,_n=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.columnWidth||`13rem`,l=`display: grid; grid-template-columns: ${s.maxColumns&&s.maxColumns>0?`repeat(${s.maxColumns}, minmax(0, 1fr))`:`repeat(auto-fill, minmax(min(100%, ${c}), 1fr))`}; gap: ${gn} var(--lumo-space-l, 1.5rem); align-items: start;`;return s.labelsAside&&(l+=` --mateu-label-width: 10rem;`),s.fullWidth&&(l+=` width: 100%;`),l+=t.style??``,T`
+    `}};k([y()],gn.prototype,`totalElements`,void 0),k([y()],gn.prototype,`pageSize`,void 0),k([y()],gn.prototype,`pageNumber`,void 0),k([C()],gn.prototype,`totalPages`,void 0),gn=k([g(`mateu-pagination`)],gn);var _n=`var(--lumo-space-m, 1rem)`,vn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.columnWidth||`13rem`,l=`display: grid; grid-template-columns: ${s.maxColumns&&s.maxColumns>0?`repeat(${s.maxColumns}, minmax(0, 1fr))`:`repeat(auto-fill, minmax(min(100%, ${c}), 1fr))`}; gap: ${_n} var(--lumo-space-l, 1.5rem); align-items: start;`;return s.labelsAside&&(l+=` --mateu-label-width: 10rem;`),s.fullWidth&&(l+=` width: 100%;`),l+=t.style??``,T`
         <div id="${t.id??v}" style="${l}" class="${t.cssClasses}" slot="${t.slot||v}">
-            ${t.children?.map(t=>vn(s,e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>yn(s,e,t,n,r,i,a,o))}
         </div>
-    `},vn=(e,t,n,r,i,a,o,s)=>n.type==A.ClientSide&&n.metadata?.type==j.FormRow?xn(e,t,n,r,i,a,o,s):T`<div style="grid-column: span ${yn(n)}; min-width: 0;">${e.labelsAside?bn(t,n,r,i,a,o,s):I(t,n,r,i,a,o,s)}</div>`,yn=e=>{if(e.type==A.ClientSide){let t=e.metadata;if(t?.type==j.FormField)return t.colspan||1}return 1},bn=(e,t,n,r,i,a,o)=>{if(t.type==A.ClientSide&&t.metadata?.type==j.FormField&&t.metadata.label){let s=t.metadata;return T`
-            <div style="display: flex; gap: ${gn}; align-items: baseline;">
+    `},yn=(e,t,n,r,i,a,o,s)=>n.type==A.ClientSide&&n.metadata?.type==j.FormRow?Sn(e,t,n,r,i,a,o,s):T`<div style="grid-column: span ${bn(n)}; min-width: 0;">${e.labelsAside?xn(t,n,r,i,a,o,s):F(t,n,r,i,a,o,s)}</div>`,bn=e=>{if(e.type==A.ClientSide){let t=e.metadata;if(t?.type==j.FormField)return t.colspan||1}return 1},xn=(e,t,n,r,i,a,o)=>{if(t.type==A.ClientSide&&t.metadata?.type==j.FormField&&t.metadata.label){let s=t.metadata;return T`
+            <div style="display: flex; gap: ${_n}; align-items: baseline;">
                 <label style="flex: 0 0 var(--mateu-label-width, 10rem); color: var(--lumo-secondary-text-color, #667);">${s.label?.includes("${")?e._evalTemplate(s.label):s.label}</label>
-                <div style="flex: 1; min-width: 0;">${I(e,t,n,r,i,a,o,!0)}</div>
+                <div style="flex: 1; min-width: 0;">${F(e,t,n,r,i,a,o,!0)}</div>
             </div>
-        `}return I(e,t,n,r,i,a,o)},xn=(e,t,n,r,i,a,o,s)=>T`
-        <div style="grid-column: 1 / -1; display: flex; gap: ${gn}; flex-wrap: wrap;">
-            ${n.children?.map(c=>T`<div style="flex: 1 1 ${100/Math.max(1,n.children.length)}%; min-width: min(100%, 13rem);">${vn(e,t,c,r,i,a,o,s)}</div>`)}
+        `}return F(e,t,n,r,i,a,o)},Sn=(e,t,n,r,i,a,o,s)=>T`
+        <div style="grid-column: 1 / -1; display: flex; gap: ${_n}; flex-wrap: wrap;">
+            ${n.children?.map(c=>T`<div style="flex: 1 1 ${100/Math.max(1,n.children.length)}%; min-width: min(100%, 13rem);">${yn(e,t,c,r,i,a,o,s)}</div>`)}
         </div>
-    `,Sn=(e,t,n,r,i,a,o,s)=>{let c=n.metadata,l=`display: flex; flex-direction: ${e};`;c.spacing&&(l+=` gap: ${gn};`),c.padding&&(l+=` padding: var(--lumo-space-m, 1rem);`),c.wrap&&(l+=` flex-wrap: wrap;`),c.fullWidth&&(l+=` width: 100%;`),c.justification&&(l+=` justify-content: ${c.justification};`);let u=e===`row`?c.verticalAlignment:c.horizontalAlignment;return u&&(l+=` align-items: ${u};`),l+=n.style??``,T`
+    `,Cn=(e,t,n,r,i,a,o,s)=>{let c=n.metadata,l=`display: flex; flex-direction: ${e};`;c.spacing&&(l+=` gap: ${_n};`),c.padding&&(l+=` padding: var(--lumo-space-m, 1rem);`),c.wrap&&(l+=` flex-wrap: wrap;`),c.fullWidth&&(l+=` width: 100%;`),c.justification&&(l+=` justify-content: ${c.justification};`);let u=e===`row`?c.verticalAlignment:c.horizontalAlignment;return u&&(l+=` align-items: ${u};`),l+=n.style??``,T`
         <div id="${n.id??v}" style="${l}" class="${n.cssClasses}" slot="${n.slot??v}">
-            ${n.children?.map(e=>I(t,e,r,i,a,o,s))}
+            ${n.children?.map(e=>F(t,e,r,i,a,o,s))}
         </div>
-    `},Cn=(e,t,n,r,i,a,o)=>Sn(`row`,e,t,n,r,i,a,o),wn=(e,t,n,r,i,a,o)=>Sn(`column`,e,t,n,r,i,a,o),Tn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=`display: flex; flex-direction: ${s.orientation===`vertical`?`column`:`row`}; gap: var(--lumo-space-s, 0.5rem);`;return s.fullWidth&&(c+=` width: 100%;`),c+=t.style??``,T`
+    `},wn=(e,t,n,r,i,a,o)=>Cn(`row`,e,t,n,r,i,a,o),Tn=(e,t,n,r,i,a,o)=>Cn(`column`,e,t,n,r,i,a,o),En=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=`display: flex; flex-direction: ${s.orientation===`vertical`?`column`:`row`}; gap: var(--lumo-space-s, 0.5rem);`;return s.fullWidth&&(c+=` width: 100%;`),c+=t.style??``,T`
         <div id="${t.id??v}" style="${c}" class="${t.cssClasses}" slot="${t.slot??v}">
-            <div style="flex: 1; min-width: 0; min-height: 0;">${I(e,t.children[0],n,r,i,a,o)}</div>
-            <div style="flex: 1; min-width: 0; min-height: 0;">${I(e,t.children[1],n,r,i,a,o)}</div>
+            <div style="flex: 1; min-width: 0; min-height: 0;">${F(e,t.children[0],n,r,i,a,o)}</div>
+            <div style="flex: 1; min-width: 0; min-height: 0;">${F(e,t.children[1],n,r,i,a,o)}</div>
         </div>
-    `},En=(e,t,n,r,i,a,o)=>{let s=t.children&&t.children.length>1?t.children[1]:null,c=i?.detailComponent??null,l=!!i?.hasDetail||!!s,u=c??s;return T`
+    `},Dn=(e,t,n,r,i,a,o)=>{let s=t.children&&t.children.length>1?t.children[1]:null,c=i?.detailComponent??null,l=!!i?.hasDetail||!!s,u=c??s;return T`
         <div id="${t.id??v}" style="display: flex; gap: var(--lumo-space-m, 1rem); ${t.style??``}" class="${t.cssClasses}" slot="${t.slot??v}">
-            <div style="flex: 1; min-width: 0;">${I(e,t.children[0],n,r,i,a,o)}</div>
-            ${l&&u?T`<div style="flex: 1; min-width: 0;">${I(e,u,n,r,i,a,o)}</div>`:T`<div style="flex: 1; display: flex; align-items: center; justify-content: center; color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-s, .875rem);">Select an item to view details</div>`}
+            <div style="flex: 1; min-width: 0;">${F(e,t.children[0],n,r,i,a,o)}</div>
+            ${l&&u?T`<div style="flex: 1; min-width: 0;">${F(e,u,n,r,i,a,o)}</div>`:T`<div style="flex: 1; display: flex; align-items: center; justify-content: center; color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-s, .875rem);">Select an item to view details</div>`}
         </div>
-    `},Dn=(e,t,n,r,i,a,o)=>{let s=t.style??``;t.metadata.fullWidth&&(s+=` width: 100%;`);let c=Math.max(0,(t.children??[]).findIndex(e=>e.metadata.active));return T`
+    `},On=(e,t,n,r,i,a,o)=>{let s=t.style??``;t.metadata.fullWidth&&(s+=` width: 100%;`);let c=Math.max(0,(t.children??[]).findIndex(e=>e.metadata.active));return T`
         <div id="${t.id??v}" style="${s}" class="${t.cssClasses}" slot="${t.slot??v}">
             ${t.children?.map((t,s)=>{let l=t,u=l.metadata.label,d=u?.includes("${")?e._evalTemplate(u):u;return T`
                     <details ?open="${s===c}" style="border-bottom: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));">
                         <summary style="cursor: pointer; padding: var(--lumo-space-s, .5rem) 0; font-weight: 600;">${d}</summary>
                         <div style="padding: var(--lumo-space-m, 1rem) 0;">
-                            ${l.children?.map(t=>I(e,t,n,r,i,a,o))}
+                            ${l.children?.map(t=>F(e,t,n,r,i,a,o))}
                         </div>
                     </details>
                 `})}
         </div>
-    `},On=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style??``;return s.fullWidth&&(c+=` width: 100%;`),T`
+    `},kn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style??``;return s.fullWidth&&(c+=` width: 100%;`),T`
         <div style="${c}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${t.children?.map(t=>kn(e,t,n,r,i,a,o,s.variant))}
+            ${t.children?.map(t=>An(e,t,n,r,i,a,o,s.variant))}
         </div>
-    `},kn=(e,t,n,r,i,a,o,s)=>{let c=t.metadata,l=c.label?.includes("${")?e._evalTemplate(c.label):c.label;return T`
+    `},An=(e,t,n,r,i,a,o,s)=>{let c=t.metadata,l=c.label?.includes("${")?e._evalTemplate(c.label):c.label;return T`
         <details ?open="${c.active}" style="border-bottom: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1)); ${t.style??``}" class="${t.cssClasses}">
             <summary style="cursor: pointer; padding: var(--lumo-space-s, .5rem) 0; font-weight: 600; ${c.disabled?`pointer-events: none; opacity: .5;`:``}">${l}</summary>
             <div style="padding: var(--lumo-space-s, .5rem) 0;">
-                ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+                ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
             </div>
         </details>
-    `},An=(e,t,n,r,i,a,o)=>T`
+    `},jn=(e,t,n,r,i,a,o)=>T`
         <div style="overflow: auto; ${t.style??``}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
-        </div>
-    `,jn=(e,t,n,r,i,a,o)=>T`
-        <div style="width: 100%; ${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
         </div>
     `,Mn=(e,t,n,r,i,a,o)=>T`
-        <div style="max-width: min(100%, 1200px); margin: auto; ${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+        <div style="width: 100%; ${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
         </div>
     `,Nn=(e,t,n,r,i,a,o)=>T`
-        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr)); gap: ${gn}; ${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+        <div style="max-width: min(100%, 1200px); margin: auto; ${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
         </div>
     `,Pn=(e,t,n,r,i,a,o)=>T`
-        <div style="display: flex; gap: ${gn}; flex-wrap: wrap; ${t.style}" class="${t.cssClasses}">
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr)); gap: ${_n}; ${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
         </div>
     `,Fn=(e,t,n,r,i,a,o)=>T`
-        <div style="flex: ${t.metadata.boardCols??1} 1 0; min-width: min(100%, 12rem); ${t.style}" class="${t.cssClasses}">
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+        <div style="display: flex; gap: ${_n}; flex-wrap: wrap; ${t.style}" class="${t.cssClasses}">
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
         </div>
-    `,In=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+    `,In=(e,t,n,r,i,a,o)=>T`
+        <div style="flex: ${t.metadata.boardCols??1} 1 0; min-width: min(100%, 12rem); ${t.style}" class="${t.cssClasses}">
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+        </div>
+    `,Ln=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
         <div
                 style="display: flex; flex-direction: column; overflow: auto; ${t.style}"
                 class="${t.cssClasses}"
                 slot="${t.slot??v}"
         >
-            ${s.page.content.map(t=>I(e,t,n,r,i,a,o))}
+            ${s.page.content.map(t=>F(e,t,n,r,i,a,o))}
         </div>
-    `},Ln=e=>{let t=e.metadata;return(t?.content??t?.columns??[]).filter(e=>e&&e.metadata).map(e=>{let t=e.metadata;return{id:e.id??``,label:t?.label??e.id??``,autoWidth:t?.autoWidth,width:t?.width}})},Rn=(e,t)=>{let n=e?.[t];return n==null?``:typeof n==`object`?n.text??n.label??n.value??``:String(n)},zn=(e,t,n)=>{let r=Ln(e);return T`
+    `},Rn=e=>{let t=e.metadata;return(t?.content??t?.columns??[]).filter(e=>e&&e.metadata).map(e=>{let t=e.metadata;return{id:e.id??``,label:t?.label??e.id??``,autoWidth:t?.autoWidth,width:t?.width}})},zn=(e,t)=>{let n=e?.[t];return n==null?``:typeof n==`object`?n.text??n.label??n.value??``:String(n)},Bn=(e,t,n)=>{let r=Rn(e);return T`
         <div style="overflow:auto; width:100%; ${e.style}" class="${e.cssClasses}" slot="${e.slot??v}">
             <table style="border-collapse:collapse; width:100%; font-size: var(--lumo-font-size-s,.875rem);">
                 <thead><tr>${r.map(e=>T`<th style="${`text-align:left; padding:.45rem .6rem; border-bottom:2px solid var(--lumo-contrast-20pct,rgba(0,0,0,.2)); font-weight:600; white-space:nowrap; color: var(--lumo-secondary-text-color,#556);`}">${e.label}</th>`)}</tr></thead>
                 <tbody>
-                    ${(t??[]).length===0?T`<tr><td colspan="${Math.max(1,r.length)}" style="padding:1.5rem; text-align:center; color: var(--lumo-secondary-text-color,#888);">${n??`No data.`}</td></tr>`:t.map(e=>T`<tr>${r.map(t=>T`<td style="${`padding:.4rem .6rem; border-bottom:1px solid var(--lumo-contrast-10pct,rgba(0,0,0,.08)); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:24rem;`}" title="${Rn(e,t.id)}">${Rn(e,t.id)}</td>`)}</tr>`)}
+                    ${(t??[]).length===0?T`<tr><td colspan="${Math.max(1,r.length)}" style="padding:1.5rem; text-align:center; color: var(--lumo-secondary-text-color,#888);">${n??`No data.`}</td></tr>`:t.map(e=>T`<tr>${r.map(t=>T`<td style="${`padding:.4rem .6rem; border-bottom:1px solid var(--lumo-contrast-10pct,rgba(0,0,0,.08)); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:24rem;`}" title="${zn(e,t.id)}">${zn(e,t.id)}</td>`)}</tr>`)}
                 </tbody>
             </table>
         </div>
-    `},Bn=(e,t)=>{let n=e.metadata;return e.id&&t&&t[e.id]?t[e.id]:n?.page?.content??[]},Vn=e=>{let t=e.metadata.items??[];return T`
+    `},Vn=(e,t)=>{let n=e.metadata;return e.id&&t&&t[e.id]?t[e.id]:n?.page?.content??[]},Hn=e=>{let t=e.metadata.items??[];return T`
         <div class="mateu-message-list ${e.cssClasses??``}"
              style="display:flex; flex-direction:column; gap:.75rem; ${e.style??``}"
              slot="${e.slot??v}">
@@ -1141,15 +1141,15 @@ ${i}
                 </div>
             `)}
         </div>
-    `},Hn=(e,t,n,r,i,a,o)=>t.separator?T`<span style="align-self: stretch; width: 1px; background: var(--lumo-contrast-20pct, rgba(0,0,0,.2));"></span>`:t.submenus?T`
+    `},Un=(e,t,n,r,i,a,o)=>t.separator?T`<span style="align-self: stretch; width: 1px; background: var(--lumo-contrast-20pct, rgba(0,0,0,.2));"></span>`:t.submenus?T`
             <details style="position: relative;">
                 <summary style="cursor: pointer; list-style: none; padding: .35rem .7rem; border-radius: var(--lumo-border-radius-m, 6px);">
-                    ${t.component?I(e,t.component,n,r,i,a,o):t.label} ▾
+                    ${t.component?F(e,t.component,n,r,i,a,o):t.label} ▾
                 </summary>
                 <div style="display: flex; flex-direction: column; gap: .1rem; padding: .3rem; min-width: 10rem;
                             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1)); border-radius: var(--lumo-border-radius-m, 6px);
                             background: var(--lumo-base-color, #fff); box-shadow: var(--lumo-box-shadow-s, 0 2px 8px rgba(0,0,0,.15));">
-                    ${t.submenus.map(t=>Hn(e,t,n,r,i,a,o))}
+                    ${t.submenus.map(t=>Un(e,t,n,r,i,a,o))}
                 </div>
             </details>
         `:T`
@@ -1157,27 +1157,27 @@ ${i}
               style="cursor: ${t.disabled?`default`:`pointer`}; opacity: ${t.disabled?.5:1};
                      padding: .35rem .7rem; border-radius: var(--lumo-border-radius-m, 6px);
                      ${t.selected?`background: var(--lumo-primary-color-10pct, rgba(26,115,232,.12));`:``}">
-            ${t.component?I(e,t.component,n,r,i,a,o):t.label}
+            ${t.component?F(e,t.component,n,r,i,a,o):t.label}
         </span>
-    `,Un=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+    `,Wn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
         <div style="display: flex; flex-wrap: wrap; gap: .25rem; align-items: center; ${t.style}"
              class="${t.cssClasses}" slot="${t.slot??v}">
-            ${s.options?.map(t=>Hn(e,t,n,r,i,a??{},o??{}))}
+            ${s.options?.map(t=>Un(e,t,n,r,i,a??{},o??{}))}
         </div>
-    `},Wn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+    `},Gn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
         <div style="${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${I(e,s.wrapped,n,r,i,a,o)}
+            ${F(e,s.wrapped,n,r,i,a,o)}
         </div>
-    `},Gn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.content?.metadata,l=c?.type==j.Notice&&c.fullWidth===!0;return T`
+    `},Kn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.content?.metadata,l=c?.type==j.Notice&&c.fullWidth===!0;return T`
         <div style="display:flex; flex-direction:column; ${l?`width: 100%; `:``}${t.style}"
              class="${t.cssClasses}"
              slot="${t.slot??v}"
              data-colspan="${s.colspan||(l?99:v)}"
         >
             ${s.label?T`<label style="font-size: var(--lumo-font-size-s,.875rem); color: var(--lumo-secondary-text-color,#667); margin-bottom:.15rem;">${s.label}</label>`:v}
-            ${I(e,s.content,n,r,i,a,o)}
+            ${F(e,s.content,n,r,i,a,o)}
         </div>
-            `},Kn=e=>{let t=e.metadata,n=e=>{let n=e.closest(`.mateu-message-input`)?.querySelector(`input`),r=n?.value??``;!t.actionId||!r.trim()||(e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:{message:r}},bubbles:!0,composed:!0})),n&&(n.value=``))};return T`
+            `},qn=e=>{let t=e.metadata,n=e=>{let n=e.closest(`.mateu-message-input`)?.querySelector(`input`),r=n?.value??``;!t.actionId||!r.trim()||(e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:{message:r}},bubbles:!0,composed:!0})),n&&(n.value=``))};return T`
         <div class="mateu-message-input ${e.cssClasses??``}"
              style="display:flex; gap:.5rem; align-items:center; ${e.style??``}"
              slot="${e.slot??v}">
@@ -1187,62 +1187,62 @@ ${i}
             <button style="font:inherit; font-weight:500; cursor:pointer; padding:.5rem 1rem; border:none; border-radius:var(--lumo-border-radius-m,6px); background:var(--lumo-primary-color,#3b5bdb); color:var(--lumo-primary-contrast-color,#fff);"
                     @click="${e=>n(e.currentTarget)}">Send</button>
         </div>
-    `},qn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`<span title="${s.text}" style="${t.style}" class="${t.cssClasses}" slot="${t.slot??v}"
-        >${I(e,s.wrapped,n,r,i,a,o)}</span>`},Jn=e=>{if(e instanceof CustomEvent)return e.detail;let t={};for(let n in e){let r=e[n];[`number`,`string`,`boolean`].indexOf(typeof r)>=0&&(t[n]=e[n])}return t},Yn=(e,t,n,r,i)=>{let a={appState:r??{},appData:i??{}},o={};for(let r in e.attributes)o[r]=M(e.attributes[r],t,n,a);return{attributes:o,content:M(e.content,t,n,a)}},Xn=(e,t,n,r)=>{for(let t in r.attributes)e.setAttribute(t,r.attributes[t]);n.style&&e.setAttribute(`style`,n.style),n.cssClasses&&e.setAttribute(`class`,n.cssClasses),n.slot&&e.setAttribute(`slot`,n.slot),r.content&&(t.html?e.innerHTML=r.content:e.append(r.content))},Zn=e=>{let t=e.name,n=e.attributes?e.attributes.import:void 0;n&&t.includes(`-`)&&!customElements.get(t)&&D(()=>import(n),[])},Qn=(e,t,n,r,i,a,o)=>{Zn(t);let s=Yn(t,r,i,a,o),c=t.name;s.attributes.id&&(c=`#`+s.attributes.id);let l=n.id?`.element-container[data-element-id="${n.id}"]`:`.element-container`;return setTimeout(()=>{let r=e.shadowRoot?.querySelector(l),i=r?.querySelector(c);if(i){for(;i.firstChild;)i.removeChild(i.lastChild);Xn(i,t,n,s)}else{let i=document.createElement(t.name);Xn(i,t,n,s);for(let n in t.on)i.addEventListener(n,r=>{let i=Jn(r);e.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.on[n],parameters:{event:i}},bubbles:!0,composed:!0}))});r?.appendChild(i)}}),T`<div class="element-container" data-element-id="${S(n.id)}"></div>`},$n=function(e){return e.div=`div`,e.p=`p`,e.h1=`h1`,e.h2=`h2`,e.h3=`h3`,e.h4=`h4`,e.h5=`h5`,e.h6=`h6`,e.span=`span`,e}({}),er=(e,t,n,r,i)=>{let a=e.metadata,o=a.attributes?.[`data-colspan`],s=xt(a.text,t,n,r,i),c={xl:`var(--lumo-font-size-xl, 1.375rem)`,l:`var(--lumo-font-size-l, 1.125rem)`,s:`var(--lumo-font-size-s, .875rem)`,xs:`var(--lumo-font-size-xs, .8125rem)`},l=(a.size&&c[a.size]?`font-size: ${c[a.size]}; `:``)+(a.noMargins?`margin-block-start: 0; margin-block-end: 0; `:``);return $n.h1==a.container?T`
+    `},Jn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`<span title="${s.text}" style="${t.style}" class="${t.cssClasses}" slot="${t.slot??v}"
+        >${F(e,s.wrapped,n,r,i,a,o)}</span>`},Yn=e=>{if(e instanceof CustomEvent)return e.detail;let t={};for(let n in e){let r=e[n];[`number`,`string`,`boolean`].indexOf(typeof r)>=0&&(t[n]=e[n])}return t},Xn=(e,t,n,r,i)=>{let a={appState:r??{},appData:i??{}},o={};for(let r in e.attributes)o[r]=M(e.attributes[r],t,n,a);return{attributes:o,content:M(e.content,t,n,a)}},Zn=(e,t,n,r)=>{for(let t in r.attributes)e.setAttribute(t,r.attributes[t]);n.style&&e.setAttribute(`style`,n.style),n.cssClasses&&e.setAttribute(`class`,n.cssClasses),n.slot&&e.setAttribute(`slot`,n.slot),r.content&&(t.html?e.innerHTML=r.content:e.append(r.content))},Qn=e=>{let t=e.name,n=e.attributes?e.attributes.import:void 0;n&&t.includes(`-`)&&!customElements.get(t)&&D(()=>import(n),[])},$n=(e,t,n,r,i,a,o)=>{Qn(t);let s=Xn(t,r,i,a,o),c=t.name;s.attributes.id&&(c=`#`+s.attributes.id);let l=n.id?`.element-container[data-element-id="${n.id}"]`:`.element-container`;return setTimeout(()=>{let r=e.shadowRoot?.querySelector(l),i=r?.querySelector(c);if(i){for(;i.firstChild;)i.removeChild(i.lastChild);Zn(i,t,n,s)}else{let i=document.createElement(t.name);Zn(i,t,n,s);for(let n in t.on)i.addEventListener(n,r=>{let i=Yn(r);e.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.on[n],parameters:{event:i}},bubbles:!0,composed:!0}))});r?.appendChild(i)}}),T`<div class="element-container" data-element-id="${S(n.id)}"></div>`},er=function(e){return e.div=`div`,e.p=`p`,e.h1=`h1`,e.h2=`h2`,e.h3=`h3`,e.h4=`h4`,e.h5=`h5`,e.h6=`h6`,e.span=`span`,e}({}),tr=(e,t,n,r,i)=>{let a=e.metadata,o=a.attributes?.[`data-colspan`],s=xt(a.text,t,n,r,i),c={xl:`var(--lumo-font-size-xl, 1.375rem)`,l:`var(--lumo-font-size-l, 1.125rem)`,s:`var(--lumo-font-size-s, .875rem)`,xs:`var(--lumo-font-size-xs, .8125rem)`},l=(a.size&&c[a.size]?`font-size: ${c[a.size]}; `:``)+(a.noMargins?`margin-block-start: 0; margin-block-end: 0; `:``);return er.h1==a.container?T`
             <h1 style="${l}${e.style}" class="${e.cssClasses}"
                 id="${S(e.id)}"
                 data-colspan="${S(o)}"
                 slot="${e.slot??v}">
                 ${s??v}
             </h1>
-        `:$n.h2==a.container?T`
+        `:er.h2==a.container?T`
             <h2 style="${l}${e.style}" class="${e.cssClasses}"
                 id="${S(e.id)}"
                 data-colspan="${S(o)}"
                 slot="${e.slot??v}">
                 ${s??v}
             </h2>
-        `:$n.h3==a.container?T`
+        `:er.h3==a.container?T`
             <h3 style="${l}${e.style}" class="${e.cssClasses}"
                 id="${S(e.id)}"
                 data-colspan="${S(o)}"
                 slot="${e.slot??v}">
                 ${s??v}
             </h3>
-        `:$n.h4==a.container?T`
+        `:er.h4==a.container?T`
             <h4 style="${l}${e.style}" class="${e.cssClasses}"
                 id="${S(e.id)}"
                 data-colspan="${S(o)}"
                 slot="${e.slot??v}">
                 ${s??v}
             </h4>
-        `:$n.h5==a.container?T`
+        `:er.h5==a.container?T`
             <h5 style="${l}${e.style}" class="${e.cssClasses}"
                 id="${S(e.id)}"
                 data-colspan="${S(o)}"
                 slot="${e.slot??v}">
                 ${s??v}
             </h5>
-        `:$n.h6==a.container?T`
+        `:er.h6==a.container?T`
             <h6 style="${l}${e.style}" class="${e.cssClasses}"
                 id="${S(e.id)}"
                 data-colspan="${S(o)}"
                 slot="${e.slot??v}">
                 ${s??v}
             </h6>
-        `:$n.p==a.container?T`
+        `:er.p==a.container?T`
                <p style="${l}${e.style}" class="${e.cssClasses}"
                   id="${S(e.id)}"
                   data-colspan="${S(o)}"
                   slot="${e.slot??v}">
                    ${s??v}
                </p>
-            `:$n.div==a.container?T`
+            `:er.div==a.container?T`
                <div style="${l}${e.style}" class="${e.cssClasses}"
                     id="${S(e.id)}"
                     data-colspan="${S(o)}"
                     slot="${e.slot??v}">${s?_(s):v}</div>
-            `:$n.span==a.container?T`
+            `:er.span==a.container?T`
                <span style="${l}${e.style}" class="${e.cssClasses}"
                      id="${S(e.id)}"
                      data-colspan="${S(o)}"
@@ -1254,20 +1254,20 @@ ${i}
                        slot="${e.slot??v}">
                    Unknown text container: ${a.container} 
                </p>
-            `},tr=e=>{let t=e.metadata;return T`<a href="${t.url}" target="${t.target??v}"
+            `},nr=e=>{let t=e.metadata;return T`<a href="${t.url}" target="${t.target??v}"
                    rel="${t.target===`_blank`?`noopener`:v}"
                    style="${e.style}" class="${e.cssClasses}"
-                   slot="${e.slot??v}">${t.text}</a>`},nr=(e,t)=>{let n=e.toLowerCase().split(`+`);return t.ctrlKey===n.includes(`ctrl`)&&t.altKey===n.includes(`alt`)&&t.shiftKey===n.includes(`shift`)&&t.metaKey===n.includes(`meta`)},rr=(e,t)=>{if(!nr(e,t))return!1;let n=e.toLowerCase().split(`+`),r=n[n.length-1];return!!(t.key.toLowerCase()===r||/^[a-z]$/.test(r)&&t.code===`Key`+r.toUpperCase()||/^[0-9]$/.test(r)&&(t.code===`Digit`+r||t.code===`Numpad`+r))},ir=e=>e?e.split(`+`).map(e=>e.length<=1?e.toUpperCase():e.charAt(0).toUpperCase()+e.slice(1)).join(`+`):void 0,ar=(e,t)=>{let n=e.currentTarget.dataset.actionId;e.currentTarget?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:n,parameters:t.parameters},bubbles:!0,composed:!0}))},or=`display:inline-flex; align-items:center; justify-content:center; gap:.4em; box-sizing:border-box; font:inherit; font-weight:500; cursor:pointer; border-radius:var(--lumo-border-radius-m,6px); border:1px solid transparent; line-height:1; white-space:nowrap;`,sr=e=>{let t=e.buttonStyle??``,n=e.color&&e.color!==`none`&&e.color!==`normal`?e.color:``,r=e.size,i=n===`success`?`var(--lumo-success-color,#1a7f37)`:n===`error`?`var(--lumo-error-color,#c5221f)`:n===`contrast`?`var(--lumo-contrast,#161513)`:`var(--lumo-primary-color,#3b5bdb)`,a=n===`success`?`var(--lumo-success-contrast-color,#fff)`:n===`error`?`var(--lumo-error-contrast-color,#fff)`:n===`contrast`?`var(--lumo-base-color,#fff)`:`var(--lumo-primary-contrast-color,#fff)`,o=n===`success`?`var(--lumo-success-text-color,#1a7f37)`:n===`error`?`var(--lumo-error-text-color,#c5221f)`:n===`contrast`?`var(--lumo-body-text-color,#161513)`:`var(--lumo-primary-text-color,#3b5bdb)`,s;return s=t===`primary`?`background:${i}; color:${a};`:t===`tertiary`||t===`tertiaryInline`?`background:transparent; color:${o};`:`background:var(--lumo-contrast-5pct,rgba(0,0,0,.04)); color:${o}; border-color:var(--lumo-contrast-20pct,rgba(0,0,0,.16));`,`${or}${s}${r===`small`?`padding:.25rem .6rem; font-size:var(--lumo-font-size-s,.875rem);`:r===`large`?`padding:.65rem 1.4rem; font-size:var(--lumo-font-size-l,1.125rem);`:`padding:.45rem 1rem; font-size:var(--lumo-font-size-m,1rem);`}`},cr=(e,t,n)=>{let r=e.metadata,i=M(r.label,t,n);return T`<button
+                   slot="${e.slot??v}">${t.text}</a>`},rr=(e,t)=>{let n=e.toLowerCase().split(`+`);return t.ctrlKey===n.includes(`ctrl`)&&t.altKey===n.includes(`alt`)&&t.shiftKey===n.includes(`shift`)&&t.metaKey===n.includes(`meta`)},ir=(e,t)=>{if(!rr(e,t))return!1;let n=e.toLowerCase().split(`+`),r=n[n.length-1];return!!(t.key.toLowerCase()===r||/^[a-z]$/.test(r)&&t.code===`Key`+r.toUpperCase()||/^[0-9]$/.test(r)&&(t.code===`Digit`+r||t.code===`Numpad`+r))},ar=e=>e?e.split(`+`).map(e=>e.length<=1?e.toUpperCase():e.charAt(0).toUpperCase()+e.slice(1)).join(`+`):void 0,or=(e,t)=>{let n=e.currentTarget.dataset.actionId;e.currentTarget?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:n,parameters:t.parameters},bubbles:!0,composed:!0}))},sr=`display:inline-flex; align-items:center; justify-content:center; gap:.4em; box-sizing:border-box; font:inherit; font-weight:500; cursor:pointer; border-radius:var(--lumo-border-radius-m,6px); border:1px solid transparent; line-height:1; white-space:nowrap;`,cr=e=>{let t=e.buttonStyle??``,n=e.color&&e.color!==`none`&&e.color!==`normal`?e.color:``,r=e.size,i=n===`success`?`var(--lumo-success-color,#1a7f37)`:n===`error`?`var(--lumo-error-color,#c5221f)`:n===`contrast`?`var(--lumo-contrast,#161513)`:`var(--lumo-primary-color,#3b5bdb)`,a=n===`success`?`var(--lumo-success-contrast-color,#fff)`:n===`error`?`var(--lumo-error-contrast-color,#fff)`:n===`contrast`?`var(--lumo-base-color,#fff)`:`var(--lumo-primary-contrast-color,#fff)`,o=n===`success`?`var(--lumo-success-text-color,#1a7f37)`:n===`error`?`var(--lumo-error-text-color,#c5221f)`:n===`contrast`?`var(--lumo-body-text-color,#161513)`:`var(--lumo-primary-text-color,#3b5bdb)`,s;return s=t===`primary`?`background:${i}; color:${a};`:t===`tertiary`||t===`tertiaryInline`?`background:transparent; color:${o};`:`background:var(--lumo-contrast-5pct,rgba(0,0,0,.04)); color:${o}; border-color:var(--lumo-contrast-20pct,rgba(0,0,0,.16));`,`${sr}${s}${r===`small`?`padding:.25rem .6rem; font-size:var(--lumo-font-size-s,.875rem);`:r===`large`?`padding:.65rem 1.4rem; font-size:var(--lumo-font-size-l,1.125rem);`:`padding:.45rem 1rem; font-size:var(--lumo-font-size-m,1rem);`}`},lr=(e,t,n)=>{let r=e.metadata,i=M(r.label,t,n);return T`<button
             id="${e.id}"
             data-action-id="${r.actionId}"
-            @click="${e=>ar(e,r)}"
-            style="${sr(r)}${e.style}"
+            @click="${e=>or(e,r)}"
+            style="${cr(r)}${e.style}"
             class="${e.cssClasses}"
             ?disabled="${r.disabled}"
-            title="${r.shortcut?`${i} (${ir(r.shortcut)})`:v}"
+            title="${r.shortcut?`${i} (${ar(r.shortcut)})`:v}"
             slot="${e.slot??v}"
-    >${r.iconOnLeft?L(r.iconOnLeft):v}${i}${r.iconOnRight?L(r.iconOnRight):v}</button>`},lr=`display:block; box-sizing:border-box; background:var(--lumo-base-color,#fff); border:1px solid var(--lumo-contrast-10pct,rgba(0,0,0,.1)); border-radius:var(--lumo-border-radius-l,12px); box-shadow:var(--lumo-box-shadow-xs,0 1px 3px rgba(0,0,0,.08)); overflow:hidden;`,ur=(e,t,n,r,i,a,o)=>{let s=t.metadata;if(!s)return T``;let c=t=>t?I(e,t,n,r,i,a,o,!1):v,l=s.header||s.headerPrefix||s.headerSuffix||s.title||s.subtitle;return T`
-        <div id="${t.id??v}" style="${lr}${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
+    >${r.iconOnLeft?I(r.iconOnLeft):v}${i}${r.iconOnRight?I(r.iconOnRight):v}</button>`},ur=`display:block; box-sizing:border-box; background:var(--lumo-base-color,#fff); border:1px solid var(--lumo-contrast-10pct,rgba(0,0,0,.1)); border-radius:var(--lumo-border-radius-l,12px); box-shadow:var(--lumo-box-shadow-xs,0 1px 3px rgba(0,0,0,.08)); overflow:hidden;`,dr=(e,t,n,r,i,a,o)=>{let s=t.metadata;if(!s)return T``;let c=t=>t?F(e,t,n,r,i,a,o,!1):v,l=s.header||s.headerPrefix||s.headerSuffix||s.title||s.subtitle;return T`
+        <div id="${t.id??v}" style="${ur}${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
             ${s.media?c(s.media):v}
             ${l?T`<div style="display:flex; align-items:flex-start; gap:.75rem; padding:1rem 1.25rem ${s.content||s.footer?`0`:`1rem`};">
                 ${s.headerPrefix?c(s.headerPrefix):v}
@@ -1281,7 +1281,7 @@ ${i}
             ${s.content?T`<div style="padding:1rem 1.25rem;">${c(s.content)}</div>`:v}
             ${s.footer?T`<div style="padding:0 1.25rem 1rem;">${c(s.footer)}</div>`:v}
         </div>
-    `},dr=e=>{let t=e.metadata;return T`
+    `},fr=e=>{let t=e.metadata;return T`
         <mateu-chart 
                 style="${e.style}" 
                 class="${e.cssClasses}"
@@ -1291,21 +1291,21 @@ ${i}
                 .options="${t.chartOptions}"
         >
         </mateu-chart>
-    `},fr=e=>{let t=e.metadata;return L(t.icon,e.style,e.cssClasses,e.slot)},pr=(e,t)=>{e&&e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},mr=`font:inherit; font-weight:500; cursor:pointer; padding:.45rem 1rem; border-radius:var(--lumo-border-radius-m,6px);`,hr=`${mr} background:var(--lumo-contrast-5pct,rgba(0,0,0,.04)); color:var(--lumo-body-text-color,#161513); border:1px solid var(--lumo-contrast-20pct,rgba(0,0,0,.16));`,gr=`${mr} background:var(--lumo-primary-color,#3b5bdb); color:var(--lumo-primary-contrast-color,#fff); border:1px solid transparent;`,_r=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!1;if(s.openedCondition)try{c=St(s.openedCondition,r,i,a,o)}catch(e){console.error(`when evaluating `+s.openedCondition+` :`+e+`, where data is `+i+` and state is `+r)}return c?T`
+    `},pr=e=>{let t=e.metadata;return I(t.icon,e.style,e.cssClasses,e.slot)},mr=(e,t)=>{e&&e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},hr=`font:inherit; font-weight:500; cursor:pointer; padding:.45rem 1rem; border-radius:var(--lumo-border-radius-m,6px);`,gr=`${hr} background:var(--lumo-contrast-5pct,rgba(0,0,0,.04)); color:var(--lumo-body-text-color,#161513); border:1px solid var(--lumo-contrast-20pct,rgba(0,0,0,.16));`,_r=`${hr} background:var(--lumo-primary-color,#3b5bdb); color:var(--lumo-primary-contrast-color,#fff); border:1px solid transparent;`,vr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!1;if(s.openedCondition)try{c=St(s.openedCondition,r,i,a,o)}catch(e){console.error(`when evaluating `+s.openedCondition+` :`+e+`, where data is `+i+` and state is `+r)}return c?T`
         <div class="mateu-confirm-dialog ${t.cssClasses??``}"
              style="position:fixed; inset:0; z-index:1000; display:flex; align-items:center; justify-content:center; background:rgba(0,0,0,.4); ${t.style??``}"
              slot="${t.slot??v}">
             <div style="background:var(--lumo-base-color,#fff); color:var(--lumo-body-text-color,#161513); border-radius:var(--lumo-border-radius-l,12px); box-shadow:var(--lumo-box-shadow-l,0 8px 24px rgba(0,0,0,.2)); width:100%; max-width:min(90vw,32rem); padding:1.5rem; box-sizing:border-box;">
                 ${s.header?T`<h3 style="margin:0 0 .75rem; font-size:1.15rem;">${s.header}</h3>`:v}
-                <div>${t.children?.map(t=>I(e,t,n,r,i,a,o))}</div>
+                <div>${t.children?.map(t=>F(e,t,n,r,i,a,o))}</div>
                 <div style="display:flex; gap:.5rem; justify-content:flex-end; margin-top:1.25rem;">
-                    ${s.canCancel?T`<button style="${hr}" @click="${e=>pr(e.currentTarget,s.cancelActionId)}">${s.rejectText&&!s.canReject?s.rejectText:`Cancel`}</button>`:v}
-                    ${s.canReject?T`<button style="${hr}" @click="${e=>pr(e.currentTarget,s.rejectActionId)}">${s.rejectText||`No`}</button>`:v}
-                    <button style="${gr}" @click="${e=>pr(e.currentTarget,s.confirmActionId)}">${s.confirmText||`OK`}</button>
+                    ${s.canCancel?T`<button style="${gr}" @click="${e=>mr(e.currentTarget,s.cancelActionId)}">${s.rejectText&&!s.canReject?s.rejectText:`Cancel`}</button>`:v}
+                    ${s.canReject?T`<button style="${gr}" @click="${e=>mr(e.currentTarget,s.rejectActionId)}">${s.rejectText||`No`}</button>`:v}
+                    <button style="${_r}" @click="${e=>mr(e.currentTarget,s.confirmActionId)}">${s.confirmText||`OK`}</button>
                 </div>
             </div>
         </div>
-    `:T``},vr=e=>{let t=e.metadata,n;return t.position&&(n={Top:`top`,Bottom:`bottom`,TopLeft:`top-left`,TopRight:`top-right`,BottomLeft:`bottom-left`,BottomRight:`bottom-right`}[t.position]),T`
+    `:T``},yr=e=>{let t=e.metadata,n;return t.position&&(n={Top:`top`,Bottom:`bottom`,TopLeft:`top-left`,TopRight:`top-right`,BottomLeft:`bottom-left`,BottomRight:`bottom-right`}[t.position]),T`
         <mateu-cookie-consent style="${e.style}" class="${e.cssClasses}"
                                slot="${e.slot??v}"
                                position="${n??v}"
@@ -1316,17 +1316,17 @@ ${i}
                                .learnMoreLink="${t.learnMoreLink??v}"
                                .dismiss="${t.dismiss??v}"
         ></mateu-cookie-consent>
-    `},yr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+    `},br=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
         <details
                 ?open="${s.opened}"
                 style="${t.style}"
                 class="${t.cssClasses}"
                 slot="${t.slot??v}"
         >
-            <summary>${I(e,s.summary,n,r,i,a,o)}</summary>
-            ${I(e,s.content,n,r,i,a,o)}
+            <summary>${F(e,s.summary,n,r,i,a,o)}</summary>
+            ${F(e,s.content,n,r,i,a,o)}
         </details>
-            `},br=(e,t,n,r,i,a)=>T`
+            `},xr=(e,t,n,r,i,a)=>T`
         <mateu-dialog
                 id="${e.metadata.id}"
             .component="${e}"
@@ -1336,7 +1336,7 @@ ${i}
             .appState="${i}"
             .appdata="${a}"
         ></mateu-dialog>
-            `,xr=(e,t,n,r,i,a)=>T`
+            `,Sr=(e,t,n,r,i,a)=>T`
         <mateu-drawer
                 id="${e.metadata.id}"
             .component="${e}"
@@ -1346,7 +1346,7 @@ ${i}
             .appState="${i}"
             .appdata="${a}"
         ></mateu-drawer>
-            `,Sr=e=>{let t=e.metadata;return T`
+            `,Cr=e=>{let t=e.metadata;return T`
         <mateu-api-caller>
         <mateu-ux baseUrl="${t.baseUrl}"  
                   route="${t.route}" 
@@ -1358,11 +1358,11 @@ ${i}
                   slot="${e.slot??v}"
         ></mateu-ux>
         </mateu-api-caller>
-            `},Cr=e=>T`
+            `},wr=e=>T`
         <mateu-markdown .content=${e.metadata.markdown}
                         style="display:block; max-width: 72ch; ${e.style??``}" class="${e.cssClasses}"
                         slot="${e.slot??v}"></mateu-markdown>
-            `,wr=e=>{let t=e.metadata;return T`
+            `,Tr=e=>{let t=e.metadata;return T`
         <div
             role="status"
             slot="${e.slot??v}"
@@ -1375,7 +1375,7 @@ ${i}
             ${t.title?T`<strong>${t.title}</strong>`:v}
             ${t.text?T`<span>${t.text}</span>`:v}
         </div>
-    `},Tr=(e,t={})=>{let n=e.metadata,r=n.valueKey?t[n.valueKey]:n.value,i=n.max&&n.max!=0?n.max:1,a=!n.indeterminate&&r!=null;return T`
+    `},Er=(e,t={})=>{let n=e.metadata,r=n.valueKey?t[n.valueKey]:n.value,i=n.max&&n.max!=0?n.max:1,a=!n.indeterminate&&r!=null;return T`
         <div style="${e.style}" class="${e.cssClasses}" slot="${e.slot??v}">
             <progress
                     style="width:100%;"
@@ -1386,29 +1386,29 @@ ${i}
     ${n.text}
   </span>`:v}
         </div>
-    `},Er=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+    `},Dr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
         <details style="position: relative; ${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
-            <summary style="list-style: none; cursor: pointer;">${I(e,s.wrapped,n,r,i,a,o)}</summary>
+            <summary style="list-style: none; cursor: pointer;">${F(e,s.wrapped,n,r,i,a,o)}</summary>
             <div style="position: absolute; z-index: 100; min-width: 300px; margin-top: .25rem; padding: .6rem .8rem;
                         border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1)); border-radius: var(--lumo-border-radius-m, 8px);
                         background: var(--lumo-base-color, #fff); box-shadow: var(--lumo-box-shadow-m, 0 4px 16px rgba(0,0,0,.2));">
-                ${I(e,s.content,n,r,i,a,o)}
+                ${F(e,s.content,n,r,i,a,o)}
             </div>
         </details>
-    `},Dr=e=>{let t=e.metadata;return T`
+    `},Or=e=>{let t=e.metadata;return T`
         <mateu-map position="${t.position}" zoom="${t.zoom}"
                    style="${e.style}" class="${e.cssClasses}"
                    slot="${e.slot??v}"></mateu-map>
-            `},Or=e=>T`
+            `},kr=e=>T`
         <img src="${e.metadata.src}" style="${e.style}" class="${e.cssClasses}"
              slot="${e.slot??v}">
-            `,kr=e=>{let t=e.metadata;return T`<div style="display:flex; align-items:center; gap:0.5rem;" slot="${e.slot??v}">
+            `,Ar=e=>{let t=e.metadata;return T`<div style="display:flex; align-items:center; gap:0.5rem;" slot="${e.slot??v}">
         ${t.breadcrumbs.map(e=>T`
             <a href="${e.link}">${e.text}</a>
             <span>/</span>
         `)}
         <span style="${e.style}" class="${e.cssClasses}">${t.currentItemText}</span>
-    </div>`},Ar=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+    </div>`},jr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
         <skeleton-carousel 
                 id="${t.id}"
                 ?dots = "${s.dots}" 
@@ -1417,54 +1417,54 @@ ${i}
                 style="${t.style}"
                 css="${t.cssClasses}"
         >
-            ${t.children?.map(t=>T`<div>${I(e,t,n,r,i,a,o)}</div>`)}
+            ${t.children?.map(t=>T`<div>${F(e,t,n,r,i,a,o)}</div>`)}
         </skeleton-carousel>
-    `},jr=(e,t,n,r)=>{let i=e.metadata;return T`
+    `},Mr=(e,t,n,r)=>{let i=e.metadata;return T`
         <div style="display: flex; gap: 3rem; ${e.style}" class="${e.cssClasses}" slot="${e.slot??v}">
-            ${i.menu.map(e=>Mr(e))}
+            ${i.menu.map(e=>Nr(e))}
         </div>
-            `},Mr=e=>T`
+            `},Nr=e=>T`
         ${e.submenus?T`
                 <details open>
                     <summary>${e.label}</summary>
                     <div style="display:flex; flex-direction:column; gap:0.25rem; padding-left:0.5rem;">
-                        ${e.submenus.map(e=>Mr(e))}
+                        ${e.submenus.map(e=>Nr(e))}
                     </div>
                 </details>
             `:T`
                 <a href="${e.path}">${e.label}</a>
         `}
-        `,Nr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`<div
+        `,Pr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`<div
                 slot="${t.slot??v}"
                 style="${t.style}" class="${t.cssClasses}"
-        >${s.content?_(s.content):v}${t.children?.map(t=>I(e,t,n,r,i,a,o))}</div>
-    `},Pr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.title?.includes("${")?e._evalTemplate(s.title):s.title;return T`<div
+        >${s.content?_(s.content):v}${t.children?.map(t=>F(e,t,n,r,i,a,o))}</div>
+    `},Fr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.title?.includes("${")?e._evalTemplate(s.title):s.title;return T`<div
                 id="${t.id??v}"
                 slot="${t.slot??v}"
                 style="width: 100%; margin-bottom: var(--lumo-space-m); ${t.style}"
                 class="${t.cssClasses}"
         >
         ${c?T`<div style="font-size: var(--lumo-font-size-l); font-weight: 600; color: var(--lumo-header-text-color); margin-bottom: var(--lumo-space-s);">${c}</div>`:v}
-        ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+        ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
     </div>
-    `},Fr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.title?.includes("${")?e._evalTemplate(s.title):s.title;return T`
+    `},Ir=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.title?.includes("${")?e._evalTemplate(s.title):s.title;return T`
         <div
                 slot="${t.slot??v}"
                 style="${t.style}" class="${t.cssClasses}"
         >
         <h4>${c}</h4>
-        ${t.children?.map(t=>I(e,t,n,r,i,a,o))}</div>
-    `},Ir=(e,t,n)=>{n.dispatchEvent(new CustomEvent(`value-changed`,{detail:{fieldId:e,value:t},bubbles:!0,composed:!0}))},Lr=e=>t=>{let n=t.target,r=n.type===`checkbox`?n.checked:n.value;Ir(e.fieldId,r,n)},Rr=(e,t)=>{let n=e.metadata,r=t?.[n.fieldId]??``,i=n,a=i.dataType,o=i.stereotype,s=!!i.readOnly,c=!!i.disabled,l=i.options,u=n.label?T`<label style="display:block; font-size: var(--lumo-font-size-s,.875rem); color: var(--lumo-secondary-text-color,#667); margin-bottom:.15rem;">${n.label}</label>`:v,d=`width:100%; box-sizing:border-box; padding:.4rem .6rem; border:1px solid var(--lumo-contrast-30pct,rgba(0,0,0,.3)); border-radius: var(--lumo-border-radius-m,6px); font:inherit; background: var(--lumo-base-color,#fff); color: var(--lumo-body-text-color,#1a1a1a);`,f;return f=s||o===`plainText`?T`<div style="padding:.4rem 0;">${String(r??``)}</div>`:a===`boolean`||o===`checkbox`||o===`badge`?T`<input type="checkbox" ?checked="${!!r}" ?disabled="${c}" @change="${Lr(n)}">`:l&&l.length?T`
-            <select style="${d}" ?disabled="${c}" @change="${Lr(n)}">
+        ${t.children?.map(t=>F(e,t,n,r,i,a,o))}</div>
+    `},Lr=(e,t,n)=>{n.dispatchEvent(new CustomEvent(`value-changed`,{detail:{fieldId:e,value:t},bubbles:!0,composed:!0}))},Rr=e=>t=>{let n=t.target,r=n.type===`checkbox`?n.checked:n.value;Lr(e.fieldId,r,n)},zr=(e,t)=>{let n=e.metadata,r=t?.[n.fieldId]??``,i=n,a=i.dataType,o=i.stereotype,s=!!i.readOnly,c=!!i.disabled,l=i.options,u=n.label?T`<label style="display:block; font-size: var(--lumo-font-size-s,.875rem); color: var(--lumo-secondary-text-color,#667); margin-bottom:.15rem;">${n.label}</label>`:v,d=`width:100%; box-sizing:border-box; padding:.4rem .6rem; border:1px solid var(--lumo-contrast-30pct,rgba(0,0,0,.3)); border-radius: var(--lumo-border-radius-m,6px); font:inherit; background: var(--lumo-base-color,#fff); color: var(--lumo-body-text-color,#1a1a1a);`,f;return f=s||o===`plainText`?T`<div style="padding:.4rem 0;">${String(r??``)}</div>`:a===`boolean`||o===`checkbox`||o===`badge`?T`<input type="checkbox" ?checked="${!!r}" ?disabled="${c}" @change="${Rr(n)}">`:l&&l.length?T`
+            <select style="${d}" ?disabled="${c}" @change="${Rr(n)}">
                 <option value="">—</option>
                 ${l.map(e=>T`<option value="${e.value}" ?selected="${e.value===r}">${e.label}</option>`)}
-            </select>`:o===`textarea`||o===`richText`||o===`html`?T`<textarea style="${d}" rows="3" ?disabled="${c}" @input="${Lr(n)}">${String(r??``)}</textarea>`:T`<input type="${a===`integer`||a===`number`||a===`double`||a===`money`?`number`:a===`date`?`date`:a===`datetime`?`datetime-local`:a===`time`?`time`:o===`password`?`password`:a===`email`?`email`:`text`}" style="${d}" .value="${String(r??``)}"
-                              placeholder="${i.placeholder??v}" ?disabled="${c}" @input="${Lr(n)}">`,T`
+            </select>`:o===`textarea`||o===`richText`||o===`html`?T`<textarea style="${d}" rows="3" ?disabled="${c}" @input="${Rr(n)}">${String(r??``)}</textarea>`:T`<input type="${a===`integer`||a===`number`||a===`double`||a===`money`?`number`:a===`date`?`date`:a===`datetime`?`datetime-local`:a===`time`?`time`:o===`password`?`password`:a===`email`?`email`:`text`}" style="${d}" .value="${String(r??``)}"
+                              placeholder="${i.placeholder??v}" ?disabled="${c}" @input="${Rr(n)}">`,T`
         <div id="${e.id??v}" style="${e.style}" class="${e.cssClasses}" slot="${e.slot??v}">
             ${u}
             ${f}
         </div>
-    `},zr=e=>{let t=e.metadata;if((t?.level??0)>0)return e;let n=e=>{if(e?.metadata?.type===j.EntityHeader)return e;let t=e?.metadata?.content,r=[...e?.children??[],...Array.isArray(t)?t:t?[t]:[]];for(let e of r){let t=n(e);if(t)return t}},r;for(let t of e.children??[])if(r=n(t),r)break;if(!r)return e;let i=r.metadata;r.__hoistedToPageHeader=!0;let a=[...(i.facts??[]).filter(e=>e.label||e.value).map(e=>({title:e.label??``,text:e.value??``})),...i.metricLabel?[{title:i.metricLabel,text:i.metricValue??``}]:[]],o=(i.badges??[]).filter(e=>e.label).map(e=>({text:e.label,color:e.color})),s={...t,title:i.title||t.title,subtitle:i.subtitle??t.subtitle,kpis:[...t.kpis??[],...a],kpisBelow:!0,badges:[...t.badges??[],...o]};return{...e,metadata:s}},Br=(e,t,n,r,i,a,o,s)=>{let c=zr(t),l=c.metadata,u=l?.fabs??[];return T`<mateu-page
+    `},Br=e=>{let t=e.metadata;if((t?.level??0)>0)return e;let n=e=>{if(e?.metadata?.type===j.EntityHeader)return e;let t=e?.metadata?.content,r=[...e?.children??[],...Array.isArray(t)?t:t?[t]:[]];for(let e of r){let t=n(e);if(t)return t}},r;for(let t of e.children??[])if(r=n(t),r)break;if(!r)return e;let i=r.metadata;r.__hoistedToPageHeader=!0;let a=[...(i.facts??[]).filter(e=>e.label||e.value).map(e=>({title:e.label??``,text:e.value??``})),...i.metricLabel?[{title:i.metricLabel,text:i.metricValue??``}]:[]],o=(i.badges??[]).filter(e=>e.label).map(e=>({text:e.label,color:e.color})),s={...t,title:i.title||t.title,subtitle:i.subtitle??t.subtitle,kpis:[...t.kpis??[],...a],kpisBelow:!0,badges:[...t.badges??[],...o]};return{...e,metadata:s}},Vr=(e,t,n,r,i,a,o,s)=>{let c=Br(t),l=c.metadata,u=l?.fabs??[];return T`<mateu-page
             .component="${c}"
             baseUrl="${n}"
             .state="${r}"
@@ -1476,19 +1476,19 @@ ${i}
             class="${c.cssClasses}"
             ?standalone="${s??!1}"
     >
-        ${c.children?.map(t=>I(e,t,n,r,i,a,o))}
+        ${c.children?.map(t=>F(e,t,n,r,i,a,o))}
         ${l?.buttons?.map(t=>T`
-                   ${I(e,{id:t.actionId,metadata:t,type:A.ClientSide,slot:`buttons`},void 0,r,i,a,o)}
+                   ${F(e,{id:t.actionId,metadata:t,type:A.ClientSide,slot:`buttons`},void 0,r,i,a,o)}
 `)}
         ${u.map((t,n)=>T`
             <button class="page-fab" style="position: fixed; bottom: ${1.5+n*4}rem; right: 5.5rem;"
                 @click="${()=>e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))}"
                 title="${t.label}">
-                ${L(t.icon)}
+                ${I(t.icon)}
             </button>
         `)}
 </mateu-page>
-    `},Vr=(e,t,n,r,i,a,o,s)=>T`<mateu-table-crud
+    `},Hr=(e,t,n,r,i,a,o,s)=>T`<mateu-table-crud
             id="${t.id}"
             baseUrl="${n}"
             .component="${t}"
@@ -1502,8 +1502,8 @@ ${i}
             slot="${t.slot??v}"
             ?standalone="${s??!1}"
     >
-        ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
-    </mateu-table-crud>`,Hr=e=>{let t=e.metadata;return T`
+        ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+    </mateu-table-crud>`,Ur=e=>{let t=e.metadata;return T`
         <mateu-bpmn
                 style="${e.style}"
                 class="${e.cssClasses}"
@@ -1511,64 +1511,64 @@ ${i}
                 xml="${t.xml}"
         >
         </mateu-bpmn>
-    `},Ur=(e,t,n)=>T`<mateu-chat sseUrl="${e.metadata.sseUrl}"
+    `},Wr=(e,t,n)=>T`<mateu-chat sseUrl="${e.metadata.sseUrl}"
                             style="${e.style}" 
                             class="${e.cssClasses}" 
-                            slot="${e.slot??v}"></mateu-chat>`,Wr=e=>{let t=e.metadata;return T`
+                            slot="${e.slot??v}"></mateu-chat>`,Gr=e=>{let t=e.metadata;return T`
         <mateu-workflow
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
                 value="${t.value??`{"name":"New Workflow","steps":[]}`}"
         ></mateu-workflow>
-    `},Gr=e=>{let t=e.metadata;return T`
+    `},Kr=e=>{let t=e.metadata;return T`
         <mateu-form-editor
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
                 value="${t.value??`{"name":"New Form","fields":[]}`}"
         ></mateu-form-editor>
-    `},Kr=`
+    `},qr=`
     background: var(--lumo-base-color, #fff);
     border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.08));
     border-radius: var(--lumo-border-radius-l, 12px);
     padding: var(--lumo-space-m, 1rem);
     box-sizing: border-box;
-`,qr=e=>e==`up`?`var(--lumo-success-text-color, #1a7f37)`:e==`down`?`var(--lumo-error-text-color, #c5221f)`:`var(--lumo-secondary-text-color, #666)`,Jr=e=>e==`up`?`▲`:e==`down`?`▼`:``,Yr=(e,t)=>{t.actionId&&e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))},Xr=e=>{let t=e.metadata,n=!!t.actionId;return T`
+`,Jr=e=>e==`up`?`var(--lumo-success-text-color, #1a7f37)`:e==`down`?`var(--lumo-error-text-color, #c5221f)`:`var(--lumo-secondary-text-color, #666)`,Yr=e=>e==`up`?`▲`:e==`down`?`▼`:``,Xr=(e,t)=>{t.actionId&&e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))},Zr=e=>{let t=e.metadata,n=!!t.actionId;return T`
         <div class="mateu-metric-card ${e.cssClasses??``}"
-             style="${Kr} display: flex; flex-direction: column; gap: .25rem; min-width: 11rem; flex: 1; ${n?`cursor: pointer;`:``} ${e.style??``}"
+             style="${qr} display: flex; flex-direction: column; gap: .25rem; min-width: 11rem; flex: 1; ${n?`cursor: pointer;`:``} ${e.style??``}"
              slot="${e.slot??v}"
              role="${n?`button`:v}"
-             @click="${e=>Yr(e,t)}"
+             @click="${e=>Xr(e,t)}"
         >
             <div style="display: flex; align-items: center; justify-content: space-between; gap: .5rem;">
                 <span style="font-size: var(--lumo-font-size-s, .875rem); color: var(--lumo-secondary-text-color, #666);">${t.title}</span>
-                ${t.icon?L(t.icon,`color: var(--lumo-tertiary-text-color, #999); width: 1.1em; height: 1.1em;`):v}
+                ${t.icon?I(t.icon,`color: var(--lumo-tertiary-text-color, #999); width: 1.1em; height: 1.1em;`):v}
             </div>
             <div style="display: flex; align-items: baseline; gap: .35rem;">
                 <span style="font-size: var(--lumo-font-size-xxxl, 2rem); font-weight: 600; line-height: 1.1;">${t.value}</span>
                 ${t.unit?T`<span style="font-size: var(--lumo-font-size-m, 1rem); color: var(--lumo-secondary-text-color, #666);">${t.unit}</span>`:v}
             </div>
             ${t.trend||t.trendLabel?T`
-                <span style="font-size: var(--lumo-font-size-s, .875rem); color: ${qr(t.trend)};">
-                    ${Jr(t.trend)} ${t.trendLabel??v}
+                <span style="font-size: var(--lumo-font-size-s, .875rem); color: ${Jr(t.trend)};">
+                    ${Yr(t.trend)} ${t.trendLabel??v}
                 </span>
             `:v}
             ${t.description?T`<span style="font-size: var(--lumo-font-size-xs, .8rem); color: var(--lumo-tertiary-text-color, #999);">${t.description}</span>`:v}
         </div>
-    `},Zr=(e,t,n,r,i,a,o)=>T`
+    `},Qr=(e,t,n,r,i,a,o)=>T`
         <div class="mateu-scoreboard ${t.cssClasses??``}"
              style="display: flex; flex-wrap: wrap; gap: var(--lumo-space-m, 1rem); grid-column: 1 / -1; ${t.style??``}"
              slot="${t.slot??v}"
         >
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
         </div>
-    `,Qr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.colSpan&&s.colSpan>1?`grid-column: span ${s.colSpan};`:``,l=s.rowSpan&&s.rowSpan>1?`grid-row: span ${s.rowSpan};`:``,u=t.children??[];return u.length===1&&u[0].metadata?.type===`MetricCard`?T`
+    `,$r=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.colSpan&&s.colSpan>1?`grid-column: span ${s.colSpan};`:``,l=s.rowSpan&&s.rowSpan>1?`grid-row: span ${s.rowSpan};`:``,u=t.children??[];return u.length===1&&u[0].metadata?.type===`MetricCard`?T`
             <div style="min-width: 0; ${c} ${l} ${t.style??``}" slot="${t.slot??v}">
-                ${I(e,u[0],n,r,i,a,o)}
+                ${F(e,u[0],n,r,i,a,o)}
             </div>`:T`
         <div class="mateu-dashboard-panel ${t.cssClasses??``}"
-             style="${Kr} display: flex; flex-direction: column; gap: .5rem; min-width: 0; ${c} ${l} ${t.style??``}"
+             style="${qr} display: flex; flex-direction: column; gap: .5rem; min-width: 0; ${c} ${l} ${t.style??``}"
              slot="${t.slot??v}"
         >
             ${s.title?T`
@@ -1578,17 +1578,17 @@ ${i}
                 </div>
             `:v}
             <div style="flex: 1; min-height: 0;">
-                ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+                ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
             </div>
         </div>
-    `},$r=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.columns&&s.columns>0?`repeat(${s.columns}, minmax(0, 1fr))`:`repeat(auto-fit, minmax(20rem, 1fr))`;return T`
+    `},ei=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.columns&&s.columns>0?`repeat(${s.columns}, minmax(0, 1fr))`:`repeat(auto-fit, minmax(20rem, 1fr))`;return T`
         <div class="mateu-dashboard ${t.cssClasses??``}"
              style="display: grid; grid-template-columns: ${c}; gap: var(--lumo-space-m, 1rem); align-items: stretch; ${t.style??``}"
              slot="${t.slot??v}"
         >
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
         </div>
-    `},ei=class extends b{constructor(...e){super(...e),this.panels=[],this.headerTitle=``,this.badges=[],this.orientation=`vertical`,this.navigation=null,this.overviewEditActionId=``,this.openPanels=new Set,this.expandedPanel=null,this._onPopState=()=>{let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(e.startsWith(`expand=`)){let t=e.slice(7),n=this.panels.findIndex((e,n)=>this.panelAnchor(e,n)===t);this.expandedPanel=n>=0?n:null}else this.expandedPanel=null},this.initialized=!1}navAction(e){e&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{}},bubbles:!0,composed:!0}))}connectedCallback(){super.connectedCallback(),window.addEventListener(`popstate`,this._onPopState)}disconnectedCallback(){window.removeEventListener(`popstate`,this._onPopState),super.disconnectedCallback()}willUpdate(){if(!this.initialized&&this.panels.length){this.openPanels=new Set(this.panels.map((e,t)=>e.open?t:-1).filter(e=>e>=0));let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(e.startsWith(`expand=`)){let t=e.slice(7),n=this.panels.findIndex((e,n)=>this.panelAnchor(e,n)===t);n>=0&&(this.expandedPanel=n)}else if(e){let t=this.panels.findIndex((t,n)=>this.panelAnchor(t,n)===e);t>=0&&this.openPanels.add(t)}this.initialized=!0}}firstUpdated(){let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(!e)return;let t=this.renderRoot.querySelector(`[data-anchor="${CSS.escape(e)}"]`);t&&t.scrollIntoView({block:`nearest`})}panelAnchor(e,t){return(e.title??``).toLowerCase().replace(/[^a-z0-9]+/g,`-`).replace(/^-|-$/g,``)||`panel-${t}`}bookmarkPanel(e){let t=this.panelAnchor(this.panels[e],e);try{history.replaceState(history.state,``,`#`+t)}catch{}}clearBookmark(e){let t=this.panelAnchor(this.panels[e],e);if(decodeURIComponent((location.hash||``).replace(/^#/,``))===t)try{history.replaceState(history.state,``,location.pathname+location.search)}catch{}}expandPanel(e,t){t?.stopPropagation(),this.expandedPanel=e;let n=this.panelAnchor(this.panels[e],e);try{history.pushState(history.state,``,`#expand=`+n)}catch{}}collapsePanel(){try{history.back()}catch{this.expandedPanel=null}}toggle(e){let t=new Set(this.openPanels);t.has(e)?(t.delete(e),this.clearBookmark(e)):(t.add(e),this.bookmarkPanel(e)),this.openPanels=t}static{this.styles=h`
+    `},ti=class extends b{constructor(...e){super(...e),this.panels=[],this.headerTitle=``,this.badges=[],this.orientation=`vertical`,this.navigation=null,this.overviewEditActionId=``,this.openPanels=new Set,this.expandedPanel=null,this._onPopState=()=>{let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(e.startsWith(`expand=`)){let t=e.slice(7),n=this.panels.findIndex((e,n)=>this.panelAnchor(e,n)===t);this.expandedPanel=n>=0?n:null}else this.expandedPanel=null},this.initialized=!1}navAction(e){e&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{}},bubbles:!0,composed:!0}))}connectedCallback(){super.connectedCallback(),window.addEventListener(`popstate`,this._onPopState)}disconnectedCallback(){window.removeEventListener(`popstate`,this._onPopState),super.disconnectedCallback()}willUpdate(){if(!this.initialized&&this.panels.length){this.openPanels=new Set(this.panels.map((e,t)=>e.open?t:-1).filter(e=>e>=0));let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(e.startsWith(`expand=`)){let t=e.slice(7),n=this.panels.findIndex((e,n)=>this.panelAnchor(e,n)===t);n>=0&&(this.expandedPanel=n)}else if(e){let t=this.panels.findIndex((t,n)=>this.panelAnchor(t,n)===e);t>=0&&this.openPanels.add(t)}this.initialized=!0}}firstUpdated(){let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(!e)return;let t=this.renderRoot.querySelector(`[data-anchor="${CSS.escape(e)}"]`);t&&t.scrollIntoView({block:`nearest`})}panelAnchor(e,t){return(e.title??``).toLowerCase().replace(/[^a-z0-9]+/g,`-`).replace(/^-|-$/g,``)||`panel-${t}`}bookmarkPanel(e){let t=this.panelAnchor(this.panels[e],e);try{history.replaceState(history.state,``,`#`+t)}catch{}}clearBookmark(e){let t=this.panelAnchor(this.panels[e],e);if(decodeURIComponent((location.hash||``).replace(/^#/,``))===t)try{history.replaceState(history.state,``,location.pathname+location.search)}catch{}}expandPanel(e,t){t?.stopPropagation(),this.expandedPanel=e;let n=this.panelAnchor(this.panels[e],e);try{history.pushState(history.state,``,`#expand=`+n)}catch{}}collapsePanel(){try{history.back()}catch{this.expandedPanel=null}}toggle(e){let t=new Set(this.openPanels);t.has(e)?(t.delete(e),this.clearBookmark(e)):(t.add(e),this.bookmarkPanel(e)),this.openPanels=t}static{this.styles=h`
         :host {
             display: flex;
             flex-direction: column;
@@ -1974,7 +1974,7 @@ ${i}
                     `)}
                 </div>
             </div>
-        `}};k([y({type:Array})],ei.prototype,`panels`,void 0),k([y({type:String})],ei.prototype,`headerTitle`,void 0),k([y({type:Array})],ei.prototype,`badges`,void 0),k([y({type:String,reflect:!0})],ei.prototype,`orientation`,void 0),k([y({attribute:!1})],ei.prototype,`navigation`,void 0),k([y({type:String})],ei.prototype,`overviewEditActionId`,void 0),k([C()],ei.prototype,`openPanels`,void 0),k([C()],ei.prototype,`expandedPanel`,void 0),ei=k([g(`mateu-foldout`)],ei);var ti=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+        `}};k([y({type:Array})],ti.prototype,`panels`,void 0),k([y({type:String})],ti.prototype,`headerTitle`,void 0),k([y({type:Array})],ti.prototype,`badges`,void 0),k([y({type:String,reflect:!0})],ti.prototype,`orientation`,void 0),k([y({attribute:!1})],ti.prototype,`navigation`,void 0),k([y({type:String})],ti.prototype,`overviewEditActionId`,void 0),k([C()],ti.prototype,`openPanels`,void 0),k([C()],ti.prototype,`expandedPanel`,void 0),ti=k([g(`mateu-foldout`)],ti);var ni=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
         <mateu-foldout
                 .panels="${s.panels??[]}"
                 .headerTitle="${s.headerTitle??``}"
@@ -1986,9 +1986,9 @@ ${i}
                 class="${t.cssClasses}"
                 slot="${t.slot??v}"
         >
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
         </mateu-foldout>
-    `},ni=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.children??[],l=e=>c.filter(t=>(t.slot??``).startsWith(e)),u=l(`main-`),d=l(`aside-`),f=l(`footer-`),p=s.asideWidth&&s.asideWidth.trim()?s.asideWidth:`32%`,ee=s.asidePosition===`start`,m=s.asideSticky!==!1,te=t=>t.map(t=>I(e,t,n,r,i,a,o)),ne=T`
+    `},ri=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.children??[],l=e=>c.filter(t=>(t.slot??``).startsWith(e)),u=l(`main-`),d=l(`aside-`),f=l(`footer-`),p=s.asideWidth&&s.asideWidth.trim()?s.asideWidth:`32%`,ee=s.asidePosition===`start`,m=s.asideSticky!==!1,te=t=>t.map(t=>F(e,t,n,r,i,a,o)),ne=T`
         <div class="mateu-content-main"
              style="flex: 1 1 0; min-width: min(20rem, 100%); box-sizing: border-box;">
             ${te(u)}
@@ -2009,7 +2009,7 @@ ${i}
                     ${te(f)}
                 </div>`:v}
         </div>
-    `},ri=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!!s.image,l=c?`background-image: linear-gradient(rgba(0,0,0,.35), rgba(0,0,0,.35)), url('${s.image}'); background-size: cover; background-position: center; color: #fff;`:``,u=s.centered===!1?`flex-start`:`center`,d=s.centered===!1?`left`:`center`;return T`
+    `},ii=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!!s.image,l=c?`background-image: linear-gradient(rgba(0,0,0,.35), rgba(0,0,0,.35)), url('${s.image}'); background-size: cover; background-position: center; color: #fff;`:``,u=s.centered===!1?`flex-start`:`center`,d=s.centered===!1?`left`:`center`;return T`
         <div class="mateu-hero ${t.cssClasses??``}"
              style="display: flex; flex-direction: column; align-items: ${u}; justify-content: center; gap: var(--lumo-space-m, 1rem); text-align: ${d}; padding: var(--lumo-space-xl, 2.5rem) var(--lumo-space-l, 1.5rem); border-radius: var(--lumo-border-radius-l, 12px); min-height: ${s.height??`12rem`}; box-sizing: border-box; ${l} ${t.style??``}"
              slot="${t.slot??v}"
@@ -2018,11 +2018,11 @@ ${i}
             ${s.subtitle?T`<p style="margin: 0; font-size: var(--lumo-font-size-l, 1.125rem); ${c?``:`color: var(--lumo-secondary-text-color, #666);`} max-width: 40rem;">${s.subtitle}</p>`:v}
             ${t.children?.length?T`
                 <div style="display: flex; gap: var(--lumo-space-s, .5rem); flex-wrap: wrap; justify-content: ${u}; width: 100%; max-width: 40rem;">
-                    ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+                    ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
                 </div>
             `:v}
         </div>
-    `},z=e=>t=>{if(t.key===`Enter`){e(t);return}(t.key===` `||t.key===`Spacebar`)&&(t.preventDefault(),e(t))},B=h`
+    `},R=e=>t=>{if(t.key===`Enter`){e(t);return}(t.key===` `||t.key===`Spacebar`)&&(t.preventDefault(),e(t))},z=h`
     [role="button"]:focus-visible,
     [role="option"]:focus-visible,
     [role="treeitem"]:focus-visible,
@@ -2033,7 +2033,7 @@ ${i}
         outline-offset: 2px;
         border-radius: var(--lumo-border-radius-s, 4px);
     }
-`,ii=1440*60*1e3,ai=class extends b{constructor(...e){super(...e),this.tasks=[],this.onTaskSelectionActionId=``}selectTask(e){this.onTaskSelectionActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.onTaskSelectionActionId,parameters:{_clickedTaskId:e.id}},bubbles:!0,composed:!0}))}static{this.styles=h`
+`,ai=1440*60*1e3,oi=class extends b{constructor(...e){super(...e),this.tasks=[],this.onTaskSelectionActionId=``}selectTask(e){this.onTaskSelectionActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.onTaskSelectionActionId,parameters:{_clickedTaskId:e.id}},bubbles:!0,composed:!0}))}static{this.styles=h`
         :host {
             display: block;
             width: 100%;
@@ -2108,8 +2108,8 @@ ${i}
             opacity: .55;
         }
     
-        ${B}
-    `}range(){let e=this.tasks.flatMap(e=>[e.start,e.end]).filter(e=>!!e).map(e=>new Date(e+`T00:00:00`).getTime());return e.length?{min:Math.min(...e)-ii,max:Math.max(...e)+2*ii}:null}months(e,t){let n=[],r=new Date(e);for(r.setDate(1);r.getTime()<=t;){let i=Math.max(r.getTime(),e),a=new Date(r.getFullYear(),r.getMonth()+1,1),o=Math.min(a.getTime(),t);n.push({label:r.toLocaleDateString(void 0,{month:`short`,year:`2-digit`}),from:i,to:o}),r.setMonth(r.getMonth()+1)}return n}render(){let e=this.range();if(!e)return T``;let t=e.max-e.min,n=n=>(n-e.min)/t*100,r=Date.now();return T`
+        ${z}
+    `}range(){let e=this.tasks.flatMap(e=>[e.start,e.end]).filter(e=>!!e).map(e=>new Date(e+`T00:00:00`).getTime());return e.length?{min:Math.min(...e)-ai,max:Math.max(...e)+2*ai}:null}months(e,t){let n=[],r=new Date(e);for(r.setDate(1);r.getTime()<=t;){let i=Math.max(r.getTime(),e),a=new Date(r.getFullYear(),r.getMonth()+1,1),o=Math.min(a.getTime(),t);n.push({label:r.toLocaleDateString(void 0,{month:`short`,year:`2-digit`}),from:i,to:o}),r.setMonth(r.getMonth()+1)}return n}render(){let e=this.range();if(!e)return T``;let t=e.max-e.min,n=n=>(n-e.min)/t*100,r=Date.now();return T`
             <div class="frame">
                 <div class="head">Task</div>
                 <div class="head months">
@@ -2117,7 +2117,7 @@ ${i}
                         <div class="month" style="width: ${(e.to-e.from)/t*100}%;">${e.label}</div>
                     `)}
                 </div>
-                ${this.tasks.map(i=>{let a=new Date(i.start+`T00:00:00`).getTime(),o=new Date(i.end+`T00:00:00`).getTime()+ii;return T`
+                ${this.tasks.map(i=>{let a=new Date(i.start+`T00:00:00`).getTime(),o=new Date(i.end+`T00:00:00`).getTime()+ai;return T`
                         <div class="label" title="${i.title}">${i.title}</div>
                         <div class="lane">
                             ${r>=e.min&&r<=e.max?T`<div class="today" style="left: ${n(r)}%;"></div>`:v}
@@ -2125,14 +2125,14 @@ ${i}
                                  aria-label="${i.title}, ${i.start} to ${i.end}${i.progress?`, ${i.progress}% complete`:``}"
                                  class="bar ${this.onTaskSelectionActionId?`clickable`:``}"
                                  title="${i.title} · ${i.start} → ${i.end}${i.progress?` · ${i.progress}%`:``}"
-                                 @click="${()=>this.selectTask(i)}" @keydown="${z(()=>this.selectTask(i))}"
+                                 @click="${()=>this.selectTask(i)}" @keydown="${R(()=>this.selectTask(i))}"
                                  style="left: ${n(a)}%; width: ${(o-a)/t*100}%; ${i.color?`--mateu-gantt-fill: ${i.color};`:``}">
                                 <div class="fill" style="width: ${i.progress??0}%;"></div>
                             </div>
                         </div>
                     `})}
             </div>
-        `}};k([y({type:Array})],ai.prototype,`tasks`,void 0),k([y()],ai.prototype,`onTaskSelectionActionId`,void 0),ai=k([g(`mateu-gantt`)],ai);var oi=e=>{let t=e.metadata;return T`
+        `}};k([y({type:Array})],oi.prototype,`tasks`,void 0),k([y()],oi.prototype,`onTaskSelectionActionId`,void 0),oi=k([g(`mateu-gantt`)],oi);var si=e=>{let t=e.metadata;return T`
         <mateu-gantt
                 .tasks="${t.tasks??[]}"
                 .onTaskSelectionActionId="${t.onTaskSelectionActionId??``}"
@@ -2140,7 +2140,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-gantt>
-    `},V,si=class extends b{static{V=this}constructor(...e){super(...e),this.resources=[],this.blocks=[],this.drag=null,this.dragStartX=0,this.dragStartY=0,this.laneRects=[],this.onDragKeydown=e=>{e.key===`Escape`&&this.drag&&(e.stopPropagation(),this.endDrag())}}static{this.styles=h`
+    `},B,ci=class extends b{static{B=this}constructor(...e){super(...e),this.resources=[],this.blocks=[],this.drag=null,this.dragStartX=0,this.dragStartY=0,this.laneRects=[],this.onDragKeydown=e=>{e.key===`Escape`&&this.drag&&(e.stopPropagation(),this.endDrag())}}static{this.styles=h`
         :host {
             display: block;
             width: 100%;
@@ -2282,7 +2282,7 @@ ${i}
             pointer-events: none;
             z-index: 2;
         }
-    `}static parse(e){return new Date(e+`T00:00:00`)}static iso(e){let t=e=>String(e).padStart(2,`0`);return`${e.getFullYear()}-${t(e.getMonth()+1)}-${t(e.getDate())}`}static addDays(e,t){return new Date(e.getFullYear(),e.getMonth(),e.getDate()+t)}static daysBetween(e,t){return Math.round((t.getTime()-e.getTime())/864e5)}window(){if(this.from&&this.to){let e=V.parse(this.from),t=V.daysBetween(e,V.parse(this.to))+1;return t>0?{from:e,days:t}:null}let e=this.blocks.flatMap(e=>[e.start,e.end]).filter(e=>!!e).map(e=>V.parse(e));if(!e.length)return null;let t=new Date(Math.min(...e.map(e=>e.getTime()))),n=new Date(Math.max(...e.map(e=>e.getTime())));return{from:t,days:V.daysBetween(t,n)+1}}onBlockPointerDown(e,t,n){if(!this.moveActionId&&!this.selectActionId||(e.preventDefault(),e.currentTarget.setPointerCapture(e.pointerId),this.dragStartX=e.clientX,this.dragStartY=e.clientY,!this.window()))return;let r=V.parse(t.start),i=V.parse(t.end),a=Math.max(1,V.daysBetween(r,i)+1);this.laneRects=[...this.renderRoot.querySelectorAll(`.lane[data-resource-id]`)].map(e=>({resourceId:e.dataset.resourceId,rect:e.getBoundingClientRect()}));let o=this.dayAt(t.resourceId,e.clientX)??n;this.drag={blockId:t.id,duration:a,grabOffsetDays:o-n,originResourceId:t.resourceId,originStartIdx:n,targetResourceId:t.resourceId,targetStartIdx:n,moved:!1},window.addEventListener(`keydown`,this.onDragKeydown)}dayAt(e,t){let n=this.laneRects.find(t=>t.resourceId===e),r=this.window();if(!n||!r||n.rect.width===0)return null;let i=Math.floor((t-n.rect.left)/n.rect.width*r.days);return Math.max(0,Math.min(r.days-1,i))}onBlockPointerMove(e){if(!this.drag||!this.drag.moved&&Math.abs(e.clientX-this.dragStartX)<4&&Math.abs(e.clientY-this.dragStartY)<4||!this.moveActionId)return;let t=this.window();if(!t)return;let n=this.laneRects.find(t=>e.clientY>=t.rect.top&&e.clientY<=t.rect.bottom)??this.laneRects.find(e=>e.resourceId===this.drag.targetResourceId);if(!n)return;let r=this.dayAt(n.resourceId,e.clientX);if(r==null)return;let i=Math.max(0,Math.min(t.days-this.drag.duration,r-this.drag.grabOffsetDays));this.drag={...this.drag,moved:!0,targetResourceId:n.resourceId,targetStartIdx:i}}onBlockPointerUp(e){let t=this.drag;if(this.endDrag(),!t)return;if(!t.moved){this.selectActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.selectActionId,parameters:{_blockId:e.id}},bubbles:!0,composed:!0}));return}if(!this.moveActionId||t.targetResourceId===t.originResourceId&&t.targetStartIdx===t.originStartIdx)return;let n=this.window();if(!n)return;let r=V.addDays(n.from,t.targetStartIdx),i=V.addDays(r,t.duration-1);this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.moveActionId,parameters:{_blockId:t.blockId,_resourceId:t.targetResourceId,_start:V.iso(r),_end:V.iso(i)}},bubbles:!0,composed:!0}))}endDrag(){this.drag=null,window.removeEventListener(`keydown`,this.onDragKeydown)}disconnectedCallback(){super.disconnectedCallback(),window.removeEventListener(`keydown`,this.onDragKeydown)}render(){let e=this.window();if(!e||!this.resources.length)return T``;let t=[...Array(e.days).keys()].map(t=>V.addDays(e.from,t)),n=new Date,r=V.daysBetween(e.from,new Date(n.getFullYear(),n.getMonth(),n.getDate())),i=r>=0&&r<e.days,a=[],o;return this.resources.forEach(n=>{n.group&&n.group!==o&&a.push(T`<div class="group">${n.group}</div>`),o=n.group,a.push(this.renderRow(n,e,t,i?r:null))}),T`
+    `}static parse(e){return new Date(e+`T00:00:00`)}static iso(e){let t=e=>String(e).padStart(2,`0`);return`${e.getFullYear()}-${t(e.getMonth()+1)}-${t(e.getDate())}`}static addDays(e,t){return new Date(e.getFullYear(),e.getMonth(),e.getDate()+t)}static daysBetween(e,t){return Math.round((t.getTime()-e.getTime())/864e5)}window(){if(this.from&&this.to){let e=B.parse(this.from),t=B.daysBetween(e,B.parse(this.to))+1;return t>0?{from:e,days:t}:null}let e=this.blocks.flatMap(e=>[e.start,e.end]).filter(e=>!!e).map(e=>B.parse(e));if(!e.length)return null;let t=new Date(Math.min(...e.map(e=>e.getTime()))),n=new Date(Math.max(...e.map(e=>e.getTime())));return{from:t,days:B.daysBetween(t,n)+1}}onBlockPointerDown(e,t,n){if(!this.moveActionId&&!this.selectActionId||(e.preventDefault(),e.currentTarget.setPointerCapture(e.pointerId),this.dragStartX=e.clientX,this.dragStartY=e.clientY,!this.window()))return;let r=B.parse(t.start),i=B.parse(t.end),a=Math.max(1,B.daysBetween(r,i)+1);this.laneRects=[...this.renderRoot.querySelectorAll(`.lane[data-resource-id]`)].map(e=>({resourceId:e.dataset.resourceId,rect:e.getBoundingClientRect()}));let o=this.dayAt(t.resourceId,e.clientX)??n;this.drag={blockId:t.id,duration:a,grabOffsetDays:o-n,originResourceId:t.resourceId,originStartIdx:n,targetResourceId:t.resourceId,targetStartIdx:n,moved:!1},window.addEventListener(`keydown`,this.onDragKeydown)}dayAt(e,t){let n=this.laneRects.find(t=>t.resourceId===e),r=this.window();if(!n||!r||n.rect.width===0)return null;let i=Math.floor((t-n.rect.left)/n.rect.width*r.days);return Math.max(0,Math.min(r.days-1,i))}onBlockPointerMove(e){if(!this.drag||!this.drag.moved&&Math.abs(e.clientX-this.dragStartX)<4&&Math.abs(e.clientY-this.dragStartY)<4||!this.moveActionId)return;let t=this.window();if(!t)return;let n=this.laneRects.find(t=>e.clientY>=t.rect.top&&e.clientY<=t.rect.bottom)??this.laneRects.find(e=>e.resourceId===this.drag.targetResourceId);if(!n)return;let r=this.dayAt(n.resourceId,e.clientX);if(r==null)return;let i=Math.max(0,Math.min(t.days-this.drag.duration,r-this.drag.grabOffsetDays));this.drag={...this.drag,moved:!0,targetResourceId:n.resourceId,targetStartIdx:i}}onBlockPointerUp(e){let t=this.drag;if(this.endDrag(),!t)return;if(!t.moved){this.selectActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.selectActionId,parameters:{_blockId:e.id}},bubbles:!0,composed:!0}));return}if(!this.moveActionId||t.targetResourceId===t.originResourceId&&t.targetStartIdx===t.originStartIdx)return;let n=this.window();if(!n)return;let r=B.addDays(n.from,t.targetStartIdx),i=B.addDays(r,t.duration-1);this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.moveActionId,parameters:{_blockId:t.blockId,_resourceId:t.targetResourceId,_start:B.iso(r),_end:B.iso(i)}},bubbles:!0,composed:!0}))}endDrag(){this.drag=null,window.removeEventListener(`keydown`,this.onDragKeydown)}disconnectedCallback(){super.disconnectedCallback(),window.removeEventListener(`keydown`,this.onDragKeydown)}render(){let e=this.window();if(!e||!this.resources.length)return T``;let t=[...Array(e.days).keys()].map(t=>B.addDays(e.from,t)),n=new Date,r=B.daysBetween(e.from,new Date(n.getFullYear(),n.getMonth(),n.getDate())),i=r>=0&&r<e.days,a=[],o;return this.resources.forEach(n=>{n.group&&n.group!==o&&a.push(T`<div class="group">${n.group}</div>`),o=n.group,a.push(this.renderRow(n,e,t,i?r:null))}),T`
             <div class="frame" style="grid-template-columns: minmax(8rem, 12rem) repeat(${e.days}, minmax(2.2rem, 1fr));">
                 <div class="corner">Resource</div>
                 ${t.map((e,t)=>T`
@@ -2300,7 +2300,7 @@ ${i}
                     ${n.map(e=>T`<div class="cell ${this.isWeekend(e)?`weekend`:``}"></div>`)}
                 </div>
                 ${r==null?v:T`<div class="today-line" style="left: ${(r+.5)*i}%;"></div>`}
-                ${a.map(e=>{let n=V.daysBetween(t.from,V.parse(e.start)),r=V.daysBetween(t.from,V.parse(e.end));if(r<0||n>=t.days)return v;let a=Math.max(0,n),o=Math.min(t.days-1,r),s=this.drag?.moved&&this.drag.blockId===e.id;return T`
+                ${a.map(e=>{let n=B.daysBetween(t.from,B.parse(e.start)),r=B.daysBetween(t.from,B.parse(e.end));if(r<0||n>=t.days)return v;let a=Math.max(0,n),o=Math.min(t.days-1,r),s=this.drag?.moved&&this.drag.blockId===e.id;return T`
                         <div class="block ${this.selectActionId?`clickable`:``} ${this.moveActionId?`draggable`:``} ${s?`dragging`:``}"
                              title="${e.label??``} · ${e.start} → ${e.end}${e.status?` · ${e.status}`:``}"
                              style="left: ${a*i}%; width: ${(o-a+1)*i}%; ${e.color?`--mateu-planning-block: ${e.color};`:``}"
@@ -2315,7 +2315,7 @@ ${i}
                          style="left: ${o.targetStartIdx*i}%; width: ${Math.min(o.duration,t.days-o.targetStartIdx)*i}%;"></div>
                 `:v}
             </div>
-        `}};k([y({type:Array})],si.prototype,`resources`,void 0),k([y({type:Array})],si.prototype,`blocks`,void 0),k([y()],si.prototype,`from`,void 0),k([y()],si.prototype,`to`,void 0),k([y()],si.prototype,`moveActionId`,void 0),k([y()],si.prototype,`selectActionId`,void 0),k([C()],si.prototype,`drag`,void 0),si=V=k([g(`mateu-planning-board`)],si);var ci=e=>{let t=e.metadata;return T`
+        `}};k([y({type:Array})],ci.prototype,`resources`,void 0),k([y({type:Array})],ci.prototype,`blocks`,void 0),k([y()],ci.prototype,`from`,void 0),k([y()],ci.prototype,`to`,void 0),k([y()],ci.prototype,`moveActionId`,void 0),k([y()],ci.prototype,`selectActionId`,void 0),k([C()],ci.prototype,`drag`,void 0),ci=B=k([g(`mateu-planning-board`)],ci);var li=e=>{let t=e.metadata;return T`
         <mateu-planning-board
                 .resources="${t.resources??[]}"
                 .blocks="${t.blocks??[]}"
@@ -2327,7 +2327,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-planning-board>
-    `},li=class extends b{constructor(...e){super(...e),this.columns=[]}static{this.styles=h`
+    `},ui=class extends b{constructor(...e){super(...e),this.columns=[]}static{this.styles=h`
         :host {
             display: block;
             width: 100%;
@@ -2410,7 +2410,7 @@ ${i}
             .card { background: var(--lumo-contrast-5pct, #2a2a2a); }
         }
     
-        ${B}
+        ${z}
     `}clickCard(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_clickedCard:e}},bubbles:!0,composed:!0}))}render(){return T`
             <div class="board">
                 ${this.columns.map(e=>T`
@@ -2422,7 +2422,7 @@ ${i}
                         ${(e.cards??[]).map(e=>T`
                             <div role="button" tabindex="0" class="card ${e.actionId?`clickable`:``}"
                                  style="${e.color?`--mateu-kanban-card-accent: ${e.color};`:``}"
-                                 @click="${()=>this.clickCard(e)}" @keydown="${z(()=>this.clickCard(e))}">
+                                 @click="${()=>this.clickCard(e)}" @keydown="${R(()=>this.clickCard(e))}">
                                 <span class="card-title">${e.title}</span>
                                 ${e.description?T`<span class="card-desc">${e.description}</span>`:v}
                                 ${e.badge?T`<span class="badge">${e.badge}</span>`:v}
@@ -2431,14 +2431,14 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};k([y({type:Array})],li.prototype,`columns`,void 0),li=k([g(`mateu-kanban`)],li);var ui=e=>T`
+        `}};k([y({type:Array})],ui.prototype,`columns`,void 0),ui=k([g(`mateu-kanban`)],ui);var di=e=>T`
         <mateu-kanban
                 .columns="${e.metadata.columns??[]}"
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-kanban>
-    `,di=class extends b{constructor(...e){super(...e),this.items=[]}static{this.styles=h`
+    `,fi=class extends b{constructor(...e){super(...e),this.items=[]}static{this.styles=h`
         :host {
             display: block;
             width: 100%;
@@ -2510,7 +2510,7 @@ ${i}
             margin-top: .15rem;
         }
     
-        ${B}
+        ${z}
     `}clickItem(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_clickedItem:e}},bubbles:!0,composed:!0}))}render(){return T`
             <div class="feed">
                 ${this.items.map(e=>T`
@@ -2519,7 +2519,7 @@ ${i}
                             <div class="dot" style="${e.color?`--mateu-timeline-dot: ${e.color};`:``}">${e.icon??``}</div>
                             <div class="line"></div>
                         </div>
-                        <div role="button" tabindex="0" class="body" @click="${()=>this.clickItem(e)}" @keydown="${z(()=>this.clickItem(e))}">
+                        <div role="button" tabindex="0" class="body" @click="${()=>this.clickItem(e)}" @keydown="${R(()=>this.clickItem(e))}">
                             <div class="head">
                                 <span class="title">${e.title}</span>
                                 ${e.timestamp?T`<span class="time">${e.timestamp}</span>`:v}
@@ -2529,14 +2529,14 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};k([y({type:Array})],di.prototype,`items`,void 0),di=k([g(`mateu-timeline`)],di);var fi=e=>T`
+        `}};k([y({type:Array})],fi.prototype,`items`,void 0),fi=k([g(`mateu-timeline`)],fi);var pi=e=>T`
         <mateu-timeline
                 .items="${e.metadata.items??[]}"
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-timeline>
-    `,pi=class extends b{constructor(...e){super(...e),this.steps=[],this.vertical=!1}static{this.styles=h`
+    `,mi=class extends b{constructor(...e){super(...e),this.steps=[],this.vertical=!1}static{this.styles=h`
         :host {
             display: block;
             width: 100%;
@@ -2650,7 +2650,7 @@ ${i}
                         </div>
                     `})}
             </div>
-        `}};k([y({type:Array})],pi.prototype,`steps`,void 0),k([y({type:Boolean,reflect:!0})],pi.prototype,`vertical`,void 0),pi=k([g(`mateu-progress-steps`)],pi);var mi=e=>{let t=e.metadata;return T`
+        `}};k([y({type:Array})],mi.prototype,`steps`,void 0),k([y({type:Boolean,reflect:!0})],mi.prototype,`vertical`,void 0),mi=k([g(`mateu-progress-steps`)],mi);var hi=e=>{let t=e.metadata;return T`
         <mateu-progress-steps
                 .steps="${t.steps??[]}"
                 ?vertical="${t.vertical??!1}"
@@ -2658,7 +2658,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-progress-steps>
-    `},hi=class extends b{constructor(...e){super(...e),this.spark=[]}static{this.styles=h`
+    `},gi=class extends b{constructor(...e){super(...e),this.spark=[]}static{this.styles=h`
         :host {
             display: block;
         }
@@ -2713,7 +2713,7 @@ ${i}
             .tile { background: var(--lumo-contrast-5pct, #2a2a2a); }
         }
     
-        ${B}
+        ${z}
     `}sparkline(){let e=this.spark;if(!e||e.length<2)return v;let t=Math.min(...e),n=Math.max(...e)-t||1,r=80/(e.length-1),i=e.map((e,i)=>[2+i*r,2+26*(1-(e-t)/n)]),a=i.map(([e,t],n)=>`${n===0?`M`:`L`}${e.toFixed(1)} ${t.toFixed(1)}`).join(` `),o=`${a} L${i[i.length-1][0].toFixed(1)} 30 L${i[0][0].toFixed(1)} 30 Z`,s=this.trend===`down`?`var(--lumo-error-color, #e11d48)`:this.trend===`flat`?`var(--lumo-secondary-text-color, #888)`:`var(--lumo-success-color, #12b76a)`;return w`
             <svg width="${84}" height="${30}" viewBox="0 0 ${84} ${30}">
                 <path d="${o}" fill="${s}" opacity="0.12"></path>
@@ -2721,7 +2721,7 @@ ${i}
                       stroke-linejoin="round" stroke-linecap="round"></path>
             </svg>
         `}dispatchAction(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId},bubbles:!0,composed:!0}))}render(){let e=this.trend??`up`;return T`
-            <div role="button" tabindex="0" class="tile ${this.actionId?`clickable`:``}" @click="${()=>this.dispatchAction()}" @keydown="${z(()=>this.dispatchAction())}">
+            <div role="button" tabindex="0" class="tile ${this.actionId?`clickable`:``}" @click="${()=>this.dispatchAction()}" @keydown="${R(()=>this.dispatchAction())}">
                 ${this.label?T`<span class="label">${this.label}</span>`:v}
                 <span class="value">${this.value}${this.unit?T`<span class="unit">${this.unit}</span>`:v}</span>
                 <div class="foot">
@@ -2729,7 +2729,7 @@ ${i}
                     ${this.sparkline()}
                 </div>
             </div>
-        `}};k([y()],hi.prototype,`label`,void 0),k([y()],hi.prototype,`value`,void 0),k([y()],hi.prototype,`unit`,void 0),k([y()],hi.prototype,`delta`,void 0),k([y()],hi.prototype,`trend`,void 0),k([y({type:Array})],hi.prototype,`spark`,void 0),k([y()],hi.prototype,`actionId`,void 0),hi=k([g(`mateu-stat`)],hi);var gi=e=>{let t=e.metadata;return T`
+        `}};k([y()],gi.prototype,`label`,void 0),k([y()],gi.prototype,`value`,void 0),k([y()],gi.prototype,`unit`,void 0),k([y()],gi.prototype,`delta`,void 0),k([y()],gi.prototype,`trend`,void 0),k([y({type:Array})],gi.prototype,`spark`,void 0),k([y()],gi.prototype,`actionId`,void 0),gi=k([g(`mateu-stat`)],gi);var _i=e=>{let t=e.metadata;return T`
         <mateu-stat
                 label="${t.label??v}"
                 value="${t.value??v}"
@@ -2742,7 +2742,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-stat>
-    `},_i=class extends b{constructor(...e){super(...e),this.events=[]}static{this.styles=h`
+    `},vi=class extends b{constructor(...e){super(...e),this.events=[]}static{this.styles=h`
         :host {
             display: block;
             width: 100%;
@@ -2816,7 +2816,7 @@ ${i}
             .dow { background: var(--lumo-contrast-10pct, #333); }
         }
     
-        ${B}
+        ${z}
     `}clickEvent(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_clickedEvent:e}},bubbles:!0,composed:!0}))}render(){let e=this.month?new Date(this.month+`T00:00:00`):new Date,t=e.getFullYear(),n=e.getMonth(),r=new Date(t,n,1),i=(r.getDay()+6)%7,a=new Date(t,n+1,0).getDate(),o=new Date,s=e=>o.getFullYear()===t&&o.getMonth()===n&&o.getDate()===e,c={};for(let e of this.events){if(!e.date)continue;let r=new Date(e.date+`T00:00:00`);r.getFullYear()===t&&r.getMonth()===n&&(c[r.getDate()]??=[]).push(e)}let l=[`Mon`,`Tue`,`Wed`,`Thu`,`Fri`,`Sat`,`Sun`],u=[];for(let e=0;e<i;e++)u.push(T`<div class="cell blank"></div>`);for(let e=1;e<=a;e++)u.push(T`
                 <div class="cell ${s(e)?`today`:``}">
                     <span class="num">${e}</span>
@@ -2824,7 +2824,7 @@ ${i}
                         <span role="button" tabindex="0" class="chip ${e.actionId?`clickable`:``}"
                               style="${e.color?`--mateu-cal-accent: ${e.color};`:``}"
                               title="${e.title??``}"
-                              @click="${()=>this.clickEvent(e)}" @keydown="${z(()=>this.clickEvent(e))}">${e.title}</span>
+                              @click="${()=>this.clickEvent(e)}" @keydown="${R(()=>this.clickEvent(e))}">${e.title}</span>
                     `)}
                 </div>
             `);return T`
@@ -2833,7 +2833,7 @@ ${i}
                 ${l.map(e=>T`<div class="dow">${e}</div>`)}
                 ${u}
             </div>
-        `}};k([y()],_i.prototype,`month`,void 0),k([y({type:Array})],_i.prototype,`events`,void 0),_i=k([g(`mateu-calendar`)],_i);var vi=e=>{let t=e.metadata;return T`
+        `}};k([y()],vi.prototype,`month`,void 0),k([y({type:Array})],vi.prototype,`events`,void 0),vi=k([g(`mateu-calendar`)],vi);var yi=e=>{let t=e.metadata;return T`
         <mateu-calendar
                 month="${t.month??v}"
                 .events="${t.events??[]}"
@@ -2841,7 +2841,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-calendar>
-    `},yi=class extends b{constructor(...e){super(...e),this.plans=[]}static{this.styles=h`
+    `},bi=class extends b{constructor(...e){super(...e),this.plans=[]}static{this.styles=h`
         :host {
             display: block;
             width: 100%;
@@ -2953,14 +2953,14 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};k([y({type:Array})],yi.prototype,`plans`,void 0),yi=k([g(`mateu-pricing-table`)],yi);var bi=e=>T`
+        `}};k([y({type:Array})],bi.prototype,`plans`,void 0),bi=k([g(`mateu-pricing-table`)],bi);var xi=e=>T`
         <mateu-pricing-table
                 .plans="${e.metadata.plans??[]}"
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-pricing-table>
-    `,xi=class extends b{static{this.styles=h`
+    `,Si=class extends b{static{this.styles=h`
         :host {
             display: block;
             width: 100%;
@@ -3056,26 +3056,26 @@ ${i}
             .node { background: var(--lumo-contrast-5pct, #2a2a2a); }
         }
     
-        ${B}
+        ${z}
     `}clickNode(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_clickedNode:e}},bubbles:!0,composed:!0}))}renderNode(e){let t=e.avatar,n=t&&(t.startsWith(`http`)||t.startsWith(`data:`));return T`
             <li>
                 <div role="button" tabindex="0" class="node ${e.actionId?`clickable`:``}"
                      style="${e.color?`--mateu-org-accent: ${e.color};`:``}"
-                     @click="${()=>this.clickNode(e)}" @keydown="${z(()=>this.clickNode(e))}">
+                     @click="${()=>this.clickNode(e)}" @keydown="${R(()=>this.clickNode(e))}">
                     ${t?T`<span class="avatar">${n?T`<img src="${t}" alt="">`:t}</span>`:v}
                     <span class="title">${e.title}</span>
                     ${e.subtitle?T`<span class="subtitle">${e.subtitle}</span>`:v}
                 </div>
                 ${e.children&&e.children.length?T`<ul>${e.children.map(e=>this.renderNode(e))}</ul>`:v}
             </li>
-        `}render(){return this.root?T`<div class="tree"><ul>${this.renderNode(this.root)}</ul></div>`:T``}};k([y({attribute:!1})],xi.prototype,`root`,void 0),xi=k([g(`mateu-org-chart`)],xi);var Si=e=>T`
+        `}render(){return this.root?T`<div class="tree"><ul>${this.renderNode(this.root)}</ul></div>`:T``}};k([y({attribute:!1})],Si.prototype,`root`,void 0),Si=k([g(`mateu-org-chart`)],Si);var Ci=e=>T`
         <mateu-org-chart
                 .root="${e.metadata.root}"
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-org-chart>
-    `,Ci=1440*60*1e3,wi=class extends b{constructor(...e){super(...e),this.cells=[]}static{this.styles=h`
+    `,wi=1440*60*1e3,Ti=class extends b{constructor(...e){super(...e),this.cells=[]}static{this.styles=h`
         :host {
             display: block;
             width: 100%;
@@ -3099,7 +3099,7 @@ ${i}
             margin-top: .15rem;
         }
         .legend .cell { width: 10px; height: 10px; }
-    `}color(e,t){if(e<=0||t<=0)return`var(--lumo-contrast-10pct, #ebedf0)`;let n=e/t;return`color-mix(in srgb, var(--lumo-primary-color, #1a73e8) ${Math.round((n>.75?1:n>.5?.75:n>.25?.5:.3)*100)}%, transparent)`}render(){let e=this.cells.filter(e=>!!e.date);if(!e.length)return T``;let t=e.map(e=>new Date(e.date+`T00:00:00`).getTime()),n=Math.min(...t),r=Math.max(...t),i=new Date(n);i.setDate(i.getDate()-(i.getDay()+6)%7);let a={};for(let t of e)a[t.date]=t;let o=Math.max(...e.map(e=>e.value??0),1),s=[];for(let e=i.getTime();e<=r;e+=Ci){let t=new Date(e),n=t.toISOString().slice(0,10),r=a[n],i=r?.value??0,c=(t.getDay()+6)%7+1,l=r?.label??`${n}: ${i}`;s.push(T`
+    `}color(e,t){if(e<=0||t<=0)return`var(--lumo-contrast-10pct, #ebedf0)`;let n=e/t;return`color-mix(in srgb, var(--lumo-primary-color, #1a73e8) ${Math.round((n>.75?1:n>.5?.75:n>.25?.5:.3)*100)}%, transparent)`}render(){let e=this.cells.filter(e=>!!e.date);if(!e.length)return T``;let t=e.map(e=>new Date(e.date+`T00:00:00`).getTime()),n=Math.min(...t),r=Math.max(...t),i=new Date(n);i.setDate(i.getDate()-(i.getDay()+6)%7);let a={};for(let t of e)a[t.date]=t;let o=Math.max(...e.map(e=>e.value??0),1),s=[];for(let e=i.getTime();e<=r;e+=wi){let t=new Date(e),n=t.toISOString().slice(0,10),r=a[n],i=r?.value??0,c=(t.getDay()+6)%7+1,l=r?.label??`${n}: ${i}`;s.push(T`
                 <div class="cell" style="grid-row: ${c}; --cell: ${this.color(i,o)};" title="${l}"></div>
             `)}return T`
             <div class="wrap">
@@ -3114,14 +3114,14 @@ ${i}
                     <span>More</span>
                 </div>
             </div>
-        `}};k([y({type:Array})],wi.prototype,`cells`,void 0),wi=k([g(`mateu-heatmap`)],wi);var Ti=e=>T`
+        `}};k([y({type:Array})],Ti.prototype,`cells`,void 0),Ti=k([g(`mateu-heatmap`)],Ti);var Ei=e=>T`
         <mateu-heatmap
                 .cells="${e.metadata.cells??[]}"
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-heatmap>
-    `,Ei=class extends b{constructor(...e){super(...e),this.stages=[]}static{this.styles=h`
+    `,Di=class extends b{constructor(...e){super(...e),this.stages=[]}static{this.styles=h`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .funnel { display: flex; flex-direction: column; gap: .35rem; }
         .stage { display: flex; flex-direction: column; align-items: center; gap: .1rem; }
@@ -3154,14 +3154,14 @@ ${i}
                         </div>
                     `})}
             </div>
-        `}};k([y({type:Array})],Ei.prototype,`stages`,void 0),Ei=k([g(`mateu-funnel`)],Ei);var Di=e=>T`
+        `}};k([y({type:Array})],Di.prototype,`stages`,void 0),Di=k([g(`mateu-funnel`)],Di);var Oi=e=>T`
         <mateu-funnel
                 .stages="${e.metadata.stages??[]}"
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-funnel>
-    `,Oi=class extends b{constructor(...e){super(...e),this.values=[],this.labels=[],this.area=!1}static{this.styles=h`
+    `,ki=class extends b{constructor(...e){super(...e),this.values=[],this.labels=[],this.area=!1}static{this.styles=h`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .title { font-weight: 600; margin-bottom: .35rem; color: var(--lumo-body-text-color, #222); }
         svg { display: block; width: 100%; height: auto; overflow: visible; }
@@ -3174,7 +3174,7 @@ ${i}
                 ${a.map((t,n)=>n===l||n===u?w`<circle cx="${t[0]}" cy="${t[1]}" r="3.2" fill="${c}"><title>${this.labels[n]??``}: ${e[n]}</title></circle>`:w`<circle cx="${t[0]}" cy="${t[1]}" r="6" fill="transparent"><title>${this.labels[n]??``}: ${e[n]}</title></circle>`)}
             </svg>
             ${this.labels&&this.labels.length?T`<div class="labels"><span>${this.labels[0]}</span><span>${this.labels[this.labels.length-1]}</span></div>`:v}
-        `}};k([y()],Oi.prototype,`heading`,void 0),k([y({type:Array})],Oi.prototype,`values`,void 0),k([y({type:Array})],Oi.prototype,`labels`,void 0),k([y()],Oi.prototype,`color`,void 0),k([y({type:Boolean})],Oi.prototype,`area`,void 0),Oi=k([g(`mateu-trend-chart`)],Oi);var ki=e=>{let t=e.metadata;return T`
+        `}};k([y()],ki.prototype,`heading`,void 0),k([y({type:Array})],ki.prototype,`values`,void 0),k([y({type:Array})],ki.prototype,`labels`,void 0),k([y()],ki.prototype,`color`,void 0),k([y({type:Boolean})],ki.prototype,`area`,void 0),ki=k([g(`mateu-trend-chart`)],ki);var Ai=e=>{let t=e.metadata;return T`
         <mateu-trend-chart
                 heading="${t.title??v}"
                 color="${t.color??v}"
@@ -3185,7 +3185,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-trend-chart>
-    `},Ai=class extends b{constructor(...e){super(...e),this.features=[],this.columns=0}static{this.styles=h`
+    `},ji=class extends b{constructor(...e){super(...e),this.features=[],this.columns=0}static{this.styles=h`
         :host { display: block; width: 100%; }
         .grid {
             display: grid;
@@ -3215,18 +3215,18 @@ ${i}
             .card { background: var(--lumo-contrast-5pct, #2a2a2a); }
         }
     
-        ${B}
+        ${z}
     `}clickFeature(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))}render(){return T`
             <div class="grid" style="grid-template-columns: ${this.columns&&this.columns>0?`repeat(${this.columns}, minmax(0, 1fr))`:`repeat(auto-fit, minmax(15rem, 1fr))`};">
                 ${this.features.map(e=>T`
-                    <div role="button" tabindex="0" class="card ${e.actionId?`clickable`:``}" @click="${()=>this.clickFeature(e)}" @keydown="${z(()=>this.clickFeature(e))}">
+                    <div role="button" tabindex="0" class="card ${e.actionId?`clickable`:``}" @click="${()=>this.clickFeature(e)}" @keydown="${R(()=>this.clickFeature(e))}">
                         ${e.icon?T`<span class="icon">${e.icon}</span>`:v}
                         <span class="title">${e.title}</span>
                         ${e.description?T`<span class="desc">${e.description}</span>`:v}
                     </div>
                 `)}
             </div>
-        `}};k([y({type:Array})],Ai.prototype,`features`,void 0),k([y({type:Number})],Ai.prototype,`columns`,void 0),Ai=k([g(`mateu-feature-grid`)],Ai);var ji=e=>{let t=e.metadata;return T`
+        `}};k([y({type:Array})],ji.prototype,`features`,void 0),k([y({type:Number})],ji.prototype,`columns`,void 0),ji=k([g(`mateu-feature-grid`)],ji);var Mi=e=>{let t=e.metadata;return T`
         <mateu-feature-grid
                 .features="${t.features??[]}"
                 .columns="${t.columns??0}"
@@ -3234,7 +3234,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-feature-grid>
-    `},Mi=class extends b{constructor(...e){super(...e),this.items=[]}static{this.styles=h`
+    `},Ni=class extends b{constructor(...e){super(...e),this.items=[]}static{this.styles=h`
         :host { display: block; width: 100%; }
         .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr)); gap: var(--lumo-space-m, 1rem); }
         .card {
@@ -3274,14 +3274,14 @@ ${i}
                         </div>
                     `})}
             </div>
-        `}};k([y({type:Array})],Mi.prototype,`items`,void 0),Mi=k([g(`mateu-testimonials`)],Mi);var Ni=e=>T`
+        `}};k([y({type:Array})],Ni.prototype,`items`,void 0),Ni=k([g(`mateu-testimonials`)],Ni);var Pi=e=>T`
         <mateu-testimonials
                 .items="${e.metadata.items??[]}"
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-testimonials>
-    `,Pi=class extends b{constructor(...e){super(...e),this.items=[],this.openSet=new Set,this.seeded=!1}static{this.styles=h`
+    `,Fi=class extends b{constructor(...e){super(...e),this.items=[],this.openSet=new Set,this.seeded=!1}static{this.styles=h`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-m, 1rem); }
         .list {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -3305,12 +3305,12 @@ ${i}
         }
         @media (prefers-color-scheme: dark) { .q { background: var(--lumo-contrast-5pct, #2a2a2a); } }
     
-        ${B}
+        ${z}
     `}seed(){this.seeded||(this.seeded=!0,this.items.forEach((e,t)=>{e.open&&this.openSet.add(t)}))}toggle(e){this.openSet.has(e)?this.openSet.delete(e):this.openSet.add(e),this.requestUpdate()}render(){return this.seed(),T`
             <div class="list">
                 ${this.items.map((e,t)=>{let n=this.openSet.has(t);return T`
                         <div class="item ${n?`open`:``}">
-                            <div role="button" tabindex="0" aria-expanded="${n}" class="q" @click="${()=>this.toggle(t)}" @keydown="${z(()=>this.toggle(t))}">
+                            <div role="button" tabindex="0" aria-expanded="${n}" class="q" @click="${()=>this.toggle(t)}" @keydown="${R(()=>this.toggle(t))}">
                                 <span>${e.question}</span>
                                 <span class="chevron">›</span>
                             </div>
@@ -3318,14 +3318,14 @@ ${i}
                         </div>
                     `})}
             </div>
-        `}};k([y({type:Array})],Pi.prototype,`items`,void 0),k([C()],Pi.prototype,`openSet`,void 0),Pi=k([g(`mateu-faq`)],Pi);var Fi=e=>T`
+        `}};k([y({type:Array})],Fi.prototype,`items`,void 0),k([C()],Fi.prototype,`openSet`,void 0),Fi=k([g(`mateu-faq`)],Fi);var Ii=e=>T`
         <mateu-faq
                 .items="${e.metadata.items??[]}"
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-faq>
-    `,Ii=class extends b{static{this.styles=h`
+    `,Li=class extends b{static{this.styles=h`
         :host { display: block; width: 100%; }
         .callout {
             display: flex; gap: 1rem; align-items: flex-start;
@@ -3354,7 +3354,7 @@ ${i}
                     ${this.ctaLabel?T`<button class="cta" @click="${()=>this.cta()}">${this.ctaLabel}</button>`:v}
                 </div>
             </div>
-        `}};k([y()],Ii.prototype,`heading`,void 0),k([y()],Ii.prototype,`description`,void 0),k([y()],Ii.prototype,`icon`,void 0),k([y()],Ii.prototype,`ctaLabel`,void 0),k([y()],Ii.prototype,`actionId`,void 0),k([y()],Ii.prototype,`theme`,void 0),Ii=k([g(`mateu-callout-card`)],Ii);var Li=e=>{let t=e.metadata;return T`
+        `}};k([y()],Li.prototype,`heading`,void 0),k([y()],Li.prototype,`description`,void 0),k([y()],Li.prototype,`icon`,void 0),k([y()],Li.prototype,`ctaLabel`,void 0),k([y()],Li.prototype,`actionId`,void 0),k([y()],Li.prototype,`theme`,void 0),Li=k([g(`mateu-callout-card`)],Li);var Ri=e=>{let t=e.metadata;return T`
         <mateu-callout-card
                 heading="${t.title??v}"
                 description="${t.description??v}"
@@ -3366,7 +3366,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-callout-card>
-    `},Ri=class extends b{constructor(...e){super(...e),this.comments=[]}static{this.styles=h`
+    `},zi=class extends b{constructor(...e){super(...e),this.comments=[]}static{this.styles=h`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .thread { display: flex; flex-direction: column; gap: 1rem; }
         .replies {
@@ -3398,14 +3398,14 @@ ${i}
                     ${e.replies&&e.replies.length?T`<div class="replies">${e.replies.map(e=>this.renderComment(e))}</div>`:v}
                 </div>
             </div>
-        `}render(){return T`<div class="thread">${this.comments.map(e=>this.renderComment(e))}</div>`}};k([y({type:Array})],Ri.prototype,`comments`,void 0),Ri=k([g(`mateu-comment-thread`)],Ri);var zi=e=>T`
+        `}render(){return T`<div class="thread">${this.comments.map(e=>this.renderComment(e))}</div>`}};k([y({type:Array})],zi.prototype,`comments`,void 0),zi=k([g(`mateu-comment-thread`)],zi);var Bi=e=>T`
         <mateu-comment-thread
                 .comments="${e.metadata.comments??[]}"
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-comment-thread>
-    `,Bi={pdf:`📕`,image:`🖼️`,img:`🖼️`,doc:`📘`,docx:`📘`,word:`📘`,xls:`📗`,xlsx:`📗`,excel:`📗`,sheet:`📗`,zip:`🗜️`,archive:`🗜️`,video:`🎬`,audio:`🎵`,code:`💻`,csv:`📄`,txt:`📄`},Vi=class extends b{constructor(...e){super(...e),this.files=[]}static{this.styles=h`
+    `,Vi={pdf:`📕`,image:`🖼️`,img:`🖼️`,doc:`📘`,docx:`📘`,word:`📘`,xls:`📗`,xlsx:`📗`,excel:`📗`,sheet:`📗`,zip:`🗜️`,archive:`🗜️`,video:`🎬`,audio:`🎵`,code:`💻`,csv:`📄`,txt:`📄`},Hi=class extends b{constructor(...e){super(...e),this.files=[]}static{this.styles=h`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .list {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -3421,24 +3421,24 @@ ${i}
         .size { color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-xs, .75rem); flex: 0 0 auto; }
         .dl { color: var(--lumo-primary-color, #1a73e8); flex: 0 0 auto; }
     
-        ${B}
-    `}icon(e){return e&&Bi[e.toLowerCase()]||`📄`}clickFile(e,t){e.url||e.actionId&&(t.preventDefault(),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_file:e}},bubbles:!0,composed:!0})))}render(){return T`
+        ${z}
+    `}icon(e){return e&&Vi[e.toLowerCase()]||`📄`}clickFile(e,t){e.url||e.actionId&&(t.preventDefault(),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_file:e}},bubbles:!0,composed:!0})))}render(){return T`
             <div class="list">
                 ${this.files.map(e=>{let t=!!e.url||!!e.actionId,n=T`
                         <span class="icon">${this.icon(e.type)}</span>
                         <span class="name">${e.name}</span>
                         ${e.size?T`<span class="size">${e.size}</span>`:v}
                         ${e.url?T`<span class="dl">⬇</span>`:v}
-                    `;return e.url?T`<a class="file clickable" href="${e.url}" download target="_blank" rel="noopener">${n}</a>`:T`<div role="button" tabindex="0" class="file ${t?`clickable`:``}" @click="${t=>this.clickFile(e,t)}" @keydown="${z(t=>this.clickFile(e,t))}">${n}</div>`})}
+                    `;return e.url?T`<a class="file clickable" href="${e.url}" download target="_blank" rel="noopener">${n}</a>`:T`<div role="button" tabindex="0" class="file ${t?`clickable`:``}" @click="${t=>this.clickFile(e,t)}" @keydown="${R(t=>this.clickFile(e,t))}">${n}</div>`})}
             </div>
-        `}};k([y({type:Array})],Vi.prototype,`files`,void 0),Vi=k([g(`mateu-file-list`)],Vi);var Hi=e=>T`
+        `}};k([y({type:Array})],Hi.prototype,`files`,void 0),Hi=k([g(`mateu-file-list`)],Hi);var Ui=e=>T`
         <mateu-file-list
                 .files="${e.metadata.files??[]}"
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-file-list>
-    `,Ui=class extends b{constructor(...e){super(...e),this.items=[],this.localDone=new Map}static{this.styles=h`
+    `,Wi=class extends b{constructor(...e){super(...e),this.items=[],this.localDone=new Map}static{this.styles=h`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .head { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: .5rem; }
         .title { font-weight: 700; color: var(--lumo-body-text-color, #222); }
@@ -3455,7 +3455,7 @@ ${i}
         .label { color: var(--lumo-body-text-color, #333); }
         .item.done .label { color: var(--lumo-secondary-text-color, #999); text-decoration: line-through; }
     
-        ${B}
+        ${z}
     `}isDone(e,t){return this.localDone.has(t)?!!this.localDone.get(t):!!e.done}toggle(e,t){let n=!this.isDone(e,t);this.localDone.set(t,n),this.requestUpdate(),e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_item:e,_done:n}},bubbles:!0,composed:!0}))}render(){let e=this.items.length,t=this.items.filter((e,t)=>this.isDone(e,t)).length,n=e>0?Math.round(t/e*100):0;return T`
             <div class="head">
                 ${this.heading?T`<span class="title">${this.heading}</span>`:T`<span></span>`}
@@ -3463,12 +3463,12 @@ ${i}
             </div>
             <div class="bar"><div class="fill" style="width: ${n}%;"></div></div>
             ${this.items.map((e,t)=>{let n=this.isDone(e,t);return T`
-                    <div role="button" tabindex="0" class="item ${n?`done`:``}" @click="${()=>this.toggle(e,t)}" @keydown="${z(()=>this.toggle(e,t))}">
+                    <div role="button" tabindex="0" class="item ${n?`done`:``}" @click="${()=>this.toggle(e,t)}" @keydown="${R(()=>this.toggle(e,t))}">
                         <span class="box">${n?`✓`:v}</span>
                         <span class="label">${e.label}</span>
                     </div>
                 `})}
-        `}};k([y()],Ui.prototype,`heading`,void 0),k([y({type:Array})],Ui.prototype,`items`,void 0),k([C()],Ui.prototype,`localDone`,void 0),Ui=k([g(`mateu-checklist`)],Ui);var Wi=e=>{let t=e.metadata;return T`
+        `}};k([y()],Wi.prototype,`heading`,void 0),k([y({type:Array})],Wi.prototype,`items`,void 0),k([C()],Wi.prototype,`localDone`,void 0),Wi=k([g(`mateu-checklist`)],Wi);var Gi=e=>{let t=e.metadata;return T`
         <mateu-checklist
                 heading="${t.title??v}"
                 .items="${t.items??[]}"
@@ -3476,7 +3476,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-checklist>
-    `},Gi=class extends b{static{this.styles=h`
+    `},Ki=class extends b{static{this.styles=h`
         :host { display: block; width: 100%; }
         .card {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -3516,7 +3516,7 @@ ${i}
                     </div>
                 </div>
             </div>
-        `}};k([y()],Gi.prototype,`heading`,void 0),k([y()],Gi.prototype,`leftLabel`,void 0),k([y()],Gi.prototype,`leftValue`,void 0),k([y()],Gi.prototype,`rightLabel`,void 0),k([y()],Gi.prototype,`rightValue`,void 0),k([y()],Gi.prototype,`delta`,void 0),k([y()],Gi.prototype,`trend`,void 0),Gi=k([g(`mateu-comparison-card`)],Gi);var Ki=e=>{let t=e.metadata;return T`
+        `}};k([y()],Ki.prototype,`heading`,void 0),k([y()],Ki.prototype,`leftLabel`,void 0),k([y()],Ki.prototype,`leftValue`,void 0),k([y()],Ki.prototype,`rightLabel`,void 0),k([y()],Ki.prototype,`rightValue`,void 0),k([y()],Ki.prototype,`delta`,void 0),k([y()],Ki.prototype,`trend`,void 0),Ki=k([g(`mateu-comparison-card`)],Ki);var qi=e=>{let t=e.metadata;return T`
         <mateu-comparison-card
                 heading="${t.title??v}"
                 leftLabel="${t.leftLabel??v}"
@@ -3529,7 +3529,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-comparison-card>
-    `},qi=h`
+    `},Ji=h`
     .chip {
         display: inline-flex;
         align-items: center;
@@ -3559,7 +3559,7 @@ ${i}
         color: var(--lumo-contrast-80pct, #333);
         background: var(--lumo-contrast-10pct, rgba(0, 0, 0, .08));
     }
-`,Ji=new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}),Yi=e=>Number.isFinite(e)?Ji.format(e):``,Xi=(e,t)=>{let n=e<0?`-`:``,r=Yi(Math.abs(e));return t?`${n}${t} ${r}`:`${n}${r}`},Zi=(e,t)=>t?`${Yi(e)} ${t}`:Yi(e),Qi=class extends b{constructor(...e){super(...e),this.title=``,this.badges=[],this.facts=[]}static{this.styles=[qi,h`
+`,Yi=new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}),Xi=e=>Number.isFinite(e)?Yi.format(e):``,Zi=(e,t)=>{let n=e<0?`-`:``,r=Xi(Math.abs(e));return t?`${n}${t} ${r}`:`${n}${r}`},Qi=(e,t)=>t?`${Xi(e)} ${t}`:Xi(e),$i=class extends b{constructor(...e){super(...e),this.title=``,this.badges=[],this.facts=[]}static{this.styles=[Ji,h`
         :host { display: block; width: 100%; }
         .card {
             display: flex;
@@ -3642,7 +3642,7 @@ ${i}
                     </div>
                 `:v}
             </div>
-        `}};k([y()],Qi.prototype,`title`,void 0),k([y({type:Array})],Qi.prototype,`badges`,void 0),k([y()],Qi.prototype,`subtitle`,void 0),k([y({type:Array})],Qi.prototype,`facts`,void 0),k([y()],Qi.prototype,`metricLabel`,void 0),k([y()],Qi.prototype,`metricValue`,void 0),k([y()],Qi.prototype,`metricCaption`,void 0),Qi=k([g(`mateu-entity-header`)],Qi);var $i=e=>{if(e.__hoistedToPageHeader)return T``;let t=e.metadata;return T`
+        `}};k([y()],$i.prototype,`title`,void 0),k([y({type:Array})],$i.prototype,`badges`,void 0),k([y()],$i.prototype,`subtitle`,void 0),k([y({type:Array})],$i.prototype,`facts`,void 0),k([y()],$i.prototype,`metricLabel`,void 0),k([y()],$i.prototype,`metricValue`,void 0),k([y()],$i.prototype,`metricCaption`,void 0),$i=k([g(`mateu-entity-header`)],$i);var ea=e=>{if(e.__hoistedToPageHeader)return T``;let t=e.metadata;return T`
         <mateu-entity-header
                 .title="${t.title??``}"
                 .badges="${t.badges??[]}"
@@ -3655,7 +3655,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-entity-header>
-    `},ea=class extends b{constructor(...e){super(...e),this.value=0,this.max=0}static{this.styles=h`
+    `},ta=class extends b{constructor(...e){super(...e),this.value=0,this.max=0}static{this.styles=h`
         :host { display: block; width: 100%; }
         .meter { display: flex; flex-direction: column; gap: .35rem; }
         .label {
@@ -3680,13 +3680,13 @@ ${i}
     `}fillColor(){return this.dangerAt!=null&&this.value>=this.dangerAt?`error`:this.warnAt!=null&&this.value>=this.warnAt?`warning`:this.warnAt!=null||this.dangerAt!=null?`success`:`primary`}render(){let e=this.max>0?Math.min(Math.max(this.value/this.max,0),1):0,t=Math.round(e*100);return T`
             <div class="meter">
                 ${this.label?T`<span class="label">${this.label}</span>`:v}
-                <span class="value">${Zi(this.value,this.unit)}</span>
+                <span class="value">${Qi(this.value,this.unit)}</span>
                 <div class="track">
                     <div class="fill ${this.fillColor()}" style="width: ${t}%"></div>
                 </div>
                 <span class="caption">${this.caption?this.caption:`${t}%`}</span>
             </div>
-        `}};k([y()],ea.prototype,`label`,void 0),k([y({type:Number})],ea.prototype,`value`,void 0),k([y({type:Number})],ea.prototype,`max`,void 0),k([y()],ea.prototype,`unit`,void 0),k([y()],ea.prototype,`caption`,void 0),k([y({type:Number})],ea.prototype,`warnAt`,void 0),k([y({type:Number})],ea.prototype,`dangerAt`,void 0),ea=k([g(`mateu-meter`)],ea);var ta=e=>{let t=e.metadata;return T`
+        `}};k([y()],ta.prototype,`label`,void 0),k([y({type:Number})],ta.prototype,`value`,void 0),k([y({type:Number})],ta.prototype,`max`,void 0),k([y()],ta.prototype,`unit`,void 0),k([y()],ta.prototype,`caption`,void 0),k([y({type:Number})],ta.prototype,`warnAt`,void 0),k([y({type:Number})],ta.prototype,`dangerAt`,void 0),ta=k([g(`mateu-meter`)],ta);var na=e=>{let t=e.metadata;return T`
         <mateu-meter
                 .label="${t.label}"
                 .value="${t.value??0}"
@@ -3699,7 +3699,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-meter>
-    `},na=class extends b{constructor(...e){super(...e),this.total=0,this.done=0}static{this.styles=h`
+    `},ra=class extends b{constructor(...e){super(...e),this.total=0,this.done=0}static{this.styles=h`
         :host { display: block; width: 100%; }
         .banner {
             display: flex; align-items: center; gap: .8rem; flex-wrap: wrap;
@@ -3754,7 +3754,7 @@ ${i}
                 <span class="spacer"></span>
                 ${t?T`<button @click="${()=>this.runAction()}">${this.actionLabel} →</button>`:v}
             </div>
-        `}};k([y()],na.prototype,`label`,void 0),k([y({type:Number})],na.prototype,`total`,void 0),k([y({type:Number})],na.prototype,`done`,void 0),k([y()],na.prototype,`actionLabel`,void 0),k([y()],na.prototype,`actionId`,void 0),na=k([g(`mateu-task-progress`)],na);var ra=e=>{let t=e.metadata;return T`
+        `}};k([y()],ra.prototype,`label`,void 0),k([y({type:Number})],ra.prototype,`total`,void 0),k([y({type:Number})],ra.prototype,`done`,void 0),k([y()],ra.prototype,`actionLabel`,void 0),k([y()],ra.prototype,`actionId`,void 0),ra=k([g(`mateu-task-progress`)],ra);var ia=e=>{let t=e.metadata;return T`
         <mateu-task-progress
                 .label="${t.label}"
                 .total="${t.total??0}"
@@ -3765,7 +3765,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-task-progress>
-    `},ia=class extends b{constructor(...e){super(...e),this.items=[],this.compact=!1,this.frameless=!1,this.columns=0,this.itemHeadingLevel=3}static{this.styles=[qi,B,h`
+    `},aa=class extends b{constructor(...e){super(...e),this.items=[],this.compact=!1,this.frameless=!1,this.columns=0,this.itemHeadingLevel=3}static{this.styles=[Ji,z,h`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .list {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -3870,7 +3870,7 @@ ${i}
     `]}runAction(e,t){t&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_item:e.id}},bubbles:!0,composed:!0}))}rowClicked(e){this.rowActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.rowActionId,parameters:{_item:e.id}},bubbles:!0,composed:!0}))}renderItemAction(e,t,n,r){return!t||!n?v:r?T`
                 <button class="icon-action" title="${t}" aria-label="${t}"
                     @click="${t=>{t.stopPropagation(),this.runAction(e,n)}}">
-                    ${L(r)}
+                    ${I(r)}
                 </button>`:T`
             <button class="row-action" title="${t}"
                 @click="${t=>{t.stopPropagation(),this.runAction(e,n)}}">${t}</button>`}render(){let e=this.columns>1||this.items.some(e=>e.actionId||e.actionId2||e.actionId3||(e.lines?.length??0)>0),t=this.itemHeadingLevel===4?`h4`:`h3`;return e?T`
@@ -3878,7 +3878,7 @@ ${i}
                      style="${this.columns>1?`grid-template-columns: repeat(auto-fit, minmax(min(18rem, calc(100% / ${this.columns} - 1.5rem)), 1fr));`:``}">
                     ${this.items.map(e=>T`
                         <div role="button" tabindex="0" class="cell ${(e.lines?.length??0)>0?`with-lines`:``} ${this.rowActionId?`clickable`:``}"
-                             @click="${()=>this.rowClicked(e)}" @keydown="${z(()=>this.rowClicked(e))}">
+                             @click="${()=>this.rowClicked(e)}" @keydown="${R(()=>this.rowClicked(e))}">
                             <div class="cell-title-row">
                                 ${t===`h4`?T`<h4 class="cell-title">${e.title}</h4>`:T`<h3 class="cell-title">${e.title}</h3>`}
                                 ${e.status?T`<span class="chip ${e.statusColor??``}">${e.status}</span>`:v}
@@ -3898,7 +3898,7 @@ ${i}
             <div class="list ${this.compact?`compact`:``} ${this.frameless?`frameless`:``}">
                 ${this.items.map(e=>T`
                     <div role="button" tabindex="0" class="row ${this.rowActionId?`clickable`:``}"
-                         @click="${()=>this.rowClicked(e)}" @keydown="${z(()=>this.rowClicked(e))}">
+                         @click="${()=>this.rowClicked(e)}" @keydown="${R(()=>this.rowClicked(e))}">
                         ${e.avatar?T`<span class="avatar">${e.avatar}</span>`:e.icon?T`<span class="icon">${e.icon}</span>`:v}
                         <div class="body">
                             <span class="title">${e.title}</span>
@@ -3908,7 +3908,7 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};k([y({type:Array})],ia.prototype,`items`,void 0),k([y({type:Boolean})],ia.prototype,`compact`,void 0),k([y({type:Boolean})],ia.prototype,`frameless`,void 0),k([y()],ia.prototype,`rowActionId`,void 0),k([y({type:Number})],ia.prototype,`columns`,void 0),k([y({type:Number})],ia.prototype,`itemHeadingLevel`,void 0),ia=k([g(`mateu-status-list`)],ia);var aa=e=>{let t=e.metadata;return T`
+        `}};k([y({type:Array})],aa.prototype,`items`,void 0),k([y({type:Boolean})],aa.prototype,`compact`,void 0),k([y({type:Boolean})],aa.prototype,`frameless`,void 0),k([y()],aa.prototype,`rowActionId`,void 0),k([y({type:Number})],aa.prototype,`columns`,void 0),k([y({type:Number})],aa.prototype,`itemHeadingLevel`,void 0),aa=k([g(`mateu-status-list`)],aa);var oa=e=>{let t=e.metadata;return T`
         <mateu-status-list
                 .items="${t.items??[]}"
                 ?compact="${t.compact??!1}"
@@ -3920,7 +3920,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-status-list>
-    `},oa=class extends b{constructor(...e){super(...e),this.items=[]}static{this.styles=h`
+    `},sa=class extends b{constructor(...e){super(...e),this.items=[]}static{this.styles=h`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         ul {
             margin: 0; padding-inline-start: 1.2rem;
@@ -3935,20 +3935,20 @@ ${i}
             <ul>
                 ${this.items.map(e=>T`<li>${e}</li>`)}
             </ul>
-        `}};k([y({type:Array})],oa.prototype,`items`,void 0),oa=k([g(`mateu-bulleted-list`)],oa);var sa=e=>T`
+        `}};k([y({type:Array})],sa.prototype,`items`,void 0),sa=k([g(`mateu-bulleted-list`)],sa);var ca=e=>T`
         <mateu-bulleted-list
                 .items="${e.metadata.items??[]}"
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-bulleted-list>
-    `,ca=e=>{let t=e.metadata.attributes?.[`data-colspan`];return T`
+    `,la=e=>{let t=e.metadata.attributes?.[`data-colspan`];return T`
         <hr style="border: none; border-top: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1)); width: 100%; margin: var(--lumo-space-s, .5rem) 0; ${e.style??``}"
             class="${e.cssClasses??v}"
             id="${S(e.id??void 0)}"
             data-colspan="${S(t)}"
             slot="${e.slot??v}"/>
-    `},la={info:`ℹ`,success:`✓`,warning:`!`,danger:`!`},H=class extends b{constructor(...e){super(...e),this.text=``,this.theme=`info`,this.noIcon=!1,this.slim=!1,this.fullWidth=!1,this.hasContent=!1,this.inlineContent=!1}static{this.styles=h`
+    `},ua={info:`ℹ`,success:`✓`,warning:`!`,danger:`!`},V=class extends b{constructor(...e){super(...e),this.text=``,this.theme=`info`,this.noIcon=!1,this.slim=!1,this.fullWidth=!1,this.hasContent=!1,this.inlineContent=!1}static{this.styles=h`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .notice {
             display: flex;
@@ -4013,14 +4013,14 @@ ${i}
         .danger  .icon  { background: #b25b3d; }
     `}runAction(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId},bubbles:!0,composed:!0}))}render(){let e=!!this.text&&!!this.text.trim();if(!e&&!this.hasContent)return T``;let t=[`info`,`success`,`warning`,`danger`].includes(this.theme)?this.theme:`info`;return T`
             <div class="notice ${t} ${this.slim?`slim`:``}">
-                ${this.noIcon?v:T`<span class="icon ${this.icon?`custom`:``}">${this.icon||la[t]}</span>`}
+                ${this.noIcon?v:T`<span class="icon ${this.icon?`custom`:``}">${this.icon||ua[t]}</span>`}
                 <div class="body ${this.inlineContent?`inline`:``}">
                     ${e?T`<span class="text">${this.text}</span>`:v}
                     ${this.hasContent?T`<div class="content"><slot></slot></div>`:v}
                 </div>
                 ${this.actionLabel&&this.actionId?T`<button class="notice-action" @click="${()=>this.runAction()}">${this.actionLabel}</button>`:this.status?T`<span class="status">${this.status}</span>`:v}
             </div>
-        `}};k([y()],H.prototype,`text`,void 0),k([y()],H.prototype,`theme`,void 0),k([y()],H.prototype,`icon`,void 0),k([y({type:Boolean})],H.prototype,`noIcon`,void 0),k([y()],H.prototype,`actionLabel`,void 0),k([y()],H.prototype,`actionId`,void 0),k([y()],H.prototype,`status`,void 0),k([y({type:Boolean})],H.prototype,`slim`,void 0),k([y({type:Boolean})],H.prototype,`fullWidth`,void 0),k([y({type:Boolean})],H.prototype,`hasContent`,void 0),k([y({type:Boolean})],H.prototype,`inlineContent`,void 0),H=k([g(`mateu-notice`)],H);var ua=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=xt(s.text??``,r,i,a,o)??``,l=t.children??[];return T`
+        `}};k([y()],V.prototype,`text`,void 0),k([y()],V.prototype,`theme`,void 0),k([y()],V.prototype,`icon`,void 0),k([y({type:Boolean})],V.prototype,`noIcon`,void 0),k([y()],V.prototype,`actionLabel`,void 0),k([y()],V.prototype,`actionId`,void 0),k([y()],V.prototype,`status`,void 0),k([y({type:Boolean})],V.prototype,`slim`,void 0),k([y({type:Boolean})],V.prototype,`fullWidth`,void 0),k([y({type:Boolean})],V.prototype,`hasContent`,void 0),k([y({type:Boolean})],V.prototype,`inlineContent`,void 0),V=k([g(`mateu-notice`)],V);var da=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=xt(s.text??``,r,i,a,o)??``,l=t.children??[];return T`
         <mateu-notice
                 text="${c}"
                 theme="${s.theme??`info`}"
@@ -4037,8 +4037,8 @@ ${i}
                 style="${t.style??v}"
                 class="${t.cssClasses??v}"
                 slot="${t.slot??v}"
-        >${l.map(t=>I(e,t,n,r,i,a,o))}</mateu-notice>
-    `},da=class extends b{constructor(...e){super(...e),this.groups=[]}static{this.styles=[qi,B,h`
+        >${l.map(t=>F(e,t,n,r,i,a,o))}</mateu-notice>
+    `},fa=class extends b{constructor(...e){super(...e),this.groups=[]}static{this.styles=[Ji,z,h`
         :host { display: block; width: 100%; }
         .rail { display: flex; flex-direction: column; gap: var(--lumo-space-m, 1rem); }
         .group { display: flex; flex-direction: column; gap: .45rem; }
@@ -4086,7 +4086,7 @@ ${i}
                         ${e.label?T`<span class="group-label">${e.label}</span>`:v}
                         ${(e.items??[]).map(e=>T`
                             <div role="option" tabindex="0" aria-selected="${e.id===this.selectedId}" class="card ${e.id===this.selectedId?`selected`:``}"
-                                 @click="${()=>this.select(e.id)}" @keydown="${z(()=>this.select(e.id))}">
+                                 @click="${()=>this.select(e.id)}" @keydown="${R(()=>this.select(e.id))}">
                                 <span class="title">${e.title}</span>
                                 <div class="meta">
                                     ${e.caption?T`<span class="caption">${e.caption}</span>`:v}
@@ -4101,7 +4101,7 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};k([y()],da.prototype,`actionId`,void 0),k([y({type:Array})],da.prototype,`groups`,void 0),k([C()],da.prototype,`selectedId`,void 0),da=k([g(`mateu-task-queue`)],da);var fa=e=>{let t=e.metadata;return T`
+        `}};k([y()],fa.prototype,`actionId`,void 0),k([y({type:Array})],fa.prototype,`groups`,void 0),k([C()],fa.prototype,`selectedId`,void 0),fa=k([g(`mateu-task-queue`)],fa);var pa=e=>{let t=e.metadata;return T`
         <mateu-task-queue
                 .actionId="${t.actionId}"
                 .groups="${t.groups??[]}"
@@ -4109,7 +4109,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-task-queue>
-    `},pa=class extends b{constructor(...e){super(...e),this.columns=0,this.items=[]}static{this.styles=[qi,B,h`
+    `},ma=class extends b{constructor(...e){super(...e),this.columns=0,this.items=[]}static{this.styles=[Ji,z,h`
         /* explicit line-height: inside a form field wrapper the inherited one is the 44px
            field height, which blows up every text row */
         :host { display: block; width: 100%; line-height: var(--lumo-line-height-m, 1.4); }
@@ -4164,7 +4164,7 @@ ${i}
             <div class="grid" style="${this.columns>0?`grid-template-columns: repeat(${this.columns}, minmax(0, 1fr));`:`grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));`}">
                 ${this.items.map(e=>T`
                     <div role="button" tabindex="0" class="cell ${e.disabled?`disabled`:``} ${e.recommended?`recommended`:``} ${e.id===this.selectedId?`selected`:``}"
-                         @click="${()=>this.select(e)}" @keydown="${z(()=>this.select(e))}">
+                         @click="${()=>this.select(e)}" @keydown="${R(()=>this.select(e))}">
                         ${e.recommended?T`<span class="tag">${this.recommendedLabel||`Recommended`}</span>`:v}
                         <span class="title">${e.title}</span>
                         ${e.subtitle?T`<span class="subtitle">${e.subtitle}</span>`:v}
@@ -4173,7 +4173,7 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};k([y()],pa.prototype,`actionId`,void 0),k([y({type:Number})],pa.prototype,`columns`,void 0),k([y()],pa.prototype,`recommendedLabel`,void 0),k([y({type:Array})],pa.prototype,`items`,void 0),k([C()],pa.prototype,`selectedId`,void 0),pa=k([g(`mateu-resource-grid`)],pa);var ma=e=>{let t=e.metadata;return T`
+        `}};k([y()],ma.prototype,`actionId`,void 0),k([y({type:Number})],ma.prototype,`columns`,void 0),k([y()],ma.prototype,`recommendedLabel`,void 0),k([y({type:Array})],ma.prototype,`items`,void 0),k([C()],ma.prototype,`selectedId`,void 0),ma=k([g(`mateu-resource-grid`)],ma);var ha=e=>{let t=e.metadata;return T`
         <mateu-resource-grid
                 .actionId="${t.actionId}"
                 .columns="${t.columns??0}"
@@ -4183,7 +4183,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-resource-grid>
-    `},U=class extends b{constructor(...e){super(...e),this.title=``,this.features=[],this.current=!1,this.added=!1}static{this.styles=h`
+    `},H=class extends b{constructor(...e){super(...e),this.title=``,this.features=[],this.current=!1,this.added=!1}static{this.styles=h`
         /* explicit line-height: inside a form field wrapper the inherited one is the 44px
            field height, which blows up every text row */
         :host { display: block; width: 100%; line-height: var(--lumo-line-height-m, 1.4); }
@@ -4271,7 +4271,7 @@ ${i}
                         `:v}
                 </div>
             </div>
-        `}};k([y()],U.prototype,`tag`,void 0),k([y()],U.prototype,`title`,void 0),k([y()],U.prototype,`subtitle`,void 0),k([y()],U.prototype,`image`,void 0),k([y({type:Array})],U.prototype,`features`,void 0),k([y()],U.prototype,`priceLabel`,void 0),k([y()],U.prototype,`actionLabel`,void 0),k([y()],U.prototype,`actionId`,void 0),k([y({type:Boolean})],U.prototype,`current`,void 0),k([y()],U.prototype,`currentLabel`,void 0),k([y({type:Boolean})],U.prototype,`added`,void 0),k([y()],U.prototype,`addedLabel`,void 0),U=k([g(`mateu-offer-card`)],U);var ha=e=>{let t=e.metadata;return T`
+        `}};k([y()],H.prototype,`tag`,void 0),k([y()],H.prototype,`title`,void 0),k([y()],H.prototype,`subtitle`,void 0),k([y()],H.prototype,`image`,void 0),k([y({type:Array})],H.prototype,`features`,void 0),k([y()],H.prototype,`priceLabel`,void 0),k([y()],H.prototype,`actionLabel`,void 0),k([y()],H.prototype,`actionId`,void 0),k([y({type:Boolean})],H.prototype,`current`,void 0),k([y()],H.prototype,`currentLabel`,void 0),k([y({type:Boolean})],H.prototype,`added`,void 0),k([y()],H.prototype,`addedLabel`,void 0),H=k([g(`mateu-offer-card`)],H);var ga=e=>{let t=e.metadata;return T`
         <mateu-offer-card
                 .tag="${t.tag}"
                 .title="${t.title??``}"
@@ -4289,7 +4289,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-offer-card>
-    `},ga=class extends b{constructor(...e){super(...e),this.items=[],this.added=new Set}static{this.styles=h`
+    `},_a=class extends b{constructor(...e){super(...e),this.items=[],this.added=new Set}static{this.styles=h`
         :host { display: block; width: 100%; }
         .header { display: flex; align-items: baseline; justify-content: flex-end; gap: .4rem; margin-bottom: .6rem; }
         .total-label { font-size: var(--lumo-font-size-s, .875rem); color: var(--lumo-secondary-text-color, #888); }
@@ -4357,7 +4357,7 @@ ${i}
     `}willUpdate(e){e.has(`items`)&&(this.added=new Set(this.items.filter(e=>e.added).map(e=>e.id)))}total(){return this.items.filter(e=>e.id!=null&&this.added.has(e.id)).reduce((e,t)=>e+(t.price??0),0)}toggle(e){if(e.id==null)return;let t=new Set(this.added),n=!t.has(e.id);n?t.add(e.id):t.delete(e.id),this.added=t,this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{_item:e.id,_added:n,_total:this.total()}},bubbles:!0,composed:!0}))}render(){return T`
             <div class="header">
                 ${this.totalLabel?T`<span class="total-label">${this.totalLabel}:</span>`:v}
-                <span class="total">${Xi(this.total(),this.currency)}</span>
+                <span class="total">${Zi(this.total(),this.currency)}</span>
             </div>
             <div class="grid">
                 ${this.items.map(e=>{let t=e.id!=null&&this.added.has(e.id);return T`
@@ -4367,7 +4367,7 @@ ${i}
                             ${e.description?T`<span class="description">${e.description}</span>`:v}
                             ${e.includedLabel?T`<span class="included">${e.includedLabel}</span>`:T`
                                     ${e.price==null?v:T`
-                                        <span class="price">${Xi(e.price,this.currency)}${e.unit?` / ${e.unit}`:``}</span>
+                                        <span class="price">${Zi(e.price,this.currency)}${e.unit?` / ${e.unit}`:``}</span>
                                     `}
                                     <button class="toggle ${t?`on`:``}" @click="${()=>this.toggle(e)}"
                                             aria-pressed="${t}">${t?`✓`:`+`}</button>
@@ -4375,7 +4375,7 @@ ${i}
                         </div>
                     `})}
             </div>
-        `}};k([y()],ga.prototype,`totalLabel`,void 0),k([y()],ga.prototype,`currency`,void 0),k([y()],ga.prototype,`actionId`,void 0),k([y({type:Array})],ga.prototype,`items`,void 0),k([C()],ga.prototype,`added`,void 0),ga=k([g(`mateu-addon-picker`)],ga);var _a=e=>{let t=e.metadata;return T`
+        `}};k([y()],_a.prototype,`totalLabel`,void 0),k([y()],_a.prototype,`currency`,void 0),k([y()],_a.prototype,`actionId`,void 0),k([y({type:Array})],_a.prototype,`items`,void 0),k([C()],_a.prototype,`added`,void 0),_a=k([g(`mateu-addon-picker`)],_a);var va=e=>{let t=e.metadata;return T`
         <mateu-addon-picker
                 .totalLabel="${t.totalLabel}"
                 .currency="${t.currency}"
@@ -4385,7 +4385,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-addon-picker>
-    `},va=class extends b{constructor(...e){super(...e),this.lines=[]}static{this.styles=h`
+    `},ya=class extends b{constructor(...e){super(...e),this.lines=[]}static{this.styles=h`
         :host {
             display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem);
             /* an ancestor (e.g. a form-layout row) may set an inherited line-height like 44px —
@@ -4427,14 +4427,14 @@ ${i}
                 <div class="row">
                     <span class="dot"></span>
                     <span class="concept">${e.concept}</span>
-                    ${e.included?T`<span class="included-label">${e.includedLabel||`Included`}</span>`:T`<span class="amount ${(e.amount??0)<0?`negative`:``}">${Xi(e.amount??0,this.currency)}</span>`}
+                    ${e.included?T`<span class="included-label">${e.includedLabel||`Included`}</span>`:T`<span class="amount ${(e.amount??0)<0?`negative`:``}">${Zi(e.amount??0,this.currency)}</span>`}
                 </div>
             `)}
             <div class="total-row">
                 <span class="total-label">${this.totalLabel||`Total`}</span>
-                <span class="total">${Xi(this.computedTotal(),this.currency)}</span>
+                <span class="total">${Zi(this.computedTotal(),this.currency)}</span>
             </div>
-        `}};k([y()],va.prototype,`currency`,void 0),k([y()],va.prototype,`totalLabel`,void 0),k([y({type:Array})],va.prototype,`lines`,void 0),k([y({type:Number})],va.prototype,`total`,void 0),va=k([g(`mateu-ledger`)],va);var ya=e=>{let t=e.metadata;return T`
+        `}};k([y()],ya.prototype,`currency`,void 0),k([y()],ya.prototype,`totalLabel`,void 0),k([y({type:Array})],ya.prototype,`lines`,void 0),k([y({type:Number})],ya.prototype,`total`,void 0),ya=k([g(`mateu-ledger`)],ya);var ba=e=>{let t=e.metadata;return T`
         <mateu-ledger
                 .currency="${t.currency}"
                 .totalLabel="${t.totalLabel}"
@@ -4444,7 +4444,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-ledger>
-    `},ba=class extends b{constructor(...e){super(...e),this.methods=[]}static{this.styles=h`
+    `},xa=class extends b{constructor(...e){super(...e),this.methods=[]}static{this.styles=h`
         :host { display: block; width: 100%; }
         .bar { display: flex; align-items: stretch; gap: .6rem; flex-wrap: wrap; }
         .methods { display: flex; gap: .4rem; flex-wrap: wrap; }
@@ -4506,7 +4506,7 @@ ${i}
                 <span class="spacer"></span>
                 ${this.confirmLabel&&this.actionId?T`<button class="confirm" @click="${()=>this.confirm()}">${this.confirmLabel}</button>`:v}
             </div>
-        `}};k([y()],ba.prototype,`actionId`,void 0),k([y()],ba.prototype,`methodActionId`,void 0),k([y({type:Array})],ba.prototype,`methods`,void 0),k([y()],ba.prototype,`selected`,void 0),k([y()],ba.prototype,`contextLabel`,void 0),k([y()],ba.prototype,`contextValue`,void 0),k([y()],ba.prototype,`confirmLabel`,void 0),k([C()],ba.prototype,`selectedId`,void 0),ba=k([g(`mateu-payment-picker`)],ba);var xa=e=>{let t=e.metadata;return T`
+        `}};k([y()],xa.prototype,`actionId`,void 0),k([y()],xa.prototype,`methodActionId`,void 0),k([y({type:Array})],xa.prototype,`methods`,void 0),k([y()],xa.prototype,`selected`,void 0),k([y()],xa.prototype,`contextLabel`,void 0),k([y()],xa.prototype,`contextValue`,void 0),k([y()],xa.prototype,`confirmLabel`,void 0),k([C()],xa.prototype,`selectedId`,void 0),xa=k([g(`mateu-payment-picker`)],xa);var Sa=e=>{let t=e.metadata;return T`
         <mateu-payment-picker
                 .actionId="${t.actionId}"
                 .methodActionId="${t.methodActionId}"
@@ -4519,7 +4519,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-payment-picker>
-    `},Sa=class extends b{constructor(...e){super(...e),this.items=[]}static{this.styles=h`
+    `},Ca=class extends b{constructor(...e){super(...e),this.items=[]}static{this.styles=h`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .list {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -4573,14 +4573,14 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};k([y({type:Array})],Sa.prototype,`items`,void 0),Sa=k([g(`mateu-process-monitor`)],Sa);var Ca=e=>T`
+        `}};k([y({type:Array})],Ca.prototype,`items`,void 0),Ca=k([g(`mateu-process-monitor`)],Ca);var wa=e=>T`
         <mateu-process-monitor
                 .items="${e.metadata.items??[]}"
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-process-monitor>
-    `,wa=(e,t)=>{let n=e.style;return e.id&&(n&&!n.endsWith(`;`)&&(n+=`;`),n??=``,t[e.id+`.hidden`]==1&&(n+=`display: none;`)),n},Ta=(e,t)=>{let n={...e.metadata};if(e.id&&n){if(n.type==j.Button){let r=n;t[e.id+`.disabled`]==1&&(r.disabled=!0)}if(n.type==j.FormField){let r=n;t[e.id+`.disabled`]==1&&(r.disabled=!0)}}return n},W=e=>t=>e(t.container,t.component,t.baseUrl,t.state,t.data,t.appState,t.appData),Ea={[j.Bpmn]:({component:e})=>Hr(e),[j.Workflow]:({component:e})=>Wr(e),[j.FormEditor]:({component:e})=>Gr(e),[j.Page]:W(Br),[j.Div]:W(Nr),[j.Directory]:({component:e,baseUrl:t,state:n,data:r})=>jr(e,t,n,r),[j.FormLayout]:W(_n),[j.HorizontalLayout]:W(Cn),[j.VerticalLayout]:W(wn),[j.SplitLayout]:W(Tn),[j.MasterDetailLayout]:W(En),[j.TabLayout]:W(Dn),[j.AccordionLayout]:W(On),[j.BoardLayout]:W(Nn),[j.BoardLayoutRow]:W(Pn),[j.BoardLayoutItem]:W(Fn),[j.Scroller]:W(An),[j.FullWidth]:W(jn),[j.Container]:W(Mn),[j.Form]:({container:e,component:t,baseUrl:n,state:r,data:i,appState:a,appData:o})=>{let s=t.metadata;return T`<mateu-form
+    `,Ta=(e,t)=>{let n=e.style;return e.id&&(n&&!n.endsWith(`;`)&&(n+=`;`),n??=``,t[e.id+`.hidden`]==1&&(n+=`display: none;`)),n},Ea=(e,t)=>{let n={...e.metadata};if(e.id&&n){if(n.type==j.Button){let r=n;t[e.id+`.disabled`]==1&&(r.disabled=!0)}if(n.type==j.FormField){let r=n;t[e.id+`.disabled`]==1&&(r.disabled=!0)}}return n},U=e=>t=>e(t.container,t.component,t.baseUrl,t.state,t.data,t.appState,t.appData),Da={[j.Bpmn]:({component:e})=>Ur(e),[j.Workflow]:({component:e})=>Gr(e),[j.FormEditor]:({component:e})=>Kr(e),[j.Page]:U(Vr),[j.Div]:U(Pr),[j.Directory]:({component:e,baseUrl:t,state:n,data:r})=>Mr(e,t,n,r),[j.FormLayout]:U(vn),[j.HorizontalLayout]:U(wn),[j.VerticalLayout]:U(Tn),[j.SplitLayout]:U(En),[j.MasterDetailLayout]:U(Dn),[j.TabLayout]:U(On),[j.AccordionLayout]:U(kn),[j.BoardLayout]:U(Pn),[j.BoardLayoutRow]:U(Fn),[j.BoardLayoutItem]:U(In),[j.Scroller]:U(jn),[j.FullWidth]:U(Mn),[j.Container]:U(Nn),[j.Form]:({container:e,component:t,baseUrl:n,state:r,data:i,appState:a,appData:o})=>{let s=t.metadata;return T`<mateu-form
             id="${t.id}"
         baseUrl="${n}"
             .component="${t}"
@@ -4593,12 +4593,12 @@ ${i}
             class="${t.cssClasses}"
             slot="${t.slot??v}"
             >
-                ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+                ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
             ${s?.buttons?.map(t=>T`
-               ${I(e,{id:t.actionId,metadata:t,type:A.ClientSide,slot:`buttons`},void 0,r,i,a,o)}
+               ${F(e,{id:t.actionId,metadata:t,type:A.ClientSide,slot:`buttons`},void 0,r,i,a,o)}
 `)}
 
-            </mateu-form>`},[j.Table]:({component:e,state:t,data:n})=>zn(e,(e.id?n?.[e.id]:void 0)?.page?.content??Bn(e,t)),[j.Crud]:W(Vr),[j.App]:({container:e,component:t,baseUrl:n,state:r,data:i,appState:a,appData:o})=>T`
+            </mateu-form>`},[j.Table]:({component:e,state:t,data:n})=>Bn(e,(e.id?n?.[e.id]:void 0)?.page?.content??Vn(e,t)),[j.Crud]:U(Hr),[j.App]:({container:e,component:t,baseUrl:n,state:r,data:i,appState:a,appData:o})=>T`
             <mateu-app
                         id="${t.id}"
                         baseUrl="${n}"
@@ -4610,20 +4610,20 @@ ${i}
                         .appState="${a}"
                         .appData="${o}"
             >
-             ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
-         </mateu-app>`,[j.Element]:({container:e,component:t,state:n,data:r,appState:i,appData:a})=>Qn(e,t.metadata,t,n,r,i,a),[j.FormField]:({component:e,state:t})=>Rr(e,t),[j.Text]:({component:e,state:t,data:n,appState:r,appData:i})=>er(e,t,n,r,i),[j.Avatar]:({component:e,state:t,data:n})=>Dt(e,t,n),[j.Chat]:({component:e,state:t,data:n})=>Ur(e,t,n),[j.AvatarGroup]:({component:e})=>Ot(e),[j.Badge]:({component:e,state:t,data:n})=>kt(e,t,n),[j.Breadcrumbs]:({component:e})=>kr(e),[j.Anchor]:({component:e})=>tr(e),[j.Button]:({component:e,state:t,data:n})=>cr(e,t,n),[j.Card]:W(ur),[j.Chart]:({component:e})=>dr(e),[j.Icon]:({component:e})=>fr(e),[j.ConfirmDialog]:W(_r),[j.ContextMenu]:W(Wn),[j.CookieConsent]:({component:e})=>vr(e),[j.Details]:W(yr),[j.Dialog]:({component:e,baseUrl:t,state:n,data:r,appState:i,appData:a})=>br(e,t,n,r,i,a),[j.Drawer]:({component:e,baseUrl:t,state:n,data:r,appState:i,appData:a})=>xr(e,t,n,r,i,a),[j.Image]:({component:e})=>Or(e),[j.Map]:({component:e})=>Dr(e),[j.Markdown]:({component:e})=>Cr(e),[j.MicroFrontend]:({component:e})=>Sr(e),[j.Notification]:({component:e})=>wr(e),[j.ProgressBar]:({component:e,state:t})=>Tr(e,t),[j.Popover]:W(Er),[j.CarouselLayout]:W(Ar),[j.Tooltip]:W(qn),[j.MessageInput]:({component:e})=>Kn(e),[j.MessageList]:({component:e})=>Vn(e),[j.CustomField]:W(Gn),[j.MenuBar]:({container:e,component:t,baseUrl:n,state:r,data:i})=>Un(e,t,n,r,i),[j.Grid]:({component:e,state:t})=>zn(e,Bn(e,t)),[j.VirtualList]:W(In),[j.FormSection]:W(Pr),[j.FormSubSection]:W(Fr),[j.MetricCard]:({component:e})=>Xr(e),[j.Scoreboard]:W(Zr),[j.DashboardPanel]:W(Qr),[j.DashboardLayout]:W($r),[j.FoldoutLayout]:W(ti),[j.ContentLayout]:W(ni),[j.HeroSection]:W(ri),[j.EmptyState]:({component:e})=>Bt(e),[j.Skeleton]:({component:e})=>Vt(e),[j.Gantt]:({component:e})=>oi(e),[j.PlanningBoard]:({component:e})=>ci(e),[j.Kanban]:({component:e})=>ui(e),[j.Timeline]:({component:e})=>fi(e),[j.ProgressSteps]:({component:e})=>mi(e),[j.Stat]:({component:e})=>gi(e),[j.Calendar]:({component:e})=>vi(e),[j.PricingTable]:({component:e})=>bi(e),[j.OrgChart]:({component:e})=>Si(e),[j.Heatmap]:({component:e})=>Ti(e),[j.Funnel]:({component:e})=>Di(e),[j.TrendChart]:({component:e})=>ki(e),[j.FeatureGrid]:({component:e})=>ji(e),[j.Testimonials]:({component:e})=>Ni(e),[j.Faq]:({component:e})=>Fi(e),[j.CalloutCard]:({component:e})=>Li(e),[j.CommentThread]:({component:e})=>zi(e),[j.FileList]:({component:e})=>Hi(e),[j.Checklist]:({component:e})=>Wi(e),[j.ComparisonCard]:({component:e})=>Ki(e),[j.EntityHeader]:({component:e})=>$i(e),[j.Meter]:({component:e})=>ta(e),[j.TaskProgress]:({component:e})=>ra(e),[j.StatusList]:({component:e})=>aa(e),[j.BulletedList]:({component:e})=>sa(e),[j.Separator]:({component:e})=>ca(e),[j.Notice]:W(ua),[j.TaskQueue]:({component:e})=>fa(e),[j.ResourceGrid]:({component:e})=>ma(e),[j.OfferCard]:({component:e})=>ha(e),[j.AddOnPicker]:({component:e})=>_a(e),[j.Ledger]:({component:e})=>ya(e),[j.PaymentPicker]:({component:e})=>xa(e),[j.ProcessMonitor]:({component:e})=>Ca(e)},Da=(e,t,n,r,i,a,o,s)=>{if(!t?.metadata)return t==null?(console.warn(`No metadata for component`,t),T`<p>No metadata for component</p>`):Da(e,{id:E(),metadata:t,type:A.ClientSide},n,r,i,a,o,s);let c=t.metadata.type,l={...t,style:wa(t,i),metadata:Ta(t,i)},u=Ea[c];return u?u({container:e,component:l,baseUrl:n,state:r,data:i,appState:a,appData:o,labelAlreadyRendered:s}):T`<p ${l?.slot??v}>Unknown metadata type ${c} for component ${l?.id}</p>`},Oa=function(e){return e.NONE=`NONE`,e.INFO=`INFO`,e.SUCCESS=`SUCCESS`,e.WARNING=`WARNING`,e.DANGER=`DANGER`,e}({}),ka=(e,t,n)=>{let r=e[n.path];return r?T`<span theme="badge pill ${Aa(r.type)}">${r.message}</span>`:T``},Aa=e=>{switch(e){case Oa.SUCCESS:return`success`;case Oa.WARNING:return`warning`;case Oa.DANGER:return`error`;case Oa.NONE:return`contrast`}return``},G=class extends b{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.respondToVisibility=(e,t)=>{var n={root:document.documentElement};new IntersectionObserver(e=>{e.forEach(e=>{t(e.intersectionRatio>0)})},n).observe(e)},this.keepAsking=!1,this.askToUpper=()=>{let e=this.data[this.id]?.page,t=e?.content?.length/e?.pageSize;this.dispatchEvent(new CustomEvent(`fetch-more-elements`,{detail:{params:{page:t,pageSize:this.metadata?.pageSize},callback:()=>{this.keepAsking&&this.askToUpper()}},bubbles:!0,composed:!0}))},this.renderItem=e=>e.card?Da(this,e.card,this.baseUrl,this.state,this.data,this.appState,this.appData,!1):e.title?T`<div class="neutral-card">
+             ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+         </mateu-app>`,[j.Element]:({container:e,component:t,state:n,data:r,appState:i,appData:a})=>$n(e,t.metadata,t,n,r,i,a),[j.FormField]:({component:e,state:t})=>zr(e,t),[j.Text]:({component:e,state:t,data:n,appState:r,appData:i})=>tr(e,t,n,r,i),[j.Avatar]:({component:e,state:t,data:n})=>Dt(e,t,n),[j.Chat]:({component:e,state:t,data:n})=>Wr(e,t,n),[j.AvatarGroup]:({component:e})=>kt(e),[j.Badge]:({component:e,state:t,data:n})=>At(e,t,n),[j.Breadcrumbs]:({component:e})=>Ar(e),[j.Anchor]:({component:e})=>nr(e),[j.Button]:({component:e,state:t,data:n})=>lr(e,t,n),[j.Card]:U(dr),[j.Chart]:({component:e})=>fr(e),[j.Icon]:({component:e})=>pr(e),[j.ConfirmDialog]:U(vr),[j.ContextMenu]:U(Gn),[j.CookieConsent]:({component:e})=>yr(e),[j.Details]:U(br),[j.Dialog]:({component:e,baseUrl:t,state:n,data:r,appState:i,appData:a})=>xr(e,t,n,r,i,a),[j.Drawer]:({component:e,baseUrl:t,state:n,data:r,appState:i,appData:a})=>Sr(e,t,n,r,i,a),[j.Image]:({component:e})=>kr(e),[j.Map]:({component:e})=>Or(e),[j.Markdown]:({component:e})=>wr(e),[j.MicroFrontend]:({component:e})=>Cr(e),[j.Notification]:({component:e})=>Tr(e),[j.ProgressBar]:({component:e,state:t})=>Er(e,t),[j.Popover]:U(Dr),[j.CarouselLayout]:U(jr),[j.Tooltip]:U(Jn),[j.MessageInput]:({component:e})=>qn(e),[j.MessageList]:({component:e})=>Hn(e),[j.CustomField]:U(Kn),[j.MenuBar]:({container:e,component:t,baseUrl:n,state:r,data:i})=>Wn(e,t,n,r,i),[j.Grid]:({component:e,state:t})=>Bn(e,Vn(e,t)),[j.VirtualList]:U(Ln),[j.FormSection]:U(Fr),[j.FormSubSection]:U(Ir),[j.MetricCard]:({component:e})=>Zr(e),[j.Scoreboard]:U(Qr),[j.DashboardPanel]:U($r),[j.DashboardLayout]:U(ei),[j.FoldoutLayout]:U(ni),[j.ContentLayout]:U(ri),[j.HeroSection]:U(ii),[j.EmptyState]:({component:e})=>Vt(e),[j.Skeleton]:({component:e})=>Ht(e),[j.Gantt]:({component:e})=>si(e),[j.PlanningBoard]:({component:e})=>li(e),[j.Kanban]:({component:e})=>di(e),[j.Timeline]:({component:e})=>pi(e),[j.ProgressSteps]:({component:e})=>hi(e),[j.Stat]:({component:e})=>_i(e),[j.Calendar]:({component:e})=>yi(e),[j.PricingTable]:({component:e})=>xi(e),[j.OrgChart]:({component:e})=>Ci(e),[j.Heatmap]:({component:e})=>Ei(e),[j.Funnel]:({component:e})=>Oi(e),[j.TrendChart]:({component:e})=>Ai(e),[j.FeatureGrid]:({component:e})=>Mi(e),[j.Testimonials]:({component:e})=>Pi(e),[j.Faq]:({component:e})=>Ii(e),[j.CalloutCard]:({component:e})=>Ri(e),[j.CommentThread]:({component:e})=>Bi(e),[j.FileList]:({component:e})=>Ui(e),[j.Checklist]:({component:e})=>Gi(e),[j.ComparisonCard]:({component:e})=>qi(e),[j.EntityHeader]:({component:e})=>ea(e),[j.Meter]:({component:e})=>na(e),[j.TaskProgress]:({component:e})=>ia(e),[j.StatusList]:({component:e})=>oa(e),[j.BulletedList]:({component:e})=>ca(e),[j.Separator]:({component:e})=>la(e),[j.Notice]:U(da),[j.TaskQueue]:({component:e})=>pa(e),[j.ResourceGrid]:({component:e})=>ha(e),[j.OfferCard]:({component:e})=>ga(e),[j.AddOnPicker]:({component:e})=>va(e),[j.Ledger]:({component:e})=>ba(e),[j.PaymentPicker]:({component:e})=>Sa(e),[j.ProcessMonitor]:({component:e})=>wa(e)},Oa=(e,t,n,r,i,a,o,s)=>{if(!t?.metadata)return t==null?(console.warn(`No metadata for component`,t),T`<p>No metadata for component</p>`):Oa(e,{id:E(),metadata:t,type:A.ClientSide},n,r,i,a,o,s);let c=t.metadata.type,l={...t,style:Ta(t,i),metadata:Ea(t,i)},u=Da[c];return u?u({container:e,component:l,baseUrl:n,state:r,data:i,appState:a,appData:o,labelAlreadyRendered:s}):T`<p ${l?.slot??v}>Unknown metadata type ${c} for component ${l?.id}</p>`},ka=function(e){return e.NONE=`NONE`,e.INFO=`INFO`,e.SUCCESS=`SUCCESS`,e.WARNING=`WARNING`,e.DANGER=`DANGER`,e}({}),Aa=(e,t,n)=>{let r=e[n.path];return r?T`<span theme="badge pill ${ja(r.type)}">${r.message}</span>`:T``},ja=e=>{switch(e){case ka.SUCCESS:return`success`;case ka.WARNING:return`warning`;case ka.DANGER:return`error`;case ka.NONE:return`contrast`}return``},W=class extends b{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.respondToVisibility=(e,t)=>{var n={root:document.documentElement};new IntersectionObserver(e=>{e.forEach(e=>{t(e.intersectionRatio>0)})},n).observe(e)},this.keepAsking=!1,this.askToUpper=()=>{let e=this.data[this.id]?.page,t=e?.content?.length/e?.pageSize;this.dispatchEvent(new CustomEvent(`fetch-more-elements`,{detail:{params:{page:t,pageSize:this.metadata?.pageSize},callback:()=>{this.keepAsking&&this.askToUpper()}},bubbles:!0,composed:!0}))},this.renderItem=e=>e.card?Oa(this,e.card,this.baseUrl,this.state,this.data,this.appState,this.appData,!1):e.title?T`<div class="neutral-card">
                 ${e.image?T`<img class="card-media" src="${e.image}" alt="" />`:v}
                 <div class="card-body">
                     <div class="card-head">
                         ${e.title?T`<span class="card-title">${e.title}</span>`:v}
-                        ${e.status?T`<span theme="badge ${Aa(e.status.type)}">${e.status.message}</span>`:v}
+                        ${e.status?T`<span theme="badge ${ja(e.status.type)}">${e.status.message}</span>`:v}
                     </div>
                     ${e.subtitle?T`<div class="card-subtitle">${e.subtitle}</div>`:v}
                     ${e.content?T`<div>${e.content}</div>`:v}
                 </div>
         </div>`:T`${e}`,this.hasMore=!1,this.clickedOnCard=e=>{this.state[this.id+`_selected_items`]=[e],this.metadata?.onRowSelectionChangedActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.metadata?.onRowSelectionChangedActionId},bubbles:!0,composed:!0}))}}updated(e){super.updated(e);let t=this.data[this.id]?.page;this.hasMore=t?.content?.length<t?.totalElements}firstUpdated(e){super.firstUpdated(e),this.respondToVisibility(this.askForMore,e=>{this.keepAsking=e,e&&this.askToUpper()})}render(){return T`
             <div class="card-container">
-                ${(this.data[this.id]?.page)?.content?.map(e=>T`<div role="button" tabindex="0" @click="${()=>this.clickedOnCard(e)}" @keydown="${z(()=>this.clickedOnCard(e))}" class="car-container">${this.renderItem(e)}</div>`)}
+                ${(this.data[this.id]?.page)?.content?.map(e=>T`<div role="button" tabindex="0" @click="${()=>this.clickedOnCard(e)}" @keydown="${R(()=>this.clickedOnCard(e))}" class="car-container">${this.renderItem(e)}</div>`)}
                 <div id="ask-for-more" style="display: ${this.hasMore?`flex`:`none`}; width: 100%; justify-content: center; padding: var(--lumo-space-m); color: var(--lumo-secondary-text-color); font-size: var(--lumo-font-size-s);">Loading more…</div>
             </div>
 
@@ -4653,39 +4653,39 @@ ${i}
         .neutral-card .card-title { font-weight: 600; }
         .neutral-card .card-subtitle { color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-s, .875rem); }
     
-        ${B}
-    `}};k([y()],G.prototype,`id`,void 0),k([y()],G.prototype,`metadata`,void 0),k([y()],G.prototype,`baseUrl`,void 0),k([y()],G.prototype,`state`,void 0),k([y()],G.prototype,`data`,void 0),k([y()],G.prototype,`appState`,void 0),k([y()],G.prototype,`appData`,void 0),k([y()],G.prototype,`emptyStateMessage`,void 0),k([C()],G.prototype,`keepAsking`,void 0),k([x(`#ask-for-more`)],G.prototype,`askForMore`,void 0),k([C()],G.prototype,`hasMore`,void 0),G=k([g(`mateu-card-list`)],G);var ja={show:e=>console.debug(`[mateu] no notifier registered, dropping toast:`,e.text)};function Ma(e){ja=e}function Na(e,t){ja.show(e,t)}var Pa=function(e){return e.none=`none`,e.success=`success`,e.error=`error`,e.warning=`warning`,e.contrast=`contrast`,e.normal=`normal`,e}({}),Fa=function(e){return e.primary=`primary`,e.secondary=`secondary`,e.tertiary=`tertiary`,e.tertiaryInline=`tertiaryInline`,e}({});function Ia(e){if(e.weight!=null)return e.weight;let t=e.stereotype??``;if(t===`icon`)return 1;if(t===`image`)return 4;if(t===`html`||t===`richText`||t===`markdown`||t===`textarea`)return 5;if(t===`link`)return 2.5;if(t===`combobox`||t===`select`)return 2;let n=e.dataType??``;return n===`bool`?1:n===`status`||n===`integer`?1.5:n===`number`||n===`date`||n===`money`?2:n===`dateTime`||n===`dateRange`?2.5:3}function La(e,t){if(e.length===0)return`table`;let n=e.reduce((e,t)=>e+Ia(t),0)/(t/76);if(n<=1.1)return`table`;if(n>1.6||e.length>10)return`masterDetail`;let r=e.filter(e=>e.identifier||(e.priority??2**53-1)<=2),i=r.reduce((e,t)=>e+Ia(t),0);return r.length>0&&i<=8?`list`:e.some(e=>e.stereotype===`image`||e.stereotype===`html`)||r.length===0&&e.length>=4&&e.length<=8?`cards`:`masterDetail`}function Ra(e){return e.filter(e=>e.identifier||(e.priority??2**53-1)<=2).sort((e,t)=>(e.priority??2**53-1)-(t.priority??2**53-1))}function za(e){let t=Ra(e);return t.length>0?t:e.slice(0,3)}var Ba,Va={asc:`ascending`,desc:`descending`},K=class extends b{static{Ba=this}constructor(...e){super(...e),this.component=void 0,this.standalone=!1,this.state={},this.data={},this.appState={},this.appData={},this.showImportDialog=!1,this.availableWidthPx=1024,this.selectedItem=null,this._columnPrefsRevision=0,this._prefsRevisionApplied=-1,this.pendingMeasure=!0,this.corrections=0,this.windowResizeListener=()=>this.scheduleMeasure(),this.search=()=>{let e=this.component.metadata;this.state={...this.state,size:e.pageSize,page:0,crud_selected_items:[]},this._syncStateToUrl(e),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`search`,parameters:{crudId:this.id,_searchState:{...this.state}}},bubbles:!0,composed:!0}))},this.notify=e=>{Na({text:e,position:`bottomEnd`,variant:`error`,duration:3e3},this)},this.handleSearchRequested=e=>{this.state={...this.state,crud_selected_items:[]};let t=this.component.metadata;if(this._syncStateToUrl(t),t.rowsSource){this._fetchRowsFromRest(t,e);return}!t.infiniteScrolling&&this.data?.[this.id]?.page&&(this.data[this.id].page.content=[]),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`search`,parameters:{crudId:this.id,_searchState:{...this.state}},callback:e},bubbles:!0,composed:!0}))},this._fetchRowsFromRest=(e,t)=>{let n=this.cols.map(e=>e.id).filter(Boolean),r=e.rowsSource;(r.proxy?new Promise(e=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`__restfetch__`,parameters:{_sourceKind:`rows`,_sourceId:this.id},callback:t=>e(dn(t?.appData?._restfetch,r.itemsPath,n)),callbackonly:!0},bubbles:!0,composed:!0}))}):mn(r,n,e=>M(e,this.state,this.data))).then(r=>{let i=String(this.state?.searchText??``).trim().toLowerCase(),a=i?r.filter(e=>n.some(t=>String(e[t]??``).toLowerCase().includes(i))):r,o=e.pageSize&&e.pageSize>0?e.pageSize:a.length||1,s=Number(this.state?.page??0),c=a.slice(s*o,s*o+o);this.data={...this.data,[this.id]:{page:{totalElements:a.length,pageSize:o,pageNumber:s,content:c}}},this.requestUpdate(),t?.()}).catch(e=>{console.warn(`mateu: external rows fetch failed`,e),t?.()})},this.fetchMoreElements=e=>{let{params:t,callback:n}=e.detail;this.state={...this.state,size:t.pageSize,page:t.page},this.handleSearchRequested(n)},this.directionChanged=e=>{let t=e.detail.grid._sorters;this.state={...this.state,sort:t.map(e=>({fieldId:e.__data.path,direction:e.__data.direction?Va[e.__data.direction]:void 0}))},this.handleSearchRequested(void 0)},this._initializedForComponentId=void 0,this.evalLabel=e=>M(e,this.state,this.data),this.handleToolbarButtonClick=e=>{if(e===`import`){this.showImportDialog=!0;return}this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.handleImportUploadSuccess=e=>{let t=e.detail.xhr.responseText;this.showImportDialog=!1,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`process-import`,parameters:{fileId:t}},bubbles:!0,composed:!0}))}}get columnPrefsScope(){return window.location.pathname}get effectiveComponent(){let e=this.component,t=e?.metadata;if(!e||!t?.columns)return e;if(this._prefsSource===e&&this._prefsRevisionApplied===this._columnPrefsRevision)return this._prefsApplied;let n=en(this.columnPrefsScope),r=an(t.columns,n,e=>e.metadata??{});return this._prefsApplied=r===t.columns?e:{...e,metadata:{...t,columns:r}},this._prefsSource=e,this._prefsRevisionApplied=this._columnPrefsRevision,this._prefsApplied}get columnChooserEntries(){return(this.component?.metadata?.columns??[]).map(e=>{let t=e.metadata??{},n=t.id??e.id;return n?{id:n,label:t.label??n,protected:rn(t)}:void 0}).filter(e=>!!e)}renderColumnChooser(){let e=this.columnChooserEntries;return e.filter(e=>!e.protected).length===0?v:T`
+        ${z}
+    `}};k([y()],W.prototype,`id`,void 0),k([y()],W.prototype,`metadata`,void 0),k([y()],W.prototype,`baseUrl`,void 0),k([y()],W.prototype,`state`,void 0),k([y()],W.prototype,`data`,void 0),k([y()],W.prototype,`appState`,void 0),k([y()],W.prototype,`appData`,void 0),k([y()],W.prototype,`emptyStateMessage`,void 0),k([C()],W.prototype,`keepAsking`,void 0),k([x(`#ask-for-more`)],W.prototype,`askForMore`,void 0),k([C()],W.prototype,`hasMore`,void 0),W=k([g(`mateu-card-list`)],W);var Ma={show:e=>console.debug(`[mateu] no notifier registered, dropping toast:`,e.text)};function Na(e){Ma=e}function Pa(e,t){Ma.show(e,t)}var Fa=function(e){return e.none=`none`,e.success=`success`,e.error=`error`,e.warning=`warning`,e.contrast=`contrast`,e.normal=`normal`,e}({}),Ia=function(e){return e.primary=`primary`,e.secondary=`secondary`,e.tertiary=`tertiary`,e.tertiaryInline=`tertiaryInline`,e}({});function La(e){if(e.weight!=null)return e.weight;let t=e.stereotype??``;if(t===`icon`)return 1;if(t===`image`)return 4;if(t===`html`||t===`richText`||t===`markdown`||t===`textarea`)return 5;if(t===`link`)return 2.5;if(t===`combobox`||t===`select`)return 2;let n=e.dataType??``;return n===`bool`?1:n===`status`||n===`integer`?1.5:n===`number`||n===`date`||n===`money`?2:n===`dateTime`||n===`dateRange`?2.5:3}function Ra(e,t){if(e.length===0)return`table`;let n=e.reduce((e,t)=>e+La(t),0)/(t/76);if(n<=1.1)return`table`;if(n>1.6||e.length>10)return`masterDetail`;let r=e.filter(e=>e.identifier||(e.priority??2**53-1)<=2),i=r.reduce((e,t)=>e+La(t),0);return r.length>0&&i<=8?`list`:e.some(e=>e.stereotype===`image`||e.stereotype===`html`)||r.length===0&&e.length>=4&&e.length<=8?`cards`:`masterDetail`}function za(e){return e.filter(e=>e.identifier||(e.priority??2**53-1)<=2).sort((e,t)=>(e.priority??2**53-1)-(t.priority??2**53-1))}function Ba(e){let t=za(e);return t.length>0?t:e.slice(0,3)}var Va,Ha={asc:`ascending`,desc:`descending`},G=class extends b{static{Va=this}constructor(...e){super(...e),this.component=void 0,this.standalone=!1,this.state={},this.data={},this.appState={},this.appData={},this.showImportDialog=!1,this.availableWidthPx=1024,this.selectedItem=null,this._columnPrefsRevision=0,this._prefsRevisionApplied=-1,this.pendingMeasure=!0,this.corrections=0,this.windowResizeListener=()=>this.scheduleMeasure(),this.search=()=>{this.beginLoading();let e=this.component.metadata;this.state={...this.state,size:e.pageSize,page:0,crud_selected_items:[]},this._syncStateToUrl(e),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`search`,parameters:{crudId:this.id,_searchState:{...this.state}}},bubbles:!0,composed:!0}))},this.notify=e=>{Pa({text:e,position:`bottomEnd`,variant:`error`,duration:3e3},this)},this.handleSearchRequested=e=>{this.state={...this.state,crud_selected_items:[]};let t=this.component.metadata;if(this._syncStateToUrl(t),t.rowsSource){this._fetchRowsFromRest(t,e);return}!t.infiniteScrolling&&this.data?.[this.id]?.page&&(this.data[this.id].page.content=[]),this.beginLoading(),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`search`,parameters:{crudId:this.id,_searchState:{...this.state}},callback:e},bubbles:!0,composed:!0}))},this._fetchRowsFromRest=(e,t)=>{let n=this.cols.map(e=>e.id).filter(Boolean),r=e.rowsSource;(r.proxy?new Promise(e=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`__restfetch__`,parameters:{_sourceKind:`rows`,_sourceId:this.id},callback:t=>e(fn(t?.appData?._restfetch,r.itemsPath,n)),callbackonly:!0},bubbles:!0,composed:!0}))}):hn(r,n,e=>M(e,this.state,this.data))).then(r=>{let i=String(this.state?.searchText??``).trim().toLowerCase(),a=i?r.filter(e=>n.some(t=>String(e[t]??``).toLowerCase().includes(i))):r,o=e.pageSize&&e.pageSize>0?e.pageSize:a.length||1,s=Number(this.state?.page??0),c=a.slice(s*o,s*o+o);this.data={...this.data,[this.id]:{page:{totalElements:a.length,pageSize:o,pageNumber:s,content:c}}},this.requestUpdate(),t?.()}).catch(e=>{console.warn(`mateu: external rows fetch failed`,e),t?.()})},this.fetchMoreElements=e=>{let{params:t,callback:n}=e.detail;this.state={...this.state,size:t.pageSize,page:t.page},this.handleSearchRequested(n)},this.directionChanged=e=>{let t=e.detail.grid._sorters;this.state={...this.state,sort:t.map(e=>({fieldId:e.__data.path,direction:e.__data.direction?Ha[e.__data.direction]:void 0}))},this.handleSearchRequested(void 0)},this._initializedForComponentId=void 0,this.evalLabel=e=>M(e,this.state,this.data),this.handleToolbarButtonClick=e=>{if(e===`import`){this.showImportDialog=!0;return}this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.handleImportUploadSuccess=e=>{let t=e.detail.xhr.responseText;this.showImportDialog=!1,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`process-import`,parameters:{fileId:t}},bubbles:!0,composed:!0}))}}get columnPrefsScope(){return window.location.pathname}get effectiveComponent(){let e=this.component,t=e?.metadata;if(!e||!t?.columns)return e;if(this._prefsSource===e&&this._prefsRevisionApplied===this._columnPrefsRevision)return this._prefsApplied;let n=tn(this.columnPrefsScope),r=on(t.columns,n,e=>e.metadata??{});return this._prefsApplied=r===t.columns?e:{...e,metadata:{...t,columns:r}},this._prefsSource=e,this._prefsRevisionApplied=this._columnPrefsRevision,this._prefsApplied}get columnChooserEntries(){return(this.component?.metadata?.columns??[]).map(e=>{let t=e.metadata??{},n=t.id??e.id;return n?{id:n,label:t.label??n,protected:an(t)}:void 0}).filter(e=>!!e)}renderColumnChooser(){let e=this.columnChooserEntries;return e.filter(e=>!e.protected).length===0?v:T`
             <mateu-column-chooser
                 .columns="${e}"
                 .scope="${this.columnPrefsScope}"
                 @column-prefs-changed="${e=>{e.stopPropagation(),this._columnPrefsRevision++}}"
             ></mateu-column-chooser>
-        `}get cols(){return(this.effectiveComponent?.metadata)?.columns?.map(e=>e.metadata)??[]}get identifierFieldName(){let e=this.cols.find(e=>e.identifier);return e?e.id:this.cols.find(e=>e.id===`id`)?.id}get effectiveGridLayout(){let e=this.component?.metadata,t=e?.gridLayout??`auto`;return t===`auto`?e?.crudlType===`card`?`cards`:La(this.cols,this.availableWidthPx):t}scheduleMeasure(){this.pendingMeasure=!0,this.corrections=0,this.fillHeightPx==null?this.requestUpdate():this.fillHeightPx=void 0}measureFill(){if(!this.pendingMeasure||this.fillHeightPx!=null)return;let e=this.renderRoot?.querySelector?.(`[data-crud-box]`);if(!e)return;if(this.closest?.(`mateu-dialog, mateu-drawer`)){this.pendingMeasure=!1;return}let t=e.getBoundingClientRect().top,n=Math.round(window.innerHeight-t-this.measureBottomInset(e)-Ba.BOTTOM_GUTTER_PX);this.pendingMeasure=!1,n>=Ba.MIN_FILL_PX&&(this.fillHeightPx=n)}trimOverflow(){if(this.fillHeightPx==null||this.pendingMeasure||this.corrections>=Ba.MAX_CORRECTIONS)return;let e=document.documentElement.scrollHeight-window.innerHeight;e<=1||e>Ba.MAX_SLIVER_PX||(this.corrections++,this.fillHeightPx=Math.max(Ba.MIN_FILL_PX,this.fillHeightPx-e))}measureBottomInset(e){let t=e,n=0;for(let e=0;t&&e<20;e++){n+=parseFloat(getComputedStyle(t).marginBottom)||0;let e=t.getRootNode(),r=t.assignedSlot??t.parentElement??e.host??null;if(!r||r===document.documentElement||r===document.body)break;let i=getComputedStyle(r);n+=(parseFloat(i.paddingBottom)||0)+(parseFloat(i.borderBottomWidth)||0);let a=parseFloat(i.rowGap)||0;for(let e=t.nextElementSibling;e;e=e.nextElementSibling){let t=getComputedStyle(e);n+=e.getBoundingClientRect().height+(parseFloat(t.marginTop)||0)+(parseFloat(t.marginBottom)||0)+a}t=r}return Math.round(n)}static{this.BOTTOM_GUTTER_PX=16}static{this.MAX_SLIVER_PX=64}static{this.MAX_CORRECTIONS=3}static{this.MIN_FILL_PX=320}boxStyle(){let e=`border: var(--mateu-section-border, none); background: var(--mateu-section-bg, transparent); overflow: hidden; padding: var(--mateu-section-padding, 0); display: flex; flex-direction: column;`;return this.fillHeightPx==null?`${e} max-height: calc(100dvh - 12rem);`:`${e} height: ${this.fillHeightPx}px;`}connectedCallback(){super.connectedCallback(),window.addEventListener(`resize`,this.windowResizeListener),this.resizeObserver=new ResizeObserver(e=>{let t=e[0]?.contentRect.width;t&&Math.abs(t-this.availableWidthPx)>10&&(this.availableWidthPx=t)}),this.resizeObserver.observe(this)}disconnectedCallback(){super.disconnectedCallback(),window.removeEventListener(`resize`,this.windowResizeListener),this.resizeObserver?.disconnect()}_filterIds(e){return new Set([`searchText`,...(e.filters??[]).flatMap(e=>e.stereotype===`dateRange`||e.stereotype===`numberRange`?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId])])}_syncStateToUrl(e){let t=this._filterIds(e),n=new URLSearchParams(window.location.search);t.forEach(e=>n.delete(e)),n.delete(`page`),n.delete(`sort`),t.forEach(e=>{let t=this.state[e];t!=null&&t!==``&&n.set(e,String(t))});let r=this.state.page;r&&r>0&&n.set(`page`,String(r));let i=this.state.sort;if(i&&i.length>0){let e=i.filter(e=>e.fieldId&&e.direction).map(e=>`${e.fieldId}:${e.direction}`).join(`,`);e&&n.set(`sort`,e)}let a=n.toString(),o=a?`${window.location.pathname}?${a}`:window.location.pathname;window.location.pathname+window.location.search!==o&&history.replaceState(null,``,o)}_initStateFromUrl(e,t){let n=new URLSearchParams(window.location.search),r=this._filterIds(e),i={...t};n.forEach((e,t)=>{r.has(t)&&(i[t]=e)});let a=n.get(`page`);if(a!==null){let e=parseInt(a,10);!isNaN(e)&&e>0&&(i.page=e)}let o=n.get(`sort`);if(o){let e=o.split(`,`).map(e=>{let[t,n]=e.split(`:`);return t&&n?{fieldId:t,direction:n}:null}).filter(Boolean);e.length>0&&(i.sort=e)}return i}pageChanged(e){this.state={...this.state,page:e.detail.page},this.handleSearchRequested(void 0)}updated(e){if(super.updated(e),e.has(`component`)&&(this.pendingMeasure=!0),this.measureFill(),this.trimOverflow(),e.has(`component`)){let e=this.component?.id;if(e!==this._initializedForComponentId){this._initializedForComponentId=e;let t=this.component?.metadata,n=t.initialPage&&t.initialPage>0?t.initialPage:0;this.state=this._initStateFromUrl(t,{...this.state,size:t.pageSize,page:n,sort:[]}),(this.state.page!==n||this.state.sort?.length>0||[...this._filterIds(t)].some(e=>this.state[e]!=null)||t.rowsSource)&&this.handleSearchRequested(void 0)}}}render(){let e=e=>{let t=[];return e.color&&e.color!==Pa.normal&&t.push(e.color),e.buttonStyle&&t.push(e.buttonStyle===Fa.tertiaryInline?`tertiary-inline`:e.buttonStyle),t.length?t.join(` `):void 0},t=e=>e===`back`||e===`backToList`||!!e&&e.startsWith(`cancel`),n=t=>F.get()?.renderToolbarButton?.(t,this.evalLabel(t.label),()=>this.handleToolbarButtonClick(t.actionId))||T`
+        `}get cols(){return(this.effectiveComponent?.metadata)?.columns?.map(e=>e.metadata)??[]}get identifierFieldName(){let e=this.cols.find(e=>e.identifier);return e?e.id:this.cols.find(e=>e.id===`id`)?.id}get effectiveGridLayout(){let e=this.component?.metadata,t=e?.gridLayout??`auto`;return t===`auto`?e?.crudlType===`card`?`cards`:Ra(this.cols,this.availableWidthPx):t}scheduleMeasure(){this.pendingMeasure=!0,this.corrections=0,this.fillHeightPx==null?this.requestUpdate():this.fillHeightPx=void 0}measureFill(){if(!this.pendingMeasure||this.fillHeightPx!=null)return;let e=this.renderRoot?.querySelector?.(`[data-crud-box]`);if(!e)return;if(this.closest?.(`mateu-dialog, mateu-drawer`)){this.pendingMeasure=!1;return}let t=e.getBoundingClientRect().top,n=Math.round(window.innerHeight-t-this.measureBottomInset(e)-Va.BOTTOM_GUTTER_PX);this.pendingMeasure=!1,n>=Va.MIN_FILL_PX&&(this.fillHeightPx=n)}trimOverflow(){if(this.fillHeightPx==null||this.pendingMeasure||this.corrections>=Va.MAX_CORRECTIONS)return;let e=document.documentElement.scrollHeight-window.innerHeight;e<=1||e>Va.MAX_SLIVER_PX||(this.corrections++,this.fillHeightPx=Math.max(Va.MIN_FILL_PX,this.fillHeightPx-e))}measureBottomInset(e){let t=e,n=0;for(let e=0;t&&e<20;e++){n+=parseFloat(getComputedStyle(t).marginBottom)||0;let e=t.getRootNode(),r=t.assignedSlot??t.parentElement??e.host??null;if(!r||r===document.documentElement||r===document.body)break;let i=getComputedStyle(r);n+=(parseFloat(i.paddingBottom)||0)+(parseFloat(i.borderBottomWidth)||0);let a=parseFloat(i.rowGap)||0;for(let e=t.nextElementSibling;e;e=e.nextElementSibling){let t=getComputedStyle(e);n+=e.getBoundingClientRect().height+(parseFloat(t.marginTop)||0)+(parseFloat(t.marginBottom)||0)+a}t=r}return Math.round(n)}static{this.BOTTOM_GUTTER_PX=16}static{this.MAX_SLIVER_PX=64}static{this.MAX_CORRECTIONS=3}static{this.MIN_FILL_PX=320}boxStyle(){let e=`border: var(--mateu-section-border, none); background: var(--mateu-section-bg, transparent); overflow: hidden; padding: var(--mateu-section-padding, 0); display: flex; flex-direction: column;`;return this.fillHeightPx==null?`${e} max-height: calc(100dvh - 12rem);`:`${e} height: ${this.fillHeightPx}px;`}connectedCallback(){super.connectedCallback(),window.addEventListener(`resize`,this.windowResizeListener),this.resizeObserver=new ResizeObserver(e=>{let t=e[0]?.contentRect.width;t&&Math.abs(t-this.availableWidthPx)>10&&(this.availableWidthPx=t)}),this.resizeObserver.observe(this)}disconnectedCallback(){super.disconnectedCallback(),clearTimeout(this.loadingTimer),window.removeEventListener(`resize`,this.windowResizeListener),this.resizeObserver?.disconnect()}static{this.LOADING_VALVE_MS=15e3}get awaitingRows(){return this.loadingSince!=null&&Date.now()-this.loadingSince<Va.LOADING_VALVE_MS}beginLoading(){this.loadingSince=Date.now(),clearTimeout(this.loadingTimer),this.loadingTimer=setTimeout(()=>this.requestUpdate(),Va.LOADING_VALVE_MS)}endLoading(){this.loadingSince=void 0,clearTimeout(this.loadingTimer)}_filterIds(e){return new Set([`searchText`,...(e.filters??[]).flatMap(e=>e.stereotype===`dateRange`||e.stereotype===`numberRange`?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId])])}_syncStateToUrl(e){let t=this._filterIds(e),n=new URLSearchParams(window.location.search);t.forEach(e=>n.delete(e)),n.delete(`page`),n.delete(`sort`),t.forEach(e=>{let t=this.state[e];t!=null&&t!==``&&n.set(e,String(t))});let r=this.state.page;r&&r>0&&n.set(`page`,String(r));let i=this.state.sort;if(i&&i.length>0){let e=i.filter(e=>e.fieldId&&e.direction).map(e=>`${e.fieldId}:${e.direction}`).join(`,`);e&&n.set(`sort`,e)}let a=n.toString(),o=a?`${window.location.pathname}?${a}`:window.location.pathname;window.location.pathname+window.location.search!==o&&history.replaceState(null,``,o)}_initStateFromUrl(e,t){let n=new URLSearchParams(window.location.search),r=this._filterIds(e),i={...t};n.forEach((e,t)=>{r.has(t)&&(i[t]=e)});let a=n.get(`page`);if(a!==null){let e=parseInt(a,10);!isNaN(e)&&e>0&&(i.page=e)}let o=n.get(`sort`);if(o){let e=o.split(`,`).map(e=>{let[t,n]=e.split(`:`);return t&&n?{fieldId:t,direction:n}:null}).filter(Boolean);e.length>0&&(i.sort=e)}return i}pageChanged(e){this.state={...this.state,page:e.detail.page},this.handleSearchRequested(void 0)}updated(e){if(super.updated(e),e.has(`component`)&&(this.pendingMeasure=!0),this.measureFill(),this.trimOverflow(),this.data?.[this.id]==null?this.loadingSince==null&&this._initializedForComponentId!=null&&!this.awaitingRows&&this.beginLoading():this.endLoading(),e.has(`component`)){let e=this.component?.id;if(e!==this._initializedForComponentId){this._initializedForComponentId=e;let t=this.component?.metadata,n=t.initialPage&&t.initialPage>0?t.initialPage:0;this.state=this._initStateFromUrl(t,{...this.state,size:t.pageSize,page:n,sort:[]}),(this.state.page!==n||this.state.sort?.length>0||[...this._filterIds(t)].some(e=>this.state[e]!=null)||t.rowsSource)&&this.handleSearchRequested(void 0)}}}render(){let e=e=>{let t=[];return e.color&&e.color!==Fa.normal&&t.push(e.color),e.buttonStyle&&t.push(e.buttonStyle===Ia.tertiaryInline?`tertiary-inline`:e.buttonStyle),t.length?t.join(` `):void 0},t=e=>e===`back`||e===`backToList`||!!e&&e.startsWith(`cancel`),n=t=>P.get()?.renderToolbarButton?.(t,this.evalLabel(t.label),()=>this.handleToolbarButtonClick(t.actionId))||T`
                 <button class="crud-btn"
                         data-action-id="${t.id}"
                         theme="${e(t)||v}"
                         @click="${()=>this.handleToolbarButtonClick(t.actionId)}"
                 >${this.evalLabel(t.label)}</button>
-            `;if(!this.component)return T`no component`;let r=this.effectiveComponent,i=r.metadata;i.serverSideOrdering=!0;let a=(()=>{let e=this;for(;e;){let t=e;if(t.tagName===`MATEU-PAGE`)return(t.component?.metadata?.toolbar?.length??0)>0;e=t.parentElement??(t.getRootNode?.()instanceof ShadowRoot?t.getRootNode().host:null)}return!1})()?[]:i?.toolbar??[],o=a.filter(e=>t(e.actionId)),s=a.filter(e=>!t(e.actionId)),c=o.length>0&&s.length>0,l=!!i?.title||!!i?.subtitle||a.length>0,u=this.effectiveGridLayout,d=this.cols,f=Ra(d),p=this.data[this.id]?.page?.content??[],ee=this.state[this.component?.id]?.emptyStateMessage,m=(e,t)=>{let n=t[e.id];return n==null?T``:e.dataType===`status`?T`<span theme="badge pill ${Aa(n.type)}">${n.message}</span>`:e.dataType===`bool`?T`${n?`✓`:`✗`}`:typeof n==`object`?T`${n.label??n.name??n.message??``}`:T`${n}`},te=()=>{let e=this.identifierFieldName,t=this.state._selectedId??this.appState?._splitDetailId,n=f.find(e=>e.identifier)??f[0],r=e=>e.dataType===`action`||e.dataType===`actionGroup`||e.dataType===`menu`||e.stereotype===`button`,i=f.filter(e=>e!==n&&!r(e)),a=d.filter(e=>r(e)),o=(e,t,n)=>{e.stopPropagation(),e.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_clickedRow:n}},bubbles:!0,composed:!0}))},s=e=>{let t=[];for(let n of a){let r=e[n.id];if(n.dataType===`action`){let i=r?.methodNameInCrud?r:e.action?.methodNameInCrud?e.action:{methodNameInCrud:n.id,label:n.label,icon:null,disabled:!1};t.push(T`
+            `;if(!this.component)return T`no component`;let r=this.effectiveComponent,i=r.metadata;i.serverSideOrdering=!0;let a=(()=>{let e=this;for(;e;){let t=e;if(t.tagName===`MATEU-PAGE`)return(t.component?.metadata?.toolbar?.length??0)>0;e=t.parentElement??(t.getRootNode?.()instanceof ShadowRoot?t.getRootNode().host:null)}return!1})()?[]:i?.toolbar??[],o=a.filter(e=>t(e.actionId)),s=a.filter(e=>!t(e.actionId)),c=o.length>0&&s.length>0,l=!!i?.title||!!i?.subtitle||a.length>0,u=this.effectiveGridLayout,d=this.cols,f=za(d),p=this.data[this.id]?.page?.content??[],ee=this.state[this.component?.id]?.emptyStateMessage,m=(e,t)=>{let n=t[e.id];return n==null?T``:e.dataType===`status`?T`<span theme="badge pill ${ja(n.type)}">${n.message}</span>`:e.dataType===`bool`?T`${n?`✓`:`✗`}`:typeof n==`object`?T`${n.label??n.name??n.message??``}`:T`${n}`},te=()=>{let e=this.identifierFieldName,t=this.state._selectedId??this.appState?._splitDetailId,n=f.find(e=>e.identifier)??f[0],r=e=>e.dataType===`action`||e.dataType===`actionGroup`||e.dataType===`menu`||e.stereotype===`button`,i=f.filter(e=>e!==n&&!r(e)),a=d.filter(e=>r(e)),o=(e,t,n)=>{e.stopPropagation(),e.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_clickedRow:n}},bubbles:!0,composed:!0}))},s=e=>{let t=[];for(let n of a){let r=e[n.id];if(n.dataType===`action`){let i=r?.methodNameInCrud?r:e.action?.methodNameInCrud?e.action:{methodNameInCrud:n.id,label:n.label,icon:null,disabled:!1};t.push(T`
                             <button class="crud-btn" theme="tertiary small" title="${i.label||v}"
                                 @click="${t=>o(t,`action-on-row-`+i.methodNameInCrud,e)}">
-                                ${i.icon?L(i.icon):v}
+                                ${i.icon?I(i.icon):v}
                                 ${i.label??v}
                             </button>`)}else(n.dataType===`actionGroup`||n.dataType===`menu`)&&(r?.actions??[]).forEach(n=>t.push(T`
                             <button class="crud-btn" theme="tertiary small" title="${n.label||v}"
                                 @click="${t=>o(t,`action-on-row-`+n.methodNameInCrud,e)}">
-                                ${n.icon?L(n.icon):v}
+                                ${n.icon?I(n.icon):v}
                                 ${n.label??v}
                             </button>`))}return t.length?T`
                     <div style="display: flex; flex-wrap: wrap; gap: var(--lumo-space-xs); margin-top: var(--lumo-space-xs);">
                         ${t}
                     </div>`:v};return T`
                 <div class="m-listbox" style="width: 100%;">
-                    ${p.length===0?T`<div class="m-item" disabled>${zt(ee)}</div>`:v}
+                    ${p.length===0?T`<div class="m-item" disabled>${Bt(ee)}</div>`:v}
                     ${p.map(r=>T`
                         <div role="button" tabindex="0" class="m-item"
                             ?selected="${e&&t!==void 0&&String(r[e])===String(t)}"
-                            @click="${()=>{e&&r[e]!==void 0&&(this.state={...this.state,_selectedId:String(r[e])}),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`view`,parameters:r},bubbles:!0,composed:!0}))}}" @keydown="${z(()=>{e&&r[e]!==void 0&&(this.state={...this.state,_selectedId:String(r[e])}),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`view`,parameters:r},bubbles:!0,composed:!0}))})}"
+                            @click="${()=>{e&&r[e]!==void 0&&(this.state={...this.state,_selectedId:String(r[e])}),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`view`,parameters:r},bubbles:!0,composed:!0}))}}" @keydown="${R(()=>{e&&r[e]!==void 0&&(this.state={...this.state,_selectedId:String(r[e])}),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`view`,parameters:r},bubbles:!0,composed:!0}))})}"
                             style="cursor: pointer;"
                         >
                             <div style="font-weight: 600;">${n?r[n.id]??``:``}</div>
@@ -4698,24 +4698,24 @@ ${i}
                 </div>`},ne=(e,t,n)=>{let r=this.identifierFieldName;r&&n[r]!==void 0&&(this.state={...this.state,_selectedId:String(n[r])}),e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:n},bubbles:!0,composed:!0}))},h=()=>{let e=this.identifierFieldName,t=this.state._selectedId??this.appState?._splitDetailId,n=e=>!!e.actionId,r=e=>e.dataType===`action`||e.dataType===`actionGroup`||e.dataType===`menu`||e.stereotype===`button`,i=[...d.slice(0,6),...d.slice(6).filter(e=>r(e)||e.dataType===`status`)],a=i.filter(e=>e.stereotype===`image`),o=i.find(e=>e.identifier)??i[0],s=i.find(e=>e.id===`select`&&e.dataType===`action`),c=!!s,l=i.filter(e=>e!==o&&!a.includes(e)&&!n(e)&&!r(e)),u=i.filter(e=>r(e)&&!(c&&e===s)),f=(e,t,n)=>{e.stopPropagation(),e.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_clickedRow:n}},bubbles:!0,composed:!0}))},te=e=>{let t=[];for(let n of u){let r=e[n.id];if(n.dataType===`action`){let i=r?.methodNameInCrud?r:e.action?.methodNameInCrud?e.action:{methodNameInCrud:n.id,label:n.label,icon:null,disabled:!1};t.push(T`
                             <button class="crud-btn" theme="tertiary" title="${i.label||v}"
                                 @click="${t=>f(t,`action-on-row-`+i.methodNameInCrud,e)}">
-                                ${i.icon?L(i.icon):v}
+                                ${i.icon?I(i.icon):v}
                                 ${i.label??v}
                             </button>`)}else(n.dataType===`actionGroup`||n.dataType===`menu`)&&(r?.actions??[]).forEach(n=>t.push(T`
                             <button class="crud-btn" theme="tertiary" title="${n.label||v}"
                                 @click="${t=>f(t,`action-on-row-`+n.methodNameInCrud,e)}">
-                                ${n.icon?L(n.icon):v}
+                                ${n.icon?I(n.icon):v}
                                 ${n.label??v}
                             </button>`))}return t.length?T`
                     <div style="display: flex; flex-wrap: wrap; gap: var(--lumo-space-xs); padding-top: var(--lumo-space-s); border-top: 1px solid var(--lumo-contrast-10pct);">
                         ${t}
                     </div>`:v};return T`
                 <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: var(--lumo-space-m); padding: var(--lumo-space-s) 0;">
-                    ${p.length===0?T`<div style="grid-column: 1 / -1;">${zt(ee)}</div>`:v}
+                    ${p.length===0?T`<div style="grid-column: 1 / -1;">${Bt(ee)}</div>`:v}
                     ${p.map(n=>T`
                         <div role="button" tabindex="0" class="crud-card"
                             ?data-selected="${e&&t!==void 0&&String(n[e])===String(t)}"
                             style="cursor: pointer;"
-                            @click="${e=>c?f(e,`action-on-row-select`,n):ne(e.target,`view`,n)}" @keydown="${z(e=>c?f(e,`action-on-row-select`,n):ne(e.target,`view`,n))}"
+                            @click="${e=>c?f(e,`action-on-row-select`,n):ne(e.target,`view`,n)}" @keydown="${R(e=>c?f(e,`action-on-row-select`,n):ne(e.target,`view`,n))}"
                         >
                             ${a.length?T`<img src="${n[a[0].id]??``}" alt="" style="width: 100%; max-height: 160px; object-fit: cover; border-radius: var(--lumo-border-radius-m, 8px);" />`:v}
                             ${o?T`<div class="crud-card-title">${n[o.id]??``}</div>`:v}
@@ -4730,15 +4730,15 @@ ${i}
                             ${te(n)}
                         </div>
                     `)}
-                </div>`},g=()=>{let e=za(d),t=e.find(e=>e.identifier)??e[0],n=e.filter(e=>e!==t);return T`
+                </div>`},g=()=>{let e=Ba(d),t=e.find(e=>e.identifier)??e[0],n=e.filter(e=>e!==t);return T`
                 <div style="display: flex; height: 100%; min-height: 400px; gap: 0;">
                     <div style="width: 260px; flex-shrink: 0; border-right: 1px solid var(--lumo-contrast-20pct); overflow-y: auto;">
                         <div class="m-listbox" style="width: 100%;">
-                            ${p.length===0?T`<div class="m-item" disabled>${zt(ee)}</div>`:v}
+                            ${p.length===0?T`<div class="m-item" disabled>${Bt(ee)}</div>`:v}
                             ${p.map(e=>T`
                                 <div role="button" tabindex="0" class="m-item"
                                     ?selected="${this.selectedItem===e}"
-                                    @click="${()=>{this.selectedItem=e}}" @keydown="${z(()=>{this.selectedItem=e})}"
+                                    @click="${()=>{this.selectedItem=e}}" @keydown="${R(()=>{this.selectedItem=e})}"
                                     style="cursor: pointer;"
                                 >
                                     <div style="font-weight: 600;">${t?e[t.id]??``:``}</div>
@@ -4779,10 +4779,18 @@ ${i}
                         ${i?T`<th></th>`:v}
                     </tr></thead>
                     <tbody>
-                        ${o.length===0?T`<tr><td colspan="99" style="padding: 1.5rem; text-align: center; color: var(--lumo-secondary-text-color, #888);">${zt(ee)}</td></tr>`:v}
+                        ${o.length===0?T`<tr><td colspan="99" style="padding: 1.5rem; text-align: center; color: var(--lumo-secondary-text-color, #888);">${Bt(ee)}</td></tr>`:v}
                         ${o.map(e=>c(e,0))}
                     </tbody>
-                </table>`},re=F.get()?.rendersCrudLayouts?.()===!0,y=T`
+                </table>`},re=P.get()?.rendersCrudLayouts?.()===!0,y=p.length===0&&this.awaitingRows?T`
+            <div role="status" aria-live="polite" aria-busy="true"
+                 style="padding: var(--lumo-space-m, 1rem); width: 100%; box-sizing: border-box;">
+                <span style="position: absolute; width: 1px; height: 1px; overflow: hidden;
+                             clip: rect(0 0 0 0); clip-path: inset(50%); white-space: nowrap;"
+                >Loading…</span>
+                <mateu-skeleton variant="grid" count="6"></mateu-skeleton>
+            </div>
+        `:T`
             ${i.infiniteScrolling?T`
                 <div>${this.data[this.id]?.page?.totalElements} items found.</div>
             `:v}
@@ -4790,10 +4798,10 @@ ${i}
                 <div class="m-scroll" style="width: 100%; height: ${i.contentHeight};">
                     ${h()}
                 </div>
-            `:h():!re&&u===`masterDetail`?g():!re&&u===`tree`?(()=>{let e=F.get();return e?.renderTreeComponent?e.renderTreeComponent(this,{rows:p,columns:d.map(e=>({id:e.id,label:e.label})),idField:this.identifierFieldName,navigable:!!d[0]?.actionId,selectedId:this.state._selectedId??this.appState?._splitDetailId}):_()})():F.get()?.renderTableComponent(this,r,this.baseUrl,this.state,this.data,this.appState,this.appData)}
+            `:h():!re&&u===`masterDetail`?g():!re&&u===`tree`?(()=>{let e=P.get();return e?.renderTreeComponent?e.renderTreeComponent(this,{rows:p,columns:d.map(e=>({id:e.id,label:e.label})),idField:this.identifierFieldName,navigable:!!d[0]?.actionId,selectedId:this.state._selectedId??this.appState?._splitDetailId}):_()})():P.get()?.renderTableComponent(this,r,this.baseUrl,this.state,this.data,this.appState,this.appData)}
             <slot></slot>
-        `,b=i.infiniteScrolling?v:F.get()?.renderPagination(this,this.component),x=this.showImportDialog?T`
-            <div role="button" tabindex="0" class="crud-modal-backdrop" @click="${e=>{e.target===e.currentTarget&&(this.showImportDialog=!1)}}" @keydown="${z(e=>{e.target===e.currentTarget&&(this.showImportDialog=!1)})}">
+        `,b=i.infiniteScrolling?v:P.get()?.renderPagination(this,this.component),x=this.showImportDialog?T`
+            <div role="button" tabindex="0" class="crud-modal-backdrop" @click="${e=>{e.target===e.currentTarget&&(this.showImportDialog=!1)}}" @keydown="${R(e=>{e.target===e.currentTarget&&(this.showImportDialog=!1)})}">
                 <div class="crud-modal">
                     <h3 style="margin: 0 0 .75rem;">Import</h3>
                     <input type="file" @change="${e=>{let t=e.target.files?.[0];if(t){let e=new FormData;e.append(`file`,t),fetch(`/upload`,{method:`POST`,body:e}).then(e=>e.json()).then(e=>this.handleImportUploadSuccess({detail:e})).catch(()=>this.notify(`Import failed`))}}}">
@@ -4823,7 +4831,7 @@ ${i}
                         ></mateu-content-header>
                     </div>
                     <div style="flex-shrink: 0; display: flex; align-items: center; gap: var(--lumo-space-s, 0.5rem);">
-                        <div style="flex: 1; min-width: 0;">${F.get()?.renderFilterBar(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData,!0)}</div>
+                        <div style="flex: 1; min-width: 0;">${P.get()?.renderFilterBar(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData,!0)}</div>
                         ${this.renderColumnChooser()}
                     </div>
                     <div data-crud-area style="flex: 1; overflow-y: auto; min-height: 0; display: flex; flex-direction: column;">${y}</div>
@@ -4856,13 +4864,13 @@ ${i}
                 </style>
             <div data-crud-box style="${this.boxStyle()}">
                 <div style="flex-shrink: 0; display: flex; align-items: center; gap: var(--lumo-space-s, 0.5rem);">
-                    <div style="flex: 1; min-width: 0;">${F.get()?.renderFilterBar(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData)}</div>
+                    <div style="flex: 1; min-width: 0;">${P.get()?.renderFilterBar(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData)}</div>
                     ${this.renderColumnChooser()}
                 </div>
                 <div data-crud-area style="flex: 1; overflow-y: auto; min-height: 0; display: flex; flex-direction: column;">${y}</div>
                 <div style="flex-shrink: 0;">${b}</div>
             </div>
-        `}createRenderRoot(){return F.mustUseShadowRoot()?super.createRenderRoot():this}static{this.styles=h`
+        `}createRenderRoot(){return P.mustUseShadowRoot()?super.createRenderRoot():this}static{this.styles=h`
         ${de}
         /* DS-neutral crud widgets (replace vaadin-button/card/grid/list-box/form-layout/dialog). */
         .crud-btn {
@@ -4916,8 +4924,8 @@ ${i}
             outline-offset: -2px;
         }
     
-        ${B}
-    `}};k([y()],K.prototype,`component`,void 0),k([y()],K.prototype,`baseUrl`,void 0),k([y({type:Boolean})],K.prototype,`standalone`,void 0),k([y()],K.prototype,`state`,void 0),k([y()],K.prototype,`data`,void 0),k([y()],K.prototype,`appState`,void 0),k([y()],K.prototype,`appData`,void 0),k([C()],K.prototype,`showImportDialog`,void 0),k([C()],K.prototype,`availableWidthPx`,void 0),k([C()],K.prototype,`selectedItem`,void 0),k([C()],K.prototype,`_columnPrefsRevision`,void 0),k([C()],K.prototype,`fillHeightPx`,void 0),K=Ba=k([g(`mateu-table-crud`)],K);var Ha=function(e){return e.OnLoad=`OnLoad`,e.OnSuccess=`OnSuccess`,e.OnError=`OnError`,e.OnValueChange=`OnValueChange`,e.OnCustomEvent=`OnCustomEvent`,e.AutoSave=`AutoSave`,e}({}),Ua=class extends vt{constructor(...e){super(...e),this.state={},this.data={},this.appData={},this.appState={},this.triggerOnLoad=()=>{let e=this.component;this.registerCustomEventListeners(),e.triggers?.filter(e=>e.type==Ha.OnLoad).forEach(e=>{if((!e.condition||this._evalExpr(e.condition))&&!e.triggered){let n=e;n.triggered=!0;var t=n.times-1;n.timeoutMillis>0?this.scheduleOnload(n,t,this.id):this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.actionId},bubbles:!0,composed:!0}))}})},this.scheduleOnload=(e,t,n)=>{if(n!=this.component?.id)return;let r=this.callbackToken;setTimeout(()=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,callbackToken:r},bubbles:!0,composed:!0}))},e.timeoutMillis)},this._registeredCustomEventListeners=[],this.customEventManager=e=>{if(!(e instanceof CustomEvent))return;let t=e,n=(this.component.triggers??[]).filter(e=>e.type==Ha.OnCustomEvent).filter(e=>e.eventName==t.type).filter(e=>e.source!==`COMPONENT`||t.detail?.__source===e.from);n.length!==0&&(n.some(e=>!e.source||e.source===`SELF`)&&(e.stopPropagation(),e.preventDefault()),n.forEach(e=>{(!e.condition||this._evalExpr(e.condition))&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:t.detail},bubbles:!0,composed:!0}))}))}}_interpolationExtra(){return{appState:this.appState??{},appData:this.appData??{},component:this.component}}_evalExpr(e){return Ct(e,this.state??{},this.data??{},this._interpolationExtra())}_evalTemplate(e){return wt(e,this.state??{},this.data??{},this._interpolationExtra())}isOverlayChild(e){let t=e?.metadata?.type;return t==j.Drawer||t==j.Dialog}removeSelfFromOwnerChildren(){let e=this.component;if(!e)return!1;let t=t=>{if(t===e)return!0;let n=t;return e.id!=null&&n?.id==e.id&&this.isOverlayChild(n)},n=this.parentNode;for(;n;){let e=n instanceof ShadowRoot?n.host:n,r=e.component?.children;if(Array.isArray(r)){let n=r.findIndex(t);if(n>=0)return r.splice(n,1),e.requestUpdate?.(),!0}n=n instanceof ShadowRoot?e:n.parentNode}return!1}applyFragment(e){if(this.id==e.targetComponentId){if(e.component)if(ut.Add==e.action){if(this.component){let t=this.component.children??(this.component.children=[]),n=e.component.id?t.findIndex(t=>t.id==e.component.id&&this.isOverlayChild(t)):-1;n>=0?(t[n]=e.component,this.component={...this.component}):t.push(e.component)}}else{this.callbackToken=E();let t=!1;if(e.component?.type==A.ServerSide)if(this.component){let n=this.component,r=e.component;t=n.serverSideType==r.serverSideType;let i=t?(n.children??[]).filter(e=>this.isOverlayChild(e)):[];n.actions=r.actions,n.type=r.type,n.rules=r.rules,n.triggers=r.triggers,n.serverSideType=r.serverSideType,n.route=r.route,n.initialData=r.initialData,n.validations=r.validations,n.cssClasses=r.cssClasses,n.slot=r.slot,n.style=r.style,n.children=i.length?[...r.children??[],...i]:r.children,(n.serverSideType!=r.serverSideType||n.id!=r.id)&&setTimeout(()=>this.triggerOnLoad())}else this.component=e.component,setTimeout(()=>this.triggerOnLoad());else{let t=[e.component];this.component&&(this.component.children=t)}e.action!==ut.ReplaceKeepData&&!t&&(this.state={},this.data={})}if(e.state&&(this.state={...this.state,...e.state}),e.data){for(let t in e.data){let n=e.data[t]?.page;n?.pageNumber>0&&this.data[t]&&this.data[t].page.content&&(n.content?n.content=[...this.data[t].page.content,...n.content]:n.content=[...this.data[t].page.content])}this.data={...this.data,...e.data}}this._lastFragmentData=this.data,this.registerCustomEventListeners();let t=F.getAfterRenderHook();t&&setTimeout(()=>t(this)),this.requestUpdate()}}willUpdate(e){super.willUpdate(e);let t=this.component?.serverSideType,n=t!=null&&this._lastViewKey!=null&&t!==this._lastViewKey;if(t!=null&&(this._lastViewKey=t),!e.has(`data`)||this.data===this._lastFragmentData||n)return;let r=this.data,i=e.get(`data`);r&&Object.keys(r).length===0&&i&&Object.keys(i).length>0&&(this.data=i)}registerCustomEventListeners(){this._registeredCustomEventListeners.forEach(({target:e,name:t})=>e.removeEventListener(t,this.customEventManager)),this._registeredCustomEventListeners=[],this.component?.triggers?.filter(e=>e.type==Ha.OnCustomEvent).forEach(e=>{let t=e.source===`DOCUMENT`||e.source===`COMPONENT`?document:this;t.addEventListener(e.eventName,this.customEventManager),this._registeredCustomEventListeners.push({target:t,name:e.eventName})})}disconnectedCallback(){this._registeredCustomEventListeners.forEach(({target:e,name:t})=>e.removeEventListener(t,this.customEventManager)),this._registeredCustomEventListeners=[],super.disconnectedCallback()}connectedCallback(){super.connectedCallback(),this.component&&this.registerCustomEventListeners()}};k([y()],Ua.prototype,`state`,void 0),k([y()],Ua.prototype,`data`,void 0),k([y()],Ua.prototype,`appData`,void 0),k([y()],Ua.prototype,`appState`,void 0);var Wa=`mateu-recent-routes`,Ga=8;function Ka(){try{return JSON.parse(localStorage.getItem(Wa)??`{}`)}catch{return{}}}function qa(e){try{localStorage.setItem(Wa,JSON.stringify(e))}catch{}}function Ja(e){return Ka()[e||`_`]??[]}function Ya(e,t){if(!t?.route||!t.label)return;let n=e||`_`,r=Ka(),i=(r[n]??[]).filter(e=>e.route!==t.route);i.unshift({route:t.route,label:t.label}),r[n]=i.slice(0,Ga),qa(r)}var Xa=class extends b{constructor(...e){super(...e),this.baseUrl=``,this.open=!1,this.queryText=``,this.dataHits=[],this.loading=!1,this.selectedIndex=0,this.fabOffset=0,this.keydownHandler=null}connectedCallback(){super.connectedCallback(),this.keydownHandler=e=>{(e.metaKey||e.ctrlKey)&&(e.key===`k`||e.key===`K`)?(e.preventDefault(),this.toggle()):e.key===`Escape`&&this.open&&this.close()},document.addEventListener(`keydown`,this.keydownHandler),this.setupFabObserver()}disconnectedCallback(){super.disconnectedCallback(),this.keydownHandler&&document.removeEventListener(`keydown`,this.keydownHandler),clearTimeout(this.searchTimer),this.fabObserver?.disconnect(),this.fabObserver=void 0}setupFabObserver(){let e=this.getRootNode(),t=e instanceof ShadowRoot?e:document.body;this.measureFabStack(),this.fabObserver?.disconnect(),this.fabObserver=new MutationObserver(()=>this.measureFabStack()),this.fabObserver.observe(t,{childList:!0,subtree:!0})}measureFabStack(){let e=(this.getRootNode().querySelectorAll?.(`.ai-fab, .app-fab, .page-fab`).length??0)*4;e!==this.fabOffset&&(this.fabOffset=e)}updated(e){e.has(`open`)&&this.open&&requestAnimationFrame(()=>this.inputEl?.focus())}toggle(){this.open?this.close():this.openCenter()}openCenter(){this.open=!0,this.queryText=``,this.dataHits=[],this.selectedIndex=0}close(){this.open=!1,this.queryText=``,this.dataHits=[],clearTimeout(this.searchTimer)}flattenMenu(e,t){let n=[];for(let r of e??[])if(!r.separator)if(r.submenus&&r.submenus.length>0){let e=t?`${t} › ${r.label}`:r.label;n.push(...this.flattenMenu(r.submenus,e))}else r.route!==void 0&&r.route!==null&&n.push({label:r.label,breadcrumb:t,route:r.route});return n}onInput(e){this.queryText=e,this.selectedIndex=0;let t=e.trim();if(clearTimeout(this.searchTimer),!t||!this.app?.globalSearchEnabled){this.dataHits=[],this.loading=!1;return}this.loading=!0,this.searchTimer=setTimeout(()=>this.fetchGlobalSearch(t),250)}async fetchGlobalSearch(e){let t=this.app;if(!t?.globalSearchEnabled){this.loading=!1;return}try{let n=(await lt.runAction(this.baseUrl??``,t.rootRoute??``,``,`_globalsearch`,`command-center`,void 0,t.serverSideType,{},{searchText:e},this,!0))?.fragments?.map(e=>e.data).find(e=>e&&e._globalsearch);this.dataHits=n?._globalsearch??[]}catch{this.dataHits=[]}finally{this.loading=!1}}navigateTo(e,t){Ya(this.app?.serverSideType??``,{route:e,label:t}),this.close();for(let t of[`route-changed`,`navigate-to-requested`])this.dispatchEvent(new CustomEvent(t,{detail:{route:e},bubbles:!0,composed:!0}))}askAi(){let e=this.queryText.trim();this.close(),this.dispatchEvent(new CustomEvent(`mateu-open-ai`,{detail:{query:e},bubbles:!0,composed:!0}))}visibleTargets(e){if(!this.queryText.trim()){let e=this.flattenMenu(this.app?.menu,``).map(e=>({route:e.route,label:e.label})),t=Ja(this.app?.serverSideType??``);return[...e,...t]}return[...e.map(e=>({route:e.route,label:e.label})),...this.dataHits.map(e=>({route:e.route,label:e.label}))]}onKeydown(e,t){if(e.key===`ArrowDown`)e.preventDefault(),this.selectedIndex=Math.min(this.selectedIndex+1,t.length-1);else if(e.key===`ArrowUp`)e.preventDefault(),this.selectedIndex=Math.max(this.selectedIndex-1,0);else if(e.key===`Enter`){let e=t[this.selectedIndex];e&&this.navigateTo(e.route,e.label)}}render(){return T`
+        ${z}
+    `}};k([y()],G.prototype,`component`,void 0),k([y()],G.prototype,`baseUrl`,void 0),k([y({type:Boolean})],G.prototype,`standalone`,void 0),k([y()],G.prototype,`state`,void 0),k([y()],G.prototype,`data`,void 0),k([y()],G.prototype,`appState`,void 0),k([y()],G.prototype,`appData`,void 0),k([C()],G.prototype,`showImportDialog`,void 0),k([C()],G.prototype,`availableWidthPx`,void 0),k([C()],G.prototype,`selectedItem`,void 0),k([C()],G.prototype,`_columnPrefsRevision`,void 0),k([C()],G.prototype,`fillHeightPx`,void 0),k([C()],G.prototype,`loadingSince`,void 0),G=Va=k([g(`mateu-table-crud`)],G);var Ua=function(e){return e.OnLoad=`OnLoad`,e.OnSuccess=`OnSuccess`,e.OnError=`OnError`,e.OnValueChange=`OnValueChange`,e.OnCustomEvent=`OnCustomEvent`,e.AutoSave=`AutoSave`,e}({}),Wa=class extends vt{constructor(...e){super(...e),this.state={},this.data={},this.appData={},this.appState={},this.triggerOnLoad=()=>{let e=this.component;this.registerCustomEventListeners(),e.triggers?.filter(e=>e.type==Ua.OnLoad).forEach(e=>{if((!e.condition||this._evalExpr(e.condition))&&!e.triggered){let n=e;n.triggered=!0;var t=n.times-1;n.timeoutMillis>0?this.scheduleOnload(n,t,this.id):this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.actionId},bubbles:!0,composed:!0}))}})},this.scheduleOnload=(e,t,n)=>{if(n!=this.component?.id)return;let r=this.callbackToken;setTimeout(()=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,callbackToken:r},bubbles:!0,composed:!0}))},e.timeoutMillis)},this._registeredCustomEventListeners=[],this.customEventManager=e=>{if(!(e instanceof CustomEvent))return;let t=e,n=(this.component.triggers??[]).filter(e=>e.type==Ua.OnCustomEvent).filter(e=>e.eventName==t.type).filter(e=>e.source!==`COMPONENT`||t.detail?.__source===e.from);n.length!==0&&(n.some(e=>!e.source||e.source===`SELF`)&&(e.stopPropagation(),e.preventDefault()),n.forEach(e=>{(!e.condition||this._evalExpr(e.condition))&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:t.detail},bubbles:!0,composed:!0}))}))}}_interpolationExtra(){return{appState:this.appState??{},appData:this.appData??{},component:this.component}}_evalExpr(e){return Ct(e,this.state??{},this.data??{},this._interpolationExtra())}_evalTemplate(e){return wt(e,this.state??{},this.data??{},this._interpolationExtra())}isOverlayChild(e){let t=e?.metadata?.type;return t==j.Drawer||t==j.Dialog}removeSelfFromOwnerChildren(){let e=this.component;if(!e)return!1;let t=t=>{if(t===e)return!0;let n=t;return e.id!=null&&n?.id==e.id&&this.isOverlayChild(n)},n=this.parentNode;for(;n;){let e=n instanceof ShadowRoot?n.host:n,r=e.component?.children;if(Array.isArray(r)){let n=r.findIndex(t);if(n>=0)return r.splice(n,1),e.requestUpdate?.(),!0}n=n instanceof ShadowRoot?e:n.parentNode}return!1}applyFragment(e){if(this.id==e.targetComponentId){if(e.component)if(ut.Add==e.action){if(this.component){let t=this.component.children??(this.component.children=[]),n=e.component.id?t.findIndex(t=>t.id==e.component.id&&this.isOverlayChild(t)):-1;n>=0?(t[n]=e.component,this.component={...this.component}):t.push(e.component)}}else{this.callbackToken=E();let t=!1;if(e.component?.type==A.ServerSide)if(this.component){let n=this.component,r=e.component;t=n.serverSideType==r.serverSideType;let i=t?(n.children??[]).filter(e=>this.isOverlayChild(e)):[];n.actions=r.actions,n.type=r.type,n.rules=r.rules,n.triggers=r.triggers,n.serverSideType=r.serverSideType,n.route=r.route,n.initialData=r.initialData,n.validations=r.validations,n.cssClasses=r.cssClasses,n.slot=r.slot,n.style=r.style,n.children=i.length?[...r.children??[],...i]:r.children,(n.serverSideType!=r.serverSideType||n.id!=r.id)&&setTimeout(()=>this.triggerOnLoad())}else this.component=e.component,setTimeout(()=>this.triggerOnLoad());else{let t=[e.component];this.component&&(this.component.children=t)}e.action!==ut.ReplaceKeepData&&!t&&(this.state={},this.data={})}if(e.state&&(this.state={...this.state,...e.state}),e.data){for(let t in e.data){let n=e.data[t]?.page;n?.pageNumber>0&&this.data[t]&&this.data[t].page.content&&(n.content?n.content=[...this.data[t].page.content,...n.content]:n.content=[...this.data[t].page.content])}this.data={...this.data,...e.data}}this._lastFragmentData=this.data,this.registerCustomEventListeners();let t=P.getAfterRenderHook();t&&setTimeout(()=>t(this)),this.requestUpdate()}}willUpdate(e){super.willUpdate(e);let t=this.component?.serverSideType,n=t!=null&&this._lastViewKey!=null&&t!==this._lastViewKey;if(t!=null&&(this._lastViewKey=t),!e.has(`data`)||this.data===this._lastFragmentData||n)return;let r=this.data,i=e.get(`data`);r&&Object.keys(r).length===0&&i&&Object.keys(i).length>0&&(this.data=i)}registerCustomEventListeners(){this._registeredCustomEventListeners.forEach(({target:e,name:t})=>e.removeEventListener(t,this.customEventManager)),this._registeredCustomEventListeners=[],this.component?.triggers?.filter(e=>e.type==Ua.OnCustomEvent).forEach(e=>{let t=e.source===`DOCUMENT`||e.source===`COMPONENT`?document:this;t.addEventListener(e.eventName,this.customEventManager),this._registeredCustomEventListeners.push({target:t,name:e.eventName})})}disconnectedCallback(){this._registeredCustomEventListeners.forEach(({target:e,name:t})=>e.removeEventListener(t,this.customEventManager)),this._registeredCustomEventListeners=[],super.disconnectedCallback()}connectedCallback(){super.connectedCallback(),this.component&&this.registerCustomEventListeners()}};k([y()],Wa.prototype,`state`,void 0),k([y()],Wa.prototype,`data`,void 0),k([y()],Wa.prototype,`appData`,void 0),k([y()],Wa.prototype,`appState`,void 0);var Ga=`mateu-recent-routes`,Ka=8;function qa(){try{return JSON.parse(localStorage.getItem(Ga)??`{}`)}catch{return{}}}function Ja(e){try{localStorage.setItem(Ga,JSON.stringify(e))}catch{}}function Ya(e){return qa()[e||`_`]??[]}function Xa(e,t){if(!t?.route||!t.label)return;let n=e||`_`,r=qa(),i=(r[n]??[]).filter(e=>e.route!==t.route);i.unshift({route:t.route,label:t.label}),r[n]=i.slice(0,Ka),Ja(r)}var Za=class extends b{constructor(...e){super(...e),this.baseUrl=``,this.open=!1,this.queryText=``,this.dataHits=[],this.loading=!1,this.selectedIndex=0,this.fabOffset=0,this.keydownHandler=null}connectedCallback(){super.connectedCallback(),this.keydownHandler=e=>{(e.metaKey||e.ctrlKey)&&(e.key===`k`||e.key===`K`)?(e.preventDefault(),this.toggle()):e.key===`Escape`&&this.open&&this.close()},document.addEventListener(`keydown`,this.keydownHandler),this.setupFabObserver()}disconnectedCallback(){super.disconnectedCallback(),this.keydownHandler&&document.removeEventListener(`keydown`,this.keydownHandler),clearTimeout(this.searchTimer),this.fabObserver?.disconnect(),this.fabObserver=void 0}setupFabObserver(){let e=this.getRootNode(),t=e instanceof ShadowRoot?e:document.body;this.measureFabStack(),this.fabObserver?.disconnect(),this.fabObserver=new MutationObserver(()=>this.measureFabStack()),this.fabObserver.observe(t,{childList:!0,subtree:!0})}measureFabStack(){let e=(this.getRootNode().querySelectorAll?.(`.ai-fab, .app-fab, .page-fab`).length??0)*4;e!==this.fabOffset&&(this.fabOffset=e)}updated(e){e.has(`open`)&&this.open&&requestAnimationFrame(()=>this.inputEl?.focus())}toggle(){this.open?this.close():this.openCenter()}openCenter(){this.open=!0,this.queryText=``,this.dataHits=[],this.selectedIndex=0}close(){this.open=!1,this.queryText=``,this.dataHits=[],clearTimeout(this.searchTimer)}flattenMenu(e,t){let n=[];for(let r of e??[])if(!r.separator)if(r.submenus&&r.submenus.length>0){let e=t?`${t} › ${r.label}`:r.label;n.push(...this.flattenMenu(r.submenus,e))}else r.route!==void 0&&r.route!==null&&n.push({label:r.label,breadcrumb:t,route:r.route});return n}onInput(e){this.queryText=e,this.selectedIndex=0;let t=e.trim();if(clearTimeout(this.searchTimer),!t||!this.app?.globalSearchEnabled){this.dataHits=[],this.loading=!1;return}this.loading=!0,this.searchTimer=setTimeout(()=>this.fetchGlobalSearch(t),250)}async fetchGlobalSearch(e){let t=this.app;if(!t?.globalSearchEnabled){this.loading=!1;return}try{let n=(await lt.runAction(this.baseUrl??``,t.rootRoute??``,``,`_globalsearch`,`command-center`,void 0,t.serverSideType,{},{searchText:e},this,!0))?.fragments?.map(e=>e.data).find(e=>e&&e._globalsearch);this.dataHits=n?._globalsearch??[]}catch{this.dataHits=[]}finally{this.loading=!1}}navigateTo(e,t){Xa(this.app?.serverSideType??``,{route:e,label:t}),this.close();for(let t of[`route-changed`,`navigate-to-requested`])this.dispatchEvent(new CustomEvent(t,{detail:{route:e},bubbles:!0,composed:!0}))}askAi(){let e=this.queryText.trim();this.close(),this.dispatchEvent(new CustomEvent(`mateu-open-ai`,{detail:{query:e},bubbles:!0,composed:!0}))}visibleTargets(e){if(!this.queryText.trim()){let e=this.flattenMenu(this.app?.menu,``).map(e=>({route:e.route,label:e.label})),t=Ya(this.app?.serverSideType??``);return[...e,...t]}return[...e.map(e=>({route:e.route,label:e.label})),...this.dataHits.map(e=>({route:e.route,label:e.label}))]}onKeydown(e,t){if(e.key===`ArrowDown`)e.preventDefault(),this.selectedIndex=Math.min(this.selectedIndex+1,t.length-1);else if(e.key===`ArrowUp`)e.preventDefault(),this.selectedIndex=Math.max(this.selectedIndex-1,0);else if(e.key===`Enter`){let e=t[this.selectedIndex];e&&this.navigateTo(e.route,e.label)}}render(){return T`
             <button class="cc-fab" style="bottom: ${1.5+this.fabOffset}rem;"
                 @click=${()=>this.openCenter()} title="Buscar y navegar (⌘K)" aria-label="Command center">
                 ${this.fabIcon()}
@@ -4943,7 +4951,7 @@ ${i}
                 </div>
                 <button class="cc-close" @click=${()=>this.close()} title="Cerrar">${this.clearIcon()}</button>
             </div>
-        `}renderDefault(){let e=this.flattenMenu(this.app?.menu,``),t=Ja(this.app?.serverSideType??``),n=-1;return T`
+        `}renderDefault(){let e=this.flattenMenu(this.app?.menu,``),t=Ya(this.app?.serverSideType??``),n=-1;return T`
             <div class="cc-columns">
                 <div class="cc-col">
                     <div class="cc-section-title">Ir a</div>
@@ -5078,7 +5086,7 @@ ${i}
             display: flex; align-items: center; justify-content: center; cursor: pointer; z-index: 1110;
         }
         .cc-close:hover { background: rgba(0,0,0,0.75); }
-    `}};k([y({attribute:!1})],Xa.prototype,`app`,void 0),k([y()],Xa.prototype,`baseUrl`,void 0),k([C()],Xa.prototype,`open`,void 0),k([C()],Xa.prototype,`queryText`,void 0),k([C()],Xa.prototype,`dataHits`,void 0),k([C()],Xa.prototype,`loading`,void 0),k([C()],Xa.prototype,`selectedIndex`,void 0),k([C()],Xa.prototype,`fabOffset`,void 0),k([x(`.cc-input`)],Xa.prototype,`inputEl`,void 0),Xa=k([g(`mateu-command-center`)],Xa);var Za=null;function Qa(e){let t=e.component?.metadata;t&&(t.commandCenterEnabled||t.chromeless)&&t.variant!==`MEDIATOR`?((!Za||!Za.isConnected)&&(Za=document.createElement(`mateu-command-center`),e.renderRoot.appendChild(Za)),Za.app=t,Za.baseUrl=e.baseUrl??``):Za&&e.renderRoot.contains(Za)&&(Za.remove(),Za=null)}var $a=class extends b{constructor(...e){super(...e),this.fetchStarted=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!0},this.fetchFinished=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!1},this.fetchFailed=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!1;let t=e.detail??{},n=t.failure??$e(t.reason,{online:at.isOnline()});if(n.kind===`cancelled`)return;let r=t.retry;Na({text:n.message,variant:`error`,duration:r?8e3:5e3,position:`bottomEnd`,...r?{actionLabel:`Retry`,onAction:r}:{}},this)}}connectedCallback(){super.connectedCallback(),this.addEventListener(`backend-called-event`,this.fetchStarted),this.addEventListener(`backend-succeeded-event`,this.fetchFinished),this.addEventListener(`backend-cancelled-event`,this.fetchFinished),this.addEventListener(`backend-failed-event`,this.fetchFailed)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`backend-called-event`,this.fetchStarted),this.removeEventListener(`backend-succeeded-event`,this.fetchFinished),this.removeEventListener(`backend-cancelled-event`,this.fetchFinished),this.removeEventListener(`backend-failed-event`,this.fetchFailed)}render(){return T`<div class="loader-container">
+    `}};k([y({attribute:!1})],Za.prototype,`app`,void 0),k([y()],Za.prototype,`baseUrl`,void 0),k([C()],Za.prototype,`open`,void 0),k([C()],Za.prototype,`queryText`,void 0),k([C()],Za.prototype,`dataHits`,void 0),k([C()],Za.prototype,`loading`,void 0),k([C()],Za.prototype,`selectedIndex`,void 0),k([C()],Za.prototype,`fabOffset`,void 0),k([x(`.cc-input`)],Za.prototype,`inputEl`,void 0),Za=k([g(`mateu-command-center`)],Za);var Qa=null;function $a(e){let t=e.component?.metadata;t&&(t.commandCenterEnabled||t.chromeless)&&t.variant!==`MEDIATOR`?((!Qa||!Qa.isConnected)&&(Qa=document.createElement(`mateu-command-center`),e.renderRoot.appendChild(Qa)),Qa.app=t,Qa.baseUrl=e.baseUrl??``):Qa&&e.renderRoot.contains(Qa)&&(Qa.remove(),Qa=null)}var eo=class extends b{constructor(...e){super(...e),this.fetchStarted=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!0},this.fetchFinished=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!1},this.fetchFailed=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!1;let t=e.detail??{},n=t.failure??$e(t.reason,{online:at.isOnline()});if(n.kind===`cancelled`)return;let r=t.retry;Pa({text:n.message,variant:`error`,duration:r?8e3:5e3,position:`bottomEnd`,...r?{actionLabel:`Retry`,onAction:r}:{}},this)}}connectedCallback(){super.connectedCallback(),this.addEventListener(`backend-called-event`,this.fetchStarted),this.addEventListener(`backend-succeeded-event`,this.fetchFinished),this.addEventListener(`backend-cancelled-event`,this.fetchFinished),this.addEventListener(`backend-failed-event`,this.fetchFailed)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`backend-called-event`,this.fetchStarted),this.removeEventListener(`backend-succeeded-event`,this.fetchFinished),this.removeEventListener(`backend-cancelled-event`,this.fetchFinished),this.removeEventListener(`backend-failed-event`,this.fetchFailed)}render(){return T`<div class="loader-container">
             <div style="display: flex; flex-direction: column;">
                 <slot></slot>
                 <div class="loader-frame ${this.loading?`delayed-show`:``}" style="${this.loading?`pointer-events: all;`:`display: none;`}"><div class="loader"></div></div>
@@ -5146,11 +5154,11 @@ ${i}
             animation: l5 1s infinite;
         }
         @keyframes l5 {to{transform: rotate(.5turn)}}
-  `}};k([C()],$a.prototype,`loading`,void 0),$a=k([g(`mateu-api-caller`)],$a);var eo=new class{constructor(){this._dirty=!1,this._installed=!1,this.message=`You have unsaved changes. Are you sure you want to leave this page?`,this._onDirty=()=>{this._dirty=!0},this._onClean=()=>{this._dirty=!1},this._onBeforeUnload=e=>{this._dirty&&(e.preventDefault(),e.returnValue=``)}}install(){this._installed||(this._installed=!0,document.addEventListener(`dirty`,this._onDirty),document.addEventListener(`clean`,this._onClean),window.addEventListener(`beforeunload`,this._onBeforeUnload))}get dirty(){return this._dirty}markDirty(){this._dirty=!0}markClean(){this._dirty=!1}confirmLeave(){if(!this._dirty)return!0;let e=window.confirm(this.message);return e&&(this._dirty=!1),e}},to,q=class extends Ua{static{to=this}constructor(...e){super(...e),this.filter=``,this.instant=void 0,this.selectedConsumedRoute=void 0,this.selectedRoute=void 0,this.selectedUriPrefix=void 0,this.selectedBaseUrl=void 0,this.selectedServerSideType=void 0,this.selectedParams=void 0,this.tilesMenuOption=null,this.railOpenOption=null,this.commandPaletteOpen=!1,this.commandPaletteQuery=``,this.commandPaletteSelectedIndex=0,this.commandPaletteDataHits=[],this.openDataHit=e=>{eo.confirmLeave()&&(this.commandPaletteOpen=!1,this.commandPaletteQuery=``,this.commandPaletteDataHits=[],this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:e.route},bubbles:!0,composed:!0})),this.dispatchEvent(new CustomEvent(`navigate-to-requested`,{detail:{route:e.route},bubbles:!0,composed:!0})))},this._commandPaletteHandler=null,this.pageCompact=!1,this._compactHandler=e=>{this.pageCompact=e.detail?.compact??!1},this._openAiHandler=()=>{this.chatOpen||this.showHideIa()},this.isDark=document.documentElement.getAttribute(`theme`)===`dark`,this.chatOpen=!1,this.toggleTheme=()=>{this.isDark=!this.isDark;let e=this.isDark?`dark`:`light`;document.documentElement.setAttribute(`theme`,e),localStorage.setItem(`mateu-theme`,e)},this.showHideIa=()=>{this.chat&&(this.chatOpen=!this.chatOpen,this.chat.slot=this.chatOpen?`detail`:`detail-hidden`)},this.runAction=e=>{let t=this.renderRoot.querySelector?.(`mateu-component`);t&&t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.getSelectedOption=e=>{if(e)for(let t=0;t<e.length;t++){let n=e[t];if(this.selectedRoute?this.isActiveOption(n):n.selected)return n;let r=this.getSelectedOption(n.submenus);if(r)return r}return null},this.itemSelected=e=>{let t=e.detail.value;this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix)},this.itemSelectedTiles=e=>{let t=e.detail.value._menuOption;t.submenus&&t.submenus.length>0?this.tilesMenuOption=t:(this.tilesMenuOption=null,this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix))},this.mapItemsForTiles=e=>e.map(e=>({text:e.label,consumedRoute:e.consumedRoute,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:e.selected,_menuOption:e})),this.flattenMenuForPalette=(e,t)=>{let n=[];for(let r of e)if(!r.separator)if(r.submenus&&r.submenus.length>0){let e=t?`${t} › ${r.label}`:r.label;n.push(...this.flattenMenuForPalette(r.submenus,e))}else n.push({label:r.label,breadcrumb:t,consumedRoute:r.consumedRoute,route:r.route,actionId:r.actionId,baseUrl:r.baseUrl,serverSideType:r.serverSideType,uriPrefix:r.uriPrefix});return n},this.handleCommandPaletteKeydown=(e,t)=>{let n=Math.min(t.length,10),r=n+Math.min(this.commandPaletteDataHits.length,8);if(e.key===`ArrowDown`)e.preventDefault(),this.commandPaletteSelectedIndex=Math.min(this.commandPaletteSelectedIndex+1,r-1);else if(e.key===`ArrowUp`)e.preventDefault(),this.commandPaletteSelectedIndex=Math.max(this.commandPaletteSelectedIndex-1,0);else if(e.key===`Enter`){if(this.commandPaletteSelectedIndex>=n){let e=this.commandPaletteDataHits[this.commandPaletteSelectedIndex-n];e&&this.openDataHit(e);return}let e=t[this.commandPaletteSelectedIndex];e&&(this.selectRoute(e.consumedRoute,e.route,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix),this.commandPaletteOpen=!1,this.commandPaletteQuery=``)}},this.renderCommandPalette=()=>{if(!this.commandPaletteOpen)return v;let e=this.component?.metadata;if(e?.commandCenterEnabled||!e?.menu)return v;let t=this.flattenMenuForPalette(e.menu,``),n=this.commandPaletteQuery.toLowerCase(),r=n?t.filter(e=>e.label.toLowerCase().includes(n)||e.breadcrumb.toLowerCase().includes(n)):t;return T`
+  `}};k([C()],eo.prototype,`loading`,void 0),eo=k([g(`mateu-api-caller`)],eo);var to=new class{constructor(){this._dirty=!1,this._installed=!1,this.message=`You have unsaved changes. Are you sure you want to leave this page?`,this._onDirty=()=>{this._dirty=!0},this._onClean=()=>{this._dirty=!1},this._onBeforeUnload=e=>{this._dirty&&(e.preventDefault(),e.returnValue=``)}}install(){this._installed||(this._installed=!0,document.addEventListener(`dirty`,this._onDirty),document.addEventListener(`clean`,this._onClean),window.addEventListener(`beforeunload`,this._onBeforeUnload))}get dirty(){return this._dirty}markDirty(){this._dirty=!0}markClean(){this._dirty=!1}confirmLeave(){if(!this._dirty)return!0;let e=window.confirm(this.message);return e&&(this._dirty=!1),e}},no,K=class extends Wa{static{no=this}constructor(...e){super(...e),this.filter=``,this.instant=void 0,this.selectedConsumedRoute=void 0,this.selectedRoute=void 0,this.selectedUriPrefix=void 0,this.selectedBaseUrl=void 0,this.selectedServerSideType=void 0,this.selectedParams=void 0,this.tilesMenuOption=null,this.railOpenOption=null,this.commandPaletteOpen=!1,this.commandPaletteQuery=``,this.commandPaletteSelectedIndex=0,this.commandPaletteDataHits=[],this.openDataHit=e=>{to.confirmLeave()&&(this.commandPaletteOpen=!1,this.commandPaletteQuery=``,this.commandPaletteDataHits=[],this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:e.route},bubbles:!0,composed:!0})),this.dispatchEvent(new CustomEvent(`navigate-to-requested`,{detail:{route:e.route},bubbles:!0,composed:!0})))},this._commandPaletteHandler=null,this.pageCompact=!1,this._compactHandler=e=>{this.pageCompact=e.detail?.compact??!1},this._openAiHandler=()=>{this.chatOpen||this.showHideIa()},this.isDark=document.documentElement.getAttribute(`theme`)===`dark`,this.chatOpen=!1,this.toggleTheme=()=>{this.isDark=!this.isDark;let e=this.isDark?`dark`:`light`;document.documentElement.setAttribute(`theme`,e),localStorage.setItem(`mateu-theme`,e)},this.showHideIa=()=>{this.chat&&(this.chatOpen=!this.chatOpen,this.chat.slot=this.chatOpen?`detail`:`detail-hidden`)},this.runAction=e=>{let t=this.renderRoot.querySelector?.(`mateu-component`);t&&t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.getSelectedOption=e=>{if(e)for(let t=0;t<e.length;t++){let n=e[t];if(this.selectedRoute?this.isActiveOption(n):n.selected)return n;let r=this.getSelectedOption(n.submenus);if(r)return r}return null},this.itemSelected=e=>{let t=e.detail.value;this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix)},this.itemSelectedTiles=e=>{let t=e.detail.value._menuOption;t.submenus&&t.submenus.length>0?this.tilesMenuOption=t:(this.tilesMenuOption=null,this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix))},this.mapItemsForTiles=e=>e.map(e=>({text:e.label,consumedRoute:e.consumedRoute,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:e.selected,_menuOption:e})),this.flattenMenuForPalette=(e,t)=>{let n=[];for(let r of e)if(!r.separator)if(r.submenus&&r.submenus.length>0){let e=t?`${t} › ${r.label}`:r.label;n.push(...this.flattenMenuForPalette(r.submenus,e))}else n.push({label:r.label,breadcrumb:t,consumedRoute:r.consumedRoute,route:r.route,actionId:r.actionId,baseUrl:r.baseUrl,serverSideType:r.serverSideType,uriPrefix:r.uriPrefix});return n},this.handleCommandPaletteKeydown=(e,t)=>{let n=Math.min(t.length,10),r=n+Math.min(this.commandPaletteDataHits.length,8);if(e.key===`ArrowDown`)e.preventDefault(),this.commandPaletteSelectedIndex=Math.min(this.commandPaletteSelectedIndex+1,r-1);else if(e.key===`ArrowUp`)e.preventDefault(),this.commandPaletteSelectedIndex=Math.max(this.commandPaletteSelectedIndex-1,0);else if(e.key===`Enter`){if(this.commandPaletteSelectedIndex>=n){let e=this.commandPaletteDataHits[this.commandPaletteSelectedIndex-n];e&&this.openDataHit(e);return}let e=t[this.commandPaletteSelectedIndex];e&&(this.selectRoute(e.consumedRoute,e.route,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix),this.commandPaletteOpen=!1,this.commandPaletteQuery=``)}},this.renderCommandPalette=()=>{if(!this.commandPaletteOpen)return v;let e=this.component?.metadata;if(e?.commandCenterEnabled||!e?.menu)return v;let t=this.flattenMenuForPalette(e.menu,``),n=this.commandPaletteQuery.toLowerCase(),r=n?t.filter(e=>e.label.toLowerCase().includes(n)||e.breadcrumb.toLowerCase().includes(n)):t;return T`
             <div class="cmd-backdrop" @click=${()=>{this.commandPaletteOpen=!1,this.commandPaletteQuery=``}}>
                 <div class="cmd-palette" @click=${e=>e.stopPropagation()}>
                     <div class="cmd-search-wrapper">
-                        ${L(`vaadin:search`,void 0,`cmd-search-icon`)}
+                        ${I(`vaadin:search`,void 0,`cmd-search-icon`)}
                         <input
                             class="cmd-input"
                             placeholder="Go to…"
@@ -5192,7 +5200,7 @@ ${i}
             <div class="rail-item ${(e.submenus?.length>0?this.railOpenOption?.label===e.label:e.selected)?`rail-item--active`:``}"
                 @click=${()=>{e.submenus&&e.submenus.length>0?this.railOpenOption=this.railOpenOption?.label===e.label?null:e:(this.railOpenOption=null,this.selectRoute(e.consumedRoute,e.route,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix))}}
             >
-                ${e.icon?L(e.icon,void 0,`rail-icon`):T`<div class="rail-icon-placeholder">${e.label.charAt(0).toUpperCase()}</div>`}
+                ${e.icon?I(e.icon,void 0,`rail-icon`):T`<div class="rail-icon-placeholder">${e.label.charAt(0).toUpperCase()}</div>`}
                 <span class="rail-label">${e.label}</span>
             </div>
         `,this.renderRailSubPanel=e=>T`
@@ -5212,14 +5220,14 @@ ${i}
                         <div class="nav-tile"
                             @click=${()=>{e.submenus&&e.submenus.length>0?this.tilesMenuOption=e:(this.tilesMenuOption=null,this.selectRoute(e.consumedRoute,e.route,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix))}}
                         >
-                            ${e.icon?L(e.icon,`font-size: 2rem; color: var(--lumo-primary-color); display: block; margin-bottom: 0.75rem;`):v}
+                            ${e.icon?I(e.icon,`font-size: 2rem; color: var(--lumo-primary-color); display: block; margin-bottom: 0.75rem;`):v}
                             <div class="nav-tile-title">${e.label}</div>
                             ${e.description?T`<div class="nav-tile-desc">${e.description}</div>`:v}
                         </div>
                     `)}
                 </div>
             </div>
-        `,this.goHome=()=>{eo.confirmLeave()&&(window.history.pushState(null,``,`/`),window.dispatchEvent(new PopStateEvent(`popstate`,{state:null})))},this.selectRoute=(e,t,n,r,i,a)=>{eo.confirmLeave()&&this._selectRoute(e,t,n,r,i,a)},this._selectRoute=(e,t,n,r,i,a)=>{{this.selectedConsumedRoute=e,this.selectedBaseUrl=r,this.selectedRoute=t,this.selectedServerSideType=i,this.selectedUriPrefix=a,this.instant=E(),this.state&&this.state._route!=null&&(this.state._route=void 0);let n=this.baseUrl??``;n.indexOf(`://`)<0&&(n.startsWith(`/`)||(n=`/`+n),n=window.location.origin+n),n.endsWith(`/`)&&(t??``).startsWith(`/`)&&(t=(t??``).substring(1));let o=new URL(n+t);if(e&&o.pathname.startsWith(e)){let t=o.pathname.substring(e.length);o=new URL(o.origin+(t||`/`))}if((window.location.pathname||o.pathname)&&window.location.pathname!=o.pathname){let e=o.pathname;o.search&&(e+=o.search),e&&!e.startsWith(`/`)&&(e=`/`+e),this.baseUrl&&e.startsWith(this.baseUrl)&&(e=e.substring(this.baseUrl.length));let t=e;this.selectedUriPrefix&&(t=t.startsWith(`/`)&&this.selectedUriPrefix.endsWith(`/`)?this.selectedUriPrefix+t.substring(1):!t.startsWith(`/`)&&!this.selectedUriPrefix.endsWith(`/`)?this.selectedUriPrefix+`/`+t:this.selectedUriPrefix+t),t==`/_page`&&(t=``),this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0}))}}},this.isActiveOption=e=>this.selectedRoute?!!e.route&&(this.selectedRoute==e.route||this.selectedRoute.startsWith(e.route+`/`)):!!e.selected,this.mapItems=(e,t)=>e.map(e=>{if(e.submenus&&e.submenus.length>0){let n=this.mapItems(e.submenus,t);return t&&e.label.toLowerCase().includes(t)&&(n=this.mapItems(e.submenus,``)),n&&n.length>0?{consumedRoute:e.consumedRoute,text:e.label,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:t||this.isActiveOption(e),children:n}:void 0}if(e.separator)return t?void 0:{component:`hr`};if(!t||e.label.toLowerCase().includes(t))return{consumedRoute:e.consumedRoute,text:e.label,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:t||this.isActiveOption(e)}}).filter(e=>e!=null),this.getSelectedIndex=e=>{if(!e)return NaN;let t=e=>{let t=(e??``).trim();return t.length>1&&t.endsWith(`/`)&&(t=t.slice(0,-1)),t},n=t(this.selectedRoute??window.location.pathname),r=NaN,i=-1;for(let a=0;a<e.length;a++){let o=t(e[a].route);o!==``&&(n===o||n.startsWith(o+`/`))&&o.length>i&&(i=o.length,r=a)}if(!Number.isNaN(r))return r;let a=this.getSelectedOption(e);return a?e.indexOf(a):NaN},this.renderOptionOnLeftMenu=e=>e.submenus&&e.submenus.length>0?T`
+        `,this.goHome=()=>{to.confirmLeave()&&(window.history.pushState(null,``,`/`),window.dispatchEvent(new PopStateEvent(`popstate`,{state:null})))},this.selectRoute=(e,t,n,r,i,a)=>{to.confirmLeave()&&this._selectRoute(e,t,n,r,i,a)},this._selectRoute=(e,t,n,r,i,a)=>{{this.selectedConsumedRoute=e,this.selectedBaseUrl=r,this.selectedRoute=t,this.selectedServerSideType=i,this.selectedUriPrefix=a,this.instant=E(),this.state&&this.state._route!=null&&(this.state._route=void 0);let n=this.baseUrl??``;n.indexOf(`://`)<0&&(n.startsWith(`/`)||(n=`/`+n),n=window.location.origin+n),n.endsWith(`/`)&&(t??``).startsWith(`/`)&&(t=(t??``).substring(1));let o=new URL(n+t);if(e&&o.pathname.startsWith(e)){let t=o.pathname.substring(e.length);o=new URL(o.origin+(t||`/`))}if((window.location.pathname||o.pathname)&&window.location.pathname!=o.pathname){let e=o.pathname;o.search&&(e+=o.search),e&&!e.startsWith(`/`)&&(e=`/`+e),this.baseUrl&&e.startsWith(this.baseUrl)&&(e=e.substring(this.baseUrl.length));let t=e;this.selectedUriPrefix&&(t=t.startsWith(`/`)&&this.selectedUriPrefix.endsWith(`/`)?this.selectedUriPrefix+t.substring(1):!t.startsWith(`/`)&&!this.selectedUriPrefix.endsWith(`/`)?this.selectedUriPrefix+`/`+t:this.selectedUriPrefix+t),t==`/_page`&&(t=``),this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0}))}}},this.isActiveOption=e=>this.selectedRoute?!!e.route&&(this.selectedRoute==e.route||this.selectedRoute.startsWith(e.route+`/`)):!!e.selected,this.mapItems=(e,t)=>e.map(e=>{if(e.submenus&&e.submenus.length>0){let n=this.mapItems(e.submenus,t);return t&&e.label.toLowerCase().includes(t)&&(n=this.mapItems(e.submenus,``)),n&&n.length>0?{consumedRoute:e.consumedRoute,text:e.label,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:t||this.isActiveOption(e),children:n}:void 0}if(e.separator)return t?void 0:{component:`hr`};if(!t||e.label.toLowerCase().includes(t))return{consumedRoute:e.consumedRoute,text:e.label,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:t||this.isActiveOption(e)}}).filter(e=>e!=null),this.getSelectedIndex=e=>{if(!e)return NaN;let t=e=>{let t=(e??``).trim();return t.length>1&&t.endsWith(`/`)&&(t=t.slice(0,-1)),t},n=t(this.selectedRoute??window.location.pathname),r=NaN,i=-1;for(let a=0;a<e.length;a++){let o=t(e[a].route);o!==``&&(n===o||n.startsWith(o+`/`))&&o.length>i&&(i=o.length,r=a)}if(!Number.isNaN(r))return r;let a=this.getSelectedOption(e);return a?e.indexOf(a):NaN},this.renderOptionOnLeftMenu=e=>e.submenus&&e.submenus.length>0?T`
                 <details open class="left-menu-group">
                     <summary>${e.label}</summary>
                     <div class="left-menu-children">
@@ -5235,14 +5243,14 @@ ${i}
                                 <div class="side-nav-item ${t.selected?`side-nav-item--active`:``}">
                                     <button class="side-nav-link"
                                             @click="${()=>{t.route&&!t.children&&this.selectRoute(void 0,t.route,void 0,this.baseUrl,void 0,void 0)}}">
-                                        ${t.icon?L(`vaadin:dashboard`,`margin-right:.5rem;`):v}${t.text}
+                                        ${t.icon?I(`vaadin:dashboard`,`margin-right:.5rem;`):v}${t.text}
                                     </button>
                                     ${t.children?T`<div class="side-nav-children">${this.renderSideNav(t.children,`children`)}</div>`:v}
                                 </div>
                         `}
 
-                            `})}`:v,this.updateRoute=e=>{e.preventDefault(),e.stopPropagation();var t=e.detail;this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix)}}createRenderRoot(){return F.mustUseShadowRoot()?super.createRenderRoot():(to.injectLightDomStyles(),this)}static{this.lightDomStylesInjected=!1}static injectLightDomStyles(){if(to.lightDomStylesInjected||typeof document>`u`||(to.lightDomStylesInjected=!0,document.getElementById(`mateu-app-light-styles`)))return;let e=to.styles,t=Array.isArray(e)?e.map(e=>e?.cssText??``).join(`
-`):e?.cssText??``;if(!t)return;let n=document.createElement(`style`);n.id=`mateu-app-light-styles`,n.textContent=t,document.head.appendChild(n)}fetchGlobalSearch(e){let t=this.component?.metadata;if(t?.globalSearchEnabled){if(clearTimeout(this._globalSearchTimer),!e){this.commandPaletteDataHits=[];return}this._globalSearchTimer=setTimeout(async()=>{try{let n=(await lt.runAction(this.baseUrl??``,t.rootRoute??``,``,`_globalsearch`,`cmd-palette`,void 0,t.serverSideType,{},{searchText:e},this,!0))?.fragments?.map(e=>e.data).find(e=>e&&e._globalsearch);this.commandPaletteDataHits=n?._globalsearch??[]}catch{this.commandPaletteDataHits=[]}},250)}}connectedCallback(){super.connectedCallback(),this.isDark=document.documentElement.getAttribute(`theme`)===`dark`,this._commandPaletteHandler=e=>{this.component?.metadata?.commandCenterEnabled||((e.metaKey||e.ctrlKey)&&e.key===`k`&&(e.preventDefault(),this.commandPaletteOpen=!this.commandPaletteOpen,this.commandPaletteQuery=``,this.commandPaletteSelectedIndex=0),e.key===`Escape`&&this.commandPaletteOpen&&(this.commandPaletteOpen=!1,this.commandPaletteQuery=``))},document.addEventListener(`keydown`,this._commandPaletteHandler),eo.install(),this.addEventListener(`compact-changed`,this._compactHandler),this.addEventListener(`mateu-open-ai`,this._openAiHandler)}disconnectedCallback(){super.disconnectedCallback(),this._commandPaletteHandler&&document.removeEventListener(`keydown`,this._commandPaletteHandler),this.removeEventListener(`compact-changed`,this._compactHandler),this.removeEventListener(`mateu-open-ai`,this._openAiHandler)}updated(e){if(super.updated(e),Qa(this),this.component){let t=this.component.metadata;if(t){let n=t;if(Ne(n.restSources),n.favicon){let e=document.querySelector(`link[rel~='icon']`);e||(e=document.createElement(`link`),e.rel=`icon`,document.head.appendChild(e)),e.href=n.favicon}e.has(`component`)&&(this.selectedRoute=n.homeRoute,this.selectedConsumedRoute=n.homeConsumedRoute,this.selectedServerSideType=n.homeServerSideType,this.selectedBaseUrl=n.homeBaseUrl,this.selectedUriPrefix=n.homeUriPrefix)}}e.has(`commandPaletteOpen`)&&this.commandPaletteOpen&&setTimeout(()=>{this.renderRoot.querySelector(`.cmd-input`)?.focus()},0)}render(){return F.get()?.renderAppComponent(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData)}static{this.styles=h`
+                            `})}`:v,this.updateRoute=e=>{e.preventDefault(),e.stopPropagation();var t=e.detail;this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix)}}createRenderRoot(){return P.mustUseShadowRoot()?super.createRenderRoot():(no.injectLightDomStyles(),this)}static{this.lightDomStylesInjected=!1}static injectLightDomStyles(){if(no.lightDomStylesInjected||typeof document>`u`||(no.lightDomStylesInjected=!0,document.getElementById(`mateu-app-light-styles`)))return;let e=no.styles,t=Array.isArray(e)?e.map(e=>e?.cssText??``).join(`
+`):e?.cssText??``;if(!t)return;let n=document.createElement(`style`);n.id=`mateu-app-light-styles`,n.textContent=t,document.head.appendChild(n)}fetchGlobalSearch(e){let t=this.component?.metadata;if(t?.globalSearchEnabled){if(clearTimeout(this._globalSearchTimer),!e){this.commandPaletteDataHits=[];return}this._globalSearchTimer=setTimeout(async()=>{try{let n=(await lt.runAction(this.baseUrl??``,t.rootRoute??``,``,`_globalsearch`,`cmd-palette`,void 0,t.serverSideType,{},{searchText:e},this,!0))?.fragments?.map(e=>e.data).find(e=>e&&e._globalsearch);this.commandPaletteDataHits=n?._globalsearch??[]}catch{this.commandPaletteDataHits=[]}},250)}}connectedCallback(){super.connectedCallback(),this.isDark=document.documentElement.getAttribute(`theme`)===`dark`,this._commandPaletteHandler=e=>{this.component?.metadata?.commandCenterEnabled||((e.metaKey||e.ctrlKey)&&e.key===`k`&&(e.preventDefault(),this.commandPaletteOpen=!this.commandPaletteOpen,this.commandPaletteQuery=``,this.commandPaletteSelectedIndex=0),e.key===`Escape`&&this.commandPaletteOpen&&(this.commandPaletteOpen=!1,this.commandPaletteQuery=``))},document.addEventListener(`keydown`,this._commandPaletteHandler),to.install(),this.addEventListener(`compact-changed`,this._compactHandler),this.addEventListener(`mateu-open-ai`,this._openAiHandler)}disconnectedCallback(){super.disconnectedCallback(),this._commandPaletteHandler&&document.removeEventListener(`keydown`,this._commandPaletteHandler),this.removeEventListener(`compact-changed`,this._compactHandler),this.removeEventListener(`mateu-open-ai`,this._openAiHandler)}updated(e){if(super.updated(e),$a(this),this.component){let t=this.component.metadata;if(t){let n=t;if(Ne(n.restSources),n.favicon){let e=document.querySelector(`link[rel~='icon']`);e||(e=document.createElement(`link`),e.rel=`icon`,document.head.appendChild(e)),e.href=n.favicon}e.has(`component`)&&(this.selectedRoute=n.homeRoute,this.selectedConsumedRoute=n.homeConsumedRoute,this.selectedServerSideType=n.homeServerSideType,this.selectedBaseUrl=n.homeBaseUrl,this.selectedUriPrefix=n.homeUriPrefix)}}e.has(`commandPaletteOpen`)&&this.commandPaletteOpen&&setTimeout(()=>{this.renderRoot.querySelector(`.cmd-input`)?.focus()},0)}render(){return P.get()?.renderAppComponent(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData)}static{this.styles=h`
         /* DS-neutral app chrome (replaces vaadin-app-layout / menu-bar / tabs / side-nav). */
         .m-hl { display: flex; flex-direction: row; }
         .m-vl { display: flex; flex-direction: column; }
@@ -5592,14 +5600,14 @@ ${i}
             transform: scale(1.08);
         }
 
-  `}};k([C()],q.prototype,`filter`,void 0),k([C()],q.prototype,`instant`,void 0),k([C()],q.prototype,`selectedConsumedRoute`,void 0),k([C()],q.prototype,`selectedRoute`,void 0),k([C()],q.prototype,`selectedUriPrefix`,void 0),k([C()],q.prototype,`selectedBaseUrl`,void 0),k([C()],q.prototype,`selectedServerSideType`,void 0),k([C()],q.prototype,`selectedParams`,void 0),k([C()],q.prototype,`tilesMenuOption`,void 0),k([C()],q.prototype,`railOpenOption`,void 0),k([C()],q.prototype,`commandPaletteOpen`,void 0),k([C()],q.prototype,`commandPaletteQuery`,void 0),k([C()],q.prototype,`commandPaletteSelectedIndex`,void 0),k([C()],q.prototype,`commandPaletteDataHits`,void 0),k([C()],q.prototype,`pageCompact`,void 0),k([x(`mateu-chat`)],q.prototype,`chat`,void 0),k([C()],q.prototype,`isDark`,void 0),k([C()],q.prototype,`chatOpen`,void 0),k([x(`.mateu-app-layout`)],q.prototype,`vaadinAppLayout`,void 0),q=to=k([g(`mateu-app`)],q);var no=class extends b{constructor(...e){super(...e),this.message=`This website uses cookies.`,this.dismiss=`Ok. Thanks :).`,this.learnMore=`Learn more`,this.learnMoreLink=`https://cookiesandyou.com/`,this.showLearnMore=!0,this.position=`top`,this.cookieName=`mateu-cookieconsent`}updated(e){super.updated(e)}connectedCallback(){super.connectedCallback(),this._css=document.createElement(`style`),this._css.innerText=`.cc-window{opacity:1;transition:opacity 1s ease}.cc-window.cc-invisible{opacity:0}.cc-animate.cc-revoke{transition:transform 1s ease}.cc-animate.cc-revoke.cc-top{transform:translateY(-2em)}.cc-animate.cc-revoke.cc-bottom{transform:translateY(2em)}.cc-animate.cc-revoke.cc-active.cc-bottom,.cc-animate.cc-revoke.cc-active.cc-top,.cc-revoke:hover{transform:translateY(0)}.cc-grower{max-height:0;overflow:hidden;transition:max-height 1s}.cc-link,.cc-revoke:hover{text-decoration:underline}.cc-revoke,.cc-window{position:fixed;overflow:hidden;box-sizing:border-box;font-family:Helvetica,Calibri,Arial,sans-serif;font-size:16px;line-height:1.5em;display:flex;flex-wrap:nowrap;z-index:9999}.cc-window.cc-static{position:static}.cc-window.cc-floating{padding:2em;max-width:24em;flex-direction:column}.cc-window.cc-banner{padding:1em 1.8em;width:100%;flex-direction:row}.cc-revoke{padding:.5em}.cc-header{font-size:18px;font-weight:700}.cc-btn,.cc-close,.cc-link,.cc-revoke{cursor:pointer}.cc-link{opacity:.8;display:inline-block;padding:.2em}.cc-link:hover{opacity:1}.cc-link:active,.cc-link:visited{color:initial}.cc-btn{display:block;padding:.4em .8em;font-size:.9em;font-weight:700;border-width:2px;border-style:solid;text-align:center;white-space:nowrap}.cc-banner .cc-btn:last-child{min-width:140px}.cc-highlight .cc-btn:first-child{background-color:transparent;border-color:transparent}.cc-highlight .cc-btn:first-child:focus,.cc-highlight .cc-btn:first-child:hover{background-color:transparent;text-decoration:underline}.cc-close{display:block;position:absolute;top:.5em;right:.5em;font-size:1.6em;opacity:.9;line-height:.75}.cc-close:focus,.cc-close:hover{opacity:1}.cc-revoke.cc-top{top:0;left:3em;border-bottom-left-radius:.5em;border-bottom-right-radius:.5em}.cc-revoke.cc-bottom{bottom:0;left:3em;border-top-left-radius:.5em;border-top-right-radius:.5em}.cc-revoke.cc-left{left:3em;right:unset}.cc-revoke.cc-right{right:3em;left:unset}.cc-top{top:1em}.cc-left{left:1em}.cc-right{right:1em}.cc-bottom{bottom:1em}.cc-floating>.cc-link{margin-bottom:1em}.cc-floating .cc-message{display:block;margin-bottom:1em}.cc-window.cc-floating .cc-compliance{flex:1 0 auto}.cc-window.cc-banner{align-items:center}.cc-banner.cc-top{left:0;right:0;top:0}.cc-banner.cc-bottom{left:0;right:0;bottom:0}.cc-banner .cc-message{flex:1}.cc-compliance{display:flex;align-items:center;align-content:space-between}.cc-compliance>.cc-btn{flex:1}.cc-btn+.cc-btn{margin-left:.5em}@media print{.cc-revoke,.cc-window{display:none}}@media screen and (max-width:900px){.cc-btn{white-space:normal}}@media screen and (max-width:414px) and (orientation:portrait),screen and (max-width:736px) and (orientation:landscape){.cc-window.cc-top{top:0}.cc-window.cc-bottom{bottom:0}.cc-window.cc-banner,.cc-window.cc-left,.cc-window.cc-right{left:0;right:0}.cc-window.cc-banner{flex-direction:column}.cc-window.cc-banner .cc-compliance{flex:1}.cc-window.cc-floating{max-width:none}.cc-window .cc-message{margin-bottom:1em}.cc-window.cc-banner{align-items:unset}}.cc-floating.cc-theme-classic{padding:1.2em;border-radius:5px}.cc-floating.cc-type-info.cc-theme-classic .cc-compliance{text-align:center;display:inline;flex:none}.cc-theme-classic .cc-btn{border-radius:5px}.cc-theme-classic .cc-btn:last-child{min-width:140px}.cc-floating.cc-type-info.cc-theme-classic .cc-btn{display:inline-block}.cc-theme-edgeless.cc-window{padding:0}.cc-floating.cc-theme-edgeless .cc-message{margin:2em 2em 1.5em}.cc-banner.cc-theme-edgeless .cc-btn{margin:0;padding:.8em 1.8em;height:100%}.cc-banner.cc-theme-edgeless .cc-message{margin-left:1em}.cc-floating.cc-theme-edgeless .cc-btn+.cc-btn{margin-left:0}`,document.head.appendChild(this._css),this.__updatePopup()}disconnectedCallback(){super.disconnectedCallback(),this.__closePopup(),this._css.isConnected&&this._css.remove()}__closePopup(){let e=this.popup;e&&e.parentNode?.removeChild(e)}_show(){let e=this.popup;e&&(e.classList.remove(`cc-invisible`),e.style.display=``)}__updatePopup(){this.__closePopup(),window.cookieconsent.initialise({palette:{popup:{background:`#000`},button:{background:`rgba(22, 118, 243, 0.95)`,hover:`rgba(22, 118, 243, 1)`}},showLink:this.showLearnMore,content:{message:this.message,dismiss:this.dismiss,link:this.learnMore,href:this.learnMoreLink},cookie:{name:this.cookieName},position:this.position,elements:{messagelink:`<span id="cookieconsent:desc" class="cc-message">${this.message} <a tabindex="0" class="cc-link" href="${this.learnMoreLink}" target="_blank" rel="noopener noreferrer nofollow">${this.learnMore}</a></span>`,dismiss:`<a tabindex="0" class="cc-btn cc-dismiss">${this.dismiss}</a>`}});let e=this.popup;if(e){e.setAttribute(`role`,`alert`);let t=e.querySelector(`a.cc-btn`);t?.addEventListener(`keydown`,e=>{let n=e.keyCode||e.which;(n===32||n===13)&&t.click()})}}render(){return T`
+  `}};k([C()],K.prototype,`filter`,void 0),k([C()],K.prototype,`instant`,void 0),k([C()],K.prototype,`selectedConsumedRoute`,void 0),k([C()],K.prototype,`selectedRoute`,void 0),k([C()],K.prototype,`selectedUriPrefix`,void 0),k([C()],K.prototype,`selectedBaseUrl`,void 0),k([C()],K.prototype,`selectedServerSideType`,void 0),k([C()],K.prototype,`selectedParams`,void 0),k([C()],K.prototype,`tilesMenuOption`,void 0),k([C()],K.prototype,`railOpenOption`,void 0),k([C()],K.prototype,`commandPaletteOpen`,void 0),k([C()],K.prototype,`commandPaletteQuery`,void 0),k([C()],K.prototype,`commandPaletteSelectedIndex`,void 0),k([C()],K.prototype,`commandPaletteDataHits`,void 0),k([C()],K.prototype,`pageCompact`,void 0),k([x(`mateu-chat`)],K.prototype,`chat`,void 0),k([C()],K.prototype,`isDark`,void 0),k([C()],K.prototype,`chatOpen`,void 0),k([x(`.mateu-app-layout`)],K.prototype,`vaadinAppLayout`,void 0),K=no=k([g(`mateu-app`)],K);var ro=class extends b{constructor(...e){super(...e),this.message=`This website uses cookies.`,this.dismiss=`Ok. Thanks :).`,this.learnMore=`Learn more`,this.learnMoreLink=`https://cookiesandyou.com/`,this.showLearnMore=!0,this.position=`top`,this.cookieName=`mateu-cookieconsent`}updated(e){super.updated(e)}connectedCallback(){super.connectedCallback(),this._css=document.createElement(`style`),this._css.innerText=`.cc-window{opacity:1;transition:opacity 1s ease}.cc-window.cc-invisible{opacity:0}.cc-animate.cc-revoke{transition:transform 1s ease}.cc-animate.cc-revoke.cc-top{transform:translateY(-2em)}.cc-animate.cc-revoke.cc-bottom{transform:translateY(2em)}.cc-animate.cc-revoke.cc-active.cc-bottom,.cc-animate.cc-revoke.cc-active.cc-top,.cc-revoke:hover{transform:translateY(0)}.cc-grower{max-height:0;overflow:hidden;transition:max-height 1s}.cc-link,.cc-revoke:hover{text-decoration:underline}.cc-revoke,.cc-window{position:fixed;overflow:hidden;box-sizing:border-box;font-family:Helvetica,Calibri,Arial,sans-serif;font-size:16px;line-height:1.5em;display:flex;flex-wrap:nowrap;z-index:9999}.cc-window.cc-static{position:static}.cc-window.cc-floating{padding:2em;max-width:24em;flex-direction:column}.cc-window.cc-banner{padding:1em 1.8em;width:100%;flex-direction:row}.cc-revoke{padding:.5em}.cc-header{font-size:18px;font-weight:700}.cc-btn,.cc-close,.cc-link,.cc-revoke{cursor:pointer}.cc-link{opacity:.8;display:inline-block;padding:.2em}.cc-link:hover{opacity:1}.cc-link:active,.cc-link:visited{color:initial}.cc-btn{display:block;padding:.4em .8em;font-size:.9em;font-weight:700;border-width:2px;border-style:solid;text-align:center;white-space:nowrap}.cc-banner .cc-btn:last-child{min-width:140px}.cc-highlight .cc-btn:first-child{background-color:transparent;border-color:transparent}.cc-highlight .cc-btn:first-child:focus,.cc-highlight .cc-btn:first-child:hover{background-color:transparent;text-decoration:underline}.cc-close{display:block;position:absolute;top:.5em;right:.5em;font-size:1.6em;opacity:.9;line-height:.75}.cc-close:focus,.cc-close:hover{opacity:1}.cc-revoke.cc-top{top:0;left:3em;border-bottom-left-radius:.5em;border-bottom-right-radius:.5em}.cc-revoke.cc-bottom{bottom:0;left:3em;border-top-left-radius:.5em;border-top-right-radius:.5em}.cc-revoke.cc-left{left:3em;right:unset}.cc-revoke.cc-right{right:3em;left:unset}.cc-top{top:1em}.cc-left{left:1em}.cc-right{right:1em}.cc-bottom{bottom:1em}.cc-floating>.cc-link{margin-bottom:1em}.cc-floating .cc-message{display:block;margin-bottom:1em}.cc-window.cc-floating .cc-compliance{flex:1 0 auto}.cc-window.cc-banner{align-items:center}.cc-banner.cc-top{left:0;right:0;top:0}.cc-banner.cc-bottom{left:0;right:0;bottom:0}.cc-banner .cc-message{flex:1}.cc-compliance{display:flex;align-items:center;align-content:space-between}.cc-compliance>.cc-btn{flex:1}.cc-btn+.cc-btn{margin-left:.5em}@media print{.cc-revoke,.cc-window{display:none}}@media screen and (max-width:900px){.cc-btn{white-space:normal}}@media screen and (max-width:414px) and (orientation:portrait),screen and (max-width:736px) and (orientation:landscape){.cc-window.cc-top{top:0}.cc-window.cc-bottom{bottom:0}.cc-window.cc-banner,.cc-window.cc-left,.cc-window.cc-right{left:0;right:0}.cc-window.cc-banner{flex-direction:column}.cc-window.cc-banner .cc-compliance{flex:1}.cc-window.cc-floating{max-width:none}.cc-window .cc-message{margin-bottom:1em}.cc-window.cc-banner{align-items:unset}}.cc-floating.cc-theme-classic{padding:1.2em;border-radius:5px}.cc-floating.cc-type-info.cc-theme-classic .cc-compliance{text-align:center;display:inline;flex:none}.cc-theme-classic .cc-btn{border-radius:5px}.cc-theme-classic .cc-btn:last-child{min-width:140px}.cc-floating.cc-type-info.cc-theme-classic .cc-btn{display:inline-block}.cc-theme-edgeless.cc-window{padding:0}.cc-floating.cc-theme-edgeless .cc-message{margin:2em 2em 1.5em}.cc-banner.cc-theme-edgeless .cc-btn{margin:0;padding:.8em 1.8em;height:100%}.cc-banner.cc-theme-edgeless .cc-message{margin-left:1em}.cc-floating.cc-theme-edgeless .cc-btn+.cc-btn{margin-left:0}`,document.head.appendChild(this._css),this.__updatePopup()}disconnectedCallback(){super.disconnectedCallback(),this.__closePopup(),this._css.isConnected&&this._css.remove()}__closePopup(){let e=this.popup;e&&e.parentNode?.removeChild(e)}_show(){let e=this.popup;e&&(e.classList.remove(`cc-invisible`),e.style.display=``)}__updatePopup(){this.__closePopup(),window.cookieconsent.initialise({palette:{popup:{background:`#000`},button:{background:`rgba(22, 118, 243, 0.95)`,hover:`rgba(22, 118, 243, 1)`}},showLink:this.showLearnMore,content:{message:this.message,dismiss:this.dismiss,link:this.learnMore,href:this.learnMoreLink},cookie:{name:this.cookieName},position:this.position,elements:{messagelink:`<span id="cookieconsent:desc" class="cc-message">${this.message} <a tabindex="0" class="cc-link" href="${this.learnMoreLink}" target="_blank" rel="noopener noreferrer nofollow">${this.learnMore}</a></span>`,dismiss:`<a tabindex="0" class="cc-btn cc-dismiss">${this.dismiss}</a>`}});let e=this.popup;if(e){e.setAttribute(`role`,`alert`);let t=e.querySelector(`a.cc-btn`);t?.addEventListener(`keydown`,e=>{let n=e.keyCode||e.which;(n===32||n===13)&&t.click()})}}render(){return T`
        `}static{this.styles=h`
-  `}};k([y()],no.prototype,`message`,void 0),k([y()],no.prototype,`dismiss`,void 0),k([y()],no.prototype,`learnMore`,void 0),k([y()],no.prototype,`learnMoreLink`,void 0),k([y()],no.prototype,`showLearnMore`,void 0),k([y()],no.prototype,`position`,void 0),k([y()],no.prototype,`cookieName`,void 0),k([C()],no.prototype,`_css`,void 0),k([x(`[aria-label="cookieconsent"]`)],no.prototype,`popup`,void 0),no=k([g(`mateu-cookie-consent`)],no);var ro=class extends b{constructor(...e){super(...e),this.redispatchEvent=e=>{e instanceof CustomEvent&&(e.stopPropagation(),e.preventDefault(),this.target?.dispatchEvent(new CustomEvent(e.type,{detail:e.detail,bubbles:!0,composed:!0})))}}connectedCallback(){super.connectedCallback(),this.addEventListener(`value-changed`,this.redispatchEvent),this.addEventListener(`data-changed`,this.redispatchEvent),this.addEventListener(`action-requested`,this.redispatchEvent),this.addEventListener(`server-side-action-requested`,this.redispatchEvent),this.addEventListener(`route-changed`,this.redispatchEvent),this.addEventListener(`close-modal-requested`,this.redispatchEvent)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`value-changed`,this.redispatchEvent),this.removeEventListener(`data-changed`,this.redispatchEvent),this.removeEventListener(`action-requested`,this.redispatchEvent),this.removeEventListener(`server-side-action-requested`,this.redispatchEvent),this.removeEventListener(`route-changed`,this.redispatchEvent)}render(){return T`<slot></slot>`}static{this.styles=h`
+  `}};k([y()],ro.prototype,`message`,void 0),k([y()],ro.prototype,`dismiss`,void 0),k([y()],ro.prototype,`learnMore`,void 0),k([y()],ro.prototype,`learnMoreLink`,void 0),k([y()],ro.prototype,`showLearnMore`,void 0),k([y()],ro.prototype,`position`,void 0),k([y()],ro.prototype,`cookieName`,void 0),k([C()],ro.prototype,`_css`,void 0),k([x(`[aria-label="cookieconsent"]`)],ro.prototype,`popup`,void 0),ro=k([g(`mateu-cookie-consent`)],ro);var io=class extends b{constructor(...e){super(...e),this.redispatchEvent=e=>{e instanceof CustomEvent&&(e.stopPropagation(),e.preventDefault(),this.target?.dispatchEvent(new CustomEvent(e.type,{detail:e.detail,bubbles:!0,composed:!0})))}}connectedCallback(){super.connectedCallback(),this.addEventListener(`value-changed`,this.redispatchEvent),this.addEventListener(`data-changed`,this.redispatchEvent),this.addEventListener(`action-requested`,this.redispatchEvent),this.addEventListener(`server-side-action-requested`,this.redispatchEvent),this.addEventListener(`route-changed`,this.redispatchEvent),this.addEventListener(`close-modal-requested`,this.redispatchEvent)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`value-changed`,this.redispatchEvent),this.removeEventListener(`data-changed`,this.redispatchEvent),this.removeEventListener(`action-requested`,this.redispatchEvent),this.removeEventListener(`server-side-action-requested`,this.redispatchEvent),this.removeEventListener(`route-changed`,this.redispatchEvent)}render(){return T`<slot></slot>`}static{this.styles=h`
         :host {
             /* width: 100%; */
             display: inline-block;
         }
-  `}};k([y()],ro.prototype,`target`,void 0),ro=k([g(`mateu-event-interceptor`)],ro);var io=[`a[href]`,`button`,`input`,`select`,`textarea`,`[tabindex]`,`vaadin-button`,`vaadin-text-field`,`vaadin-combo-box`,`vaadin-select`,`vaadin-checkbox`,`vaadin-date-picker`,`ui5-button`,`oj-c-button`].join(`,`),ao=e=>{let t=e;return t.hidden||t.hasAttribute(`disabled`)||t.getAttribute(`aria-hidden`)===`true`||t.getAttribute(`tabindex`)===`-1`?!1:!!(t.offsetParent||t.getClientRects().length)},oo=e=>{let t=[],n=e=>{e.querySelectorAll(`*`).forEach(e=>{e.matches(io)&&ao(e)&&t.push(e),e.shadowRoot&&n(e.shadowRoot),e instanceof HTMLSlotElement&&e.assignedElements().forEach(e=>{e.matches(io)&&ao(e)&&t.push(e),n(e)})})};return n(e),t.filter((e,n)=>t.indexOf(e)===n)},so=(e,t={})=>{let n=co(),r=[],i=()=>{r=oo(e)},a=t=>{if(t.key!==`Tab`)return;if(i(),r.length===0){t.preventDefault(),e.focus();return}let n=r[0],a=r[r.length-1],o=co();t.shiftKey&&(o===n||!o||!lo(o,e))?(t.preventDefault(),a.focus()):!t.shiftKey&&o===a&&(t.preventDefault(),n.focus())};return e.addEventListener(`keydown`,a),requestAnimationFrame(()=>{i();let n=t.initialFocus?.()??r[0];n?n.focus():(e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus())}),{refresh:i,release(){e.removeEventListener(`keydown`,a);let t=co();(!t||t===document.body||lo(t,e))&&n?.focus?.()}}},co=()=>{let e=document.activeElement;for(;e?.shadowRoot?.activeElement;)e=e.shadowRoot.activeElement;return e},lo=(e,t)=>{let n=e;for(;n;){if(n===t)return!0;n=n.parentNode??n.host??null}return!1},uo=class extends Ua{constructor(...e){super(...e),this.opened=!0,this.close=()=>{this.opened=!1,this.releaseFocusTrap(),setTimeout(()=>{this.removeSelfFromOwnerChildren()||this.parentElement?.removeChild(this)},500)},this.onKeydown=e=>{e.key===`Escape`&&this.opened&&(e.stopPropagation(),this.close())}}connectedCallback(){super.connectedCallback(),this.addEventListener(`keydown`,this.onKeydown)}disconnectedCallback(){super.disconnectedCallback(),this.releaseFocusTrap()}releaseFocusTrap(){this.focusTrap?.release(),this.focusTrap=void 0}applyFragment(e){super.applyFragment(e);let t=e.state?._closeAfterMillis;t&&setTimeout(()=>this.close(),t)}updated(e){if(super.updated(e),e.has(`component`)&&this.component){let e=this.component.metadata;this.state=e.initialData}let t=this.renderRoot.querySelector(`[role="dialog"]`),n=this.component?.metadata?.modeless;this.opened&&t&&!this.focusTrap&&!n?this.focusTrap=so(t):this.focusTrap&&this.opened&&this.focusTrap.refresh()}render(){if(!this.opened)return T``;let e=this.component.metadata,t=xt(e.headerTitle,this.state,this.data,this.appState,this.appData),n=!!(t||e.header||e.closeButtonOnHeader),r=[e.width?`width:${e.width};`:`min-width:min(90vw,28rem);`,e.height?`height:${e.height};`:``,e.top?`margin-top:${e.top};`:``].join(``);return T`
+  `}};k([y()],io.prototype,`target`,void 0),io=k([g(`mateu-event-interceptor`)],io);var ao=[`a[href]`,`button`,`input`,`select`,`textarea`,`[tabindex]`,`vaadin-button`,`vaadin-text-field`,`vaadin-combo-box`,`vaadin-select`,`vaadin-checkbox`,`vaadin-date-picker`,`ui5-button`,`oj-c-button`].join(`,`),oo=e=>{let t=e;return t.hidden||t.hasAttribute(`disabled`)||t.getAttribute(`aria-hidden`)===`true`||t.getAttribute(`tabindex`)===`-1`?!1:!!(t.offsetParent||t.getClientRects().length)},so=e=>{let t=[],n=e=>{e.querySelectorAll(`*`).forEach(e=>{e.matches(ao)&&oo(e)&&t.push(e),e.shadowRoot&&n(e.shadowRoot),e instanceof HTMLSlotElement&&e.assignedElements().forEach(e=>{e.matches(ao)&&oo(e)&&t.push(e),n(e)})})};return n(e),t.filter((e,n)=>t.indexOf(e)===n)},co=(e,t={})=>{let n=lo(),r=[],i=()=>{r=so(e)},a=t=>{if(t.key!==`Tab`)return;if(i(),r.length===0){t.preventDefault(),e.focus();return}let n=r[0],a=r[r.length-1],o=lo();t.shiftKey&&(o===n||!o||!uo(o,e))?(t.preventDefault(),a.focus()):!t.shiftKey&&o===a&&(t.preventDefault(),n.focus())};return e.addEventListener(`keydown`,a),requestAnimationFrame(()=>{i();let n=t.initialFocus?.()??r[0];n?n.focus():(e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus())}),{refresh:i,release(){e.removeEventListener(`keydown`,a);let t=lo();(!t||t===document.body||uo(t,e))&&n?.focus?.()}}},lo=()=>{let e=document.activeElement;for(;e?.shadowRoot?.activeElement;)e=e.shadowRoot.activeElement;return e},uo=(e,t)=>{let n=e;for(;n;){if(n===t)return!0;n=n.parentNode??n.host??null}return!1},fo=class extends Wa{constructor(...e){super(...e),this.opened=!0,this.close=()=>{this.opened=!1,this.releaseFocusTrap(),setTimeout(()=>{this.removeSelfFromOwnerChildren()||this.parentElement?.removeChild(this)},500)},this.onKeydown=e=>{e.key===`Escape`&&this.opened&&(e.stopPropagation(),this.close())}}connectedCallback(){super.connectedCallback(),this.addEventListener(`keydown`,this.onKeydown)}disconnectedCallback(){super.disconnectedCallback(),this.releaseFocusTrap()}releaseFocusTrap(){this.focusTrap?.release(),this.focusTrap=void 0}applyFragment(e){super.applyFragment(e);let t=e.state?._closeAfterMillis;t&&setTimeout(()=>this.close(),t)}updated(e){if(super.updated(e),e.has(`component`)&&this.component){let e=this.component.metadata;this.state=e.initialData}let t=this.renderRoot.querySelector(`[role="dialog"]`),n=this.component?.metadata?.modeless;this.opened&&t&&!this.focusTrap&&!n?this.focusTrap=co(t):this.focusTrap&&this.opened&&this.focusTrap.refresh()}render(){if(!this.opened)return T``;let e=this.component.metadata,t=xt(e.headerTitle,this.state,this.data,this.appState,this.appData),n=!!(t||e.header||e.closeButtonOnHeader),r=[e.width?`width:${e.width};`:`min-width:min(90vw,28rem);`,e.height?`height:${e.height};`:``,e.top?`margin-top:${e.top};`:``].join(``);return T`
             <div class="backdrop ${e.modeless?`modeless`:``}"
                  @click="${t=>{!e.modeless&&t.target===t.currentTarget&&this.close()}}">
                 <div class="dialog ${e.noPadding?`no-padding`:``} ${this.component?.cssClasses??``}"
@@ -5611,20 +5619,20 @@ ${i}
                         <div class="dialog-header">
                             <mateu-event-interceptor .target="${this}" style="flex:1; min-width:0;">
                                 ${t?T`<span class="dialog-title">${t}</span>`:v}
-                                ${e.header?I(this,e.header,this.baseUrl,this.state,this.data,this.appState,this.appData):v}
+                                ${e.header?F(this,e.header,this.baseUrl,this.state,this.data,this.appState,this.appData):v}
                             </mateu-event-interceptor>
                             ${e.closeButtonOnHeader?T`<button class="dialog-close" @click="${this.close}" aria-label="Close">✕</button>`:v}
                         </div>`:v}
                     ${e.content?T`
                         <div class="dialog-body">
                             <mateu-event-interceptor .target="${this}" style="--mateu-section-border: none; width:100%;">
-                                ${I(this,e.content,this.baseUrl,this.state,this.data,this.appState,this.appData)}
+                                ${F(this,e.content,this.baseUrl,this.state,this.data,this.appState,this.appData)}
                             </mateu-event-interceptor>
                         </div>`:v}
                     ${e.footer?T`
                         <div class="dialog-footer">
                             <mateu-event-interceptor .target="${this}" style="width:100%;">
-                                ${I(this,e.footer,this.baseUrl,this.state,this.data,this.appState,this.appData)}
+                                ${F(this,e.footer,this.baseUrl,this.state,this.data,this.appState,this.appData)}
                             </mateu-event-interceptor>
                         </div>`:v}
                 </div>
@@ -5654,7 +5662,7 @@ ${i}
         .dialog-body { padding: .5rem 1.2rem; flex: 1; }
         .dialog.no-padding .dialog-body { padding: 0; }
         .dialog-footer { padding: .5rem 1.2rem 1rem; display: flex; justify-content: flex-end; gap: .5rem; }
-    `}};k([C()],uo.prototype,`opened`,void 0),uo=k([g(`mateu-dialog`)],uo);var fo,po=class extends Ua{static{fo=this}constructor(...e){super(...e),this.opened=!1,this.maximizeSteps=0,this.collapsed=!1,this.pagerMenuOpen=!1,this.onGuidedProgress=e=>{let t=e.detail;t&&t.total>0&&(this.guidedProgress=t)},this.close=()=>{this.opened=!1,this.releaseLayoutInset(),this.releaseFocusTrap(),setTimeout(()=>{this.removeSelfFromOwnerChildren()||this.parentElement?.removeChild(this)},300)},this._escListener=e=>{if(e.key!==`Escape`)return;let t=this.getRootNode().querySelectorAll(`mateu-drawer, mateu-dialog`);t[t.length-1]===this&&(e.stopPropagation(),this.close())}}jumpToStep(e){this.pagerMenuOpen=!1,e&&(this.renderRoot.querySelector(`.content mateu-component`)??this.renderRoot.querySelector(`mateu-component`))?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`goToStep`,parameters:{_stepId:e}},bubbles:!0,composed:!0}))}static{this.SIZE_LADDER=[`s`,`m`,`l`,`xl`]}static{this.SIZE_WIDTHS={s:`464px`,m:`648px`,l:`968px`,xl:`90vw`}}effectiveWidth(e){if(e.width)return e.width;if(!e.size)return;let t=fo.SIZE_LADDER,n=Math.max(0,t.indexOf(e.size)),r=Math.min(t.length-1,n+this.maximizeSteps);return fo.SIZE_WIDTHS[t[r]]}canMaximize(e){if(!e.maximizable)return!1;let t=fo.SIZE_LADDER;return Math.max(0,t.indexOf(e.size??`m`))+this.maximizeSteps<t.length-1}firstUpdated(){requestAnimationFrame(()=>this.opened=!0),this.addEventListener(`mateu-guided-progress`,this.onGuidedProgress);let e=this.component?.metadata;e&&requestAnimationFrame(()=>this.applyLayoutInset(e))}releaseFocusTrap(){this.focusTrap?.release(),this.focusTrap=void 0}applyLayoutInset(e){if(!e.layout)return;let t=document.querySelector(`mateu-ui`);if(!t)return;let n=e.position??`end`,r=n===`bottom`?`var(--mateu-drawer-height, 50vh)`:this.effectiveWidth(e)??`648px`;this._insetProp=n===`start`?`paddingLeft`:n===`bottom`?`paddingBottom`:`paddingRight`,t.style.transition=`padding .25s ease`,t.style[this._insetProp]=r}releaseLayoutInset(){if(!this._insetProp)return;let e=document.querySelector(`mateu-ui`);e&&(e.style[this._insetProp]=``),this._insetProp=void 0}applyFragment(e){super.applyFragment(e);let t=e.state?._closeAfterMillis;t&&setTimeout(()=>this.close(),t)}updated(e){if(super.updated(e),e.has(`component`)&&this.component){let e=this.component.metadata;this.state=e.initialData}let t=this.component?.metadata,n=this.renderRoot.querySelector(`[role="dialog"]`);this.opened&&n&&!t?.modeless&&!t?.layout&&!this.focusTrap?this.focusTrap=so(n):this.focusTrap&&this.opened&&this.focusTrap.refresh()}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._escListener)}disconnectedCallback(){document.removeEventListener(`keydown`,this._escListener),this.releaseLayoutInset(),this.releaseFocusTrap(),super.disconnectedCallback()}render(){let e=this.component.metadata,t=e.position??`end`,n=xt(e.headerTitle,this.state,this.data,this.appState,this.appData),r=xt(e.subtitle,this.state,this.data,this.appState,this.appData),i=this.effectiveWidth(e),a=e.peerNav&&(e.peerNav.prevRoute||e.peerNav.nextRoute)?e.peerNav:void 0;return T`
+    `}};k([C()],fo.prototype,`opened`,void 0),fo=k([g(`mateu-dialog`)],fo);var po,mo=class extends Wa{static{po=this}constructor(...e){super(...e),this.opened=!1,this.maximizeSteps=0,this.collapsed=!1,this.pagerMenuOpen=!1,this.onGuidedProgress=e=>{let t=e.detail;t&&t.total>0&&(this.guidedProgress=t)},this.close=()=>{this.opened=!1,this.releaseLayoutInset(),this.releaseFocusTrap(),setTimeout(()=>{this.removeSelfFromOwnerChildren()||this.parentElement?.removeChild(this)},300)},this._escListener=e=>{if(e.key!==`Escape`)return;let t=this.getRootNode().querySelectorAll(`mateu-drawer, mateu-dialog`);t[t.length-1]===this&&(e.stopPropagation(),this.close())}}jumpToStep(e){this.pagerMenuOpen=!1,e&&(this.renderRoot.querySelector(`.content mateu-component`)??this.renderRoot.querySelector(`mateu-component`))?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`goToStep`,parameters:{_stepId:e}},bubbles:!0,composed:!0}))}static{this.SIZE_LADDER=[`s`,`m`,`l`,`xl`]}static{this.SIZE_WIDTHS={s:`464px`,m:`648px`,l:`968px`,xl:`90vw`}}effectiveWidth(e){if(e.width)return e.width;if(!e.size)return;let t=po.SIZE_LADDER,n=Math.max(0,t.indexOf(e.size)),r=Math.min(t.length-1,n+this.maximizeSteps);return po.SIZE_WIDTHS[t[r]]}canMaximize(e){if(!e.maximizable)return!1;let t=po.SIZE_LADDER;return Math.max(0,t.indexOf(e.size??`m`))+this.maximizeSteps<t.length-1}firstUpdated(){requestAnimationFrame(()=>this.opened=!0),this.addEventListener(`mateu-guided-progress`,this.onGuidedProgress);let e=this.component?.metadata;e&&requestAnimationFrame(()=>this.applyLayoutInset(e))}releaseFocusTrap(){this.focusTrap?.release(),this.focusTrap=void 0}applyLayoutInset(e){if(!e.layout)return;let t=document.querySelector(`mateu-ui`);if(!t)return;let n=e.position??`end`,r=n===`bottom`?`var(--mateu-drawer-height, 50vh)`:this.effectiveWidth(e)??`648px`;this._insetProp=n===`start`?`paddingLeft`:n===`bottom`?`paddingBottom`:`paddingRight`,t.style.transition=`padding .25s ease`,t.style[this._insetProp]=r}releaseLayoutInset(){if(!this._insetProp)return;let e=document.querySelector(`mateu-ui`);e&&(e.style[this._insetProp]=``),this._insetProp=void 0}applyFragment(e){super.applyFragment(e);let t=e.state?._closeAfterMillis;t&&setTimeout(()=>this.close(),t)}updated(e){if(super.updated(e),e.has(`component`)&&this.component){let e=this.component.metadata;this.state=e.initialData}let t=this.component?.metadata,n=this.renderRoot.querySelector(`[role="dialog"]`);this.opened&&n&&!t?.modeless&&!t?.layout&&!this.focusTrap?this.focusTrap=co(n):this.focusTrap&&this.opened&&this.focusTrap.refresh()}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._escListener)}disconnectedCallback(){document.removeEventListener(`keydown`,this._escListener),this.releaseLayoutInset(),this.releaseFocusTrap(),super.disconnectedCallback()}render(){let e=this.component.metadata,t=e.position??`end`,n=xt(e.headerTitle,this.state,this.data,this.appState,this.appData),r=xt(e.subtitle,this.state,this.data,this.appState,this.appData),i=this.effectiveWidth(e),a=e.peerNav&&(e.peerNav.prevRoute||e.peerNav.nextRoute)?e.peerNav:void 0;return T`
         ${e.modeless||e.layout?v:T`
             <div class="backdrop ${this.opened?`open`:``}" @click="${this.close}"></div>
         `}
@@ -5683,7 +5691,7 @@ ${i}
                     </div>
                 `:v}
                 ${e.header?T`
-                    <mateu-event-interceptor .target="${this}">${I(this,e.header,this.baseUrl,this.state,this.data,this.appState,this.appData)}</mateu-event-interceptor>
+                    <mateu-event-interceptor .target="${this}">${F(this,e.header,this.baseUrl,this.state,this.data,this.appState,this.appData)}</mateu-event-interceptor>
                 `:v}
                 ${a?T`
                     <button class="drawer-icon" aria-label="${a.prevLabel??`Previous`}" title="${a.prevLabel??`Previous`}"
@@ -5703,12 +5711,12 @@ ${i}
             ${this.collapsed?v:T`
             <div class="content ${e.noPadding?`no-padding`:``}">
                 ${e.content?T`
-                    <mateu-event-interceptor .target="${this}" style="--mateu-section-border: none; width: 100%;">${I(this,e.content,this.baseUrl,this.state,this.data,this.appState,this.appData)}</mateu-event-interceptor>
+                    <mateu-event-interceptor .target="${this}" style="--mateu-section-border: none; width: 100%;">${F(this,e.content,this.baseUrl,this.state,this.data,this.appState,this.appData)}</mateu-event-interceptor>
                 `:v}
             </div>
             ${e.footer?T`
                 <footer>
-                    <mateu-event-interceptor .target="${this}" style="width: 100%;">${I(this,e.footer,this.baseUrl,this.state,this.data,this.appState,this.appData)}</mateu-event-interceptor>
+                    <mateu-event-interceptor .target="${this}" style="width: 100%;">${F(this,e.footer,this.baseUrl,this.state,this.data,this.appState,this.appData)}</mateu-event-interceptor>
                 </footer>
             `:v}
             `}
@@ -5932,7 +5940,7 @@ ${i}
             display: flex;
             justify-content: flex-end;
         }
-  `}};k([C()],po.prototype,`opened`,void 0),k([C()],po.prototype,`maximizeSteps`,void 0),k([C()],po.prototype,`collapsed`,void 0),k([C()],po.prototype,`guidedProgress`,void 0),k([C()],po.prototype,`pagerMenuOpen`,void 0),po=fo=k([g(`mateu-drawer`)],po);function mo(e){if(e.parentElement)return e.parentElement;let t=e.getRootNode();return t instanceof ShadowRoot?t.host:null}var J=class extends b{constructor(...e){super(...e),this.appState={},this.appData={},this.standalone=!1,this.actionBanners=[],this.dismissedStaticBannerIndices=new Set,this._tocEntries=[],this._activeToc=0,this._tocVisible=!1,this._tocRebuildScheduled=!1,this._headerH=0,this._onResize=()=>this._layoutStickyTops(),this._tocLocked=!1,this._unlockToc=e=>{if(e&&e.type===`keydown`){let t=e;if(t.ctrlKey&&t.altKey&&!t.shiftKey&&!t.metaKey&&/^(?:Digit|Numpad)[1-9]$/.test(t.code))return}this._tocLocked=!1},this._actionBannerTimers=[],this._staticBannerTimers=[],this._bannersHandler=e=>{let t=e.detail,n=t.banners??[],r=t.append??!1;r?this.actionBanners=[...this.actionBanners,...n]:(this._clearActionBannerTimers(),this.actionBanners=n);let i=r?this.actionBanners.length-n.length:0;n.forEach((e,t)=>{if(e.timeoutSeconds&&e.timeoutSeconds>0){let n=i+t;this._actionBannerTimers.push(setTimeout(()=>{this.actionBanners=this.actionBanners.filter((e,t)=>t!==n)},e.timeoutSeconds*1e3))}})},this._onTocKey=e=>{if(!this._tocVisible||!e.ctrlKey||!e.altKey||e.shiftKey||e.metaKey)return;let t=/^(?:Digit|Numpad)([1-9])$/.exec(e.code);if(!t)return;let n=parseInt(t[1],10)-1;n>=this._tocEntries.length||(e.preventDefault(),this._scrollToSection(n))},this._onScrollSpy=()=>{if(this._tocLocked)return;let e=this._sectionCards();if(!e.length)return;let t=this.shadowRoot?.querySelector(`mateu-content-header`),n=t?t.getBoundingClientRect().bottom:0;for(let t of e){if(!t.classList.contains(`mateu-section--sticky`))continue;let e=t.getBoundingClientRect();e.top<=n+12+2&&(n=Math.max(n,e.bottom))}let r=n+12+4,i=0;this._tocEntries.forEach((e,t)=>{e.el.getBoundingClientRect().top<=r&&(i=t)}),this._activeToc=i}}connectedCallback(){super.connectedCallback(),document.addEventListener(`page-banners-received`,this._bannersHandler),window.addEventListener(`resize`,this._onResize),document.addEventListener(`keydown`,this._onTocKey)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`page-banners-received`,this._bannersHandler),window.removeEventListener(`resize`,this._onResize),document.removeEventListener(`keydown`,this._onTocKey),this._clearAllTimers(),this._teardownScrollSpy()}updated(e){if(super.updated(e),e.has(`component`)&&e.get(`component`)!==void 0&&(this._clearAllTimers(),this.actionBanners=[],this.dismissedStaticBannerIndices=new Set),e.has(`component`)){let e=this.component?.metadata?.level??0;this.toggleAttribute(`data-nested`,e>0),this._scheduleStaticBannerTimeouts();let t=this.component?.metadata?.pageWidth===`edgeToEdge`;this.toggleAttribute(`data-edge`,t),this.dispatchEvent(new CustomEvent(`compact-changed`,{detail:{compact:!!this.component?.style?.includes(`--mateu-compact:1`)||t},bubbles:!0,composed:!0})),this._scheduleTocRebuild()}}_scheduleStaticBannerTimeouts(){this._staticBannerTimers.forEach(e=>clearTimeout(e)),this._staticBannerTimers=[],(this.component?.metadata?.banners??[]).forEach((e,t)=>{e.timeoutSeconds&&e.timeoutSeconds>0&&this._staticBannerTimers.push(setTimeout(()=>{this.dismissedStaticBannerIndices=new Set([...this.dismissedStaticBannerIndices,t])},e.timeoutSeconds*1e3))})}_clearActionBannerTimers(){this._actionBannerTimers.forEach(e=>clearTimeout(e)),this._actionBannerTimers=[]}_clearAllTimers(){this._clearActionBannerTimers(),this._staticBannerTimers.forEach(e=>clearTimeout(e)),this._staticBannerTimers=[]}_dismissActionBanner(e){this.actionBanners=this.actionBanners.filter((t,n)=>n!==e)}_dismissStaticBanner(e){this.dismissedStaticBannerIndices=new Set([...this.dismissedStaticBannerIndices,e])}bannerThemeClass(e){let t=e.theme?.toLowerCase()??`info`;return t===`none`?``:t}_evalBannerText(e){return M(e,this.state,this.data)}_renderBanner(e,t){let n=this._evalBannerText(e.title),r=this._evalBannerText(e.description);return T`
+  `}};k([C()],mo.prototype,`opened`,void 0),k([C()],mo.prototype,`maximizeSteps`,void 0),k([C()],mo.prototype,`collapsed`,void 0),k([C()],mo.prototype,`guidedProgress`,void 0),k([C()],mo.prototype,`pagerMenuOpen`,void 0),mo=po=k([g(`mateu-drawer`)],mo);function ho(e){if(e.parentElement)return e.parentElement;let t=e.getRootNode();return t instanceof ShadowRoot?t.host:null}var q=class extends b{constructor(...e){super(...e),this.appState={},this.appData={},this.standalone=!1,this.actionBanners=[],this.dismissedStaticBannerIndices=new Set,this._tocEntries=[],this._activeToc=0,this._tocVisible=!1,this._tocRebuildScheduled=!1,this._headerH=0,this._onResize=()=>this._layoutStickyTops(),this._tocLocked=!1,this._unlockToc=e=>{if(e&&e.type===`keydown`){let t=e;if(t.ctrlKey&&t.altKey&&!t.shiftKey&&!t.metaKey&&/^(?:Digit|Numpad)[1-9]$/.test(t.code))return}this._tocLocked=!1},this._actionBannerTimers=[],this._staticBannerTimers=[],this._bannersHandler=e=>{let t=e.detail,n=t.banners??[],r=t.append??!1;r?this.actionBanners=[...this.actionBanners,...n]:(this._clearActionBannerTimers(),this.actionBanners=n);let i=r?this.actionBanners.length-n.length:0;n.forEach((e,t)=>{if(e.timeoutSeconds&&e.timeoutSeconds>0){let n=i+t;this._actionBannerTimers.push(setTimeout(()=>{this.actionBanners=this.actionBanners.filter((e,t)=>t!==n)},e.timeoutSeconds*1e3))}})},this._onTocKey=e=>{if(!this._tocVisible||!e.ctrlKey||!e.altKey||e.shiftKey||e.metaKey)return;let t=/^(?:Digit|Numpad)([1-9])$/.exec(e.code);if(!t)return;let n=parseInt(t[1],10)-1;n>=this._tocEntries.length||(e.preventDefault(),this._scrollToSection(n))},this._onScrollSpy=()=>{if(this._tocLocked)return;let e=this._sectionCards();if(!e.length)return;let t=this.shadowRoot?.querySelector(`mateu-content-header`),n=t?t.getBoundingClientRect().bottom:0;for(let t of e){if(!t.classList.contains(`mateu-section--sticky`))continue;let e=t.getBoundingClientRect();e.top<=n+12+2&&(n=Math.max(n,e.bottom))}let r=n+12+4,i=0;this._tocEntries.forEach((e,t)=>{e.el.getBoundingClientRect().top<=r&&(i=t)}),this._activeToc=i}}connectedCallback(){super.connectedCallback(),document.addEventListener(`page-banners-received`,this._bannersHandler),window.addEventListener(`resize`,this._onResize),document.addEventListener(`keydown`,this._onTocKey)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`page-banners-received`,this._bannersHandler),window.removeEventListener(`resize`,this._onResize),document.removeEventListener(`keydown`,this._onTocKey),this._clearAllTimers(),this._teardownScrollSpy()}updated(e){if(super.updated(e),e.has(`component`)&&e.get(`component`)!==void 0&&(this._clearAllTimers(),this.actionBanners=[],this.dismissedStaticBannerIndices=new Set),e.has(`component`)){let e=this.component?.metadata?.level??0;this.toggleAttribute(`data-nested`,e>0),this._scheduleStaticBannerTimeouts();let t=this.component?.metadata?.pageWidth===`edgeToEdge`;this.toggleAttribute(`data-edge`,t),this.dispatchEvent(new CustomEvent(`compact-changed`,{detail:{compact:!!this.component?.style?.includes(`--mateu-compact:1`)||t},bubbles:!0,composed:!0})),this._scheduleTocRebuild()}}_scheduleStaticBannerTimeouts(){this._staticBannerTimers.forEach(e=>clearTimeout(e)),this._staticBannerTimers=[],(this.component?.metadata?.banners??[]).forEach((e,t)=>{e.timeoutSeconds&&e.timeoutSeconds>0&&this._staticBannerTimers.push(setTimeout(()=>{this.dismissedStaticBannerIndices=new Set([...this.dismissedStaticBannerIndices,t])},e.timeoutSeconds*1e3))})}_clearActionBannerTimers(){this._actionBannerTimers.forEach(e=>clearTimeout(e)),this._actionBannerTimers=[]}_clearAllTimers(){this._clearActionBannerTimers(),this._staticBannerTimers.forEach(e=>clearTimeout(e)),this._staticBannerTimers=[]}_dismissActionBanner(e){this.actionBanners=this.actionBanners.filter((t,n)=>n!==e)}_dismissStaticBanner(e){this.dismissedStaticBannerIndices=new Set([...this.dismissedStaticBannerIndices,e])}bannerThemeClass(e){let t=e.theme?.toLowerCase()??`info`;return t===`none`?``:t}_evalBannerText(e){return M(e,this.state,this.data)}_renderBanner(e,t){let n=this._evalBannerText(e.title),r=this._evalBannerText(e.description);return T`
             <div class="page-banner page-banner--${this.bannerThemeClass(e)}">
                 ${n||e.hasCloseButton?T`
                     <div style="display: flex; align-items: center; justify-content: space-between; color: #1a1a1a; width: 100%;">
@@ -5944,7 +5952,7 @@ ${i}
                 `:v}
                 ${r?T`<p>${r}</p>`:v}
             </div>
-        `}_onSlotChange(){this._scheduleTocRebuild()}_scheduleTocRebuild(){this._tocRebuildScheduled||(this._tocRebuildScheduled=!0,requestAnimationFrame(()=>{this._tocRebuildScheduled=!1,this._rebuildToc()}))}_sectionCards(){return Array.from(this.querySelectorAll(`.mateu-section`))}_sectionTitle(e){return e.querySelector(`[slot="title"]`)?.textContent?.trim()||e.querySelector(`h1,h2,h3,h4,h5,h6`)?.textContent?.trim()||void 0}_rebuildToc(){let e=this._sectionCards(),t=e.map(e=>({title:this._sectionTitle(e),el:e})).filter(e=>!!e.title),n=this.component?.metadata?.toc,r=t.length>4&&e.every(e=>!e.closest(`vaadin-horizontal-layout`)),i=(n===!0||n!==!1&&r)&&t.length>0;this._tocEntries=t,this._tocVisible=i,this._activeToc>=t.length&&(this._activeToc=0),this._teardownScrollSpy(),i?requestAnimationFrame(()=>{this._layoutStickyTops(),this._setupScrollSpy()}):this._layoutStickyTops()}_layoutStickyTops(){let e=this.shadowRoot?.querySelector(`mateu-content-header`);this._headerH=this._tocVisible&&e?e.offsetHeight:0,this.style.setProperty(`--mateu-header-h`,this._headerH+`px`);let t=this._headerH+12;for(let e of this._sectionCards())e.classList.contains(`mateu-section--sticky`)&&(e.style.top=t+`px`,t+=e.offsetHeight+12)}_scrollContainer(){let e=mo(this);for(;e;){let t=getComputedStyle(e).overflowY;if((t===`auto`||t===`scroll`)&&e.scrollHeight>e.clientHeight)return e;e=mo(e)}return null}_setupScrollSpy(){this._tocEntries.length&&(this._spyTarget=this._scrollContainer()??window,this._spyTarget.addEventListener(`scroll`,this._onScrollSpy,{passive:!0}),window.addEventListener(`wheel`,this._unlockToc,{passive:!0}),window.addEventListener(`touchstart`,this._unlockToc,{passive:!0}),window.addEventListener(`keydown`,this._unlockToc),this._onScrollSpy())}_teardownScrollSpy(){this._spyTarget?.removeEventListener(`scroll`,this._onScrollSpy),window.removeEventListener(`wheel`,this._unlockToc),window.removeEventListener(`touchstart`,this._unlockToc),window.removeEventListener(`keydown`,this._unlockToc),this._spyTarget=void 0}_scrollToSection(e){let t=this._tocEntries[e];if(!t)return;this._activeToc=e,this._tocLocked=!0;let n=this._headerH+12;for(let e of this._sectionCards()){if(e===t.el)break;e.classList.contains(`mateu-section--sticky`)&&(n+=e.offsetHeight+12)}let r=this._scrollContainer(),i=r?r.getBoundingClientRect().top:0,a=t.el.getBoundingClientRect().top-i-n;(r??window).scrollBy({top:a,behavior:`smooth`})}_showHeaderBand(){let e=this.component?.metadata,t=!!(e?.title||e?.subtitle||e?.overline||e?.titlePlaceholder||e?.toolbar?.length),n=!!this.component?.children?.some(e=>e.metadata?.type===j.Crud);return t&&!n&&!this._hasWelcomeBanner()}_hasWelcomeBanner(){let e=t=>t?.metadata?.type===j.HeroSection||(t?.children??[]).some(e);return(this.component?.children??[]).some(e)}render(){let e=this.component?.metadata,t=[...(e?.banners??[]).map((e,t)=>({banner:e,index:t})).filter(({index:e})=>!this.dismissedStaticBannerIndices.has(e)).map(({banner:e,index:t})=>({banner:e,onDismiss:()=>this._dismissStaticBanner(t)})),...this.actionBanners.map((e,t)=>({banner:e,onDismiss:()=>this._dismissActionBanner(t)}))];return T`<div style="display: flex; flex-direction: column; width: 100%;">${T`
+        `}_onSlotChange(){this._scheduleTocRebuild()}_scheduleTocRebuild(){this._tocRebuildScheduled||(this._tocRebuildScheduled=!0,requestAnimationFrame(()=>{this._tocRebuildScheduled=!1,this._rebuildToc()}))}_sectionCards(){return Array.from(this.querySelectorAll(`.mateu-section`))}_sectionTitle(e){return e.querySelector(`[slot="title"]`)?.textContent?.trim()||e.querySelector(`h1,h2,h3,h4,h5,h6`)?.textContent?.trim()||void 0}_rebuildToc(){let e=this._sectionCards(),t=e.map(e=>({title:this._sectionTitle(e),el:e})).filter(e=>!!e.title),n=this.component?.metadata?.toc,r=t.length>4&&e.every(e=>!e.closest(`vaadin-horizontal-layout`)),i=(n===!0||n!==!1&&r)&&t.length>0;this._tocEntries=t,this._tocVisible=i,this._activeToc>=t.length&&(this._activeToc=0),this._teardownScrollSpy(),i?requestAnimationFrame(()=>{this._layoutStickyTops(),this._setupScrollSpy()}):this._layoutStickyTops()}_layoutStickyTops(){let e=this.shadowRoot?.querySelector(`mateu-content-header`);this._headerH=this._tocVisible&&e?e.offsetHeight:0,this.style.setProperty(`--mateu-header-h`,this._headerH+`px`);let t=this._headerH+12;for(let e of this._sectionCards())e.classList.contains(`mateu-section--sticky`)&&(e.style.top=t+`px`,t+=e.offsetHeight+12)}_scrollContainer(){let e=ho(this);for(;e;){let t=getComputedStyle(e).overflowY;if((t===`auto`||t===`scroll`)&&e.scrollHeight>e.clientHeight)return e;e=ho(e)}return null}_setupScrollSpy(){this._tocEntries.length&&(this._spyTarget=this._scrollContainer()??window,this._spyTarget.addEventListener(`scroll`,this._onScrollSpy,{passive:!0}),window.addEventListener(`wheel`,this._unlockToc,{passive:!0}),window.addEventListener(`touchstart`,this._unlockToc,{passive:!0}),window.addEventListener(`keydown`,this._unlockToc),this._onScrollSpy())}_teardownScrollSpy(){this._spyTarget?.removeEventListener(`scroll`,this._onScrollSpy),window.removeEventListener(`wheel`,this._unlockToc),window.removeEventListener(`touchstart`,this._unlockToc),window.removeEventListener(`keydown`,this._unlockToc),this._spyTarget=void 0}_scrollToSection(e){let t=this._tocEntries[e];if(!t)return;this._activeToc=e,this._tocLocked=!0;let n=this._headerH+12;for(let e of this._sectionCards()){if(e===t.el)break;e.classList.contains(`mateu-section--sticky`)&&(n+=e.offsetHeight+12)}let r=this._scrollContainer(),i=r?r.getBoundingClientRect().top:0,a=t.el.getBoundingClientRect().top-i-n;(r??window).scrollBy({top:a,behavior:`smooth`})}_showHeaderBand(){let e=this.component?.metadata,t=!!(e?.title||e?.subtitle||e?.overline||e?.titlePlaceholder||e?.toolbar?.length),n=!!this.component?.children?.some(e=>e.metadata?.type===j.Crud);return t&&!n&&!this._hasWelcomeBanner()}_hasWelcomeBanner(){let e=t=>t?.metadata?.type===j.HeroSection||(t?.children??[]).some(e);return(this.component?.children??[]).some(e)}render(){let e=this.component?.metadata,t=[...(e?.banners??[]).map((e,t)=>({banner:e,index:t})).filter(({index:e})=>!this.dismissedStaticBannerIndices.has(e)).map(({banner:e,index:t})=>({banner:e,onDismiss:()=>this._dismissStaticBanner(t)})),...this.actionBanners.map((e,t)=>({banner:e,onDismiss:()=>this._dismissActionBanner(t)}))];return T`<div style="display: flex; flex-direction: column; width: 100%;">${T`
             <div class="page-header-wrap">
                 <mateu-content-header
                     class="${this._tocVisible?`sticky-header`:``}"
@@ -5987,7 +5995,7 @@ ${i}
                 `:v}
             </div>
             <div class="form-footer">
-                ${e?.footer?.map(e=>I(this,e,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData))}
+                ${e?.footer?.map(e=>F(this,e,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData))}
             </div>
         `}</div>`}static{this.styles=h`
         /* Design-system hook: background behind the page header (the RDS "Header + Background"
@@ -6188,7 +6196,7 @@ ${i}
             background: #fdf2f2;
             border-leftx: 4px solid var(--lumo-error-color);
         }
-    `}};k([y()],J.prototype,`component`,void 0),k([y()],J.prototype,`baseUrl`,void 0),k([y()],J.prototype,`state`,void 0),k([y()],J.prototype,`data`,void 0),k([y()],J.prototype,`appState`,void 0),k([y()],J.prototype,`appData`,void 0),k([y()],J.prototype,`value`,void 0),k([y({type:Boolean})],J.prototype,`standalone`,void 0),k([C()],J.prototype,`actionBanners`,void 0),k([C()],J.prototype,`dismissedStaticBannerIndices`,void 0),k([C()],J.prototype,`_tocEntries`,void 0),k([C()],J.prototype,`_activeToc`,void 0),k([C()],J.prototype,`_tocVisible`,void 0),J=k([g(`mateu-page`)],J);var ho=h`
+    `}};k([y()],q.prototype,`component`,void 0),k([y()],q.prototype,`baseUrl`,void 0),k([y()],q.prototype,`state`,void 0),k([y()],q.prototype,`data`,void 0),k([y()],q.prototype,`appState`,void 0),k([y()],q.prototype,`appData`,void 0),k([y()],q.prototype,`value`,void 0),k([y({type:Boolean})],q.prototype,`standalone`,void 0),k([C()],q.prototype,`actionBanners`,void 0),k([C()],q.prototype,`dismissedStaticBannerIndices`,void 0),k([C()],q.prototype,`_tocEntries`,void 0),k([C()],q.prototype,`_activeToc`,void 0),k([C()],q.prototype,`_tocVisible`,void 0),q=k([g(`mateu-page`)],q);var go=h`
     .nbtn {
         display: inline-flex;
         align-items: center;
@@ -6217,25 +6225,25 @@ ${i}
     }
     .nbtn.primary:hover { background: var(--lumo-primary-color, #1676f3); filter: brightness(1.08); }
     .nbtn svg { width: 1em; height: 1em; flex-shrink: 0; }
-`,go=e=>w`
+`,_o=e=>w`
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-         stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${e}</svg>`,_o=go(w`
+         stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${e}</svg>`,vo=_o(w`
     <circle cx="12" cy="12" r="3"></circle>
-    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path>`),vo=go(w`
+    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path>`),yo=_o(w`
     <line x1="12" y1="5" x2="12" y2="19"></line>
-    <line x1="5" y1="12" x2="19" y2="12"></line>`),yo=go(w`
+    <line x1="5" y1="12" x2="19" y2="12"></line>`),bo=_o(w`
     <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
     <polyline points="7 10 12 15 17 10"></polyline>
-    <line x1="12" y1="15" x2="12" y2="3"></line>`);go(w`
+    <line x1="12" y1="15" x2="12" y2="3"></line>`);_o(w`
     <rect x="9" y="2" width="6" height="5" rx="1"></rect>
     <rect x="2" y="17" width="6" height="5" rx="1"></rect>
     <rect x="16" y="17" width="6" height="5" rx="1"></rect>
-    <path d="M12 7v4M5 17v-3h14v3M12 11v3"></path>`);var bo=go(w`
+    <path d="M12 7v4M5 17v-3h14v3M12 11v3"></path>`);var xo=_o(w`
     <rect x="9" y="2" width="6" height="12" rx="3"></rect>
     <path d="M5 10v1a7 7 0 0 0 14 0v-1"></path>
-    <line x1="12" y1="18" x2="12" y2="22"></line>`),xo=go(w`
+    <line x1="12" y1="18" x2="12" y2="22"></line>`),So=_o(w`
     <line x1="18" y1="6" x2="6" y2="18"></line>
-    <line x1="6" y1="6" x2="18" y2="18"></line>`),So=[`#e91e63`,`#1676f3`,`#10b981`,`#8b5cf6`,`#f59e0b`,`#ef4444`],Co=e=>So[Math.abs(e??0)%So.length],wo=e=>(e??`?`).split(/\s+/).filter(e=>e).map(e=>e[0]).slice(0,2).join(``).toUpperCase()||`?`,Y=class extends b{constructor(...e){super(...e),this.localAgentUrl=`http://127.0.0.1:8776`,this.localAgentAlive=!1,this.menu=[],this.chatSessionId=E(),this.menuContextSent=!1,this.attachments=[],this.uploading=!1,this.expanded=!1,this.toggleExpanded=()=>{this.expanded=!this.expanded},this.items=[],this.listening=!1,this.recognitionAvailable=!1,this.loading=!1,this.elapsedSeconds=0,this.startListening=()=>{this.recognition&&(this.listening?(this.recognition.stop(),this.listening=!1):(this.recognition.start(),this.listening=!0))},this.onSpeechResult=e=>{if(this.recognition){let t=e,n=t.results[t.results[0].length-1][0].transcript;this.messageInputElement&&(this.messageInputElement.value=n,this.send(new CustomEvent(`submit`,{detail:{value:n},bubbles:!0,composed:!0})))}},this.probeLocalAgent=async()=>{if(this.localAgentUrl)try{let e=new AbortController,t=setTimeout(()=>e.abort(),1200),n=await fetch(this.localAgentUrl+`/health`,{signal:e.signal});clearTimeout(t),this.localAgentAlive=n.ok}catch{this.localAgentAlive=!1}},this.pickFiles=()=>this.fileInputElement?.click(),this.onFilesPicked=async e=>{let t=e.target,n=Array.from(t.files??[]);if(t.value=``,!(!n.length||!this.uploadUrl)){this.uploading=!0;try{let e=new FormData;e.append(`sessionId`,this.chatSessionId);for(let t of n)e.append(`files`,t,t.name);let t={},r=localStorage.getItem(`__mateu_auth_token`);r&&(t.Authorization=`Bearer `+r);let i=sessionStorage.getItem(`__mateu_sesion_id`);i&&(t[`X-Session-Id`]=i);let a=await fetch(this.uploadUrl,{method:`POST`,headers:t,body:e});if(!a.ok)throw Error(`Upload failed: ${a.status}`);let o=((await a.json()).files??[]).filter(e=>e&&e.path);this.attachments=[...this.attachments,...o]}catch(e){this.addMessage(`⚠️ No se pudieron subir los ficheros: ${e instanceof Error?e.message:e}`,`agent`)}finally{this.uploading=!1}}},this.removeAttachment=e=>{this.attachments=this.attachments.filter(t=>t.path!==e)},this.send=async e=>{this.messageInputElement?.setAttribute(`disabled`,`disabled`);let t=e.detail.value.trim(),n=this.localAgentAlive?this.localAgentUrl+`/mateu/agent/stream`:this.sseUrl,r=this.attachments;if(!t&&r.length===0||!n)return;let i=r.length?`${t}${t?`
+    <line x1="6" y1="6" x2="18" y2="18"></line>`),Co=[`#e91e63`,`#1676f3`,`#10b981`,`#8b5cf6`,`#f59e0b`,`#ef4444`],wo=e=>Co[Math.abs(e??0)%Co.length],To=e=>(e??`?`).split(/\s+/).filter(e=>e).map(e=>e[0]).slice(0,2).join(``).toUpperCase()||`?`,J=class extends b{constructor(...e){super(...e),this.localAgentUrl=`http://127.0.0.1:8776`,this.localAgentAlive=!1,this.menu=[],this.chatSessionId=E(),this.menuContextSent=!1,this.attachments=[],this.uploading=!1,this.expanded=!1,this.toggleExpanded=()=>{this.expanded=!this.expanded},this.items=[],this.listening=!1,this.recognitionAvailable=!1,this.loading=!1,this.elapsedSeconds=0,this.startListening=()=>{this.recognition&&(this.listening?(this.recognition.stop(),this.listening=!1):(this.recognition.start(),this.listening=!0))},this.onSpeechResult=e=>{if(this.recognition){let t=e,n=t.results[t.results[0].length-1][0].transcript;this.messageInputElement&&(this.messageInputElement.value=n,this.send(new CustomEvent(`submit`,{detail:{value:n},bubbles:!0,composed:!0})))}},this.probeLocalAgent=async()=>{if(this.localAgentUrl)try{let e=new AbortController,t=setTimeout(()=>e.abort(),1200),n=await fetch(this.localAgentUrl+`/health`,{signal:e.signal});clearTimeout(t),this.localAgentAlive=n.ok}catch{this.localAgentAlive=!1}},this.pickFiles=()=>this.fileInputElement?.click(),this.onFilesPicked=async e=>{let t=e.target,n=Array.from(t.files??[]);if(t.value=``,!(!n.length||!this.uploadUrl)){this.uploading=!0;try{let e=new FormData;e.append(`sessionId`,this.chatSessionId);for(let t of n)e.append(`files`,t,t.name);let t={},r=localStorage.getItem(`__mateu_auth_token`);r&&(t.Authorization=`Bearer `+r);let i=sessionStorage.getItem(`__mateu_sesion_id`);i&&(t[`X-Session-Id`]=i);let a=await fetch(this.uploadUrl,{method:`POST`,headers:t,body:e});if(!a.ok)throw Error(`Upload failed: ${a.status}`);let o=((await a.json()).files??[]).filter(e=>e&&e.path);this.attachments=[...this.attachments,...o]}catch(e){this.addMessage(`⚠️ No se pudieron subir los ficheros: ${e instanceof Error?e.message:e}`,`agent`)}finally{this.uploading=!1}}},this.removeAttachment=e=>{this.attachments=this.attachments.filter(t=>t.path!==e)},this.send=async e=>{this.messageInputElement?.setAttribute(`disabled`,`disabled`);let t=e.detail.value.trim(),n=this.localAgentAlive?this.localAgentUrl+`/mateu/agent/stream`:this.sseUrl,r=this.attachments;if(!t&&r.length===0||!n)return;let i=r.length?`${t}${t?`
 
 `:``}📎 ${r.map(e=>e.name).join(`, `)}`:t;this.addMessage(i,`user`),this.attachments=[];let a=this.addMessage(``,`agent`);this.startLoading();let o=``;try{let e={Accept:`text/event-stream`,"Content-Type":`application/json`},i=localStorage.getItem(`__mateu_auth_token`);i&&(e.Authorization=`Bearer `+i);let s=sessionStorage.getItem(`__mateu_sesion_id`);s&&(e[`X-Session-Id`]=s);let c=this.contextProvider?.(),l=JSON.stringify({message:t,sessionId:this.chatSessionId,...r.length&&{attachments:r},...c!=null&&{context:c},...this.mcpUrl&&{mcpUrl:new URL(this.mcpUrl,window.location.origin).href},...!this.menuContextSent&&{menuContext:this.buildMenuContext(this.menu)}});this.menuContextSent=!0;let u=await fetch(n,{method:`POST`,headers:e,body:l});if(!u.ok){let e=await u.text();throw Error(`Servidor respondió ${u.status}: ${e}`)}let d=u.body?.getReader();if(!d)throw Error(`No se pudo obtener el reader del stream.`);let f=new TextDecoder,p=``;for(;;){let{done:e,value:t}=await d.read();if(e){if(p.trim().startsWith(`data:`)){let e=p.trim().slice(5).trim(),t=this.tryParseTokenUsage(e),n=!t&&this.tryParseCustomEvent(e);t?this.tokenUsage={...this.tokenUsage,...t}:n?n.event===`agent-error`?(o=`⚠️ `+(n.detail?.message??`Error desconocido del agente`),this.updateMessage(a,o)):this.dispatchEvent(new CustomEvent(n.event,{detail:n.detail,bubbles:!0,composed:!0})):(o+=e,this.updateMessage(a,o))}break}let n=f.decode(t,{stream:!0});p+=n;let r=p.split(`
 `);p=r.pop()||``;let i=!1;for(let e of r)if(e.trim().startsWith(`data:`)){let t=e.trim().slice(5).trim(),n=this.tryParseTokenUsage(t),r=!n&&this.tryParseCustomEvent(t);n?this.tokenUsage={...this.tokenUsage,...n}:r?r.event===`agent-error`?(o=`⚠️ `+(r.detail?.message??`Error desconocido del agente`),this.updateMessage(a,o)):this.dispatchEvent(new CustomEvent(r.event,{detail:r.detail,bubbles:!0,composed:!0})):(o+=t+`
@@ -6250,14 +6258,14 @@ ${i}
                         ${this.expanded?`⤡`:`⤢`}
                     </button>
                     <button class="chat-close" @click="${this.closeChat}" title="Cerrar">
-                        ${xo}
+                        ${So}
                     </button>
                 </div>
                 <div class="scroll-container">
                     <div class="message-list" role="list">
                         ${this.items.map(e=>T`
                             <div class="message" role="listitem">
-                                <div class="avatar" style="background: ${Co(e.userColorIndex)};">${wo(e.userName)}</div>
+                                <div class="avatar" style="background: ${wo(e.userColorIndex)};">${To(e.userName)}</div>
                                 <div class="message-body">
                                     <div class="message-meta">
                                         <span class="message-name">${e.userName}</span>
@@ -6305,7 +6313,7 @@ ${i}
                             style="color: ${this.listening?`red`:`var(--lumo-contrast-50pct, #767676)`};"
                             @click="${this.startListening}"
                             ?disabled="${!this.recognitionAvailable}"
-                    >${bo}</button>
+                    >${xo}</button>
                     <input class="msg-input"
                            placeholder="Message"
                            aria-label="Message"
@@ -6313,7 +6321,7 @@ ${i}
                     <button class="nbtn primary" ?disabled="${this.loading}" @click="${this.submitFromInput}">Send</button>
                 </div>
             </div>
-        `}static{this.styles=[ho,h`
+        `}static{this.styles=[go,h`
         :host {
             display: block;
             height: 100%;
@@ -6638,7 +6646,7 @@ ${i}
         @keyframes spin {
             to { transform: rotate(360deg); }
         }
-    `]}};k([y({attribute:!1})],Y.prototype,`contextProvider`,void 0),k([y()],Y.prototype,`localAgentUrl`,void 0),k([y({attribute:!1})],Y.prototype,`mcpUrl`,void 0),k([C()],Y.prototype,`localAgentAlive`,void 0),k([y()],Y.prototype,`sseUrl`,void 0),k([y()],Y.prototype,`uploadUrl`,void 0),k([y({attribute:!1})],Y.prototype,`menu`,void 0),k([C()],Y.prototype,`attachments`,void 0),k([C()],Y.prototype,`uploading`,void 0),k([x(`.file-input`)],Y.prototype,`fileInputElement`,void 0),k([y({type:Boolean,reflect:!0})],Y.prototype,`expanded`,void 0),k([y()],Y.prototype,`items`,void 0),k([x(`.scroll-container`)],Y.prototype,`scrollContainer`,void 0),k([x(`.msg-input`)],Y.prototype,`messageInputElement`,void 0),k([C()],Y.prototype,`recognition`,void 0),k([C()],Y.prototype,`listening`,void 0),k([C()],Y.prototype,`recognitionAvailable`,void 0),k([C()],Y.prototype,`loading`,void 0),k([C()],Y.prototype,`elapsedSeconds`,void 0),k([C()],Y.prototype,`tokenUsage`,void 0),Y=k([g(`mateu-chat`)],Y);var To=class extends b{updated(e){super.updated(e),this.chart&&=(this.chart.destroy(),void 0),this.data&&this.createChart(this.data)}async createChart(e){let[{default:t}]=await Promise.all([D(()=>import(`./vendor-chartjs.js`).then(e=>e.n),__vite__mapDeps([3,1])),D(()=>import(`./vendor-chartjs.js`).then(e=>e.t),__vite__mapDeps([3,1]))]);if(e!==this.data)return;this.chart&&this.chart.destroy();let n={type:this.type,data:this.data,options:this.options};this.chart=new t(this.chartElement,n)}handleSlotChange(){}render(){return T`
+    `]}};k([y({attribute:!1})],J.prototype,`contextProvider`,void 0),k([y()],J.prototype,`localAgentUrl`,void 0),k([y({attribute:!1})],J.prototype,`mcpUrl`,void 0),k([C()],J.prototype,`localAgentAlive`,void 0),k([y()],J.prototype,`sseUrl`,void 0),k([y()],J.prototype,`uploadUrl`,void 0),k([y({attribute:!1})],J.prototype,`menu`,void 0),k([C()],J.prototype,`attachments`,void 0),k([C()],J.prototype,`uploading`,void 0),k([x(`.file-input`)],J.prototype,`fileInputElement`,void 0),k([y({type:Boolean,reflect:!0})],J.prototype,`expanded`,void 0),k([y()],J.prototype,`items`,void 0),k([x(`.scroll-container`)],J.prototype,`scrollContainer`,void 0),k([x(`.msg-input`)],J.prototype,`messageInputElement`,void 0),k([C()],J.prototype,`recognition`,void 0),k([C()],J.prototype,`listening`,void 0),k([C()],J.prototype,`recognitionAvailable`,void 0),k([C()],J.prototype,`loading`,void 0),k([C()],J.prototype,`elapsedSeconds`,void 0),k([C()],J.prototype,`tokenUsage`,void 0),J=k([g(`mateu-chat`)],J);var Eo=class extends b{updated(e){super.updated(e),this.chart&&=(this.chart.destroy(),void 0),this.data&&this.createChart(this.data)}async createChart(e){let[{default:t}]=await Promise.all([D(()=>import(`./vendor-chartjs.js`).then(e=>e.n),__vite__mapDeps([3,1])),D(()=>import(`./vendor-chartjs.js`).then(e=>e.t),__vite__mapDeps([3,1]))]);if(e!==this.data)return;this.chart&&this.chart.destroy();let n={type:this.type,data:this.data,options:this.options};this.chart=new t(this.chartElement,n)}handleSlotChange(){}render(){return T`
             <div class="container">
                 <canvas id="chart"></canvas>
             </div>
@@ -6655,7 +6663,7 @@ ${i}
         height: 100%;
         position: relative;
     }
-  `}};k([y()],To.prototype,`type`,void 0),k([y()],To.prototype,`data`,void 0),k([y()],To.prototype,`options`,void 0),k([x(`#chart`)],To.prototype,`chartElement`,void 0),To=k([g(`mateu-chart`)],To);var Eo=class extends b{updated(e){super.updated(e),this.chart&&=(this.chart.destroy(),void 0),this.xml&&this.createViewer(this.xml)}async createViewer(e){let{default:t}=await D(async()=>{let{default:e}=await import(`./vendor-diagrams.js`).then(e=>e.t);return{default:e}},__vite__mapDeps([4,1,2]));if(e!==this.xml)return;this.chart&&this.chart.destroy();let n={container:this.divElement};this.chart=new t(n),this.chart.importXML(e)}handleSlotChange(){}render(){return T`
+  `}};k([y()],Eo.prototype,`type`,void 0),k([y()],Eo.prototype,`data`,void 0),k([y()],Eo.prototype,`options`,void 0),k([x(`#chart`)],Eo.prototype,`chartElement`,void 0),Eo=k([g(`mateu-chart`)],Eo);var Do=class extends b{updated(e){super.updated(e),this.chart&&=(this.chart.destroy(),void 0),this.xml&&this.createViewer(this.xml)}async createViewer(e){let{default:t}=await D(async()=>{let{default:e}=await import(`./vendor-diagrams.js`).then(e=>e.t);return{default:e}},__vite__mapDeps([4,1,2]));if(e!==this.xml)return;this.chart&&this.chart.destroy();let n={container:this.divElement};this.chart=new t(n),this.chart.importXML(e)}handleSlotChange(){}render(){return T`
             <div class="container" style="width: 20rem; height: 15rem; overflow: auto;">
                 <!-- BPMN diagram container -->
                 <div id="canvas" style="width: 60rem; height: 30rem; zoom: 0.5;"></div>
@@ -6664,7 +6672,7 @@ ${i}
                 <slot @slotchange=${this.handleSlotChange}></slot>
             </div>
        `}static{this.styles=h`
-  `}};k([y()],Eo.prototype,`xml`,void 0),k([x(`#canvas`)],Eo.prototype,`divElement`,void 0),Eo=k([g(`mateu-bpmn`)],Eo);var Do=160,Oo=56,ko=220,Ao=110,jo=60,Mo={ACTION:`#3B82F6`,JOIN:`#8B5CF6`,FORK:`#F59E0B`,END:`#EF4444`,USER_TASK:`#10B981`,PROCESS:`#6366F1`},No={ACTION:`▶`,JOIN:`⟨`,FORK:`⟩`,END:`◼`,USER_TASK:`👤`,PROCESS:`⚙`},Po=[`ACTION`,`JOIN`,`FORK`,`END`,`USER_TASK`,`PROCESS`];function Fo(){return`step-`+Math.random().toString(36).slice(2,8)}var Io=class extends b{constructor(...e){super(...e),this.value=`{"name":"New Workflow","steps":[]}`,this.wf={name:`New Workflow`,steps:[]},this.positions={},this.selectedId=null,this.showMeta=!1,this.draggingId=null,this.dragOffset={x:0,y:0},this.svgEl=null,this.onMouseMove=e=>{if(!this.draggingId||!this.svgEl)return;let t=this.toSvgPoint(e);this.positions={...this.positions,[this.draggingId]:{x:Math.max(0,t.x-this.dragOffset.x),y:Math.max(0,t.y-this.dragOffset.y)}}},this.onMouseUp=()=>{this.draggingId=null,window.removeEventListener(`mousemove`,this.onMouseMove),window.removeEventListener(`mouseup`,this.onMouseUp)}}updated(e){if(e.has(`value`)){try{this.wf=JSON.parse(this.value)}catch{}this.autoLayout()}}autoLayout(){let e=this.wf.steps??[],t={};e.forEach(e=>{t[e.id]=0});let n=!0;for(;n;)n=!1,e.forEach(e=>{if(e.preconditionStepId!=null&&t[e.preconditionStepId]!==void 0){let r=t[e.preconditionStepId]+1;r>t[e.id]&&(t[e.id]=r,n=!0)}});let r={};e.forEach(e=>{let n=t[e.id]??0;(r[n]??=[]).push(e.id)});let i={...this.positions},a=!1;Object.entries(r).forEach(([e,t])=>{let n=Number(e);t.forEach((e,t)=>{i[e]||(i[e]={x:jo+n*ko,y:jo+t*Ao},a=!0)})}),a&&(this.positions=i)}emit(){let e=JSON.stringify(this.wf,null,2);this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e},bubbles:!0,composed:!0}))}updateWf(e){this.wf={...this.wf,...e},this.emit()}updateStep(e,t){this.wf={...this.wf,steps:this.wf.steps.map(n=>n.id===e?{...n,...t}:n)},this.emit()}addStep(){let e=Fo(),t={id:e,type:`ACTION`,name:`New Step`};this.wf={...this.wf,steps:[...this.wf.steps??[],t]};let n=Object.values(this.positions).map(e=>e.y),r=n.length?Math.max(...n)+Ao:jo;this.positions={...this.positions,[e]:{x:jo,y:r}},this.selectedId=e,this.emit()}deleteStep(e){this.wf={...this.wf,steps:this.wf.steps.filter(t=>t.id!==e).map(t=>t.preconditionStepId===e?{...t,preconditionStepId:void 0}:t)};let{[e]:t,...n}=this.positions;this.positions=n,this.selectedId===e&&(this.selectedId=null),this.emit()}onNodeMouseDown(e,t){e.preventDefault(),this.draggingId=t;let n=this.positions[t]??{x:0,y:0},r=this.toSvgPoint(e);this.dragOffset={x:r.x-n.x,y:r.y-n.y},this.svgEl=e.currentTarget.closest(`svg`),window.addEventListener(`mousemove`,this.onMouseMove),window.addEventListener(`mouseup`,this.onMouseUp)}toSvgPoint(e){if(!this.svgEl)return{x:0,y:0};let t=this.svgEl.getBoundingClientRect();return{x:e.clientX-t.left,y:e.clientY-t.top}}canvasSize(){let e=Object.values(this.positions),t=e.length?Math.max(...e.map(e=>e.x))+Do+jo:600,n=e.length?Math.max(...e.map(e=>e.y))+Oo+jo:400;return{w:Math.max(t,600),h:Math.max(n,400)}}render(){let{w:e,h:t}=this.canvasSize(),n=this.wf.steps??[];return T`
+  `}};k([y()],Do.prototype,`xml`,void 0),k([x(`#canvas`)],Do.prototype,`divElement`,void 0),Do=k([g(`mateu-bpmn`)],Do);var Oo=160,ko=56,Ao=220,jo=110,Mo=60,No={ACTION:`#3B82F6`,JOIN:`#8B5CF6`,FORK:`#F59E0B`,END:`#EF4444`,USER_TASK:`#10B981`,PROCESS:`#6366F1`},Po={ACTION:`▶`,JOIN:`⟨`,FORK:`⟩`,END:`◼`,USER_TASK:`👤`,PROCESS:`⚙`},Fo=[`ACTION`,`JOIN`,`FORK`,`END`,`USER_TASK`,`PROCESS`];function Io(){return`step-`+Math.random().toString(36).slice(2,8)}var Lo=class extends b{constructor(...e){super(...e),this.value=`{"name":"New Workflow","steps":[]}`,this.wf={name:`New Workflow`,steps:[]},this.positions={},this.selectedId=null,this.showMeta=!1,this.draggingId=null,this.dragOffset={x:0,y:0},this.svgEl=null,this.onMouseMove=e=>{if(!this.draggingId||!this.svgEl)return;let t=this.toSvgPoint(e);this.positions={...this.positions,[this.draggingId]:{x:Math.max(0,t.x-this.dragOffset.x),y:Math.max(0,t.y-this.dragOffset.y)}}},this.onMouseUp=()=>{this.draggingId=null,window.removeEventListener(`mousemove`,this.onMouseMove),window.removeEventListener(`mouseup`,this.onMouseUp)}}updated(e){if(e.has(`value`)){try{this.wf=JSON.parse(this.value)}catch{}this.autoLayout()}}autoLayout(){let e=this.wf.steps??[],t={};e.forEach(e=>{t[e.id]=0});let n=!0;for(;n;)n=!1,e.forEach(e=>{if(e.preconditionStepId!=null&&t[e.preconditionStepId]!==void 0){let r=t[e.preconditionStepId]+1;r>t[e.id]&&(t[e.id]=r,n=!0)}});let r={};e.forEach(e=>{let n=t[e.id]??0;(r[n]??=[]).push(e.id)});let i={...this.positions},a=!1;Object.entries(r).forEach(([e,t])=>{let n=Number(e);t.forEach((e,t)=>{i[e]||(i[e]={x:Mo+n*Ao,y:Mo+t*jo},a=!0)})}),a&&(this.positions=i)}emit(){let e=JSON.stringify(this.wf,null,2);this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e},bubbles:!0,composed:!0}))}updateWf(e){this.wf={...this.wf,...e},this.emit()}updateStep(e,t){this.wf={...this.wf,steps:this.wf.steps.map(n=>n.id===e?{...n,...t}:n)},this.emit()}addStep(){let e=Io(),t={id:e,type:`ACTION`,name:`New Step`};this.wf={...this.wf,steps:[...this.wf.steps??[],t]};let n=Object.values(this.positions).map(e=>e.y),r=n.length?Math.max(...n)+jo:Mo;this.positions={...this.positions,[e]:{x:Mo,y:r}},this.selectedId=e,this.emit()}deleteStep(e){this.wf={...this.wf,steps:this.wf.steps.filter(t=>t.id!==e).map(t=>t.preconditionStepId===e?{...t,preconditionStepId:void 0}:t)};let{[e]:t,...n}=this.positions;this.positions=n,this.selectedId===e&&(this.selectedId=null),this.emit()}onNodeMouseDown(e,t){e.preventDefault(),this.draggingId=t;let n=this.positions[t]??{x:0,y:0},r=this.toSvgPoint(e);this.dragOffset={x:r.x-n.x,y:r.y-n.y},this.svgEl=e.currentTarget.closest(`svg`),window.addEventListener(`mousemove`,this.onMouseMove),window.addEventListener(`mouseup`,this.onMouseUp)}toSvgPoint(e){if(!this.svgEl)return{x:0,y:0};let t=this.svgEl.getBoundingClientRect();return{x:e.clientX-t.left,y:e.clientY-t.top}}canvasSize(){let e=Object.values(this.positions),t=e.length?Math.max(...e.map(e=>e.x))+Oo+Mo:600,n=e.length?Math.max(...e.map(e=>e.y))+ko+Mo:400;return{w:Math.max(t,600),h:Math.max(n,400)}}render(){let{w:e,h:t}=this.canvasSize(),n=this.wf.steps??[];return T`
             <div class="root">
                 ${this.renderToolbar()}
                 ${this.showMeta?this.renderMeta():``}
@@ -6691,15 +6699,15 @@ ${i}
                 <span class="badge badge-${e.toLowerCase()}">${e}</span>
                 <div style="flex:1"></div>
                 <button class="nbtn" @click="${()=>this.showMeta=!this.showMeta}">
-                    ${_o}
+                    ${vo}
                     Settings
                 </button>
                 <button class="nbtn primary" @click="${()=>this.addStep()}">
-                    ${vo}
+                    ${yo}
                     Add Step
                 </button>
                 <button class="nbtn" @click="${()=>this.exportJson()}">
-                    ${yo}
+                    ${bo}
                     Export
                 </button>
             </div>
@@ -6728,27 +6736,27 @@ ${i}
                     `:``}
                 </div>
             </div>
-        `}renderArrow(e){if(!e.preconditionStepId)return w``;let t=this.positions[e.preconditionStepId],n=this.positions[e.id];if(!t||!n)return w``;let r=t.x+Do,i=t.y+Oo/2,a=n.x,o=n.y+Oo/2,s=(r+a)/2;return w`
+        `}renderArrow(e){if(!e.preconditionStepId)return w``;let t=this.positions[e.preconditionStepId],n=this.positions[e.id];if(!t||!n)return w``;let r=t.x+Oo,i=t.y+ko/2,a=n.x,o=n.y+ko/2,s=(r+a)/2;return w`
             <path d="M${r},${i} C${s},${i} ${s},${o} ${a},${o}"
                   fill="none" stroke="#94a3b8" stroke-width="2"
                   marker-end="url(#arrow)"/>
-        `}renderNode(e){let t=this.positions[e.id]??{x:jo,y:jo},n=Mo[e.type]??`#64748b`,r=No[e.type]??`•`,i=this.selectedId===e.id;return w`
+        `}renderNode(e){let t=this.positions[e.id]??{x:Mo,y:Mo},n=No[e.type]??`#64748b`,r=Po[e.type]??`•`,i=this.selectedId===e.id;return w`
             <g transform="translate(${t.x},${t.y})"
                style="cursor:grab"
                @mousedown="${t=>this.onNodeMouseDown(t,e.id)}"
                @click="${t=>{t.stopPropagation(),this.selectedId=e.id}}">
-                <rect width="${Do}" height="${Oo}" rx="8"
+                <rect width="${Oo}" height="${ko}" rx="8"
                       fill="white"
                       stroke="${i?n:`#e2e8f0`}"
                       stroke-width="${i?2.5:1.5}"
                       filter="url(#shadow)"/>
                 <!-- type badge -->
-                <rect x="0" y="0" width="32" height="${Oo}" rx="8" fill="${n}" clip-path="inset(0 -8px 0 0 round 8px)"/>
-                <rect x="24" y="0" width="8" height="${Oo}" fill="${n}"/>
+                <rect x="0" y="0" width="32" height="${ko}" rx="8" fill="${n}" clip-path="inset(0 -8px 0 0 round 8px)"/>
+                <rect x="24" y="0" width="8" height="${ko}" fill="${n}"/>
                 <text x="16" y="${33}" text-anchor="middle"
                       font-size="14" fill="white">${r}</text>
                 <!-- name -->
-                <text x="44" y="${Oo/2-6}" font-size="11" fill="#1e293b" font-weight="600">
+                <text x="44" y="${ko/2-6}" font-size="11" fill="#1e293b" font-weight="600">
                     ${e.name.length>16?e.name.slice(0,15)+`…`:e.name}
                 </text>
                 <text x="44" y="${36}" font-size="9" fill="#94a3b8">${e.id}</text>
@@ -6773,7 +6781,7 @@ ${i}
                         @change="${t=>this.updateStep(e.id,{name:t.target.value})}"/>`)}
                     ${n(`Type`,T`
                         <select class="inp" @change="${t=>this.updateStep(e.id,{type:t.target.value})}">
-                            ${Po.map(t=>T`<option value="${t}" ?selected="${e.type===t}">${t}</option>`)}
+                            ${Fo.map(t=>T`<option value="${t}" ?selected="${e.type===t}">${t}</option>`)}
                         </select>`)}
                     ${n(`Description`,T`<textarea class="inp" rows="2"
                         @change="${t=>this.updateStep(e.id,{description:t.target.value})}">${e.description??``}</textarea>`)}
@@ -6818,7 +6826,7 @@ ${i}
                         @change="${t=>this.updateStep(e.id,{childWorkflowDefinitionId:t.target.value||void 0})}"/>`):``}
                 </div>
             </div>
-        `}exportJson(){let e=JSON.stringify(this.wf,null,2),t=new Blob([e],{type:`application/json`}),n=URL.createObjectURL(t),r=document.createElement(`a`);r.href=n,r.download=(this.wf.name??`workflow`).replace(/\s+/g,`-`).toLowerCase()+`.json`,r.click(),URL.revokeObjectURL(n)}static{this.styles=[ho,h`
+        `}exportJson(){let e=JSON.stringify(this.wf,null,2),t=new Blob([e],{type:`application/json`}),n=URL.createObjectURL(t),r=document.createElement(`a`);r.href=n,r.download=(this.wf.name??`workflow`).replace(/\s+/g,`-`).toLowerCase()+`.json`,r.click(),URL.revokeObjectURL(n)}static{this.styles=[go,h`
         :host { display: block; height: 100%; font-family: var(--lumo-font-family, sans-serif); }
 
         .root { display: flex; flex-direction: column; height: 100%; background: var(--lumo-base-color, #fff); }
@@ -6896,7 +6904,7 @@ ${i}
         .inp:focus { border-color: #3B82F6; }
         textarea.inp { resize: vertical; }
         input[readonly].inp { background: #f8fafc; color: #94a3b8; }
-    `]}};k([y()],Io.prototype,`value`,void 0),k([C()],Io.prototype,`wf`,void 0),k([C()],Io.prototype,`positions`,void 0),k([C()],Io.prototype,`selectedId`,void 0),k([C()],Io.prototype,`showMeta`,void 0),Io=k([g(`mateu-workflow`)],Io);var Lo=[`string`,`integer`,`number`,`bool`,`date`,`time`,`dateTime`,`dateRange`,`money`,`file`,`array`,`status`,`component`,`menu`,`range`,`action`,`actionGroup`],Ro=[`regular`,`radio`,`checkbox`,`textarea`,`toggle`,`combobox`,`select`,`email`,`password`,`richText`,`listBox`,`html`,`markdown`,`image`,`icon`,`link`,`money`,`grid`,`color`,`choice`,`popover`,`slider`,`button`,`stars`],zo={string:`#3B82F6`,integer:`#8B5CF6`,number:`#6366F1`,bool:`#10B981`,date:`#F59E0B`,time:`#F59E0B`,dateTime:`#F59E0B`,dateRange:`#F59E0B`,money:`#EF4444`,file:`#64748B`,array:`#0EA5E9`,status:`#EC4899`,component:`#14B8A6`,menu:`#94A3B8`,range:`#A855F7`,action:`#F97316`,actionGroup:`#FB923C`};function Bo(){return`field-`+Math.random().toString(36).slice(2,8)}var Vo=class extends b{constructor(...e){super(...e),this.value=`{"name":"New Form","fields":[]}`,this.form={name:`New Form`,fields:[]},this.selectedId=null,this.showMeta=!1,this.sortable=null,this.listEl=null}updated(e){if(e.has(`value`))try{this.form=JSON.parse(this.value)}catch{}this.attachSortable()}disconnectedCallback(){super.disconnectedCallback(),this.sortable?.destroy(),this.sortable=null}attachSortable(){let e=this.shadowRoot?.querySelector(`.field-list`);!e||e===this.listEl||(this.listEl=e,this.sortable?.destroy(),this.sortable=se.create(e,{animation:150,handle:`.drag-handle`,ghostClass:`sortable-ghost`,onEnd:e=>{let{oldIndex:t,newIndex:n}=e;if(t===void 0||n===void 0||t===n)return;let r=[...this.form.fields],[i]=r.splice(t,1);r.splice(n,0,i),this.form={...this.form,fields:r},this.emit()}}))}emit(){let e=JSON.stringify(this.form,null,2);this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e},bubbles:!0,composed:!0}))}updateForm(e){this.form={...this.form,...e},this.emit()}updateField(e,t){this.form={...this.form,fields:this.form.fields.map(n=>n.id===e?{...n,...t}:n)},this.emit()}addField(){let e=Bo(),t={id:e,label:`New Field`,dataType:`string`};this.form={...this.form,fields:[...this.form.fields,t]},this.selectedId=e,this.emit()}deleteField(e){this.form={...this.form,fields:this.form.fields.filter(t=>t.id!==e)},this.selectedId===e&&(this.selectedId=null),this.emit()}duplicateField(e){let t=this.form.fields.find(t=>t.id===e);if(!t)return;let n={...t,id:Bo(),label:t.label+` (copy)`},r=this.form.fields.findIndex(t=>t.id===e),i=[...this.form.fields];i.splice(r+1,0,n),this.form={...this.form,fields:i},this.selectedId=n.id,this.emit()}render(){return T`
+    `]}};k([y()],Lo.prototype,`value`,void 0),k([C()],Lo.prototype,`wf`,void 0),k([C()],Lo.prototype,`positions`,void 0),k([C()],Lo.prototype,`selectedId`,void 0),k([C()],Lo.prototype,`showMeta`,void 0),Lo=k([g(`mateu-workflow`)],Lo);var Ro=[`string`,`integer`,`number`,`bool`,`date`,`time`,`dateTime`,`dateRange`,`money`,`file`,`array`,`status`,`component`,`menu`,`range`,`action`,`actionGroup`],zo=[`regular`,`radio`,`checkbox`,`textarea`,`toggle`,`combobox`,`select`,`email`,`password`,`richText`,`listBox`,`html`,`markdown`,`image`,`icon`,`link`,`money`,`grid`,`color`,`choice`,`popover`,`slider`,`button`,`stars`],Bo={string:`#3B82F6`,integer:`#8B5CF6`,number:`#6366F1`,bool:`#10B981`,date:`#F59E0B`,time:`#F59E0B`,dateTime:`#F59E0B`,dateRange:`#F59E0B`,money:`#EF4444`,file:`#64748B`,array:`#0EA5E9`,status:`#EC4899`,component:`#14B8A6`,menu:`#94A3B8`,range:`#A855F7`,action:`#F97316`,actionGroup:`#FB923C`};function Vo(){return`field-`+Math.random().toString(36).slice(2,8)}var Ho=class extends b{constructor(...e){super(...e),this.value=`{"name":"New Form","fields":[]}`,this.form={name:`New Form`,fields:[]},this.selectedId=null,this.showMeta=!1,this.sortable=null,this.listEl=null}updated(e){if(e.has(`value`))try{this.form=JSON.parse(this.value)}catch{}this.attachSortable()}disconnectedCallback(){super.disconnectedCallback(),this.sortable?.destroy(),this.sortable=null}attachSortable(){let e=this.shadowRoot?.querySelector(`.field-list`);!e||e===this.listEl||(this.listEl=e,this.sortable?.destroy(),this.sortable=se.create(e,{animation:150,handle:`.drag-handle`,ghostClass:`sortable-ghost`,onEnd:e=>{let{oldIndex:t,newIndex:n}=e;if(t===void 0||n===void 0||t===n)return;let r=[...this.form.fields],[i]=r.splice(t,1);r.splice(n,0,i),this.form={...this.form,fields:r},this.emit()}}))}emit(){let e=JSON.stringify(this.form,null,2);this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e},bubbles:!0,composed:!0}))}updateForm(e){this.form={...this.form,...e},this.emit()}updateField(e,t){this.form={...this.form,fields:this.form.fields.map(n=>n.id===e?{...n,...t}:n)},this.emit()}addField(){let e=Vo(),t={id:e,label:`New Field`,dataType:`string`};this.form={...this.form,fields:[...this.form.fields,t]},this.selectedId=e,this.emit()}deleteField(e){this.form={...this.form,fields:this.form.fields.filter(t=>t.id!==e)},this.selectedId===e&&(this.selectedId=null),this.emit()}duplicateField(e){let t=this.form.fields.find(t=>t.id===e);if(!t)return;let n={...t,id:Vo(),label:t.label+` (copy)`},r=this.form.fields.findIndex(t=>t.id===e),i=[...this.form.fields];i.splice(r+1,0,n),this.form={...this.form,fields:i},this.selectedId=n.id,this.emit()}render(){return T`
             <div class="root">
                 ${this.renderToolbar()}
                 ${this.showMeta?this.renderMeta():v}
@@ -6910,15 +6918,15 @@ ${i}
                 <span class="form-name">${this.form.name}</span>
                 <div style="flex:1"></div>
                 <button class="nbtn" @click="${()=>this.showMeta=!this.showMeta}">
-                    ${_o}
+                    ${vo}
                     Settings
                 </button>
                 <button class="nbtn primary" @click="${()=>this.addField()}">
-                    ${vo}
+                    ${yo}
                     Add Field
                 </button>
                 <button class="nbtn" @click="${()=>this.exportJson()}">
-                    ${yo}
+                    ${bo}
                     Export
                 </button>
             </div>
@@ -6943,10 +6951,10 @@ ${i}
                     ${e.map(e=>this.renderRow(e))}
                 </div>
             </div>
-        `}renderRow(e){let t=zo[e.dataType]??`#64748b`;return T`
+        `}renderRow(e){let t=Bo[e.dataType]??`#64748b`;return T`
             <div role="button" tabindex="0" class="field-row ${this.selectedId===e.id?`selected`:``}"
                  data-id="${e.id}"
-                 @click="${()=>this.selectedId=this.selectedId===e.id?null:e.id}" @keydown="${z(()=>this.selectedId=this.selectedId===e.id?null:e.id)}">
+                 @click="${()=>this.selectedId=this.selectedId===e.id?null:e.id}" @keydown="${R(()=>this.selectedId=this.selectedId===e.id?null:e.id)}">
                 <span class="drag-handle" title="Drag to reorder">⠿</span>
                 <span class="type-badge" style="background:${t}">${e.dataType}</span>
                 <span class="field-label-text">${e.label}</span>
@@ -6978,13 +6986,13 @@ ${i}
                     ${t(`Data type`,T`
                         <select class="inp"
                                 @change="${t=>this.updateField(e.id,{dataType:t.target.value})}">
-                            ${Lo.map(t=>T`
+                            ${Ro.map(t=>T`
                                 <option value="${t}" ?selected="${e.dataType===t}">${t}</option>`)}
                         </select>`)}
                     ${t(`Stereotype`,T`
                         <select class="inp"
                                 @change="${t=>this.updateField(e.id,{stereotype:t.target.value||void 0})}">
-                            ${Ro.map(t=>T`
+                            ${zo.map(t=>T`
                                 <option value="${t}" ?selected="${(e.stereotype??`regular`)===t}">${t}</option>`)}
                         </select>`)}
                     <div class="prop-field row">
@@ -6997,7 +7005,7 @@ ${i}
                                   @change="${t=>this.updateField(e.id,{description:t.target.value||void 0})}">${e.description??``}</textarea>`)}
                 </div>
             </div>
-        `}exportJson(){let e=JSON.stringify(this.form,null,2),t=new Blob([e],{type:`application/json`}),n=URL.createObjectURL(t),r=document.createElement(`a`);r.href=n,r.download=(this.form.name??`form`).replace(/\s+/g,`-`).toLowerCase()+`.json`,r.click(),URL.revokeObjectURL(n)}static{this.styles=[ho,B,h`
+        `}exportJson(){let e=JSON.stringify(this.form,null,2),t=new Blob([e],{type:`application/json`}),n=URL.createObjectURL(t),r=document.createElement(`a`);r.href=n,r.download=(this.form.name??`form`).replace(/\s+/g,`-`).toLowerCase()+`.json`,r.click(),URL.revokeObjectURL(n)}static{this.styles=[go,z,h`
         :host { display: block; height: 100%; font-family: var(--lumo-font-family, sans-serif); }
 
         .root { display: flex; flex-direction: column; height: 100%; background: var(--lumo-base-color, #fff); }
@@ -7112,7 +7120,7 @@ ${i}
         .inp:focus { border-color: #3B82F6; }
         textarea.inp { resize: vertical; }
         input[readonly].inp { background: #f8fafc; color: #94a3b8; }
-    `]}};k([y()],Vo.prototype,`value`,void 0),k([C()],Vo.prototype,`form`,void 0),k([C()],Vo.prototype,`selectedId`,void 0),k([C()],Vo.prototype,`showMeta`,void 0),Vo=k([g(`mateu-form-editor`)],Vo);var Ho=class extends b{constructor(...e){super(...e),this.appState={},this.appData={},this.open=!1,this.activeTab=`appstate`,this.hoveredTag=``,this.hoveredId=``,this.hoveredState=null,this.hoveredData=null,this.hoveredMeta=null,this._prevTarget=null,this._onMouseover=e=>{let t=e.target;for(;t&&!(t.tagName?.toLowerCase().startsWith(`mateu-`)&&t!==this);)t=t.parentElement;if(t===this||t===null){t===null&&this._prevTarget&&(this._prevTarget.style.outline=``,this._prevTarget.style.outlineOffset=``,this._prevTarget=null,this.hoveredTag=``,this.hoveredId=``,this.hoveredState=null,this.hoveredData=null,this.hoveredMeta=null);return}t!==this._prevTarget&&(this._prevTarget&&(this._prevTarget.style.outline=``,this._prevTarget.style.outlineOffset=``),this._prevTarget=t,t.style.outline=`2px solid #0070f3`,t.style.outlineOffset=`-2px`,this.hoveredTag=t.tagName.toLowerCase(),this.hoveredId=t.id||``,this.hoveredState=t.state,this.hoveredData=t.data,this.hoveredMeta=t.component?.metadata)}}connectedCallback(){super.connectedCallback(),document.addEventListener(`mouseover`,this._onMouseover,!0)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`mouseover`,this._onMouseover,!0),this._prevTarget&&=(this._prevTarget.style.outline=``,null)}_fmt(e){try{return JSON.stringify(e,null,2)??`null`}catch{return String(e)}}_renderTab(e,t){return T`
+    `]}};k([y()],Ho.prototype,`value`,void 0),k([C()],Ho.prototype,`form`,void 0),k([C()],Ho.prototype,`selectedId`,void 0),k([C()],Ho.prototype,`showMeta`,void 0),Ho=k([g(`mateu-form-editor`)],Ho);var Uo=class extends b{constructor(...e){super(...e),this.appState={},this.appData={},this.open=!1,this.activeTab=`appstate`,this.hoveredTag=``,this.hoveredId=``,this.hoveredState=null,this.hoveredData=null,this.hoveredMeta=null,this._prevTarget=null,this._onMouseover=e=>{let t=e.target;for(;t&&!(t.tagName?.toLowerCase().startsWith(`mateu-`)&&t!==this);)t=t.parentElement;if(t===this||t===null){t===null&&this._prevTarget&&(this._prevTarget.style.outline=``,this._prevTarget.style.outlineOffset=``,this._prevTarget=null,this.hoveredTag=``,this.hoveredId=``,this.hoveredState=null,this.hoveredData=null,this.hoveredMeta=null);return}t!==this._prevTarget&&(this._prevTarget&&(this._prevTarget.style.outline=``,this._prevTarget.style.outlineOffset=``),this._prevTarget=t,t.style.outline=`2px solid #0070f3`,t.style.outlineOffset=`-2px`,this.hoveredTag=t.tagName.toLowerCase(),this.hoveredId=t.id||``,this.hoveredState=t.state,this.hoveredData=t.data,this.hoveredMeta=t.component?.metadata)}}connectedCallback(){super.connectedCallback(),document.addEventListener(`mouseover`,this._onMouseover,!0)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`mouseover`,this._onMouseover,!0),this._prevTarget&&=(this._prevTarget.style.outline=``,null)}_fmt(e){try{return JSON.stringify(e,null,2)??`null`}catch{return String(e)}}_renderTab(e,t){return T`
             <button class="tab ${this.activeTab===e?`tab--active`:``}"
                 @click=${()=>{this.activeTab=e}}>
                 ${t}
@@ -7285,7 +7293,7 @@ ${i}
             border-bottom: 1px solid #2a2a3a;
         }
         .section-label:first-of-type { margin-top: 0; }
-    `}};k([y()],Ho.prototype,`appState`,void 0),k([y()],Ho.prototype,`appData`,void 0),k([C()],Ho.prototype,`open`,void 0),k([C()],Ho.prototype,`activeTab`,void 0),k([C()],Ho.prototype,`hoveredTag`,void 0),k([C()],Ho.prototype,`hoveredId`,void 0),k([C()],Ho.prototype,`hoveredState`,void 0),k([C()],Ho.prototype,`hoveredData`,void 0),k([C()],Ho.prototype,`hoveredMeta`,void 0),Ho=k([g(`mateu-debug-overlay`)],Ho);var Uo=(e,t)=>{let n=t?.initiatorState;return n&&typeof n==`object`?{...n}:{...e??{}}},Wo=e=>{if(e)try{return JSON.parse(e)}catch{return{value:e}}else return{}},Go=function(e){return e.SetAppDataValue=`SetAppDataValue`,e.SetAppStateValue=`SetAppStateValue`,e.SetDataValue=`SetDataValue`,e.RunAction=`RunAction`,e.RunJS=`RunJS`,e.SetAttributeValue=`SetAttributeValue`,e.SetStateValue=`SetStateValue`,e.SetCssClass=`SetCssClass`,e.SetStyle=`SetStyle`,e}({}),Ko=function(e){return e.required=`required`,e.disabled=`disabled`,e.hidden=`hidden`,e.pattern=`pattern`,e.minValue=`minValue`,e.maxValue=`maxValue`,e.minLength=`minLength`,e.maxLength=`maxLength`,e.css=`css`,e.style=`style`,e.theme=`theme`,e.errorMessage=`errorMessage`,e.description=`description`,e.none=`none`,e}({}),qo=function(e){return e.Continue=`Continue`,e.Stop=`Stop`,e}({}),Jo=12e4,Yo=(e,t)=>`${e??`_`}::${t}`,Xo=new class{constructor(){this.started=new Map,this.listeners=new Set}begin(e,t=Date.now()){let n=this.started.get(e);return n!==void 0&&t-n<Jo?!1:(this.started.set(e,t),this.emit(),!0)}end(e){this.started.delete(e)&&this.emit()}isPending(e,t=Date.now()){let n=this.started.get(e);return n!==void 0&&t-n<Jo}snapshot(){return new Set(this.started.keys())}subscribe(e){return this.listeners.add(e),()=>this.listeners.delete(e)}reset(){this.started.clear(),this.emit()}emit(){let e=this.snapshot();this.listeners.forEach(t=>t(e))}},Zo=`data-mateu-pending-styles`,Qo=`
+    `}};k([y()],Uo.prototype,`appState`,void 0),k([y()],Uo.prototype,`appData`,void 0),k([C()],Uo.prototype,`open`,void 0),k([C()],Uo.prototype,`activeTab`,void 0),k([C()],Uo.prototype,`hoveredTag`,void 0),k([C()],Uo.prototype,`hoveredId`,void 0),k([C()],Uo.prototype,`hoveredState`,void 0),k([C()],Uo.prototype,`hoveredData`,void 0),k([C()],Uo.prototype,`hoveredMeta`,void 0),Uo=k([g(`mateu-debug-overlay`)],Uo);var Wo=(e,t)=>{let n=t?.initiatorState;return n&&typeof n==`object`?{...n}:{...e??{}}},Go=e=>{if(e)try{return JSON.parse(e)}catch{return{value:e}}else return{}},Ko=function(e){return e.SetAppDataValue=`SetAppDataValue`,e.SetAppStateValue=`SetAppStateValue`,e.SetDataValue=`SetDataValue`,e.RunAction=`RunAction`,e.RunJS=`RunJS`,e.SetAttributeValue=`SetAttributeValue`,e.SetStateValue=`SetStateValue`,e.SetCssClass=`SetCssClass`,e.SetStyle=`SetStyle`,e}({}),qo=function(e){return e.required=`required`,e.disabled=`disabled`,e.hidden=`hidden`,e.pattern=`pattern`,e.minValue=`minValue`,e.maxValue=`maxValue`,e.minLength=`minLength`,e.maxLength=`maxLength`,e.css=`css`,e.style=`style`,e.theme=`theme`,e.errorMessage=`errorMessage`,e.description=`description`,e.none=`none`,e}({}),Jo=function(e){return e.Continue=`Continue`,e.Stop=`Stop`,e}({}),Yo=12e4,Xo=(e,t)=>`${e??`_`}::${t}`,Zo=new class{constructor(){this.started=new Map,this.listeners=new Set}begin(e,t=Date.now()){let n=this.started.get(e);return n!==void 0&&t-n<Yo?!1:(this.started.set(e,t),this.emit(),!0)}end(e){this.started.delete(e)&&this.emit()}isPending(e,t=Date.now()){let n=this.started.get(e);return n!==void 0&&t-n<Yo}snapshot(){return new Set(this.started.keys())}subscribe(e){return this.listeners.add(e),()=>this.listeners.delete(e)}reset(){this.started.clear(),this.emit()}emit(){let e=this.snapshot();this.listeners.forEach(t=>t(e))}},Qo=`data-mateu-pending-styles`,$o=`
 [data-mateu-pending] {
     pointer-events: none;
     cursor: progress;
@@ -7299,9 +7307,9 @@ ${i}
     0%, 100% { opacity: .45; }
     50% { opacity: .85; }
 }
-`,$o=new WeakSet,es=e=>{if($o.has(e))return;$o.add(e);let t=e;if(typeof CSSStyleSheet<`u`&&Array.isArray(t.adoptedStyleSheets))try{let e=new CSSStyleSheet;e.replaceSync(Qo),t.adoptedStyleSheets=[...t.adoptedStyleSheets,e];return}catch{}let n=e instanceof Document?e.head:e;if(!n)return;let r=document.createElement(`style`);r.setAttribute(Zo,``),r.textContent=Qo,n.appendChild(r)},ts=e=>{let t=e.getRootNode();if(t instanceof ShadowRoot||t instanceof Document)return t},ns=e=>{if(!e||e.hasAttribute(`data-mateu-pending`))return;let t=ts(e);t&&es(t),e.setAttribute(`data-mateu-pending`,``),e.setAttribute(`aria-busy`,`true`)},rs=e=>{e&&(e.removeAttribute(`data-mateu-pending`),e.removeAttribute(`aria-busy`))},is=e=>{let t=(typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target;return t instanceof Element?t:void 0},as=[`button`,`a[href]`,`[role="button"]`,`[role="menuitem"]`,`input[type="button"]`,`input[type="submit"]`,`vaadin-button`,`vaadin-menu-bar-button`,`ui5-button`,`oj-c-button`,`oj-button`].join(`, `),os=e=>{if(!(!e||typeof e.closest!=`function`))return e.closest(as)??void 0},ss=null,cs=class extends Ua{constructor(...e){super(...e),this.baseUrl=``,this.route=``,this.consumedRoute=``,this.formerState={},this.applyRules=()=>{let e=this.component.rules;if(e&&e.length>0){let t=this.state,n=this.data,r=this.appState,i=this.appData,a=this.component,o=e=>Ct(e,t,n,{appState:r,appData:i,component:a}),s=e=>St(e,t,n,r,i,{component:a}),c=[`state`,`data`,`appState`,`appData`,`component`],l=[t,n,r,i,a],u={...this.state},d={...this.data},f=!1,p=!1;for(let t=0;t<e.length;t++){let n=e[t];try{if(o(n.filter)){if(Go.SetStateValue==n.action||Go.SetDataValue==n.action){let e=Go.SetStateValue==n.action?u:d,t=n.fieldName.split(`,`);for(let r=0;r<t.length;r++){let i=t[r];if(!e[i]||e[i]!=n.value){let t=n.expression?s(n.expression):n.value,r=Ko.none==n.fieldAttribute?i:i+`.`+n.fieldAttribute;t!=e[r]&&(e[r]=t,Go.SetStateValue==n.action&&(f=!0),Go.SetDataValue==n.action&&(p=!0))}}}if(Go.RunAction==n.action&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.actionId},bubbles:!0,composed:!0})),Go.RunJS==n.action&&Function(...c,n.value)(...l),Go.SetAttributeValue==n.action){let e=n.expression?o(n.expression):n.value;if(n.fieldAttribute==`disabled`){e?this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(n.fieldAttribute,`disabled`):this.shadowRoot?.getElementById(n.fieldName)?.removeAttribute(n.fieldAttribute);continue}this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(n.fieldAttribute,e)}if(Go.SetCssClass==n.action&&this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(`class`,n.value),Go.SetStyle==n.action&&this.shadowRoot?.getElementById(n.fieldName)?.style.setProperty(n.expression,n.value),qo.Stop==n.result)break}}catch(e){console.error(`rule failed`,n,e)}}f&&(this.state=u),p&&(this.data=d),f&&this.checkValidations()}},this.skipValidation=(e,t)=>e&&t.fieldId&&!e.includes(t.fieldId)||!e&&t.fieldId&&t.fieldId.includes(`-`),this.checkValidations=e=>{let t=e?e.split(`,`):void 0,n=this.component.validations,r=!0,i=!1,a=this.data??{},o={...this.data??{},errors:{}};if(n){for(let e=0;e<n.length;e++){let r=n[e];if(this.skipValidation(t,r))continue;let i=(r.fieldId??`_component`).split(`,`);for(let e=0;e<i.length;e++){let t=i[e];o.errors[t]=[]}}for(let e=0;e<n.length;e++){let i=n[e];if(!this.skipValidation(t,i))try{let e=i.condition&&i.condition.includes("${")?this._evalTemplate(i.condition):this._evalExpr(i.condition);if(i.condition&&!e){r=!1;let e=(i.fieldId??`_component`).split(`,`);for(let t=0;t<e.length;t++){let n=e[t],r=o.errors[n];if(r||(o.errors[n]=[]),r=o.errors[n],!a[n]){let e=i.message;try{e=this._evalTemplate(i.message)}catch{}r.push(e)}}}}catch(e){console.error(`validation failed`,i,e)}}for(let e=0;e<n.length;e++){let r=n[e];if(this.skipValidation(t,r))continue;let s=(r.fieldId??`_component`).split(`,`);for(let e=0;e<s.length;e++){let t=s[e];if((a.errors||o.errors==``)&&[t].join(`,`)){i=!0;break}}}(a.errors||o.errors==``)&&[`_component`].join(`,`)&&(i=!0)}o._valid=r,o._valid!=a._valid&&(i=!0),i&&(this.data=o)},this._autoSaveTimers=new Map,this.onChange=()=>{this.applyRules()},this.closeModalRequestedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.closeModal()},this.resetFilters=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail,n={};t.fieldIds.forEach(e=>{n[e]=void 0}),n.searchText=void 0,this.state={...this.state,...n}}},this.dataChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail,n={};n[t.key]=t.value,e.type==`data-changed`&&(this.data={...this.data,...n})}},this.valueChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail;if(e.type==`value-changed`){let n={...this.state};n[t.fieldId]=t.value,this.state=n,(this.state[t.fieldId]||this.formerState[t.fieldId])&&this.state[t.fieldId]!=this.formerState[t.fieldId]&&this.component?.confirmOnNavigationIfDirty&&this.dispatchEvent(new CustomEvent(`dirty`,{detail:e.detail,bubbles:!0,composed:!0}));let r=this.component;r.triggers?.filter(e=>e.type==Ha.OnValueChange).filter(e=>!e.propertyName||t.fieldId==e.propertyName).forEach(e=>{(!e.condition||this._evalExpr(e.condition))&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))}),r.triggers?.filter(e=>e.type==Ha.AutoSave).forEach(e=>{let t=e.actionId,n=this._autoSaveTimers.get(t);n!==void 0&&clearTimeout(n),this._autoSaveTimers.set(t,setTimeout(()=>{this._autoSaveTimers.delete(t),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))},e.debounceMillis??800))})}}},this.actionRequestedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.manageActionRequestedEvent(e)},this.manageActionRequestedEvent=e=>{let t=e.detail,n=t?._originElement??is(e);if(e.type==`action-requested`){e.preventDefault(),e.stopPropagation();let r=this.component,i=r.actions?.find(e=>e.id==t.actionId)??r.actions?.find(e=>e.id.endsWith(`*`)&&t.actionId.startsWith(e.id.replace(`*`,``)));if(i){if(i&&i.rowsSelectedRequired&&(!this.state.crud_selected_items||this.state.crud_selected_items.length==0)){this.notify(`You first need to select some rows`);return}if(i&&i.validationRequired){let e=ss??this;if(ss=null,e.checkValidations(i.fieldsToValidate),!e.data._valid){e.notifyValidationErrors();return}}ss=null;let e={...t,initiatorComponentId:this.id};i&&i.confirmationRequired?this.callAfterConfirmation(i,()=>this.requestActionCallToServerOrBubble(e,r,i,n)):this.requestActionCallToServerOrBubble(e,r,i,n)}else{let r={...t.parameters};r.initiatorState||=this.state,ss||=this,this.dispatchEvent(new CustomEvent(e.type,{detail:{...e.detail,_originElement:n,parameters:r},bubbles:!0,composed:!0}))}}},this.buildFieldLabelMap=()=>{let e={},t=n=>{if(n)for(let r of n){let n=r.metadata;if(n?.type===j.FormField){let t=n;t.fieldId&&t.label&&(e[t.fieldId]=t.label)}t(r.children)}};return t(this.component?.children),e},this.notifyValidationErrors=()=>{let e=this.data?.errors??{},t=this.buildFieldLabelMap(),n=[];if(Object.entries(e).forEach(([e,r])=>{if(!Array.isArray(r))return;let i=e===`_component`?void 0:t[e]??e;r.forEach(e=>{e&&!n.some(t=>t.label===i&&t.msg===e)&&n.push({label:i,msg:e})})}),n.length===0){this.notify(`There are validation errors`);return}Na({text:`There are validation errors
+`,es=new WeakSet,ts=e=>{if(es.has(e))return;es.add(e);let t=e;if(typeof CSSStyleSheet<`u`&&Array.isArray(t.adoptedStyleSheets))try{let e=new CSSStyleSheet;e.replaceSync($o),t.adoptedStyleSheets=[...t.adoptedStyleSheets,e];return}catch{}let n=e instanceof Document?e.head:e;if(!n)return;let r=document.createElement(`style`);r.setAttribute(Qo,``),r.textContent=$o,n.appendChild(r)},ns=e=>{let t=e.getRootNode();if(t instanceof ShadowRoot||t instanceof Document)return t},rs=e=>{if(!e||e.hasAttribute(`data-mateu-pending`))return;let t=ns(e);t&&ts(t),e.setAttribute(`data-mateu-pending`,``),e.setAttribute(`aria-busy`,`true`)},is=e=>{e&&(e.removeAttribute(`data-mateu-pending`),e.removeAttribute(`aria-busy`))},as=e=>{let t=(typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target;return t instanceof Element?t:void 0},os=[`button`,`a[href]`,`[role="button"]`,`[role="menuitem"]`,`input[type="button"]`,`input[type="submit"]`,`vaadin-button`,`vaadin-menu-bar-button`,`ui5-button`,`oj-c-button`,`oj-button`].join(`, `),ss=e=>{if(!(!e||typeof e.closest!=`function`))return e.closest(os)??void 0},cs=null,ls=class extends Wa{constructor(...e){super(...e),this.baseUrl=``,this.route=``,this.consumedRoute=``,this.formerState={},this.applyRules=()=>{let e=this.component.rules;if(e&&e.length>0){let t=this.state,n=this.data,r=this.appState,i=this.appData,a=this.component,o=e=>Ct(e,t,n,{appState:r,appData:i,component:a}),s=e=>St(e,t,n,r,i,{component:a}),c=[`state`,`data`,`appState`,`appData`,`component`],l=[t,n,r,i,a],u={...this.state},d={...this.data},f=!1,p=!1;for(let t=0;t<e.length;t++){let n=e[t];try{if(o(n.filter)){if(Ko.SetStateValue==n.action||Ko.SetDataValue==n.action){let e=Ko.SetStateValue==n.action?u:d,t=n.fieldName.split(`,`);for(let r=0;r<t.length;r++){let i=t[r];if(!e[i]||e[i]!=n.value){let t=n.expression?s(n.expression):n.value,r=qo.none==n.fieldAttribute?i:i+`.`+n.fieldAttribute;t!=e[r]&&(e[r]=t,Ko.SetStateValue==n.action&&(f=!0),Ko.SetDataValue==n.action&&(p=!0))}}}if(Ko.RunAction==n.action&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.actionId},bubbles:!0,composed:!0})),Ko.RunJS==n.action&&Function(...c,n.value)(...l),Ko.SetAttributeValue==n.action){let e=n.expression?o(n.expression):n.value;if(n.fieldAttribute==`disabled`){e?this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(n.fieldAttribute,`disabled`):this.shadowRoot?.getElementById(n.fieldName)?.removeAttribute(n.fieldAttribute);continue}this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(n.fieldAttribute,e)}if(Ko.SetCssClass==n.action&&this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(`class`,n.value),Ko.SetStyle==n.action&&this.shadowRoot?.getElementById(n.fieldName)?.style.setProperty(n.expression,n.value),Jo.Stop==n.result)break}}catch(e){console.error(`rule failed`,n,e)}}f&&(this.state=u),p&&(this.data=d),f&&this.checkValidations()}},this.skipValidation=(e,t)=>e&&t.fieldId&&!e.includes(t.fieldId)||!e&&t.fieldId&&t.fieldId.includes(`-`),this.checkValidations=e=>{let t=e?e.split(`,`):void 0,n=this.component.validations,r=!0,i=!1,a=this.data??{},o={...this.data??{},errors:{}};if(n){for(let e=0;e<n.length;e++){let r=n[e];if(this.skipValidation(t,r))continue;let i=(r.fieldId??`_component`).split(`,`);for(let e=0;e<i.length;e++){let t=i[e];o.errors[t]=[]}}for(let e=0;e<n.length;e++){let i=n[e];if(!this.skipValidation(t,i))try{let e=i.condition&&i.condition.includes("${")?this._evalTemplate(i.condition):this._evalExpr(i.condition);if(i.condition&&!e){r=!1;let e=(i.fieldId??`_component`).split(`,`);for(let t=0;t<e.length;t++){let n=e[t],r=o.errors[n];if(r||(o.errors[n]=[]),r=o.errors[n],!a[n]){let e=i.message;try{e=this._evalTemplate(i.message)}catch{}r.push(e)}}}}catch(e){console.error(`validation failed`,i,e)}}for(let e=0;e<n.length;e++){let r=n[e];if(this.skipValidation(t,r))continue;let s=(r.fieldId??`_component`).split(`,`);for(let e=0;e<s.length;e++){let t=s[e];if((a.errors||o.errors==``)&&[t].join(`,`)){i=!0;break}}}(a.errors||o.errors==``)&&[`_component`].join(`,`)&&(i=!0)}o._valid=r,o._valid!=a._valid&&(i=!0),i&&(this.data=o)},this._autoSaveTimers=new Map,this.onChange=()=>{this.applyRules()},this.closeModalRequestedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.closeModal()},this.resetFilters=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail,n={};t.fieldIds.forEach(e=>{n[e]=void 0}),n.searchText=void 0,this.state={...this.state,...n}}},this.dataChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail,n={};n[t.key]=t.value,e.type==`data-changed`&&(this.data={...this.data,...n})}},this.valueChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail;if(e.type==`value-changed`){let n={...this.state};n[t.fieldId]=t.value,this.state=n,(this.state[t.fieldId]||this.formerState[t.fieldId])&&this.state[t.fieldId]!=this.formerState[t.fieldId]&&this.component?.confirmOnNavigationIfDirty&&this.dispatchEvent(new CustomEvent(`dirty`,{detail:e.detail,bubbles:!0,composed:!0}));let r=this.component;r.triggers?.filter(e=>e.type==Ua.OnValueChange).filter(e=>!e.propertyName||t.fieldId==e.propertyName).forEach(e=>{(!e.condition||this._evalExpr(e.condition))&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))}),r.triggers?.filter(e=>e.type==Ua.AutoSave).forEach(e=>{let t=e.actionId,n=this._autoSaveTimers.get(t);n!==void 0&&clearTimeout(n),this._autoSaveTimers.set(t,setTimeout(()=>{this._autoSaveTimers.delete(t),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))},e.debounceMillis??800))})}}},this.actionRequestedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.manageActionRequestedEvent(e)},this.manageActionRequestedEvent=e=>{let t=e.detail,n=t?._originElement??as(e);if(e.type==`action-requested`){e.preventDefault(),e.stopPropagation();let r=this.component,i=r.actions?.find(e=>e.id==t.actionId)??r.actions?.find(e=>e.id.endsWith(`*`)&&t.actionId.startsWith(e.id.replace(`*`,``)));if(i){if(i&&i.rowsSelectedRequired&&(!this.state.crud_selected_items||this.state.crud_selected_items.length==0)){this.notify(`You first need to select some rows`);return}if(i&&i.validationRequired){let e=cs??this;if(cs=null,e.checkValidations(i.fieldsToValidate),!e.data._valid){e.notifyValidationErrors();return}}cs=null;let e={...t,initiatorComponentId:this.id};i&&i.confirmationRequired?this.callAfterConfirmation(i,()=>this.requestActionCallToServerOrBubble(e,r,i,n)):this.requestActionCallToServerOrBubble(e,r,i,n)}else{let r={...t.parameters};r.initiatorState||=this.state,cs||=this,this.dispatchEvent(new CustomEvent(e.type,{detail:{...e.detail,_originElement:n,parameters:r},bubbles:!0,composed:!0}))}}},this.buildFieldLabelMap=()=>{let e={},t=n=>{if(n)for(let r of n){let n=r.metadata;if(n?.type===j.FormField){let t=n;t.fieldId&&t.label&&(e[t.fieldId]=t.label)}t(r.children)}};return t(this.component?.children),e},this.notifyValidationErrors=()=>{let e=this.data?.errors??{},t=this.buildFieldLabelMap(),n=[];if(Object.entries(e).forEach(([e,r])=>{if(!Array.isArray(r))return;let i=e===`_component`?void 0:t[e]??e;r.forEach(e=>{e&&!n.some(t=>t.label===i&&t.msg===e)&&n.push({label:i,msg:e})})}),n.length===0){this.notify(`There are validation errors`);return}Pa({text:`There are validation errors
 `+n.map(({label:e,msg:t})=>e?`• ${e}: ${t}`:`• ${t}`).join(`
-`),variant:`error`,position:`bottomEnd`,duration:Math.max(3e3,1500+n.length*1e3)},this),this.focusFirstInvalidField()},this.notify=e=>{Na({text:e,variant:`error`,position:`bottomEnd`,duration:3e3},this)},this.handleRestAction=(e,t)=>{let n=t=>{if(e.resultPath!=null){let n=ln(t,e.resultPath);n&&typeof n==`object`&&(this.state={...this.state,...n})}let n=M(e.successMessage,this.state,this.data);n&&Na({text:n,variant:`success`,position:`bottomEnd`,duration:3e3},this)};if(e.source?.proxy){let e=t===`__restdata__`?`data`:`action`;this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:`__restfetch__`,parameters:{_sourceKind:e,_sourceId:t},callback:e=>n(e?.appData?._restfetch),callbackonly:!0},bubbles:!0,composed:!0}));return}fn(e.source,e=>M(e,this.state,this.data)).then(n).catch(e=>{console.warn(`mateu: rest action failed`,e),Na({text:`Request failed`,variant:`error`,position:`bottomEnd`,duration:3e3},this)})},this.callAfterConfirmation=(e,t)=>{let n=`One moment, please`,r=`Are you sure?`,i=`Yes`,a=`No`;e.confirmationTexts&&(n=e.confirmationTexts.title,r=e.confirmationTexts.message,i=e.confirmationTexts.confirmationText,a=e.confirmationTexts.denialText);let o=document.createElement(`div`);o.style.cssText=`position:fixed;inset:0;z-index:1100;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.35);padding:1rem;`;let s=document.createElement(`div`);s.style.cssText=`background:var(--lumo-base-color,#fff);color:var(--lumo-body-text-color,#1a1a1a);border-radius:var(--lumo-border-radius-l,12px);box-shadow:var(--lumo-box-shadow-xl,0 12px 40px rgba(0,0,0,.3));padding:1.2rem;max-width:min(90vw,26rem);`;let c=()=>{o.parentElement&&document.body.removeChild(o)},l=`font:inherit;font-weight:600;padding:.45rem 1rem;border-radius:var(--lumo-border-radius-m,6px);cursor:pointer;`;re(T`
+`),variant:`error`,position:`bottomEnd`,duration:Math.max(3e3,1500+n.length*1e3)},this),this.focusFirstInvalidField()},this.notify=e=>{Pa({text:e,variant:`error`,position:`bottomEnd`,duration:3e3},this)},this.handleRestAction=(e,t)=>{let n=t=>{if(e.resultPath!=null){let n=un(t,e.resultPath);n&&typeof n==`object`&&(this.state={...this.state,...n})}let n=M(e.successMessage,this.state,this.data);n&&Pa({text:n,variant:`success`,position:`bottomEnd`,duration:3e3},this)};if(e.source?.proxy){let e=t===`__restdata__`?`data`:`action`;this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:`__restfetch__`,parameters:{_sourceKind:e,_sourceId:t},callback:e=>n(e?.appData?._restfetch),callbackonly:!0},bubbles:!0,composed:!0}));return}pn(e.source,e=>M(e,this.state,this.data)).then(n).catch(e=>{console.warn(`mateu: rest action failed`,e),Pa({text:`Request failed`,variant:`error`,position:`bottomEnd`,duration:3e3},this)})},this.callAfterConfirmation=(e,t)=>{let n=`One moment, please`,r=`Are you sure?`,i=`Yes`,a=`No`;e.confirmationTexts&&(n=e.confirmationTexts.title,r=e.confirmationTexts.message,i=e.confirmationTexts.confirmationText,a=e.confirmationTexts.denialText);let o=document.createElement(`div`);o.style.cssText=`position:fixed;inset:0;z-index:1100;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.35);padding:1rem;`;let s=document.createElement(`div`);s.style.cssText=`background:var(--lumo-base-color,#fff);color:var(--lumo-body-text-color,#1a1a1a);border-radius:var(--lumo-border-radius-l,12px);box-shadow:var(--lumo-box-shadow-xl,0 12px 40px rgba(0,0,0,.3));padding:1.2rem;max-width:min(90vw,26rem);`;let c=()=>{o.parentElement&&document.body.removeChild(o)},l=`font:inherit;font-weight:600;padding:.45rem 1rem;border-radius:var(--lumo-border-radius-m,6px);cursor:pointer;`;re(T`
             <h3 style="margin:0 0 .5rem;">${n}</h3>
             <div style="margin-bottom:1.2rem;">${r}</div>
             <div style="display:flex;justify-content:flex-end;gap:.5rem;">
@@ -7310,18 +7318,18 @@ ${i}
                 <button style="${l}border:none;background:var(--lumo-primary-color,#1676f3);color:var(--lumo-primary-contrast-color,#fff);"
                         @click="${()=>{c(),t()}}">${i}</button>
             </div>
-        `,s),o.appendChild(s),o.addEventListener(`click`,e=>{e.target===o&&c()}),document.body.appendChild(o)},this.requestActionCallToServerOrBubble=(e,t,n,r)=>{if(n&&n.bubble){let t={...e.parameters};t.initiatorState||=this.state,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{...e,_originElement:r,parameters:t},bubbles:!0,composed:!0}))}else this.requestActionCallToServer(e,t,n,r)},this.requestActionCallToServer=(e,t,n,r)=>{if(n&&n.href){window.location.href=n.href;return}if(n&&n.js)try{Function(`state`,`data`,`appState`,`appData`,`component`,n.js).call(this,this.state??{},this.data??{},this.appState??{},this.appData??{},this.component),this.state={...this.state},this.data={...this.data}}catch(e){console.error(`when evaluating `+n.js,e,this.component,this.state,this.data)}if(n&&n.customEvent&&this.dispatchEvent(new CustomEvent(n.customEvent.name,{detail:n.customEvent.detail,bubbles:!0,composed:!0})),n&&(n.js||n.customEvent))return;if(n&&n.restAction){this.handleRestAction(n.restAction,n.id);return}if(e.actionId==`search`){let t=e.parameters?._searchState;t?this.state={...this.state,...t}:this.state.size||(this.state={...this.state,size:10,page:0,sort:[]})}if(!n?.background){if(!nt(e.actionId,n?.idempotent)&&!Xo.begin(Yo(this.id,e.actionId)))return;let t=os(r);this._pendingOrigins.set(e.actionId,t),ns(t)}let i=Uo(this.state,e.parameters);this.dispatchEvent(new CustomEvent(`server-side-action-requested`,{detail:{route:this.route,consumedRoute:this.consumedRoute,componentState:i,parameters:e.parameters??{},actionId:e.actionId,serverSideType:t.serverSideType,serverSideComponentRoute:t.route,initiatorComponentId:e.initiatorComponentId??t.id,initiator:this,background:n?.background,sse:n?.sse,timeoutMillis:n?.timeoutMillis,idempotent:n?.idempotent,callback:e.callback,callbackonly:e.callbackonly,callbackToken:e.callbackToken??this.callbackToken},bubbles:!0,composed:!0}))},this.handleBackendSucceeded=e=>{e.detail.actionId&&this.component.triggers?.filter(e=>e.type==Ha.OnSuccess).filter(t=>e.detail.actionId==t.calledActionId).forEach(t=>{if(!t.condition||this._evalExpr(t.condition))if(e.preventDefault(),e.stopPropagation(),t.timeoutMillis>0){let e=this.callbackToken;setTimeout(()=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,callbackToken:e},bubbles:!0,composed:!0}))},t.timeoutMillis)}else this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))})},this.handleBackendFailed=e=>{e.detail.actionId&&this.component.triggers?.filter(e=>e.type==Ha.OnError).filter(t=>e.detail.actionId==t.calledActionId).forEach(t=>{(!t.condition||this._evalExpr(t.condition))&&(e.preventDefault(),e.stopPropagation(),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0})))})},this._pendingOrigins=new Map,this._backendSettledListener=e=>{((typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target)===this&&this._releasePending(e.detail?.actionId)},this._keydownListener=e=>{if(this._handleTabShortcut(e))return;let t=this.component;if(t)for(let n of t.actions??[]){let t=n.shortcut||(n.runOnEnter?`enter`:null);if(t&&this._shortcutMatchesEvent(t,e)){e.preventDefault(),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.id},bubbles:!0,composed:!0}));return}}}}createRenderRoot(){return F.mustUseShadowRoot()?super.createRenderRoot():this}updated(e){super.updated(e),e.has(`state`)&&this.state&&JSON.stringify(this.state)!=JSON.stringify({})&&this.onChange(),e.has(`component`)&&(this.formerState={...this.state},this.component?.confirmOnNavigationIfDirty&&this.dispatchEvent(new CustomEvent(`clean`,{detail:{},bubbles:!0,composed:!0})),setTimeout(()=>this.triggerOnLoad()))}focusFirstInvalidField(){let e=t=>requestAnimationFrame(()=>{let n=this.findFirstInvalid(this.renderRoot);if(n){n.focus?.(),n.scrollIntoView?.({block:`center`,behavior:`smooth`});return}t>0&&e(t-1)});e(3)}findFirstInvalid(e){if(!e?.querySelectorAll)return null;for(let t of Array.from(e.querySelectorAll(`*`))){if(t.invalid===!0)return t;if(t.shadowRoot){let e=this.findFirstInvalid(t.shadowRoot);if(e)return e}}return null}_releasePending(e){(e===void 0?Array.from(this._pendingOrigins.keys()):[e]).forEach(e=>{Xo.end(Yo(this.id,e)),rs(this._pendingOrigins.get(e)),this._pendingOrigins.delete(e)})}_shortcutMatchesEvent(e,t){return rr(e,t)}_collectShortcutTabs(){let e=this.renderRoot;if(!e)return[];let t=Array.from(e.querySelectorAll(`vaadin-tab[data-shortcut]`));return e.querySelectorAll(`mateu-drawer, mateu-dialog`).forEach(e=>{let n=e.shadowRoot;n&&t.push(...Array.from(n.querySelectorAll(`vaadin-tab[data-shortcut]`)))}),t}_handleTabShortcut(e){let t=this._collectShortcutTabs();if(t.length===0)return!1;for(let n of Array.from(t)){let t=n.dataset.shortcut;if(!t||!this._shortcutMatchesEvent(t,e))continue;let r=n.closest(`vaadin-tabs`);if(!r)continue;let i=Array.from(r.querySelectorAll(`vaadin-tab`)).indexOf(n);if(!(i<0))return e.preventDefault(),r.selected=i,!0}return!1}connectedCallback(){super.connectedCallback(),this.addEventListener(`backend-call-succeeded`,this.handleBackendSucceeded),this.addEventListener(`backend-call-failed`,this.handleBackendFailed),this.addEventListener(`backend-succeeded-event`,this._backendSettledListener),this.addEventListener(`backend-failed-event`,this._backendSettledListener),this.addEventListener(`backend-cancelled-event`,this._backendSettledListener),document.addEventListener(`keydown`,this._keydownListener)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`backend-call-succeeded`,this.handleBackendSucceeded),this.removeEventListener(`backend-call-failed`,this.handleBackendFailed),this.removeEventListener(`backend-succeeded-event`,this._backendSettledListener),this.removeEventListener(`backend-failed-event`,this._backendSettledListener),this.removeEventListener(`backend-cancelled-event`,this._backendSettledListener),document.removeEventListener(`keydown`,this._keydownListener),this._releasePending()}render(){return T`<div>
+        `,s),o.appendChild(s),o.addEventListener(`click`,e=>{e.target===o&&c()}),document.body.appendChild(o)},this.requestActionCallToServerOrBubble=(e,t,n,r)=>{if(n&&n.bubble){let t={...e.parameters};t.initiatorState||=this.state,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{...e,_originElement:r,parameters:t},bubbles:!0,composed:!0}))}else this.requestActionCallToServer(e,t,n,r)},this.requestActionCallToServer=(e,t,n,r)=>{if(n&&n.href){window.location.href=n.href;return}if(n&&n.js)try{Function(`state`,`data`,`appState`,`appData`,`component`,n.js).call(this,this.state??{},this.data??{},this.appState??{},this.appData??{},this.component),this.state={...this.state},this.data={...this.data}}catch(e){console.error(`when evaluating `+n.js,e,this.component,this.state,this.data)}if(n&&n.customEvent&&this.dispatchEvent(new CustomEvent(n.customEvent.name,{detail:n.customEvent.detail,bubbles:!0,composed:!0})),n&&(n.js||n.customEvent))return;if(n&&n.restAction){this.handleRestAction(n.restAction,n.id);return}if(e.actionId==`search`){let t=e.parameters?._searchState;t?this.state={...this.state,...t}:this.state.size||(this.state={...this.state,size:10,page:0,sort:[]})}if(!n?.background){if(!nt(e.actionId,n?.idempotent)&&!Zo.begin(Xo(this.id,e.actionId)))return;let t=ss(r);this._pendingOrigins.set(e.actionId,t),rs(t)}let i=Wo(this.state,e.parameters);this.dispatchEvent(new CustomEvent(`server-side-action-requested`,{detail:{route:this.route,consumedRoute:this.consumedRoute,componentState:i,parameters:e.parameters??{},actionId:e.actionId,serverSideType:t.serverSideType,serverSideComponentRoute:t.route,initiatorComponentId:e.initiatorComponentId??t.id,initiator:this,background:n?.background,sse:n?.sse,timeoutMillis:n?.timeoutMillis,idempotent:n?.idempotent,callback:e.callback,callbackonly:e.callbackonly,callbackToken:e.callbackToken??this.callbackToken},bubbles:!0,composed:!0}))},this.handleBackendSucceeded=e=>{e.detail.actionId&&this.component.triggers?.filter(e=>e.type==Ua.OnSuccess).filter(t=>e.detail.actionId==t.calledActionId).forEach(t=>{if(!t.condition||this._evalExpr(t.condition))if(e.preventDefault(),e.stopPropagation(),t.timeoutMillis>0){let e=this.callbackToken;setTimeout(()=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,callbackToken:e},bubbles:!0,composed:!0}))},t.timeoutMillis)}else this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))})},this.handleBackendFailed=e=>{e.detail.actionId&&this.component.triggers?.filter(e=>e.type==Ua.OnError).filter(t=>e.detail.actionId==t.calledActionId).forEach(t=>{(!t.condition||this._evalExpr(t.condition))&&(e.preventDefault(),e.stopPropagation(),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0})))})},this._pendingOrigins=new Map,this._backendSettledListener=e=>{((typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target)===this&&this._releasePending(e.detail?.actionId)},this._keydownListener=e=>{if(this._handleTabShortcut(e))return;let t=this.component;if(t)for(let n of t.actions??[]){let t=n.shortcut||(n.runOnEnter?`enter`:null);if(t&&this._shortcutMatchesEvent(t,e)){e.preventDefault(),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.id},bubbles:!0,composed:!0}));return}}}}createRenderRoot(){return P.mustUseShadowRoot()?super.createRenderRoot():this}updated(e){super.updated(e),e.has(`state`)&&this.state&&JSON.stringify(this.state)!=JSON.stringify({})&&this.onChange(),e.has(`component`)&&(this.formerState={...this.state},this.component?.confirmOnNavigationIfDirty&&this.dispatchEvent(new CustomEvent(`clean`,{detail:{},bubbles:!0,composed:!0})),setTimeout(()=>this.triggerOnLoad()))}focusFirstInvalidField(){let e=t=>requestAnimationFrame(()=>{let n=this.findFirstInvalid(this.renderRoot);if(n){n.focus?.(),n.scrollIntoView?.({block:`center`,behavior:`smooth`});return}t>0&&e(t-1)});e(3)}findFirstInvalid(e){if(!e?.querySelectorAll)return null;for(let t of Array.from(e.querySelectorAll(`*`))){if(t.invalid===!0)return t;if(t.shadowRoot){let e=this.findFirstInvalid(t.shadowRoot);if(e)return e}}return null}_releasePending(e){(e===void 0?Array.from(this._pendingOrigins.keys()):[e]).forEach(e=>{Zo.end(Xo(this.id,e)),is(this._pendingOrigins.get(e)),this._pendingOrigins.delete(e)})}_shortcutMatchesEvent(e,t){return ir(e,t)}_collectShortcutTabs(){let e=this.renderRoot;if(!e)return[];let t=Array.from(e.querySelectorAll(`vaadin-tab[data-shortcut]`));return e.querySelectorAll(`mateu-drawer, mateu-dialog`).forEach(e=>{let n=e.shadowRoot;n&&t.push(...Array.from(n.querySelectorAll(`vaadin-tab[data-shortcut]`)))}),t}_handleTabShortcut(e){let t=this._collectShortcutTabs();if(t.length===0)return!1;for(let n of Array.from(t)){let t=n.dataset.shortcut;if(!t||!this._shortcutMatchesEvent(t,e))continue;let r=n.closest(`vaadin-tabs`);if(!r)continue;let i=Array.from(r.querySelectorAll(`vaadin-tab`)).indexOf(n);if(!(i<0))return e.preventDefault(),r.selected=i,!0}return!1}connectedCallback(){super.connectedCallback(),this.addEventListener(`backend-call-succeeded`,this.handleBackendSucceeded),this.addEventListener(`backend-call-failed`,this.handleBackendFailed),this.addEventListener(`backend-succeeded-event`,this._backendSettledListener),this.addEventListener(`backend-failed-event`,this._backendSettledListener),this.addEventListener(`backend-cancelled-event`,this._backendSettledListener),document.addEventListener(`keydown`,this._keydownListener)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`backend-call-succeeded`,this.handleBackendSucceeded),this.removeEventListener(`backend-call-failed`,this.handleBackendFailed),this.removeEventListener(`backend-succeeded-event`,this._backendSettledListener),this.removeEventListener(`backend-failed-event`,this._backendSettledListener),this.removeEventListener(`backend-cancelled-event`,this._backendSettledListener),document.removeEventListener(`keydown`,this._keydownListener),this._releasePending()}render(){return T`<div>
             <div>${this._render()}</div>
             ${this.data&&this.data.errors&&this.data.errors._component&&this.data.errors._component.length>0?T`
                 <div><ul>${this.data.errors._component.map(e=>T`<li>${e}</li>`)}</ul></div>
-            `:v}</div>`}_render(){if(this.component?.type==A.ClientSide){let e=this.component;return e.metadata?.type==j.Page?Br(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!0):e.metadata?.type==j.Crud?Vr(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!0):F.get()?.renderClientSideComponent(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!1)}return T`
+            `:v}</div>`}_render(){if(this.component?.type==A.ClientSide){let e=this.component;return e.metadata?.type==j.Page?Vr(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!0):e.metadata?.type==j.Crud?Hr(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!0):P.get()?.renderClientSideComponent(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!1)}return T`
             <mateu-api-caller 
                     @value-changed="${this.valueChangedListener}"
                     @data-changed="${this.dataChangedListener}"
                     @close-modal-requested="${this.closeModalRequestedListener}"
                     @filter-reset-requested="${this.resetFilters}"
                     @action-requested="${this.actionRequestedListener}">
-            ${this.component?.children?.map(e=>{if(e.type==A.ClientSide){let t=e;if(t.metadata?.type==j.Page)return Br(this,t,this.baseUrl,this.state,this.data,this.appState,this.appData,!0);if(t.metadata?.type==j.Crud)return Vr(this,t,this.baseUrl,this.state,this.data,this.appState,this.appData,!0)}return I(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData)})}
+            ${this.component?.children?.map(e=>{if(e.type==A.ClientSide){let t=e;if(t.metadata?.type==j.Page)return Vr(this,t,this.baseUrl,this.state,this.data,this.appState,this.appData,!0);if(t.metadata?.type==j.Crud)return Hr(this,t,this.baseUrl,this.state,this.data,this.appState,this.appData,!0)}return F(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData)})}
             </mateu-api-caller>
         `}static{this.styles=h`
         :host {
@@ -7358,15 +7366,15 @@ ${i}
             padding-block: var(--lumo-space-xs);
             box-shadow: 0 1px 0 0 var(--lumo-contrast-10pct, rgba(0, 0, 0, 0.1));
         }
-  `}};k([y()],cs.prototype,`baseUrl`,void 0),k([y()],cs.prototype,`route`,void 0),k([y()],cs.prototype,`consumedRoute`,void 0),cs=k([g(`mateu-component`)],cs);var ls=new class{async handle(e,t){return await e.runAction(t.baseUrl,t.route,t.consumedRoute,t.actionId,t.initiatorComponentId,t.appState,t.serverSideType,t.componentState,t.parameters,t.initiator,t.background,t.options)}},us=new class{constructor(){this.handleUIIncrement=(e,t,n)=>{if(e?.fragments?.forEach(e=>{le.next({command:void 0,fragment:e,ui:void 0,error:void 0,callbackToken:n})}),e?.appState&&(O.value={...e.appState},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))),e?.appData){let n=e?.appData;ue.value={...e.appData,...n},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))}e?.messages?.forEach(e=>{Na({text:e.text,position:e.position,variant:e.variant,duration:e.duration,undoLabel:e.undoLabel,undoActionId:e.undoActionId,undoParameters:e.undoParameters},t)}),e?.banners&&e.banners.length>0&&document.dispatchEvent(new CustomEvent(`page-banners-received`,{detail:{banners:e.banners,append:e.appendBanners??!1},bubbles:!1,composed:!1})),e?.commands?.forEach(e=>{le.next({command:e,fragment:void 0,ui:void 0,error:void 0,callbackToken:n})})}}async runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,m={}){let te=()=>{this.runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,m)};try{let o=await ls.handle(e,{baseUrl:t,route:n,consumedRoute:r,actionId:i,appState:O.value,initiatorComponentId:a,componentState:c,parameters:l,serverSideType:s,initiator:u,background:d,options:{...m,retry:te}});f&&f(o),p||this.handleUIIncrement(o,u,ee),o.messages&&o.messages.length==1&&o.messages[0].variant==`error`&&u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-succeeded`,{detail:{actionId:i,evevntId:E()},bubbles:!0,composed:!0}))}catch(e){console.warn(`Action request failed`,e),e?.__mateuReported||u.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:i,reason:this.serialize(e),retry:te}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))}}serialize(e){return e?.message?e:JSON.stringify(e)}},ds=new class{constructor(){this.handleUIIncrement=(e,t,n)=>{if(e?.messages?.forEach(e=>{Na({text:e.text,position:e.position,variant:e.variant,duration:e.duration,undoLabel:e.undoLabel,undoActionId:e.undoActionId,undoParameters:e.undoParameters},t)}),e?.banners&&e.banners.length>0&&document.dispatchEvent(new CustomEvent(`page-banners-received`,{detail:{banners:e.banners,append:e.appendBanners??!1},bubbles:!1,composed:!1})),e?.commands?.forEach(e=>{le.next({command:e,fragment:void 0,ui:void 0,error:void 0,callbackToken:n})}),e?.fragments?.forEach(e=>{le.next({command:void 0,fragment:e,ui:void 0,error:void 0,callbackToken:n})}),e?.appState&&(O.value={...e.appState},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))),e?.appData){let n=e?.appData;ue.value={...e.appData,...n},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))}}}async runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,m={}){let te=()=>{this.runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,m)};if(n){n||=`_no_route`,n&&n.startsWith(`/`)&&(n=n.substring(1));let e={serverSideType:s,appState:O.value,componentState:c,parameters:l,initiatorComponentId:a,consumedRoute:r,route:`/`+n,actionId:i};d||u.dispatchEvent(new CustomEvent(`backend-called-event`,{bubbles:!0,composed:!0,detail:{}}));let o={Accept:`text/event-stream`,"Content-Type":`application/json`},m=localStorage.getItem(`__mateu_auth_token`);m&&(o.Authorization=`Bearer `+m);let ne=sessionStorage.getItem(`__mateu_sesion_id`);ne&&(o[`X-Session-Id`]=ne),fetch(t+`/mateu/v3/sse/`+n,{method:`POST`,headers:o,body:JSON.stringify(e)}).then(async e=>{let t=e.body?.pipeThrough(new TextDecoderStream).getReader();if(t){let e=``;for(;;){let{value:n,done:r}=await t.read();if(r)break;e+=n;let a=e.split(`
+  `}};k([y()],ls.prototype,`baseUrl`,void 0),k([y()],ls.prototype,`route`,void 0),k([y()],ls.prototype,`consumedRoute`,void 0),ls=k([g(`mateu-component`)],ls);var us=new class{async handle(e,t){return await e.runAction(t.baseUrl,t.route,t.consumedRoute,t.actionId,t.initiatorComponentId,t.appState,t.serverSideType,t.componentState,t.parameters,t.initiator,t.background,t.options)}},ds=new class{constructor(){this.handleUIIncrement=(e,t,n)=>{if(e?.fragments?.forEach(e=>{le.next({command:void 0,fragment:e,ui:void 0,error:void 0,callbackToken:n})}),e?.appState&&(O.value={...e.appState},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))),e?.appData){let n=e?.appData;ue.value={...e.appData,...n},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))}e?.messages?.forEach(e=>{Pa({text:e.text,position:e.position,variant:e.variant,duration:e.duration,undoLabel:e.undoLabel,undoActionId:e.undoActionId,undoParameters:e.undoParameters},t)}),e?.banners&&e.banners.length>0&&document.dispatchEvent(new CustomEvent(`page-banners-received`,{detail:{banners:e.banners,append:e.appendBanners??!1},bubbles:!1,composed:!1})),e?.commands?.forEach(e=>{le.next({command:e,fragment:void 0,ui:void 0,error:void 0,callbackToken:n})})}}async runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,m={}){let te=()=>{this.runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,m)};try{let o=await us.handle(e,{baseUrl:t,route:n,consumedRoute:r,actionId:i,appState:O.value,initiatorComponentId:a,componentState:c,parameters:l,serverSideType:s,initiator:u,background:d,options:{...m,retry:te}});f&&f(o),p||this.handleUIIncrement(o,u,ee),o.messages&&o.messages.length==1&&o.messages[0].variant==`error`&&u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-succeeded`,{detail:{actionId:i,evevntId:E()},bubbles:!0,composed:!0}))}catch(e){console.warn(`Action request failed`,e),e?.__mateuReported||u.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:i,reason:this.serialize(e),retry:te}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))}}serialize(e){return e?.message?e:JSON.stringify(e)}},fs=new class{constructor(){this.handleUIIncrement=(e,t,n)=>{if(e?.messages?.forEach(e=>{Pa({text:e.text,position:e.position,variant:e.variant,duration:e.duration,undoLabel:e.undoLabel,undoActionId:e.undoActionId,undoParameters:e.undoParameters},t)}),e?.banners&&e.banners.length>0&&document.dispatchEvent(new CustomEvent(`page-banners-received`,{detail:{banners:e.banners,append:e.appendBanners??!1},bubbles:!1,composed:!1})),e?.commands?.forEach(e=>{le.next({command:e,fragment:void 0,ui:void 0,error:void 0,callbackToken:n})}),e?.fragments?.forEach(e=>{le.next({command:void 0,fragment:e,ui:void 0,error:void 0,callbackToken:n})}),e?.appState&&(O.value={...e.appState},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))),e?.appData){let n=e?.appData;ue.value={...e.appData,...n},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))}}}async runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,m={}){let te=()=>{this.runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,m)};if(n){n||=`_no_route`,n&&n.startsWith(`/`)&&(n=n.substring(1));let e={serverSideType:s,appState:O.value,componentState:c,parameters:l,initiatorComponentId:a,consumedRoute:r,route:`/`+n,actionId:i};d||u.dispatchEvent(new CustomEvent(`backend-called-event`,{bubbles:!0,composed:!0,detail:{}}));let o={Accept:`text/event-stream`,"Content-Type":`application/json`},m=localStorage.getItem(`__mateu_auth_token`);m&&(o.Authorization=`Bearer `+m);let ne=sessionStorage.getItem(`__mateu_sesion_id`);ne&&(o[`X-Session-Id`]=ne),fetch(t+`/mateu/v3/sse/`+n,{method:`POST`,headers:o,body:JSON.stringify(e)}).then(async e=>{let t=e.body?.pipeThrough(new TextDecoderStream).getReader();if(t){let e=``;for(;;){let{value:n,done:r}=await t.read();if(r)break;e+=n;let a=e.split(`
 
-`);e=a.pop()??``;for(let e of a){let t=e.trim();if(t)if(t.startsWith(`data:`)){let e=JSON.parse(t.substring(5).trim());f&&f(e),p||this.handleUIIncrement(e,u,ee),e.messages&&e.messages.length==1&&e.messages[0].variant==`error`&&u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))}else{let e=t;try{let n=JSON.parse(t);e=n.message,n._embedded?.errors?.length>0&&n._embedded.errors[0].message&&(e=n._embedded.errors[0].message)}catch{}throw Error(e)}}}}d||u.dispatchEvent(new CustomEvent(`backend-succeeded-event`,{bubbles:!0,composed:!0,detail:{actionId:i}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-succeeded`,{detail:{actionId:i},bubbles:!0,composed:!0}))}).catch(e=>{u.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:i,reason:this.serialize(e),retry:te}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))})}}serialize(e){return e?.message?e:JSON.stringify(e)}},fs={fixed:`fixed`,fullWidth:`full`,edgeToEdge:`edge`},ps=new Set([j.Gantt,j.PlanningBoard,j.Kanban,j.Bpmn,j.Workflow,j.Map]),ms={landing:`fixed`,form:`fixed`,process:`fixed`},hs=e=>e?fs[e]:void 0,gs=e=>e.type==A.ClientSide?e.metadata:void 0,_s=e=>{let t=gs(e);if(t?.type==j.Page){let e=hs(t.pageWidth);if(e)return e}for(let t of e.children??[]){let e=_s(t);if(e)return e}},vs=e=>{let t=e.pageType;if(t)return t;let n=e=>{let t=gs(e);if(t?.type==j.Page&&t.pageType)return t.pageType;for(let t of e.children??[]){let e=n(t);if(e)return e}};return n(e)},ys=e=>{let t=gs(e);if(t?.type!=j.Crud)return!1;let n=t;return n.compact?!0:(n.columns??[]).some(e=>e.metadata?.editable)},bs=(e,t)=>t(e)||(e.children??[]).some(e=>bs(e,t)),xs=e=>!!e&&bs(e,e=>gs(e)?.type==j.HeroSection),Ss=e=>gs(e)?.type==j.App||(e.children??[]).some(e=>gs(e)?.type==j.App),Cs=(e,t)=>e?(hs(e.pageWidth)??_s(e))||(t?.top&&Ss(e)?`edge`:ms[vs(e)??``]||(bs(e,e=>{let t=gs(e)?.type;return t!=null&&ps.has(t)})?`edge`:bs(e,ys)?`full`:`fixed`)):`fixed`,ws=`mateu-route-structure-cache`,Ts=1,Es=50,Ds=(()=>{try{return localStorage.getItem(`mateu-route-structure-cache-off`)!==`1`}catch{return!0}})(),Os=()=>{try{return JSON.parse(localStorage.getItem(ws)??`{}`)}catch{return{}}},ks=e=>{try{localStorage.setItem(ws,JSON.stringify(e))}catch{try{let t=Object.entries(e).sort((e,t)=>t[1].t-e[1].t).slice(0,Math.floor(Es/2));localStorage.setItem(ws,JSON.stringify(Object.fromEntries(t)))}catch{}}},As=e=>{let t=e.initialState&&Object.keys(e.initialState).length?`#`+Ns(JSON.stringify(e.initialState)):``;return[e.baseUrl,e.consumedRoute??``,e.route??``,e.serverSideType??``].join(`|`)+t},js=e=>{if(!Ds)return;let t=Os()[e];if(!(!t||t.v!==Ts))return{component:t.component,hash:t.hash}},Ms=(e,t,n)=>{if(!Ds)return;let r=Os();r[e]={v:Ts,t:Date.now(),component:t,hash:n};let i=Object.keys(r);if(i.length>Es){let e=i.sort((e,t)=>r[e].t-r[t].t).slice(0,i.length-Es);for(let t of e)delete r[t]}ks(r)},Ns=e=>{let t=2166136261;for(let n=0;n<e.length;n++)t^=e.charCodeAt(n),t=Math.imul(t,16777619);return(t>>>0).toString(36)},Ps=30,Fs=new Map,Is=!0,Ls=e=>{if(Is)return Fs.get(e)},Rs=(e,t)=>{if(Is&&(Fs.delete(e),Fs.set(e,t),Fs.size>Ps)){let e=Fs.keys().next().value;e!==void 0&&Fs.delete(e)}},zs,X=class extends _t{static{zs=this}constructor(...e){super(...e),this.consumedRoute=``,this.serverSideType=void 0,this.uriPrefix=void 0,this.overrides=void 0,this.homeRoute=void 0,this.route=void 0,this.top=void 0,this.appState={},this.appData={},this.preventNavigation=!1,this.overridesParsed={},this.fragment=void 0,this.showSkeleton=!1,this.pendingRouteFocus=!1,this.hasRenderedContent=!1,this.loadLifecycleListener=e=>{if(((typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target)===this)if(clearTimeout(this.skeletonTimer),e.type===`backend-called-event`){if(this.fragment?.component)return;this.skeletonTimer=setTimeout(()=>{this.showSkeleton=!0},zs.SKELETON_DELAY_MS)}else this.showSkeleton=!1},this.actionRequestedListener=e=>{e instanceof CustomEvent&&(e.preventDefault(),e.stopPropagation(),this.manageActionEvent(e))},this.historyPushed=e=>{e instanceof CustomEvent&&(e.preventDefault(),e.stopPropagation(),this.preventNavigation=!0,this.route=e.detail.route)},this.routeChangedListener=e=>{if(e instanceof CustomEvent){e.preventDefault(),e.stopPropagation();let t=e.detail.route;typeof t==`string`&&(t===``||t.startsWith(`/`))&&this.consumedRoute&&this.consumedRoute!==`_empty`&&this.consumedRoute.startsWith(`/`)&&!t.startsWith(this.consumedRoute)&&(t=this.consumedRoute+t),this.uriPrefix&&(t=t.startsWith(`/`)&&this.uriPrefix.endsWith(`/`)?this.uriPrefix+t.substring(1):!t.startsWith(`/`)&&!this.uriPrefix.endsWith(`/`)?this.uriPrefix+`/`+t:this.uriPrefix+t),this.dispatchEvent(new CustomEvent(`url-update-requested`,{detail:{route:t},bubbles:!0,composed:!0}))}},this.backendFailedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&e.detail.actionId==``&&(this.fragment={targetComponentId:this.id,data:{},state:{},component:{type:A.ClientSide,metadata:{type:j.Element,name:`div`,content:`Not found`},id:`fieldId`},action:ut.Replace,containerId:void 0})},this.detail1=void 0,this.manageActionEvent=e=>{e.preventDefault(),e.stopPropagation(),this.detail1=e.detail;let t=this.detail1;if(e.type==`server-side-action-requested`){let e=us;t.sse&&(e=ds),e.runAction(lt,this.baseUrl,t.route??``,t.consumedRoute,t.actionId,t.initiatorComponentId,this.getCustomisedAppState(),t.serverSideType,t.componentState,t.parameters,t.initiator,t.background,t.callback,t.callbackonly,t.callbackToken,{timeoutMillis:t.timeoutMillis,idempotent:t.idempotent,knownStructureHash:t.knownStructureHash})}},this.getCustomisedAppState=()=>{let e={...O.value};if(this.overrides){let t=Wo(this.overrides);e={...e,...t}}return e}}manageActionRequestedEvent(e){throw Error(`Method not implemented.`)}createRenderRoot(){return F.mustUseShadowRoot()?super.createRenderRoot():this}structureCacheKey(){return As({baseUrl:this.baseUrl,consumedRoute:this.consumedRoute,route:this.route,serverSideType:this.serverSideType,initialState:this.initialState})}focusNewContent(){requestAnimationFrame(()=>{let e=this.renderRoot?.querySelector?.(`h1, h2, [role="heading"]`)??this;e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus?.({preventScroll:!0})})}static{this.SKELETON_DELAY_MS=400}connectedCallback(){super.connectedCallback(),this.overridesParsed=Wo(this.overrides),this.addEventListener(`server-side-action-requested`,this.actionRequestedListener),this.addEventListener(`backend-call-failed`,this.backendFailedListener),this.addEventListener(`history-pushed`,this.historyPushed),this.addEventListener(`route-changed`,this.routeChangedListener),this.addEventListener(`backend-called-event`,this.loadLifecycleListener),this.addEventListener(`backend-succeeded-event`,this.loadLifecycleListener),this.addEventListener(`backend-failed-event`,this.loadLifecycleListener),this.addEventListener(`backend-cancelled-event`,this.loadLifecycleListener)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`server-side-action-requested`,this.actionRequestedListener),this.removeEventListener(`backend-call-failed`,this.backendFailedListener),this.removeEventListener(`history-pushed`,this.historyPushed),this.removeEventListener(`route-changed`,this.routeChangedListener),this.removeEventListener(`backend-called-event`,this.loadLifecycleListener),this.removeEventListener(`backend-succeeded-event`,this.loadLifecycleListener),this.removeEventListener(`backend-failed-event`,this.loadLifecycleListener),this.removeEventListener(`backend-cancelled-event`,this.loadLifecycleListener),clearTimeout(this.skeletonTimer)}shouldUpdate(e){if(this.fragment?.component&&[...e.keys()].every(e=>e===`appState`||e===`appData`)){let t=this.renderRoot.querySelector(`mateu-component`);if(t)return e.has(`appState`)&&(t.appState=this.appState),e.has(`appData`)&&(t.appData=this.appData),!1}return!0}updated(e){if((e.has(`id`)||e.has(`baseurl`)||e.has(`route`)||e.has(`consumedRoute`)||e.has(`instant`))&&!this.preventNavigation){this.callbackToken=this.instant||E();let e=this.structureCacheKey(),t=e===this.lastAuthoritativeKey?void 0:Ls(e);if(t)queueMicrotask(()=>this.applyFragment(t));else{if(e!==this.lastAuthoritativeKey){let t=js(e);this.currentStructureHash=t?.hash,t&&(this.fragment={targetComponentId:this.id,component:t.component,state:{},data:{},action:ut.Replace,containerId:void 0})}this.manageActionEvent(new CustomEvent(`server-side-action-requested`,{detail:{route:this.route,consumedRoute:this.consumedRoute,userData:void 0,actionId:``,serverSideType:this.serverSideType,initiatorComponentId:this.id,initiator:this,componentState:this.initialState,knownStructureHash:this.currentStructureHash,callbackToken:this.callbackToken},bubbles:!0,composed:!0}))}}e.has(`route`)&&this.top&&(this.preventNavigation||(this.pendingRouteFocus=!0),this.preventNavigation||this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:this.route},bubbles:!0,composed:!0}))),this.preventNavigation&&=!1}applyFragment(e){if(!e.component&&this.fragment?.component){this.fragment={...this.fragment,state:{...this.fragment.state??{},...e.state??{}},data:{...this.fragment.data??{},...e.data??{}}};return}if(this.fragment=e,e.component){if(e.action!==ut.Add){let t=this.structureCacheKey(),n=e.component.structureHash;Ms(t,e.component,n),this.lastAuthoritativeKey=t,this.currentStructureHash=n,e.component.staticView&&Rs(t,e)}this.pendingRouteFocus&&this.hasRenderedContent&&this.focusNewContent(),this.pendingRouteFocus=!1,this.hasRenderedContent=!0}e.component&&(this.dataset.pageWidth=Cs(e.component,{top:this.top}),this.dataset.pageType=vs(e.component)??``,this.dataset.hasWelcomeBanner=String(xs(e.component)))}render(){return!this.fragment?.component&&this.showSkeleton?T`
+`);e=a.pop()??``;for(let e of a){let t=e.trim();if(t)if(t.startsWith(`data:`)){let e=JSON.parse(t.substring(5).trim());f&&f(e),p||this.handleUIIncrement(e,u,ee),e.messages&&e.messages.length==1&&e.messages[0].variant==`error`&&u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))}else{let e=t;try{let n=JSON.parse(t);e=n.message,n._embedded?.errors?.length>0&&n._embedded.errors[0].message&&(e=n._embedded.errors[0].message)}catch{}throw Error(e)}}}}d||u.dispatchEvent(new CustomEvent(`backend-succeeded-event`,{bubbles:!0,composed:!0,detail:{actionId:i}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-succeeded`,{detail:{actionId:i},bubbles:!0,composed:!0}))}).catch(e=>{u.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:i,reason:this.serialize(e),retry:te}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))})}}serialize(e){return e?.message?e:JSON.stringify(e)}},ps={fixed:`fixed`,fullWidth:`full`,edgeToEdge:`edge`},ms=new Set([j.Gantt,j.PlanningBoard,j.Kanban,j.Bpmn,j.Workflow,j.Map]),hs={landing:`fixed`,form:`fixed`,process:`fixed`},gs=e=>e?ps[e]:void 0,_s=e=>e.type==A.ClientSide?e.metadata:void 0,vs=e=>{let t=_s(e);if(t?.type==j.Page){let e=gs(t.pageWidth);if(e)return e}for(let t of e.children??[]){let e=vs(t);if(e)return e}},ys=e=>{let t=e.pageType;if(t)return t;let n=e=>{let t=_s(e);if(t?.type==j.Page&&t.pageType)return t.pageType;for(let t of e.children??[]){let e=n(t);if(e)return e}};return n(e)},bs=e=>{let t=_s(e);if(t?.type!=j.Crud)return!1;let n=t;return n.compact?!0:(n.columns??[]).some(e=>e.metadata?.editable)},xs=(e,t)=>t(e)||(e.children??[]).some(e=>xs(e,t)),Ss=e=>!!e&&xs(e,e=>_s(e)?.type==j.HeroSection),Cs=e=>_s(e)?.type==j.App||(e.children??[]).some(e=>_s(e)?.type==j.App),ws=(e,t)=>e?(gs(e.pageWidth)??vs(e))||(t?.top&&Cs(e)?`edge`:hs[ys(e)??``]||(xs(e,e=>{let t=_s(e)?.type;return t!=null&&ms.has(t)})?`edge`:xs(e,bs)?`full`:`fixed`)):`fixed`,Ts=`mateu-route-structure-cache`,Es=1,Ds=50,Os=(()=>{try{return localStorage.getItem(`mateu-route-structure-cache-off`)!==`1`}catch{return!0}})(),ks=()=>{try{return JSON.parse(localStorage.getItem(Ts)??`{}`)}catch{return{}}},As=e=>{try{localStorage.setItem(Ts,JSON.stringify(e))}catch{try{let t=Object.entries(e).sort((e,t)=>t[1].t-e[1].t).slice(0,Math.floor(Ds/2));localStorage.setItem(Ts,JSON.stringify(Object.fromEntries(t)))}catch{}}},js=e=>{let t=e.initialState&&Object.keys(e.initialState).length?`#`+Ps(JSON.stringify(e.initialState)):``;return[e.baseUrl,e.consumedRoute??``,e.route??``,e.serverSideType??``].join(`|`)+t},Ms=e=>{if(!Os)return;let t=ks()[e];if(!(!t||t.v!==Es))return{component:t.component,hash:t.hash}},Ns=(e,t,n)=>{if(!Os)return;let r=ks();r[e]={v:Es,t:Date.now(),component:t,hash:n};let i=Object.keys(r);if(i.length>Ds){let e=i.sort((e,t)=>r[e].t-r[t].t).slice(0,i.length-Ds);for(let t of e)delete r[t]}As(r)},Ps=e=>{let t=2166136261;for(let n=0;n<e.length;n++)t^=e.charCodeAt(n),t=Math.imul(t,16777619);return(t>>>0).toString(36)},Fs=30,Is=new Map,Ls=!0,Rs=e=>{if(Ls)return Is.get(e)},zs=(e,t)=>{if(Ls&&(Is.delete(e),Is.set(e,t),Is.size>Fs)){let e=Is.keys().next().value;e!==void 0&&Is.delete(e)}},Bs,Y=class extends _t{static{Bs=this}constructor(...e){super(...e),this.consumedRoute=``,this.serverSideType=void 0,this.uriPrefix=void 0,this.overrides=void 0,this.homeRoute=void 0,this.route=void 0,this.top=void 0,this.appState={},this.appData={},this.preventNavigation=!1,this.overridesParsed={},this.fragment=void 0,this.showSkeleton=!1,this.pendingRouteFocus=!1,this.hasRenderedContent=!1,this.loadLifecycleListener=e=>{if(((typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target)===this)if(clearTimeout(this.skeletonTimer),e.type===`backend-called-event`){if(this.fragment?.component)return;this.skeletonTimer=setTimeout(()=>{this.showSkeleton=!0},Bs.SKELETON_DELAY_MS)}else this.showSkeleton=!1},this.actionRequestedListener=e=>{e instanceof CustomEvent&&(e.preventDefault(),e.stopPropagation(),this.manageActionEvent(e))},this.historyPushed=e=>{e instanceof CustomEvent&&(e.preventDefault(),e.stopPropagation(),this.preventNavigation=!0,this.route=e.detail.route)},this.routeChangedListener=e=>{if(e instanceof CustomEvent){e.preventDefault(),e.stopPropagation();let t=e.detail.route;typeof t==`string`&&(t===``||t.startsWith(`/`))&&this.consumedRoute&&this.consumedRoute!==`_empty`&&this.consumedRoute.startsWith(`/`)&&!t.startsWith(this.consumedRoute)&&(t=this.consumedRoute+t),this.uriPrefix&&(t=t.startsWith(`/`)&&this.uriPrefix.endsWith(`/`)?this.uriPrefix+t.substring(1):!t.startsWith(`/`)&&!this.uriPrefix.endsWith(`/`)?this.uriPrefix+`/`+t:this.uriPrefix+t),this.dispatchEvent(new CustomEvent(`url-update-requested`,{detail:{route:t},bubbles:!0,composed:!0}))}},this.backendFailedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&e.detail.actionId==``&&(this.fragment={targetComponentId:this.id,data:{},state:{},component:{type:A.ClientSide,metadata:{type:j.Element,name:`div`,content:`Not found`},id:`fieldId`},action:ut.Replace,containerId:void 0})},this.detail1=void 0,this.manageActionEvent=e=>{e.preventDefault(),e.stopPropagation(),this.detail1=e.detail;let t=this.detail1;if(e.type==`server-side-action-requested`){let e=ds;t.sse&&(e=fs),e.runAction(lt,this.baseUrl,t.route??``,t.consumedRoute,t.actionId,t.initiatorComponentId,this.getCustomisedAppState(),t.serverSideType,t.componentState,t.parameters,t.initiator,t.background,t.callback,t.callbackonly,t.callbackToken,{timeoutMillis:t.timeoutMillis,idempotent:t.idempotent,knownStructureHash:t.knownStructureHash})}},this.getCustomisedAppState=()=>{let e={...O.value};if(this.overrides){let t=Go(this.overrides);e={...e,...t}}return e}}manageActionRequestedEvent(e){throw Error(`Method not implemented.`)}createRenderRoot(){return P.mustUseShadowRoot()?super.createRenderRoot():this}structureCacheKey(){return js({baseUrl:this.baseUrl,consumedRoute:this.consumedRoute,route:this.route,serverSideType:this.serverSideType,initialState:this.initialState})}focusNewContent(){requestAnimationFrame(()=>{let e=this.renderRoot?.querySelector?.(`h1, h2, [role="heading"]`)??this;e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus?.({preventScroll:!0})})}static{this.SKELETON_DELAY_MS=400}connectedCallback(){super.connectedCallback(),this.overridesParsed=Go(this.overrides),this.addEventListener(`server-side-action-requested`,this.actionRequestedListener),this.addEventListener(`backend-call-failed`,this.backendFailedListener),this.addEventListener(`history-pushed`,this.historyPushed),this.addEventListener(`route-changed`,this.routeChangedListener),this.addEventListener(`backend-called-event`,this.loadLifecycleListener),this.addEventListener(`backend-succeeded-event`,this.loadLifecycleListener),this.addEventListener(`backend-failed-event`,this.loadLifecycleListener),this.addEventListener(`backend-cancelled-event`,this.loadLifecycleListener)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`server-side-action-requested`,this.actionRequestedListener),this.removeEventListener(`backend-call-failed`,this.backendFailedListener),this.removeEventListener(`history-pushed`,this.historyPushed),this.removeEventListener(`route-changed`,this.routeChangedListener),this.removeEventListener(`backend-called-event`,this.loadLifecycleListener),this.removeEventListener(`backend-succeeded-event`,this.loadLifecycleListener),this.removeEventListener(`backend-failed-event`,this.loadLifecycleListener),this.removeEventListener(`backend-cancelled-event`,this.loadLifecycleListener),clearTimeout(this.skeletonTimer)}shouldUpdate(e){if(this.fragment?.component&&[...e.keys()].every(e=>e===`appState`||e===`appData`)){let t=this.renderRoot.querySelector(`mateu-component`);if(t)return e.has(`appState`)&&(t.appState=this.appState),e.has(`appData`)&&(t.appData=this.appData),!1}return!0}updated(e){if((e.has(`id`)||e.has(`baseurl`)||e.has(`route`)||e.has(`consumedRoute`)||e.has(`instant`))&&!this.preventNavigation){this.callbackToken=this.instant||E();let e=this.structureCacheKey(),t=e===this.lastAuthoritativeKey?void 0:Rs(e);if(t)queueMicrotask(()=>this.applyFragment(t));else{if(e!==this.lastAuthoritativeKey){let t=Ms(e);this.currentStructureHash=t?.hash,t&&(this.fragment={targetComponentId:this.id,component:t.component,state:{},data:{},action:ut.Replace,containerId:void 0})}this.manageActionEvent(new CustomEvent(`server-side-action-requested`,{detail:{route:this.route,consumedRoute:this.consumedRoute,userData:void 0,actionId:``,serverSideType:this.serverSideType,initiatorComponentId:this.id,initiator:this,componentState:this.initialState,knownStructureHash:this.currentStructureHash,callbackToken:this.callbackToken},bubbles:!0,composed:!0}))}}e.has(`route`)&&this.top&&(this.preventNavigation||(this.pendingRouteFocus=!0),this.preventNavigation||this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:this.route},bubbles:!0,composed:!0}))),this.preventNavigation&&=!1}applyFragment(e){if(!e.component&&this.fragment?.component){this.fragment={...this.fragment,state:{...this.fragment.state??{},...e.state??{}},data:{...this.fragment.data??{},...e.data??{}}};return}if(this.fragment=e,e.component){if(e.action!==ut.Add){let t=this.structureCacheKey(),n=e.component.structureHash;Ns(t,e.component,n),this.lastAuthoritativeKey=t,this.currentStructureHash=n,e.component.staticView&&zs(t,e)}this.pendingRouteFocus&&this.hasRenderedContent&&this.focusNewContent(),this.pendingRouteFocus=!1,this.hasRenderedContent=!0}e.component&&(this.dataset.pageWidth=ws(e.component,{top:this.top}),this.dataset.pageType=ys(e.component)??``,this.dataset.hasWelcomeBanner=String(Ss(e.component)))}render(){return!this.fragment?.component&&this.showSkeleton?T`
                 <div class="route-skeleton" aria-busy="true" aria-live="polite">
                     <mateu-skeleton variant="text" count="1"></mateu-skeleton>
                     <mateu-skeleton variant="form" count="4"></mateu-skeleton>
                 </div>
             `:T`
-           ${this.fragment?.component?I(this,this.fragment?.component,this.baseUrl,this.fragment?.state??{},this.fragment?.data??{},this.appState,this.appData):v}
+           ${this.fragment?.component?F(this,this.fragment?.component,this.baseUrl,this.fragment?.state??{},this.fragment?.data??{},this.appState,this.appData):v}
        `}static{this.styles=h`
         :host {
             display: block;
@@ -7405,7 +7413,7 @@ ${i}
             max-width: 16rem;
             margin-block-end: var(--lumo-space-l, 1.5rem);
         }
-  `}};k([y()],X.prototype,`consumedRoute`,void 0),k([y()],X.prototype,`serverSideType`,void 0),k([y()],X.prototype,`uriPrefix`,void 0),k([y()],X.prototype,`overrides`,void 0),k([y()],X.prototype,`homeRoute`,void 0),k([y()],X.prototype,`route`,void 0),k([y()],X.prototype,`top`,void 0),k([y()],X.prototype,`instant`,void 0),k([y()],X.prototype,`initialState`,void 0),k([y()],X.prototype,`appState`,void 0),k([y()],X.prototype,`appData`,void 0),k([C()],X.prototype,`fragment`,void 0),k([C()],X.prototype,`showSkeleton`,void 0),X=zs=k([g(`mateu-ux`)],X);function Bs(e){let t=`var(--lumo-space-m, 1rem)`,n={left:`50%`,transform:`translateX(-50%)`};switch(e){case`topStart`:return{top:t,left:t};case`topCenter`:return{top:t,...n};case`topEnd`:return{top:t,right:t};case`topStretch`:return{top:t,left:t,right:t};case`middle`:return{top:`50%`,left:`50%`,transform:`translate(-50%, -50%)`};case`bottomStart`:return{bottom:t,left:t};case`bottomCenter`:return{bottom:t,...n};case`bottomStretch`:return{bottom:t,left:t,right:t};default:return{bottom:t,right:t}}}function Vs(e){switch(e){case`success`:return{bg:`var(--lumo-success-color, #2e7d32)`,fg:`#fff`};case`error`:return{bg:`var(--lumo-error-color, #c62828)`,fg:`#fff`};case`warning`:return{bg:`var(--lumo-warning-color, #f9a825)`,fg:`#1a1a1a`};case`contrast`:return{bg:`var(--lumo-contrast-90pct, #1a1a1a)`,fg:`#fff`};default:return{bg:`var(--lumo-base-color, #fff)`,fg:`var(--lumo-body-text-color, #1a1a1a)`}}}var Hs={show(e,t){let{bg:n,fg:r}=Vs(e.variant),i=Bs(e.position),a=document.createElement(`div`),o=e.variant===`error`;a.setAttribute(`role`,o?`alert`:`status`),a.setAttribute(`aria-live`,o?`assertive`:`polite`),a.setAttribute(`aria-atomic`,`true`),Object.assign(a.style,{position:`fixed`,zIndex:`2000`,display:`flex`,alignItems:`center`,gap:`0.75rem`,maxWidth:`min(90vw, 28rem)`,padding:`0.7rem 1rem`,borderRadius:`var(--lumo-border-radius-m, 8px)`,boxShadow:`var(--lumo-box-shadow-m, 0 4px 16px rgba(0,0,0,0.2))`,background:n,color:r,font:`inherit`,fontSize:`var(--lumo-font-size-s, 0.875rem)`,opacity:`0`,transition:`opacity 0.2s ease`,...i});let s=document.createElement(`span`);s.textContent=e.text,a.appendChild(s);let c=()=>{a.style.opacity=`0`,setTimeout(()=>a.remove(),200)},l=e.onAction?{label:e.actionLabel??`Retry`,run:e.onAction}:e.undoActionId?{label:e.undoLabel??`Undo`,run:()=>t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.undoActionId,parameters:e.undoParameters??{}},bubbles:!0,composed:!0}))}:void 0;if(l){let e=document.createElement(`button`);e.textContent=l.label,e.style.cssText=`margin-left: 0.25rem; background: none; border: 1px solid currentColor; border-radius: var(--lumo-border-radius-s, 4px); color: inherit; cursor: pointer; padding: 0.15rem 0.6rem; font: inherit; font-weight: 600;`,e.addEventListener(`click`,()=>{l.run(),c()}),a.appendChild(e)}document.body.appendChild(a),requestAnimationFrame(()=>{a.style.opacity=`1`});let u=e.duration??(l?1e4:5e3);u>0&&setTimeout(c,u)}};function Us(){Ma(Hs)}var Ws=class extends b{constructor(...e){super(...e),this.online=!0,this.recovered=!1}connectedCallback(){super.connectedCallback(),this.online=at.isOnline(),this.unsubscribe=at.subscribe(e=>{let t=!this.online;this.online=e,e&&t&&(this.recovered=!0,clearTimeout(this.recoveredTimer),this.recoveredTimer=setTimeout(()=>{this.recovered=!1},4e3))})}disconnectedCallback(){super.disconnectedCallback(),this.unsubscribe?.(),clearTimeout(this.recoveredTimer),this.releaseSpace()}updated(){let e=this.renderRoot.querySelector(`.bar`);if(!e){this.releaseSpace();return}document.body.style.setProperty(`padding-block-start`,`${e.offsetHeight}px`)}releaseSpace(){typeof document<`u`&&document.body?.style.removeProperty(`padding-block-start`)}render(){if(this.online&&!this.recovered)return v;let e=!this.online;return T`<div class="bar ${e?`offline`:`back`}" role="status" aria-live="polite">
+  `}};k([y()],Y.prototype,`consumedRoute`,void 0),k([y()],Y.prototype,`serverSideType`,void 0),k([y()],Y.prototype,`uriPrefix`,void 0),k([y()],Y.prototype,`overrides`,void 0),k([y()],Y.prototype,`homeRoute`,void 0),k([y()],Y.prototype,`route`,void 0),k([y()],Y.prototype,`top`,void 0),k([y()],Y.prototype,`instant`,void 0),k([y()],Y.prototype,`initialState`,void 0),k([y()],Y.prototype,`appState`,void 0),k([y()],Y.prototype,`appData`,void 0),k([C()],Y.prototype,`fragment`,void 0),k([C()],Y.prototype,`showSkeleton`,void 0),Y=Bs=k([g(`mateu-ux`)],Y);function Vs(e){let t=`var(--lumo-space-m, 1rem)`,n={left:`50%`,transform:`translateX(-50%)`};switch(e){case`topStart`:return{top:t,left:t};case`topCenter`:return{top:t,...n};case`topEnd`:return{top:t,right:t};case`topStretch`:return{top:t,left:t,right:t};case`middle`:return{top:`50%`,left:`50%`,transform:`translate(-50%, -50%)`};case`bottomStart`:return{bottom:t,left:t};case`bottomCenter`:return{bottom:t,...n};case`bottomStretch`:return{bottom:t,left:t,right:t};default:return{bottom:t,right:t}}}function Hs(e){switch(e){case`success`:return{bg:`var(--lumo-success-color, #2e7d32)`,fg:`#fff`};case`error`:return{bg:`var(--lumo-error-color, #c62828)`,fg:`#fff`};case`warning`:return{bg:`var(--lumo-warning-color, #f9a825)`,fg:`#1a1a1a`};case`contrast`:return{bg:`var(--lumo-contrast-90pct, #1a1a1a)`,fg:`#fff`};default:return{bg:`var(--lumo-base-color, #fff)`,fg:`var(--lumo-body-text-color, #1a1a1a)`}}}var Us={show(e,t){let{bg:n,fg:r}=Hs(e.variant),i=Vs(e.position),a=document.createElement(`div`),o=e.variant===`error`;a.setAttribute(`role`,o?`alert`:`status`),a.setAttribute(`aria-live`,o?`assertive`:`polite`),a.setAttribute(`aria-atomic`,`true`),Object.assign(a.style,{position:`fixed`,zIndex:`2000`,display:`flex`,alignItems:`center`,gap:`0.75rem`,maxWidth:`min(90vw, 28rem)`,padding:`0.7rem 1rem`,borderRadius:`var(--lumo-border-radius-m, 8px)`,boxShadow:`var(--lumo-box-shadow-m, 0 4px 16px rgba(0,0,0,0.2))`,background:n,color:r,font:`inherit`,fontSize:`var(--lumo-font-size-s, 0.875rem)`,opacity:`0`,transition:`opacity 0.2s ease`,...i});let s=document.createElement(`span`);s.textContent=e.text,a.appendChild(s);let c=()=>{a.style.opacity=`0`,setTimeout(()=>a.remove(),200)},l=e.onAction?{label:e.actionLabel??`Retry`,run:e.onAction}:e.undoActionId?{label:e.undoLabel??`Undo`,run:()=>t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.undoActionId,parameters:e.undoParameters??{}},bubbles:!0,composed:!0}))}:void 0;if(l){let e=document.createElement(`button`);e.textContent=l.label,e.style.cssText=`margin-left: 0.25rem; background: none; border: 1px solid currentColor; border-radius: var(--lumo-border-radius-s, 4px); color: inherit; cursor: pointer; padding: 0.15rem 0.6rem; font: inherit; font-weight: 600;`,e.addEventListener(`click`,()=>{l.run(),c()}),a.appendChild(e)}document.body.appendChild(a),requestAnimationFrame(()=>{a.style.opacity=`1`});let u=e.duration??(l?1e4:5e3);u>0&&setTimeout(c,u)}};function Ws(){Na(Us)}var Gs=class extends b{constructor(...e){super(...e),this.online=!0,this.recovered=!1}connectedCallback(){super.connectedCallback(),this.online=at.isOnline(),this.unsubscribe=at.subscribe(e=>{let t=!this.online;this.online=e,e&&t&&(this.recovered=!0,clearTimeout(this.recoveredTimer),this.recoveredTimer=setTimeout(()=>{this.recovered=!1},4e3))})}disconnectedCallback(){super.disconnectedCallback(),this.unsubscribe?.(),clearTimeout(this.recoveredTimer),this.releaseSpace()}updated(){let e=this.renderRoot.querySelector(`.bar`);if(!e){this.releaseSpace();return}document.body.style.setProperty(`padding-block-start`,`${e.offsetHeight}px`)}releaseSpace(){typeof document<`u`&&document.body?.style.removeProperty(`padding-block-start`)}render(){if(this.online&&!this.recovered)return v;let e=!this.online;return T`<div class="bar ${e?`offline`:`back`}" role="status" aria-live="polite">
             <span class="dot"></span>
             <span>${e?`No connection — changes you make now will not be saved.`:`Connection restored.`}</span>
         </div>`}static{this.styles=h`
@@ -7447,7 +7455,7 @@ ${i}
         @media (prefers-reduced-motion: reduce) {
             .bar, .bar.offline .dot { animation: none; }
         }
-    `}};k([C()],Ws.prototype,`online`,void 0),k([C()],Ws.prototype,`recovered`,void 0),Ws=k([g(`mateu-connectivity-banner`)],Ws);var Gs=null;function Ks(){if(!(typeof document>`u`)&&!(Gs&&Gs.isConnected)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>Ks(),{once:!0});return}Gs=document.createElement(`mateu-connectivity-banner`),document.body.appendChild(Gs)}}var qs,Js=class extends b{static{qs=this}constructor(...e){super(...e),this.skip=()=>{let e=this.findContent();e&&(e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus(),e.scrollIntoView({block:`start`}))}}static{this.TARGETS=[`.app-content`,`mateu-page`,`mateu-ux`,`mateu-component`]}findContent(){let e=new Set,t=n=>{if(e.has(n))return null;e.add(n);for(let e of qs.TARGETS){let t=n.querySelector?.(e);if(t&&t!==this)return t}for(let e of Array.from(n.querySelectorAll?.(`*`)??[]))if(e.shadowRoot){let n=t(e.shadowRoot);if(n)return n}return null};return t(document)}render(){return T`<button class="skip" @click="${this.skip}">Skip to content</button>`}static{this.styles=h`
+    `}};k([C()],Gs.prototype,`online`,void 0),k([C()],Gs.prototype,`recovered`,void 0),Gs=k([g(`mateu-connectivity-banner`)],Gs);var Ks=null;function qs(){if(!(typeof document>`u`)&&!(Ks&&Ks.isConnected)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>qs(),{once:!0});return}Ks=document.createElement(`mateu-connectivity-banner`),document.body.appendChild(Ks)}}var Js,Ys=class extends b{static{Js=this}constructor(...e){super(...e),this.skip=()=>{let e=this.findContent();e&&(e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus(),e.scrollIntoView({block:`start`}))}}static{this.TARGETS=[`.app-content`,`mateu-page`,`mateu-ux`,`mateu-component`]}findContent(){let e=new Set,t=n=>{if(e.has(n))return null;e.add(n);for(let e of Js.TARGETS){let t=n.querySelector?.(e);if(t&&t!==this)return t}for(let e of Array.from(n.querySelectorAll?.(`*`)??[]))if(e.shadowRoot){let n=t(e.shadowRoot);if(n)return n}return null};return t(document)}render(){return T`<button class="skip" @click="${this.skip}">Skip to content</button>`}static{this.styles=h`
         :host {
             position: fixed;
             inset-block-start: 0;
@@ -7480,7 +7488,7 @@ ${i}
             outline: 2px solid var(--lumo-body-text-color, #161513);
             outline-offset: 2px;
         }
-    `}};Js=qs=k([g(`mateu-skip-link`)],Js);var Ys=null;function Xs(){if(!(typeof document>`u`)&&!(Ys&&Ys.isConnected)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>Xs(),{once:!0});return}Ys=document.createElement(`mateu-skip-link`),document.body.insertBefore(Ys,document.body.firstChild)}}Us(),Ks(),ht(),Xs();var Zs=class extends b{constructor(...e){super(...e),this.baseUrl=``,this.route=void 0,this.consumedRoute=`_empty`,this.config=void 0,this.top=`true`,this.pathPrefix=void 0,this.bundleUrl=void 0,this.debug=!1,this._lastUrl=``,this.routeChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.top==`true`){let t=e.detail.route,n=this.baseUrl??``;!t||t.startsWith(`/`)?n=window.location.origin+(this.pathPrefix??``):(t=(this.pathPrefix??``)+t,n.indexOf(`://`)<0&&(n.startsWith(`/`)||(n=`/`+n),n=window.location.origin+n)),t.startsWith(this.pathPrefix+`/`)&&(t=t.substring(this.pathPrefix?.length)),n.endsWith(`/`)&&t.startsWith(`/`)&&(t=t.substring(1));let r=new URL(n+t);if((window.location.pathname||r.pathname)&&window.location.pathname!=r.pathname){let e=r.pathname;r.search&&(e+=r.search),e&&!e.startsWith(`/`)&&(e=`/`+e),window.history.pushState({},``,e),this._lastUrl=window.location.href}}},this.navigateToRequestedListener=e=>{if(e.preventDefault(),e.stopPropagation(),eo.markClean(),e instanceof CustomEvent){let t=e.detail.route,n=this.renderRoot.querySelector(`mateu-ux`);n&&(n.setAttribute(`route`,t),n.setAttribute(`instant`,E()))}}}createRenderRoot(){return F.mustUseShadowRoot()?super.createRenderRoot():this}connectedCallback(){if(super.connectedCallback(),eo.install(),this._lastUrl=window.location.href,window.onpopstate=e=>{if(!eo.confirmLeave()){window.history.pushState({},``,this._lastUrl);return}let t=e.target;this.loadUrl(t)},this.top==`true`?(this.bundleUrl&&Ke(this.bundleUrl),this.loadUrl(window)):this.route&&(this.consumedRoute=``),this.config)try{let e=JSON.parse(this.config);O.value={...O.value,...e}}catch{O.value={...O.value,config:this.config}}this.addEventListener(`url-update-requested`,this.routeChangedListener),this.addEventListener(`navigate-to-requested`,this.navigateToRequestedListener)}disconnectedCallback(){super.disconnectedCallback(),this.upstreamSubscription?.unsubscribe(),this.removeEventListener(`url-update-requested`,this.routeChangedListener),this.removeEventListener(`navigate-to-requested`,this.navigateToRequestedListener)}loadUrl(e){if(this.route=this.extractRouteFromUrl(e),this.setAttribute(`route`,this.route),this.instant=E(),this._lastUrl=e.location.href,e.location.search){let t=new URLSearchParams(e.location.search).get(`overrides`);if(t&&(this.config=t,this.config))try{let e=JSON.parse(this.config);O.value={...O.value,...e}}catch{O.value={...O.value,config:this.config}}}}extractRouteFromUrl(e){return this.addQueryParams(this.extractRouteWithoutParamsFromUrl(e),e.location)}extractRouteWithoutParamsFromUrl(e){let t=this.extractGrossRouteFromUrl(e);return this.pathPrefix&&t.startsWith(this.pathPrefix)?t.substring(this.pathPrefix.length):t==`/`?``:t}addQueryParams(e,t){return e+(t.search?``+t.search:``)}extractGrossRouteFromUrl(e){let t=e.location.pathname,n=this.baseUrl&&(this.baseUrl.startsWith(`http://`)||this.baseUrl.startsWith(`https://`))?this.baseUrl.substring(this.getContextPathStartingIndex(this.baseUrl)):this.baseUrl;return t.startsWith(n)?t.substring(n.length):t}getContextPathStartingIndex(e){return e.startsWith(`http:`)?e.indexOf(`/`,7):e.startsWith(`https:`)?e.indexOf(`/`,8):0}render(){return T`
+    `}};Ys=Js=k([g(`mateu-skip-link`)],Ys);var Xs=null;function Zs(){if(!(typeof document>`u`)&&!(Xs&&Xs.isConnected)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>Zs(),{once:!0});return}Xs=document.createElement(`mateu-skip-link`),document.body.insertBefore(Xs,document.body.firstChild)}}Ws(),qs(),ht(),Zs();var Qs=class extends b{constructor(...e){super(...e),this.baseUrl=``,this.route=void 0,this.consumedRoute=`_empty`,this.config=void 0,this.top=`true`,this.pathPrefix=void 0,this.bundleUrl=void 0,this.debug=!1,this._lastUrl=``,this.routeChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.top==`true`){let t=e.detail.route,n=this.baseUrl??``;!t||t.startsWith(`/`)?n=window.location.origin+(this.pathPrefix??``):(t=(this.pathPrefix??``)+t,n.indexOf(`://`)<0&&(n.startsWith(`/`)||(n=`/`+n),n=window.location.origin+n)),t.startsWith(this.pathPrefix+`/`)&&(t=t.substring(this.pathPrefix?.length)),n.endsWith(`/`)&&t.startsWith(`/`)&&(t=t.substring(1));let r=new URL(n+t);if((window.location.pathname||r.pathname)&&window.location.pathname!=r.pathname){let e=r.pathname;r.search&&(e+=r.search),e&&!e.startsWith(`/`)&&(e=`/`+e),window.history.pushState({},``,e),this._lastUrl=window.location.href}}},this.navigateToRequestedListener=e=>{if(e.preventDefault(),e.stopPropagation(),to.markClean(),e instanceof CustomEvent){let t=e.detail.route,n=this.renderRoot.querySelector(`mateu-ux`);n&&(n.setAttribute(`route`,t),n.setAttribute(`instant`,E()))}}}createRenderRoot(){return P.mustUseShadowRoot()?super.createRenderRoot():this}connectedCallback(){if(super.connectedCallback(),to.install(),this._lastUrl=window.location.href,window.onpopstate=e=>{if(!to.confirmLeave()){window.history.pushState({},``,this._lastUrl);return}let t=e.target;this.loadUrl(t)},this.top==`true`?(this.bundleUrl&&Ke(this.bundleUrl),this.loadUrl(window)):this.route&&(this.consumedRoute=``),this.config)try{let e=JSON.parse(this.config);O.value={...O.value,...e}}catch{O.value={...O.value,config:this.config}}this.addEventListener(`url-update-requested`,this.routeChangedListener),this.addEventListener(`navigate-to-requested`,this.navigateToRequestedListener)}disconnectedCallback(){super.disconnectedCallback(),this.upstreamSubscription?.unsubscribe(),this.removeEventListener(`url-update-requested`,this.routeChangedListener),this.removeEventListener(`navigate-to-requested`,this.navigateToRequestedListener)}loadUrl(e){if(this.route=this.extractRouteFromUrl(e),this.setAttribute(`route`,this.route),this.instant=E(),this._lastUrl=e.location.href,e.location.search){let t=new URLSearchParams(e.location.search).get(`overrides`);if(t&&(this.config=t,this.config))try{let e=JSON.parse(this.config);O.value={...O.value,...e}}catch{O.value={...O.value,config:this.config}}}}extractRouteFromUrl(e){return this.addQueryParams(this.extractRouteWithoutParamsFromUrl(e),e.location)}extractRouteWithoutParamsFromUrl(e){let t=this.extractGrossRouteFromUrl(e);return this.pathPrefix&&t.startsWith(this.pathPrefix)?t.substring(this.pathPrefix.length):t==`/`?``:t}addQueryParams(e,t){return e+(t.search?``+t.search:``)}extractGrossRouteFromUrl(e){let t=e.location.pathname,n=this.baseUrl&&(this.baseUrl.startsWith(`http://`)||this.baseUrl.startsWith(`https://`))?this.baseUrl.substring(this.getContextPathStartingIndex(this.baseUrl)):this.baseUrl;return t.startsWith(n)?t.substring(n.length):t}getContextPathStartingIndex(e){return e.startsWith(`http:`)?e.indexOf(`/`,7):e.startsWith(`https:`)?e.indexOf(`/`,8):0}render(){return T`
            <mateu-api-caller>
                 <mateu-ux id="_ux"
                           baseurl="${this.baseUrl}"
@@ -7504,9 +7512,9 @@ ${i}
         :host {
             --lumo-clickable-cursor: pointer;
         }
-  `}};k([y()],Zs.prototype,`baseUrl`,void 0),k([y()],Zs.prototype,`route`,void 0),k([y()],Zs.prototype,`consumedRoute`,void 0),k([y()],Zs.prototype,`config`,void 0),k([y()],Zs.prototype,`top`,void 0),k([y()],Zs.prototype,`pathPrefix`,void 0),k([y()],Zs.prototype,`bundleUrl`,void 0),k([C()],Zs.prototype,`instant`,void 0),k([y({type:Boolean})],Zs.prototype,`debug`,void 0),Zs=k([g(`mateu-ui`)],Zs);var Qs,$s=class extends b{static{Qs=this}constructor(...e){super(...e),this.baseUrl=``,this.opened=!1,this.searchText=``}static{this.SEARCHABLE_THRESHOLD=7}connectedCallback(){super.connectedCallback(),Ee()}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick(),this.searchTimer&&clearTimeout(this.searchTimer)}currentValue(){return String(Se()[this.selector.fieldName]??``)}currentLabel(){let e=this.currentValue();if(!e)return`—`;let t=(this.searchedOptions??this.selector.options)?.find(t=>String(t.value)===e);if(t)return t.label;let n=Ce()[this.selector.fieldName];return n===void 0?e:String(n)}pick(e,t){we(this.selector.fieldName,e,t),window.location.reload()}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}openPanel(){this.opened||(this.opened=!0,this.searchText=``,this.searchedOptions=void 0,this.remoteSearch(),this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick),this.updateComplete.then(()=>this.renderRoot.querySelector(`input.picker-search`)?.focus()))}closePanel(){this.detachOutsideClick(),this.opened=!1}onSearchInput(e){this.searchText=e.target.value,this.searchTimer&&clearTimeout(this.searchTimer),this.searchTimer=setTimeout(()=>this.remoteSearch(),300)}async remoteSearch(){let e=this.app;if(e?.serverSideType)try{let t=await lt.runAction(this.baseUrl??``,e.rootRoute??e.initialRoute??``,``,`_appcontext-search-${this.selector.fieldName}`,`appcontext-${this.selector.fieldName}`,void 0,e.serverSideType,{},{searchText:this.searchText},this,!0);for(let e of t?.fragments??[]){let t=e.data?.[`_appcontext_${this.selector.fieldName}`]?.content;if(Array.isArray(t)){this.searchedOptions=t.map(e=>({value:e.value,label:e.label??String(e.value)}));return}}}catch{}}visibleOptions(){let e=this.searchedOptions??this.selector.options??[],t=this.searchText.trim().toLowerCase();return t?e.filter(e=>e.label.toLowerCase().includes(t)):e}renderPanel(){let e=this.currentValue(),t=this.visibleOptions();return T`
+  `}};k([y()],Qs.prototype,`baseUrl`,void 0),k([y()],Qs.prototype,`route`,void 0),k([y()],Qs.prototype,`consumedRoute`,void 0),k([y()],Qs.prototype,`config`,void 0),k([y()],Qs.prototype,`top`,void 0),k([y()],Qs.prototype,`pathPrefix`,void 0),k([y()],Qs.prototype,`bundleUrl`,void 0),k([C()],Qs.prototype,`instant`,void 0),k([y({type:Boolean})],Qs.prototype,`debug`,void 0),Qs=k([g(`mateu-ui`)],Qs);var $s,ec=class extends b{static{$s=this}constructor(...e){super(...e),this.baseUrl=``,this.opened=!1,this.searchText=``}static{this.SEARCHABLE_THRESHOLD=7}connectedCallback(){super.connectedCallback(),Ee()}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick(),this.searchTimer&&clearTimeout(this.searchTimer)}currentValue(){return String(Se()[this.selector.fieldName]??``)}currentLabel(){let e=this.currentValue();if(!e)return`—`;let t=(this.searchedOptions??this.selector.options)?.find(t=>String(t.value)===e);if(t)return t.label;let n=Ce()[this.selector.fieldName];return n===void 0?e:String(n)}pick(e,t){we(this.selector.fieldName,e,t),window.location.reload()}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}openPanel(){this.opened||(this.opened=!0,this.searchText=``,this.searchedOptions=void 0,this.remoteSearch(),this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick),this.updateComplete.then(()=>this.renderRoot.querySelector(`input.picker-search`)?.focus()))}closePanel(){this.detachOutsideClick(),this.opened=!1}onSearchInput(e){this.searchText=e.target.value,this.searchTimer&&clearTimeout(this.searchTimer),this.searchTimer=setTimeout(()=>this.remoteSearch(),300)}async remoteSearch(){let e=this.app;if(e?.serverSideType)try{let t=await lt.runAction(this.baseUrl??``,e.rootRoute??e.initialRoute??``,``,`_appcontext-search-${this.selector.fieldName}`,`appcontext-${this.selector.fieldName}`,void 0,e.serverSideType,{},{searchText:this.searchText},this,!0);for(let e of t?.fragments??[]){let t=e.data?.[`_appcontext_${this.selector.fieldName}`]?.content;if(Array.isArray(t)){this.searchedOptions=t.map(e=>({value:e.value,label:e.label??String(e.value)}));return}}}catch{}}visibleOptions(){let e=this.searchedOptions??this.selector.options??[],t=this.searchText.trim().toLowerCase();return t?e.filter(e=>e.label.toLowerCase().includes(t)):e}renderPanel(){let e=this.currentValue(),t=this.visibleOptions();return T`
             <div class="panel">
-                ${this.searchText!==``||t.length>Qs.SEARCHABLE_THRESHOLD?T`
+                ${this.searchText!==``||t.length>$s.SEARCHABLE_THRESHOLD?T`
                     <input class="picker-search" type="text" placeholder="Search"
                            .value="${this.searchText}"
                            @input="${this.onSearchInput}"
@@ -7598,9 +7606,9 @@ ${i}
         .option--clear {
             color: var(--lumo-secondary-text-color, rgba(0, 0, 0, 0.55));
         }
-    `}};k([y()],$s.prototype,`selector`,void 0),k([y()],$s.prototype,`app`,void 0),k([y()],$s.prototype,`baseUrl`,void 0),k([C()],$s.prototype,`opened`,void 0),k([C()],$s.prototype,`searchText`,void 0),k([C()],$s.prototype,`searchedOptions`,void 0),$s=Qs=k([g(`mateu-app-context-picker`)],$s);var ec=class extends b{constructor(...e){super(...e),this.baseUrl=``,this.opened=!1,this.notifications=[],this.fetched=!1}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}updated(){!this.fetched&&this.app?.serverSideType&&(this.fetched=!0,this.refresh())}unreadCount(){return this.notifications.filter(e=>e.unread).length}async runNotificationsAction(e,t){let n=this.app;if(n?.serverSideType)try{let r=await lt.runAction(this.baseUrl??``,n.rootRoute??n.initialRoute??``,``,e,`notification-bell`,void 0,n.serverSideType,{},t,this,!0);for(let e of r?.fragments??[]){let t=e.data?._notifications;if(Array.isArray(t)){this.notifications=t;return}}}catch{}}refresh(){return this.runNotificationsAction(`_notifications-list`,{})}markRead(e){return this.runNotificationsAction(`_notifications-read`,{ids:e})}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}openPanel(){this.opened||(this.opened=!0,this.refresh(),this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick))}closePanel(){this.detachOutsideClick(),this.opened=!1}async entryClicked(e){e.unread&&await this.markRead([e.id]);let t=e.route;if(t){if(!eo.confirmLeave())return;this.closePanel(),this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0})),this.dispatchEvent(new CustomEvent(`navigate-to-requested`,{detail:{route:t},bubbles:!0,composed:!0}))}}renderEntry(e){return T`
+    `}};k([y()],ec.prototype,`selector`,void 0),k([y()],ec.prototype,`app`,void 0),k([y()],ec.prototype,`baseUrl`,void 0),k([C()],ec.prototype,`opened`,void 0),k([C()],ec.prototype,`searchText`,void 0),k([C()],ec.prototype,`searchedOptions`,void 0),ec=$s=k([g(`mateu-app-context-picker`)],ec);var tc=class extends b{constructor(...e){super(...e),this.baseUrl=``,this.opened=!1,this.notifications=[],this.fetched=!1}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}updated(){!this.fetched&&this.app?.serverSideType&&(this.fetched=!0,this.refresh())}unreadCount(){return this.notifications.filter(e=>e.unread).length}async runNotificationsAction(e,t){let n=this.app;if(n?.serverSideType)try{let r=await lt.runAction(this.baseUrl??``,n.rootRoute??n.initialRoute??``,``,e,`notification-bell`,void 0,n.serverSideType,{},t,this,!0);for(let e of r?.fragments??[]){let t=e.data?._notifications;if(Array.isArray(t)){this.notifications=t;return}}}catch{}}refresh(){return this.runNotificationsAction(`_notifications-list`,{})}markRead(e){return this.runNotificationsAction(`_notifications-read`,{ids:e})}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}openPanel(){this.opened||(this.opened=!0,this.refresh(),this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick))}closePanel(){this.detachOutsideClick(),this.opened=!1}async entryClicked(e){e.unread&&await this.markRead([e.id]);let t=e.route;if(t){if(!to.confirmLeave())return;this.closePanel(),this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0})),this.dispatchEvent(new CustomEvent(`navigate-to-requested`,{detail:{route:t},bubbles:!0,composed:!0}))}}renderEntry(e){return T`
             <div role="button" tabindex="0" class="entry ${e.unread?`entry--unread`:``}"
-                 @click="${()=>this.entryClicked(e)}" @keydown="${z(()=>this.entryClicked(e))}">
+                 @click="${()=>this.entryClicked(e)}" @keydown="${R(()=>this.entryClicked(e))}">
                 <span class="unread-dot" aria-hidden="true"></span>
                 <div class="entry-body">
                     <div class="entry-top">
@@ -7785,48 +7793,48 @@ ${i}
             cursor: default;
         }
     
-        ${B}
-    `}};k([y()],ec.prototype,`app`,void 0),k([y()],ec.prototype,`baseUrl`,void 0),k([C()],ec.prototype,`opened`,void 0),k([C()],ec.prototype,`notifications`,void 0),ec=k([g(`mateu-notification-bell`)],ec);var tc=e=>{if(!e||!(`querySelectorAll`in e))return null;for(let t of e.querySelectorAll(`*`)){if(t.tagName?.toLowerCase()===`mateu-component`)return t;let e=tc(t.shadowRoot);if(e)return e}return null},nc=async(e,t,n)=>{let r=tc(t.renderRoot??t);await ds.runAction(lt,t.baseUrl??``,e.rootRoute||`_no_route`,``,n,r?.id??`app-header-action`,{},e.serverSideType??``,{},{},r??t,!0,void 0,!1,``)},rc=async(e,t,n)=>{try{await nc(e,t,n)}catch(e){Na({text:`La acción falló: `+e,position:`bottomStart`,duration:6e3,variant:`error`},t)}},ic=(e,t)=>{let n=e.contextSelectors??[],r=e.contextActions??[];return n.length===0&&r.length===0&&!e.notificationsEnabled?v:T`${e.notificationsEnabled?T`
+        ${z}
+    `}};k([y()],tc.prototype,`app`,void 0),k([y()],tc.prototype,`baseUrl`,void 0),k([C()],tc.prototype,`opened`,void 0),k([C()],tc.prototype,`notifications`,void 0),tc=k([g(`mateu-notification-bell`)],tc);var nc=e=>{if(!e||!(`querySelectorAll`in e))return null;for(let t of e.querySelectorAll(`*`)){if(t.tagName?.toLowerCase()===`mateu-component`)return t;let e=nc(t.shadowRoot);if(e)return e}return null},rc=async(e,t,n)=>{let r=nc(t.renderRoot??t);await fs.runAction(lt,t.baseUrl??``,e.rootRoute||`_no_route`,``,n,r?.id??`app-header-action`,{},e.serverSideType??``,{},{},r??t,!0,void 0,!1,``)},ic=async(e,t,n)=>{try{await rc(e,t,n)}catch(e){Pa({text:`La acción falló: `+e,position:`bottomStart`,duration:6e3,variant:`error`},t)}},ac=(e,t)=>{let n=e.contextSelectors??[],r=e.contextActions??[];return n.length===0&&r.length===0&&!e.notificationsEnabled?v:T`${e.notificationsEnabled?T`
         <mateu-notification-bell .app="${e}" .baseUrl="${t.baseUrl??``}"></mateu-notification-bell>`:v}${n.map(n=>T`
         <mateu-app-context-picker .selector="${n}" .app="${e}" .baseUrl="${t.baseUrl??``}"></mateu-app-context-picker>`)}${r.map(n=>(n.children?.length??0)>0?T`
         <details class="mateu-nav-group" style="margin-left: 0.5rem; flex-shrink: 0;">
             <summary class="app-header-action-btn">${n.label} ▾</summary>
             <div class="mateu-nav-panel" style="right: 0; left: auto;">
                 ${n.children.map(n=>T`
-                    <button class="mateu-nav-item" @click="${()=>n.actionId&&rc(e,t,n.actionId)}">${n.label}</button>`)}
+                    <button class="mateu-nav-item" @click="${()=>n.actionId&&ic(e,t,n.actionId)}">${n.label}</button>`)}
             </div>
         </details>`:T`
         <button class="app-header-action-btn" style="margin-left: 0.5rem; flex-shrink: 0;"
-            @click="${()=>n.actionId&&rc(e,t,n.actionId)}" title="${n.label}">${n.icon?L(n.icon):v}${n.label}</button>`)}`},ac=(e,t)=>T`
+            @click="${()=>n.actionId&&ic(e,t,n.actionId)}" title="${n.label}">${n.icon?I(n.icon):v}${n.label}</button>`)}`},oc=(e,t)=>T`
     <button class="mateu-nav-item ${e.selected?`mateu-nav-item--active`:``}"
             ?disabled="${e.disabled}"
-            @click="${()=>t(e)}">${e.text}</button>`,oc=(e,t,n=``)=>T`
+            @click="${()=>t(e)}">${e.text}</button>`,sc=(e,t,n=``)=>T`
     <nav class="mateu-nav ${n}">
         ${e.map(e=>(e.children?.length??0)>0?T`<details class="mateu-nav-group">
                        <summary class="mateu-nav-item">${e.text} ▾</summary>
                        <div class="mateu-nav-panel">
-                           ${e.children.map(e=>ac(e,t))}
+                           ${e.children.map(e=>oc(e,t))}
                        </div>
-                   </details>`:ac(e,t))}
-    </nav>`,sc=(e,t)=>n=>t.call(e,{detail:{value:n}}),cc=(e,t)=>e.themeToggle?T`
+                   </details>`:oc(e,t))}
+    </nav>`,cc=(e,t)=>n=>t.call(e,{detail:{value:n}}),lc=(e,t)=>e.themeToggle?T`
         <button class="app-chrome-icon-btn" @click="${t.toggleTheme}"
             title="${t.isDark?`Switch to light mode`:`Switch to dark mode`}"
             style="margin-left: 0.5rem; margin-right: 0.5rem; flex-shrink: 0;">
-            ${L(t.isDark?`vaadin:sun-o`:`vaadin:moon`,`color: var(--lumo-body-text-color);`)}
+            ${I(t.isDark?`vaadin:sun-o`:`vaadin:moon`,`color: var(--lumo-body-text-color);`)}
         </button>
-    `:v,lc=(e,t)=>{t.filter!=e.detail.value&&(t.filter=e.detail.value)},uc=(e,t,n)=>{let r=dc(e,t,n),i=Z(t,n);return r==`list`||r==i?`new`:r},dc=(e,t,n)=>{let r=e?._route;if(r!=null&&(r===``||r.startsWith(`/`))){let e=n.homeRoute??``,i=e.indexOf(`?`),a=i>=0?e.substring(i+1):``,o=Z(t,n)+r;return a?o+(o.indexOf(`?`)>=0?`&`:`?`)+a:o}return t.selectedRoute?t.selectedRoute:n.homeRoute},Z=(e,t)=>e.selectedRoute?e.selectedConsumedRoute??t.route:t.homeConsumedRoute,fc=(e,t)=>e.selectedRoute?e.selectedBaseUrl??e.baseUrl:t.homeBaseUrl,pc=(e,t)=>e.selectedRoute?e.selectedServerSideType??t.serverSideType:t.homeServerSideType,mc=(e,t)=>e.selectedRoute?e.selectedUriPrefix:t.homeUriPrefix,hc=(e,t)=>`ux_`+((Z(e,t)||`root`)+`|`+(pc(e,t)??``)).replace(/[^a-zA-Z0-9]/g,`_`),gc=(e,t,n,r,i,a,o)=>{let s=hc(e,t);if(t.chromeless)return T`
+    `:v,uc=(e,t)=>{t.filter!=e.detail.value&&(t.filter=e.detail.value)},dc=(e,t,n)=>{let r=fc(e,t,n),i=X(t,n);return r==`list`||r==i?`new`:r},fc=(e,t,n)=>{let r=e?._route;if(r!=null&&(r===``||r.startsWith(`/`))){let e=n.homeRoute??``,i=e.indexOf(`?`),a=i>=0?e.substring(i+1):``,o=X(t,n)+r;return a?o+(o.indexOf(`?`)>=0?`&`:`?`)+a:o}return t.selectedRoute?t.selectedRoute:n.homeRoute},X=(e,t)=>e.selectedRoute?e.selectedConsumedRoute??t.route:t.homeConsumedRoute,pc=(e,t)=>e.selectedRoute?e.selectedBaseUrl??e.baseUrl:t.homeBaseUrl,mc=(e,t)=>e.selectedRoute?e.selectedServerSideType??t.serverSideType:t.homeServerSideType,hc=(e,t)=>e.selectedRoute?e.selectedUriPrefix:t.homeUriPrefix,gc=(e,t)=>`ux_`+((X(e,t)||`root`)+`|`+(mc(e,t)??``)).replace(/[^a-zA-Z0-9]/g,`_`),_c=(e,t,n,r,i,a,o)=>{let s=gc(e,t);if(t.chromeless)return T`
             <div class="app chromeless">
                 <div role="main" class="${`app-content`+(e.pageCompact?` no-padding`:``)}" style="height: 100%;">
                     <div class="m-md">
                         <div class="m-scroll" style="height: 100%;">
                             <mateu-api-caller>
                                 <mateu-ux
-                                        route="${dc(r,e,t)}"
+                                        route="${fc(r,e,t)}"
                                         id="${s}"
-                                        baseUrl="${fc(e,t)}"
-                                        consumedRoute="${Z(e,t)}"
-                                        serverSideType="${pc(e,t)}"
-                                        uriPrefix="${mc(e,t)}"
+                                        baseUrl="${pc(e,t)}"
+                                        consumedRoute="${X(e,t)}"
+                                        serverSideType="${mc(e,t)}"
+                                        uriPrefix="${hc(e,t)}"
                                         style="width: 100%;"
                                         .appState="${a}"
                                         .appData="${o}"
@@ -7840,7 +7848,7 @@ ${i}
                 </div>
                 <slot></slot>
             </div>
-        `;let c=e.mapItems(t.menu,e.filter?.toLowerCase()??``),l=Z(e,t),u=uc(r,e,t),d=u&&u!==`new`&&u.startsWith(l+`/`)?u.substring(l.length+1).split(`/`)[0]:void 0;return T`
+        `;let c=e.mapItems(t.menu,e.filter?.toLowerCase()??``),l=X(e,t),u=dc(r,e,t),d=u&&u!==`new`&&u.startsWith(l+`/`)?u.substring(l.length+1).split(`/`)[0]:void 0;return T`
                     ${t.variant==dt.MEDIATOR?T`
 
                         ${t.layout==`SPLIT`?T`
@@ -7848,12 +7856,12 @@ ${i}
                                 <mateu-api-caller>
                                     <div style="display: block; width: calc(100% - 1rem);">
                                     <mateu-ux
-                                            route="${Z(e,t)}"
+                                            route="${X(e,t)}"
                                             id="${s}"
-                                            baseUrl="${fc(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${pc(e,t)}"
-                                            uriPrefix="${mc(e,t)}"
+                                            baseUrl="${pc(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${mc(e,t)}"
+                                            uriPrefix="${hc(e,t)}"
                                             style="width: 100%;"
                                             .appState="${{...a,_splitDetailId:d}}"
                                             .appData="${o}"
@@ -7865,12 +7873,12 @@ ${i}
                                 <mateu-api-caller slot="detail">
                                     <div style="padding-left: 1rem; width: calc(100% - 1rem);">
                                     <mateu-ux
-                                            route="${uc(r,e,t)}"
+                                            route="${dc(r,e,t)}"
                                             id="${s}_detail"
-                                            baseUrl="${fc(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${pc(e,t)}"
-                                            uriPrefix="${mc(e,t)}"
+                                            baseUrl="${pc(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${mc(e,t)}"
+                                            uriPrefix="${hc(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -7884,12 +7892,12 @@ ${i}
                         `:T`
                             <mateu-api-caller>
                                 <mateu-ux
-                                        route="${dc(r,e,t)}"
+                                        route="${fc(r,e,t)}"
                                         id="${s}"
-                                        baseUrl="${fc(e,t)}"
-                                        consumedRoute="${Z(e,t)}"
-                                        serverSideType="${pc(e,t)}"
-                                        uriPrefix="${mc(e,t)}"
+                                        baseUrl="${pc(e,t)}"
+                                        consumedRoute="${X(e,t)}"
+                                        serverSideType="${mc(e,t)}"
+                                        uriPrefix="${hc(e,t)}"
                                         style="width: 100%;"
                                         .appState="${a}"
                                         .appData="${o}"
@@ -7906,12 +7914,12 @@ ${i}
                     <header class="app-navbar">
                         <button class="drawer-toggle" title="Menu"
                                 @click="${e=>e.currentTarget.closest(`.m-app-layout`)?.classList.toggle(`drawer-open`)}">
-                            ${L(`vaadin:menu`)}
+                            ${I(`vaadin:menu`)}
                         </button>
                         <h2 style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; margin: 0 .5rem;">${t.title}</h2><p style="margin: 0;">${t.subtitle}</p>
                         <div class="m-hl" style="margin-left: auto; align-items: center;">
                             <slot name="widgets"></slot>
-                            ${ic(t,e)}${cc(t,e)}
+                            ${ac(t,e)}${lc(t,e)}
                         </div>
                     </header>
                     <div class="app-body">
@@ -7919,7 +7927,7 @@ ${i}
                             ${t.menu&&t.totalMenuOptions>10?T`
                                 <div style="position: sticky; top: 0; z-index: 2; background: var(--lumo-base-color); padding: .25rem 0 .5rem;">
                                     <input class="drawer-search" placeholder="Search…" style="width: calc(100% - 20px); margin: 0 10px;"
-                                           @input="${t=>lc({detail:{value:t.target.value}},e)}">
+                                           @input="${t=>uc({detail:{value:t.target.value}},e)}">
                                 </div>
                                 `:v}
                             <nav class="side-nav">
@@ -7931,12 +7939,12 @@ ${i}
                                 <div class="m-scroll" style="height: 100%;">
                                     <mateu-api-caller>
                                         <mateu-ux
-                                                route="${dc(r,e,t)}"
+                                                route="${fc(r,e,t)}"
                                                 id="${s}"
-                                                baseUrl="${fc(e,t)}"
-                                                consumedRoute="${Z(e,t)}"
-                                                serverSideType="${pc(e,t)}"
-                                                uriPrefix="${mc(e,t)}"
+                                                baseUrl="${pc(e,t)}"
+                                                consumedRoute="${X(e,t)}"
+                                                serverSideType="${mc(e,t)}"
+                                                uriPrefix="${hc(e,t)}"
                                                 style="width: 100%;"
                                                 .appState="${a}"
                                                 .appData="${o}"
@@ -7965,10 +7973,10 @@ ${i}
                             ${t.title?T`<h2 style="margin: 0 var(--lumo-space-l, 1.5rem) 0 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;">${t.title}</h2>`:v}
                         </div>
                         </a>
-                        ${(()=>{let t=sc(e,e.itemSelected);return F.get()?.renderTopNav?.(c,t,`menu-on-top`)??oc(c,t,`menu-on-top`)})()}
+                        ${(()=>{let t=cc(e,e.itemSelected);return P.get()?.renderTopNav?.(c,t,`menu-on-top`)??sc(c,t,`menu-on-top`)})()}
                         <div class="m-hl" style="margin-left: auto; flex-shrink: 0; align-items: center;">
                             <slot name="widgets"></slot>
-                            ${ic(t,e)}${cc(t,e)}
+                            ${ac(t,e)}${lc(t,e)}
                         </div>
                     </div>
                     <div style="flex: 1; min-height: 0; overflow-y: auto; overflow-x: hidden; box-sizing: border-box; width: 100%;">
@@ -7976,12 +7984,12 @@ ${i}
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${dc(r,e,t)}"
+                                            route="${fc(r,e,t)}"
                                             id="${s}"
-                                            baseUrl="${fc(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${pc(e,t)}"
-                                            uriPrefix="${mc(e,t)}"
+                                            baseUrl="${pc(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${mc(e,t)}"
+                                            uriPrefix="${hc(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -8009,10 +8017,10 @@ ${i}
                             ${t.title?T`<h2 style="margin: 0 var(--lumo-space-l, 1.5rem) 0 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;">${t.title}</h2>`:v}
                         </div>
                         </a>
-                        ${oc(e.mapItemsForTiles(t.menu),sc(e,e.itemSelectedTiles),`menu-on-top`)}
+                        ${sc(e.mapItemsForTiles(t.menu),cc(e,e.itemSelectedTiles),`menu-on-top`)}
                         <div class="m-hl" style="margin-left: auto; flex-shrink: 0; align-items: center;">
                             <slot name="widgets"></slot>
-                            ${ic(t,e)}${cc(t,e)}
+                            ${ac(t,e)}${lc(t,e)}
                         </div>
                     </div>
                     <div style="flex: 1; min-height: 0; overflow-y: auto; overflow-x: hidden; box-sizing: border-box; width: 100%;">
@@ -8021,12 +8029,12 @@ ${i}
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${dc(r,e,t)}"
+                                            route="${fc(r,e,t)}"
                                             id="${s}"
-                                            baseUrl="${fc(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${pc(e,t)}"
-                                            uriPrefix="${mc(e,t)}"
+                                            baseUrl="${pc(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${mc(e,t)}"
+                                            uriPrefix="${hc(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -8051,12 +8059,12 @@ ${i}
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${dc(r,e,t)}"
+                                            route="${fc(r,e,t)}"
                                             id="${s}"
-                                            baseUrl="${fc(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${pc(e,t)}"
-                                            uriPrefix="${mc(e,t)}"
+                                            baseUrl="${pc(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${mc(e,t)}"
+                                            uriPrefix="${hc(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -8078,7 +8086,7 @@ ${i}
                         <div class="m-vl"
                                 @navigation-requested="${e.updateRoute}">
                             ${t.menu.map(t=>e.renderOptionOnLeftMenu(t))}
-                            ${ic(t,e)}${cc(t,e)}
+                            ${ac(t,e)}${lc(t,e)}
                         </div>
                     </div>
                     <div role="main" class="${`app-content`+(e.pageCompact?` no-padding`:``)}">
@@ -8086,12 +8094,12 @@ ${i}
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${dc(r,e,t)}"
+                                            route="${fc(r,e,t)}"
                                             id="${s}"
-                                            baseUrl="${fc(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${pc(e,t)}"
-                                            uriPrefix="${mc(e,t)}"
+                                            baseUrl="${pc(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${mc(e,t)}"
+                                            uriPrefix="${hc(e,t)}"
                                             style="width: 100%; padding: 1em;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -8135,7 +8143,7 @@ ${i}
                             </nav>
                             <div class="m-hl" style="flex-shrink: 0; align-items: center;">
                                 <slot name="widgets"></slot>
-                                ${ic(t,e)}${cc(t,e)}
+                                ${ac(t,e)}${lc(t,e)}
                             </div>
                         </div>
                     </div>
@@ -8144,12 +8152,12 @@ ${i}
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${dc(r,e,t)}"
+                                            route="${fc(r,e,t)}"
                                             id="${s}"
-                                            baseUrl="${fc(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${pc(e,t)}"
-                                            uriPrefix="${mc(e,t)}"
+                                            baseUrl="${pc(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${mc(e,t)}"
+                                            uriPrefix="${hc(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -8169,17 +8177,17 @@ ${i}
                 <button class="app-fab" style="bottom: ${(t.sseUrl?5.5:1.5)+r*4}rem; right: 1.5rem;"
                     @click="${()=>e.runAction(n.actionId)}"
                     title="${n.label}">
-                    ${L(n.icon)}
+                    ${I(n.icon)}
                 </button>
             `)}
             ${t.sseUrl&&!e.chatOpen?T`
                 <button class="ai-fab" @click="${e.showHideIa}" title="Asistente IA">
-                    ${L(`vaadin:comments-o`)}
+                    ${I(`vaadin:comments-o`)}
                 </button>
             `:v}
             ${e.renderCommandPalette()}
             <slot></slot>
-       `},_c=(e,t)=>t!=null&&e!=null&&!e.has(t),vc=typeof HTMLElement<`u`?HTMLElement:class{},yc=class extends vc{static get observedAttributes(){return[`type`,`renderer`]}connectedCallback(){this.render()}attributeChangedCallback(){this.render()}render(){let e=this.getAttribute(`type`)??`unknown`,t=this.getAttribute(`renderer`)??`unknown`;this.shadowRoot||this.attachShadow({mode:`open`}),this.shadowRoot.innerHTML=`
+       `},vc=(e,t)=>t!=null&&e!=null&&!e.has(t),yc=typeof HTMLElement<`u`?HTMLElement:class{},bc=class extends yc{static get observedAttributes(){return[`type`,`renderer`]}connectedCallback(){this.render()}attributeChangedCallback(){this.render()}render(){let e=this.getAttribute(`type`)??`unknown`,t=this.getAttribute(`renderer`)??`unknown`;this.shadowRoot||this.attachShadow({mode:`open`}),this.shadowRoot.innerHTML=`
             <style>
                 :host { display: block; }
                 .mateu-unsupported {
@@ -8198,12 +8206,12 @@ ${i}
             <div class="mateu-unsupported" role="note">
                 ⚠ Component “${e}” is not supported by the “${t}” renderer yet.
             </div>
-        `}};typeof customElements<`u`&&!customElements.get(`mateu-unsupported`)&&customElements.define(`mateu-unsupported`,yc);var bc=new Set,xc=(e,t,n)=>{let r=`${n}/${t}`;return bc.has(r)||(bc.add(r),console.warn(`[mateu] Component type "${t}" is not supported by the "${n}" renderer — rendering <mateu-unsupported> placeholder.`)),T`<mateu-unsupported
+        `}};typeof customElements<`u`&&!customElements.get(`mateu-unsupported`)&&customElements.define(`mateu-unsupported`,bc);var xc=new Set,Sc=(e,t,n)=>{let r=`${n}/${t}`;return xc.has(r)||(xc.add(r),console.warn(`[mateu] Component type "${t}" is not supported by the "${n}" renderer — rendering <mateu-unsupported> placeholder.`)),T`<mateu-unsupported
             type="${t}"
             renderer="${n}"
             data-component-id="${e?.id??v}"
             slot="${e?.slot??v}"
-    ></mateu-unsupported>`},Sc=class{renderFilterBar(e,t,n,r,i,a,o,s){let c=t?.metadata;return T`
+    ></mateu-unsupported>`},Cc=class{renderFilterBar(e,t,n,r,i,a,o,s){let c=t?.metadata;return T`
             <mateu-filter-bar
                 .metadata="${c}"
                 @search-requested="${e.search}"
@@ -8215,7 +8223,7 @@ ${i}
                 .appData="${o}"
                 ?searchOnly="${s??!1}"
             >
-                ${c?.header?.map(t=>I(e,t,n,r,i,a,o))}
+                ${c?.header?.map(t=>F(e,t,n,r,i,a,o))}
             </mateu-filter-bar>
         `}renderPagination(e,t){return T`
         <mateu-pagination
@@ -8226,14 +8234,14 @@ ${i}
                 data-testid="pagination"
                 .pageNumber="${e.data[t?.id]?.page?.pageNumber??0}"
         ></mateu-pagination>
-        `}renderTableComponent(e,t,n,r,i,a,o){return zn(t,(e.data?.[e.id])?.page?.content??[],r[t?.id]?.emptyStateMessage)}rendererName(){return this.constructor?.name??`unknown`}supportedClientSideTypes(){}renderClientSideComponent(e,t,n,r,i,a,o,s){let c=t?.metadata?.type??t?.type,l=Object.values(j).includes(c)?c:void 0;return _c(this.supportedClientSideTypes(),l)?xc(t,l,this.rendererName()):Da(e,t,n,r,i,a,o,s)}renderAppComponent(e,t,n,r,i,a,o){return gc(e,t?.metadata,n,r,i,a,o)}},Cc=(e,t,n,r,i,a,o)=>T`
+        `}renderTableComponent(e,t,n,r,i,a,o){return Bn(t,(e.data?.[e.id])?.page?.content??[],r[t?.id]?.emptyStateMessage)}rendererName(){return this.constructor?.name??`unknown`}supportedClientSideTypes(){}renderClientSideComponent(e,t,n,r,i,a,o,s){let c=t?.metadata?.type??t?.type,l=Object.values(j).includes(c)?c:void 0;return vc(this.supportedClientSideTypes(),l)?Sc(t,l,this.rendererName()):Oa(e,t,n,r,i,a,o,s)}renderAppComponent(e,t,n,r,i,a,o){return _c(e,t?.metadata,n,r,i,a,o)}},wc=(e,t,n,r,i,a,o)=>T`
         <vaadin-virtual-list
                 .items="${t.metadata.page.content}"
-                ${te(t=>T`${I(e,t,n,r,i,a,o)}`,[])}
+                ${te(t=>T`${F(e,t,n,r,i,a,o)}`,[])}
                 style="${t.style}" class="${t.cssClasses}"
                 slot="${t.slot??v}"
         ></vaadin-virtual-list>
-    `,wc=e=>{let t=e.metadata;return T`
+    `,Tc=e=>{let t=e.metadata;return T`
         <vaadin-notification
                 .opened="${!0}"
                 slot="${e.slot??v}"
@@ -8246,7 +8254,7 @@ ${i}
                     </vaadin-horizontal-layout>
                 `,[])}
         ></vaadin-notification>
-    `},Tc=(e,t={})=>{let n=e.metadata,r=n.valueKey?t[n.valueKey]:n.value;return T`
+    `},Ec=(e,t={})=>{let n=e.metadata,r=n.valueKey?t[n.valueKey]:n.value;return T`
         <div style="${e.style}">
         <vaadin-progress-bar
                 ?indeterminate="${n.indeterminate}"
@@ -8261,7 +8269,7 @@ ${i}
     ${n.text}
   </span>`:v}
         </div>
-    `},Ec=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+    `},Dc=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
         <vaadin-details
                 ?opened="${s.opened}"
                 style="${t.style}"
@@ -8269,37 +8277,37 @@ ${i}
                 slot="${t.slot??v}"
         >
             <vaadin-details-summary slot="summary">
-            ${I(e,s.summary,n,r,i,a,o)}
+            ${F(e,s.summary,n,r,i,a,o)}
             </vaadin-details-summary>
-            ${I(e,s.content,n,r,i,a,o)}
+            ${F(e,s.content,n,r,i,a,o)}
         </vaadin-details>
-            `},Dc=(e,t,n)=>{let r=e.metadata;return T`<vaadin-avatar
+            `},Oc=(e,t,n)=>{let r=e.metadata;return T`<vaadin-avatar
             img="${r.image}"
-            name="${P(r.name,t,n)}"
+            name="${Ot(r.name,t,n)}"
             abbr="${r.abbreviation}"
             style="${e.style}" class="${e.cssClasses}"
             slot="${e.slot??v}"
-    ></vaadin-avatar>`},Oc=e=>{let t=e.metadata;return T`<vaadin-avatar-group max-items-visible="${t.maxItemsVisible}"
+    ></vaadin-avatar>`},kc=e=>{let t=e.metadata;return T`<vaadin-avatar-group max-items-visible="${t.maxItemsVisible}"
                                      .items="${t.avatars}"
                                      style="${e.style}" class="${e.cssClasses}"
                                      slot="${e.slot??v}">
-    </vaadin-avatar-group>`},kc=(e,t,n,r,i,a,o)=>{let s=t.metadata;if(!s)return T``;let c=``;return s.variants?.map(e=>e==`stretchMedia`?`stretch-media`:e==`coverMedia`?`cover-media`:e).forEach(e=>c+=` `+e),c=c.trim(),T`
+    </vaadin-avatar-group>`},Ac=(e,t,n,r,i,a,o)=>{let s=t.metadata;if(!s)return T``;let c=``;return s.variants?.map(e=>e==`stretchMedia`?`stretch-media`:e==`coverMedia`?`cover-media`:e).forEach(e=>c+=` `+e),c=c.trim(),T`
         <vaadin-card
                 style="${t.style}"
                 class="${t.cssClasses}"
                 theme="${c}"
                 slot="${t.slot??v}"
         >
-            ${s.media?jt(e,s.media,n,r,i,a,o,`media`,!1):v}
-            ${s.title?jt(e,s.title,n,r,i,a,o,`title`,!1):v}
-            ${s.subtitle?jt(e,s.subtitle,n,r,i,a,o,`subtitle`,!1):v}
-            ${s.header?jt(e,s.header,n,r,i,a,o,`header`,!1):v}
-            ${s.headerPrefix?jt(e,s.headerPrefix,n,r,i,a,o,`header-prefix`,!1):v}
-            ${s.headerSuffix?jt(e,s.headerSuffix,n,r,i,a,o,`header-suffix`,!1):v}
-            ${s.footer?jt(e,s.footer,n,r,i,a,o,`footer`,!1):v}
-            ${s.content?I(e,s.content,n,r,i,a,o,!1):v}
+            ${s.media?Mt(e,s.media,n,r,i,a,o,`media`,!1):v}
+            ${s.title?Mt(e,s.title,n,r,i,a,o,`title`,!1):v}
+            ${s.subtitle?Mt(e,s.subtitle,n,r,i,a,o,`subtitle`,!1):v}
+            ${s.header?Mt(e,s.header,n,r,i,a,o,`header`,!1):v}
+            ${s.headerPrefix?Mt(e,s.headerPrefix,n,r,i,a,o,`header-prefix`,!1):v}
+            ${s.headerSuffix?Mt(e,s.headerSuffix,n,r,i,a,o,`header-suffix`,!1):v}
+            ${s.footer?Mt(e,s.footer,n,r,i,a,o,`footer`,!1):v}
+            ${s.content?F(e,s.content,n,r,i,a,o,!1):v}
         </vaadin-card>
-    `},Ac=e=>e>0&&e<640?`accordion`:`tabs`,jc=class extends b{constructor(...e){super(...e),this.tabLabels=[],this.mode=`tabs`,this.selected=0,this.selectedChangedListener=e=>{let t=e.detail?.value;typeof t==`number`&&t>=0&&(this.selected=t)}}connectedCallback(){super.connectedCallback(),this.resizeObserver=new ResizeObserver(e=>{for(let t of e)this.mode=Ac(t.contentRect.width)}),this.resizeObserver.observe(this)}disconnectedCallback(){super.disconnectedCallback(),this.resizeObserver?.disconnect(),this.resizeObserver=void 0,this.detachTabsListener()}detachTabsListener(){this.slottedTabs?.removeEventListener(`selected-changed`,this.selectedChangedListener),this.slottedTabs=void 0}tabsSlotChanged(e){this.detachTabsListener();let t=e.target.assignedElements().find(e=>`selected`in e);t&&(this.slottedTabs=t,t.addEventListener(`selected-changed`,this.selectedChangedListener),t.selected=this.selected)}select(e){this.selected=e,this.slottedTabs&&(this.slottedTabs.selected=e)}updated(){this.slottedTabs&&this.slottedTabs.selected!=this.selected&&(this.slottedTabs.selected=this.selected)}static{this.styles=h`
+    `},jc=e=>e>0&&e<640?`accordion`:`tabs`,Mc=class extends b{constructor(...e){super(...e),this.tabLabels=[],this.mode=`tabs`,this.selected=0,this.selectedChangedListener=e=>{let t=e.detail?.value;typeof t==`number`&&t>=0&&(this.selected=t)}}connectedCallback(){super.connectedCallback(),this.resizeObserver=new ResizeObserver(e=>{for(let t of e)this.mode=jc(t.contentRect.width)}),this.resizeObserver.observe(this)}disconnectedCallback(){super.disconnectedCallback(),this.resizeObserver?.disconnect(),this.resizeObserver=void 0,this.detachTabsListener()}detachTabsListener(){this.slottedTabs?.removeEventListener(`selected-changed`,this.selectedChangedListener),this.slottedTabs=void 0}tabsSlotChanged(e){this.detachTabsListener();let t=e.target.assignedElements().find(e=>`selected`in e);t&&(this.slottedTabs=t,t.addEventListener(`selected-changed`,this.selectedChangedListener),t.selected=this.selected)}select(e){this.selected=e,this.slottedTabs&&(this.slottedTabs.selected=e)}updated(){this.slottedTabs&&this.slottedTabs.selected!=this.selected&&(this.slottedTabs.selected=this.selected)}static{this.styles=h`
         :host {
             display: block;
         }
@@ -8383,7 +8391,7 @@ ${i}
                     `)}
                 </div>
             `}
-        `}};k([y({type:Array})],jc.prototype,`tabLabels`,void 0),k([C()],jc.prototype,`mode`,void 0),k([C()],jc.prototype,`selected`,void 0),jc=k([g(`mateu-adaptive-tabs`)],jc);var Mc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;c??=``,s.columnSpacing&&(c+=`--vaadin-form-layout-column-spacing: `+s.columnSpacing+`;`);let l=s.itemRowSpacing&&s.itemRowSpacing!==`0`?s.itemRowSpacing:`var(--lumo-space-m)`;return c+=`--vaadin-form-layout-row-spacing: `+l+`;`,s.itemLabelSpacing&&(c+=`--vaadin-form-layout-label-spacing: `+s.itemLabelSpacing+`;`),s.labelsAside&&(c+=`--vaadin-form-item-label-width: 10rem;`),s.fullWidth&&(c+=`width: 100%;`),T`
+        `}};k([y({type:Array})],Mc.prototype,`tabLabels`,void 0),k([C()],Mc.prototype,`mode`,void 0),k([C()],Mc.prototype,`selected`,void 0),Mc=k([g(`mateu-adaptive-tabs`)],Mc);var Nc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;c??=``,s.columnSpacing&&(c+=`--vaadin-form-layout-column-spacing: `+s.columnSpacing+`;`);let l=s.itemRowSpacing&&s.itemRowSpacing!==`0`?s.itemRowSpacing:`var(--lumo-space-m)`;return c+=`--vaadin-form-layout-row-spacing: `+l+`;`,s.itemLabelSpacing&&(c+=`--vaadin-form-layout-label-spacing: `+s.itemLabelSpacing+`;`),s.labelsAside&&(c+=`--vaadin-form-item-label-width: 10rem;`),s.fullWidth&&(c+=`width: 100%;`),T`
                <vaadin-form-layout 
                        .responsiveSteps="${s.responsiveSteps||v}"  
                        style="${c||v}" 
@@ -8396,36 +8404,36 @@ ${i}
                        labels-aside="${s.labelsAside||v}"
                        slot="${t.slot||v}"
                >
-                   ${t.children?.map(t=>Nc(s,e,t,n,r,i,a,o))}
+                   ${t.children?.map(t=>Pc(s,e,t,n,r,i,a,o))}
                </vaadin-form-layout>
-            `},Nc=(e,t,n,r,i,a,o,s)=>n.type==A.ClientSide&&n.metadata?.type==j.FormRow?Fc(e,t,n,r,i,a,o,s):e.labelsAside?Pc(t,n,r,i,a,o,s):I(t,n,r,i,a,o,s),Pc=(e,t,n,r,i,a,o)=>{if(t.type==A.ClientSide&&t.metadata?.type==j.FormField&&t.metadata.label){let s=t.metadata,c=s.label?.includes("${")?e._evalTemplate(s.label):s.label;return T`
+            `},Pc=(e,t,n,r,i,a,o,s)=>n.type==A.ClientSide&&n.metadata?.type==j.FormRow?Ic(e,t,n,r,i,a,o,s):e.labelsAside?Fc(t,n,r,i,a,o,s):F(t,n,r,i,a,o,s),Fc=(e,t,n,r,i,a,o)=>{if(t.type==A.ClientSide&&t.metadata?.type==j.FormField&&t.metadata.label){let s=t.metadata,c=s.label?.includes("${")?e._evalTemplate(s.label):s.label;return T`
                        <vaadin-form-item data-colspan="${s.colspan}">
                            <label slot="label">${c}</label>
-                           ${I(e,t,n,r,i,a,o,!0)}
+                           ${F(e,t,n,r,i,a,o,!0)}
                        </vaadin-form-item>
-                   `}return I(e,t,n,r,i,a,o)},Fc=(e,t,n,r,i,a,o,s)=>T`
+                   `}return F(e,t,n,r,i,a,o)},Ic=(e,t,n,r,i,a,o,s)=>T`
         <vaadin-form-row>
-            ${n.children?.map(n=>Nc(e,t,n,r,i,a,o,s))}
+            ${n.children?.map(n=>Pc(e,t,n,r,i,a,o,s))}
         </vaadin-form-row>
-            `,Ic=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=(s.padding?` padding`:``)+(s.spacing?` spacing`:``)+(s.spacingVariant?` spacing-`+s.spacingVariant:``)+(s.wrap?` wrap`:``),l=t.style;return s.fullWidth&&(l=l?`width: 100%;`+l:`width: 100%;`),s.justification&&(l=l?`justify-content: `+s.justification+`;`+l:`justify-content: `+s.justification+`;`),s.verticalAlignment&&(l=l?`align-items: `+s.verticalAlignment+`;`+l:`align-items: `+s.verticalAlignment+`;`),T`
+            `,Lc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=(s.padding?` padding`:``)+(s.spacing?` spacing`:``)+(s.spacingVariant?` spacing-`+s.spacingVariant:``)+(s.wrap?` wrap`:``),l=t.style;return s.fullWidth&&(l=l?`width: 100%;`+l:`width: 100%;`),s.justification&&(l=l?`justify-content: `+s.justification+`;`+l:`justify-content: `+s.justification+`;`),s.verticalAlignment&&(l=l?`align-items: `+s.verticalAlignment+`;`+l:`align-items: `+s.verticalAlignment+`;`),T`
                <vaadin-horizontal-layout 
                        style="${l}" 
                        class="${t.cssClasses}"
                        theme="${c}"
                        slot="${t.slot??v}"
                >
-                   ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+                   ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
                </vaadin-horizontal-layout>
-            `},Lc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=(s.padding?` padding`:``)+(s.spacing?` spacing`:``)+(s.spacingVariant?` spacing-`+s.spacingVariant:``)+(s.wrap?` wrap`:``),l=t.style;return s.fullWidth&&(l=l?`width: 100%;`+l:`width: 100%;`),s.justification&&(l=l?`justify-content: `+s.justification+`;`+l:`justify-content: `+s.justification+`;`),s.horizontalAlignment&&(l=l?`align-items: `+s.horizontalAlignment+`;`+l:`align-items: `+s.horizontalAlignment+`;`),T`
+            `},Rc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=(s.padding?` padding`:``)+(s.spacing?` spacing`:``)+(s.spacingVariant?` spacing-`+s.spacingVariant:``)+(s.wrap?` wrap`:``),l=t.style;return s.fullWidth&&(l=l?`width: 100%;`+l:`width: 100%;`),s.justification&&(l=l?`justify-content: `+s.justification+`;`+l:`justify-content: `+s.justification+`;`),s.horizontalAlignment&&(l=l?`align-items: `+s.horizontalAlignment+`;`+l:`align-items: `+s.horizontalAlignment+`;`),T`
         <vaadin-vertical-layout
                 style="${l}"
                 class="${t.cssClasses}"
                 theme="${c}"
                 slot="${t.slot??v}"
         >
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
         </vaadin-vertical-layout>
-    `},Rc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;return s.fullWidth&&(c=c?`width: 100%;`+c:`width: 100%;`),T`
+    `},zc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;return s.fullWidth&&(c=c?`width: 100%;`+c:`width: 100%;`),T`
                <vaadin-split-layout 
                        style="${c}" 
                        class="${t.cssClasses}"
@@ -8433,18 +8441,18 @@ ${i}
                        theme="${s.variant??v}"
                        slot="${t.slot??v}"
                >
-                   <master-content>${I(e,t.children[0],n,r,i,a,o)}</master-content>
-                   <detail-content>${I(e,t.children[1],n,r,i,a,o)}</detail-content>
+                   <master-content>${F(e,t.children[0],n,r,i,a,o)}</master-content>
+                   <detail-content>${F(e,t.children[1],n,r,i,a,o)}</detail-content>
                </vaadin-split-layout>
-            `},zc=(e,t,n,r,i,a,o)=>{let s=t.children&&t.children.length>1?t.children[1]:null,c=i?.detailComponent??null,l=!!i?.hasDetail||!!s,u=c??s;return T`
+            `},Bc=(e,t,n,r,i,a,o)=>{let s=t.children&&t.children.length>1?t.children[1]:null,c=i?.detailComponent??null,l=!!i?.hasDetail||!!s,u=c??s;return T`
                <vaadin-master-detail-layout ?has-detail="${l}"
                                             style="${t.style}"
                                             class="${t.cssClasses}"
                                             slot="${t.slot??v}">
-                   <div>${I(e,t.children[0],n,r,i,a,o)}</div>
-                   ${l&&u?T`<div slot="detail">${I(e,u,n,r,i,a,o)}</div>`:T`<div slot="detail" style="display: flex; align-items: center; justify-content: center; height: 100%; color: var(--lumo-secondary-text-color); font-size: var(--lumo-font-size-s);">Select an item to view details</div>`}
+                   <div>${F(e,t.children[0],n,r,i,a,o)}</div>
+                   ${l&&u?T`<div slot="detail">${F(e,u,n,r,i,a,o)}</div>`:T`<div slot="detail" style="display: flex; align-items: center; justify-content: center; height: 100%; color: var(--lumo-secondary-text-color); font-size: var(--lumo-font-size-s);">Select an item to view details</div>`}
                </vaadin-master-detail-layout>
-            `},Bc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;c??=``,s.fullWidth&&(c+=`width: 100%;`);let l=s.variant;l==`equalWidth`&&(l=`equal-width-tabs`);let u=Math.max(0,(t.children??[]).findIndex(e=>e.metadata.active)),d=e=>{e.target.selected=u};if(s.adaptable){let u=(t.children??[]).map(t=>{let n=t.metadata.label;return n?.includes("${")?e._evalTemplate(n):n});return T`
+            `},Vc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;c??=``,s.fullWidth&&(c+=`width: 100%;`);let l=s.variant;l==`equalWidth`&&(l=`equal-width-tabs`);let u=Math.max(0,(t.children??[]).findIndex(e=>e.metadata.active)),d=e=>{e.target.selected=u};if(s.adaptable){let u=(t.children??[]).map(t=>{let n=t.metadata.label;return n?.includes("${")?e._evalTemplate(n):n});return T`
             <mateu-adaptive-tabs
                     .tabLabels="${u}"
                     style="${c}"
@@ -8466,7 +8474,7 @@ ${i}
 
                 ${t.children?.map((t,s)=>T`
                     <div slot="panel-${s}" style="padding: var(--lumo-space-m) 0;">
-                        ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+                        ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
                     </div>`)}
             </mateu-adaptive-tabs>
                 `}return T`
@@ -8489,73 +8497,73 @@ ${i}
                     >${r}</vaadin-tab>`})}
             </vaadin-tabs>
 
-            ${t.children?.map(t=>Vc(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>Hc(e,t,n,r,i,a,o))}
         </vaadin-tabsheet>
-            `},Vc=(e,t,n,r,i,a,o)=>{let s=t.metadata.label;return T`
+            `},Hc=(e,t,n,r,i,a,o)=>{let s=t.metadata.label;return T`
         <div tab="${s?.includes("${")?e._evalTemplate(s):s}" style="padding: var(--lumo-space-m) 0;">
-                   ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+                   ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
                </div>
-            `},Hc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;s.fullWidth&&(c=c?`width: 100%;`+c:`width: 100%;`);let l=0;if(t.children){for(let e=0;e<t.children.length;e++)if(t.children[e].metadata?.active){l=e;break}}return T`
+            `},Uc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;s.fullWidth&&(c=c?`width: 100%;`+c:`width: 100%;`);let l=0;if(t.children){for(let e=0;e<t.children.length;e++)if(t.children[e].metadata?.active){l=e;break}}return T`
                <vaadin-accordion
                        style="${t.style}"
                        class="${t.cssClasses}"
                        opened="${l}"
                        slot="${t.slot??v}"
                >
-                   ${t.children?.map(t=>Uc(e,t,n,r,i,a,o,s.variant))}
+                   ${t.children?.map(t=>Wc(e,t,n,r,i,a,o,s.variant))}
                </vaadin-accordion>
-            `},Uc=(e,t,n,r,i,a,o,s)=>{let c=t.metadata,l=c.label?.includes("${")?e._evalTemplate(c.label):c.label;return T`
+            `},Wc=(e,t,n,r,i,a,o,s)=>{let c=t.metadata,l=c.label?.includes("${")?e._evalTemplate(c.label):c.label;return T`
         <vaadin-accordion-panel style="${t.style}"
                                 class="${t.cssClasses}"
                                 theme="${s??v}"
                                 ?opened="${c.active}"
                                 ?disabled="${c.disabled}">
             <vaadin-accordion-heading slot="summary">${l}</vaadin-accordion-heading>
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
         </vaadin-accordion-panel>
-            `},Wc=(e,t,n,r,i,a,o)=>T`
+            `},Gc=(e,t,n,r,i,a,o)=>T`
                <vaadin-scroller style="${t.style}" 
                                 class="${t.cssClasses}"
                                 slot="${t.slot??v}">
-                   ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+                   ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
                </vaadin-scroller>
-            `,Gc=(e,t,n,r,i,a,o)=>T`
+            `,Kc=(e,t,n,r,i,a,o)=>T`
         <vaadin-board style="${t.style}" 
                       class="${t.cssClasses}"
                       slot="${t.slot??v}">
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
         </vaadin-board>
-            `,Kc=(e,t,n,r,i,a,o)=>T`
+            `,qc=(e,t,n,r,i,a,o)=>T`
         <vaadin-board-row style="${t.style}" class="${t.cssClasses}">
-                   ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+                   ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
                </vaadin-board-row>
-            `,qc=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+            `,Jc=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
         <div style="${t.style}" 
              class="${t.cssClasses}"
              board-cols="${s.boardCols??v}"
         >
-                   ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+                   ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
                </div>
-            `},Jc=(e,t,n)=>T`
+            `},Yc=(e,t,n)=>T`
     <vaadin-menu-bar
         theme="tertiary"
         .items=${e}
         class="${n??v}"
         @item-selected=${e=>t(e.detail.value)}>
-    </vaadin-menu-bar>`,Yc=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
-        <vaadin-context-menu .items=${Qc(e,s.menu,n,r,i,a,o)} 
+    </vaadin-menu-bar>`,Xc=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+        <vaadin-context-menu .items=${$c(e,s.menu,n,r,i,a,o)} 
                              style="${t.style}" 
                              class="${t.cssClasses}"
                              open-on="${s.activateOnLeftClick?`click`:v}"
                              slot="${t.slot??v}">
-            ${I(e,s.wrapped,n,r,i,a,o)}
+            ${F(e,s.wrapped,n,r,i,a,o)}
         </vaadin-context-menu>
-            `},Xc=(e,t,n,r,i)=>{let a=t.metadata;return T`
-        <vaadin-menu-bar .items=${Qc(e,a.options,n,r,i,O,ue)}
+            `},Zc=(e,t,n,r,i)=>{let a=t.metadata;return T`
+        <vaadin-menu-bar .items=${$c(e,a.options,n,r,i,O,ue)}
                          style="${t.style}" class="${t.cssClasses}"
                          slot="${t.slot??v}">
         </vaadin-menu-bar>
-            `},Zc=(e,t,n,r,i,a,o)=>{let s=document.createElement(`vaadin-context-menu-item`);return re(I(e,t,n,r,i,a,o),s),s},Qc=(e,t,n,r,i,a,o)=>t.map(t=>t.submenus?{text:t.component?void 0:t.label,route:t.path,checked:t.selected,disabled:t.disabled,className:t.className,component:t.component?Zc(e,t.component,n,r,i,a,o):void 0,children:Qc(e,t.submenus,n,r,i,a,o)}:t.separator?{component:`hr`}:{text:t.component?void 0:t.label,route:t.path,checked:t.selected,disabled:t.disabled,className:t.className,component:t.component?Zc(e,t.component,n,r,i,a,o):void 0}),$c=class extends b{constructor(...e){super(...e),this.fieldId=``,this.signing=!1,this.hasStrokes=!1,this.drawing=!1,this.startStroke=e=>{let t=e.target;this.ensureCanvasSize(t),t.setPointerCapture(e.pointerId),this.drawing=!0;let n=t.getContext(`2d`);n.lineWidth=2,n.lineCap=`round`,n.lineJoin=`round`,n.strokeStyle=getComputedStyle(this).getPropertyValue(`--lumo-body-text-color`)||`#1a1a1a`;let[r,i]=this.pointerPosition(e);n.beginPath(),n.moveTo(r,i),e.preventDefault()},this.stroke=e=>{if(!this.drawing)return;let t=e.target.getContext(`2d`),[n,r]=this.pointerPosition(e);t.lineTo(n,r),t.stroke(),this.hasStrokes=!0,e.preventDefault()},this.endStroke=e=>{this.drawing=!1,e.target.releasePointerCapture(e.pointerId)}}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}canvas(){return this.renderRoot.querySelector(`canvas`)}pointerPosition(e){let t=e.target.getBoundingClientRect();return[e.clientX-t.left,e.clientY-t.top]}ensureCanvasSize(e){let t=e.getBoundingClientRect();(e.width!==Math.round(t.width)||e.height!==Math.round(t.height))&&(e.width=Math.round(t.width),e.height=Math.round(t.height))}clear(){let e=this.canvas();e&&e.getContext(`2d`).clearRect(0,0,e.width,e.height),this.hasStrokes=!1}accept(){let e=this.canvas();!e||!this.hasStrokes||(this.signing=!1,this.emit(e.toDataURL(`image/png`)))}renderPad(){return T`
+            `},Qc=(e,t,n,r,i,a,o)=>{let s=document.createElement(`vaadin-context-menu-item`);return re(F(e,t,n,r,i,a,o),s),s},$c=(e,t,n,r,i,a,o)=>t.map(t=>t.submenus?{text:t.component?void 0:t.label,route:t.path,checked:t.selected,disabled:t.disabled,className:t.className,component:t.component?Qc(e,t.component,n,r,i,a,o):void 0,children:$c(e,t.submenus,n,r,i,a,o)}:t.separator?{component:`hr`}:{text:t.component?void 0:t.label,route:t.path,checked:t.selected,disabled:t.disabled,className:t.className,component:t.component?Qc(e,t.component,n,r,i,a,o):void 0}),el=class extends b{constructor(...e){super(...e),this.fieldId=``,this.signing=!1,this.hasStrokes=!1,this.drawing=!1,this.startStroke=e=>{let t=e.target;this.ensureCanvasSize(t),t.setPointerCapture(e.pointerId),this.drawing=!0;let n=t.getContext(`2d`);n.lineWidth=2,n.lineCap=`round`,n.lineJoin=`round`,n.strokeStyle=getComputedStyle(this).getPropertyValue(`--lumo-body-text-color`)||`#1a1a1a`;let[r,i]=this.pointerPosition(e);n.beginPath(),n.moveTo(r,i),e.preventDefault()},this.stroke=e=>{if(!this.drawing)return;let t=e.target.getContext(`2d`),[n,r]=this.pointerPosition(e);t.lineTo(n,r),t.stroke(),this.hasStrokes=!0,e.preventDefault()},this.endStroke=e=>{this.drawing=!1,e.target.releasePointerCapture(e.pointerId)}}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}canvas(){return this.renderRoot.querySelector(`canvas`)}pointerPosition(e){let t=e.target.getBoundingClientRect();return[e.clientX-t.left,e.clientY-t.top]}ensureCanvasSize(e){let t=e.getBoundingClientRect();(e.width!==Math.round(t.width)||e.height!==Math.round(t.height))&&(e.width=Math.round(t.width),e.height=Math.round(t.height))}clear(){let e=this.canvas();e&&e.getContext(`2d`).clearRect(0,0,e.width,e.height),this.hasStrokes=!1}accept(){let e=this.canvas();!e||!this.hasStrokes||(this.signing=!1,this.emit(e.toDataURL(`image/png`)))}renderPad(){return T`
             <canvas class="pad"
                     @pointerdown="${this.startStroke}"
                     @pointermove="${this.stroke}"
@@ -8622,7 +8630,7 @@ ${i}
         .button--danger {
             color: var(--lumo-error-text-color, rgb(179, 49, 31));
         }
-    `}};k([y()],$c.prototype,`fieldId`,void 0),k([y()],$c.prototype,`value`,void 0),k([C()],$c.prototype,`signing`,void 0),k([C()],$c.prototype,`hasStrokes`,void 0),$c=k([g(`mateu-signature-pad`)],$c);var el=class extends b{constructor(...e){super(...e),this.fieldId=``,this.options=[],this.leavesOnly=!1,this.opened=!1,this.expandedItems=[],this._normalized=[],this.dataProvider=(e,t)=>{let n=e.parentItem?e.parentItem.children??[]:this.normalized;t(n,n.length)}}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}get normalized(){return this._optsSource!==this.options&&(this._optsSource=this.options,this._normalized=this.normalizeOptions(this.options??[])),this._normalized}normalizeOptions(e){return e.map(e=>{let t=e.children&&e.children.length?this.normalizeOptions(e.children):void 0;return{...e,children:t}})}ancestorsOf(e,t){for(let n of t){if(String(n.value)===e)return[];let t=n.children?this.ancestorsOf(e,n.children):null;if(t!=null)return[n,...t]}return null}labelOf(e,t){for(let n of t){if(String(n.value)===e)return n.label;let t=n.children?this.labelOf(e,n.children):null;if(t!=null)return t}return null}open(){this.opened||(this.expandedItems=this.value==null?[]:this.ancestorsOf(String(this.value),this.normalized)??[],this.opened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.close()},document.addEventListener(`mousedown`,this.outsideClick))}close(){this.detachOutsideClick(),this.opened=!1}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}pick(e){this.close(),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e.value,fieldId:this.fieldId},bubbles:!0,composed:!0}))}clear(){this.close(),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:void 0,fieldId:this.fieldId},bubbles:!0,composed:!0}))}onActiveItemChanged(e){let t=e.detail.value;if(t){if((t.children?.length??0)>0&&this.leavesOnly){this.expandedItems=this.expandedItems.includes(t)?this.expandedItems.filter(e=>e!==t):[...this.expandedItems,t],e.target.activeItem=null;return}this.pick(t)}}render(){let e=this.value!=null&&this.value!==``?this.labelOf(String(this.value),this.normalized)??String(this.value):``;return T`
+    `}};k([y()],el.prototype,`fieldId`,void 0),k([y()],el.prototype,`value`,void 0),k([C()],el.prototype,`signing`,void 0),k([C()],el.prototype,`hasStrokes`,void 0),el=k([g(`mateu-signature-pad`)],el);var tl=class extends b{constructor(...e){super(...e),this.fieldId=``,this.options=[],this.leavesOnly=!1,this.opened=!1,this.expandedItems=[],this._normalized=[],this.dataProvider=(e,t)=>{let n=e.parentItem?e.parentItem.children??[]:this.normalized;t(n,n.length)}}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}get normalized(){return this._optsSource!==this.options&&(this._optsSource=this.options,this._normalized=this.normalizeOptions(this.options??[])),this._normalized}normalizeOptions(e){return e.map(e=>{let t=e.children&&e.children.length?this.normalizeOptions(e.children):void 0;return{...e,children:t}})}ancestorsOf(e,t){for(let n of t){if(String(n.value)===e)return[];let t=n.children?this.ancestorsOf(e,n.children):null;if(t!=null)return[n,...t]}return null}labelOf(e,t){for(let n of t){if(String(n.value)===e)return n.label;let t=n.children?this.labelOf(e,n.children):null;if(t!=null)return t}return null}open(){this.opened||(this.expandedItems=this.value==null?[]:this.ancestorsOf(String(this.value),this.normalized)??[],this.opened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.close()},document.addEventListener(`mousedown`,this.outsideClick))}close(){this.detachOutsideClick(),this.opened=!1}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}pick(e){this.close(),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e.value,fieldId:this.fieldId},bubbles:!0,composed:!0}))}clear(){this.close(),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:void 0,fieldId:this.fieldId},bubbles:!0,composed:!0}))}onActiveItemChanged(e){let t=e.detail.value;if(t){if((t.children?.length??0)>0&&this.leavesOnly){this.expandedItems=this.expandedItems.includes(t)?this.expandedItems.filter(e=>e!==t):[...this.expandedItems,t],e.target.activeItem=null;return}this.pick(t)}}render(){let e=this.value!=null&&this.value!==``?this.labelOf(String(this.value),this.normalized)??String(this.value):``;return T`
             <div class="root">
                 <vaadin-button class="control" theme="tertiary"
                                @click="${()=>this.opened?this.close():this.open()}">
@@ -8693,7 +8701,7 @@ ${i}
             min-width: 16rem;
             max-height: 18rem;
         }
-    `}};k([y()],el.prototype,`fieldId`,void 0),k([y()],el.prototype,`value`,void 0),k([y()],el.prototype,`options`,void 0),k([y({type:Boolean})],el.prototype,`leavesOnly`,void 0),k([C()],el.prototype,`opened`,void 0),k([C()],el.prototype,`expandedItems`,void 0),el=k([g(`mateu-vaadin-tree-select`)],el);var tl=class extends b{constructor(...e){super(...e),this.fieldId=``,this.cameraOpen=!1,this.cameraError=!1,this.fileFallback=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>this.emit(r.result),r.readAsDataURL(n),t.value=``}}disconnectedCallback(){super.disconnectedCallback(),this.stopStream()}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}stopStream(){this.stream?.getTracks().forEach(e=>e.stop()),this.stream=void 0}async openCamera(){this.cameraError=!1;try{this.stream=await navigator.mediaDevices.getUserMedia({video:{facingMode:`environment`},audio:!1}),this.cameraOpen=!0,await this.updateComplete;let e=this.renderRoot.querySelector(`video`);e&&(e.srcObject=this.stream,await e.play())}catch{this.stopStream(),this.cameraOpen=!1,this.cameraError=!0}}closeCamera(){this.stopStream(),this.cameraOpen=!1}shoot(){let e=this.renderRoot.querySelector(`video`);if(!e||e.videoWidth===0)return;let t=document.createElement(`canvas`);t.width=e.videoWidth,t.height=e.videoHeight,t.getContext(`2d`).drawImage(e,0,0),this.closeCamera(),this.emit(t.toDataURL(`image/jpeg`,.9))}triggerFallback(){this.renderRoot.querySelector(`input[type=file]`)?.click()}render(){let e=this.value!=null&&this.value!==``;return T`
+    `}};k([y()],tl.prototype,`fieldId`,void 0),k([y()],tl.prototype,`value`,void 0),k([y()],tl.prototype,`options`,void 0),k([y({type:Boolean})],tl.prototype,`leavesOnly`,void 0),k([C()],tl.prototype,`opened`,void 0),k([C()],tl.prototype,`expandedItems`,void 0),tl=k([g(`mateu-vaadin-tree-select`)],tl);var nl=class extends b{constructor(...e){super(...e),this.fieldId=``,this.cameraOpen=!1,this.cameraError=!1,this.fileFallback=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>this.emit(r.result),r.readAsDataURL(n),t.value=``}}disconnectedCallback(){super.disconnectedCallback(),this.stopStream()}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}stopStream(){this.stream?.getTracks().forEach(e=>e.stop()),this.stream=void 0}async openCamera(){this.cameraError=!1;try{this.stream=await navigator.mediaDevices.getUserMedia({video:{facingMode:`environment`},audio:!1}),this.cameraOpen=!0,await this.updateComplete;let e=this.renderRoot.querySelector(`video`);e&&(e.srcObject=this.stream,await e.play())}catch{this.stopStream(),this.cameraOpen=!1,this.cameraError=!0}}closeCamera(){this.stopStream(),this.cameraOpen=!1}shoot(){let e=this.renderRoot.querySelector(`video`);if(!e||e.videoWidth===0)return;let t=document.createElement(`canvas`);t.width=e.videoWidth,t.height=e.videoHeight,t.getContext(`2d`).drawImage(e,0,0),this.closeCamera(),this.emit(t.toDataURL(`image/jpeg`,.9))}triggerFallback(){this.renderRoot.querySelector(`input[type=file]`)?.click()}render(){let e=this.value!=null&&this.value!==``;return T`
             <input type="file" accept="image/*" capture="environment" style="display: none;"
                    @change="${this.fileFallback}">
             ${this.cameraOpen?T`
@@ -8771,7 +8779,7 @@ ${i}
             font-size: var(--lumo-font-size-xs, 0.75rem);
             color: var(--lumo-secondary-text-color, rgba(0, 0, 0, 0.6));
         }
-    `}};k([y()],tl.prototype,`fieldId`,void 0),k([y()],tl.prototype,`value`,void 0),k([C()],tl.prototype,`cameraOpen`,void 0),k([C()],tl.prototype,`cameraError`,void 0),tl=k([g(`mateu-camera-capture`)],tl);var nl,rl=(e,t)=>{if(!e)return;if(Array.isArray(e)){let n=e.find(e=>e.key==t);return n?.value==null?void 0:String(n.value)}let n=e[t];return n==null?void 0:String(n)},il=class extends b{static{nl=this}constructor(...e){super(...e),this.fieldId=``,this.editable=!0,this.filePicked=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>{let e=r.result,t=e.indexOf(`,`),i=e.substring(0,t).replace(`;base64`,`;name=${encodeURIComponent(n.name)};base64`);this.emit(i+e.substring(t))},r.readAsDataURL(n),t.value=``}}static fileName(e){if(!e)return``;if(e.startsWith(`data:`)){let t=e.indexOf(`,`),n=e.substring(5,t<0?e.length:t).split(`;`).find(e=>e.startsWith(`name=`));if(n)try{return decodeURIComponent(n.substring(5))}catch{return n.substring(5)}return`Attached file`}return e.split(`/`).pop()||e}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}triggerPick(){this.renderRoot.querySelector(`input[type=file]`)?.click()}render(){let e=this.value!=null&&this.value!==``,t=nl.fileName(this.value),n=e&&this.value.startsWith(`data:`),r=e?T`<span class="file" title="${t}">📄 ${n?T`<a href="${this.value}" download="${t}">${t}</a>`:T`<a href="${this.value}" target="_blank">${t}</a>`}</span>`:v;return this.editable?T`
+    `}};k([y()],nl.prototype,`fieldId`,void 0),k([y()],nl.prototype,`value`,void 0),k([C()],nl.prototype,`cameraOpen`,void 0),k([C()],nl.prototype,`cameraError`,void 0),nl=k([g(`mateu-camera-capture`)],nl);var rl,il=(e,t)=>{if(!e)return;if(Array.isArray(e)){let n=e.find(e=>e.key==t);return n?.value==null?void 0:String(n.value)}let n=e[t];return n==null?void 0:String(n)},al=class extends b{static{rl=this}constructor(...e){super(...e),this.fieldId=``,this.editable=!0,this.filePicked=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>{let e=r.result,t=e.indexOf(`,`),i=e.substring(0,t).replace(`;base64`,`;name=${encodeURIComponent(n.name)};base64`);this.emit(i+e.substring(t))},r.readAsDataURL(n),t.value=``}}static fileName(e){if(!e)return``;if(e.startsWith(`data:`)){let t=e.indexOf(`,`),n=e.substring(5,t<0?e.length:t).split(`;`).find(e=>e.startsWith(`name=`));if(n)try{return decodeURIComponent(n.substring(5))}catch{return n.substring(5)}return`Attached file`}return e.split(`/`).pop()||e}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}triggerPick(){this.renderRoot.querySelector(`input[type=file]`)?.click()}render(){let e=this.value!=null&&this.value!==``,t=rl.fileName(this.value),n=e&&this.value.startsWith(`data:`),r=e?T`<span class="file" title="${t}">📄 ${n?T`<a href="${this.value}" download="${t}">${t}</a>`:T`<a href="${this.value}" target="_blank">${t}</a>`}</span>`:v;return this.editable?T`
             <input type="file" accept="${this.accept||v}" style="display: none;"
                    @change="${this.filePicked}">
             <div class="row">
@@ -8819,28 +8827,28 @@ ${i}
         .button--danger {
             color: var(--lumo-error-text-color, rgb(179, 49, 31));
         }
-    `}};k([y()],il.prototype,`fieldId`,void 0),k([y()],il.prototype,`value`,void 0),k([y()],il.prototype,`accept`,void 0),k([y({type:Boolean})],il.prototype,`editable`,void 0),il=nl=k([g(`mateu-file-upload`)],il);var al=e=>e==null||typeof e==`string`&&e.trim()===``,ol=(e,t)=>{if(al(e))return null;let n=t?parseInt(String(e),10):Number(e);return Number.isNaN(n)?null:n},sl=(e,t)=>al(e)&&al(t)?!0:e==t,cl=e=>!!e&&typeof e==`object`&&`__mateuGroup`in e,ll=e=>String(e??``),ul=(e,t,n)=>{let r=e??[];if(!t||!n||n.length===0)return r;let i=[],a,o=!1;return r.forEach((e,s)=>{let c=ll(e?.[t]);if(!o||c!==a){let e=n.find(e=>ll(e.value)===c)??{value:c,count:r.filter(e=>ll(e?.[t])===c).length,aggregates:{}};i.push({__mateuGroup:e,__mateuGroupBy:t,_rowNumber:`__mateuGroup:${s}:${c}`}),o=!0,a=c}i.push(e)}),i},dl=(e,t)=>e==null?``:t.dataType===`money`||t.stereotype===`money`?new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e):t.aggregate===`count`?new Intl.NumberFormat(void 0,{maximumFractionDigits:0}).format(Math.round(e)):new Intl.NumberFormat(void 0,{maximumFractionDigits:2}).format(e),fl=(e,t)=>e&&t.includes(e)?e:t.find(e=>!!e),pl=(e,t,n)=>{let r=e.__mateuGroup;return t.id===n?`${r.value} (${r.count})`:t.aggregate?dl(r.aggregates?.[t.id],t):``},ml=(e,t,n)=>{let r=t?.aggregates;if(!r||!e.some(e=>e.aggregate))return;let i={};e.forEach(e=>{e.aggregate&&r[e.id]!=null&&(i[e.id]=dl(r[e.id],e))});let a=e[0];if(a&&i[a.id]===void 0){let e=t?.page?.totalElements;i[a.id]=n&&a.id===n&&e!=null?`Total (${e})`:`Total`}return i},hl=(e,t,n)=>L(e[n.path]?`vaadin:check`:`vaadin:minus`,`height: 16px; width: 16px; color: var(--lumo-body-text-color);`),gl=(e,t,n,r,i)=>{let a=e[n.path],o=a;return r==`money`&&a&&a.locale&&a.currency?o=new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(a.value):i==`money`&&(o=new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(a)),T`${o}`},_l=(e,t,n)=>{e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:n},bubbles:!0,composed:!0}))},vl=(e,t,n,r,i,a)=>{let o=n.xcolumn??a;if(o.text)return o.actionId?T`<a href="javascript: void(0);" @click="${t=>_l(n,o,e)}">${o.text}</a>`:T`<a href="${e[n.path]}">${o.text}</a>`;if(r==`string`){if(o.actionId)return T`<a href="javascript: void(0);" @click="${t=>_l(n,o,e)}">${e[n.path]}</a>`;let t=e[n.path];return T`<a href="${t}">${t}</a>`}let s=e[n.path];return T`<a href="${s.href}">${s.text}</a>`},yl=(e,t,n,r,i)=>{let a=e[n.path];return r==`string`?a.split(`,`).map(e=>L(e,`width: 16px;`)):a.split(`,`).map(e=>L(e.icon,`width: 16px;`))},bl=(e,t,n,r,i)=>{let a=e[n.path];return T`${_(a)}`},xl=(e,t,n,r,i,a)=>r==`string`?T`<img src="${e[n.path]}" style="${`max-height: 40px; `+(a.style??``)}">`:T`<img src="${e[n.path].src}" style="${a.style??``}">`,Sl=e=>{let t={_clickedRow:e.target.row};e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+e.detail.value.methodNameInCrud,parameters:t},bubbles:!0,composed:!0}))},Cl=e=>{let t={_clickedRow:e.target.row},n=e.target.action;e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+n.methodNameInCrud,parameters:t},bubbles:!0,composed:!0}))},wl=e=>{let t=document.createElement(`vaadin-context-menu-item`),n=document.createElement(`vaadin-icon`);return n.style.color=`var(--lumo-secondary-text-color)`,n.style.marginInlineEnd=`var(--lumo-space-s)`,n.style.padding=`var(--lumo-space-xs)`,n.setAttribute(`icon`,e.icon),t.appendChild(n),e.label&&t.appendChild(document.createTextNode(e.label)),t.disabled=e.disabled,t},Tl=(e,t,n)=>{let r=e[n.path]?.actions?.map(e=>e.icon?{component:wl(e),methodNameInCrud:e.methodNameInCrud}:{...e,text:e.label});return!r||r.length==0?T``:T`
+    `}};k([y()],al.prototype,`fieldId`,void 0),k([y()],al.prototype,`value`,void 0),k([y()],al.prototype,`accept`,void 0),k([y({type:Boolean})],al.prototype,`editable`,void 0),al=rl=k([g(`mateu-file-upload`)],al);var ol=e=>e==null||typeof e==`string`&&e.trim()===``,sl=(e,t)=>{if(ol(e))return null;let n=t?parseInt(String(e),10):Number(e);return Number.isNaN(n)?null:n},cl=(e,t)=>ol(e)&&ol(t)?!0:e==t,ll=e=>!!e&&typeof e==`object`&&`__mateuGroup`in e,ul=e=>String(e??``),dl=(e,t,n)=>{let r=e??[];if(!t||!n||n.length===0)return r;let i=[],a,o=!1;return r.forEach((e,s)=>{let c=ul(e?.[t]);if(!o||c!==a){let e=n.find(e=>ul(e.value)===c)??{value:c,count:r.filter(e=>ul(e?.[t])===c).length,aggregates:{}};i.push({__mateuGroup:e,__mateuGroupBy:t,_rowNumber:`__mateuGroup:${s}:${c}`}),o=!0,a=c}i.push(e)}),i},fl=(e,t)=>e==null?``:t.dataType===`money`||t.stereotype===`money`?new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e):t.aggregate===`count`?new Intl.NumberFormat(void 0,{maximumFractionDigits:0}).format(Math.round(e)):new Intl.NumberFormat(void 0,{maximumFractionDigits:2}).format(e),pl=(e,t)=>e&&t.includes(e)?e:t.find(e=>!!e),ml=(e,t,n)=>{let r=e.__mateuGroup;return t.id===n?`${r.value} (${r.count})`:t.aggregate?fl(r.aggregates?.[t.id],t):``},hl=(e,t,n)=>{let r=t?.aggregates;if(!r||!e.some(e=>e.aggregate))return;let i={};e.forEach(e=>{e.aggregate&&r[e.id]!=null&&(i[e.id]=fl(r[e.id],e))});let a=e[0];if(a&&i[a.id]===void 0){let e=t?.page?.totalElements;i[a.id]=n&&a.id===n&&e!=null?`Total (${e})`:`Total`}return i},gl=(e,t,n)=>I(e[n.path]?`vaadin:check`:`vaadin:minus`,`height: 16px; width: 16px; color: var(--lumo-body-text-color);`),_l=(e,t,n,r,i)=>{let a=e[n.path],o=a;return r==`money`&&a&&a.locale&&a.currency?o=new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(a.value):i==`money`&&(o=new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(a)),T`${o}`},vl=(e,t,n)=>{e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:n},bubbles:!0,composed:!0}))},yl=(e,t,n,r,i,a)=>{let o=n.xcolumn??a;if(o.text)return o.actionId?T`<a href="javascript: void(0);" @click="${t=>vl(n,o,e)}">${o.text}</a>`:T`<a href="${e[n.path]}">${o.text}</a>`;if(r==`string`){if(o.actionId)return T`<a href="javascript: void(0);" @click="${t=>vl(n,o,e)}">${e[n.path]}</a>`;let t=e[n.path];return T`<a href="${t}">${t}</a>`}let s=e[n.path];return T`<a href="${s.href}">${s.text}</a>`},bl=(e,t,n,r,i)=>{let a=e[n.path];return r==`string`?a.split(`,`).map(e=>I(e,`width: 16px;`)):a.split(`,`).map(e=>I(e.icon,`width: 16px;`))},xl=(e,t,n,r,i)=>{let a=e[n.path];return T`${_(a)}`},Sl=(e,t,n,r,i,a)=>r==`string`?T`<img src="${e[n.path]}" style="${`max-height: 40px; `+(a.style??``)}">`:T`<img src="${e[n.path].src}" style="${a.style??``}">`,Cl=e=>{let t={_clickedRow:e.target.row};e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+e.detail.value.methodNameInCrud,parameters:t},bubbles:!0,composed:!0}))},wl=e=>{let t={_clickedRow:e.target.row},n=e.target.action;e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+n.methodNameInCrud,parameters:t},bubbles:!0,composed:!0}))},Tl=e=>{let t=document.createElement(`vaadin-context-menu-item`),n=document.createElement(`vaadin-icon`);return n.style.color=`var(--lumo-secondary-text-color)`,n.style.marginInlineEnd=`var(--lumo-space-s)`,n.style.padding=`var(--lumo-space-xs)`,n.setAttribute(`icon`,e.icon),t.appendChild(n),e.label&&t.appendChild(document.createTextNode(e.label)),t.disabled=e.disabled,t},El=(e,t,n)=>{let r=e[n.path]?.actions?.map(e=>e.icon?{component:Tl(e),methodNameInCrud:e.methodNameInCrud}:{...e,text:e.label});return!r||r.length==0?T``:T`
                                      <vaadin-menu-bar
                                          .items=${[{text:`···`,children:r}]}
                                          theme="tertiary"
                                          .row="${e}"
                                          data-testid="menubar-${n.path}"
-                                         @item-selected="${Sl}"
+                                         @item-selected="${Cl}"
                                      ></vaadin-menu-bar>
-                                   `},El=(e,t,n)=>{if(n.path==`select`)return T`
-         <vaadin-button theme="tertiary" title="Select" @click="${Cl}" .row="${e}" .action="${{actionId:n.path,icon:``,label:`Select`,disabled:!1,methodNameInCrud:`select`}}">
+                                   `},Dl=(e,t,n)=>{if(n.path==`select`)return T`
+         <vaadin-button theme="tertiary" title="Select" @click="${wl}" .row="${e}" .action="${{actionId:n.path,icon:``,label:`Select`,disabled:!1,methodNameInCrud:`select`}}">
              Select
          </vaadin-button>
     `;let r=n.path&&e[n.path]?.methodNameInCrud?e[n.path]:e.action;return r?T`
-         <vaadin-button theme="tertiary${r.icon&&!r.label?` icon`:``}" title="${r.label||v}" @click="${Cl}" .row="${e}" .action="${r}">
+         <vaadin-button theme="tertiary${r.icon&&!r.label?` icon`:``}" title="${r.label||v}" @click="${wl}" .row="${e}" .action="${r}">
              ${r.icon?T`<vaadin-icon icon="${r.icon}"></vaadin-icon>`:v}
              ${r.label?r.label:v}
          </vaadin-button>
-    `:T``},Dl=(e,t,n)=>{e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:n},bubbles:!0,composed:!0}))},Ol=(e,t,n,r,i,a)=>{let o=n.xcolumn??a;if(o.actionId)return T`
-            <vaadin-button theme="tertiary" @click="${t=>Dl(n,o,e)}" .row="${e}">
+    `:T``},Ol=(e,t,n)=>{e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:n},bubbles:!0,composed:!0}))},kl=(e,t,n,r,i,a)=>{let o=n.xcolumn??a;if(o.actionId)return T`
+            <vaadin-button theme="tertiary" @click="${t=>Ol(n,o,e)}" .row="${e}">
                 ${o.text||e[n.path]}
             </vaadin-button>
-        `;let s=e[n.path];return T`<a href="${s}">${o.text||s}</a>`},kl=(e,t,n,r,i,a,o,s,c)=>{let l=e[n.path];return I(r,l,i,a,o,s,c)},Al=new WeakMap,jl=(e,t)=>Al.get(e)?.[t],Ml=(e,t,n)=>{let r=Al.get(e);r||(r={},Al.set(e,r)),r[t]=n},Nl=(e,t=!1)=>ol(e,t),Pl=(e,t,n,r)=>{let i=n?.field?.fieldId,a=a=>{if(e[t.id]===a||e[t.id]==null&&(a===``||a==null))return;if(e[t.id]=a,!i){n.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`update-row`,parameters:{_editedRow:{...e}}},bubbles:!0,composed:!0}));return}let o=(n?.state??r)[i];n.dispatchEvent(new CustomEvent(`value-changed`,{detail:{fieldId:i,value:Array.isArray(o)?[...o]:o},bubbles:!0,composed:!0}))},o=e[t.id],s=o==null?``:String(o);switch(t.editorType){case`boolean`:return T`<vaadin-checkbox ?checked=${!!o} @checked-changed=${e=>a(e.detail.value)}></vaadin-checkbox>`;case`integer`:return T`<vaadin-integer-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(Nl(e.target.value,!0))}></vaadin-integer-field>`;case`number`:return T`<vaadin-number-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(Nl(e.target.value))}></vaadin-number-field>`;case`date`:return T`<vaadin-date-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-date-picker>`;case`time`:return T`<vaadin-time-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-time-picker>`;case`datetime`:return T`<vaadin-date-time-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-date-time-picker>`;case`select`:return T`<vaadin-combo-box
+        `;let s=e[n.path];return T`<a href="${s}">${o.text||s}</a>`},Al=(e,t,n,r,i,a,o,s,c)=>{let l=e[n.path];return F(r,l,i,a,o,s,c)},jl=new WeakMap,Ml=(e,t)=>jl.get(e)?.[t],Nl=(e,t,n)=>{let r=jl.get(e);r||(r={},jl.set(e,r)),r[t]=n},Pl=(e,t=!1)=>sl(e,t),Fl=(e,t,n,r)=>{let i=n?.field?.fieldId,a=a=>{if(e[t.id]===a||e[t.id]==null&&(a===``||a==null))return;if(e[t.id]=a,!i){n.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`update-row`,parameters:{_editedRow:{...e}}},bubbles:!0,composed:!0}));return}let o=(n?.state??r)[i];n.dispatchEvent(new CustomEvent(`value-changed`,{detail:{fieldId:i,value:Array.isArray(o)?[...o]:o},bubbles:!0,composed:!0}))},o=e[t.id],s=o==null?``:String(o);switch(t.editorType){case`boolean`:return T`<vaadin-checkbox ?checked=${!!o} @checked-changed=${e=>a(e.detail.value)}></vaadin-checkbox>`;case`integer`:return T`<vaadin-integer-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(Pl(e.target.value,!0))}></vaadin-integer-field>`;case`number`:return T`<vaadin-number-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(Pl(e.target.value))}></vaadin-number-field>`;case`date`:return T`<vaadin-date-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-date-picker>`;case`time`:return T`<vaadin-time-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-time-picker>`;case`datetime`:return T`<vaadin-date-time-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-date-time-picker>`;case`select`:return T`<vaadin-combo-box
                 theme="small" style="width:100%;"
                 .items=${(t.editorOptions??[]).map(e=>({label:e.label,value:String(e.value)}))}
                 item-label-path="label" item-value-path="value"
@@ -8849,12 +8857,12 @@ ${i}
                 theme="small" style="width:100%;"
                 item-label-path="label" item-id-path="value"
                 .dataProvider=${(e,t)=>{n.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:i,parameters:{searchText:e.filter,size:e.pageSize,page:e.page},callback:e=>{let n=e?.fragments?.[0]?.data?.[o];t(n?.content??[],n?.totalElements??0)},callbackonly:!0},bubbles:!0,composed:!0}))}}
-                .selectedItem=${(t.editorOptions??[]).find(e=>String(e.value)===s)??(s?{value:s,label:jl(e,t.id)??s}:void 0)}
-                @selected-item-changed=${n=>{let r=n.detail.value,i=r?r.value:null;String(i??``)!==s&&(r&&Ml(e,t.id,r.label),a(i))}}></vaadin-combo-box>`}default:return T`<vaadin-text-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(e.target.value)}></vaadin-text-field>`}},Fl=e=>ee(()=>T`<span title="${e}" style="white-space:normal;overflow-wrap:break-word;">${e}</span>`,[e]),Il=e=>e===void 0?v:d(()=>T`<span style="font-weight: 600; white-space: nowrap;">${e}</span>`,[e]),Ll=e=>{e.preventDefault(),e.stopPropagation(),e.currentTarget?.dispatchEvent(new CustomEvent(`sort-direction-changed`,{detail:{grid:e.currentTarget.parentElement},bubbles:!0,composed:!0}))},Rl=(e,t,n,r,i,a,o,s)=>T`
+                .selectedItem=${(t.editorOptions??[]).find(e=>String(e.value)===s)??(s?{value:s,label:Ml(e,t.id)??s}:void 0)}
+                @selected-item-changed=${n=>{let r=n.detail.value,i=r?r.value:null;String(i??``)!==s&&(r&&Nl(e,t.id,r.label),a(i))}}></vaadin-combo-box>`}default:return T`<vaadin-text-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(e.target.value)}></vaadin-text-field>`}},Il=e=>ee(()=>T`<span title="${e}" style="white-space:normal;overflow-wrap:break-word;">${e}</span>`,[e]),Ll=e=>e===void 0?v:d(()=>T`<span style="font-weight: 600; white-space: nowrap;">${e}</span>`,[e]),Rl=e=>{e.preventDefault(),e.stopPropagation(),e.currentTarget?.dispatchEvent(new CustomEvent(`sort-direction-changed`,{detail:{grid:e.currentTarget.parentElement},bubbles:!0,composed:!0}))},zl=(e,t,n,r,i,a,o,s)=>T`
 <vaadin-grid-column-group header="${M(e.label,r,i)}">
-    ${e.columns.map(e=>Bl(e.metadata,t,n,r,i,a,o,s?.[e.metadata?.id]))}
+    ${e.columns.map(e=>Vl(e.metadata,t,n,r,i,a,o,s?.[e.metadata?.id]))}
 </vaadin-grid-column-group>
-`,zl=(e,t,n,r,i,a,o,s)=>j.GridGroupColumn==e.metadata?.type?Rl(e.metadata,t,n,r,i,a,o,s):Bl(e.metadata,t,n,r,i,a,o,s?.[e.metadata?.id]),Bl=(e,n,r,i,a,o,s,c)=>{let l=M(e.label,i,a);return e.sortable?T`
+`,Bl=(e,t,n,r,i,a,o,s)=>j.GridGroupColumn==e.metadata?.type?zl(e.metadata,t,n,r,i,a,o,s):Vl(e.metadata,t,n,r,i,a,o,s?.[e.metadata?.id]),Vl=(e,n,r,i,a,o,s,c)=>{let l=M(e.label,i,a);return e.sortable?T`
                         <vaadin-grid-sort-column
                                 path="${e.id}"
                                 text-align="${e.align??v}"
@@ -8864,12 +8872,12 @@ ${i}
                                 flex-grow="${e.flexGrow??v}"
                                 ?resizable="${e.resizable}"
                                 width="${e.width??v}"
-                                @direction-changed="${Ll}"
+                                @direction-changed="${Rl}"
                                 data-data-type="${e.dataType}"
                                 data-stereotype="${e.stereotype}"
-                                ${Fl(l)}
-                                ${Il(c)}
-                                ${t((t,c,l)=>Vl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
+                                ${Il(l)}
+                                ${Ll(c)}
+                                ${t((t,c,l)=>Hl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
                         ></vaadin-grid-sort-column>
                     `:e.filterable?T`
                         <vaadin-grid-filter-column
@@ -8883,9 +8891,9 @@ ${i}
                                 width="${e.width??v}"
                                 data-data-type="${e.dataType}"
                                 data-stereotype="${e.stereotype}"
-                                ${Fl(l)}
-                                ${Il(c)}
-                                ${t((t,c,l)=>Vl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
+                                ${Il(l)}
+                                ${Ll(c)}
+                                ${t((t,c,l)=>Hl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
                         ></vaadin-grid-filter-column>
                     `:T`
                         <vaadin-grid-column
@@ -8900,17 +8908,17 @@ ${i}
                                 data-data-type="${e.dataType}"
                                 data-stereotype="${e.stereotype}"
                                 .xcolumn="${e}"
-                                ${Fl(l)}
-                                ${Il(c)}
-                                ${t((t,c,l)=>Vl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
+                                ${Il(l)}
+                                ${Ll(c)}
+                                ${t((t,c,l)=>Hl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
                         ></vaadin-grid-column>
-                    `},Vl=(e,t,n,r,i,a,o,s,c,l)=>{let u=n.dataset.dataType??``,d=n.dataset.stereotype??``;if(cl(e)){let t=i?.metadata,n=(t?.columns??[]).flatMap(e=>e?.metadata?.type===j.GridGroupColumn?(e.metadata.columns??[]).map(e=>e?.metadata?.id):[e?.metadata?.id]),a=pl(e,r,fl(e.__mateuGroupBy,n)),o=e.__mateuGroup.hiddenActions??[],s=r.id===n[n.length-1]?(t?.groupActions??[]).filter(e=>!o.includes(e.actionId??e.id)):[];return s.length?T`<span style="display: flex; align-items: center; justify-content: flex-end; gap: var(--lumo-space-s); overflow: hidden;">
+                    `},Hl=(e,t,n,r,i,a,o,s,c,l)=>{let u=n.dataset.dataType??``,d=n.dataset.stereotype??``;if(ll(e)){let t=i?.metadata,n=(t?.columns??[]).flatMap(e=>e?.metadata?.type===j.GridGroupColumn?(e.metadata.columns??[]).map(e=>e?.metadata?.id):[e?.metadata?.id]),a=ml(e,r,pl(e.__mateuGroupBy,n)),o=e.__mateuGroup.hiddenActions??[],s=r.id===n[n.length-1]?(t?.groupActions??[]).filter(e=>!o.includes(e.actionId??e.id)):[];return s.length?T`<span style="display: flex; align-items: center; justify-content: flex-end; gap: var(--lumo-space-s); overflow: hidden;">
                 ${a?T`<span style="font-weight: 600;">${a}</span>`:v}
                 ${s.map(t=>T`
                     <vaadin-button theme="tertiary small" style="flex-shrink: 0;"
                         @click="${n=>{n.stopPropagation(),n.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+(t.actionId??t.id),parameters:{_groupValue:e.__mateuGroup.value}},bubbles:!0,composed:!0}))}}">${t.label??t.caption??``}</vaadin-button>
                 `)}
-            </span>`:T`<span title="${a}" style="font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block;">${a}</span>`}if(r.editable)return Pl(e,r,i,o);if(u==`status`)return ka(e,t,n);if(u==`bool`)return hl(e,t,n);if(u==`money`||d==`money`)return gl(e,t,n,u,d);if(u==`link`||d==`link`)return vl(e,t,n,u,d,r);if(u==`icon`||d==`icon`)return yl(e,t,n,u,d);if(d==`html`)return bl(e,t,n,u,d);if(d==`image`)return xl(e,t,n,u,d,r);if(u==`menu`)return Tl(e,t,n);if(u==`component`)return kl(e,t,n,i,a,o,s,c,l);if(u==`action`)return El(e,t,n);if(u==`actionGroup`)return Tl(e,t,n);if(d==`button`||r.actionId)return Ol(e,t,n,u,d,r);let f=e[n.path];return T`<span title="${f}" style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block;">${f}</span>`},Hl=()=>{let e=document.activeElement;for(;e?.shadowRoot?.activeElement;)e=e.shadowRoot.activeElement;return e},Ul=(e,t)=>{let n=t;for(;n;){if(n===e)return!0;n=n.assignedSlot??n.parentNode??n.host??null}return!1},Wl=class extends vt{constructor(...e){super(...e),this.state={},this.data={},this.appState={},this.appData={},this.detailsOpenedItems=[],this.hoveredItem=null,this.onGridHoverMove=e=>{let t=e.currentTarget,n=t.getEventContext(e)?.item??null;n!==this.hoveredItem&&(this.hoveredItem=n,t.generateCellPartNames())},this.onGridHoverLeave=e=>{this.hoveredItem!==null&&(this.hoveredItem=null,e.currentTarget.generateCellPartNames())},this.hoverCellPartNameGenerator=(e,t)=>t?.item!=null&&t.item===this.hoveredItem?`hovered-cell`:``,this._onRowKey=e=>{let t=this.field?.rowSelectionShortcut;if(!t||!this.field?.onItemSelectionActionId||!this._isRowShortcutRelevant()||!nr(t,e))return;let n=/^(?:Digit|Numpad)([1-9])$/.exec(e.code);if(!n)return;let r=this.currentItems(),i=parseInt(n[1],10)-1;i>=r.length||(e.preventDefault(),this.selectRow(r[i]))},this.handleButtonClick=e=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))}}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._onRowKey)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`keydown`,this._onRowKey)}currentItems(){return this.field?.remoteCoordinates?this.data?.[this.id]?.content??[]:this.field?.fieldId&&this.state?this.state[this.field.fieldId]??[]:[]}selectRow(e){!e||!this.field?.onItemSelectionActionId||(this.selectedItems=[e],this.state[this.id+`_selected_items`]=[e],this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.field.onItemSelectionActionId,parameters:{_clickedRow:e}},bubbles:!0,composed:!0})))}_isRowShortcutRelevant(){if(this.offsetParent===null&&this.getClientRects().length===0)return!1;let e=Hl();if(e&&e!==document.body&&!Ul(this,e)){let t=e.tagName?.toLowerCase()??``;if(e.isContentEditable||/^(input|textarea|select)$/.test(t)||t.startsWith(`vaadin-`)&&/(field|combo|picker|area|select)/.test(t))return!1}return!0}handleItemToggle(e){let{item:t,selected:n,shiftKey:r}=e.detail;if(this.rangeStartItem??=t,r){let e=[];this.field?.fieldId&&this.state&&this.state[this.field.fieldId]&&(e=this.state[this.field.fieldId]);let[r,i]=[this.rangeStartItem,t].map(t=>e.indexOf(t)).sort((e,t)=>e-t),a=e.slice(r,i+1),o=new Set(this.selectedItems);a.forEach(e=>{n?o.add(e):o.delete(e)}),this.selectedItems=[...o],this.state[this.id+`_selected_items`]=this.selectedItems}this.rangeStartItem=t}render(){let e=[];this.field?.fieldId&&this.state&&this.state[this.field.fieldId]&&(e=this.state[this.field.fieldId]);let t=this.state[this.field?.fieldId+`_show_detail`]||this.state._show_detail&&this.state._show_detail[this.field.fieldId];if(this.field?.remoteCoordinates){let t=this.field.remoteCoordinates;this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements?e=this.data[this.id].content:this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}if(Array.isArray(e)&&e.forEach((e,t)=>{e&&typeof e==`object`&&e._rowNumber===void 0&&(e._rowNumber=t)}),this.field?.inlineEditing)return this.renderMaster(e);if(this.field?.formPosition&&this.field?.formPosition.startsWith(`modal`)){let n=this;return T`
+            </span>`:T`<span title="${a}" style="font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block;">${a}</span>`}if(r.editable)return Fl(e,r,i,o);if(u==`status`)return Aa(e,t,n);if(u==`bool`)return gl(e,t,n);if(u==`money`||d==`money`)return _l(e,t,n,u,d);if(u==`link`||d==`link`)return yl(e,t,n,u,d,r);if(u==`icon`||d==`icon`)return bl(e,t,n,u,d);if(d==`html`)return xl(e,t,n,u,d);if(d==`image`)return Sl(e,t,n,u,d,r);if(u==`menu`)return El(e,t,n);if(u==`component`)return Al(e,t,n,i,a,o,s,c,l);if(u==`action`)return Dl(e,t,n);if(u==`actionGroup`)return El(e,t,n);if(d==`button`||r.actionId)return kl(e,t,n,u,d,r);let f=e[n.path];return T`<span title="${f}" style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block;">${f}</span>`},Ul=()=>{let e=document.activeElement;for(;e?.shadowRoot?.activeElement;)e=e.shadowRoot.activeElement;return e},Wl=(e,t)=>{let n=t;for(;n;){if(n===e)return!0;n=n.assignedSlot??n.parentNode??n.host??null}return!1},Gl=class extends vt{constructor(...e){super(...e),this.state={},this.data={},this.appState={},this.appData={},this.detailsOpenedItems=[],this.hoveredItem=null,this.onGridHoverMove=e=>{let t=e.currentTarget,n=t.getEventContext(e)?.item??null;n!==this.hoveredItem&&(this.hoveredItem=n,t.generateCellPartNames())},this.onGridHoverLeave=e=>{this.hoveredItem!==null&&(this.hoveredItem=null,e.currentTarget.generateCellPartNames())},this.hoverCellPartNameGenerator=(e,t)=>t?.item!=null&&t.item===this.hoveredItem?`hovered-cell`:``,this._onRowKey=e=>{let t=this.field?.rowSelectionShortcut;if(!t||!this.field?.onItemSelectionActionId||!this._isRowShortcutRelevant()||!rr(t,e))return;let n=/^(?:Digit|Numpad)([1-9])$/.exec(e.code);if(!n)return;let r=this.currentItems(),i=parseInt(n[1],10)-1;i>=r.length||(e.preventDefault(),this.selectRow(r[i]))},this.handleButtonClick=e=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))}}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._onRowKey)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`keydown`,this._onRowKey)}currentItems(){return this.field?.remoteCoordinates?this.data?.[this.id]?.content??[]:this.field?.fieldId&&this.state?this.state[this.field.fieldId]??[]:[]}selectRow(e){!e||!this.field?.onItemSelectionActionId||(this.selectedItems=[e],this.state[this.id+`_selected_items`]=[e],this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.field.onItemSelectionActionId,parameters:{_clickedRow:e}},bubbles:!0,composed:!0})))}_isRowShortcutRelevant(){if(this.offsetParent===null&&this.getClientRects().length===0)return!1;let e=Ul();if(e&&e!==document.body&&!Wl(this,e)){let t=e.tagName?.toLowerCase()??``;if(e.isContentEditable||/^(input|textarea|select)$/.test(t)||t.startsWith(`vaadin-`)&&/(field|combo|picker|area|select)/.test(t))return!1}return!0}handleItemToggle(e){let{item:t,selected:n,shiftKey:r}=e.detail;if(this.rangeStartItem??=t,r){let e=[];this.field?.fieldId&&this.state&&this.state[this.field.fieldId]&&(e=this.state[this.field.fieldId]);let[r,i]=[this.rangeStartItem,t].map(t=>e.indexOf(t)).sort((e,t)=>e-t),a=e.slice(r,i+1),o=new Set(this.selectedItems);a.forEach(e=>{n?o.add(e):o.delete(e)}),this.selectedItems=[...o],this.state[this.id+`_selected_items`]=this.selectedItems}this.rangeStartItem=t}render(){let e=[];this.field?.fieldId&&this.state&&this.state[this.field.fieldId]&&(e=this.state[this.field.fieldId]);let t=this.state[this.field?.fieldId+`_show_detail`]||this.state._show_detail&&this.state._show_detail[this.field.fieldId];if(this.field?.remoteCoordinates){let t=this.field.remoteCoordinates;this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements?e=this.data[this.id].content:this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}if(Array.isArray(e)&&e.forEach((e,t)=>{e&&typeof e==`object`&&e._rowNumber===void 0&&(e._rowNumber=t)}),this.field?.inlineEditing)return this.renderMaster(e);if(this.field?.formPosition&&this.field?.formPosition.startsWith(`modal`)){let n=this;return T`
 
                 ${this.renderMaster(e)}
 
@@ -8954,14 +8962,14 @@ ${i}
                     @click="${S(this.field?.onItemSelectionActionId?e=>{if(e.composedPath().some(e=>e instanceof HTMLElement&&(e.localName===`vaadin-button`||e.localName===`button`||e.localName===`a`||e.localName===`vaadin-checkbox`||e.getAttribute?.(`role`)===`button`)))return;let t=e.currentTarget.getEventContext(e)?.item;t&&this.selectRow(t)}:void 0)}"
                     @active-item-changed="${S(this.field?.detailPath&&!this.field?.useButtonForDetail?e=>{if(this.field?.detailPath){let t=e.detail.value;t?this.detailsOpenedItems=[t]:this.detailsOpenedItems=[]}}:void 0)}"
                     .detailsOpenedItems="${this.detailsOpenedItems}"
-                    ${S(this.field?.detailPath?n(e=>T`${I(this,e[this.field?.detailPath],this.baseUrl,this.state,this.data,this.appState,this.appData)}`):void 0)}
+                    ${S(this.field?.detailPath?n(e=>T`${F(this,e[this.field?.detailPath],this.baseUrl,this.state,this.data,this.appState,this.appData)}`):void 0)}
                     ?all-rows-visible=${e?.length<10}
             >
                 <span slot="empty-state">${this.field?.label?`No ${this.field.label.toLowerCase()} added yet.`:`No items added yet.`}</span>
                 ${this.field?.readOnly||this.field?.inlineEditing?v:T`
                     <vaadin-grid-selection-column drag-select></vaadin-grid-selection-column>
                 `}
-                ${this.field?.columns?.map(e=>zl(e,this,this.baseUrl,this.state,this.data,this.appState,this.appData))}
+                ${this.field?.columns?.map(e=>Bl(e,this,this.baseUrl,this.state,this.data,this.appState,this.appData))}
 
                 ${this.field?.inlineEditing&&!this.field?.readOnly?T`
                     <vaadin-grid-column width="3.5rem" flex-grow="0" frozen-to-end
@@ -9018,12 +9026,12 @@ ${i}
             background-color: var(--lumo-primary-color-10pct);
             cursor: pointer;
         }
-    `}};k([y()],Wl.prototype,`field`,void 0),k([y()],Wl.prototype,`state`,void 0),k([y()],Wl.prototype,`data`,void 0),k([y()],Wl.prototype,`appState`,void 0),k([y()],Wl.prototype,`appData`,void 0),k([y()],Wl.prototype,`selectedItems`,void 0),k([C()],Wl.prototype,`detailsOpenedItems`,void 0),Wl=k([g(`mateu-grid`)],Wl);var Gl=class extends b{constructor(...e){super(...e),this.getNewValue=e=>{if(this.field?.dataType==`array`){if(!this.value)return[e];let t=this.value;return t.indexOf(e)>=0?t.filter(t=>t!==e):[...t,e]}return e}}render(){let e=this.field?.options;if(this.field?.remoteCoordinates){let t=this.field.remoteCoordinates;this.data?.[this.field.fieldId]&&this.data[this.field.fieldId].content&&this.data[this.field.fieldId].totalElements?e=this.data[this.field.fieldId].content:this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}return T`
+    `}};k([y()],Gl.prototype,`field`,void 0),k([y()],Gl.prototype,`state`,void 0),k([y()],Gl.prototype,`data`,void 0),k([y()],Gl.prototype,`appState`,void 0),k([y()],Gl.prototype,`appData`,void 0),k([y()],Gl.prototype,`selectedItems`,void 0),k([C()],Gl.prototype,`detailsOpenedItems`,void 0),Gl=k([g(`mateu-grid`)],Gl);var Kl=class extends b{constructor(...e){super(...e),this.getNewValue=e=>{if(this.field?.dataType==`array`){if(!this.value)return[e];let t=this.value;return t.indexOf(e)>=0?t.filter(t=>t!==e):[...t,e]}return e}}render(){let e=this.field?.options;if(this.field?.remoteCoordinates){let t=this.field.remoteCoordinates;this.data?.[this.field.fieldId]&&this.data[this.field.fieldId].content&&this.data[this.field.fieldId].totalElements?e=this.data[this.field.fieldId].content:this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}return T`
         <div style="display: flex; gap: 1rem; padding: 1rem; flex-wrap: wrap; ${this.field?.attributes?.divStyle}">
                                     ${e?.map(e=>T`
                             <div role="button" tabindex="0" 
                                     class="choice ${this.value==e.value||Array.isArray(this.value)&&this.value.includes(e.value)?`selected`:``}"
-                                    @click="${()=>this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.getNewValue(e.value),fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}" @keydown="${z(()=>this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.getNewValue(e.value),fieldId:this.field?.fieldId},bubbles:!0,composed:!0})))}"
+                                    @click="${()=>this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.getNewValue(e.value),fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}" @keydown="${R(()=>this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.getNewValue(e.value),fieldId:this.field?.fieldId},bubbles:!0,composed:!0})))}"
                             >${e.description||e.image?T`
                                 <div style="display: flex; align-items: center; gap: var(--lumo-space-m, 1rem);">
                                     ${e.image?T`
@@ -9065,8 +9073,8 @@ ${i}
             border: 1px solid var(--lumo-shade-20pct);
         }
   
-        ${B}
-    `}};k([y()],Gl.prototype,`field`,void 0),k([y()],Gl.prototype,`baseUrl`,void 0),k([y()],Gl.prototype,`state`,void 0),k([y()],Gl.prototype,`data`,void 0),k([y()],Gl.prototype,`value`,void 0),Gl=k([g(`mateu-choice`)],Gl);var Kl,ql=class extends b{static{Kl=this}constructor(...e){super(...e),this.commit=e=>{this.value=e,this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:{...e},fieldId:this.fieldId}}))},this.currencyChanged=e=>{let t=this.value??Kl.EMPTY;!e.detail.value||e.detail.value===t.currency||this.commit({...t,currency:e.detail.value})},this.valueChanged=e=>{let t=this.value??Kl.EMPTY,n=ol(e.detail.value,!1)??0;n!==t.value&&this.commit({...t,value:n})}}static{this.EMPTY={value:0,currency:`EUR`,locale:`es-ES`}}render(){return T`
+        ${z}
+    `}};k([y()],Kl.prototype,`field`,void 0),k([y()],Kl.prototype,`baseUrl`,void 0),k([y()],Kl.prototype,`state`,void 0),k([y()],Kl.prototype,`data`,void 0),k([y()],Kl.prototype,`value`,void 0),Kl=k([g(`mateu-choice`)],Kl);var ql,Jl=class extends b{static{ql=this}constructor(...e){super(...e),this.commit=e=>{this.value=e,this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:{...e},fieldId:this.fieldId}}))},this.currencyChanged=e=>{let t=this.value??ql.EMPTY;!e.detail.value||e.detail.value===t.currency||this.commit({...t,currency:e.detail.value})},this.valueChanged=e=>{let t=this.value??ql.EMPTY,n=sl(e.detail.value,!1)??0;n!==t.value&&this.commit({...t,value:n})}}static{this.EMPTY={value:0,currency:`EUR`,locale:`es-ES`}}render(){return T`
             <vaadin-number-field
                     id="${this.fieldId}"
                     label="${this.label}"
@@ -9086,10 +9094,10 @@ ${i}
                     theme="small"
             ></vaadin-select></div></vaadin-number-field>
        `}static{this.styles=h`
-  `}};k([y()],ql.prototype,`fieldId`,void 0),k([y()],ql.prototype,`label`,void 0),k([y()],ql.prototype,`state`,void 0),k([y()],ql.prototype,`data`,void 0),k([y()],ql.prototype,`value`,void 0),k([y()],ql.prototype,`autoFocus`,void 0),k([y()],ql.prototype,`required`,void 0),k([y()],ql.prototype,`colspan`,void 0),k([y()],ql.prototype,`helperText`,void 0),ql=Kl=k([g(`mateu-money-field`)],ql);var Jl=`vaadin:abacus.vaadin:absolute-position.vaadin:academy-cap.vaadin:accessibility.vaadin:accordion-menu.vaadin:add-dock.vaadin:adjust.vaadin:adobe-flash.vaadin:airplane.vaadin:alarm.vaadin:align-center.vaadin:align-justify.vaadin:align-left.vaadin:align-right.vaadin:alt-a.vaadin:alt.vaadin:ambulance.vaadin:anchor.vaadin:angle-double-down.vaadin:angle-double-left.vaadin:angle-double-right.vaadin:angle-double-up.vaadin:angle-down.vaadin:angle-left.vaadin:angle-right.vaadin:angle-up.vaadin:archive.vaadin:archives.vaadin:area-select.vaadin:arrow-backward.vaadin:arrow-circle-down-o.vaadin:arrow-circle-down.vaadin:arrow-circle-left-o.vaadin:arrow-circle-left.vaadin:arrow-circle-right-o.vaadin:arrow-circle-right.vaadin:arrow-circle-up-o.vaadin:arrow-circle-up.vaadin:arrow-down.vaadin:arrow-forward.vaadin:arrow-left.vaadin:arrow-long-down.vaadin:arrow-long-left.vaadin:arrow-right.vaadin:arrow-up.vaadin:arrows-cross.vaadin:arrows-long-h.vaadin:arrows-long-right.vaadin:arrows-long-up.vaadin:arrows-long-v.vaadin:arrows.vaadin:asterisk.vaadin:at.vaadin:automation.vaadin:backspace-a.vaadin:backspace.vaadin:backwards.vaadin:ban.vaadin:bar-chart-h.vaadin:bar-chart-v.vaadin:bar-chart.vaadin:barcode.vaadin:bed.vaadin:bell-o.vaadin:bell-slash-o.vaadin:bell-slash.vaadin:bell.vaadin:boat.vaadin:bold.vaadin:bolt.vaadin:bomb.vaadin:book-dollar.vaadin:book-percent.vaadin:book.vaadin:bookmark-o.vaadin:bookmark.vaadin:briefcase.vaadin:browser.vaadin:bug-o.vaadin:bug.vaadin:building-o.vaadin:building.vaadin:bullets.vaadin:bullseye.vaadin:bus.vaadin:buss.vaadin:button.vaadin:calc-book.vaadin:calc.vaadin:calendar-briefcase.vaadin:calendar-clock.vaadin:calendar-envelope.vaadin:calendar-o.vaadin:calendar-user.vaadin:calendar.vaadin:camera.vaadin:car.vaadin:caret-down.vaadin:caret-left.vaadin:caret-right.vaadin:caret-square-down-o.vaadin:caret-square-left-o.vaadin:caret-square-right-o.vaadin:caret-square-up-o.vaadin:caret-up.vaadin:cart-o.vaadin:cart.vaadin:cash.vaadin:chart-3d.vaadin:chart-grid.vaadin:chart-line.vaadin:chart-timeline.vaadin:chart.vaadin:chat.vaadin:check-circle-o.vaadin:check-circle.vaadin:check-square-o.vaadin:check-square.vaadin:check.vaadin:chevron-circle-down-o.vaadin:chevron-circle-down.vaadin:chevron-circle-left-o.vaadin:chevron-circle-left.vaadin:chevron-circle-right-o.vaadin:chevron-circle-right.vaadin:chevron-circle-up-o.vaadin:chevron-circle-up.vaadin:chevron-down-small.vaadin:chevron-down.vaadin:chevron-left-small.vaadin:chevron-left.vaadin:chevron-right-small.vaadin:chevron-right.vaadin:chevron-up-small.vaadin:chevron-up.vaadin:child.vaadin:circle-thin.vaadin:circle.vaadin:clipboard-check.vaadin:clipboard-cross.vaadin:clipboard-heart.vaadin:clipboard-pulse.vaadin:clipboard-text.vaadin:clipboard-user.vaadin:clipboard.vaadin:clock.vaadin:close-big.vaadin:close-circle-o.vaadin:close-circle.vaadin:close-small.vaadin:close.vaadin:cloud-download-o.vaadin:cloud-download.vaadin:cloud-o.vaadin:cloud-upload-o.vaadin:cloud-upload.vaadin:cloud.vaadin:cluster.vaadin:code.vaadin:coffee.vaadin:cog-o.vaadin:cog.vaadin:cogs.vaadin:coin-piles.vaadin:coins.vaadin:combobox.vaadin:comment-ellipsis-o.vaadin:comment-ellipsis.vaadin:comment-o.vaadin:comment.vaadin:comments-o.vaadin:comments.vaadin:compile.vaadin:compress-square.vaadin:compress.vaadin:connect-o.vaadin:connect.vaadin:controller.vaadin:copy-o.vaadin:copy.vaadin:copyright.vaadin:corner-lower-left.vaadin:corner-lower-right.vaadin:corner-upper-left.vaadin:corner-upper-right.vaadin:credit-card.vaadin:crop.vaadin:cross-cutlery.vaadin:crosshairs.vaadin:css.vaadin:ctrl-a.vaadin:ctrl.vaadin:cube.vaadin:cubes.vaadin:curly-brackets.vaadin:cursor-o.vaadin:cursor.vaadin:cutlery.vaadin:dashboard.vaadin:database.vaadin:date-input.vaadin:deindent.vaadin:del-a.vaadin:del.vaadin:dental-chair.vaadin:desktop.vaadin:diamond-o.vaadin:diamond.vaadin:diploma-scroll.vaadin:diploma.vaadin:disc.vaadin:doctor-briefcase.vaadin:doctor.vaadin:dollar.vaadin:dot-circle.vaadin:download-alt.vaadin:download.vaadin:drop.vaadin:edit.vaadin:eject.vaadin:elastic.vaadin:ellipsis-circle-o.vaadin:ellipsis-circle.vaadin:ellipsis-dots-h.vaadin:ellipsis-dots-v.vaadin:ellipsis-h.vaadin:ellipsis-v.vaadin:enter-arrow.vaadin:enter.vaadin:envelope-o.vaadin:envelope-open-o.vaadin:envelope-open.vaadin:envelope.vaadin:envelopes-o.vaadin:envelopes.vaadin:eraser.vaadin:esc-a.vaadin:esc.vaadin:euro.vaadin:exchange.vaadin:exclamation-circle-o.vaadin:exclamation-circle.vaadin:exclamation.vaadin:exit-o.vaadin:exit.vaadin:expand-full.vaadin:expand-square.vaadin:expand.vaadin:external-browser.vaadin:external-link.vaadin:eye-slash.vaadin:eye.vaadin:eyedropper.vaadin:facebook-square.vaadin:facebook.vaadin:factory.vaadin:family.vaadin:fast-backward.vaadin:fast-forward.vaadin:female.vaadin:file-add.vaadin:file-code.vaadin:file-font.vaadin:file-movie.vaadin:file-o.vaadin:file-picture.vaadin:file-presentation.vaadin:file-process.vaadin:file-refresh.vaadin:file-remove.vaadin:file-search.vaadin:file-sound.vaadin:file-start.vaadin:file-table.vaadin:file-text-o.vaadin:file-text.vaadin:file-tree-small.vaadin:file-tree-sub.vaadin:file-tree.vaadin:file-zip.vaadin:file.vaadin:fill.vaadin:film.vaadin:filter.vaadin:fire.vaadin:flag-checkered.vaadin:flag-o.vaadin:flag.vaadin:flash.vaadin:flask.vaadin:flight-landing.vaadin:flight-takeoff.vaadin:flip-h.vaadin:flip-v.vaadin:folder-add.vaadin:folder-o.vaadin:folder-open-o.vaadin:folder-open.vaadin:folder-remove.vaadin:folder-search.vaadin:folder.vaadin:font.vaadin:form.vaadin:forward.vaadin:frown-o.vaadin:funcion.vaadin:function.vaadin:funnel.vaadin:gamepad.vaadin:gavel.vaadin:gift.vaadin:glass.vaadin:glasses.vaadin:globe-wire.vaadin:globe.vaadin:golf.vaadin:google-plus-square.vaadin:google-plus.vaadin:grab.vaadin:grid-bevel.vaadin:grid-big-o.vaadin:grid-big.vaadin:grid-h.vaadin:grid-small-o.vaadin:grid-small.vaadin:grid-v.vaadin:grid.vaadin:group.vaadin:hammer.vaadin:hand.vaadin:handle-corner.vaadin:hands-up.vaadin:handshake.vaadin:harddrive-o.vaadin:harddrive.vaadin:hash.vaadin:header.vaadin:headphones.vaadin:headset.vaadin:health-card.vaadin:heart-o.vaadin:heart.vaadin:home-o.vaadin:home.vaadin:hospital.vaadin:hourglass-empty.vaadin:hourglass-end.vaadin:hourglass-start.vaadin:hourglass.vaadin:inbox.vaadin:indent.vaadin:info-circle-o.vaadin:info-circle.vaadin:info.vaadin:input.vaadin:insert.vaadin:institution.vaadin:invoice.vaadin:italic.vaadin:key-o.vaadin:key.vaadin:keyboard-o.vaadin:keyboard.vaadin:laptop.vaadin:layout.vaadin:level-down-bold.vaadin:level-down.vaadin:level-left-bold.vaadin:level-left.vaadin:level-right-bold.vaadin:level-right.vaadin:level-up-bold.vaadin:level-up.vaadin:lifebuoy.vaadin:lightbulb.vaadin:line-bar-chart.vaadin:line-chart.vaadin:line-h.vaadin:line-v.vaadin:lines-list.vaadin:lines.vaadin:link.vaadin:list-ol.vaadin:list-select.vaadin:list-ul.vaadin:list.vaadin:location-arrow-circle-o.vaadin:location-arrow-circle.vaadin:location-arrow.vaadin:lock.vaadin:magic.vaadin:magnet.vaadin:mailbox.vaadin:male.vaadin:map-marker.vaadin:margin-bottom.vaadin:margin-left.vaadin:margin-right.vaadin:margin-top.vaadin:margin.vaadin:medal.vaadin:megafone.vaadin:megaphone.vaadin:meh-o.vaadin:menu.vaadin:microphone.vaadin:minus-circle-o.vaadin:minus-circle.vaadin:minus-square-o.vaadin:minus.vaadin:mobile-browser.vaadin:mobile-retro.vaadin:mobile.vaadin:modal-list.vaadin:modal.vaadin:money-deposit.vaadin:money-exchange.vaadin:money-withdraw.vaadin:money.vaadin:moon-o.vaadin:moon.vaadin:morning.vaadin:movie.vaadin:music.vaadin:mute.vaadin:native-button.vaadin:newspaper.vaadin:notebook.vaadin:nurse.vaadin:office.vaadin:open-book.vaadin:option-a.vaadin:option.vaadin:options.vaadin:orientation.vaadin:out.vaadin:outbox.vaadin:package.vaadin:padding-bottom.vaadin:padding-left.vaadin:padding-right.vaadin:padding-top.vaadin:padding.vaadin:paint-roll.vaadin:paintbrush.vaadin:palete.vaadin:palette.vaadin:panel.vaadin:paperclip.vaadin:paperplane-o.vaadin:paperplane.vaadin:paragraph.vaadin:password.vaadin:paste.vaadin:pause.vaadin:pencil.vaadin:phone-landline.vaadin:phone.vaadin:picture.vaadin:pie-bar-chart.vaadin:pie-chart.vaadin:piggy-bank-coin.vaadin:piggy-bank.vaadin:pill.vaadin:pills.vaadin:pin-post.vaadin:pin.vaadin:play-circle-o.vaadin:play-circle.vaadin:play.vaadin:plug.vaadin:plus-circle-o.vaadin:plus-circle.vaadin:plus-minus.vaadin:plus-square-o.vaadin:plus.vaadin:pointer.vaadin:power-off.vaadin:presentation.vaadin:print.vaadin:progressbar.vaadin:puzzle-piece.vaadin:pyramid-chart.vaadin:qrcode.vaadin:question-circle-o.vaadin:question-circle.vaadin:question.vaadin:quote-left.vaadin:quote-right.vaadin:random.vaadin:raster-lower-left.vaadin:raster.vaadin:records.vaadin:recycle.vaadin:refresh.vaadin:reply-all.vaadin:reply.vaadin:resize-h.vaadin:resize-v.vaadin:retweet.vaadin:rhombus.vaadin:road-branch.vaadin:road-branches.vaadin:road-split.vaadin:road.vaadin:rocket.vaadin:rotate-left.vaadin:rotate-right.vaadin:rss-square.vaadin:rss.vaadin:safe-lock.vaadin:safe.vaadin:scale-unbalance.vaadin:scale.vaadin:scatter-chart.vaadin:scissors.vaadin:screwdriver.vaadin:search-minus.vaadin:search-plus.vaadin:search.vaadin:select.vaadin:server.vaadin:share-square.vaadin:share.vaadin:shield.vaadin:shift-arrow.vaadin:shift.vaadin:shop.vaadin:sign-in-alt.vaadin:sign-in.vaadin:sign-out-alt.vaadin:sign-out.vaadin:signal.vaadin:sitemap.vaadin:slider.vaadin:sliders.vaadin:smiley-o.vaadin:sort.vaadin:sound-disable.vaadin:spark-line.vaadin:specialist.vaadin:spinner-arc.vaadin:spinner-third.vaadin:spinner.vaadin:spline-area-chart.vaadin:spline-chart.vaadin:split-h.vaadin:split-v.vaadin:split.vaadin:spoon.vaadin:square-shadow.vaadin:star-half-left-o.vaadin:star-half-left.vaadin:star-half-right-o.vaadin:star-half-right.vaadin:star-o.vaadin:star.vaadin:start-cog.vaadin:step-backward.vaadin:step-forward.vaadin:stethoscope.vaadin:stock.vaadin:stop-cog.vaadin:stop.vaadin:stopwatch.vaadin:storage.vaadin:strikethrough.vaadin:subscript.vaadin:suitcase.vaadin:sun-down.vaadin:sun-o.vaadin:sun-rise.vaadin:superscript.vaadin:sword.vaadin:tab-a.vaadin:tab.vaadin:table.vaadin:tablet.vaadin:tabs.vaadin:tag.vaadin:tags.vaadin:tasks.vaadin:taxi.vaadin:teeth.vaadin:terminal.vaadin:text-height.vaadin:text-input.vaadin:text-label.vaadin:text-width.vaadin:thin-square.vaadin:thumbs-down-o.vaadin:thumbs-down.vaadin:thumbs-up-o.vaadin:thumbs-up.vaadin:ticket.vaadin:time-backward.vaadin:time-forward.vaadin:timer.vaadin:toolbox.vaadin:tools.vaadin:tooth.vaadin:touch.vaadin:train.vaadin:trash.vaadin:tree-table.vaadin:trendind-down.vaadin:trending-down.vaadin:trending-up.vaadin:trophy.vaadin:truck.vaadin:twin-col-select.vaadin:twitter-square.vaadin:twitter.vaadin:umbrella.vaadin:underline.vaadin:unlink.vaadin:unlock.vaadin:upload-alt.vaadin:upload.vaadin:user-card.vaadin:user-check.vaadin:user-clock.vaadin:user-heart.vaadin:user-star.vaadin:user.vaadin:users.vaadin:vaadin-h.vaadin:vaadin-v.vaadin:viewport.vaadin:vimeo-square.vaadin:vimeo.vaadin:volume-down.vaadin:volume-off.vaadin:volume-up.vaadin:volume.vaadin:wallet.vaadin:warning.vaadin:workplace.vaadin:wrench.vaadin:youtube-square.vaadin:youtube`.split(`.`),Yl=null,Xl=()=>(Yl||=Promise.all([D(()=>import(`./vendor-ui5.js`).then(e=>e.n),__vite__mapDeps([5,1])),D(()=>import(`./vendor-ui5.js`).then(e=>e.t),__vite__mapDeps([5,1]))]),Yl),Q=class extends b{constructor(...e){super(...e),this.ui5FieldComponentsReady=!1,this.component=void 0,this.field=void 0,this.baseUrl=void 0,this.state={},this.data={},this.appState={},this.appData={},this.colorPickerOpened=!1,this.colorPickerValue=void 0,this.comboData=[],this._comboFilter=``,this.rendered=!1,this.renderColorPicker=()=>{this.loadUi5FieldComponents();let e=this.field?.fieldId;return T`
+  `}};k([y()],Jl.prototype,`fieldId`,void 0),k([y()],Jl.prototype,`label`,void 0),k([y()],Jl.prototype,`state`,void 0),k([y()],Jl.prototype,`data`,void 0),k([y()],Jl.prototype,`value`,void 0),k([y()],Jl.prototype,`autoFocus`,void 0),k([y()],Jl.prototype,`required`,void 0),k([y()],Jl.prototype,`colspan`,void 0),k([y()],Jl.prototype,`helperText`,void 0),Jl=ql=k([g(`mateu-money-field`)],Jl);var Yl=`vaadin:abacus.vaadin:absolute-position.vaadin:academy-cap.vaadin:accessibility.vaadin:accordion-menu.vaadin:add-dock.vaadin:adjust.vaadin:adobe-flash.vaadin:airplane.vaadin:alarm.vaadin:align-center.vaadin:align-justify.vaadin:align-left.vaadin:align-right.vaadin:alt-a.vaadin:alt.vaadin:ambulance.vaadin:anchor.vaadin:angle-double-down.vaadin:angle-double-left.vaadin:angle-double-right.vaadin:angle-double-up.vaadin:angle-down.vaadin:angle-left.vaadin:angle-right.vaadin:angle-up.vaadin:archive.vaadin:archives.vaadin:area-select.vaadin:arrow-backward.vaadin:arrow-circle-down-o.vaadin:arrow-circle-down.vaadin:arrow-circle-left-o.vaadin:arrow-circle-left.vaadin:arrow-circle-right-o.vaadin:arrow-circle-right.vaadin:arrow-circle-up-o.vaadin:arrow-circle-up.vaadin:arrow-down.vaadin:arrow-forward.vaadin:arrow-left.vaadin:arrow-long-down.vaadin:arrow-long-left.vaadin:arrow-right.vaadin:arrow-up.vaadin:arrows-cross.vaadin:arrows-long-h.vaadin:arrows-long-right.vaadin:arrows-long-up.vaadin:arrows-long-v.vaadin:arrows.vaadin:asterisk.vaadin:at.vaadin:automation.vaadin:backspace-a.vaadin:backspace.vaadin:backwards.vaadin:ban.vaadin:bar-chart-h.vaadin:bar-chart-v.vaadin:bar-chart.vaadin:barcode.vaadin:bed.vaadin:bell-o.vaadin:bell-slash-o.vaadin:bell-slash.vaadin:bell.vaadin:boat.vaadin:bold.vaadin:bolt.vaadin:bomb.vaadin:book-dollar.vaadin:book-percent.vaadin:book.vaadin:bookmark-o.vaadin:bookmark.vaadin:briefcase.vaadin:browser.vaadin:bug-o.vaadin:bug.vaadin:building-o.vaadin:building.vaadin:bullets.vaadin:bullseye.vaadin:bus.vaadin:buss.vaadin:button.vaadin:calc-book.vaadin:calc.vaadin:calendar-briefcase.vaadin:calendar-clock.vaadin:calendar-envelope.vaadin:calendar-o.vaadin:calendar-user.vaadin:calendar.vaadin:camera.vaadin:car.vaadin:caret-down.vaadin:caret-left.vaadin:caret-right.vaadin:caret-square-down-o.vaadin:caret-square-left-o.vaadin:caret-square-right-o.vaadin:caret-square-up-o.vaadin:caret-up.vaadin:cart-o.vaadin:cart.vaadin:cash.vaadin:chart-3d.vaadin:chart-grid.vaadin:chart-line.vaadin:chart-timeline.vaadin:chart.vaadin:chat.vaadin:check-circle-o.vaadin:check-circle.vaadin:check-square-o.vaadin:check-square.vaadin:check.vaadin:chevron-circle-down-o.vaadin:chevron-circle-down.vaadin:chevron-circle-left-o.vaadin:chevron-circle-left.vaadin:chevron-circle-right-o.vaadin:chevron-circle-right.vaadin:chevron-circle-up-o.vaadin:chevron-circle-up.vaadin:chevron-down-small.vaadin:chevron-down.vaadin:chevron-left-small.vaadin:chevron-left.vaadin:chevron-right-small.vaadin:chevron-right.vaadin:chevron-up-small.vaadin:chevron-up.vaadin:child.vaadin:circle-thin.vaadin:circle.vaadin:clipboard-check.vaadin:clipboard-cross.vaadin:clipboard-heart.vaadin:clipboard-pulse.vaadin:clipboard-text.vaadin:clipboard-user.vaadin:clipboard.vaadin:clock.vaadin:close-big.vaadin:close-circle-o.vaadin:close-circle.vaadin:close-small.vaadin:close.vaadin:cloud-download-o.vaadin:cloud-download.vaadin:cloud-o.vaadin:cloud-upload-o.vaadin:cloud-upload.vaadin:cloud.vaadin:cluster.vaadin:code.vaadin:coffee.vaadin:cog-o.vaadin:cog.vaadin:cogs.vaadin:coin-piles.vaadin:coins.vaadin:combobox.vaadin:comment-ellipsis-o.vaadin:comment-ellipsis.vaadin:comment-o.vaadin:comment.vaadin:comments-o.vaadin:comments.vaadin:compile.vaadin:compress-square.vaadin:compress.vaadin:connect-o.vaadin:connect.vaadin:controller.vaadin:copy-o.vaadin:copy.vaadin:copyright.vaadin:corner-lower-left.vaadin:corner-lower-right.vaadin:corner-upper-left.vaadin:corner-upper-right.vaadin:credit-card.vaadin:crop.vaadin:cross-cutlery.vaadin:crosshairs.vaadin:css.vaadin:ctrl-a.vaadin:ctrl.vaadin:cube.vaadin:cubes.vaadin:curly-brackets.vaadin:cursor-o.vaadin:cursor.vaadin:cutlery.vaadin:dashboard.vaadin:database.vaadin:date-input.vaadin:deindent.vaadin:del-a.vaadin:del.vaadin:dental-chair.vaadin:desktop.vaadin:diamond-o.vaadin:diamond.vaadin:diploma-scroll.vaadin:diploma.vaadin:disc.vaadin:doctor-briefcase.vaadin:doctor.vaadin:dollar.vaadin:dot-circle.vaadin:download-alt.vaadin:download.vaadin:drop.vaadin:edit.vaadin:eject.vaadin:elastic.vaadin:ellipsis-circle-o.vaadin:ellipsis-circle.vaadin:ellipsis-dots-h.vaadin:ellipsis-dots-v.vaadin:ellipsis-h.vaadin:ellipsis-v.vaadin:enter-arrow.vaadin:enter.vaadin:envelope-o.vaadin:envelope-open-o.vaadin:envelope-open.vaadin:envelope.vaadin:envelopes-o.vaadin:envelopes.vaadin:eraser.vaadin:esc-a.vaadin:esc.vaadin:euro.vaadin:exchange.vaadin:exclamation-circle-o.vaadin:exclamation-circle.vaadin:exclamation.vaadin:exit-o.vaadin:exit.vaadin:expand-full.vaadin:expand-square.vaadin:expand.vaadin:external-browser.vaadin:external-link.vaadin:eye-slash.vaadin:eye.vaadin:eyedropper.vaadin:facebook-square.vaadin:facebook.vaadin:factory.vaadin:family.vaadin:fast-backward.vaadin:fast-forward.vaadin:female.vaadin:file-add.vaadin:file-code.vaadin:file-font.vaadin:file-movie.vaadin:file-o.vaadin:file-picture.vaadin:file-presentation.vaadin:file-process.vaadin:file-refresh.vaadin:file-remove.vaadin:file-search.vaadin:file-sound.vaadin:file-start.vaadin:file-table.vaadin:file-text-o.vaadin:file-text.vaadin:file-tree-small.vaadin:file-tree-sub.vaadin:file-tree.vaadin:file-zip.vaadin:file.vaadin:fill.vaadin:film.vaadin:filter.vaadin:fire.vaadin:flag-checkered.vaadin:flag-o.vaadin:flag.vaadin:flash.vaadin:flask.vaadin:flight-landing.vaadin:flight-takeoff.vaadin:flip-h.vaadin:flip-v.vaadin:folder-add.vaadin:folder-o.vaadin:folder-open-o.vaadin:folder-open.vaadin:folder-remove.vaadin:folder-search.vaadin:folder.vaadin:font.vaadin:form.vaadin:forward.vaadin:frown-o.vaadin:funcion.vaadin:function.vaadin:funnel.vaadin:gamepad.vaadin:gavel.vaadin:gift.vaadin:glass.vaadin:glasses.vaadin:globe-wire.vaadin:globe.vaadin:golf.vaadin:google-plus-square.vaadin:google-plus.vaadin:grab.vaadin:grid-bevel.vaadin:grid-big-o.vaadin:grid-big.vaadin:grid-h.vaadin:grid-small-o.vaadin:grid-small.vaadin:grid-v.vaadin:grid.vaadin:group.vaadin:hammer.vaadin:hand.vaadin:handle-corner.vaadin:hands-up.vaadin:handshake.vaadin:harddrive-o.vaadin:harddrive.vaadin:hash.vaadin:header.vaadin:headphones.vaadin:headset.vaadin:health-card.vaadin:heart-o.vaadin:heart.vaadin:home-o.vaadin:home.vaadin:hospital.vaadin:hourglass-empty.vaadin:hourglass-end.vaadin:hourglass-start.vaadin:hourglass.vaadin:inbox.vaadin:indent.vaadin:info-circle-o.vaadin:info-circle.vaadin:info.vaadin:input.vaadin:insert.vaadin:institution.vaadin:invoice.vaadin:italic.vaadin:key-o.vaadin:key.vaadin:keyboard-o.vaadin:keyboard.vaadin:laptop.vaadin:layout.vaadin:level-down-bold.vaadin:level-down.vaadin:level-left-bold.vaadin:level-left.vaadin:level-right-bold.vaadin:level-right.vaadin:level-up-bold.vaadin:level-up.vaadin:lifebuoy.vaadin:lightbulb.vaadin:line-bar-chart.vaadin:line-chart.vaadin:line-h.vaadin:line-v.vaadin:lines-list.vaadin:lines.vaadin:link.vaadin:list-ol.vaadin:list-select.vaadin:list-ul.vaadin:list.vaadin:location-arrow-circle-o.vaadin:location-arrow-circle.vaadin:location-arrow.vaadin:lock.vaadin:magic.vaadin:magnet.vaadin:mailbox.vaadin:male.vaadin:map-marker.vaadin:margin-bottom.vaadin:margin-left.vaadin:margin-right.vaadin:margin-top.vaadin:margin.vaadin:medal.vaadin:megafone.vaadin:megaphone.vaadin:meh-o.vaadin:menu.vaadin:microphone.vaadin:minus-circle-o.vaadin:minus-circle.vaadin:minus-square-o.vaadin:minus.vaadin:mobile-browser.vaadin:mobile-retro.vaadin:mobile.vaadin:modal-list.vaadin:modal.vaadin:money-deposit.vaadin:money-exchange.vaadin:money-withdraw.vaadin:money.vaadin:moon-o.vaadin:moon.vaadin:morning.vaadin:movie.vaadin:music.vaadin:mute.vaadin:native-button.vaadin:newspaper.vaadin:notebook.vaadin:nurse.vaadin:office.vaadin:open-book.vaadin:option-a.vaadin:option.vaadin:options.vaadin:orientation.vaadin:out.vaadin:outbox.vaadin:package.vaadin:padding-bottom.vaadin:padding-left.vaadin:padding-right.vaadin:padding-top.vaadin:padding.vaadin:paint-roll.vaadin:paintbrush.vaadin:palete.vaadin:palette.vaadin:panel.vaadin:paperclip.vaadin:paperplane-o.vaadin:paperplane.vaadin:paragraph.vaadin:password.vaadin:paste.vaadin:pause.vaadin:pencil.vaadin:phone-landline.vaadin:phone.vaadin:picture.vaadin:pie-bar-chart.vaadin:pie-chart.vaadin:piggy-bank-coin.vaadin:piggy-bank.vaadin:pill.vaadin:pills.vaadin:pin-post.vaadin:pin.vaadin:play-circle-o.vaadin:play-circle.vaadin:play.vaadin:plug.vaadin:plus-circle-o.vaadin:plus-circle.vaadin:plus-minus.vaadin:plus-square-o.vaadin:plus.vaadin:pointer.vaadin:power-off.vaadin:presentation.vaadin:print.vaadin:progressbar.vaadin:puzzle-piece.vaadin:pyramid-chart.vaadin:qrcode.vaadin:question-circle-o.vaadin:question-circle.vaadin:question.vaadin:quote-left.vaadin:quote-right.vaadin:random.vaadin:raster-lower-left.vaadin:raster.vaadin:records.vaadin:recycle.vaadin:refresh.vaadin:reply-all.vaadin:reply.vaadin:resize-h.vaadin:resize-v.vaadin:retweet.vaadin:rhombus.vaadin:road-branch.vaadin:road-branches.vaadin:road-split.vaadin:road.vaadin:rocket.vaadin:rotate-left.vaadin:rotate-right.vaadin:rss-square.vaadin:rss.vaadin:safe-lock.vaadin:safe.vaadin:scale-unbalance.vaadin:scale.vaadin:scatter-chart.vaadin:scissors.vaadin:screwdriver.vaadin:search-minus.vaadin:search-plus.vaadin:search.vaadin:select.vaadin:server.vaadin:share-square.vaadin:share.vaadin:shield.vaadin:shift-arrow.vaadin:shift.vaadin:shop.vaadin:sign-in-alt.vaadin:sign-in.vaadin:sign-out-alt.vaadin:sign-out.vaadin:signal.vaadin:sitemap.vaadin:slider.vaadin:sliders.vaadin:smiley-o.vaadin:sort.vaadin:sound-disable.vaadin:spark-line.vaadin:specialist.vaadin:spinner-arc.vaadin:spinner-third.vaadin:spinner.vaadin:spline-area-chart.vaadin:spline-chart.vaadin:split-h.vaadin:split-v.vaadin:split.vaadin:spoon.vaadin:square-shadow.vaadin:star-half-left-o.vaadin:star-half-left.vaadin:star-half-right-o.vaadin:star-half-right.vaadin:star-o.vaadin:star.vaadin:start-cog.vaadin:step-backward.vaadin:step-forward.vaadin:stethoscope.vaadin:stock.vaadin:stop-cog.vaadin:stop.vaadin:stopwatch.vaadin:storage.vaadin:strikethrough.vaadin:subscript.vaadin:suitcase.vaadin:sun-down.vaadin:sun-o.vaadin:sun-rise.vaadin:superscript.vaadin:sword.vaadin:tab-a.vaadin:tab.vaadin:table.vaadin:tablet.vaadin:tabs.vaadin:tag.vaadin:tags.vaadin:tasks.vaadin:taxi.vaadin:teeth.vaadin:terminal.vaadin:text-height.vaadin:text-input.vaadin:text-label.vaadin:text-width.vaadin:thin-square.vaadin:thumbs-down-o.vaadin:thumbs-down.vaadin:thumbs-up-o.vaadin:thumbs-up.vaadin:ticket.vaadin:time-backward.vaadin:time-forward.vaadin:timer.vaadin:toolbox.vaadin:tools.vaadin:tooth.vaadin:touch.vaadin:train.vaadin:trash.vaadin:tree-table.vaadin:trendind-down.vaadin:trending-down.vaadin:trending-up.vaadin:trophy.vaadin:truck.vaadin:twin-col-select.vaadin:twitter-square.vaadin:twitter.vaadin:umbrella.vaadin:underline.vaadin:unlink.vaadin:unlock.vaadin:upload-alt.vaadin:upload.vaadin:user-card.vaadin:user-check.vaadin:user-clock.vaadin:user-heart.vaadin:user-star.vaadin:user.vaadin:users.vaadin:vaadin-h.vaadin:vaadin-v.vaadin:viewport.vaadin:vimeo-square.vaadin:vimeo.vaadin:volume-down.vaadin:volume-off.vaadin:volume-up.vaadin:volume.vaadin:wallet.vaadin:warning.vaadin:workplace.vaadin:wrench.vaadin:youtube-square.vaadin:youtube`.split(`.`),Xl=null,Zl=()=>(Xl||=Promise.all([D(()=>import(`./vendor-ui5.js`).then(e=>e.n),__vite__mapDeps([5,1])),D(()=>import(`./vendor-ui5.js`).then(e=>e.t),__vite__mapDeps([5,1]))]),Xl),Z=class extends b{constructor(...e){super(...e),this.ui5FieldComponentsReady=!1,this.component=void 0,this.field=void 0,this.baseUrl=void 0,this.state={},this.data={},this.appState={},this.appData={},this.colorPickerOpened=!1,this.colorPickerValue=void 0,this.comboData=[],this._comboFilter=``,this.rendered=!1,this.renderColorPicker=()=>{this.loadUi5FieldComponents();let e=this.field?.fieldId;return T`
             <ui5-color-picker value="${this.state&&e in this.state?this.state[e]:this.field?.initialValue}" @change="${e=>this.colorPickerValue=e.target.value}">Picker</ui5-color-picker>
         `},this.saveColor=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.colorPickerValue,fieldId:this.field.fieldId},bubbles:!0,composed:!0})),this.colorPickerOpened=!1},this.renderColorPickerFooter=()=>T`<vaadin-button @click="${()=>this.colorPickerOpened=!1}">Cancel</vaadin-button>
-        <vaadin-button theme="primary" @click="${this.saveColor}">Save</vaadin-button>`,this.checked=e=>{let t=e.target;this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t.checked,fieldId:this.field.fieldId},bubbles:!0,composed:!0}))},this.convert=e=>this.field?.dataType==`integer`?ol(e,!0):e,this.multiComboBoxValueChanged=e=>{if(this.rendered){let t=this.field?.fieldId,n=this.state&&t in this.state?this.state[t]:this.field?.initialValue,r;e.detail.value&&(r=e.detail.value.map(e=>e.value),r&&r.length>0&&(this.data[this.id]||(this.data[this.id]={}),this.data[this.id].content||(this.data[this.id].content=[]),this.data[this.id]&&this.data[this.id].content&&e.detail.value.forEach(e=>{this.data[this.id].content?.find(t=>e.value==t.value)||this.data[this.id].content.push(e)}))),this.compareArrays(r,n)||this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}},this.valueChanged=e=>{this.rendered&&e.detail.value!==void 0&&!sl(e.detail.value,this.state[this.field.fieldId])&&this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.convert(e.detail.value),fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.selectedItems=e=>{if(e&&e.length>0)if(this.field?.remoteCoordinates){if(this.comboData&&this.comboData.length>0)return this.comboData?.filter(t=>e.indexOf(t.value)>=0);if(this.data[this.id]&&this.data[this.id].content&&this.data[this.id].content.length>0)return this.data[this.id].content.filter(t=>e.indexOf(t.value)>=0)}else return this.field?.options?.filter(t=>e.indexOf(t.value)>=0);return[]},this.selectedIndex=e=>{if(e)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content){let t=this.data[this.id].content.find(t=>t.value==e);if(t)return this.data[this.id].content.indexOf(t)}}else{let t=this.field?.options?.find(t=>t.value==e);if(t)return this.field?.options?.indexOf(t)}},this.selectedIndexes=e=>{if(e&&e.length>0)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content)return this.data[this.id].content.filter(t=>e.indexOf(t.value)>=0).map(e=>this.data[this.id].content.indexOf(e))}else return this.field?.options?.filter(t=>e.indexOf(t.value)>=0).map(e=>this.field?.options?.indexOf(e));return[]},this.compareArrays=(e,t)=>this.falsy(e)&&this.falsy(t)||e&&t&&e.length===t.length&&e.every((e,n)=>e===t[n]),this.falsy=e=>!e||e.length==0,this.listItemsSelected=e=>{let t=this.field?.fieldId,n=this.state&&t in this.state?this.state[t]:this.field?.initialValue,r;this.rendered&&(e.detail.value&&(this.field?.remoteCoordinates?this.data[this.id]&&this.data[this.id].content&&(r=e.detail.value.map(e=>this.data[this.id].content[e].value)):r=e.detail.value.map(e=>this.field.options[e].value)),this.compareArrays(r,n)||this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r,fieldId:this.field?.fieldId},bubbles:!0,composed:!0})))},this.listItemSelected=e=>{let t;if(e.detail.value||e.detail.value==0)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content){let n=this.data[this.id].content[e.detail.value];n&&(t=n.value)}}else{let n=this.field.options[e.detail.value];n&&(t=n.value)}this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.mapPosition=e=>{switch(e){case`topStretch`:return`top-stretch`;case`topStart`:return`top-start`;case`topCenter`:return`top-center`;case`topEnd`:return`top-end`;case`middle`:return`middle`;case`bottomStart`:return`bottom-start`;case`bottomEnd`:return`bottom-end`;case`bottomStretch`:return`bottom-stretch`;case`bottomCenter`:return`bottom-center`}return`bottom-end`},this.helperShownInControl=!1,this.lastAnnouncedError=``,this.controlOwnsValidity=!1,this.fileUploaded=e=>{let t=this.field?.fieldId??``,n=this.state[t];n.push({id:e.detail.xhr.responseText,name:e.detail.file.name}),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:n,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.fileChanged=e=>{let t=this.field?.fieldId??``,n=(e.detail.value??[]).filter(e=>e.id).map(e=>e.id),r=(this.state[t]??[]).map(e=>e.id);if(!this.compareArrays(r,n)){let t=(e.detail.value??[]).filter(e=>e.id).map(e=>({id:e.id,name:e.name}));this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}},this.triggerImageUpload=()=>{(this.renderRoot?.querySelector(`input[type="file"]`))?.click()},this.imageUpload=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r.result,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},r.readAsDataURL(n),t.value=``},this.imageDelete=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:``,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.iconComboboxRenderer=e=>T`
+        <vaadin-button theme="primary" @click="${this.saveColor}">Save</vaadin-button>`,this.checked=e=>{let t=e.target;this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t.checked,fieldId:this.field.fieldId},bubbles:!0,composed:!0}))},this.convert=e=>this.field?.dataType==`integer`?sl(e,!0):e,this.multiComboBoxValueChanged=e=>{if(this.rendered){let t=this.field?.fieldId,n=this.state&&t in this.state?this.state[t]:this.field?.initialValue,r;e.detail.value&&(r=e.detail.value.map(e=>e.value),r&&r.length>0&&(this.data[this.id]||(this.data[this.id]={}),this.data[this.id].content||(this.data[this.id].content=[]),this.data[this.id]&&this.data[this.id].content&&e.detail.value.forEach(e=>{this.data[this.id].content?.find(t=>e.value==t.value)||this.data[this.id].content.push(e)}))),this.compareArrays(r,n)||this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}},this.valueChanged=e=>{this.rendered&&e.detail.value!==void 0&&!cl(e.detail.value,this.state[this.field.fieldId])&&this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.convert(e.detail.value),fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.selectedItems=e=>{if(e&&e.length>0)if(this.field?.remoteCoordinates){if(this.comboData&&this.comboData.length>0)return this.comboData?.filter(t=>e.indexOf(t.value)>=0);if(this.data[this.id]&&this.data[this.id].content&&this.data[this.id].content.length>0)return this.data[this.id].content.filter(t=>e.indexOf(t.value)>=0)}else return this.field?.options?.filter(t=>e.indexOf(t.value)>=0);return[]},this.selectedIndex=e=>{if(e)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content){let t=this.data[this.id].content.find(t=>t.value==e);if(t)return this.data[this.id].content.indexOf(t)}}else{let t=this.field?.options?.find(t=>t.value==e);if(t)return this.field?.options?.indexOf(t)}},this.selectedIndexes=e=>{if(e&&e.length>0)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content)return this.data[this.id].content.filter(t=>e.indexOf(t.value)>=0).map(e=>this.data[this.id].content.indexOf(e))}else return this.field?.options?.filter(t=>e.indexOf(t.value)>=0).map(e=>this.field?.options?.indexOf(e));return[]},this.compareArrays=(e,t)=>this.falsy(e)&&this.falsy(t)||e&&t&&e.length===t.length&&e.every((e,n)=>e===t[n]),this.falsy=e=>!e||e.length==0,this.listItemsSelected=e=>{let t=this.field?.fieldId,n=this.state&&t in this.state?this.state[t]:this.field?.initialValue,r;this.rendered&&(e.detail.value&&(this.field?.remoteCoordinates?this.data[this.id]&&this.data[this.id].content&&(r=e.detail.value.map(e=>this.data[this.id].content[e].value)):r=e.detail.value.map(e=>this.field.options[e].value)),this.compareArrays(r,n)||this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r,fieldId:this.field?.fieldId},bubbles:!0,composed:!0})))},this.listItemSelected=e=>{let t;if(e.detail.value||e.detail.value==0)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content){let n=this.data[this.id].content[e.detail.value];n&&(t=n.value)}}else{let n=this.field.options[e.detail.value];n&&(t=n.value)}this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.mapPosition=e=>{switch(e){case`topStretch`:return`top-stretch`;case`topStart`:return`top-start`;case`topCenter`:return`top-center`;case`topEnd`:return`top-end`;case`middle`:return`middle`;case`bottomStart`:return`bottom-start`;case`bottomEnd`:return`bottom-end`;case`bottomStretch`:return`bottom-stretch`;case`bottomCenter`:return`bottom-center`}return`bottom-end`},this.helperShownInControl=!1,this.lastAnnouncedError=``,this.controlOwnsValidity=!1,this.fileUploaded=e=>{let t=this.field?.fieldId??``,n=this.state[t];n.push({id:e.detail.xhr.responseText,name:e.detail.file.name}),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:n,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.fileChanged=e=>{let t=this.field?.fieldId??``,n=(e.detail.value??[]).filter(e=>e.id).map(e=>e.id),r=(this.state[t]??[]).map(e=>e.id);if(!this.compareArrays(r,n)){let t=(e.detail.value??[]).filter(e=>e.id).map(e=>({id:e.id,name:e.name}));this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}},this.triggerImageUpload=()=>{(this.renderRoot?.querySelector(`input[type="file"]`))?.click()},this.imageUpload=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r.result,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},r.readAsDataURL(n),t.value=``},this.imageDelete=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:``,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.iconComboboxRenderer=e=>T`
   <div style="display: flex;">
       <vaadin-icon
               icon="${e}"
@@ -9127,13 +9135,13 @@ ${i}
 
             </vaadin-horizontal-layout>
                             `:e.label}
-`,this.filteredIcons=[],this.navLinkOffset=null,this.iconFilterChanged=e=>{this.filteredIcons=Jl.filter(t=>!e.detail.value||t.indexOf(e.detail.value)>=0)}}loadUi5FieldComponents(){this.ui5FieldComponentsReady||Xl().then(()=>{this.ui5FieldComponentsReady=!0})}remoteComboDataProvider(e){return(t,n)=>{let{filter:i,page:a,pageSize:o}=t,s=i??``;this._comboFilter=s,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{searchText:i,fieldId:this.field?.fieldId,size:o,page:a,sort:void 0},callback:e=>{if(s===this._comboFilter)if(e?.messages?.forEach(e=>{r.show(e.text,{position:e.position?this.mapPosition(e.position):void 0,theme:e.variant,duration:e.duration})}),!e.fragments||e.fragments.length==0)this.comboData=[],n([],0);else{let t=e.fragments[0].data?.[this.id];this.comboData=t?.content,n(t?.content,t?.totalElements)}},callbackonly:!0},bubbles:!0,composed:!0}))}}disconnectedCallback(){super.disconnectedCallback(),this.rendered=!1}renderNavLink(){let e=this.field?.link;if(!e?.href)return v;let t=M(e.href,this.state,this.data)??e.href,n=M(e.title,this.state,this.data)||t,r=e.icon||(t.startsWith(`http`)?`vaadin:external-link`:`vaadin:link`),i=this.navLinkOffset??`calc(var(--lumo-font-size-s) * 1.6 + (var(--lumo-size-m) - var(--lumo-icon-size-s)) / 2)`;return T`<a
+`,this.filteredIcons=[],this.navLinkOffset=null,this.iconFilterChanged=e=>{this.filteredIcons=Yl.filter(t=>!e.detail.value||t.indexOf(e.detail.value)>=0)}}loadUi5FieldComponents(){this.ui5FieldComponentsReady||Zl().then(()=>{this.ui5FieldComponentsReady=!0})}remoteComboDataProvider(e){return(t,n)=>{let{filter:i,page:a,pageSize:o}=t,s=i??``;this._comboFilter=s,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{searchText:i,fieldId:this.field?.fieldId,size:o,page:a,sort:void 0},callback:e=>{if(s===this._comboFilter)if(e?.messages?.forEach(e=>{r.show(e.text,{position:e.position?this.mapPosition(e.position):void 0,theme:e.variant,duration:e.duration})}),!e.fragments||e.fragments.length==0)this.comboData=[],n([],0);else{let t=e.fragments[0].data?.[this.id];this.comboData=t?.content,n(t?.content,t?.totalElements)}},callbackonly:!0},bubbles:!0,composed:!0}))}}disconnectedCallback(){super.disconnectedCallback(),this.rendered=!1}renderNavLink(){let e=this.field?.link;if(!e?.href)return v;let t=M(e.href,this.state,this.data)??e.href,n=M(e.title,this.state,this.data)||t,r=e.icon||(t.startsWith(`http`)?`vaadin:external-link`:`vaadin:link`),i=this.navLinkOffset??`calc(var(--lumo-font-size-s) * 1.6 + (var(--lumo-size-m) - var(--lumo-icon-size-s)) / 2)`;return T`<a
                 data-navlink
                 href="${t}"
                 title="${n}"
                 target="${S(e.target||void 0)}"
                 style="display: flex; align-items: center; color: var(--lumo-secondary-text-color); align-self: flex-start; margin-top: ${i};"
-        ><vaadin-icon icon="${r}" style="width: var(--lumo-icon-size-s); height: var(--lumo-icon-size-s);"></vaadin-icon></a>`}positionNavLink(){let e=this.renderRoot?.querySelector(`a[data-navlink]`);e&&setTimeout(()=>{let t=e.parentElement,n=t?.firstElementChild?.firstElementChild;if(!t||!n)return;let r=(n.shadowRoot?.querySelector(`[part="input-field"]`)??n).getBoundingClientRect();if(r.height===0)return;let i=Math.max(0,r.top+r.height/2-e.offsetHeight/2-t.getBoundingClientRect().top),a=`${Math.round(i)}px`;this.navLinkOffset!==a&&(this.navLinkOffset=a)})}helperText(){return this.helperShownInControl=!0,P(this.field?.description??``,this.state,this.data)??``}fieldErrors(){let e=this.field?.fieldId??``,t=this.data?.errors?.[e];return Array.isArray(t)?t.filter(e=>!!e):[]}validatableControl(){let e=this.renderRoot.querySelectorAll(`*`);for(let t of e)if(`invalid`in t&&`errorMessage`in t)return t;return null}applyValidationState(){let e=this.fieldErrors(),t=this.validatableControl();if(!t){this.lastAnnouncedError=e.join(`. `);return}let n=e.join(`. `);if(t.errorMessage=n,t.invalid=e.length>0,n&&n!==this.lastAnnouncedError){let e=(this.field?.label??``).toString().trim();gt(e?`${e}: ${n}`:n,{politeness:`assertive`})}this.lastAnnouncedError=n}render(){this.rendered=!0;let e=this.renderNavLink();this.helperShownInControl=!1;let t=this.renderField(),n=this.field?.description&&!this.helperShownInControl?P(this.field.description,this.state,this.data):void 0,r=this.fieldErrors(),i=r.length>0&&!this.controlOwnsValidity;return T`<div style="display: block;">
+        ><vaadin-icon icon="${r}" style="width: var(--lumo-icon-size-s); height: var(--lumo-icon-size-s);"></vaadin-icon></a>`}positionNavLink(){let e=this.renderRoot?.querySelector(`a[data-navlink]`);e&&setTimeout(()=>{let t=e.parentElement,n=t?.firstElementChild?.firstElementChild;if(!t||!n)return;let r=(n.shadowRoot?.querySelector(`[part="input-field"]`)??n).getBoundingClientRect();if(r.height===0)return;let i=Math.max(0,r.top+r.height/2-e.offsetHeight/2-t.getBoundingClientRect().top),a=`${Math.round(i)}px`;this.navLinkOffset!==a&&(this.navLinkOffset=a)})}helperText(){return this.helperShownInControl=!0,Ot(this.field?.description??``,this.state,this.data)??``}fieldErrors(){let e=this.field?.fieldId??``,t=this.data?.errors?.[e];return Array.isArray(t)?t.filter(e=>!!e):[]}validatableControl(){let e=this.renderRoot.querySelectorAll(`*`);for(let t of e)if(`invalid`in t&&`errorMessage`in t)return t;return null}applyValidationState(){let e=this.fieldErrors(),t=this.validatableControl();if(!t){this.lastAnnouncedError=e.join(`. `);return}let n=e.join(`. `);if(t.errorMessage=n,t.invalid=e.length>0,n&&n!==this.lastAnnouncedError){let e=(this.field?.label??``).toString().trim();gt(e?`${e}: ${n}`:n,{politeness:`assertive`})}this.lastAnnouncedError=n}render(){this.rendered=!0;let e=this.renderNavLink();this.helperShownInControl=!1;let t=this.renderField(),n=this.field?.description&&!this.helperShownInControl?Ot(this.field.description,this.state,this.data):void 0,r=this.fieldErrors(),i=r.length>0&&!this.controlOwnsValidity;return T`<div style="display: block;">
             <div style="${e===v?``:`display: flex; gap: var(--lumo-space-xs);`}"><div style="flex: 1; min-width: 0;">${t}</div>${e}</div>
             ${n?T`
                 <div style="font-size: var(--lumo-font-size-xs); color: var(--lumo-secondary-text-color); margin-top: var(--lumo-space-xs);">${n}</div>
@@ -9141,29 +9149,29 @@ ${i}
             ${i?T`
                 <div role="alert"><ul>${r.map(e=>T`<li>${e}</li>`)}</ul></div>
             `:v}
-        </div>`}async firstUpdated(){this.filteredIcons=Jl}update(e){e.has(`component`)&&(this.rendered=!1),super.update(e)}updated(e){super.updated(e),this.positionNavLink(),this.applyValidationState(),this.controlOwnsValidity=!!this.validatableControl()}renderField(){let e=this.field?.fieldId??``,t=this.state&&e in this.state?this.state[e]:this.field?.initialValue,n=M(this.field?.label+``,this.state,this.data),r=this.labelAlreadyRendered||!n||n==`null`?v:n;return this.field?.propertyRow?this.renderPropertyRowField(e,t,r,n):this.field?.stereotype==`badge`?this.renderBadgeField(e,t,r,n):this.field?.stereotype==`plainText`?this.renderPlainTextField(e,t,r,n):this.field?.stereotype==`bulletedList`?this.renderBulletedListField(e,t,r,n):this.field?.readOnly&&this.field.stereotype!=`grid`&&this.field.dataType!=`status`&&this.field?.dataType!=`money`?this.renderReadOnlyField(e,t,r,n):this.field?.dataType==`file`?this.renderFileField(e,t,r,n):this.field?.dataType==`string`?this.renderStringField(e,t,r,n):this.field?.dataType==`number`?this.renderNumberField(e,t,r,n):this.field?.dataType==`integer`?this.renderIntegerField(e,t,r,n):this.field?.dataType==`bool`?this.renderBoolField(e,t,r,n):this.field?.dataType==`dateRange`?this.renderDateRangeField(e,t,r,n):this.field?.dataType==`date`?this.renderDateField(e,t,r,n):this.field?.dataType==`dateTime`?this.renderDateTimeField(e,t,r,n):this.field?.dataType==`time`?this.renderTimeField(e,t,r,n):this.field?.dataType==`array`?this.renderArrayField(e,t,r,n):this.field?.dataType==`money`?this.renderMoneyField(e,t,r,n):this.field?.dataType==`status`?this.renderStatusField(e,t,r,n):this.field?.dataType==`range`?this.renderRangeField(e,t,r,n):T`<p>Unknown field type ${this.field?.dataType} / ${this.field?.stereotype}</p>`}renderBadgeField(e,t,n,r){if(!this.field)return T``;let i=t===!0||t===`true`;return T`<vaadin-custom-field
+        </div>`}async firstUpdated(){this.filteredIcons=Yl}update(e){e.has(`component`)&&(this.rendered=!1),super.update(e)}updated(e){super.updated(e),this.positionNavLink(),this.applyValidationState(),this.controlOwnsValidity=!!this.validatableControl()}renderField(){let e=this.field?.fieldId??``,t=this.state&&e in this.state?this.state[e]:this.field?.initialValue,n=M(this.field?.label+``,this.state,this.data),r=this.labelAlreadyRendered||!n||n==`null`?v:n;return this.field?.propertyRow?this.renderPropertyRowField(e,t,r,n):this.field?.stereotype==`badge`?this.renderBadgeField(e,t,r,n):this.field?.stereotype==`plainText`?this.renderPlainTextField(e,t,r,n):this.field?.stereotype==`bulletedList`?this.renderBulletedListField(e,t,r,n):this.field?.readOnly&&this.field.stereotype!=`grid`&&this.field.dataType!=`status`&&this.field?.dataType!=`money`?this.renderReadOnlyField(e,t,r,n):this.field?.dataType==`file`?this.renderFileField(e,t,r,n):this.field?.dataType==`string`?this.renderStringField(e,t,r,n):this.field?.dataType==`number`?this.renderNumberField(e,t,r,n):this.field?.dataType==`integer`?this.renderIntegerField(e,t,r,n):this.field?.dataType==`bool`?this.renderBoolField(e,t,r,n):this.field?.dataType==`dateRange`?this.renderDateRangeField(e,t,r,n):this.field?.dataType==`date`?this.renderDateField(e,t,r,n):this.field?.dataType==`dateTime`?this.renderDateTimeField(e,t,r,n):this.field?.dataType==`time`?this.renderTimeField(e,t,r,n):this.field?.dataType==`array`?this.renderArrayField(e,t,r,n):this.field?.dataType==`money`?this.renderMoneyField(e,t,r,n):this.field?.dataType==`status`?this.renderStatusField(e,t,r,n):this.field?.dataType==`range`?this.renderRangeField(e,t,r,n):T`<p>Unknown field type ${this.field?.dataType} / ${this.field?.stereotype}</p>`}renderBadgeField(e,t,n,r){if(!this.field)return T``;let i=t===!0||t===`true`;return T`<vaadin-custom-field
                     id="${this.field.fieldId}"
                     .helperText="${this.helperText()}"
                     data-colspan="${this.field?.colspan}"
                     style="${this.field?.style}"
             ><span theme="badge ${i?`success`:``} pill" style="${i?``:`opacity: 0.4;`}">${r}</span>
-            </vaadin-custom-field>`}renderPropertyRowField(e,t,n,r){if(!this.field)return T``;let i=P(t,this.state,this.data),a=i&&typeof i==`object`&&`value`in i?i:null;i&&i.value&&(i=i.value);let o=this.field?.dataType==`bool`||i===!0||i===!1,s=this.field?.dataType==`money`,c=i!=null&&i!==``,l=c?String(i):`—`;if(s&&c){let e=typeof i==`number`?i:parseFloat(String(i));isNaN(e)||(l=a&&a.locale&&a.currency?new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(e):new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e))}let u=o?T`<vaadin-icon icon="${i===!0||i===`true`?`vaadin:check`:`vaadin:minus`}" style="height: 16px; width: 16px;"></vaadin-icon>`:T`<span style="font-weight: 500; text-align: right; word-break: break-word; margin-left: auto;${s?` font-variant-numeric: tabular-nums;`:``}">${l}</span>`,d=r&&r!=`null`;return T`<div
+            </vaadin-custom-field>`}renderPropertyRowField(e,t,n,r){if(!this.field)return T``;let i=Ot(t,this.state,this.data),a=i&&typeof i==`object`&&`value`in i?i:null;i&&i.value&&(i=i.value);let o=this.field?.dataType==`bool`||i===!0||i===!1,s=this.field?.dataType==`money`,c=i!=null&&i!==``,l=c?String(i):`—`;if(s&&c){let e=typeof i==`number`?i:parseFloat(String(i));isNaN(e)||(l=a&&a.locale&&a.currency?new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(e):new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e))}let u=o?T`<vaadin-icon icon="${i===!0||i===`true`?`vaadin:check`:`vaadin:minus`}" style="height: 16px; width: 16px;"></vaadin-icon>`:T`<span style="font-weight: 500; text-align: right; word-break: break-word; margin-left: auto;${s?` font-variant-numeric: tabular-nums;`:``}">${l}</span>`,d=r&&r!=`null`;return T`<div
                     id="${this.field.fieldId}"
                     data-colspan="${this.field?.colspan}"
                     style="display: flex; justify-content: space-between; align-items: baseline; gap: 1rem; width: 100%; padding: 0.4rem 0; border-bottom: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.08)); font-size: var(--lumo-font-size-s, .875rem); ${this.field?.style}"
-            >${d?T`<span style="color: var(--lumo-secondary-text-color, #888); white-space: nowrap;">${r}</span>`:v}${u}</div>`}renderBulletedListField(e,t,n,r){if(!this.field)return T``;let i=P(t,this.state,this.data),a=Array.isArray(i)?i.map(e=>String(e)):i!=null&&i!==``?[String(i)]:[];return T`<vaadin-custom-field
+            >${d?T`<span style="color: var(--lumo-secondary-text-color, #888); white-space: nowrap;">${r}</span>`:v}${u}</div>`}renderBulletedListField(e,t,n,r){if(!this.field)return T``;let i=Ot(t,this.state,this.data),a=Array.isArray(i)?i.map(e=>String(e)):i!=null&&i!==``?[String(i)]:[];return T`<vaadin-custom-field
                     id="${this.field.fieldId}"
                     label="${n}"
                     .helperText="${this.helperText()}"
                     data-colspan="${this.field?.colspan}"
                     style="${this.field?.style}"
             ><mateu-bulleted-list .items="${a}"></mateu-bulleted-list>
-            </vaadin-custom-field>`}renderPlainTextField(e,t,n,r){if(!this.field)return T``;let i=P(t,this.state,this.data),a=i&&typeof i==`object`&&`value`in i?i:null;i&&i.value&&(i=i.value);let o=this.field?.dataType==`bool`||i===!0||i===!1,s=this.field?.dataType==`money`,c=i!=null&&i!==``,l=c?String(i):`—`;if(s&&c){let e=typeof i==`number`?i:parseFloat(String(i));isNaN(e)||(l=a&&a.locale&&a.currency?new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(e):new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e))}let u=o?T`<vaadin-icon icon="${i===!0||i===`true`?`vaadin:check`:`vaadin:minus`}" style="height: 16px; width: 16px;"></vaadin-icon>`:this.field?.multiline?T`<span style="font-weight: 500; white-space: pre-wrap; word-break: break-word;">${l}</span>`:T`<span style="font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;${s?` font-variant-numeric: tabular-nums;`:``}">${l}</span>`;return T`<vaadin-custom-field
+            </vaadin-custom-field>`}renderPlainTextField(e,t,n,r){if(!this.field)return T``;let i=Ot(t,this.state,this.data),a=i&&typeof i==`object`&&`value`in i?i:null;i&&i.value&&(i=i.value);let o=this.field?.dataType==`bool`||i===!0||i===!1,s=this.field?.dataType==`money`,c=i!=null&&i!==``,l=c?String(i):`—`;if(s&&c){let e=typeof i==`number`?i:parseFloat(String(i));isNaN(e)||(l=a&&a.locale&&a.currency?new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(e):new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e))}let u=o?T`<vaadin-icon icon="${i===!0||i===`true`?`vaadin:check`:`vaadin:minus`}" style="height: 16px; width: 16px;"></vaadin-icon>`:this.field?.multiline?T`<span style="font-weight: 500; white-space: pre-wrap; word-break: break-word;">${l}</span>`:T`<span style="font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;${s?` font-variant-numeric: tabular-nums;`:``}">${l}</span>`;return T`<vaadin-custom-field
                     id="${this.field.fieldId}"
                     label="${n}"
                     data-colspan="${this.field?.colspan}"
                     style="${s?`text-align: right; `:``}${this.field?.style}"
-            >${u}</vaadin-custom-field>`}renderReadOnlyField(e,t,n,r){if(!this.field)return T``;let i=P(t,this.state,this.data)||this.data[e];if(i&&i.value&&(i=i.value),this.field.stereotype==`fileUpload`)return T`<vaadin-custom-field
+            >${u}</vaadin-custom-field>`}renderReadOnlyField(e,t,n,r){if(!this.field)return T``;let i=Ot(t,this.state,this.data)||this.data[e];if(i&&i.value&&(i=i.value),this.field.stereotype==`fileUpload`)return T`<vaadin-custom-field
                         id="${this.field.fieldId}"
                         label="${n}"
                         .helperText="${this.helperText()}"
@@ -9226,7 +9234,7 @@ ${i}
                             <vaadin-button theme="icon" @click="${e=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`codesearch-`+this.field?.fieldId,parameters:{}},bubbles:!0,composed:!0}))}}"><vaadin-icon icon="lumo:search"></vaadin-icon></vaadin-button>
                         </vaadin-horizontal-layout>
                     </vaadin-custom-field>
-                `;if(this.field?.stereotype==`select`){if(this.field?.optionsSource){let e=this.field.optionsSource,r=M(e.url,this.state,this.data)??e.url;this.data[this.id]?.sourceSignature!==r&&(this.data[this.id]={content:this.data[this.id]?.content??[],sourceSignature:r},e.proxy?this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`__restfetch__`,parameters:{_sourceKind:`options`,_sourceId:this.field.fieldId},callback:t=>{let n=t?.appData?._restfetch,i=un(n,e.itemsPath,e.valuePath,e.labelPath);this.data[this.id]={content:i,totalElements:i.length,sourceSignature:r},this.requestUpdate()},callbackonly:!0},bubbles:!0,composed:!0})):pn(e,e=>M(e,this.state,this.data)).then(e=>{this.data[this.id]={content:e,totalElements:e.length,sourceSignature:r},this.requestUpdate()}).catch(e=>console.warn(`mateu: external options fetch failed`,e)));let i=t;return t&&t.value&&(i=t.value),T`
+                `;if(this.field?.stereotype==`select`){if(this.field?.optionsSource){let e=this.field.optionsSource,r=M(e.url,this.state,this.data)??e.url;this.data[this.id]?.sourceSignature!==r&&(this.data[this.id]={content:this.data[this.id]?.content??[],sourceSignature:r},e.proxy?this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`__restfetch__`,parameters:{_sourceKind:`options`,_sourceId:this.field.fieldId},callback:t=>{let n=t?.appData?._restfetch,i=dn(n,e.itemsPath,e.valuePath,e.labelPath);this.data[this.id]={content:i,totalElements:i.length,sourceSignature:r},this.requestUpdate()},callbackonly:!0},bubbles:!0,composed:!0})):mn(e,e=>M(e,this.state,this.data)).then(e=>{this.data[this.id]={content:e,totalElements:e.length,sourceSignature:r},this.requestUpdate()}).catch(e=>console.warn(`mateu: external options fetch failed`,e)));let i=t;return t&&t.value&&(i=t.value),T`
                     <vaadin-select
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9629,7 +9637,7 @@ ${i}
                     >
                         <mateu-camera-capture .fieldId="${this.field.fieldId}" .value="${t}"></mateu-camera-capture>
                     </vaadin-custom-field>
-                `;if(this.field?.stereotype==`fileUpload`){let e=rl(this.field.attributes,`accept`);return T`
+                `;if(this.field?.stereotype==`fileUpload`){let e=il(this.field.attributes,`accept`);return T`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9981,7 +9989,7 @@ ${i}
                         .helperText="${this.helperText()}"
                         data-colspan="${this.field.colspan}"
                 >
-                    ${i?T`<span theme="badge pill ${Aa(i.type)}">${i.message}</span>`:T``}                    
+                    ${i?T`<span theme="badge pill ${ja(i.type)}">${i.message}</span>`:T``}                    
                 </vaadin-custom-field>
             `}renderRangeField(e,t,n,r){if(!this.field)return T``;this.loadUi5FieldComponents();let i=t;return T`
                 <vaadin-custom-field
@@ -10079,7 +10087,7 @@ ${i}
             text-overflow: clip;
             height: auto;
         }
-  `}};k([C()],Q.prototype,`ui5FieldComponentsReady`,void 0),k([y()],Q.prototype,`component`,void 0),k([y()],Q.prototype,`field`,void 0),k([y()],Q.prototype,`baseUrl`,void 0),k([y()],Q.prototype,`state`,void 0),k([y()],Q.prototype,`data`,void 0),k([y()],Q.prototype,`appState`,void 0),k([y()],Q.prototype,`appData`,void 0),k([y()],Q.prototype,`labelAlreadyRendered`,void 0),k([C()],Q.prototype,`colorPickerOpened`,void 0),k([C()],Q.prototype,`colorPickerValue`,void 0),k([C()],Q.prototype,`controlOwnsValidity`,void 0),k([C()],Q.prototype,`filteredIcons`,void 0),k([C()],Q.prototype,`navLinkOffset`,void 0),Q=k([g(`mateu-field`)],Q);var Zl=(e,t,n,r,i,a,o,s)=>{let c=t.metadata;return T`
+  `}};k([C()],Z.prototype,`ui5FieldComponentsReady`,void 0),k([y()],Z.prototype,`component`,void 0),k([y()],Z.prototype,`field`,void 0),k([y()],Z.prototype,`baseUrl`,void 0),k([y()],Z.prototype,`state`,void 0),k([y()],Z.prototype,`data`,void 0),k([y()],Z.prototype,`appState`,void 0),k([y()],Z.prototype,`appData`,void 0),k([y()],Z.prototype,`labelAlreadyRendered`,void 0),k([C()],Z.prototype,`colorPickerOpened`,void 0),k([C()],Z.prototype,`colorPickerValue`,void 0),k([C()],Z.prototype,`controlOwnsValidity`,void 0),k([C()],Z.prototype,`filteredIcons`,void 0),k([C()],Z.prototype,`navLinkOffset`,void 0),Z=k([g(`mateu-field`)],Z);var Ql=(e,t,n,r,i,a,o,s)=>{let c=t.metadata;return T`
         <mateu-field
                 id="${t.id}"
                 .component="${t}"
@@ -10088,15 +10096,15 @@ ${i}
                 .data="${i}"
                 .appState="${a}"
                 .appdata="${o}"
-                style="${wa(t,i)}" class="${t.cssClasses}"
+                style="${Ta(t,i)}" class="${t.cssClasses}"
                 slot="${t.slot??v}"
                 data-colspan="${c.colspan}"
                 colspan="${(c.colspan??1)>1?c.colspan:v}"
                 .labelAlreadyRendered="${s}"
         >
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o,s))}
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o,s))}
         </mateu-field>
-    `},Ql=(e,n,r,i,a,o,s)=>{let c=n.metadata;if(c.tree)return T`
+    `},$l=(e,n,r,i,a,o,s)=>{let c=n.metadata;if(c.tree)return T`
         <vaadin-grid style="${n.style}" class="${n.cssClasses}"
                      .itemHasChildrenPath="${`children`}" .dataProvider="${async(e,t)=>{let n=e.parentItem?e.parentItem.children:c.page.content;t(n,n.length)}}"
                      slot="${n.slot??v}"
@@ -10109,7 +10117,7 @@ ${i}
                                 flex-grow="${l?.flexGrow??v}"
                                 width="${l?.width??v}"
                                 .column="${n.metadata}"
-                                ${t((t,n,c)=>Vl(t,n,c,l,e,r,i,a,o,s),[])}></vaadin-grid-column>
+                                ${t((t,n,c)=>Hl(t,n,c,l,e,r,i,a,o,s),[])}></vaadin-grid-column>
 `:T`
             <vaadin-grid-tree-column path="${n.id}"
                                 header="${l?.label??v}"
@@ -10118,7 +10126,7 @@ ${i}
                                 width="${l?.width??v}"
             ></vaadin-grid-tree-column>
 `})}
-            <span slot="empty-state">${zt()}</span>
+            <span slot="empty-state">${Bt()}</span>
         </vaadin-grid>
     `;let l=c.page?.content;return n.id&&i&&i[n.id]&&(l=i[n.id]),l||=[],T`
         <vaadin-grid 
@@ -10127,9 +10135,9 @@ ${i}
                 .items="${l}"
                 all-rows-visible
         >
-            ${c?.content?.map(t=>zl(t,e,r,i,a,o,s))}
+            ${c?.content?.map(t=>Bl(t,e,r,i,a,o,s))}
         </vaadin-grid>
-    `},$=class extends b{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.detailsOpenedItems=[],this.pagesRequested=[],this._lastGridHeight=0,this.emptyArray=e=>!e||e.length==0,this.dataProvider=(e,t)=>{let n=this.data[this.id]?.page;if(this.metadata?.infiniteScrolling&&e.page>0){let r=!1;n&&n.content&&(n.content.length>=(e.page+1)*e.pageSize||n.content.length==n.totalElements)&&(t(n.content.slice(e.page*e.pageSize,(e.page+1)*e.pageSize),n.totalElements),r=!0,this.grid&&this.grid.recalculateColumnWidths()),r||this.pagesRequested.find(t=>t==e.page)||(this.pagesRequested.push(e.page),this.dispatchEvent(new CustomEvent(`fetch-more-elements`,{detail:{params:e,callback:()=>{this.data[this.id]?.page?.content&&(t(this.data[this.id].page.content.slice(e.page*e.pageSize,(e.page+1)*e.pageSize),this.data[this.id].page.totalElements),this.grid&&this.grid.recalculateColumnWidths())}},bubbles:!0,composed:!0})))}else{let e=this.metadata?.infiniteScrolling?n?.totalElements:n?.content?.length??0;t(n?.content??[],e),this.grid&&this.grid.recalculateColumnWidths()}},this._onActionRequested=e=>{let t=e.detail,n=this.identifierFieldName;if(!n||!t.parameters||t.actionId?.startsWith(`action-on-row-`))return;let r=t.parameters[n];r!==void 0&&(this.state._selectedId=String(r),this._applyCellPartNameGenerator(),this.grid?.requestContentUpdate())},this.tooltipGenerator=e=>{let t=``,{column:n,item:r}=e,i=this.metadata?.columns?.find(e=>e.metadata.id==n?.path);if(i?.metadata){let e=(i?.metadata).tooltipPath;e&&n&&r&&(t=r[e])}return t}}get identifierFieldName(){let e=this.metadata?.columns?.find(e=>e.metadata?.identifier);if(e)return e.metadata?.id;if(this.metadata?.columns?.find(e=>e.metadata?.id===`id`))return`id`}_applyCellPartNameGenerator(){if(!this.grid)return;let e=this.identifierFieldName,t=this.state?._selectedId??this.appState?._splitDetailId,n=!!this.metadata?.groupBy;e&&t!==void 0||n?this.grid.cellPartNameGenerator=(n,r)=>{let i=r.item;return cl(i)?`mateu-group-row`:e&&t!==void 0&&String(i[e])===String(t)?`selected-row`:``}:this.grid.cellPartNameGenerator=null}connectedCallback(){super.connectedCallback(),this.addEventListener(`action-requested`,this._onActionRequested)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`action-requested`,this._onActionRequested),this._resizeObserver?.disconnect(),this._resizeObserver=void 0}firstUpdated(){let e=this.grid;!e||this._resizeObserver||(this._resizeObserver=new ResizeObserver(()=>{let t=e.offsetHeight;t>0&&this._lastGridHeight===0&&requestAnimationFrame(()=>{e.recalculateColumnWidths(),e.requestContentUpdate(),e.notifyResize?.()}),this._lastGridHeight=t}),this._resizeObserver.observe(e))}updated(e){super.updated(e),this._applyCellPartNameGenerator(),this.grid?.clearCache(),this.grid?.requestContentUpdate(),this.grid?.recalculateColumnWidths(),this.pagesRequested=[]}render(){let e=this.data[this.id],r=e?.page,i=this.metadata?.groupBy,a=this.metadata?.infiniteScrolling?void 0:r?.content?ul(r.content,i,e?.groups):r?.content,o=ml((this.metadata?.columns??[]).flatMap(e=>e.metadata?.type===j.GridGroupColumn?(e.metadata.columns??[]).map(e=>e.metadata):[e.metadata]),e,i),s=``;return this.metadata?.wrapCellContent&&(s+=` wrap-cell-content`),this.metadata?.compact&&(s+=` compact`),this.metadata?.noBorder&&(s+=` no-border`),this.metadata?.noRowBorder&&(s+=` no-row-borders`),this.metadata?.columnBorders&&(s+=` column-borders`),this.metadata?.rowStripes&&(s+=` row-stripes`),T`
+    `},Q=class extends b{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.detailsOpenedItems=[],this.pagesRequested=[],this._lastGridHeight=0,this.emptyArray=e=>!e||e.length==0,this.dataProvider=(e,t)=>{let n=this.data[this.id]?.page;if(this.metadata?.infiniteScrolling&&e.page>0){let r=!1;n&&n.content&&(n.content.length>=(e.page+1)*e.pageSize||n.content.length==n.totalElements)&&(t(n.content.slice(e.page*e.pageSize,(e.page+1)*e.pageSize),n.totalElements),r=!0,this.grid&&this.grid.recalculateColumnWidths()),r||this.pagesRequested.find(t=>t==e.page)||(this.pagesRequested.push(e.page),this.dispatchEvent(new CustomEvent(`fetch-more-elements`,{detail:{params:e,callback:()=>{this.data[this.id]?.page?.content&&(t(this.data[this.id].page.content.slice(e.page*e.pageSize,(e.page+1)*e.pageSize),this.data[this.id].page.totalElements),this.grid&&this.grid.recalculateColumnWidths())}},bubbles:!0,composed:!0})))}else{let e=this.metadata?.infiniteScrolling?n?.totalElements:n?.content?.length??0;t(n?.content??[],e),this.grid&&this.grid.recalculateColumnWidths()}},this._onActionRequested=e=>{let t=e.detail,n=this.identifierFieldName;if(!n||!t.parameters||t.actionId?.startsWith(`action-on-row-`))return;let r=t.parameters[n];r!==void 0&&(this.state._selectedId=String(r),this._applyCellPartNameGenerator(),this.grid?.requestContentUpdate())},this.tooltipGenerator=e=>{let t=``,{column:n,item:r}=e,i=this.metadata?.columns?.find(e=>e.metadata.id==n?.path);if(i?.metadata){let e=(i?.metadata).tooltipPath;e&&n&&r&&(t=r[e])}return t}}get identifierFieldName(){let e=this.metadata?.columns?.find(e=>e.metadata?.identifier);if(e)return e.metadata?.id;if(this.metadata?.columns?.find(e=>e.metadata?.id===`id`))return`id`}_applyCellPartNameGenerator(){if(!this.grid)return;let e=this.identifierFieldName,t=this.state?._selectedId??this.appState?._splitDetailId,n=!!this.metadata?.groupBy;e&&t!==void 0||n?this.grid.cellPartNameGenerator=(n,r)=>{let i=r.item;return ll(i)?`mateu-group-row`:e&&t!==void 0&&String(i[e])===String(t)?`selected-row`:``}:this.grid.cellPartNameGenerator=null}connectedCallback(){super.connectedCallback(),this.addEventListener(`action-requested`,this._onActionRequested)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`action-requested`,this._onActionRequested),this._resizeObserver?.disconnect(),this._resizeObserver=void 0}firstUpdated(){let e=this.grid;!e||this._resizeObserver||(this._resizeObserver=new ResizeObserver(()=>{let t=e.offsetHeight;t>0&&this._lastGridHeight===0&&requestAnimationFrame(()=>{e.recalculateColumnWidths(),e.requestContentUpdate(),e.notifyResize?.()}),this._lastGridHeight=t}),this._resizeObserver.observe(e))}updated(e){super.updated(e),this._applyCellPartNameGenerator(),this.grid?.clearCache(),this.grid?.requestContentUpdate(),this.grid?.recalculateColumnWidths(),this.pagesRequested=[]}render(){let e=this.data[this.id],r=e?.page,i=this.metadata?.groupBy,a=this.metadata?.infiniteScrolling?void 0:r?.content?dl(r.content,i,e?.groups):r?.content,o=hl((this.metadata?.columns??[]).flatMap(e=>e.metadata?.type===j.GridGroupColumn?(e.metadata.columns??[]).map(e=>e.metadata):[e.metadata]),e,i),s=``;return this.metadata?.wrapCellContent&&(s+=` wrap-cell-content`),this.metadata?.compact&&(s+=` compact`),this.metadata?.noBorder&&(s+=` no-border`),this.metadata?.noRowBorder&&(s+=` no-row-borders`),this.metadata?.columnBorders&&(s+=` column-borders`),this.metadata?.rowStripes&&(s+=` row-stripes`),T`
             <vaadin-grid
                     .items="${a}"
                     item-id-path="_rowNumber"
@@ -10141,17 +10149,17 @@ ${i}
                     .dataProvider="${this.metadata?.infiniteScrolling?this.dataProvider:void 0}"
                     page-size="${this.metadata?.pageSize}"
                     multi-sort-on-shift-click
-                    @selected-items-changed="${e=>{let t=(e.detail.value??[]).filter(e=>!cl(e));this.emptyArray(this.state[this.id+`_selected_items`])&&this.emptyArray(t)||(this.state[this.id+`_selected_items`]=t,this.metadata?.onRowSelectionChangedActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.metadata?.onRowSelectionChangedActionId},bubbles:!0,composed:!0})))}}"
-                    @active-item-changed="${S(this.metadata?.detailPath&&!this.metadata?.useButtonForDetail?e=>{if(this.metadata?.detailPath){let t=e.detail.value;if(t&&cl(t))return;t?this.detailsOpenedItems=[t]:this.detailsOpenedItems=[]}}:void 0)}"
+                    @selected-items-changed="${e=>{let t=(e.detail.value??[]).filter(e=>!ll(e));this.emptyArray(this.state[this.id+`_selected_items`])&&this.emptyArray(t)||(this.state[this.id+`_selected_items`]=t,this.metadata?.onRowSelectionChangedActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.metadata?.onRowSelectionChangedActionId},bubbles:!0,composed:!0})))}}"
+                    @active-item-changed="${S(this.metadata?.detailPath&&!this.metadata?.useButtonForDetail?e=>{if(this.metadata?.detailPath){let t=e.detail.value;if(t&&ll(t))return;t?this.detailsOpenedItems=[t]:this.detailsOpenedItems=[]}}:void 0)}"
                     .detailsOpenedItems="${this.detailsOpenedItems}"
-                    ${S(this.metadata?.detailPath?n(e=>T`${I(this,e[this.metadata?.detailPath],this.baseUrl,this.state,this.data,this.appState,this.appData)}`):void 0)}
+                    ${S(this.metadata?.detailPath?n(e=>T`${F(this,e[this.metadata?.detailPath],this.baseUrl,this.state,this.data,this.appState,this.appData)}`):void 0)}
                     theme="${s}"
                     style="${this.metadata?.gridStyle}"
             >
                 ${this.metadata?.rowsSelectionEnabled?T`
                     <vaadin-grid-selection-column></vaadin-grid-selection-column>
                 `:v}
-                ${this.metadata?.columns?.map(e=>zl(e,this,this.baseUrl,this.state,this.data,this.appState,this.appData,o))}
+                ${this.metadata?.columns?.map(e=>Bl(e,this,this.baseUrl,this.state,this.data,this.appState,this.appData,o))}
                 ${this.metadata?.useButtonForDetail?T`
                     <vaadin-grid-column
                             width="44px"
@@ -10171,7 +10179,7 @@ ${i}
             `,[])}
                     ></vaadin-grid-column>
                 `:v}
-                <span slot="empty-state">${zt(this.emptyStateMessage??this.metadata?.emptyStateMessage)}</span>
+                <span slot="empty-state">${Bt(this.emptyStateMessage??this.metadata?.emptyStateMessage)}</span>
                 ${this.metadata?.columns?.find(e=>e.metadata.tooltipPath)?T`<vaadin-tooltip slot="tooltip" .generator="${this.tooltipGenerator}"></vaadin-tooltip>`:v}
             </vaadin-grid>
             <slot></slot>
@@ -10190,7 +10198,7 @@ ${i}
             background-color: var(--lumo-contrast-5pct, rgba(0, 0, 0, 0.04));
             font-weight: 600;
         }
-  `}};k([y()],$.prototype,`id`,void 0),k([y()],$.prototype,`metadata`,void 0),k([y()],$.prototype,`baseUrl`,void 0),k([y()],$.prototype,`state`,void 0),k([y()],$.prototype,`data`,void 0),k([y()],$.prototype,`appState`,void 0),k([y()],$.prototype,`appData`,void 0),k([y()],$.prototype,`emptyStateMessage`,void 0),k([C()],$.prototype,`detailsOpenedItems`,void 0),k([x(`vaadin-grid`)],$.prototype,`grid`,void 0),$=k([g(`mateu-table`)],$);var $l=(e,t,n,r,i,a,o)=>T`
+  `}};k([y()],Q.prototype,`id`,void 0),k([y()],Q.prototype,`metadata`,void 0),k([y()],Q.prototype,`baseUrl`,void 0),k([y()],Q.prototype,`state`,void 0),k([y()],Q.prototype,`data`,void 0),k([y()],Q.prototype,`appState`,void 0),k([y()],Q.prototype,`appData`,void 0),k([y()],Q.prototype,`emptyStateMessage`,void 0),k([C()],Q.prototype,`detailsOpenedItems`,void 0),k([x(`vaadin-grid`)],Q.prototype,`grid`,void 0),Q=k([g(`mateu-table`)],Q);var eu=(e,t,n,r,i,a,o)=>T`
     <mateu-table
             id="${t.id}"
             baseUrl="${n}"
@@ -10202,8 +10210,8 @@ ${i}
             style="${t.style}" class="${t.cssClasses}"
             slot="${t.slot??v}"
     >
-        ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
-    </mateu-table>`,eu=(e,t,n,r,i,a)=>T`
+        ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+    </mateu-table>`,tu=(e,t,n,r,i,a)=>T`
     <mateu-table id="${e.id}"
                  .metadata="${t?.metadata}"
                  .data="${e.data}"
@@ -10214,8 +10222,8 @@ ${i}
                  @sort-direction-changed="${e.directionChanged}"
                  @fetch-more-elements="${e.fetchMoreElements}"
                  baseUrl="${n}"
-    ></mateu-table>`,tu=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
-        <div id="show-notifications" slot="${t.slot??v}">${I(e,s.wrapped,n,r,i,a,o)}</div>
+    ></mateu-table>`,nu=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+        <div id="show-notifications" slot="${t.slot??v}">${F(e,s.wrapped,n,r,i,a,o)}</div>
         <vaadin-popover
                 for="show-notifications"
                 theme="arrow no-padding"
@@ -10223,17 +10231,17 @@ ${i}
                 accessible-name-ref="notifications-heading"
                 content-width="300px"
                 position="bottom"
-                ${m(()=>T`${I(e,s.content,n,r,i,a,o)}`,[])}
+                ${m(()=>T`${F(e,s.content,n,r,i,a,o)}`,[])}
                 style="${t.style}" class="${t.cssClasses}"
         ></vaadin-popover>
-    `},nu=(e,t,n)=>{let r=e;return T`
+    `},ru=(e,t,n)=>{let r=e;return T`
         <vaadin-button
                 data-action-id="${r.id}"
-                theme="${Mt(e)||v}"
+                theme="${Nt(e)||v}"
                 @click="${n}"
                 ?disabled="${r.disabled}"
         >${r.iconOnLeft?T`<vaadin-icon icon="${r.iconOnLeft}"></vaadin-icon>`:v}${t}${r.iconOnRight?T`<vaadin-icon icon="${r.iconOnRight}"></vaadin-icon>`:v}</vaadin-button>
-    `},ru=e=>T`
+    `},iu=e=>T`
     <div style="display: flex; gap: var(--lumo-space-xs, .25rem); align-items: center;" class="peer-nav">
         <vaadin-button theme="tertiary icon" class="peer-nav-prev" title="${e.prevLabel??`Previous`}"
                 ?disabled="${!e.prevRoute}"
@@ -10245,30 +10253,30 @@ ${i}
                 @click="${()=>{e.nextRoute&&(window.location.href=e.nextRoute)}}">
             <vaadin-icon icon="vaadin:angle-right"></vaadin-icon>
         </vaadin-button>
-    </div>`,iu={"vaadin:wifi":`vaadin:connect`,"vaadin:pen":`vaadin:pencil`,"vaadin:automation":`vaadin:cogs`},au=(e,t,n)=>T`<vaadin-icon icon="${iu[e]??e}" style="${t??v}" class="${n??v}"></vaadin-icon>`,ou=(e,t,n)=>{let r=e.metadata,i=M(r.label,t,n),a=``;return r.buttonStyle&&(a+=` `+r.buttonStyle),r.color&&r.color!==`none`&&r.color!==`normal`&&(a+=` `+r.color),r.size&&r.size!==`none`&&r.size!==`normal`&&(a+=` `+r.size),T`<vaadin-button
+    </div>`,au={"vaadin:wifi":`vaadin:connect`,"vaadin:pen":`vaadin:pencil`,"vaadin:automation":`vaadin:cogs`},ou=(e,t,n)=>T`<vaadin-icon icon="${au[e]??e}" style="${t??v}" class="${n??v}"></vaadin-icon>`,su=(e,t,n)=>{let r=e.metadata,i=M(r.label,t,n),a=``;return r.buttonStyle&&(a+=` `+r.buttonStyle),r.color&&r.color!==`none`&&r.color!==`normal`&&(a+=` `+r.color),r.size&&r.size!==`none`&&r.size!==`normal`&&(a+=` `+r.size),T`<vaadin-button
             id="${e.id}"
             data-action-id="${r.actionId}"
-            @click="${e=>ar(e,r)}"
+            @click="${e=>or(e,r)}"
             style="${e.style}"
             class="${e.cssClasses}"
             theme="${a}"
             ?disabled="${r.disabled}"
-            title="${r.shortcut?`${i} (${ir(r.shortcut)})`:v}"
+            title="${r.shortcut?`${i} (${ar(r.shortcut)})`:v}"
             slot="${e.slot??v}"
-    >${r.iconOnLeft?T`<vaadin-icon icon="${r.iconOnLeft}"></vaadin-icon>`:v}${i}${r.iconOnRight?T`<vaadin-icon icon="${r.iconOnRight}"></vaadin-icon>`:v}</vaadin-button>`},su=e=>{let t=e.metadata;return T`
+    >${r.iconOnLeft?T`<vaadin-icon icon="${r.iconOnLeft}"></vaadin-icon>`:v}${i}${r.iconOnRight?T`<vaadin-icon icon="${r.iconOnRight}"></vaadin-icon>`:v}</vaadin-button>`},cu=e=>{let t=e.metadata;return T`
         <vaadin-message-input
                 style="${e.style}" class="${e.cssClasses}"
                 slot="${e.slot??v}"
                 @submit="${e=>{let n=e.detail?.value??``;!t.actionId||!n.trim()||e.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:{message:n}},bubbles:!0,composed:!0}))}}"
         ></vaadin-message-input>
-    `},cu=e=>{let t=(e.metadata.items??[]).map(e=>({text:e.text,time:e.time,userName:e.userName,userImg:e.userImg,userAbbr:e.userAbbr,userColorIndex:e.userColorIndex}));return T`
+    `},lu=e=>{let t=(e.metadata.items??[]).map(e=>({text:e.text,time:e.time,userName:e.userName,userImg:e.userImg,userAbbr:e.userAbbr,userColorIndex:e.userColorIndex}));return T`
         <vaadin-message-list
                 markdown
                 style="${e.style}" class="${e.cssClasses}"
                 slot="${e.slot??v}"
                 .items="${t}"
         ></vaadin-message-list>
-    `},lu=(e,t)=>{e&&e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},uu=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!1;if(s.openedCondition)try{c=St(s.openedCondition,r,i,a,o)}catch(e){console.error(`when evaluating `+s.openedCondition+` :`+e+`, where data is `+i+` and state is `+r)}return T`
+    `},uu=(e,t)=>{e&&e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},du=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!1;if(s.openedCondition)try{c=St(s.openedCondition,r,i,a,o)}catch(e){console.error(`when evaluating `+s.openedCondition+` :`+e+`, where data is `+i+` and state is `+r)}return T`
         <vaadin-confirm-dialog
                 header="${s.header}"
                 ?cancel-button-visible="${s.canCancel}"
@@ -10276,15 +10284,15 @@ ${i}
                 reject-text="${s.rejectText}"
                 confirm-text="${s.confirmText}"
                 .opened="${c}"
-                @confirm="${e=>lu(e.currentTarget,s.confirmActionId)}"
-                @reject="${e=>lu(e.currentTarget,s.rejectActionId)}"
-                @cancel="${e=>lu(e.currentTarget,s.cancelActionId)}"
+                @confirm="${e=>uu(e.currentTarget,s.confirmActionId)}"
+                @reject="${e=>uu(e.currentTarget,s.rejectActionId)}"
+                @cancel="${e=>uu(e.currentTarget,s.cancelActionId)}"
                 style="${t.style}" class="${t.cssClasses}"
                 slot="${t.slot??v}"
         >
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
         </vaadin-confirm-dialog>
-    `},du=class extends b{constructor(...e){super(...e),this.panels=[],this.headerTitle=``,this.badges=[],this.navigation=null,this.overviewEditActionId=``,this._raf=0,this._snapping=!1,this._less=!1,this._more=!1,this._onScroll=()=>{this._raf||=requestAnimationFrame(()=>{this._raf=0,this._syncPin()})},this._onScrollEnd=()=>{this._snapping||this._snapToNearest()},this._fit=()=>{let e=this.getBoundingClientRect().top;this.style.setProperty(`--mateu-foldout-fill`,`${Math.max(240,window.innerHeight-e)}px`),this._syncPin()},this._onKeydown=e=>{if(e.key!==`ArrowRight`&&e.key!==`ArrowLeft`||e.defaultPrevented||e.ctrlKey||e.metaKey||e.altKey||this._isEditingContext())return;let t=this._rail;!t||t.scrollWidth<=t.clientWidth||(e.preventDefault(),this._step(e.key===`ArrowRight`?1:-1))}}navAction(e){e&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{}},bubbles:!0,composed:!0}))}_stride(){let e=this.renderRoot.querySelectorAll(`.section`);return e.length>1?e[1].offsetLeft:this._rail?.clientWidth??0}_boundaries(){let e=this._rail;if(!e)return[];let t=e.scrollWidth-e.clientWidth,n=[...this.renderRoot.querySelectorAll(`.section`)].map(e=>Math.max(0,Math.min(e.offsetLeft,t)));return[...new Set(n)]}_snapToNearest(){let e=this._rail;if(!e)return;let t=this._boundaries();if(!t.length)return;let n=t.reduce((t,n)=>Math.abs(n-e.scrollLeft)<Math.abs(t-e.scrollLeft)?n:t);Math.abs(n-e.scrollLeft)<1||(this._snapping=!0,e.scrollTo({left:n,behavior:`smooth`}),window.setTimeout(()=>{this._snapping=!1},400))}_syncPin(){let e=this._rail,t=this._first;if(!e||!t)return;let n=this._stride(),r=Math.min(e.scrollLeft,n);t.style.transform=r?`translateX(${r}px)`:``,t.classList.toggle(`floating`,e.scrollLeft>0);let i=e.scrollWidth-e.clientWidth,a=i>32;this._less=a&&e.scrollLeft>2,this._more=a&&e.scrollLeft<i-2}_step(e){let t=this._rail;if(!t)return;let n=this._boundaries();if(!n.length)return;let r=n.reduce((e,r,i)=>Math.abs(r-t.scrollLeft)<Math.abs(n[e]-t.scrollLeft)?i:e,0),i=n[Math.max(0,Math.min(r+e,n.length-1))];this._snapping=!0,t.scrollTo({left:i,behavior:`smooth`}),window.setTimeout(()=>{this._snapping=!1},400)}_isEditingContext(){let e=document.activeElement;for(;e&&e.shadowRoot&&e.shadowRoot.activeElement;)e=e.shadowRoot.activeElement;if(!e)return!1;let t=e.tagName;return t===`INPUT`||t===`TEXTAREA`||t===`SELECT`||e.isContentEditable}_sectionFlex(e,t){if(!e.width)return v;let n=parseFloat(e.width)||1;return t===this.panels.length-1&&n<22?`flex: 22 1 var(--mateu-foldout-overview-width, 22rem);`:`flex: ${n} 1 ${e.width};`}firstUpdated(){this._fit(),this._resizeObserver=new ResizeObserver(()=>this._syncPin()),this._rail&&this._resizeObserver.observe(this._rail);for(let e of this.renderRoot.querySelectorAll(`.section`))this._resizeObserver.observe(e)}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._onKeydown),window.addEventListener(`resize`,this._fit)}disconnectedCallback(){document.removeEventListener(`keydown`,this._onKeydown),window.removeEventListener(`resize`,this._fit),this._resizeObserver?.disconnect(),this._resizeObserver=void 0,this._raf&&=(cancelAnimationFrame(this._raf),0),super.disconnectedCallback()}static{this.styles=h`
+    `},$=class extends b{constructor(...e){super(...e),this.panels=[],this.headerTitle=``,this.badges=[],this.navigation=null,this.overviewEditActionId=``,this._raf=0,this._snapping=!1,this._less=!1,this._more=!1,this._onScroll=()=>{this._raf||=requestAnimationFrame(()=>{this._raf=0,this._syncPin()})},this._onScrollEnd=()=>{this._snapping||this._snapToNearest()},this._fit=()=>{let e=this.getBoundingClientRect().top;this.style.setProperty(`--mateu-foldout-fill`,`${Math.max(240,window.innerHeight-e)}px`),this._syncPin()},this._onKeydown=e=>{if(e.key!==`ArrowRight`&&e.key!==`ArrowLeft`||e.defaultPrevented||e.ctrlKey||e.metaKey||e.altKey||this._isEditingContext())return;let t=this._rail;!t||t.scrollWidth<=t.clientWidth||(e.preventDefault(),this._step(e.key===`ArrowRight`?1:-1))}}navAction(e){e&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{}},bubbles:!0,composed:!0}))}_stride(){let e=this.renderRoot.querySelectorAll(`.section`);return e.length>1?e[1].offsetLeft:this._rail?.clientWidth??0}_boundaries(){let e=this._rail;if(!e)return[];let t=e.scrollWidth-e.clientWidth,n=[...this.renderRoot.querySelectorAll(`.section`)].map(e=>Math.max(0,Math.min(e.offsetLeft,t)));return[...new Set(n)]}_snapToNearest(){let e=this._rail;if(!e)return;let t=this._boundaries();if(!t.length)return;let n=t.reduce((t,n)=>Math.abs(n-e.scrollLeft)<Math.abs(t-e.scrollLeft)?n:t);Math.abs(n-e.scrollLeft)<1||(this._snapping=!0,e.scrollTo({left:n,behavior:`smooth`}),window.setTimeout(()=>{this._snapping=!1},400))}_syncPin(){let e=this._rail,t=this._first;if(!e||!t)return;let n=this._stride(),r=Math.min(e.scrollLeft,n);t.style.transform=r?`translateX(${r}px)`:``,t.classList.toggle(`floating`,e.scrollLeft>0);let i=e.scrollWidth-e.clientWidth,a=i>32;this._less=a&&e.scrollLeft>2,this._more=a&&e.scrollLeft<i-2}_step(e){let t=this._rail;if(!t)return;let n=this._boundaries();if(!n.length)return;let r=n.reduce((e,r,i)=>Math.abs(r-t.scrollLeft)<Math.abs(n[e]-t.scrollLeft)?i:e,0),i=n[Math.max(0,Math.min(r+e,n.length-1))];this._snapping=!0,t.scrollTo({left:i,behavior:`smooth`}),window.setTimeout(()=>{this._snapping=!1},400)}_isEditingContext(){let e=document.activeElement;for(;e&&e.shadowRoot&&e.shadowRoot.activeElement;)e=e.shadowRoot.activeElement;if(!e)return!1;let t=e.tagName;return t===`INPUT`||t===`TEXTAREA`||t===`SELECT`||e.isContentEditable}_sectionFlex(e,t){if(!e.width)return v;let n=parseFloat(e.width)||1;return t===this.panels.length-1&&n<22?`flex: 22 1 var(--mateu-foldout-overview-width, 22rem);`:`flex: ${n} 1 ${e.width};`}firstUpdated(){this._fit(),this._resizeObserver=new ResizeObserver(()=>this._syncPin()),this._rail&&this._resizeObserver.observe(this._rail);for(let e of this.renderRoot.querySelectorAll(`.section`))this._resizeObserver.observe(e)}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._onKeydown),window.addEventListener(`resize`,this._fit)}disconnectedCallback(){document.removeEventListener(`keydown`,this._onKeydown),window.removeEventListener(`resize`,this._fit),this._resizeObserver?.disconnect(),this._resizeObserver=void 0,this._raf&&=(cancelAnimationFrame(this._raf),0),super.disconnectedCallback()}static{this.styles=h`
         :host {
             position: relative;
             display: flex;
@@ -10545,7 +10553,7 @@ ${i}
                     </svg>
                 </button>
             `:v}
-        `}};k([y({type:Array})],du.prototype,`panels`,void 0),k([y({type:String})],du.prototype,`headerTitle`,void 0),k([y({type:Array})],du.prototype,`badges`,void 0),k([y({attribute:!1})],du.prototype,`navigation`,void 0),k([y({type:String})],du.prototype,`overviewEditActionId`,void 0),k([x(`.rail`)],du.prototype,`_rail`,void 0),k([x(`.section--first`)],du.prototype,`_first`,void 0),k([C()],du.prototype,`_less`,void 0),k([C()],du.prototype,`_more`,void 0),du=k([g(`mateu-vaadin-foldout`)],du);var fu=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+        `}};k([y({type:Array})],$.prototype,`panels`,void 0),k([y({type:String})],$.prototype,`headerTitle`,void 0),k([y({type:Array})],$.prototype,`badges`,void 0),k([y({attribute:!1})],$.prototype,`navigation`,void 0),k([y({type:String})],$.prototype,`overviewEditActionId`,void 0),k([x(`.rail`)],$.prototype,`_rail`,void 0),k([x(`.section--first`)],$.prototype,`_first`,void 0),k([C()],$.prototype,`_less`,void 0),k([C()],$.prototype,`_more`,void 0),$=k([g(`mateu-vaadin-foldout`)],$);var fu=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
         <mateu-vaadin-foldout
                 .panels="${s.panels??[]}"
                 .headerTitle="${s.headerTitle??``}"
@@ -10556,7 +10564,7 @@ ${i}
                 class="${t.cssClasses}"
                 slot="${t.slot??v}"
         >
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
         </mateu-vaadin-foldout>
     `},pu=class extends b{constructor(...e){super(...e),this.rows=[],this.columns=[],this.navigable=!1,this.expandedItems=[],this._normalized=[],this.dataProvider=(e,t)=>{let n=e.parentItem?e.parentItem.children??[]:this.normalized;t(n,n.length)}}get normalized(){return this._src!==this.rows&&(this._src=this.rows,this._normalized=this.normalizeRows(this.rows??[])),this._normalized}normalizeRows(e){return(e??[]).map(e=>{let t=Array.isArray(e.children)&&e.children.length?this.normalizeRows(e.children):void 0;return{...e,children:t}})}collectGroups(e,t=[]){return e.forEach(e=>{e.children&&e.children.length&&(t.push(e),this.collectGroups(e.children,t))}),t}willUpdate(){this._expandedSrc!==this.rows&&(this._expandedSrc=this.rows,this.expandedItems=this.collectGroups(this.normalized))}updated(e){e.has(`rows`)&&this._grid?.clearCache?.()}dispatch(e,t){this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:t},bubbles:!0,composed:!0}))}render(){let e=this.columns??[],n=e[0],r=e.slice(1);return T`
             <vaadin-grid
@@ -10588,11 +10596,11 @@ ${i}
             max-height: min(60vh, 32rem);
             min-width: 22rem;
         }
-    `}};k([y({attribute:!1})],pu.prototype,`rows`,void 0),k([y({attribute:!1})],pu.prototype,`columns`,void 0),k([y()],pu.prototype,`idField`,void 0),k([y({type:Boolean})],pu.prototype,`navigable`,void 0),k([y()],pu.prototype,`selectedId`,void 0),k([C()],pu.prototype,`expandedItems`,void 0),k([x(`vaadin-grid`)],pu.prototype,`_grid`,void 0),pu=k([g(`mateu-vaadin-tree`)],pu);var mu={[j.VirtualList]:(e,t,n,r,i,a,o)=>Cc(e,t,n,r,i,a,o),[j.Notification]:(e,t)=>wc(t),[j.ProgressBar]:(e,t,n,r)=>Tc(t,r),[j.Details]:(e,t,n,r,i,a,o)=>Ec(e,t,n,r,i,a,o),[j.Avatar]:(e,t,n,r,i)=>Dc(t,r,i),[j.AvatarGroup]:(e,t)=>Oc(t),[j.Card]:(e,t,n,r,i,a,o)=>kc(e,t,n,r,i,a,o),[j.Button]:(e,t,n,r,i)=>ou(t,r,i),[j.MessageInput]:(e,t)=>su(t),[j.MessageList]:(e,t)=>cu(t),[j.ConfirmDialog]:(e,t,n,r,i,a,o)=>uu(e,t,n,r,i,a,o),[j.FormLayout]:(e,t,n,r,i,a,o)=>Mc(e,t,n,r,i,a,o),[j.HorizontalLayout]:(e,t,n,r,i,a,o)=>Ic(e,t,n,r,i,a,o),[j.VerticalLayout]:(e,t,n,r,i,a,o)=>Lc(e,t,n,r,i,a,o),[j.SplitLayout]:(e,t,n,r,i,a,o)=>Rc(e,t,n,r,i,a,o),[j.MasterDetailLayout]:(e,t,n,r,i,a,o)=>zc(e,t,n,r,i,a,o),[j.TabLayout]:(e,t,n,r,i,a,o)=>Bc(e,t,n,r,i,a,o),[j.AccordionLayout]:(e,t,n,r,i,a,o)=>Hc(e,t,n,r,i,a,o),[j.BoardLayout]:(e,t,n,r,i,a,o)=>Gc(e,t,n,r,i,a,o),[j.BoardLayoutRow]:(e,t,n,r,i,a,o)=>Kc(e,t,n,r,i,a,o),[j.BoardLayoutItem]:(e,t,n,r,i,a,o)=>qc(e,t,n,r,i,a,o),[j.Scroller]:(e,t,n,r,i,a,o)=>Wc(e,t,n,r,i,a,o),[j.MenuBar]:(e,t,n,r,i)=>Xc(e,t,n,r,i),[j.ContextMenu]:(e,t,n,r,i,a,o)=>Yc(e,t,n,r,i,a,o),[j.FormField]:(e,t,n,r,i,a,o,s)=>Zl(e,t,n,r,i,a,o,s),[j.Grid]:(e,t,n,r,i,a,o)=>Ql(e,t,n,r,i,a,o),[j.Table]:(e,t,n,r,i,a,o)=>$l(e,t,n,r,i,a,o),[j.Popover]:(e,t,n,r,i,a,o)=>tu(e,t,n,r,i,a,o),[j.FoldoutLayout]:(e,t,n,r,i,a,o)=>fu(e,t,n,r,i,a,o)},hu=class extends Sc{rendererName(){return`vaadin`}renderClientSideComponent(e,t,n,r,i,a,o,s){let c=t?.metadata?.type,l=c?mu[c]:void 0;return l&&t?l(e,t,n,r,i,a,o,s):super.renderClientSideComponent(e,t,n,r,i,a,o,s)}renderTableComponent(e,t,n,r,i,a,o){return eu(e,t,n,r,a,o)}renderTreeComponent(e,t){return T`
+    `}};k([y({attribute:!1})],pu.prototype,`rows`,void 0),k([y({attribute:!1})],pu.prototype,`columns`,void 0),k([y()],pu.prototype,`idField`,void 0),k([y({type:Boolean})],pu.prototype,`navigable`,void 0),k([y()],pu.prototype,`selectedId`,void 0),k([C()],pu.prototype,`expandedItems`,void 0),k([x(`vaadin-grid`)],pu.prototype,`_grid`,void 0),pu=k([g(`mateu-vaadin-tree`)],pu);var mu={[j.VirtualList]:(e,t,n,r,i,a,o)=>wc(e,t,n,r,i,a,o),[j.Notification]:(e,t)=>Tc(t),[j.ProgressBar]:(e,t,n,r)=>Ec(t,r),[j.Details]:(e,t,n,r,i,a,o)=>Dc(e,t,n,r,i,a,o),[j.Avatar]:(e,t,n,r,i)=>Oc(t,r,i),[j.AvatarGroup]:(e,t)=>kc(t),[j.Card]:(e,t,n,r,i,a,o)=>Ac(e,t,n,r,i,a,o),[j.Button]:(e,t,n,r,i)=>su(t,r,i),[j.MessageInput]:(e,t)=>cu(t),[j.MessageList]:(e,t)=>lu(t),[j.ConfirmDialog]:(e,t,n,r,i,a,o)=>du(e,t,n,r,i,a,o),[j.FormLayout]:(e,t,n,r,i,a,o)=>Nc(e,t,n,r,i,a,o),[j.HorizontalLayout]:(e,t,n,r,i,a,o)=>Lc(e,t,n,r,i,a,o),[j.VerticalLayout]:(e,t,n,r,i,a,o)=>Rc(e,t,n,r,i,a,o),[j.SplitLayout]:(e,t,n,r,i,a,o)=>zc(e,t,n,r,i,a,o),[j.MasterDetailLayout]:(e,t,n,r,i,a,o)=>Bc(e,t,n,r,i,a,o),[j.TabLayout]:(e,t,n,r,i,a,o)=>Vc(e,t,n,r,i,a,o),[j.AccordionLayout]:(e,t,n,r,i,a,o)=>Uc(e,t,n,r,i,a,o),[j.BoardLayout]:(e,t,n,r,i,a,o)=>Kc(e,t,n,r,i,a,o),[j.BoardLayoutRow]:(e,t,n,r,i,a,o)=>qc(e,t,n,r,i,a,o),[j.BoardLayoutItem]:(e,t,n,r,i,a,o)=>Jc(e,t,n,r,i,a,o),[j.Scroller]:(e,t,n,r,i,a,o)=>Gc(e,t,n,r,i,a,o),[j.MenuBar]:(e,t,n,r,i)=>Zc(e,t,n,r,i),[j.ContextMenu]:(e,t,n,r,i,a,o)=>Xc(e,t,n,r,i,a,o),[j.FormField]:(e,t,n,r,i,a,o,s)=>Ql(e,t,n,r,i,a,o,s),[j.Grid]:(e,t,n,r,i,a,o)=>$l(e,t,n,r,i,a,o),[j.Table]:(e,t,n,r,i,a,o)=>eu(e,t,n,r,i,a,o),[j.Popover]:(e,t,n,r,i,a,o)=>nu(e,t,n,r,i,a,o),[j.FoldoutLayout]:(e,t,n,r,i,a,o)=>fu(e,t,n,r,i,a,o)},hu=class extends Cc{rendererName(){return`vaadin`}renderClientSideComponent(e,t,n,r,i,a,o,s){let c=t?.metadata?.type,l=c?mu[c]:void 0;return l&&t?l(e,t,n,r,i,a,o,s):super.renderClientSideComponent(e,t,n,r,i,a,o,s)}renderTableComponent(e,t,n,r,i,a,o){return tu(e,t,n,r,a,o)}renderTreeComponent(e,t){return T`
             <mateu-vaadin-tree
                     .rows="${t.rows}"
                     .columns="${t.columns}"
                     .idField="${t.idField}"
                     .navigable="${t.navigable}"
                     .selectedId="${t.selectedId}"
-            ></mateu-vaadin-tree>`}renderToolbarButton(e,t,n){return nu(e,t,n)}renderPeerNav(e){return ru(e)}renderIcon(e,t,n){return au(e,t,n)}renderTopNav(e,t,n){return Jc(e,t,n)}};function gu(e){switch(e){case`topStretch`:return`top-stretch`;case`topStart`:return`top-start`;case`topCenter`:return`top-center`;case`topEnd`:return`top-end`;case`middle`:return`middle`;case`bottomStart`:return`bottom-start`;case`bottomEnd`:return`bottom-end`;case`bottomStretch`:return`bottom-stretch`;case`bottomCenter`:return`bottom-center`}return`bottom-end`}function _u(e,t){if(e.onAction)return{label:e.actionLabel??`Retry`,run:e.onAction};if(e.undoActionId)return{label:e.undoLabel??`Undo`,run:()=>t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.undoActionId,parameters:e.undoParameters??{}},bubbles:!0,composed:!0}))}}function vu(e,t){let n=new r;n.position=gu(e.position),n.duration=e.duration??1e4,e.variant&&n.setAttribute(`theme`,e.variant),n.renderer=r=>{if(r.firstElementChild)return;let i=document.createElement(`span`);i.textContent=e.text;let a=_u(e,t),o=document.createElement(`button`);o.textContent=a.label,o.style.cssText=`margin-left: 0.75rem; background: none; border: 1px solid currentColor; border-radius: var(--lumo-border-radius-s, 4px); color: inherit; cursor: pointer; padding: 0.15rem 0.6rem; font: inherit; font-weight: 600;`,o.addEventListener(`click`,()=>{a.run(),n.opened=!1}),r.append(i,o)},document.body.appendChild(n),n.opened=!0,n.addEventListener(`opened-changed`,e=>{e.detail.value||n.remove()})}F.set(new hu),Ma({show(e,t){if(gt(e.text,{politeness:e.variant===`error`?`assertive`:`polite`}),e.undoActionId||e.onAction){vu(e,t);return}r.show(e.text,{position:e.position?gu(e.position):`bottom-end`,theme:e.variant,duration:e.duration})}});
+            ></mateu-vaadin-tree>`}renderToolbarButton(e,t,n){return ru(e,t,n)}renderPeerNav(e){return iu(e)}renderIcon(e,t,n){return ou(e,t,n)}renderTopNav(e,t,n){return Yc(e,t,n)}};function gu(e){switch(e){case`topStretch`:return`top-stretch`;case`topStart`:return`top-start`;case`topCenter`:return`top-center`;case`topEnd`:return`top-end`;case`middle`:return`middle`;case`bottomStart`:return`bottom-start`;case`bottomEnd`:return`bottom-end`;case`bottomStretch`:return`bottom-stretch`;case`bottomCenter`:return`bottom-center`}return`bottom-end`}function _u(e,t){if(e.onAction)return{label:e.actionLabel??`Retry`,run:e.onAction};if(e.undoActionId)return{label:e.undoLabel??`Undo`,run:()=>t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.undoActionId,parameters:e.undoParameters??{}},bubbles:!0,composed:!0}))}}function vu(e,t){let n=new r;n.position=gu(e.position),n.duration=e.duration??1e4,e.variant&&n.setAttribute(`theme`,e.variant),n.renderer=r=>{if(r.firstElementChild)return;let i=document.createElement(`span`);i.textContent=e.text;let a=_u(e,t),o=document.createElement(`button`);o.textContent=a.label,o.style.cssText=`margin-left: 0.75rem; background: none; border: 1px solid currentColor; border-radius: var(--lumo-border-radius-s, 4px); color: inherit; cursor: pointer; padding: 0.15rem 0.6rem; font: inherit; font-weight: 600;`,o.addEventListener(`click`,()=>{a.run(),n.opened=!1}),r.append(i,o)},document.body.appendChild(n),n.opened=!0,n.addEventListener(`opened-changed`,e=>{e.detail.value||n.remove()})}P.set(new hu),Na({show(e,t){if(gt(e.text,{politeness:e.variant===`error`?`assertive`:`polite`}),e.undoActionId||e.onAction){vu(e,t);return}r.show(e.text,{position:e.position?gu(e.position):`bottom-end`,theme:e.variant,duration:e.duration})}});

--- a/demo/sites/vaadin/assets/mateu-vaadin.js
+++ b/demo/sites/vaadin/assets/mateu-vaadin.js
@@ -139,17 +139,17 @@ ${i}
             width: 100%;
             height: 100%;
         }
-    `}};k([y()],he.prototype,`position`,void 0),k([y()],he.prototype,`zoom`,void 0),k([x(`#map`)],he.prototype,`mapElement`,void 0),he=k([g(`mateu-map`)],he);var ge=typeof HTMLElement<`u`?HTMLElement:class{},_e=class extends ge{static get observedAttributes(){return[`content`]}#e;#t=0;get content(){return this.#e}set content(e){this.#e=e,this.#n()}attributeChangedCallback(e,t,n){this.content=n??void 0}connectedCallback(){this.style.display=`block`,this.#n()}async#n(){if(!this.isConnected)return;let e=this.#e??``,t=++this.#t,[{marked:n},{default:r}]=await Promise.all([D(()=>import(`./vendor.js`).then(e=>e.n),__vite__mapDeps([2,1])),D(()=>import(`./vendor.js`).then(e=>e.a),__vite__mapDeps([2,1]))]);t===this.#t&&(this.innerHTML=r.sanitize(await n.parse(e),{USE_PROFILES:{html:!0,svg:!0,svgFilters:!0},CUSTOM_ELEMENT_HANDLING:{tagNameCheck:e=>!0}}))}};typeof customElements<`u`&&!customElements.get(`mateu-markdown`)&&customElements.define(`mateu-markdown`,_e);var A=function(e){return e.ServerSide=`ServerSide`,e.ClientSide=`ClientSide`,e}({}),j=function(e){return e.Page=`Page`,e.Div=`Div`,e.Element=`Element`,e.MicroFrontend=`MicroFrontend`,e.Form=`Form`,e.Crud=`Crud`,e.Result=`Result`,e.Card=`Card`,e.Directory=`Directory`,e.Stepper=`Stepper`,e.HorizontalLayout=`HorizontalLayout`,e.VerticalLayout=`VerticalLayout`,e.SplitLayout=`SplitLayout`,e.MasterDetailLayout=`MasterDetailLayout`,e.TabLayout=`TabLayout`,e.AccordionLayout=`AccordionLayout`,e.FormLayout=`FormLayout`,e.FormRow=`FormRow`,e.FormItem=`FormItem`,e.BoardLayout=`BoardLayout`,e.BoardLayoutRow=`BoardLayoutRow`,e.BoardLayoutItem=`BoardLayoutItem`,e.Scroller=`Scroller`,e.FullWidth=`FullWidth`,e.Container=`Container`,e.FormField=`FormField`,e.Table=`Table`,e.App=`App`,e.Text=`Text`,e.Avatar=`Avatar`,e.Chat=`Chat`,e.AvatarGroup=`AvatarGroup`,e.Badge=`Badge`,e.Breadcrumbs=`Breadcrumbs`,e.Anchor=`Anchor`,e.Button=`Button`,e.Chart=`Chart`,e.Icon=`Icon`,e.ConfirmDialog=`ConfirmDialog`,e.ContextMenu=`ContextMenu`,e.CookieConsent=`CookieConsent`,e.Details=`Details`,e.Dialog=`Dialog`,e.Drawer=`Drawer`,e.Image=`Image`,e.Map=`Map`,e.Markdown=`Markdown`,e.Notification=`Notification`,e.ProgressBar=`ProgressBar`,e.Popover=`Popover`,e.CarouselLayout=`CarouselLayout`,e.Tooltip=`Tooltip`,e.MessageInput=`MessageInput`,e.MessageList=`MessageList`,e.CustomField=`CustomField`,e.MenuBar=`MenuBar`,e.Grid=`Grid`,e.GridColumn=`GridColumn`,e.GridGroupColumn=`GridGroupColumn`,e.VirtualList=`VirtualList`,e.FormSection=`FormSection`,e.FormSubSection=`FormSubSection`,e.Bpmn=`Bpmn`,e.Workflow=`Workflow`,e.FormEditor=`FormEditor`,e.MetricCard=`MetricCard`,e.Scoreboard=`Scoreboard`,e.DashboardPanel=`DashboardPanel`,e.DashboardLayout=`DashboardLayout`,e.FoldoutLayout=`FoldoutLayout`,e.ContentLayout=`ContentLayout`,e.HeroSection=`HeroSection`,e.EmptyState=`EmptyState`,e.Skeleton=`Skeleton`,e.Gantt=`Gantt`,e.PlanningBoard=`PlanningBoard`,e.Kanban=`Kanban`,e.Timeline=`Timeline`,e.ProgressSteps=`ProgressSteps`,e.Stat=`Stat`,e.Calendar=`Calendar`,e.PricingTable=`PricingTable`,e.OrgChart=`OrgChart`,e.Heatmap=`Heatmap`,e.Funnel=`Funnel`,e.TrendChart=`TrendChart`,e.FeatureGrid=`FeatureGrid`,e.Testimonials=`Testimonials`,e.Faq=`Faq`,e.CalloutCard=`CalloutCard`,e.CommentThread=`CommentThread`,e.FileList=`FileList`,e.Checklist=`Checklist`,e.ComparisonCard=`ComparisonCard`,e.EntityHeader=`EntityHeader`,e.Meter=`Meter`,e.TaskProgress=`TaskProgress`,e.StatusList=`StatusList`,e.BulletedList=`BulletedList`,e.Separator=`Separator`,e.Notice=`Notice`,e.TaskQueue=`TaskQueue`,e.ResourceGrid=`ResourceGrid`,e.OfferCard=`OfferCard`,e.AddOnPicker=`AddOnPicker`,e.Ledger=`Ledger`,e.PaymentPicker=`PaymentPicker`,e.ProcessMonitor=`ProcessMonitor`,e}({}),ve=`mateu-app-context`,ye=`mateu-app-context-labels`,be=e=>{try{return JSON.parse(localStorage.getItem(e)??`{}`)}catch{return{}}},xe=(e,t)=>{try{localStorage.setItem(e,JSON.stringify(t))}catch{}},Se=()=>be(ve),Ce=()=>be(ye),we=(e,t,n)=>{let r=Se(),i=Ce();t==null||t===``?(delete r[e],delete i[e]):(r[e]=t,n!==void 0&&(i[e]=n)),xe(ve,r),xe(ye,i)},Te=!1,Ee=()=>{Te||(Te=!0,window.addEventListener(`storage`,e=>{e.key===ve&&e.newValue!==e.oldValue&&window.location.reload()}))},De,Oe=(e,t)=>new Promise((n,r)=>{let i=!1,a={retry:()=>{i||(i=!0,t().then(n,r))},giveUp:()=>{i||(i=!0,r(e))}};if(De){De(a);return}let o=new CustomEvent(`mateu-session-expired`,{detail:a,cancelable:!0,bubbles:!1});typeof document<`u`&&!document.dispatchEvent(o)||a.giveUp()}),ke=(e,t)=>e.includes(`json`)?!0:typeof t==`object`&&!!t,Ae=(e,t)=>{let n=e.finalUrl;if(!n)return;let r=t??(typeof window<`u`?window.location.href:void 0),i;try{i=new URL(e.requestedUrl,r).href}catch{return}if(i!==n&&!ke(e.contentType??``,e.data))return n},je=new class{constructor(){this.windowMs=4e3,this.threshold=12,this.events=[],this.reported=new Set}check(e,t=Date.now()){this.events.push({sig:e,t});let n=t-this.windowMs;this.events=this.events.filter(e=>e.t>=n);let r=0;for(let t of this.events)t.sig===e&&r++;if(r>=this.threshold){let t=!this.reported.has(e);return this.reported.add(e),{blocked:!0,firstTrip:t}}return this.reported.delete(e),{blocked:!1,firstTrip:!1}}reset(){this.events=[],this.reported.clear()}configure(e){e.windowMs!==void 0&&(this.windowMs=e.windowMs),e.threshold!==void 0&&(this.threshold=e.threshold)}},Me=[],Ne=e=>{Me=Array.isArray(e)?e:[]},Pe=e=>e?Me.find(t=>t.name===e):void 0,Fe=e=>e==null||e===``,Ie=e=>{if(!e?.ref)return e;let t=Pe(e.ref);if(!t?.source)return console.warn(`mateu: no REST source named "${e.ref}" in the app's catalogue`),e;let n=t.source;return{...e,url:Fe(e.url)?n.url:e.url,method:Fe(e.method)?n.method:e.method,headers:e.headers&&Object.keys(e.headers).length>0?e.headers:n.headers,body:Fe(e.body)?n.body:e.body,itemsPath:Fe(e.itemsPath)?n.itemsPath:e.itemsPath,valuePath:Fe(e.valuePath)?n.valuePath:e.valuePath,labelPath:Fe(e.labelPath)?n.labelPath:e.labelPath,proxy:e.proxy||n.proxy}},Le=(e,t)=>{let n=Pe(e?.ref)?.fields?.[t];return n&&n!==``?n:t},Re,ze=[],Be,Ve=[],He=e=>e.split(`/`).filter(e=>e.startsWith(`:`)&&e.length>1).map(e=>e.substring(1)),Ue=e=>{let t=e=>e.replace(/^\/+/,``).replace(/\/+$/,``),n=t(e===`_no_route`?``:e),r=n===``?[]:n.split(`/`),i;for(let e of Ve){let n=t(e.route??``),a=n===``?[]:n.split(`/`);if(a.length!==r.length)continue;let o={},s=!0;for(let e=0;e<a.length;e++){let t=a[e];if(t.startsWith(`:`)&&t.length>1)o[t.substring(1)]=r[e];else if(t!==r[e]){s=!1;break}}if(!s)continue;let c={entry:e,pathParams:o};(!i||He(n).length<He(t(i.entry.route??``)).length)&&(i=c)}return i},We=(e,t)=>{let n=Ue(e);if(!n)return t;let{entry:r,pathParams:i}=n,a=r.defaultParams??{},o=r.fixedParams??{};return!Object.keys(a).length&&!Object.keys(o).length&&!Object.keys(i).length?t:{...t,fragments:(t.fragments??[]).map(e=>({...e,state:{...a,...e.state??{},...i,...o},data:{...a,...e.data??{},...i,...o}}))}},Ge=e=>{let t=e&&e.startsWith(`/`)?e.substring(1):e??``;return t===``?`_no_route`:t};function Ke(e,t=fetch){return Be=(async()=>{try{let n=await t(e);if(!n.ok)return;let r=await n.json(),i=new Map,a=[];for(let e of r.entries??[])if(!(!e.ok||!e.json))try{let t=JSON.parse(e.json);e.routePattern?a.push({regex:new RegExp(e.routePattern),paramNames:e.paramNames??[],increment:t}):i.set(e.syncPath,t)}catch(t){console.warn(`mateu: bundle entry parse failed for`,e.syncPath,t)}Re=i,ze=a,Ve=r.routes?.routes??[],Ne(r.sources?.sources)}catch(e){console.warn(`mateu: bundle manifest load failed`,e)}})(),Be}var qe=()=>Be??Promise.resolve(),Je=()=>Re!==void 0&&Re.size>0||ze.length>0,Ye=e=>{let t=Re?.get(e);return t===void 0?void 0:We(e,t)},Xe=e=>{for(let t of ze){let n=t.regex.exec(e);if(!n)continue;let r={};return t.paramNames.forEach((e,t)=>{r[e]=n[t+1]}),We(e,{...t.increment,fragments:(t.increment.fragments??[]).map(e=>({...e,state:{...e.state??{},...r},data:{...e.data??{},...r}}))})}},Ze={offline:()=>`No connection. Your changes have not been sent — check your network and try again.`,timeout:()=>`The server is taking too long to answer. Your changes may not have been saved.`,server:e=>`The server could not complete the request${e?` (error ${e})`:``}. Please try again.`,unauthorized:()=>`Your session is no longer valid. Please sign in again.`,notFound:()=>`This is no longer available. It may have been moved or deleted.`,client:e=>`The request was rejected${e?` (error ${e})`:``}.`,cancelled:()=>``,unknown:()=>`Something went wrong. Please try again.`},Qe=new Set([`offline`,`timeout`,`server`]),$e=(e,t={})=>{let n=e??{},r=n.response?.status,i=n.code,a=t.online??(typeof navigator<`u`&&typeof navigator.onLine==`boolean`?navigator.onLine:!0),o=e=>({kind:e,message:Ze[e](r),retryable:Qe.has(e),status:r});return i===`ERR_CANCELED`?o(`cancelled`):i===`ECONNABORTED`||i===`ETIMEDOUT`||/timeout/i.test(n.message??``)?o(`timeout`):r===void 0?!a||i===`ERR_NETWORK`||/network error/i.test(n.message??``)?o(`offline`):o(`unknown`):o(r===401||r===403?`unauthorized`:r===404||r===410?`notFound`:r===408||r===429?`timeout`:r>=500?`server`:r>=400?`client`:`unknown`)},et=new Set([``,`__load__`,`search`,`_globalsearch`,`_notifications-list`]),tt=[`_appcontext-search-`,`search-`],nt=(e,t)=>t===!0?!0:e==null?!1:et.has(e)?!0:tt.some(t=>e.startsWith(t)),rt=(e,t=Math.random)=>{let n=300*3**Math.max(0,e-1);return Math.round(n*(.75+t()*.5))},it=(e,t,n)=>!n.idempotent||t>2||!e.retryable?!1:e.kind===`timeout`||e.kind===`server`,at=new class{constructor(){this.linkUp=!0,this.listeners=new Set,this.waiters=new Set,this.started=!1}start(){this.started||typeof window>`u`||(this.started=!0,this.linkUp=typeof navigator<`u`&&typeof navigator.onLine==`boolean`?navigator.onLine:!0,window.addEventListener(`online`,()=>{this.linkUp=!0,this.reachable=void 0,this.changed(),this.releaseWaiters()}),window.addEventListener(`offline`,()=>{this.linkUp=!1,this.changed()}))}isOnline(){return this.linkUp?this.reachable!==!1:!1}noteReachable(){let e=this.isOnline();this.reachable=!0,e||(this.changed(),this.releaseWaiters())}noteUnreachable(){let e=this.isOnline();this.reachable=!1,e&&this.changed()}subscribe(e){return this.listeners.add(e),()=>this.listeners.delete(e)}whenBack(e){return this.isOnline()?(e(),()=>{}):(this.waiters.add(e),()=>this.waiters.delete(e))}reset(){this.linkUp=!0,this.reachable=void 0,this.waiters.clear()}changed(){let e=this.isOnline();this.listeners.forEach(t=>t(e))}releaseWaiters(){let e=Array.from(this.waiters);this.waiters.clear(),e.forEach(e=>e())}};at.start();var ot=[],st=6e4,ct=e=>new Promise(t=>setTimeout(t,e)),lt=new class{constructor(){this.axiosInstance=ae.create({timeout:st}),this.axiosInstance.interceptors.request.use(e=>(this.addAuthToken(e),this.addSessionId(e),e)),this.axiosInstance.interceptors.response.use(e=>{let t=Ae({requestedUrl:this.axiosInstance.getUri(e.config),finalUrl:e.request?.responseURL,contentType:String(e.headers?.[`content-type`]??``),data:e.data});if(t)throw window.location.assign(t),Object.assign(Error(`session lost — redirecting to `+t),{code:`ERR_CANCELED`});return e},e=>{let t=e;if(t?.response?.status===401&&t.config&&!t.config.__mateuRetried){let n=t.config;return n.__mateuRetried=!0,Oe(e,()=>this.axiosInstance.request(n))}throw e})}addSessionId(e){let t=sessionStorage.getItem(`__mateu_sesion_id`);t||(t=E(),sessionStorage.setItem(`__mateu_sesion_id`,t)),e.headers[`X-Session-Id`]=t}addAuthToken(e){let t=localStorage.getItem(`__mateu_auth_token`);t&&(e.headers.Authorization=`Bearer `+t)}async wrap(e,t,n,r,i){return n||t.dispatchEvent(new CustomEvent(`backend-called-event`,{bubbles:!0,composed:!0,detail:{}})),e().then(e=>(t.dispatchEvent(new CustomEvent(`backend-succeeded-event`,{bubbles:!0,composed:!0,detail:{actionId:r}})),e)).catch(e=>{let n=$e(e,{online:at.isOnline()});throw n.kind==`cancelled`?t.dispatchEvent(new CustomEvent(`backend-cancelled-event`,{bubbles:!0,composed:!0,detail:{actionId:r}})):(e&&typeof e==`object`&&(e.__mateuReported=!0),t.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:r,reason:this.serialize(e),failure:n,retry:i}}))),e})}async sendWithRetry(e,t){let n=0;for(;;)try{let t=await e();return at.noteReachable(),t}catch(e){let r=$e(e,{online:at.isOnline()});if(r.kind==`offline`&&at.noteUnreachable(),n++,!it(r,n,{idempotent:t}))throw e;await ct(rt(n))}}serialize(e){return e?.message?e:JSON.stringify(e)}release(e){ot=ot.filter(t=>t!==e)}async get(e){let t=new AbortController;return ot=[...ot,t],this.axiosInstance.get(e,{signal:t.signal}).finally(()=>this.release(t))}async post(e,t,n){let r=new AbortController;return ot=[...ot,r],this.axiosInstance.post(e,t,{signal:r.signal,...n&&n>0?{timeout:n}:{}}).finally(()=>this.release(r))}async abortAll(){ot.forEach(e=>e.abort()),ot=[]}async runAction(e,t,n,r,i,a,o,s,c,l,u,d={}){if(t&&t.startsWith(`/`)&&(t=t.substring(1)),r===``&&(await qe(),Je())){let e=Ye(Ge(t))??Xe(Ge(t));if(e){let t={...e,fragments:(e.fragments??[]).map(e=>e.targetComponentId?e:{...e,targetComponentId:i})};return await this.wrap(()=>Promise.resolve(t),l,u,r,d.retry)}}let f=[e,t,n,o??``,r,i].join(``),p=je.check(f);if(p.blocked)return await this.abortAll(),p.firstTrip&&console.error(`[mateu] request loop detected — aborting repeated request`,f),{messages:p.firstTrip?[{title:``,text:`A repeating request was detected and stopped to protect the server. Reload the page or navigate elsewhere.`,position:`bottom-end`,variant:`error`,duration:6e3}]:[],commands:[],fragments:[],banners:[],appendBanners:!1,appData:void 0,appState:void 0};a={...Se(),...a};let ee=e+`/mateu/v3/sync/`+(t&&t!=``?t:`_no_route`),m={serverSideType:o,appState:a,componentState:s,parameters:c,initiatorComponentId:i,consumedRoute:n,route:t&&t!=``?`/`+t:``,actionId:r,knownStructureHash:d.knownStructureHash},te=nt(r,d.idempotent),ne=()=>this.post(ee,m,d.timeoutMillis).then(e=>e.data);return await this.wrap(()=>this.sendWithRetry(ne,te),l,u,r,d.retry)}},ut=function(e){return e.Add=`Add`,e.Replace=`Replace`,e.ReplaceKeepData=`ReplaceKeepData`,e}({}),dt=function(e){return e.HAMBURGUER_MENU=`HAMBURGUER_MENU`,e.MENU_ON_LEFT=`MENU_ON_LEFT`,e.MENU_ON_TOP=`MENU_ON_TOP`,e.TABS=`TABS`,e.TILES=`TILES`,e.RAIL=`RAIL`,e.AUTO=`AUTO`,e.MEDIATOR=`MEDIATOR`,e}({}),ft=new Map,pt=[`position:absolute`,`width:1px`,`height:1px`,`margin:-1px`,`padding:0`,`overflow:hidden`,`clip:rect(0 0 0 0)`,`clip-path:inset(50%)`,`white-space:nowrap`,`border:0`].join(`;`),mt=e=>{if(typeof document>`u`||!document.body)return;let t=ft.get(e);return t?.isConnected?t:(t=document.createElement(`div`),t.setAttribute(`aria-live`,e),t.setAttribute(`aria-atomic`,`true`),t.setAttribute(`role`,e===`assertive`?`alert`:`status`),t.setAttribute(`data-mateu-live-region`,e),t.style.cssText=pt,document.body.appendChild(t),ft.set(e,t),t)},ht=()=>{if(!(typeof document>`u`)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>ht(),{once:!0});return}mt(`polite`),mt(`assertive`)}},gt=(e,t={})=>{let n=(e??``).trim();if(!n)return;let r=mt(t.politeness??`polite`);if(r){if(r.textContent===n){r.textContent=``,setTimeout(()=>{r.textContent=n},60);return}r.textContent=n}},_t=class extends b{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.callbackToken=``,this.createElement=e=>{let t=e.data,n=document.createElement(t.name);for(let e in t.attributes)n.setAttribute(e,t.attributes[e]);for(let e in t.on)n.addEventListener(e,n=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.on[e],parameters:{event:n}},bubbles:!0,composed:!0}))});return n},this.closeModal=()=>{let e=(this.shadowRoot??this).querySelectorAll(`mateu-dialog, mateu-drawer`);if(e&&e.length>0){e[e.length-1].close();return}this.dispatchEvent(new CustomEvent(`close-modal-requested`,{bubbles:!0,composed:!0}))},this.changeFavicon=e=>{let t=document.querySelector(`link[rel="icon"]`);t===null?(t=document.createElement(`link`),t.setAttribute(`rel`,`icon`),t.setAttribute(`href`,e),document.head.appendChild(t)):t.setAttribute(`href`,e)}}connectedCallback(){super.connectedCallback(),this.upstreamSubscription=le.subscribe(e=>{if(e.command){let t=e.command;this.id==t.targetComponentId&&this.applyCommand(t)}if((!e.callbackToken||!this.callbackToken||e.callbackToken===this.callbackToken)&&e.fragment){let t=e.fragment;this.id==t.targetComponentId&&(this.applyFragment(t),this.completeMenu(t))}})}completeMenu(e){if(e.component&&e.component.type==A.ClientSide){let t=e.component,n=t.metadata;if(n?.type==j.App){let e=n,r=this.getRemoteMenus(e.menu);if(r.length>0){let n=r.map(e=>lt.runAction(e.baseUrl,e.route,`_empty`,``,e.baseUrl+`#`+e.route,void 0,void 0,void 0,e.params,this,!0));Promise.all(n).then(n=>{e.menu=this.updateMenu(e.menu,n.map(e=>e.fragments).filter(e=>e).map(e=>e).flat()),e.variant=dt.MENU_ON_TOP,le.next({fragment:{component:t,data:void 0,state:void 0,action:ut.Replace,targetComponentId:this.id,containerId:void 0},callbackToken:this.callbackToken})})}}}}updateMenu(e,t){let n=[];return e.forEach(e=>{if(e.remote){let r=t.find(t=>t.targetComponentId==e.baseUrl+`#`+e.route);if(r&&r.component?.type==A.ClientSide){let t=r.component;if(t.metadata?.type==j.App){let r=t.metadata,i=e.serverSideType&&e.serverSideType!=``?e.serverSideType:r.serverSideType;this.changeBaseUrl(r.menu,e.baseUrl,i,e.route,r.route),n.push(...r.menu)}}}else n.push(e)}),n}changeBaseUrl(e,t,n,r,i){e.forEach(e=>{e.baseUrl||(e.submenus&&e.submenus.length>0?this.changeBaseUrl(e.submenus,t,n,r,i):(e.consumedRoute=i??``,e.baseUrl=t,e.serverSideType=n,e.uriPrefix=r))})}getRemoteMenus(e){let t=[];return e.forEach(e=>{e.remote&&t.push(e)}),t}disconnectedCallback(){super.disconnectedCallback(),this.upstreamSubscription?.unsubscribe()}applyCommand(e){if(e.type==`SetWindowTitle`&&(document.title=e.data,gt(document.title)),e.type==`SetFavicon`&&this.changeFavicon(e.data),e.type==`DispatchEvent`&&this.dispatchNamedEvent(e.data),e.type==`NavigateTo`){let t=e.data;t&&(t.startsWith(`http:`)||t.startsWith(`https:`)?window.open(e.data,`_blank`):window.location.href=e.data)}if(e.type==`PushStateToHistory`){let t=e.data;t!==void 0&&this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0}))}if(e.type==`RunAction`){let t=e.data;if(t&&t.actionId)if(t.targetComponentId){let e={command:{type:`RunAction`,data:{actionId:t.actionId},targetComponentId:t.targetComponentId},fragment:void 0,ui:void 0,error:void 0,callbackToken:``};setTimeout(()=>le.next(e))}else this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:{}},bubbles:!0,composed:!0}))}if(e.type==`MarkAsDirty`&&this.dispatchEvent(new CustomEvent(`dirty`,{detail:{},bubbles:!0,composed:!0})),e.type==`MarkAsClean`&&this.dispatchEvent(new CustomEvent(`clean`,{detail:{},bubbles:!0,composed:!0})),e.type==`DownloadFile`){let t=e.data;if(t&&t.base64Content){let e=atob(t.base64Content),n=new Uint8Array(e.length);for(let t=0;t<e.length;t++)n[t]=e.charCodeAt(t);let r=new Blob([n],{type:t.mimeType}),i=URL.createObjectURL(r),a=document.createElement(`a`);a.href=i,a.download=t.filename??`export`,a.click(),URL.revokeObjectURL(i)}}if(e.type==`CloseModal`&&(this.closeModal(),this.dispatchNamedEvent(e.data)),e.type==`AddContentToHead`){let t=e.data;if(t&&t.name){if(t.attributes&&t.attributes.id&&document.getElementById(t.attributes.id))return;document.head.appendChild(this.createElement(e))}}if(e.type==`AddContentToBody`){let t=e.data;if(t&&t.name){if(t.attributes&&t.attributes.id&&document.getElementById(t.attributes.id))return;document.body.appendChild(this.createElement(e))}}}dispatchNamedEvent(e){if(e&&e.eventName){let t=this.component,n=t?.emitsName??t?.serverSideType,r=e.payload??e.detail;n&&r&&typeof r==`object`&&(r={...r,__source:n}),this.dispatchEvent(new CustomEvent(e.eventName,{detail:r,bubbles:!0,composed:!0}))}}};k([y()],_t.prototype,`id`,void 0),k([y()],_t.prototype,`baseUrl`,void 0);var vt=class extends _t{applyFragment(e){}manageActionRequestedEvent(e){}};k([y()],vt.prototype,`component`,void 0);var yt=(e,t)=>Function(...Object.keys(t),"return `"+e+"`")(...Object.values(t)),bt=(e,t,n)=>({state:e??{},data:t??{},...n});function M(e,t,n,r){if(!e?.includes("${"))return e;try{return yt(e,bt(t,n,r))}catch(t){return console.warn(`Mateu: could not interpolate "${e}":`,t),e}}var N=(e,t,n)=>{if(e&&e.indexOf("${")>=0)try{return yt(e,bt(t,n))}catch(e){return e.message}return e},xt=(e,t,n,r,i)=>{if(!e)return e;let a=bt(t,n,{appState:r??{},appData:i??{}}),o=e;try{if(o=yt(e,a),o.includes("${"))try{o=yt(o,a)}catch(a){o=`when evaluating nested `+e+` :`+a+`, where data is `+n+` and state is `+t+` and app state is `+r+` and app data is `+i,console.error(a,o,t,n,r,i)}}catch(a){o=`when evaluating `+e+` :`+a+`, where data is `+n+` and state is `+t+` and app state is `+r+` and app data is `+i,console.error(a,o,t,n,r,i)}return o},St=(e,t,n,r,i,a)=>{let o=bt(t,n,{appState:r??{},appData:i??{},...a}),s=yt(e,o);return Function(...Object.keys(o),`return (${s})`)(...Object.values(o))},Ct=(e,t,n,r)=>{let i=bt(t,n,r);return Function(...Object.keys(i),`return (${e})`)(...Object.values(i))},wt=(e,t,n,r)=>yt(e,bt(t,n,r)),Tt=`display:inline-flex; align-items:center; justify-content:center; width:2rem; height:2rem; border-radius:50%; background:var(--lumo-contrast-10pct,#e0e0e0); color:var(--lumo-secondary-text-color,#555); font-size:.8rem; font-weight:600; overflow:hidden; flex:none;`,Et=(e,t)=>t||(typeof e==`string`&&e?e.trim().split(/\s+/).map(e=>e[0]).slice(0,2).join(``).toUpperCase():``),Dt=(e,t,n)=>{let r=e.metadata,i=P(r.name,t,n);return T`<span style="${Tt}${e.style}" class="${e.cssClasses}"
+    `}};k([y()],he.prototype,`position`,void 0),k([y()],he.prototype,`zoom`,void 0),k([x(`#map`)],he.prototype,`mapElement`,void 0),he=k([g(`mateu-map`)],he);var ge=typeof HTMLElement<`u`?HTMLElement:class{},_e=class extends ge{static get observedAttributes(){return[`content`]}#e;#t=0;get content(){return this.#e}set content(e){this.#e=e,this.#n()}attributeChangedCallback(e,t,n){this.content=n??void 0}connectedCallback(){this.style.display=`block`,this.#n()}async#n(){if(!this.isConnected)return;let e=this.#e??``,t=++this.#t,[{marked:n},{default:r}]=await Promise.all([D(()=>import(`./vendor.js`).then(e=>e.n),__vite__mapDeps([2,1])),D(()=>import(`./vendor.js`).then(e=>e.a),__vite__mapDeps([2,1]))]);t===this.#t&&(this.innerHTML=r.sanitize(await n.parse(e),{USE_PROFILES:{html:!0,svg:!0,svgFilters:!0},CUSTOM_ELEMENT_HANDLING:{tagNameCheck:e=>!0}}))}};typeof customElements<`u`&&!customElements.get(`mateu-markdown`)&&customElements.define(`mateu-markdown`,_e);var A=function(e){return e.ServerSide=`ServerSide`,e.ClientSide=`ClientSide`,e}({}),j=function(e){return e.Page=`Page`,e.Div=`Div`,e.Element=`Element`,e.MicroFrontend=`MicroFrontend`,e.Form=`Form`,e.Crud=`Crud`,e.Result=`Result`,e.Card=`Card`,e.Directory=`Directory`,e.Stepper=`Stepper`,e.HorizontalLayout=`HorizontalLayout`,e.VerticalLayout=`VerticalLayout`,e.SplitLayout=`SplitLayout`,e.MasterDetailLayout=`MasterDetailLayout`,e.TabLayout=`TabLayout`,e.AccordionLayout=`AccordionLayout`,e.FormLayout=`FormLayout`,e.FormRow=`FormRow`,e.FormItem=`FormItem`,e.BoardLayout=`BoardLayout`,e.BoardLayoutRow=`BoardLayoutRow`,e.BoardLayoutItem=`BoardLayoutItem`,e.Scroller=`Scroller`,e.FullWidth=`FullWidth`,e.Container=`Container`,e.FormField=`FormField`,e.Table=`Table`,e.App=`App`,e.Text=`Text`,e.Avatar=`Avatar`,e.Chat=`Chat`,e.AvatarGroup=`AvatarGroup`,e.Badge=`Badge`,e.Breadcrumbs=`Breadcrumbs`,e.Anchor=`Anchor`,e.Button=`Button`,e.Chart=`Chart`,e.Icon=`Icon`,e.ConfirmDialog=`ConfirmDialog`,e.ContextMenu=`ContextMenu`,e.CookieConsent=`CookieConsent`,e.Details=`Details`,e.Dialog=`Dialog`,e.Drawer=`Drawer`,e.Image=`Image`,e.Map=`Map`,e.Markdown=`Markdown`,e.Notification=`Notification`,e.ProgressBar=`ProgressBar`,e.Popover=`Popover`,e.CarouselLayout=`CarouselLayout`,e.Tooltip=`Tooltip`,e.MessageInput=`MessageInput`,e.MessageList=`MessageList`,e.CustomField=`CustomField`,e.MenuBar=`MenuBar`,e.Grid=`Grid`,e.GridColumn=`GridColumn`,e.GridGroupColumn=`GridGroupColumn`,e.VirtualList=`VirtualList`,e.FormSection=`FormSection`,e.FormSubSection=`FormSubSection`,e.Bpmn=`Bpmn`,e.Workflow=`Workflow`,e.FormEditor=`FormEditor`,e.MetricCard=`MetricCard`,e.Scoreboard=`Scoreboard`,e.DashboardPanel=`DashboardPanel`,e.DashboardLayout=`DashboardLayout`,e.FoldoutLayout=`FoldoutLayout`,e.ContentLayout=`ContentLayout`,e.HeroSection=`HeroSection`,e.EmptyState=`EmptyState`,e.Skeleton=`Skeleton`,e.Gantt=`Gantt`,e.PlanningBoard=`PlanningBoard`,e.Kanban=`Kanban`,e.Timeline=`Timeline`,e.ProgressSteps=`ProgressSteps`,e.Stat=`Stat`,e.Calendar=`Calendar`,e.PricingTable=`PricingTable`,e.OrgChart=`OrgChart`,e.Heatmap=`Heatmap`,e.Funnel=`Funnel`,e.TrendChart=`TrendChart`,e.FeatureGrid=`FeatureGrid`,e.Testimonials=`Testimonials`,e.Faq=`Faq`,e.CalloutCard=`CalloutCard`,e.CommentThread=`CommentThread`,e.FileList=`FileList`,e.Checklist=`Checklist`,e.ComparisonCard=`ComparisonCard`,e.EntityHeader=`EntityHeader`,e.Meter=`Meter`,e.TaskProgress=`TaskProgress`,e.StatusList=`StatusList`,e.BulletedList=`BulletedList`,e.Separator=`Separator`,e.Notice=`Notice`,e.TaskQueue=`TaskQueue`,e.ResourceGrid=`ResourceGrid`,e.OfferCard=`OfferCard`,e.AddOnPicker=`AddOnPicker`,e.Ledger=`Ledger`,e.PaymentPicker=`PaymentPicker`,e.ProcessMonitor=`ProcessMonitor`,e}({}),ve=`mateu-app-context`,ye=`mateu-app-context-labels`,be=e=>{try{return JSON.parse(localStorage.getItem(e)??`{}`)}catch{return{}}},xe=(e,t)=>{try{localStorage.setItem(e,JSON.stringify(t))}catch{}},Se=()=>be(ve),Ce=()=>be(ye),we=(e,t,n)=>{let r=Se(),i=Ce();t==null||t===``?(delete r[e],delete i[e]):(r[e]=t,n!==void 0&&(i[e]=n)),xe(ve,r),xe(ye,i)},Te=!1,Ee=()=>{Te||(Te=!0,window.addEventListener(`storage`,e=>{e.key===ve&&e.newValue!==e.oldValue&&window.location.reload()}))},De,Oe=(e,t)=>new Promise((n,r)=>{let i=!1,a={retry:()=>{i||(i=!0,t().then(n,r))},giveUp:()=>{i||(i=!0,r(e))}};if(De){De(a);return}let o=new CustomEvent(`mateu-session-expired`,{detail:a,cancelable:!0,bubbles:!1});typeof document<`u`&&!document.dispatchEvent(o)||a.giveUp()}),ke=(e,t)=>e.includes(`json`)?!0:typeof t==`object`&&!!t,Ae=(e,t)=>{let n=e.finalUrl;if(!n)return;let r=t??(typeof window<`u`?window.location.href:void 0),i;try{i=new URL(e.requestedUrl,r).href}catch{return}if(i!==n&&!ke(e.contentType??``,e.data))return n},je=new class{constructor(){this.windowMs=4e3,this.threshold=12,this.events=[],this.reported=new Set}check(e,t=Date.now()){this.events.push({sig:e,t});let n=t-this.windowMs;this.events=this.events.filter(e=>e.t>=n);let r=0;for(let t of this.events)t.sig===e&&r++;if(r>=this.threshold){let t=!this.reported.has(e);return this.reported.add(e),{blocked:!0,firstTrip:t}}return this.reported.delete(e),{blocked:!1,firstTrip:!1}}reset(){this.events=[],this.reported.clear()}configure(e){e.windowMs!==void 0&&(this.windowMs=e.windowMs),e.threshold!==void 0&&(this.threshold=e.threshold)}},Me=[],Ne=e=>{Me=Array.isArray(e)?e:[]},Pe=e=>e?Me.find(t=>t.name===e):void 0,Fe=e=>e==null||e===``,Ie=e=>{if(!e?.ref)return e;let t=Pe(e.ref);if(!t?.source)return console.warn(`mateu: no REST source named "${e.ref}" in the app's catalogue`),e;let n=t.source;return{...e,url:Fe(e.url)?n.url:e.url,method:Fe(e.method)?n.method:e.method,headers:e.headers&&Object.keys(e.headers).length>0?e.headers:n.headers,body:Fe(e.body)?n.body:e.body,itemsPath:Fe(e.itemsPath)?n.itemsPath:e.itemsPath,valuePath:Fe(e.valuePath)?n.valuePath:e.valuePath,labelPath:Fe(e.labelPath)?n.labelPath:e.labelPath,proxy:e.proxy||n.proxy}},Le=(e,t)=>{let n=Pe(e?.ref)?.fields?.[t];return n&&n!==``?n:t},Re,ze=[],Be,Ve=[],He=e=>e.split(`/`).filter(e=>e.startsWith(`:`)&&e.length>1).map(e=>e.substring(1)),Ue=e=>{let t=e=>e.replace(/^\/+/,``).replace(/\/+$/,``),n=t(e===`_no_route`?``:e),r=n===``?[]:n.split(`/`),i;for(let e of Ve){let n=t(e.route??``),a=n===``?[]:n.split(`/`);if(a.length!==r.length)continue;let o={},s=!0;for(let e=0;e<a.length;e++){let t=a[e];if(t.startsWith(`:`)&&t.length>1)o[t.substring(1)]=r[e];else if(t!==r[e]){s=!1;break}}if(!s)continue;let c={entry:e,pathParams:o};(!i||He(n).length<He(t(i.entry.route??``)).length)&&(i=c)}return i},We=(e,t)=>{let n=Ue(e);if(!n)return t;let{entry:r,pathParams:i}=n,a=r.defaultParams??{},o=r.fixedParams??{};return!Object.keys(a).length&&!Object.keys(o).length&&!Object.keys(i).length?t:{...t,fragments:(t.fragments??[]).map(e=>({...e,state:{...a,...e.state??{},...i,...o},data:{...a,...e.data??{},...i,...o}}))}},Ge=e=>{let t=e&&e.startsWith(`/`)?e.substring(1):e??``;return t===``?`_no_route`:t};function Ke(e,t=fetch){return Be=(async()=>{try{let n=await t(e);if(!n.ok)return;let r=await n.json(),i=new Map,a=[];for(let e of r.entries??[])if(!(!e.ok||!e.json))try{let t=JSON.parse(e.json);e.routePattern?a.push({regex:new RegExp(e.routePattern),paramNames:e.paramNames??[],increment:t}):i.set(e.syncPath,t)}catch(t){console.warn(`mateu: bundle entry parse failed for`,e.syncPath,t)}Re=i,ze=a,Ve=r.routes?.routes??[],Ne(r.sources?.sources)}catch(e){console.warn(`mateu: bundle manifest load failed`,e)}})(),Be}var qe=()=>Be??Promise.resolve(),Je=()=>Re!==void 0&&Re.size>0||ze.length>0,Ye=e=>{let t=Re?.get(e);return t===void 0?void 0:We(e,t)},Xe=e=>{for(let t of ze){let n=t.regex.exec(e);if(!n)continue;let r={};return t.paramNames.forEach((e,t)=>{r[e]=n[t+1]}),We(e,{...t.increment,fragments:(t.increment.fragments??[]).map(e=>({...e,state:{...e.state??{},...r},data:{...e.data??{},...r}}))})}},Ze={offline:()=>`No connection. Your changes have not been sent — check your network and try again.`,timeout:()=>`The server is taking too long to answer. Your changes may not have been saved.`,server:e=>`The server could not complete the request${e?` (error ${e})`:``}. Please try again.`,unauthorized:()=>`Your session is no longer valid. Please sign in again.`,notFound:()=>`This is no longer available. It may have been moved or deleted.`,client:e=>`The request was rejected${e?` (error ${e})`:``}.`,cancelled:()=>``,unknown:()=>`Something went wrong. Please try again.`},Qe=new Set([`offline`,`timeout`,`server`]),$e=(e,t={})=>{let n=e??{},r=n.response?.status,i=n.code,a=t.online??(typeof navigator<`u`&&typeof navigator.onLine==`boolean`?navigator.onLine:!0),o=e=>({kind:e,message:Ze[e](r),retryable:Qe.has(e),status:r});return i===`ERR_CANCELED`?o(`cancelled`):i===`ECONNABORTED`||i===`ETIMEDOUT`||/timeout/i.test(n.message??``)?o(`timeout`):r===void 0?!a||i===`ERR_NETWORK`||/network error/i.test(n.message??``)?o(`offline`):o(`unknown`):o(r===401||r===403?`unauthorized`:r===404||r===410?`notFound`:r===408||r===429?`timeout`:r>=500?`server`:r>=400?`client`:`unknown`)},et=new Set([``,`__load__`,`search`,`_globalsearch`,`_notifications-list`]),tt=[`_appcontext-search-`,`search-`],nt=(e,t)=>t===!0?!0:e==null?!1:et.has(e)?!0:tt.some(t=>e.startsWith(t)),rt=(e,t=Math.random)=>{let n=300*3**Math.max(0,e-1);return Math.round(n*(.75+t()*.5))},it=(e,t,n)=>!n.idempotent||t>2||!e.retryable?!1:e.kind===`timeout`||e.kind===`server`,at=new class{constructor(){this.linkUp=!0,this.listeners=new Set,this.waiters=new Set,this.started=!1}start(){this.started||typeof window>`u`||(this.started=!0,this.linkUp=typeof navigator<`u`&&typeof navigator.onLine==`boolean`?navigator.onLine:!0,window.addEventListener(`online`,()=>{this.linkUp=!0,this.reachable=void 0,this.changed(),this.releaseWaiters()}),window.addEventListener(`offline`,()=>{this.linkUp=!1,this.changed()}))}isOnline(){return this.linkUp?this.reachable!==!1:!1}noteReachable(){let e=this.isOnline();this.reachable=!0,e||(this.changed(),this.releaseWaiters())}noteUnreachable(){let e=this.isOnline();this.reachable=!1,e&&this.changed()}subscribe(e){return this.listeners.add(e),()=>this.listeners.delete(e)}whenBack(e){return this.isOnline()?(e(),()=>{}):(this.waiters.add(e),()=>this.waiters.delete(e))}reset(){this.linkUp=!0,this.reachable=void 0,this.waiters.clear()}changed(){let e=this.isOnline();this.listeners.forEach(t=>t(e))}releaseWaiters(){let e=Array.from(this.waiters);this.waiters.clear(),e.forEach(e=>e())}};at.start();var ot=[],st=6e4,ct=e=>new Promise(t=>setTimeout(t,e)),lt=new class{constructor(){this.axiosInstance=ae.create({timeout:st}),this.axiosInstance.interceptors.request.use(e=>(this.addAuthToken(e),this.addSessionId(e),e)),this.axiosInstance.interceptors.response.use(e=>{let t=Ae({requestedUrl:this.axiosInstance.getUri(e.config),finalUrl:e.request?.responseURL,contentType:String(e.headers?.[`content-type`]??``),data:e.data});if(t)throw window.location.assign(t),Object.assign(Error(`session lost — redirecting to `+t),{code:`ERR_CANCELED`});return e},e=>{let t=e;if(t?.response?.status===401&&t.config&&!t.config.__mateuRetried){let n=t.config;return n.__mateuRetried=!0,Oe(e,()=>this.axiosInstance.request(n))}throw e})}addSessionId(e){let t=sessionStorage.getItem(`__mateu_sesion_id`);t||(t=E(),sessionStorage.setItem(`__mateu_sesion_id`,t)),e.headers[`X-Session-Id`]=t}addAuthToken(e){let t=localStorage.getItem(`__mateu_auth_token`);t&&(e.headers.Authorization=`Bearer `+t)}async wrap(e,t,n,r,i){return n||t.dispatchEvent(new CustomEvent(`backend-called-event`,{bubbles:!0,composed:!0,detail:{}})),e().then(e=>(t.dispatchEvent(new CustomEvent(`backend-succeeded-event`,{bubbles:!0,composed:!0,detail:{actionId:r}})),e)).catch(e=>{let n=$e(e,{online:at.isOnline()});throw n.kind==`cancelled`?t.dispatchEvent(new CustomEvent(`backend-cancelled-event`,{bubbles:!0,composed:!0,detail:{actionId:r}})):(e&&typeof e==`object`&&(e.__mateuReported=!0),t.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:r,reason:this.serialize(e),failure:n,retry:i}}))),e})}async sendWithRetry(e,t){let n=0;for(;;)try{let t=await e();return at.noteReachable(),t}catch(e){let r=$e(e,{online:at.isOnline()});if(r.kind==`offline`&&at.noteUnreachable(),n++,!it(r,n,{idempotent:t}))throw e;await ct(rt(n))}}serialize(e){return e?.message?e:JSON.stringify(e)}release(e){ot=ot.filter(t=>t!==e)}async get(e){let t=new AbortController;return ot=[...ot,t],this.axiosInstance.get(e,{signal:t.signal}).finally(()=>this.release(t))}async post(e,t,n){let r=new AbortController;return ot=[...ot,r],this.axiosInstance.post(e,t,{signal:r.signal,...n&&n>0?{timeout:n}:{}}).finally(()=>this.release(r))}async abortAll(){ot.forEach(e=>e.abort()),ot=[]}async runAction(e,t,n,r,i,a,o,s,c,l,u,d={}){if(t&&t.startsWith(`/`)&&(t=t.substring(1)),r===``&&(await qe(),Je())){let e=Ye(Ge(t))??Xe(Ge(t));if(e){let t={...e,fragments:(e.fragments??[]).map(e=>e.targetComponentId?e:{...e,targetComponentId:i})};return await this.wrap(()=>Promise.resolve(t),l,u,r,d.retry)}}let f=[e,t,n,o??``,r,i].join(``),p=je.check(f);if(p.blocked)return await this.abortAll(),p.firstTrip&&console.error(`[mateu] request loop detected — aborting repeated request`,f),{messages:p.firstTrip?[{title:``,text:`A repeating request was detected and stopped to protect the server. Reload the page or navigate elsewhere.`,position:`bottom-end`,variant:`error`,duration:6e3}]:[],commands:[],fragments:[],banners:[],appendBanners:!1,appData:void 0,appState:void 0};a={...Se(),...a};let ee=e+`/mateu/v3/sync/`+(t&&t!=``?t:`_no_route`),m={serverSideType:o,appState:a,componentState:s,parameters:c,initiatorComponentId:i,consumedRoute:n,route:t&&t!=``?`/`+t:``,actionId:r,knownStructureHash:d.knownStructureHash},te=nt(r,d.idempotent),ne=()=>this.post(ee,m,d.timeoutMillis).then(e=>e.data);return await this.wrap(()=>this.sendWithRetry(ne,te),l,u,r,d.retry)}},ut=function(e){return e.Add=`Add`,e.Replace=`Replace`,e.ReplaceKeepData=`ReplaceKeepData`,e}({}),dt=function(e){return e.HAMBURGUER_MENU=`HAMBURGUER_MENU`,e.MENU_ON_LEFT=`MENU_ON_LEFT`,e.MENU_ON_TOP=`MENU_ON_TOP`,e.TABS=`TABS`,e.TILES=`TILES`,e.RAIL=`RAIL`,e.AUTO=`AUTO`,e.MEDIATOR=`MEDIATOR`,e}({}),ft=new Map,pt=[`position:absolute`,`width:1px`,`height:1px`,`margin:-1px`,`padding:0`,`overflow:hidden`,`clip:rect(0 0 0 0)`,`clip-path:inset(50%)`,`white-space:nowrap`,`border:0`].join(`;`),mt=e=>{if(typeof document>`u`||!document.body)return;let t=ft.get(e);return t?.isConnected?t:(t=document.createElement(`div`),t.setAttribute(`aria-live`,e),t.setAttribute(`aria-atomic`,`true`),t.setAttribute(`role`,e===`assertive`?`alert`:`status`),t.setAttribute(`data-mateu-live-region`,e),t.style.cssText=pt,document.body.appendChild(t),ft.set(e,t),t)},ht=()=>{if(!(typeof document>`u`)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>ht(),{once:!0});return}mt(`polite`),mt(`assertive`)}},gt=(e,t={})=>{let n=(e??``).trim();if(!n)return;let r=mt(t.politeness??`polite`);if(r){if(r.textContent===n){r.textContent=``,setTimeout(()=>{r.textContent=n},60);return}r.textContent=n}},_t=class extends b{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.callbackToken=``,this.createElement=e=>{let t=e.data,n=document.createElement(t.name);for(let e in t.attributes)n.setAttribute(e,t.attributes[e]);for(let e in t.on)n.addEventListener(e,n=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.on[e],parameters:{event:n}},bubbles:!0,composed:!0}))});return n},this.closeModal=()=>{let e=(this.shadowRoot??this).querySelectorAll(`mateu-dialog, mateu-drawer`);if(e&&e.length>0){e[e.length-1].close();return}this.dispatchEvent(new CustomEvent(`close-modal-requested`,{bubbles:!0,composed:!0}))},this.changeFavicon=e=>{let t=document.querySelector(`link[rel="icon"]`);t===null?(t=document.createElement(`link`),t.setAttribute(`rel`,`icon`),t.setAttribute(`href`,e),document.head.appendChild(t)):t.setAttribute(`href`,e)}}connectedCallback(){super.connectedCallback(),this.upstreamSubscription=le.subscribe(e=>{if(e.command){let t=e.command;this.id==t.targetComponentId&&this.applyCommand(t)}if((!e.callbackToken||!this.callbackToken||e.callbackToken===this.callbackToken)&&e.fragment){let t=e.fragment;this.id==t.targetComponentId&&(this.applyFragment(t),this.completeMenu(t))}})}completeMenu(e){if(e.component&&e.component.type==A.ClientSide){let t=e.component,n=t.metadata;if(n?.type==j.App){let e=n,r=this.getRemoteMenus(e.menu);if(r.length>0){let n=r.map(e=>lt.runAction(e.baseUrl,e.route,`_empty`,``,e.baseUrl+`#`+e.route,void 0,void 0,void 0,e.params,this,!0));Promise.all(n).then(n=>{e.menu=this.updateMenu(e.menu,n.map(e=>e.fragments).filter(e=>e).map(e=>e).flat()),e.variant=dt.MENU_ON_TOP,le.next({fragment:{component:t,data:void 0,state:void 0,action:ut.Replace,targetComponentId:this.id,containerId:void 0},callbackToken:this.callbackToken})})}}}}updateMenu(e,t){let n=[];return e.forEach(e=>{if(e.remote){let r=t.find(t=>t.targetComponentId==e.baseUrl+`#`+e.route);if(r&&r.component?.type==A.ClientSide){let t=r.component;if(t.metadata?.type==j.App){let r=t.metadata,i=e.serverSideType&&e.serverSideType!=``?e.serverSideType:r.serverSideType;this.changeBaseUrl(r.menu,e.baseUrl,i,e.route,r.route),n.push(...r.menu)}}}else n.push(e)}),n}changeBaseUrl(e,t,n,r,i){e.forEach(e=>{e.baseUrl||(e.submenus&&e.submenus.length>0?this.changeBaseUrl(e.submenus,t,n,r,i):(e.consumedRoute=i??``,e.baseUrl=t,e.serverSideType=n,e.uriPrefix=r))})}getRemoteMenus(e){let t=[];return e.forEach(e=>{e.remote&&t.push(e)}),t}disconnectedCallback(){super.disconnectedCallback(),this.upstreamSubscription?.unsubscribe()}applyCommand(e){if(e.type==`SetWindowTitle`&&(document.title=e.data,gt(document.title)),e.type==`SetFavicon`&&this.changeFavicon(e.data),e.type==`DispatchEvent`&&this.dispatchNamedEvent(e.data),e.type==`NavigateTo`){let t=e.data;t&&(t.startsWith(`http:`)||t.startsWith(`https:`)?window.open(e.data,`_blank`):window.location.href=e.data)}if(e.type==`PushStateToHistory`){let t=e.data;t!==void 0&&this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0}))}if(e.type==`RunAction`){let t=e.data;if(t&&t.actionId)if(t.targetComponentId){let e={command:{type:`RunAction`,data:{actionId:t.actionId},targetComponentId:t.targetComponentId},fragment:void 0,ui:void 0,error:void 0,callbackToken:``};setTimeout(()=>le.next(e))}else this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:{}},bubbles:!0,composed:!0}))}if(e.type==`MarkAsDirty`&&this.dispatchEvent(new CustomEvent(`dirty`,{detail:{},bubbles:!0,composed:!0})),e.type==`MarkAsClean`&&this.dispatchEvent(new CustomEvent(`clean`,{detail:{},bubbles:!0,composed:!0})),e.type==`DownloadFile`){let t=e.data;if(t&&t.base64Content){let e=atob(t.base64Content),n=new Uint8Array(e.length);for(let t=0;t<e.length;t++)n[t]=e.charCodeAt(t);let r=new Blob([n],{type:t.mimeType}),i=URL.createObjectURL(r),a=document.createElement(`a`);a.href=i,a.download=t.filename??`export`,a.click(),URL.revokeObjectURL(i)}}if(e.type==`CloseModal`&&(this.closeModal(),this.dispatchNamedEvent(e.data)),e.type==`AddContentToHead`){let t=e.data;if(t&&t.name){if(t.attributes&&t.attributes.id&&document.getElementById(t.attributes.id))return;document.head.appendChild(this.createElement(e))}}if(e.type==`AddContentToBody`){let t=e.data;if(t&&t.name){if(t.attributes&&t.attributes.id&&document.getElementById(t.attributes.id))return;document.body.appendChild(this.createElement(e))}}}dispatchNamedEvent(e){if(e&&e.eventName){let t=this.component,n=t?.emitsName??t?.serverSideType,r=e.payload??e.detail;n&&r&&typeof r==`object`&&(r={...r,__source:n}),this.dispatchEvent(new CustomEvent(e.eventName,{detail:r,bubbles:!0,composed:!0}))}}};k([y()],_t.prototype,`id`,void 0),k([y()],_t.prototype,`baseUrl`,void 0);var vt=class extends _t{applyFragment(e){}manageActionRequestedEvent(e){}};k([y()],vt.prototype,`component`,void 0);var yt=(e,t)=>Function(...Object.keys(t),"return `"+e+"`")(...Object.values(t)),bt=(e,t,n)=>({state:e??{},data:t??{},...n});function M(e,t,n,r){if(!e?.includes("${"))return e;try{return yt(e,bt(t,n,r))}catch(t){return console.warn(`Mateu: could not interpolate "${e}":`,t),e}}var N=(e,t,n)=>{if(e&&e.indexOf("${")>=0)try{return yt(e,bt(t,n))}catch(e){return e.message}return e},xt=(e,t,n,r,i)=>{if(!e)return e;let a=bt(t,n,{appState:r??{},appData:i??{}}),o=e;try{if(o=yt(e,a),o.includes("${"))try{o=yt(o,a)}catch(a){o=`when evaluating nested `+e+` :`+a+`, where data is `+n+` and state is `+t+` and app state is `+r+` and app data is `+i,console.error(a,o,t,n,r,i)}}catch(a){o=`when evaluating `+e+` :`+a+`, where data is `+n+` and state is `+t+` and app state is `+r+` and app data is `+i,console.error(a,o,t,n,r,i)}return o},St=(e,t,n,r,i,a)=>{let o=bt(t,n,{appState:r??{},appData:i??{},...a}),s=yt(e,o);return Function(...Object.keys(o),`return (${s})`)(...Object.values(o))},Ct=(e,t,n,r)=>{let i=bt(t,n,r);return Function(...Object.keys(i),`return (${e})`)(...Object.values(i))},wt=(e,t,n,r)=>yt(e,bt(t,n,r)),Tt=`display:inline-flex; align-items:center; justify-content:center; width:2rem; height:2rem; border-radius:50%; background:var(--lumo-contrast-10pct,#e0e0e0); color:var(--lumo-secondary-text-color,#555); font-size:.8rem; font-weight:600; overflow:hidden; flex:none;`,Et=(e,t)=>t||(typeof e==`string`&&e?e.trim().split(/\s+/).map(e=>e[0]).slice(0,2).join(``).toUpperCase():``),Dt=(e,t,n)=>{let r=e.metadata,i=Ot(r.name,t,n);return T`<span style="${Tt}${e.style}" class="${e.cssClasses}"
                       title="${i||v}" slot="${e.slot??v}">
         ${r.image?T`<img src="${r.image}" alt="${i}" style="width:100%;height:100%;object-fit:cover;">`:Et(i,r.abbreviation)}
-    </span>`},P=(e,t,n)=>typeof e==`string`&&e.includes("${")?M(e,t,n):e,Ot=e=>{let t=e.metadata,n=t.avatars??[],r=t.maxItemsVisible&&t.maxItemsVisible>0?t.maxItemsVisible:n.length,i=n.slice(0,r),a=n.length-i.length,o=`margin-left:-0.4rem; border:2px solid var(--lumo-base-color,#fff);`;return T`<span style="display:inline-flex; ${e.style}" class="${e.cssClasses}" slot="${e.slot??v}">
+    </span>`},Ot=(e,t,n)=>typeof e==`string`&&e.includes("${")?M(e,t,n):e,kt=e=>{let t=e.metadata,n=t.avatars??[],r=t.maxItemsVisible&&t.maxItemsVisible>0?t.maxItemsVisible:n.length,i=n.slice(0,r),a=n.length-i.length,o=`margin-left:-0.4rem; border:2px solid var(--lumo-base-color,#fff);`;return T`<span style="display:inline-flex; ${e.style}" class="${e.cssClasses}" slot="${e.slot??v}">
         ${i.map(e=>T`<span style="${Tt}${o}" title="${e.name||v}">
             ${e.img?T`<img src="${e.img}" style="width:100%;height:100%;object-fit:cover;">`:Et(e.name??``,e.abbr)}
         </span>`)}
         ${a>0?T`<span style="${Tt}${o}">+${a}</span>`:v}
-    </span>`},kt=(e,t,n)=>{let r=e.metadata;return T`<span theme="badge ${r.color} ${r.pill?`pill`:``} ${r.small?`small`:``} ${r.primary?`primary`:``}"
+    </span>`},At=(e,t,n)=>{let r=e.metadata;return T`<span theme="badge ${r.color} ${r.pill?`pill`:``} ${r.small?`small`:``} ${r.primary?`primary`:``}"
                       style="${e.style}" class="${e.cssClasses}"
-                      slot="${e.slot??v}">${P(r.text,t,n)}</span>`},At=(e,t,n)=>{let r=P(e.text,t,n);if(!r)return v;let i=P(e.color,t,n);return i==`SUCCESS`&&(i=`success`),i==`ERROR`&&(i=`error`),i==`DANGER`&&(i=`error`),i==`WARNING`&&(i=`warning`),i==`INFO`&&(i=`info`),i==`PRIMARY`&&(i=`primary`),i==`SECONDARY`&&(i=`secondary`),i==`TERTIARY`&&(i=`tertiary`),i==`QUATERNARY`&&(i=`quaternary`),i==`LIGHT`&&(i=`light`),i==`DARK`&&(i=`dark`),T`<span theme="badge ${i} ${e.pill?`pill`:``} ${e.small?`small`:``} ${e.primary?`primary`:``}">${r}</span>`},F=new class{constructor(){this.afterRenderHook=void 0,this.useShadowRoot=!0,this.componentRenderer=void 0}set(e){if(this.componentRenderer=e,typeof window<`u`){let t=e.supportedClientSideTypes?.();window.__mateuRendererInfo={name:e.rendererName?.()??e.constructor?.name??`unknown`,supportedTypes:t?[...t].sort():null}}}get(){return this.componentRenderer}setUseShadowRoot(e){this.useShadowRoot=e}mustUseShadowRoot(){return this.useShadowRoot}setAfterRenderHook(e){this.afterRenderHook=e}getAfterRenderHook(){return this.afterRenderHook}},jt=(e,t,n,r,i,a,o,s,c)=>(t.slot=s,I(e,t,n,r,i,a,o,c)),I=(e,t,n,r,i,a,o,s)=>{if(!t)return T``;if(t.type==A.ClientSide)return F.get().renderClientSideComponent(e,t,n,r,i,a,o,s);let c=e.route,l=e.consumedRoute;return T`
+                      slot="${e.slot??v}">${Ot(r.text,t,n)}</span>`},jt=(e,t,n)=>{let r=Ot(e.text,t,n);if(!r)return v;let i=Ot(e.color,t,n);return i==`SUCCESS`&&(i=`success`),i==`ERROR`&&(i=`error`),i==`DANGER`&&(i=`error`),i==`WARNING`&&(i=`warning`),i==`INFO`&&(i=`info`),i==`PRIMARY`&&(i=`primary`),i==`SECONDARY`&&(i=`secondary`),i==`TERTIARY`&&(i=`tertiary`),i==`QUATERNARY`&&(i=`quaternary`),i==`LIGHT`&&(i=`light`),i==`DARK`&&(i=`dark`),T`<span theme="badge ${i} ${e.pill?`pill`:``} ${e.small?`small`:``} ${e.primary?`primary`:``}">${r}</span>`},P=new class{constructor(){this.afterRenderHook=void 0,this.useShadowRoot=!0,this.componentRenderer=void 0}set(e){if(this.componentRenderer=e,typeof window<`u`){let t=e.supportedClientSideTypes?.();window.__mateuRendererInfo={name:e.rendererName?.()??e.constructor?.name??`unknown`,supportedTypes:t?[...t].sort():null}}}get(){return this.componentRenderer}setUseShadowRoot(e){this.useShadowRoot=e}mustUseShadowRoot(){return this.useShadowRoot}setAfterRenderHook(e){this.afterRenderHook=e}getAfterRenderHook(){return this.afterRenderHook}},Mt=(e,t,n,r,i,a,o,s,c)=>(t.slot=s,F(e,t,n,r,i,a,o,c)),F=(e,t,n,r,i,a,o,s)=>{if(!t)return T``;if(t.type==A.ClientSide)return P.get().renderClientSideComponent(e,t,n,r,i,a,o,s);let c=e.route,l=e.consumedRoute;return T`
         <mateu-component id="${t.id}"
                          .component="${t}"
                         route="${c}"
@@ -163,8 +163,8 @@ ${i}
                          .appState="${a}"
                          .appData="${o}"
         >
-       </mateu-component>`},Mt=e=>{let t=[];return e.color&&e.color!==`normal`&&e.color!==`none`&&t.push(e.color),e.buttonStyle&&t.push(e.buttonStyle===`tertiaryInline`?`tertiary-inline`:e.buttonStyle),e.size&&e.size!==`none`&&e.size!==`normal`&&t.push(e.size),t.length?t.join(` `):void 0},Nt=e=>{let t=Mt(e)??``,n=[];return t.includes(`primary`)&&n.push(`primary`),t.includes(`tertiary`)&&n.push(`tertiary`),(t.includes(`error`)||e.color===`error`)&&n.push(`danger`),n.join(` `)},Pt=e=>e===`back`||e===`backToList`||!!e&&e.startsWith(`cancel`),Ft=class extends b{constructor(...e){super(...e),this.appState={},this.appData={},this._overflowOpen=!1,this._overflowN=0,this._secCount=0,this._onDocClick=e=>{e.composedPath().includes(this)||(this._overflowOpen=!1)},this._resetOverflow=()=>{this._overflowN===0?this.requestUpdate():this._overflowN=0},this.handleButtonClick=e=>{this._overflowOpen=!1,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.evalLabel=e=>M(e,this.state,this.data),this.renderBtn=e=>{if((this.data??{})[e.actionId+`.hidden`])return v;let t=this.evalLabel(e.label);return F.get()?.renderToolbarButton?.(e,t,()=>this.handleButtonClick(e.actionId))||T`
-        <button class="mtb ${Nt(e)}"
+       </mateu-component>`},Nt=e=>{let t=[];return e.color&&e.color!==`normal`&&e.color!==`none`&&t.push(e.color),e.buttonStyle&&t.push(e.buttonStyle===`tertiaryInline`?`tertiary-inline`:e.buttonStyle),e.size&&e.size!==`none`&&e.size!==`normal`&&t.push(e.size),t.length?t.join(` `):void 0},Pt=e=>{let t=Nt(e)??``,n=[];return t.includes(`primary`)&&n.push(`primary`),t.includes(`tertiary`)&&n.push(`tertiary`),(t.includes(`error`)||e.color===`error`)&&n.push(`danger`),n.join(` `)},Ft=e=>e===`back`||e===`backToList`||!!e&&e.startsWith(`cancel`),It=class extends b{constructor(...e){super(...e),this.appState={},this.appData={},this._overflowOpen=!1,this._overflowN=0,this._secCount=0,this._onDocClick=e=>{e.composedPath().includes(this)||(this._overflowOpen=!1)},this._resetOverflow=()=>{this._overflowN===0?this.requestUpdate():this._overflowN=0},this.handleButtonClick=e=>{this._overflowOpen=!1,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.evalLabel=e=>M(e,this.state,this.data),this.renderBtn=e=>{if((this.data??{})[e.actionId+`.hidden`])return v;let t=this.evalLabel(e.label);return P.get()?.renderToolbarButton?.(e,t,()=>this.handleButtonClick(e.actionId))||T`
+        <button class="mtb ${Pt(e)}"
                 data-action-id="${e.id}"
                 @click="${()=>this.handleButtonClick(e.actionId)}"
                 ?disabled="${e.disabled}"
@@ -190,7 +190,7 @@ ${i}
                     </div>
                 `:v}
             </div>
-        `},this.renderPeerNav=e=>F.get()?.renderPeerNav?.(e)||T`
+        `},this.renderPeerNav=e=>P.get()?.renderPeerNav?.(e)||T`
             <div style="display: flex; gap: var(--lumo-space-xs, .25rem); align-items: center;" class="peer-nav">
                 <button class="mtb tertiary peer-nav-prev"
                         title="${e.prevLabel??`Previous`}"
@@ -201,7 +201,7 @@ ${i}
                         ?disabled="${!e.nextRoute}"
                         @click="${()=>{e.nextRoute&&(window.location.href=e.nextRoute)}}">›</button>
             </div>
-        `}connectedCallback(){super.connectedCallback(),document.addEventListener(`click`,this._onDocClick),this._ro=new ResizeObserver(()=>this._resetOverflow()),this._ro.observe(this),window.addEventListener(`resize`,this._resetOverflow)}disconnectedCallback(){document.removeEventListener(`click`,this._onDocClick),window.removeEventListener(`resize`,this._resetOverflow),this._ro?.disconnect(),this._ro=void 0,super.disconnectedCallback()}updated(e){if(e.has(`metadata`)||e.has(`data`)){this._resetOverflow();return}let t=this.renderRoot.querySelector(`.actions-cluster`);if(!t||this._secCount===0)return;let n=t.closest(`.form-header, .no-header-row`);if(!n)return;let r=t.getBoundingClientRect(),i=n.getBoundingClientRect();(r.top-i.top>8||r.right>i.right+1)&&this._overflowN<this._secCount&&(this._overflowN+=1)}render(){let e=this.metadata;if(!e)return T``;let t=e.peerNav&&(e.peerNav.prevRoute||e.peerNav.nextRoute)?e.peerNav:void 0,n=e.toolbar??[],r=n.filter(e=>Pt(e.actionId)),i=n.filter(e=>!Pt(e.actionId)),a=r.length>0&&i.length>0?T`<span class="toolbar-divider"></span>`:v,o=e.overline,s=e.title?void 0:e.titlePlaceholder,c=e.avatar||e.title||e.subtitle||o||s||e.kpis?.length>0||e.header?.length>0||n.length>0||!!t,l=e.level??0;return l>0?this.setAttribute(`data-nested`,``):this.removeAttribute(`data-nested`),T`
+        `}connectedCallback(){super.connectedCallback(),document.addEventListener(`click`,this._onDocClick),this._ro=new ResizeObserver(()=>this._resetOverflow()),this._ro.observe(this),window.addEventListener(`resize`,this._resetOverflow)}disconnectedCallback(){document.removeEventListener(`click`,this._onDocClick),window.removeEventListener(`resize`,this._resetOverflow),this._ro?.disconnect(),this._ro=void 0,super.disconnectedCallback()}updated(e){if(e.has(`metadata`)||e.has(`data`)){this._resetOverflow();return}let t=this.renderRoot.querySelector(`.actions-cluster`);if(!t||this._secCount===0)return;let n=t.closest(`.form-header, .no-header-row`);if(!n)return;let r=t.getBoundingClientRect(),i=n.getBoundingClientRect();(r.top-i.top>8||r.right>i.right+1)&&this._overflowN<this._secCount&&(this._overflowN+=1)}render(){let e=this.metadata;if(!e)return T``;let t=e.peerNav&&(e.peerNav.prevRoute||e.peerNav.nextRoute)?e.peerNav:void 0,n=e.toolbar??[],r=n.filter(e=>Ft(e.actionId)),i=n.filter(e=>!Ft(e.actionId)),a=r.length>0&&i.length>0?T`<span class="toolbar-divider"></span>`:v,o=e.overline,s=e.title?void 0:e.titlePlaceholder,c=e.avatar||e.title||e.subtitle||o||s||e.kpis?.length>0||e.header?.length>0||n.length>0||!!t,l=e.level??0;return l>0?this.setAttribute(`data-nested`,``):this.removeAttribute(`data-nested`),T`
             ${e.breadcrumbs&&e.breadcrumbs.length>0?T`
                 <div style="display: flex; gap: var(--lumo-space-m, 1rem); width: 100%; align-items: center;" class="breadcrumbs-bar">
                     ${e.breadcrumbs.map((e,t)=>T`
@@ -212,7 +212,7 @@ ${i}
             `:v}
             ${e.noHeader?T`
                 <div style="display: flex; gap: var(--lumo-space-m, 1rem); align-items: center;" class="no-header-row">
-                    ${e?.header?.map(e=>I(this,e,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData))}
+                    ${e?.header?.map(e=>F(this,e,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData))}
                     ${t?this.renderPeerNav(t):v}
                     ${r.map(this.renderBtn)}
                     ${a}
@@ -220,13 +220,13 @@ ${i}
                 </div>
             `:c?T`
                 <div style="display: flex; gap: var(--lumo-space-m, 1rem); width: 100%; align-items: center; flex-wrap: wrap;" class="form-header">
-                    ${e.avatar?I(this,e.avatar,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData):v}
+                    ${e.avatar?F(this,e.avatar,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData):v}
                     <div style="flex: 1; min-width: min(22rem, 100%); overflow: hidden;">
                         ${o?T`<div class="page-overline">${_(N(o,this.state??{},this.data??{}))}</div>`:v}
                         ${(e?.title||s)&&l==0?T`
                             <div style="display: flex; align-items: center; gap: var(--lumo-space-s, .5rem); min-width: 0;">
                                 <h2 style="margin: 0; margin-block-end: 0px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">${e?.title?_(N(e?.title,this.state??{},this.data??{})):T`<span class="page-title-placeholder">${_(N(s,this.state??{},this.data??{}))}</span>`}</h2>
-                                ${e.kpisBelow&&e.badges?.length?e.badges.map(e=>At(e,this.state??{},this.data??{})):v}
+                                ${e.kpisBelow&&e.badges?.length?e.badges.map(e=>jt(e,this.state??{},this.data??{})):v}
                             </div>`:v}
                         ${e?.title&&l==1?T`<h3 style="margin: 0; margin-block-end: 0px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; width: 100%;">${_(N(e?.title,this.state??{},this.data??{}))}</h3>`:v}
                         ${e?.title&&l==2?T`<h4 style="margin: 0; margin-block-end: 0px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; width: 100%;">${_(N(e?.title,this.state??{},this.data??{}))}</h4>`:v}
@@ -243,7 +243,7 @@ ${i}
                                 <div>${_(N(e.text,this.state??{},this.data??{}))}</div>
                             </div>
                         `)}
-                        ${e?.header?.map(e=>I(this,e,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData))}
+                        ${e?.header?.map(e=>F(this,e,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData))}
                         ${t?this.renderPeerNav(t):v}
                         ${r.map(this.renderBtn)}
                         ${a}
@@ -263,7 +263,7 @@ ${i}
             `:v}
             ${e.badges&&e.badges.length>0&&!e.kpisBelow?T`
                 <div style="display: flex; gap: var(--lumo-space-s, .5rem); padding-bottom: var(--lumo-space-s, .5rem);">
-                    ${e.badges.map(e=>At(e,this.state??{},this.data??{}))}
+                    ${e.badges.map(e=>jt(e,this.state??{},this.data??{}))}
                 </div>
             `:v}
         `}static{this.styles=h`
@@ -408,7 +408,7 @@ ${i}
         .mtb.danger.primary { background: var(--lumo-error-color, #c0392b); color: #fff; border-color: transparent; }
 
         ${de}
-    `}};k([y()],Ft.prototype,`metadata`,void 0),k([y()],Ft.prototype,`baseUrl`,void 0),k([y()],Ft.prototype,`state`,void 0),k([y()],Ft.prototype,`data`,void 0),k([y()],Ft.prototype,`appState`,void 0),k([y()],Ft.prototype,`appData`,void 0),k([C()],Ft.prototype,`_overflowOpen`,void 0),k([C()],Ft.prototype,`_overflowN`,void 0),Ft=k([g(`mateu-content-header`)],Ft);var It=class extends vt{constructor(...e){super(...e),this.state={},this.data={},this.appState={},this.appData={}}render(){let e=this.component?.metadata;return T`
+    `}};k([y()],It.prototype,`metadata`,void 0),k([y()],It.prototype,`baseUrl`,void 0),k([y()],It.prototype,`state`,void 0),k([y()],It.prototype,`data`,void 0),k([y()],It.prototype,`appState`,void 0),k([y()],It.prototype,`appData`,void 0),k([C()],It.prototype,`_overflowOpen`,void 0),k([C()],It.prototype,`_overflowN`,void 0),It=k([g(`mateu-content-header`)],It);var Lt=class extends vt{constructor(...e){super(...e),this.state={},this.data={},this.appState={},this.appData={}}render(){let e=this.component?.metadata;return T`
             <div class="mateu-vlayout ${this.component?.cssClasses??``}">
                 <mateu-content-header
                     .metadata="${e}"
@@ -454,7 +454,7 @@ ${i}
         .form-content {
             padding-bottom: 3rem;
         }
-    `}};k([y()],It.prototype,`state`,void 0),k([y()],It.prototype,`data`,void 0),k([y()],It.prototype,`appState`,void 0),k([y()],It.prototype,`appData`,void 0),It=k([g(`mateu-form`)],It);var Lt=class extends b{constructor(...e){super(...e),this.variant=`text`,this.count=3}static{this.styles=h`
+    `}};k([y()],Lt.prototype,`state`,void 0),k([y()],Lt.prototype,`data`,void 0),k([y()],Lt.prototype,`appState`,void 0),k([y()],Lt.prototype,`appData`,void 0),Lt=k([g(`mateu-form`)],Lt);var Rt=class extends b{constructor(...e){super(...e),this.variant=`text`,this.count=3}static{this.styles=h`
         :host {
             display: block;
             flex: 1 1 0;
@@ -488,7 +488,7 @@ ${i}
                     <div class="bone label"></div>
                     <div class="bone field"></div>
                 </div>
-            `)}`:T`${e.map(()=>T`<div class="bone line"></div>`)}`}};k([y()],Lt.prototype,`variant`,void 0),k([y({type:Number})],Lt.prototype,`count`,void 0),Lt=k([g(`mateu-skeleton`)],Lt);var Rt=(e,t)=>{t&&e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},zt=(e,t,n,r,i,a)=>T`
+            `)}`:T`${e.map(()=>T`<div class="bone line"></div>`)}`}};k([y()],Rt.prototype,`variant`,void 0),k([y({type:Number})],Rt.prototype,`count`,void 0),Rt=k([g(`mateu-skeleton`)],Rt);var zt=(e,t)=>{t&&e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},Bt=(e,t,n,r,i,a)=>T`
         <div class="mateu-empty-state"
              style="display: flex; flex-direction: column; align-items: center; justify-content: center; gap: .35rem; padding: var(--lumo-space-l, 1.5rem); text-align: center; color: var(--lumo-secondary-text-color, #666);">
             <span style="font-size: 1.8rem; line-height: 1; opacity: .6;">${t??`🗂`}</span>
@@ -496,14 +496,14 @@ ${i}
             <span style="font-size: var(--lumo-font-size-s, .875rem);">${r??e??`Nothing here yet.`}</span>
             ${i&&a?T`
                 <button style="margin-top: .25rem; font: inherit; font-weight: 500; cursor: pointer; padding: .4rem .9rem; border: none; border-radius: var(--lumo-border-radius-m, 6px); background: transparent; color: var(--lumo-primary-text-color, #3b5bdb);"
-                        @click="${e=>Rt(e,i)}">${a}</button>
+                        @click="${e=>zt(e,i)}">${a}</button>
             `:v}
         </div>
-    `,Bt=e=>{let t=e.metadata;return T`
+    `,Vt=e=>{let t=e.metadata;return T`
         <div style="${e.style??v}" class="${e.cssClasses??v}" slot="${e.slot??v}">
-            ${zt(void 0,t.icon,t.title,t.description,t.actionId,t.actionLabel)}
+            ${Bt(void 0,t.icon,t.title,t.description,t.actionId,t.actionLabel)}
         </div>
-    `},Vt=e=>{let t=e.metadata;return T`
+    `},Ht=e=>{let t=e.metadata;return T`
         <mateu-skeleton
                 variant="${t.variant??`text`}"
                 count="${t.count&&t.count>0?t.count:3}"
@@ -511,8 +511,8 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-skeleton>
-    `},L=(e,t,n,r)=>{if(!e)return T``;let i=F.get()?.renderIcon;if(i){let a=i.call(F.get(),e,t,n);return r?T`<span slot="${r}">${a}</span>`:a}return T`<span class="mateu-icon ${n??``}" data-icon="${e}" aria-hidden="true"
-                      style="display:inline-block; width:1em; height:1em; ${t??``}" slot="${r??v}"></span>`},Ht=`mateu-saved-views`,Ut=()=>{try{return JSON.parse(localStorage.getItem(Ht)??`{}`)}catch{return{}}},Wt=e=>{try{localStorage.setItem(Ht,JSON.stringify(e))}catch{}},Gt=e=>Ut()[e]??[],Kt=(e,t)=>{let n=t.name?.trim();if(!n||Object.keys(t.values??{}).length===0)return;let r=Ut(),i=(r[e]??[]).filter(e=>e.name!==n);i.push({...t,name:n}),r[e]=i,Wt(r)},qt=(e,t)=>{let n=Ut(),r=(n[e]??[]).filter(e=>e.name!==t);r.length===0?delete n[e]:n[e]=r,Wt(n)},Jt=(e,t)=>{let n=Ut();n[e]=(n[e]??[]).map(e=>({...e,isDefault:e.name===t&&!e.isDefault})),Wt(n)},Yt=e=>Gt(e).find(e=>e.isDefault),R=class extends b{constructor(...e){super(...e),this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.searchOnly=!1,this.panelOpened=!1,this.viewsOpened=!1,this.draftText=``,this.openPanel=()=>{this.panelOpened||this.filters.length===0||(this.panelOpened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick))},this.closePanel=()=>{this.detachOutsideClick(),this.panelOpened=!1,this.activeFilter=void 0},this.clearAllFilters=()=>{let e=this.filters.flatMap(e=>this.isRangeFilter(e)?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId]),t={searchText:void 0};e.forEach(e=>{t[e]=void 0}),this.state={...this.state,...t},this.dispatchEvent(new CustomEvent(`filter-reset-requested`,{detail:{fieldIds:e},bubbles:!0,composed:!0})),this.requestSearch()},this.keepFocus=e=>e.preventDefault()}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}get filters(){return this.metadata?.filters??[]}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}requestSearch(){this.closePanel(),this.dispatchEvent(new CustomEvent(`search-requested`,{detail:{},bubbles:!0,composed:!0}))}emitValueChanged(e,t){this.state={...this.state,[e]:t},this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:e},bubbles:!0,composed:!0}))}applyFilter(e,t){this.emitValueChanged(e,t),this.requestSearch()}removeChip(e){let t=this.filters.find(t=>t.fieldId===e);t&&this.isRangeFilter(t)?(this.emitValueChanged(`${e}_from`,void 0),this.emitValueChanged(`${e}_to`,void 0)):this.emitValueChanged(e,e===`searchText`?``:void 0),this.requestSearch()}commitText(e){this.emitValueChanged(`searchText`,e.value),this.draftText=``,e.value=``,this.requestSearch()}get viewsScope(){return window.location.pathname}allFilterKeys(){return[`searchText`,...this.filters.flatMap(e=>this.isRangeFilter(e)?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId])]}snapshotValues(){let e={};return this.state.searchText&&(e.searchText=this.state.searchText),this.filters.forEach(t=>{if(this.isSet(t))if(this.isRangeFilter(t)){let n=this.rangeBound(t,`from`),r=this.rangeBound(t,`to`);n&&(e[`${t.fieldId}_from`]=n),r&&(e[`${t.fieldId}_to`]=r)}else this.isMultiFilter(t)?e[t.fieldId]=this.multiValues(t):e[t.fieldId]=this.state[t.fieldId]}),e}applyView(e){let t=this.allFilterKeys(),n={};t.forEach(e=>{n[e]=void 0}),this.state={...this.state,...n},this.dispatchEvent(new CustomEvent(`filter-reset-requested`,{detail:{fieldIds:t},bubbles:!0,composed:!0})),Object.entries(e.values).forEach(([e,t])=>this.emitValueChanged(e,t)),this.viewsOpened=!1,this.detachOutsideClick(),this.requestSearch()}saveCurrentView(e){let t=e.value.trim();t&&(Kt(this.viewsScope,{name:t,values:this.snapshotValues()}),e.value=``,this.requestUpdate())}firstUpdated(){if(window.location.search)return;let e=Yt(this.viewsScope);e&&setTimeout(()=>{this.state.searchText||this.filters.some(e=>this.isSet(e))||this.applyView(e)},0)}isBooleanFilter(e){return e.dataType===`boolean`||e.dataType===`bool`||e.stereotype===`checkbox`||e.stereotype===`toggle`}isNumericFilter(e){return[`integer`,`decimal`,`number`,`money`].includes(e.dataType??``)}isRangeFilter(e){return e.stereotype===`dateRange`||e.stereotype===`numberRange`}isMultiFilter(e){return e.stereotype===`multiSelect`}hasOptions(e){return(e.options?.length??0)>0}multiValues(e){let t=this.state[e.fieldId];return Array.isArray(t)?t.map(String):typeof t==`string`&&t!==``?t.split(`,`).map(e=>e.trim()).filter(e=>e):[]}rangeBound(e,t){let n=this.state[`${e.fieldId}_${t}`];return n==null?``:String(n)}isSet(e){if(this.isRangeFilter(e))return this.rangeBound(e,`from`)!==``||this.rangeBound(e,`to`)!==``;if(this.isMultiFilter(e))return this.multiValues(e).length>0;let t=this.state[e.fieldId];return t!=null&&t!==``&&!Number.isNaN(t)}getFilterDisplayValue(e,t){if(e.options?.length){let n=e.options.find(e=>e.value===String(t));if(n)return n.label??n.value}return typeof t==`boolean`?t?`Yes`:`No`:String(t)}conditionDisplay(e){if(this.isRangeFilter(e)){let t=this.rangeBound(e,`from`),n=this.rangeBound(e,`to`);return t&&n?`${t} – ${n}`:t?`≥ ${t}`:`≤ ${n}`}return this.isMultiFilter(e)?this.multiValues(e).map(t=>this.getFilterDisplayValue(e,t)).join(`, `):this.getFilterDisplayValue(e,this.state[e.fieldId])}labelOf(e){return M(e.label,this.state,this.data)||e.fieldId}panelRow(e,t,n=`panel-row`){return T`
+    `},I=(e,t,n,r)=>{if(!e)return T``;let i=P.get()?.renderIcon;if(i){let a=i.call(P.get(),e,t,n);return r?T`<span slot="${r}">${a}</span>`:a}return T`<span class="mateu-icon ${n??``}" data-icon="${e}" aria-hidden="true"
+                      style="display:inline-block; width:1em; height:1em; ${t??``}" slot="${r??v}"></span>`},Ut=`mateu-saved-views`,Wt=()=>{try{return JSON.parse(localStorage.getItem(Ut)??`{}`)}catch{return{}}},Gt=e=>{try{localStorage.setItem(Ut,JSON.stringify(e))}catch{}},Kt=e=>Wt()[e]??[],qt=(e,t)=>{let n=t.name?.trim();if(!n||Object.keys(t.values??{}).length===0)return;let r=Wt(),i=(r[e]??[]).filter(e=>e.name!==n);i.push({...t,name:n}),r[e]=i,Gt(r)},Jt=(e,t)=>{let n=Wt(),r=(n[e]??[]).filter(e=>e.name!==t);r.length===0?delete n[e]:n[e]=r,Gt(n)},Yt=(e,t)=>{let n=Wt();n[e]=(n[e]??[]).map(e=>({...e,isDefault:e.name===t&&!e.isDefault})),Gt(n)},Xt=e=>Kt(e).find(e=>e.isDefault),L=class extends b{constructor(...e){super(...e),this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.searchOnly=!1,this.panelOpened=!1,this.viewsOpened=!1,this.draftText=``,this.openPanel=()=>{this.panelOpened||this.filters.length===0||(this.panelOpened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick))},this.closePanel=()=>{this.detachOutsideClick(),this.panelOpened=!1,this.activeFilter=void 0},this.clearAllFilters=()=>{let e=this.filters.flatMap(e=>this.isRangeFilter(e)?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId]),t={searchText:void 0};e.forEach(e=>{t[e]=void 0}),this.state={...this.state,...t},this.dispatchEvent(new CustomEvent(`filter-reset-requested`,{detail:{fieldIds:e},bubbles:!0,composed:!0})),this.requestSearch()},this.keepFocus=e=>e.preventDefault()}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}get filters(){return this.metadata?.filters??[]}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}requestSearch(){this.closePanel(),this.dispatchEvent(new CustomEvent(`search-requested`,{detail:{},bubbles:!0,composed:!0}))}emitValueChanged(e,t){this.state={...this.state,[e]:t},this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:e},bubbles:!0,composed:!0}))}applyFilter(e,t){this.emitValueChanged(e,t),this.requestSearch()}removeChip(e){let t=this.filters.find(t=>t.fieldId===e);t&&this.isRangeFilter(t)?(this.emitValueChanged(`${e}_from`,void 0),this.emitValueChanged(`${e}_to`,void 0)):this.emitValueChanged(e,e===`searchText`?``:void 0),this.requestSearch()}commitText(e){this.emitValueChanged(`searchText`,e.value),this.draftText=``,e.value=``,this.requestSearch()}get viewsScope(){return window.location.pathname}allFilterKeys(){return[`searchText`,...this.filters.flatMap(e=>this.isRangeFilter(e)?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId])]}snapshotValues(){let e={};return this.state.searchText&&(e.searchText=this.state.searchText),this.filters.forEach(t=>{if(this.isSet(t))if(this.isRangeFilter(t)){let n=this.rangeBound(t,`from`),r=this.rangeBound(t,`to`);n&&(e[`${t.fieldId}_from`]=n),r&&(e[`${t.fieldId}_to`]=r)}else this.isMultiFilter(t)?e[t.fieldId]=this.multiValues(t):e[t.fieldId]=this.state[t.fieldId]}),e}applyView(e){let t=this.allFilterKeys(),n={};t.forEach(e=>{n[e]=void 0}),this.state={...this.state,...n},this.dispatchEvent(new CustomEvent(`filter-reset-requested`,{detail:{fieldIds:t},bubbles:!0,composed:!0})),Object.entries(e.values).forEach(([e,t])=>this.emitValueChanged(e,t)),this.viewsOpened=!1,this.detachOutsideClick(),this.requestSearch()}saveCurrentView(e){let t=e.value.trim();t&&(qt(this.viewsScope,{name:t,values:this.snapshotValues()}),e.value=``,this.requestUpdate())}firstUpdated(){if(window.location.search)return;let e=Xt(this.viewsScope);e&&setTimeout(()=>{this.state.searchText||this.filters.some(e=>this.isSet(e))||this.applyView(e)},0)}isBooleanFilter(e){return e.dataType===`boolean`||e.dataType===`bool`||e.stereotype===`checkbox`||e.stereotype===`toggle`}isNumericFilter(e){return[`integer`,`decimal`,`number`,`money`].includes(e.dataType??``)}isRangeFilter(e){return e.stereotype===`dateRange`||e.stereotype===`numberRange`}isMultiFilter(e){return e.stereotype===`multiSelect`}hasOptions(e){return(e.options?.length??0)>0}multiValues(e){let t=this.state[e.fieldId];return Array.isArray(t)?t.map(String):typeof t==`string`&&t!==``?t.split(`,`).map(e=>e.trim()).filter(e=>e):[]}rangeBound(e,t){let n=this.state[`${e.fieldId}_${t}`];return n==null?``:String(n)}isSet(e){if(this.isRangeFilter(e))return this.rangeBound(e,`from`)!==``||this.rangeBound(e,`to`)!==``;if(this.isMultiFilter(e))return this.multiValues(e).length>0;let t=this.state[e.fieldId];return t!=null&&t!==``&&!Number.isNaN(t)}getFilterDisplayValue(e,t){if(e.options?.length){let n=e.options.find(e=>e.value===String(t));if(n)return n.label??n.value}return typeof t==`boolean`?t?`Yes`:`No`:String(t)}conditionDisplay(e){if(this.isRangeFilter(e)){let t=this.rangeBound(e,`from`),n=this.rangeBound(e,`to`);return t&&n?`${t} – ${n}`:t?`≥ ${t}`:`≤ ${n}`}return this.isMultiFilter(e)?this.multiValues(e).map(t=>this.getFilterDisplayValue(e,t)).join(`, `):this.getFilterDisplayValue(e,this.state[e.fieldId])}labelOf(e){return M(e.label,this.state,this.data)||e.fieldId}panelRow(e,t,n=`panel-row`){return T`
             <div class="${n}" @mousedown="${this.keepFocus}" @click="${t}">${e}</div>`}renderRangeWidget(e){let t=e.stereotype===`numberRange`?`number`:e.dataType===`dateTime`?`datetime-local`:e.dataType===`time`?`time`:`date`,n=t=>{let n=t.closest(`.panel-input-row`),r=n.querySelector(`input.range-from`).value,i=n.querySelector(`input.range-to`).value;this.emitValueChanged(`${e.fieldId}_from`,r===``?void 0:r),this.emitValueChanged(`${e.fieldId}_to`,i===``?void 0:i),this.requestSearch()},r=e=>{e.key===`Enter`&&n(e.target),e.key===`Escape`&&this.closePanel()};return T`
             <div class="panel-input-row">
                 <input class="range-from" type="${t}" placeholder="From"
@@ -542,7 +542,7 @@ ${i}
                 <button class="apply-button"
                         @mousedown="${this.keepFocus}"
                         @click="${e=>n(e.target.previousElementSibling)}">Apply</button>
-            </div>`}renderViewsPanel(){if(!this.viewsOpened)return v;let e=Gt(this.viewsScope),t=!!this.state.searchText||this.filters.some(e=>this.isSet(e));return T`
+            </div>`}renderViewsPanel(){if(!this.viewsOpened)return v;let e=Kt(this.viewsScope),t=!!this.state.searchText||this.filters.some(e=>this.isSet(e));return T`
             <div class="panel views-panel">
                 <div class="panel-caption">Saved views</div>
                 ${e.length===0?T`
@@ -552,9 +552,9 @@ ${i}
                         <span class="view-name" @click="${()=>this.applyView(e)}">${e.name}</span>
                         <button class="view-star ${e.isDefault?`view-star--on`:``}"
                                 title="${e.isDefault?`Unset as default`:`Open this listing with this view`}"
-                                @click="${()=>{Jt(this.viewsScope,e.name),this.requestUpdate()}}">★</button>
+                                @click="${()=>{Yt(this.viewsScope,e.name),this.requestUpdate()}}">★</button>
                         <button class="chip-remove" aria-label="Delete view ${e.name}"
-                                @click="${()=>{qt(this.viewsScope,e.name),this.requestUpdate()}}">✕</button>
+                                @click="${()=>{Jt(this.viewsScope,e.name),this.requestUpdate()}}">✕</button>
                     </div>`)}
                 ${t?T`
                     <div class="panel-input-row" @mousedown="${e=>e.stopPropagation()}">
@@ -811,7 +811,7 @@ ${i}
             padding: 0.35rem 0.75rem;
             cursor: pointer;
         }
-    `}};k([y()],R.prototype,`metadata`,void 0),k([y()],R.prototype,`baseUrl`,void 0),k([C()],R.prototype,`state`,void 0),k([C()],R.prototype,`data`,void 0),k([y()],R.prototype,`appState`,void 0),k([y()],R.prototype,`appData`,void 0),k([y({type:Boolean})],R.prototype,`searchOnly`,void 0),k([C()],R.prototype,`panelOpened`,void 0),k([C()],R.prototype,`viewsOpened`,void 0),k([C()],R.prototype,`activeFilter`,void 0),k([C()],R.prototype,`draftText`,void 0),R=k([g(`mateu-filter-bar`)],R);var Xt=`mateu-column-prefs`,Zt=()=>{try{let e=JSON.parse(localStorage.getItem(Xt)??`{}`);return e&&typeof e==`object`&&!Array.isArray(e)?e:{}}catch{return{}}},Qt=e=>{try{localStorage.setItem(Xt,JSON.stringify(e))}catch{}},$t=e=>{if(!e||typeof e!=`object`)return;let t=e=>Array.isArray(e)?e.filter(e=>typeof e==`string`):[];return{hidden:t(e.hidden),order:t(e.order)}},en=e=>$t(Zt()[e]),tn=(e,t)=>{let n=Zt(),r=$t(t);r.hidden.length===0&&r.order.length===0?delete n[e]:n[e]=r,Qt(n)},nn=e=>{let t=Zt();delete t[e],Qt(t)},rn=e=>e?!!e.identifier||e.dataType===`action`||e.dataType===`actionGroup`||e.dataType===`menu`||e.id===`select`||e.id===`menu`:!1,an=(e,t,n=e=>e)=>{let r=$t(t);if(!r||r.hidden.length===0&&r.order.length===0)return e;let i=e=>n(e)?.id??e.id,a=new Set(r.hidden),o=e.filter(e=>{let t=i(e);return!t||!a.has(t)||rn(n(e))});if(r.order.length===0)return o.length===e.length?e:o;let s=new Map;o.forEach(e=>{let t=i(e);t&&!s.has(t)&&s.set(t,e)});let c=[],l=new Set;return r.order.forEach(e=>{let t=s.get(e);t&&!l.has(t)&&(c.push(t),l.add(t))}),o.forEach(e=>{l.has(e)||(c.push(e),l.add(e))}),c.length===e.length&&c.every((t,n)=>t===e[n])?e:c},on=class extends b{constructor(...e){super(...e),this.columns=[],this.scope=``,this.panelOpened=!1,this.revision=0,this.togglePanel=()=>{if(this.panelOpened){this.closePanel();return}this.panelOpened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick)},this.closePanel=()=>{this.detachOutsideClick(),this.panelOpened=!1},this.reset=()=>{nn(this.scope),this.revision++,this.dispatchEvent(new CustomEvent(`column-prefs-changed`,{bubbles:!0,composed:!0}))}}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}get prefs(){return en(this.scope)??{hidden:[],order:[]}}effectiveEntries(e){return an(this.columns,{hidden:[],order:e.order})}commit(e){tn(this.scope,e),this.revision++,this.dispatchEvent(new CustomEvent(`column-prefs-changed`,{bubbles:!0,composed:!0}))}toggleVisibility(e){let t=this.prefs,n=t.hidden.includes(e)?t.hidden.filter(t=>t!==e):[...t.hidden,e];this.commit({...t,hidden:n})}move(e,t){let n=this.prefs,r=[...this.effectiveEntries(n)],i=r.findIndex(t=>t.id===e);if(i<0)return;let a=i+t;for(;a>=0&&a<r.length&&r[a].protected;)a+=t;if(a<0||a>=r.length)return;let o=r[i];r[i]=r[a],r[a]=o,this.commit({...n,order:r.map(e=>e.id)})}render(){this.revision;let e=this.prefs,t=this.effectiveEntries(e).filter(e=>!e.protected);if(t.length===0)return T``;let n=e.hidden.length>0||e.order.length>0;return T`
+    `}};k([y()],L.prototype,`metadata`,void 0),k([y()],L.prototype,`baseUrl`,void 0),k([C()],L.prototype,`state`,void 0),k([C()],L.prototype,`data`,void 0),k([y()],L.prototype,`appState`,void 0),k([y()],L.prototype,`appData`,void 0),k([y({type:Boolean})],L.prototype,`searchOnly`,void 0),k([C()],L.prototype,`panelOpened`,void 0),k([C()],L.prototype,`viewsOpened`,void 0),k([C()],L.prototype,`activeFilter`,void 0),k([C()],L.prototype,`draftText`,void 0),L=k([g(`mateu-filter-bar`)],L);var Zt=`mateu-column-prefs`,Qt=()=>{try{let e=JSON.parse(localStorage.getItem(Zt)??`{}`);return e&&typeof e==`object`&&!Array.isArray(e)?e:{}}catch{return{}}},$t=e=>{try{localStorage.setItem(Zt,JSON.stringify(e))}catch{}},en=e=>{if(!e||typeof e!=`object`)return;let t=e=>Array.isArray(e)?e.filter(e=>typeof e==`string`):[];return{hidden:t(e.hidden),order:t(e.order)}},tn=e=>en(Qt()[e]),nn=(e,t)=>{let n=Qt(),r=en(t);r.hidden.length===0&&r.order.length===0?delete n[e]:n[e]=r,$t(n)},rn=e=>{let t=Qt();delete t[e],$t(t)},an=e=>e?!!e.identifier||e.dataType===`action`||e.dataType===`actionGroup`||e.dataType===`menu`||e.id===`select`||e.id===`menu`:!1,on=(e,t,n=e=>e)=>{let r=en(t);if(!r||r.hidden.length===0&&r.order.length===0)return e;let i=e=>n(e)?.id??e.id,a=new Set(r.hidden),o=e.filter(e=>{let t=i(e);return!t||!a.has(t)||an(n(e))});if(r.order.length===0)return o.length===e.length?e:o;let s=new Map;o.forEach(e=>{let t=i(e);t&&!s.has(t)&&s.set(t,e)});let c=[],l=new Set;return r.order.forEach(e=>{let t=s.get(e);t&&!l.has(t)&&(c.push(t),l.add(t))}),o.forEach(e=>{l.has(e)||(c.push(e),l.add(e))}),c.length===e.length&&c.every((t,n)=>t===e[n])?e:c},sn=class extends b{constructor(...e){super(...e),this.columns=[],this.scope=``,this.panelOpened=!1,this.revision=0,this.togglePanel=()=>{if(this.panelOpened){this.closePanel();return}this.panelOpened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick)},this.closePanel=()=>{this.detachOutsideClick(),this.panelOpened=!1},this.reset=()=>{rn(this.scope),this.revision++,this.dispatchEvent(new CustomEvent(`column-prefs-changed`,{bubbles:!0,composed:!0}))}}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}get prefs(){return tn(this.scope)??{hidden:[],order:[]}}effectiveEntries(e){return on(this.columns,{hidden:[],order:e.order})}commit(e){nn(this.scope,e),this.revision++,this.dispatchEvent(new CustomEvent(`column-prefs-changed`,{bubbles:!0,composed:!0}))}toggleVisibility(e){let t=this.prefs,n=t.hidden.includes(e)?t.hidden.filter(t=>t!==e):[...t.hidden,e];this.commit({...t,hidden:n})}move(e,t){let n=this.prefs,r=[...this.effectiveEntries(n)],i=r.findIndex(t=>t.id===e);if(i<0)return;let a=i+t;for(;a>=0&&a<r.length&&r[a].protected;)a+=t;if(a<0||a>=r.length)return;let o=r[i];r[i]=r[a],r[a]=o,this.commit({...n,order:r.map(e=>e.id)})}render(){this.revision;let e=this.prefs,t=this.effectiveEntries(e).filter(e=>!e.protected);if(t.length===0)return T``;let n=e.hidden.length>0||e.order.length>0;return T`
             <div class="chooser">
                 <button
                     class="trigger ${n?`active`:``}"
@@ -968,7 +968,7 @@ ${i}
             opacity: 0.4;
             cursor: default;
         }
-    `}};k([y()],on.prototype,`columns`,void 0),k([y()],on.prototype,`scope`,void 0),k([C()],on.prototype,`panelOpened`,void 0),k([C()],on.prototype,`revision`,void 0),on=k([g(`mateu-column-chooser`)],on);var sn;async function cn(e){if(!sn)return{};try{return await sn(e)??{}}catch(e){return console.warn(`mateu: external auth provider failed`,e),{}}}function ln(e,t){return t?t.split(`.`).reduce((e,t)=>typeof e==`object`&&e?e[t]:void 0,e):e}function un(e,t,n=`value`,r=`label`){let i=ln(e,t);return Array.isArray(i)?i.map(e=>{if(typeof e==`object`&&e){let t=ln(e,n),i=ln(e,r);return{value:t??i,label:String(i??t??``)}}return{value:e,label:String(e)}}):[]}function dn(e,t,n,r=e=>e){let i=ln(e,t);return Array.isArray(i)?i.map(e=>{let t={};for(let i of n)t[i]=ln(e,r(i));return t}):[]}async function fn(e,t=e=>e,n=fetch){let r=Ie(e);if(!r.url)throw Error(`External REST fetch has no url${e.ref?` (unknown source "${e.ref}")`:``}`);let i=t(r.url)??r.url,a=(r.method||`GET`).toUpperCase(),o={};for(let[e,n]of Object.entries(r.headers??{}))o[e]=t(n)??n;Object.assign(o,await cn({url:i,method:a}));let s={method:a,headers:o};a!==`GET`&&a!==`HEAD`&&r.body&&(s.body=t(r.body)??r.body);let c=await n(i,s);if(!c.ok)throw Error(`External REST fetch failed: ${c.status}`);return c.json()}async function pn(e,t=e=>e,n=fetch){let r=await fn(e,t,n),i=Ie(e);return un(r,i.itemsPath,i.valuePath,i.labelPath)}async function mn(e,t,n=e=>e,r=fetch){return dn(await fn(e,n,r),Ie(e).itemsPath,t,t=>Le(e,t))}var hn=class extends b{constructor(...e){super(...e),this.totalElements=0,this.pageSize=100,this.pageNumber=0,this.totalPages=0}updated(e){super.updated(e),(e.has(`totalElements`)||e.has(`pageSize`))&&(this.totalPages=Math.ceil(this.totalElements/this.pageSize))}dispatch(e){this.dispatchEvent(new CustomEvent(`page-changed`,{bubbles:!0,composed:!0,detail:{page:e}}))}render(){if(!this.totalElements)return v;let e=this.totalPages>1,t=this.pageNumber,n=t===0,r=t>=this.totalPages-1;return T`
+    `}};k([y()],sn.prototype,`columns`,void 0),k([y()],sn.prototype,`scope`,void 0),k([C()],sn.prototype,`panelOpened`,void 0),k([C()],sn.prototype,`revision`,void 0),sn=k([g(`mateu-column-chooser`)],sn);var cn;async function ln(e){if(!cn)return{};try{return await cn(e)??{}}catch(e){return console.warn(`mateu: external auth provider failed`,e),{}}}function un(e,t){return t?t.split(`.`).reduce((e,t)=>typeof e==`object`&&e?e[t]:void 0,e):e}function dn(e,t,n=`value`,r=`label`){let i=un(e,t);return Array.isArray(i)?i.map(e=>{if(typeof e==`object`&&e){let t=un(e,n),i=un(e,r);return{value:t??i,label:String(i??t??``)}}return{value:e,label:String(e)}}):[]}function fn(e,t,n,r=e=>e){let i=un(e,t);return Array.isArray(i)?i.map(e=>{let t={};for(let i of n)t[i]=un(e,r(i));return t}):[]}async function pn(e,t=e=>e,n=fetch){let r=Ie(e);if(!r.url)throw Error(`External REST fetch has no url${e.ref?` (unknown source "${e.ref}")`:``}`);let i=t(r.url)??r.url,a=(r.method||`GET`).toUpperCase(),o={};for(let[e,n]of Object.entries(r.headers??{}))o[e]=t(n)??n;Object.assign(o,await ln({url:i,method:a}));let s={method:a,headers:o};a!==`GET`&&a!==`HEAD`&&r.body&&(s.body=t(r.body)??r.body);let c=await n(i,s);if(!c.ok)throw Error(`External REST fetch failed: ${c.status}`);return c.json()}async function mn(e,t=e=>e,n=fetch){let r=await pn(e,t,n),i=Ie(e);return dn(r,i.itemsPath,i.valuePath,i.labelPath)}async function hn(e,t,n=e=>e,r=fetch){return fn(await pn(e,n,r),Ie(e).itemsPath,t,t=>Le(e,t))}var gn=class extends b{constructor(...e){super(...e),this.totalElements=0,this.pageSize=100,this.pageNumber=0,this.totalPages=0}updated(e){super.updated(e),(e.has(`totalElements`)||e.has(`pageSize`))&&(this.totalPages=Math.ceil(this.totalElements/this.pageSize))}dispatch(e){this.dispatchEvent(new CustomEvent(`page-changed`,{bubbles:!0,composed:!0,detail:{page:e}}))}render(){if(!this.totalElements)return v;let e=this.totalPages>1,t=this.pageNumber,n=t===0,r=t>=this.totalPages-1;return T`
             <div class="bar">
                 ${e?T`
                     <button class="nav" title="First page" ?disabled="${n}"
@@ -1032,97 +1032,97 @@ ${i}
             align-self: center;
             margin: 0 4px;
         }
-    `}};k([y()],hn.prototype,`totalElements`,void 0),k([y()],hn.prototype,`pageSize`,void 0),k([y()],hn.prototype,`pageNumber`,void 0),k([C()],hn.prototype,`totalPages`,void 0),hn=k([g(`mateu-pagination`)],hn);var gn=`var(--lumo-space-m, 1rem)`,_n=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.columnWidth||`13rem`,l=`display: grid; grid-template-columns: ${s.maxColumns&&s.maxColumns>0?`repeat(${s.maxColumns}, minmax(0, 1fr))`:`repeat(auto-fill, minmax(min(100%, ${c}), 1fr))`}; gap: ${gn} var(--lumo-space-l, 1.5rem); align-items: start;`;return s.labelsAside&&(l+=` --mateu-label-width: 10rem;`),s.fullWidth&&(l+=` width: 100%;`),l+=t.style??``,T`
+    `}};k([y()],gn.prototype,`totalElements`,void 0),k([y()],gn.prototype,`pageSize`,void 0),k([y()],gn.prototype,`pageNumber`,void 0),k([C()],gn.prototype,`totalPages`,void 0),gn=k([g(`mateu-pagination`)],gn);var _n=`var(--lumo-space-m, 1rem)`,vn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.columnWidth||`13rem`,l=`display: grid; grid-template-columns: ${s.maxColumns&&s.maxColumns>0?`repeat(${s.maxColumns}, minmax(0, 1fr))`:`repeat(auto-fill, minmax(min(100%, ${c}), 1fr))`}; gap: ${_n} var(--lumo-space-l, 1.5rem); align-items: start;`;return s.labelsAside&&(l+=` --mateu-label-width: 10rem;`),s.fullWidth&&(l+=` width: 100%;`),l+=t.style??``,T`
         <div id="${t.id??v}" style="${l}" class="${t.cssClasses}" slot="${t.slot||v}">
-            ${t.children?.map(t=>vn(s,e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>yn(s,e,t,n,r,i,a,o))}
         </div>
-    `},vn=(e,t,n,r,i,a,o,s)=>n.type==A.ClientSide&&n.metadata?.type==j.FormRow?xn(e,t,n,r,i,a,o,s):T`<div style="grid-column: span ${yn(n)}; min-width: 0;">${e.labelsAside?bn(t,n,r,i,a,o,s):I(t,n,r,i,a,o,s)}</div>`,yn=e=>{if(e.type==A.ClientSide){let t=e.metadata;if(t?.type==j.FormField)return t.colspan||1}return 1},bn=(e,t,n,r,i,a,o)=>{if(t.type==A.ClientSide&&t.metadata?.type==j.FormField&&t.metadata.label){let s=t.metadata;return T`
-            <div style="display: flex; gap: ${gn}; align-items: baseline;">
+    `},yn=(e,t,n,r,i,a,o,s)=>n.type==A.ClientSide&&n.metadata?.type==j.FormRow?Sn(e,t,n,r,i,a,o,s):T`<div style="grid-column: span ${bn(n)}; min-width: 0;">${e.labelsAside?xn(t,n,r,i,a,o,s):F(t,n,r,i,a,o,s)}</div>`,bn=e=>{if(e.type==A.ClientSide){let t=e.metadata;if(t?.type==j.FormField)return t.colspan||1}return 1},xn=(e,t,n,r,i,a,o)=>{if(t.type==A.ClientSide&&t.metadata?.type==j.FormField&&t.metadata.label){let s=t.metadata;return T`
+            <div style="display: flex; gap: ${_n}; align-items: baseline;">
                 <label style="flex: 0 0 var(--mateu-label-width, 10rem); color: var(--lumo-secondary-text-color, #667);">${s.label?.includes("${")?e._evalTemplate(s.label):s.label}</label>
-                <div style="flex: 1; min-width: 0;">${I(e,t,n,r,i,a,o,!0)}</div>
+                <div style="flex: 1; min-width: 0;">${F(e,t,n,r,i,a,o,!0)}</div>
             </div>
-        `}return I(e,t,n,r,i,a,o)},xn=(e,t,n,r,i,a,o,s)=>T`
-        <div style="grid-column: 1 / -1; display: flex; gap: ${gn}; flex-wrap: wrap;">
-            ${n.children?.map(c=>T`<div style="flex: 1 1 ${100/Math.max(1,n.children.length)}%; min-width: min(100%, 13rem);">${vn(e,t,c,r,i,a,o,s)}</div>`)}
+        `}return F(e,t,n,r,i,a,o)},Sn=(e,t,n,r,i,a,o,s)=>T`
+        <div style="grid-column: 1 / -1; display: flex; gap: ${_n}; flex-wrap: wrap;">
+            ${n.children?.map(c=>T`<div style="flex: 1 1 ${100/Math.max(1,n.children.length)}%; min-width: min(100%, 13rem);">${yn(e,t,c,r,i,a,o,s)}</div>`)}
         </div>
-    `,Sn=(e,t,n,r,i,a,o,s)=>{let c=n.metadata,l=`display: flex; flex-direction: ${e};`;c.spacing&&(l+=` gap: ${gn};`),c.padding&&(l+=` padding: var(--lumo-space-m, 1rem);`),c.wrap&&(l+=` flex-wrap: wrap;`),c.fullWidth&&(l+=` width: 100%;`),c.justification&&(l+=` justify-content: ${c.justification};`);let u=e===`row`?c.verticalAlignment:c.horizontalAlignment;return u&&(l+=` align-items: ${u};`),l+=n.style??``,T`
+    `,Cn=(e,t,n,r,i,a,o,s)=>{let c=n.metadata,l=`display: flex; flex-direction: ${e};`;c.spacing&&(l+=` gap: ${_n};`),c.padding&&(l+=` padding: var(--lumo-space-m, 1rem);`),c.wrap&&(l+=` flex-wrap: wrap;`),c.fullWidth&&(l+=` width: 100%;`),c.justification&&(l+=` justify-content: ${c.justification};`);let u=e===`row`?c.verticalAlignment:c.horizontalAlignment;return u&&(l+=` align-items: ${u};`),l+=n.style??``,T`
         <div id="${n.id??v}" style="${l}" class="${n.cssClasses}" slot="${n.slot??v}">
-            ${n.children?.map(e=>I(t,e,r,i,a,o,s))}
+            ${n.children?.map(e=>F(t,e,r,i,a,o,s))}
         </div>
-    `},Cn=(e,t,n,r,i,a,o)=>Sn(`row`,e,t,n,r,i,a,o),wn=(e,t,n,r,i,a,o)=>Sn(`column`,e,t,n,r,i,a,o),Tn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=`display: flex; flex-direction: ${s.orientation===`vertical`?`column`:`row`}; gap: var(--lumo-space-s, 0.5rem);`;return s.fullWidth&&(c+=` width: 100%;`),c+=t.style??``,T`
+    `},wn=(e,t,n,r,i,a,o)=>Cn(`row`,e,t,n,r,i,a,o),Tn=(e,t,n,r,i,a,o)=>Cn(`column`,e,t,n,r,i,a,o),En=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=`display: flex; flex-direction: ${s.orientation===`vertical`?`column`:`row`}; gap: var(--lumo-space-s, 0.5rem);`;return s.fullWidth&&(c+=` width: 100%;`),c+=t.style??``,T`
         <div id="${t.id??v}" style="${c}" class="${t.cssClasses}" slot="${t.slot??v}">
-            <div style="flex: 1; min-width: 0; min-height: 0;">${I(e,t.children[0],n,r,i,a,o)}</div>
-            <div style="flex: 1; min-width: 0; min-height: 0;">${I(e,t.children[1],n,r,i,a,o)}</div>
+            <div style="flex: 1; min-width: 0; min-height: 0;">${F(e,t.children[0],n,r,i,a,o)}</div>
+            <div style="flex: 1; min-width: 0; min-height: 0;">${F(e,t.children[1],n,r,i,a,o)}</div>
         </div>
-    `},En=(e,t,n,r,i,a,o)=>{let s=t.children&&t.children.length>1?t.children[1]:null,c=i?.detailComponent??null,l=!!i?.hasDetail||!!s,u=c??s;return T`
+    `},Dn=(e,t,n,r,i,a,o)=>{let s=t.children&&t.children.length>1?t.children[1]:null,c=i?.detailComponent??null,l=!!i?.hasDetail||!!s,u=c??s;return T`
         <div id="${t.id??v}" style="display: flex; gap: var(--lumo-space-m, 1rem); ${t.style??``}" class="${t.cssClasses}" slot="${t.slot??v}">
-            <div style="flex: 1; min-width: 0;">${I(e,t.children[0],n,r,i,a,o)}</div>
-            ${l&&u?T`<div style="flex: 1; min-width: 0;">${I(e,u,n,r,i,a,o)}</div>`:T`<div style="flex: 1; display: flex; align-items: center; justify-content: center; color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-s, .875rem);">Select an item to view details</div>`}
+            <div style="flex: 1; min-width: 0;">${F(e,t.children[0],n,r,i,a,o)}</div>
+            ${l&&u?T`<div style="flex: 1; min-width: 0;">${F(e,u,n,r,i,a,o)}</div>`:T`<div style="flex: 1; display: flex; align-items: center; justify-content: center; color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-s, .875rem);">Select an item to view details</div>`}
         </div>
-    `},Dn=(e,t,n,r,i,a,o)=>{let s=t.style??``;t.metadata.fullWidth&&(s+=` width: 100%;`);let c=Math.max(0,(t.children??[]).findIndex(e=>e.metadata.active));return T`
+    `},On=(e,t,n,r,i,a,o)=>{let s=t.style??``;t.metadata.fullWidth&&(s+=` width: 100%;`);let c=Math.max(0,(t.children??[]).findIndex(e=>e.metadata.active));return T`
         <div id="${t.id??v}" style="${s}" class="${t.cssClasses}" slot="${t.slot??v}">
             ${t.children?.map((t,s)=>{let l=t,u=l.metadata.label,d=u?.includes("${")?e._evalTemplate(u):u;return T`
                     <details ?open="${s===c}" style="border-bottom: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));">
                         <summary style="cursor: pointer; padding: var(--lumo-space-s, .5rem) 0; font-weight: 600;">${d}</summary>
                         <div style="padding: var(--lumo-space-m, 1rem) 0;">
-                            ${l.children?.map(t=>I(e,t,n,r,i,a,o))}
+                            ${l.children?.map(t=>F(e,t,n,r,i,a,o))}
                         </div>
                     </details>
                 `})}
         </div>
-    `},On=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style??``;return s.fullWidth&&(c+=` width: 100%;`),T`
+    `},kn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style??``;return s.fullWidth&&(c+=` width: 100%;`),T`
         <div style="${c}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${t.children?.map(t=>kn(e,t,n,r,i,a,o,s.variant))}
+            ${t.children?.map(t=>An(e,t,n,r,i,a,o,s.variant))}
         </div>
-    `},kn=(e,t,n,r,i,a,o,s)=>{let c=t.metadata,l=c.label?.includes("${")?e._evalTemplate(c.label):c.label;return T`
+    `},An=(e,t,n,r,i,a,o,s)=>{let c=t.metadata,l=c.label?.includes("${")?e._evalTemplate(c.label):c.label;return T`
         <details ?open="${c.active}" style="border-bottom: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1)); ${t.style??``}" class="${t.cssClasses}">
             <summary style="cursor: pointer; padding: var(--lumo-space-s, .5rem) 0; font-weight: 600; ${c.disabled?`pointer-events: none; opacity: .5;`:``}">${l}</summary>
             <div style="padding: var(--lumo-space-s, .5rem) 0;">
-                ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+                ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
             </div>
         </details>
-    `},An=(e,t,n,r,i,a,o)=>T`
+    `},jn=(e,t,n,r,i,a,o)=>T`
         <div style="overflow: auto; ${t.style??``}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
-        </div>
-    `,jn=(e,t,n,r,i,a,o)=>T`
-        <div style="width: 100%; ${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
         </div>
     `,Mn=(e,t,n,r,i,a,o)=>T`
-        <div style="max-width: min(100%, 1200px); margin: auto; ${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+        <div style="width: 100%; ${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
         </div>
     `,Nn=(e,t,n,r,i,a,o)=>T`
-        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr)); gap: ${gn}; ${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+        <div style="max-width: min(100%, 1200px); margin: auto; ${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
         </div>
     `,Pn=(e,t,n,r,i,a,o)=>T`
-        <div style="display: flex; gap: ${gn}; flex-wrap: wrap; ${t.style}" class="${t.cssClasses}">
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr)); gap: ${_n}; ${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
         </div>
     `,Fn=(e,t,n,r,i,a,o)=>T`
-        <div style="flex: ${t.metadata.boardCols??1} 1 0; min-width: min(100%, 12rem); ${t.style}" class="${t.cssClasses}">
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+        <div style="display: flex; gap: ${_n}; flex-wrap: wrap; ${t.style}" class="${t.cssClasses}">
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
         </div>
-    `,In=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+    `,In=(e,t,n,r,i,a,o)=>T`
+        <div style="flex: ${t.metadata.boardCols??1} 1 0; min-width: min(100%, 12rem); ${t.style}" class="${t.cssClasses}">
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+        </div>
+    `,Ln=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
         <div
                 style="display: flex; flex-direction: column; overflow: auto; ${t.style}"
                 class="${t.cssClasses}"
                 slot="${t.slot??v}"
         >
-            ${s.page.content.map(t=>I(e,t,n,r,i,a,o))}
+            ${s.page.content.map(t=>F(e,t,n,r,i,a,o))}
         </div>
-    `},Ln=e=>{let t=e.metadata;return(t?.content??t?.columns??[]).filter(e=>e&&e.metadata).map(e=>{let t=e.metadata;return{id:e.id??``,label:t?.label??e.id??``,autoWidth:t?.autoWidth,width:t?.width}})},Rn=(e,t)=>{let n=e?.[t];return n==null?``:typeof n==`object`?n.text??n.label??n.value??``:String(n)},zn=(e,t,n)=>{let r=Ln(e);return T`
+    `},Rn=e=>{let t=e.metadata;return(t?.content??t?.columns??[]).filter(e=>e&&e.metadata).map(e=>{let t=e.metadata;return{id:e.id??``,label:t?.label??e.id??``,autoWidth:t?.autoWidth,width:t?.width}})},zn=(e,t)=>{let n=e?.[t];return n==null?``:typeof n==`object`?n.text??n.label??n.value??``:String(n)},Bn=(e,t,n)=>{let r=Rn(e);return T`
         <div style="overflow:auto; width:100%; ${e.style}" class="${e.cssClasses}" slot="${e.slot??v}">
             <table style="border-collapse:collapse; width:100%; font-size: var(--lumo-font-size-s,.875rem);">
                 <thead><tr>${r.map(e=>T`<th style="${`text-align:left; padding:.45rem .6rem; border-bottom:2px solid var(--lumo-contrast-20pct,rgba(0,0,0,.2)); font-weight:600; white-space:nowrap; color: var(--lumo-secondary-text-color,#556);`}">${e.label}</th>`)}</tr></thead>
                 <tbody>
-                    ${(t??[]).length===0?T`<tr><td colspan="${Math.max(1,r.length)}" style="padding:1.5rem; text-align:center; color: var(--lumo-secondary-text-color,#888);">${n??`No data.`}</td></tr>`:t.map(e=>T`<tr>${r.map(t=>T`<td style="${`padding:.4rem .6rem; border-bottom:1px solid var(--lumo-contrast-10pct,rgba(0,0,0,.08)); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:24rem;`}" title="${Rn(e,t.id)}">${Rn(e,t.id)}</td>`)}</tr>`)}
+                    ${(t??[]).length===0?T`<tr><td colspan="${Math.max(1,r.length)}" style="padding:1.5rem; text-align:center; color: var(--lumo-secondary-text-color,#888);">${n??`No data.`}</td></tr>`:t.map(e=>T`<tr>${r.map(t=>T`<td style="${`padding:.4rem .6rem; border-bottom:1px solid var(--lumo-contrast-10pct,rgba(0,0,0,.08)); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:24rem;`}" title="${zn(e,t.id)}">${zn(e,t.id)}</td>`)}</tr>`)}
                 </tbody>
             </table>
         </div>
-    `},Bn=(e,t)=>{let n=e.metadata;return e.id&&t&&t[e.id]?t[e.id]:n?.page?.content??[]},Vn=e=>{let t=e.metadata.items??[];return T`
+    `},Vn=(e,t)=>{let n=e.metadata;return e.id&&t&&t[e.id]?t[e.id]:n?.page?.content??[]},Hn=e=>{let t=e.metadata.items??[];return T`
         <div class="mateu-message-list ${e.cssClasses??``}"
              style="display:flex; flex-direction:column; gap:.75rem; ${e.style??``}"
              slot="${e.slot??v}">
@@ -1141,15 +1141,15 @@ ${i}
                 </div>
             `)}
         </div>
-    `},Hn=(e,t,n,r,i,a,o)=>t.separator?T`<span style="align-self: stretch; width: 1px; background: var(--lumo-contrast-20pct, rgba(0,0,0,.2));"></span>`:t.submenus?T`
+    `},Un=(e,t,n,r,i,a,o)=>t.separator?T`<span style="align-self: stretch; width: 1px; background: var(--lumo-contrast-20pct, rgba(0,0,0,.2));"></span>`:t.submenus?T`
             <details style="position: relative;">
                 <summary style="cursor: pointer; list-style: none; padding: .35rem .7rem; border-radius: var(--lumo-border-radius-m, 6px);">
-                    ${t.component?I(e,t.component,n,r,i,a,o):t.label} ▾
+                    ${t.component?F(e,t.component,n,r,i,a,o):t.label} ▾
                 </summary>
                 <div style="display: flex; flex-direction: column; gap: .1rem; padding: .3rem; min-width: 10rem;
                             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1)); border-radius: var(--lumo-border-radius-m, 6px);
                             background: var(--lumo-base-color, #fff); box-shadow: var(--lumo-box-shadow-s, 0 2px 8px rgba(0,0,0,.15));">
-                    ${t.submenus.map(t=>Hn(e,t,n,r,i,a,o))}
+                    ${t.submenus.map(t=>Un(e,t,n,r,i,a,o))}
                 </div>
             </details>
         `:T`
@@ -1157,27 +1157,27 @@ ${i}
               style="cursor: ${t.disabled?`default`:`pointer`}; opacity: ${t.disabled?.5:1};
                      padding: .35rem .7rem; border-radius: var(--lumo-border-radius-m, 6px);
                      ${t.selected?`background: var(--lumo-primary-color-10pct, rgba(26,115,232,.12));`:``}">
-            ${t.component?I(e,t.component,n,r,i,a,o):t.label}
+            ${t.component?F(e,t.component,n,r,i,a,o):t.label}
         </span>
-    `,Un=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+    `,Wn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
         <div style="display: flex; flex-wrap: wrap; gap: .25rem; align-items: center; ${t.style}"
              class="${t.cssClasses}" slot="${t.slot??v}">
-            ${s.options?.map(t=>Hn(e,t,n,r,i,a??{},o??{}))}
+            ${s.options?.map(t=>Un(e,t,n,r,i,a??{},o??{}))}
         </div>
-    `},Wn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+    `},Gn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
         <div style="${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
-            ${I(e,s.wrapped,n,r,i,a,o)}
+            ${F(e,s.wrapped,n,r,i,a,o)}
         </div>
-    `},Gn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.content?.metadata,l=c?.type==j.Notice&&c.fullWidth===!0;return T`
+    `},Kn=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.content?.metadata,l=c?.type==j.Notice&&c.fullWidth===!0;return T`
         <div style="display:flex; flex-direction:column; ${l?`width: 100%; `:``}${t.style}"
              class="${t.cssClasses}"
              slot="${t.slot??v}"
              data-colspan="${s.colspan||(l?99:v)}"
         >
             ${s.label?T`<label style="font-size: var(--lumo-font-size-s,.875rem); color: var(--lumo-secondary-text-color,#667); margin-bottom:.15rem;">${s.label}</label>`:v}
-            ${I(e,s.content,n,r,i,a,o)}
+            ${F(e,s.content,n,r,i,a,o)}
         </div>
-            `},Kn=e=>{let t=e.metadata,n=e=>{let n=e.closest(`.mateu-message-input`)?.querySelector(`input`),r=n?.value??``;!t.actionId||!r.trim()||(e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:{message:r}},bubbles:!0,composed:!0})),n&&(n.value=``))};return T`
+            `},qn=e=>{let t=e.metadata,n=e=>{let n=e.closest(`.mateu-message-input`)?.querySelector(`input`),r=n?.value??``;!t.actionId||!r.trim()||(e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:{message:r}},bubbles:!0,composed:!0})),n&&(n.value=``))};return T`
         <div class="mateu-message-input ${e.cssClasses??``}"
              style="display:flex; gap:.5rem; align-items:center; ${e.style??``}"
              slot="${e.slot??v}">
@@ -1187,62 +1187,62 @@ ${i}
             <button style="font:inherit; font-weight:500; cursor:pointer; padding:.5rem 1rem; border:none; border-radius:var(--lumo-border-radius-m,6px); background:var(--lumo-primary-color,#3b5bdb); color:var(--lumo-primary-contrast-color,#fff);"
                     @click="${e=>n(e.currentTarget)}">Send</button>
         </div>
-    `},qn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`<span title="${s.text}" style="${t.style}" class="${t.cssClasses}" slot="${t.slot??v}"
-        >${I(e,s.wrapped,n,r,i,a,o)}</span>`},Jn=e=>{if(e instanceof CustomEvent)return e.detail;let t={};for(let n in e){let r=e[n];[`number`,`string`,`boolean`].indexOf(typeof r)>=0&&(t[n]=e[n])}return t},Yn=(e,t,n,r,i)=>{let a={appState:r??{},appData:i??{}},o={};for(let r in e.attributes)o[r]=M(e.attributes[r],t,n,a);return{attributes:o,content:M(e.content,t,n,a)}},Xn=(e,t,n,r)=>{for(let t in r.attributes)e.setAttribute(t,r.attributes[t]);n.style&&e.setAttribute(`style`,n.style),n.cssClasses&&e.setAttribute(`class`,n.cssClasses),n.slot&&e.setAttribute(`slot`,n.slot),r.content&&(t.html?e.innerHTML=r.content:e.append(r.content))},Zn=e=>{let t=e.name,n=e.attributes?e.attributes.import:void 0;n&&t.includes(`-`)&&!customElements.get(t)&&D(()=>import(n),[])},Qn=(e,t,n,r,i,a,o)=>{Zn(t);let s=Yn(t,r,i,a,o),c=t.name;s.attributes.id&&(c=`#`+s.attributes.id);let l=n.id?`.element-container[data-element-id="${n.id}"]`:`.element-container`;return setTimeout(()=>{let r=e.shadowRoot?.querySelector(l),i=r?.querySelector(c);if(i){for(;i.firstChild;)i.removeChild(i.lastChild);Xn(i,t,n,s)}else{let i=document.createElement(t.name);Xn(i,t,n,s);for(let n in t.on)i.addEventListener(n,r=>{let i=Jn(r);e.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.on[n],parameters:{event:i}},bubbles:!0,composed:!0}))});r?.appendChild(i)}}),T`<div class="element-container" data-element-id="${S(n.id)}"></div>`},$n=function(e){return e.div=`div`,e.p=`p`,e.h1=`h1`,e.h2=`h2`,e.h3=`h3`,e.h4=`h4`,e.h5=`h5`,e.h6=`h6`,e.span=`span`,e}({}),er=(e,t,n,r,i)=>{let a=e.metadata,o=a.attributes?.[`data-colspan`],s=xt(a.text,t,n,r,i),c={xl:`var(--lumo-font-size-xl, 1.375rem)`,l:`var(--lumo-font-size-l, 1.125rem)`,s:`var(--lumo-font-size-s, .875rem)`,xs:`var(--lumo-font-size-xs, .8125rem)`},l=(a.size&&c[a.size]?`font-size: ${c[a.size]}; `:``)+(a.noMargins?`margin-block-start: 0; margin-block-end: 0; `:``);return $n.h1==a.container?T`
+    `},Jn=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`<span title="${s.text}" style="${t.style}" class="${t.cssClasses}" slot="${t.slot??v}"
+        >${F(e,s.wrapped,n,r,i,a,o)}</span>`},Yn=e=>{if(e instanceof CustomEvent)return e.detail;let t={};for(let n in e){let r=e[n];[`number`,`string`,`boolean`].indexOf(typeof r)>=0&&(t[n]=e[n])}return t},Xn=(e,t,n,r,i)=>{let a={appState:r??{},appData:i??{}},o={};for(let r in e.attributes)o[r]=M(e.attributes[r],t,n,a);return{attributes:o,content:M(e.content,t,n,a)}},Zn=(e,t,n,r)=>{for(let t in r.attributes)e.setAttribute(t,r.attributes[t]);n.style&&e.setAttribute(`style`,n.style),n.cssClasses&&e.setAttribute(`class`,n.cssClasses),n.slot&&e.setAttribute(`slot`,n.slot),r.content&&(t.html?e.innerHTML=r.content:e.append(r.content))},Qn=e=>{let t=e.name,n=e.attributes?e.attributes.import:void 0;n&&t.includes(`-`)&&!customElements.get(t)&&D(()=>import(n),[])},$n=(e,t,n,r,i,a,o)=>{Qn(t);let s=Xn(t,r,i,a,o),c=t.name;s.attributes.id&&(c=`#`+s.attributes.id);let l=n.id?`.element-container[data-element-id="${n.id}"]`:`.element-container`;return setTimeout(()=>{let r=e.shadowRoot?.querySelector(l),i=r?.querySelector(c);if(i){for(;i.firstChild;)i.removeChild(i.lastChild);Zn(i,t,n,s)}else{let i=document.createElement(t.name);Zn(i,t,n,s);for(let n in t.on)i.addEventListener(n,r=>{let i=Yn(r);e.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.on[n],parameters:{event:i}},bubbles:!0,composed:!0}))});r?.appendChild(i)}}),T`<div class="element-container" data-element-id="${S(n.id)}"></div>`},er=function(e){return e.div=`div`,e.p=`p`,e.h1=`h1`,e.h2=`h2`,e.h3=`h3`,e.h4=`h4`,e.h5=`h5`,e.h6=`h6`,e.span=`span`,e}({}),tr=(e,t,n,r,i)=>{let a=e.metadata,o=a.attributes?.[`data-colspan`],s=xt(a.text,t,n,r,i),c={xl:`var(--lumo-font-size-xl, 1.375rem)`,l:`var(--lumo-font-size-l, 1.125rem)`,s:`var(--lumo-font-size-s, .875rem)`,xs:`var(--lumo-font-size-xs, .8125rem)`},l=(a.size&&c[a.size]?`font-size: ${c[a.size]}; `:``)+(a.noMargins?`margin-block-start: 0; margin-block-end: 0; `:``);return er.h1==a.container?T`
             <h1 style="${l}${e.style}" class="${e.cssClasses}"
                 id="${S(e.id)}"
                 data-colspan="${S(o)}"
                 slot="${e.slot??v}">
                 ${s??v}
             </h1>
-        `:$n.h2==a.container?T`
+        `:er.h2==a.container?T`
             <h2 style="${l}${e.style}" class="${e.cssClasses}"
                 id="${S(e.id)}"
                 data-colspan="${S(o)}"
                 slot="${e.slot??v}">
                 ${s??v}
             </h2>
-        `:$n.h3==a.container?T`
+        `:er.h3==a.container?T`
             <h3 style="${l}${e.style}" class="${e.cssClasses}"
                 id="${S(e.id)}"
                 data-colspan="${S(o)}"
                 slot="${e.slot??v}">
                 ${s??v}
             </h3>
-        `:$n.h4==a.container?T`
+        `:er.h4==a.container?T`
             <h4 style="${l}${e.style}" class="${e.cssClasses}"
                 id="${S(e.id)}"
                 data-colspan="${S(o)}"
                 slot="${e.slot??v}">
                 ${s??v}
             </h4>
-        `:$n.h5==a.container?T`
+        `:er.h5==a.container?T`
             <h5 style="${l}${e.style}" class="${e.cssClasses}"
                 id="${S(e.id)}"
                 data-colspan="${S(o)}"
                 slot="${e.slot??v}">
                 ${s??v}
             </h5>
-        `:$n.h6==a.container?T`
+        `:er.h6==a.container?T`
             <h6 style="${l}${e.style}" class="${e.cssClasses}"
                 id="${S(e.id)}"
                 data-colspan="${S(o)}"
                 slot="${e.slot??v}">
                 ${s??v}
             </h6>
-        `:$n.p==a.container?T`
+        `:er.p==a.container?T`
                <p style="${l}${e.style}" class="${e.cssClasses}"
                   id="${S(e.id)}"
                   data-colspan="${S(o)}"
                   slot="${e.slot??v}">
                    ${s??v}
                </p>
-            `:$n.div==a.container?T`
+            `:er.div==a.container?T`
                <div style="${l}${e.style}" class="${e.cssClasses}"
                     id="${S(e.id)}"
                     data-colspan="${S(o)}"
                     slot="${e.slot??v}">${s?_(s):v}</div>
-            `:$n.span==a.container?T`
+            `:er.span==a.container?T`
                <span style="${l}${e.style}" class="${e.cssClasses}"
                      id="${S(e.id)}"
                      data-colspan="${S(o)}"
@@ -1254,20 +1254,20 @@ ${i}
                        slot="${e.slot??v}">
                    Unknown text container: ${a.container} 
                </p>
-            `},tr=e=>{let t=e.metadata;return T`<a href="${t.url}" target="${t.target??v}"
+            `},nr=e=>{let t=e.metadata;return T`<a href="${t.url}" target="${t.target??v}"
                    rel="${t.target===`_blank`?`noopener`:v}"
                    style="${e.style}" class="${e.cssClasses}"
-                   slot="${e.slot??v}">${t.text}</a>`},nr=(e,t)=>{let n=e.toLowerCase().split(`+`);return t.ctrlKey===n.includes(`ctrl`)&&t.altKey===n.includes(`alt`)&&t.shiftKey===n.includes(`shift`)&&t.metaKey===n.includes(`meta`)},rr=(e,t)=>{if(!nr(e,t))return!1;let n=e.toLowerCase().split(`+`),r=n[n.length-1];return!!(t.key.toLowerCase()===r||/^[a-z]$/.test(r)&&t.code===`Key`+r.toUpperCase()||/^[0-9]$/.test(r)&&(t.code===`Digit`+r||t.code===`Numpad`+r))},ir=e=>e?e.split(`+`).map(e=>e.length<=1?e.toUpperCase():e.charAt(0).toUpperCase()+e.slice(1)).join(`+`):void 0,ar=(e,t)=>{let n=e.currentTarget.dataset.actionId;e.currentTarget?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:n,parameters:t.parameters},bubbles:!0,composed:!0}))},or=`display:inline-flex; align-items:center; justify-content:center; gap:.4em; box-sizing:border-box; font:inherit; font-weight:500; cursor:pointer; border-radius:var(--lumo-border-radius-m,6px); border:1px solid transparent; line-height:1; white-space:nowrap;`,sr=e=>{let t=e.buttonStyle??``,n=e.color&&e.color!==`none`&&e.color!==`normal`?e.color:``,r=e.size,i=n===`success`?`var(--lumo-success-color,#1a7f37)`:n===`error`?`var(--lumo-error-color,#c5221f)`:n===`contrast`?`var(--lumo-contrast,#161513)`:`var(--lumo-primary-color,#3b5bdb)`,a=n===`success`?`var(--lumo-success-contrast-color,#fff)`:n===`error`?`var(--lumo-error-contrast-color,#fff)`:n===`contrast`?`var(--lumo-base-color,#fff)`:`var(--lumo-primary-contrast-color,#fff)`,o=n===`success`?`var(--lumo-success-text-color,#1a7f37)`:n===`error`?`var(--lumo-error-text-color,#c5221f)`:n===`contrast`?`var(--lumo-body-text-color,#161513)`:`var(--lumo-primary-text-color,#3b5bdb)`,s;return s=t===`primary`?`background:${i}; color:${a};`:t===`tertiary`||t===`tertiaryInline`?`background:transparent; color:${o};`:`background:var(--lumo-contrast-5pct,rgba(0,0,0,.04)); color:${o}; border-color:var(--lumo-contrast-20pct,rgba(0,0,0,.16));`,`${or}${s}${r===`small`?`padding:.25rem .6rem; font-size:var(--lumo-font-size-s,.875rem);`:r===`large`?`padding:.65rem 1.4rem; font-size:var(--lumo-font-size-l,1.125rem);`:`padding:.45rem 1rem; font-size:var(--lumo-font-size-m,1rem);`}`},cr=(e,t,n)=>{let r=e.metadata,i=M(r.label,t,n);return T`<button
+                   slot="${e.slot??v}">${t.text}</a>`},rr=(e,t)=>{let n=e.toLowerCase().split(`+`);return t.ctrlKey===n.includes(`ctrl`)&&t.altKey===n.includes(`alt`)&&t.shiftKey===n.includes(`shift`)&&t.metaKey===n.includes(`meta`)},ir=(e,t)=>{if(!rr(e,t))return!1;let n=e.toLowerCase().split(`+`),r=n[n.length-1];return!!(t.key.toLowerCase()===r||/^[a-z]$/.test(r)&&t.code===`Key`+r.toUpperCase()||/^[0-9]$/.test(r)&&(t.code===`Digit`+r||t.code===`Numpad`+r))},ar=e=>e?e.split(`+`).map(e=>e.length<=1?e.toUpperCase():e.charAt(0).toUpperCase()+e.slice(1)).join(`+`):void 0,or=(e,t)=>{let n=e.currentTarget.dataset.actionId;e.currentTarget?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:n,parameters:t.parameters},bubbles:!0,composed:!0}))},sr=`display:inline-flex; align-items:center; justify-content:center; gap:.4em; box-sizing:border-box; font:inherit; font-weight:500; cursor:pointer; border-radius:var(--lumo-border-radius-m,6px); border:1px solid transparent; line-height:1; white-space:nowrap;`,cr=e=>{let t=e.buttonStyle??``,n=e.color&&e.color!==`none`&&e.color!==`normal`?e.color:``,r=e.size,i=n===`success`?`var(--lumo-success-color,#1a7f37)`:n===`error`?`var(--lumo-error-color,#c5221f)`:n===`contrast`?`var(--lumo-contrast,#161513)`:`var(--lumo-primary-color,#3b5bdb)`,a=n===`success`?`var(--lumo-success-contrast-color,#fff)`:n===`error`?`var(--lumo-error-contrast-color,#fff)`:n===`contrast`?`var(--lumo-base-color,#fff)`:`var(--lumo-primary-contrast-color,#fff)`,o=n===`success`?`var(--lumo-success-text-color,#1a7f37)`:n===`error`?`var(--lumo-error-text-color,#c5221f)`:n===`contrast`?`var(--lumo-body-text-color,#161513)`:`var(--lumo-primary-text-color,#3b5bdb)`,s;return s=t===`primary`?`background:${i}; color:${a};`:t===`tertiary`||t===`tertiaryInline`?`background:transparent; color:${o};`:`background:var(--lumo-contrast-5pct,rgba(0,0,0,.04)); color:${o}; border-color:var(--lumo-contrast-20pct,rgba(0,0,0,.16));`,`${sr}${s}${r===`small`?`padding:.25rem .6rem; font-size:var(--lumo-font-size-s,.875rem);`:r===`large`?`padding:.65rem 1.4rem; font-size:var(--lumo-font-size-l,1.125rem);`:`padding:.45rem 1rem; font-size:var(--lumo-font-size-m,1rem);`}`},lr=(e,t,n)=>{let r=e.metadata,i=M(r.label,t,n);return T`<button
             id="${e.id}"
             data-action-id="${r.actionId}"
-            @click="${e=>ar(e,r)}"
-            style="${sr(r)}${e.style}"
+            @click="${e=>or(e,r)}"
+            style="${cr(r)}${e.style}"
             class="${e.cssClasses}"
             ?disabled="${r.disabled}"
-            title="${r.shortcut?`${i} (${ir(r.shortcut)})`:v}"
+            title="${r.shortcut?`${i} (${ar(r.shortcut)})`:v}"
             slot="${e.slot??v}"
-    >${r.iconOnLeft?L(r.iconOnLeft):v}${i}${r.iconOnRight?L(r.iconOnRight):v}</button>`},lr=`display:block; box-sizing:border-box; background:var(--lumo-base-color,#fff); border:1px solid var(--lumo-contrast-10pct,rgba(0,0,0,.1)); border-radius:var(--lumo-border-radius-l,12px); box-shadow:var(--lumo-box-shadow-xs,0 1px 3px rgba(0,0,0,.08)); overflow:hidden;`,ur=(e,t,n,r,i,a,o)=>{let s=t.metadata;if(!s)return T``;let c=t=>t?I(e,t,n,r,i,a,o,!1):v,l=s.header||s.headerPrefix||s.headerSuffix||s.title||s.subtitle;return T`
-        <div id="${t.id??v}" style="${lr}${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
+    >${r.iconOnLeft?I(r.iconOnLeft):v}${i}${r.iconOnRight?I(r.iconOnRight):v}</button>`},ur=`display:block; box-sizing:border-box; background:var(--lumo-base-color,#fff); border:1px solid var(--lumo-contrast-10pct,rgba(0,0,0,.1)); border-radius:var(--lumo-border-radius-l,12px); box-shadow:var(--lumo-box-shadow-xs,0 1px 3px rgba(0,0,0,.08)); overflow:hidden;`,dr=(e,t,n,r,i,a,o)=>{let s=t.metadata;if(!s)return T``;let c=t=>t?F(e,t,n,r,i,a,o,!1):v,l=s.header||s.headerPrefix||s.headerSuffix||s.title||s.subtitle;return T`
+        <div id="${t.id??v}" style="${ur}${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
             ${s.media?c(s.media):v}
             ${l?T`<div style="display:flex; align-items:flex-start; gap:.75rem; padding:1rem 1.25rem ${s.content||s.footer?`0`:`1rem`};">
                 ${s.headerPrefix?c(s.headerPrefix):v}
@@ -1281,7 +1281,7 @@ ${i}
             ${s.content?T`<div style="padding:1rem 1.25rem;">${c(s.content)}</div>`:v}
             ${s.footer?T`<div style="padding:0 1.25rem 1rem;">${c(s.footer)}</div>`:v}
         </div>
-    `},dr=e=>{let t=e.metadata;return T`
+    `},fr=e=>{let t=e.metadata;return T`
         <mateu-chart 
                 style="${e.style}" 
                 class="${e.cssClasses}"
@@ -1291,21 +1291,21 @@ ${i}
                 .options="${t.chartOptions}"
         >
         </mateu-chart>
-    `},fr=e=>{let t=e.metadata;return L(t.icon,e.style,e.cssClasses,e.slot)},pr=(e,t)=>{e&&e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},mr=`font:inherit; font-weight:500; cursor:pointer; padding:.45rem 1rem; border-radius:var(--lumo-border-radius-m,6px);`,hr=`${mr} background:var(--lumo-contrast-5pct,rgba(0,0,0,.04)); color:var(--lumo-body-text-color,#161513); border:1px solid var(--lumo-contrast-20pct,rgba(0,0,0,.16));`,gr=`${mr} background:var(--lumo-primary-color,#3b5bdb); color:var(--lumo-primary-contrast-color,#fff); border:1px solid transparent;`,_r=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!1;if(s.openedCondition)try{c=St(s.openedCondition,r,i,a,o)}catch(e){console.error(`when evaluating `+s.openedCondition+` :`+e+`, where data is `+i+` and state is `+r)}return c?T`
+    `},pr=e=>{let t=e.metadata;return I(t.icon,e.style,e.cssClasses,e.slot)},mr=(e,t)=>{e&&e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},hr=`font:inherit; font-weight:500; cursor:pointer; padding:.45rem 1rem; border-radius:var(--lumo-border-radius-m,6px);`,gr=`${hr} background:var(--lumo-contrast-5pct,rgba(0,0,0,.04)); color:var(--lumo-body-text-color,#161513); border:1px solid var(--lumo-contrast-20pct,rgba(0,0,0,.16));`,_r=`${hr} background:var(--lumo-primary-color,#3b5bdb); color:var(--lumo-primary-contrast-color,#fff); border:1px solid transparent;`,vr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!1;if(s.openedCondition)try{c=St(s.openedCondition,r,i,a,o)}catch(e){console.error(`when evaluating `+s.openedCondition+` :`+e+`, where data is `+i+` and state is `+r)}return c?T`
         <div class="mateu-confirm-dialog ${t.cssClasses??``}"
              style="position:fixed; inset:0; z-index:1000; display:flex; align-items:center; justify-content:center; background:rgba(0,0,0,.4); ${t.style??``}"
              slot="${t.slot??v}">
             <div style="background:var(--lumo-base-color,#fff); color:var(--lumo-body-text-color,#161513); border-radius:var(--lumo-border-radius-l,12px); box-shadow:var(--lumo-box-shadow-l,0 8px 24px rgba(0,0,0,.2)); width:100%; max-width:min(90vw,32rem); padding:1.5rem; box-sizing:border-box;">
                 ${s.header?T`<h3 style="margin:0 0 .75rem; font-size:1.15rem;">${s.header}</h3>`:v}
-                <div>${t.children?.map(t=>I(e,t,n,r,i,a,o))}</div>
+                <div>${t.children?.map(t=>F(e,t,n,r,i,a,o))}</div>
                 <div style="display:flex; gap:.5rem; justify-content:flex-end; margin-top:1.25rem;">
-                    ${s.canCancel?T`<button style="${hr}" @click="${e=>pr(e.currentTarget,s.cancelActionId)}">${s.rejectText&&!s.canReject?s.rejectText:`Cancel`}</button>`:v}
-                    ${s.canReject?T`<button style="${hr}" @click="${e=>pr(e.currentTarget,s.rejectActionId)}">${s.rejectText||`No`}</button>`:v}
-                    <button style="${gr}" @click="${e=>pr(e.currentTarget,s.confirmActionId)}">${s.confirmText||`OK`}</button>
+                    ${s.canCancel?T`<button style="${gr}" @click="${e=>mr(e.currentTarget,s.cancelActionId)}">${s.rejectText&&!s.canReject?s.rejectText:`Cancel`}</button>`:v}
+                    ${s.canReject?T`<button style="${gr}" @click="${e=>mr(e.currentTarget,s.rejectActionId)}">${s.rejectText||`No`}</button>`:v}
+                    <button style="${_r}" @click="${e=>mr(e.currentTarget,s.confirmActionId)}">${s.confirmText||`OK`}</button>
                 </div>
             </div>
         </div>
-    `:T``},vr=e=>{let t=e.metadata,n;return t.position&&(n={Top:`top`,Bottom:`bottom`,TopLeft:`top-left`,TopRight:`top-right`,BottomLeft:`bottom-left`,BottomRight:`bottom-right`}[t.position]),T`
+    `:T``},yr=e=>{let t=e.metadata,n;return t.position&&(n={Top:`top`,Bottom:`bottom`,TopLeft:`top-left`,TopRight:`top-right`,BottomLeft:`bottom-left`,BottomRight:`bottom-right`}[t.position]),T`
         <mateu-cookie-consent style="${e.style}" class="${e.cssClasses}"
                                slot="${e.slot??v}"
                                position="${n??v}"
@@ -1316,17 +1316,17 @@ ${i}
                                .learnMoreLink="${t.learnMoreLink??v}"
                                .dismiss="${t.dismiss??v}"
         ></mateu-cookie-consent>
-    `},yr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+    `},br=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
         <details
                 ?open="${s.opened}"
                 style="${t.style}"
                 class="${t.cssClasses}"
                 slot="${t.slot??v}"
         >
-            <summary>${I(e,s.summary,n,r,i,a,o)}</summary>
-            ${I(e,s.content,n,r,i,a,o)}
+            <summary>${F(e,s.summary,n,r,i,a,o)}</summary>
+            ${F(e,s.content,n,r,i,a,o)}
         </details>
-            `},br=(e,t,n,r,i,a)=>T`
+            `},xr=(e,t,n,r,i,a)=>T`
         <mateu-dialog
                 id="${e.metadata.id}"
             .component="${e}"
@@ -1336,7 +1336,7 @@ ${i}
             .appState="${i}"
             .appdata="${a}"
         ></mateu-dialog>
-            `,xr=(e,t,n,r,i,a)=>T`
+            `,Sr=(e,t,n,r,i,a)=>T`
         <mateu-drawer
                 id="${e.metadata.id}"
             .component="${e}"
@@ -1346,7 +1346,7 @@ ${i}
             .appState="${i}"
             .appdata="${a}"
         ></mateu-drawer>
-            `,Sr=e=>{let t=e.metadata;return T`
+            `,Cr=e=>{let t=e.metadata;return T`
         <mateu-api-caller>
         <mateu-ux baseUrl="${t.baseUrl}"  
                   route="${t.route}" 
@@ -1358,11 +1358,11 @@ ${i}
                   slot="${e.slot??v}"
         ></mateu-ux>
         </mateu-api-caller>
-            `},Cr=e=>T`
+            `},wr=e=>T`
         <mateu-markdown .content=${e.metadata.markdown}
                         style="display:block; max-width: 72ch; ${e.style??``}" class="${e.cssClasses}"
                         slot="${e.slot??v}"></mateu-markdown>
-            `,wr=e=>{let t=e.metadata;return T`
+            `,Tr=e=>{let t=e.metadata;return T`
         <div
             role="status"
             slot="${e.slot??v}"
@@ -1375,7 +1375,7 @@ ${i}
             ${t.title?T`<strong>${t.title}</strong>`:v}
             ${t.text?T`<span>${t.text}</span>`:v}
         </div>
-    `},Tr=(e,t={})=>{let n=e.metadata,r=n.valueKey?t[n.valueKey]:n.value,i=n.max&&n.max!=0?n.max:1,a=!n.indeterminate&&r!=null;return T`
+    `},Er=(e,t={})=>{let n=e.metadata,r=n.valueKey?t[n.valueKey]:n.value,i=n.max&&n.max!=0?n.max:1,a=!n.indeterminate&&r!=null;return T`
         <div style="${e.style}" class="${e.cssClasses}" slot="${e.slot??v}">
             <progress
                     style="width:100%;"
@@ -1386,29 +1386,29 @@ ${i}
     ${n.text}
   </span>`:v}
         </div>
-    `},Er=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+    `},Dr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
         <details style="position: relative; ${t.style}" class="${t.cssClasses}" slot="${t.slot??v}">
-            <summary style="list-style: none; cursor: pointer;">${I(e,s.wrapped,n,r,i,a,o)}</summary>
+            <summary style="list-style: none; cursor: pointer;">${F(e,s.wrapped,n,r,i,a,o)}</summary>
             <div style="position: absolute; z-index: 100; min-width: 300px; margin-top: .25rem; padding: .6rem .8rem;
                         border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1)); border-radius: var(--lumo-border-radius-m, 8px);
                         background: var(--lumo-base-color, #fff); box-shadow: var(--lumo-box-shadow-m, 0 4px 16px rgba(0,0,0,.2));">
-                ${I(e,s.content,n,r,i,a,o)}
+                ${F(e,s.content,n,r,i,a,o)}
             </div>
         </details>
-    `},Dr=e=>{let t=e.metadata;return T`
+    `},Or=e=>{let t=e.metadata;return T`
         <mateu-map position="${t.position}" zoom="${t.zoom}"
                    style="${e.style}" class="${e.cssClasses}"
                    slot="${e.slot??v}"></mateu-map>
-            `},Or=e=>T`
+            `},kr=e=>T`
         <img src="${e.metadata.src}" style="${e.style}" class="${e.cssClasses}"
              slot="${e.slot??v}">
-            `,kr=e=>{let t=e.metadata;return T`<div style="display:flex; align-items:center; gap:0.5rem;" slot="${e.slot??v}">
+            `,Ar=e=>{let t=e.metadata;return T`<div style="display:flex; align-items:center; gap:0.5rem;" slot="${e.slot??v}">
         ${t.breadcrumbs.map(e=>T`
             <a href="${e.link}">${e.text}</a>
             <span>/</span>
         `)}
         <span style="${e.style}" class="${e.cssClasses}">${t.currentItemText}</span>
-    </div>`},Ar=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+    </div>`},jr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
         <skeleton-carousel 
                 id="${t.id}"
                 ?dots = "${s.dots}" 
@@ -1417,54 +1417,54 @@ ${i}
                 style="${t.style}"
                 css="${t.cssClasses}"
         >
-            ${t.children?.map(t=>T`<div>${I(e,t,n,r,i,a,o)}</div>`)}
+            ${t.children?.map(t=>T`<div>${F(e,t,n,r,i,a,o)}</div>`)}
         </skeleton-carousel>
-    `},jr=(e,t,n,r)=>{let i=e.metadata;return T`
+    `},Mr=(e,t,n,r)=>{let i=e.metadata;return T`
         <div style="display: flex; gap: 3rem; ${e.style}" class="${e.cssClasses}" slot="${e.slot??v}">
-            ${i.menu.map(e=>Mr(e))}
+            ${i.menu.map(e=>Nr(e))}
         </div>
-            `},Mr=e=>T`
+            `},Nr=e=>T`
         ${e.submenus?T`
                 <details open>
                     <summary>${e.label}</summary>
                     <div style="display:flex; flex-direction:column; gap:0.25rem; padding-left:0.5rem;">
-                        ${e.submenus.map(e=>Mr(e))}
+                        ${e.submenus.map(e=>Nr(e))}
                     </div>
                 </details>
             `:T`
                 <a href="${e.path}">${e.label}</a>
         `}
-        `,Nr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`<div
+        `,Pr=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`<div
                 slot="${t.slot??v}"
                 style="${t.style}" class="${t.cssClasses}"
-        >${s.content?_(s.content):v}${t.children?.map(t=>I(e,t,n,r,i,a,o))}</div>
-    `},Pr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.title?.includes("${")?e._evalTemplate(s.title):s.title;return T`<div
+        >${s.content?_(s.content):v}${t.children?.map(t=>F(e,t,n,r,i,a,o))}</div>
+    `},Fr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.title?.includes("${")?e._evalTemplate(s.title):s.title;return T`<div
                 id="${t.id??v}"
                 slot="${t.slot??v}"
                 style="width: 100%; margin-bottom: var(--lumo-space-m); ${t.style}"
                 class="${t.cssClasses}"
         >
         ${c?T`<div style="font-size: var(--lumo-font-size-l); font-weight: 600; color: var(--lumo-header-text-color); margin-bottom: var(--lumo-space-s);">${c}</div>`:v}
-        ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+        ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
     </div>
-    `},Fr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.title?.includes("${")?e._evalTemplate(s.title):s.title;return T`
+    `},Ir=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.title?.includes("${")?e._evalTemplate(s.title):s.title;return T`
         <div
                 slot="${t.slot??v}"
                 style="${t.style}" class="${t.cssClasses}"
         >
         <h4>${c}</h4>
-        ${t.children?.map(t=>I(e,t,n,r,i,a,o))}</div>
-    `},Ir=(e,t,n)=>{n.dispatchEvent(new CustomEvent(`value-changed`,{detail:{fieldId:e,value:t},bubbles:!0,composed:!0}))},Lr=e=>t=>{let n=t.target,r=n.type===`checkbox`?n.checked:n.value;Ir(e.fieldId,r,n)},Rr=(e,t)=>{let n=e.metadata,r=t?.[n.fieldId]??``,i=n,a=i.dataType,o=i.stereotype,s=!!i.readOnly,c=!!i.disabled,l=i.options,u=n.label?T`<label style="display:block; font-size: var(--lumo-font-size-s,.875rem); color: var(--lumo-secondary-text-color,#667); margin-bottom:.15rem;">${n.label}</label>`:v,d=`width:100%; box-sizing:border-box; padding:.4rem .6rem; border:1px solid var(--lumo-contrast-30pct,rgba(0,0,0,.3)); border-radius: var(--lumo-border-radius-m,6px); font:inherit; background: var(--lumo-base-color,#fff); color: var(--lumo-body-text-color,#1a1a1a);`,f;return f=s||o===`plainText`?T`<div style="padding:.4rem 0;">${String(r??``)}</div>`:a===`boolean`||o===`checkbox`||o===`badge`?T`<input type="checkbox" ?checked="${!!r}" ?disabled="${c}" @change="${Lr(n)}">`:l&&l.length?T`
-            <select style="${d}" ?disabled="${c}" @change="${Lr(n)}">
+        ${t.children?.map(t=>F(e,t,n,r,i,a,o))}</div>
+    `},Lr=(e,t,n)=>{n.dispatchEvent(new CustomEvent(`value-changed`,{detail:{fieldId:e,value:t},bubbles:!0,composed:!0}))},Rr=e=>t=>{let n=t.target,r=n.type===`checkbox`?n.checked:n.value;Lr(e.fieldId,r,n)},zr=(e,t)=>{let n=e.metadata,r=t?.[n.fieldId]??``,i=n,a=i.dataType,o=i.stereotype,s=!!i.readOnly,c=!!i.disabled,l=i.options,u=n.label?T`<label style="display:block; font-size: var(--lumo-font-size-s,.875rem); color: var(--lumo-secondary-text-color,#667); margin-bottom:.15rem;">${n.label}</label>`:v,d=`width:100%; box-sizing:border-box; padding:.4rem .6rem; border:1px solid var(--lumo-contrast-30pct,rgba(0,0,0,.3)); border-radius: var(--lumo-border-radius-m,6px); font:inherit; background: var(--lumo-base-color,#fff); color: var(--lumo-body-text-color,#1a1a1a);`,f;return f=s||o===`plainText`?T`<div style="padding:.4rem 0;">${String(r??``)}</div>`:a===`boolean`||o===`checkbox`||o===`badge`?T`<input type="checkbox" ?checked="${!!r}" ?disabled="${c}" @change="${Rr(n)}">`:l&&l.length?T`
+            <select style="${d}" ?disabled="${c}" @change="${Rr(n)}">
                 <option value="">—</option>
                 ${l.map(e=>T`<option value="${e.value}" ?selected="${e.value===r}">${e.label}</option>`)}
-            </select>`:o===`textarea`||o===`richText`||o===`html`?T`<textarea style="${d}" rows="3" ?disabled="${c}" @input="${Lr(n)}">${String(r??``)}</textarea>`:T`<input type="${a===`integer`||a===`number`||a===`double`||a===`money`?`number`:a===`date`?`date`:a===`datetime`?`datetime-local`:a===`time`?`time`:o===`password`?`password`:a===`email`?`email`:`text`}" style="${d}" .value="${String(r??``)}"
-                              placeholder="${i.placeholder??v}" ?disabled="${c}" @input="${Lr(n)}">`,T`
+            </select>`:o===`textarea`||o===`richText`||o===`html`?T`<textarea style="${d}" rows="3" ?disabled="${c}" @input="${Rr(n)}">${String(r??``)}</textarea>`:T`<input type="${a===`integer`||a===`number`||a===`double`||a===`money`?`number`:a===`date`?`date`:a===`datetime`?`datetime-local`:a===`time`?`time`:o===`password`?`password`:a===`email`?`email`:`text`}" style="${d}" .value="${String(r??``)}"
+                              placeholder="${i.placeholder??v}" ?disabled="${c}" @input="${Rr(n)}">`,T`
         <div id="${e.id??v}" style="${e.style}" class="${e.cssClasses}" slot="${e.slot??v}">
             ${u}
             ${f}
         </div>
-    `},zr=e=>{let t=e.metadata;if((t?.level??0)>0)return e;let n=e=>{if(e?.metadata?.type===j.EntityHeader)return e;let t=e?.metadata?.content,r=[...e?.children??[],...Array.isArray(t)?t:t?[t]:[]];for(let e of r){let t=n(e);if(t)return t}},r;for(let t of e.children??[])if(r=n(t),r)break;if(!r)return e;let i=r.metadata;r.__hoistedToPageHeader=!0;let a=[...(i.facts??[]).filter(e=>e.label||e.value).map(e=>({title:e.label??``,text:e.value??``})),...i.metricLabel?[{title:i.metricLabel,text:i.metricValue??``}]:[]],o=(i.badges??[]).filter(e=>e.label).map(e=>({text:e.label,color:e.color})),s={...t,title:i.title||t.title,subtitle:i.subtitle??t.subtitle,kpis:[...t.kpis??[],...a],kpisBelow:!0,badges:[...t.badges??[],...o]};return{...e,metadata:s}},Br=(e,t,n,r,i,a,o,s)=>{let c=zr(t),l=c.metadata,u=l?.fabs??[];return T`<mateu-page
+    `},Br=e=>{let t=e.metadata;if((t?.level??0)>0)return e;let n=e=>{if(e?.metadata?.type===j.EntityHeader)return e;let t=e?.metadata?.content,r=[...e?.children??[],...Array.isArray(t)?t:t?[t]:[]];for(let e of r){let t=n(e);if(t)return t}},r;for(let t of e.children??[])if(r=n(t),r)break;if(!r)return e;let i=r.metadata;r.__hoistedToPageHeader=!0;let a=[...(i.facts??[]).filter(e=>e.label||e.value).map(e=>({title:e.label??``,text:e.value??``})),...i.metricLabel?[{title:i.metricLabel,text:i.metricValue??``}]:[]],o=(i.badges??[]).filter(e=>e.label).map(e=>({text:e.label,color:e.color})),s={...t,title:i.title||t.title,subtitle:i.subtitle??t.subtitle,kpis:[...t.kpis??[],...a],kpisBelow:!0,badges:[...t.badges??[],...o]};return{...e,metadata:s}},Vr=(e,t,n,r,i,a,o,s)=>{let c=Br(t),l=c.metadata,u=l?.fabs??[];return T`<mateu-page
             .component="${c}"
             baseUrl="${n}"
             .state="${r}"
@@ -1476,19 +1476,19 @@ ${i}
             class="${c.cssClasses}"
             ?standalone="${s??!1}"
     >
-        ${c.children?.map(t=>I(e,t,n,r,i,a,o))}
+        ${c.children?.map(t=>F(e,t,n,r,i,a,o))}
         ${l?.buttons?.map(t=>T`
-                   ${I(e,{id:t.actionId,metadata:t,type:A.ClientSide,slot:`buttons`},void 0,r,i,a,o)}
+                   ${F(e,{id:t.actionId,metadata:t,type:A.ClientSide,slot:`buttons`},void 0,r,i,a,o)}
 `)}
         ${u.map((t,n)=>T`
             <button class="page-fab" style="position: fixed; bottom: ${1.5+n*4}rem; right: 5.5rem;"
                 @click="${()=>e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))}"
                 title="${t.label}">
-                ${L(t.icon)}
+                ${I(t.icon)}
             </button>
         `)}
 </mateu-page>
-    `},Vr=(e,t,n,r,i,a,o,s)=>T`<mateu-table-crud
+    `},Hr=(e,t,n,r,i,a,o,s)=>T`<mateu-table-crud
             id="${t.id}"
             baseUrl="${n}"
             .component="${t}"
@@ -1502,8 +1502,8 @@ ${i}
             slot="${t.slot??v}"
             ?standalone="${s??!1}"
     >
-        ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
-    </mateu-table-crud>`,Hr=e=>{let t=e.metadata;return T`
+        ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+    </mateu-table-crud>`,Ur=e=>{let t=e.metadata;return T`
         <mateu-bpmn
                 style="${e.style}"
                 class="${e.cssClasses}"
@@ -1511,64 +1511,64 @@ ${i}
                 xml="${t.xml}"
         >
         </mateu-bpmn>
-    `},Ur=(e,t,n)=>T`<mateu-chat sseUrl="${e.metadata.sseUrl}"
+    `},Wr=(e,t,n)=>T`<mateu-chat sseUrl="${e.metadata.sseUrl}"
                             style="${e.style}" 
                             class="${e.cssClasses}" 
-                            slot="${e.slot??v}"></mateu-chat>`,Wr=e=>{let t=e.metadata;return T`
+                            slot="${e.slot??v}"></mateu-chat>`,Gr=e=>{let t=e.metadata;return T`
         <mateu-workflow
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
                 value="${t.value??`{"name":"New Workflow","steps":[]}`}"
         ></mateu-workflow>
-    `},Gr=e=>{let t=e.metadata;return T`
+    `},Kr=e=>{let t=e.metadata;return T`
         <mateu-form-editor
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
                 value="${t.value??`{"name":"New Form","fields":[]}`}"
         ></mateu-form-editor>
-    `},Kr=`
+    `},qr=`
     background: var(--lumo-base-color, #fff);
     border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.08));
     border-radius: var(--lumo-border-radius-l, 12px);
     padding: var(--lumo-space-m, 1rem);
     box-sizing: border-box;
-`,qr=e=>e==`up`?`var(--lumo-success-text-color, #1a7f37)`:e==`down`?`var(--lumo-error-text-color, #c5221f)`:`var(--lumo-secondary-text-color, #666)`,Jr=e=>e==`up`?`▲`:e==`down`?`▼`:``,Yr=(e,t)=>{t.actionId&&e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))},Xr=e=>{let t=e.metadata,n=!!t.actionId;return T`
+`,Jr=e=>e==`up`?`var(--lumo-success-text-color, #1a7f37)`:e==`down`?`var(--lumo-error-text-color, #c5221f)`:`var(--lumo-secondary-text-color, #666)`,Yr=e=>e==`up`?`▲`:e==`down`?`▼`:``,Xr=(e,t)=>{t.actionId&&e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))},Zr=e=>{let t=e.metadata,n=!!t.actionId;return T`
         <div class="mateu-metric-card ${e.cssClasses??``}"
-             style="${Kr} display: flex; flex-direction: column; gap: .25rem; min-width: 11rem; flex: 1; ${n?`cursor: pointer;`:``} ${e.style??``}"
+             style="${qr} display: flex; flex-direction: column; gap: .25rem; min-width: 11rem; flex: 1; ${n?`cursor: pointer;`:``} ${e.style??``}"
              slot="${e.slot??v}"
              role="${n?`button`:v}"
-             @click="${e=>Yr(e,t)}"
+             @click="${e=>Xr(e,t)}"
         >
             <div style="display: flex; align-items: center; justify-content: space-between; gap: .5rem;">
                 <span style="font-size: var(--lumo-font-size-s, .875rem); color: var(--lumo-secondary-text-color, #666);">${t.title}</span>
-                ${t.icon?L(t.icon,`color: var(--lumo-tertiary-text-color, #999); width: 1.1em; height: 1.1em;`):v}
+                ${t.icon?I(t.icon,`color: var(--lumo-tertiary-text-color, #999); width: 1.1em; height: 1.1em;`):v}
             </div>
             <div style="display: flex; align-items: baseline; gap: .35rem;">
                 <span style="font-size: var(--lumo-font-size-xxxl, 2rem); font-weight: 600; line-height: 1.1;">${t.value}</span>
                 ${t.unit?T`<span style="font-size: var(--lumo-font-size-m, 1rem); color: var(--lumo-secondary-text-color, #666);">${t.unit}</span>`:v}
             </div>
             ${t.trend||t.trendLabel?T`
-                <span style="font-size: var(--lumo-font-size-s, .875rem); color: ${qr(t.trend)};">
-                    ${Jr(t.trend)} ${t.trendLabel??v}
+                <span style="font-size: var(--lumo-font-size-s, .875rem); color: ${Jr(t.trend)};">
+                    ${Yr(t.trend)} ${t.trendLabel??v}
                 </span>
             `:v}
             ${t.description?T`<span style="font-size: var(--lumo-font-size-xs, .8rem); color: var(--lumo-tertiary-text-color, #999);">${t.description}</span>`:v}
         </div>
-    `},Zr=(e,t,n,r,i,a,o)=>T`
+    `},Qr=(e,t,n,r,i,a,o)=>T`
         <div class="mateu-scoreboard ${t.cssClasses??``}"
              style="display: flex; flex-wrap: wrap; gap: var(--lumo-space-m, 1rem); grid-column: 1 / -1; ${t.style??``}"
              slot="${t.slot??v}"
         >
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
         </div>
-    `,Qr=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.colSpan&&s.colSpan>1?`grid-column: span ${s.colSpan};`:``,l=s.rowSpan&&s.rowSpan>1?`grid-row: span ${s.rowSpan};`:``,u=t.children??[];return u.length===1&&u[0].metadata?.type===`MetricCard`?T`
+    `,$r=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.colSpan&&s.colSpan>1?`grid-column: span ${s.colSpan};`:``,l=s.rowSpan&&s.rowSpan>1?`grid-row: span ${s.rowSpan};`:``,u=t.children??[];return u.length===1&&u[0].metadata?.type===`MetricCard`?T`
             <div style="min-width: 0; ${c} ${l} ${t.style??``}" slot="${t.slot??v}">
-                ${I(e,u[0],n,r,i,a,o)}
+                ${F(e,u[0],n,r,i,a,o)}
             </div>`:T`
         <div class="mateu-dashboard-panel ${t.cssClasses??``}"
-             style="${Kr} display: flex; flex-direction: column; gap: .5rem; min-width: 0; ${c} ${l} ${t.style??``}"
+             style="${qr} display: flex; flex-direction: column; gap: .5rem; min-width: 0; ${c} ${l} ${t.style??``}"
              slot="${t.slot??v}"
         >
             ${s.title?T`
@@ -1578,17 +1578,17 @@ ${i}
                 </div>
             `:v}
             <div style="flex: 1; min-height: 0;">
-                ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+                ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
             </div>
         </div>
-    `},$r=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.columns&&s.columns>0?`repeat(${s.columns}, minmax(0, 1fr))`:`repeat(auto-fit, minmax(20rem, 1fr))`;return T`
+    `},ei=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=s.columns&&s.columns>0?`repeat(${s.columns}, minmax(0, 1fr))`:`repeat(auto-fit, minmax(20rem, 1fr))`;return T`
         <div class="mateu-dashboard ${t.cssClasses??``}"
              style="display: grid; grid-template-columns: ${c}; gap: var(--lumo-space-m, 1rem); align-items: stretch; ${t.style??``}"
              slot="${t.slot??v}"
         >
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
         </div>
-    `},ei=class extends b{constructor(...e){super(...e),this.panels=[],this.headerTitle=``,this.badges=[],this.orientation=`vertical`,this.navigation=null,this.overviewEditActionId=``,this.openPanels=new Set,this.expandedPanel=null,this._onPopState=()=>{let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(e.startsWith(`expand=`)){let t=e.slice(7),n=this.panels.findIndex((e,n)=>this.panelAnchor(e,n)===t);this.expandedPanel=n>=0?n:null}else this.expandedPanel=null},this.initialized=!1}navAction(e){e&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{}},bubbles:!0,composed:!0}))}connectedCallback(){super.connectedCallback(),window.addEventListener(`popstate`,this._onPopState)}disconnectedCallback(){window.removeEventListener(`popstate`,this._onPopState),super.disconnectedCallback()}willUpdate(){if(!this.initialized&&this.panels.length){this.openPanels=new Set(this.panels.map((e,t)=>e.open?t:-1).filter(e=>e>=0));let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(e.startsWith(`expand=`)){let t=e.slice(7),n=this.panels.findIndex((e,n)=>this.panelAnchor(e,n)===t);n>=0&&(this.expandedPanel=n)}else if(e){let t=this.panels.findIndex((t,n)=>this.panelAnchor(t,n)===e);t>=0&&this.openPanels.add(t)}this.initialized=!0}}firstUpdated(){let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(!e)return;let t=this.renderRoot.querySelector(`[data-anchor="${CSS.escape(e)}"]`);t&&t.scrollIntoView({block:`nearest`})}panelAnchor(e,t){return(e.title??``).toLowerCase().replace(/[^a-z0-9]+/g,`-`).replace(/^-|-$/g,``)||`panel-${t}`}bookmarkPanel(e){let t=this.panelAnchor(this.panels[e],e);try{history.replaceState(history.state,``,`#`+t)}catch{}}clearBookmark(e){let t=this.panelAnchor(this.panels[e],e);if(decodeURIComponent((location.hash||``).replace(/^#/,``))===t)try{history.replaceState(history.state,``,location.pathname+location.search)}catch{}}expandPanel(e,t){t?.stopPropagation(),this.expandedPanel=e;let n=this.panelAnchor(this.panels[e],e);try{history.pushState(history.state,``,`#expand=`+n)}catch{}}collapsePanel(){try{history.back()}catch{this.expandedPanel=null}}toggle(e){let t=new Set(this.openPanels);t.has(e)?(t.delete(e),this.clearBookmark(e)):(t.add(e),this.bookmarkPanel(e)),this.openPanels=t}static{this.styles=h`
+    `},ti=class extends b{constructor(...e){super(...e),this.panels=[],this.headerTitle=``,this.badges=[],this.orientation=`vertical`,this.navigation=null,this.overviewEditActionId=``,this.openPanels=new Set,this.expandedPanel=null,this._onPopState=()=>{let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(e.startsWith(`expand=`)){let t=e.slice(7),n=this.panels.findIndex((e,n)=>this.panelAnchor(e,n)===t);this.expandedPanel=n>=0?n:null}else this.expandedPanel=null},this.initialized=!1}navAction(e){e&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{}},bubbles:!0,composed:!0}))}connectedCallback(){super.connectedCallback(),window.addEventListener(`popstate`,this._onPopState)}disconnectedCallback(){window.removeEventListener(`popstate`,this._onPopState),super.disconnectedCallback()}willUpdate(){if(!this.initialized&&this.panels.length){this.openPanels=new Set(this.panels.map((e,t)=>e.open?t:-1).filter(e=>e>=0));let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(e.startsWith(`expand=`)){let t=e.slice(7),n=this.panels.findIndex((e,n)=>this.panelAnchor(e,n)===t);n>=0&&(this.expandedPanel=n)}else if(e){let t=this.panels.findIndex((t,n)=>this.panelAnchor(t,n)===e);t>=0&&this.openPanels.add(t)}this.initialized=!0}}firstUpdated(){let e=decodeURIComponent((location.hash||``).replace(/^#/,``));if(!e)return;let t=this.renderRoot.querySelector(`[data-anchor="${CSS.escape(e)}"]`);t&&t.scrollIntoView({block:`nearest`})}panelAnchor(e,t){return(e.title??``).toLowerCase().replace(/[^a-z0-9]+/g,`-`).replace(/^-|-$/g,``)||`panel-${t}`}bookmarkPanel(e){let t=this.panelAnchor(this.panels[e],e);try{history.replaceState(history.state,``,`#`+t)}catch{}}clearBookmark(e){let t=this.panelAnchor(this.panels[e],e);if(decodeURIComponent((location.hash||``).replace(/^#/,``))===t)try{history.replaceState(history.state,``,location.pathname+location.search)}catch{}}expandPanel(e,t){t?.stopPropagation(),this.expandedPanel=e;let n=this.panelAnchor(this.panels[e],e);try{history.pushState(history.state,``,`#expand=`+n)}catch{}}collapsePanel(){try{history.back()}catch{this.expandedPanel=null}}toggle(e){let t=new Set(this.openPanels);t.has(e)?(t.delete(e),this.clearBookmark(e)):(t.add(e),this.bookmarkPanel(e)),this.openPanels=t}static{this.styles=h`
         :host {
             display: flex;
             flex-direction: column;
@@ -1974,7 +1974,7 @@ ${i}
                     `)}
                 </div>
             </div>
-        `}};k([y({type:Array})],ei.prototype,`panels`,void 0),k([y({type:String})],ei.prototype,`headerTitle`,void 0),k([y({type:Array})],ei.prototype,`badges`,void 0),k([y({type:String,reflect:!0})],ei.prototype,`orientation`,void 0),k([y({attribute:!1})],ei.prototype,`navigation`,void 0),k([y({type:String})],ei.prototype,`overviewEditActionId`,void 0),k([C()],ei.prototype,`openPanels`,void 0),k([C()],ei.prototype,`expandedPanel`,void 0),ei=k([g(`mateu-foldout`)],ei);var ti=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+        `}};k([y({type:Array})],ti.prototype,`panels`,void 0),k([y({type:String})],ti.prototype,`headerTitle`,void 0),k([y({type:Array})],ti.prototype,`badges`,void 0),k([y({type:String,reflect:!0})],ti.prototype,`orientation`,void 0),k([y({attribute:!1})],ti.prototype,`navigation`,void 0),k([y({type:String})],ti.prototype,`overviewEditActionId`,void 0),k([C()],ti.prototype,`openPanels`,void 0),k([C()],ti.prototype,`expandedPanel`,void 0),ti=k([g(`mateu-foldout`)],ti);var ni=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
         <mateu-foldout
                 .panels="${s.panels??[]}"
                 .headerTitle="${s.headerTitle??``}"
@@ -1986,9 +1986,9 @@ ${i}
                 class="${t.cssClasses}"
                 slot="${t.slot??v}"
         >
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
         </mateu-foldout>
-    `},ni=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.children??[],l=e=>c.filter(t=>(t.slot??``).startsWith(e)),u=l(`main-`),d=l(`aside-`),f=l(`footer-`),p=s.asideWidth&&s.asideWidth.trim()?s.asideWidth:`32%`,ee=s.asidePosition===`start`,m=s.asideSticky!==!1,te=t=>t.map(t=>I(e,t,n,r,i,a,o)),ne=T`
+    `},ri=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.children??[],l=e=>c.filter(t=>(t.slot??``).startsWith(e)),u=l(`main-`),d=l(`aside-`),f=l(`footer-`),p=s.asideWidth&&s.asideWidth.trim()?s.asideWidth:`32%`,ee=s.asidePosition===`start`,m=s.asideSticky!==!1,te=t=>t.map(t=>F(e,t,n,r,i,a,o)),ne=T`
         <div class="mateu-content-main"
              style="flex: 1 1 0; min-width: min(20rem, 100%); box-sizing: border-box;">
             ${te(u)}
@@ -2009,7 +2009,7 @@ ${i}
                     ${te(f)}
                 </div>`:v}
         </div>
-    `},ri=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!!s.image,l=c?`background-image: linear-gradient(rgba(0,0,0,.35), rgba(0,0,0,.35)), url('${s.image}'); background-size: cover; background-position: center; color: #fff;`:``,u=s.centered===!1?`flex-start`:`center`,d=s.centered===!1?`left`:`center`;return T`
+    `},ii=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!!s.image,l=c?`background-image: linear-gradient(rgba(0,0,0,.35), rgba(0,0,0,.35)), url('${s.image}'); background-size: cover; background-position: center; color: #fff;`:``,u=s.centered===!1?`flex-start`:`center`,d=s.centered===!1?`left`:`center`;return T`
         <div class="mateu-hero ${t.cssClasses??``}"
              style="display: flex; flex-direction: column; align-items: ${u}; justify-content: center; gap: var(--lumo-space-m, 1rem); text-align: ${d}; padding: var(--lumo-space-xl, 2.5rem) var(--lumo-space-l, 1.5rem); border-radius: var(--lumo-border-radius-l, 12px); min-height: ${s.height??`12rem`}; box-sizing: border-box; ${l} ${t.style??``}"
              slot="${t.slot??v}"
@@ -2018,11 +2018,11 @@ ${i}
             ${s.subtitle?T`<p style="margin: 0; font-size: var(--lumo-font-size-l, 1.125rem); ${c?``:`color: var(--lumo-secondary-text-color, #666);`} max-width: 40rem;">${s.subtitle}</p>`:v}
             ${t.children?.length?T`
                 <div style="display: flex; gap: var(--lumo-space-s, .5rem); flex-wrap: wrap; justify-content: ${u}; width: 100%; max-width: 40rem;">
-                    ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+                    ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
                 </div>
             `:v}
         </div>
-    `},z=e=>t=>{if(t.key===`Enter`){e(t);return}(t.key===` `||t.key===`Spacebar`)&&(t.preventDefault(),e(t))},B=h`
+    `},R=e=>t=>{if(t.key===`Enter`){e(t);return}(t.key===` `||t.key===`Spacebar`)&&(t.preventDefault(),e(t))},z=h`
     [role="button"]:focus-visible,
     [role="option"]:focus-visible,
     [role="treeitem"]:focus-visible,
@@ -2033,7 +2033,7 @@ ${i}
         outline-offset: 2px;
         border-radius: var(--lumo-border-radius-s, 4px);
     }
-`,ii=1440*60*1e3,ai=class extends b{constructor(...e){super(...e),this.tasks=[],this.onTaskSelectionActionId=``}selectTask(e){this.onTaskSelectionActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.onTaskSelectionActionId,parameters:{_clickedTaskId:e.id}},bubbles:!0,composed:!0}))}static{this.styles=h`
+`,ai=1440*60*1e3,oi=class extends b{constructor(...e){super(...e),this.tasks=[],this.onTaskSelectionActionId=``}selectTask(e){this.onTaskSelectionActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.onTaskSelectionActionId,parameters:{_clickedTaskId:e.id}},bubbles:!0,composed:!0}))}static{this.styles=h`
         :host {
             display: block;
             width: 100%;
@@ -2108,8 +2108,8 @@ ${i}
             opacity: .55;
         }
     
-        ${B}
-    `}range(){let e=this.tasks.flatMap(e=>[e.start,e.end]).filter(e=>!!e).map(e=>new Date(e+`T00:00:00`).getTime());return e.length?{min:Math.min(...e)-ii,max:Math.max(...e)+2*ii}:null}months(e,t){let n=[],r=new Date(e);for(r.setDate(1);r.getTime()<=t;){let i=Math.max(r.getTime(),e),a=new Date(r.getFullYear(),r.getMonth()+1,1),o=Math.min(a.getTime(),t);n.push({label:r.toLocaleDateString(void 0,{month:`short`,year:`2-digit`}),from:i,to:o}),r.setMonth(r.getMonth()+1)}return n}render(){let e=this.range();if(!e)return T``;let t=e.max-e.min,n=n=>(n-e.min)/t*100,r=Date.now();return T`
+        ${z}
+    `}range(){let e=this.tasks.flatMap(e=>[e.start,e.end]).filter(e=>!!e).map(e=>new Date(e+`T00:00:00`).getTime());return e.length?{min:Math.min(...e)-ai,max:Math.max(...e)+2*ai}:null}months(e,t){let n=[],r=new Date(e);for(r.setDate(1);r.getTime()<=t;){let i=Math.max(r.getTime(),e),a=new Date(r.getFullYear(),r.getMonth()+1,1),o=Math.min(a.getTime(),t);n.push({label:r.toLocaleDateString(void 0,{month:`short`,year:`2-digit`}),from:i,to:o}),r.setMonth(r.getMonth()+1)}return n}render(){let e=this.range();if(!e)return T``;let t=e.max-e.min,n=n=>(n-e.min)/t*100,r=Date.now();return T`
             <div class="frame">
                 <div class="head">Task</div>
                 <div class="head months">
@@ -2117,7 +2117,7 @@ ${i}
                         <div class="month" style="width: ${(e.to-e.from)/t*100}%;">${e.label}</div>
                     `)}
                 </div>
-                ${this.tasks.map(i=>{let a=new Date(i.start+`T00:00:00`).getTime(),o=new Date(i.end+`T00:00:00`).getTime()+ii;return T`
+                ${this.tasks.map(i=>{let a=new Date(i.start+`T00:00:00`).getTime(),o=new Date(i.end+`T00:00:00`).getTime()+ai;return T`
                         <div class="label" title="${i.title}">${i.title}</div>
                         <div class="lane">
                             ${r>=e.min&&r<=e.max?T`<div class="today" style="left: ${n(r)}%;"></div>`:v}
@@ -2125,14 +2125,14 @@ ${i}
                                  aria-label="${i.title}, ${i.start} to ${i.end}${i.progress?`, ${i.progress}% complete`:``}"
                                  class="bar ${this.onTaskSelectionActionId?`clickable`:``}"
                                  title="${i.title} · ${i.start} → ${i.end}${i.progress?` · ${i.progress}%`:``}"
-                                 @click="${()=>this.selectTask(i)}" @keydown="${z(()=>this.selectTask(i))}"
+                                 @click="${()=>this.selectTask(i)}" @keydown="${R(()=>this.selectTask(i))}"
                                  style="left: ${n(a)}%; width: ${(o-a)/t*100}%; ${i.color?`--mateu-gantt-fill: ${i.color};`:``}">
                                 <div class="fill" style="width: ${i.progress??0}%;"></div>
                             </div>
                         </div>
                     `})}
             </div>
-        `}};k([y({type:Array})],ai.prototype,`tasks`,void 0),k([y()],ai.prototype,`onTaskSelectionActionId`,void 0),ai=k([g(`mateu-gantt`)],ai);var oi=e=>{let t=e.metadata;return T`
+        `}};k([y({type:Array})],oi.prototype,`tasks`,void 0),k([y()],oi.prototype,`onTaskSelectionActionId`,void 0),oi=k([g(`mateu-gantt`)],oi);var si=e=>{let t=e.metadata;return T`
         <mateu-gantt
                 .tasks="${t.tasks??[]}"
                 .onTaskSelectionActionId="${t.onTaskSelectionActionId??``}"
@@ -2140,7 +2140,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-gantt>
-    `},V,si=class extends b{static{V=this}constructor(...e){super(...e),this.resources=[],this.blocks=[],this.drag=null,this.dragStartX=0,this.dragStartY=0,this.laneRects=[],this.onDragKeydown=e=>{e.key===`Escape`&&this.drag&&(e.stopPropagation(),this.endDrag())}}static{this.styles=h`
+    `},B,ci=class extends b{static{B=this}constructor(...e){super(...e),this.resources=[],this.blocks=[],this.drag=null,this.dragStartX=0,this.dragStartY=0,this.laneRects=[],this.onDragKeydown=e=>{e.key===`Escape`&&this.drag&&(e.stopPropagation(),this.endDrag())}}static{this.styles=h`
         :host {
             display: block;
             width: 100%;
@@ -2282,7 +2282,7 @@ ${i}
             pointer-events: none;
             z-index: 2;
         }
-    `}static parse(e){return new Date(e+`T00:00:00`)}static iso(e){let t=e=>String(e).padStart(2,`0`);return`${e.getFullYear()}-${t(e.getMonth()+1)}-${t(e.getDate())}`}static addDays(e,t){return new Date(e.getFullYear(),e.getMonth(),e.getDate()+t)}static daysBetween(e,t){return Math.round((t.getTime()-e.getTime())/864e5)}window(){if(this.from&&this.to){let e=V.parse(this.from),t=V.daysBetween(e,V.parse(this.to))+1;return t>0?{from:e,days:t}:null}let e=this.blocks.flatMap(e=>[e.start,e.end]).filter(e=>!!e).map(e=>V.parse(e));if(!e.length)return null;let t=new Date(Math.min(...e.map(e=>e.getTime()))),n=new Date(Math.max(...e.map(e=>e.getTime())));return{from:t,days:V.daysBetween(t,n)+1}}onBlockPointerDown(e,t,n){if(!this.moveActionId&&!this.selectActionId||(e.preventDefault(),e.currentTarget.setPointerCapture(e.pointerId),this.dragStartX=e.clientX,this.dragStartY=e.clientY,!this.window()))return;let r=V.parse(t.start),i=V.parse(t.end),a=Math.max(1,V.daysBetween(r,i)+1);this.laneRects=[...this.renderRoot.querySelectorAll(`.lane[data-resource-id]`)].map(e=>({resourceId:e.dataset.resourceId,rect:e.getBoundingClientRect()}));let o=this.dayAt(t.resourceId,e.clientX)??n;this.drag={blockId:t.id,duration:a,grabOffsetDays:o-n,originResourceId:t.resourceId,originStartIdx:n,targetResourceId:t.resourceId,targetStartIdx:n,moved:!1},window.addEventListener(`keydown`,this.onDragKeydown)}dayAt(e,t){let n=this.laneRects.find(t=>t.resourceId===e),r=this.window();if(!n||!r||n.rect.width===0)return null;let i=Math.floor((t-n.rect.left)/n.rect.width*r.days);return Math.max(0,Math.min(r.days-1,i))}onBlockPointerMove(e){if(!this.drag||!this.drag.moved&&Math.abs(e.clientX-this.dragStartX)<4&&Math.abs(e.clientY-this.dragStartY)<4||!this.moveActionId)return;let t=this.window();if(!t)return;let n=this.laneRects.find(t=>e.clientY>=t.rect.top&&e.clientY<=t.rect.bottom)??this.laneRects.find(e=>e.resourceId===this.drag.targetResourceId);if(!n)return;let r=this.dayAt(n.resourceId,e.clientX);if(r==null)return;let i=Math.max(0,Math.min(t.days-this.drag.duration,r-this.drag.grabOffsetDays));this.drag={...this.drag,moved:!0,targetResourceId:n.resourceId,targetStartIdx:i}}onBlockPointerUp(e){let t=this.drag;if(this.endDrag(),!t)return;if(!t.moved){this.selectActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.selectActionId,parameters:{_blockId:e.id}},bubbles:!0,composed:!0}));return}if(!this.moveActionId||t.targetResourceId===t.originResourceId&&t.targetStartIdx===t.originStartIdx)return;let n=this.window();if(!n)return;let r=V.addDays(n.from,t.targetStartIdx),i=V.addDays(r,t.duration-1);this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.moveActionId,parameters:{_blockId:t.blockId,_resourceId:t.targetResourceId,_start:V.iso(r),_end:V.iso(i)}},bubbles:!0,composed:!0}))}endDrag(){this.drag=null,window.removeEventListener(`keydown`,this.onDragKeydown)}disconnectedCallback(){super.disconnectedCallback(),window.removeEventListener(`keydown`,this.onDragKeydown)}render(){let e=this.window();if(!e||!this.resources.length)return T``;let t=[...Array(e.days).keys()].map(t=>V.addDays(e.from,t)),n=new Date,r=V.daysBetween(e.from,new Date(n.getFullYear(),n.getMonth(),n.getDate())),i=r>=0&&r<e.days,a=[],o;return this.resources.forEach(n=>{n.group&&n.group!==o&&a.push(T`<div class="group">${n.group}</div>`),o=n.group,a.push(this.renderRow(n,e,t,i?r:null))}),T`
+    `}static parse(e){return new Date(e+`T00:00:00`)}static iso(e){let t=e=>String(e).padStart(2,`0`);return`${e.getFullYear()}-${t(e.getMonth()+1)}-${t(e.getDate())}`}static addDays(e,t){return new Date(e.getFullYear(),e.getMonth(),e.getDate()+t)}static daysBetween(e,t){return Math.round((t.getTime()-e.getTime())/864e5)}window(){if(this.from&&this.to){let e=B.parse(this.from),t=B.daysBetween(e,B.parse(this.to))+1;return t>0?{from:e,days:t}:null}let e=this.blocks.flatMap(e=>[e.start,e.end]).filter(e=>!!e).map(e=>B.parse(e));if(!e.length)return null;let t=new Date(Math.min(...e.map(e=>e.getTime()))),n=new Date(Math.max(...e.map(e=>e.getTime())));return{from:t,days:B.daysBetween(t,n)+1}}onBlockPointerDown(e,t,n){if(!this.moveActionId&&!this.selectActionId||(e.preventDefault(),e.currentTarget.setPointerCapture(e.pointerId),this.dragStartX=e.clientX,this.dragStartY=e.clientY,!this.window()))return;let r=B.parse(t.start),i=B.parse(t.end),a=Math.max(1,B.daysBetween(r,i)+1);this.laneRects=[...this.renderRoot.querySelectorAll(`.lane[data-resource-id]`)].map(e=>({resourceId:e.dataset.resourceId,rect:e.getBoundingClientRect()}));let o=this.dayAt(t.resourceId,e.clientX)??n;this.drag={blockId:t.id,duration:a,grabOffsetDays:o-n,originResourceId:t.resourceId,originStartIdx:n,targetResourceId:t.resourceId,targetStartIdx:n,moved:!1},window.addEventListener(`keydown`,this.onDragKeydown)}dayAt(e,t){let n=this.laneRects.find(t=>t.resourceId===e),r=this.window();if(!n||!r||n.rect.width===0)return null;let i=Math.floor((t-n.rect.left)/n.rect.width*r.days);return Math.max(0,Math.min(r.days-1,i))}onBlockPointerMove(e){if(!this.drag||!this.drag.moved&&Math.abs(e.clientX-this.dragStartX)<4&&Math.abs(e.clientY-this.dragStartY)<4||!this.moveActionId)return;let t=this.window();if(!t)return;let n=this.laneRects.find(t=>e.clientY>=t.rect.top&&e.clientY<=t.rect.bottom)??this.laneRects.find(e=>e.resourceId===this.drag.targetResourceId);if(!n)return;let r=this.dayAt(n.resourceId,e.clientX);if(r==null)return;let i=Math.max(0,Math.min(t.days-this.drag.duration,r-this.drag.grabOffsetDays));this.drag={...this.drag,moved:!0,targetResourceId:n.resourceId,targetStartIdx:i}}onBlockPointerUp(e){let t=this.drag;if(this.endDrag(),!t)return;if(!t.moved){this.selectActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.selectActionId,parameters:{_blockId:e.id}},bubbles:!0,composed:!0}));return}if(!this.moveActionId||t.targetResourceId===t.originResourceId&&t.targetStartIdx===t.originStartIdx)return;let n=this.window();if(!n)return;let r=B.addDays(n.from,t.targetStartIdx),i=B.addDays(r,t.duration-1);this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.moveActionId,parameters:{_blockId:t.blockId,_resourceId:t.targetResourceId,_start:B.iso(r),_end:B.iso(i)}},bubbles:!0,composed:!0}))}endDrag(){this.drag=null,window.removeEventListener(`keydown`,this.onDragKeydown)}disconnectedCallback(){super.disconnectedCallback(),window.removeEventListener(`keydown`,this.onDragKeydown)}render(){let e=this.window();if(!e||!this.resources.length)return T``;let t=[...Array(e.days).keys()].map(t=>B.addDays(e.from,t)),n=new Date,r=B.daysBetween(e.from,new Date(n.getFullYear(),n.getMonth(),n.getDate())),i=r>=0&&r<e.days,a=[],o;return this.resources.forEach(n=>{n.group&&n.group!==o&&a.push(T`<div class="group">${n.group}</div>`),o=n.group,a.push(this.renderRow(n,e,t,i?r:null))}),T`
             <div class="frame" style="grid-template-columns: minmax(8rem, 12rem) repeat(${e.days}, minmax(2.2rem, 1fr));">
                 <div class="corner">Resource</div>
                 ${t.map((e,t)=>T`
@@ -2300,7 +2300,7 @@ ${i}
                     ${n.map(e=>T`<div class="cell ${this.isWeekend(e)?`weekend`:``}"></div>`)}
                 </div>
                 ${r==null?v:T`<div class="today-line" style="left: ${(r+.5)*i}%;"></div>`}
-                ${a.map(e=>{let n=V.daysBetween(t.from,V.parse(e.start)),r=V.daysBetween(t.from,V.parse(e.end));if(r<0||n>=t.days)return v;let a=Math.max(0,n),o=Math.min(t.days-1,r),s=this.drag?.moved&&this.drag.blockId===e.id;return T`
+                ${a.map(e=>{let n=B.daysBetween(t.from,B.parse(e.start)),r=B.daysBetween(t.from,B.parse(e.end));if(r<0||n>=t.days)return v;let a=Math.max(0,n),o=Math.min(t.days-1,r),s=this.drag?.moved&&this.drag.blockId===e.id;return T`
                         <div class="block ${this.selectActionId?`clickable`:``} ${this.moveActionId?`draggable`:``} ${s?`dragging`:``}"
                              title="${e.label??``} · ${e.start} → ${e.end}${e.status?` · ${e.status}`:``}"
                              style="left: ${a*i}%; width: ${(o-a+1)*i}%; ${e.color?`--mateu-planning-block: ${e.color};`:``}"
@@ -2315,7 +2315,7 @@ ${i}
                          style="left: ${o.targetStartIdx*i}%; width: ${Math.min(o.duration,t.days-o.targetStartIdx)*i}%;"></div>
                 `:v}
             </div>
-        `}};k([y({type:Array})],si.prototype,`resources`,void 0),k([y({type:Array})],si.prototype,`blocks`,void 0),k([y()],si.prototype,`from`,void 0),k([y()],si.prototype,`to`,void 0),k([y()],si.prototype,`moveActionId`,void 0),k([y()],si.prototype,`selectActionId`,void 0),k([C()],si.prototype,`drag`,void 0),si=V=k([g(`mateu-planning-board`)],si);var ci=e=>{let t=e.metadata;return T`
+        `}};k([y({type:Array})],ci.prototype,`resources`,void 0),k([y({type:Array})],ci.prototype,`blocks`,void 0),k([y()],ci.prototype,`from`,void 0),k([y()],ci.prototype,`to`,void 0),k([y()],ci.prototype,`moveActionId`,void 0),k([y()],ci.prototype,`selectActionId`,void 0),k([C()],ci.prototype,`drag`,void 0),ci=B=k([g(`mateu-planning-board`)],ci);var li=e=>{let t=e.metadata;return T`
         <mateu-planning-board
                 .resources="${t.resources??[]}"
                 .blocks="${t.blocks??[]}"
@@ -2327,7 +2327,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-planning-board>
-    `},li=class extends b{constructor(...e){super(...e),this.columns=[]}static{this.styles=h`
+    `},ui=class extends b{constructor(...e){super(...e),this.columns=[]}static{this.styles=h`
         :host {
             display: block;
             width: 100%;
@@ -2410,7 +2410,7 @@ ${i}
             .card { background: var(--lumo-contrast-5pct, #2a2a2a); }
         }
     
-        ${B}
+        ${z}
     `}clickCard(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_clickedCard:e}},bubbles:!0,composed:!0}))}render(){return T`
             <div class="board">
                 ${this.columns.map(e=>T`
@@ -2422,7 +2422,7 @@ ${i}
                         ${(e.cards??[]).map(e=>T`
                             <div role="button" tabindex="0" class="card ${e.actionId?`clickable`:``}"
                                  style="${e.color?`--mateu-kanban-card-accent: ${e.color};`:``}"
-                                 @click="${()=>this.clickCard(e)}" @keydown="${z(()=>this.clickCard(e))}">
+                                 @click="${()=>this.clickCard(e)}" @keydown="${R(()=>this.clickCard(e))}">
                                 <span class="card-title">${e.title}</span>
                                 ${e.description?T`<span class="card-desc">${e.description}</span>`:v}
                                 ${e.badge?T`<span class="badge">${e.badge}</span>`:v}
@@ -2431,14 +2431,14 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};k([y({type:Array})],li.prototype,`columns`,void 0),li=k([g(`mateu-kanban`)],li);var ui=e=>T`
+        `}};k([y({type:Array})],ui.prototype,`columns`,void 0),ui=k([g(`mateu-kanban`)],ui);var di=e=>T`
         <mateu-kanban
                 .columns="${e.metadata.columns??[]}"
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-kanban>
-    `,di=class extends b{constructor(...e){super(...e),this.items=[]}static{this.styles=h`
+    `,fi=class extends b{constructor(...e){super(...e),this.items=[]}static{this.styles=h`
         :host {
             display: block;
             width: 100%;
@@ -2510,7 +2510,7 @@ ${i}
             margin-top: .15rem;
         }
     
-        ${B}
+        ${z}
     `}clickItem(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_clickedItem:e}},bubbles:!0,composed:!0}))}render(){return T`
             <div class="feed">
                 ${this.items.map(e=>T`
@@ -2519,7 +2519,7 @@ ${i}
                             <div class="dot" style="${e.color?`--mateu-timeline-dot: ${e.color};`:``}">${e.icon??``}</div>
                             <div class="line"></div>
                         </div>
-                        <div role="button" tabindex="0" class="body" @click="${()=>this.clickItem(e)}" @keydown="${z(()=>this.clickItem(e))}">
+                        <div role="button" tabindex="0" class="body" @click="${()=>this.clickItem(e)}" @keydown="${R(()=>this.clickItem(e))}">
                             <div class="head">
                                 <span class="title">${e.title}</span>
                                 ${e.timestamp?T`<span class="time">${e.timestamp}</span>`:v}
@@ -2529,14 +2529,14 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};k([y({type:Array})],di.prototype,`items`,void 0),di=k([g(`mateu-timeline`)],di);var fi=e=>T`
+        `}};k([y({type:Array})],fi.prototype,`items`,void 0),fi=k([g(`mateu-timeline`)],fi);var pi=e=>T`
         <mateu-timeline
                 .items="${e.metadata.items??[]}"
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-timeline>
-    `,pi=class extends b{constructor(...e){super(...e),this.steps=[],this.vertical=!1}static{this.styles=h`
+    `,mi=class extends b{constructor(...e){super(...e),this.steps=[],this.vertical=!1}static{this.styles=h`
         :host {
             display: block;
             width: 100%;
@@ -2650,7 +2650,7 @@ ${i}
                         </div>
                     `})}
             </div>
-        `}};k([y({type:Array})],pi.prototype,`steps`,void 0),k([y({type:Boolean,reflect:!0})],pi.prototype,`vertical`,void 0),pi=k([g(`mateu-progress-steps`)],pi);var mi=e=>{let t=e.metadata;return T`
+        `}};k([y({type:Array})],mi.prototype,`steps`,void 0),k([y({type:Boolean,reflect:!0})],mi.prototype,`vertical`,void 0),mi=k([g(`mateu-progress-steps`)],mi);var hi=e=>{let t=e.metadata;return T`
         <mateu-progress-steps
                 .steps="${t.steps??[]}"
                 ?vertical="${t.vertical??!1}"
@@ -2658,7 +2658,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-progress-steps>
-    `},hi=class extends b{constructor(...e){super(...e),this.spark=[]}static{this.styles=h`
+    `},gi=class extends b{constructor(...e){super(...e),this.spark=[]}static{this.styles=h`
         :host {
             display: block;
         }
@@ -2713,7 +2713,7 @@ ${i}
             .tile { background: var(--lumo-contrast-5pct, #2a2a2a); }
         }
     
-        ${B}
+        ${z}
     `}sparkline(){let e=this.spark;if(!e||e.length<2)return v;let t=Math.min(...e),n=Math.max(...e)-t||1,r=80/(e.length-1),i=e.map((e,i)=>[2+i*r,2+26*(1-(e-t)/n)]),a=i.map(([e,t],n)=>`${n===0?`M`:`L`}${e.toFixed(1)} ${t.toFixed(1)}`).join(` `),o=`${a} L${i[i.length-1][0].toFixed(1)} 30 L${i[0][0].toFixed(1)} 30 Z`,s=this.trend===`down`?`var(--lumo-error-color, #e11d48)`:this.trend===`flat`?`var(--lumo-secondary-text-color, #888)`:`var(--lumo-success-color, #12b76a)`;return w`
             <svg width="${84}" height="${30}" viewBox="0 0 ${84} ${30}">
                 <path d="${o}" fill="${s}" opacity="0.12"></path>
@@ -2721,7 +2721,7 @@ ${i}
                       stroke-linejoin="round" stroke-linecap="round"></path>
             </svg>
         `}dispatchAction(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId},bubbles:!0,composed:!0}))}render(){let e=this.trend??`up`;return T`
-            <div role="button" tabindex="0" class="tile ${this.actionId?`clickable`:``}" @click="${()=>this.dispatchAction()}" @keydown="${z(()=>this.dispatchAction())}">
+            <div role="button" tabindex="0" class="tile ${this.actionId?`clickable`:``}" @click="${()=>this.dispatchAction()}" @keydown="${R(()=>this.dispatchAction())}">
                 ${this.label?T`<span class="label">${this.label}</span>`:v}
                 <span class="value">${this.value}${this.unit?T`<span class="unit">${this.unit}</span>`:v}</span>
                 <div class="foot">
@@ -2729,7 +2729,7 @@ ${i}
                     ${this.sparkline()}
                 </div>
             </div>
-        `}};k([y()],hi.prototype,`label`,void 0),k([y()],hi.prototype,`value`,void 0),k([y()],hi.prototype,`unit`,void 0),k([y()],hi.prototype,`delta`,void 0),k([y()],hi.prototype,`trend`,void 0),k([y({type:Array})],hi.prototype,`spark`,void 0),k([y()],hi.prototype,`actionId`,void 0),hi=k([g(`mateu-stat`)],hi);var gi=e=>{let t=e.metadata;return T`
+        `}};k([y()],gi.prototype,`label`,void 0),k([y()],gi.prototype,`value`,void 0),k([y()],gi.prototype,`unit`,void 0),k([y()],gi.prototype,`delta`,void 0),k([y()],gi.prototype,`trend`,void 0),k([y({type:Array})],gi.prototype,`spark`,void 0),k([y()],gi.prototype,`actionId`,void 0),gi=k([g(`mateu-stat`)],gi);var _i=e=>{let t=e.metadata;return T`
         <mateu-stat
                 label="${t.label??v}"
                 value="${t.value??v}"
@@ -2742,7 +2742,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-stat>
-    `},_i=class extends b{constructor(...e){super(...e),this.events=[]}static{this.styles=h`
+    `},vi=class extends b{constructor(...e){super(...e),this.events=[]}static{this.styles=h`
         :host {
             display: block;
             width: 100%;
@@ -2816,7 +2816,7 @@ ${i}
             .dow { background: var(--lumo-contrast-10pct, #333); }
         }
     
-        ${B}
+        ${z}
     `}clickEvent(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_clickedEvent:e}},bubbles:!0,composed:!0}))}render(){let e=this.month?new Date(this.month+`T00:00:00`):new Date,t=e.getFullYear(),n=e.getMonth(),r=new Date(t,n,1),i=(r.getDay()+6)%7,a=new Date(t,n+1,0).getDate(),o=new Date,s=e=>o.getFullYear()===t&&o.getMonth()===n&&o.getDate()===e,c={};for(let e of this.events){if(!e.date)continue;let r=new Date(e.date+`T00:00:00`);r.getFullYear()===t&&r.getMonth()===n&&(c[r.getDate()]??=[]).push(e)}let l=[`Mon`,`Tue`,`Wed`,`Thu`,`Fri`,`Sat`,`Sun`],u=[];for(let e=0;e<i;e++)u.push(T`<div class="cell blank"></div>`);for(let e=1;e<=a;e++)u.push(T`
                 <div class="cell ${s(e)?`today`:``}">
                     <span class="num">${e}</span>
@@ -2824,7 +2824,7 @@ ${i}
                         <span role="button" tabindex="0" class="chip ${e.actionId?`clickable`:``}"
                               style="${e.color?`--mateu-cal-accent: ${e.color};`:``}"
                               title="${e.title??``}"
-                              @click="${()=>this.clickEvent(e)}" @keydown="${z(()=>this.clickEvent(e))}">${e.title}</span>
+                              @click="${()=>this.clickEvent(e)}" @keydown="${R(()=>this.clickEvent(e))}">${e.title}</span>
                     `)}
                 </div>
             `);return T`
@@ -2833,7 +2833,7 @@ ${i}
                 ${l.map(e=>T`<div class="dow">${e}</div>`)}
                 ${u}
             </div>
-        `}};k([y()],_i.prototype,`month`,void 0),k([y({type:Array})],_i.prototype,`events`,void 0),_i=k([g(`mateu-calendar`)],_i);var vi=e=>{let t=e.metadata;return T`
+        `}};k([y()],vi.prototype,`month`,void 0),k([y({type:Array})],vi.prototype,`events`,void 0),vi=k([g(`mateu-calendar`)],vi);var yi=e=>{let t=e.metadata;return T`
         <mateu-calendar
                 month="${t.month??v}"
                 .events="${t.events??[]}"
@@ -2841,7 +2841,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-calendar>
-    `},yi=class extends b{constructor(...e){super(...e),this.plans=[]}static{this.styles=h`
+    `},bi=class extends b{constructor(...e){super(...e),this.plans=[]}static{this.styles=h`
         :host {
             display: block;
             width: 100%;
@@ -2953,14 +2953,14 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};k([y({type:Array})],yi.prototype,`plans`,void 0),yi=k([g(`mateu-pricing-table`)],yi);var bi=e=>T`
+        `}};k([y({type:Array})],bi.prototype,`plans`,void 0),bi=k([g(`mateu-pricing-table`)],bi);var xi=e=>T`
         <mateu-pricing-table
                 .plans="${e.metadata.plans??[]}"
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-pricing-table>
-    `,xi=class extends b{static{this.styles=h`
+    `,Si=class extends b{static{this.styles=h`
         :host {
             display: block;
             width: 100%;
@@ -3056,26 +3056,26 @@ ${i}
             .node { background: var(--lumo-contrast-5pct, #2a2a2a); }
         }
     
-        ${B}
+        ${z}
     `}clickNode(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_clickedNode:e}},bubbles:!0,composed:!0}))}renderNode(e){let t=e.avatar,n=t&&(t.startsWith(`http`)||t.startsWith(`data:`));return T`
             <li>
                 <div role="button" tabindex="0" class="node ${e.actionId?`clickable`:``}"
                      style="${e.color?`--mateu-org-accent: ${e.color};`:``}"
-                     @click="${()=>this.clickNode(e)}" @keydown="${z(()=>this.clickNode(e))}">
+                     @click="${()=>this.clickNode(e)}" @keydown="${R(()=>this.clickNode(e))}">
                     ${t?T`<span class="avatar">${n?T`<img src="${t}" alt="">`:t}</span>`:v}
                     <span class="title">${e.title}</span>
                     ${e.subtitle?T`<span class="subtitle">${e.subtitle}</span>`:v}
                 </div>
                 ${e.children&&e.children.length?T`<ul>${e.children.map(e=>this.renderNode(e))}</ul>`:v}
             </li>
-        `}render(){return this.root?T`<div class="tree"><ul>${this.renderNode(this.root)}</ul></div>`:T``}};k([y({attribute:!1})],xi.prototype,`root`,void 0),xi=k([g(`mateu-org-chart`)],xi);var Si=e=>T`
+        `}render(){return this.root?T`<div class="tree"><ul>${this.renderNode(this.root)}</ul></div>`:T``}};k([y({attribute:!1})],Si.prototype,`root`,void 0),Si=k([g(`mateu-org-chart`)],Si);var Ci=e=>T`
         <mateu-org-chart
                 .root="${e.metadata.root}"
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-org-chart>
-    `,Ci=1440*60*1e3,wi=class extends b{constructor(...e){super(...e),this.cells=[]}static{this.styles=h`
+    `,wi=1440*60*1e3,Ti=class extends b{constructor(...e){super(...e),this.cells=[]}static{this.styles=h`
         :host {
             display: block;
             width: 100%;
@@ -3099,7 +3099,7 @@ ${i}
             margin-top: .15rem;
         }
         .legend .cell { width: 10px; height: 10px; }
-    `}color(e,t){if(e<=0||t<=0)return`var(--lumo-contrast-10pct, #ebedf0)`;let n=e/t;return`color-mix(in srgb, var(--lumo-primary-color, #1a73e8) ${Math.round((n>.75?1:n>.5?.75:n>.25?.5:.3)*100)}%, transparent)`}render(){let e=this.cells.filter(e=>!!e.date);if(!e.length)return T``;let t=e.map(e=>new Date(e.date+`T00:00:00`).getTime()),n=Math.min(...t),r=Math.max(...t),i=new Date(n);i.setDate(i.getDate()-(i.getDay()+6)%7);let a={};for(let t of e)a[t.date]=t;let o=Math.max(...e.map(e=>e.value??0),1),s=[];for(let e=i.getTime();e<=r;e+=Ci){let t=new Date(e),n=t.toISOString().slice(0,10),r=a[n],i=r?.value??0,c=(t.getDay()+6)%7+1,l=r?.label??`${n}: ${i}`;s.push(T`
+    `}color(e,t){if(e<=0||t<=0)return`var(--lumo-contrast-10pct, #ebedf0)`;let n=e/t;return`color-mix(in srgb, var(--lumo-primary-color, #1a73e8) ${Math.round((n>.75?1:n>.5?.75:n>.25?.5:.3)*100)}%, transparent)`}render(){let e=this.cells.filter(e=>!!e.date);if(!e.length)return T``;let t=e.map(e=>new Date(e.date+`T00:00:00`).getTime()),n=Math.min(...t),r=Math.max(...t),i=new Date(n);i.setDate(i.getDate()-(i.getDay()+6)%7);let a={};for(let t of e)a[t.date]=t;let o=Math.max(...e.map(e=>e.value??0),1),s=[];for(let e=i.getTime();e<=r;e+=wi){let t=new Date(e),n=t.toISOString().slice(0,10),r=a[n],i=r?.value??0,c=(t.getDay()+6)%7+1,l=r?.label??`${n}: ${i}`;s.push(T`
                 <div class="cell" style="grid-row: ${c}; --cell: ${this.color(i,o)};" title="${l}"></div>
             `)}return T`
             <div class="wrap">
@@ -3114,14 +3114,14 @@ ${i}
                     <span>More</span>
                 </div>
             </div>
-        `}};k([y({type:Array})],wi.prototype,`cells`,void 0),wi=k([g(`mateu-heatmap`)],wi);var Ti=e=>T`
+        `}};k([y({type:Array})],Ti.prototype,`cells`,void 0),Ti=k([g(`mateu-heatmap`)],Ti);var Ei=e=>T`
         <mateu-heatmap
                 .cells="${e.metadata.cells??[]}"
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-heatmap>
-    `,Ei=class extends b{constructor(...e){super(...e),this.stages=[]}static{this.styles=h`
+    `,Di=class extends b{constructor(...e){super(...e),this.stages=[]}static{this.styles=h`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .funnel { display: flex; flex-direction: column; gap: .35rem; }
         .stage { display: flex; flex-direction: column; align-items: center; gap: .1rem; }
@@ -3154,14 +3154,14 @@ ${i}
                         </div>
                     `})}
             </div>
-        `}};k([y({type:Array})],Ei.prototype,`stages`,void 0),Ei=k([g(`mateu-funnel`)],Ei);var Di=e=>T`
+        `}};k([y({type:Array})],Di.prototype,`stages`,void 0),Di=k([g(`mateu-funnel`)],Di);var Oi=e=>T`
         <mateu-funnel
                 .stages="${e.metadata.stages??[]}"
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-funnel>
-    `,Oi=class extends b{constructor(...e){super(...e),this.values=[],this.labels=[],this.area=!1}static{this.styles=h`
+    `,ki=class extends b{constructor(...e){super(...e),this.values=[],this.labels=[],this.area=!1}static{this.styles=h`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .title { font-weight: 600; margin-bottom: .35rem; color: var(--lumo-body-text-color, #222); }
         svg { display: block; width: 100%; height: auto; overflow: visible; }
@@ -3174,7 +3174,7 @@ ${i}
                 ${a.map((t,n)=>n===l||n===u?w`<circle cx="${t[0]}" cy="${t[1]}" r="3.2" fill="${c}"><title>${this.labels[n]??``}: ${e[n]}</title></circle>`:w`<circle cx="${t[0]}" cy="${t[1]}" r="6" fill="transparent"><title>${this.labels[n]??``}: ${e[n]}</title></circle>`)}
             </svg>
             ${this.labels&&this.labels.length?T`<div class="labels"><span>${this.labels[0]}</span><span>${this.labels[this.labels.length-1]}</span></div>`:v}
-        `}};k([y()],Oi.prototype,`heading`,void 0),k([y({type:Array})],Oi.prototype,`values`,void 0),k([y({type:Array})],Oi.prototype,`labels`,void 0),k([y()],Oi.prototype,`color`,void 0),k([y({type:Boolean})],Oi.prototype,`area`,void 0),Oi=k([g(`mateu-trend-chart`)],Oi);var ki=e=>{let t=e.metadata;return T`
+        `}};k([y()],ki.prototype,`heading`,void 0),k([y({type:Array})],ki.prototype,`values`,void 0),k([y({type:Array})],ki.prototype,`labels`,void 0),k([y()],ki.prototype,`color`,void 0),k([y({type:Boolean})],ki.prototype,`area`,void 0),ki=k([g(`mateu-trend-chart`)],ki);var Ai=e=>{let t=e.metadata;return T`
         <mateu-trend-chart
                 heading="${t.title??v}"
                 color="${t.color??v}"
@@ -3185,7 +3185,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-trend-chart>
-    `},Ai=class extends b{constructor(...e){super(...e),this.features=[],this.columns=0}static{this.styles=h`
+    `},ji=class extends b{constructor(...e){super(...e),this.features=[],this.columns=0}static{this.styles=h`
         :host { display: block; width: 100%; }
         .grid {
             display: grid;
@@ -3215,18 +3215,18 @@ ${i}
             .card { background: var(--lumo-contrast-5pct, #2a2a2a); }
         }
     
-        ${B}
+        ${z}
     `}clickFeature(e){e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))}render(){return T`
             <div class="grid" style="grid-template-columns: ${this.columns&&this.columns>0?`repeat(${this.columns}, minmax(0, 1fr))`:`repeat(auto-fit, minmax(15rem, 1fr))`};">
                 ${this.features.map(e=>T`
-                    <div role="button" tabindex="0" class="card ${e.actionId?`clickable`:``}" @click="${()=>this.clickFeature(e)}" @keydown="${z(()=>this.clickFeature(e))}">
+                    <div role="button" tabindex="0" class="card ${e.actionId?`clickable`:``}" @click="${()=>this.clickFeature(e)}" @keydown="${R(()=>this.clickFeature(e))}">
                         ${e.icon?T`<span class="icon">${e.icon}</span>`:v}
                         <span class="title">${e.title}</span>
                         ${e.description?T`<span class="desc">${e.description}</span>`:v}
                     </div>
                 `)}
             </div>
-        `}};k([y({type:Array})],Ai.prototype,`features`,void 0),k([y({type:Number})],Ai.prototype,`columns`,void 0),Ai=k([g(`mateu-feature-grid`)],Ai);var ji=e=>{let t=e.metadata;return T`
+        `}};k([y({type:Array})],ji.prototype,`features`,void 0),k([y({type:Number})],ji.prototype,`columns`,void 0),ji=k([g(`mateu-feature-grid`)],ji);var Mi=e=>{let t=e.metadata;return T`
         <mateu-feature-grid
                 .features="${t.features??[]}"
                 .columns="${t.columns??0}"
@@ -3234,7 +3234,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-feature-grid>
-    `},Mi=class extends b{constructor(...e){super(...e),this.items=[]}static{this.styles=h`
+    `},Ni=class extends b{constructor(...e){super(...e),this.items=[]}static{this.styles=h`
         :host { display: block; width: 100%; }
         .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr)); gap: var(--lumo-space-m, 1rem); }
         .card {
@@ -3274,14 +3274,14 @@ ${i}
                         </div>
                     `})}
             </div>
-        `}};k([y({type:Array})],Mi.prototype,`items`,void 0),Mi=k([g(`mateu-testimonials`)],Mi);var Ni=e=>T`
+        `}};k([y({type:Array})],Ni.prototype,`items`,void 0),Ni=k([g(`mateu-testimonials`)],Ni);var Pi=e=>T`
         <mateu-testimonials
                 .items="${e.metadata.items??[]}"
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-testimonials>
-    `,Pi=class extends b{constructor(...e){super(...e),this.items=[],this.openSet=new Set,this.seeded=!1}static{this.styles=h`
+    `,Fi=class extends b{constructor(...e){super(...e),this.items=[],this.openSet=new Set,this.seeded=!1}static{this.styles=h`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-m, 1rem); }
         .list {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -3305,12 +3305,12 @@ ${i}
         }
         @media (prefers-color-scheme: dark) { .q { background: var(--lumo-contrast-5pct, #2a2a2a); } }
     
-        ${B}
+        ${z}
     `}seed(){this.seeded||(this.seeded=!0,this.items.forEach((e,t)=>{e.open&&this.openSet.add(t)}))}toggle(e){this.openSet.has(e)?this.openSet.delete(e):this.openSet.add(e),this.requestUpdate()}render(){return this.seed(),T`
             <div class="list">
                 ${this.items.map((e,t)=>{let n=this.openSet.has(t);return T`
                         <div class="item ${n?`open`:``}">
-                            <div role="button" tabindex="0" aria-expanded="${n}" class="q" @click="${()=>this.toggle(t)}" @keydown="${z(()=>this.toggle(t))}">
+                            <div role="button" tabindex="0" aria-expanded="${n}" class="q" @click="${()=>this.toggle(t)}" @keydown="${R(()=>this.toggle(t))}">
                                 <span>${e.question}</span>
                                 <span class="chevron">›</span>
                             </div>
@@ -3318,14 +3318,14 @@ ${i}
                         </div>
                     `})}
             </div>
-        `}};k([y({type:Array})],Pi.prototype,`items`,void 0),k([C()],Pi.prototype,`openSet`,void 0),Pi=k([g(`mateu-faq`)],Pi);var Fi=e=>T`
+        `}};k([y({type:Array})],Fi.prototype,`items`,void 0),k([C()],Fi.prototype,`openSet`,void 0),Fi=k([g(`mateu-faq`)],Fi);var Ii=e=>T`
         <mateu-faq
                 .items="${e.metadata.items??[]}"
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-faq>
-    `,Ii=class extends b{static{this.styles=h`
+    `,Li=class extends b{static{this.styles=h`
         :host { display: block; width: 100%; }
         .callout {
             display: flex; gap: 1rem; align-items: flex-start;
@@ -3354,7 +3354,7 @@ ${i}
                     ${this.ctaLabel?T`<button class="cta" @click="${()=>this.cta()}">${this.ctaLabel}</button>`:v}
                 </div>
             </div>
-        `}};k([y()],Ii.prototype,`heading`,void 0),k([y()],Ii.prototype,`description`,void 0),k([y()],Ii.prototype,`icon`,void 0),k([y()],Ii.prototype,`ctaLabel`,void 0),k([y()],Ii.prototype,`actionId`,void 0),k([y()],Ii.prototype,`theme`,void 0),Ii=k([g(`mateu-callout-card`)],Ii);var Li=e=>{let t=e.metadata;return T`
+        `}};k([y()],Li.prototype,`heading`,void 0),k([y()],Li.prototype,`description`,void 0),k([y()],Li.prototype,`icon`,void 0),k([y()],Li.prototype,`ctaLabel`,void 0),k([y()],Li.prototype,`actionId`,void 0),k([y()],Li.prototype,`theme`,void 0),Li=k([g(`mateu-callout-card`)],Li);var Ri=e=>{let t=e.metadata;return T`
         <mateu-callout-card
                 heading="${t.title??v}"
                 description="${t.description??v}"
@@ -3366,7 +3366,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-callout-card>
-    `},Ri=class extends b{constructor(...e){super(...e),this.comments=[]}static{this.styles=h`
+    `},zi=class extends b{constructor(...e){super(...e),this.comments=[]}static{this.styles=h`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .thread { display: flex; flex-direction: column; gap: 1rem; }
         .replies {
@@ -3398,14 +3398,14 @@ ${i}
                     ${e.replies&&e.replies.length?T`<div class="replies">${e.replies.map(e=>this.renderComment(e))}</div>`:v}
                 </div>
             </div>
-        `}render(){return T`<div class="thread">${this.comments.map(e=>this.renderComment(e))}</div>`}};k([y({type:Array})],Ri.prototype,`comments`,void 0),Ri=k([g(`mateu-comment-thread`)],Ri);var zi=e=>T`
+        `}render(){return T`<div class="thread">${this.comments.map(e=>this.renderComment(e))}</div>`}};k([y({type:Array})],zi.prototype,`comments`,void 0),zi=k([g(`mateu-comment-thread`)],zi);var Bi=e=>T`
         <mateu-comment-thread
                 .comments="${e.metadata.comments??[]}"
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-comment-thread>
-    `,Bi={pdf:`📕`,image:`🖼️`,img:`🖼️`,doc:`📘`,docx:`📘`,word:`📘`,xls:`📗`,xlsx:`📗`,excel:`📗`,sheet:`📗`,zip:`🗜️`,archive:`🗜️`,video:`🎬`,audio:`🎵`,code:`💻`,csv:`📄`,txt:`📄`},Vi=class extends b{constructor(...e){super(...e),this.files=[]}static{this.styles=h`
+    `,Vi={pdf:`📕`,image:`🖼️`,img:`🖼️`,doc:`📘`,docx:`📘`,word:`📘`,xls:`📗`,xlsx:`📗`,excel:`📗`,sheet:`📗`,zip:`🗜️`,archive:`🗜️`,video:`🎬`,audio:`🎵`,code:`💻`,csv:`📄`,txt:`📄`},Hi=class extends b{constructor(...e){super(...e),this.files=[]}static{this.styles=h`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .list {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -3421,24 +3421,24 @@ ${i}
         .size { color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-xs, .75rem); flex: 0 0 auto; }
         .dl { color: var(--lumo-primary-color, #1a73e8); flex: 0 0 auto; }
     
-        ${B}
-    `}icon(e){return e&&Bi[e.toLowerCase()]||`📄`}clickFile(e,t){e.url||e.actionId&&(t.preventDefault(),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_file:e}},bubbles:!0,composed:!0})))}render(){return T`
+        ${z}
+    `}icon(e){return e&&Vi[e.toLowerCase()]||`📄`}clickFile(e,t){e.url||e.actionId&&(t.preventDefault(),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_file:e}},bubbles:!0,composed:!0})))}render(){return T`
             <div class="list">
                 ${this.files.map(e=>{let t=!!e.url||!!e.actionId,n=T`
                         <span class="icon">${this.icon(e.type)}</span>
                         <span class="name">${e.name}</span>
                         ${e.size?T`<span class="size">${e.size}</span>`:v}
                         ${e.url?T`<span class="dl">⬇</span>`:v}
-                    `;return e.url?T`<a class="file clickable" href="${e.url}" download target="_blank" rel="noopener">${n}</a>`:T`<div role="button" tabindex="0" class="file ${t?`clickable`:``}" @click="${t=>this.clickFile(e,t)}" @keydown="${z(t=>this.clickFile(e,t))}">${n}</div>`})}
+                    `;return e.url?T`<a class="file clickable" href="${e.url}" download target="_blank" rel="noopener">${n}</a>`:T`<div role="button" tabindex="0" class="file ${t?`clickable`:``}" @click="${t=>this.clickFile(e,t)}" @keydown="${R(t=>this.clickFile(e,t))}">${n}</div>`})}
             </div>
-        `}};k([y({type:Array})],Vi.prototype,`files`,void 0),Vi=k([g(`mateu-file-list`)],Vi);var Hi=e=>T`
+        `}};k([y({type:Array})],Hi.prototype,`files`,void 0),Hi=k([g(`mateu-file-list`)],Hi);var Ui=e=>T`
         <mateu-file-list
                 .files="${e.metadata.files??[]}"
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-file-list>
-    `,Ui=class extends b{constructor(...e){super(...e),this.items=[],this.localDone=new Map}static{this.styles=h`
+    `,Wi=class extends b{constructor(...e){super(...e),this.items=[],this.localDone=new Map}static{this.styles=h`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .head { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: .5rem; }
         .title { font-weight: 700; color: var(--lumo-body-text-color, #222); }
@@ -3455,7 +3455,7 @@ ${i}
         .label { color: var(--lumo-body-text-color, #333); }
         .item.done .label { color: var(--lumo-secondary-text-color, #999); text-decoration: line-through; }
     
-        ${B}
+        ${z}
     `}isDone(e,t){return this.localDone.has(t)?!!this.localDone.get(t):!!e.done}toggle(e,t){let n=!this.isDone(e,t);this.localDone.set(t,n),this.requestUpdate(),e.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:{_item:e,_done:n}},bubbles:!0,composed:!0}))}render(){let e=this.items.length,t=this.items.filter((e,t)=>this.isDone(e,t)).length,n=e>0?Math.round(t/e*100):0;return T`
             <div class="head">
                 ${this.heading?T`<span class="title">${this.heading}</span>`:T`<span></span>`}
@@ -3463,12 +3463,12 @@ ${i}
             </div>
             <div class="bar"><div class="fill" style="width: ${n}%;"></div></div>
             ${this.items.map((e,t)=>{let n=this.isDone(e,t);return T`
-                    <div role="button" tabindex="0" class="item ${n?`done`:``}" @click="${()=>this.toggle(e,t)}" @keydown="${z(()=>this.toggle(e,t))}">
+                    <div role="button" tabindex="0" class="item ${n?`done`:``}" @click="${()=>this.toggle(e,t)}" @keydown="${R(()=>this.toggle(e,t))}">
                         <span class="box">${n?`✓`:v}</span>
                         <span class="label">${e.label}</span>
                     </div>
                 `})}
-        `}};k([y()],Ui.prototype,`heading`,void 0),k([y({type:Array})],Ui.prototype,`items`,void 0),k([C()],Ui.prototype,`localDone`,void 0),Ui=k([g(`mateu-checklist`)],Ui);var Wi=e=>{let t=e.metadata;return T`
+        `}};k([y()],Wi.prototype,`heading`,void 0),k([y({type:Array})],Wi.prototype,`items`,void 0),k([C()],Wi.prototype,`localDone`,void 0),Wi=k([g(`mateu-checklist`)],Wi);var Gi=e=>{let t=e.metadata;return T`
         <mateu-checklist
                 heading="${t.title??v}"
                 .items="${t.items??[]}"
@@ -3476,7 +3476,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-checklist>
-    `},Gi=class extends b{static{this.styles=h`
+    `},Ki=class extends b{static{this.styles=h`
         :host { display: block; width: 100%; }
         .card {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -3516,7 +3516,7 @@ ${i}
                     </div>
                 </div>
             </div>
-        `}};k([y()],Gi.prototype,`heading`,void 0),k([y()],Gi.prototype,`leftLabel`,void 0),k([y()],Gi.prototype,`leftValue`,void 0),k([y()],Gi.prototype,`rightLabel`,void 0),k([y()],Gi.prototype,`rightValue`,void 0),k([y()],Gi.prototype,`delta`,void 0),k([y()],Gi.prototype,`trend`,void 0),Gi=k([g(`mateu-comparison-card`)],Gi);var Ki=e=>{let t=e.metadata;return T`
+        `}};k([y()],Ki.prototype,`heading`,void 0),k([y()],Ki.prototype,`leftLabel`,void 0),k([y()],Ki.prototype,`leftValue`,void 0),k([y()],Ki.prototype,`rightLabel`,void 0),k([y()],Ki.prototype,`rightValue`,void 0),k([y()],Ki.prototype,`delta`,void 0),k([y()],Ki.prototype,`trend`,void 0),Ki=k([g(`mateu-comparison-card`)],Ki);var qi=e=>{let t=e.metadata;return T`
         <mateu-comparison-card
                 heading="${t.title??v}"
                 leftLabel="${t.leftLabel??v}"
@@ -3529,7 +3529,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-comparison-card>
-    `},qi=h`
+    `},Ji=h`
     .chip {
         display: inline-flex;
         align-items: center;
@@ -3559,7 +3559,7 @@ ${i}
         color: var(--lumo-contrast-80pct, #333);
         background: var(--lumo-contrast-10pct, rgba(0, 0, 0, .08));
     }
-`,Ji=new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}),Yi=e=>Number.isFinite(e)?Ji.format(e):``,Xi=(e,t)=>{let n=e<0?`-`:``,r=Yi(Math.abs(e));return t?`${n}${t} ${r}`:`${n}${r}`},Zi=(e,t)=>t?`${Yi(e)} ${t}`:Yi(e),Qi=class extends b{constructor(...e){super(...e),this.title=``,this.badges=[],this.facts=[]}static{this.styles=[qi,h`
+`,Yi=new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}),Xi=e=>Number.isFinite(e)?Yi.format(e):``,Zi=(e,t)=>{let n=e<0?`-`:``,r=Xi(Math.abs(e));return t?`${n}${t} ${r}`:`${n}${r}`},Qi=(e,t)=>t?`${Xi(e)} ${t}`:Xi(e),$i=class extends b{constructor(...e){super(...e),this.title=``,this.badges=[],this.facts=[]}static{this.styles=[Ji,h`
         :host { display: block; width: 100%; }
         .card {
             display: flex;
@@ -3642,7 +3642,7 @@ ${i}
                     </div>
                 `:v}
             </div>
-        `}};k([y()],Qi.prototype,`title`,void 0),k([y({type:Array})],Qi.prototype,`badges`,void 0),k([y()],Qi.prototype,`subtitle`,void 0),k([y({type:Array})],Qi.prototype,`facts`,void 0),k([y()],Qi.prototype,`metricLabel`,void 0),k([y()],Qi.prototype,`metricValue`,void 0),k([y()],Qi.prototype,`metricCaption`,void 0),Qi=k([g(`mateu-entity-header`)],Qi);var $i=e=>{if(e.__hoistedToPageHeader)return T``;let t=e.metadata;return T`
+        `}};k([y()],$i.prototype,`title`,void 0),k([y({type:Array})],$i.prototype,`badges`,void 0),k([y()],$i.prototype,`subtitle`,void 0),k([y({type:Array})],$i.prototype,`facts`,void 0),k([y()],$i.prototype,`metricLabel`,void 0),k([y()],$i.prototype,`metricValue`,void 0),k([y()],$i.prototype,`metricCaption`,void 0),$i=k([g(`mateu-entity-header`)],$i);var ea=e=>{if(e.__hoistedToPageHeader)return T``;let t=e.metadata;return T`
         <mateu-entity-header
                 .title="${t.title??``}"
                 .badges="${t.badges??[]}"
@@ -3655,7 +3655,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-entity-header>
-    `},ea=class extends b{constructor(...e){super(...e),this.value=0,this.max=0}static{this.styles=h`
+    `},ta=class extends b{constructor(...e){super(...e),this.value=0,this.max=0}static{this.styles=h`
         :host { display: block; width: 100%; }
         .meter { display: flex; flex-direction: column; gap: .35rem; }
         .label {
@@ -3680,13 +3680,13 @@ ${i}
     `}fillColor(){return this.dangerAt!=null&&this.value>=this.dangerAt?`error`:this.warnAt!=null&&this.value>=this.warnAt?`warning`:this.warnAt!=null||this.dangerAt!=null?`success`:`primary`}render(){let e=this.max>0?Math.min(Math.max(this.value/this.max,0),1):0,t=Math.round(e*100);return T`
             <div class="meter">
                 ${this.label?T`<span class="label">${this.label}</span>`:v}
-                <span class="value">${Zi(this.value,this.unit)}</span>
+                <span class="value">${Qi(this.value,this.unit)}</span>
                 <div class="track">
                     <div class="fill ${this.fillColor()}" style="width: ${t}%"></div>
                 </div>
                 <span class="caption">${this.caption?this.caption:`${t}%`}</span>
             </div>
-        `}};k([y()],ea.prototype,`label`,void 0),k([y({type:Number})],ea.prototype,`value`,void 0),k([y({type:Number})],ea.prototype,`max`,void 0),k([y()],ea.prototype,`unit`,void 0),k([y()],ea.prototype,`caption`,void 0),k([y({type:Number})],ea.prototype,`warnAt`,void 0),k([y({type:Number})],ea.prototype,`dangerAt`,void 0),ea=k([g(`mateu-meter`)],ea);var ta=e=>{let t=e.metadata;return T`
+        `}};k([y()],ta.prototype,`label`,void 0),k([y({type:Number})],ta.prototype,`value`,void 0),k([y({type:Number})],ta.prototype,`max`,void 0),k([y()],ta.prototype,`unit`,void 0),k([y()],ta.prototype,`caption`,void 0),k([y({type:Number})],ta.prototype,`warnAt`,void 0),k([y({type:Number})],ta.prototype,`dangerAt`,void 0),ta=k([g(`mateu-meter`)],ta);var na=e=>{let t=e.metadata;return T`
         <mateu-meter
                 .label="${t.label}"
                 .value="${t.value??0}"
@@ -3699,7 +3699,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-meter>
-    `},na=class extends b{constructor(...e){super(...e),this.total=0,this.done=0}static{this.styles=h`
+    `},ra=class extends b{constructor(...e){super(...e),this.total=0,this.done=0}static{this.styles=h`
         :host { display: block; width: 100%; }
         .banner {
             display: flex; align-items: center; gap: .8rem; flex-wrap: wrap;
@@ -3754,7 +3754,7 @@ ${i}
                 <span class="spacer"></span>
                 ${t?T`<button @click="${()=>this.runAction()}">${this.actionLabel} →</button>`:v}
             </div>
-        `}};k([y()],na.prototype,`label`,void 0),k([y({type:Number})],na.prototype,`total`,void 0),k([y({type:Number})],na.prototype,`done`,void 0),k([y()],na.prototype,`actionLabel`,void 0),k([y()],na.prototype,`actionId`,void 0),na=k([g(`mateu-task-progress`)],na);var ra=e=>{let t=e.metadata;return T`
+        `}};k([y()],ra.prototype,`label`,void 0),k([y({type:Number})],ra.prototype,`total`,void 0),k([y({type:Number})],ra.prototype,`done`,void 0),k([y()],ra.prototype,`actionLabel`,void 0),k([y()],ra.prototype,`actionId`,void 0),ra=k([g(`mateu-task-progress`)],ra);var ia=e=>{let t=e.metadata;return T`
         <mateu-task-progress
                 .label="${t.label}"
                 .total="${t.total??0}"
@@ -3765,7 +3765,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-task-progress>
-    `},ia=class extends b{constructor(...e){super(...e),this.items=[],this.compact=!1,this.frameless=!1,this.columns=0,this.itemHeadingLevel=3}static{this.styles=[qi,B,h`
+    `},aa=class extends b{constructor(...e){super(...e),this.items=[],this.compact=!1,this.frameless=!1,this.columns=0,this.itemHeadingLevel=3}static{this.styles=[Ji,z,h`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .list {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -3870,7 +3870,7 @@ ${i}
     `]}runAction(e,t){t&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_item:e.id}},bubbles:!0,composed:!0}))}rowClicked(e){this.rowActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.rowActionId,parameters:{_item:e.id}},bubbles:!0,composed:!0}))}renderItemAction(e,t,n,r){return!t||!n?v:r?T`
                 <button class="icon-action" title="${t}" aria-label="${t}"
                     @click="${t=>{t.stopPropagation(),this.runAction(e,n)}}">
-                    ${L(r)}
+                    ${I(r)}
                 </button>`:T`
             <button class="row-action" title="${t}"
                 @click="${t=>{t.stopPropagation(),this.runAction(e,n)}}">${t}</button>`}render(){let e=this.columns>1||this.items.some(e=>e.actionId||e.actionId2||e.actionId3||(e.lines?.length??0)>0),t=this.itemHeadingLevel===4?`h4`:`h3`;return e?T`
@@ -3878,7 +3878,7 @@ ${i}
                      style="${this.columns>1?`grid-template-columns: repeat(auto-fit, minmax(min(18rem, calc(100% / ${this.columns} - 1.5rem)), 1fr));`:``}">
                     ${this.items.map(e=>T`
                         <div role="button" tabindex="0" class="cell ${(e.lines?.length??0)>0?`with-lines`:``} ${this.rowActionId?`clickable`:``}"
-                             @click="${()=>this.rowClicked(e)}" @keydown="${z(()=>this.rowClicked(e))}">
+                             @click="${()=>this.rowClicked(e)}" @keydown="${R(()=>this.rowClicked(e))}">
                             <div class="cell-title-row">
                                 ${t===`h4`?T`<h4 class="cell-title">${e.title}</h4>`:T`<h3 class="cell-title">${e.title}</h3>`}
                                 ${e.status?T`<span class="chip ${e.statusColor??``}">${e.status}</span>`:v}
@@ -3898,7 +3898,7 @@ ${i}
             <div class="list ${this.compact?`compact`:``} ${this.frameless?`frameless`:``}">
                 ${this.items.map(e=>T`
                     <div role="button" tabindex="0" class="row ${this.rowActionId?`clickable`:``}"
-                         @click="${()=>this.rowClicked(e)}" @keydown="${z(()=>this.rowClicked(e))}">
+                         @click="${()=>this.rowClicked(e)}" @keydown="${R(()=>this.rowClicked(e))}">
                         ${e.avatar?T`<span class="avatar">${e.avatar}</span>`:e.icon?T`<span class="icon">${e.icon}</span>`:v}
                         <div class="body">
                             <span class="title">${e.title}</span>
@@ -3908,7 +3908,7 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};k([y({type:Array})],ia.prototype,`items`,void 0),k([y({type:Boolean})],ia.prototype,`compact`,void 0),k([y({type:Boolean})],ia.prototype,`frameless`,void 0),k([y()],ia.prototype,`rowActionId`,void 0),k([y({type:Number})],ia.prototype,`columns`,void 0),k([y({type:Number})],ia.prototype,`itemHeadingLevel`,void 0),ia=k([g(`mateu-status-list`)],ia);var aa=e=>{let t=e.metadata;return T`
+        `}};k([y({type:Array})],aa.prototype,`items`,void 0),k([y({type:Boolean})],aa.prototype,`compact`,void 0),k([y({type:Boolean})],aa.prototype,`frameless`,void 0),k([y()],aa.prototype,`rowActionId`,void 0),k([y({type:Number})],aa.prototype,`columns`,void 0),k([y({type:Number})],aa.prototype,`itemHeadingLevel`,void 0),aa=k([g(`mateu-status-list`)],aa);var oa=e=>{let t=e.metadata;return T`
         <mateu-status-list
                 .items="${t.items??[]}"
                 ?compact="${t.compact??!1}"
@@ -3920,7 +3920,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-status-list>
-    `},oa=class extends b{constructor(...e){super(...e),this.items=[]}static{this.styles=h`
+    `},sa=class extends b{constructor(...e){super(...e),this.items=[]}static{this.styles=h`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         ul {
             margin: 0; padding-inline-start: 1.2rem;
@@ -3935,20 +3935,20 @@ ${i}
             <ul>
                 ${this.items.map(e=>T`<li>${e}</li>`)}
             </ul>
-        `}};k([y({type:Array})],oa.prototype,`items`,void 0),oa=k([g(`mateu-bulleted-list`)],oa);var sa=e=>T`
+        `}};k([y({type:Array})],sa.prototype,`items`,void 0),sa=k([g(`mateu-bulleted-list`)],sa);var ca=e=>T`
         <mateu-bulleted-list
                 .items="${e.metadata.items??[]}"
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-bulleted-list>
-    `,ca=e=>{let t=e.metadata.attributes?.[`data-colspan`];return T`
+    `,la=e=>{let t=e.metadata.attributes?.[`data-colspan`];return T`
         <hr style="border: none; border-top: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1)); width: 100%; margin: var(--lumo-space-s, .5rem) 0; ${e.style??``}"
             class="${e.cssClasses??v}"
             id="${S(e.id??void 0)}"
             data-colspan="${S(t)}"
             slot="${e.slot??v}"/>
-    `},la={info:`ℹ`,success:`✓`,warning:`!`,danger:`!`},H=class extends b{constructor(...e){super(...e),this.text=``,this.theme=`info`,this.noIcon=!1,this.slim=!1,this.fullWidth=!1,this.hasContent=!1,this.inlineContent=!1}static{this.styles=h`
+    `},ua={info:`ℹ`,success:`✓`,warning:`!`,danger:`!`},V=class extends b{constructor(...e){super(...e),this.text=``,this.theme=`info`,this.noIcon=!1,this.slim=!1,this.fullWidth=!1,this.hasContent=!1,this.inlineContent=!1}static{this.styles=h`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .notice {
             display: flex;
@@ -4013,14 +4013,14 @@ ${i}
         .danger  .icon  { background: #b25b3d; }
     `}runAction(){this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId},bubbles:!0,composed:!0}))}render(){let e=!!this.text&&!!this.text.trim();if(!e&&!this.hasContent)return T``;let t=[`info`,`success`,`warning`,`danger`].includes(this.theme)?this.theme:`info`;return T`
             <div class="notice ${t} ${this.slim?`slim`:``}">
-                ${this.noIcon?v:T`<span class="icon ${this.icon?`custom`:``}">${this.icon||la[t]}</span>`}
+                ${this.noIcon?v:T`<span class="icon ${this.icon?`custom`:``}">${this.icon||ua[t]}</span>`}
                 <div class="body ${this.inlineContent?`inline`:``}">
                     ${e?T`<span class="text">${this.text}</span>`:v}
                     ${this.hasContent?T`<div class="content"><slot></slot></div>`:v}
                 </div>
                 ${this.actionLabel&&this.actionId?T`<button class="notice-action" @click="${()=>this.runAction()}">${this.actionLabel}</button>`:this.status?T`<span class="status">${this.status}</span>`:v}
             </div>
-        `}};k([y()],H.prototype,`text`,void 0),k([y()],H.prototype,`theme`,void 0),k([y()],H.prototype,`icon`,void 0),k([y({type:Boolean})],H.prototype,`noIcon`,void 0),k([y()],H.prototype,`actionLabel`,void 0),k([y()],H.prototype,`actionId`,void 0),k([y()],H.prototype,`status`,void 0),k([y({type:Boolean})],H.prototype,`slim`,void 0),k([y({type:Boolean})],H.prototype,`fullWidth`,void 0),k([y({type:Boolean})],H.prototype,`hasContent`,void 0),k([y({type:Boolean})],H.prototype,`inlineContent`,void 0),H=k([g(`mateu-notice`)],H);var ua=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=xt(s.text??``,r,i,a,o)??``,l=t.children??[];return T`
+        `}};k([y()],V.prototype,`text`,void 0),k([y()],V.prototype,`theme`,void 0),k([y()],V.prototype,`icon`,void 0),k([y({type:Boolean})],V.prototype,`noIcon`,void 0),k([y()],V.prototype,`actionLabel`,void 0),k([y()],V.prototype,`actionId`,void 0),k([y()],V.prototype,`status`,void 0),k([y({type:Boolean})],V.prototype,`slim`,void 0),k([y({type:Boolean})],V.prototype,`fullWidth`,void 0),k([y({type:Boolean})],V.prototype,`hasContent`,void 0),k([y({type:Boolean})],V.prototype,`inlineContent`,void 0),V=k([g(`mateu-notice`)],V);var da=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=xt(s.text??``,r,i,a,o)??``,l=t.children??[];return T`
         <mateu-notice
                 text="${c}"
                 theme="${s.theme??`info`}"
@@ -4037,8 +4037,8 @@ ${i}
                 style="${t.style??v}"
                 class="${t.cssClasses??v}"
                 slot="${t.slot??v}"
-        >${l.map(t=>I(e,t,n,r,i,a,o))}</mateu-notice>
-    `},da=class extends b{constructor(...e){super(...e),this.groups=[]}static{this.styles=[qi,B,h`
+        >${l.map(t=>F(e,t,n,r,i,a,o))}</mateu-notice>
+    `},fa=class extends b{constructor(...e){super(...e),this.groups=[]}static{this.styles=[Ji,z,h`
         :host { display: block; width: 100%; }
         .rail { display: flex; flex-direction: column; gap: var(--lumo-space-m, 1rem); }
         .group { display: flex; flex-direction: column; gap: .45rem; }
@@ -4086,7 +4086,7 @@ ${i}
                         ${e.label?T`<span class="group-label">${e.label}</span>`:v}
                         ${(e.items??[]).map(e=>T`
                             <div role="option" tabindex="0" aria-selected="${e.id===this.selectedId}" class="card ${e.id===this.selectedId?`selected`:``}"
-                                 @click="${()=>this.select(e.id)}" @keydown="${z(()=>this.select(e.id))}">
+                                 @click="${()=>this.select(e.id)}" @keydown="${R(()=>this.select(e.id))}">
                                 <span class="title">${e.title}</span>
                                 <div class="meta">
                                     ${e.caption?T`<span class="caption">${e.caption}</span>`:v}
@@ -4101,7 +4101,7 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};k([y()],da.prototype,`actionId`,void 0),k([y({type:Array})],da.prototype,`groups`,void 0),k([C()],da.prototype,`selectedId`,void 0),da=k([g(`mateu-task-queue`)],da);var fa=e=>{let t=e.metadata;return T`
+        `}};k([y()],fa.prototype,`actionId`,void 0),k([y({type:Array})],fa.prototype,`groups`,void 0),k([C()],fa.prototype,`selectedId`,void 0),fa=k([g(`mateu-task-queue`)],fa);var pa=e=>{let t=e.metadata;return T`
         <mateu-task-queue
                 .actionId="${t.actionId}"
                 .groups="${t.groups??[]}"
@@ -4109,7 +4109,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-task-queue>
-    `},pa=class extends b{constructor(...e){super(...e),this.columns=0,this.items=[]}static{this.styles=[qi,B,h`
+    `},ma=class extends b{constructor(...e){super(...e),this.columns=0,this.items=[]}static{this.styles=[Ji,z,h`
         /* explicit line-height: inside a form field wrapper the inherited one is the 44px
            field height, which blows up every text row */
         :host { display: block; width: 100%; line-height: var(--lumo-line-height-m, 1.4); }
@@ -4164,7 +4164,7 @@ ${i}
             <div class="grid" style="${this.columns>0?`grid-template-columns: repeat(${this.columns}, minmax(0, 1fr));`:`grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));`}">
                 ${this.items.map(e=>T`
                     <div role="button" tabindex="0" class="cell ${e.disabled?`disabled`:``} ${e.recommended?`recommended`:``} ${e.id===this.selectedId?`selected`:``}"
-                         @click="${()=>this.select(e)}" @keydown="${z(()=>this.select(e))}">
+                         @click="${()=>this.select(e)}" @keydown="${R(()=>this.select(e))}">
                         ${e.recommended?T`<span class="tag">${this.recommendedLabel||`Recommended`}</span>`:v}
                         <span class="title">${e.title}</span>
                         ${e.subtitle?T`<span class="subtitle">${e.subtitle}</span>`:v}
@@ -4173,7 +4173,7 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};k([y()],pa.prototype,`actionId`,void 0),k([y({type:Number})],pa.prototype,`columns`,void 0),k([y()],pa.prototype,`recommendedLabel`,void 0),k([y({type:Array})],pa.prototype,`items`,void 0),k([C()],pa.prototype,`selectedId`,void 0),pa=k([g(`mateu-resource-grid`)],pa);var ma=e=>{let t=e.metadata;return T`
+        `}};k([y()],ma.prototype,`actionId`,void 0),k([y({type:Number})],ma.prototype,`columns`,void 0),k([y()],ma.prototype,`recommendedLabel`,void 0),k([y({type:Array})],ma.prototype,`items`,void 0),k([C()],ma.prototype,`selectedId`,void 0),ma=k([g(`mateu-resource-grid`)],ma);var ha=e=>{let t=e.metadata;return T`
         <mateu-resource-grid
                 .actionId="${t.actionId}"
                 .columns="${t.columns??0}"
@@ -4183,7 +4183,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-resource-grid>
-    `},U=class extends b{constructor(...e){super(...e),this.title=``,this.features=[],this.current=!1,this.added=!1}static{this.styles=h`
+    `},H=class extends b{constructor(...e){super(...e),this.title=``,this.features=[],this.current=!1,this.added=!1}static{this.styles=h`
         /* explicit line-height: inside a form field wrapper the inherited one is the 44px
            field height, which blows up every text row */
         :host { display: block; width: 100%; line-height: var(--lumo-line-height-m, 1.4); }
@@ -4271,7 +4271,7 @@ ${i}
                         `:v}
                 </div>
             </div>
-        `}};k([y()],U.prototype,`tag`,void 0),k([y()],U.prototype,`title`,void 0),k([y()],U.prototype,`subtitle`,void 0),k([y()],U.prototype,`image`,void 0),k([y({type:Array})],U.prototype,`features`,void 0),k([y()],U.prototype,`priceLabel`,void 0),k([y()],U.prototype,`actionLabel`,void 0),k([y()],U.prototype,`actionId`,void 0),k([y({type:Boolean})],U.prototype,`current`,void 0),k([y()],U.prototype,`currentLabel`,void 0),k([y({type:Boolean})],U.prototype,`added`,void 0),k([y()],U.prototype,`addedLabel`,void 0),U=k([g(`mateu-offer-card`)],U);var ha=e=>{let t=e.metadata;return T`
+        `}};k([y()],H.prototype,`tag`,void 0),k([y()],H.prototype,`title`,void 0),k([y()],H.prototype,`subtitle`,void 0),k([y()],H.prototype,`image`,void 0),k([y({type:Array})],H.prototype,`features`,void 0),k([y()],H.prototype,`priceLabel`,void 0),k([y()],H.prototype,`actionLabel`,void 0),k([y()],H.prototype,`actionId`,void 0),k([y({type:Boolean})],H.prototype,`current`,void 0),k([y()],H.prototype,`currentLabel`,void 0),k([y({type:Boolean})],H.prototype,`added`,void 0),k([y()],H.prototype,`addedLabel`,void 0),H=k([g(`mateu-offer-card`)],H);var ga=e=>{let t=e.metadata;return T`
         <mateu-offer-card
                 .tag="${t.tag}"
                 .title="${t.title??``}"
@@ -4289,7 +4289,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-offer-card>
-    `},ga=class extends b{constructor(...e){super(...e),this.items=[],this.added=new Set}static{this.styles=h`
+    `},_a=class extends b{constructor(...e){super(...e),this.items=[],this.added=new Set}static{this.styles=h`
         :host { display: block; width: 100%; }
         .header { display: flex; align-items: baseline; justify-content: flex-end; gap: .4rem; margin-bottom: .6rem; }
         .total-label { font-size: var(--lumo-font-size-s, .875rem); color: var(--lumo-secondary-text-color, #888); }
@@ -4357,7 +4357,7 @@ ${i}
     `}willUpdate(e){e.has(`items`)&&(this.added=new Set(this.items.filter(e=>e.added).map(e=>e.id)))}total(){return this.items.filter(e=>e.id!=null&&this.added.has(e.id)).reduce((e,t)=>e+(t.price??0),0)}toggle(e){if(e.id==null)return;let t=new Set(this.added),n=!t.has(e.id);n?t.add(e.id):t.delete(e.id),this.added=t,this.actionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.actionId,parameters:{_item:e.id,_added:n,_total:this.total()}},bubbles:!0,composed:!0}))}render(){return T`
             <div class="header">
                 ${this.totalLabel?T`<span class="total-label">${this.totalLabel}:</span>`:v}
-                <span class="total">${Xi(this.total(),this.currency)}</span>
+                <span class="total">${Zi(this.total(),this.currency)}</span>
             </div>
             <div class="grid">
                 ${this.items.map(e=>{let t=e.id!=null&&this.added.has(e.id);return T`
@@ -4367,7 +4367,7 @@ ${i}
                             ${e.description?T`<span class="description">${e.description}</span>`:v}
                             ${e.includedLabel?T`<span class="included">${e.includedLabel}</span>`:T`
                                     ${e.price==null?v:T`
-                                        <span class="price">${Xi(e.price,this.currency)}${e.unit?` / ${e.unit}`:``}</span>
+                                        <span class="price">${Zi(e.price,this.currency)}${e.unit?` / ${e.unit}`:``}</span>
                                     `}
                                     <button class="toggle ${t?`on`:``}" @click="${()=>this.toggle(e)}"
                                             aria-pressed="${t}">${t?`✓`:`+`}</button>
@@ -4375,7 +4375,7 @@ ${i}
                         </div>
                     `})}
             </div>
-        `}};k([y()],ga.prototype,`totalLabel`,void 0),k([y()],ga.prototype,`currency`,void 0),k([y()],ga.prototype,`actionId`,void 0),k([y({type:Array})],ga.prototype,`items`,void 0),k([C()],ga.prototype,`added`,void 0),ga=k([g(`mateu-addon-picker`)],ga);var _a=e=>{let t=e.metadata;return T`
+        `}};k([y()],_a.prototype,`totalLabel`,void 0),k([y()],_a.prototype,`currency`,void 0),k([y()],_a.prototype,`actionId`,void 0),k([y({type:Array})],_a.prototype,`items`,void 0),k([C()],_a.prototype,`added`,void 0),_a=k([g(`mateu-addon-picker`)],_a);var va=e=>{let t=e.metadata;return T`
         <mateu-addon-picker
                 .totalLabel="${t.totalLabel}"
                 .currency="${t.currency}"
@@ -4385,7 +4385,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-addon-picker>
-    `},va=class extends b{constructor(...e){super(...e),this.lines=[]}static{this.styles=h`
+    `},ya=class extends b{constructor(...e){super(...e),this.lines=[]}static{this.styles=h`
         :host {
             display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem);
             /* an ancestor (e.g. a form-layout row) may set an inherited line-height like 44px —
@@ -4427,14 +4427,14 @@ ${i}
                 <div class="row">
                     <span class="dot"></span>
                     <span class="concept">${e.concept}</span>
-                    ${e.included?T`<span class="included-label">${e.includedLabel||`Included`}</span>`:T`<span class="amount ${(e.amount??0)<0?`negative`:``}">${Xi(e.amount??0,this.currency)}</span>`}
+                    ${e.included?T`<span class="included-label">${e.includedLabel||`Included`}</span>`:T`<span class="amount ${(e.amount??0)<0?`negative`:``}">${Zi(e.amount??0,this.currency)}</span>`}
                 </div>
             `)}
             <div class="total-row">
                 <span class="total-label">${this.totalLabel||`Total`}</span>
-                <span class="total">${Xi(this.computedTotal(),this.currency)}</span>
+                <span class="total">${Zi(this.computedTotal(),this.currency)}</span>
             </div>
-        `}};k([y()],va.prototype,`currency`,void 0),k([y()],va.prototype,`totalLabel`,void 0),k([y({type:Array})],va.prototype,`lines`,void 0),k([y({type:Number})],va.prototype,`total`,void 0),va=k([g(`mateu-ledger`)],va);var ya=e=>{let t=e.metadata;return T`
+        `}};k([y()],ya.prototype,`currency`,void 0),k([y()],ya.prototype,`totalLabel`,void 0),k([y({type:Array})],ya.prototype,`lines`,void 0),k([y({type:Number})],ya.prototype,`total`,void 0),ya=k([g(`mateu-ledger`)],ya);var ba=e=>{let t=e.metadata;return T`
         <mateu-ledger
                 .currency="${t.currency}"
                 .totalLabel="${t.totalLabel}"
@@ -4444,7 +4444,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-ledger>
-    `},ba=class extends b{constructor(...e){super(...e),this.methods=[]}static{this.styles=h`
+    `},xa=class extends b{constructor(...e){super(...e),this.methods=[]}static{this.styles=h`
         :host { display: block; width: 100%; }
         .bar { display: flex; align-items: stretch; gap: .6rem; flex-wrap: wrap; }
         .methods { display: flex; gap: .4rem; flex-wrap: wrap; }
@@ -4506,7 +4506,7 @@ ${i}
                 <span class="spacer"></span>
                 ${this.confirmLabel&&this.actionId?T`<button class="confirm" @click="${()=>this.confirm()}">${this.confirmLabel}</button>`:v}
             </div>
-        `}};k([y()],ba.prototype,`actionId`,void 0),k([y()],ba.prototype,`methodActionId`,void 0),k([y({type:Array})],ba.prototype,`methods`,void 0),k([y()],ba.prototype,`selected`,void 0),k([y()],ba.prototype,`contextLabel`,void 0),k([y()],ba.prototype,`contextValue`,void 0),k([y()],ba.prototype,`confirmLabel`,void 0),k([C()],ba.prototype,`selectedId`,void 0),ba=k([g(`mateu-payment-picker`)],ba);var xa=e=>{let t=e.metadata;return T`
+        `}};k([y()],xa.prototype,`actionId`,void 0),k([y()],xa.prototype,`methodActionId`,void 0),k([y({type:Array})],xa.prototype,`methods`,void 0),k([y()],xa.prototype,`selected`,void 0),k([y()],xa.prototype,`contextLabel`,void 0),k([y()],xa.prototype,`contextValue`,void 0),k([y()],xa.prototype,`confirmLabel`,void 0),k([C()],xa.prototype,`selectedId`,void 0),xa=k([g(`mateu-payment-picker`)],xa);var Sa=e=>{let t=e.metadata;return T`
         <mateu-payment-picker
                 .actionId="${t.actionId}"
                 .methodActionId="${t.methodActionId}"
@@ -4519,7 +4519,7 @@ ${i}
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-payment-picker>
-    `},Sa=class extends b{constructor(...e){super(...e),this.items=[]}static{this.styles=h`
+    `},Ca=class extends b{constructor(...e){super(...e),this.items=[]}static{this.styles=h`
         :host { display: block; width: 100%; font-size: var(--lumo-font-size-s, .875rem); }
         .list {
             border: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.1));
@@ -4573,14 +4573,14 @@ ${i}
                     </div>
                 `)}
             </div>
-        `}};k([y({type:Array})],Sa.prototype,`items`,void 0),Sa=k([g(`mateu-process-monitor`)],Sa);var Ca=e=>T`
+        `}};k([y({type:Array})],Ca.prototype,`items`,void 0),Ca=k([g(`mateu-process-monitor`)],Ca);var wa=e=>T`
         <mateu-process-monitor
                 .items="${e.metadata.items??[]}"
                 style="${e.style??v}"
                 class="${e.cssClasses??v}"
                 slot="${e.slot??v}"
         ></mateu-process-monitor>
-    `,wa=(e,t)=>{let n=e.style;return e.id&&(n&&!n.endsWith(`;`)&&(n+=`;`),n??=``,t[e.id+`.hidden`]==1&&(n+=`display: none;`)),n},Ta=(e,t)=>{let n={...e.metadata};if(e.id&&n){if(n.type==j.Button){let r=n;t[e.id+`.disabled`]==1&&(r.disabled=!0)}if(n.type==j.FormField){let r=n;t[e.id+`.disabled`]==1&&(r.disabled=!0)}}return n},W=e=>t=>e(t.container,t.component,t.baseUrl,t.state,t.data,t.appState,t.appData),Ea={[j.Bpmn]:({component:e})=>Hr(e),[j.Workflow]:({component:e})=>Wr(e),[j.FormEditor]:({component:e})=>Gr(e),[j.Page]:W(Br),[j.Div]:W(Nr),[j.Directory]:({component:e,baseUrl:t,state:n,data:r})=>jr(e,t,n,r),[j.FormLayout]:W(_n),[j.HorizontalLayout]:W(Cn),[j.VerticalLayout]:W(wn),[j.SplitLayout]:W(Tn),[j.MasterDetailLayout]:W(En),[j.TabLayout]:W(Dn),[j.AccordionLayout]:W(On),[j.BoardLayout]:W(Nn),[j.BoardLayoutRow]:W(Pn),[j.BoardLayoutItem]:W(Fn),[j.Scroller]:W(An),[j.FullWidth]:W(jn),[j.Container]:W(Mn),[j.Form]:({container:e,component:t,baseUrl:n,state:r,data:i,appState:a,appData:o})=>{let s=t.metadata;return T`<mateu-form
+    `,Ta=(e,t)=>{let n=e.style;return e.id&&(n&&!n.endsWith(`;`)&&(n+=`;`),n??=``,t[e.id+`.hidden`]==1&&(n+=`display: none;`)),n},Ea=(e,t)=>{let n={...e.metadata};if(e.id&&n){if(n.type==j.Button){let r=n;t[e.id+`.disabled`]==1&&(r.disabled=!0)}if(n.type==j.FormField){let r=n;t[e.id+`.disabled`]==1&&(r.disabled=!0)}}return n},U=e=>t=>e(t.container,t.component,t.baseUrl,t.state,t.data,t.appState,t.appData),Da={[j.Bpmn]:({component:e})=>Ur(e),[j.Workflow]:({component:e})=>Gr(e),[j.FormEditor]:({component:e})=>Kr(e),[j.Page]:U(Vr),[j.Div]:U(Pr),[j.Directory]:({component:e,baseUrl:t,state:n,data:r})=>Mr(e,t,n,r),[j.FormLayout]:U(vn),[j.HorizontalLayout]:U(wn),[j.VerticalLayout]:U(Tn),[j.SplitLayout]:U(En),[j.MasterDetailLayout]:U(Dn),[j.TabLayout]:U(On),[j.AccordionLayout]:U(kn),[j.BoardLayout]:U(Pn),[j.BoardLayoutRow]:U(Fn),[j.BoardLayoutItem]:U(In),[j.Scroller]:U(jn),[j.FullWidth]:U(Mn),[j.Container]:U(Nn),[j.Form]:({container:e,component:t,baseUrl:n,state:r,data:i,appState:a,appData:o})=>{let s=t.metadata;return T`<mateu-form
             id="${t.id}"
         baseUrl="${n}"
             .component="${t}"
@@ -4593,12 +4593,12 @@ ${i}
             class="${t.cssClasses}"
             slot="${t.slot??v}"
             >
-                ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+                ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
             ${s?.buttons?.map(t=>T`
-               ${I(e,{id:t.actionId,metadata:t,type:A.ClientSide,slot:`buttons`},void 0,r,i,a,o)}
+               ${F(e,{id:t.actionId,metadata:t,type:A.ClientSide,slot:`buttons`},void 0,r,i,a,o)}
 `)}
 
-            </mateu-form>`},[j.Table]:({component:e,state:t,data:n})=>zn(e,(e.id?n?.[e.id]:void 0)?.page?.content??Bn(e,t)),[j.Crud]:W(Vr),[j.App]:({container:e,component:t,baseUrl:n,state:r,data:i,appState:a,appData:o})=>T`
+            </mateu-form>`},[j.Table]:({component:e,state:t,data:n})=>Bn(e,(e.id?n?.[e.id]:void 0)?.page?.content??Vn(e,t)),[j.Crud]:U(Hr),[j.App]:({container:e,component:t,baseUrl:n,state:r,data:i,appState:a,appData:o})=>T`
             <mateu-app
                         id="${t.id}"
                         baseUrl="${n}"
@@ -4610,20 +4610,20 @@ ${i}
                         .appState="${a}"
                         .appData="${o}"
             >
-             ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
-         </mateu-app>`,[j.Element]:({container:e,component:t,state:n,data:r,appState:i,appData:a})=>Qn(e,t.metadata,t,n,r,i,a),[j.FormField]:({component:e,state:t})=>Rr(e,t),[j.Text]:({component:e,state:t,data:n,appState:r,appData:i})=>er(e,t,n,r,i),[j.Avatar]:({component:e,state:t,data:n})=>Dt(e,t,n),[j.Chat]:({component:e,state:t,data:n})=>Ur(e,t,n),[j.AvatarGroup]:({component:e})=>Ot(e),[j.Badge]:({component:e,state:t,data:n})=>kt(e,t,n),[j.Breadcrumbs]:({component:e})=>kr(e),[j.Anchor]:({component:e})=>tr(e),[j.Button]:({component:e,state:t,data:n})=>cr(e,t,n),[j.Card]:W(ur),[j.Chart]:({component:e})=>dr(e),[j.Icon]:({component:e})=>fr(e),[j.ConfirmDialog]:W(_r),[j.ContextMenu]:W(Wn),[j.CookieConsent]:({component:e})=>vr(e),[j.Details]:W(yr),[j.Dialog]:({component:e,baseUrl:t,state:n,data:r,appState:i,appData:a})=>br(e,t,n,r,i,a),[j.Drawer]:({component:e,baseUrl:t,state:n,data:r,appState:i,appData:a})=>xr(e,t,n,r,i,a),[j.Image]:({component:e})=>Or(e),[j.Map]:({component:e})=>Dr(e),[j.Markdown]:({component:e})=>Cr(e),[j.MicroFrontend]:({component:e})=>Sr(e),[j.Notification]:({component:e})=>wr(e),[j.ProgressBar]:({component:e,state:t})=>Tr(e,t),[j.Popover]:W(Er),[j.CarouselLayout]:W(Ar),[j.Tooltip]:W(qn),[j.MessageInput]:({component:e})=>Kn(e),[j.MessageList]:({component:e})=>Vn(e),[j.CustomField]:W(Gn),[j.MenuBar]:({container:e,component:t,baseUrl:n,state:r,data:i})=>Un(e,t,n,r,i),[j.Grid]:({component:e,state:t})=>zn(e,Bn(e,t)),[j.VirtualList]:W(In),[j.FormSection]:W(Pr),[j.FormSubSection]:W(Fr),[j.MetricCard]:({component:e})=>Xr(e),[j.Scoreboard]:W(Zr),[j.DashboardPanel]:W(Qr),[j.DashboardLayout]:W($r),[j.FoldoutLayout]:W(ti),[j.ContentLayout]:W(ni),[j.HeroSection]:W(ri),[j.EmptyState]:({component:e})=>Bt(e),[j.Skeleton]:({component:e})=>Vt(e),[j.Gantt]:({component:e})=>oi(e),[j.PlanningBoard]:({component:e})=>ci(e),[j.Kanban]:({component:e})=>ui(e),[j.Timeline]:({component:e})=>fi(e),[j.ProgressSteps]:({component:e})=>mi(e),[j.Stat]:({component:e})=>gi(e),[j.Calendar]:({component:e})=>vi(e),[j.PricingTable]:({component:e})=>bi(e),[j.OrgChart]:({component:e})=>Si(e),[j.Heatmap]:({component:e})=>Ti(e),[j.Funnel]:({component:e})=>Di(e),[j.TrendChart]:({component:e})=>ki(e),[j.FeatureGrid]:({component:e})=>ji(e),[j.Testimonials]:({component:e})=>Ni(e),[j.Faq]:({component:e})=>Fi(e),[j.CalloutCard]:({component:e})=>Li(e),[j.CommentThread]:({component:e})=>zi(e),[j.FileList]:({component:e})=>Hi(e),[j.Checklist]:({component:e})=>Wi(e),[j.ComparisonCard]:({component:e})=>Ki(e),[j.EntityHeader]:({component:e})=>$i(e),[j.Meter]:({component:e})=>ta(e),[j.TaskProgress]:({component:e})=>ra(e),[j.StatusList]:({component:e})=>aa(e),[j.BulletedList]:({component:e})=>sa(e),[j.Separator]:({component:e})=>ca(e),[j.Notice]:W(ua),[j.TaskQueue]:({component:e})=>fa(e),[j.ResourceGrid]:({component:e})=>ma(e),[j.OfferCard]:({component:e})=>ha(e),[j.AddOnPicker]:({component:e})=>_a(e),[j.Ledger]:({component:e})=>ya(e),[j.PaymentPicker]:({component:e})=>xa(e),[j.ProcessMonitor]:({component:e})=>Ca(e)},Da=(e,t,n,r,i,a,o,s)=>{if(!t?.metadata)return t==null?(console.warn(`No metadata for component`,t),T`<p>No metadata for component</p>`):Da(e,{id:E(),metadata:t,type:A.ClientSide},n,r,i,a,o,s);let c=t.metadata.type,l={...t,style:wa(t,i),metadata:Ta(t,i)},u=Ea[c];return u?u({container:e,component:l,baseUrl:n,state:r,data:i,appState:a,appData:o,labelAlreadyRendered:s}):T`<p ${l?.slot??v}>Unknown metadata type ${c} for component ${l?.id}</p>`},Oa=function(e){return e.NONE=`NONE`,e.INFO=`INFO`,e.SUCCESS=`SUCCESS`,e.WARNING=`WARNING`,e.DANGER=`DANGER`,e}({}),ka=(e,t,n)=>{let r=e[n.path];return r?T`<span theme="badge pill ${Aa(r.type)}">${r.message}</span>`:T``},Aa=e=>{switch(e){case Oa.SUCCESS:return`success`;case Oa.WARNING:return`warning`;case Oa.DANGER:return`error`;case Oa.NONE:return`contrast`}return``},G=class extends b{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.respondToVisibility=(e,t)=>{var n={root:document.documentElement};new IntersectionObserver(e=>{e.forEach(e=>{t(e.intersectionRatio>0)})},n).observe(e)},this.keepAsking=!1,this.askToUpper=()=>{let e=this.data[this.id]?.page,t=e?.content?.length/e?.pageSize;this.dispatchEvent(new CustomEvent(`fetch-more-elements`,{detail:{params:{page:t,pageSize:this.metadata?.pageSize},callback:()=>{this.keepAsking&&this.askToUpper()}},bubbles:!0,composed:!0}))},this.renderItem=e=>e.card?Da(this,e.card,this.baseUrl,this.state,this.data,this.appState,this.appData,!1):e.title?T`<div class="neutral-card">
+             ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+         </mateu-app>`,[j.Element]:({container:e,component:t,state:n,data:r,appState:i,appData:a})=>$n(e,t.metadata,t,n,r,i,a),[j.FormField]:({component:e,state:t})=>zr(e,t),[j.Text]:({component:e,state:t,data:n,appState:r,appData:i})=>tr(e,t,n,r,i),[j.Avatar]:({component:e,state:t,data:n})=>Dt(e,t,n),[j.Chat]:({component:e,state:t,data:n})=>Wr(e,t,n),[j.AvatarGroup]:({component:e})=>kt(e),[j.Badge]:({component:e,state:t,data:n})=>At(e,t,n),[j.Breadcrumbs]:({component:e})=>Ar(e),[j.Anchor]:({component:e})=>nr(e),[j.Button]:({component:e,state:t,data:n})=>lr(e,t,n),[j.Card]:U(dr),[j.Chart]:({component:e})=>fr(e),[j.Icon]:({component:e})=>pr(e),[j.ConfirmDialog]:U(vr),[j.ContextMenu]:U(Gn),[j.CookieConsent]:({component:e})=>yr(e),[j.Details]:U(br),[j.Dialog]:({component:e,baseUrl:t,state:n,data:r,appState:i,appData:a})=>xr(e,t,n,r,i,a),[j.Drawer]:({component:e,baseUrl:t,state:n,data:r,appState:i,appData:a})=>Sr(e,t,n,r,i,a),[j.Image]:({component:e})=>kr(e),[j.Map]:({component:e})=>Or(e),[j.Markdown]:({component:e})=>wr(e),[j.MicroFrontend]:({component:e})=>Cr(e),[j.Notification]:({component:e})=>Tr(e),[j.ProgressBar]:({component:e,state:t})=>Er(e,t),[j.Popover]:U(Dr),[j.CarouselLayout]:U(jr),[j.Tooltip]:U(Jn),[j.MessageInput]:({component:e})=>qn(e),[j.MessageList]:({component:e})=>Hn(e),[j.CustomField]:U(Kn),[j.MenuBar]:({container:e,component:t,baseUrl:n,state:r,data:i})=>Wn(e,t,n,r,i),[j.Grid]:({component:e,state:t})=>Bn(e,Vn(e,t)),[j.VirtualList]:U(Ln),[j.FormSection]:U(Fr),[j.FormSubSection]:U(Ir),[j.MetricCard]:({component:e})=>Zr(e),[j.Scoreboard]:U(Qr),[j.DashboardPanel]:U($r),[j.DashboardLayout]:U(ei),[j.FoldoutLayout]:U(ni),[j.ContentLayout]:U(ri),[j.HeroSection]:U(ii),[j.EmptyState]:({component:e})=>Vt(e),[j.Skeleton]:({component:e})=>Ht(e),[j.Gantt]:({component:e})=>si(e),[j.PlanningBoard]:({component:e})=>li(e),[j.Kanban]:({component:e})=>di(e),[j.Timeline]:({component:e})=>pi(e),[j.ProgressSteps]:({component:e})=>hi(e),[j.Stat]:({component:e})=>_i(e),[j.Calendar]:({component:e})=>yi(e),[j.PricingTable]:({component:e})=>xi(e),[j.OrgChart]:({component:e})=>Ci(e),[j.Heatmap]:({component:e})=>Ei(e),[j.Funnel]:({component:e})=>Oi(e),[j.TrendChart]:({component:e})=>Ai(e),[j.FeatureGrid]:({component:e})=>Mi(e),[j.Testimonials]:({component:e})=>Pi(e),[j.Faq]:({component:e})=>Ii(e),[j.CalloutCard]:({component:e})=>Ri(e),[j.CommentThread]:({component:e})=>Bi(e),[j.FileList]:({component:e})=>Ui(e),[j.Checklist]:({component:e})=>Gi(e),[j.ComparisonCard]:({component:e})=>qi(e),[j.EntityHeader]:({component:e})=>ea(e),[j.Meter]:({component:e})=>na(e),[j.TaskProgress]:({component:e})=>ia(e),[j.StatusList]:({component:e})=>oa(e),[j.BulletedList]:({component:e})=>ca(e),[j.Separator]:({component:e})=>la(e),[j.Notice]:U(da),[j.TaskQueue]:({component:e})=>pa(e),[j.ResourceGrid]:({component:e})=>ha(e),[j.OfferCard]:({component:e})=>ga(e),[j.AddOnPicker]:({component:e})=>va(e),[j.Ledger]:({component:e})=>ba(e),[j.PaymentPicker]:({component:e})=>Sa(e),[j.ProcessMonitor]:({component:e})=>wa(e)},Oa=(e,t,n,r,i,a,o,s)=>{if(!t?.metadata)return t==null?(console.warn(`No metadata for component`,t),T`<p>No metadata for component</p>`):Oa(e,{id:E(),metadata:t,type:A.ClientSide},n,r,i,a,o,s);let c=t.metadata.type,l={...t,style:Ta(t,i),metadata:Ea(t,i)},u=Da[c];return u?u({container:e,component:l,baseUrl:n,state:r,data:i,appState:a,appData:o,labelAlreadyRendered:s}):T`<p ${l?.slot??v}>Unknown metadata type ${c} for component ${l?.id}</p>`},ka=function(e){return e.NONE=`NONE`,e.INFO=`INFO`,e.SUCCESS=`SUCCESS`,e.WARNING=`WARNING`,e.DANGER=`DANGER`,e}({}),Aa=(e,t,n)=>{let r=e[n.path];return r?T`<span theme="badge pill ${ja(r.type)}">${r.message}</span>`:T``},ja=e=>{switch(e){case ka.SUCCESS:return`success`;case ka.WARNING:return`warning`;case ka.DANGER:return`error`;case ka.NONE:return`contrast`}return``},W=class extends b{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.respondToVisibility=(e,t)=>{var n={root:document.documentElement};new IntersectionObserver(e=>{e.forEach(e=>{t(e.intersectionRatio>0)})},n).observe(e)},this.keepAsking=!1,this.askToUpper=()=>{let e=this.data[this.id]?.page,t=e?.content?.length/e?.pageSize;this.dispatchEvent(new CustomEvent(`fetch-more-elements`,{detail:{params:{page:t,pageSize:this.metadata?.pageSize},callback:()=>{this.keepAsking&&this.askToUpper()}},bubbles:!0,composed:!0}))},this.renderItem=e=>e.card?Oa(this,e.card,this.baseUrl,this.state,this.data,this.appState,this.appData,!1):e.title?T`<div class="neutral-card">
                 ${e.image?T`<img class="card-media" src="${e.image}" alt="" />`:v}
                 <div class="card-body">
                     <div class="card-head">
                         ${e.title?T`<span class="card-title">${e.title}</span>`:v}
-                        ${e.status?T`<span theme="badge ${Aa(e.status.type)}">${e.status.message}</span>`:v}
+                        ${e.status?T`<span theme="badge ${ja(e.status.type)}">${e.status.message}</span>`:v}
                     </div>
                     ${e.subtitle?T`<div class="card-subtitle">${e.subtitle}</div>`:v}
                     ${e.content?T`<div>${e.content}</div>`:v}
                 </div>
         </div>`:T`${e}`,this.hasMore=!1,this.clickedOnCard=e=>{this.state[this.id+`_selected_items`]=[e],this.metadata?.onRowSelectionChangedActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.metadata?.onRowSelectionChangedActionId},bubbles:!0,composed:!0}))}}updated(e){super.updated(e);let t=this.data[this.id]?.page;this.hasMore=t?.content?.length<t?.totalElements}firstUpdated(e){super.firstUpdated(e),this.respondToVisibility(this.askForMore,e=>{this.keepAsking=e,e&&this.askToUpper()})}render(){return T`
             <div class="card-container">
-                ${(this.data[this.id]?.page)?.content?.map(e=>T`<div role="button" tabindex="0" @click="${()=>this.clickedOnCard(e)}" @keydown="${z(()=>this.clickedOnCard(e))}" class="car-container">${this.renderItem(e)}</div>`)}
+                ${(this.data[this.id]?.page)?.content?.map(e=>T`<div role="button" tabindex="0" @click="${()=>this.clickedOnCard(e)}" @keydown="${R(()=>this.clickedOnCard(e))}" class="car-container">${this.renderItem(e)}</div>`)}
                 <div id="ask-for-more" style="display: ${this.hasMore?`flex`:`none`}; width: 100%; justify-content: center; padding: var(--lumo-space-m); color: var(--lumo-secondary-text-color); font-size: var(--lumo-font-size-s);">Loading more…</div>
             </div>
 
@@ -4653,39 +4653,39 @@ ${i}
         .neutral-card .card-title { font-weight: 600; }
         .neutral-card .card-subtitle { color: var(--lumo-secondary-text-color, #888); font-size: var(--lumo-font-size-s, .875rem); }
     
-        ${B}
-    `}};k([y()],G.prototype,`id`,void 0),k([y()],G.prototype,`metadata`,void 0),k([y()],G.prototype,`baseUrl`,void 0),k([y()],G.prototype,`state`,void 0),k([y()],G.prototype,`data`,void 0),k([y()],G.prototype,`appState`,void 0),k([y()],G.prototype,`appData`,void 0),k([y()],G.prototype,`emptyStateMessage`,void 0),k([C()],G.prototype,`keepAsking`,void 0),k([x(`#ask-for-more`)],G.prototype,`askForMore`,void 0),k([C()],G.prototype,`hasMore`,void 0),G=k([g(`mateu-card-list`)],G);var ja={show:e=>console.debug(`[mateu] no notifier registered, dropping toast:`,e.text)};function Ma(e){ja=e}function Na(e,t){ja.show(e,t)}var Pa=function(e){return e.none=`none`,e.success=`success`,e.error=`error`,e.warning=`warning`,e.contrast=`contrast`,e.normal=`normal`,e}({}),Fa=function(e){return e.primary=`primary`,e.secondary=`secondary`,e.tertiary=`tertiary`,e.tertiaryInline=`tertiaryInline`,e}({});function Ia(e){if(e.weight!=null)return e.weight;let t=e.stereotype??``;if(t===`icon`)return 1;if(t===`image`)return 4;if(t===`html`||t===`richText`||t===`markdown`||t===`textarea`)return 5;if(t===`link`)return 2.5;if(t===`combobox`||t===`select`)return 2;let n=e.dataType??``;return n===`bool`?1:n===`status`||n===`integer`?1.5:n===`number`||n===`date`||n===`money`?2:n===`dateTime`||n===`dateRange`?2.5:3}function La(e,t){if(e.length===0)return`table`;let n=e.reduce((e,t)=>e+Ia(t),0)/(t/76);if(n<=1.1)return`table`;if(n>1.6||e.length>10)return`masterDetail`;let r=e.filter(e=>e.identifier||(e.priority??2**53-1)<=2),i=r.reduce((e,t)=>e+Ia(t),0);return r.length>0&&i<=8?`list`:e.some(e=>e.stereotype===`image`||e.stereotype===`html`)||r.length===0&&e.length>=4&&e.length<=8?`cards`:`masterDetail`}function Ra(e){return e.filter(e=>e.identifier||(e.priority??2**53-1)<=2).sort((e,t)=>(e.priority??2**53-1)-(t.priority??2**53-1))}function za(e){let t=Ra(e);return t.length>0?t:e.slice(0,3)}var Ba,Va={asc:`ascending`,desc:`descending`},K=class extends b{static{Ba=this}constructor(...e){super(...e),this.component=void 0,this.standalone=!1,this.state={},this.data={},this.appState={},this.appData={},this.showImportDialog=!1,this.availableWidthPx=1024,this.selectedItem=null,this._columnPrefsRevision=0,this._prefsRevisionApplied=-1,this.pendingMeasure=!0,this.corrections=0,this.windowResizeListener=()=>this.scheduleMeasure(),this.search=()=>{let e=this.component.metadata;this.state={...this.state,size:e.pageSize,page:0,crud_selected_items:[]},this._syncStateToUrl(e),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`search`,parameters:{crudId:this.id,_searchState:{...this.state}}},bubbles:!0,composed:!0}))},this.notify=e=>{Na({text:e,position:`bottomEnd`,variant:`error`,duration:3e3},this)},this.handleSearchRequested=e=>{this.state={...this.state,crud_selected_items:[]};let t=this.component.metadata;if(this._syncStateToUrl(t),t.rowsSource){this._fetchRowsFromRest(t,e);return}!t.infiniteScrolling&&this.data?.[this.id]?.page&&(this.data[this.id].page.content=[]),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`search`,parameters:{crudId:this.id,_searchState:{...this.state}},callback:e},bubbles:!0,composed:!0}))},this._fetchRowsFromRest=(e,t)=>{let n=this.cols.map(e=>e.id).filter(Boolean),r=e.rowsSource;(r.proxy?new Promise(e=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`__restfetch__`,parameters:{_sourceKind:`rows`,_sourceId:this.id},callback:t=>e(dn(t?.appData?._restfetch,r.itemsPath,n)),callbackonly:!0},bubbles:!0,composed:!0}))}):mn(r,n,e=>M(e,this.state,this.data))).then(r=>{let i=String(this.state?.searchText??``).trim().toLowerCase(),a=i?r.filter(e=>n.some(t=>String(e[t]??``).toLowerCase().includes(i))):r,o=e.pageSize&&e.pageSize>0?e.pageSize:a.length||1,s=Number(this.state?.page??0),c=a.slice(s*o,s*o+o);this.data={...this.data,[this.id]:{page:{totalElements:a.length,pageSize:o,pageNumber:s,content:c}}},this.requestUpdate(),t?.()}).catch(e=>{console.warn(`mateu: external rows fetch failed`,e),t?.()})},this.fetchMoreElements=e=>{let{params:t,callback:n}=e.detail;this.state={...this.state,size:t.pageSize,page:t.page},this.handleSearchRequested(n)},this.directionChanged=e=>{let t=e.detail.grid._sorters;this.state={...this.state,sort:t.map(e=>({fieldId:e.__data.path,direction:e.__data.direction?Va[e.__data.direction]:void 0}))},this.handleSearchRequested(void 0)},this._initializedForComponentId=void 0,this.evalLabel=e=>M(e,this.state,this.data),this.handleToolbarButtonClick=e=>{if(e===`import`){this.showImportDialog=!0;return}this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.handleImportUploadSuccess=e=>{let t=e.detail.xhr.responseText;this.showImportDialog=!1,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`process-import`,parameters:{fileId:t}},bubbles:!0,composed:!0}))}}get columnPrefsScope(){return window.location.pathname}get effectiveComponent(){let e=this.component,t=e?.metadata;if(!e||!t?.columns)return e;if(this._prefsSource===e&&this._prefsRevisionApplied===this._columnPrefsRevision)return this._prefsApplied;let n=en(this.columnPrefsScope),r=an(t.columns,n,e=>e.metadata??{});return this._prefsApplied=r===t.columns?e:{...e,metadata:{...t,columns:r}},this._prefsSource=e,this._prefsRevisionApplied=this._columnPrefsRevision,this._prefsApplied}get columnChooserEntries(){return(this.component?.metadata?.columns??[]).map(e=>{let t=e.metadata??{},n=t.id??e.id;return n?{id:n,label:t.label??n,protected:rn(t)}:void 0}).filter(e=>!!e)}renderColumnChooser(){let e=this.columnChooserEntries;return e.filter(e=>!e.protected).length===0?v:T`
+        ${z}
+    `}};k([y()],W.prototype,`id`,void 0),k([y()],W.prototype,`metadata`,void 0),k([y()],W.prototype,`baseUrl`,void 0),k([y()],W.prototype,`state`,void 0),k([y()],W.prototype,`data`,void 0),k([y()],W.prototype,`appState`,void 0),k([y()],W.prototype,`appData`,void 0),k([y()],W.prototype,`emptyStateMessage`,void 0),k([C()],W.prototype,`keepAsking`,void 0),k([x(`#ask-for-more`)],W.prototype,`askForMore`,void 0),k([C()],W.prototype,`hasMore`,void 0),W=k([g(`mateu-card-list`)],W);var Ma={show:e=>console.debug(`[mateu] no notifier registered, dropping toast:`,e.text)};function Na(e){Ma=e}function Pa(e,t){Ma.show(e,t)}var Fa=function(e){return e.none=`none`,e.success=`success`,e.error=`error`,e.warning=`warning`,e.contrast=`contrast`,e.normal=`normal`,e}({}),Ia=function(e){return e.primary=`primary`,e.secondary=`secondary`,e.tertiary=`tertiary`,e.tertiaryInline=`tertiaryInline`,e}({});function La(e){if(e.weight!=null)return e.weight;let t=e.stereotype??``;if(t===`icon`)return 1;if(t===`image`)return 4;if(t===`html`||t===`richText`||t===`markdown`||t===`textarea`)return 5;if(t===`link`)return 2.5;if(t===`combobox`||t===`select`)return 2;let n=e.dataType??``;return n===`bool`?1:n===`status`||n===`integer`?1.5:n===`number`||n===`date`||n===`money`?2:n===`dateTime`||n===`dateRange`?2.5:3}function Ra(e,t){if(e.length===0)return`table`;let n=e.reduce((e,t)=>e+La(t),0)/(t/76);if(n<=1.1)return`table`;if(n>1.6||e.length>10)return`masterDetail`;let r=e.filter(e=>e.identifier||(e.priority??2**53-1)<=2),i=r.reduce((e,t)=>e+La(t),0);return r.length>0&&i<=8?`list`:e.some(e=>e.stereotype===`image`||e.stereotype===`html`)||r.length===0&&e.length>=4&&e.length<=8?`cards`:`masterDetail`}function za(e){return e.filter(e=>e.identifier||(e.priority??2**53-1)<=2).sort((e,t)=>(e.priority??2**53-1)-(t.priority??2**53-1))}function Ba(e){let t=za(e);return t.length>0?t:e.slice(0,3)}var Va,Ha={asc:`ascending`,desc:`descending`},G=class extends b{static{Va=this}constructor(...e){super(...e),this.component=void 0,this.standalone=!1,this.state={},this.data={},this.appState={},this.appData={},this.showImportDialog=!1,this.availableWidthPx=1024,this.selectedItem=null,this._columnPrefsRevision=0,this._prefsRevisionApplied=-1,this.pendingMeasure=!0,this.corrections=0,this.windowResizeListener=()=>this.scheduleMeasure(),this.search=()=>{this.beginLoading();let e=this.component.metadata;this.state={...this.state,size:e.pageSize,page:0,crud_selected_items:[]},this._syncStateToUrl(e),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`search`,parameters:{crudId:this.id,_searchState:{...this.state}}},bubbles:!0,composed:!0}))},this.notify=e=>{Pa({text:e,position:`bottomEnd`,variant:`error`,duration:3e3},this)},this.handleSearchRequested=e=>{this.state={...this.state,crud_selected_items:[]};let t=this.component.metadata;if(this._syncStateToUrl(t),t.rowsSource){this._fetchRowsFromRest(t,e);return}!t.infiniteScrolling&&this.data?.[this.id]?.page&&(this.data[this.id].page.content=[]),this.beginLoading(),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`search`,parameters:{crudId:this.id,_searchState:{...this.state}},callback:e},bubbles:!0,composed:!0}))},this._fetchRowsFromRest=(e,t)=>{let n=this.cols.map(e=>e.id).filter(Boolean),r=e.rowsSource;(r.proxy?new Promise(e=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`__restfetch__`,parameters:{_sourceKind:`rows`,_sourceId:this.id},callback:t=>e(fn(t?.appData?._restfetch,r.itemsPath,n)),callbackonly:!0},bubbles:!0,composed:!0}))}):hn(r,n,e=>M(e,this.state,this.data))).then(r=>{let i=String(this.state?.searchText??``).trim().toLowerCase(),a=i?r.filter(e=>n.some(t=>String(e[t]??``).toLowerCase().includes(i))):r,o=e.pageSize&&e.pageSize>0?e.pageSize:a.length||1,s=Number(this.state?.page??0),c=a.slice(s*o,s*o+o);this.data={...this.data,[this.id]:{page:{totalElements:a.length,pageSize:o,pageNumber:s,content:c}}},this.requestUpdate(),t?.()}).catch(e=>{console.warn(`mateu: external rows fetch failed`,e),t?.()})},this.fetchMoreElements=e=>{let{params:t,callback:n}=e.detail;this.state={...this.state,size:t.pageSize,page:t.page},this.handleSearchRequested(n)},this.directionChanged=e=>{let t=e.detail.grid._sorters;this.state={...this.state,sort:t.map(e=>({fieldId:e.__data.path,direction:e.__data.direction?Ha[e.__data.direction]:void 0}))},this.handleSearchRequested(void 0)},this._initializedForComponentId=void 0,this.evalLabel=e=>M(e,this.state,this.data),this.handleToolbarButtonClick=e=>{if(e===`import`){this.showImportDialog=!0;return}this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.handleImportUploadSuccess=e=>{let t=e.detail.xhr.responseText;this.showImportDialog=!1,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`process-import`,parameters:{fileId:t}},bubbles:!0,composed:!0}))}}get columnPrefsScope(){return window.location.pathname}get effectiveComponent(){let e=this.component,t=e?.metadata;if(!e||!t?.columns)return e;if(this._prefsSource===e&&this._prefsRevisionApplied===this._columnPrefsRevision)return this._prefsApplied;let n=tn(this.columnPrefsScope),r=on(t.columns,n,e=>e.metadata??{});return this._prefsApplied=r===t.columns?e:{...e,metadata:{...t,columns:r}},this._prefsSource=e,this._prefsRevisionApplied=this._columnPrefsRevision,this._prefsApplied}get columnChooserEntries(){return(this.component?.metadata?.columns??[]).map(e=>{let t=e.metadata??{},n=t.id??e.id;return n?{id:n,label:t.label??n,protected:an(t)}:void 0}).filter(e=>!!e)}renderColumnChooser(){let e=this.columnChooserEntries;return e.filter(e=>!e.protected).length===0?v:T`
             <mateu-column-chooser
                 .columns="${e}"
                 .scope="${this.columnPrefsScope}"
                 @column-prefs-changed="${e=>{e.stopPropagation(),this._columnPrefsRevision++}}"
             ></mateu-column-chooser>
-        `}get cols(){return(this.effectiveComponent?.metadata)?.columns?.map(e=>e.metadata)??[]}get identifierFieldName(){let e=this.cols.find(e=>e.identifier);return e?e.id:this.cols.find(e=>e.id===`id`)?.id}get effectiveGridLayout(){let e=this.component?.metadata,t=e?.gridLayout??`auto`;return t===`auto`?e?.crudlType===`card`?`cards`:La(this.cols,this.availableWidthPx):t}scheduleMeasure(){this.pendingMeasure=!0,this.corrections=0,this.fillHeightPx==null?this.requestUpdate():this.fillHeightPx=void 0}measureFill(){if(!this.pendingMeasure||this.fillHeightPx!=null)return;let e=this.renderRoot?.querySelector?.(`[data-crud-box]`);if(!e)return;if(this.closest?.(`mateu-dialog, mateu-drawer`)){this.pendingMeasure=!1;return}let t=e.getBoundingClientRect().top,n=Math.round(window.innerHeight-t-this.measureBottomInset(e)-Ba.BOTTOM_GUTTER_PX);this.pendingMeasure=!1,n>=Ba.MIN_FILL_PX&&(this.fillHeightPx=n)}trimOverflow(){if(this.fillHeightPx==null||this.pendingMeasure||this.corrections>=Ba.MAX_CORRECTIONS)return;let e=document.documentElement.scrollHeight-window.innerHeight;e<=1||e>Ba.MAX_SLIVER_PX||(this.corrections++,this.fillHeightPx=Math.max(Ba.MIN_FILL_PX,this.fillHeightPx-e))}measureBottomInset(e){let t=e,n=0;for(let e=0;t&&e<20;e++){n+=parseFloat(getComputedStyle(t).marginBottom)||0;let e=t.getRootNode(),r=t.assignedSlot??t.parentElement??e.host??null;if(!r||r===document.documentElement||r===document.body)break;let i=getComputedStyle(r);n+=(parseFloat(i.paddingBottom)||0)+(parseFloat(i.borderBottomWidth)||0);let a=parseFloat(i.rowGap)||0;for(let e=t.nextElementSibling;e;e=e.nextElementSibling){let t=getComputedStyle(e);n+=e.getBoundingClientRect().height+(parseFloat(t.marginTop)||0)+(parseFloat(t.marginBottom)||0)+a}t=r}return Math.round(n)}static{this.BOTTOM_GUTTER_PX=16}static{this.MAX_SLIVER_PX=64}static{this.MAX_CORRECTIONS=3}static{this.MIN_FILL_PX=320}boxStyle(){let e=`border: var(--mateu-section-border, none); background: var(--mateu-section-bg, transparent); overflow: hidden; padding: var(--mateu-section-padding, 0); display: flex; flex-direction: column;`;return this.fillHeightPx==null?`${e} max-height: calc(100dvh - 12rem);`:`${e} height: ${this.fillHeightPx}px;`}connectedCallback(){super.connectedCallback(),window.addEventListener(`resize`,this.windowResizeListener),this.resizeObserver=new ResizeObserver(e=>{let t=e[0]?.contentRect.width;t&&Math.abs(t-this.availableWidthPx)>10&&(this.availableWidthPx=t)}),this.resizeObserver.observe(this)}disconnectedCallback(){super.disconnectedCallback(),window.removeEventListener(`resize`,this.windowResizeListener),this.resizeObserver?.disconnect()}_filterIds(e){return new Set([`searchText`,...(e.filters??[]).flatMap(e=>e.stereotype===`dateRange`||e.stereotype===`numberRange`?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId])])}_syncStateToUrl(e){let t=this._filterIds(e),n=new URLSearchParams(window.location.search);t.forEach(e=>n.delete(e)),n.delete(`page`),n.delete(`sort`),t.forEach(e=>{let t=this.state[e];t!=null&&t!==``&&n.set(e,String(t))});let r=this.state.page;r&&r>0&&n.set(`page`,String(r));let i=this.state.sort;if(i&&i.length>0){let e=i.filter(e=>e.fieldId&&e.direction).map(e=>`${e.fieldId}:${e.direction}`).join(`,`);e&&n.set(`sort`,e)}let a=n.toString(),o=a?`${window.location.pathname}?${a}`:window.location.pathname;window.location.pathname+window.location.search!==o&&history.replaceState(null,``,o)}_initStateFromUrl(e,t){let n=new URLSearchParams(window.location.search),r=this._filterIds(e),i={...t};n.forEach((e,t)=>{r.has(t)&&(i[t]=e)});let a=n.get(`page`);if(a!==null){let e=parseInt(a,10);!isNaN(e)&&e>0&&(i.page=e)}let o=n.get(`sort`);if(o){let e=o.split(`,`).map(e=>{let[t,n]=e.split(`:`);return t&&n?{fieldId:t,direction:n}:null}).filter(Boolean);e.length>0&&(i.sort=e)}return i}pageChanged(e){this.state={...this.state,page:e.detail.page},this.handleSearchRequested(void 0)}updated(e){if(super.updated(e),e.has(`component`)&&(this.pendingMeasure=!0),this.measureFill(),this.trimOverflow(),e.has(`component`)){let e=this.component?.id;if(e!==this._initializedForComponentId){this._initializedForComponentId=e;let t=this.component?.metadata,n=t.initialPage&&t.initialPage>0?t.initialPage:0;this.state=this._initStateFromUrl(t,{...this.state,size:t.pageSize,page:n,sort:[]}),(this.state.page!==n||this.state.sort?.length>0||[...this._filterIds(t)].some(e=>this.state[e]!=null)||t.rowsSource)&&this.handleSearchRequested(void 0)}}}render(){let e=e=>{let t=[];return e.color&&e.color!==Pa.normal&&t.push(e.color),e.buttonStyle&&t.push(e.buttonStyle===Fa.tertiaryInline?`tertiary-inline`:e.buttonStyle),t.length?t.join(` `):void 0},t=e=>e===`back`||e===`backToList`||!!e&&e.startsWith(`cancel`),n=t=>F.get()?.renderToolbarButton?.(t,this.evalLabel(t.label),()=>this.handleToolbarButtonClick(t.actionId))||T`
+        `}get cols(){return(this.effectiveComponent?.metadata)?.columns?.map(e=>e.metadata)??[]}get identifierFieldName(){let e=this.cols.find(e=>e.identifier);return e?e.id:this.cols.find(e=>e.id===`id`)?.id}get effectiveGridLayout(){let e=this.component?.metadata,t=e?.gridLayout??`auto`;return t===`auto`?e?.crudlType===`card`?`cards`:Ra(this.cols,this.availableWidthPx):t}scheduleMeasure(){this.pendingMeasure=!0,this.corrections=0,this.fillHeightPx==null?this.requestUpdate():this.fillHeightPx=void 0}measureFill(){if(!this.pendingMeasure||this.fillHeightPx!=null)return;let e=this.renderRoot?.querySelector?.(`[data-crud-box]`);if(!e)return;if(this.closest?.(`mateu-dialog, mateu-drawer`)){this.pendingMeasure=!1;return}let t=e.getBoundingClientRect().top,n=Math.round(window.innerHeight-t-this.measureBottomInset(e)-Va.BOTTOM_GUTTER_PX);this.pendingMeasure=!1,n>=Va.MIN_FILL_PX&&(this.fillHeightPx=n)}trimOverflow(){if(this.fillHeightPx==null||this.pendingMeasure||this.corrections>=Va.MAX_CORRECTIONS)return;let e=document.documentElement.scrollHeight-window.innerHeight;e<=1||e>Va.MAX_SLIVER_PX||(this.corrections++,this.fillHeightPx=Math.max(Va.MIN_FILL_PX,this.fillHeightPx-e))}measureBottomInset(e){let t=e,n=0;for(let e=0;t&&e<20;e++){n+=parseFloat(getComputedStyle(t).marginBottom)||0;let e=t.getRootNode(),r=t.assignedSlot??t.parentElement??e.host??null;if(!r||r===document.documentElement||r===document.body)break;let i=getComputedStyle(r);n+=(parseFloat(i.paddingBottom)||0)+(parseFloat(i.borderBottomWidth)||0);let a=parseFloat(i.rowGap)||0;for(let e=t.nextElementSibling;e;e=e.nextElementSibling){let t=getComputedStyle(e);n+=e.getBoundingClientRect().height+(parseFloat(t.marginTop)||0)+(parseFloat(t.marginBottom)||0)+a}t=r}return Math.round(n)}static{this.BOTTOM_GUTTER_PX=16}static{this.MAX_SLIVER_PX=64}static{this.MAX_CORRECTIONS=3}static{this.MIN_FILL_PX=320}boxStyle(){let e=`border: var(--mateu-section-border, none); background: var(--mateu-section-bg, transparent); overflow: hidden; padding: var(--mateu-section-padding, 0); display: flex; flex-direction: column;`;return this.fillHeightPx==null?`${e} max-height: calc(100dvh - 12rem);`:`${e} height: ${this.fillHeightPx}px;`}connectedCallback(){super.connectedCallback(),window.addEventListener(`resize`,this.windowResizeListener),this.resizeObserver=new ResizeObserver(e=>{let t=e[0]?.contentRect.width;t&&Math.abs(t-this.availableWidthPx)>10&&(this.availableWidthPx=t)}),this.resizeObserver.observe(this)}disconnectedCallback(){super.disconnectedCallback(),clearTimeout(this.loadingTimer),window.removeEventListener(`resize`,this.windowResizeListener),this.resizeObserver?.disconnect()}static{this.LOADING_VALVE_MS=15e3}get awaitingRows(){return this.loadingSince!=null&&Date.now()-this.loadingSince<Va.LOADING_VALVE_MS}beginLoading(){this.loadingSince=Date.now(),clearTimeout(this.loadingTimer),this.loadingTimer=setTimeout(()=>this.requestUpdate(),Va.LOADING_VALVE_MS)}endLoading(){this.loadingSince=void 0,clearTimeout(this.loadingTimer)}_filterIds(e){return new Set([`searchText`,...(e.filters??[]).flatMap(e=>e.stereotype===`dateRange`||e.stereotype===`numberRange`?[`${e.fieldId}_from`,`${e.fieldId}_to`]:[e.fieldId])])}_syncStateToUrl(e){let t=this._filterIds(e),n=new URLSearchParams(window.location.search);t.forEach(e=>n.delete(e)),n.delete(`page`),n.delete(`sort`),t.forEach(e=>{let t=this.state[e];t!=null&&t!==``&&n.set(e,String(t))});let r=this.state.page;r&&r>0&&n.set(`page`,String(r));let i=this.state.sort;if(i&&i.length>0){let e=i.filter(e=>e.fieldId&&e.direction).map(e=>`${e.fieldId}:${e.direction}`).join(`,`);e&&n.set(`sort`,e)}let a=n.toString(),o=a?`${window.location.pathname}?${a}`:window.location.pathname;window.location.pathname+window.location.search!==o&&history.replaceState(null,``,o)}_initStateFromUrl(e,t){let n=new URLSearchParams(window.location.search),r=this._filterIds(e),i={...t};n.forEach((e,t)=>{r.has(t)&&(i[t]=e)});let a=n.get(`page`);if(a!==null){let e=parseInt(a,10);!isNaN(e)&&e>0&&(i.page=e)}let o=n.get(`sort`);if(o){let e=o.split(`,`).map(e=>{let[t,n]=e.split(`:`);return t&&n?{fieldId:t,direction:n}:null}).filter(Boolean);e.length>0&&(i.sort=e)}return i}pageChanged(e){this.state={...this.state,page:e.detail.page},this.handleSearchRequested(void 0)}updated(e){if(super.updated(e),e.has(`component`)&&(this.pendingMeasure=!0),this.measureFill(),this.trimOverflow(),this.data?.[this.id]==null?this.loadingSince==null&&this._initializedForComponentId!=null&&!this.awaitingRows&&this.beginLoading():this.endLoading(),e.has(`component`)){let e=this.component?.id;if(e!==this._initializedForComponentId){this._initializedForComponentId=e;let t=this.component?.metadata,n=t.initialPage&&t.initialPage>0?t.initialPage:0;this.state=this._initStateFromUrl(t,{...this.state,size:t.pageSize,page:n,sort:[]}),(this.state.page!==n||this.state.sort?.length>0||[...this._filterIds(t)].some(e=>this.state[e]!=null)||t.rowsSource)&&this.handleSearchRequested(void 0)}}}render(){let e=e=>{let t=[];return e.color&&e.color!==Fa.normal&&t.push(e.color),e.buttonStyle&&t.push(e.buttonStyle===Ia.tertiaryInline?`tertiary-inline`:e.buttonStyle),t.length?t.join(` `):void 0},t=e=>e===`back`||e===`backToList`||!!e&&e.startsWith(`cancel`),n=t=>P.get()?.renderToolbarButton?.(t,this.evalLabel(t.label),()=>this.handleToolbarButtonClick(t.actionId))||T`
                 <button class="crud-btn"
                         data-action-id="${t.id}"
                         theme="${e(t)||v}"
                         @click="${()=>this.handleToolbarButtonClick(t.actionId)}"
                 >${this.evalLabel(t.label)}</button>
-            `;if(!this.component)return T`no component`;let r=this.effectiveComponent,i=r.metadata;i.serverSideOrdering=!0;let a=(()=>{let e=this;for(;e;){let t=e;if(t.tagName===`MATEU-PAGE`)return(t.component?.metadata?.toolbar?.length??0)>0;e=t.parentElement??(t.getRootNode?.()instanceof ShadowRoot?t.getRootNode().host:null)}return!1})()?[]:i?.toolbar??[],o=a.filter(e=>t(e.actionId)),s=a.filter(e=>!t(e.actionId)),c=o.length>0&&s.length>0,l=!!i?.title||!!i?.subtitle||a.length>0,u=this.effectiveGridLayout,d=this.cols,f=Ra(d),p=this.data[this.id]?.page?.content??[],ee=this.state[this.component?.id]?.emptyStateMessage,m=(e,t)=>{let n=t[e.id];return n==null?T``:e.dataType===`status`?T`<span theme="badge pill ${Aa(n.type)}">${n.message}</span>`:e.dataType===`bool`?T`${n?`✓`:`✗`}`:typeof n==`object`?T`${n.label??n.name??n.message??``}`:T`${n}`},te=()=>{let e=this.identifierFieldName,t=this.state._selectedId??this.appState?._splitDetailId,n=f.find(e=>e.identifier)??f[0],r=e=>e.dataType===`action`||e.dataType===`actionGroup`||e.dataType===`menu`||e.stereotype===`button`,i=f.filter(e=>e!==n&&!r(e)),a=d.filter(e=>r(e)),o=(e,t,n)=>{e.stopPropagation(),e.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_clickedRow:n}},bubbles:!0,composed:!0}))},s=e=>{let t=[];for(let n of a){let r=e[n.id];if(n.dataType===`action`){let i=r?.methodNameInCrud?r:e.action?.methodNameInCrud?e.action:{methodNameInCrud:n.id,label:n.label,icon:null,disabled:!1};t.push(T`
+            `;if(!this.component)return T`no component`;let r=this.effectiveComponent,i=r.metadata;i.serverSideOrdering=!0;let a=(()=>{let e=this;for(;e;){let t=e;if(t.tagName===`MATEU-PAGE`)return(t.component?.metadata?.toolbar?.length??0)>0;e=t.parentElement??(t.getRootNode?.()instanceof ShadowRoot?t.getRootNode().host:null)}return!1})()?[]:i?.toolbar??[],o=a.filter(e=>t(e.actionId)),s=a.filter(e=>!t(e.actionId)),c=o.length>0&&s.length>0,l=!!i?.title||!!i?.subtitle||a.length>0,u=this.effectiveGridLayout,d=this.cols,f=za(d),p=this.data[this.id]?.page?.content??[],ee=this.state[this.component?.id]?.emptyStateMessage,m=(e,t)=>{let n=t[e.id];return n==null?T``:e.dataType===`status`?T`<span theme="badge pill ${ja(n.type)}">${n.message}</span>`:e.dataType===`bool`?T`${n?`✓`:`✗`}`:typeof n==`object`?T`${n.label??n.name??n.message??``}`:T`${n}`},te=()=>{let e=this.identifierFieldName,t=this.state._selectedId??this.appState?._splitDetailId,n=f.find(e=>e.identifier)??f[0],r=e=>e.dataType===`action`||e.dataType===`actionGroup`||e.dataType===`menu`||e.stereotype===`button`,i=f.filter(e=>e!==n&&!r(e)),a=d.filter(e=>r(e)),o=(e,t,n)=>{e.stopPropagation(),e.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_clickedRow:n}},bubbles:!0,composed:!0}))},s=e=>{let t=[];for(let n of a){let r=e[n.id];if(n.dataType===`action`){let i=r?.methodNameInCrud?r:e.action?.methodNameInCrud?e.action:{methodNameInCrud:n.id,label:n.label,icon:null,disabled:!1};t.push(T`
                             <button class="crud-btn" theme="tertiary small" title="${i.label||v}"
                                 @click="${t=>o(t,`action-on-row-`+i.methodNameInCrud,e)}">
-                                ${i.icon?L(i.icon):v}
+                                ${i.icon?I(i.icon):v}
                                 ${i.label??v}
                             </button>`)}else(n.dataType===`actionGroup`||n.dataType===`menu`)&&(r?.actions??[]).forEach(n=>t.push(T`
                             <button class="crud-btn" theme="tertiary small" title="${n.label||v}"
                                 @click="${t=>o(t,`action-on-row-`+n.methodNameInCrud,e)}">
-                                ${n.icon?L(n.icon):v}
+                                ${n.icon?I(n.icon):v}
                                 ${n.label??v}
                             </button>`))}return t.length?T`
                     <div style="display: flex; flex-wrap: wrap; gap: var(--lumo-space-xs); margin-top: var(--lumo-space-xs);">
                         ${t}
                     </div>`:v};return T`
                 <div class="m-listbox" style="width: 100%;">
-                    ${p.length===0?T`<div class="m-item" disabled>${zt(ee)}</div>`:v}
+                    ${p.length===0?T`<div class="m-item" disabled>${Bt(ee)}</div>`:v}
                     ${p.map(r=>T`
                         <div role="button" tabindex="0" class="m-item"
                             ?selected="${e&&t!==void 0&&String(r[e])===String(t)}"
-                            @click="${()=>{e&&r[e]!==void 0&&(this.state={...this.state,_selectedId:String(r[e])}),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`view`,parameters:r},bubbles:!0,composed:!0}))}}" @keydown="${z(()=>{e&&r[e]!==void 0&&(this.state={...this.state,_selectedId:String(r[e])}),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`view`,parameters:r},bubbles:!0,composed:!0}))})}"
+                            @click="${()=>{e&&r[e]!==void 0&&(this.state={...this.state,_selectedId:String(r[e])}),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`view`,parameters:r},bubbles:!0,composed:!0}))}}" @keydown="${R(()=>{e&&r[e]!==void 0&&(this.state={...this.state,_selectedId:String(r[e])}),this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`view`,parameters:r},bubbles:!0,composed:!0}))})}"
                             style="cursor: pointer;"
                         >
                             <div style="font-weight: 600;">${n?r[n.id]??``:``}</div>
@@ -4698,24 +4698,24 @@ ${i}
                 </div>`},ne=(e,t,n)=>{let r=this.identifierFieldName;r&&n[r]!==void 0&&(this.state={...this.state,_selectedId:String(n[r])}),e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:n},bubbles:!0,composed:!0}))},h=()=>{let e=this.identifierFieldName,t=this.state._selectedId??this.appState?._splitDetailId,n=e=>!!e.actionId,r=e=>e.dataType===`action`||e.dataType===`actionGroup`||e.dataType===`menu`||e.stereotype===`button`,i=[...d.slice(0,6),...d.slice(6).filter(e=>r(e)||e.dataType===`status`)],a=i.filter(e=>e.stereotype===`image`),o=i.find(e=>e.identifier)??i[0],s=i.find(e=>e.id===`select`&&e.dataType===`action`),c=!!s,l=i.filter(e=>e!==o&&!a.includes(e)&&!n(e)&&!r(e)),u=i.filter(e=>r(e)&&!(c&&e===s)),f=(e,t,n)=>{e.stopPropagation(),e.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t,parameters:{_clickedRow:n}},bubbles:!0,composed:!0}))},te=e=>{let t=[];for(let n of u){let r=e[n.id];if(n.dataType===`action`){let i=r?.methodNameInCrud?r:e.action?.methodNameInCrud?e.action:{methodNameInCrud:n.id,label:n.label,icon:null,disabled:!1};t.push(T`
                             <button class="crud-btn" theme="tertiary" title="${i.label||v}"
                                 @click="${t=>f(t,`action-on-row-`+i.methodNameInCrud,e)}">
-                                ${i.icon?L(i.icon):v}
+                                ${i.icon?I(i.icon):v}
                                 ${i.label??v}
                             </button>`)}else(n.dataType===`actionGroup`||n.dataType===`menu`)&&(r?.actions??[]).forEach(n=>t.push(T`
                             <button class="crud-btn" theme="tertiary" title="${n.label||v}"
                                 @click="${t=>f(t,`action-on-row-`+n.methodNameInCrud,e)}">
-                                ${n.icon?L(n.icon):v}
+                                ${n.icon?I(n.icon):v}
                                 ${n.label??v}
                             </button>`))}return t.length?T`
                     <div style="display: flex; flex-wrap: wrap; gap: var(--lumo-space-xs); padding-top: var(--lumo-space-s); border-top: 1px solid var(--lumo-contrast-10pct);">
                         ${t}
                     </div>`:v};return T`
                 <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: var(--lumo-space-m); padding: var(--lumo-space-s) 0;">
-                    ${p.length===0?T`<div style="grid-column: 1 / -1;">${zt(ee)}</div>`:v}
+                    ${p.length===0?T`<div style="grid-column: 1 / -1;">${Bt(ee)}</div>`:v}
                     ${p.map(n=>T`
                         <div role="button" tabindex="0" class="crud-card"
                             ?data-selected="${e&&t!==void 0&&String(n[e])===String(t)}"
                             style="cursor: pointer;"
-                            @click="${e=>c?f(e,`action-on-row-select`,n):ne(e.target,`view`,n)}" @keydown="${z(e=>c?f(e,`action-on-row-select`,n):ne(e.target,`view`,n))}"
+                            @click="${e=>c?f(e,`action-on-row-select`,n):ne(e.target,`view`,n)}" @keydown="${R(e=>c?f(e,`action-on-row-select`,n):ne(e.target,`view`,n))}"
                         >
                             ${a.length?T`<img src="${n[a[0].id]??``}" alt="" style="width: 100%; max-height: 160px; object-fit: cover; border-radius: var(--lumo-border-radius-m, 8px);" />`:v}
                             ${o?T`<div class="crud-card-title">${n[o.id]??``}</div>`:v}
@@ -4730,15 +4730,15 @@ ${i}
                             ${te(n)}
                         </div>
                     `)}
-                </div>`},g=()=>{let e=za(d),t=e.find(e=>e.identifier)??e[0],n=e.filter(e=>e!==t);return T`
+                </div>`},g=()=>{let e=Ba(d),t=e.find(e=>e.identifier)??e[0],n=e.filter(e=>e!==t);return T`
                 <div style="display: flex; height: 100%; min-height: 400px; gap: 0;">
                     <div style="width: 260px; flex-shrink: 0; border-right: 1px solid var(--lumo-contrast-20pct); overflow-y: auto;">
                         <div class="m-listbox" style="width: 100%;">
-                            ${p.length===0?T`<div class="m-item" disabled>${zt(ee)}</div>`:v}
+                            ${p.length===0?T`<div class="m-item" disabled>${Bt(ee)}</div>`:v}
                             ${p.map(e=>T`
                                 <div role="button" tabindex="0" class="m-item"
                                     ?selected="${this.selectedItem===e}"
-                                    @click="${()=>{this.selectedItem=e}}" @keydown="${z(()=>{this.selectedItem=e})}"
+                                    @click="${()=>{this.selectedItem=e}}" @keydown="${R(()=>{this.selectedItem=e})}"
                                     style="cursor: pointer;"
                                 >
                                     <div style="font-weight: 600;">${t?e[t.id]??``:``}</div>
@@ -4779,10 +4779,18 @@ ${i}
                         ${i?T`<th></th>`:v}
                     </tr></thead>
                     <tbody>
-                        ${o.length===0?T`<tr><td colspan="99" style="padding: 1.5rem; text-align: center; color: var(--lumo-secondary-text-color, #888);">${zt(ee)}</td></tr>`:v}
+                        ${o.length===0?T`<tr><td colspan="99" style="padding: 1.5rem; text-align: center; color: var(--lumo-secondary-text-color, #888);">${Bt(ee)}</td></tr>`:v}
                         ${o.map(e=>c(e,0))}
                     </tbody>
-                </table>`},re=F.get()?.rendersCrudLayouts?.()===!0,y=T`
+                </table>`},re=P.get()?.rendersCrudLayouts?.()===!0,y=p.length===0&&this.awaitingRows?T`
+            <div role="status" aria-live="polite" aria-busy="true"
+                 style="padding: var(--lumo-space-m, 1rem); width: 100%; box-sizing: border-box;">
+                <span style="position: absolute; width: 1px; height: 1px; overflow: hidden;
+                             clip: rect(0 0 0 0); clip-path: inset(50%); white-space: nowrap;"
+                >Loading…</span>
+                <mateu-skeleton variant="grid" count="6"></mateu-skeleton>
+            </div>
+        `:T`
             ${i.infiniteScrolling?T`
                 <div>${this.data[this.id]?.page?.totalElements} items found.</div>
             `:v}
@@ -4790,10 +4798,10 @@ ${i}
                 <div class="m-scroll" style="width: 100%; height: ${i.contentHeight};">
                     ${h()}
                 </div>
-            `:h():!re&&u===`masterDetail`?g():!re&&u===`tree`?(()=>{let e=F.get();return e?.renderTreeComponent?e.renderTreeComponent(this,{rows:p,columns:d.map(e=>({id:e.id,label:e.label})),idField:this.identifierFieldName,navigable:!!d[0]?.actionId,selectedId:this.state._selectedId??this.appState?._splitDetailId}):_()})():F.get()?.renderTableComponent(this,r,this.baseUrl,this.state,this.data,this.appState,this.appData)}
+            `:h():!re&&u===`masterDetail`?g():!re&&u===`tree`?(()=>{let e=P.get();return e?.renderTreeComponent?e.renderTreeComponent(this,{rows:p,columns:d.map(e=>({id:e.id,label:e.label})),idField:this.identifierFieldName,navigable:!!d[0]?.actionId,selectedId:this.state._selectedId??this.appState?._splitDetailId}):_()})():P.get()?.renderTableComponent(this,r,this.baseUrl,this.state,this.data,this.appState,this.appData)}
             <slot></slot>
-        `,b=i.infiniteScrolling?v:F.get()?.renderPagination(this,this.component),x=this.showImportDialog?T`
-            <div role="button" tabindex="0" class="crud-modal-backdrop" @click="${e=>{e.target===e.currentTarget&&(this.showImportDialog=!1)}}" @keydown="${z(e=>{e.target===e.currentTarget&&(this.showImportDialog=!1)})}">
+        `,b=i.infiniteScrolling?v:P.get()?.renderPagination(this,this.component),x=this.showImportDialog?T`
+            <div role="button" tabindex="0" class="crud-modal-backdrop" @click="${e=>{e.target===e.currentTarget&&(this.showImportDialog=!1)}}" @keydown="${R(e=>{e.target===e.currentTarget&&(this.showImportDialog=!1)})}">
                 <div class="crud-modal">
                     <h3 style="margin: 0 0 .75rem;">Import</h3>
                     <input type="file" @change="${e=>{let t=e.target.files?.[0];if(t){let e=new FormData;e.append(`file`,t),fetch(`/upload`,{method:`POST`,body:e}).then(e=>e.json()).then(e=>this.handleImportUploadSuccess({detail:e})).catch(()=>this.notify(`Import failed`))}}}">
@@ -4823,7 +4831,7 @@ ${i}
                         ></mateu-content-header>
                     </div>
                     <div style="flex-shrink: 0; display: flex; align-items: center; gap: var(--lumo-space-s, 0.5rem);">
-                        <div style="flex: 1; min-width: 0;">${F.get()?.renderFilterBar(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData,!0)}</div>
+                        <div style="flex: 1; min-width: 0;">${P.get()?.renderFilterBar(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData,!0)}</div>
                         ${this.renderColumnChooser()}
                     </div>
                     <div data-crud-area style="flex: 1; overflow-y: auto; min-height: 0; display: flex; flex-direction: column;">${y}</div>
@@ -4856,13 +4864,13 @@ ${i}
                 </style>
             <div data-crud-box style="${this.boxStyle()}">
                 <div style="flex-shrink: 0; display: flex; align-items: center; gap: var(--lumo-space-s, 0.5rem);">
-                    <div style="flex: 1; min-width: 0;">${F.get()?.renderFilterBar(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData)}</div>
+                    <div style="flex: 1; min-width: 0;">${P.get()?.renderFilterBar(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData)}</div>
                     ${this.renderColumnChooser()}
                 </div>
                 <div data-crud-area style="flex: 1; overflow-y: auto; min-height: 0; display: flex; flex-direction: column;">${y}</div>
                 <div style="flex-shrink: 0;">${b}</div>
             </div>
-        `}createRenderRoot(){return F.mustUseShadowRoot()?super.createRenderRoot():this}static{this.styles=h`
+        `}createRenderRoot(){return P.mustUseShadowRoot()?super.createRenderRoot():this}static{this.styles=h`
         ${de}
         /* DS-neutral crud widgets (replace vaadin-button/card/grid/list-box/form-layout/dialog). */
         .crud-btn {
@@ -4916,8 +4924,8 @@ ${i}
             outline-offset: -2px;
         }
     
-        ${B}
-    `}};k([y()],K.prototype,`component`,void 0),k([y()],K.prototype,`baseUrl`,void 0),k([y({type:Boolean})],K.prototype,`standalone`,void 0),k([y()],K.prototype,`state`,void 0),k([y()],K.prototype,`data`,void 0),k([y()],K.prototype,`appState`,void 0),k([y()],K.prototype,`appData`,void 0),k([C()],K.prototype,`showImportDialog`,void 0),k([C()],K.prototype,`availableWidthPx`,void 0),k([C()],K.prototype,`selectedItem`,void 0),k([C()],K.prototype,`_columnPrefsRevision`,void 0),k([C()],K.prototype,`fillHeightPx`,void 0),K=Ba=k([g(`mateu-table-crud`)],K);var Ha=function(e){return e.OnLoad=`OnLoad`,e.OnSuccess=`OnSuccess`,e.OnError=`OnError`,e.OnValueChange=`OnValueChange`,e.OnCustomEvent=`OnCustomEvent`,e.AutoSave=`AutoSave`,e}({}),Ua=class extends vt{constructor(...e){super(...e),this.state={},this.data={},this.appData={},this.appState={},this.triggerOnLoad=()=>{let e=this.component;this.registerCustomEventListeners(),e.triggers?.filter(e=>e.type==Ha.OnLoad).forEach(e=>{if((!e.condition||this._evalExpr(e.condition))&&!e.triggered){let n=e;n.triggered=!0;var t=n.times-1;n.timeoutMillis>0?this.scheduleOnload(n,t,this.id):this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.actionId},bubbles:!0,composed:!0}))}})},this.scheduleOnload=(e,t,n)=>{if(n!=this.component?.id)return;let r=this.callbackToken;setTimeout(()=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,callbackToken:r},bubbles:!0,composed:!0}))},e.timeoutMillis)},this._registeredCustomEventListeners=[],this.customEventManager=e=>{if(!(e instanceof CustomEvent))return;let t=e,n=(this.component.triggers??[]).filter(e=>e.type==Ha.OnCustomEvent).filter(e=>e.eventName==t.type).filter(e=>e.source!==`COMPONENT`||t.detail?.__source===e.from);n.length!==0&&(n.some(e=>!e.source||e.source===`SELF`)&&(e.stopPropagation(),e.preventDefault()),n.forEach(e=>{(!e.condition||this._evalExpr(e.condition))&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:t.detail},bubbles:!0,composed:!0}))}))}}_interpolationExtra(){return{appState:this.appState??{},appData:this.appData??{},component:this.component}}_evalExpr(e){return Ct(e,this.state??{},this.data??{},this._interpolationExtra())}_evalTemplate(e){return wt(e,this.state??{},this.data??{},this._interpolationExtra())}isOverlayChild(e){let t=e?.metadata?.type;return t==j.Drawer||t==j.Dialog}removeSelfFromOwnerChildren(){let e=this.component;if(!e)return!1;let t=t=>{if(t===e)return!0;let n=t;return e.id!=null&&n?.id==e.id&&this.isOverlayChild(n)},n=this.parentNode;for(;n;){let e=n instanceof ShadowRoot?n.host:n,r=e.component?.children;if(Array.isArray(r)){let n=r.findIndex(t);if(n>=0)return r.splice(n,1),e.requestUpdate?.(),!0}n=n instanceof ShadowRoot?e:n.parentNode}return!1}applyFragment(e){if(this.id==e.targetComponentId){if(e.component)if(ut.Add==e.action){if(this.component){let t=this.component.children??(this.component.children=[]),n=e.component.id?t.findIndex(t=>t.id==e.component.id&&this.isOverlayChild(t)):-1;n>=0?(t[n]=e.component,this.component={...this.component}):t.push(e.component)}}else{this.callbackToken=E();let t=!1;if(e.component?.type==A.ServerSide)if(this.component){let n=this.component,r=e.component;t=n.serverSideType==r.serverSideType;let i=t?(n.children??[]).filter(e=>this.isOverlayChild(e)):[];n.actions=r.actions,n.type=r.type,n.rules=r.rules,n.triggers=r.triggers,n.serverSideType=r.serverSideType,n.route=r.route,n.initialData=r.initialData,n.validations=r.validations,n.cssClasses=r.cssClasses,n.slot=r.slot,n.style=r.style,n.children=i.length?[...r.children??[],...i]:r.children,(n.serverSideType!=r.serverSideType||n.id!=r.id)&&setTimeout(()=>this.triggerOnLoad())}else this.component=e.component,setTimeout(()=>this.triggerOnLoad());else{let t=[e.component];this.component&&(this.component.children=t)}e.action!==ut.ReplaceKeepData&&!t&&(this.state={},this.data={})}if(e.state&&(this.state={...this.state,...e.state}),e.data){for(let t in e.data){let n=e.data[t]?.page;n?.pageNumber>0&&this.data[t]&&this.data[t].page.content&&(n.content?n.content=[...this.data[t].page.content,...n.content]:n.content=[...this.data[t].page.content])}this.data={...this.data,...e.data}}this._lastFragmentData=this.data,this.registerCustomEventListeners();let t=F.getAfterRenderHook();t&&setTimeout(()=>t(this)),this.requestUpdate()}}willUpdate(e){super.willUpdate(e);let t=this.component?.serverSideType,n=t!=null&&this._lastViewKey!=null&&t!==this._lastViewKey;if(t!=null&&(this._lastViewKey=t),!e.has(`data`)||this.data===this._lastFragmentData||n)return;let r=this.data,i=e.get(`data`);r&&Object.keys(r).length===0&&i&&Object.keys(i).length>0&&(this.data=i)}registerCustomEventListeners(){this._registeredCustomEventListeners.forEach(({target:e,name:t})=>e.removeEventListener(t,this.customEventManager)),this._registeredCustomEventListeners=[],this.component?.triggers?.filter(e=>e.type==Ha.OnCustomEvent).forEach(e=>{let t=e.source===`DOCUMENT`||e.source===`COMPONENT`?document:this;t.addEventListener(e.eventName,this.customEventManager),this._registeredCustomEventListeners.push({target:t,name:e.eventName})})}disconnectedCallback(){this._registeredCustomEventListeners.forEach(({target:e,name:t})=>e.removeEventListener(t,this.customEventManager)),this._registeredCustomEventListeners=[],super.disconnectedCallback()}connectedCallback(){super.connectedCallback(),this.component&&this.registerCustomEventListeners()}};k([y()],Ua.prototype,`state`,void 0),k([y()],Ua.prototype,`data`,void 0),k([y()],Ua.prototype,`appData`,void 0),k([y()],Ua.prototype,`appState`,void 0);var Wa=`mateu-recent-routes`,Ga=8;function Ka(){try{return JSON.parse(localStorage.getItem(Wa)??`{}`)}catch{return{}}}function qa(e){try{localStorage.setItem(Wa,JSON.stringify(e))}catch{}}function Ja(e){return Ka()[e||`_`]??[]}function Ya(e,t){if(!t?.route||!t.label)return;let n=e||`_`,r=Ka(),i=(r[n]??[]).filter(e=>e.route!==t.route);i.unshift({route:t.route,label:t.label}),r[n]=i.slice(0,Ga),qa(r)}var Xa=class extends b{constructor(...e){super(...e),this.baseUrl=``,this.open=!1,this.queryText=``,this.dataHits=[],this.loading=!1,this.selectedIndex=0,this.fabOffset=0,this.keydownHandler=null}connectedCallback(){super.connectedCallback(),this.keydownHandler=e=>{(e.metaKey||e.ctrlKey)&&(e.key===`k`||e.key===`K`)?(e.preventDefault(),this.toggle()):e.key===`Escape`&&this.open&&this.close()},document.addEventListener(`keydown`,this.keydownHandler),this.setupFabObserver()}disconnectedCallback(){super.disconnectedCallback(),this.keydownHandler&&document.removeEventListener(`keydown`,this.keydownHandler),clearTimeout(this.searchTimer),this.fabObserver?.disconnect(),this.fabObserver=void 0}setupFabObserver(){let e=this.getRootNode(),t=e instanceof ShadowRoot?e:document.body;this.measureFabStack(),this.fabObserver?.disconnect(),this.fabObserver=new MutationObserver(()=>this.measureFabStack()),this.fabObserver.observe(t,{childList:!0,subtree:!0})}measureFabStack(){let e=(this.getRootNode().querySelectorAll?.(`.ai-fab, .app-fab, .page-fab`).length??0)*4;e!==this.fabOffset&&(this.fabOffset=e)}updated(e){e.has(`open`)&&this.open&&requestAnimationFrame(()=>this.inputEl?.focus())}toggle(){this.open?this.close():this.openCenter()}openCenter(){this.open=!0,this.queryText=``,this.dataHits=[],this.selectedIndex=0}close(){this.open=!1,this.queryText=``,this.dataHits=[],clearTimeout(this.searchTimer)}flattenMenu(e,t){let n=[];for(let r of e??[])if(!r.separator)if(r.submenus&&r.submenus.length>0){let e=t?`${t} › ${r.label}`:r.label;n.push(...this.flattenMenu(r.submenus,e))}else r.route!==void 0&&r.route!==null&&n.push({label:r.label,breadcrumb:t,route:r.route});return n}onInput(e){this.queryText=e,this.selectedIndex=0;let t=e.trim();if(clearTimeout(this.searchTimer),!t||!this.app?.globalSearchEnabled){this.dataHits=[],this.loading=!1;return}this.loading=!0,this.searchTimer=setTimeout(()=>this.fetchGlobalSearch(t),250)}async fetchGlobalSearch(e){let t=this.app;if(!t?.globalSearchEnabled){this.loading=!1;return}try{let n=(await lt.runAction(this.baseUrl??``,t.rootRoute??``,``,`_globalsearch`,`command-center`,void 0,t.serverSideType,{},{searchText:e},this,!0))?.fragments?.map(e=>e.data).find(e=>e&&e._globalsearch);this.dataHits=n?._globalsearch??[]}catch{this.dataHits=[]}finally{this.loading=!1}}navigateTo(e,t){Ya(this.app?.serverSideType??``,{route:e,label:t}),this.close();for(let t of[`route-changed`,`navigate-to-requested`])this.dispatchEvent(new CustomEvent(t,{detail:{route:e},bubbles:!0,composed:!0}))}askAi(){let e=this.queryText.trim();this.close(),this.dispatchEvent(new CustomEvent(`mateu-open-ai`,{detail:{query:e},bubbles:!0,composed:!0}))}visibleTargets(e){if(!this.queryText.trim()){let e=this.flattenMenu(this.app?.menu,``).map(e=>({route:e.route,label:e.label})),t=Ja(this.app?.serverSideType??``);return[...e,...t]}return[...e.map(e=>({route:e.route,label:e.label})),...this.dataHits.map(e=>({route:e.route,label:e.label}))]}onKeydown(e,t){if(e.key===`ArrowDown`)e.preventDefault(),this.selectedIndex=Math.min(this.selectedIndex+1,t.length-1);else if(e.key===`ArrowUp`)e.preventDefault(),this.selectedIndex=Math.max(this.selectedIndex-1,0);else if(e.key===`Enter`){let e=t[this.selectedIndex];e&&this.navigateTo(e.route,e.label)}}render(){return T`
+        ${z}
+    `}};k([y()],G.prototype,`component`,void 0),k([y()],G.prototype,`baseUrl`,void 0),k([y({type:Boolean})],G.prototype,`standalone`,void 0),k([y()],G.prototype,`state`,void 0),k([y()],G.prototype,`data`,void 0),k([y()],G.prototype,`appState`,void 0),k([y()],G.prototype,`appData`,void 0),k([C()],G.prototype,`showImportDialog`,void 0),k([C()],G.prototype,`availableWidthPx`,void 0),k([C()],G.prototype,`selectedItem`,void 0),k([C()],G.prototype,`_columnPrefsRevision`,void 0),k([C()],G.prototype,`fillHeightPx`,void 0),k([C()],G.prototype,`loadingSince`,void 0),G=Va=k([g(`mateu-table-crud`)],G);var Ua=function(e){return e.OnLoad=`OnLoad`,e.OnSuccess=`OnSuccess`,e.OnError=`OnError`,e.OnValueChange=`OnValueChange`,e.OnCustomEvent=`OnCustomEvent`,e.AutoSave=`AutoSave`,e}({}),Wa=class extends vt{constructor(...e){super(...e),this.state={},this.data={},this.appData={},this.appState={},this.triggerOnLoad=()=>{let e=this.component;this.registerCustomEventListeners(),e.triggers?.filter(e=>e.type==Ua.OnLoad).forEach(e=>{if((!e.condition||this._evalExpr(e.condition))&&!e.triggered){let n=e;n.triggered=!0;var t=n.times-1;n.timeoutMillis>0?this.scheduleOnload(n,t,this.id):this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.actionId},bubbles:!0,composed:!0}))}})},this.scheduleOnload=(e,t,n)=>{if(n!=this.component?.id)return;let r=this.callbackToken;setTimeout(()=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,callbackToken:r},bubbles:!0,composed:!0}))},e.timeoutMillis)},this._registeredCustomEventListeners=[],this.customEventManager=e=>{if(!(e instanceof CustomEvent))return;let t=e,n=(this.component.triggers??[]).filter(e=>e.type==Ua.OnCustomEvent).filter(e=>e.eventName==t.type).filter(e=>e.source!==`COMPONENT`||t.detail?.__source===e.from);n.length!==0&&(n.some(e=>!e.source||e.source===`SELF`)&&(e.stopPropagation(),e.preventDefault()),n.forEach(e=>{(!e.condition||this._evalExpr(e.condition))&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId,parameters:t.detail},bubbles:!0,composed:!0}))}))}}_interpolationExtra(){return{appState:this.appState??{},appData:this.appData??{},component:this.component}}_evalExpr(e){return Ct(e,this.state??{},this.data??{},this._interpolationExtra())}_evalTemplate(e){return wt(e,this.state??{},this.data??{},this._interpolationExtra())}isOverlayChild(e){let t=e?.metadata?.type;return t==j.Drawer||t==j.Dialog}removeSelfFromOwnerChildren(){let e=this.component;if(!e)return!1;let t=t=>{if(t===e)return!0;let n=t;return e.id!=null&&n?.id==e.id&&this.isOverlayChild(n)},n=this.parentNode;for(;n;){let e=n instanceof ShadowRoot?n.host:n,r=e.component?.children;if(Array.isArray(r)){let n=r.findIndex(t);if(n>=0)return r.splice(n,1),e.requestUpdate?.(),!0}n=n instanceof ShadowRoot?e:n.parentNode}return!1}applyFragment(e){if(this.id==e.targetComponentId){if(e.component)if(ut.Add==e.action){if(this.component){let t=this.component.children??(this.component.children=[]),n=e.component.id?t.findIndex(t=>t.id==e.component.id&&this.isOverlayChild(t)):-1;n>=0?(t[n]=e.component,this.component={...this.component}):t.push(e.component)}}else{this.callbackToken=E();let t=!1;if(e.component?.type==A.ServerSide)if(this.component){let n=this.component,r=e.component;t=n.serverSideType==r.serverSideType;let i=t?(n.children??[]).filter(e=>this.isOverlayChild(e)):[];n.actions=r.actions,n.type=r.type,n.rules=r.rules,n.triggers=r.triggers,n.serverSideType=r.serverSideType,n.route=r.route,n.initialData=r.initialData,n.validations=r.validations,n.cssClasses=r.cssClasses,n.slot=r.slot,n.style=r.style,n.children=i.length?[...r.children??[],...i]:r.children,(n.serverSideType!=r.serverSideType||n.id!=r.id)&&setTimeout(()=>this.triggerOnLoad())}else this.component=e.component,setTimeout(()=>this.triggerOnLoad());else{let t=[e.component];this.component&&(this.component.children=t)}e.action!==ut.ReplaceKeepData&&!t&&(this.state={},this.data={})}if(e.state&&(this.state={...this.state,...e.state}),e.data){for(let t in e.data){let n=e.data[t]?.page;n?.pageNumber>0&&this.data[t]&&this.data[t].page.content&&(n.content?n.content=[...this.data[t].page.content,...n.content]:n.content=[...this.data[t].page.content])}this.data={...this.data,...e.data}}this._lastFragmentData=this.data,this.registerCustomEventListeners();let t=P.getAfterRenderHook();t&&setTimeout(()=>t(this)),this.requestUpdate()}}willUpdate(e){super.willUpdate(e);let t=this.component?.serverSideType,n=t!=null&&this._lastViewKey!=null&&t!==this._lastViewKey;if(t!=null&&(this._lastViewKey=t),!e.has(`data`)||this.data===this._lastFragmentData||n)return;let r=this.data,i=e.get(`data`);r&&Object.keys(r).length===0&&i&&Object.keys(i).length>0&&(this.data=i)}registerCustomEventListeners(){this._registeredCustomEventListeners.forEach(({target:e,name:t})=>e.removeEventListener(t,this.customEventManager)),this._registeredCustomEventListeners=[],this.component?.triggers?.filter(e=>e.type==Ua.OnCustomEvent).forEach(e=>{let t=e.source===`DOCUMENT`||e.source===`COMPONENT`?document:this;t.addEventListener(e.eventName,this.customEventManager),this._registeredCustomEventListeners.push({target:t,name:e.eventName})})}disconnectedCallback(){this._registeredCustomEventListeners.forEach(({target:e,name:t})=>e.removeEventListener(t,this.customEventManager)),this._registeredCustomEventListeners=[],super.disconnectedCallback()}connectedCallback(){super.connectedCallback(),this.component&&this.registerCustomEventListeners()}};k([y()],Wa.prototype,`state`,void 0),k([y()],Wa.prototype,`data`,void 0),k([y()],Wa.prototype,`appData`,void 0),k([y()],Wa.prototype,`appState`,void 0);var Ga=`mateu-recent-routes`,Ka=8;function qa(){try{return JSON.parse(localStorage.getItem(Ga)??`{}`)}catch{return{}}}function Ja(e){try{localStorage.setItem(Ga,JSON.stringify(e))}catch{}}function Ya(e){return qa()[e||`_`]??[]}function Xa(e,t){if(!t?.route||!t.label)return;let n=e||`_`,r=qa(),i=(r[n]??[]).filter(e=>e.route!==t.route);i.unshift({route:t.route,label:t.label}),r[n]=i.slice(0,Ka),Ja(r)}var Za=class extends b{constructor(...e){super(...e),this.baseUrl=``,this.open=!1,this.queryText=``,this.dataHits=[],this.loading=!1,this.selectedIndex=0,this.fabOffset=0,this.keydownHandler=null}connectedCallback(){super.connectedCallback(),this.keydownHandler=e=>{(e.metaKey||e.ctrlKey)&&(e.key===`k`||e.key===`K`)?(e.preventDefault(),this.toggle()):e.key===`Escape`&&this.open&&this.close()},document.addEventListener(`keydown`,this.keydownHandler),this.setupFabObserver()}disconnectedCallback(){super.disconnectedCallback(),this.keydownHandler&&document.removeEventListener(`keydown`,this.keydownHandler),clearTimeout(this.searchTimer),this.fabObserver?.disconnect(),this.fabObserver=void 0}setupFabObserver(){let e=this.getRootNode(),t=e instanceof ShadowRoot?e:document.body;this.measureFabStack(),this.fabObserver?.disconnect(),this.fabObserver=new MutationObserver(()=>this.measureFabStack()),this.fabObserver.observe(t,{childList:!0,subtree:!0})}measureFabStack(){let e=(this.getRootNode().querySelectorAll?.(`.ai-fab, .app-fab, .page-fab`).length??0)*4;e!==this.fabOffset&&(this.fabOffset=e)}updated(e){e.has(`open`)&&this.open&&requestAnimationFrame(()=>this.inputEl?.focus())}toggle(){this.open?this.close():this.openCenter()}openCenter(){this.open=!0,this.queryText=``,this.dataHits=[],this.selectedIndex=0}close(){this.open=!1,this.queryText=``,this.dataHits=[],clearTimeout(this.searchTimer)}flattenMenu(e,t){let n=[];for(let r of e??[])if(!r.separator)if(r.submenus&&r.submenus.length>0){let e=t?`${t} › ${r.label}`:r.label;n.push(...this.flattenMenu(r.submenus,e))}else r.route!==void 0&&r.route!==null&&n.push({label:r.label,breadcrumb:t,route:r.route});return n}onInput(e){this.queryText=e,this.selectedIndex=0;let t=e.trim();if(clearTimeout(this.searchTimer),!t||!this.app?.globalSearchEnabled){this.dataHits=[],this.loading=!1;return}this.loading=!0,this.searchTimer=setTimeout(()=>this.fetchGlobalSearch(t),250)}async fetchGlobalSearch(e){let t=this.app;if(!t?.globalSearchEnabled){this.loading=!1;return}try{let n=(await lt.runAction(this.baseUrl??``,t.rootRoute??``,``,`_globalsearch`,`command-center`,void 0,t.serverSideType,{},{searchText:e},this,!0))?.fragments?.map(e=>e.data).find(e=>e&&e._globalsearch);this.dataHits=n?._globalsearch??[]}catch{this.dataHits=[]}finally{this.loading=!1}}navigateTo(e,t){Xa(this.app?.serverSideType??``,{route:e,label:t}),this.close();for(let t of[`route-changed`,`navigate-to-requested`])this.dispatchEvent(new CustomEvent(t,{detail:{route:e},bubbles:!0,composed:!0}))}askAi(){let e=this.queryText.trim();this.close(),this.dispatchEvent(new CustomEvent(`mateu-open-ai`,{detail:{query:e},bubbles:!0,composed:!0}))}visibleTargets(e){if(!this.queryText.trim()){let e=this.flattenMenu(this.app?.menu,``).map(e=>({route:e.route,label:e.label})),t=Ya(this.app?.serverSideType??``);return[...e,...t]}return[...e.map(e=>({route:e.route,label:e.label})),...this.dataHits.map(e=>({route:e.route,label:e.label}))]}onKeydown(e,t){if(e.key===`ArrowDown`)e.preventDefault(),this.selectedIndex=Math.min(this.selectedIndex+1,t.length-1);else if(e.key===`ArrowUp`)e.preventDefault(),this.selectedIndex=Math.max(this.selectedIndex-1,0);else if(e.key===`Enter`){let e=t[this.selectedIndex];e&&this.navigateTo(e.route,e.label)}}render(){return T`
             <button class="cc-fab" style="bottom: ${1.5+this.fabOffset}rem;"
                 @click=${()=>this.openCenter()} title="Buscar y navegar (⌘K)" aria-label="Command center">
                 ${this.fabIcon()}
@@ -4943,7 +4951,7 @@ ${i}
                 </div>
                 <button class="cc-close" @click=${()=>this.close()} title="Cerrar">${this.clearIcon()}</button>
             </div>
-        `}renderDefault(){let e=this.flattenMenu(this.app?.menu,``),t=Ja(this.app?.serverSideType??``),n=-1;return T`
+        `}renderDefault(){let e=this.flattenMenu(this.app?.menu,``),t=Ya(this.app?.serverSideType??``),n=-1;return T`
             <div class="cc-columns">
                 <div class="cc-col">
                     <div class="cc-section-title">Ir a</div>
@@ -5078,7 +5086,7 @@ ${i}
             display: flex; align-items: center; justify-content: center; cursor: pointer; z-index: 1110;
         }
         .cc-close:hover { background: rgba(0,0,0,0.75); }
-    `}};k([y({attribute:!1})],Xa.prototype,`app`,void 0),k([y()],Xa.prototype,`baseUrl`,void 0),k([C()],Xa.prototype,`open`,void 0),k([C()],Xa.prototype,`queryText`,void 0),k([C()],Xa.prototype,`dataHits`,void 0),k([C()],Xa.prototype,`loading`,void 0),k([C()],Xa.prototype,`selectedIndex`,void 0),k([C()],Xa.prototype,`fabOffset`,void 0),k([x(`.cc-input`)],Xa.prototype,`inputEl`,void 0),Xa=k([g(`mateu-command-center`)],Xa);var Za=null;function Qa(e){let t=e.component?.metadata;t&&(t.commandCenterEnabled||t.chromeless)&&t.variant!==`MEDIATOR`?((!Za||!Za.isConnected)&&(Za=document.createElement(`mateu-command-center`),e.renderRoot.appendChild(Za)),Za.app=t,Za.baseUrl=e.baseUrl??``):Za&&e.renderRoot.contains(Za)&&(Za.remove(),Za=null)}var $a=class extends b{constructor(...e){super(...e),this.fetchStarted=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!0},this.fetchFinished=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!1},this.fetchFailed=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!1;let t=e.detail??{},n=t.failure??$e(t.reason,{online:at.isOnline()});if(n.kind===`cancelled`)return;let r=t.retry;Na({text:n.message,variant:`error`,duration:r?8e3:5e3,position:`bottomEnd`,...r?{actionLabel:`Retry`,onAction:r}:{}},this)}}connectedCallback(){super.connectedCallback(),this.addEventListener(`backend-called-event`,this.fetchStarted),this.addEventListener(`backend-succeeded-event`,this.fetchFinished),this.addEventListener(`backend-cancelled-event`,this.fetchFinished),this.addEventListener(`backend-failed-event`,this.fetchFailed)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`backend-called-event`,this.fetchStarted),this.removeEventListener(`backend-succeeded-event`,this.fetchFinished),this.removeEventListener(`backend-cancelled-event`,this.fetchFinished),this.removeEventListener(`backend-failed-event`,this.fetchFailed)}render(){return T`<div class="loader-container">
+    `}};k([y({attribute:!1})],Za.prototype,`app`,void 0),k([y()],Za.prototype,`baseUrl`,void 0),k([C()],Za.prototype,`open`,void 0),k([C()],Za.prototype,`queryText`,void 0),k([C()],Za.prototype,`dataHits`,void 0),k([C()],Za.prototype,`loading`,void 0),k([C()],Za.prototype,`selectedIndex`,void 0),k([C()],Za.prototype,`fabOffset`,void 0),k([x(`.cc-input`)],Za.prototype,`inputEl`,void 0),Za=k([g(`mateu-command-center`)],Za);var Qa=null;function $a(e){let t=e.component?.metadata;t&&(t.commandCenterEnabled||t.chromeless)&&t.variant!==`MEDIATOR`?((!Qa||!Qa.isConnected)&&(Qa=document.createElement(`mateu-command-center`),e.renderRoot.appendChild(Qa)),Qa.app=t,Qa.baseUrl=e.baseUrl??``):Qa&&e.renderRoot.contains(Qa)&&(Qa.remove(),Qa=null)}var eo=class extends b{constructor(...e){super(...e),this.fetchStarted=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!0},this.fetchFinished=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!1},this.fetchFailed=e=>{e.preventDefault(),e.stopPropagation(),this.loading=!1;let t=e.detail??{},n=t.failure??$e(t.reason,{online:at.isOnline()});if(n.kind===`cancelled`)return;let r=t.retry;Pa({text:n.message,variant:`error`,duration:r?8e3:5e3,position:`bottomEnd`,...r?{actionLabel:`Retry`,onAction:r}:{}},this)}}connectedCallback(){super.connectedCallback(),this.addEventListener(`backend-called-event`,this.fetchStarted),this.addEventListener(`backend-succeeded-event`,this.fetchFinished),this.addEventListener(`backend-cancelled-event`,this.fetchFinished),this.addEventListener(`backend-failed-event`,this.fetchFailed)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`backend-called-event`,this.fetchStarted),this.removeEventListener(`backend-succeeded-event`,this.fetchFinished),this.removeEventListener(`backend-cancelled-event`,this.fetchFinished),this.removeEventListener(`backend-failed-event`,this.fetchFailed)}render(){return T`<div class="loader-container">
             <div style="display: flex; flex-direction: column;">
                 <slot></slot>
                 <div class="loader-frame ${this.loading?`delayed-show`:``}" style="${this.loading?`pointer-events: all;`:`display: none;`}"><div class="loader"></div></div>
@@ -5146,11 +5154,11 @@ ${i}
             animation: l5 1s infinite;
         }
         @keyframes l5 {to{transform: rotate(.5turn)}}
-  `}};k([C()],$a.prototype,`loading`,void 0),$a=k([g(`mateu-api-caller`)],$a);var eo=new class{constructor(){this._dirty=!1,this._installed=!1,this.message=`You have unsaved changes. Are you sure you want to leave this page?`,this._onDirty=()=>{this._dirty=!0},this._onClean=()=>{this._dirty=!1},this._onBeforeUnload=e=>{this._dirty&&(e.preventDefault(),e.returnValue=``)}}install(){this._installed||(this._installed=!0,document.addEventListener(`dirty`,this._onDirty),document.addEventListener(`clean`,this._onClean),window.addEventListener(`beforeunload`,this._onBeforeUnload))}get dirty(){return this._dirty}markDirty(){this._dirty=!0}markClean(){this._dirty=!1}confirmLeave(){if(!this._dirty)return!0;let e=window.confirm(this.message);return e&&(this._dirty=!1),e}},to,q=class extends Ua{static{to=this}constructor(...e){super(...e),this.filter=``,this.instant=void 0,this.selectedConsumedRoute=void 0,this.selectedRoute=void 0,this.selectedUriPrefix=void 0,this.selectedBaseUrl=void 0,this.selectedServerSideType=void 0,this.selectedParams=void 0,this.tilesMenuOption=null,this.railOpenOption=null,this.commandPaletteOpen=!1,this.commandPaletteQuery=``,this.commandPaletteSelectedIndex=0,this.commandPaletteDataHits=[],this.openDataHit=e=>{eo.confirmLeave()&&(this.commandPaletteOpen=!1,this.commandPaletteQuery=``,this.commandPaletteDataHits=[],this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:e.route},bubbles:!0,composed:!0})),this.dispatchEvent(new CustomEvent(`navigate-to-requested`,{detail:{route:e.route},bubbles:!0,composed:!0})))},this._commandPaletteHandler=null,this.pageCompact=!1,this._compactHandler=e=>{this.pageCompact=e.detail?.compact??!1},this._openAiHandler=()=>{this.chatOpen||this.showHideIa()},this.isDark=document.documentElement.getAttribute(`theme`)===`dark`,this.chatOpen=!1,this.toggleTheme=()=>{this.isDark=!this.isDark;let e=this.isDark?`dark`:`light`;document.documentElement.setAttribute(`theme`,e),localStorage.setItem(`mateu-theme`,e)},this.showHideIa=()=>{this.chat&&(this.chatOpen=!this.chatOpen,this.chat.slot=this.chatOpen?`detail`:`detail-hidden`)},this.runAction=e=>{let t=this.renderRoot.querySelector?.(`mateu-component`);t&&t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.getSelectedOption=e=>{if(e)for(let t=0;t<e.length;t++){let n=e[t];if(this.selectedRoute?this.isActiveOption(n):n.selected)return n;let r=this.getSelectedOption(n.submenus);if(r)return r}return null},this.itemSelected=e=>{let t=e.detail.value;this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix)},this.itemSelectedTiles=e=>{let t=e.detail.value._menuOption;t.submenus&&t.submenus.length>0?this.tilesMenuOption=t:(this.tilesMenuOption=null,this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix))},this.mapItemsForTiles=e=>e.map(e=>({text:e.label,consumedRoute:e.consumedRoute,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:e.selected,_menuOption:e})),this.flattenMenuForPalette=(e,t)=>{let n=[];for(let r of e)if(!r.separator)if(r.submenus&&r.submenus.length>0){let e=t?`${t} › ${r.label}`:r.label;n.push(...this.flattenMenuForPalette(r.submenus,e))}else n.push({label:r.label,breadcrumb:t,consumedRoute:r.consumedRoute,route:r.route,actionId:r.actionId,baseUrl:r.baseUrl,serverSideType:r.serverSideType,uriPrefix:r.uriPrefix});return n},this.handleCommandPaletteKeydown=(e,t)=>{let n=Math.min(t.length,10),r=n+Math.min(this.commandPaletteDataHits.length,8);if(e.key===`ArrowDown`)e.preventDefault(),this.commandPaletteSelectedIndex=Math.min(this.commandPaletteSelectedIndex+1,r-1);else if(e.key===`ArrowUp`)e.preventDefault(),this.commandPaletteSelectedIndex=Math.max(this.commandPaletteSelectedIndex-1,0);else if(e.key===`Enter`){if(this.commandPaletteSelectedIndex>=n){let e=this.commandPaletteDataHits[this.commandPaletteSelectedIndex-n];e&&this.openDataHit(e);return}let e=t[this.commandPaletteSelectedIndex];e&&(this.selectRoute(e.consumedRoute,e.route,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix),this.commandPaletteOpen=!1,this.commandPaletteQuery=``)}},this.renderCommandPalette=()=>{if(!this.commandPaletteOpen)return v;let e=this.component?.metadata;if(e?.commandCenterEnabled||!e?.menu)return v;let t=this.flattenMenuForPalette(e.menu,``),n=this.commandPaletteQuery.toLowerCase(),r=n?t.filter(e=>e.label.toLowerCase().includes(n)||e.breadcrumb.toLowerCase().includes(n)):t;return T`
+  `}};k([C()],eo.prototype,`loading`,void 0),eo=k([g(`mateu-api-caller`)],eo);var to=new class{constructor(){this._dirty=!1,this._installed=!1,this.message=`You have unsaved changes. Are you sure you want to leave this page?`,this._onDirty=()=>{this._dirty=!0},this._onClean=()=>{this._dirty=!1},this._onBeforeUnload=e=>{this._dirty&&(e.preventDefault(),e.returnValue=``)}}install(){this._installed||(this._installed=!0,document.addEventListener(`dirty`,this._onDirty),document.addEventListener(`clean`,this._onClean),window.addEventListener(`beforeunload`,this._onBeforeUnload))}get dirty(){return this._dirty}markDirty(){this._dirty=!0}markClean(){this._dirty=!1}confirmLeave(){if(!this._dirty)return!0;let e=window.confirm(this.message);return e&&(this._dirty=!1),e}},no,K=class extends Wa{static{no=this}constructor(...e){super(...e),this.filter=``,this.instant=void 0,this.selectedConsumedRoute=void 0,this.selectedRoute=void 0,this.selectedUriPrefix=void 0,this.selectedBaseUrl=void 0,this.selectedServerSideType=void 0,this.selectedParams=void 0,this.tilesMenuOption=null,this.railOpenOption=null,this.commandPaletteOpen=!1,this.commandPaletteQuery=``,this.commandPaletteSelectedIndex=0,this.commandPaletteDataHits=[],this.openDataHit=e=>{to.confirmLeave()&&(this.commandPaletteOpen=!1,this.commandPaletteQuery=``,this.commandPaletteDataHits=[],this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:e.route},bubbles:!0,composed:!0})),this.dispatchEvent(new CustomEvent(`navigate-to-requested`,{detail:{route:e.route},bubbles:!0,composed:!0})))},this._commandPaletteHandler=null,this.pageCompact=!1,this._compactHandler=e=>{this.pageCompact=e.detail?.compact??!1},this._openAiHandler=()=>{this.chatOpen||this.showHideIa()},this.isDark=document.documentElement.getAttribute(`theme`)===`dark`,this.chatOpen=!1,this.toggleTheme=()=>{this.isDark=!this.isDark;let e=this.isDark?`dark`:`light`;document.documentElement.setAttribute(`theme`,e),localStorage.setItem(`mateu-theme`,e)},this.showHideIa=()=>{this.chat&&(this.chatOpen=!this.chatOpen,this.chat.slot=this.chatOpen?`detail`:`detail-hidden`)},this.runAction=e=>{let t=this.renderRoot.querySelector?.(`mateu-component`);t&&t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))},this.getSelectedOption=e=>{if(e)for(let t=0;t<e.length;t++){let n=e[t];if(this.selectedRoute?this.isActiveOption(n):n.selected)return n;let r=this.getSelectedOption(n.submenus);if(r)return r}return null},this.itemSelected=e=>{let t=e.detail.value;this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix)},this.itemSelectedTiles=e=>{let t=e.detail.value._menuOption;t.submenus&&t.submenus.length>0?this.tilesMenuOption=t:(this.tilesMenuOption=null,this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix))},this.mapItemsForTiles=e=>e.map(e=>({text:e.label,consumedRoute:e.consumedRoute,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:e.selected,_menuOption:e})),this.flattenMenuForPalette=(e,t)=>{let n=[];for(let r of e)if(!r.separator)if(r.submenus&&r.submenus.length>0){let e=t?`${t} › ${r.label}`:r.label;n.push(...this.flattenMenuForPalette(r.submenus,e))}else n.push({label:r.label,breadcrumb:t,consumedRoute:r.consumedRoute,route:r.route,actionId:r.actionId,baseUrl:r.baseUrl,serverSideType:r.serverSideType,uriPrefix:r.uriPrefix});return n},this.handleCommandPaletteKeydown=(e,t)=>{let n=Math.min(t.length,10),r=n+Math.min(this.commandPaletteDataHits.length,8);if(e.key===`ArrowDown`)e.preventDefault(),this.commandPaletteSelectedIndex=Math.min(this.commandPaletteSelectedIndex+1,r-1);else if(e.key===`ArrowUp`)e.preventDefault(),this.commandPaletteSelectedIndex=Math.max(this.commandPaletteSelectedIndex-1,0);else if(e.key===`Enter`){if(this.commandPaletteSelectedIndex>=n){let e=this.commandPaletteDataHits[this.commandPaletteSelectedIndex-n];e&&this.openDataHit(e);return}let e=t[this.commandPaletteSelectedIndex];e&&(this.selectRoute(e.consumedRoute,e.route,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix),this.commandPaletteOpen=!1,this.commandPaletteQuery=``)}},this.renderCommandPalette=()=>{if(!this.commandPaletteOpen)return v;let e=this.component?.metadata;if(e?.commandCenterEnabled||!e?.menu)return v;let t=this.flattenMenuForPalette(e.menu,``),n=this.commandPaletteQuery.toLowerCase(),r=n?t.filter(e=>e.label.toLowerCase().includes(n)||e.breadcrumb.toLowerCase().includes(n)):t;return T`
             <div class="cmd-backdrop" @click=${()=>{this.commandPaletteOpen=!1,this.commandPaletteQuery=``}}>
                 <div class="cmd-palette" @click=${e=>e.stopPropagation()}>
                     <div class="cmd-search-wrapper">
-                        ${L(`vaadin:search`,void 0,`cmd-search-icon`)}
+                        ${I(`vaadin:search`,void 0,`cmd-search-icon`)}
                         <input
                             class="cmd-input"
                             placeholder="Go to…"
@@ -5192,7 +5200,7 @@ ${i}
             <div class="rail-item ${(e.submenus?.length>0?this.railOpenOption?.label===e.label:e.selected)?`rail-item--active`:``}"
                 @click=${()=>{e.submenus&&e.submenus.length>0?this.railOpenOption=this.railOpenOption?.label===e.label?null:e:(this.railOpenOption=null,this.selectRoute(e.consumedRoute,e.route,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix))}}
             >
-                ${e.icon?L(e.icon,void 0,`rail-icon`):T`<div class="rail-icon-placeholder">${e.label.charAt(0).toUpperCase()}</div>`}
+                ${e.icon?I(e.icon,void 0,`rail-icon`):T`<div class="rail-icon-placeholder">${e.label.charAt(0).toUpperCase()}</div>`}
                 <span class="rail-label">${e.label}</span>
             </div>
         `,this.renderRailSubPanel=e=>T`
@@ -5212,14 +5220,14 @@ ${i}
                         <div class="nav-tile"
                             @click=${()=>{e.submenus&&e.submenus.length>0?this.tilesMenuOption=e:(this.tilesMenuOption=null,this.selectRoute(e.consumedRoute,e.route,e.actionId,e.baseUrl,e.serverSideType,e.uriPrefix))}}
                         >
-                            ${e.icon?L(e.icon,`font-size: 2rem; color: var(--lumo-primary-color); display: block; margin-bottom: 0.75rem;`):v}
+                            ${e.icon?I(e.icon,`font-size: 2rem; color: var(--lumo-primary-color); display: block; margin-bottom: 0.75rem;`):v}
                             <div class="nav-tile-title">${e.label}</div>
                             ${e.description?T`<div class="nav-tile-desc">${e.description}</div>`:v}
                         </div>
                     `)}
                 </div>
             </div>
-        `,this.goHome=()=>{eo.confirmLeave()&&(window.history.pushState(null,``,`/`),window.dispatchEvent(new PopStateEvent(`popstate`,{state:null})))},this.selectRoute=(e,t,n,r,i,a)=>{eo.confirmLeave()&&this._selectRoute(e,t,n,r,i,a)},this._selectRoute=(e,t,n,r,i,a)=>{{this.selectedConsumedRoute=e,this.selectedBaseUrl=r,this.selectedRoute=t,this.selectedServerSideType=i,this.selectedUriPrefix=a,this.instant=E(),this.state&&this.state._route!=null&&(this.state._route=void 0);let n=this.baseUrl??``;n.indexOf(`://`)<0&&(n.startsWith(`/`)||(n=`/`+n),n=window.location.origin+n),n.endsWith(`/`)&&(t??``).startsWith(`/`)&&(t=(t??``).substring(1));let o=new URL(n+t);if(e&&o.pathname.startsWith(e)){let t=o.pathname.substring(e.length);o=new URL(o.origin+(t||`/`))}if((window.location.pathname||o.pathname)&&window.location.pathname!=o.pathname){let e=o.pathname;o.search&&(e+=o.search),e&&!e.startsWith(`/`)&&(e=`/`+e),this.baseUrl&&e.startsWith(this.baseUrl)&&(e=e.substring(this.baseUrl.length));let t=e;this.selectedUriPrefix&&(t=t.startsWith(`/`)&&this.selectedUriPrefix.endsWith(`/`)?this.selectedUriPrefix+t.substring(1):!t.startsWith(`/`)&&!this.selectedUriPrefix.endsWith(`/`)?this.selectedUriPrefix+`/`+t:this.selectedUriPrefix+t),t==`/_page`&&(t=``),this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0}))}}},this.isActiveOption=e=>this.selectedRoute?!!e.route&&(this.selectedRoute==e.route||this.selectedRoute.startsWith(e.route+`/`)):!!e.selected,this.mapItems=(e,t)=>e.map(e=>{if(e.submenus&&e.submenus.length>0){let n=this.mapItems(e.submenus,t);return t&&e.label.toLowerCase().includes(t)&&(n=this.mapItems(e.submenus,``)),n&&n.length>0?{consumedRoute:e.consumedRoute,text:e.label,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:t||this.isActiveOption(e),children:n}:void 0}if(e.separator)return t?void 0:{component:`hr`};if(!t||e.label.toLowerCase().includes(t))return{consumedRoute:e.consumedRoute,text:e.label,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:t||this.isActiveOption(e)}}).filter(e=>e!=null),this.getSelectedIndex=e=>{if(!e)return NaN;let t=e=>{let t=(e??``).trim();return t.length>1&&t.endsWith(`/`)&&(t=t.slice(0,-1)),t},n=t(this.selectedRoute??window.location.pathname),r=NaN,i=-1;for(let a=0;a<e.length;a++){let o=t(e[a].route);o!==``&&(n===o||n.startsWith(o+`/`))&&o.length>i&&(i=o.length,r=a)}if(!Number.isNaN(r))return r;let a=this.getSelectedOption(e);return a?e.indexOf(a):NaN},this.renderOptionOnLeftMenu=e=>e.submenus&&e.submenus.length>0?T`
+        `,this.goHome=()=>{to.confirmLeave()&&(window.history.pushState(null,``,`/`),window.dispatchEvent(new PopStateEvent(`popstate`,{state:null})))},this.selectRoute=(e,t,n,r,i,a)=>{to.confirmLeave()&&this._selectRoute(e,t,n,r,i,a)},this._selectRoute=(e,t,n,r,i,a)=>{{this.selectedConsumedRoute=e,this.selectedBaseUrl=r,this.selectedRoute=t,this.selectedServerSideType=i,this.selectedUriPrefix=a,this.instant=E(),this.state&&this.state._route!=null&&(this.state._route=void 0);let n=this.baseUrl??``;n.indexOf(`://`)<0&&(n.startsWith(`/`)||(n=`/`+n),n=window.location.origin+n),n.endsWith(`/`)&&(t??``).startsWith(`/`)&&(t=(t??``).substring(1));let o=new URL(n+t);if(e&&o.pathname.startsWith(e)){let t=o.pathname.substring(e.length);o=new URL(o.origin+(t||`/`))}if((window.location.pathname||o.pathname)&&window.location.pathname!=o.pathname){let e=o.pathname;o.search&&(e+=o.search),e&&!e.startsWith(`/`)&&(e=`/`+e),this.baseUrl&&e.startsWith(this.baseUrl)&&(e=e.substring(this.baseUrl.length));let t=e;this.selectedUriPrefix&&(t=t.startsWith(`/`)&&this.selectedUriPrefix.endsWith(`/`)?this.selectedUriPrefix+t.substring(1):!t.startsWith(`/`)&&!this.selectedUriPrefix.endsWith(`/`)?this.selectedUriPrefix+`/`+t:this.selectedUriPrefix+t),t==`/_page`&&(t=``),this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0}))}}},this.isActiveOption=e=>this.selectedRoute?!!e.route&&(this.selectedRoute==e.route||this.selectedRoute.startsWith(e.route+`/`)):!!e.selected,this.mapItems=(e,t)=>e.map(e=>{if(e.submenus&&e.submenus.length>0){let n=this.mapItems(e.submenus,t);return t&&e.label.toLowerCase().includes(t)&&(n=this.mapItems(e.submenus,``)),n&&n.length>0?{consumedRoute:e.consumedRoute,text:e.label,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:t||this.isActiveOption(e),children:n}:void 0}if(e.separator)return t?void 0:{component:`hr`};if(!t||e.label.toLowerCase().includes(t))return{consumedRoute:e.consumedRoute,text:e.label,route:e.route,baseUrl:e.baseUrl,serverSideType:e.serverSideType,uriPrefix:e.uriPrefix,actionId:e.actionId,selected:t||this.isActiveOption(e)}}).filter(e=>e!=null),this.getSelectedIndex=e=>{if(!e)return NaN;let t=e=>{let t=(e??``).trim();return t.length>1&&t.endsWith(`/`)&&(t=t.slice(0,-1)),t},n=t(this.selectedRoute??window.location.pathname),r=NaN,i=-1;for(let a=0;a<e.length;a++){let o=t(e[a].route);o!==``&&(n===o||n.startsWith(o+`/`))&&o.length>i&&(i=o.length,r=a)}if(!Number.isNaN(r))return r;let a=this.getSelectedOption(e);return a?e.indexOf(a):NaN},this.renderOptionOnLeftMenu=e=>e.submenus&&e.submenus.length>0?T`
                 <details open class="left-menu-group">
                     <summary>${e.label}</summary>
                     <div class="left-menu-children">
@@ -5235,14 +5243,14 @@ ${i}
                                 <div class="side-nav-item ${t.selected?`side-nav-item--active`:``}">
                                     <button class="side-nav-link"
                                             @click="${()=>{t.route&&!t.children&&this.selectRoute(void 0,t.route,void 0,this.baseUrl,void 0,void 0)}}">
-                                        ${t.icon?L(`vaadin:dashboard`,`margin-right:.5rem;`):v}${t.text}
+                                        ${t.icon?I(`vaadin:dashboard`,`margin-right:.5rem;`):v}${t.text}
                                     </button>
                                     ${t.children?T`<div class="side-nav-children">${this.renderSideNav(t.children,`children`)}</div>`:v}
                                 </div>
                         `}
 
-                            `})}`:v,this.updateRoute=e=>{e.preventDefault(),e.stopPropagation();var t=e.detail;this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix)}}createRenderRoot(){return F.mustUseShadowRoot()?super.createRenderRoot():(to.injectLightDomStyles(),this)}static{this.lightDomStylesInjected=!1}static injectLightDomStyles(){if(to.lightDomStylesInjected||typeof document>`u`||(to.lightDomStylesInjected=!0,document.getElementById(`mateu-app-light-styles`)))return;let e=to.styles,t=Array.isArray(e)?e.map(e=>e?.cssText??``).join(`
-`):e?.cssText??``;if(!t)return;let n=document.createElement(`style`);n.id=`mateu-app-light-styles`,n.textContent=t,document.head.appendChild(n)}fetchGlobalSearch(e){let t=this.component?.metadata;if(t?.globalSearchEnabled){if(clearTimeout(this._globalSearchTimer),!e){this.commandPaletteDataHits=[];return}this._globalSearchTimer=setTimeout(async()=>{try{let n=(await lt.runAction(this.baseUrl??``,t.rootRoute??``,``,`_globalsearch`,`cmd-palette`,void 0,t.serverSideType,{},{searchText:e},this,!0))?.fragments?.map(e=>e.data).find(e=>e&&e._globalsearch);this.commandPaletteDataHits=n?._globalsearch??[]}catch{this.commandPaletteDataHits=[]}},250)}}connectedCallback(){super.connectedCallback(),this.isDark=document.documentElement.getAttribute(`theme`)===`dark`,this._commandPaletteHandler=e=>{this.component?.metadata?.commandCenterEnabled||((e.metaKey||e.ctrlKey)&&e.key===`k`&&(e.preventDefault(),this.commandPaletteOpen=!this.commandPaletteOpen,this.commandPaletteQuery=``,this.commandPaletteSelectedIndex=0),e.key===`Escape`&&this.commandPaletteOpen&&(this.commandPaletteOpen=!1,this.commandPaletteQuery=``))},document.addEventListener(`keydown`,this._commandPaletteHandler),eo.install(),this.addEventListener(`compact-changed`,this._compactHandler),this.addEventListener(`mateu-open-ai`,this._openAiHandler)}disconnectedCallback(){super.disconnectedCallback(),this._commandPaletteHandler&&document.removeEventListener(`keydown`,this._commandPaletteHandler),this.removeEventListener(`compact-changed`,this._compactHandler),this.removeEventListener(`mateu-open-ai`,this._openAiHandler)}updated(e){if(super.updated(e),Qa(this),this.component){let t=this.component.metadata;if(t){let n=t;if(Ne(n.restSources),n.favicon){let e=document.querySelector(`link[rel~='icon']`);e||(e=document.createElement(`link`),e.rel=`icon`,document.head.appendChild(e)),e.href=n.favicon}e.has(`component`)&&(this.selectedRoute=n.homeRoute,this.selectedConsumedRoute=n.homeConsumedRoute,this.selectedServerSideType=n.homeServerSideType,this.selectedBaseUrl=n.homeBaseUrl,this.selectedUriPrefix=n.homeUriPrefix)}}e.has(`commandPaletteOpen`)&&this.commandPaletteOpen&&setTimeout(()=>{this.renderRoot.querySelector(`.cmd-input`)?.focus()},0)}render(){return F.get()?.renderAppComponent(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData)}static{this.styles=h`
+                            `})}`:v,this.updateRoute=e=>{e.preventDefault(),e.stopPropagation();var t=e.detail;this.selectRoute(t.consumedRoute,t.route,t.actionId,t.baseUrl,t.serverSideType,t.uriPrefix)}}createRenderRoot(){return P.mustUseShadowRoot()?super.createRenderRoot():(no.injectLightDomStyles(),this)}static{this.lightDomStylesInjected=!1}static injectLightDomStyles(){if(no.lightDomStylesInjected||typeof document>`u`||(no.lightDomStylesInjected=!0,document.getElementById(`mateu-app-light-styles`)))return;let e=no.styles,t=Array.isArray(e)?e.map(e=>e?.cssText??``).join(`
+`):e?.cssText??``;if(!t)return;let n=document.createElement(`style`);n.id=`mateu-app-light-styles`,n.textContent=t,document.head.appendChild(n)}fetchGlobalSearch(e){let t=this.component?.metadata;if(t?.globalSearchEnabled){if(clearTimeout(this._globalSearchTimer),!e){this.commandPaletteDataHits=[];return}this._globalSearchTimer=setTimeout(async()=>{try{let n=(await lt.runAction(this.baseUrl??``,t.rootRoute??``,``,`_globalsearch`,`cmd-palette`,void 0,t.serverSideType,{},{searchText:e},this,!0))?.fragments?.map(e=>e.data).find(e=>e&&e._globalsearch);this.commandPaletteDataHits=n?._globalsearch??[]}catch{this.commandPaletteDataHits=[]}},250)}}connectedCallback(){super.connectedCallback(),this.isDark=document.documentElement.getAttribute(`theme`)===`dark`,this._commandPaletteHandler=e=>{this.component?.metadata?.commandCenterEnabled||((e.metaKey||e.ctrlKey)&&e.key===`k`&&(e.preventDefault(),this.commandPaletteOpen=!this.commandPaletteOpen,this.commandPaletteQuery=``,this.commandPaletteSelectedIndex=0),e.key===`Escape`&&this.commandPaletteOpen&&(this.commandPaletteOpen=!1,this.commandPaletteQuery=``))},document.addEventListener(`keydown`,this._commandPaletteHandler),to.install(),this.addEventListener(`compact-changed`,this._compactHandler),this.addEventListener(`mateu-open-ai`,this._openAiHandler)}disconnectedCallback(){super.disconnectedCallback(),this._commandPaletteHandler&&document.removeEventListener(`keydown`,this._commandPaletteHandler),this.removeEventListener(`compact-changed`,this._compactHandler),this.removeEventListener(`mateu-open-ai`,this._openAiHandler)}updated(e){if(super.updated(e),$a(this),this.component){let t=this.component.metadata;if(t){let n=t;if(Ne(n.restSources),n.favicon){let e=document.querySelector(`link[rel~='icon']`);e||(e=document.createElement(`link`),e.rel=`icon`,document.head.appendChild(e)),e.href=n.favicon}e.has(`component`)&&(this.selectedRoute=n.homeRoute,this.selectedConsumedRoute=n.homeConsumedRoute,this.selectedServerSideType=n.homeServerSideType,this.selectedBaseUrl=n.homeBaseUrl,this.selectedUriPrefix=n.homeUriPrefix)}}e.has(`commandPaletteOpen`)&&this.commandPaletteOpen&&setTimeout(()=>{this.renderRoot.querySelector(`.cmd-input`)?.focus()},0)}render(){return P.get()?.renderAppComponent(this,this.component,this.baseUrl,this.state,this.data,this.appState,this.appData)}static{this.styles=h`
         /* DS-neutral app chrome (replaces vaadin-app-layout / menu-bar / tabs / side-nav). */
         .m-hl { display: flex; flex-direction: row; }
         .m-vl { display: flex; flex-direction: column; }
@@ -5592,14 +5600,14 @@ ${i}
             transform: scale(1.08);
         }
 
-  `}};k([C()],q.prototype,`filter`,void 0),k([C()],q.prototype,`instant`,void 0),k([C()],q.prototype,`selectedConsumedRoute`,void 0),k([C()],q.prototype,`selectedRoute`,void 0),k([C()],q.prototype,`selectedUriPrefix`,void 0),k([C()],q.prototype,`selectedBaseUrl`,void 0),k([C()],q.prototype,`selectedServerSideType`,void 0),k([C()],q.prototype,`selectedParams`,void 0),k([C()],q.prototype,`tilesMenuOption`,void 0),k([C()],q.prototype,`railOpenOption`,void 0),k([C()],q.prototype,`commandPaletteOpen`,void 0),k([C()],q.prototype,`commandPaletteQuery`,void 0),k([C()],q.prototype,`commandPaletteSelectedIndex`,void 0),k([C()],q.prototype,`commandPaletteDataHits`,void 0),k([C()],q.prototype,`pageCompact`,void 0),k([x(`mateu-chat`)],q.prototype,`chat`,void 0),k([C()],q.prototype,`isDark`,void 0),k([C()],q.prototype,`chatOpen`,void 0),k([x(`.mateu-app-layout`)],q.prototype,`vaadinAppLayout`,void 0),q=to=k([g(`mateu-app`)],q);var no=class extends b{constructor(...e){super(...e),this.message=`This website uses cookies.`,this.dismiss=`Ok. Thanks :).`,this.learnMore=`Learn more`,this.learnMoreLink=`https://cookiesandyou.com/`,this.showLearnMore=!0,this.position=`top`,this.cookieName=`mateu-cookieconsent`}updated(e){super.updated(e)}connectedCallback(){super.connectedCallback(),this._css=document.createElement(`style`),this._css.innerText=`.cc-window{opacity:1;transition:opacity 1s ease}.cc-window.cc-invisible{opacity:0}.cc-animate.cc-revoke{transition:transform 1s ease}.cc-animate.cc-revoke.cc-top{transform:translateY(-2em)}.cc-animate.cc-revoke.cc-bottom{transform:translateY(2em)}.cc-animate.cc-revoke.cc-active.cc-bottom,.cc-animate.cc-revoke.cc-active.cc-top,.cc-revoke:hover{transform:translateY(0)}.cc-grower{max-height:0;overflow:hidden;transition:max-height 1s}.cc-link,.cc-revoke:hover{text-decoration:underline}.cc-revoke,.cc-window{position:fixed;overflow:hidden;box-sizing:border-box;font-family:Helvetica,Calibri,Arial,sans-serif;font-size:16px;line-height:1.5em;display:flex;flex-wrap:nowrap;z-index:9999}.cc-window.cc-static{position:static}.cc-window.cc-floating{padding:2em;max-width:24em;flex-direction:column}.cc-window.cc-banner{padding:1em 1.8em;width:100%;flex-direction:row}.cc-revoke{padding:.5em}.cc-header{font-size:18px;font-weight:700}.cc-btn,.cc-close,.cc-link,.cc-revoke{cursor:pointer}.cc-link{opacity:.8;display:inline-block;padding:.2em}.cc-link:hover{opacity:1}.cc-link:active,.cc-link:visited{color:initial}.cc-btn{display:block;padding:.4em .8em;font-size:.9em;font-weight:700;border-width:2px;border-style:solid;text-align:center;white-space:nowrap}.cc-banner .cc-btn:last-child{min-width:140px}.cc-highlight .cc-btn:first-child{background-color:transparent;border-color:transparent}.cc-highlight .cc-btn:first-child:focus,.cc-highlight .cc-btn:first-child:hover{background-color:transparent;text-decoration:underline}.cc-close{display:block;position:absolute;top:.5em;right:.5em;font-size:1.6em;opacity:.9;line-height:.75}.cc-close:focus,.cc-close:hover{opacity:1}.cc-revoke.cc-top{top:0;left:3em;border-bottom-left-radius:.5em;border-bottom-right-radius:.5em}.cc-revoke.cc-bottom{bottom:0;left:3em;border-top-left-radius:.5em;border-top-right-radius:.5em}.cc-revoke.cc-left{left:3em;right:unset}.cc-revoke.cc-right{right:3em;left:unset}.cc-top{top:1em}.cc-left{left:1em}.cc-right{right:1em}.cc-bottom{bottom:1em}.cc-floating>.cc-link{margin-bottom:1em}.cc-floating .cc-message{display:block;margin-bottom:1em}.cc-window.cc-floating .cc-compliance{flex:1 0 auto}.cc-window.cc-banner{align-items:center}.cc-banner.cc-top{left:0;right:0;top:0}.cc-banner.cc-bottom{left:0;right:0;bottom:0}.cc-banner .cc-message{flex:1}.cc-compliance{display:flex;align-items:center;align-content:space-between}.cc-compliance>.cc-btn{flex:1}.cc-btn+.cc-btn{margin-left:.5em}@media print{.cc-revoke,.cc-window{display:none}}@media screen and (max-width:900px){.cc-btn{white-space:normal}}@media screen and (max-width:414px) and (orientation:portrait),screen and (max-width:736px) and (orientation:landscape){.cc-window.cc-top{top:0}.cc-window.cc-bottom{bottom:0}.cc-window.cc-banner,.cc-window.cc-left,.cc-window.cc-right{left:0;right:0}.cc-window.cc-banner{flex-direction:column}.cc-window.cc-banner .cc-compliance{flex:1}.cc-window.cc-floating{max-width:none}.cc-window .cc-message{margin-bottom:1em}.cc-window.cc-banner{align-items:unset}}.cc-floating.cc-theme-classic{padding:1.2em;border-radius:5px}.cc-floating.cc-type-info.cc-theme-classic .cc-compliance{text-align:center;display:inline;flex:none}.cc-theme-classic .cc-btn{border-radius:5px}.cc-theme-classic .cc-btn:last-child{min-width:140px}.cc-floating.cc-type-info.cc-theme-classic .cc-btn{display:inline-block}.cc-theme-edgeless.cc-window{padding:0}.cc-floating.cc-theme-edgeless .cc-message{margin:2em 2em 1.5em}.cc-banner.cc-theme-edgeless .cc-btn{margin:0;padding:.8em 1.8em;height:100%}.cc-banner.cc-theme-edgeless .cc-message{margin-left:1em}.cc-floating.cc-theme-edgeless .cc-btn+.cc-btn{margin-left:0}`,document.head.appendChild(this._css),this.__updatePopup()}disconnectedCallback(){super.disconnectedCallback(),this.__closePopup(),this._css.isConnected&&this._css.remove()}__closePopup(){let e=this.popup;e&&e.parentNode?.removeChild(e)}_show(){let e=this.popup;e&&(e.classList.remove(`cc-invisible`),e.style.display=``)}__updatePopup(){this.__closePopup(),window.cookieconsent.initialise({palette:{popup:{background:`#000`},button:{background:`rgba(22, 118, 243, 0.95)`,hover:`rgba(22, 118, 243, 1)`}},showLink:this.showLearnMore,content:{message:this.message,dismiss:this.dismiss,link:this.learnMore,href:this.learnMoreLink},cookie:{name:this.cookieName},position:this.position,elements:{messagelink:`<span id="cookieconsent:desc" class="cc-message">${this.message} <a tabindex="0" class="cc-link" href="${this.learnMoreLink}" target="_blank" rel="noopener noreferrer nofollow">${this.learnMore}</a></span>`,dismiss:`<a tabindex="0" class="cc-btn cc-dismiss">${this.dismiss}</a>`}});let e=this.popup;if(e){e.setAttribute(`role`,`alert`);let t=e.querySelector(`a.cc-btn`);t?.addEventListener(`keydown`,e=>{let n=e.keyCode||e.which;(n===32||n===13)&&t.click()})}}render(){return T`
+  `}};k([C()],K.prototype,`filter`,void 0),k([C()],K.prototype,`instant`,void 0),k([C()],K.prototype,`selectedConsumedRoute`,void 0),k([C()],K.prototype,`selectedRoute`,void 0),k([C()],K.prototype,`selectedUriPrefix`,void 0),k([C()],K.prototype,`selectedBaseUrl`,void 0),k([C()],K.prototype,`selectedServerSideType`,void 0),k([C()],K.prototype,`selectedParams`,void 0),k([C()],K.prototype,`tilesMenuOption`,void 0),k([C()],K.prototype,`railOpenOption`,void 0),k([C()],K.prototype,`commandPaletteOpen`,void 0),k([C()],K.prototype,`commandPaletteQuery`,void 0),k([C()],K.prototype,`commandPaletteSelectedIndex`,void 0),k([C()],K.prototype,`commandPaletteDataHits`,void 0),k([C()],K.prototype,`pageCompact`,void 0),k([x(`mateu-chat`)],K.prototype,`chat`,void 0),k([C()],K.prototype,`isDark`,void 0),k([C()],K.prototype,`chatOpen`,void 0),k([x(`.mateu-app-layout`)],K.prototype,`vaadinAppLayout`,void 0),K=no=k([g(`mateu-app`)],K);var ro=class extends b{constructor(...e){super(...e),this.message=`This website uses cookies.`,this.dismiss=`Ok. Thanks :).`,this.learnMore=`Learn more`,this.learnMoreLink=`https://cookiesandyou.com/`,this.showLearnMore=!0,this.position=`top`,this.cookieName=`mateu-cookieconsent`}updated(e){super.updated(e)}connectedCallback(){super.connectedCallback(),this._css=document.createElement(`style`),this._css.innerText=`.cc-window{opacity:1;transition:opacity 1s ease}.cc-window.cc-invisible{opacity:0}.cc-animate.cc-revoke{transition:transform 1s ease}.cc-animate.cc-revoke.cc-top{transform:translateY(-2em)}.cc-animate.cc-revoke.cc-bottom{transform:translateY(2em)}.cc-animate.cc-revoke.cc-active.cc-bottom,.cc-animate.cc-revoke.cc-active.cc-top,.cc-revoke:hover{transform:translateY(0)}.cc-grower{max-height:0;overflow:hidden;transition:max-height 1s}.cc-link,.cc-revoke:hover{text-decoration:underline}.cc-revoke,.cc-window{position:fixed;overflow:hidden;box-sizing:border-box;font-family:Helvetica,Calibri,Arial,sans-serif;font-size:16px;line-height:1.5em;display:flex;flex-wrap:nowrap;z-index:9999}.cc-window.cc-static{position:static}.cc-window.cc-floating{padding:2em;max-width:24em;flex-direction:column}.cc-window.cc-banner{padding:1em 1.8em;width:100%;flex-direction:row}.cc-revoke{padding:.5em}.cc-header{font-size:18px;font-weight:700}.cc-btn,.cc-close,.cc-link,.cc-revoke{cursor:pointer}.cc-link{opacity:.8;display:inline-block;padding:.2em}.cc-link:hover{opacity:1}.cc-link:active,.cc-link:visited{color:initial}.cc-btn{display:block;padding:.4em .8em;font-size:.9em;font-weight:700;border-width:2px;border-style:solid;text-align:center;white-space:nowrap}.cc-banner .cc-btn:last-child{min-width:140px}.cc-highlight .cc-btn:first-child{background-color:transparent;border-color:transparent}.cc-highlight .cc-btn:first-child:focus,.cc-highlight .cc-btn:first-child:hover{background-color:transparent;text-decoration:underline}.cc-close{display:block;position:absolute;top:.5em;right:.5em;font-size:1.6em;opacity:.9;line-height:.75}.cc-close:focus,.cc-close:hover{opacity:1}.cc-revoke.cc-top{top:0;left:3em;border-bottom-left-radius:.5em;border-bottom-right-radius:.5em}.cc-revoke.cc-bottom{bottom:0;left:3em;border-top-left-radius:.5em;border-top-right-radius:.5em}.cc-revoke.cc-left{left:3em;right:unset}.cc-revoke.cc-right{right:3em;left:unset}.cc-top{top:1em}.cc-left{left:1em}.cc-right{right:1em}.cc-bottom{bottom:1em}.cc-floating>.cc-link{margin-bottom:1em}.cc-floating .cc-message{display:block;margin-bottom:1em}.cc-window.cc-floating .cc-compliance{flex:1 0 auto}.cc-window.cc-banner{align-items:center}.cc-banner.cc-top{left:0;right:0;top:0}.cc-banner.cc-bottom{left:0;right:0;bottom:0}.cc-banner .cc-message{flex:1}.cc-compliance{display:flex;align-items:center;align-content:space-between}.cc-compliance>.cc-btn{flex:1}.cc-btn+.cc-btn{margin-left:.5em}@media print{.cc-revoke,.cc-window{display:none}}@media screen and (max-width:900px){.cc-btn{white-space:normal}}@media screen and (max-width:414px) and (orientation:portrait),screen and (max-width:736px) and (orientation:landscape){.cc-window.cc-top{top:0}.cc-window.cc-bottom{bottom:0}.cc-window.cc-banner,.cc-window.cc-left,.cc-window.cc-right{left:0;right:0}.cc-window.cc-banner{flex-direction:column}.cc-window.cc-banner .cc-compliance{flex:1}.cc-window.cc-floating{max-width:none}.cc-window .cc-message{margin-bottom:1em}.cc-window.cc-banner{align-items:unset}}.cc-floating.cc-theme-classic{padding:1.2em;border-radius:5px}.cc-floating.cc-type-info.cc-theme-classic .cc-compliance{text-align:center;display:inline;flex:none}.cc-theme-classic .cc-btn{border-radius:5px}.cc-theme-classic .cc-btn:last-child{min-width:140px}.cc-floating.cc-type-info.cc-theme-classic .cc-btn{display:inline-block}.cc-theme-edgeless.cc-window{padding:0}.cc-floating.cc-theme-edgeless .cc-message{margin:2em 2em 1.5em}.cc-banner.cc-theme-edgeless .cc-btn{margin:0;padding:.8em 1.8em;height:100%}.cc-banner.cc-theme-edgeless .cc-message{margin-left:1em}.cc-floating.cc-theme-edgeless .cc-btn+.cc-btn{margin-left:0}`,document.head.appendChild(this._css),this.__updatePopup()}disconnectedCallback(){super.disconnectedCallback(),this.__closePopup(),this._css.isConnected&&this._css.remove()}__closePopup(){let e=this.popup;e&&e.parentNode?.removeChild(e)}_show(){let e=this.popup;e&&(e.classList.remove(`cc-invisible`),e.style.display=``)}__updatePopup(){this.__closePopup(),window.cookieconsent.initialise({palette:{popup:{background:`#000`},button:{background:`rgba(22, 118, 243, 0.95)`,hover:`rgba(22, 118, 243, 1)`}},showLink:this.showLearnMore,content:{message:this.message,dismiss:this.dismiss,link:this.learnMore,href:this.learnMoreLink},cookie:{name:this.cookieName},position:this.position,elements:{messagelink:`<span id="cookieconsent:desc" class="cc-message">${this.message} <a tabindex="0" class="cc-link" href="${this.learnMoreLink}" target="_blank" rel="noopener noreferrer nofollow">${this.learnMore}</a></span>`,dismiss:`<a tabindex="0" class="cc-btn cc-dismiss">${this.dismiss}</a>`}});let e=this.popup;if(e){e.setAttribute(`role`,`alert`);let t=e.querySelector(`a.cc-btn`);t?.addEventListener(`keydown`,e=>{let n=e.keyCode||e.which;(n===32||n===13)&&t.click()})}}render(){return T`
        `}static{this.styles=h`
-  `}};k([y()],no.prototype,`message`,void 0),k([y()],no.prototype,`dismiss`,void 0),k([y()],no.prototype,`learnMore`,void 0),k([y()],no.prototype,`learnMoreLink`,void 0),k([y()],no.prototype,`showLearnMore`,void 0),k([y()],no.prototype,`position`,void 0),k([y()],no.prototype,`cookieName`,void 0),k([C()],no.prototype,`_css`,void 0),k([x(`[aria-label="cookieconsent"]`)],no.prototype,`popup`,void 0),no=k([g(`mateu-cookie-consent`)],no);var ro=class extends b{constructor(...e){super(...e),this.redispatchEvent=e=>{e instanceof CustomEvent&&(e.stopPropagation(),e.preventDefault(),this.target?.dispatchEvent(new CustomEvent(e.type,{detail:e.detail,bubbles:!0,composed:!0})))}}connectedCallback(){super.connectedCallback(),this.addEventListener(`value-changed`,this.redispatchEvent),this.addEventListener(`data-changed`,this.redispatchEvent),this.addEventListener(`action-requested`,this.redispatchEvent),this.addEventListener(`server-side-action-requested`,this.redispatchEvent),this.addEventListener(`route-changed`,this.redispatchEvent),this.addEventListener(`close-modal-requested`,this.redispatchEvent)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`value-changed`,this.redispatchEvent),this.removeEventListener(`data-changed`,this.redispatchEvent),this.removeEventListener(`action-requested`,this.redispatchEvent),this.removeEventListener(`server-side-action-requested`,this.redispatchEvent),this.removeEventListener(`route-changed`,this.redispatchEvent)}render(){return T`<slot></slot>`}static{this.styles=h`
+  `}};k([y()],ro.prototype,`message`,void 0),k([y()],ro.prototype,`dismiss`,void 0),k([y()],ro.prototype,`learnMore`,void 0),k([y()],ro.prototype,`learnMoreLink`,void 0),k([y()],ro.prototype,`showLearnMore`,void 0),k([y()],ro.prototype,`position`,void 0),k([y()],ro.prototype,`cookieName`,void 0),k([C()],ro.prototype,`_css`,void 0),k([x(`[aria-label="cookieconsent"]`)],ro.prototype,`popup`,void 0),ro=k([g(`mateu-cookie-consent`)],ro);var io=class extends b{constructor(...e){super(...e),this.redispatchEvent=e=>{e instanceof CustomEvent&&(e.stopPropagation(),e.preventDefault(),this.target?.dispatchEvent(new CustomEvent(e.type,{detail:e.detail,bubbles:!0,composed:!0})))}}connectedCallback(){super.connectedCallback(),this.addEventListener(`value-changed`,this.redispatchEvent),this.addEventListener(`data-changed`,this.redispatchEvent),this.addEventListener(`action-requested`,this.redispatchEvent),this.addEventListener(`server-side-action-requested`,this.redispatchEvent),this.addEventListener(`route-changed`,this.redispatchEvent),this.addEventListener(`close-modal-requested`,this.redispatchEvent)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`value-changed`,this.redispatchEvent),this.removeEventListener(`data-changed`,this.redispatchEvent),this.removeEventListener(`action-requested`,this.redispatchEvent),this.removeEventListener(`server-side-action-requested`,this.redispatchEvent),this.removeEventListener(`route-changed`,this.redispatchEvent)}render(){return T`<slot></slot>`}static{this.styles=h`
         :host {
             /* width: 100%; */
             display: inline-block;
         }
-  `}};k([y()],ro.prototype,`target`,void 0),ro=k([g(`mateu-event-interceptor`)],ro);var io=[`a[href]`,`button`,`input`,`select`,`textarea`,`[tabindex]`,`vaadin-button`,`vaadin-text-field`,`vaadin-combo-box`,`vaadin-select`,`vaadin-checkbox`,`vaadin-date-picker`,`ui5-button`,`oj-c-button`].join(`,`),ao=e=>{let t=e;return t.hidden||t.hasAttribute(`disabled`)||t.getAttribute(`aria-hidden`)===`true`||t.getAttribute(`tabindex`)===`-1`?!1:!!(t.offsetParent||t.getClientRects().length)},oo=e=>{let t=[],n=e=>{e.querySelectorAll(`*`).forEach(e=>{e.matches(io)&&ao(e)&&t.push(e),e.shadowRoot&&n(e.shadowRoot),e instanceof HTMLSlotElement&&e.assignedElements().forEach(e=>{e.matches(io)&&ao(e)&&t.push(e),n(e)})})};return n(e),t.filter((e,n)=>t.indexOf(e)===n)},so=(e,t={})=>{let n=co(),r=[],i=()=>{r=oo(e)},a=t=>{if(t.key!==`Tab`)return;if(i(),r.length===0){t.preventDefault(),e.focus();return}let n=r[0],a=r[r.length-1],o=co();t.shiftKey&&(o===n||!o||!lo(o,e))?(t.preventDefault(),a.focus()):!t.shiftKey&&o===a&&(t.preventDefault(),n.focus())};return e.addEventListener(`keydown`,a),requestAnimationFrame(()=>{i();let n=t.initialFocus?.()??r[0];n?n.focus():(e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus())}),{refresh:i,release(){e.removeEventListener(`keydown`,a);let t=co();(!t||t===document.body||lo(t,e))&&n?.focus?.()}}},co=()=>{let e=document.activeElement;for(;e?.shadowRoot?.activeElement;)e=e.shadowRoot.activeElement;return e},lo=(e,t)=>{let n=e;for(;n;){if(n===t)return!0;n=n.parentNode??n.host??null}return!1},uo=class extends Ua{constructor(...e){super(...e),this.opened=!0,this.close=()=>{this.opened=!1,this.releaseFocusTrap(),setTimeout(()=>{this.removeSelfFromOwnerChildren()||this.parentElement?.removeChild(this)},500)},this.onKeydown=e=>{e.key===`Escape`&&this.opened&&(e.stopPropagation(),this.close())}}connectedCallback(){super.connectedCallback(),this.addEventListener(`keydown`,this.onKeydown)}disconnectedCallback(){super.disconnectedCallback(),this.releaseFocusTrap()}releaseFocusTrap(){this.focusTrap?.release(),this.focusTrap=void 0}applyFragment(e){super.applyFragment(e);let t=e.state?._closeAfterMillis;t&&setTimeout(()=>this.close(),t)}updated(e){if(super.updated(e),e.has(`component`)&&this.component){let e=this.component.metadata;this.state=e.initialData}let t=this.renderRoot.querySelector(`[role="dialog"]`),n=this.component?.metadata?.modeless;this.opened&&t&&!this.focusTrap&&!n?this.focusTrap=so(t):this.focusTrap&&this.opened&&this.focusTrap.refresh()}render(){if(!this.opened)return T``;let e=this.component.metadata,t=xt(e.headerTitle,this.state,this.data,this.appState,this.appData),n=!!(t||e.header||e.closeButtonOnHeader),r=[e.width?`width:${e.width};`:`min-width:min(90vw,28rem);`,e.height?`height:${e.height};`:``,e.top?`margin-top:${e.top};`:``].join(``);return T`
+  `}};k([y()],io.prototype,`target`,void 0),io=k([g(`mateu-event-interceptor`)],io);var ao=[`a[href]`,`button`,`input`,`select`,`textarea`,`[tabindex]`,`vaadin-button`,`vaadin-text-field`,`vaadin-combo-box`,`vaadin-select`,`vaadin-checkbox`,`vaadin-date-picker`,`ui5-button`,`oj-c-button`].join(`,`),oo=e=>{let t=e;return t.hidden||t.hasAttribute(`disabled`)||t.getAttribute(`aria-hidden`)===`true`||t.getAttribute(`tabindex`)===`-1`?!1:!!(t.offsetParent||t.getClientRects().length)},so=e=>{let t=[],n=e=>{e.querySelectorAll(`*`).forEach(e=>{e.matches(ao)&&oo(e)&&t.push(e),e.shadowRoot&&n(e.shadowRoot),e instanceof HTMLSlotElement&&e.assignedElements().forEach(e=>{e.matches(ao)&&oo(e)&&t.push(e),n(e)})})};return n(e),t.filter((e,n)=>t.indexOf(e)===n)},co=(e,t={})=>{let n=lo(),r=[],i=()=>{r=so(e)},a=t=>{if(t.key!==`Tab`)return;if(i(),r.length===0){t.preventDefault(),e.focus();return}let n=r[0],a=r[r.length-1],o=lo();t.shiftKey&&(o===n||!o||!uo(o,e))?(t.preventDefault(),a.focus()):!t.shiftKey&&o===a&&(t.preventDefault(),n.focus())};return e.addEventListener(`keydown`,a),requestAnimationFrame(()=>{i();let n=t.initialFocus?.()??r[0];n?n.focus():(e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus())}),{refresh:i,release(){e.removeEventListener(`keydown`,a);let t=lo();(!t||t===document.body||uo(t,e))&&n?.focus?.()}}},lo=()=>{let e=document.activeElement;for(;e?.shadowRoot?.activeElement;)e=e.shadowRoot.activeElement;return e},uo=(e,t)=>{let n=e;for(;n;){if(n===t)return!0;n=n.parentNode??n.host??null}return!1},fo=class extends Wa{constructor(...e){super(...e),this.opened=!0,this.close=()=>{this.opened=!1,this.releaseFocusTrap(),setTimeout(()=>{this.removeSelfFromOwnerChildren()||this.parentElement?.removeChild(this)},500)},this.onKeydown=e=>{e.key===`Escape`&&this.opened&&(e.stopPropagation(),this.close())}}connectedCallback(){super.connectedCallback(),this.addEventListener(`keydown`,this.onKeydown)}disconnectedCallback(){super.disconnectedCallback(),this.releaseFocusTrap()}releaseFocusTrap(){this.focusTrap?.release(),this.focusTrap=void 0}applyFragment(e){super.applyFragment(e);let t=e.state?._closeAfterMillis;t&&setTimeout(()=>this.close(),t)}updated(e){if(super.updated(e),e.has(`component`)&&this.component){let e=this.component.metadata;this.state=e.initialData}let t=this.renderRoot.querySelector(`[role="dialog"]`),n=this.component?.metadata?.modeless;this.opened&&t&&!this.focusTrap&&!n?this.focusTrap=co(t):this.focusTrap&&this.opened&&this.focusTrap.refresh()}render(){if(!this.opened)return T``;let e=this.component.metadata,t=xt(e.headerTitle,this.state,this.data,this.appState,this.appData),n=!!(t||e.header||e.closeButtonOnHeader),r=[e.width?`width:${e.width};`:`min-width:min(90vw,28rem);`,e.height?`height:${e.height};`:``,e.top?`margin-top:${e.top};`:``].join(``);return T`
             <div class="backdrop ${e.modeless?`modeless`:``}"
                  @click="${t=>{!e.modeless&&t.target===t.currentTarget&&this.close()}}">
                 <div class="dialog ${e.noPadding?`no-padding`:``} ${this.component?.cssClasses??``}"
@@ -5611,20 +5619,20 @@ ${i}
                         <div class="dialog-header">
                             <mateu-event-interceptor .target="${this}" style="flex:1; min-width:0;">
                                 ${t?T`<span class="dialog-title">${t}</span>`:v}
-                                ${e.header?I(this,e.header,this.baseUrl,this.state,this.data,this.appState,this.appData):v}
+                                ${e.header?F(this,e.header,this.baseUrl,this.state,this.data,this.appState,this.appData):v}
                             </mateu-event-interceptor>
                             ${e.closeButtonOnHeader?T`<button class="dialog-close" @click="${this.close}" aria-label="Close">✕</button>`:v}
                         </div>`:v}
                     ${e.content?T`
                         <div class="dialog-body">
                             <mateu-event-interceptor .target="${this}" style="--mateu-section-border: none; width:100%;">
-                                ${I(this,e.content,this.baseUrl,this.state,this.data,this.appState,this.appData)}
+                                ${F(this,e.content,this.baseUrl,this.state,this.data,this.appState,this.appData)}
                             </mateu-event-interceptor>
                         </div>`:v}
                     ${e.footer?T`
                         <div class="dialog-footer">
                             <mateu-event-interceptor .target="${this}" style="width:100%;">
-                                ${I(this,e.footer,this.baseUrl,this.state,this.data,this.appState,this.appData)}
+                                ${F(this,e.footer,this.baseUrl,this.state,this.data,this.appState,this.appData)}
                             </mateu-event-interceptor>
                         </div>`:v}
                 </div>
@@ -5654,7 +5662,7 @@ ${i}
         .dialog-body { padding: .5rem 1.2rem; flex: 1; }
         .dialog.no-padding .dialog-body { padding: 0; }
         .dialog-footer { padding: .5rem 1.2rem 1rem; display: flex; justify-content: flex-end; gap: .5rem; }
-    `}};k([C()],uo.prototype,`opened`,void 0),uo=k([g(`mateu-dialog`)],uo);var fo,po=class extends Ua{static{fo=this}constructor(...e){super(...e),this.opened=!1,this.maximizeSteps=0,this.collapsed=!1,this.pagerMenuOpen=!1,this.onGuidedProgress=e=>{let t=e.detail;t&&t.total>0&&(this.guidedProgress=t)},this.close=()=>{this.opened=!1,this.releaseLayoutInset(),this.releaseFocusTrap(),setTimeout(()=>{this.removeSelfFromOwnerChildren()||this.parentElement?.removeChild(this)},300)},this._escListener=e=>{if(e.key!==`Escape`)return;let t=this.getRootNode().querySelectorAll(`mateu-drawer, mateu-dialog`);t[t.length-1]===this&&(e.stopPropagation(),this.close())}}jumpToStep(e){this.pagerMenuOpen=!1,e&&(this.renderRoot.querySelector(`.content mateu-component`)??this.renderRoot.querySelector(`mateu-component`))?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`goToStep`,parameters:{_stepId:e}},bubbles:!0,composed:!0}))}static{this.SIZE_LADDER=[`s`,`m`,`l`,`xl`]}static{this.SIZE_WIDTHS={s:`464px`,m:`648px`,l:`968px`,xl:`90vw`}}effectiveWidth(e){if(e.width)return e.width;if(!e.size)return;let t=fo.SIZE_LADDER,n=Math.max(0,t.indexOf(e.size)),r=Math.min(t.length-1,n+this.maximizeSteps);return fo.SIZE_WIDTHS[t[r]]}canMaximize(e){if(!e.maximizable)return!1;let t=fo.SIZE_LADDER;return Math.max(0,t.indexOf(e.size??`m`))+this.maximizeSteps<t.length-1}firstUpdated(){requestAnimationFrame(()=>this.opened=!0),this.addEventListener(`mateu-guided-progress`,this.onGuidedProgress);let e=this.component?.metadata;e&&requestAnimationFrame(()=>this.applyLayoutInset(e))}releaseFocusTrap(){this.focusTrap?.release(),this.focusTrap=void 0}applyLayoutInset(e){if(!e.layout)return;let t=document.querySelector(`mateu-ui`);if(!t)return;let n=e.position??`end`,r=n===`bottom`?`var(--mateu-drawer-height, 50vh)`:this.effectiveWidth(e)??`648px`;this._insetProp=n===`start`?`paddingLeft`:n===`bottom`?`paddingBottom`:`paddingRight`,t.style.transition=`padding .25s ease`,t.style[this._insetProp]=r}releaseLayoutInset(){if(!this._insetProp)return;let e=document.querySelector(`mateu-ui`);e&&(e.style[this._insetProp]=``),this._insetProp=void 0}applyFragment(e){super.applyFragment(e);let t=e.state?._closeAfterMillis;t&&setTimeout(()=>this.close(),t)}updated(e){if(super.updated(e),e.has(`component`)&&this.component){let e=this.component.metadata;this.state=e.initialData}let t=this.component?.metadata,n=this.renderRoot.querySelector(`[role="dialog"]`);this.opened&&n&&!t?.modeless&&!t?.layout&&!this.focusTrap?this.focusTrap=so(n):this.focusTrap&&this.opened&&this.focusTrap.refresh()}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._escListener)}disconnectedCallback(){document.removeEventListener(`keydown`,this._escListener),this.releaseLayoutInset(),this.releaseFocusTrap(),super.disconnectedCallback()}render(){let e=this.component.metadata,t=e.position??`end`,n=xt(e.headerTitle,this.state,this.data,this.appState,this.appData),r=xt(e.subtitle,this.state,this.data,this.appState,this.appData),i=this.effectiveWidth(e),a=e.peerNav&&(e.peerNav.prevRoute||e.peerNav.nextRoute)?e.peerNav:void 0;return T`
+    `}};k([C()],fo.prototype,`opened`,void 0),fo=k([g(`mateu-dialog`)],fo);var po,mo=class extends Wa{static{po=this}constructor(...e){super(...e),this.opened=!1,this.maximizeSteps=0,this.collapsed=!1,this.pagerMenuOpen=!1,this.onGuidedProgress=e=>{let t=e.detail;t&&t.total>0&&(this.guidedProgress=t)},this.close=()=>{this.opened=!1,this.releaseLayoutInset(),this.releaseFocusTrap(),setTimeout(()=>{this.removeSelfFromOwnerChildren()||this.parentElement?.removeChild(this)},300)},this._escListener=e=>{if(e.key!==`Escape`)return;let t=this.getRootNode().querySelectorAll(`mateu-drawer, mateu-dialog`);t[t.length-1]===this&&(e.stopPropagation(),this.close())}}jumpToStep(e){this.pagerMenuOpen=!1,e&&(this.renderRoot.querySelector(`.content mateu-component`)??this.renderRoot.querySelector(`mateu-component`))?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`goToStep`,parameters:{_stepId:e}},bubbles:!0,composed:!0}))}static{this.SIZE_LADDER=[`s`,`m`,`l`,`xl`]}static{this.SIZE_WIDTHS={s:`464px`,m:`648px`,l:`968px`,xl:`90vw`}}effectiveWidth(e){if(e.width)return e.width;if(!e.size)return;let t=po.SIZE_LADDER,n=Math.max(0,t.indexOf(e.size)),r=Math.min(t.length-1,n+this.maximizeSteps);return po.SIZE_WIDTHS[t[r]]}canMaximize(e){if(!e.maximizable)return!1;let t=po.SIZE_LADDER;return Math.max(0,t.indexOf(e.size??`m`))+this.maximizeSteps<t.length-1}firstUpdated(){requestAnimationFrame(()=>this.opened=!0),this.addEventListener(`mateu-guided-progress`,this.onGuidedProgress);let e=this.component?.metadata;e&&requestAnimationFrame(()=>this.applyLayoutInset(e))}releaseFocusTrap(){this.focusTrap?.release(),this.focusTrap=void 0}applyLayoutInset(e){if(!e.layout)return;let t=document.querySelector(`mateu-ui`);if(!t)return;let n=e.position??`end`,r=n===`bottom`?`var(--mateu-drawer-height, 50vh)`:this.effectiveWidth(e)??`648px`;this._insetProp=n===`start`?`paddingLeft`:n===`bottom`?`paddingBottom`:`paddingRight`,t.style.transition=`padding .25s ease`,t.style[this._insetProp]=r}releaseLayoutInset(){if(!this._insetProp)return;let e=document.querySelector(`mateu-ui`);e&&(e.style[this._insetProp]=``),this._insetProp=void 0}applyFragment(e){super.applyFragment(e);let t=e.state?._closeAfterMillis;t&&setTimeout(()=>this.close(),t)}updated(e){if(super.updated(e),e.has(`component`)&&this.component){let e=this.component.metadata;this.state=e.initialData}let t=this.component?.metadata,n=this.renderRoot.querySelector(`[role="dialog"]`);this.opened&&n&&!t?.modeless&&!t?.layout&&!this.focusTrap?this.focusTrap=co(n):this.focusTrap&&this.opened&&this.focusTrap.refresh()}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._escListener)}disconnectedCallback(){document.removeEventListener(`keydown`,this._escListener),this.releaseLayoutInset(),this.releaseFocusTrap(),super.disconnectedCallback()}render(){let e=this.component.metadata,t=e.position??`end`,n=xt(e.headerTitle,this.state,this.data,this.appState,this.appData),r=xt(e.subtitle,this.state,this.data,this.appState,this.appData),i=this.effectiveWidth(e),a=e.peerNav&&(e.peerNav.prevRoute||e.peerNav.nextRoute)?e.peerNav:void 0;return T`
         ${e.modeless||e.layout?v:T`
             <div class="backdrop ${this.opened?`open`:``}" @click="${this.close}"></div>
         `}
@@ -5683,7 +5691,7 @@ ${i}
                     </div>
                 `:v}
                 ${e.header?T`
-                    <mateu-event-interceptor .target="${this}">${I(this,e.header,this.baseUrl,this.state,this.data,this.appState,this.appData)}</mateu-event-interceptor>
+                    <mateu-event-interceptor .target="${this}">${F(this,e.header,this.baseUrl,this.state,this.data,this.appState,this.appData)}</mateu-event-interceptor>
                 `:v}
                 ${a?T`
                     <button class="drawer-icon" aria-label="${a.prevLabel??`Previous`}" title="${a.prevLabel??`Previous`}"
@@ -5703,12 +5711,12 @@ ${i}
             ${this.collapsed?v:T`
             <div class="content ${e.noPadding?`no-padding`:``}">
                 ${e.content?T`
-                    <mateu-event-interceptor .target="${this}" style="--mateu-section-border: none; width: 100%;">${I(this,e.content,this.baseUrl,this.state,this.data,this.appState,this.appData)}</mateu-event-interceptor>
+                    <mateu-event-interceptor .target="${this}" style="--mateu-section-border: none; width: 100%;">${F(this,e.content,this.baseUrl,this.state,this.data,this.appState,this.appData)}</mateu-event-interceptor>
                 `:v}
             </div>
             ${e.footer?T`
                 <footer>
-                    <mateu-event-interceptor .target="${this}" style="width: 100%;">${I(this,e.footer,this.baseUrl,this.state,this.data,this.appState,this.appData)}</mateu-event-interceptor>
+                    <mateu-event-interceptor .target="${this}" style="width: 100%;">${F(this,e.footer,this.baseUrl,this.state,this.data,this.appState,this.appData)}</mateu-event-interceptor>
                 </footer>
             `:v}
             `}
@@ -5932,7 +5940,7 @@ ${i}
             display: flex;
             justify-content: flex-end;
         }
-  `}};k([C()],po.prototype,`opened`,void 0),k([C()],po.prototype,`maximizeSteps`,void 0),k([C()],po.prototype,`collapsed`,void 0),k([C()],po.prototype,`guidedProgress`,void 0),k([C()],po.prototype,`pagerMenuOpen`,void 0),po=fo=k([g(`mateu-drawer`)],po);function mo(e){if(e.parentElement)return e.parentElement;let t=e.getRootNode();return t instanceof ShadowRoot?t.host:null}var J=class extends b{constructor(...e){super(...e),this.appState={},this.appData={},this.standalone=!1,this.actionBanners=[],this.dismissedStaticBannerIndices=new Set,this._tocEntries=[],this._activeToc=0,this._tocVisible=!1,this._tocRebuildScheduled=!1,this._headerH=0,this._onResize=()=>this._layoutStickyTops(),this._tocLocked=!1,this._unlockToc=e=>{if(e&&e.type===`keydown`){let t=e;if(t.ctrlKey&&t.altKey&&!t.shiftKey&&!t.metaKey&&/^(?:Digit|Numpad)[1-9]$/.test(t.code))return}this._tocLocked=!1},this._actionBannerTimers=[],this._staticBannerTimers=[],this._bannersHandler=e=>{let t=e.detail,n=t.banners??[],r=t.append??!1;r?this.actionBanners=[...this.actionBanners,...n]:(this._clearActionBannerTimers(),this.actionBanners=n);let i=r?this.actionBanners.length-n.length:0;n.forEach((e,t)=>{if(e.timeoutSeconds&&e.timeoutSeconds>0){let n=i+t;this._actionBannerTimers.push(setTimeout(()=>{this.actionBanners=this.actionBanners.filter((e,t)=>t!==n)},e.timeoutSeconds*1e3))}})},this._onTocKey=e=>{if(!this._tocVisible||!e.ctrlKey||!e.altKey||e.shiftKey||e.metaKey)return;let t=/^(?:Digit|Numpad)([1-9])$/.exec(e.code);if(!t)return;let n=parseInt(t[1],10)-1;n>=this._tocEntries.length||(e.preventDefault(),this._scrollToSection(n))},this._onScrollSpy=()=>{if(this._tocLocked)return;let e=this._sectionCards();if(!e.length)return;let t=this.shadowRoot?.querySelector(`mateu-content-header`),n=t?t.getBoundingClientRect().bottom:0;for(let t of e){if(!t.classList.contains(`mateu-section--sticky`))continue;let e=t.getBoundingClientRect();e.top<=n+12+2&&(n=Math.max(n,e.bottom))}let r=n+12+4,i=0;this._tocEntries.forEach((e,t)=>{e.el.getBoundingClientRect().top<=r&&(i=t)}),this._activeToc=i}}connectedCallback(){super.connectedCallback(),document.addEventListener(`page-banners-received`,this._bannersHandler),window.addEventListener(`resize`,this._onResize),document.addEventListener(`keydown`,this._onTocKey)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`page-banners-received`,this._bannersHandler),window.removeEventListener(`resize`,this._onResize),document.removeEventListener(`keydown`,this._onTocKey),this._clearAllTimers(),this._teardownScrollSpy()}updated(e){if(super.updated(e),e.has(`component`)&&e.get(`component`)!==void 0&&(this._clearAllTimers(),this.actionBanners=[],this.dismissedStaticBannerIndices=new Set),e.has(`component`)){let e=this.component?.metadata?.level??0;this.toggleAttribute(`data-nested`,e>0),this._scheduleStaticBannerTimeouts();let t=this.component?.metadata?.pageWidth===`edgeToEdge`;this.toggleAttribute(`data-edge`,t),this.dispatchEvent(new CustomEvent(`compact-changed`,{detail:{compact:!!this.component?.style?.includes(`--mateu-compact:1`)||t},bubbles:!0,composed:!0})),this._scheduleTocRebuild()}}_scheduleStaticBannerTimeouts(){this._staticBannerTimers.forEach(e=>clearTimeout(e)),this._staticBannerTimers=[],(this.component?.metadata?.banners??[]).forEach((e,t)=>{e.timeoutSeconds&&e.timeoutSeconds>0&&this._staticBannerTimers.push(setTimeout(()=>{this.dismissedStaticBannerIndices=new Set([...this.dismissedStaticBannerIndices,t])},e.timeoutSeconds*1e3))})}_clearActionBannerTimers(){this._actionBannerTimers.forEach(e=>clearTimeout(e)),this._actionBannerTimers=[]}_clearAllTimers(){this._clearActionBannerTimers(),this._staticBannerTimers.forEach(e=>clearTimeout(e)),this._staticBannerTimers=[]}_dismissActionBanner(e){this.actionBanners=this.actionBanners.filter((t,n)=>n!==e)}_dismissStaticBanner(e){this.dismissedStaticBannerIndices=new Set([...this.dismissedStaticBannerIndices,e])}bannerThemeClass(e){let t=e.theme?.toLowerCase()??`info`;return t===`none`?``:t}_evalBannerText(e){return M(e,this.state,this.data)}_renderBanner(e,t){let n=this._evalBannerText(e.title),r=this._evalBannerText(e.description);return T`
+  `}};k([C()],mo.prototype,`opened`,void 0),k([C()],mo.prototype,`maximizeSteps`,void 0),k([C()],mo.prototype,`collapsed`,void 0),k([C()],mo.prototype,`guidedProgress`,void 0),k([C()],mo.prototype,`pagerMenuOpen`,void 0),mo=po=k([g(`mateu-drawer`)],mo);function ho(e){if(e.parentElement)return e.parentElement;let t=e.getRootNode();return t instanceof ShadowRoot?t.host:null}var q=class extends b{constructor(...e){super(...e),this.appState={},this.appData={},this.standalone=!1,this.actionBanners=[],this.dismissedStaticBannerIndices=new Set,this._tocEntries=[],this._activeToc=0,this._tocVisible=!1,this._tocRebuildScheduled=!1,this._headerH=0,this._onResize=()=>this._layoutStickyTops(),this._tocLocked=!1,this._unlockToc=e=>{if(e&&e.type===`keydown`){let t=e;if(t.ctrlKey&&t.altKey&&!t.shiftKey&&!t.metaKey&&/^(?:Digit|Numpad)[1-9]$/.test(t.code))return}this._tocLocked=!1},this._actionBannerTimers=[],this._staticBannerTimers=[],this._bannersHandler=e=>{let t=e.detail,n=t.banners??[],r=t.append??!1;r?this.actionBanners=[...this.actionBanners,...n]:(this._clearActionBannerTimers(),this.actionBanners=n);let i=r?this.actionBanners.length-n.length:0;n.forEach((e,t)=>{if(e.timeoutSeconds&&e.timeoutSeconds>0){let n=i+t;this._actionBannerTimers.push(setTimeout(()=>{this.actionBanners=this.actionBanners.filter((e,t)=>t!==n)},e.timeoutSeconds*1e3))}})},this._onTocKey=e=>{if(!this._tocVisible||!e.ctrlKey||!e.altKey||e.shiftKey||e.metaKey)return;let t=/^(?:Digit|Numpad)([1-9])$/.exec(e.code);if(!t)return;let n=parseInt(t[1],10)-1;n>=this._tocEntries.length||(e.preventDefault(),this._scrollToSection(n))},this._onScrollSpy=()=>{if(this._tocLocked)return;let e=this._sectionCards();if(!e.length)return;let t=this.shadowRoot?.querySelector(`mateu-content-header`),n=t?t.getBoundingClientRect().bottom:0;for(let t of e){if(!t.classList.contains(`mateu-section--sticky`))continue;let e=t.getBoundingClientRect();e.top<=n+12+2&&(n=Math.max(n,e.bottom))}let r=n+12+4,i=0;this._tocEntries.forEach((e,t)=>{e.el.getBoundingClientRect().top<=r&&(i=t)}),this._activeToc=i}}connectedCallback(){super.connectedCallback(),document.addEventListener(`page-banners-received`,this._bannersHandler),window.addEventListener(`resize`,this._onResize),document.addEventListener(`keydown`,this._onTocKey)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`page-banners-received`,this._bannersHandler),window.removeEventListener(`resize`,this._onResize),document.removeEventListener(`keydown`,this._onTocKey),this._clearAllTimers(),this._teardownScrollSpy()}updated(e){if(super.updated(e),e.has(`component`)&&e.get(`component`)!==void 0&&(this._clearAllTimers(),this.actionBanners=[],this.dismissedStaticBannerIndices=new Set),e.has(`component`)){let e=this.component?.metadata?.level??0;this.toggleAttribute(`data-nested`,e>0),this._scheduleStaticBannerTimeouts();let t=this.component?.metadata?.pageWidth===`edgeToEdge`;this.toggleAttribute(`data-edge`,t),this.dispatchEvent(new CustomEvent(`compact-changed`,{detail:{compact:!!this.component?.style?.includes(`--mateu-compact:1`)||t},bubbles:!0,composed:!0})),this._scheduleTocRebuild()}}_scheduleStaticBannerTimeouts(){this._staticBannerTimers.forEach(e=>clearTimeout(e)),this._staticBannerTimers=[],(this.component?.metadata?.banners??[]).forEach((e,t)=>{e.timeoutSeconds&&e.timeoutSeconds>0&&this._staticBannerTimers.push(setTimeout(()=>{this.dismissedStaticBannerIndices=new Set([...this.dismissedStaticBannerIndices,t])},e.timeoutSeconds*1e3))})}_clearActionBannerTimers(){this._actionBannerTimers.forEach(e=>clearTimeout(e)),this._actionBannerTimers=[]}_clearAllTimers(){this._clearActionBannerTimers(),this._staticBannerTimers.forEach(e=>clearTimeout(e)),this._staticBannerTimers=[]}_dismissActionBanner(e){this.actionBanners=this.actionBanners.filter((t,n)=>n!==e)}_dismissStaticBanner(e){this.dismissedStaticBannerIndices=new Set([...this.dismissedStaticBannerIndices,e])}bannerThemeClass(e){let t=e.theme?.toLowerCase()??`info`;return t===`none`?``:t}_evalBannerText(e){return M(e,this.state,this.data)}_renderBanner(e,t){let n=this._evalBannerText(e.title),r=this._evalBannerText(e.description);return T`
             <div class="page-banner page-banner--${this.bannerThemeClass(e)}">
                 ${n||e.hasCloseButton?T`
                     <div style="display: flex; align-items: center; justify-content: space-between; color: #1a1a1a; width: 100%;">
@@ -5944,7 +5952,7 @@ ${i}
                 `:v}
                 ${r?T`<p>${r}</p>`:v}
             </div>
-        `}_onSlotChange(){this._scheduleTocRebuild()}_scheduleTocRebuild(){this._tocRebuildScheduled||(this._tocRebuildScheduled=!0,requestAnimationFrame(()=>{this._tocRebuildScheduled=!1,this._rebuildToc()}))}_sectionCards(){return Array.from(this.querySelectorAll(`.mateu-section`))}_sectionTitle(e){return e.querySelector(`[slot="title"]`)?.textContent?.trim()||e.querySelector(`h1,h2,h3,h4,h5,h6`)?.textContent?.trim()||void 0}_rebuildToc(){let e=this._sectionCards(),t=e.map(e=>({title:this._sectionTitle(e),el:e})).filter(e=>!!e.title),n=this.component?.metadata?.toc,r=t.length>4&&e.every(e=>!e.closest(`vaadin-horizontal-layout`)),i=(n===!0||n!==!1&&r)&&t.length>0;this._tocEntries=t,this._tocVisible=i,this._activeToc>=t.length&&(this._activeToc=0),this._teardownScrollSpy(),i?requestAnimationFrame(()=>{this._layoutStickyTops(),this._setupScrollSpy()}):this._layoutStickyTops()}_layoutStickyTops(){let e=this.shadowRoot?.querySelector(`mateu-content-header`);this._headerH=this._tocVisible&&e?e.offsetHeight:0,this.style.setProperty(`--mateu-header-h`,this._headerH+`px`);let t=this._headerH+12;for(let e of this._sectionCards())e.classList.contains(`mateu-section--sticky`)&&(e.style.top=t+`px`,t+=e.offsetHeight+12)}_scrollContainer(){let e=mo(this);for(;e;){let t=getComputedStyle(e).overflowY;if((t===`auto`||t===`scroll`)&&e.scrollHeight>e.clientHeight)return e;e=mo(e)}return null}_setupScrollSpy(){this._tocEntries.length&&(this._spyTarget=this._scrollContainer()??window,this._spyTarget.addEventListener(`scroll`,this._onScrollSpy,{passive:!0}),window.addEventListener(`wheel`,this._unlockToc,{passive:!0}),window.addEventListener(`touchstart`,this._unlockToc,{passive:!0}),window.addEventListener(`keydown`,this._unlockToc),this._onScrollSpy())}_teardownScrollSpy(){this._spyTarget?.removeEventListener(`scroll`,this._onScrollSpy),window.removeEventListener(`wheel`,this._unlockToc),window.removeEventListener(`touchstart`,this._unlockToc),window.removeEventListener(`keydown`,this._unlockToc),this._spyTarget=void 0}_scrollToSection(e){let t=this._tocEntries[e];if(!t)return;this._activeToc=e,this._tocLocked=!0;let n=this._headerH+12;for(let e of this._sectionCards()){if(e===t.el)break;e.classList.contains(`mateu-section--sticky`)&&(n+=e.offsetHeight+12)}let r=this._scrollContainer(),i=r?r.getBoundingClientRect().top:0,a=t.el.getBoundingClientRect().top-i-n;(r??window).scrollBy({top:a,behavior:`smooth`})}_showHeaderBand(){let e=this.component?.metadata,t=!!(e?.title||e?.subtitle||e?.overline||e?.titlePlaceholder||e?.toolbar?.length),n=!!this.component?.children?.some(e=>e.metadata?.type===j.Crud);return t&&!n&&!this._hasWelcomeBanner()}_hasWelcomeBanner(){let e=t=>t?.metadata?.type===j.HeroSection||(t?.children??[]).some(e);return(this.component?.children??[]).some(e)}render(){let e=this.component?.metadata,t=[...(e?.banners??[]).map((e,t)=>({banner:e,index:t})).filter(({index:e})=>!this.dismissedStaticBannerIndices.has(e)).map(({banner:e,index:t})=>({banner:e,onDismiss:()=>this._dismissStaticBanner(t)})),...this.actionBanners.map((e,t)=>({banner:e,onDismiss:()=>this._dismissActionBanner(t)}))];return T`<div style="display: flex; flex-direction: column; width: 100%;">${T`
+        `}_onSlotChange(){this._scheduleTocRebuild()}_scheduleTocRebuild(){this._tocRebuildScheduled||(this._tocRebuildScheduled=!0,requestAnimationFrame(()=>{this._tocRebuildScheduled=!1,this._rebuildToc()}))}_sectionCards(){return Array.from(this.querySelectorAll(`.mateu-section`))}_sectionTitle(e){return e.querySelector(`[slot="title"]`)?.textContent?.trim()||e.querySelector(`h1,h2,h3,h4,h5,h6`)?.textContent?.trim()||void 0}_rebuildToc(){let e=this._sectionCards(),t=e.map(e=>({title:this._sectionTitle(e),el:e})).filter(e=>!!e.title),n=this.component?.metadata?.toc,r=t.length>4&&e.every(e=>!e.closest(`vaadin-horizontal-layout`)),i=(n===!0||n!==!1&&r)&&t.length>0;this._tocEntries=t,this._tocVisible=i,this._activeToc>=t.length&&(this._activeToc=0),this._teardownScrollSpy(),i?requestAnimationFrame(()=>{this._layoutStickyTops(),this._setupScrollSpy()}):this._layoutStickyTops()}_layoutStickyTops(){let e=this.shadowRoot?.querySelector(`mateu-content-header`);this._headerH=this._tocVisible&&e?e.offsetHeight:0,this.style.setProperty(`--mateu-header-h`,this._headerH+`px`);let t=this._headerH+12;for(let e of this._sectionCards())e.classList.contains(`mateu-section--sticky`)&&(e.style.top=t+`px`,t+=e.offsetHeight+12)}_scrollContainer(){let e=ho(this);for(;e;){let t=getComputedStyle(e).overflowY;if((t===`auto`||t===`scroll`)&&e.scrollHeight>e.clientHeight)return e;e=ho(e)}return null}_setupScrollSpy(){this._tocEntries.length&&(this._spyTarget=this._scrollContainer()??window,this._spyTarget.addEventListener(`scroll`,this._onScrollSpy,{passive:!0}),window.addEventListener(`wheel`,this._unlockToc,{passive:!0}),window.addEventListener(`touchstart`,this._unlockToc,{passive:!0}),window.addEventListener(`keydown`,this._unlockToc),this._onScrollSpy())}_teardownScrollSpy(){this._spyTarget?.removeEventListener(`scroll`,this._onScrollSpy),window.removeEventListener(`wheel`,this._unlockToc),window.removeEventListener(`touchstart`,this._unlockToc),window.removeEventListener(`keydown`,this._unlockToc),this._spyTarget=void 0}_scrollToSection(e){let t=this._tocEntries[e];if(!t)return;this._activeToc=e,this._tocLocked=!0;let n=this._headerH+12;for(let e of this._sectionCards()){if(e===t.el)break;e.classList.contains(`mateu-section--sticky`)&&(n+=e.offsetHeight+12)}let r=this._scrollContainer(),i=r?r.getBoundingClientRect().top:0,a=t.el.getBoundingClientRect().top-i-n;(r??window).scrollBy({top:a,behavior:`smooth`})}_showHeaderBand(){let e=this.component?.metadata,t=!!(e?.title||e?.subtitle||e?.overline||e?.titlePlaceholder||e?.toolbar?.length),n=!!this.component?.children?.some(e=>e.metadata?.type===j.Crud);return t&&!n&&!this._hasWelcomeBanner()}_hasWelcomeBanner(){let e=t=>t?.metadata?.type===j.HeroSection||(t?.children??[]).some(e);return(this.component?.children??[]).some(e)}render(){let e=this.component?.metadata,t=[...(e?.banners??[]).map((e,t)=>({banner:e,index:t})).filter(({index:e})=>!this.dismissedStaticBannerIndices.has(e)).map(({banner:e,index:t})=>({banner:e,onDismiss:()=>this._dismissStaticBanner(t)})),...this.actionBanners.map((e,t)=>({banner:e,onDismiss:()=>this._dismissActionBanner(t)}))];return T`<div style="display: flex; flex-direction: column; width: 100%;">${T`
             <div class="page-header-wrap">
                 <mateu-content-header
                     class="${this._tocVisible?`sticky-header`:``}"
@@ -5987,7 +5995,7 @@ ${i}
                 `:v}
             </div>
             <div class="form-footer">
-                ${e?.footer?.map(e=>I(this,e,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData))}
+                ${e?.footer?.map(e=>F(this,e,this.baseUrl,this.state??{},this.data??{},this.appState,this.appData))}
             </div>
         `}</div>`}static{this.styles=h`
         /* Design-system hook: background behind the page header (the RDS "Header + Background"
@@ -6188,7 +6196,7 @@ ${i}
             background: #fdf2f2;
             border-leftx: 4px solid var(--lumo-error-color);
         }
-    `}};k([y()],J.prototype,`component`,void 0),k([y()],J.prototype,`baseUrl`,void 0),k([y()],J.prototype,`state`,void 0),k([y()],J.prototype,`data`,void 0),k([y()],J.prototype,`appState`,void 0),k([y()],J.prototype,`appData`,void 0),k([y()],J.prototype,`value`,void 0),k([y({type:Boolean})],J.prototype,`standalone`,void 0),k([C()],J.prototype,`actionBanners`,void 0),k([C()],J.prototype,`dismissedStaticBannerIndices`,void 0),k([C()],J.prototype,`_tocEntries`,void 0),k([C()],J.prototype,`_activeToc`,void 0),k([C()],J.prototype,`_tocVisible`,void 0),J=k([g(`mateu-page`)],J);var ho=h`
+    `}};k([y()],q.prototype,`component`,void 0),k([y()],q.prototype,`baseUrl`,void 0),k([y()],q.prototype,`state`,void 0),k([y()],q.prototype,`data`,void 0),k([y()],q.prototype,`appState`,void 0),k([y()],q.prototype,`appData`,void 0),k([y()],q.prototype,`value`,void 0),k([y({type:Boolean})],q.prototype,`standalone`,void 0),k([C()],q.prototype,`actionBanners`,void 0),k([C()],q.prototype,`dismissedStaticBannerIndices`,void 0),k([C()],q.prototype,`_tocEntries`,void 0),k([C()],q.prototype,`_activeToc`,void 0),k([C()],q.prototype,`_tocVisible`,void 0),q=k([g(`mateu-page`)],q);var go=h`
     .nbtn {
         display: inline-flex;
         align-items: center;
@@ -6217,25 +6225,25 @@ ${i}
     }
     .nbtn.primary:hover { background: var(--lumo-primary-color, #1676f3); filter: brightness(1.08); }
     .nbtn svg { width: 1em; height: 1em; flex-shrink: 0; }
-`,go=e=>w`
+`,_o=e=>w`
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-         stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${e}</svg>`,_o=go(w`
+         stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${e}</svg>`,vo=_o(w`
     <circle cx="12" cy="12" r="3"></circle>
-    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path>`),vo=go(w`
+    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path>`),yo=_o(w`
     <line x1="12" y1="5" x2="12" y2="19"></line>
-    <line x1="5" y1="12" x2="19" y2="12"></line>`),yo=go(w`
+    <line x1="5" y1="12" x2="19" y2="12"></line>`),bo=_o(w`
     <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
     <polyline points="7 10 12 15 17 10"></polyline>
-    <line x1="12" y1="15" x2="12" y2="3"></line>`);go(w`
+    <line x1="12" y1="15" x2="12" y2="3"></line>`);_o(w`
     <rect x="9" y="2" width="6" height="5" rx="1"></rect>
     <rect x="2" y="17" width="6" height="5" rx="1"></rect>
     <rect x="16" y="17" width="6" height="5" rx="1"></rect>
-    <path d="M12 7v4M5 17v-3h14v3M12 11v3"></path>`);var bo=go(w`
+    <path d="M12 7v4M5 17v-3h14v3M12 11v3"></path>`);var xo=_o(w`
     <rect x="9" y="2" width="6" height="12" rx="3"></rect>
     <path d="M5 10v1a7 7 0 0 0 14 0v-1"></path>
-    <line x1="12" y1="18" x2="12" y2="22"></line>`),xo=go(w`
+    <line x1="12" y1="18" x2="12" y2="22"></line>`),So=_o(w`
     <line x1="18" y1="6" x2="6" y2="18"></line>
-    <line x1="6" y1="6" x2="18" y2="18"></line>`),So=[`#e91e63`,`#1676f3`,`#10b981`,`#8b5cf6`,`#f59e0b`,`#ef4444`],Co=e=>So[Math.abs(e??0)%So.length],wo=e=>(e??`?`).split(/\s+/).filter(e=>e).map(e=>e[0]).slice(0,2).join(``).toUpperCase()||`?`,Y=class extends b{constructor(...e){super(...e),this.localAgentUrl=`http://127.0.0.1:8776`,this.localAgentAlive=!1,this.menu=[],this.chatSessionId=E(),this.menuContextSent=!1,this.attachments=[],this.uploading=!1,this.expanded=!1,this.toggleExpanded=()=>{this.expanded=!this.expanded},this.items=[],this.listening=!1,this.recognitionAvailable=!1,this.loading=!1,this.elapsedSeconds=0,this.startListening=()=>{this.recognition&&(this.listening?(this.recognition.stop(),this.listening=!1):(this.recognition.start(),this.listening=!0))},this.onSpeechResult=e=>{if(this.recognition){let t=e,n=t.results[t.results[0].length-1][0].transcript;this.messageInputElement&&(this.messageInputElement.value=n,this.send(new CustomEvent(`submit`,{detail:{value:n},bubbles:!0,composed:!0})))}},this.probeLocalAgent=async()=>{if(this.localAgentUrl)try{let e=new AbortController,t=setTimeout(()=>e.abort(),1200),n=await fetch(this.localAgentUrl+`/health`,{signal:e.signal});clearTimeout(t),this.localAgentAlive=n.ok}catch{this.localAgentAlive=!1}},this.pickFiles=()=>this.fileInputElement?.click(),this.onFilesPicked=async e=>{let t=e.target,n=Array.from(t.files??[]);if(t.value=``,!(!n.length||!this.uploadUrl)){this.uploading=!0;try{let e=new FormData;e.append(`sessionId`,this.chatSessionId);for(let t of n)e.append(`files`,t,t.name);let t={},r=localStorage.getItem(`__mateu_auth_token`);r&&(t.Authorization=`Bearer `+r);let i=sessionStorage.getItem(`__mateu_sesion_id`);i&&(t[`X-Session-Id`]=i);let a=await fetch(this.uploadUrl,{method:`POST`,headers:t,body:e});if(!a.ok)throw Error(`Upload failed: ${a.status}`);let o=((await a.json()).files??[]).filter(e=>e&&e.path);this.attachments=[...this.attachments,...o]}catch(e){this.addMessage(`⚠️ No se pudieron subir los ficheros: ${e instanceof Error?e.message:e}`,`agent`)}finally{this.uploading=!1}}},this.removeAttachment=e=>{this.attachments=this.attachments.filter(t=>t.path!==e)},this.send=async e=>{this.messageInputElement?.setAttribute(`disabled`,`disabled`);let t=e.detail.value.trim(),n=this.localAgentAlive?this.localAgentUrl+`/mateu/agent/stream`:this.sseUrl,r=this.attachments;if(!t&&r.length===0||!n)return;let i=r.length?`${t}${t?`
+    <line x1="6" y1="6" x2="18" y2="18"></line>`),Co=[`#e91e63`,`#1676f3`,`#10b981`,`#8b5cf6`,`#f59e0b`,`#ef4444`],wo=e=>Co[Math.abs(e??0)%Co.length],To=e=>(e??`?`).split(/\s+/).filter(e=>e).map(e=>e[0]).slice(0,2).join(``).toUpperCase()||`?`,J=class extends b{constructor(...e){super(...e),this.localAgentUrl=`http://127.0.0.1:8776`,this.localAgentAlive=!1,this.menu=[],this.chatSessionId=E(),this.menuContextSent=!1,this.attachments=[],this.uploading=!1,this.expanded=!1,this.toggleExpanded=()=>{this.expanded=!this.expanded},this.items=[],this.listening=!1,this.recognitionAvailable=!1,this.loading=!1,this.elapsedSeconds=0,this.startListening=()=>{this.recognition&&(this.listening?(this.recognition.stop(),this.listening=!1):(this.recognition.start(),this.listening=!0))},this.onSpeechResult=e=>{if(this.recognition){let t=e,n=t.results[t.results[0].length-1][0].transcript;this.messageInputElement&&(this.messageInputElement.value=n,this.send(new CustomEvent(`submit`,{detail:{value:n},bubbles:!0,composed:!0})))}},this.probeLocalAgent=async()=>{if(this.localAgentUrl)try{let e=new AbortController,t=setTimeout(()=>e.abort(),1200),n=await fetch(this.localAgentUrl+`/health`,{signal:e.signal});clearTimeout(t),this.localAgentAlive=n.ok}catch{this.localAgentAlive=!1}},this.pickFiles=()=>this.fileInputElement?.click(),this.onFilesPicked=async e=>{let t=e.target,n=Array.from(t.files??[]);if(t.value=``,!(!n.length||!this.uploadUrl)){this.uploading=!0;try{let e=new FormData;e.append(`sessionId`,this.chatSessionId);for(let t of n)e.append(`files`,t,t.name);let t={},r=localStorage.getItem(`__mateu_auth_token`);r&&(t.Authorization=`Bearer `+r);let i=sessionStorage.getItem(`__mateu_sesion_id`);i&&(t[`X-Session-Id`]=i);let a=await fetch(this.uploadUrl,{method:`POST`,headers:t,body:e});if(!a.ok)throw Error(`Upload failed: ${a.status}`);let o=((await a.json()).files??[]).filter(e=>e&&e.path);this.attachments=[...this.attachments,...o]}catch(e){this.addMessage(`⚠️ No se pudieron subir los ficheros: ${e instanceof Error?e.message:e}`,`agent`)}finally{this.uploading=!1}}},this.removeAttachment=e=>{this.attachments=this.attachments.filter(t=>t.path!==e)},this.send=async e=>{this.messageInputElement?.setAttribute(`disabled`,`disabled`);let t=e.detail.value.trim(),n=this.localAgentAlive?this.localAgentUrl+`/mateu/agent/stream`:this.sseUrl,r=this.attachments;if(!t&&r.length===0||!n)return;let i=r.length?`${t}${t?`
 
 `:``}📎 ${r.map(e=>e.name).join(`, `)}`:t;this.addMessage(i,`user`),this.attachments=[];let a=this.addMessage(``,`agent`);this.startLoading();let o=``;try{let e={Accept:`text/event-stream`,"Content-Type":`application/json`},i=localStorage.getItem(`__mateu_auth_token`);i&&(e.Authorization=`Bearer `+i);let s=sessionStorage.getItem(`__mateu_sesion_id`);s&&(e[`X-Session-Id`]=s);let c=this.contextProvider?.(),l=JSON.stringify({message:t,sessionId:this.chatSessionId,...r.length&&{attachments:r},...c!=null&&{context:c},...this.mcpUrl&&{mcpUrl:new URL(this.mcpUrl,window.location.origin).href},...!this.menuContextSent&&{menuContext:this.buildMenuContext(this.menu)}});this.menuContextSent=!0;let u=await fetch(n,{method:`POST`,headers:e,body:l});if(!u.ok){let e=await u.text();throw Error(`Servidor respondió ${u.status}: ${e}`)}let d=u.body?.getReader();if(!d)throw Error(`No se pudo obtener el reader del stream.`);let f=new TextDecoder,p=``;for(;;){let{done:e,value:t}=await d.read();if(e){if(p.trim().startsWith(`data:`)){let e=p.trim().slice(5).trim(),t=this.tryParseTokenUsage(e),n=!t&&this.tryParseCustomEvent(e);t?this.tokenUsage={...this.tokenUsage,...t}:n?n.event===`agent-error`?(o=`⚠️ `+(n.detail?.message??`Error desconocido del agente`),this.updateMessage(a,o)):this.dispatchEvent(new CustomEvent(n.event,{detail:n.detail,bubbles:!0,composed:!0})):(o+=e,this.updateMessage(a,o))}break}let n=f.decode(t,{stream:!0});p+=n;let r=p.split(`
 `);p=r.pop()||``;let i=!1;for(let e of r)if(e.trim().startsWith(`data:`)){let t=e.trim().slice(5).trim(),n=this.tryParseTokenUsage(t),r=!n&&this.tryParseCustomEvent(t);n?this.tokenUsage={...this.tokenUsage,...n}:r?r.event===`agent-error`?(o=`⚠️ `+(r.detail?.message??`Error desconocido del agente`),this.updateMessage(a,o)):this.dispatchEvent(new CustomEvent(r.event,{detail:r.detail,bubbles:!0,composed:!0})):(o+=t+`
@@ -6250,14 +6258,14 @@ ${i}
                         ${this.expanded?`⤡`:`⤢`}
                     </button>
                     <button class="chat-close" @click="${this.closeChat}" title="Cerrar">
-                        ${xo}
+                        ${So}
                     </button>
                 </div>
                 <div class="scroll-container">
                     <div class="message-list" role="list">
                         ${this.items.map(e=>T`
                             <div class="message" role="listitem">
-                                <div class="avatar" style="background: ${Co(e.userColorIndex)};">${wo(e.userName)}</div>
+                                <div class="avatar" style="background: ${wo(e.userColorIndex)};">${To(e.userName)}</div>
                                 <div class="message-body">
                                     <div class="message-meta">
                                         <span class="message-name">${e.userName}</span>
@@ -6305,7 +6313,7 @@ ${i}
                             style="color: ${this.listening?`red`:`var(--lumo-contrast-50pct, #767676)`};"
                             @click="${this.startListening}"
                             ?disabled="${!this.recognitionAvailable}"
-                    >${bo}</button>
+                    >${xo}</button>
                     <input class="msg-input"
                            placeholder="Message"
                            aria-label="Message"
@@ -6313,7 +6321,7 @@ ${i}
                     <button class="nbtn primary" ?disabled="${this.loading}" @click="${this.submitFromInput}">Send</button>
                 </div>
             </div>
-        `}static{this.styles=[ho,h`
+        `}static{this.styles=[go,h`
         :host {
             display: block;
             height: 100%;
@@ -6638,7 +6646,7 @@ ${i}
         @keyframes spin {
             to { transform: rotate(360deg); }
         }
-    `]}};k([y({attribute:!1})],Y.prototype,`contextProvider`,void 0),k([y()],Y.prototype,`localAgentUrl`,void 0),k([y({attribute:!1})],Y.prototype,`mcpUrl`,void 0),k([C()],Y.prototype,`localAgentAlive`,void 0),k([y()],Y.prototype,`sseUrl`,void 0),k([y()],Y.prototype,`uploadUrl`,void 0),k([y({attribute:!1})],Y.prototype,`menu`,void 0),k([C()],Y.prototype,`attachments`,void 0),k([C()],Y.prototype,`uploading`,void 0),k([x(`.file-input`)],Y.prototype,`fileInputElement`,void 0),k([y({type:Boolean,reflect:!0})],Y.prototype,`expanded`,void 0),k([y()],Y.prototype,`items`,void 0),k([x(`.scroll-container`)],Y.prototype,`scrollContainer`,void 0),k([x(`.msg-input`)],Y.prototype,`messageInputElement`,void 0),k([C()],Y.prototype,`recognition`,void 0),k([C()],Y.prototype,`listening`,void 0),k([C()],Y.prototype,`recognitionAvailable`,void 0),k([C()],Y.prototype,`loading`,void 0),k([C()],Y.prototype,`elapsedSeconds`,void 0),k([C()],Y.prototype,`tokenUsage`,void 0),Y=k([g(`mateu-chat`)],Y);var To=class extends b{updated(e){super.updated(e),this.chart&&=(this.chart.destroy(),void 0),this.data&&this.createChart(this.data)}async createChart(e){let[{default:t}]=await Promise.all([D(()=>import(`./vendor-chartjs.js`).then(e=>e.n),__vite__mapDeps([3,1])),D(()=>import(`./vendor-chartjs.js`).then(e=>e.t),__vite__mapDeps([3,1]))]);if(e!==this.data)return;this.chart&&this.chart.destroy();let n={type:this.type,data:this.data,options:this.options};this.chart=new t(this.chartElement,n)}handleSlotChange(){}render(){return T`
+    `]}};k([y({attribute:!1})],J.prototype,`contextProvider`,void 0),k([y()],J.prototype,`localAgentUrl`,void 0),k([y({attribute:!1})],J.prototype,`mcpUrl`,void 0),k([C()],J.prototype,`localAgentAlive`,void 0),k([y()],J.prototype,`sseUrl`,void 0),k([y()],J.prototype,`uploadUrl`,void 0),k([y({attribute:!1})],J.prototype,`menu`,void 0),k([C()],J.prototype,`attachments`,void 0),k([C()],J.prototype,`uploading`,void 0),k([x(`.file-input`)],J.prototype,`fileInputElement`,void 0),k([y({type:Boolean,reflect:!0})],J.prototype,`expanded`,void 0),k([y()],J.prototype,`items`,void 0),k([x(`.scroll-container`)],J.prototype,`scrollContainer`,void 0),k([x(`.msg-input`)],J.prototype,`messageInputElement`,void 0),k([C()],J.prototype,`recognition`,void 0),k([C()],J.prototype,`listening`,void 0),k([C()],J.prototype,`recognitionAvailable`,void 0),k([C()],J.prototype,`loading`,void 0),k([C()],J.prototype,`elapsedSeconds`,void 0),k([C()],J.prototype,`tokenUsage`,void 0),J=k([g(`mateu-chat`)],J);var Eo=class extends b{updated(e){super.updated(e),this.chart&&=(this.chart.destroy(),void 0),this.data&&this.createChart(this.data)}async createChart(e){let[{default:t}]=await Promise.all([D(()=>import(`./vendor-chartjs.js`).then(e=>e.n),__vite__mapDeps([3,1])),D(()=>import(`./vendor-chartjs.js`).then(e=>e.t),__vite__mapDeps([3,1]))]);if(e!==this.data)return;this.chart&&this.chart.destroy();let n={type:this.type,data:this.data,options:this.options};this.chart=new t(this.chartElement,n)}handleSlotChange(){}render(){return T`
             <div class="container">
                 <canvas id="chart"></canvas>
             </div>
@@ -6655,7 +6663,7 @@ ${i}
         height: 100%;
         position: relative;
     }
-  `}};k([y()],To.prototype,`type`,void 0),k([y()],To.prototype,`data`,void 0),k([y()],To.prototype,`options`,void 0),k([x(`#chart`)],To.prototype,`chartElement`,void 0),To=k([g(`mateu-chart`)],To);var Eo=class extends b{updated(e){super.updated(e),this.chart&&=(this.chart.destroy(),void 0),this.xml&&this.createViewer(this.xml)}async createViewer(e){let{default:t}=await D(async()=>{let{default:e}=await import(`./vendor-diagrams.js`).then(e=>e.t);return{default:e}},__vite__mapDeps([4,1,2]));if(e!==this.xml)return;this.chart&&this.chart.destroy();let n={container:this.divElement};this.chart=new t(n),this.chart.importXML(e)}handleSlotChange(){}render(){return T`
+  `}};k([y()],Eo.prototype,`type`,void 0),k([y()],Eo.prototype,`data`,void 0),k([y()],Eo.prototype,`options`,void 0),k([x(`#chart`)],Eo.prototype,`chartElement`,void 0),Eo=k([g(`mateu-chart`)],Eo);var Do=class extends b{updated(e){super.updated(e),this.chart&&=(this.chart.destroy(),void 0),this.xml&&this.createViewer(this.xml)}async createViewer(e){let{default:t}=await D(async()=>{let{default:e}=await import(`./vendor-diagrams.js`).then(e=>e.t);return{default:e}},__vite__mapDeps([4,1,2]));if(e!==this.xml)return;this.chart&&this.chart.destroy();let n={container:this.divElement};this.chart=new t(n),this.chart.importXML(e)}handleSlotChange(){}render(){return T`
             <div class="container" style="width: 20rem; height: 15rem; overflow: auto;">
                 <!-- BPMN diagram container -->
                 <div id="canvas" style="width: 60rem; height: 30rem; zoom: 0.5;"></div>
@@ -6664,7 +6672,7 @@ ${i}
                 <slot @slotchange=${this.handleSlotChange}></slot>
             </div>
        `}static{this.styles=h`
-  `}};k([y()],Eo.prototype,`xml`,void 0),k([x(`#canvas`)],Eo.prototype,`divElement`,void 0),Eo=k([g(`mateu-bpmn`)],Eo);var Do=160,Oo=56,ko=220,Ao=110,jo=60,Mo={ACTION:`#3B82F6`,JOIN:`#8B5CF6`,FORK:`#F59E0B`,END:`#EF4444`,USER_TASK:`#10B981`,PROCESS:`#6366F1`},No={ACTION:`▶`,JOIN:`⟨`,FORK:`⟩`,END:`◼`,USER_TASK:`👤`,PROCESS:`⚙`},Po=[`ACTION`,`JOIN`,`FORK`,`END`,`USER_TASK`,`PROCESS`];function Fo(){return`step-`+Math.random().toString(36).slice(2,8)}var Io=class extends b{constructor(...e){super(...e),this.value=`{"name":"New Workflow","steps":[]}`,this.wf={name:`New Workflow`,steps:[]},this.positions={},this.selectedId=null,this.showMeta=!1,this.draggingId=null,this.dragOffset={x:0,y:0},this.svgEl=null,this.onMouseMove=e=>{if(!this.draggingId||!this.svgEl)return;let t=this.toSvgPoint(e);this.positions={...this.positions,[this.draggingId]:{x:Math.max(0,t.x-this.dragOffset.x),y:Math.max(0,t.y-this.dragOffset.y)}}},this.onMouseUp=()=>{this.draggingId=null,window.removeEventListener(`mousemove`,this.onMouseMove),window.removeEventListener(`mouseup`,this.onMouseUp)}}updated(e){if(e.has(`value`)){try{this.wf=JSON.parse(this.value)}catch{}this.autoLayout()}}autoLayout(){let e=this.wf.steps??[],t={};e.forEach(e=>{t[e.id]=0});let n=!0;for(;n;)n=!1,e.forEach(e=>{if(e.preconditionStepId!=null&&t[e.preconditionStepId]!==void 0){let r=t[e.preconditionStepId]+1;r>t[e.id]&&(t[e.id]=r,n=!0)}});let r={};e.forEach(e=>{let n=t[e.id]??0;(r[n]??=[]).push(e.id)});let i={...this.positions},a=!1;Object.entries(r).forEach(([e,t])=>{let n=Number(e);t.forEach((e,t)=>{i[e]||(i[e]={x:jo+n*ko,y:jo+t*Ao},a=!0)})}),a&&(this.positions=i)}emit(){let e=JSON.stringify(this.wf,null,2);this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e},bubbles:!0,composed:!0}))}updateWf(e){this.wf={...this.wf,...e},this.emit()}updateStep(e,t){this.wf={...this.wf,steps:this.wf.steps.map(n=>n.id===e?{...n,...t}:n)},this.emit()}addStep(){let e=Fo(),t={id:e,type:`ACTION`,name:`New Step`};this.wf={...this.wf,steps:[...this.wf.steps??[],t]};let n=Object.values(this.positions).map(e=>e.y),r=n.length?Math.max(...n)+Ao:jo;this.positions={...this.positions,[e]:{x:jo,y:r}},this.selectedId=e,this.emit()}deleteStep(e){this.wf={...this.wf,steps:this.wf.steps.filter(t=>t.id!==e).map(t=>t.preconditionStepId===e?{...t,preconditionStepId:void 0}:t)};let{[e]:t,...n}=this.positions;this.positions=n,this.selectedId===e&&(this.selectedId=null),this.emit()}onNodeMouseDown(e,t){e.preventDefault(),this.draggingId=t;let n=this.positions[t]??{x:0,y:0},r=this.toSvgPoint(e);this.dragOffset={x:r.x-n.x,y:r.y-n.y},this.svgEl=e.currentTarget.closest(`svg`),window.addEventListener(`mousemove`,this.onMouseMove),window.addEventListener(`mouseup`,this.onMouseUp)}toSvgPoint(e){if(!this.svgEl)return{x:0,y:0};let t=this.svgEl.getBoundingClientRect();return{x:e.clientX-t.left,y:e.clientY-t.top}}canvasSize(){let e=Object.values(this.positions),t=e.length?Math.max(...e.map(e=>e.x))+Do+jo:600,n=e.length?Math.max(...e.map(e=>e.y))+Oo+jo:400;return{w:Math.max(t,600),h:Math.max(n,400)}}render(){let{w:e,h:t}=this.canvasSize(),n=this.wf.steps??[];return T`
+  `}};k([y()],Do.prototype,`xml`,void 0),k([x(`#canvas`)],Do.prototype,`divElement`,void 0),Do=k([g(`mateu-bpmn`)],Do);var Oo=160,ko=56,Ao=220,jo=110,Mo=60,No={ACTION:`#3B82F6`,JOIN:`#8B5CF6`,FORK:`#F59E0B`,END:`#EF4444`,USER_TASK:`#10B981`,PROCESS:`#6366F1`},Po={ACTION:`▶`,JOIN:`⟨`,FORK:`⟩`,END:`◼`,USER_TASK:`👤`,PROCESS:`⚙`},Fo=[`ACTION`,`JOIN`,`FORK`,`END`,`USER_TASK`,`PROCESS`];function Io(){return`step-`+Math.random().toString(36).slice(2,8)}var Lo=class extends b{constructor(...e){super(...e),this.value=`{"name":"New Workflow","steps":[]}`,this.wf={name:`New Workflow`,steps:[]},this.positions={},this.selectedId=null,this.showMeta=!1,this.draggingId=null,this.dragOffset={x:0,y:0},this.svgEl=null,this.onMouseMove=e=>{if(!this.draggingId||!this.svgEl)return;let t=this.toSvgPoint(e);this.positions={...this.positions,[this.draggingId]:{x:Math.max(0,t.x-this.dragOffset.x),y:Math.max(0,t.y-this.dragOffset.y)}}},this.onMouseUp=()=>{this.draggingId=null,window.removeEventListener(`mousemove`,this.onMouseMove),window.removeEventListener(`mouseup`,this.onMouseUp)}}updated(e){if(e.has(`value`)){try{this.wf=JSON.parse(this.value)}catch{}this.autoLayout()}}autoLayout(){let e=this.wf.steps??[],t={};e.forEach(e=>{t[e.id]=0});let n=!0;for(;n;)n=!1,e.forEach(e=>{if(e.preconditionStepId!=null&&t[e.preconditionStepId]!==void 0){let r=t[e.preconditionStepId]+1;r>t[e.id]&&(t[e.id]=r,n=!0)}});let r={};e.forEach(e=>{let n=t[e.id]??0;(r[n]??=[]).push(e.id)});let i={...this.positions},a=!1;Object.entries(r).forEach(([e,t])=>{let n=Number(e);t.forEach((e,t)=>{i[e]||(i[e]={x:Mo+n*Ao,y:Mo+t*jo},a=!0)})}),a&&(this.positions=i)}emit(){let e=JSON.stringify(this.wf,null,2);this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e},bubbles:!0,composed:!0}))}updateWf(e){this.wf={...this.wf,...e},this.emit()}updateStep(e,t){this.wf={...this.wf,steps:this.wf.steps.map(n=>n.id===e?{...n,...t}:n)},this.emit()}addStep(){let e=Io(),t={id:e,type:`ACTION`,name:`New Step`};this.wf={...this.wf,steps:[...this.wf.steps??[],t]};let n=Object.values(this.positions).map(e=>e.y),r=n.length?Math.max(...n)+jo:Mo;this.positions={...this.positions,[e]:{x:Mo,y:r}},this.selectedId=e,this.emit()}deleteStep(e){this.wf={...this.wf,steps:this.wf.steps.filter(t=>t.id!==e).map(t=>t.preconditionStepId===e?{...t,preconditionStepId:void 0}:t)};let{[e]:t,...n}=this.positions;this.positions=n,this.selectedId===e&&(this.selectedId=null),this.emit()}onNodeMouseDown(e,t){e.preventDefault(),this.draggingId=t;let n=this.positions[t]??{x:0,y:0},r=this.toSvgPoint(e);this.dragOffset={x:r.x-n.x,y:r.y-n.y},this.svgEl=e.currentTarget.closest(`svg`),window.addEventListener(`mousemove`,this.onMouseMove),window.addEventListener(`mouseup`,this.onMouseUp)}toSvgPoint(e){if(!this.svgEl)return{x:0,y:0};let t=this.svgEl.getBoundingClientRect();return{x:e.clientX-t.left,y:e.clientY-t.top}}canvasSize(){let e=Object.values(this.positions),t=e.length?Math.max(...e.map(e=>e.x))+Oo+Mo:600,n=e.length?Math.max(...e.map(e=>e.y))+ko+Mo:400;return{w:Math.max(t,600),h:Math.max(n,400)}}render(){let{w:e,h:t}=this.canvasSize(),n=this.wf.steps??[];return T`
             <div class="root">
                 ${this.renderToolbar()}
                 ${this.showMeta?this.renderMeta():``}
@@ -6691,15 +6699,15 @@ ${i}
                 <span class="badge badge-${e.toLowerCase()}">${e}</span>
                 <div style="flex:1"></div>
                 <button class="nbtn" @click="${()=>this.showMeta=!this.showMeta}">
-                    ${_o}
+                    ${vo}
                     Settings
                 </button>
                 <button class="nbtn primary" @click="${()=>this.addStep()}">
-                    ${vo}
+                    ${yo}
                     Add Step
                 </button>
                 <button class="nbtn" @click="${()=>this.exportJson()}">
-                    ${yo}
+                    ${bo}
                     Export
                 </button>
             </div>
@@ -6728,27 +6736,27 @@ ${i}
                     `:``}
                 </div>
             </div>
-        `}renderArrow(e){if(!e.preconditionStepId)return w``;let t=this.positions[e.preconditionStepId],n=this.positions[e.id];if(!t||!n)return w``;let r=t.x+Do,i=t.y+Oo/2,a=n.x,o=n.y+Oo/2,s=(r+a)/2;return w`
+        `}renderArrow(e){if(!e.preconditionStepId)return w``;let t=this.positions[e.preconditionStepId],n=this.positions[e.id];if(!t||!n)return w``;let r=t.x+Oo,i=t.y+ko/2,a=n.x,o=n.y+ko/2,s=(r+a)/2;return w`
             <path d="M${r},${i} C${s},${i} ${s},${o} ${a},${o}"
                   fill="none" stroke="#94a3b8" stroke-width="2"
                   marker-end="url(#arrow)"/>
-        `}renderNode(e){let t=this.positions[e.id]??{x:jo,y:jo},n=Mo[e.type]??`#64748b`,r=No[e.type]??`•`,i=this.selectedId===e.id;return w`
+        `}renderNode(e){let t=this.positions[e.id]??{x:Mo,y:Mo},n=No[e.type]??`#64748b`,r=Po[e.type]??`•`,i=this.selectedId===e.id;return w`
             <g transform="translate(${t.x},${t.y})"
                style="cursor:grab"
                @mousedown="${t=>this.onNodeMouseDown(t,e.id)}"
                @click="${t=>{t.stopPropagation(),this.selectedId=e.id}}">
-                <rect width="${Do}" height="${Oo}" rx="8"
+                <rect width="${Oo}" height="${ko}" rx="8"
                       fill="white"
                       stroke="${i?n:`#e2e8f0`}"
                       stroke-width="${i?2.5:1.5}"
                       filter="url(#shadow)"/>
                 <!-- type badge -->
-                <rect x="0" y="0" width="32" height="${Oo}" rx="8" fill="${n}" clip-path="inset(0 -8px 0 0 round 8px)"/>
-                <rect x="24" y="0" width="8" height="${Oo}" fill="${n}"/>
+                <rect x="0" y="0" width="32" height="${ko}" rx="8" fill="${n}" clip-path="inset(0 -8px 0 0 round 8px)"/>
+                <rect x="24" y="0" width="8" height="${ko}" fill="${n}"/>
                 <text x="16" y="${33}" text-anchor="middle"
                       font-size="14" fill="white">${r}</text>
                 <!-- name -->
-                <text x="44" y="${Oo/2-6}" font-size="11" fill="#1e293b" font-weight="600">
+                <text x="44" y="${ko/2-6}" font-size="11" fill="#1e293b" font-weight="600">
                     ${e.name.length>16?e.name.slice(0,15)+`…`:e.name}
                 </text>
                 <text x="44" y="${36}" font-size="9" fill="#94a3b8">${e.id}</text>
@@ -6773,7 +6781,7 @@ ${i}
                         @change="${t=>this.updateStep(e.id,{name:t.target.value})}"/>`)}
                     ${n(`Type`,T`
                         <select class="inp" @change="${t=>this.updateStep(e.id,{type:t.target.value})}">
-                            ${Po.map(t=>T`<option value="${t}" ?selected="${e.type===t}">${t}</option>`)}
+                            ${Fo.map(t=>T`<option value="${t}" ?selected="${e.type===t}">${t}</option>`)}
                         </select>`)}
                     ${n(`Description`,T`<textarea class="inp" rows="2"
                         @change="${t=>this.updateStep(e.id,{description:t.target.value})}">${e.description??``}</textarea>`)}
@@ -6818,7 +6826,7 @@ ${i}
                         @change="${t=>this.updateStep(e.id,{childWorkflowDefinitionId:t.target.value||void 0})}"/>`):``}
                 </div>
             </div>
-        `}exportJson(){let e=JSON.stringify(this.wf,null,2),t=new Blob([e],{type:`application/json`}),n=URL.createObjectURL(t),r=document.createElement(`a`);r.href=n,r.download=(this.wf.name??`workflow`).replace(/\s+/g,`-`).toLowerCase()+`.json`,r.click(),URL.revokeObjectURL(n)}static{this.styles=[ho,h`
+        `}exportJson(){let e=JSON.stringify(this.wf,null,2),t=new Blob([e],{type:`application/json`}),n=URL.createObjectURL(t),r=document.createElement(`a`);r.href=n,r.download=(this.wf.name??`workflow`).replace(/\s+/g,`-`).toLowerCase()+`.json`,r.click(),URL.revokeObjectURL(n)}static{this.styles=[go,h`
         :host { display: block; height: 100%; font-family: var(--lumo-font-family, sans-serif); }
 
         .root { display: flex; flex-direction: column; height: 100%; background: var(--lumo-base-color, #fff); }
@@ -6896,7 +6904,7 @@ ${i}
         .inp:focus { border-color: #3B82F6; }
         textarea.inp { resize: vertical; }
         input[readonly].inp { background: #f8fafc; color: #94a3b8; }
-    `]}};k([y()],Io.prototype,`value`,void 0),k([C()],Io.prototype,`wf`,void 0),k([C()],Io.prototype,`positions`,void 0),k([C()],Io.prototype,`selectedId`,void 0),k([C()],Io.prototype,`showMeta`,void 0),Io=k([g(`mateu-workflow`)],Io);var Lo=[`string`,`integer`,`number`,`bool`,`date`,`time`,`dateTime`,`dateRange`,`money`,`file`,`array`,`status`,`component`,`menu`,`range`,`action`,`actionGroup`],Ro=[`regular`,`radio`,`checkbox`,`textarea`,`toggle`,`combobox`,`select`,`email`,`password`,`richText`,`listBox`,`html`,`markdown`,`image`,`icon`,`link`,`money`,`grid`,`color`,`choice`,`popover`,`slider`,`button`,`stars`],zo={string:`#3B82F6`,integer:`#8B5CF6`,number:`#6366F1`,bool:`#10B981`,date:`#F59E0B`,time:`#F59E0B`,dateTime:`#F59E0B`,dateRange:`#F59E0B`,money:`#EF4444`,file:`#64748B`,array:`#0EA5E9`,status:`#EC4899`,component:`#14B8A6`,menu:`#94A3B8`,range:`#A855F7`,action:`#F97316`,actionGroup:`#FB923C`};function Bo(){return`field-`+Math.random().toString(36).slice(2,8)}var Vo=class extends b{constructor(...e){super(...e),this.value=`{"name":"New Form","fields":[]}`,this.form={name:`New Form`,fields:[]},this.selectedId=null,this.showMeta=!1,this.sortable=null,this.listEl=null}updated(e){if(e.has(`value`))try{this.form=JSON.parse(this.value)}catch{}this.attachSortable()}disconnectedCallback(){super.disconnectedCallback(),this.sortable?.destroy(),this.sortable=null}attachSortable(){let e=this.shadowRoot?.querySelector(`.field-list`);!e||e===this.listEl||(this.listEl=e,this.sortable?.destroy(),this.sortable=se.create(e,{animation:150,handle:`.drag-handle`,ghostClass:`sortable-ghost`,onEnd:e=>{let{oldIndex:t,newIndex:n}=e;if(t===void 0||n===void 0||t===n)return;let r=[...this.form.fields],[i]=r.splice(t,1);r.splice(n,0,i),this.form={...this.form,fields:r},this.emit()}}))}emit(){let e=JSON.stringify(this.form,null,2);this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e},bubbles:!0,composed:!0}))}updateForm(e){this.form={...this.form,...e},this.emit()}updateField(e,t){this.form={...this.form,fields:this.form.fields.map(n=>n.id===e?{...n,...t}:n)},this.emit()}addField(){let e=Bo(),t={id:e,label:`New Field`,dataType:`string`};this.form={...this.form,fields:[...this.form.fields,t]},this.selectedId=e,this.emit()}deleteField(e){this.form={...this.form,fields:this.form.fields.filter(t=>t.id!==e)},this.selectedId===e&&(this.selectedId=null),this.emit()}duplicateField(e){let t=this.form.fields.find(t=>t.id===e);if(!t)return;let n={...t,id:Bo(),label:t.label+` (copy)`},r=this.form.fields.findIndex(t=>t.id===e),i=[...this.form.fields];i.splice(r+1,0,n),this.form={...this.form,fields:i},this.selectedId=n.id,this.emit()}render(){return T`
+    `]}};k([y()],Lo.prototype,`value`,void 0),k([C()],Lo.prototype,`wf`,void 0),k([C()],Lo.prototype,`positions`,void 0),k([C()],Lo.prototype,`selectedId`,void 0),k([C()],Lo.prototype,`showMeta`,void 0),Lo=k([g(`mateu-workflow`)],Lo);var Ro=[`string`,`integer`,`number`,`bool`,`date`,`time`,`dateTime`,`dateRange`,`money`,`file`,`array`,`status`,`component`,`menu`,`range`,`action`,`actionGroup`],zo=[`regular`,`radio`,`checkbox`,`textarea`,`toggle`,`combobox`,`select`,`email`,`password`,`richText`,`listBox`,`html`,`markdown`,`image`,`icon`,`link`,`money`,`grid`,`color`,`choice`,`popover`,`slider`,`button`,`stars`],Bo={string:`#3B82F6`,integer:`#8B5CF6`,number:`#6366F1`,bool:`#10B981`,date:`#F59E0B`,time:`#F59E0B`,dateTime:`#F59E0B`,dateRange:`#F59E0B`,money:`#EF4444`,file:`#64748B`,array:`#0EA5E9`,status:`#EC4899`,component:`#14B8A6`,menu:`#94A3B8`,range:`#A855F7`,action:`#F97316`,actionGroup:`#FB923C`};function Vo(){return`field-`+Math.random().toString(36).slice(2,8)}var Ho=class extends b{constructor(...e){super(...e),this.value=`{"name":"New Form","fields":[]}`,this.form={name:`New Form`,fields:[]},this.selectedId=null,this.showMeta=!1,this.sortable=null,this.listEl=null}updated(e){if(e.has(`value`))try{this.form=JSON.parse(this.value)}catch{}this.attachSortable()}disconnectedCallback(){super.disconnectedCallback(),this.sortable?.destroy(),this.sortable=null}attachSortable(){let e=this.shadowRoot?.querySelector(`.field-list`);!e||e===this.listEl||(this.listEl=e,this.sortable?.destroy(),this.sortable=se.create(e,{animation:150,handle:`.drag-handle`,ghostClass:`sortable-ghost`,onEnd:e=>{let{oldIndex:t,newIndex:n}=e;if(t===void 0||n===void 0||t===n)return;let r=[...this.form.fields],[i]=r.splice(t,1);r.splice(n,0,i),this.form={...this.form,fields:r},this.emit()}}))}emit(){let e=JSON.stringify(this.form,null,2);this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e},bubbles:!0,composed:!0}))}updateForm(e){this.form={...this.form,...e},this.emit()}updateField(e,t){this.form={...this.form,fields:this.form.fields.map(n=>n.id===e?{...n,...t}:n)},this.emit()}addField(){let e=Vo(),t={id:e,label:`New Field`,dataType:`string`};this.form={...this.form,fields:[...this.form.fields,t]},this.selectedId=e,this.emit()}deleteField(e){this.form={...this.form,fields:this.form.fields.filter(t=>t.id!==e)},this.selectedId===e&&(this.selectedId=null),this.emit()}duplicateField(e){let t=this.form.fields.find(t=>t.id===e);if(!t)return;let n={...t,id:Vo(),label:t.label+` (copy)`},r=this.form.fields.findIndex(t=>t.id===e),i=[...this.form.fields];i.splice(r+1,0,n),this.form={...this.form,fields:i},this.selectedId=n.id,this.emit()}render(){return T`
             <div class="root">
                 ${this.renderToolbar()}
                 ${this.showMeta?this.renderMeta():v}
@@ -6910,15 +6918,15 @@ ${i}
                 <span class="form-name">${this.form.name}</span>
                 <div style="flex:1"></div>
                 <button class="nbtn" @click="${()=>this.showMeta=!this.showMeta}">
-                    ${_o}
+                    ${vo}
                     Settings
                 </button>
                 <button class="nbtn primary" @click="${()=>this.addField()}">
-                    ${vo}
+                    ${yo}
                     Add Field
                 </button>
                 <button class="nbtn" @click="${()=>this.exportJson()}">
-                    ${yo}
+                    ${bo}
                     Export
                 </button>
             </div>
@@ -6943,10 +6951,10 @@ ${i}
                     ${e.map(e=>this.renderRow(e))}
                 </div>
             </div>
-        `}renderRow(e){let t=zo[e.dataType]??`#64748b`;return T`
+        `}renderRow(e){let t=Bo[e.dataType]??`#64748b`;return T`
             <div role="button" tabindex="0" class="field-row ${this.selectedId===e.id?`selected`:``}"
                  data-id="${e.id}"
-                 @click="${()=>this.selectedId=this.selectedId===e.id?null:e.id}" @keydown="${z(()=>this.selectedId=this.selectedId===e.id?null:e.id)}">
+                 @click="${()=>this.selectedId=this.selectedId===e.id?null:e.id}" @keydown="${R(()=>this.selectedId=this.selectedId===e.id?null:e.id)}">
                 <span class="drag-handle" title="Drag to reorder">⠿</span>
                 <span class="type-badge" style="background:${t}">${e.dataType}</span>
                 <span class="field-label-text">${e.label}</span>
@@ -6978,13 +6986,13 @@ ${i}
                     ${t(`Data type`,T`
                         <select class="inp"
                                 @change="${t=>this.updateField(e.id,{dataType:t.target.value})}">
-                            ${Lo.map(t=>T`
+                            ${Ro.map(t=>T`
                                 <option value="${t}" ?selected="${e.dataType===t}">${t}</option>`)}
                         </select>`)}
                     ${t(`Stereotype`,T`
                         <select class="inp"
                                 @change="${t=>this.updateField(e.id,{stereotype:t.target.value||void 0})}">
-                            ${Ro.map(t=>T`
+                            ${zo.map(t=>T`
                                 <option value="${t}" ?selected="${(e.stereotype??`regular`)===t}">${t}</option>`)}
                         </select>`)}
                     <div class="prop-field row">
@@ -6997,7 +7005,7 @@ ${i}
                                   @change="${t=>this.updateField(e.id,{description:t.target.value||void 0})}">${e.description??``}</textarea>`)}
                 </div>
             </div>
-        `}exportJson(){let e=JSON.stringify(this.form,null,2),t=new Blob([e],{type:`application/json`}),n=URL.createObjectURL(t),r=document.createElement(`a`);r.href=n,r.download=(this.form.name??`form`).replace(/\s+/g,`-`).toLowerCase()+`.json`,r.click(),URL.revokeObjectURL(n)}static{this.styles=[ho,B,h`
+        `}exportJson(){let e=JSON.stringify(this.form,null,2),t=new Blob([e],{type:`application/json`}),n=URL.createObjectURL(t),r=document.createElement(`a`);r.href=n,r.download=(this.form.name??`form`).replace(/\s+/g,`-`).toLowerCase()+`.json`,r.click(),URL.revokeObjectURL(n)}static{this.styles=[go,z,h`
         :host { display: block; height: 100%; font-family: var(--lumo-font-family, sans-serif); }
 
         .root { display: flex; flex-direction: column; height: 100%; background: var(--lumo-base-color, #fff); }
@@ -7112,7 +7120,7 @@ ${i}
         .inp:focus { border-color: #3B82F6; }
         textarea.inp { resize: vertical; }
         input[readonly].inp { background: #f8fafc; color: #94a3b8; }
-    `]}};k([y()],Vo.prototype,`value`,void 0),k([C()],Vo.prototype,`form`,void 0),k([C()],Vo.prototype,`selectedId`,void 0),k([C()],Vo.prototype,`showMeta`,void 0),Vo=k([g(`mateu-form-editor`)],Vo);var Ho=class extends b{constructor(...e){super(...e),this.appState={},this.appData={},this.open=!1,this.activeTab=`appstate`,this.hoveredTag=``,this.hoveredId=``,this.hoveredState=null,this.hoveredData=null,this.hoveredMeta=null,this._prevTarget=null,this._onMouseover=e=>{let t=e.target;for(;t&&!(t.tagName?.toLowerCase().startsWith(`mateu-`)&&t!==this);)t=t.parentElement;if(t===this||t===null){t===null&&this._prevTarget&&(this._prevTarget.style.outline=``,this._prevTarget.style.outlineOffset=``,this._prevTarget=null,this.hoveredTag=``,this.hoveredId=``,this.hoveredState=null,this.hoveredData=null,this.hoveredMeta=null);return}t!==this._prevTarget&&(this._prevTarget&&(this._prevTarget.style.outline=``,this._prevTarget.style.outlineOffset=``),this._prevTarget=t,t.style.outline=`2px solid #0070f3`,t.style.outlineOffset=`-2px`,this.hoveredTag=t.tagName.toLowerCase(),this.hoveredId=t.id||``,this.hoveredState=t.state,this.hoveredData=t.data,this.hoveredMeta=t.component?.metadata)}}connectedCallback(){super.connectedCallback(),document.addEventListener(`mouseover`,this._onMouseover,!0)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`mouseover`,this._onMouseover,!0),this._prevTarget&&=(this._prevTarget.style.outline=``,null)}_fmt(e){try{return JSON.stringify(e,null,2)??`null`}catch{return String(e)}}_renderTab(e,t){return T`
+    `]}};k([y()],Ho.prototype,`value`,void 0),k([C()],Ho.prototype,`form`,void 0),k([C()],Ho.prototype,`selectedId`,void 0),k([C()],Ho.prototype,`showMeta`,void 0),Ho=k([g(`mateu-form-editor`)],Ho);var Uo=class extends b{constructor(...e){super(...e),this.appState={},this.appData={},this.open=!1,this.activeTab=`appstate`,this.hoveredTag=``,this.hoveredId=``,this.hoveredState=null,this.hoveredData=null,this.hoveredMeta=null,this._prevTarget=null,this._onMouseover=e=>{let t=e.target;for(;t&&!(t.tagName?.toLowerCase().startsWith(`mateu-`)&&t!==this);)t=t.parentElement;if(t===this||t===null){t===null&&this._prevTarget&&(this._prevTarget.style.outline=``,this._prevTarget.style.outlineOffset=``,this._prevTarget=null,this.hoveredTag=``,this.hoveredId=``,this.hoveredState=null,this.hoveredData=null,this.hoveredMeta=null);return}t!==this._prevTarget&&(this._prevTarget&&(this._prevTarget.style.outline=``,this._prevTarget.style.outlineOffset=``),this._prevTarget=t,t.style.outline=`2px solid #0070f3`,t.style.outlineOffset=`-2px`,this.hoveredTag=t.tagName.toLowerCase(),this.hoveredId=t.id||``,this.hoveredState=t.state,this.hoveredData=t.data,this.hoveredMeta=t.component?.metadata)}}connectedCallback(){super.connectedCallback(),document.addEventListener(`mouseover`,this._onMouseover,!0)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`mouseover`,this._onMouseover,!0),this._prevTarget&&=(this._prevTarget.style.outline=``,null)}_fmt(e){try{return JSON.stringify(e,null,2)??`null`}catch{return String(e)}}_renderTab(e,t){return T`
             <button class="tab ${this.activeTab===e?`tab--active`:``}"
                 @click=${()=>{this.activeTab=e}}>
                 ${t}
@@ -7285,7 +7293,7 @@ ${i}
             border-bottom: 1px solid #2a2a3a;
         }
         .section-label:first-of-type { margin-top: 0; }
-    `}};k([y()],Ho.prototype,`appState`,void 0),k([y()],Ho.prototype,`appData`,void 0),k([C()],Ho.prototype,`open`,void 0),k([C()],Ho.prototype,`activeTab`,void 0),k([C()],Ho.prototype,`hoveredTag`,void 0),k([C()],Ho.prototype,`hoveredId`,void 0),k([C()],Ho.prototype,`hoveredState`,void 0),k([C()],Ho.prototype,`hoveredData`,void 0),k([C()],Ho.prototype,`hoveredMeta`,void 0),Ho=k([g(`mateu-debug-overlay`)],Ho);var Uo=(e,t)=>{let n=t?.initiatorState;return n&&typeof n==`object`?{...n}:{...e??{}}},Wo=e=>{if(e)try{return JSON.parse(e)}catch{return{value:e}}else return{}},Go=function(e){return e.SetAppDataValue=`SetAppDataValue`,e.SetAppStateValue=`SetAppStateValue`,e.SetDataValue=`SetDataValue`,e.RunAction=`RunAction`,e.RunJS=`RunJS`,e.SetAttributeValue=`SetAttributeValue`,e.SetStateValue=`SetStateValue`,e.SetCssClass=`SetCssClass`,e.SetStyle=`SetStyle`,e}({}),Ko=function(e){return e.required=`required`,e.disabled=`disabled`,e.hidden=`hidden`,e.pattern=`pattern`,e.minValue=`minValue`,e.maxValue=`maxValue`,e.minLength=`minLength`,e.maxLength=`maxLength`,e.css=`css`,e.style=`style`,e.theme=`theme`,e.errorMessage=`errorMessage`,e.description=`description`,e.none=`none`,e}({}),qo=function(e){return e.Continue=`Continue`,e.Stop=`Stop`,e}({}),Jo=12e4,Yo=(e,t)=>`${e??`_`}::${t}`,Xo=new class{constructor(){this.started=new Map,this.listeners=new Set}begin(e,t=Date.now()){let n=this.started.get(e);return n!==void 0&&t-n<Jo?!1:(this.started.set(e,t),this.emit(),!0)}end(e){this.started.delete(e)&&this.emit()}isPending(e,t=Date.now()){let n=this.started.get(e);return n!==void 0&&t-n<Jo}snapshot(){return new Set(this.started.keys())}subscribe(e){return this.listeners.add(e),()=>this.listeners.delete(e)}reset(){this.started.clear(),this.emit()}emit(){let e=this.snapshot();this.listeners.forEach(t=>t(e))}},Zo=`data-mateu-pending-styles`,Qo=`
+    `}};k([y()],Uo.prototype,`appState`,void 0),k([y()],Uo.prototype,`appData`,void 0),k([C()],Uo.prototype,`open`,void 0),k([C()],Uo.prototype,`activeTab`,void 0),k([C()],Uo.prototype,`hoveredTag`,void 0),k([C()],Uo.prototype,`hoveredId`,void 0),k([C()],Uo.prototype,`hoveredState`,void 0),k([C()],Uo.prototype,`hoveredData`,void 0),k([C()],Uo.prototype,`hoveredMeta`,void 0),Uo=k([g(`mateu-debug-overlay`)],Uo);var Wo=(e,t)=>{let n=t?.initiatorState;return n&&typeof n==`object`?{...n}:{...e??{}}},Go=e=>{if(e)try{return JSON.parse(e)}catch{return{value:e}}else return{}},Ko=function(e){return e.SetAppDataValue=`SetAppDataValue`,e.SetAppStateValue=`SetAppStateValue`,e.SetDataValue=`SetDataValue`,e.RunAction=`RunAction`,e.RunJS=`RunJS`,e.SetAttributeValue=`SetAttributeValue`,e.SetStateValue=`SetStateValue`,e.SetCssClass=`SetCssClass`,e.SetStyle=`SetStyle`,e}({}),qo=function(e){return e.required=`required`,e.disabled=`disabled`,e.hidden=`hidden`,e.pattern=`pattern`,e.minValue=`minValue`,e.maxValue=`maxValue`,e.minLength=`minLength`,e.maxLength=`maxLength`,e.css=`css`,e.style=`style`,e.theme=`theme`,e.errorMessage=`errorMessage`,e.description=`description`,e.none=`none`,e}({}),Jo=function(e){return e.Continue=`Continue`,e.Stop=`Stop`,e}({}),Yo=12e4,Xo=(e,t)=>`${e??`_`}::${t}`,Zo=new class{constructor(){this.started=new Map,this.listeners=new Set}begin(e,t=Date.now()){let n=this.started.get(e);return n!==void 0&&t-n<Yo?!1:(this.started.set(e,t),this.emit(),!0)}end(e){this.started.delete(e)&&this.emit()}isPending(e,t=Date.now()){let n=this.started.get(e);return n!==void 0&&t-n<Yo}snapshot(){return new Set(this.started.keys())}subscribe(e){return this.listeners.add(e),()=>this.listeners.delete(e)}reset(){this.started.clear(),this.emit()}emit(){let e=this.snapshot();this.listeners.forEach(t=>t(e))}},Qo=`data-mateu-pending-styles`,$o=`
 [data-mateu-pending] {
     pointer-events: none;
     cursor: progress;
@@ -7299,9 +7307,9 @@ ${i}
     0%, 100% { opacity: .45; }
     50% { opacity: .85; }
 }
-`,$o=new WeakSet,es=e=>{if($o.has(e))return;$o.add(e);let t=e;if(typeof CSSStyleSheet<`u`&&Array.isArray(t.adoptedStyleSheets))try{let e=new CSSStyleSheet;e.replaceSync(Qo),t.adoptedStyleSheets=[...t.adoptedStyleSheets,e];return}catch{}let n=e instanceof Document?e.head:e;if(!n)return;let r=document.createElement(`style`);r.setAttribute(Zo,``),r.textContent=Qo,n.appendChild(r)},ts=e=>{let t=e.getRootNode();if(t instanceof ShadowRoot||t instanceof Document)return t},ns=e=>{if(!e||e.hasAttribute(`data-mateu-pending`))return;let t=ts(e);t&&es(t),e.setAttribute(`data-mateu-pending`,``),e.setAttribute(`aria-busy`,`true`)},rs=e=>{e&&(e.removeAttribute(`data-mateu-pending`),e.removeAttribute(`aria-busy`))},is=e=>{let t=(typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target;return t instanceof Element?t:void 0},as=[`button`,`a[href]`,`[role="button"]`,`[role="menuitem"]`,`input[type="button"]`,`input[type="submit"]`,`vaadin-button`,`vaadin-menu-bar-button`,`ui5-button`,`oj-c-button`,`oj-button`].join(`, `),os=e=>{if(!(!e||typeof e.closest!=`function`))return e.closest(as)??void 0},ss=null,cs=class extends Ua{constructor(...e){super(...e),this.baseUrl=``,this.route=``,this.consumedRoute=``,this.formerState={},this.applyRules=()=>{let e=this.component.rules;if(e&&e.length>0){let t=this.state,n=this.data,r=this.appState,i=this.appData,a=this.component,o=e=>Ct(e,t,n,{appState:r,appData:i,component:a}),s=e=>St(e,t,n,r,i,{component:a}),c=[`state`,`data`,`appState`,`appData`,`component`],l=[t,n,r,i,a],u={...this.state},d={...this.data},f=!1,p=!1;for(let t=0;t<e.length;t++){let n=e[t];try{if(o(n.filter)){if(Go.SetStateValue==n.action||Go.SetDataValue==n.action){let e=Go.SetStateValue==n.action?u:d,t=n.fieldName.split(`,`);for(let r=0;r<t.length;r++){let i=t[r];if(!e[i]||e[i]!=n.value){let t=n.expression?s(n.expression):n.value,r=Ko.none==n.fieldAttribute?i:i+`.`+n.fieldAttribute;t!=e[r]&&(e[r]=t,Go.SetStateValue==n.action&&(f=!0),Go.SetDataValue==n.action&&(p=!0))}}}if(Go.RunAction==n.action&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.actionId},bubbles:!0,composed:!0})),Go.RunJS==n.action&&Function(...c,n.value)(...l),Go.SetAttributeValue==n.action){let e=n.expression?o(n.expression):n.value;if(n.fieldAttribute==`disabled`){e?this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(n.fieldAttribute,`disabled`):this.shadowRoot?.getElementById(n.fieldName)?.removeAttribute(n.fieldAttribute);continue}this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(n.fieldAttribute,e)}if(Go.SetCssClass==n.action&&this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(`class`,n.value),Go.SetStyle==n.action&&this.shadowRoot?.getElementById(n.fieldName)?.style.setProperty(n.expression,n.value),qo.Stop==n.result)break}}catch(e){console.error(`rule failed`,n,e)}}f&&(this.state=u),p&&(this.data=d),f&&this.checkValidations()}},this.skipValidation=(e,t)=>e&&t.fieldId&&!e.includes(t.fieldId)||!e&&t.fieldId&&t.fieldId.includes(`-`),this.checkValidations=e=>{let t=e?e.split(`,`):void 0,n=this.component.validations,r=!0,i=!1,a=this.data??{},o={...this.data??{},errors:{}};if(n){for(let e=0;e<n.length;e++){let r=n[e];if(this.skipValidation(t,r))continue;let i=(r.fieldId??`_component`).split(`,`);for(let e=0;e<i.length;e++){let t=i[e];o.errors[t]=[]}}for(let e=0;e<n.length;e++){let i=n[e];if(!this.skipValidation(t,i))try{let e=i.condition&&i.condition.includes("${")?this._evalTemplate(i.condition):this._evalExpr(i.condition);if(i.condition&&!e){r=!1;let e=(i.fieldId??`_component`).split(`,`);for(let t=0;t<e.length;t++){let n=e[t],r=o.errors[n];if(r||(o.errors[n]=[]),r=o.errors[n],!a[n]){let e=i.message;try{e=this._evalTemplate(i.message)}catch{}r.push(e)}}}}catch(e){console.error(`validation failed`,i,e)}}for(let e=0;e<n.length;e++){let r=n[e];if(this.skipValidation(t,r))continue;let s=(r.fieldId??`_component`).split(`,`);for(let e=0;e<s.length;e++){let t=s[e];if((a.errors||o.errors==``)&&[t].join(`,`)){i=!0;break}}}(a.errors||o.errors==``)&&[`_component`].join(`,`)&&(i=!0)}o._valid=r,o._valid!=a._valid&&(i=!0),i&&(this.data=o)},this._autoSaveTimers=new Map,this.onChange=()=>{this.applyRules()},this.closeModalRequestedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.closeModal()},this.resetFilters=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail,n={};t.fieldIds.forEach(e=>{n[e]=void 0}),n.searchText=void 0,this.state={...this.state,...n}}},this.dataChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail,n={};n[t.key]=t.value,e.type==`data-changed`&&(this.data={...this.data,...n})}},this.valueChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail;if(e.type==`value-changed`){let n={...this.state};n[t.fieldId]=t.value,this.state=n,(this.state[t.fieldId]||this.formerState[t.fieldId])&&this.state[t.fieldId]!=this.formerState[t.fieldId]&&this.component?.confirmOnNavigationIfDirty&&this.dispatchEvent(new CustomEvent(`dirty`,{detail:e.detail,bubbles:!0,composed:!0}));let r=this.component;r.triggers?.filter(e=>e.type==Ha.OnValueChange).filter(e=>!e.propertyName||t.fieldId==e.propertyName).forEach(e=>{(!e.condition||this._evalExpr(e.condition))&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))}),r.triggers?.filter(e=>e.type==Ha.AutoSave).forEach(e=>{let t=e.actionId,n=this._autoSaveTimers.get(t);n!==void 0&&clearTimeout(n),this._autoSaveTimers.set(t,setTimeout(()=>{this._autoSaveTimers.delete(t),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))},e.debounceMillis??800))})}}},this.actionRequestedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.manageActionRequestedEvent(e)},this.manageActionRequestedEvent=e=>{let t=e.detail,n=t?._originElement??is(e);if(e.type==`action-requested`){e.preventDefault(),e.stopPropagation();let r=this.component,i=r.actions?.find(e=>e.id==t.actionId)??r.actions?.find(e=>e.id.endsWith(`*`)&&t.actionId.startsWith(e.id.replace(`*`,``)));if(i){if(i&&i.rowsSelectedRequired&&(!this.state.crud_selected_items||this.state.crud_selected_items.length==0)){this.notify(`You first need to select some rows`);return}if(i&&i.validationRequired){let e=ss??this;if(ss=null,e.checkValidations(i.fieldsToValidate),!e.data._valid){e.notifyValidationErrors();return}}ss=null;let e={...t,initiatorComponentId:this.id};i&&i.confirmationRequired?this.callAfterConfirmation(i,()=>this.requestActionCallToServerOrBubble(e,r,i,n)):this.requestActionCallToServerOrBubble(e,r,i,n)}else{let r={...t.parameters};r.initiatorState||=this.state,ss||=this,this.dispatchEvent(new CustomEvent(e.type,{detail:{...e.detail,_originElement:n,parameters:r},bubbles:!0,composed:!0}))}}},this.buildFieldLabelMap=()=>{let e={},t=n=>{if(n)for(let r of n){let n=r.metadata;if(n?.type===j.FormField){let t=n;t.fieldId&&t.label&&(e[t.fieldId]=t.label)}t(r.children)}};return t(this.component?.children),e},this.notifyValidationErrors=()=>{let e=this.data?.errors??{},t=this.buildFieldLabelMap(),n=[];if(Object.entries(e).forEach(([e,r])=>{if(!Array.isArray(r))return;let i=e===`_component`?void 0:t[e]??e;r.forEach(e=>{e&&!n.some(t=>t.label===i&&t.msg===e)&&n.push({label:i,msg:e})})}),n.length===0){this.notify(`There are validation errors`);return}Na({text:`There are validation errors
+`,es=new WeakSet,ts=e=>{if(es.has(e))return;es.add(e);let t=e;if(typeof CSSStyleSheet<`u`&&Array.isArray(t.adoptedStyleSheets))try{let e=new CSSStyleSheet;e.replaceSync($o),t.adoptedStyleSheets=[...t.adoptedStyleSheets,e];return}catch{}let n=e instanceof Document?e.head:e;if(!n)return;let r=document.createElement(`style`);r.setAttribute(Qo,``),r.textContent=$o,n.appendChild(r)},ns=e=>{let t=e.getRootNode();if(t instanceof ShadowRoot||t instanceof Document)return t},rs=e=>{if(!e||e.hasAttribute(`data-mateu-pending`))return;let t=ns(e);t&&ts(t),e.setAttribute(`data-mateu-pending`,``),e.setAttribute(`aria-busy`,`true`)},is=e=>{e&&(e.removeAttribute(`data-mateu-pending`),e.removeAttribute(`aria-busy`))},as=e=>{let t=(typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target;return t instanceof Element?t:void 0},os=[`button`,`a[href]`,`[role="button"]`,`[role="menuitem"]`,`input[type="button"]`,`input[type="submit"]`,`vaadin-button`,`vaadin-menu-bar-button`,`ui5-button`,`oj-c-button`,`oj-button`].join(`, `),ss=e=>{if(!(!e||typeof e.closest!=`function`))return e.closest(os)??void 0},cs=null,ls=class extends Wa{constructor(...e){super(...e),this.baseUrl=``,this.route=``,this.consumedRoute=``,this.formerState={},this.applyRules=()=>{let e=this.component.rules;if(e&&e.length>0){let t=this.state,n=this.data,r=this.appState,i=this.appData,a=this.component,o=e=>Ct(e,t,n,{appState:r,appData:i,component:a}),s=e=>St(e,t,n,r,i,{component:a}),c=[`state`,`data`,`appState`,`appData`,`component`],l=[t,n,r,i,a],u={...this.state},d={...this.data},f=!1,p=!1;for(let t=0;t<e.length;t++){let n=e[t];try{if(o(n.filter)){if(Ko.SetStateValue==n.action||Ko.SetDataValue==n.action){let e=Ko.SetStateValue==n.action?u:d,t=n.fieldName.split(`,`);for(let r=0;r<t.length;r++){let i=t[r];if(!e[i]||e[i]!=n.value){let t=n.expression?s(n.expression):n.value,r=qo.none==n.fieldAttribute?i:i+`.`+n.fieldAttribute;t!=e[r]&&(e[r]=t,Ko.SetStateValue==n.action&&(f=!0),Ko.SetDataValue==n.action&&(p=!0))}}}if(Ko.RunAction==n.action&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.actionId},bubbles:!0,composed:!0})),Ko.RunJS==n.action&&Function(...c,n.value)(...l),Ko.SetAttributeValue==n.action){let e=n.expression?o(n.expression):n.value;if(n.fieldAttribute==`disabled`){e?this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(n.fieldAttribute,`disabled`):this.shadowRoot?.getElementById(n.fieldName)?.removeAttribute(n.fieldAttribute);continue}this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(n.fieldAttribute,e)}if(Ko.SetCssClass==n.action&&this.shadowRoot?.getElementById(n.fieldName)?.setAttribute(`class`,n.value),Ko.SetStyle==n.action&&this.shadowRoot?.getElementById(n.fieldName)?.style.setProperty(n.expression,n.value),Jo.Stop==n.result)break}}catch(e){console.error(`rule failed`,n,e)}}f&&(this.state=u),p&&(this.data=d),f&&this.checkValidations()}},this.skipValidation=(e,t)=>e&&t.fieldId&&!e.includes(t.fieldId)||!e&&t.fieldId&&t.fieldId.includes(`-`),this.checkValidations=e=>{let t=e?e.split(`,`):void 0,n=this.component.validations,r=!0,i=!1,a=this.data??{},o={...this.data??{},errors:{}};if(n){for(let e=0;e<n.length;e++){let r=n[e];if(this.skipValidation(t,r))continue;let i=(r.fieldId??`_component`).split(`,`);for(let e=0;e<i.length;e++){let t=i[e];o.errors[t]=[]}}for(let e=0;e<n.length;e++){let i=n[e];if(!this.skipValidation(t,i))try{let e=i.condition&&i.condition.includes("${")?this._evalTemplate(i.condition):this._evalExpr(i.condition);if(i.condition&&!e){r=!1;let e=(i.fieldId??`_component`).split(`,`);for(let t=0;t<e.length;t++){let n=e[t],r=o.errors[n];if(r||(o.errors[n]=[]),r=o.errors[n],!a[n]){let e=i.message;try{e=this._evalTemplate(i.message)}catch{}r.push(e)}}}}catch(e){console.error(`validation failed`,i,e)}}for(let e=0;e<n.length;e++){let r=n[e];if(this.skipValidation(t,r))continue;let s=(r.fieldId??`_component`).split(`,`);for(let e=0;e<s.length;e++){let t=s[e];if((a.errors||o.errors==``)&&[t].join(`,`)){i=!0;break}}}(a.errors||o.errors==``)&&[`_component`].join(`,`)&&(i=!0)}o._valid=r,o._valid!=a._valid&&(i=!0),i&&(this.data=o)},this._autoSaveTimers=new Map,this.onChange=()=>{this.applyRules()},this.closeModalRequestedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.closeModal()},this.resetFilters=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail,n={};t.fieldIds.forEach(e=>{n[e]=void 0}),n.searchText=void 0,this.state={...this.state,...n}}},this.dataChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail,n={};n[t.key]=t.value,e.type==`data-changed`&&(this.data={...this.data,...n})}},this.valueChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent){let t=e.detail;if(e.type==`value-changed`){let n={...this.state};n[t.fieldId]=t.value,this.state=n,(this.state[t.fieldId]||this.formerState[t.fieldId])&&this.state[t.fieldId]!=this.formerState[t.fieldId]&&this.component?.confirmOnNavigationIfDirty&&this.dispatchEvent(new CustomEvent(`dirty`,{detail:e.detail,bubbles:!0,composed:!0}));let r=this.component;r.triggers?.filter(e=>e.type==Ua.OnValueChange).filter(e=>!e.propertyName||t.fieldId==e.propertyName).forEach(e=>{(!e.condition||this._evalExpr(e.condition))&&this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))}),r.triggers?.filter(e=>e.type==Ua.AutoSave).forEach(e=>{let t=e.actionId,n=this._autoSaveTimers.get(t);n!==void 0&&clearTimeout(n),this._autoSaveTimers.set(t,setTimeout(()=>{this._autoSaveTimers.delete(t),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.actionId},bubbles:!0,composed:!0}))},e.debounceMillis??800))})}}},this.actionRequestedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.manageActionRequestedEvent(e)},this.manageActionRequestedEvent=e=>{let t=e.detail,n=t?._originElement??as(e);if(e.type==`action-requested`){e.preventDefault(),e.stopPropagation();let r=this.component,i=r.actions?.find(e=>e.id==t.actionId)??r.actions?.find(e=>e.id.endsWith(`*`)&&t.actionId.startsWith(e.id.replace(`*`,``)));if(i){if(i&&i.rowsSelectedRequired&&(!this.state.crud_selected_items||this.state.crud_selected_items.length==0)){this.notify(`You first need to select some rows`);return}if(i&&i.validationRequired){let e=cs??this;if(cs=null,e.checkValidations(i.fieldsToValidate),!e.data._valid){e.notifyValidationErrors();return}}cs=null;let e={...t,initiatorComponentId:this.id};i&&i.confirmationRequired?this.callAfterConfirmation(i,()=>this.requestActionCallToServerOrBubble(e,r,i,n)):this.requestActionCallToServerOrBubble(e,r,i,n)}else{let r={...t.parameters};r.initiatorState||=this.state,cs||=this,this.dispatchEvent(new CustomEvent(e.type,{detail:{...e.detail,_originElement:n,parameters:r},bubbles:!0,composed:!0}))}}},this.buildFieldLabelMap=()=>{let e={},t=n=>{if(n)for(let r of n){let n=r.metadata;if(n?.type===j.FormField){let t=n;t.fieldId&&t.label&&(e[t.fieldId]=t.label)}t(r.children)}};return t(this.component?.children),e},this.notifyValidationErrors=()=>{let e=this.data?.errors??{},t=this.buildFieldLabelMap(),n=[];if(Object.entries(e).forEach(([e,r])=>{if(!Array.isArray(r))return;let i=e===`_component`?void 0:t[e]??e;r.forEach(e=>{e&&!n.some(t=>t.label===i&&t.msg===e)&&n.push({label:i,msg:e})})}),n.length===0){this.notify(`There are validation errors`);return}Pa({text:`There are validation errors
 `+n.map(({label:e,msg:t})=>e?`• ${e}: ${t}`:`• ${t}`).join(`
-`),variant:`error`,position:`bottomEnd`,duration:Math.max(3e3,1500+n.length*1e3)},this),this.focusFirstInvalidField()},this.notify=e=>{Na({text:e,variant:`error`,position:`bottomEnd`,duration:3e3},this)},this.handleRestAction=(e,t)=>{let n=t=>{if(e.resultPath!=null){let n=ln(t,e.resultPath);n&&typeof n==`object`&&(this.state={...this.state,...n})}let n=M(e.successMessage,this.state,this.data);n&&Na({text:n,variant:`success`,position:`bottomEnd`,duration:3e3},this)};if(e.source?.proxy){let e=t===`__restdata__`?`data`:`action`;this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:`__restfetch__`,parameters:{_sourceKind:e,_sourceId:t},callback:e=>n(e?.appData?._restfetch),callbackonly:!0},bubbles:!0,composed:!0}));return}fn(e.source,e=>M(e,this.state,this.data)).then(n).catch(e=>{console.warn(`mateu: rest action failed`,e),Na({text:`Request failed`,variant:`error`,position:`bottomEnd`,duration:3e3},this)})},this.callAfterConfirmation=(e,t)=>{let n=`One moment, please`,r=`Are you sure?`,i=`Yes`,a=`No`;e.confirmationTexts&&(n=e.confirmationTexts.title,r=e.confirmationTexts.message,i=e.confirmationTexts.confirmationText,a=e.confirmationTexts.denialText);let o=document.createElement(`div`);o.style.cssText=`position:fixed;inset:0;z-index:1100;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.35);padding:1rem;`;let s=document.createElement(`div`);s.style.cssText=`background:var(--lumo-base-color,#fff);color:var(--lumo-body-text-color,#1a1a1a);border-radius:var(--lumo-border-radius-l,12px);box-shadow:var(--lumo-box-shadow-xl,0 12px 40px rgba(0,0,0,.3));padding:1.2rem;max-width:min(90vw,26rem);`;let c=()=>{o.parentElement&&document.body.removeChild(o)},l=`font:inherit;font-weight:600;padding:.45rem 1rem;border-radius:var(--lumo-border-radius-m,6px);cursor:pointer;`;re(T`
+`),variant:`error`,position:`bottomEnd`,duration:Math.max(3e3,1500+n.length*1e3)},this),this.focusFirstInvalidField()},this.notify=e=>{Pa({text:e,variant:`error`,position:`bottomEnd`,duration:3e3},this)},this.handleRestAction=(e,t)=>{let n=t=>{if(e.resultPath!=null){let n=un(t,e.resultPath);n&&typeof n==`object`&&(this.state={...this.state,...n})}let n=M(e.successMessage,this.state,this.data);n&&Pa({text:n,variant:`success`,position:`bottomEnd`,duration:3e3},this)};if(e.source?.proxy){let e=t===`__restdata__`?`data`:`action`;this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:`__restfetch__`,parameters:{_sourceKind:e,_sourceId:t},callback:e=>n(e?.appData?._restfetch),callbackonly:!0},bubbles:!0,composed:!0}));return}pn(e.source,e=>M(e,this.state,this.data)).then(n).catch(e=>{console.warn(`mateu: rest action failed`,e),Pa({text:`Request failed`,variant:`error`,position:`bottomEnd`,duration:3e3},this)})},this.callAfterConfirmation=(e,t)=>{let n=`One moment, please`,r=`Are you sure?`,i=`Yes`,a=`No`;e.confirmationTexts&&(n=e.confirmationTexts.title,r=e.confirmationTexts.message,i=e.confirmationTexts.confirmationText,a=e.confirmationTexts.denialText);let o=document.createElement(`div`);o.style.cssText=`position:fixed;inset:0;z-index:1100;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.35);padding:1rem;`;let s=document.createElement(`div`);s.style.cssText=`background:var(--lumo-base-color,#fff);color:var(--lumo-body-text-color,#1a1a1a);border-radius:var(--lumo-border-radius-l,12px);box-shadow:var(--lumo-box-shadow-xl,0 12px 40px rgba(0,0,0,.3));padding:1.2rem;max-width:min(90vw,26rem);`;let c=()=>{o.parentElement&&document.body.removeChild(o)},l=`font:inherit;font-weight:600;padding:.45rem 1rem;border-radius:var(--lumo-border-radius-m,6px);cursor:pointer;`;re(T`
             <h3 style="margin:0 0 .5rem;">${n}</h3>
             <div style="margin-bottom:1.2rem;">${r}</div>
             <div style="display:flex;justify-content:flex-end;gap:.5rem;">
@@ -7310,18 +7318,18 @@ ${i}
                 <button style="${l}border:none;background:var(--lumo-primary-color,#1676f3);color:var(--lumo-primary-contrast-color,#fff);"
                         @click="${()=>{c(),t()}}">${i}</button>
             </div>
-        `,s),o.appendChild(s),o.addEventListener(`click`,e=>{e.target===o&&c()}),document.body.appendChild(o)},this.requestActionCallToServerOrBubble=(e,t,n,r)=>{if(n&&n.bubble){let t={...e.parameters};t.initiatorState||=this.state,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{...e,_originElement:r,parameters:t},bubbles:!0,composed:!0}))}else this.requestActionCallToServer(e,t,n,r)},this.requestActionCallToServer=(e,t,n,r)=>{if(n&&n.href){window.location.href=n.href;return}if(n&&n.js)try{Function(`state`,`data`,`appState`,`appData`,`component`,n.js).call(this,this.state??{},this.data??{},this.appState??{},this.appData??{},this.component),this.state={...this.state},this.data={...this.data}}catch(e){console.error(`when evaluating `+n.js,e,this.component,this.state,this.data)}if(n&&n.customEvent&&this.dispatchEvent(new CustomEvent(n.customEvent.name,{detail:n.customEvent.detail,bubbles:!0,composed:!0})),n&&(n.js||n.customEvent))return;if(n&&n.restAction){this.handleRestAction(n.restAction,n.id);return}if(e.actionId==`search`){let t=e.parameters?._searchState;t?this.state={...this.state,...t}:this.state.size||(this.state={...this.state,size:10,page:0,sort:[]})}if(!n?.background){if(!nt(e.actionId,n?.idempotent)&&!Xo.begin(Yo(this.id,e.actionId)))return;let t=os(r);this._pendingOrigins.set(e.actionId,t),ns(t)}let i=Uo(this.state,e.parameters);this.dispatchEvent(new CustomEvent(`server-side-action-requested`,{detail:{route:this.route,consumedRoute:this.consumedRoute,componentState:i,parameters:e.parameters??{},actionId:e.actionId,serverSideType:t.serverSideType,serverSideComponentRoute:t.route,initiatorComponentId:e.initiatorComponentId??t.id,initiator:this,background:n?.background,sse:n?.sse,timeoutMillis:n?.timeoutMillis,idempotent:n?.idempotent,callback:e.callback,callbackonly:e.callbackonly,callbackToken:e.callbackToken??this.callbackToken},bubbles:!0,composed:!0}))},this.handleBackendSucceeded=e=>{e.detail.actionId&&this.component.triggers?.filter(e=>e.type==Ha.OnSuccess).filter(t=>e.detail.actionId==t.calledActionId).forEach(t=>{if(!t.condition||this._evalExpr(t.condition))if(e.preventDefault(),e.stopPropagation(),t.timeoutMillis>0){let e=this.callbackToken;setTimeout(()=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,callbackToken:e},bubbles:!0,composed:!0}))},t.timeoutMillis)}else this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))})},this.handleBackendFailed=e=>{e.detail.actionId&&this.component.triggers?.filter(e=>e.type==Ha.OnError).filter(t=>e.detail.actionId==t.calledActionId).forEach(t=>{(!t.condition||this._evalExpr(t.condition))&&(e.preventDefault(),e.stopPropagation(),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0})))})},this._pendingOrigins=new Map,this._backendSettledListener=e=>{((typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target)===this&&this._releasePending(e.detail?.actionId)},this._keydownListener=e=>{if(this._handleTabShortcut(e))return;let t=this.component;if(t)for(let n of t.actions??[]){let t=n.shortcut||(n.runOnEnter?`enter`:null);if(t&&this._shortcutMatchesEvent(t,e)){e.preventDefault(),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.id},bubbles:!0,composed:!0}));return}}}}createRenderRoot(){return F.mustUseShadowRoot()?super.createRenderRoot():this}updated(e){super.updated(e),e.has(`state`)&&this.state&&JSON.stringify(this.state)!=JSON.stringify({})&&this.onChange(),e.has(`component`)&&(this.formerState={...this.state},this.component?.confirmOnNavigationIfDirty&&this.dispatchEvent(new CustomEvent(`clean`,{detail:{},bubbles:!0,composed:!0})),setTimeout(()=>this.triggerOnLoad()))}focusFirstInvalidField(){let e=t=>requestAnimationFrame(()=>{let n=this.findFirstInvalid(this.renderRoot);if(n){n.focus?.(),n.scrollIntoView?.({block:`center`,behavior:`smooth`});return}t>0&&e(t-1)});e(3)}findFirstInvalid(e){if(!e?.querySelectorAll)return null;for(let t of Array.from(e.querySelectorAll(`*`))){if(t.invalid===!0)return t;if(t.shadowRoot){let e=this.findFirstInvalid(t.shadowRoot);if(e)return e}}return null}_releasePending(e){(e===void 0?Array.from(this._pendingOrigins.keys()):[e]).forEach(e=>{Xo.end(Yo(this.id,e)),rs(this._pendingOrigins.get(e)),this._pendingOrigins.delete(e)})}_shortcutMatchesEvent(e,t){return rr(e,t)}_collectShortcutTabs(){let e=this.renderRoot;if(!e)return[];let t=Array.from(e.querySelectorAll(`vaadin-tab[data-shortcut]`));return e.querySelectorAll(`mateu-drawer, mateu-dialog`).forEach(e=>{let n=e.shadowRoot;n&&t.push(...Array.from(n.querySelectorAll(`vaadin-tab[data-shortcut]`)))}),t}_handleTabShortcut(e){let t=this._collectShortcutTabs();if(t.length===0)return!1;for(let n of Array.from(t)){let t=n.dataset.shortcut;if(!t||!this._shortcutMatchesEvent(t,e))continue;let r=n.closest(`vaadin-tabs`);if(!r)continue;let i=Array.from(r.querySelectorAll(`vaadin-tab`)).indexOf(n);if(!(i<0))return e.preventDefault(),r.selected=i,!0}return!1}connectedCallback(){super.connectedCallback(),this.addEventListener(`backend-call-succeeded`,this.handleBackendSucceeded),this.addEventListener(`backend-call-failed`,this.handleBackendFailed),this.addEventListener(`backend-succeeded-event`,this._backendSettledListener),this.addEventListener(`backend-failed-event`,this._backendSettledListener),this.addEventListener(`backend-cancelled-event`,this._backendSettledListener),document.addEventListener(`keydown`,this._keydownListener)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`backend-call-succeeded`,this.handleBackendSucceeded),this.removeEventListener(`backend-call-failed`,this.handleBackendFailed),this.removeEventListener(`backend-succeeded-event`,this._backendSettledListener),this.removeEventListener(`backend-failed-event`,this._backendSettledListener),this.removeEventListener(`backend-cancelled-event`,this._backendSettledListener),document.removeEventListener(`keydown`,this._keydownListener),this._releasePending()}render(){return T`<div>
+        `,s),o.appendChild(s),o.addEventListener(`click`,e=>{e.target===o&&c()}),document.body.appendChild(o)},this.requestActionCallToServerOrBubble=(e,t,n,r)=>{if(n&&n.bubble){let t={...e.parameters};t.initiatorState||=this.state,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{...e,_originElement:r,parameters:t},bubbles:!0,composed:!0}))}else this.requestActionCallToServer(e,t,n,r)},this.requestActionCallToServer=(e,t,n,r)=>{if(n&&n.href){window.location.href=n.href;return}if(n&&n.js)try{Function(`state`,`data`,`appState`,`appData`,`component`,n.js).call(this,this.state??{},this.data??{},this.appState??{},this.appData??{},this.component),this.state={...this.state},this.data={...this.data}}catch(e){console.error(`when evaluating `+n.js,e,this.component,this.state,this.data)}if(n&&n.customEvent&&this.dispatchEvent(new CustomEvent(n.customEvent.name,{detail:n.customEvent.detail,bubbles:!0,composed:!0})),n&&(n.js||n.customEvent))return;if(n&&n.restAction){this.handleRestAction(n.restAction,n.id);return}if(e.actionId==`search`){let t=e.parameters?._searchState;t?this.state={...this.state,...t}:this.state.size||(this.state={...this.state,size:10,page:0,sort:[]})}if(!n?.background){if(!nt(e.actionId,n?.idempotent)&&!Zo.begin(Xo(this.id,e.actionId)))return;let t=ss(r);this._pendingOrigins.set(e.actionId,t),rs(t)}let i=Wo(this.state,e.parameters);this.dispatchEvent(new CustomEvent(`server-side-action-requested`,{detail:{route:this.route,consumedRoute:this.consumedRoute,componentState:i,parameters:e.parameters??{},actionId:e.actionId,serverSideType:t.serverSideType,serverSideComponentRoute:t.route,initiatorComponentId:e.initiatorComponentId??t.id,initiator:this,background:n?.background,sse:n?.sse,timeoutMillis:n?.timeoutMillis,idempotent:n?.idempotent,callback:e.callback,callbackonly:e.callbackonly,callbackToken:e.callbackToken??this.callbackToken},bubbles:!0,composed:!0}))},this.handleBackendSucceeded=e=>{e.detail.actionId&&this.component.triggers?.filter(e=>e.type==Ua.OnSuccess).filter(t=>e.detail.actionId==t.calledActionId).forEach(t=>{if(!t.condition||this._evalExpr(t.condition))if(e.preventDefault(),e.stopPropagation(),t.timeoutMillis>0){let e=this.callbackToken;setTimeout(()=>{this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,callbackToken:e},bubbles:!0,composed:!0}))},t.timeoutMillis)}else this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0}))})},this.handleBackendFailed=e=>{e.detail.actionId&&this.component.triggers?.filter(e=>e.type==Ua.OnError).filter(t=>e.detail.actionId==t.calledActionId).forEach(t=>{(!t.condition||this._evalExpr(t.condition))&&(e.preventDefault(),e.stopPropagation(),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId},bubbles:!0,composed:!0})))})},this._pendingOrigins=new Map,this._backendSettledListener=e=>{((typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target)===this&&this._releasePending(e.detail?.actionId)},this._keydownListener=e=>{if(this._handleTabShortcut(e))return;let t=this.component;if(t)for(let n of t.actions??[]){let t=n.shortcut||(n.runOnEnter?`enter`:null);if(t&&this._shortcutMatchesEvent(t,e)){e.preventDefault(),this.manageActionRequestedEvent(new CustomEvent(`action-requested`,{detail:{actionId:n.id},bubbles:!0,composed:!0}));return}}}}createRenderRoot(){return P.mustUseShadowRoot()?super.createRenderRoot():this}updated(e){super.updated(e),e.has(`state`)&&this.state&&JSON.stringify(this.state)!=JSON.stringify({})&&this.onChange(),e.has(`component`)&&(this.formerState={...this.state},this.component?.confirmOnNavigationIfDirty&&this.dispatchEvent(new CustomEvent(`clean`,{detail:{},bubbles:!0,composed:!0})),setTimeout(()=>this.triggerOnLoad()))}focusFirstInvalidField(){let e=t=>requestAnimationFrame(()=>{let n=this.findFirstInvalid(this.renderRoot);if(n){n.focus?.(),n.scrollIntoView?.({block:`center`,behavior:`smooth`});return}t>0&&e(t-1)});e(3)}findFirstInvalid(e){if(!e?.querySelectorAll)return null;for(let t of Array.from(e.querySelectorAll(`*`))){if(t.invalid===!0)return t;if(t.shadowRoot){let e=this.findFirstInvalid(t.shadowRoot);if(e)return e}}return null}_releasePending(e){(e===void 0?Array.from(this._pendingOrigins.keys()):[e]).forEach(e=>{Zo.end(Xo(this.id,e)),is(this._pendingOrigins.get(e)),this._pendingOrigins.delete(e)})}_shortcutMatchesEvent(e,t){return ir(e,t)}_collectShortcutTabs(){let e=this.renderRoot;if(!e)return[];let t=Array.from(e.querySelectorAll(`vaadin-tab[data-shortcut]`));return e.querySelectorAll(`mateu-drawer, mateu-dialog`).forEach(e=>{let n=e.shadowRoot;n&&t.push(...Array.from(n.querySelectorAll(`vaadin-tab[data-shortcut]`)))}),t}_handleTabShortcut(e){let t=this._collectShortcutTabs();if(t.length===0)return!1;for(let n of Array.from(t)){let t=n.dataset.shortcut;if(!t||!this._shortcutMatchesEvent(t,e))continue;let r=n.closest(`vaadin-tabs`);if(!r)continue;let i=Array.from(r.querySelectorAll(`vaadin-tab`)).indexOf(n);if(!(i<0))return e.preventDefault(),r.selected=i,!0}return!1}connectedCallback(){super.connectedCallback(),this.addEventListener(`backend-call-succeeded`,this.handleBackendSucceeded),this.addEventListener(`backend-call-failed`,this.handleBackendFailed),this.addEventListener(`backend-succeeded-event`,this._backendSettledListener),this.addEventListener(`backend-failed-event`,this._backendSettledListener),this.addEventListener(`backend-cancelled-event`,this._backendSettledListener),document.addEventListener(`keydown`,this._keydownListener)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`backend-call-succeeded`,this.handleBackendSucceeded),this.removeEventListener(`backend-call-failed`,this.handleBackendFailed),this.removeEventListener(`backend-succeeded-event`,this._backendSettledListener),this.removeEventListener(`backend-failed-event`,this._backendSettledListener),this.removeEventListener(`backend-cancelled-event`,this._backendSettledListener),document.removeEventListener(`keydown`,this._keydownListener),this._releasePending()}render(){return T`<div>
             <div>${this._render()}</div>
             ${this.data&&this.data.errors&&this.data.errors._component&&this.data.errors._component.length>0?T`
                 <div><ul>${this.data.errors._component.map(e=>T`<li>${e}</li>`)}</ul></div>
-            `:v}</div>`}_render(){if(this.component?.type==A.ClientSide){let e=this.component;return e.metadata?.type==j.Page?Br(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!0):e.metadata?.type==j.Crud?Vr(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!0):F.get()?.renderClientSideComponent(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!1)}return T`
+            `:v}</div>`}_render(){if(this.component?.type==A.ClientSide){let e=this.component;return e.metadata?.type==j.Page?Vr(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!0):e.metadata?.type==j.Crud?Hr(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!0):P.get()?.renderClientSideComponent(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData,!1)}return T`
             <mateu-api-caller 
                     @value-changed="${this.valueChangedListener}"
                     @data-changed="${this.dataChangedListener}"
                     @close-modal-requested="${this.closeModalRequestedListener}"
                     @filter-reset-requested="${this.resetFilters}"
                     @action-requested="${this.actionRequestedListener}">
-            ${this.component?.children?.map(e=>{if(e.type==A.ClientSide){let t=e;if(t.metadata?.type==j.Page)return Br(this,t,this.baseUrl,this.state,this.data,this.appState,this.appData,!0);if(t.metadata?.type==j.Crud)return Vr(this,t,this.baseUrl,this.state,this.data,this.appState,this.appData,!0)}return I(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData)})}
+            ${this.component?.children?.map(e=>{if(e.type==A.ClientSide){let t=e;if(t.metadata?.type==j.Page)return Vr(this,t,this.baseUrl,this.state,this.data,this.appState,this.appData,!0);if(t.metadata?.type==j.Crud)return Hr(this,t,this.baseUrl,this.state,this.data,this.appState,this.appData,!0)}return F(this,e,this.baseUrl,this.state,this.data,this.appState,this.appData)})}
             </mateu-api-caller>
         `}static{this.styles=h`
         :host {
@@ -7358,15 +7366,15 @@ ${i}
             padding-block: var(--lumo-space-xs);
             box-shadow: 0 1px 0 0 var(--lumo-contrast-10pct, rgba(0, 0, 0, 0.1));
         }
-  `}};k([y()],cs.prototype,`baseUrl`,void 0),k([y()],cs.prototype,`route`,void 0),k([y()],cs.prototype,`consumedRoute`,void 0),cs=k([g(`mateu-component`)],cs);var ls=new class{async handle(e,t){return await e.runAction(t.baseUrl,t.route,t.consumedRoute,t.actionId,t.initiatorComponentId,t.appState,t.serverSideType,t.componentState,t.parameters,t.initiator,t.background,t.options)}},us=new class{constructor(){this.handleUIIncrement=(e,t,n)=>{if(e?.fragments?.forEach(e=>{le.next({command:void 0,fragment:e,ui:void 0,error:void 0,callbackToken:n})}),e?.appState&&(O.value={...e.appState},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))),e?.appData){let n=e?.appData;ue.value={...e.appData,...n},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))}e?.messages?.forEach(e=>{Na({text:e.text,position:e.position,variant:e.variant,duration:e.duration,undoLabel:e.undoLabel,undoActionId:e.undoActionId,undoParameters:e.undoParameters},t)}),e?.banners&&e.banners.length>0&&document.dispatchEvent(new CustomEvent(`page-banners-received`,{detail:{banners:e.banners,append:e.appendBanners??!1},bubbles:!1,composed:!1})),e?.commands?.forEach(e=>{le.next({command:e,fragment:void 0,ui:void 0,error:void 0,callbackToken:n})})}}async runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,m={}){let te=()=>{this.runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,m)};try{let o=await ls.handle(e,{baseUrl:t,route:n,consumedRoute:r,actionId:i,appState:O.value,initiatorComponentId:a,componentState:c,parameters:l,serverSideType:s,initiator:u,background:d,options:{...m,retry:te}});f&&f(o),p||this.handleUIIncrement(o,u,ee),o.messages&&o.messages.length==1&&o.messages[0].variant==`error`&&u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-succeeded`,{detail:{actionId:i,evevntId:E()},bubbles:!0,composed:!0}))}catch(e){console.warn(`Action request failed`,e),e?.__mateuReported||u.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:i,reason:this.serialize(e),retry:te}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))}}serialize(e){return e?.message?e:JSON.stringify(e)}},ds=new class{constructor(){this.handleUIIncrement=(e,t,n)=>{if(e?.messages?.forEach(e=>{Na({text:e.text,position:e.position,variant:e.variant,duration:e.duration,undoLabel:e.undoLabel,undoActionId:e.undoActionId,undoParameters:e.undoParameters},t)}),e?.banners&&e.banners.length>0&&document.dispatchEvent(new CustomEvent(`page-banners-received`,{detail:{banners:e.banners,append:e.appendBanners??!1},bubbles:!1,composed:!1})),e?.commands?.forEach(e=>{le.next({command:e,fragment:void 0,ui:void 0,error:void 0,callbackToken:n})}),e?.fragments?.forEach(e=>{le.next({command:void 0,fragment:e,ui:void 0,error:void 0,callbackToken:n})}),e?.appState&&(O.value={...e.appState},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))),e?.appData){let n=e?.appData;ue.value={...e.appData,...n},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))}}}async runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,m={}){let te=()=>{this.runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,m)};if(n){n||=`_no_route`,n&&n.startsWith(`/`)&&(n=n.substring(1));let e={serverSideType:s,appState:O.value,componentState:c,parameters:l,initiatorComponentId:a,consumedRoute:r,route:`/`+n,actionId:i};d||u.dispatchEvent(new CustomEvent(`backend-called-event`,{bubbles:!0,composed:!0,detail:{}}));let o={Accept:`text/event-stream`,"Content-Type":`application/json`},m=localStorage.getItem(`__mateu_auth_token`);m&&(o.Authorization=`Bearer `+m);let ne=sessionStorage.getItem(`__mateu_sesion_id`);ne&&(o[`X-Session-Id`]=ne),fetch(t+`/mateu/v3/sse/`+n,{method:`POST`,headers:o,body:JSON.stringify(e)}).then(async e=>{let t=e.body?.pipeThrough(new TextDecoderStream).getReader();if(t){let e=``;for(;;){let{value:n,done:r}=await t.read();if(r)break;e+=n;let a=e.split(`
+  `}};k([y()],ls.prototype,`baseUrl`,void 0),k([y()],ls.prototype,`route`,void 0),k([y()],ls.prototype,`consumedRoute`,void 0),ls=k([g(`mateu-component`)],ls);var us=new class{async handle(e,t){return await e.runAction(t.baseUrl,t.route,t.consumedRoute,t.actionId,t.initiatorComponentId,t.appState,t.serverSideType,t.componentState,t.parameters,t.initiator,t.background,t.options)}},ds=new class{constructor(){this.handleUIIncrement=(e,t,n)=>{if(e?.fragments?.forEach(e=>{le.next({command:void 0,fragment:e,ui:void 0,error:void 0,callbackToken:n})}),e?.appState&&(O.value={...e.appState},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))),e?.appData){let n=e?.appData;ue.value={...e.appData,...n},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))}e?.messages?.forEach(e=>{Pa({text:e.text,position:e.position,variant:e.variant,duration:e.duration,undoLabel:e.undoLabel,undoActionId:e.undoActionId,undoParameters:e.undoParameters},t)}),e?.banners&&e.banners.length>0&&document.dispatchEvent(new CustomEvent(`page-banners-received`,{detail:{banners:e.banners,append:e.appendBanners??!1},bubbles:!1,composed:!1})),e?.commands?.forEach(e=>{le.next({command:e,fragment:void 0,ui:void 0,error:void 0,callbackToken:n})})}}async runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,m={}){let te=()=>{this.runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,m)};try{let o=await us.handle(e,{baseUrl:t,route:n,consumedRoute:r,actionId:i,appState:O.value,initiatorComponentId:a,componentState:c,parameters:l,serverSideType:s,initiator:u,background:d,options:{...m,retry:te}});f&&f(o),p||this.handleUIIncrement(o,u,ee),o.messages&&o.messages.length==1&&o.messages[0].variant==`error`&&u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-succeeded`,{detail:{actionId:i,evevntId:E()},bubbles:!0,composed:!0}))}catch(e){console.warn(`Action request failed`,e),e?.__mateuReported||u.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:i,reason:this.serialize(e),retry:te}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))}}serialize(e){return e?.message?e:JSON.stringify(e)}},fs=new class{constructor(){this.handleUIIncrement=(e,t,n)=>{if(e?.messages?.forEach(e=>{Pa({text:e.text,position:e.position,variant:e.variant,duration:e.duration,undoLabel:e.undoLabel,undoActionId:e.undoActionId,undoParameters:e.undoParameters},t)}),e?.banners&&e.banners.length>0&&document.dispatchEvent(new CustomEvent(`page-banners-received`,{detail:{banners:e.banners,append:e.appendBanners??!1},bubbles:!1,composed:!1})),e?.commands?.forEach(e=>{le.next({command:e,fragment:void 0,ui:void 0,error:void 0,callbackToken:n})}),e?.fragments?.forEach(e=>{le.next({command:void 0,fragment:e,ui:void 0,error:void 0,callbackToken:n})}),e?.appState&&(O.value={...e.appState},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))),e?.appData){let n=e?.appData;ue.value={...e.appData,...n},t.dispatchEvent(new CustomEvent(`app-data-updated`,{bubbles:!0,composed:!0}))}}}async runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,m={}){let te=()=>{this.runAction(e,t,n,r,i,a,o,s,c,l,u,d,f,p,ee,m)};if(n){n||=`_no_route`,n&&n.startsWith(`/`)&&(n=n.substring(1));let e={serverSideType:s,appState:O.value,componentState:c,parameters:l,initiatorComponentId:a,consumedRoute:r,route:`/`+n,actionId:i};d||u.dispatchEvent(new CustomEvent(`backend-called-event`,{bubbles:!0,composed:!0,detail:{}}));let o={Accept:`text/event-stream`,"Content-Type":`application/json`},m=localStorage.getItem(`__mateu_auth_token`);m&&(o.Authorization=`Bearer `+m);let ne=sessionStorage.getItem(`__mateu_sesion_id`);ne&&(o[`X-Session-Id`]=ne),fetch(t+`/mateu/v3/sse/`+n,{method:`POST`,headers:o,body:JSON.stringify(e)}).then(async e=>{let t=e.body?.pipeThrough(new TextDecoderStream).getReader();if(t){let e=``;for(;;){let{value:n,done:r}=await t.read();if(r)break;e+=n;let a=e.split(`
 
-`);e=a.pop()??``;for(let e of a){let t=e.trim();if(t)if(t.startsWith(`data:`)){let e=JSON.parse(t.substring(5).trim());f&&f(e),p||this.handleUIIncrement(e,u,ee),e.messages&&e.messages.length==1&&e.messages[0].variant==`error`&&u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))}else{let e=t;try{let n=JSON.parse(t);e=n.message,n._embedded?.errors?.length>0&&n._embedded.errors[0].message&&(e=n._embedded.errors[0].message)}catch{}throw Error(e)}}}}d||u.dispatchEvent(new CustomEvent(`backend-succeeded-event`,{bubbles:!0,composed:!0,detail:{actionId:i}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-succeeded`,{detail:{actionId:i},bubbles:!0,composed:!0}))}).catch(e=>{u.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:i,reason:this.serialize(e),retry:te}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))})}}serialize(e){return e?.message?e:JSON.stringify(e)}},fs={fixed:`fixed`,fullWidth:`full`,edgeToEdge:`edge`},ps=new Set([j.Gantt,j.PlanningBoard,j.Kanban,j.Bpmn,j.Workflow,j.Map]),ms={landing:`fixed`,form:`fixed`,process:`fixed`},hs=e=>e?fs[e]:void 0,gs=e=>e.type==A.ClientSide?e.metadata:void 0,_s=e=>{let t=gs(e);if(t?.type==j.Page){let e=hs(t.pageWidth);if(e)return e}for(let t of e.children??[]){let e=_s(t);if(e)return e}},vs=e=>{let t=e.pageType;if(t)return t;let n=e=>{let t=gs(e);if(t?.type==j.Page&&t.pageType)return t.pageType;for(let t of e.children??[]){let e=n(t);if(e)return e}};return n(e)},ys=e=>{let t=gs(e);if(t?.type!=j.Crud)return!1;let n=t;return n.compact?!0:(n.columns??[]).some(e=>e.metadata?.editable)},bs=(e,t)=>t(e)||(e.children??[]).some(e=>bs(e,t)),xs=e=>!!e&&bs(e,e=>gs(e)?.type==j.HeroSection),Ss=e=>gs(e)?.type==j.App||(e.children??[]).some(e=>gs(e)?.type==j.App),Cs=(e,t)=>e?(hs(e.pageWidth)??_s(e))||(t?.top&&Ss(e)?`edge`:ms[vs(e)??``]||(bs(e,e=>{let t=gs(e)?.type;return t!=null&&ps.has(t)})?`edge`:bs(e,ys)?`full`:`fixed`)):`fixed`,ws=`mateu-route-structure-cache`,Ts=1,Es=50,Ds=(()=>{try{return localStorage.getItem(`mateu-route-structure-cache-off`)!==`1`}catch{return!0}})(),Os=()=>{try{return JSON.parse(localStorage.getItem(ws)??`{}`)}catch{return{}}},ks=e=>{try{localStorage.setItem(ws,JSON.stringify(e))}catch{try{let t=Object.entries(e).sort((e,t)=>t[1].t-e[1].t).slice(0,Math.floor(Es/2));localStorage.setItem(ws,JSON.stringify(Object.fromEntries(t)))}catch{}}},As=e=>{let t=e.initialState&&Object.keys(e.initialState).length?`#`+Ns(JSON.stringify(e.initialState)):``;return[e.baseUrl,e.consumedRoute??``,e.route??``,e.serverSideType??``].join(`|`)+t},js=e=>{if(!Ds)return;let t=Os()[e];if(!(!t||t.v!==Ts))return{component:t.component,hash:t.hash}},Ms=(e,t,n)=>{if(!Ds)return;let r=Os();r[e]={v:Ts,t:Date.now(),component:t,hash:n};let i=Object.keys(r);if(i.length>Es){let e=i.sort((e,t)=>r[e].t-r[t].t).slice(0,i.length-Es);for(let t of e)delete r[t]}ks(r)},Ns=e=>{let t=2166136261;for(let n=0;n<e.length;n++)t^=e.charCodeAt(n),t=Math.imul(t,16777619);return(t>>>0).toString(36)},Ps=30,Fs=new Map,Is=!0,Ls=e=>{if(Is)return Fs.get(e)},Rs=(e,t)=>{if(Is&&(Fs.delete(e),Fs.set(e,t),Fs.size>Ps)){let e=Fs.keys().next().value;e!==void 0&&Fs.delete(e)}},zs,X=class extends _t{static{zs=this}constructor(...e){super(...e),this.consumedRoute=``,this.serverSideType=void 0,this.uriPrefix=void 0,this.overrides=void 0,this.homeRoute=void 0,this.route=void 0,this.top=void 0,this.appState={},this.appData={},this.preventNavigation=!1,this.overridesParsed={},this.fragment=void 0,this.showSkeleton=!1,this.pendingRouteFocus=!1,this.hasRenderedContent=!1,this.loadLifecycleListener=e=>{if(((typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target)===this)if(clearTimeout(this.skeletonTimer),e.type===`backend-called-event`){if(this.fragment?.component)return;this.skeletonTimer=setTimeout(()=>{this.showSkeleton=!0},zs.SKELETON_DELAY_MS)}else this.showSkeleton=!1},this.actionRequestedListener=e=>{e instanceof CustomEvent&&(e.preventDefault(),e.stopPropagation(),this.manageActionEvent(e))},this.historyPushed=e=>{e instanceof CustomEvent&&(e.preventDefault(),e.stopPropagation(),this.preventNavigation=!0,this.route=e.detail.route)},this.routeChangedListener=e=>{if(e instanceof CustomEvent){e.preventDefault(),e.stopPropagation();let t=e.detail.route;typeof t==`string`&&(t===``||t.startsWith(`/`))&&this.consumedRoute&&this.consumedRoute!==`_empty`&&this.consumedRoute.startsWith(`/`)&&!t.startsWith(this.consumedRoute)&&(t=this.consumedRoute+t),this.uriPrefix&&(t=t.startsWith(`/`)&&this.uriPrefix.endsWith(`/`)?this.uriPrefix+t.substring(1):!t.startsWith(`/`)&&!this.uriPrefix.endsWith(`/`)?this.uriPrefix+`/`+t:this.uriPrefix+t),this.dispatchEvent(new CustomEvent(`url-update-requested`,{detail:{route:t},bubbles:!0,composed:!0}))}},this.backendFailedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&e.detail.actionId==``&&(this.fragment={targetComponentId:this.id,data:{},state:{},component:{type:A.ClientSide,metadata:{type:j.Element,name:`div`,content:`Not found`},id:`fieldId`},action:ut.Replace,containerId:void 0})},this.detail1=void 0,this.manageActionEvent=e=>{e.preventDefault(),e.stopPropagation(),this.detail1=e.detail;let t=this.detail1;if(e.type==`server-side-action-requested`){let e=us;t.sse&&(e=ds),e.runAction(lt,this.baseUrl,t.route??``,t.consumedRoute,t.actionId,t.initiatorComponentId,this.getCustomisedAppState(),t.serverSideType,t.componentState,t.parameters,t.initiator,t.background,t.callback,t.callbackonly,t.callbackToken,{timeoutMillis:t.timeoutMillis,idempotent:t.idempotent,knownStructureHash:t.knownStructureHash})}},this.getCustomisedAppState=()=>{let e={...O.value};if(this.overrides){let t=Wo(this.overrides);e={...e,...t}}return e}}manageActionRequestedEvent(e){throw Error(`Method not implemented.`)}createRenderRoot(){return F.mustUseShadowRoot()?super.createRenderRoot():this}structureCacheKey(){return As({baseUrl:this.baseUrl,consumedRoute:this.consumedRoute,route:this.route,serverSideType:this.serverSideType,initialState:this.initialState})}focusNewContent(){requestAnimationFrame(()=>{let e=this.renderRoot?.querySelector?.(`h1, h2, [role="heading"]`)??this;e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus?.({preventScroll:!0})})}static{this.SKELETON_DELAY_MS=400}connectedCallback(){super.connectedCallback(),this.overridesParsed=Wo(this.overrides),this.addEventListener(`server-side-action-requested`,this.actionRequestedListener),this.addEventListener(`backend-call-failed`,this.backendFailedListener),this.addEventListener(`history-pushed`,this.historyPushed),this.addEventListener(`route-changed`,this.routeChangedListener),this.addEventListener(`backend-called-event`,this.loadLifecycleListener),this.addEventListener(`backend-succeeded-event`,this.loadLifecycleListener),this.addEventListener(`backend-failed-event`,this.loadLifecycleListener),this.addEventListener(`backend-cancelled-event`,this.loadLifecycleListener)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`server-side-action-requested`,this.actionRequestedListener),this.removeEventListener(`backend-call-failed`,this.backendFailedListener),this.removeEventListener(`history-pushed`,this.historyPushed),this.removeEventListener(`route-changed`,this.routeChangedListener),this.removeEventListener(`backend-called-event`,this.loadLifecycleListener),this.removeEventListener(`backend-succeeded-event`,this.loadLifecycleListener),this.removeEventListener(`backend-failed-event`,this.loadLifecycleListener),this.removeEventListener(`backend-cancelled-event`,this.loadLifecycleListener),clearTimeout(this.skeletonTimer)}shouldUpdate(e){if(this.fragment?.component&&[...e.keys()].every(e=>e===`appState`||e===`appData`)){let t=this.renderRoot.querySelector(`mateu-component`);if(t)return e.has(`appState`)&&(t.appState=this.appState),e.has(`appData`)&&(t.appData=this.appData),!1}return!0}updated(e){if((e.has(`id`)||e.has(`baseurl`)||e.has(`route`)||e.has(`consumedRoute`)||e.has(`instant`))&&!this.preventNavigation){this.callbackToken=this.instant||E();let e=this.structureCacheKey(),t=e===this.lastAuthoritativeKey?void 0:Ls(e);if(t)queueMicrotask(()=>this.applyFragment(t));else{if(e!==this.lastAuthoritativeKey){let t=js(e);this.currentStructureHash=t?.hash,t&&(this.fragment={targetComponentId:this.id,component:t.component,state:{},data:{},action:ut.Replace,containerId:void 0})}this.manageActionEvent(new CustomEvent(`server-side-action-requested`,{detail:{route:this.route,consumedRoute:this.consumedRoute,userData:void 0,actionId:``,serverSideType:this.serverSideType,initiatorComponentId:this.id,initiator:this,componentState:this.initialState,knownStructureHash:this.currentStructureHash,callbackToken:this.callbackToken},bubbles:!0,composed:!0}))}}e.has(`route`)&&this.top&&(this.preventNavigation||(this.pendingRouteFocus=!0),this.preventNavigation||this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:this.route},bubbles:!0,composed:!0}))),this.preventNavigation&&=!1}applyFragment(e){if(!e.component&&this.fragment?.component){this.fragment={...this.fragment,state:{...this.fragment.state??{},...e.state??{}},data:{...this.fragment.data??{},...e.data??{}}};return}if(this.fragment=e,e.component){if(e.action!==ut.Add){let t=this.structureCacheKey(),n=e.component.structureHash;Ms(t,e.component,n),this.lastAuthoritativeKey=t,this.currentStructureHash=n,e.component.staticView&&Rs(t,e)}this.pendingRouteFocus&&this.hasRenderedContent&&this.focusNewContent(),this.pendingRouteFocus=!1,this.hasRenderedContent=!0}e.component&&(this.dataset.pageWidth=Cs(e.component,{top:this.top}),this.dataset.pageType=vs(e.component)??``,this.dataset.hasWelcomeBanner=String(xs(e.component)))}render(){return!this.fragment?.component&&this.showSkeleton?T`
+`);e=a.pop()??``;for(let e of a){let t=e.trim();if(t)if(t.startsWith(`data:`)){let e=JSON.parse(t.substring(5).trim());f&&f(e),p||this.handleUIIncrement(e,u,ee),e.messages&&e.messages.length==1&&e.messages[0].variant==`error`&&u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))}else{let e=t;try{let n=JSON.parse(t);e=n.message,n._embedded?.errors?.length>0&&n._embedded.errors[0].message&&(e=n._embedded.errors[0].message)}catch{}throw Error(e)}}}}d||u.dispatchEvent(new CustomEvent(`backend-succeeded-event`,{bubbles:!0,composed:!0,detail:{actionId:i}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-succeeded`,{detail:{actionId:i},bubbles:!0,composed:!0}))}).catch(e=>{u.dispatchEvent(new CustomEvent(`backend-failed-event`,{bubbles:!0,composed:!0,detail:{actionId:i,reason:this.serialize(e),retry:te}})),u.shadowRoot?.dispatchEvent(new CustomEvent(`backend-call-failed`,{detail:{actionId:i},bubbles:!0,composed:!0}))})}}serialize(e){return e?.message?e:JSON.stringify(e)}},ps={fixed:`fixed`,fullWidth:`full`,edgeToEdge:`edge`},ms=new Set([j.Gantt,j.PlanningBoard,j.Kanban,j.Bpmn,j.Workflow,j.Map]),hs={landing:`fixed`,form:`fixed`,process:`fixed`},gs=e=>e?ps[e]:void 0,_s=e=>e.type==A.ClientSide?e.metadata:void 0,vs=e=>{let t=_s(e);if(t?.type==j.Page){let e=gs(t.pageWidth);if(e)return e}for(let t of e.children??[]){let e=vs(t);if(e)return e}},ys=e=>{let t=e.pageType;if(t)return t;let n=e=>{let t=_s(e);if(t?.type==j.Page&&t.pageType)return t.pageType;for(let t of e.children??[]){let e=n(t);if(e)return e}};return n(e)},bs=e=>{let t=_s(e);if(t?.type!=j.Crud)return!1;let n=t;return n.compact?!0:(n.columns??[]).some(e=>e.metadata?.editable)},xs=(e,t)=>t(e)||(e.children??[]).some(e=>xs(e,t)),Ss=e=>!!e&&xs(e,e=>_s(e)?.type==j.HeroSection),Cs=e=>_s(e)?.type==j.App||(e.children??[]).some(e=>_s(e)?.type==j.App),ws=(e,t)=>e?(gs(e.pageWidth)??vs(e))||(t?.top&&Cs(e)?`edge`:hs[ys(e)??``]||(xs(e,e=>{let t=_s(e)?.type;return t!=null&&ms.has(t)})?`edge`:xs(e,bs)?`full`:`fixed`)):`fixed`,Ts=`mateu-route-structure-cache`,Es=1,Ds=50,Os=(()=>{try{return localStorage.getItem(`mateu-route-structure-cache-off`)!==`1`}catch{return!0}})(),ks=()=>{try{return JSON.parse(localStorage.getItem(Ts)??`{}`)}catch{return{}}},As=e=>{try{localStorage.setItem(Ts,JSON.stringify(e))}catch{try{let t=Object.entries(e).sort((e,t)=>t[1].t-e[1].t).slice(0,Math.floor(Ds/2));localStorage.setItem(Ts,JSON.stringify(Object.fromEntries(t)))}catch{}}},js=e=>{let t=e.initialState&&Object.keys(e.initialState).length?`#`+Ps(JSON.stringify(e.initialState)):``;return[e.baseUrl,e.consumedRoute??``,e.route??``,e.serverSideType??``].join(`|`)+t},Ms=e=>{if(!Os)return;let t=ks()[e];if(!(!t||t.v!==Es))return{component:t.component,hash:t.hash}},Ns=(e,t,n)=>{if(!Os)return;let r=ks();r[e]={v:Es,t:Date.now(),component:t,hash:n};let i=Object.keys(r);if(i.length>Ds){let e=i.sort((e,t)=>r[e].t-r[t].t).slice(0,i.length-Ds);for(let t of e)delete r[t]}As(r)},Ps=e=>{let t=2166136261;for(let n=0;n<e.length;n++)t^=e.charCodeAt(n),t=Math.imul(t,16777619);return(t>>>0).toString(36)},Fs=30,Is=new Map,Ls=!0,Rs=e=>{if(Ls)return Is.get(e)},zs=(e,t)=>{if(Ls&&(Is.delete(e),Is.set(e,t),Is.size>Fs)){let e=Is.keys().next().value;e!==void 0&&Is.delete(e)}},Bs,Y=class extends _t{static{Bs=this}constructor(...e){super(...e),this.consumedRoute=``,this.serverSideType=void 0,this.uriPrefix=void 0,this.overrides=void 0,this.homeRoute=void 0,this.route=void 0,this.top=void 0,this.appState={},this.appData={},this.preventNavigation=!1,this.overridesParsed={},this.fragment=void 0,this.showSkeleton=!1,this.pendingRouteFocus=!1,this.hasRenderedContent=!1,this.loadLifecycleListener=e=>{if(((typeof e.composedPath==`function`?e.composedPath():[])[0]??e.target)===this)if(clearTimeout(this.skeletonTimer),e.type===`backend-called-event`){if(this.fragment?.component)return;this.skeletonTimer=setTimeout(()=>{this.showSkeleton=!0},Bs.SKELETON_DELAY_MS)}else this.showSkeleton=!1},this.actionRequestedListener=e=>{e instanceof CustomEvent&&(e.preventDefault(),e.stopPropagation(),this.manageActionEvent(e))},this.historyPushed=e=>{e instanceof CustomEvent&&(e.preventDefault(),e.stopPropagation(),this.preventNavigation=!0,this.route=e.detail.route)},this.routeChangedListener=e=>{if(e instanceof CustomEvent){e.preventDefault(),e.stopPropagation();let t=e.detail.route;typeof t==`string`&&(t===``||t.startsWith(`/`))&&this.consumedRoute&&this.consumedRoute!==`_empty`&&this.consumedRoute.startsWith(`/`)&&!t.startsWith(this.consumedRoute)&&(t=this.consumedRoute+t),this.uriPrefix&&(t=t.startsWith(`/`)&&this.uriPrefix.endsWith(`/`)?this.uriPrefix+t.substring(1):!t.startsWith(`/`)&&!this.uriPrefix.endsWith(`/`)?this.uriPrefix+`/`+t:this.uriPrefix+t),this.dispatchEvent(new CustomEvent(`url-update-requested`,{detail:{route:t},bubbles:!0,composed:!0}))}},this.backendFailedListener=e=>{e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&e.detail.actionId==``&&(this.fragment={targetComponentId:this.id,data:{},state:{},component:{type:A.ClientSide,metadata:{type:j.Element,name:`div`,content:`Not found`},id:`fieldId`},action:ut.Replace,containerId:void 0})},this.detail1=void 0,this.manageActionEvent=e=>{e.preventDefault(),e.stopPropagation(),this.detail1=e.detail;let t=this.detail1;if(e.type==`server-side-action-requested`){let e=ds;t.sse&&(e=fs),e.runAction(lt,this.baseUrl,t.route??``,t.consumedRoute,t.actionId,t.initiatorComponentId,this.getCustomisedAppState(),t.serverSideType,t.componentState,t.parameters,t.initiator,t.background,t.callback,t.callbackonly,t.callbackToken,{timeoutMillis:t.timeoutMillis,idempotent:t.idempotent,knownStructureHash:t.knownStructureHash})}},this.getCustomisedAppState=()=>{let e={...O.value};if(this.overrides){let t=Go(this.overrides);e={...e,...t}}return e}}manageActionRequestedEvent(e){throw Error(`Method not implemented.`)}createRenderRoot(){return P.mustUseShadowRoot()?super.createRenderRoot():this}structureCacheKey(){return js({baseUrl:this.baseUrl,consumedRoute:this.consumedRoute,route:this.route,serverSideType:this.serverSideType,initialState:this.initialState})}focusNewContent(){requestAnimationFrame(()=>{let e=this.renderRoot?.querySelector?.(`h1, h2, [role="heading"]`)??this;e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus?.({preventScroll:!0})})}static{this.SKELETON_DELAY_MS=400}connectedCallback(){super.connectedCallback(),this.overridesParsed=Go(this.overrides),this.addEventListener(`server-side-action-requested`,this.actionRequestedListener),this.addEventListener(`backend-call-failed`,this.backendFailedListener),this.addEventListener(`history-pushed`,this.historyPushed),this.addEventListener(`route-changed`,this.routeChangedListener),this.addEventListener(`backend-called-event`,this.loadLifecycleListener),this.addEventListener(`backend-succeeded-event`,this.loadLifecycleListener),this.addEventListener(`backend-failed-event`,this.loadLifecycleListener),this.addEventListener(`backend-cancelled-event`,this.loadLifecycleListener)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`server-side-action-requested`,this.actionRequestedListener),this.removeEventListener(`backend-call-failed`,this.backendFailedListener),this.removeEventListener(`history-pushed`,this.historyPushed),this.removeEventListener(`route-changed`,this.routeChangedListener),this.removeEventListener(`backend-called-event`,this.loadLifecycleListener),this.removeEventListener(`backend-succeeded-event`,this.loadLifecycleListener),this.removeEventListener(`backend-failed-event`,this.loadLifecycleListener),this.removeEventListener(`backend-cancelled-event`,this.loadLifecycleListener),clearTimeout(this.skeletonTimer)}shouldUpdate(e){if(this.fragment?.component&&[...e.keys()].every(e=>e===`appState`||e===`appData`)){let t=this.renderRoot.querySelector(`mateu-component`);if(t)return e.has(`appState`)&&(t.appState=this.appState),e.has(`appData`)&&(t.appData=this.appData),!1}return!0}updated(e){if((e.has(`id`)||e.has(`baseurl`)||e.has(`route`)||e.has(`consumedRoute`)||e.has(`instant`))&&!this.preventNavigation){this.callbackToken=this.instant||E();let e=this.structureCacheKey(),t=e===this.lastAuthoritativeKey?void 0:Rs(e);if(t)queueMicrotask(()=>this.applyFragment(t));else{if(e!==this.lastAuthoritativeKey){let t=Ms(e);this.currentStructureHash=t?.hash,t&&(this.fragment={targetComponentId:this.id,component:t.component,state:{},data:{},action:ut.Replace,containerId:void 0})}this.manageActionEvent(new CustomEvent(`server-side-action-requested`,{detail:{route:this.route,consumedRoute:this.consumedRoute,userData:void 0,actionId:``,serverSideType:this.serverSideType,initiatorComponentId:this.id,initiator:this,componentState:this.initialState,knownStructureHash:this.currentStructureHash,callbackToken:this.callbackToken},bubbles:!0,composed:!0}))}}e.has(`route`)&&this.top&&(this.preventNavigation||(this.pendingRouteFocus=!0),this.preventNavigation||this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:this.route},bubbles:!0,composed:!0}))),this.preventNavigation&&=!1}applyFragment(e){if(!e.component&&this.fragment?.component){this.fragment={...this.fragment,state:{...this.fragment.state??{},...e.state??{}},data:{...this.fragment.data??{},...e.data??{}}};return}if(this.fragment=e,e.component){if(e.action!==ut.Add){let t=this.structureCacheKey(),n=e.component.structureHash;Ns(t,e.component,n),this.lastAuthoritativeKey=t,this.currentStructureHash=n,e.component.staticView&&zs(t,e)}this.pendingRouteFocus&&this.hasRenderedContent&&this.focusNewContent(),this.pendingRouteFocus=!1,this.hasRenderedContent=!0}e.component&&(this.dataset.pageWidth=ws(e.component,{top:this.top}),this.dataset.pageType=ys(e.component)??``,this.dataset.hasWelcomeBanner=String(Ss(e.component)))}render(){return!this.fragment?.component&&this.showSkeleton?T`
                 <div class="route-skeleton" aria-busy="true" aria-live="polite">
                     <mateu-skeleton variant="text" count="1"></mateu-skeleton>
                     <mateu-skeleton variant="form" count="4"></mateu-skeleton>
                 </div>
             `:T`
-           ${this.fragment?.component?I(this,this.fragment?.component,this.baseUrl,this.fragment?.state??{},this.fragment?.data??{},this.appState,this.appData):v}
+           ${this.fragment?.component?F(this,this.fragment?.component,this.baseUrl,this.fragment?.state??{},this.fragment?.data??{},this.appState,this.appData):v}
        `}static{this.styles=h`
         :host {
             display: block;
@@ -7405,7 +7413,7 @@ ${i}
             max-width: 16rem;
             margin-block-end: var(--lumo-space-l, 1.5rem);
         }
-  `}};k([y()],X.prototype,`consumedRoute`,void 0),k([y()],X.prototype,`serverSideType`,void 0),k([y()],X.prototype,`uriPrefix`,void 0),k([y()],X.prototype,`overrides`,void 0),k([y()],X.prototype,`homeRoute`,void 0),k([y()],X.prototype,`route`,void 0),k([y()],X.prototype,`top`,void 0),k([y()],X.prototype,`instant`,void 0),k([y()],X.prototype,`initialState`,void 0),k([y()],X.prototype,`appState`,void 0),k([y()],X.prototype,`appData`,void 0),k([C()],X.prototype,`fragment`,void 0),k([C()],X.prototype,`showSkeleton`,void 0),X=zs=k([g(`mateu-ux`)],X);function Bs(e){let t=`var(--lumo-space-m, 1rem)`,n={left:`50%`,transform:`translateX(-50%)`};switch(e){case`topStart`:return{top:t,left:t};case`topCenter`:return{top:t,...n};case`topEnd`:return{top:t,right:t};case`topStretch`:return{top:t,left:t,right:t};case`middle`:return{top:`50%`,left:`50%`,transform:`translate(-50%, -50%)`};case`bottomStart`:return{bottom:t,left:t};case`bottomCenter`:return{bottom:t,...n};case`bottomStretch`:return{bottom:t,left:t,right:t};default:return{bottom:t,right:t}}}function Vs(e){switch(e){case`success`:return{bg:`var(--lumo-success-color, #2e7d32)`,fg:`#fff`};case`error`:return{bg:`var(--lumo-error-color, #c62828)`,fg:`#fff`};case`warning`:return{bg:`var(--lumo-warning-color, #f9a825)`,fg:`#1a1a1a`};case`contrast`:return{bg:`var(--lumo-contrast-90pct, #1a1a1a)`,fg:`#fff`};default:return{bg:`var(--lumo-base-color, #fff)`,fg:`var(--lumo-body-text-color, #1a1a1a)`}}}var Hs={show(e,t){let{bg:n,fg:r}=Vs(e.variant),i=Bs(e.position),a=document.createElement(`div`),o=e.variant===`error`;a.setAttribute(`role`,o?`alert`:`status`),a.setAttribute(`aria-live`,o?`assertive`:`polite`),a.setAttribute(`aria-atomic`,`true`),Object.assign(a.style,{position:`fixed`,zIndex:`2000`,display:`flex`,alignItems:`center`,gap:`0.75rem`,maxWidth:`min(90vw, 28rem)`,padding:`0.7rem 1rem`,borderRadius:`var(--lumo-border-radius-m, 8px)`,boxShadow:`var(--lumo-box-shadow-m, 0 4px 16px rgba(0,0,0,0.2))`,background:n,color:r,font:`inherit`,fontSize:`var(--lumo-font-size-s, 0.875rem)`,opacity:`0`,transition:`opacity 0.2s ease`,...i});let s=document.createElement(`span`);s.textContent=e.text,a.appendChild(s);let c=()=>{a.style.opacity=`0`,setTimeout(()=>a.remove(),200)},l=e.onAction?{label:e.actionLabel??`Retry`,run:e.onAction}:e.undoActionId?{label:e.undoLabel??`Undo`,run:()=>t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.undoActionId,parameters:e.undoParameters??{}},bubbles:!0,composed:!0}))}:void 0;if(l){let e=document.createElement(`button`);e.textContent=l.label,e.style.cssText=`margin-left: 0.25rem; background: none; border: 1px solid currentColor; border-radius: var(--lumo-border-radius-s, 4px); color: inherit; cursor: pointer; padding: 0.15rem 0.6rem; font: inherit; font-weight: 600;`,e.addEventListener(`click`,()=>{l.run(),c()}),a.appendChild(e)}document.body.appendChild(a),requestAnimationFrame(()=>{a.style.opacity=`1`});let u=e.duration??(l?1e4:5e3);u>0&&setTimeout(c,u)}};function Us(){Ma(Hs)}var Ws=class extends b{constructor(...e){super(...e),this.online=!0,this.recovered=!1}connectedCallback(){super.connectedCallback(),this.online=at.isOnline(),this.unsubscribe=at.subscribe(e=>{let t=!this.online;this.online=e,e&&t&&(this.recovered=!0,clearTimeout(this.recoveredTimer),this.recoveredTimer=setTimeout(()=>{this.recovered=!1},4e3))})}disconnectedCallback(){super.disconnectedCallback(),this.unsubscribe?.(),clearTimeout(this.recoveredTimer),this.releaseSpace()}updated(){let e=this.renderRoot.querySelector(`.bar`);if(!e){this.releaseSpace();return}document.body.style.setProperty(`padding-block-start`,`${e.offsetHeight}px`)}releaseSpace(){typeof document<`u`&&document.body?.style.removeProperty(`padding-block-start`)}render(){if(this.online&&!this.recovered)return v;let e=!this.online;return T`<div class="bar ${e?`offline`:`back`}" role="status" aria-live="polite">
+  `}};k([y()],Y.prototype,`consumedRoute`,void 0),k([y()],Y.prototype,`serverSideType`,void 0),k([y()],Y.prototype,`uriPrefix`,void 0),k([y()],Y.prototype,`overrides`,void 0),k([y()],Y.prototype,`homeRoute`,void 0),k([y()],Y.prototype,`route`,void 0),k([y()],Y.prototype,`top`,void 0),k([y()],Y.prototype,`instant`,void 0),k([y()],Y.prototype,`initialState`,void 0),k([y()],Y.prototype,`appState`,void 0),k([y()],Y.prototype,`appData`,void 0),k([C()],Y.prototype,`fragment`,void 0),k([C()],Y.prototype,`showSkeleton`,void 0),Y=Bs=k([g(`mateu-ux`)],Y);function Vs(e){let t=`var(--lumo-space-m, 1rem)`,n={left:`50%`,transform:`translateX(-50%)`};switch(e){case`topStart`:return{top:t,left:t};case`topCenter`:return{top:t,...n};case`topEnd`:return{top:t,right:t};case`topStretch`:return{top:t,left:t,right:t};case`middle`:return{top:`50%`,left:`50%`,transform:`translate(-50%, -50%)`};case`bottomStart`:return{bottom:t,left:t};case`bottomCenter`:return{bottom:t,...n};case`bottomStretch`:return{bottom:t,left:t,right:t};default:return{bottom:t,right:t}}}function Hs(e){switch(e){case`success`:return{bg:`var(--lumo-success-color, #2e7d32)`,fg:`#fff`};case`error`:return{bg:`var(--lumo-error-color, #c62828)`,fg:`#fff`};case`warning`:return{bg:`var(--lumo-warning-color, #f9a825)`,fg:`#1a1a1a`};case`contrast`:return{bg:`var(--lumo-contrast-90pct, #1a1a1a)`,fg:`#fff`};default:return{bg:`var(--lumo-base-color, #fff)`,fg:`var(--lumo-body-text-color, #1a1a1a)`}}}var Us={show(e,t){let{bg:n,fg:r}=Hs(e.variant),i=Vs(e.position),a=document.createElement(`div`),o=e.variant===`error`;a.setAttribute(`role`,o?`alert`:`status`),a.setAttribute(`aria-live`,o?`assertive`:`polite`),a.setAttribute(`aria-atomic`,`true`),Object.assign(a.style,{position:`fixed`,zIndex:`2000`,display:`flex`,alignItems:`center`,gap:`0.75rem`,maxWidth:`min(90vw, 28rem)`,padding:`0.7rem 1rem`,borderRadius:`var(--lumo-border-radius-m, 8px)`,boxShadow:`var(--lumo-box-shadow-m, 0 4px 16px rgba(0,0,0,0.2))`,background:n,color:r,font:`inherit`,fontSize:`var(--lumo-font-size-s, 0.875rem)`,opacity:`0`,transition:`opacity 0.2s ease`,...i});let s=document.createElement(`span`);s.textContent=e.text,a.appendChild(s);let c=()=>{a.style.opacity=`0`,setTimeout(()=>a.remove(),200)},l=e.onAction?{label:e.actionLabel??`Retry`,run:e.onAction}:e.undoActionId?{label:e.undoLabel??`Undo`,run:()=>t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.undoActionId,parameters:e.undoParameters??{}},bubbles:!0,composed:!0}))}:void 0;if(l){let e=document.createElement(`button`);e.textContent=l.label,e.style.cssText=`margin-left: 0.25rem; background: none; border: 1px solid currentColor; border-radius: var(--lumo-border-radius-s, 4px); color: inherit; cursor: pointer; padding: 0.15rem 0.6rem; font: inherit; font-weight: 600;`,e.addEventListener(`click`,()=>{l.run(),c()}),a.appendChild(e)}document.body.appendChild(a),requestAnimationFrame(()=>{a.style.opacity=`1`});let u=e.duration??(l?1e4:5e3);u>0&&setTimeout(c,u)}};function Ws(){Na(Us)}var Gs=class extends b{constructor(...e){super(...e),this.online=!0,this.recovered=!1}connectedCallback(){super.connectedCallback(),this.online=at.isOnline(),this.unsubscribe=at.subscribe(e=>{let t=!this.online;this.online=e,e&&t&&(this.recovered=!0,clearTimeout(this.recoveredTimer),this.recoveredTimer=setTimeout(()=>{this.recovered=!1},4e3))})}disconnectedCallback(){super.disconnectedCallback(),this.unsubscribe?.(),clearTimeout(this.recoveredTimer),this.releaseSpace()}updated(){let e=this.renderRoot.querySelector(`.bar`);if(!e){this.releaseSpace();return}document.body.style.setProperty(`padding-block-start`,`${e.offsetHeight}px`)}releaseSpace(){typeof document<`u`&&document.body?.style.removeProperty(`padding-block-start`)}render(){if(this.online&&!this.recovered)return v;let e=!this.online;return T`<div class="bar ${e?`offline`:`back`}" role="status" aria-live="polite">
             <span class="dot"></span>
             <span>${e?`No connection — changes you make now will not be saved.`:`Connection restored.`}</span>
         </div>`}static{this.styles=h`
@@ -7447,7 +7455,7 @@ ${i}
         @media (prefers-reduced-motion: reduce) {
             .bar, .bar.offline .dot { animation: none; }
         }
-    `}};k([C()],Ws.prototype,`online`,void 0),k([C()],Ws.prototype,`recovered`,void 0),Ws=k([g(`mateu-connectivity-banner`)],Ws);var Gs=null;function Ks(){if(!(typeof document>`u`)&&!(Gs&&Gs.isConnected)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>Ks(),{once:!0});return}Gs=document.createElement(`mateu-connectivity-banner`),document.body.appendChild(Gs)}}var qs,Js=class extends b{static{qs=this}constructor(...e){super(...e),this.skip=()=>{let e=this.findContent();e&&(e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus(),e.scrollIntoView({block:`start`}))}}static{this.TARGETS=[`.app-content`,`mateu-page`,`mateu-ux`,`mateu-component`]}findContent(){let e=new Set,t=n=>{if(e.has(n))return null;e.add(n);for(let e of qs.TARGETS){let t=n.querySelector?.(e);if(t&&t!==this)return t}for(let e of Array.from(n.querySelectorAll?.(`*`)??[]))if(e.shadowRoot){let n=t(e.shadowRoot);if(n)return n}return null};return t(document)}render(){return T`<button class="skip" @click="${this.skip}">Skip to content</button>`}static{this.styles=h`
+    `}};k([C()],Gs.prototype,`online`,void 0),k([C()],Gs.prototype,`recovered`,void 0),Gs=k([g(`mateu-connectivity-banner`)],Gs);var Ks=null;function qs(){if(!(typeof document>`u`)&&!(Ks&&Ks.isConnected)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>qs(),{once:!0});return}Ks=document.createElement(`mateu-connectivity-banner`),document.body.appendChild(Ks)}}var Js,Ys=class extends b{static{Js=this}constructor(...e){super(...e),this.skip=()=>{let e=this.findContent();e&&(e.hasAttribute(`tabindex`)||e.setAttribute(`tabindex`,`-1`),e.focus(),e.scrollIntoView({block:`start`}))}}static{this.TARGETS=[`.app-content`,`mateu-page`,`mateu-ux`,`mateu-component`]}findContent(){let e=new Set,t=n=>{if(e.has(n))return null;e.add(n);for(let e of Js.TARGETS){let t=n.querySelector?.(e);if(t&&t!==this)return t}for(let e of Array.from(n.querySelectorAll?.(`*`)??[]))if(e.shadowRoot){let n=t(e.shadowRoot);if(n)return n}return null};return t(document)}render(){return T`<button class="skip" @click="${this.skip}">Skip to content</button>`}static{this.styles=h`
         :host {
             position: fixed;
             inset-block-start: 0;
@@ -7480,7 +7488,7 @@ ${i}
             outline: 2px solid var(--lumo-body-text-color, #161513);
             outline-offset: 2px;
         }
-    `}};Js=qs=k([g(`mateu-skip-link`)],Js);var Ys=null;function Xs(){if(!(typeof document>`u`)&&!(Ys&&Ys.isConnected)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>Xs(),{once:!0});return}Ys=document.createElement(`mateu-skip-link`),document.body.insertBefore(Ys,document.body.firstChild)}}Us(),Ks(),ht(),Xs();var Zs=class extends b{constructor(...e){super(...e),this.baseUrl=``,this.route=void 0,this.consumedRoute=`_empty`,this.config=void 0,this.top=`true`,this.pathPrefix=void 0,this.bundleUrl=void 0,this.debug=!1,this._lastUrl=``,this.routeChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.top==`true`){let t=e.detail.route,n=this.baseUrl??``;!t||t.startsWith(`/`)?n=window.location.origin+(this.pathPrefix??``):(t=(this.pathPrefix??``)+t,n.indexOf(`://`)<0&&(n.startsWith(`/`)||(n=`/`+n),n=window.location.origin+n)),t.startsWith(this.pathPrefix+`/`)&&(t=t.substring(this.pathPrefix?.length)),n.endsWith(`/`)&&t.startsWith(`/`)&&(t=t.substring(1));let r=new URL(n+t);if((window.location.pathname||r.pathname)&&window.location.pathname!=r.pathname){let e=r.pathname;r.search&&(e+=r.search),e&&!e.startsWith(`/`)&&(e=`/`+e),window.history.pushState({},``,e),this._lastUrl=window.location.href}}},this.navigateToRequestedListener=e=>{if(e.preventDefault(),e.stopPropagation(),eo.markClean(),e instanceof CustomEvent){let t=e.detail.route,n=this.renderRoot.querySelector(`mateu-ux`);n&&(n.setAttribute(`route`,t),n.setAttribute(`instant`,E()))}}}createRenderRoot(){return F.mustUseShadowRoot()?super.createRenderRoot():this}connectedCallback(){if(super.connectedCallback(),eo.install(),this._lastUrl=window.location.href,window.onpopstate=e=>{if(!eo.confirmLeave()){window.history.pushState({},``,this._lastUrl);return}let t=e.target;this.loadUrl(t)},this.top==`true`?(this.bundleUrl&&Ke(this.bundleUrl),this.loadUrl(window)):this.route&&(this.consumedRoute=``),this.config)try{let e=JSON.parse(this.config);O.value={...O.value,...e}}catch{O.value={...O.value,config:this.config}}this.addEventListener(`url-update-requested`,this.routeChangedListener),this.addEventListener(`navigate-to-requested`,this.navigateToRequestedListener)}disconnectedCallback(){super.disconnectedCallback(),this.upstreamSubscription?.unsubscribe(),this.removeEventListener(`url-update-requested`,this.routeChangedListener),this.removeEventListener(`navigate-to-requested`,this.navigateToRequestedListener)}loadUrl(e){if(this.route=this.extractRouteFromUrl(e),this.setAttribute(`route`,this.route),this.instant=E(),this._lastUrl=e.location.href,e.location.search){let t=new URLSearchParams(e.location.search).get(`overrides`);if(t&&(this.config=t,this.config))try{let e=JSON.parse(this.config);O.value={...O.value,...e}}catch{O.value={...O.value,config:this.config}}}}extractRouteFromUrl(e){return this.addQueryParams(this.extractRouteWithoutParamsFromUrl(e),e.location)}extractRouteWithoutParamsFromUrl(e){let t=this.extractGrossRouteFromUrl(e);return this.pathPrefix&&t.startsWith(this.pathPrefix)?t.substring(this.pathPrefix.length):t==`/`?``:t}addQueryParams(e,t){return e+(t.search?``+t.search:``)}extractGrossRouteFromUrl(e){let t=e.location.pathname,n=this.baseUrl&&(this.baseUrl.startsWith(`http://`)||this.baseUrl.startsWith(`https://`))?this.baseUrl.substring(this.getContextPathStartingIndex(this.baseUrl)):this.baseUrl;return t.startsWith(n)?t.substring(n.length):t}getContextPathStartingIndex(e){return e.startsWith(`http:`)?e.indexOf(`/`,7):e.startsWith(`https:`)?e.indexOf(`/`,8):0}render(){return T`
+    `}};Ys=Js=k([g(`mateu-skip-link`)],Ys);var Xs=null;function Zs(){if(!(typeof document>`u`)&&!(Xs&&Xs.isConnected)){if(!document.body){document.addEventListener(`DOMContentLoaded`,()=>Zs(),{once:!0});return}Xs=document.createElement(`mateu-skip-link`),document.body.insertBefore(Xs,document.body.firstChild)}}Ws(),qs(),ht(),Zs();var Qs=class extends b{constructor(...e){super(...e),this.baseUrl=``,this.route=void 0,this.consumedRoute=`_empty`,this.config=void 0,this.top=`true`,this.pathPrefix=void 0,this.bundleUrl=void 0,this.debug=!1,this._lastUrl=``,this.routeChangedListener=e=>{if(e.preventDefault(),e.stopPropagation(),e instanceof CustomEvent&&this.top==`true`){let t=e.detail.route,n=this.baseUrl??``;!t||t.startsWith(`/`)?n=window.location.origin+(this.pathPrefix??``):(t=(this.pathPrefix??``)+t,n.indexOf(`://`)<0&&(n.startsWith(`/`)||(n=`/`+n),n=window.location.origin+n)),t.startsWith(this.pathPrefix+`/`)&&(t=t.substring(this.pathPrefix?.length)),n.endsWith(`/`)&&t.startsWith(`/`)&&(t=t.substring(1));let r=new URL(n+t);if((window.location.pathname||r.pathname)&&window.location.pathname!=r.pathname){let e=r.pathname;r.search&&(e+=r.search),e&&!e.startsWith(`/`)&&(e=`/`+e),window.history.pushState({},``,e),this._lastUrl=window.location.href}}},this.navigateToRequestedListener=e=>{if(e.preventDefault(),e.stopPropagation(),to.markClean(),e instanceof CustomEvent){let t=e.detail.route,n=this.renderRoot.querySelector(`mateu-ux`);n&&(n.setAttribute(`route`,t),n.setAttribute(`instant`,E()))}}}createRenderRoot(){return P.mustUseShadowRoot()?super.createRenderRoot():this}connectedCallback(){if(super.connectedCallback(),to.install(),this._lastUrl=window.location.href,window.onpopstate=e=>{if(!to.confirmLeave()){window.history.pushState({},``,this._lastUrl);return}let t=e.target;this.loadUrl(t)},this.top==`true`?(this.bundleUrl&&Ke(this.bundleUrl),this.loadUrl(window)):this.route&&(this.consumedRoute=``),this.config)try{let e=JSON.parse(this.config);O.value={...O.value,...e}}catch{O.value={...O.value,config:this.config}}this.addEventListener(`url-update-requested`,this.routeChangedListener),this.addEventListener(`navigate-to-requested`,this.navigateToRequestedListener)}disconnectedCallback(){super.disconnectedCallback(),this.upstreamSubscription?.unsubscribe(),this.removeEventListener(`url-update-requested`,this.routeChangedListener),this.removeEventListener(`navigate-to-requested`,this.navigateToRequestedListener)}loadUrl(e){if(this.route=this.extractRouteFromUrl(e),this.setAttribute(`route`,this.route),this.instant=E(),this._lastUrl=e.location.href,e.location.search){let t=new URLSearchParams(e.location.search).get(`overrides`);if(t&&(this.config=t,this.config))try{let e=JSON.parse(this.config);O.value={...O.value,...e}}catch{O.value={...O.value,config:this.config}}}}extractRouteFromUrl(e){return this.addQueryParams(this.extractRouteWithoutParamsFromUrl(e),e.location)}extractRouteWithoutParamsFromUrl(e){let t=this.extractGrossRouteFromUrl(e);return this.pathPrefix&&t.startsWith(this.pathPrefix)?t.substring(this.pathPrefix.length):t==`/`?``:t}addQueryParams(e,t){return e+(t.search?``+t.search:``)}extractGrossRouteFromUrl(e){let t=e.location.pathname,n=this.baseUrl&&(this.baseUrl.startsWith(`http://`)||this.baseUrl.startsWith(`https://`))?this.baseUrl.substring(this.getContextPathStartingIndex(this.baseUrl)):this.baseUrl;return t.startsWith(n)?t.substring(n.length):t}getContextPathStartingIndex(e){return e.startsWith(`http:`)?e.indexOf(`/`,7):e.startsWith(`https:`)?e.indexOf(`/`,8):0}render(){return T`
            <mateu-api-caller>
                 <mateu-ux id="_ux"
                           baseurl="${this.baseUrl}"
@@ -7504,9 +7512,9 @@ ${i}
         :host {
             --lumo-clickable-cursor: pointer;
         }
-  `}};k([y()],Zs.prototype,`baseUrl`,void 0),k([y()],Zs.prototype,`route`,void 0),k([y()],Zs.prototype,`consumedRoute`,void 0),k([y()],Zs.prototype,`config`,void 0),k([y()],Zs.prototype,`top`,void 0),k([y()],Zs.prototype,`pathPrefix`,void 0),k([y()],Zs.prototype,`bundleUrl`,void 0),k([C()],Zs.prototype,`instant`,void 0),k([y({type:Boolean})],Zs.prototype,`debug`,void 0),Zs=k([g(`mateu-ui`)],Zs);var Qs,$s=class extends b{static{Qs=this}constructor(...e){super(...e),this.baseUrl=``,this.opened=!1,this.searchText=``}static{this.SEARCHABLE_THRESHOLD=7}connectedCallback(){super.connectedCallback(),Ee()}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick(),this.searchTimer&&clearTimeout(this.searchTimer)}currentValue(){return String(Se()[this.selector.fieldName]??``)}currentLabel(){let e=this.currentValue();if(!e)return`—`;let t=(this.searchedOptions??this.selector.options)?.find(t=>String(t.value)===e);if(t)return t.label;let n=Ce()[this.selector.fieldName];return n===void 0?e:String(n)}pick(e,t){we(this.selector.fieldName,e,t),window.location.reload()}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}openPanel(){this.opened||(this.opened=!0,this.searchText=``,this.searchedOptions=void 0,this.remoteSearch(),this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick),this.updateComplete.then(()=>this.renderRoot.querySelector(`input.picker-search`)?.focus()))}closePanel(){this.detachOutsideClick(),this.opened=!1}onSearchInput(e){this.searchText=e.target.value,this.searchTimer&&clearTimeout(this.searchTimer),this.searchTimer=setTimeout(()=>this.remoteSearch(),300)}async remoteSearch(){let e=this.app;if(e?.serverSideType)try{let t=await lt.runAction(this.baseUrl??``,e.rootRoute??e.initialRoute??``,``,`_appcontext-search-${this.selector.fieldName}`,`appcontext-${this.selector.fieldName}`,void 0,e.serverSideType,{},{searchText:this.searchText},this,!0);for(let e of t?.fragments??[]){let t=e.data?.[`_appcontext_${this.selector.fieldName}`]?.content;if(Array.isArray(t)){this.searchedOptions=t.map(e=>({value:e.value,label:e.label??String(e.value)}));return}}}catch{}}visibleOptions(){let e=this.searchedOptions??this.selector.options??[],t=this.searchText.trim().toLowerCase();return t?e.filter(e=>e.label.toLowerCase().includes(t)):e}renderPanel(){let e=this.currentValue(),t=this.visibleOptions();return T`
+  `}};k([y()],Qs.prototype,`baseUrl`,void 0),k([y()],Qs.prototype,`route`,void 0),k([y()],Qs.prototype,`consumedRoute`,void 0),k([y()],Qs.prototype,`config`,void 0),k([y()],Qs.prototype,`top`,void 0),k([y()],Qs.prototype,`pathPrefix`,void 0),k([y()],Qs.prototype,`bundleUrl`,void 0),k([C()],Qs.prototype,`instant`,void 0),k([y({type:Boolean})],Qs.prototype,`debug`,void 0),Qs=k([g(`mateu-ui`)],Qs);var $s,ec=class extends b{static{$s=this}constructor(...e){super(...e),this.baseUrl=``,this.opened=!1,this.searchText=``}static{this.SEARCHABLE_THRESHOLD=7}connectedCallback(){super.connectedCallback(),Ee()}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick(),this.searchTimer&&clearTimeout(this.searchTimer)}currentValue(){return String(Se()[this.selector.fieldName]??``)}currentLabel(){let e=this.currentValue();if(!e)return`—`;let t=(this.searchedOptions??this.selector.options)?.find(t=>String(t.value)===e);if(t)return t.label;let n=Ce()[this.selector.fieldName];return n===void 0?e:String(n)}pick(e,t){we(this.selector.fieldName,e,t),window.location.reload()}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}openPanel(){this.opened||(this.opened=!0,this.searchText=``,this.searchedOptions=void 0,this.remoteSearch(),this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick),this.updateComplete.then(()=>this.renderRoot.querySelector(`input.picker-search`)?.focus()))}closePanel(){this.detachOutsideClick(),this.opened=!1}onSearchInput(e){this.searchText=e.target.value,this.searchTimer&&clearTimeout(this.searchTimer),this.searchTimer=setTimeout(()=>this.remoteSearch(),300)}async remoteSearch(){let e=this.app;if(e?.serverSideType)try{let t=await lt.runAction(this.baseUrl??``,e.rootRoute??e.initialRoute??``,``,`_appcontext-search-${this.selector.fieldName}`,`appcontext-${this.selector.fieldName}`,void 0,e.serverSideType,{},{searchText:this.searchText},this,!0);for(let e of t?.fragments??[]){let t=e.data?.[`_appcontext_${this.selector.fieldName}`]?.content;if(Array.isArray(t)){this.searchedOptions=t.map(e=>({value:e.value,label:e.label??String(e.value)}));return}}}catch{}}visibleOptions(){let e=this.searchedOptions??this.selector.options??[],t=this.searchText.trim().toLowerCase();return t?e.filter(e=>e.label.toLowerCase().includes(t)):e}renderPanel(){let e=this.currentValue(),t=this.visibleOptions();return T`
             <div class="panel">
-                ${this.searchText!==``||t.length>Qs.SEARCHABLE_THRESHOLD?T`
+                ${this.searchText!==``||t.length>$s.SEARCHABLE_THRESHOLD?T`
                     <input class="picker-search" type="text" placeholder="Search"
                            .value="${this.searchText}"
                            @input="${this.onSearchInput}"
@@ -7598,9 +7606,9 @@ ${i}
         .option--clear {
             color: var(--lumo-secondary-text-color, rgba(0, 0, 0, 0.55));
         }
-    `}};k([y()],$s.prototype,`selector`,void 0),k([y()],$s.prototype,`app`,void 0),k([y()],$s.prototype,`baseUrl`,void 0),k([C()],$s.prototype,`opened`,void 0),k([C()],$s.prototype,`searchText`,void 0),k([C()],$s.prototype,`searchedOptions`,void 0),$s=Qs=k([g(`mateu-app-context-picker`)],$s);var ec=class extends b{constructor(...e){super(...e),this.baseUrl=``,this.opened=!1,this.notifications=[],this.fetched=!1}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}updated(){!this.fetched&&this.app?.serverSideType&&(this.fetched=!0,this.refresh())}unreadCount(){return this.notifications.filter(e=>e.unread).length}async runNotificationsAction(e,t){let n=this.app;if(n?.serverSideType)try{let r=await lt.runAction(this.baseUrl??``,n.rootRoute??n.initialRoute??``,``,e,`notification-bell`,void 0,n.serverSideType,{},t,this,!0);for(let e of r?.fragments??[]){let t=e.data?._notifications;if(Array.isArray(t)){this.notifications=t;return}}}catch{}}refresh(){return this.runNotificationsAction(`_notifications-list`,{})}markRead(e){return this.runNotificationsAction(`_notifications-read`,{ids:e})}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}openPanel(){this.opened||(this.opened=!0,this.refresh(),this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick))}closePanel(){this.detachOutsideClick(),this.opened=!1}async entryClicked(e){e.unread&&await this.markRead([e.id]);let t=e.route;if(t){if(!eo.confirmLeave())return;this.closePanel(),this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0})),this.dispatchEvent(new CustomEvent(`navigate-to-requested`,{detail:{route:t},bubbles:!0,composed:!0}))}}renderEntry(e){return T`
+    `}};k([y()],ec.prototype,`selector`,void 0),k([y()],ec.prototype,`app`,void 0),k([y()],ec.prototype,`baseUrl`,void 0),k([C()],ec.prototype,`opened`,void 0),k([C()],ec.prototype,`searchText`,void 0),k([C()],ec.prototype,`searchedOptions`,void 0),ec=$s=k([g(`mateu-app-context-picker`)],ec);var tc=class extends b{constructor(...e){super(...e),this.baseUrl=``,this.opened=!1,this.notifications=[],this.fetched=!1}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}updated(){!this.fetched&&this.app?.serverSideType&&(this.fetched=!0,this.refresh())}unreadCount(){return this.notifications.filter(e=>e.unread).length}async runNotificationsAction(e,t){let n=this.app;if(n?.serverSideType)try{let r=await lt.runAction(this.baseUrl??``,n.rootRoute??n.initialRoute??``,``,e,`notification-bell`,void 0,n.serverSideType,{},t,this,!0);for(let e of r?.fragments??[]){let t=e.data?._notifications;if(Array.isArray(t)){this.notifications=t;return}}}catch{}}refresh(){return this.runNotificationsAction(`_notifications-list`,{})}markRead(e){return this.runNotificationsAction(`_notifications-read`,{ids:e})}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}openPanel(){this.opened||(this.opened=!0,this.refresh(),this.outsideClick=e=>{e.composedPath().includes(this)||this.closePanel()},document.addEventListener(`mousedown`,this.outsideClick))}closePanel(){this.detachOutsideClick(),this.opened=!1}async entryClicked(e){e.unread&&await this.markRead([e.id]);let t=e.route;if(t){if(!to.confirmLeave())return;this.closePanel(),this.dispatchEvent(new CustomEvent(`route-changed`,{detail:{route:t},bubbles:!0,composed:!0})),this.dispatchEvent(new CustomEvent(`navigate-to-requested`,{detail:{route:t},bubbles:!0,composed:!0}))}}renderEntry(e){return T`
             <div role="button" tabindex="0" class="entry ${e.unread?`entry--unread`:``}"
-                 @click="${()=>this.entryClicked(e)}" @keydown="${z(()=>this.entryClicked(e))}">
+                 @click="${()=>this.entryClicked(e)}" @keydown="${R(()=>this.entryClicked(e))}">
                 <span class="unread-dot" aria-hidden="true"></span>
                 <div class="entry-body">
                     <div class="entry-top">
@@ -7785,48 +7793,48 @@ ${i}
             cursor: default;
         }
     
-        ${B}
-    `}};k([y()],ec.prototype,`app`,void 0),k([y()],ec.prototype,`baseUrl`,void 0),k([C()],ec.prototype,`opened`,void 0),k([C()],ec.prototype,`notifications`,void 0),ec=k([g(`mateu-notification-bell`)],ec);var tc=e=>{if(!e||!(`querySelectorAll`in e))return null;for(let t of e.querySelectorAll(`*`)){if(t.tagName?.toLowerCase()===`mateu-component`)return t;let e=tc(t.shadowRoot);if(e)return e}return null},nc=async(e,t,n)=>{let r=tc(t.renderRoot??t);await ds.runAction(lt,t.baseUrl??``,e.rootRoute||`_no_route`,``,n,r?.id??`app-header-action`,{},e.serverSideType??``,{},{},r??t,!0,void 0,!1,``)},rc=async(e,t,n)=>{try{await nc(e,t,n)}catch(e){Na({text:`La acción falló: `+e,position:`bottomStart`,duration:6e3,variant:`error`},t)}},ic=(e,t)=>{let n=e.contextSelectors??[],r=e.contextActions??[];return n.length===0&&r.length===0&&!e.notificationsEnabled?v:T`${e.notificationsEnabled?T`
+        ${z}
+    `}};k([y()],tc.prototype,`app`,void 0),k([y()],tc.prototype,`baseUrl`,void 0),k([C()],tc.prototype,`opened`,void 0),k([C()],tc.prototype,`notifications`,void 0),tc=k([g(`mateu-notification-bell`)],tc);var nc=e=>{if(!e||!(`querySelectorAll`in e))return null;for(let t of e.querySelectorAll(`*`)){if(t.tagName?.toLowerCase()===`mateu-component`)return t;let e=nc(t.shadowRoot);if(e)return e}return null},rc=async(e,t,n)=>{let r=nc(t.renderRoot??t);await fs.runAction(lt,t.baseUrl??``,e.rootRoute||`_no_route`,``,n,r?.id??`app-header-action`,{},e.serverSideType??``,{},{},r??t,!0,void 0,!1,``)},ic=async(e,t,n)=>{try{await rc(e,t,n)}catch(e){Pa({text:`La acción falló: `+e,position:`bottomStart`,duration:6e3,variant:`error`},t)}},ac=(e,t)=>{let n=e.contextSelectors??[],r=e.contextActions??[];return n.length===0&&r.length===0&&!e.notificationsEnabled?v:T`${e.notificationsEnabled?T`
         <mateu-notification-bell .app="${e}" .baseUrl="${t.baseUrl??``}"></mateu-notification-bell>`:v}${n.map(n=>T`
         <mateu-app-context-picker .selector="${n}" .app="${e}" .baseUrl="${t.baseUrl??``}"></mateu-app-context-picker>`)}${r.map(n=>(n.children?.length??0)>0?T`
         <details class="mateu-nav-group" style="margin-left: 0.5rem; flex-shrink: 0;">
             <summary class="app-header-action-btn">${n.label} ▾</summary>
             <div class="mateu-nav-panel" style="right: 0; left: auto;">
                 ${n.children.map(n=>T`
-                    <button class="mateu-nav-item" @click="${()=>n.actionId&&rc(e,t,n.actionId)}">${n.label}</button>`)}
+                    <button class="mateu-nav-item" @click="${()=>n.actionId&&ic(e,t,n.actionId)}">${n.label}</button>`)}
             </div>
         </details>`:T`
         <button class="app-header-action-btn" style="margin-left: 0.5rem; flex-shrink: 0;"
-            @click="${()=>n.actionId&&rc(e,t,n.actionId)}" title="${n.label}">${n.icon?L(n.icon):v}${n.label}</button>`)}`},ac=(e,t)=>T`
+            @click="${()=>n.actionId&&ic(e,t,n.actionId)}" title="${n.label}">${n.icon?I(n.icon):v}${n.label}</button>`)}`},oc=(e,t)=>T`
     <button class="mateu-nav-item ${e.selected?`mateu-nav-item--active`:``}"
             ?disabled="${e.disabled}"
-            @click="${()=>t(e)}">${e.text}</button>`,oc=(e,t,n=``)=>T`
+            @click="${()=>t(e)}">${e.text}</button>`,sc=(e,t,n=``)=>T`
     <nav class="mateu-nav ${n}">
         ${e.map(e=>(e.children?.length??0)>0?T`<details class="mateu-nav-group">
                        <summary class="mateu-nav-item">${e.text} ▾</summary>
                        <div class="mateu-nav-panel">
-                           ${e.children.map(e=>ac(e,t))}
+                           ${e.children.map(e=>oc(e,t))}
                        </div>
-                   </details>`:ac(e,t))}
-    </nav>`,sc=(e,t)=>n=>t.call(e,{detail:{value:n}}),cc=(e,t)=>e.themeToggle?T`
+                   </details>`:oc(e,t))}
+    </nav>`,cc=(e,t)=>n=>t.call(e,{detail:{value:n}}),lc=(e,t)=>e.themeToggle?T`
         <button class="app-chrome-icon-btn" @click="${t.toggleTheme}"
             title="${t.isDark?`Switch to light mode`:`Switch to dark mode`}"
             style="margin-left: 0.5rem; margin-right: 0.5rem; flex-shrink: 0;">
-            ${L(t.isDark?`vaadin:sun-o`:`vaadin:moon`,`color: var(--lumo-body-text-color);`)}
+            ${I(t.isDark?`vaadin:sun-o`:`vaadin:moon`,`color: var(--lumo-body-text-color);`)}
         </button>
-    `:v,lc=(e,t)=>{t.filter!=e.detail.value&&(t.filter=e.detail.value)},uc=(e,t,n)=>{let r=dc(e,t,n),i=Z(t,n);return r==`list`||r==i?`new`:r},dc=(e,t,n)=>{let r=e?._route;if(r!=null&&(r===``||r.startsWith(`/`))){let e=n.homeRoute??``,i=e.indexOf(`?`),a=i>=0?e.substring(i+1):``,o=Z(t,n)+r;return a?o+(o.indexOf(`?`)>=0?`&`:`?`)+a:o}return t.selectedRoute?t.selectedRoute:n.homeRoute},Z=(e,t)=>e.selectedRoute?e.selectedConsumedRoute??t.route:t.homeConsumedRoute,fc=(e,t)=>e.selectedRoute?e.selectedBaseUrl??e.baseUrl:t.homeBaseUrl,pc=(e,t)=>e.selectedRoute?e.selectedServerSideType??t.serverSideType:t.homeServerSideType,mc=(e,t)=>e.selectedRoute?e.selectedUriPrefix:t.homeUriPrefix,hc=(e,t)=>`ux_`+((Z(e,t)||`root`)+`|`+(pc(e,t)??``)).replace(/[^a-zA-Z0-9]/g,`_`),gc=(e,t,n,r,i,a,o)=>{let s=hc(e,t);if(t.chromeless)return T`
+    `:v,uc=(e,t)=>{t.filter!=e.detail.value&&(t.filter=e.detail.value)},dc=(e,t,n)=>{let r=fc(e,t,n),i=X(t,n);return r==`list`||r==i?`new`:r},fc=(e,t,n)=>{let r=e?._route;if(r!=null&&(r===``||r.startsWith(`/`))){let e=n.homeRoute??``,i=e.indexOf(`?`),a=i>=0?e.substring(i+1):``,o=X(t,n)+r;return a?o+(o.indexOf(`?`)>=0?`&`:`?`)+a:o}return t.selectedRoute?t.selectedRoute:n.homeRoute},X=(e,t)=>e.selectedRoute?e.selectedConsumedRoute??t.route:t.homeConsumedRoute,pc=(e,t)=>e.selectedRoute?e.selectedBaseUrl??e.baseUrl:t.homeBaseUrl,mc=(e,t)=>e.selectedRoute?e.selectedServerSideType??t.serverSideType:t.homeServerSideType,hc=(e,t)=>e.selectedRoute?e.selectedUriPrefix:t.homeUriPrefix,gc=(e,t)=>`ux_`+((X(e,t)||`root`)+`|`+(mc(e,t)??``)).replace(/[^a-zA-Z0-9]/g,`_`),_c=(e,t,n,r,i,a,o)=>{let s=gc(e,t);if(t.chromeless)return T`
             <div class="app chromeless">
                 <div role="main" class="${`app-content`+(e.pageCompact?` no-padding`:``)}" style="height: 100%;">
                     <div class="m-md">
                         <div class="m-scroll" style="height: 100%;">
                             <mateu-api-caller>
                                 <mateu-ux
-                                        route="${dc(r,e,t)}"
+                                        route="${fc(r,e,t)}"
                                         id="${s}"
-                                        baseUrl="${fc(e,t)}"
-                                        consumedRoute="${Z(e,t)}"
-                                        serverSideType="${pc(e,t)}"
-                                        uriPrefix="${mc(e,t)}"
+                                        baseUrl="${pc(e,t)}"
+                                        consumedRoute="${X(e,t)}"
+                                        serverSideType="${mc(e,t)}"
+                                        uriPrefix="${hc(e,t)}"
                                         style="width: 100%;"
                                         .appState="${a}"
                                         .appData="${o}"
@@ -7840,7 +7848,7 @@ ${i}
                 </div>
                 <slot></slot>
             </div>
-        `;let c=e.mapItems(t.menu,e.filter?.toLowerCase()??``),l=Z(e,t),u=uc(r,e,t),d=u&&u!==`new`&&u.startsWith(l+`/`)?u.substring(l.length+1).split(`/`)[0]:void 0;return T`
+        `;let c=e.mapItems(t.menu,e.filter?.toLowerCase()??``),l=X(e,t),u=dc(r,e,t),d=u&&u!==`new`&&u.startsWith(l+`/`)?u.substring(l.length+1).split(`/`)[0]:void 0;return T`
                     ${t.variant==dt.MEDIATOR?T`
 
                         ${t.layout==`SPLIT`?T`
@@ -7848,12 +7856,12 @@ ${i}
                                 <mateu-api-caller>
                                     <div style="display: block; width: calc(100% - 1rem);">
                                     <mateu-ux
-                                            route="${Z(e,t)}"
+                                            route="${X(e,t)}"
                                             id="${s}"
-                                            baseUrl="${fc(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${pc(e,t)}"
-                                            uriPrefix="${mc(e,t)}"
+                                            baseUrl="${pc(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${mc(e,t)}"
+                                            uriPrefix="${hc(e,t)}"
                                             style="width: 100%;"
                                             .appState="${{...a,_splitDetailId:d}}"
                                             .appData="${o}"
@@ -7865,12 +7873,12 @@ ${i}
                                 <mateu-api-caller slot="detail">
                                     <div style="padding-left: 1rem; width: calc(100% - 1rem);">
                                     <mateu-ux
-                                            route="${uc(r,e,t)}"
+                                            route="${dc(r,e,t)}"
                                             id="${s}_detail"
-                                            baseUrl="${fc(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${pc(e,t)}"
-                                            uriPrefix="${mc(e,t)}"
+                                            baseUrl="${pc(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${mc(e,t)}"
+                                            uriPrefix="${hc(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -7884,12 +7892,12 @@ ${i}
                         `:T`
                             <mateu-api-caller>
                                 <mateu-ux
-                                        route="${dc(r,e,t)}"
+                                        route="${fc(r,e,t)}"
                                         id="${s}"
-                                        baseUrl="${fc(e,t)}"
-                                        consumedRoute="${Z(e,t)}"
-                                        serverSideType="${pc(e,t)}"
-                                        uriPrefix="${mc(e,t)}"
+                                        baseUrl="${pc(e,t)}"
+                                        consumedRoute="${X(e,t)}"
+                                        serverSideType="${mc(e,t)}"
+                                        uriPrefix="${hc(e,t)}"
                                         style="width: 100%;"
                                         .appState="${a}"
                                         .appData="${o}"
@@ -7906,12 +7914,12 @@ ${i}
                     <header class="app-navbar">
                         <button class="drawer-toggle" title="Menu"
                                 @click="${e=>e.currentTarget.closest(`.m-app-layout`)?.classList.toggle(`drawer-open`)}">
-                            ${L(`vaadin:menu`)}
+                            ${I(`vaadin:menu`)}
                         </button>
                         <h2 style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; margin: 0 .5rem;">${t.title}</h2><p style="margin: 0;">${t.subtitle}</p>
                         <div class="m-hl" style="margin-left: auto; align-items: center;">
                             <slot name="widgets"></slot>
-                            ${ic(t,e)}${cc(t,e)}
+                            ${ac(t,e)}${lc(t,e)}
                         </div>
                     </header>
                     <div class="app-body">
@@ -7919,7 +7927,7 @@ ${i}
                             ${t.menu&&t.totalMenuOptions>10?T`
                                 <div style="position: sticky; top: 0; z-index: 2; background: var(--lumo-base-color); padding: .25rem 0 .5rem;">
                                     <input class="drawer-search" placeholder="Search…" style="width: calc(100% - 20px); margin: 0 10px;"
-                                           @input="${t=>lc({detail:{value:t.target.value}},e)}">
+                                           @input="${t=>uc({detail:{value:t.target.value}},e)}">
                                 </div>
                                 `:v}
                             <nav class="side-nav">
@@ -7931,12 +7939,12 @@ ${i}
                                 <div class="m-scroll" style="height: 100%;">
                                     <mateu-api-caller>
                                         <mateu-ux
-                                                route="${dc(r,e,t)}"
+                                                route="${fc(r,e,t)}"
                                                 id="${s}"
-                                                baseUrl="${fc(e,t)}"
-                                                consumedRoute="${Z(e,t)}"
-                                                serverSideType="${pc(e,t)}"
-                                                uriPrefix="${mc(e,t)}"
+                                                baseUrl="${pc(e,t)}"
+                                                consumedRoute="${X(e,t)}"
+                                                serverSideType="${mc(e,t)}"
+                                                uriPrefix="${hc(e,t)}"
                                                 style="width: 100%;"
                                                 .appState="${a}"
                                                 .appData="${o}"
@@ -7965,10 +7973,10 @@ ${i}
                             ${t.title?T`<h2 style="margin: 0 var(--lumo-space-l, 1.5rem) 0 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;">${t.title}</h2>`:v}
                         </div>
                         </a>
-                        ${(()=>{let t=sc(e,e.itemSelected);return F.get()?.renderTopNav?.(c,t,`menu-on-top`)??oc(c,t,`menu-on-top`)})()}
+                        ${(()=>{let t=cc(e,e.itemSelected);return P.get()?.renderTopNav?.(c,t,`menu-on-top`)??sc(c,t,`menu-on-top`)})()}
                         <div class="m-hl" style="margin-left: auto; flex-shrink: 0; align-items: center;">
                             <slot name="widgets"></slot>
-                            ${ic(t,e)}${cc(t,e)}
+                            ${ac(t,e)}${lc(t,e)}
                         </div>
                     </div>
                     <div style="flex: 1; min-height: 0; overflow-y: auto; overflow-x: hidden; box-sizing: border-box; width: 100%;">
@@ -7976,12 +7984,12 @@ ${i}
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${dc(r,e,t)}"
+                                            route="${fc(r,e,t)}"
                                             id="${s}"
-                                            baseUrl="${fc(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${pc(e,t)}"
-                                            uriPrefix="${mc(e,t)}"
+                                            baseUrl="${pc(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${mc(e,t)}"
+                                            uriPrefix="${hc(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -8009,10 +8017,10 @@ ${i}
                             ${t.title?T`<h2 style="margin: 0 var(--lumo-space-l, 1.5rem) 0 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;">${t.title}</h2>`:v}
                         </div>
                         </a>
-                        ${oc(e.mapItemsForTiles(t.menu),sc(e,e.itemSelectedTiles),`menu-on-top`)}
+                        ${sc(e.mapItemsForTiles(t.menu),cc(e,e.itemSelectedTiles),`menu-on-top`)}
                         <div class="m-hl" style="margin-left: auto; flex-shrink: 0; align-items: center;">
                             <slot name="widgets"></slot>
-                            ${ic(t,e)}${cc(t,e)}
+                            ${ac(t,e)}${lc(t,e)}
                         </div>
                     </div>
                     <div style="flex: 1; min-height: 0; overflow-y: auto; overflow-x: hidden; box-sizing: border-box; width: 100%;">
@@ -8021,12 +8029,12 @@ ${i}
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${dc(r,e,t)}"
+                                            route="${fc(r,e,t)}"
                                             id="${s}"
-                                            baseUrl="${fc(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${pc(e,t)}"
-                                            uriPrefix="${mc(e,t)}"
+                                            baseUrl="${pc(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${mc(e,t)}"
+                                            uriPrefix="${hc(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -8051,12 +8059,12 @@ ${i}
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${dc(r,e,t)}"
+                                            route="${fc(r,e,t)}"
                                             id="${s}"
-                                            baseUrl="${fc(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${pc(e,t)}"
-                                            uriPrefix="${mc(e,t)}"
+                                            baseUrl="${pc(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${mc(e,t)}"
+                                            uriPrefix="${hc(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -8078,7 +8086,7 @@ ${i}
                         <div class="m-vl"
                                 @navigation-requested="${e.updateRoute}">
                             ${t.menu.map(t=>e.renderOptionOnLeftMenu(t))}
-                            ${ic(t,e)}${cc(t,e)}
+                            ${ac(t,e)}${lc(t,e)}
                         </div>
                     </div>
                     <div role="main" class="${`app-content`+(e.pageCompact?` no-padding`:``)}">
@@ -8086,12 +8094,12 @@ ${i}
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${dc(r,e,t)}"
+                                            route="${fc(r,e,t)}"
                                             id="${s}"
-                                            baseUrl="${fc(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${pc(e,t)}"
-                                            uriPrefix="${mc(e,t)}"
+                                            baseUrl="${pc(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${mc(e,t)}"
+                                            uriPrefix="${hc(e,t)}"
                                             style="width: 100%; padding: 1em;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -8135,7 +8143,7 @@ ${i}
                             </nav>
                             <div class="m-hl" style="flex-shrink: 0; align-items: center;">
                                 <slot name="widgets"></slot>
-                                ${ic(t,e)}${cc(t,e)}
+                                ${ac(t,e)}${lc(t,e)}
                             </div>
                         </div>
                     </div>
@@ -8144,12 +8152,12 @@ ${i}
                             <div class="m-scroll" style="height: 100%;">
                                 <mateu-api-caller>
                                     <mateu-ux
-                                            route="${dc(r,e,t)}"
+                                            route="${fc(r,e,t)}"
                                             id="${s}"
-                                            baseUrl="${fc(e,t)}"
-                                            consumedRoute="${Z(e,t)}"
-                                            serverSideType="${pc(e,t)}"
-                                            uriPrefix="${mc(e,t)}"
+                                            baseUrl="${pc(e,t)}"
+                                            consumedRoute="${X(e,t)}"
+                                            serverSideType="${mc(e,t)}"
+                                            uriPrefix="${hc(e,t)}"
                                             style="width: 100%;"
                                             .appState="${a}"
                                             .appData="${o}"
@@ -8169,17 +8177,17 @@ ${i}
                 <button class="app-fab" style="bottom: ${(t.sseUrl?5.5:1.5)+r*4}rem; right: 1.5rem;"
                     @click="${()=>e.runAction(n.actionId)}"
                     title="${n.label}">
-                    ${L(n.icon)}
+                    ${I(n.icon)}
                 </button>
             `)}
             ${t.sseUrl&&!e.chatOpen?T`
                 <button class="ai-fab" @click="${e.showHideIa}" title="Asistente IA">
-                    ${L(`vaadin:comments-o`)}
+                    ${I(`vaadin:comments-o`)}
                 </button>
             `:v}
             ${e.renderCommandPalette()}
             <slot></slot>
-       `},_c=(e,t)=>t!=null&&e!=null&&!e.has(t),vc=typeof HTMLElement<`u`?HTMLElement:class{},yc=class extends vc{static get observedAttributes(){return[`type`,`renderer`]}connectedCallback(){this.render()}attributeChangedCallback(){this.render()}render(){let e=this.getAttribute(`type`)??`unknown`,t=this.getAttribute(`renderer`)??`unknown`;this.shadowRoot||this.attachShadow({mode:`open`}),this.shadowRoot.innerHTML=`
+       `},vc=(e,t)=>t!=null&&e!=null&&!e.has(t),yc=typeof HTMLElement<`u`?HTMLElement:class{},bc=class extends yc{static get observedAttributes(){return[`type`,`renderer`]}connectedCallback(){this.render()}attributeChangedCallback(){this.render()}render(){let e=this.getAttribute(`type`)??`unknown`,t=this.getAttribute(`renderer`)??`unknown`;this.shadowRoot||this.attachShadow({mode:`open`}),this.shadowRoot.innerHTML=`
             <style>
                 :host { display: block; }
                 .mateu-unsupported {
@@ -8198,12 +8206,12 @@ ${i}
             <div class="mateu-unsupported" role="note">
                 ⚠ Component “${e}” is not supported by the “${t}” renderer yet.
             </div>
-        `}};typeof customElements<`u`&&!customElements.get(`mateu-unsupported`)&&customElements.define(`mateu-unsupported`,yc);var bc=new Set,xc=(e,t,n)=>{let r=`${n}/${t}`;return bc.has(r)||(bc.add(r),console.warn(`[mateu] Component type "${t}" is not supported by the "${n}" renderer — rendering <mateu-unsupported> placeholder.`)),T`<mateu-unsupported
+        `}};typeof customElements<`u`&&!customElements.get(`mateu-unsupported`)&&customElements.define(`mateu-unsupported`,bc);var xc=new Set,Sc=(e,t,n)=>{let r=`${n}/${t}`;return xc.has(r)||(xc.add(r),console.warn(`[mateu] Component type "${t}" is not supported by the "${n}" renderer — rendering <mateu-unsupported> placeholder.`)),T`<mateu-unsupported
             type="${t}"
             renderer="${n}"
             data-component-id="${e?.id??v}"
             slot="${e?.slot??v}"
-    ></mateu-unsupported>`},Sc=class{renderFilterBar(e,t,n,r,i,a,o,s){let c=t?.metadata;return T`
+    ></mateu-unsupported>`},Cc=class{renderFilterBar(e,t,n,r,i,a,o,s){let c=t?.metadata;return T`
             <mateu-filter-bar
                 .metadata="${c}"
                 @search-requested="${e.search}"
@@ -8215,7 +8223,7 @@ ${i}
                 .appData="${o}"
                 ?searchOnly="${s??!1}"
             >
-                ${c?.header?.map(t=>I(e,t,n,r,i,a,o))}
+                ${c?.header?.map(t=>F(e,t,n,r,i,a,o))}
             </mateu-filter-bar>
         `}renderPagination(e,t){return T`
         <mateu-pagination
@@ -8226,14 +8234,14 @@ ${i}
                 data-testid="pagination"
                 .pageNumber="${e.data[t?.id]?.page?.pageNumber??0}"
         ></mateu-pagination>
-        `}renderTableComponent(e,t,n,r,i,a,o){return zn(t,(e.data?.[e.id])?.page?.content??[],r[t?.id]?.emptyStateMessage)}rendererName(){return this.constructor?.name??`unknown`}supportedClientSideTypes(){}renderClientSideComponent(e,t,n,r,i,a,o,s){let c=t?.metadata?.type??t?.type,l=Object.values(j).includes(c)?c:void 0;return _c(this.supportedClientSideTypes(),l)?xc(t,l,this.rendererName()):Da(e,t,n,r,i,a,o,s)}renderAppComponent(e,t,n,r,i,a,o){return gc(e,t?.metadata,n,r,i,a,o)}},Cc=(e,t,n,r,i,a,o)=>T`
+        `}renderTableComponent(e,t,n,r,i,a,o){return Bn(t,(e.data?.[e.id])?.page?.content??[],r[t?.id]?.emptyStateMessage)}rendererName(){return this.constructor?.name??`unknown`}supportedClientSideTypes(){}renderClientSideComponent(e,t,n,r,i,a,o,s){let c=t?.metadata?.type??t?.type,l=Object.values(j).includes(c)?c:void 0;return vc(this.supportedClientSideTypes(),l)?Sc(t,l,this.rendererName()):Oa(e,t,n,r,i,a,o,s)}renderAppComponent(e,t,n,r,i,a,o){return _c(e,t?.metadata,n,r,i,a,o)}},wc=(e,t,n,r,i,a,o)=>T`
         <vaadin-virtual-list
                 .items="${t.metadata.page.content}"
-                ${te(t=>T`${I(e,t,n,r,i,a,o)}`,[])}
+                ${te(t=>T`${F(e,t,n,r,i,a,o)}`,[])}
                 style="${t.style}" class="${t.cssClasses}"
                 slot="${t.slot??v}"
         ></vaadin-virtual-list>
-    `,wc=e=>{let t=e.metadata;return T`
+    `,Tc=e=>{let t=e.metadata;return T`
         <vaadin-notification
                 .opened="${!0}"
                 slot="${e.slot??v}"
@@ -8246,7 +8254,7 @@ ${i}
                     </vaadin-horizontal-layout>
                 `,[])}
         ></vaadin-notification>
-    `},Tc=(e,t={})=>{let n=e.metadata,r=n.valueKey?t[n.valueKey]:n.value;return T`
+    `},Ec=(e,t={})=>{let n=e.metadata,r=n.valueKey?t[n.valueKey]:n.value;return T`
         <div style="${e.style}">
         <vaadin-progress-bar
                 ?indeterminate="${n.indeterminate}"
@@ -8261,7 +8269,7 @@ ${i}
     ${n.text}
   </span>`:v}
         </div>
-    `},Ec=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+    `},Dc=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
         <vaadin-details
                 ?opened="${s.opened}"
                 style="${t.style}"
@@ -8269,37 +8277,37 @@ ${i}
                 slot="${t.slot??v}"
         >
             <vaadin-details-summary slot="summary">
-            ${I(e,s.summary,n,r,i,a,o)}
+            ${F(e,s.summary,n,r,i,a,o)}
             </vaadin-details-summary>
-            ${I(e,s.content,n,r,i,a,o)}
+            ${F(e,s.content,n,r,i,a,o)}
         </vaadin-details>
-            `},Dc=(e,t,n)=>{let r=e.metadata;return T`<vaadin-avatar
+            `},Oc=(e,t,n)=>{let r=e.metadata;return T`<vaadin-avatar
             img="${r.image}"
-            name="${P(r.name,t,n)}"
+            name="${Ot(r.name,t,n)}"
             abbr="${r.abbreviation}"
             style="${e.style}" class="${e.cssClasses}"
             slot="${e.slot??v}"
-    ></vaadin-avatar>`},Oc=e=>{let t=e.metadata;return T`<vaadin-avatar-group max-items-visible="${t.maxItemsVisible}"
+    ></vaadin-avatar>`},kc=e=>{let t=e.metadata;return T`<vaadin-avatar-group max-items-visible="${t.maxItemsVisible}"
                                      .items="${t.avatars}"
                                      style="${e.style}" class="${e.cssClasses}"
                                      slot="${e.slot??v}">
-    </vaadin-avatar-group>`},kc=(e,t,n,r,i,a,o)=>{let s=t.metadata;if(!s)return T``;let c=``;return s.variants?.map(e=>e==`stretchMedia`?`stretch-media`:e==`coverMedia`?`cover-media`:e).forEach(e=>c+=` `+e),c=c.trim(),T`
+    </vaadin-avatar-group>`},Ac=(e,t,n,r,i,a,o)=>{let s=t.metadata;if(!s)return T``;let c=``;return s.variants?.map(e=>e==`stretchMedia`?`stretch-media`:e==`coverMedia`?`cover-media`:e).forEach(e=>c+=` `+e),c=c.trim(),T`
         <vaadin-card
                 style="${t.style}"
                 class="${t.cssClasses}"
                 theme="${c}"
                 slot="${t.slot??v}"
         >
-            ${s.media?jt(e,s.media,n,r,i,a,o,`media`,!1):v}
-            ${s.title?jt(e,s.title,n,r,i,a,o,`title`,!1):v}
-            ${s.subtitle?jt(e,s.subtitle,n,r,i,a,o,`subtitle`,!1):v}
-            ${s.header?jt(e,s.header,n,r,i,a,o,`header`,!1):v}
-            ${s.headerPrefix?jt(e,s.headerPrefix,n,r,i,a,o,`header-prefix`,!1):v}
-            ${s.headerSuffix?jt(e,s.headerSuffix,n,r,i,a,o,`header-suffix`,!1):v}
-            ${s.footer?jt(e,s.footer,n,r,i,a,o,`footer`,!1):v}
-            ${s.content?I(e,s.content,n,r,i,a,o,!1):v}
+            ${s.media?Mt(e,s.media,n,r,i,a,o,`media`,!1):v}
+            ${s.title?Mt(e,s.title,n,r,i,a,o,`title`,!1):v}
+            ${s.subtitle?Mt(e,s.subtitle,n,r,i,a,o,`subtitle`,!1):v}
+            ${s.header?Mt(e,s.header,n,r,i,a,o,`header`,!1):v}
+            ${s.headerPrefix?Mt(e,s.headerPrefix,n,r,i,a,o,`header-prefix`,!1):v}
+            ${s.headerSuffix?Mt(e,s.headerSuffix,n,r,i,a,o,`header-suffix`,!1):v}
+            ${s.footer?Mt(e,s.footer,n,r,i,a,o,`footer`,!1):v}
+            ${s.content?F(e,s.content,n,r,i,a,o,!1):v}
         </vaadin-card>
-    `},Ac=e=>e>0&&e<640?`accordion`:`tabs`,jc=class extends b{constructor(...e){super(...e),this.tabLabels=[],this.mode=`tabs`,this.selected=0,this.selectedChangedListener=e=>{let t=e.detail?.value;typeof t==`number`&&t>=0&&(this.selected=t)}}connectedCallback(){super.connectedCallback(),this.resizeObserver=new ResizeObserver(e=>{for(let t of e)this.mode=Ac(t.contentRect.width)}),this.resizeObserver.observe(this)}disconnectedCallback(){super.disconnectedCallback(),this.resizeObserver?.disconnect(),this.resizeObserver=void 0,this.detachTabsListener()}detachTabsListener(){this.slottedTabs?.removeEventListener(`selected-changed`,this.selectedChangedListener),this.slottedTabs=void 0}tabsSlotChanged(e){this.detachTabsListener();let t=e.target.assignedElements().find(e=>`selected`in e);t&&(this.slottedTabs=t,t.addEventListener(`selected-changed`,this.selectedChangedListener),t.selected=this.selected)}select(e){this.selected=e,this.slottedTabs&&(this.slottedTabs.selected=e)}updated(){this.slottedTabs&&this.slottedTabs.selected!=this.selected&&(this.slottedTabs.selected=this.selected)}static{this.styles=h`
+    `},jc=e=>e>0&&e<640?`accordion`:`tabs`,Mc=class extends b{constructor(...e){super(...e),this.tabLabels=[],this.mode=`tabs`,this.selected=0,this.selectedChangedListener=e=>{let t=e.detail?.value;typeof t==`number`&&t>=0&&(this.selected=t)}}connectedCallback(){super.connectedCallback(),this.resizeObserver=new ResizeObserver(e=>{for(let t of e)this.mode=jc(t.contentRect.width)}),this.resizeObserver.observe(this)}disconnectedCallback(){super.disconnectedCallback(),this.resizeObserver?.disconnect(),this.resizeObserver=void 0,this.detachTabsListener()}detachTabsListener(){this.slottedTabs?.removeEventListener(`selected-changed`,this.selectedChangedListener),this.slottedTabs=void 0}tabsSlotChanged(e){this.detachTabsListener();let t=e.target.assignedElements().find(e=>`selected`in e);t&&(this.slottedTabs=t,t.addEventListener(`selected-changed`,this.selectedChangedListener),t.selected=this.selected)}select(e){this.selected=e,this.slottedTabs&&(this.slottedTabs.selected=e)}updated(){this.slottedTabs&&this.slottedTabs.selected!=this.selected&&(this.slottedTabs.selected=this.selected)}static{this.styles=h`
         :host {
             display: block;
         }
@@ -8383,7 +8391,7 @@ ${i}
                     `)}
                 </div>
             `}
-        `}};k([y({type:Array})],jc.prototype,`tabLabels`,void 0),k([C()],jc.prototype,`mode`,void 0),k([C()],jc.prototype,`selected`,void 0),jc=k([g(`mateu-adaptive-tabs`)],jc);var Mc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;c??=``,s.columnSpacing&&(c+=`--vaadin-form-layout-column-spacing: `+s.columnSpacing+`;`);let l=s.itemRowSpacing&&s.itemRowSpacing!==`0`?s.itemRowSpacing:`var(--lumo-space-m)`;return c+=`--vaadin-form-layout-row-spacing: `+l+`;`,s.itemLabelSpacing&&(c+=`--vaadin-form-layout-label-spacing: `+s.itemLabelSpacing+`;`),s.labelsAside&&(c+=`--vaadin-form-item-label-width: 10rem;`),s.fullWidth&&(c+=`width: 100%;`),T`
+        `}};k([y({type:Array})],Mc.prototype,`tabLabels`,void 0),k([C()],Mc.prototype,`mode`,void 0),k([C()],Mc.prototype,`selected`,void 0),Mc=k([g(`mateu-adaptive-tabs`)],Mc);var Nc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;c??=``,s.columnSpacing&&(c+=`--vaadin-form-layout-column-spacing: `+s.columnSpacing+`;`);let l=s.itemRowSpacing&&s.itemRowSpacing!==`0`?s.itemRowSpacing:`var(--lumo-space-m)`;return c+=`--vaadin-form-layout-row-spacing: `+l+`;`,s.itemLabelSpacing&&(c+=`--vaadin-form-layout-label-spacing: `+s.itemLabelSpacing+`;`),s.labelsAside&&(c+=`--vaadin-form-item-label-width: 10rem;`),s.fullWidth&&(c+=`width: 100%;`),T`
                <vaadin-form-layout 
                        .responsiveSteps="${s.responsiveSteps||v}"  
                        style="${c||v}" 
@@ -8396,36 +8404,36 @@ ${i}
                        labels-aside="${s.labelsAside||v}"
                        slot="${t.slot||v}"
                >
-                   ${t.children?.map(t=>Nc(s,e,t,n,r,i,a,o))}
+                   ${t.children?.map(t=>Pc(s,e,t,n,r,i,a,o))}
                </vaadin-form-layout>
-            `},Nc=(e,t,n,r,i,a,o,s)=>n.type==A.ClientSide&&n.metadata?.type==j.FormRow?Fc(e,t,n,r,i,a,o,s):e.labelsAside?Pc(t,n,r,i,a,o,s):I(t,n,r,i,a,o,s),Pc=(e,t,n,r,i,a,o)=>{if(t.type==A.ClientSide&&t.metadata?.type==j.FormField&&t.metadata.label){let s=t.metadata,c=s.label?.includes("${")?e._evalTemplate(s.label):s.label;return T`
+            `},Pc=(e,t,n,r,i,a,o,s)=>n.type==A.ClientSide&&n.metadata?.type==j.FormRow?Ic(e,t,n,r,i,a,o,s):e.labelsAside?Fc(t,n,r,i,a,o,s):F(t,n,r,i,a,o,s),Fc=(e,t,n,r,i,a,o)=>{if(t.type==A.ClientSide&&t.metadata?.type==j.FormField&&t.metadata.label){let s=t.metadata,c=s.label?.includes("${")?e._evalTemplate(s.label):s.label;return T`
                        <vaadin-form-item data-colspan="${s.colspan}">
                            <label slot="label">${c}</label>
-                           ${I(e,t,n,r,i,a,o,!0)}
+                           ${F(e,t,n,r,i,a,o,!0)}
                        </vaadin-form-item>
-                   `}return I(e,t,n,r,i,a,o)},Fc=(e,t,n,r,i,a,o,s)=>T`
+                   `}return F(e,t,n,r,i,a,o)},Ic=(e,t,n,r,i,a,o,s)=>T`
         <vaadin-form-row>
-            ${n.children?.map(n=>Nc(e,t,n,r,i,a,o,s))}
+            ${n.children?.map(n=>Pc(e,t,n,r,i,a,o,s))}
         </vaadin-form-row>
-            `,Ic=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=(s.padding?` padding`:``)+(s.spacing?` spacing`:``)+(s.spacingVariant?` spacing-`+s.spacingVariant:``)+(s.wrap?` wrap`:``),l=t.style;return s.fullWidth&&(l=l?`width: 100%;`+l:`width: 100%;`),s.justification&&(l=l?`justify-content: `+s.justification+`;`+l:`justify-content: `+s.justification+`;`),s.verticalAlignment&&(l=l?`align-items: `+s.verticalAlignment+`;`+l:`align-items: `+s.verticalAlignment+`;`),T`
+            `,Lc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=(s.padding?` padding`:``)+(s.spacing?` spacing`:``)+(s.spacingVariant?` spacing-`+s.spacingVariant:``)+(s.wrap?` wrap`:``),l=t.style;return s.fullWidth&&(l=l?`width: 100%;`+l:`width: 100%;`),s.justification&&(l=l?`justify-content: `+s.justification+`;`+l:`justify-content: `+s.justification+`;`),s.verticalAlignment&&(l=l?`align-items: `+s.verticalAlignment+`;`+l:`align-items: `+s.verticalAlignment+`;`),T`
                <vaadin-horizontal-layout 
                        style="${l}" 
                        class="${t.cssClasses}"
                        theme="${c}"
                        slot="${t.slot??v}"
                >
-                   ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+                   ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
                </vaadin-horizontal-layout>
-            `},Lc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=(s.padding?` padding`:``)+(s.spacing?` spacing`:``)+(s.spacingVariant?` spacing-`+s.spacingVariant:``)+(s.wrap?` wrap`:``),l=t.style;return s.fullWidth&&(l=l?`width: 100%;`+l:`width: 100%;`),s.justification&&(l=l?`justify-content: `+s.justification+`;`+l:`justify-content: `+s.justification+`;`),s.horizontalAlignment&&(l=l?`align-items: `+s.horizontalAlignment+`;`+l:`align-items: `+s.horizontalAlignment+`;`),T`
+            `},Rc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=(s.padding?` padding`:``)+(s.spacing?` spacing`:``)+(s.spacingVariant?` spacing-`+s.spacingVariant:``)+(s.wrap?` wrap`:``),l=t.style;return s.fullWidth&&(l=l?`width: 100%;`+l:`width: 100%;`),s.justification&&(l=l?`justify-content: `+s.justification+`;`+l:`justify-content: `+s.justification+`;`),s.horizontalAlignment&&(l=l?`align-items: `+s.horizontalAlignment+`;`+l:`align-items: `+s.horizontalAlignment+`;`),T`
         <vaadin-vertical-layout
                 style="${l}"
                 class="${t.cssClasses}"
                 theme="${c}"
                 slot="${t.slot??v}"
         >
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
         </vaadin-vertical-layout>
-    `},Rc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;return s.fullWidth&&(c=c?`width: 100%;`+c:`width: 100%;`),T`
+    `},zc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;return s.fullWidth&&(c=c?`width: 100%;`+c:`width: 100%;`),T`
                <vaadin-split-layout 
                        style="${c}" 
                        class="${t.cssClasses}"
@@ -8433,18 +8441,18 @@ ${i}
                        theme="${s.variant??v}"
                        slot="${t.slot??v}"
                >
-                   <master-content>${I(e,t.children[0],n,r,i,a,o)}</master-content>
-                   <detail-content>${I(e,t.children[1],n,r,i,a,o)}</detail-content>
+                   <master-content>${F(e,t.children[0],n,r,i,a,o)}</master-content>
+                   <detail-content>${F(e,t.children[1],n,r,i,a,o)}</detail-content>
                </vaadin-split-layout>
-            `},zc=(e,t,n,r,i,a,o)=>{let s=t.children&&t.children.length>1?t.children[1]:null,c=i?.detailComponent??null,l=!!i?.hasDetail||!!s,u=c??s;return T`
+            `},Bc=(e,t,n,r,i,a,o)=>{let s=t.children&&t.children.length>1?t.children[1]:null,c=i?.detailComponent??null,l=!!i?.hasDetail||!!s,u=c??s;return T`
                <vaadin-master-detail-layout ?has-detail="${l}"
                                             style="${t.style}"
                                             class="${t.cssClasses}"
                                             slot="${t.slot??v}">
-                   <div>${I(e,t.children[0],n,r,i,a,o)}</div>
-                   ${l&&u?T`<div slot="detail">${I(e,u,n,r,i,a,o)}</div>`:T`<div slot="detail" style="display: flex; align-items: center; justify-content: center; height: 100%; color: var(--lumo-secondary-text-color); font-size: var(--lumo-font-size-s);">Select an item to view details</div>`}
+                   <div>${F(e,t.children[0],n,r,i,a,o)}</div>
+                   ${l&&u?T`<div slot="detail">${F(e,u,n,r,i,a,o)}</div>`:T`<div slot="detail" style="display: flex; align-items: center; justify-content: center; height: 100%; color: var(--lumo-secondary-text-color); font-size: var(--lumo-font-size-s);">Select an item to view details</div>`}
                </vaadin-master-detail-layout>
-            `},Bc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;c??=``,s.fullWidth&&(c+=`width: 100%;`);let l=s.variant;l==`equalWidth`&&(l=`equal-width-tabs`);let u=Math.max(0,(t.children??[]).findIndex(e=>e.metadata.active)),d=e=>{e.target.selected=u};if(s.adaptable){let u=(t.children??[]).map(t=>{let n=t.metadata.label;return n?.includes("${")?e._evalTemplate(n):n});return T`
+            `},Vc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;c??=``,s.fullWidth&&(c+=`width: 100%;`);let l=s.variant;l==`equalWidth`&&(l=`equal-width-tabs`);let u=Math.max(0,(t.children??[]).findIndex(e=>e.metadata.active)),d=e=>{e.target.selected=u};if(s.adaptable){let u=(t.children??[]).map(t=>{let n=t.metadata.label;return n?.includes("${")?e._evalTemplate(n):n});return T`
             <mateu-adaptive-tabs
                     .tabLabels="${u}"
                     style="${c}"
@@ -8466,7 +8474,7 @@ ${i}
 
                 ${t.children?.map((t,s)=>T`
                     <div slot="panel-${s}" style="padding: var(--lumo-space-m) 0;">
-                        ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+                        ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
                     </div>`)}
             </mateu-adaptive-tabs>
                 `}return T`
@@ -8489,73 +8497,73 @@ ${i}
                     >${r}</vaadin-tab>`})}
             </vaadin-tabs>
 
-            ${t.children?.map(t=>Vc(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>Hc(e,t,n,r,i,a,o))}
         </vaadin-tabsheet>
-            `},Vc=(e,t,n,r,i,a,o)=>{let s=t.metadata.label;return T`
+            `},Hc=(e,t,n,r,i,a,o)=>{let s=t.metadata.label;return T`
         <div tab="${s?.includes("${")?e._evalTemplate(s):s}" style="padding: var(--lumo-space-m) 0;">
-                   ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+                   ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
                </div>
-            `},Hc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;s.fullWidth&&(c=c?`width: 100%;`+c:`width: 100%;`);let l=0;if(t.children){for(let e=0;e<t.children.length;e++)if(t.children[e].metadata?.active){l=e;break}}return T`
+            `},Uc=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=t.style;s.fullWidth&&(c=c?`width: 100%;`+c:`width: 100%;`);let l=0;if(t.children){for(let e=0;e<t.children.length;e++)if(t.children[e].metadata?.active){l=e;break}}return T`
                <vaadin-accordion
                        style="${t.style}"
                        class="${t.cssClasses}"
                        opened="${l}"
                        slot="${t.slot??v}"
                >
-                   ${t.children?.map(t=>Uc(e,t,n,r,i,a,o,s.variant))}
+                   ${t.children?.map(t=>Wc(e,t,n,r,i,a,o,s.variant))}
                </vaadin-accordion>
-            `},Uc=(e,t,n,r,i,a,o,s)=>{let c=t.metadata,l=c.label?.includes("${")?e._evalTemplate(c.label):c.label;return T`
+            `},Wc=(e,t,n,r,i,a,o,s)=>{let c=t.metadata,l=c.label?.includes("${")?e._evalTemplate(c.label):c.label;return T`
         <vaadin-accordion-panel style="${t.style}"
                                 class="${t.cssClasses}"
                                 theme="${s??v}"
                                 ?opened="${c.active}"
                                 ?disabled="${c.disabled}">
             <vaadin-accordion-heading slot="summary">${l}</vaadin-accordion-heading>
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
         </vaadin-accordion-panel>
-            `},Wc=(e,t,n,r,i,a,o)=>T`
+            `},Gc=(e,t,n,r,i,a,o)=>T`
                <vaadin-scroller style="${t.style}" 
                                 class="${t.cssClasses}"
                                 slot="${t.slot??v}">
-                   ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+                   ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
                </vaadin-scroller>
-            `,Gc=(e,t,n,r,i,a,o)=>T`
+            `,Kc=(e,t,n,r,i,a,o)=>T`
         <vaadin-board style="${t.style}" 
                       class="${t.cssClasses}"
                       slot="${t.slot??v}">
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
         </vaadin-board>
-            `,Kc=(e,t,n,r,i,a,o)=>T`
+            `,qc=(e,t,n,r,i,a,o)=>T`
         <vaadin-board-row style="${t.style}" class="${t.cssClasses}">
-                   ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+                   ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
                </vaadin-board-row>
-            `,qc=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+            `,Jc=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
         <div style="${t.style}" 
              class="${t.cssClasses}"
              board-cols="${s.boardCols??v}"
         >
-                   ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+                   ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
                </div>
-            `},Jc=(e,t,n)=>T`
+            `},Yc=(e,t,n)=>T`
     <vaadin-menu-bar
         theme="tertiary"
         .items=${e}
         class="${n??v}"
         @item-selected=${e=>t(e.detail.value)}>
-    </vaadin-menu-bar>`,Yc=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
-        <vaadin-context-menu .items=${Qc(e,s.menu,n,r,i,a,o)} 
+    </vaadin-menu-bar>`,Xc=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+        <vaadin-context-menu .items=${$c(e,s.menu,n,r,i,a,o)} 
                              style="${t.style}" 
                              class="${t.cssClasses}"
                              open-on="${s.activateOnLeftClick?`click`:v}"
                              slot="${t.slot??v}">
-            ${I(e,s.wrapped,n,r,i,a,o)}
+            ${F(e,s.wrapped,n,r,i,a,o)}
         </vaadin-context-menu>
-            `},Xc=(e,t,n,r,i)=>{let a=t.metadata;return T`
-        <vaadin-menu-bar .items=${Qc(e,a.options,n,r,i,O,ue)}
+            `},Zc=(e,t,n,r,i)=>{let a=t.metadata;return T`
+        <vaadin-menu-bar .items=${$c(e,a.options,n,r,i,O,ue)}
                          style="${t.style}" class="${t.cssClasses}"
                          slot="${t.slot??v}">
         </vaadin-menu-bar>
-            `},Zc=(e,t,n,r,i,a,o)=>{let s=document.createElement(`vaadin-context-menu-item`);return re(I(e,t,n,r,i,a,o),s),s},Qc=(e,t,n,r,i,a,o)=>t.map(t=>t.submenus?{text:t.component?void 0:t.label,route:t.path,checked:t.selected,disabled:t.disabled,className:t.className,component:t.component?Zc(e,t.component,n,r,i,a,o):void 0,children:Qc(e,t.submenus,n,r,i,a,o)}:t.separator?{component:`hr`}:{text:t.component?void 0:t.label,route:t.path,checked:t.selected,disabled:t.disabled,className:t.className,component:t.component?Zc(e,t.component,n,r,i,a,o):void 0}),$c=class extends b{constructor(...e){super(...e),this.fieldId=``,this.signing=!1,this.hasStrokes=!1,this.drawing=!1,this.startStroke=e=>{let t=e.target;this.ensureCanvasSize(t),t.setPointerCapture(e.pointerId),this.drawing=!0;let n=t.getContext(`2d`);n.lineWidth=2,n.lineCap=`round`,n.lineJoin=`round`,n.strokeStyle=getComputedStyle(this).getPropertyValue(`--lumo-body-text-color`)||`#1a1a1a`;let[r,i]=this.pointerPosition(e);n.beginPath(),n.moveTo(r,i),e.preventDefault()},this.stroke=e=>{if(!this.drawing)return;let t=e.target.getContext(`2d`),[n,r]=this.pointerPosition(e);t.lineTo(n,r),t.stroke(),this.hasStrokes=!0,e.preventDefault()},this.endStroke=e=>{this.drawing=!1,e.target.releasePointerCapture(e.pointerId)}}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}canvas(){return this.renderRoot.querySelector(`canvas`)}pointerPosition(e){let t=e.target.getBoundingClientRect();return[e.clientX-t.left,e.clientY-t.top]}ensureCanvasSize(e){let t=e.getBoundingClientRect();(e.width!==Math.round(t.width)||e.height!==Math.round(t.height))&&(e.width=Math.round(t.width),e.height=Math.round(t.height))}clear(){let e=this.canvas();e&&e.getContext(`2d`).clearRect(0,0,e.width,e.height),this.hasStrokes=!1}accept(){let e=this.canvas();!e||!this.hasStrokes||(this.signing=!1,this.emit(e.toDataURL(`image/png`)))}renderPad(){return T`
+            `},Qc=(e,t,n,r,i,a,o)=>{let s=document.createElement(`vaadin-context-menu-item`);return re(F(e,t,n,r,i,a,o),s),s},$c=(e,t,n,r,i,a,o)=>t.map(t=>t.submenus?{text:t.component?void 0:t.label,route:t.path,checked:t.selected,disabled:t.disabled,className:t.className,component:t.component?Qc(e,t.component,n,r,i,a,o):void 0,children:$c(e,t.submenus,n,r,i,a,o)}:t.separator?{component:`hr`}:{text:t.component?void 0:t.label,route:t.path,checked:t.selected,disabled:t.disabled,className:t.className,component:t.component?Qc(e,t.component,n,r,i,a,o):void 0}),el=class extends b{constructor(...e){super(...e),this.fieldId=``,this.signing=!1,this.hasStrokes=!1,this.drawing=!1,this.startStroke=e=>{let t=e.target;this.ensureCanvasSize(t),t.setPointerCapture(e.pointerId),this.drawing=!0;let n=t.getContext(`2d`);n.lineWidth=2,n.lineCap=`round`,n.lineJoin=`round`,n.strokeStyle=getComputedStyle(this).getPropertyValue(`--lumo-body-text-color`)||`#1a1a1a`;let[r,i]=this.pointerPosition(e);n.beginPath(),n.moveTo(r,i),e.preventDefault()},this.stroke=e=>{if(!this.drawing)return;let t=e.target.getContext(`2d`),[n,r]=this.pointerPosition(e);t.lineTo(n,r),t.stroke(),this.hasStrokes=!0,e.preventDefault()},this.endStroke=e=>{this.drawing=!1,e.target.releasePointerCapture(e.pointerId)}}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}canvas(){return this.renderRoot.querySelector(`canvas`)}pointerPosition(e){let t=e.target.getBoundingClientRect();return[e.clientX-t.left,e.clientY-t.top]}ensureCanvasSize(e){let t=e.getBoundingClientRect();(e.width!==Math.round(t.width)||e.height!==Math.round(t.height))&&(e.width=Math.round(t.width),e.height=Math.round(t.height))}clear(){let e=this.canvas();e&&e.getContext(`2d`).clearRect(0,0,e.width,e.height),this.hasStrokes=!1}accept(){let e=this.canvas();!e||!this.hasStrokes||(this.signing=!1,this.emit(e.toDataURL(`image/png`)))}renderPad(){return T`
             <canvas class="pad"
                     @pointerdown="${this.startStroke}"
                     @pointermove="${this.stroke}"
@@ -8622,7 +8630,7 @@ ${i}
         .button--danger {
             color: var(--lumo-error-text-color, rgb(179, 49, 31));
         }
-    `}};k([y()],$c.prototype,`fieldId`,void 0),k([y()],$c.prototype,`value`,void 0),k([C()],$c.prototype,`signing`,void 0),k([C()],$c.prototype,`hasStrokes`,void 0),$c=k([g(`mateu-signature-pad`)],$c);var el=class extends b{constructor(...e){super(...e),this.fieldId=``,this.options=[],this.leavesOnly=!1,this.opened=!1,this.expandedItems=[],this._normalized=[],this.dataProvider=(e,t)=>{let n=e.parentItem?e.parentItem.children??[]:this.normalized;t(n,n.length)}}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}get normalized(){return this._optsSource!==this.options&&(this._optsSource=this.options,this._normalized=this.normalizeOptions(this.options??[])),this._normalized}normalizeOptions(e){return e.map(e=>{let t=e.children&&e.children.length?this.normalizeOptions(e.children):void 0;return{...e,children:t}})}ancestorsOf(e,t){for(let n of t){if(String(n.value)===e)return[];let t=n.children?this.ancestorsOf(e,n.children):null;if(t!=null)return[n,...t]}return null}labelOf(e,t){for(let n of t){if(String(n.value)===e)return n.label;let t=n.children?this.labelOf(e,n.children):null;if(t!=null)return t}return null}open(){this.opened||(this.expandedItems=this.value==null?[]:this.ancestorsOf(String(this.value),this.normalized)??[],this.opened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.close()},document.addEventListener(`mousedown`,this.outsideClick))}close(){this.detachOutsideClick(),this.opened=!1}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}pick(e){this.close(),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e.value,fieldId:this.fieldId},bubbles:!0,composed:!0}))}clear(){this.close(),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:void 0,fieldId:this.fieldId},bubbles:!0,composed:!0}))}onActiveItemChanged(e){let t=e.detail.value;if(t){if((t.children?.length??0)>0&&this.leavesOnly){this.expandedItems=this.expandedItems.includes(t)?this.expandedItems.filter(e=>e!==t):[...this.expandedItems,t],e.target.activeItem=null;return}this.pick(t)}}render(){let e=this.value!=null&&this.value!==``?this.labelOf(String(this.value),this.normalized)??String(this.value):``;return T`
+    `}};k([y()],el.prototype,`fieldId`,void 0),k([y()],el.prototype,`value`,void 0),k([C()],el.prototype,`signing`,void 0),k([C()],el.prototype,`hasStrokes`,void 0),el=k([g(`mateu-signature-pad`)],el);var tl=class extends b{constructor(...e){super(...e),this.fieldId=``,this.options=[],this.leavesOnly=!1,this.opened=!1,this.expandedItems=[],this._normalized=[],this.dataProvider=(e,t)=>{let n=e.parentItem?e.parentItem.children??[]:this.normalized;t(n,n.length)}}disconnectedCallback(){super.disconnectedCallback(),this.detachOutsideClick()}get normalized(){return this._optsSource!==this.options&&(this._optsSource=this.options,this._normalized=this.normalizeOptions(this.options??[])),this._normalized}normalizeOptions(e){return e.map(e=>{let t=e.children&&e.children.length?this.normalizeOptions(e.children):void 0;return{...e,children:t}})}ancestorsOf(e,t){for(let n of t){if(String(n.value)===e)return[];let t=n.children?this.ancestorsOf(e,n.children):null;if(t!=null)return[n,...t]}return null}labelOf(e,t){for(let n of t){if(String(n.value)===e)return n.label;let t=n.children?this.labelOf(e,n.children):null;if(t!=null)return t}return null}open(){this.opened||(this.expandedItems=this.value==null?[]:this.ancestorsOf(String(this.value),this.normalized)??[],this.opened=!0,this.outsideClick=e=>{e.composedPath().includes(this)||this.close()},document.addEventListener(`mousedown`,this.outsideClick))}close(){this.detachOutsideClick(),this.opened=!1}detachOutsideClick(){this.outsideClick&&=(document.removeEventListener(`mousedown`,this.outsideClick),void 0)}pick(e){this.close(),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e.value,fieldId:this.fieldId},bubbles:!0,composed:!0}))}clear(){this.close(),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:void 0,fieldId:this.fieldId},bubbles:!0,composed:!0}))}onActiveItemChanged(e){let t=e.detail.value;if(t){if((t.children?.length??0)>0&&this.leavesOnly){this.expandedItems=this.expandedItems.includes(t)?this.expandedItems.filter(e=>e!==t):[...this.expandedItems,t],e.target.activeItem=null;return}this.pick(t)}}render(){let e=this.value!=null&&this.value!==``?this.labelOf(String(this.value),this.normalized)??String(this.value):``;return T`
             <div class="root">
                 <vaadin-button class="control" theme="tertiary"
                                @click="${()=>this.opened?this.close():this.open()}">
@@ -8693,7 +8701,7 @@ ${i}
             min-width: 16rem;
             max-height: 18rem;
         }
-    `}};k([y()],el.prototype,`fieldId`,void 0),k([y()],el.prototype,`value`,void 0),k([y()],el.prototype,`options`,void 0),k([y({type:Boolean})],el.prototype,`leavesOnly`,void 0),k([C()],el.prototype,`opened`,void 0),k([C()],el.prototype,`expandedItems`,void 0),el=k([g(`mateu-vaadin-tree-select`)],el);var tl=class extends b{constructor(...e){super(...e),this.fieldId=``,this.cameraOpen=!1,this.cameraError=!1,this.fileFallback=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>this.emit(r.result),r.readAsDataURL(n),t.value=``}}disconnectedCallback(){super.disconnectedCallback(),this.stopStream()}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}stopStream(){this.stream?.getTracks().forEach(e=>e.stop()),this.stream=void 0}async openCamera(){this.cameraError=!1;try{this.stream=await navigator.mediaDevices.getUserMedia({video:{facingMode:`environment`},audio:!1}),this.cameraOpen=!0,await this.updateComplete;let e=this.renderRoot.querySelector(`video`);e&&(e.srcObject=this.stream,await e.play())}catch{this.stopStream(),this.cameraOpen=!1,this.cameraError=!0}}closeCamera(){this.stopStream(),this.cameraOpen=!1}shoot(){let e=this.renderRoot.querySelector(`video`);if(!e||e.videoWidth===0)return;let t=document.createElement(`canvas`);t.width=e.videoWidth,t.height=e.videoHeight,t.getContext(`2d`).drawImage(e,0,0),this.closeCamera(),this.emit(t.toDataURL(`image/jpeg`,.9))}triggerFallback(){this.renderRoot.querySelector(`input[type=file]`)?.click()}render(){let e=this.value!=null&&this.value!==``;return T`
+    `}};k([y()],tl.prototype,`fieldId`,void 0),k([y()],tl.prototype,`value`,void 0),k([y()],tl.prototype,`options`,void 0),k([y({type:Boolean})],tl.prototype,`leavesOnly`,void 0),k([C()],tl.prototype,`opened`,void 0),k([C()],tl.prototype,`expandedItems`,void 0),tl=k([g(`mateu-vaadin-tree-select`)],tl);var nl=class extends b{constructor(...e){super(...e),this.fieldId=``,this.cameraOpen=!1,this.cameraError=!1,this.fileFallback=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>this.emit(r.result),r.readAsDataURL(n),t.value=``}}disconnectedCallback(){super.disconnectedCallback(),this.stopStream()}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}stopStream(){this.stream?.getTracks().forEach(e=>e.stop()),this.stream=void 0}async openCamera(){this.cameraError=!1;try{this.stream=await navigator.mediaDevices.getUserMedia({video:{facingMode:`environment`},audio:!1}),this.cameraOpen=!0,await this.updateComplete;let e=this.renderRoot.querySelector(`video`);e&&(e.srcObject=this.stream,await e.play())}catch{this.stopStream(),this.cameraOpen=!1,this.cameraError=!0}}closeCamera(){this.stopStream(),this.cameraOpen=!1}shoot(){let e=this.renderRoot.querySelector(`video`);if(!e||e.videoWidth===0)return;let t=document.createElement(`canvas`);t.width=e.videoWidth,t.height=e.videoHeight,t.getContext(`2d`).drawImage(e,0,0),this.closeCamera(),this.emit(t.toDataURL(`image/jpeg`,.9))}triggerFallback(){this.renderRoot.querySelector(`input[type=file]`)?.click()}render(){let e=this.value!=null&&this.value!==``;return T`
             <input type="file" accept="image/*" capture="environment" style="display: none;"
                    @change="${this.fileFallback}">
             ${this.cameraOpen?T`
@@ -8771,7 +8779,7 @@ ${i}
             font-size: var(--lumo-font-size-xs, 0.75rem);
             color: var(--lumo-secondary-text-color, rgba(0, 0, 0, 0.6));
         }
-    `}};k([y()],tl.prototype,`fieldId`,void 0),k([y()],tl.prototype,`value`,void 0),k([C()],tl.prototype,`cameraOpen`,void 0),k([C()],tl.prototype,`cameraError`,void 0),tl=k([g(`mateu-camera-capture`)],tl);var nl,rl=(e,t)=>{if(!e)return;if(Array.isArray(e)){let n=e.find(e=>e.key==t);return n?.value==null?void 0:String(n.value)}let n=e[t];return n==null?void 0:String(n)},il=class extends b{static{nl=this}constructor(...e){super(...e),this.fieldId=``,this.editable=!0,this.filePicked=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>{let e=r.result,t=e.indexOf(`,`),i=e.substring(0,t).replace(`;base64`,`;name=${encodeURIComponent(n.name)};base64`);this.emit(i+e.substring(t))},r.readAsDataURL(n),t.value=``}}static fileName(e){if(!e)return``;if(e.startsWith(`data:`)){let t=e.indexOf(`,`),n=e.substring(5,t<0?e.length:t).split(`;`).find(e=>e.startsWith(`name=`));if(n)try{return decodeURIComponent(n.substring(5))}catch{return n.substring(5)}return`Attached file`}return e.split(`/`).pop()||e}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}triggerPick(){this.renderRoot.querySelector(`input[type=file]`)?.click()}render(){let e=this.value!=null&&this.value!==``,t=nl.fileName(this.value),n=e&&this.value.startsWith(`data:`),r=e?T`<span class="file" title="${t}">📄 ${n?T`<a href="${this.value}" download="${t}">${t}</a>`:T`<a href="${this.value}" target="_blank">${t}</a>`}</span>`:v;return this.editable?T`
+    `}};k([y()],nl.prototype,`fieldId`,void 0),k([y()],nl.prototype,`value`,void 0),k([C()],nl.prototype,`cameraOpen`,void 0),k([C()],nl.prototype,`cameraError`,void 0),nl=k([g(`mateu-camera-capture`)],nl);var rl,il=(e,t)=>{if(!e)return;if(Array.isArray(e)){let n=e.find(e=>e.key==t);return n?.value==null?void 0:String(n.value)}let n=e[t];return n==null?void 0:String(n)},al=class extends b{static{rl=this}constructor(...e){super(...e),this.fieldId=``,this.editable=!0,this.filePicked=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>{let e=r.result,t=e.indexOf(`,`),i=e.substring(0,t).replace(`;base64`,`;name=${encodeURIComponent(n.name)};base64`);this.emit(i+e.substring(t))},r.readAsDataURL(n),t.value=``}}static fileName(e){if(!e)return``;if(e.startsWith(`data:`)){let t=e.indexOf(`,`),n=e.substring(5,t<0?e.length:t).split(`;`).find(e=>e.startsWith(`name=`));if(n)try{return decodeURIComponent(n.substring(5))}catch{return n.substring(5)}return`Attached file`}return e.split(`/`).pop()||e}emit(e){this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:e,fieldId:this.fieldId},bubbles:!0,composed:!0}))}triggerPick(){this.renderRoot.querySelector(`input[type=file]`)?.click()}render(){let e=this.value!=null&&this.value!==``,t=rl.fileName(this.value),n=e&&this.value.startsWith(`data:`),r=e?T`<span class="file" title="${t}">📄 ${n?T`<a href="${this.value}" download="${t}">${t}</a>`:T`<a href="${this.value}" target="_blank">${t}</a>`}</span>`:v;return this.editable?T`
             <input type="file" accept="${this.accept||v}" style="display: none;"
                    @change="${this.filePicked}">
             <div class="row">
@@ -8819,28 +8827,28 @@ ${i}
         .button--danger {
             color: var(--lumo-error-text-color, rgb(179, 49, 31));
         }
-    `}};k([y()],il.prototype,`fieldId`,void 0),k([y()],il.prototype,`value`,void 0),k([y()],il.prototype,`accept`,void 0),k([y({type:Boolean})],il.prototype,`editable`,void 0),il=nl=k([g(`mateu-file-upload`)],il);var al=e=>e==null||typeof e==`string`&&e.trim()===``,ol=(e,t)=>{if(al(e))return null;let n=t?parseInt(String(e),10):Number(e);return Number.isNaN(n)?null:n},sl=(e,t)=>al(e)&&al(t)?!0:e==t,cl=e=>!!e&&typeof e==`object`&&`__mateuGroup`in e,ll=e=>String(e??``),ul=(e,t,n)=>{let r=e??[];if(!t||!n||n.length===0)return r;let i=[],a,o=!1;return r.forEach((e,s)=>{let c=ll(e?.[t]);if(!o||c!==a){let e=n.find(e=>ll(e.value)===c)??{value:c,count:r.filter(e=>ll(e?.[t])===c).length,aggregates:{}};i.push({__mateuGroup:e,__mateuGroupBy:t,_rowNumber:`__mateuGroup:${s}:${c}`}),o=!0,a=c}i.push(e)}),i},dl=(e,t)=>e==null?``:t.dataType===`money`||t.stereotype===`money`?new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e):t.aggregate===`count`?new Intl.NumberFormat(void 0,{maximumFractionDigits:0}).format(Math.round(e)):new Intl.NumberFormat(void 0,{maximumFractionDigits:2}).format(e),fl=(e,t)=>e&&t.includes(e)?e:t.find(e=>!!e),pl=(e,t,n)=>{let r=e.__mateuGroup;return t.id===n?`${r.value} (${r.count})`:t.aggregate?dl(r.aggregates?.[t.id],t):``},ml=(e,t,n)=>{let r=t?.aggregates;if(!r||!e.some(e=>e.aggregate))return;let i={};e.forEach(e=>{e.aggregate&&r[e.id]!=null&&(i[e.id]=dl(r[e.id],e))});let a=e[0];if(a&&i[a.id]===void 0){let e=t?.page?.totalElements;i[a.id]=n&&a.id===n&&e!=null?`Total (${e})`:`Total`}return i},hl=(e,t,n)=>L(e[n.path]?`vaadin:check`:`vaadin:minus`,`height: 16px; width: 16px; color: var(--lumo-body-text-color);`),gl=(e,t,n,r,i)=>{let a=e[n.path],o=a;return r==`money`&&a&&a.locale&&a.currency?o=new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(a.value):i==`money`&&(o=new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(a)),T`${o}`},_l=(e,t,n)=>{e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:n},bubbles:!0,composed:!0}))},vl=(e,t,n,r,i,a)=>{let o=n.xcolumn??a;if(o.text)return o.actionId?T`<a href="javascript: void(0);" @click="${t=>_l(n,o,e)}">${o.text}</a>`:T`<a href="${e[n.path]}">${o.text}</a>`;if(r==`string`){if(o.actionId)return T`<a href="javascript: void(0);" @click="${t=>_l(n,o,e)}">${e[n.path]}</a>`;let t=e[n.path];return T`<a href="${t}">${t}</a>`}let s=e[n.path];return T`<a href="${s.href}">${s.text}</a>`},yl=(e,t,n,r,i)=>{let a=e[n.path];return r==`string`?a.split(`,`).map(e=>L(e,`width: 16px;`)):a.split(`,`).map(e=>L(e.icon,`width: 16px;`))},bl=(e,t,n,r,i)=>{let a=e[n.path];return T`${_(a)}`},xl=(e,t,n,r,i,a)=>r==`string`?T`<img src="${e[n.path]}" style="${`max-height: 40px; `+(a.style??``)}">`:T`<img src="${e[n.path].src}" style="${a.style??``}">`,Sl=e=>{let t={_clickedRow:e.target.row};e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+e.detail.value.methodNameInCrud,parameters:t},bubbles:!0,composed:!0}))},Cl=e=>{let t={_clickedRow:e.target.row},n=e.target.action;e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+n.methodNameInCrud,parameters:t},bubbles:!0,composed:!0}))},wl=e=>{let t=document.createElement(`vaadin-context-menu-item`),n=document.createElement(`vaadin-icon`);return n.style.color=`var(--lumo-secondary-text-color)`,n.style.marginInlineEnd=`var(--lumo-space-s)`,n.style.padding=`var(--lumo-space-xs)`,n.setAttribute(`icon`,e.icon),t.appendChild(n),e.label&&t.appendChild(document.createTextNode(e.label)),t.disabled=e.disabled,t},Tl=(e,t,n)=>{let r=e[n.path]?.actions?.map(e=>e.icon?{component:wl(e),methodNameInCrud:e.methodNameInCrud}:{...e,text:e.label});return!r||r.length==0?T``:T`
+    `}};k([y()],al.prototype,`fieldId`,void 0),k([y()],al.prototype,`value`,void 0),k([y()],al.prototype,`accept`,void 0),k([y({type:Boolean})],al.prototype,`editable`,void 0),al=rl=k([g(`mateu-file-upload`)],al);var ol=e=>e==null||typeof e==`string`&&e.trim()===``,sl=(e,t)=>{if(ol(e))return null;let n=t?parseInt(String(e),10):Number(e);return Number.isNaN(n)?null:n},cl=(e,t)=>ol(e)&&ol(t)?!0:e==t,ll=e=>!!e&&typeof e==`object`&&`__mateuGroup`in e,ul=e=>String(e??``),dl=(e,t,n)=>{let r=e??[];if(!t||!n||n.length===0)return r;let i=[],a,o=!1;return r.forEach((e,s)=>{let c=ul(e?.[t]);if(!o||c!==a){let e=n.find(e=>ul(e.value)===c)??{value:c,count:r.filter(e=>ul(e?.[t])===c).length,aggregates:{}};i.push({__mateuGroup:e,__mateuGroupBy:t,_rowNumber:`__mateuGroup:${s}:${c}`}),o=!0,a=c}i.push(e)}),i},fl=(e,t)=>e==null?``:t.dataType===`money`||t.stereotype===`money`?new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e):t.aggregate===`count`?new Intl.NumberFormat(void 0,{maximumFractionDigits:0}).format(Math.round(e)):new Intl.NumberFormat(void 0,{maximumFractionDigits:2}).format(e),pl=(e,t)=>e&&t.includes(e)?e:t.find(e=>!!e),ml=(e,t,n)=>{let r=e.__mateuGroup;return t.id===n?`${r.value} (${r.count})`:t.aggregate?fl(r.aggregates?.[t.id],t):``},hl=(e,t,n)=>{let r=t?.aggregates;if(!r||!e.some(e=>e.aggregate))return;let i={};e.forEach(e=>{e.aggregate&&r[e.id]!=null&&(i[e.id]=fl(r[e.id],e))});let a=e[0];if(a&&i[a.id]===void 0){let e=t?.page?.totalElements;i[a.id]=n&&a.id===n&&e!=null?`Total (${e})`:`Total`}return i},gl=(e,t,n)=>I(e[n.path]?`vaadin:check`:`vaadin:minus`,`height: 16px; width: 16px; color: var(--lumo-body-text-color);`),_l=(e,t,n,r,i)=>{let a=e[n.path],o=a;return r==`money`&&a&&a.locale&&a.currency?o=new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(a.value):i==`money`&&(o=new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(a)),T`${o}`},vl=(e,t,n)=>{e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:n},bubbles:!0,composed:!0}))},yl=(e,t,n,r,i,a)=>{let o=n.xcolumn??a;if(o.text)return o.actionId?T`<a href="javascript: void(0);" @click="${t=>vl(n,o,e)}">${o.text}</a>`:T`<a href="${e[n.path]}">${o.text}</a>`;if(r==`string`){if(o.actionId)return T`<a href="javascript: void(0);" @click="${t=>vl(n,o,e)}">${e[n.path]}</a>`;let t=e[n.path];return T`<a href="${t}">${t}</a>`}let s=e[n.path];return T`<a href="${s.href}">${s.text}</a>`},bl=(e,t,n,r,i)=>{let a=e[n.path];return r==`string`?a.split(`,`).map(e=>I(e,`width: 16px;`)):a.split(`,`).map(e=>I(e.icon,`width: 16px;`))},xl=(e,t,n,r,i)=>{let a=e[n.path];return T`${_(a)}`},Sl=(e,t,n,r,i,a)=>r==`string`?T`<img src="${e[n.path]}" style="${`max-height: 40px; `+(a.style??``)}">`:T`<img src="${e[n.path].src}" style="${a.style??``}">`,Cl=e=>{let t={_clickedRow:e.target.row};e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+e.detail.value.methodNameInCrud,parameters:t},bubbles:!0,composed:!0}))},wl=e=>{let t={_clickedRow:e.target.row},n=e.target.action;e.target?.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+n.methodNameInCrud,parameters:t},bubbles:!0,composed:!0}))},Tl=e=>{let t=document.createElement(`vaadin-context-menu-item`),n=document.createElement(`vaadin-icon`);return n.style.color=`var(--lumo-secondary-text-color)`,n.style.marginInlineEnd=`var(--lumo-space-s)`,n.style.padding=`var(--lumo-space-xs)`,n.setAttribute(`icon`,e.icon),t.appendChild(n),e.label&&t.appendChild(document.createTextNode(e.label)),t.disabled=e.disabled,t},El=(e,t,n)=>{let r=e[n.path]?.actions?.map(e=>e.icon?{component:Tl(e),methodNameInCrud:e.methodNameInCrud}:{...e,text:e.label});return!r||r.length==0?T``:T`
                                      <vaadin-menu-bar
                                          .items=${[{text:`···`,children:r}]}
                                          theme="tertiary"
                                          .row="${e}"
                                          data-testid="menubar-${n.path}"
-                                         @item-selected="${Sl}"
+                                         @item-selected="${Cl}"
                                      ></vaadin-menu-bar>
-                                   `},El=(e,t,n)=>{if(n.path==`select`)return T`
-         <vaadin-button theme="tertiary" title="Select" @click="${Cl}" .row="${e}" .action="${{actionId:n.path,icon:``,label:`Select`,disabled:!1,methodNameInCrud:`select`}}">
+                                   `},Dl=(e,t,n)=>{if(n.path==`select`)return T`
+         <vaadin-button theme="tertiary" title="Select" @click="${wl}" .row="${e}" .action="${{actionId:n.path,icon:``,label:`Select`,disabled:!1,methodNameInCrud:`select`}}">
              Select
          </vaadin-button>
     `;let r=n.path&&e[n.path]?.methodNameInCrud?e[n.path]:e.action;return r?T`
-         <vaadin-button theme="tertiary${r.icon&&!r.label?` icon`:``}" title="${r.label||v}" @click="${Cl}" .row="${e}" .action="${r}">
+         <vaadin-button theme="tertiary${r.icon&&!r.label?` icon`:``}" title="${r.label||v}" @click="${wl}" .row="${e}" .action="${r}">
              ${r.icon?T`<vaadin-icon icon="${r.icon}"></vaadin-icon>`:v}
              ${r.label?r.label:v}
          </vaadin-button>
-    `:T``},Dl=(e,t,n)=>{e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:n},bubbles:!0,composed:!0}))},Ol=(e,t,n,r,i,a)=>{let o=n.xcolumn??a;if(o.actionId)return T`
-            <vaadin-button theme="tertiary" @click="${t=>Dl(n,o,e)}" .row="${e}">
+    `:T``},Ol=(e,t,n)=>{e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:n},bubbles:!0,composed:!0}))},kl=(e,t,n,r,i,a)=>{let o=n.xcolumn??a;if(o.actionId)return T`
+            <vaadin-button theme="tertiary" @click="${t=>Ol(n,o,e)}" .row="${e}">
                 ${o.text||e[n.path]}
             </vaadin-button>
-        `;let s=e[n.path];return T`<a href="${s}">${o.text||s}</a>`},kl=(e,t,n,r,i,a,o,s,c)=>{let l=e[n.path];return I(r,l,i,a,o,s,c)},Al=new WeakMap,jl=(e,t)=>Al.get(e)?.[t],Ml=(e,t,n)=>{let r=Al.get(e);r||(r={},Al.set(e,r)),r[t]=n},Nl=(e,t=!1)=>ol(e,t),Pl=(e,t,n,r)=>{let i=n?.field?.fieldId,a=a=>{if(e[t.id]===a||e[t.id]==null&&(a===``||a==null))return;if(e[t.id]=a,!i){n.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`update-row`,parameters:{_editedRow:{...e}}},bubbles:!0,composed:!0}));return}let o=(n?.state??r)[i];n.dispatchEvent(new CustomEvent(`value-changed`,{detail:{fieldId:i,value:Array.isArray(o)?[...o]:o},bubbles:!0,composed:!0}))},o=e[t.id],s=o==null?``:String(o);switch(t.editorType){case`boolean`:return T`<vaadin-checkbox ?checked=${!!o} @checked-changed=${e=>a(e.detail.value)}></vaadin-checkbox>`;case`integer`:return T`<vaadin-integer-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(Nl(e.target.value,!0))}></vaadin-integer-field>`;case`number`:return T`<vaadin-number-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(Nl(e.target.value))}></vaadin-number-field>`;case`date`:return T`<vaadin-date-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-date-picker>`;case`time`:return T`<vaadin-time-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-time-picker>`;case`datetime`:return T`<vaadin-date-time-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-date-time-picker>`;case`select`:return T`<vaadin-combo-box
+        `;let s=e[n.path];return T`<a href="${s}">${o.text||s}</a>`},Al=(e,t,n,r,i,a,o,s,c)=>{let l=e[n.path];return F(r,l,i,a,o,s,c)},jl=new WeakMap,Ml=(e,t)=>jl.get(e)?.[t],Nl=(e,t,n)=>{let r=jl.get(e);r||(r={},jl.set(e,r)),r[t]=n},Pl=(e,t=!1)=>sl(e,t),Fl=(e,t,n,r)=>{let i=n?.field?.fieldId,a=a=>{if(e[t.id]===a||e[t.id]==null&&(a===``||a==null))return;if(e[t.id]=a,!i){n.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`update-row`,parameters:{_editedRow:{...e}}},bubbles:!0,composed:!0}));return}let o=(n?.state??r)[i];n.dispatchEvent(new CustomEvent(`value-changed`,{detail:{fieldId:i,value:Array.isArray(o)?[...o]:o},bubbles:!0,composed:!0}))},o=e[t.id],s=o==null?``:String(o);switch(t.editorType){case`boolean`:return T`<vaadin-checkbox ?checked=${!!o} @checked-changed=${e=>a(e.detail.value)}></vaadin-checkbox>`;case`integer`:return T`<vaadin-integer-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(Pl(e.target.value,!0))}></vaadin-integer-field>`;case`number`:return T`<vaadin-number-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(Pl(e.target.value))}></vaadin-number-field>`;case`date`:return T`<vaadin-date-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-date-picker>`;case`time`:return T`<vaadin-time-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-time-picker>`;case`datetime`:return T`<vaadin-date-time-picker theme="small" style="width:100%;" .value=${s} @value-changed=${e=>a(e.detail.value)}></vaadin-date-time-picker>`;case`select`:return T`<vaadin-combo-box
                 theme="small" style="width:100%;"
                 .items=${(t.editorOptions??[]).map(e=>({label:e.label,value:String(e.value)}))}
                 item-label-path="label" item-value-path="value"
@@ -8849,12 +8857,12 @@ ${i}
                 theme="small" style="width:100%;"
                 item-label-path="label" item-id-path="value"
                 .dataProvider=${(e,t)=>{n.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:i,parameters:{searchText:e.filter,size:e.pageSize,page:e.page},callback:e=>{let n=e?.fragments?.[0]?.data?.[o];t(n?.content??[],n?.totalElements??0)},callbackonly:!0},bubbles:!0,composed:!0}))}}
-                .selectedItem=${(t.editorOptions??[]).find(e=>String(e.value)===s)??(s?{value:s,label:jl(e,t.id)??s}:void 0)}
-                @selected-item-changed=${n=>{let r=n.detail.value,i=r?r.value:null;String(i??``)!==s&&(r&&Ml(e,t.id,r.label),a(i))}}></vaadin-combo-box>`}default:return T`<vaadin-text-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(e.target.value)}></vaadin-text-field>`}},Fl=e=>ee(()=>T`<span title="${e}" style="white-space:normal;overflow-wrap:break-word;">${e}</span>`,[e]),Il=e=>e===void 0?v:d(()=>T`<span style="font-weight: 600; white-space: nowrap;">${e}</span>`,[e]),Ll=e=>{e.preventDefault(),e.stopPropagation(),e.currentTarget?.dispatchEvent(new CustomEvent(`sort-direction-changed`,{detail:{grid:e.currentTarget.parentElement},bubbles:!0,composed:!0}))},Rl=(e,t,n,r,i,a,o,s)=>T`
+                .selectedItem=${(t.editorOptions??[]).find(e=>String(e.value)===s)??(s?{value:s,label:Ml(e,t.id)??s}:void 0)}
+                @selected-item-changed=${n=>{let r=n.detail.value,i=r?r.value:null;String(i??``)!==s&&(r&&Nl(e,t.id,r.label),a(i))}}></vaadin-combo-box>`}default:return T`<vaadin-text-field theme="small" style="width:100%;" .value=${s} @change=${e=>a(e.target.value)}></vaadin-text-field>`}},Il=e=>ee(()=>T`<span title="${e}" style="white-space:normal;overflow-wrap:break-word;">${e}</span>`,[e]),Ll=e=>e===void 0?v:d(()=>T`<span style="font-weight: 600; white-space: nowrap;">${e}</span>`,[e]),Rl=e=>{e.preventDefault(),e.stopPropagation(),e.currentTarget?.dispatchEvent(new CustomEvent(`sort-direction-changed`,{detail:{grid:e.currentTarget.parentElement},bubbles:!0,composed:!0}))},zl=(e,t,n,r,i,a,o,s)=>T`
 <vaadin-grid-column-group header="${M(e.label,r,i)}">
-    ${e.columns.map(e=>Bl(e.metadata,t,n,r,i,a,o,s?.[e.metadata?.id]))}
+    ${e.columns.map(e=>Vl(e.metadata,t,n,r,i,a,o,s?.[e.metadata?.id]))}
 </vaadin-grid-column-group>
-`,zl=(e,t,n,r,i,a,o,s)=>j.GridGroupColumn==e.metadata?.type?Rl(e.metadata,t,n,r,i,a,o,s):Bl(e.metadata,t,n,r,i,a,o,s?.[e.metadata?.id]),Bl=(e,n,r,i,a,o,s,c)=>{let l=M(e.label,i,a);return e.sortable?T`
+`,Bl=(e,t,n,r,i,a,o,s)=>j.GridGroupColumn==e.metadata?.type?zl(e.metadata,t,n,r,i,a,o,s):Vl(e.metadata,t,n,r,i,a,o,s?.[e.metadata?.id]),Vl=(e,n,r,i,a,o,s,c)=>{let l=M(e.label,i,a);return e.sortable?T`
                         <vaadin-grid-sort-column
                                 path="${e.id}"
                                 text-align="${e.align??v}"
@@ -8864,12 +8872,12 @@ ${i}
                                 flex-grow="${e.flexGrow??v}"
                                 ?resizable="${e.resizable}"
                                 width="${e.width??v}"
-                                @direction-changed="${Ll}"
+                                @direction-changed="${Rl}"
                                 data-data-type="${e.dataType}"
                                 data-stereotype="${e.stereotype}"
-                                ${Fl(l)}
-                                ${Il(c)}
-                                ${t((t,c,l)=>Vl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
+                                ${Il(l)}
+                                ${Ll(c)}
+                                ${t((t,c,l)=>Hl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
                         ></vaadin-grid-sort-column>
                     `:e.filterable?T`
                         <vaadin-grid-filter-column
@@ -8883,9 +8891,9 @@ ${i}
                                 width="${e.width??v}"
                                 data-data-type="${e.dataType}"
                                 data-stereotype="${e.stereotype}"
-                                ${Fl(l)}
-                                ${Il(c)}
-                                ${t((t,c,l)=>Vl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
+                                ${Il(l)}
+                                ${Ll(c)}
+                                ${t((t,c,l)=>Hl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
                         ></vaadin-grid-filter-column>
                     `:T`
                         <vaadin-grid-column
@@ -8900,17 +8908,17 @@ ${i}
                                 data-data-type="${e.dataType}"
                                 data-stereotype="${e.stereotype}"
                                 .xcolumn="${e}"
-                                ${Fl(l)}
-                                ${Il(c)}
-                                ${t((t,c,l)=>Vl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
+                                ${Il(l)}
+                                ${Ll(c)}
+                                ${t((t,c,l)=>Hl(t,c,l,e,n,r,i,a,o,s),[e,i,a])}
                         ></vaadin-grid-column>
-                    `},Vl=(e,t,n,r,i,a,o,s,c,l)=>{let u=n.dataset.dataType??``,d=n.dataset.stereotype??``;if(cl(e)){let t=i?.metadata,n=(t?.columns??[]).flatMap(e=>e?.metadata?.type===j.GridGroupColumn?(e.metadata.columns??[]).map(e=>e?.metadata?.id):[e?.metadata?.id]),a=pl(e,r,fl(e.__mateuGroupBy,n)),o=e.__mateuGroup.hiddenActions??[],s=r.id===n[n.length-1]?(t?.groupActions??[]).filter(e=>!o.includes(e.actionId??e.id)):[];return s.length?T`<span style="display: flex; align-items: center; justify-content: flex-end; gap: var(--lumo-space-s); overflow: hidden;">
+                    `},Hl=(e,t,n,r,i,a,o,s,c,l)=>{let u=n.dataset.dataType??``,d=n.dataset.stereotype??``;if(ll(e)){let t=i?.metadata,n=(t?.columns??[]).flatMap(e=>e?.metadata?.type===j.GridGroupColumn?(e.metadata.columns??[]).map(e=>e?.metadata?.id):[e?.metadata?.id]),a=ml(e,r,pl(e.__mateuGroupBy,n)),o=e.__mateuGroup.hiddenActions??[],s=r.id===n[n.length-1]?(t?.groupActions??[]).filter(e=>!o.includes(e.actionId??e.id)):[];return s.length?T`<span style="display: flex; align-items: center; justify-content: flex-end; gap: var(--lumo-space-s); overflow: hidden;">
                 ${a?T`<span style="font-weight: 600;">${a}</span>`:v}
                 ${s.map(t=>T`
                     <vaadin-button theme="tertiary small" style="flex-shrink: 0;"
                         @click="${n=>{n.stopPropagation(),n.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`action-on-row-`+(t.actionId??t.id),parameters:{_groupValue:e.__mateuGroup.value}},bubbles:!0,composed:!0}))}}">${t.label??t.caption??``}</vaadin-button>
                 `)}
-            </span>`:T`<span title="${a}" style="font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block;">${a}</span>`}if(r.editable)return Pl(e,r,i,o);if(u==`status`)return ka(e,t,n);if(u==`bool`)return hl(e,t,n);if(u==`money`||d==`money`)return gl(e,t,n,u,d);if(u==`link`||d==`link`)return vl(e,t,n,u,d,r);if(u==`icon`||d==`icon`)return yl(e,t,n,u,d);if(d==`html`)return bl(e,t,n,u,d);if(d==`image`)return xl(e,t,n,u,d,r);if(u==`menu`)return Tl(e,t,n);if(u==`component`)return kl(e,t,n,i,a,o,s,c,l);if(u==`action`)return El(e,t,n);if(u==`actionGroup`)return Tl(e,t,n);if(d==`button`||r.actionId)return Ol(e,t,n,u,d,r);let f=e[n.path];return T`<span title="${f}" style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block;">${f}</span>`},Hl=()=>{let e=document.activeElement;for(;e?.shadowRoot?.activeElement;)e=e.shadowRoot.activeElement;return e},Ul=(e,t)=>{let n=t;for(;n;){if(n===e)return!0;n=n.assignedSlot??n.parentNode??n.host??null}return!1},Wl=class extends vt{constructor(...e){super(...e),this.state={},this.data={},this.appState={},this.appData={},this.detailsOpenedItems=[],this.hoveredItem=null,this.onGridHoverMove=e=>{let t=e.currentTarget,n=t.getEventContext(e)?.item??null;n!==this.hoveredItem&&(this.hoveredItem=n,t.generateCellPartNames())},this.onGridHoverLeave=e=>{this.hoveredItem!==null&&(this.hoveredItem=null,e.currentTarget.generateCellPartNames())},this.hoverCellPartNameGenerator=(e,t)=>t?.item!=null&&t.item===this.hoveredItem?`hovered-cell`:``,this._onRowKey=e=>{let t=this.field?.rowSelectionShortcut;if(!t||!this.field?.onItemSelectionActionId||!this._isRowShortcutRelevant()||!nr(t,e))return;let n=/^(?:Digit|Numpad)([1-9])$/.exec(e.code);if(!n)return;let r=this.currentItems(),i=parseInt(n[1],10)-1;i>=r.length||(e.preventDefault(),this.selectRow(r[i]))},this.handleButtonClick=e=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))}}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._onRowKey)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`keydown`,this._onRowKey)}currentItems(){return this.field?.remoteCoordinates?this.data?.[this.id]?.content??[]:this.field?.fieldId&&this.state?this.state[this.field.fieldId]??[]:[]}selectRow(e){!e||!this.field?.onItemSelectionActionId||(this.selectedItems=[e],this.state[this.id+`_selected_items`]=[e],this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.field.onItemSelectionActionId,parameters:{_clickedRow:e}},bubbles:!0,composed:!0})))}_isRowShortcutRelevant(){if(this.offsetParent===null&&this.getClientRects().length===0)return!1;let e=Hl();if(e&&e!==document.body&&!Ul(this,e)){let t=e.tagName?.toLowerCase()??``;if(e.isContentEditable||/^(input|textarea|select)$/.test(t)||t.startsWith(`vaadin-`)&&/(field|combo|picker|area|select)/.test(t))return!1}return!0}handleItemToggle(e){let{item:t,selected:n,shiftKey:r}=e.detail;if(this.rangeStartItem??=t,r){let e=[];this.field?.fieldId&&this.state&&this.state[this.field.fieldId]&&(e=this.state[this.field.fieldId]);let[r,i]=[this.rangeStartItem,t].map(t=>e.indexOf(t)).sort((e,t)=>e-t),a=e.slice(r,i+1),o=new Set(this.selectedItems);a.forEach(e=>{n?o.add(e):o.delete(e)}),this.selectedItems=[...o],this.state[this.id+`_selected_items`]=this.selectedItems}this.rangeStartItem=t}render(){let e=[];this.field?.fieldId&&this.state&&this.state[this.field.fieldId]&&(e=this.state[this.field.fieldId]);let t=this.state[this.field?.fieldId+`_show_detail`]||this.state._show_detail&&this.state._show_detail[this.field.fieldId];if(this.field?.remoteCoordinates){let t=this.field.remoteCoordinates;this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements?e=this.data[this.id].content:this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}if(Array.isArray(e)&&e.forEach((e,t)=>{e&&typeof e==`object`&&e._rowNumber===void 0&&(e._rowNumber=t)}),this.field?.inlineEditing)return this.renderMaster(e);if(this.field?.formPosition&&this.field?.formPosition.startsWith(`modal`)){let n=this;return T`
+            </span>`:T`<span title="${a}" style="font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block;">${a}</span>`}if(r.editable)return Fl(e,r,i,o);if(u==`status`)return Aa(e,t,n);if(u==`bool`)return gl(e,t,n);if(u==`money`||d==`money`)return _l(e,t,n,u,d);if(u==`link`||d==`link`)return yl(e,t,n,u,d,r);if(u==`icon`||d==`icon`)return bl(e,t,n,u,d);if(d==`html`)return xl(e,t,n,u,d);if(d==`image`)return Sl(e,t,n,u,d,r);if(u==`menu`)return El(e,t,n);if(u==`component`)return Al(e,t,n,i,a,o,s,c,l);if(u==`action`)return Dl(e,t,n);if(u==`actionGroup`)return El(e,t,n);if(d==`button`||r.actionId)return kl(e,t,n,u,d,r);let f=e[n.path];return T`<span title="${f}" style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block;">${f}</span>`},Ul=()=>{let e=document.activeElement;for(;e?.shadowRoot?.activeElement;)e=e.shadowRoot.activeElement;return e},Wl=(e,t)=>{let n=t;for(;n;){if(n===e)return!0;n=n.assignedSlot??n.parentNode??n.host??null}return!1},Gl=class extends vt{constructor(...e){super(...e),this.state={},this.data={},this.appState={},this.appData={},this.detailsOpenedItems=[],this.hoveredItem=null,this.onGridHoverMove=e=>{let t=e.currentTarget,n=t.getEventContext(e)?.item??null;n!==this.hoveredItem&&(this.hoveredItem=n,t.generateCellPartNames())},this.onGridHoverLeave=e=>{this.hoveredItem!==null&&(this.hoveredItem=null,e.currentTarget.generateCellPartNames())},this.hoverCellPartNameGenerator=(e,t)=>t?.item!=null&&t.item===this.hoveredItem?`hovered-cell`:``,this._onRowKey=e=>{let t=this.field?.rowSelectionShortcut;if(!t||!this.field?.onItemSelectionActionId||!this._isRowShortcutRelevant()||!rr(t,e))return;let n=/^(?:Digit|Numpad)([1-9])$/.exec(e.code);if(!n)return;let r=this.currentItems(),i=parseInt(n[1],10)-1;i>=r.length||(e.preventDefault(),this.selectRow(r[i]))},this.handleButtonClick=e=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e},bubbles:!0,composed:!0}))}}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._onRowKey)}disconnectedCallback(){super.disconnectedCallback(),document.removeEventListener(`keydown`,this._onRowKey)}currentItems(){return this.field?.remoteCoordinates?this.data?.[this.id]?.content??[]:this.field?.fieldId&&this.state?this.state[this.field.fieldId]??[]:[]}selectRow(e){!e||!this.field?.onItemSelectionActionId||(this.selectedItems=[e],this.state[this.id+`_selected_items`]=[e],this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.field.onItemSelectionActionId,parameters:{_clickedRow:e}},bubbles:!0,composed:!0})))}_isRowShortcutRelevant(){if(this.offsetParent===null&&this.getClientRects().length===0)return!1;let e=Ul();if(e&&e!==document.body&&!Wl(this,e)){let t=e.tagName?.toLowerCase()??``;if(e.isContentEditable||/^(input|textarea|select)$/.test(t)||t.startsWith(`vaadin-`)&&/(field|combo|picker|area|select)/.test(t))return!1}return!0}handleItemToggle(e){let{item:t,selected:n,shiftKey:r}=e.detail;if(this.rangeStartItem??=t,r){let e=[];this.field?.fieldId&&this.state&&this.state[this.field.fieldId]&&(e=this.state[this.field.fieldId]);let[r,i]=[this.rangeStartItem,t].map(t=>e.indexOf(t)).sort((e,t)=>e-t),a=e.slice(r,i+1),o=new Set(this.selectedItems);a.forEach(e=>{n?o.add(e):o.delete(e)}),this.selectedItems=[...o],this.state[this.id+`_selected_items`]=this.selectedItems}this.rangeStartItem=t}render(){let e=[];this.field?.fieldId&&this.state&&this.state[this.field.fieldId]&&(e=this.state[this.field.fieldId]);let t=this.state[this.field?.fieldId+`_show_detail`]||this.state._show_detail&&this.state._show_detail[this.field.fieldId];if(this.field?.remoteCoordinates){let t=this.field.remoteCoordinates;this.data[this.id]&&this.data[this.id].searchSignature&&this.data[this.id].searchSignature!=``&&(this.data[this.id]=void 0),this.data[this.id]&&this.data[this.id].content&&this.data[this.id].totalElements?e=this.data[this.id].content:this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}if(Array.isArray(e)&&e.forEach((e,t)=>{e&&typeof e==`object`&&e._rowNumber===void 0&&(e._rowNumber=t)}),this.field?.inlineEditing)return this.renderMaster(e);if(this.field?.formPosition&&this.field?.formPosition.startsWith(`modal`)){let n=this;return T`
 
                 ${this.renderMaster(e)}
 
@@ -8954,14 +8962,14 @@ ${i}
                     @click="${S(this.field?.onItemSelectionActionId?e=>{if(e.composedPath().some(e=>e instanceof HTMLElement&&(e.localName===`vaadin-button`||e.localName===`button`||e.localName===`a`||e.localName===`vaadin-checkbox`||e.getAttribute?.(`role`)===`button`)))return;let t=e.currentTarget.getEventContext(e)?.item;t&&this.selectRow(t)}:void 0)}"
                     @active-item-changed="${S(this.field?.detailPath&&!this.field?.useButtonForDetail?e=>{if(this.field?.detailPath){let t=e.detail.value;t?this.detailsOpenedItems=[t]:this.detailsOpenedItems=[]}}:void 0)}"
                     .detailsOpenedItems="${this.detailsOpenedItems}"
-                    ${S(this.field?.detailPath?n(e=>T`${I(this,e[this.field?.detailPath],this.baseUrl,this.state,this.data,this.appState,this.appData)}`):void 0)}
+                    ${S(this.field?.detailPath?n(e=>T`${F(this,e[this.field?.detailPath],this.baseUrl,this.state,this.data,this.appState,this.appData)}`):void 0)}
                     ?all-rows-visible=${e?.length<10}
             >
                 <span slot="empty-state">${this.field?.label?`No ${this.field.label.toLowerCase()} added yet.`:`No items added yet.`}</span>
                 ${this.field?.readOnly||this.field?.inlineEditing?v:T`
                     <vaadin-grid-selection-column drag-select></vaadin-grid-selection-column>
                 `}
-                ${this.field?.columns?.map(e=>zl(e,this,this.baseUrl,this.state,this.data,this.appState,this.appData))}
+                ${this.field?.columns?.map(e=>Bl(e,this,this.baseUrl,this.state,this.data,this.appState,this.appData))}
 
                 ${this.field?.inlineEditing&&!this.field?.readOnly?T`
                     <vaadin-grid-column width="3.5rem" flex-grow="0" frozen-to-end
@@ -9018,12 +9026,12 @@ ${i}
             background-color: var(--lumo-primary-color-10pct);
             cursor: pointer;
         }
-    `}};k([y()],Wl.prototype,`field`,void 0),k([y()],Wl.prototype,`state`,void 0),k([y()],Wl.prototype,`data`,void 0),k([y()],Wl.prototype,`appState`,void 0),k([y()],Wl.prototype,`appData`,void 0),k([y()],Wl.prototype,`selectedItems`,void 0),k([C()],Wl.prototype,`detailsOpenedItems`,void 0),Wl=k([g(`mateu-grid`)],Wl);var Gl=class extends b{constructor(...e){super(...e),this.getNewValue=e=>{if(this.field?.dataType==`array`){if(!this.value)return[e];let t=this.value;return t.indexOf(e)>=0?t.filter(t=>t!==e):[...t,e]}return e}}render(){let e=this.field?.options;if(this.field?.remoteCoordinates){let t=this.field.remoteCoordinates;this.data?.[this.field.fieldId]&&this.data[this.field.fieldId].content&&this.data[this.field.fieldId].totalElements?e=this.data[this.field.fieldId].content:this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}return T`
+    `}};k([y()],Gl.prototype,`field`,void 0),k([y()],Gl.prototype,`state`,void 0),k([y()],Gl.prototype,`data`,void 0),k([y()],Gl.prototype,`appState`,void 0),k([y()],Gl.prototype,`appData`,void 0),k([y()],Gl.prototype,`selectedItems`,void 0),k([C()],Gl.prototype,`detailsOpenedItems`,void 0),Gl=k([g(`mateu-grid`)],Gl);var Kl=class extends b{constructor(...e){super(...e),this.getNewValue=e=>{if(this.field?.dataType==`array`){if(!this.value)return[e];let t=this.value;return t.indexOf(e)>=0?t.filter(t=>t!==e):[...t,e]}return e}}render(){let e=this.field?.options;if(this.field?.remoteCoordinates){let t=this.field.remoteCoordinates;this.data?.[this.field.fieldId]&&this.data[this.field.fieldId].content&&this.data[this.field.fieldId].totalElements?e=this.data[this.field.fieldId].content:this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.action,parameters:{searchText:``,fieldId:this.field?.fieldId,size:200,page:0,sort:void 0}},bubbles:!0,composed:!0}))}return T`
         <div style="display: flex; gap: 1rem; padding: 1rem; flex-wrap: wrap; ${this.field?.attributes?.divStyle}">
                                     ${e?.map(e=>T`
                             <div role="button" tabindex="0" 
                                     class="choice ${this.value==e.value||Array.isArray(this.value)&&this.value.includes(e.value)?`selected`:``}"
-                                    @click="${()=>this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.getNewValue(e.value),fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}" @keydown="${z(()=>this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.getNewValue(e.value),fieldId:this.field?.fieldId},bubbles:!0,composed:!0})))}"
+                                    @click="${()=>this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.getNewValue(e.value),fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}" @keydown="${R(()=>this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.getNewValue(e.value),fieldId:this.field?.fieldId},bubbles:!0,composed:!0})))}"
                             >${e.description||e.image?T`
                                 <div style="display: flex; align-items: center; gap: var(--lumo-space-m, 1rem);">
                                     ${e.image?T`
@@ -9065,8 +9073,8 @@ ${i}
             border: 1px solid var(--lumo-shade-20pct);
         }
   
-        ${B}
-    `}};k([y()],Gl.prototype,`field`,void 0),k([y()],Gl.prototype,`baseUrl`,void 0),k([y()],Gl.prototype,`state`,void 0),k([y()],Gl.prototype,`data`,void 0),k([y()],Gl.prototype,`value`,void 0),Gl=k([g(`mateu-choice`)],Gl);var Kl,ql=class extends b{static{Kl=this}constructor(...e){super(...e),this.commit=e=>{this.value=e,this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:{...e},fieldId:this.fieldId}}))},this.currencyChanged=e=>{let t=this.value??Kl.EMPTY;!e.detail.value||e.detail.value===t.currency||this.commit({...t,currency:e.detail.value})},this.valueChanged=e=>{let t=this.value??Kl.EMPTY,n=ol(e.detail.value,!1)??0;n!==t.value&&this.commit({...t,value:n})}}static{this.EMPTY={value:0,currency:`EUR`,locale:`es-ES`}}render(){return T`
+        ${z}
+    `}};k([y()],Kl.prototype,`field`,void 0),k([y()],Kl.prototype,`baseUrl`,void 0),k([y()],Kl.prototype,`state`,void 0),k([y()],Kl.prototype,`data`,void 0),k([y()],Kl.prototype,`value`,void 0),Kl=k([g(`mateu-choice`)],Kl);var ql,Jl=class extends b{static{ql=this}constructor(...e){super(...e),this.commit=e=>{this.value=e,this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:{...e},fieldId:this.fieldId}}))},this.currencyChanged=e=>{let t=this.value??ql.EMPTY;!e.detail.value||e.detail.value===t.currency||this.commit({...t,currency:e.detail.value})},this.valueChanged=e=>{let t=this.value??ql.EMPTY,n=sl(e.detail.value,!1)??0;n!==t.value&&this.commit({...t,value:n})}}static{this.EMPTY={value:0,currency:`EUR`,locale:`es-ES`}}render(){return T`
             <vaadin-number-field
                     id="${this.fieldId}"
                     label="${this.label}"
@@ -9086,10 +9094,10 @@ ${i}
                     theme="small"
             ></vaadin-select></div></vaadin-number-field>
        `}static{this.styles=h`
-  `}};k([y()],ql.prototype,`fieldId`,void 0),k([y()],ql.prototype,`label`,void 0),k([y()],ql.prototype,`state`,void 0),k([y()],ql.prototype,`data`,void 0),k([y()],ql.prototype,`value`,void 0),k([y()],ql.prototype,`autoFocus`,void 0),k([y()],ql.prototype,`required`,void 0),k([y()],ql.prototype,`colspan`,void 0),k([y()],ql.prototype,`helperText`,void 0),ql=Kl=k([g(`mateu-money-field`)],ql);var Jl=`vaadin:abacus.vaadin:absolute-position.vaadin:academy-cap.vaadin:accessibility.vaadin:accordion-menu.vaadin:add-dock.vaadin:adjust.vaadin:adobe-flash.vaadin:airplane.vaadin:alarm.vaadin:align-center.vaadin:align-justify.vaadin:align-left.vaadin:align-right.vaadin:alt-a.vaadin:alt.vaadin:ambulance.vaadin:anchor.vaadin:angle-double-down.vaadin:angle-double-left.vaadin:angle-double-right.vaadin:angle-double-up.vaadin:angle-down.vaadin:angle-left.vaadin:angle-right.vaadin:angle-up.vaadin:archive.vaadin:archives.vaadin:area-select.vaadin:arrow-backward.vaadin:arrow-circle-down-o.vaadin:arrow-circle-down.vaadin:arrow-circle-left-o.vaadin:arrow-circle-left.vaadin:arrow-circle-right-o.vaadin:arrow-circle-right.vaadin:arrow-circle-up-o.vaadin:arrow-circle-up.vaadin:arrow-down.vaadin:arrow-forward.vaadin:arrow-left.vaadin:arrow-long-down.vaadin:arrow-long-left.vaadin:arrow-right.vaadin:arrow-up.vaadin:arrows-cross.vaadin:arrows-long-h.vaadin:arrows-long-right.vaadin:arrows-long-up.vaadin:arrows-long-v.vaadin:arrows.vaadin:asterisk.vaadin:at.vaadin:automation.vaadin:backspace-a.vaadin:backspace.vaadin:backwards.vaadin:ban.vaadin:bar-chart-h.vaadin:bar-chart-v.vaadin:bar-chart.vaadin:barcode.vaadin:bed.vaadin:bell-o.vaadin:bell-slash-o.vaadin:bell-slash.vaadin:bell.vaadin:boat.vaadin:bold.vaadin:bolt.vaadin:bomb.vaadin:book-dollar.vaadin:book-percent.vaadin:book.vaadin:bookmark-o.vaadin:bookmark.vaadin:briefcase.vaadin:browser.vaadin:bug-o.vaadin:bug.vaadin:building-o.vaadin:building.vaadin:bullets.vaadin:bullseye.vaadin:bus.vaadin:buss.vaadin:button.vaadin:calc-book.vaadin:calc.vaadin:calendar-briefcase.vaadin:calendar-clock.vaadin:calendar-envelope.vaadin:calendar-o.vaadin:calendar-user.vaadin:calendar.vaadin:camera.vaadin:car.vaadin:caret-down.vaadin:caret-left.vaadin:caret-right.vaadin:caret-square-down-o.vaadin:caret-square-left-o.vaadin:caret-square-right-o.vaadin:caret-square-up-o.vaadin:caret-up.vaadin:cart-o.vaadin:cart.vaadin:cash.vaadin:chart-3d.vaadin:chart-grid.vaadin:chart-line.vaadin:chart-timeline.vaadin:chart.vaadin:chat.vaadin:check-circle-o.vaadin:check-circle.vaadin:check-square-o.vaadin:check-square.vaadin:check.vaadin:chevron-circle-down-o.vaadin:chevron-circle-down.vaadin:chevron-circle-left-o.vaadin:chevron-circle-left.vaadin:chevron-circle-right-o.vaadin:chevron-circle-right.vaadin:chevron-circle-up-o.vaadin:chevron-circle-up.vaadin:chevron-down-small.vaadin:chevron-down.vaadin:chevron-left-small.vaadin:chevron-left.vaadin:chevron-right-small.vaadin:chevron-right.vaadin:chevron-up-small.vaadin:chevron-up.vaadin:child.vaadin:circle-thin.vaadin:circle.vaadin:clipboard-check.vaadin:clipboard-cross.vaadin:clipboard-heart.vaadin:clipboard-pulse.vaadin:clipboard-text.vaadin:clipboard-user.vaadin:clipboard.vaadin:clock.vaadin:close-big.vaadin:close-circle-o.vaadin:close-circle.vaadin:close-small.vaadin:close.vaadin:cloud-download-o.vaadin:cloud-download.vaadin:cloud-o.vaadin:cloud-upload-o.vaadin:cloud-upload.vaadin:cloud.vaadin:cluster.vaadin:code.vaadin:coffee.vaadin:cog-o.vaadin:cog.vaadin:cogs.vaadin:coin-piles.vaadin:coins.vaadin:combobox.vaadin:comment-ellipsis-o.vaadin:comment-ellipsis.vaadin:comment-o.vaadin:comment.vaadin:comments-o.vaadin:comments.vaadin:compile.vaadin:compress-square.vaadin:compress.vaadin:connect-o.vaadin:connect.vaadin:controller.vaadin:copy-o.vaadin:copy.vaadin:copyright.vaadin:corner-lower-left.vaadin:corner-lower-right.vaadin:corner-upper-left.vaadin:corner-upper-right.vaadin:credit-card.vaadin:crop.vaadin:cross-cutlery.vaadin:crosshairs.vaadin:css.vaadin:ctrl-a.vaadin:ctrl.vaadin:cube.vaadin:cubes.vaadin:curly-brackets.vaadin:cursor-o.vaadin:cursor.vaadin:cutlery.vaadin:dashboard.vaadin:database.vaadin:date-input.vaadin:deindent.vaadin:del-a.vaadin:del.vaadin:dental-chair.vaadin:desktop.vaadin:diamond-o.vaadin:diamond.vaadin:diploma-scroll.vaadin:diploma.vaadin:disc.vaadin:doctor-briefcase.vaadin:doctor.vaadin:dollar.vaadin:dot-circle.vaadin:download-alt.vaadin:download.vaadin:drop.vaadin:edit.vaadin:eject.vaadin:elastic.vaadin:ellipsis-circle-o.vaadin:ellipsis-circle.vaadin:ellipsis-dots-h.vaadin:ellipsis-dots-v.vaadin:ellipsis-h.vaadin:ellipsis-v.vaadin:enter-arrow.vaadin:enter.vaadin:envelope-o.vaadin:envelope-open-o.vaadin:envelope-open.vaadin:envelope.vaadin:envelopes-o.vaadin:envelopes.vaadin:eraser.vaadin:esc-a.vaadin:esc.vaadin:euro.vaadin:exchange.vaadin:exclamation-circle-o.vaadin:exclamation-circle.vaadin:exclamation.vaadin:exit-o.vaadin:exit.vaadin:expand-full.vaadin:expand-square.vaadin:expand.vaadin:external-browser.vaadin:external-link.vaadin:eye-slash.vaadin:eye.vaadin:eyedropper.vaadin:facebook-square.vaadin:facebook.vaadin:factory.vaadin:family.vaadin:fast-backward.vaadin:fast-forward.vaadin:female.vaadin:file-add.vaadin:file-code.vaadin:file-font.vaadin:file-movie.vaadin:file-o.vaadin:file-picture.vaadin:file-presentation.vaadin:file-process.vaadin:file-refresh.vaadin:file-remove.vaadin:file-search.vaadin:file-sound.vaadin:file-start.vaadin:file-table.vaadin:file-text-o.vaadin:file-text.vaadin:file-tree-small.vaadin:file-tree-sub.vaadin:file-tree.vaadin:file-zip.vaadin:file.vaadin:fill.vaadin:film.vaadin:filter.vaadin:fire.vaadin:flag-checkered.vaadin:flag-o.vaadin:flag.vaadin:flash.vaadin:flask.vaadin:flight-landing.vaadin:flight-takeoff.vaadin:flip-h.vaadin:flip-v.vaadin:folder-add.vaadin:folder-o.vaadin:folder-open-o.vaadin:folder-open.vaadin:folder-remove.vaadin:folder-search.vaadin:folder.vaadin:font.vaadin:form.vaadin:forward.vaadin:frown-o.vaadin:funcion.vaadin:function.vaadin:funnel.vaadin:gamepad.vaadin:gavel.vaadin:gift.vaadin:glass.vaadin:glasses.vaadin:globe-wire.vaadin:globe.vaadin:golf.vaadin:google-plus-square.vaadin:google-plus.vaadin:grab.vaadin:grid-bevel.vaadin:grid-big-o.vaadin:grid-big.vaadin:grid-h.vaadin:grid-small-o.vaadin:grid-small.vaadin:grid-v.vaadin:grid.vaadin:group.vaadin:hammer.vaadin:hand.vaadin:handle-corner.vaadin:hands-up.vaadin:handshake.vaadin:harddrive-o.vaadin:harddrive.vaadin:hash.vaadin:header.vaadin:headphones.vaadin:headset.vaadin:health-card.vaadin:heart-o.vaadin:heart.vaadin:home-o.vaadin:home.vaadin:hospital.vaadin:hourglass-empty.vaadin:hourglass-end.vaadin:hourglass-start.vaadin:hourglass.vaadin:inbox.vaadin:indent.vaadin:info-circle-o.vaadin:info-circle.vaadin:info.vaadin:input.vaadin:insert.vaadin:institution.vaadin:invoice.vaadin:italic.vaadin:key-o.vaadin:key.vaadin:keyboard-o.vaadin:keyboard.vaadin:laptop.vaadin:layout.vaadin:level-down-bold.vaadin:level-down.vaadin:level-left-bold.vaadin:level-left.vaadin:level-right-bold.vaadin:level-right.vaadin:level-up-bold.vaadin:level-up.vaadin:lifebuoy.vaadin:lightbulb.vaadin:line-bar-chart.vaadin:line-chart.vaadin:line-h.vaadin:line-v.vaadin:lines-list.vaadin:lines.vaadin:link.vaadin:list-ol.vaadin:list-select.vaadin:list-ul.vaadin:list.vaadin:location-arrow-circle-o.vaadin:location-arrow-circle.vaadin:location-arrow.vaadin:lock.vaadin:magic.vaadin:magnet.vaadin:mailbox.vaadin:male.vaadin:map-marker.vaadin:margin-bottom.vaadin:margin-left.vaadin:margin-right.vaadin:margin-top.vaadin:margin.vaadin:medal.vaadin:megafone.vaadin:megaphone.vaadin:meh-o.vaadin:menu.vaadin:microphone.vaadin:minus-circle-o.vaadin:minus-circle.vaadin:minus-square-o.vaadin:minus.vaadin:mobile-browser.vaadin:mobile-retro.vaadin:mobile.vaadin:modal-list.vaadin:modal.vaadin:money-deposit.vaadin:money-exchange.vaadin:money-withdraw.vaadin:money.vaadin:moon-o.vaadin:moon.vaadin:morning.vaadin:movie.vaadin:music.vaadin:mute.vaadin:native-button.vaadin:newspaper.vaadin:notebook.vaadin:nurse.vaadin:office.vaadin:open-book.vaadin:option-a.vaadin:option.vaadin:options.vaadin:orientation.vaadin:out.vaadin:outbox.vaadin:package.vaadin:padding-bottom.vaadin:padding-left.vaadin:padding-right.vaadin:padding-top.vaadin:padding.vaadin:paint-roll.vaadin:paintbrush.vaadin:palete.vaadin:palette.vaadin:panel.vaadin:paperclip.vaadin:paperplane-o.vaadin:paperplane.vaadin:paragraph.vaadin:password.vaadin:paste.vaadin:pause.vaadin:pencil.vaadin:phone-landline.vaadin:phone.vaadin:picture.vaadin:pie-bar-chart.vaadin:pie-chart.vaadin:piggy-bank-coin.vaadin:piggy-bank.vaadin:pill.vaadin:pills.vaadin:pin-post.vaadin:pin.vaadin:play-circle-o.vaadin:play-circle.vaadin:play.vaadin:plug.vaadin:plus-circle-o.vaadin:plus-circle.vaadin:plus-minus.vaadin:plus-square-o.vaadin:plus.vaadin:pointer.vaadin:power-off.vaadin:presentation.vaadin:print.vaadin:progressbar.vaadin:puzzle-piece.vaadin:pyramid-chart.vaadin:qrcode.vaadin:question-circle-o.vaadin:question-circle.vaadin:question.vaadin:quote-left.vaadin:quote-right.vaadin:random.vaadin:raster-lower-left.vaadin:raster.vaadin:records.vaadin:recycle.vaadin:refresh.vaadin:reply-all.vaadin:reply.vaadin:resize-h.vaadin:resize-v.vaadin:retweet.vaadin:rhombus.vaadin:road-branch.vaadin:road-branches.vaadin:road-split.vaadin:road.vaadin:rocket.vaadin:rotate-left.vaadin:rotate-right.vaadin:rss-square.vaadin:rss.vaadin:safe-lock.vaadin:safe.vaadin:scale-unbalance.vaadin:scale.vaadin:scatter-chart.vaadin:scissors.vaadin:screwdriver.vaadin:search-minus.vaadin:search-plus.vaadin:search.vaadin:select.vaadin:server.vaadin:share-square.vaadin:share.vaadin:shield.vaadin:shift-arrow.vaadin:shift.vaadin:shop.vaadin:sign-in-alt.vaadin:sign-in.vaadin:sign-out-alt.vaadin:sign-out.vaadin:signal.vaadin:sitemap.vaadin:slider.vaadin:sliders.vaadin:smiley-o.vaadin:sort.vaadin:sound-disable.vaadin:spark-line.vaadin:specialist.vaadin:spinner-arc.vaadin:spinner-third.vaadin:spinner.vaadin:spline-area-chart.vaadin:spline-chart.vaadin:split-h.vaadin:split-v.vaadin:split.vaadin:spoon.vaadin:square-shadow.vaadin:star-half-left-o.vaadin:star-half-left.vaadin:star-half-right-o.vaadin:star-half-right.vaadin:star-o.vaadin:star.vaadin:start-cog.vaadin:step-backward.vaadin:step-forward.vaadin:stethoscope.vaadin:stock.vaadin:stop-cog.vaadin:stop.vaadin:stopwatch.vaadin:storage.vaadin:strikethrough.vaadin:subscript.vaadin:suitcase.vaadin:sun-down.vaadin:sun-o.vaadin:sun-rise.vaadin:superscript.vaadin:sword.vaadin:tab-a.vaadin:tab.vaadin:table.vaadin:tablet.vaadin:tabs.vaadin:tag.vaadin:tags.vaadin:tasks.vaadin:taxi.vaadin:teeth.vaadin:terminal.vaadin:text-height.vaadin:text-input.vaadin:text-label.vaadin:text-width.vaadin:thin-square.vaadin:thumbs-down-o.vaadin:thumbs-down.vaadin:thumbs-up-o.vaadin:thumbs-up.vaadin:ticket.vaadin:time-backward.vaadin:time-forward.vaadin:timer.vaadin:toolbox.vaadin:tools.vaadin:tooth.vaadin:touch.vaadin:train.vaadin:trash.vaadin:tree-table.vaadin:trendind-down.vaadin:trending-down.vaadin:trending-up.vaadin:trophy.vaadin:truck.vaadin:twin-col-select.vaadin:twitter-square.vaadin:twitter.vaadin:umbrella.vaadin:underline.vaadin:unlink.vaadin:unlock.vaadin:upload-alt.vaadin:upload.vaadin:user-card.vaadin:user-check.vaadin:user-clock.vaadin:user-heart.vaadin:user-star.vaadin:user.vaadin:users.vaadin:vaadin-h.vaadin:vaadin-v.vaadin:viewport.vaadin:vimeo-square.vaadin:vimeo.vaadin:volume-down.vaadin:volume-off.vaadin:volume-up.vaadin:volume.vaadin:wallet.vaadin:warning.vaadin:workplace.vaadin:wrench.vaadin:youtube-square.vaadin:youtube`.split(`.`),Yl=null,Xl=()=>(Yl||=Promise.all([D(()=>import(`./vendor-ui5.js`).then(e=>e.n),__vite__mapDeps([5,1])),D(()=>import(`./vendor-ui5.js`).then(e=>e.t),__vite__mapDeps([5,1]))]),Yl),Q=class extends b{constructor(...e){super(...e),this.ui5FieldComponentsReady=!1,this.component=void 0,this.field=void 0,this.baseUrl=void 0,this.state={},this.data={},this.appState={},this.appData={},this.colorPickerOpened=!1,this.colorPickerValue=void 0,this.comboData=[],this._comboFilter=``,this.rendered=!1,this.renderColorPicker=()=>{this.loadUi5FieldComponents();let e=this.field?.fieldId;return T`
+  `}};k([y()],Jl.prototype,`fieldId`,void 0),k([y()],Jl.prototype,`label`,void 0),k([y()],Jl.prototype,`state`,void 0),k([y()],Jl.prototype,`data`,void 0),k([y()],Jl.prototype,`value`,void 0),k([y()],Jl.prototype,`autoFocus`,void 0),k([y()],Jl.prototype,`required`,void 0),k([y()],Jl.prototype,`colspan`,void 0),k([y()],Jl.prototype,`helperText`,void 0),Jl=ql=k([g(`mateu-money-field`)],Jl);var Yl=`vaadin:abacus.vaadin:absolute-position.vaadin:academy-cap.vaadin:accessibility.vaadin:accordion-menu.vaadin:add-dock.vaadin:adjust.vaadin:adobe-flash.vaadin:airplane.vaadin:alarm.vaadin:align-center.vaadin:align-justify.vaadin:align-left.vaadin:align-right.vaadin:alt-a.vaadin:alt.vaadin:ambulance.vaadin:anchor.vaadin:angle-double-down.vaadin:angle-double-left.vaadin:angle-double-right.vaadin:angle-double-up.vaadin:angle-down.vaadin:angle-left.vaadin:angle-right.vaadin:angle-up.vaadin:archive.vaadin:archives.vaadin:area-select.vaadin:arrow-backward.vaadin:arrow-circle-down-o.vaadin:arrow-circle-down.vaadin:arrow-circle-left-o.vaadin:arrow-circle-left.vaadin:arrow-circle-right-o.vaadin:arrow-circle-right.vaadin:arrow-circle-up-o.vaadin:arrow-circle-up.vaadin:arrow-down.vaadin:arrow-forward.vaadin:arrow-left.vaadin:arrow-long-down.vaadin:arrow-long-left.vaadin:arrow-right.vaadin:arrow-up.vaadin:arrows-cross.vaadin:arrows-long-h.vaadin:arrows-long-right.vaadin:arrows-long-up.vaadin:arrows-long-v.vaadin:arrows.vaadin:asterisk.vaadin:at.vaadin:automation.vaadin:backspace-a.vaadin:backspace.vaadin:backwards.vaadin:ban.vaadin:bar-chart-h.vaadin:bar-chart-v.vaadin:bar-chart.vaadin:barcode.vaadin:bed.vaadin:bell-o.vaadin:bell-slash-o.vaadin:bell-slash.vaadin:bell.vaadin:boat.vaadin:bold.vaadin:bolt.vaadin:bomb.vaadin:book-dollar.vaadin:book-percent.vaadin:book.vaadin:bookmark-o.vaadin:bookmark.vaadin:briefcase.vaadin:browser.vaadin:bug-o.vaadin:bug.vaadin:building-o.vaadin:building.vaadin:bullets.vaadin:bullseye.vaadin:bus.vaadin:buss.vaadin:button.vaadin:calc-book.vaadin:calc.vaadin:calendar-briefcase.vaadin:calendar-clock.vaadin:calendar-envelope.vaadin:calendar-o.vaadin:calendar-user.vaadin:calendar.vaadin:camera.vaadin:car.vaadin:caret-down.vaadin:caret-left.vaadin:caret-right.vaadin:caret-square-down-o.vaadin:caret-square-left-o.vaadin:caret-square-right-o.vaadin:caret-square-up-o.vaadin:caret-up.vaadin:cart-o.vaadin:cart.vaadin:cash.vaadin:chart-3d.vaadin:chart-grid.vaadin:chart-line.vaadin:chart-timeline.vaadin:chart.vaadin:chat.vaadin:check-circle-o.vaadin:check-circle.vaadin:check-square-o.vaadin:check-square.vaadin:check.vaadin:chevron-circle-down-o.vaadin:chevron-circle-down.vaadin:chevron-circle-left-o.vaadin:chevron-circle-left.vaadin:chevron-circle-right-o.vaadin:chevron-circle-right.vaadin:chevron-circle-up-o.vaadin:chevron-circle-up.vaadin:chevron-down-small.vaadin:chevron-down.vaadin:chevron-left-small.vaadin:chevron-left.vaadin:chevron-right-small.vaadin:chevron-right.vaadin:chevron-up-small.vaadin:chevron-up.vaadin:child.vaadin:circle-thin.vaadin:circle.vaadin:clipboard-check.vaadin:clipboard-cross.vaadin:clipboard-heart.vaadin:clipboard-pulse.vaadin:clipboard-text.vaadin:clipboard-user.vaadin:clipboard.vaadin:clock.vaadin:close-big.vaadin:close-circle-o.vaadin:close-circle.vaadin:close-small.vaadin:close.vaadin:cloud-download-o.vaadin:cloud-download.vaadin:cloud-o.vaadin:cloud-upload-o.vaadin:cloud-upload.vaadin:cloud.vaadin:cluster.vaadin:code.vaadin:coffee.vaadin:cog-o.vaadin:cog.vaadin:cogs.vaadin:coin-piles.vaadin:coins.vaadin:combobox.vaadin:comment-ellipsis-o.vaadin:comment-ellipsis.vaadin:comment-o.vaadin:comment.vaadin:comments-o.vaadin:comments.vaadin:compile.vaadin:compress-square.vaadin:compress.vaadin:connect-o.vaadin:connect.vaadin:controller.vaadin:copy-o.vaadin:copy.vaadin:copyright.vaadin:corner-lower-left.vaadin:corner-lower-right.vaadin:corner-upper-left.vaadin:corner-upper-right.vaadin:credit-card.vaadin:crop.vaadin:cross-cutlery.vaadin:crosshairs.vaadin:css.vaadin:ctrl-a.vaadin:ctrl.vaadin:cube.vaadin:cubes.vaadin:curly-brackets.vaadin:cursor-o.vaadin:cursor.vaadin:cutlery.vaadin:dashboard.vaadin:database.vaadin:date-input.vaadin:deindent.vaadin:del-a.vaadin:del.vaadin:dental-chair.vaadin:desktop.vaadin:diamond-o.vaadin:diamond.vaadin:diploma-scroll.vaadin:diploma.vaadin:disc.vaadin:doctor-briefcase.vaadin:doctor.vaadin:dollar.vaadin:dot-circle.vaadin:download-alt.vaadin:download.vaadin:drop.vaadin:edit.vaadin:eject.vaadin:elastic.vaadin:ellipsis-circle-o.vaadin:ellipsis-circle.vaadin:ellipsis-dots-h.vaadin:ellipsis-dots-v.vaadin:ellipsis-h.vaadin:ellipsis-v.vaadin:enter-arrow.vaadin:enter.vaadin:envelope-o.vaadin:envelope-open-o.vaadin:envelope-open.vaadin:envelope.vaadin:envelopes-o.vaadin:envelopes.vaadin:eraser.vaadin:esc-a.vaadin:esc.vaadin:euro.vaadin:exchange.vaadin:exclamation-circle-o.vaadin:exclamation-circle.vaadin:exclamation.vaadin:exit-o.vaadin:exit.vaadin:expand-full.vaadin:expand-square.vaadin:expand.vaadin:external-browser.vaadin:external-link.vaadin:eye-slash.vaadin:eye.vaadin:eyedropper.vaadin:facebook-square.vaadin:facebook.vaadin:factory.vaadin:family.vaadin:fast-backward.vaadin:fast-forward.vaadin:female.vaadin:file-add.vaadin:file-code.vaadin:file-font.vaadin:file-movie.vaadin:file-o.vaadin:file-picture.vaadin:file-presentation.vaadin:file-process.vaadin:file-refresh.vaadin:file-remove.vaadin:file-search.vaadin:file-sound.vaadin:file-start.vaadin:file-table.vaadin:file-text-o.vaadin:file-text.vaadin:file-tree-small.vaadin:file-tree-sub.vaadin:file-tree.vaadin:file-zip.vaadin:file.vaadin:fill.vaadin:film.vaadin:filter.vaadin:fire.vaadin:flag-checkered.vaadin:flag-o.vaadin:flag.vaadin:flash.vaadin:flask.vaadin:flight-landing.vaadin:flight-takeoff.vaadin:flip-h.vaadin:flip-v.vaadin:folder-add.vaadin:folder-o.vaadin:folder-open-o.vaadin:folder-open.vaadin:folder-remove.vaadin:folder-search.vaadin:folder.vaadin:font.vaadin:form.vaadin:forward.vaadin:frown-o.vaadin:funcion.vaadin:function.vaadin:funnel.vaadin:gamepad.vaadin:gavel.vaadin:gift.vaadin:glass.vaadin:glasses.vaadin:globe-wire.vaadin:globe.vaadin:golf.vaadin:google-plus-square.vaadin:google-plus.vaadin:grab.vaadin:grid-bevel.vaadin:grid-big-o.vaadin:grid-big.vaadin:grid-h.vaadin:grid-small-o.vaadin:grid-small.vaadin:grid-v.vaadin:grid.vaadin:group.vaadin:hammer.vaadin:hand.vaadin:handle-corner.vaadin:hands-up.vaadin:handshake.vaadin:harddrive-o.vaadin:harddrive.vaadin:hash.vaadin:header.vaadin:headphones.vaadin:headset.vaadin:health-card.vaadin:heart-o.vaadin:heart.vaadin:home-o.vaadin:home.vaadin:hospital.vaadin:hourglass-empty.vaadin:hourglass-end.vaadin:hourglass-start.vaadin:hourglass.vaadin:inbox.vaadin:indent.vaadin:info-circle-o.vaadin:info-circle.vaadin:info.vaadin:input.vaadin:insert.vaadin:institution.vaadin:invoice.vaadin:italic.vaadin:key-o.vaadin:key.vaadin:keyboard-o.vaadin:keyboard.vaadin:laptop.vaadin:layout.vaadin:level-down-bold.vaadin:level-down.vaadin:level-left-bold.vaadin:level-left.vaadin:level-right-bold.vaadin:level-right.vaadin:level-up-bold.vaadin:level-up.vaadin:lifebuoy.vaadin:lightbulb.vaadin:line-bar-chart.vaadin:line-chart.vaadin:line-h.vaadin:line-v.vaadin:lines-list.vaadin:lines.vaadin:link.vaadin:list-ol.vaadin:list-select.vaadin:list-ul.vaadin:list.vaadin:location-arrow-circle-o.vaadin:location-arrow-circle.vaadin:location-arrow.vaadin:lock.vaadin:magic.vaadin:magnet.vaadin:mailbox.vaadin:male.vaadin:map-marker.vaadin:margin-bottom.vaadin:margin-left.vaadin:margin-right.vaadin:margin-top.vaadin:margin.vaadin:medal.vaadin:megafone.vaadin:megaphone.vaadin:meh-o.vaadin:menu.vaadin:microphone.vaadin:minus-circle-o.vaadin:minus-circle.vaadin:minus-square-o.vaadin:minus.vaadin:mobile-browser.vaadin:mobile-retro.vaadin:mobile.vaadin:modal-list.vaadin:modal.vaadin:money-deposit.vaadin:money-exchange.vaadin:money-withdraw.vaadin:money.vaadin:moon-o.vaadin:moon.vaadin:morning.vaadin:movie.vaadin:music.vaadin:mute.vaadin:native-button.vaadin:newspaper.vaadin:notebook.vaadin:nurse.vaadin:office.vaadin:open-book.vaadin:option-a.vaadin:option.vaadin:options.vaadin:orientation.vaadin:out.vaadin:outbox.vaadin:package.vaadin:padding-bottom.vaadin:padding-left.vaadin:padding-right.vaadin:padding-top.vaadin:padding.vaadin:paint-roll.vaadin:paintbrush.vaadin:palete.vaadin:palette.vaadin:panel.vaadin:paperclip.vaadin:paperplane-o.vaadin:paperplane.vaadin:paragraph.vaadin:password.vaadin:paste.vaadin:pause.vaadin:pencil.vaadin:phone-landline.vaadin:phone.vaadin:picture.vaadin:pie-bar-chart.vaadin:pie-chart.vaadin:piggy-bank-coin.vaadin:piggy-bank.vaadin:pill.vaadin:pills.vaadin:pin-post.vaadin:pin.vaadin:play-circle-o.vaadin:play-circle.vaadin:play.vaadin:plug.vaadin:plus-circle-o.vaadin:plus-circle.vaadin:plus-minus.vaadin:plus-square-o.vaadin:plus.vaadin:pointer.vaadin:power-off.vaadin:presentation.vaadin:print.vaadin:progressbar.vaadin:puzzle-piece.vaadin:pyramid-chart.vaadin:qrcode.vaadin:question-circle-o.vaadin:question-circle.vaadin:question.vaadin:quote-left.vaadin:quote-right.vaadin:random.vaadin:raster-lower-left.vaadin:raster.vaadin:records.vaadin:recycle.vaadin:refresh.vaadin:reply-all.vaadin:reply.vaadin:resize-h.vaadin:resize-v.vaadin:retweet.vaadin:rhombus.vaadin:road-branch.vaadin:road-branches.vaadin:road-split.vaadin:road.vaadin:rocket.vaadin:rotate-left.vaadin:rotate-right.vaadin:rss-square.vaadin:rss.vaadin:safe-lock.vaadin:safe.vaadin:scale-unbalance.vaadin:scale.vaadin:scatter-chart.vaadin:scissors.vaadin:screwdriver.vaadin:search-minus.vaadin:search-plus.vaadin:search.vaadin:select.vaadin:server.vaadin:share-square.vaadin:share.vaadin:shield.vaadin:shift-arrow.vaadin:shift.vaadin:shop.vaadin:sign-in-alt.vaadin:sign-in.vaadin:sign-out-alt.vaadin:sign-out.vaadin:signal.vaadin:sitemap.vaadin:slider.vaadin:sliders.vaadin:smiley-o.vaadin:sort.vaadin:sound-disable.vaadin:spark-line.vaadin:specialist.vaadin:spinner-arc.vaadin:spinner-third.vaadin:spinner.vaadin:spline-area-chart.vaadin:spline-chart.vaadin:split-h.vaadin:split-v.vaadin:split.vaadin:spoon.vaadin:square-shadow.vaadin:star-half-left-o.vaadin:star-half-left.vaadin:star-half-right-o.vaadin:star-half-right.vaadin:star-o.vaadin:star.vaadin:start-cog.vaadin:step-backward.vaadin:step-forward.vaadin:stethoscope.vaadin:stock.vaadin:stop-cog.vaadin:stop.vaadin:stopwatch.vaadin:storage.vaadin:strikethrough.vaadin:subscript.vaadin:suitcase.vaadin:sun-down.vaadin:sun-o.vaadin:sun-rise.vaadin:superscript.vaadin:sword.vaadin:tab-a.vaadin:tab.vaadin:table.vaadin:tablet.vaadin:tabs.vaadin:tag.vaadin:tags.vaadin:tasks.vaadin:taxi.vaadin:teeth.vaadin:terminal.vaadin:text-height.vaadin:text-input.vaadin:text-label.vaadin:text-width.vaadin:thin-square.vaadin:thumbs-down-o.vaadin:thumbs-down.vaadin:thumbs-up-o.vaadin:thumbs-up.vaadin:ticket.vaadin:time-backward.vaadin:time-forward.vaadin:timer.vaadin:toolbox.vaadin:tools.vaadin:tooth.vaadin:touch.vaadin:train.vaadin:trash.vaadin:tree-table.vaadin:trendind-down.vaadin:trending-down.vaadin:trending-up.vaadin:trophy.vaadin:truck.vaadin:twin-col-select.vaadin:twitter-square.vaadin:twitter.vaadin:umbrella.vaadin:underline.vaadin:unlink.vaadin:unlock.vaadin:upload-alt.vaadin:upload.vaadin:user-card.vaadin:user-check.vaadin:user-clock.vaadin:user-heart.vaadin:user-star.vaadin:user.vaadin:users.vaadin:vaadin-h.vaadin:vaadin-v.vaadin:viewport.vaadin:vimeo-square.vaadin:vimeo.vaadin:volume-down.vaadin:volume-off.vaadin:volume-up.vaadin:volume.vaadin:wallet.vaadin:warning.vaadin:workplace.vaadin:wrench.vaadin:youtube-square.vaadin:youtube`.split(`.`),Xl=null,Zl=()=>(Xl||=Promise.all([D(()=>import(`./vendor-ui5.js`).then(e=>e.n),__vite__mapDeps([5,1])),D(()=>import(`./vendor-ui5.js`).then(e=>e.t),__vite__mapDeps([5,1]))]),Xl),Z=class extends b{constructor(...e){super(...e),this.ui5FieldComponentsReady=!1,this.component=void 0,this.field=void 0,this.baseUrl=void 0,this.state={},this.data={},this.appState={},this.appData={},this.colorPickerOpened=!1,this.colorPickerValue=void 0,this.comboData=[],this._comboFilter=``,this.rendered=!1,this.renderColorPicker=()=>{this.loadUi5FieldComponents();let e=this.field?.fieldId;return T`
             <ui5-color-picker value="${this.state&&e in this.state?this.state[e]:this.field?.initialValue}" @change="${e=>this.colorPickerValue=e.target.value}">Picker</ui5-color-picker>
         `},this.saveColor=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.colorPickerValue,fieldId:this.field.fieldId},bubbles:!0,composed:!0})),this.colorPickerOpened=!1},this.renderColorPickerFooter=()=>T`<vaadin-button @click="${()=>this.colorPickerOpened=!1}">Cancel</vaadin-button>
-        <vaadin-button theme="primary" @click="${this.saveColor}">Save</vaadin-button>`,this.checked=e=>{let t=e.target;this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t.checked,fieldId:this.field.fieldId},bubbles:!0,composed:!0}))},this.convert=e=>this.field?.dataType==`integer`?ol(e,!0):e,this.multiComboBoxValueChanged=e=>{if(this.rendered){let t=this.field?.fieldId,n=this.state&&t in this.state?this.state[t]:this.field?.initialValue,r;e.detail.value&&(r=e.detail.value.map(e=>e.value),r&&r.length>0&&(this.data[this.id]||(this.data[this.id]={}),this.data[this.id].content||(this.data[this.id].content=[]),this.data[this.id]&&this.data[this.id].content&&e.detail.value.forEach(e=>{this.data[this.id].content?.find(t=>e.value==t.value)||this.data[this.id].content.push(e)}))),this.compareArrays(r,n)||this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}},this.valueChanged=e=>{this.rendered&&e.detail.value!==void 0&&!sl(e.detail.value,this.state[this.field.fieldId])&&this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.convert(e.detail.value),fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.selectedItems=e=>{if(e&&e.length>0)if(this.field?.remoteCoordinates){if(this.comboData&&this.comboData.length>0)return this.comboData?.filter(t=>e.indexOf(t.value)>=0);if(this.data[this.id]&&this.data[this.id].content&&this.data[this.id].content.length>0)return this.data[this.id].content.filter(t=>e.indexOf(t.value)>=0)}else return this.field?.options?.filter(t=>e.indexOf(t.value)>=0);return[]},this.selectedIndex=e=>{if(e)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content){let t=this.data[this.id].content.find(t=>t.value==e);if(t)return this.data[this.id].content.indexOf(t)}}else{let t=this.field?.options?.find(t=>t.value==e);if(t)return this.field?.options?.indexOf(t)}},this.selectedIndexes=e=>{if(e&&e.length>0)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content)return this.data[this.id].content.filter(t=>e.indexOf(t.value)>=0).map(e=>this.data[this.id].content.indexOf(e))}else return this.field?.options?.filter(t=>e.indexOf(t.value)>=0).map(e=>this.field?.options?.indexOf(e));return[]},this.compareArrays=(e,t)=>this.falsy(e)&&this.falsy(t)||e&&t&&e.length===t.length&&e.every((e,n)=>e===t[n]),this.falsy=e=>!e||e.length==0,this.listItemsSelected=e=>{let t=this.field?.fieldId,n=this.state&&t in this.state?this.state[t]:this.field?.initialValue,r;this.rendered&&(e.detail.value&&(this.field?.remoteCoordinates?this.data[this.id]&&this.data[this.id].content&&(r=e.detail.value.map(e=>this.data[this.id].content[e].value)):r=e.detail.value.map(e=>this.field.options[e].value)),this.compareArrays(r,n)||this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r,fieldId:this.field?.fieldId},bubbles:!0,composed:!0})))},this.listItemSelected=e=>{let t;if(e.detail.value||e.detail.value==0)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content){let n=this.data[this.id].content[e.detail.value];n&&(t=n.value)}}else{let n=this.field.options[e.detail.value];n&&(t=n.value)}this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.mapPosition=e=>{switch(e){case`topStretch`:return`top-stretch`;case`topStart`:return`top-start`;case`topCenter`:return`top-center`;case`topEnd`:return`top-end`;case`middle`:return`middle`;case`bottomStart`:return`bottom-start`;case`bottomEnd`:return`bottom-end`;case`bottomStretch`:return`bottom-stretch`;case`bottomCenter`:return`bottom-center`}return`bottom-end`},this.helperShownInControl=!1,this.lastAnnouncedError=``,this.controlOwnsValidity=!1,this.fileUploaded=e=>{let t=this.field?.fieldId??``,n=this.state[t];n.push({id:e.detail.xhr.responseText,name:e.detail.file.name}),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:n,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.fileChanged=e=>{let t=this.field?.fieldId??``,n=(e.detail.value??[]).filter(e=>e.id).map(e=>e.id),r=(this.state[t]??[]).map(e=>e.id);if(!this.compareArrays(r,n)){let t=(e.detail.value??[]).filter(e=>e.id).map(e=>({id:e.id,name:e.name}));this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}},this.triggerImageUpload=()=>{(this.renderRoot?.querySelector(`input[type="file"]`))?.click()},this.imageUpload=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r.result,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},r.readAsDataURL(n),t.value=``},this.imageDelete=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:``,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.iconComboboxRenderer=e=>T`
+        <vaadin-button theme="primary" @click="${this.saveColor}">Save</vaadin-button>`,this.checked=e=>{let t=e.target;this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t.checked,fieldId:this.field.fieldId},bubbles:!0,composed:!0}))},this.convert=e=>this.field?.dataType==`integer`?sl(e,!0):e,this.multiComboBoxValueChanged=e=>{if(this.rendered){let t=this.field?.fieldId,n=this.state&&t in this.state?this.state[t]:this.field?.initialValue,r;e.detail.value&&(r=e.detail.value.map(e=>e.value),r&&r.length>0&&(this.data[this.id]||(this.data[this.id]={}),this.data[this.id].content||(this.data[this.id].content=[]),this.data[this.id]&&this.data[this.id].content&&e.detail.value.forEach(e=>{this.data[this.id].content?.find(t=>e.value==t.value)||this.data[this.id].content.push(e)}))),this.compareArrays(r,n)||this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}},this.valueChanged=e=>{this.rendered&&e.detail.value!==void 0&&!cl(e.detail.value,this.state[this.field.fieldId])&&this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:this.convert(e.detail.value),fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.selectedItems=e=>{if(e&&e.length>0)if(this.field?.remoteCoordinates){if(this.comboData&&this.comboData.length>0)return this.comboData?.filter(t=>e.indexOf(t.value)>=0);if(this.data[this.id]&&this.data[this.id].content&&this.data[this.id].content.length>0)return this.data[this.id].content.filter(t=>e.indexOf(t.value)>=0)}else return this.field?.options?.filter(t=>e.indexOf(t.value)>=0);return[]},this.selectedIndex=e=>{if(e)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content){let t=this.data[this.id].content.find(t=>t.value==e);if(t)return this.data[this.id].content.indexOf(t)}}else{let t=this.field?.options?.find(t=>t.value==e);if(t)return this.field?.options?.indexOf(t)}},this.selectedIndexes=e=>{if(e&&e.length>0)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content)return this.data[this.id].content.filter(t=>e.indexOf(t.value)>=0).map(e=>this.data[this.id].content.indexOf(e))}else return this.field?.options?.filter(t=>e.indexOf(t.value)>=0).map(e=>this.field?.options?.indexOf(e));return[]},this.compareArrays=(e,t)=>this.falsy(e)&&this.falsy(t)||e&&t&&e.length===t.length&&e.every((e,n)=>e===t[n]),this.falsy=e=>!e||e.length==0,this.listItemsSelected=e=>{let t=this.field?.fieldId,n=this.state&&t in this.state?this.state[t]:this.field?.initialValue,r;this.rendered&&(e.detail.value&&(this.field?.remoteCoordinates?this.data[this.id]&&this.data[this.id].content&&(r=e.detail.value.map(e=>this.data[this.id].content[e].value)):r=e.detail.value.map(e=>this.field.options[e].value)),this.compareArrays(r,n)||this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r,fieldId:this.field?.fieldId},bubbles:!0,composed:!0})))},this.listItemSelected=e=>{let t;if(e.detail.value||e.detail.value==0)if(this.field?.remoteCoordinates){if(this.data[this.id]&&this.data[this.id].content){let n=this.data[this.id].content[e.detail.value];n&&(t=n.value)}}else{let n=this.field.options[e.detail.value];n&&(t=n.value)}this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.mapPosition=e=>{switch(e){case`topStretch`:return`top-stretch`;case`topStart`:return`top-start`;case`topCenter`:return`top-center`;case`topEnd`:return`top-end`;case`middle`:return`middle`;case`bottomStart`:return`bottom-start`;case`bottomEnd`:return`bottom-end`;case`bottomStretch`:return`bottom-stretch`;case`bottomCenter`:return`bottom-center`}return`bottom-end`},this.helperShownInControl=!1,this.lastAnnouncedError=``,this.controlOwnsValidity=!1,this.fileUploaded=e=>{let t=this.field?.fieldId??``,n=this.state[t];n.push({id:e.detail.xhr.responseText,name:e.detail.file.name}),this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:n,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.fileChanged=e=>{let t=this.field?.fieldId??``,n=(e.detail.value??[]).filter(e=>e.id).map(e=>e.id),r=(this.state[t]??[]).map(e=>e.id);if(!this.compareArrays(r,n)){let t=(e.detail.value??[]).filter(e=>e.id).map(e=>({id:e.id,name:e.name}));this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:t,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))}},this.triggerImageUpload=()=>{(this.renderRoot?.querySelector(`input[type="file"]`))?.click()},this.imageUpload=e=>{let t=e.target,n=t.files?.[0];if(!n)return;let r=new FileReader;r.onload=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:r.result,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},r.readAsDataURL(n),t.value=``},this.imageDelete=()=>{this.dispatchEvent(new CustomEvent(`value-changed`,{detail:{value:``,fieldId:this.field?.fieldId},bubbles:!0,composed:!0}))},this.iconComboboxRenderer=e=>T`
   <div style="display: flex;">
       <vaadin-icon
               icon="${e}"
@@ -9127,13 +9135,13 @@ ${i}
 
             </vaadin-horizontal-layout>
                             `:e.label}
-`,this.filteredIcons=[],this.navLinkOffset=null,this.iconFilterChanged=e=>{this.filteredIcons=Jl.filter(t=>!e.detail.value||t.indexOf(e.detail.value)>=0)}}loadUi5FieldComponents(){this.ui5FieldComponentsReady||Xl().then(()=>{this.ui5FieldComponentsReady=!0})}remoteComboDataProvider(e){return(t,n)=>{let{filter:i,page:a,pageSize:o}=t,s=i??``;this._comboFilter=s,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{searchText:i,fieldId:this.field?.fieldId,size:o,page:a,sort:void 0},callback:e=>{if(s===this._comboFilter)if(e?.messages?.forEach(e=>{r.show(e.text,{position:e.position?this.mapPosition(e.position):void 0,theme:e.variant,duration:e.duration})}),!e.fragments||e.fragments.length==0)this.comboData=[],n([],0);else{let t=e.fragments[0].data?.[this.id];this.comboData=t?.content,n(t?.content,t?.totalElements)}},callbackonly:!0},bubbles:!0,composed:!0}))}}disconnectedCallback(){super.disconnectedCallback(),this.rendered=!1}renderNavLink(){let e=this.field?.link;if(!e?.href)return v;let t=M(e.href,this.state,this.data)??e.href,n=M(e.title,this.state,this.data)||t,r=e.icon||(t.startsWith(`http`)?`vaadin:external-link`:`vaadin:link`),i=this.navLinkOffset??`calc(var(--lumo-font-size-s) * 1.6 + (var(--lumo-size-m) - var(--lumo-icon-size-s)) / 2)`;return T`<a
+`,this.filteredIcons=[],this.navLinkOffset=null,this.iconFilterChanged=e=>{this.filteredIcons=Yl.filter(t=>!e.detail.value||t.indexOf(e.detail.value)>=0)}}loadUi5FieldComponents(){this.ui5FieldComponentsReady||Zl().then(()=>{this.ui5FieldComponentsReady=!0})}remoteComboDataProvider(e){return(t,n)=>{let{filter:i,page:a,pageSize:o}=t,s=i??``;this._comboFilter=s,this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{searchText:i,fieldId:this.field?.fieldId,size:o,page:a,sort:void 0},callback:e=>{if(s===this._comboFilter)if(e?.messages?.forEach(e=>{r.show(e.text,{position:e.position?this.mapPosition(e.position):void 0,theme:e.variant,duration:e.duration})}),!e.fragments||e.fragments.length==0)this.comboData=[],n([],0);else{let t=e.fragments[0].data?.[this.id];this.comboData=t?.content,n(t?.content,t?.totalElements)}},callbackonly:!0},bubbles:!0,composed:!0}))}}disconnectedCallback(){super.disconnectedCallback(),this.rendered=!1}renderNavLink(){let e=this.field?.link;if(!e?.href)return v;let t=M(e.href,this.state,this.data)??e.href,n=M(e.title,this.state,this.data)||t,r=e.icon||(t.startsWith(`http`)?`vaadin:external-link`:`vaadin:link`),i=this.navLinkOffset??`calc(var(--lumo-font-size-s) * 1.6 + (var(--lumo-size-m) - var(--lumo-icon-size-s)) / 2)`;return T`<a
                 data-navlink
                 href="${t}"
                 title="${n}"
                 target="${S(e.target||void 0)}"
                 style="display: flex; align-items: center; color: var(--lumo-secondary-text-color); align-self: flex-start; margin-top: ${i};"
-        ><vaadin-icon icon="${r}" style="width: var(--lumo-icon-size-s); height: var(--lumo-icon-size-s);"></vaadin-icon></a>`}positionNavLink(){let e=this.renderRoot?.querySelector(`a[data-navlink]`);e&&setTimeout(()=>{let t=e.parentElement,n=t?.firstElementChild?.firstElementChild;if(!t||!n)return;let r=(n.shadowRoot?.querySelector(`[part="input-field"]`)??n).getBoundingClientRect();if(r.height===0)return;let i=Math.max(0,r.top+r.height/2-e.offsetHeight/2-t.getBoundingClientRect().top),a=`${Math.round(i)}px`;this.navLinkOffset!==a&&(this.navLinkOffset=a)})}helperText(){return this.helperShownInControl=!0,P(this.field?.description??``,this.state,this.data)??``}fieldErrors(){let e=this.field?.fieldId??``,t=this.data?.errors?.[e];return Array.isArray(t)?t.filter(e=>!!e):[]}validatableControl(){let e=this.renderRoot.querySelectorAll(`*`);for(let t of e)if(`invalid`in t&&`errorMessage`in t)return t;return null}applyValidationState(){let e=this.fieldErrors(),t=this.validatableControl();if(!t){this.lastAnnouncedError=e.join(`. `);return}let n=e.join(`. `);if(t.errorMessage=n,t.invalid=e.length>0,n&&n!==this.lastAnnouncedError){let e=(this.field?.label??``).toString().trim();gt(e?`${e}: ${n}`:n,{politeness:`assertive`})}this.lastAnnouncedError=n}render(){this.rendered=!0;let e=this.renderNavLink();this.helperShownInControl=!1;let t=this.renderField(),n=this.field?.description&&!this.helperShownInControl?P(this.field.description,this.state,this.data):void 0,r=this.fieldErrors(),i=r.length>0&&!this.controlOwnsValidity;return T`<div style="display: block;">
+        ><vaadin-icon icon="${r}" style="width: var(--lumo-icon-size-s); height: var(--lumo-icon-size-s);"></vaadin-icon></a>`}positionNavLink(){let e=this.renderRoot?.querySelector(`a[data-navlink]`);e&&setTimeout(()=>{let t=e.parentElement,n=t?.firstElementChild?.firstElementChild;if(!t||!n)return;let r=(n.shadowRoot?.querySelector(`[part="input-field"]`)??n).getBoundingClientRect();if(r.height===0)return;let i=Math.max(0,r.top+r.height/2-e.offsetHeight/2-t.getBoundingClientRect().top),a=`${Math.round(i)}px`;this.navLinkOffset!==a&&(this.navLinkOffset=a)})}helperText(){return this.helperShownInControl=!0,Ot(this.field?.description??``,this.state,this.data)??``}fieldErrors(){let e=this.field?.fieldId??``,t=this.data?.errors?.[e];return Array.isArray(t)?t.filter(e=>!!e):[]}validatableControl(){let e=this.renderRoot.querySelectorAll(`*`);for(let t of e)if(`invalid`in t&&`errorMessage`in t)return t;return null}applyValidationState(){let e=this.fieldErrors(),t=this.validatableControl();if(!t){this.lastAnnouncedError=e.join(`. `);return}let n=e.join(`. `);if(t.errorMessage=n,t.invalid=e.length>0,n&&n!==this.lastAnnouncedError){let e=(this.field?.label??``).toString().trim();gt(e?`${e}: ${n}`:n,{politeness:`assertive`})}this.lastAnnouncedError=n}render(){this.rendered=!0;let e=this.renderNavLink();this.helperShownInControl=!1;let t=this.renderField(),n=this.field?.description&&!this.helperShownInControl?Ot(this.field.description,this.state,this.data):void 0,r=this.fieldErrors(),i=r.length>0&&!this.controlOwnsValidity;return T`<div style="display: block;">
             <div style="${e===v?``:`display: flex; gap: var(--lumo-space-xs);`}"><div style="flex: 1; min-width: 0;">${t}</div>${e}</div>
             ${n?T`
                 <div style="font-size: var(--lumo-font-size-xs); color: var(--lumo-secondary-text-color); margin-top: var(--lumo-space-xs);">${n}</div>
@@ -9141,29 +9149,29 @@ ${i}
             ${i?T`
                 <div role="alert"><ul>${r.map(e=>T`<li>${e}</li>`)}</ul></div>
             `:v}
-        </div>`}async firstUpdated(){this.filteredIcons=Jl}update(e){e.has(`component`)&&(this.rendered=!1),super.update(e)}updated(e){super.updated(e),this.positionNavLink(),this.applyValidationState(),this.controlOwnsValidity=!!this.validatableControl()}renderField(){let e=this.field?.fieldId??``,t=this.state&&e in this.state?this.state[e]:this.field?.initialValue,n=M(this.field?.label+``,this.state,this.data),r=this.labelAlreadyRendered||!n||n==`null`?v:n;return this.field?.propertyRow?this.renderPropertyRowField(e,t,r,n):this.field?.stereotype==`badge`?this.renderBadgeField(e,t,r,n):this.field?.stereotype==`plainText`?this.renderPlainTextField(e,t,r,n):this.field?.stereotype==`bulletedList`?this.renderBulletedListField(e,t,r,n):this.field?.readOnly&&this.field.stereotype!=`grid`&&this.field.dataType!=`status`&&this.field?.dataType!=`money`?this.renderReadOnlyField(e,t,r,n):this.field?.dataType==`file`?this.renderFileField(e,t,r,n):this.field?.dataType==`string`?this.renderStringField(e,t,r,n):this.field?.dataType==`number`?this.renderNumberField(e,t,r,n):this.field?.dataType==`integer`?this.renderIntegerField(e,t,r,n):this.field?.dataType==`bool`?this.renderBoolField(e,t,r,n):this.field?.dataType==`dateRange`?this.renderDateRangeField(e,t,r,n):this.field?.dataType==`date`?this.renderDateField(e,t,r,n):this.field?.dataType==`dateTime`?this.renderDateTimeField(e,t,r,n):this.field?.dataType==`time`?this.renderTimeField(e,t,r,n):this.field?.dataType==`array`?this.renderArrayField(e,t,r,n):this.field?.dataType==`money`?this.renderMoneyField(e,t,r,n):this.field?.dataType==`status`?this.renderStatusField(e,t,r,n):this.field?.dataType==`range`?this.renderRangeField(e,t,r,n):T`<p>Unknown field type ${this.field?.dataType} / ${this.field?.stereotype}</p>`}renderBadgeField(e,t,n,r){if(!this.field)return T``;let i=t===!0||t===`true`;return T`<vaadin-custom-field
+        </div>`}async firstUpdated(){this.filteredIcons=Yl}update(e){e.has(`component`)&&(this.rendered=!1),super.update(e)}updated(e){super.updated(e),this.positionNavLink(),this.applyValidationState(),this.controlOwnsValidity=!!this.validatableControl()}renderField(){let e=this.field?.fieldId??``,t=this.state&&e in this.state?this.state[e]:this.field?.initialValue,n=M(this.field?.label+``,this.state,this.data),r=this.labelAlreadyRendered||!n||n==`null`?v:n;return this.field?.propertyRow?this.renderPropertyRowField(e,t,r,n):this.field?.stereotype==`badge`?this.renderBadgeField(e,t,r,n):this.field?.stereotype==`plainText`?this.renderPlainTextField(e,t,r,n):this.field?.stereotype==`bulletedList`?this.renderBulletedListField(e,t,r,n):this.field?.readOnly&&this.field.stereotype!=`grid`&&this.field.dataType!=`status`&&this.field?.dataType!=`money`?this.renderReadOnlyField(e,t,r,n):this.field?.dataType==`file`?this.renderFileField(e,t,r,n):this.field?.dataType==`string`?this.renderStringField(e,t,r,n):this.field?.dataType==`number`?this.renderNumberField(e,t,r,n):this.field?.dataType==`integer`?this.renderIntegerField(e,t,r,n):this.field?.dataType==`bool`?this.renderBoolField(e,t,r,n):this.field?.dataType==`dateRange`?this.renderDateRangeField(e,t,r,n):this.field?.dataType==`date`?this.renderDateField(e,t,r,n):this.field?.dataType==`dateTime`?this.renderDateTimeField(e,t,r,n):this.field?.dataType==`time`?this.renderTimeField(e,t,r,n):this.field?.dataType==`array`?this.renderArrayField(e,t,r,n):this.field?.dataType==`money`?this.renderMoneyField(e,t,r,n):this.field?.dataType==`status`?this.renderStatusField(e,t,r,n):this.field?.dataType==`range`?this.renderRangeField(e,t,r,n):T`<p>Unknown field type ${this.field?.dataType} / ${this.field?.stereotype}</p>`}renderBadgeField(e,t,n,r){if(!this.field)return T``;let i=t===!0||t===`true`;return T`<vaadin-custom-field
                     id="${this.field.fieldId}"
                     .helperText="${this.helperText()}"
                     data-colspan="${this.field?.colspan}"
                     style="${this.field?.style}"
             ><span theme="badge ${i?`success`:``} pill" style="${i?``:`opacity: 0.4;`}">${r}</span>
-            </vaadin-custom-field>`}renderPropertyRowField(e,t,n,r){if(!this.field)return T``;let i=P(t,this.state,this.data),a=i&&typeof i==`object`&&`value`in i?i:null;i&&i.value&&(i=i.value);let o=this.field?.dataType==`bool`||i===!0||i===!1,s=this.field?.dataType==`money`,c=i!=null&&i!==``,l=c?String(i):`—`;if(s&&c){let e=typeof i==`number`?i:parseFloat(String(i));isNaN(e)||(l=a&&a.locale&&a.currency?new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(e):new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e))}let u=o?T`<vaadin-icon icon="${i===!0||i===`true`?`vaadin:check`:`vaadin:minus`}" style="height: 16px; width: 16px;"></vaadin-icon>`:T`<span style="font-weight: 500; text-align: right; word-break: break-word; margin-left: auto;${s?` font-variant-numeric: tabular-nums;`:``}">${l}</span>`,d=r&&r!=`null`;return T`<div
+            </vaadin-custom-field>`}renderPropertyRowField(e,t,n,r){if(!this.field)return T``;let i=Ot(t,this.state,this.data),a=i&&typeof i==`object`&&`value`in i?i:null;i&&i.value&&(i=i.value);let o=this.field?.dataType==`bool`||i===!0||i===!1,s=this.field?.dataType==`money`,c=i!=null&&i!==``,l=c?String(i):`—`;if(s&&c){let e=typeof i==`number`?i:parseFloat(String(i));isNaN(e)||(l=a&&a.locale&&a.currency?new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(e):new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e))}let u=o?T`<vaadin-icon icon="${i===!0||i===`true`?`vaadin:check`:`vaadin:minus`}" style="height: 16px; width: 16px;"></vaadin-icon>`:T`<span style="font-weight: 500; text-align: right; word-break: break-word; margin-left: auto;${s?` font-variant-numeric: tabular-nums;`:``}">${l}</span>`,d=r&&r!=`null`;return T`<div
                     id="${this.field.fieldId}"
                     data-colspan="${this.field?.colspan}"
                     style="display: flex; justify-content: space-between; align-items: baseline; gap: 1rem; width: 100%; padding: 0.4rem 0; border-bottom: 1px solid var(--lumo-contrast-10pct, rgba(0,0,0,.08)); font-size: var(--lumo-font-size-s, .875rem); ${this.field?.style}"
-            >${d?T`<span style="color: var(--lumo-secondary-text-color, #888); white-space: nowrap;">${r}</span>`:v}${u}</div>`}renderBulletedListField(e,t,n,r){if(!this.field)return T``;let i=P(t,this.state,this.data),a=Array.isArray(i)?i.map(e=>String(e)):i!=null&&i!==``?[String(i)]:[];return T`<vaadin-custom-field
+            >${d?T`<span style="color: var(--lumo-secondary-text-color, #888); white-space: nowrap;">${r}</span>`:v}${u}</div>`}renderBulletedListField(e,t,n,r){if(!this.field)return T``;let i=Ot(t,this.state,this.data),a=Array.isArray(i)?i.map(e=>String(e)):i!=null&&i!==``?[String(i)]:[];return T`<vaadin-custom-field
                     id="${this.field.fieldId}"
                     label="${n}"
                     .helperText="${this.helperText()}"
                     data-colspan="${this.field?.colspan}"
                     style="${this.field?.style}"
             ><mateu-bulleted-list .items="${a}"></mateu-bulleted-list>
-            </vaadin-custom-field>`}renderPlainTextField(e,t,n,r){if(!this.field)return T``;let i=P(t,this.state,this.data),a=i&&typeof i==`object`&&`value`in i?i:null;i&&i.value&&(i=i.value);let o=this.field?.dataType==`bool`||i===!0||i===!1,s=this.field?.dataType==`money`,c=i!=null&&i!==``,l=c?String(i):`—`;if(s&&c){let e=typeof i==`number`?i:parseFloat(String(i));isNaN(e)||(l=a&&a.locale&&a.currency?new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(e):new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e))}let u=o?T`<vaadin-icon icon="${i===!0||i===`true`?`vaadin:check`:`vaadin:minus`}" style="height: 16px; width: 16px;"></vaadin-icon>`:this.field?.multiline?T`<span style="font-weight: 500; white-space: pre-wrap; word-break: break-word;">${l}</span>`:T`<span style="font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;${s?` font-variant-numeric: tabular-nums;`:``}">${l}</span>`;return T`<vaadin-custom-field
+            </vaadin-custom-field>`}renderPlainTextField(e,t,n,r){if(!this.field)return T``;let i=Ot(t,this.state,this.data),a=i&&typeof i==`object`&&`value`in i?i:null;i&&i.value&&(i=i.value);let o=this.field?.dataType==`bool`||i===!0||i===!1,s=this.field?.dataType==`money`,c=i!=null&&i!==``,l=c?String(i):`—`;if(s&&c){let e=typeof i==`number`?i:parseFloat(String(i));isNaN(e)||(l=a&&a.locale&&a.currency?new Intl.NumberFormat(a.locale,{style:`currency`,currency:a.currency}).format(e):new Intl.NumberFormat(`de-DE`,{minimumFractionDigits:2,maximumFractionDigits:2}).format(e))}let u=o?T`<vaadin-icon icon="${i===!0||i===`true`?`vaadin:check`:`vaadin:minus`}" style="height: 16px; width: 16px;"></vaadin-icon>`:this.field?.multiline?T`<span style="font-weight: 500; white-space: pre-wrap; word-break: break-word;">${l}</span>`:T`<span style="font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;${s?` font-variant-numeric: tabular-nums;`:``}">${l}</span>`;return T`<vaadin-custom-field
                     id="${this.field.fieldId}"
                     label="${n}"
                     data-colspan="${this.field?.colspan}"
                     style="${s?`text-align: right; `:``}${this.field?.style}"
-            >${u}</vaadin-custom-field>`}renderReadOnlyField(e,t,n,r){if(!this.field)return T``;let i=P(t,this.state,this.data)||this.data[e];if(i&&i.value&&(i=i.value),this.field.stereotype==`fileUpload`)return T`<vaadin-custom-field
+            >${u}</vaadin-custom-field>`}renderReadOnlyField(e,t,n,r){if(!this.field)return T``;let i=Ot(t,this.state,this.data)||this.data[e];if(i&&i.value&&(i=i.value),this.field.stereotype==`fileUpload`)return T`<vaadin-custom-field
                         id="${this.field.fieldId}"
                         label="${n}"
                         .helperText="${this.helperText()}"
@@ -9226,7 +9234,7 @@ ${i}
                             <vaadin-button theme="icon" @click="${e=>{this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`codesearch-`+this.field?.fieldId,parameters:{}},bubbles:!0,composed:!0}))}}"><vaadin-icon icon="lumo:search"></vaadin-icon></vaadin-button>
                         </vaadin-horizontal-layout>
                     </vaadin-custom-field>
-                `;if(this.field?.stereotype==`select`){if(this.field?.optionsSource){let e=this.field.optionsSource,r=M(e.url,this.state,this.data)??e.url;this.data[this.id]?.sourceSignature!==r&&(this.data[this.id]={content:this.data[this.id]?.content??[],sourceSignature:r},e.proxy?this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`__restfetch__`,parameters:{_sourceKind:`options`,_sourceId:this.field.fieldId},callback:t=>{let n=t?.appData?._restfetch,i=un(n,e.itemsPath,e.valuePath,e.labelPath);this.data[this.id]={content:i,totalElements:i.length,sourceSignature:r},this.requestUpdate()},callbackonly:!0},bubbles:!0,composed:!0})):pn(e,e=>M(e,this.state,this.data)).then(e=>{this.data[this.id]={content:e,totalElements:e.length,sourceSignature:r},this.requestUpdate()}).catch(e=>console.warn(`mateu: external options fetch failed`,e)));let i=t;return t&&t.value&&(i=t.value),T`
+                `;if(this.field?.stereotype==`select`){if(this.field?.optionsSource){let e=this.field.optionsSource,r=M(e.url,this.state,this.data)??e.url;this.data[this.id]?.sourceSignature!==r&&(this.data[this.id]={content:this.data[this.id]?.content??[],sourceSignature:r},e.proxy?this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:`__restfetch__`,parameters:{_sourceKind:`options`,_sourceId:this.field.fieldId},callback:t=>{let n=t?.appData?._restfetch,i=dn(n,e.itemsPath,e.valuePath,e.labelPath);this.data[this.id]={content:i,totalElements:i.length,sourceSignature:r},this.requestUpdate()},callbackonly:!0},bubbles:!0,composed:!0})):mn(e,e=>M(e,this.state,this.data)).then(e=>{this.data[this.id]={content:e,totalElements:e.length,sourceSignature:r},this.requestUpdate()}).catch(e=>console.warn(`mateu: external options fetch failed`,e)));let i=t;return t&&t.value&&(i=t.value),T`
                     <vaadin-select
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9629,7 +9637,7 @@ ${i}
                     >
                         <mateu-camera-capture .fieldId="${this.field.fieldId}" .value="${t}"></mateu-camera-capture>
                     </vaadin-custom-field>
-                `;if(this.field?.stereotype==`fileUpload`){let e=rl(this.field.attributes,`accept`);return T`
+                `;if(this.field?.stereotype==`fileUpload`){let e=il(this.field.attributes,`accept`);return T`
                     <vaadin-custom-field
                             id="${this.field.fieldId}"
                             label="${n}"
@@ -9981,7 +9989,7 @@ ${i}
                         .helperText="${this.helperText()}"
                         data-colspan="${this.field.colspan}"
                 >
-                    ${i?T`<span theme="badge pill ${Aa(i.type)}">${i.message}</span>`:T``}                    
+                    ${i?T`<span theme="badge pill ${ja(i.type)}">${i.message}</span>`:T``}                    
                 </vaadin-custom-field>
             `}renderRangeField(e,t,n,r){if(!this.field)return T``;this.loadUi5FieldComponents();let i=t;return T`
                 <vaadin-custom-field
@@ -10079,7 +10087,7 @@ ${i}
             text-overflow: clip;
             height: auto;
         }
-  `}};k([C()],Q.prototype,`ui5FieldComponentsReady`,void 0),k([y()],Q.prototype,`component`,void 0),k([y()],Q.prototype,`field`,void 0),k([y()],Q.prototype,`baseUrl`,void 0),k([y()],Q.prototype,`state`,void 0),k([y()],Q.prototype,`data`,void 0),k([y()],Q.prototype,`appState`,void 0),k([y()],Q.prototype,`appData`,void 0),k([y()],Q.prototype,`labelAlreadyRendered`,void 0),k([C()],Q.prototype,`colorPickerOpened`,void 0),k([C()],Q.prototype,`colorPickerValue`,void 0),k([C()],Q.prototype,`controlOwnsValidity`,void 0),k([C()],Q.prototype,`filteredIcons`,void 0),k([C()],Q.prototype,`navLinkOffset`,void 0),Q=k([g(`mateu-field`)],Q);var Zl=(e,t,n,r,i,a,o,s)=>{let c=t.metadata;return T`
+  `}};k([C()],Z.prototype,`ui5FieldComponentsReady`,void 0),k([y()],Z.prototype,`component`,void 0),k([y()],Z.prototype,`field`,void 0),k([y()],Z.prototype,`baseUrl`,void 0),k([y()],Z.prototype,`state`,void 0),k([y()],Z.prototype,`data`,void 0),k([y()],Z.prototype,`appState`,void 0),k([y()],Z.prototype,`appData`,void 0),k([y()],Z.prototype,`labelAlreadyRendered`,void 0),k([C()],Z.prototype,`colorPickerOpened`,void 0),k([C()],Z.prototype,`colorPickerValue`,void 0),k([C()],Z.prototype,`controlOwnsValidity`,void 0),k([C()],Z.prototype,`filteredIcons`,void 0),k([C()],Z.prototype,`navLinkOffset`,void 0),Z=k([g(`mateu-field`)],Z);var Ql=(e,t,n,r,i,a,o,s)=>{let c=t.metadata;return T`
         <mateu-field
                 id="${t.id}"
                 .component="${t}"
@@ -10088,15 +10096,15 @@ ${i}
                 .data="${i}"
                 .appState="${a}"
                 .appdata="${o}"
-                style="${wa(t,i)}" class="${t.cssClasses}"
+                style="${Ta(t,i)}" class="${t.cssClasses}"
                 slot="${t.slot??v}"
                 data-colspan="${c.colspan}"
                 colspan="${(c.colspan??1)>1?c.colspan:v}"
                 .labelAlreadyRendered="${s}"
         >
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o,s))}
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o,s))}
         </mateu-field>
-    `},Ql=(e,n,r,i,a,o,s)=>{let c=n.metadata;if(c.tree)return T`
+    `},$l=(e,n,r,i,a,o,s)=>{let c=n.metadata;if(c.tree)return T`
         <vaadin-grid style="${n.style}" class="${n.cssClasses}"
                      .itemHasChildrenPath="${`children`}" .dataProvider="${async(e,t)=>{let n=e.parentItem?e.parentItem.children:c.page.content;t(n,n.length)}}"
                      slot="${n.slot??v}"
@@ -10109,7 +10117,7 @@ ${i}
                                 flex-grow="${l?.flexGrow??v}"
                                 width="${l?.width??v}"
                                 .column="${n.metadata}"
-                                ${t((t,n,c)=>Vl(t,n,c,l,e,r,i,a,o,s),[])}></vaadin-grid-column>
+                                ${t((t,n,c)=>Hl(t,n,c,l,e,r,i,a,o,s),[])}></vaadin-grid-column>
 `:T`
             <vaadin-grid-tree-column path="${n.id}"
                                 header="${l?.label??v}"
@@ -10118,7 +10126,7 @@ ${i}
                                 width="${l?.width??v}"
             ></vaadin-grid-tree-column>
 `})}
-            <span slot="empty-state">${zt()}</span>
+            <span slot="empty-state">${Bt()}</span>
         </vaadin-grid>
     `;let l=c.page?.content;return n.id&&i&&i[n.id]&&(l=i[n.id]),l||=[],T`
         <vaadin-grid 
@@ -10127,9 +10135,9 @@ ${i}
                 .items="${l}"
                 all-rows-visible
         >
-            ${c?.content?.map(t=>zl(t,e,r,i,a,o,s))}
+            ${c?.content?.map(t=>Bl(t,e,r,i,a,o,s))}
         </vaadin-grid>
-    `},$=class extends b{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.detailsOpenedItems=[],this.pagesRequested=[],this._lastGridHeight=0,this.emptyArray=e=>!e||e.length==0,this.dataProvider=(e,t)=>{let n=this.data[this.id]?.page;if(this.metadata?.infiniteScrolling&&e.page>0){let r=!1;n&&n.content&&(n.content.length>=(e.page+1)*e.pageSize||n.content.length==n.totalElements)&&(t(n.content.slice(e.page*e.pageSize,(e.page+1)*e.pageSize),n.totalElements),r=!0,this.grid&&this.grid.recalculateColumnWidths()),r||this.pagesRequested.find(t=>t==e.page)||(this.pagesRequested.push(e.page),this.dispatchEvent(new CustomEvent(`fetch-more-elements`,{detail:{params:e,callback:()=>{this.data[this.id]?.page?.content&&(t(this.data[this.id].page.content.slice(e.page*e.pageSize,(e.page+1)*e.pageSize),this.data[this.id].page.totalElements),this.grid&&this.grid.recalculateColumnWidths())}},bubbles:!0,composed:!0})))}else{let e=this.metadata?.infiniteScrolling?n?.totalElements:n?.content?.length??0;t(n?.content??[],e),this.grid&&this.grid.recalculateColumnWidths()}},this._onActionRequested=e=>{let t=e.detail,n=this.identifierFieldName;if(!n||!t.parameters||t.actionId?.startsWith(`action-on-row-`))return;let r=t.parameters[n];r!==void 0&&(this.state._selectedId=String(r),this._applyCellPartNameGenerator(),this.grid?.requestContentUpdate())},this.tooltipGenerator=e=>{let t=``,{column:n,item:r}=e,i=this.metadata?.columns?.find(e=>e.metadata.id==n?.path);if(i?.metadata){let e=(i?.metadata).tooltipPath;e&&n&&r&&(t=r[e])}return t}}get identifierFieldName(){let e=this.metadata?.columns?.find(e=>e.metadata?.identifier);if(e)return e.metadata?.id;if(this.metadata?.columns?.find(e=>e.metadata?.id===`id`))return`id`}_applyCellPartNameGenerator(){if(!this.grid)return;let e=this.identifierFieldName,t=this.state?._selectedId??this.appState?._splitDetailId,n=!!this.metadata?.groupBy;e&&t!==void 0||n?this.grid.cellPartNameGenerator=(n,r)=>{let i=r.item;return cl(i)?`mateu-group-row`:e&&t!==void 0&&String(i[e])===String(t)?`selected-row`:``}:this.grid.cellPartNameGenerator=null}connectedCallback(){super.connectedCallback(),this.addEventListener(`action-requested`,this._onActionRequested)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`action-requested`,this._onActionRequested),this._resizeObserver?.disconnect(),this._resizeObserver=void 0}firstUpdated(){let e=this.grid;!e||this._resizeObserver||(this._resizeObserver=new ResizeObserver(()=>{let t=e.offsetHeight;t>0&&this._lastGridHeight===0&&requestAnimationFrame(()=>{e.recalculateColumnWidths(),e.requestContentUpdate(),e.notifyResize?.()}),this._lastGridHeight=t}),this._resizeObserver.observe(e))}updated(e){super.updated(e),this._applyCellPartNameGenerator(),this.grid?.clearCache(),this.grid?.requestContentUpdate(),this.grid?.recalculateColumnWidths(),this.pagesRequested=[]}render(){let e=this.data[this.id],r=e?.page,i=this.metadata?.groupBy,a=this.metadata?.infiniteScrolling?void 0:r?.content?ul(r.content,i,e?.groups):r?.content,o=ml((this.metadata?.columns??[]).flatMap(e=>e.metadata?.type===j.GridGroupColumn?(e.metadata.columns??[]).map(e=>e.metadata):[e.metadata]),e,i),s=``;return this.metadata?.wrapCellContent&&(s+=` wrap-cell-content`),this.metadata?.compact&&(s+=` compact`),this.metadata?.noBorder&&(s+=` no-border`),this.metadata?.noRowBorder&&(s+=` no-row-borders`),this.metadata?.columnBorders&&(s+=` column-borders`),this.metadata?.rowStripes&&(s+=` row-stripes`),T`
+    `},Q=class extends b{constructor(...e){super(...e),this.id=``,this.baseUrl=``,this.state={},this.data={},this.appState={},this.appData={},this.detailsOpenedItems=[],this.pagesRequested=[],this._lastGridHeight=0,this.emptyArray=e=>!e||e.length==0,this.dataProvider=(e,t)=>{let n=this.data[this.id]?.page;if(this.metadata?.infiniteScrolling&&e.page>0){let r=!1;n&&n.content&&(n.content.length>=(e.page+1)*e.pageSize||n.content.length==n.totalElements)&&(t(n.content.slice(e.page*e.pageSize,(e.page+1)*e.pageSize),n.totalElements),r=!0,this.grid&&this.grid.recalculateColumnWidths()),r||this.pagesRequested.find(t=>t==e.page)||(this.pagesRequested.push(e.page),this.dispatchEvent(new CustomEvent(`fetch-more-elements`,{detail:{params:e,callback:()=>{this.data[this.id]?.page?.content&&(t(this.data[this.id].page.content.slice(e.page*e.pageSize,(e.page+1)*e.pageSize),this.data[this.id].page.totalElements),this.grid&&this.grid.recalculateColumnWidths())}},bubbles:!0,composed:!0})))}else{let e=this.metadata?.infiniteScrolling?n?.totalElements:n?.content?.length??0;t(n?.content??[],e),this.grid&&this.grid.recalculateColumnWidths()}},this._onActionRequested=e=>{let t=e.detail,n=this.identifierFieldName;if(!n||!t.parameters||t.actionId?.startsWith(`action-on-row-`))return;let r=t.parameters[n];r!==void 0&&(this.state._selectedId=String(r),this._applyCellPartNameGenerator(),this.grid?.requestContentUpdate())},this.tooltipGenerator=e=>{let t=``,{column:n,item:r}=e,i=this.metadata?.columns?.find(e=>e.metadata.id==n?.path);if(i?.metadata){let e=(i?.metadata).tooltipPath;e&&n&&r&&(t=r[e])}return t}}get identifierFieldName(){let e=this.metadata?.columns?.find(e=>e.metadata?.identifier);if(e)return e.metadata?.id;if(this.metadata?.columns?.find(e=>e.metadata?.id===`id`))return`id`}_applyCellPartNameGenerator(){if(!this.grid)return;let e=this.identifierFieldName,t=this.state?._selectedId??this.appState?._splitDetailId,n=!!this.metadata?.groupBy;e&&t!==void 0||n?this.grid.cellPartNameGenerator=(n,r)=>{let i=r.item;return ll(i)?`mateu-group-row`:e&&t!==void 0&&String(i[e])===String(t)?`selected-row`:``}:this.grid.cellPartNameGenerator=null}connectedCallback(){super.connectedCallback(),this.addEventListener(`action-requested`,this._onActionRequested)}disconnectedCallback(){super.disconnectedCallback(),this.removeEventListener(`action-requested`,this._onActionRequested),this._resizeObserver?.disconnect(),this._resizeObserver=void 0}firstUpdated(){let e=this.grid;!e||this._resizeObserver||(this._resizeObserver=new ResizeObserver(()=>{let t=e.offsetHeight;t>0&&this._lastGridHeight===0&&requestAnimationFrame(()=>{e.recalculateColumnWidths(),e.requestContentUpdate(),e.notifyResize?.()}),this._lastGridHeight=t}),this._resizeObserver.observe(e))}updated(e){super.updated(e),this._applyCellPartNameGenerator(),this.grid?.clearCache(),this.grid?.requestContentUpdate(),this.grid?.recalculateColumnWidths(),this.pagesRequested=[]}render(){let e=this.data[this.id],r=e?.page,i=this.metadata?.groupBy,a=this.metadata?.infiniteScrolling?void 0:r?.content?dl(r.content,i,e?.groups):r?.content,o=hl((this.metadata?.columns??[]).flatMap(e=>e.metadata?.type===j.GridGroupColumn?(e.metadata.columns??[]).map(e=>e.metadata):[e.metadata]),e,i),s=``;return this.metadata?.wrapCellContent&&(s+=` wrap-cell-content`),this.metadata?.compact&&(s+=` compact`),this.metadata?.noBorder&&(s+=` no-border`),this.metadata?.noRowBorder&&(s+=` no-row-borders`),this.metadata?.columnBorders&&(s+=` column-borders`),this.metadata?.rowStripes&&(s+=` row-stripes`),T`
             <vaadin-grid
                     .items="${a}"
                     item-id-path="_rowNumber"
@@ -10141,17 +10149,17 @@ ${i}
                     .dataProvider="${this.metadata?.infiniteScrolling?this.dataProvider:void 0}"
                     page-size="${this.metadata?.pageSize}"
                     multi-sort-on-shift-click
-                    @selected-items-changed="${e=>{let t=(e.detail.value??[]).filter(e=>!cl(e));this.emptyArray(this.state[this.id+`_selected_items`])&&this.emptyArray(t)||(this.state[this.id+`_selected_items`]=t,this.metadata?.onRowSelectionChangedActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.metadata?.onRowSelectionChangedActionId},bubbles:!0,composed:!0})))}}"
-                    @active-item-changed="${S(this.metadata?.detailPath&&!this.metadata?.useButtonForDetail?e=>{if(this.metadata?.detailPath){let t=e.detail.value;if(t&&cl(t))return;t?this.detailsOpenedItems=[t]:this.detailsOpenedItems=[]}}:void 0)}"
+                    @selected-items-changed="${e=>{let t=(e.detail.value??[]).filter(e=>!ll(e));this.emptyArray(this.state[this.id+`_selected_items`])&&this.emptyArray(t)||(this.state[this.id+`_selected_items`]=t,this.metadata?.onRowSelectionChangedActionId&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:this.metadata?.onRowSelectionChangedActionId},bubbles:!0,composed:!0})))}}"
+                    @active-item-changed="${S(this.metadata?.detailPath&&!this.metadata?.useButtonForDetail?e=>{if(this.metadata?.detailPath){let t=e.detail.value;if(t&&ll(t))return;t?this.detailsOpenedItems=[t]:this.detailsOpenedItems=[]}}:void 0)}"
                     .detailsOpenedItems="${this.detailsOpenedItems}"
-                    ${S(this.metadata?.detailPath?n(e=>T`${I(this,e[this.metadata?.detailPath],this.baseUrl,this.state,this.data,this.appState,this.appData)}`):void 0)}
+                    ${S(this.metadata?.detailPath?n(e=>T`${F(this,e[this.metadata?.detailPath],this.baseUrl,this.state,this.data,this.appState,this.appData)}`):void 0)}
                     theme="${s}"
                     style="${this.metadata?.gridStyle}"
             >
                 ${this.metadata?.rowsSelectionEnabled?T`
                     <vaadin-grid-selection-column></vaadin-grid-selection-column>
                 `:v}
-                ${this.metadata?.columns?.map(e=>zl(e,this,this.baseUrl,this.state,this.data,this.appState,this.appData,o))}
+                ${this.metadata?.columns?.map(e=>Bl(e,this,this.baseUrl,this.state,this.data,this.appState,this.appData,o))}
                 ${this.metadata?.useButtonForDetail?T`
                     <vaadin-grid-column
                             width="44px"
@@ -10171,7 +10179,7 @@ ${i}
             `,[])}
                     ></vaadin-grid-column>
                 `:v}
-                <span slot="empty-state">${zt(this.emptyStateMessage??this.metadata?.emptyStateMessage)}</span>
+                <span slot="empty-state">${Bt(this.emptyStateMessage??this.metadata?.emptyStateMessage)}</span>
                 ${this.metadata?.columns?.find(e=>e.metadata.tooltipPath)?T`<vaadin-tooltip slot="tooltip" .generator="${this.tooltipGenerator}"></vaadin-tooltip>`:v}
             </vaadin-grid>
             <slot></slot>
@@ -10190,7 +10198,7 @@ ${i}
             background-color: var(--lumo-contrast-5pct, rgba(0, 0, 0, 0.04));
             font-weight: 600;
         }
-  `}};k([y()],$.prototype,`id`,void 0),k([y()],$.prototype,`metadata`,void 0),k([y()],$.prototype,`baseUrl`,void 0),k([y()],$.prototype,`state`,void 0),k([y()],$.prototype,`data`,void 0),k([y()],$.prototype,`appState`,void 0),k([y()],$.prototype,`appData`,void 0),k([y()],$.prototype,`emptyStateMessage`,void 0),k([C()],$.prototype,`detailsOpenedItems`,void 0),k([x(`vaadin-grid`)],$.prototype,`grid`,void 0),$=k([g(`mateu-table`)],$);var $l=(e,t,n,r,i,a,o)=>T`
+  `}};k([y()],Q.prototype,`id`,void 0),k([y()],Q.prototype,`metadata`,void 0),k([y()],Q.prototype,`baseUrl`,void 0),k([y()],Q.prototype,`state`,void 0),k([y()],Q.prototype,`data`,void 0),k([y()],Q.prototype,`appState`,void 0),k([y()],Q.prototype,`appData`,void 0),k([y()],Q.prototype,`emptyStateMessage`,void 0),k([C()],Q.prototype,`detailsOpenedItems`,void 0),k([x(`vaadin-grid`)],Q.prototype,`grid`,void 0),Q=k([g(`mateu-table`)],Q);var eu=(e,t,n,r,i,a,o)=>T`
     <mateu-table
             id="${t.id}"
             baseUrl="${n}"
@@ -10202,8 +10210,8 @@ ${i}
             style="${t.style}" class="${t.cssClasses}"
             slot="${t.slot??v}"
     >
-        ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
-    </mateu-table>`,eu=(e,t,n,r,i,a)=>T`
+        ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
+    </mateu-table>`,tu=(e,t,n,r,i,a)=>T`
     <mateu-table id="${e.id}"
                  .metadata="${t?.metadata}"
                  .data="${e.data}"
@@ -10214,8 +10222,8 @@ ${i}
                  @sort-direction-changed="${e.directionChanged}"
                  @fetch-more-elements="${e.fetchMoreElements}"
                  baseUrl="${n}"
-    ></mateu-table>`,tu=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
-        <div id="show-notifications" slot="${t.slot??v}">${I(e,s.wrapped,n,r,i,a,o)}</div>
+    ></mateu-table>`,nu=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+        <div id="show-notifications" slot="${t.slot??v}">${F(e,s.wrapped,n,r,i,a,o)}</div>
         <vaadin-popover
                 for="show-notifications"
                 theme="arrow no-padding"
@@ -10223,17 +10231,17 @@ ${i}
                 accessible-name-ref="notifications-heading"
                 content-width="300px"
                 position="bottom"
-                ${m(()=>T`${I(e,s.content,n,r,i,a,o)}`,[])}
+                ${m(()=>T`${F(e,s.content,n,r,i,a,o)}`,[])}
                 style="${t.style}" class="${t.cssClasses}"
         ></vaadin-popover>
-    `},nu=(e,t,n)=>{let r=e;return T`
+    `},ru=(e,t,n)=>{let r=e;return T`
         <vaadin-button
                 data-action-id="${r.id}"
-                theme="${Mt(e)||v}"
+                theme="${Nt(e)||v}"
                 @click="${n}"
                 ?disabled="${r.disabled}"
         >${r.iconOnLeft?T`<vaadin-icon icon="${r.iconOnLeft}"></vaadin-icon>`:v}${t}${r.iconOnRight?T`<vaadin-icon icon="${r.iconOnRight}"></vaadin-icon>`:v}</vaadin-button>
-    `},ru=e=>T`
+    `},iu=e=>T`
     <div style="display: flex; gap: var(--lumo-space-xs, .25rem); align-items: center;" class="peer-nav">
         <vaadin-button theme="tertiary icon" class="peer-nav-prev" title="${e.prevLabel??`Previous`}"
                 ?disabled="${!e.prevRoute}"
@@ -10245,30 +10253,30 @@ ${i}
                 @click="${()=>{e.nextRoute&&(window.location.href=e.nextRoute)}}">
             <vaadin-icon icon="vaadin:angle-right"></vaadin-icon>
         </vaadin-button>
-    </div>`,iu={"vaadin:wifi":`vaadin:connect`,"vaadin:pen":`vaadin:pencil`,"vaadin:automation":`vaadin:cogs`},au=(e,t,n)=>T`<vaadin-icon icon="${iu[e]??e}" style="${t??v}" class="${n??v}"></vaadin-icon>`,ou=(e,t,n)=>{let r=e.metadata,i=M(r.label,t,n),a=``;return r.buttonStyle&&(a+=` `+r.buttonStyle),r.color&&r.color!==`none`&&r.color!==`normal`&&(a+=` `+r.color),r.size&&r.size!==`none`&&r.size!==`normal`&&(a+=` `+r.size),T`<vaadin-button
+    </div>`,au={"vaadin:wifi":`vaadin:connect`,"vaadin:pen":`vaadin:pencil`,"vaadin:automation":`vaadin:cogs`},ou=(e,t,n)=>T`<vaadin-icon icon="${au[e]??e}" style="${t??v}" class="${n??v}"></vaadin-icon>`,su=(e,t,n)=>{let r=e.metadata,i=M(r.label,t,n),a=``;return r.buttonStyle&&(a+=` `+r.buttonStyle),r.color&&r.color!==`none`&&r.color!==`normal`&&(a+=` `+r.color),r.size&&r.size!==`none`&&r.size!==`normal`&&(a+=` `+r.size),T`<vaadin-button
             id="${e.id}"
             data-action-id="${r.actionId}"
-            @click="${e=>ar(e,r)}"
+            @click="${e=>or(e,r)}"
             style="${e.style}"
             class="${e.cssClasses}"
             theme="${a}"
             ?disabled="${r.disabled}"
-            title="${r.shortcut?`${i} (${ir(r.shortcut)})`:v}"
+            title="${r.shortcut?`${i} (${ar(r.shortcut)})`:v}"
             slot="${e.slot??v}"
-    >${r.iconOnLeft?T`<vaadin-icon icon="${r.iconOnLeft}"></vaadin-icon>`:v}${i}${r.iconOnRight?T`<vaadin-icon icon="${r.iconOnRight}"></vaadin-icon>`:v}</vaadin-button>`},su=e=>{let t=e.metadata;return T`
+    >${r.iconOnLeft?T`<vaadin-icon icon="${r.iconOnLeft}"></vaadin-icon>`:v}${i}${r.iconOnRight?T`<vaadin-icon icon="${r.iconOnRight}"></vaadin-icon>`:v}</vaadin-button>`},cu=e=>{let t=e.metadata;return T`
         <vaadin-message-input
                 style="${e.style}" class="${e.cssClasses}"
                 slot="${e.slot??v}"
                 @submit="${e=>{let n=e.detail?.value??``;!t.actionId||!n.trim()||e.currentTarget.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t.actionId,parameters:{message:n}},bubbles:!0,composed:!0}))}}"
         ></vaadin-message-input>
-    `},cu=e=>{let t=(e.metadata.items??[]).map(e=>({text:e.text,time:e.time,userName:e.userName,userImg:e.userImg,userAbbr:e.userAbbr,userColorIndex:e.userColorIndex}));return T`
+    `},lu=e=>{let t=(e.metadata.items??[]).map(e=>({text:e.text,time:e.time,userName:e.userName,userImg:e.userImg,userAbbr:e.userAbbr,userColorIndex:e.userColorIndex}));return T`
         <vaadin-message-list
                 markdown
                 style="${e.style}" class="${e.cssClasses}"
                 slot="${e.slot??v}"
                 .items="${t}"
         ></vaadin-message-list>
-    `},lu=(e,t)=>{e&&e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},uu=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!1;if(s.openedCondition)try{c=St(s.openedCondition,r,i,a,o)}catch(e){console.error(`when evaluating `+s.openedCondition+` :`+e+`, where data is `+i+` and state is `+r)}return T`
+    `},uu=(e,t)=>{e&&e.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:t},bubbles:!0,composed:!0}))},du=(e,t,n,r,i,a,o)=>{let s=t.metadata,c=!1;if(s.openedCondition)try{c=St(s.openedCondition,r,i,a,o)}catch(e){console.error(`when evaluating `+s.openedCondition+` :`+e+`, where data is `+i+` and state is `+r)}return T`
         <vaadin-confirm-dialog
                 header="${s.header}"
                 ?cancel-button-visible="${s.canCancel}"
@@ -10276,15 +10284,15 @@ ${i}
                 reject-text="${s.rejectText}"
                 confirm-text="${s.confirmText}"
                 .opened="${c}"
-                @confirm="${e=>lu(e.currentTarget,s.confirmActionId)}"
-                @reject="${e=>lu(e.currentTarget,s.rejectActionId)}"
-                @cancel="${e=>lu(e.currentTarget,s.cancelActionId)}"
+                @confirm="${e=>uu(e.currentTarget,s.confirmActionId)}"
+                @reject="${e=>uu(e.currentTarget,s.rejectActionId)}"
+                @cancel="${e=>uu(e.currentTarget,s.cancelActionId)}"
                 style="${t.style}" class="${t.cssClasses}"
                 slot="${t.slot??v}"
         >
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
         </vaadin-confirm-dialog>
-    `},du=class extends b{constructor(...e){super(...e),this.panels=[],this.headerTitle=``,this.badges=[],this.navigation=null,this.overviewEditActionId=``,this._raf=0,this._snapping=!1,this._less=!1,this._more=!1,this._onScroll=()=>{this._raf||=requestAnimationFrame(()=>{this._raf=0,this._syncPin()})},this._onScrollEnd=()=>{this._snapping||this._snapToNearest()},this._fit=()=>{let e=this.getBoundingClientRect().top;this.style.setProperty(`--mateu-foldout-fill`,`${Math.max(240,window.innerHeight-e)}px`),this._syncPin()},this._onKeydown=e=>{if(e.key!==`ArrowRight`&&e.key!==`ArrowLeft`||e.defaultPrevented||e.ctrlKey||e.metaKey||e.altKey||this._isEditingContext())return;let t=this._rail;!t||t.scrollWidth<=t.clientWidth||(e.preventDefault(),this._step(e.key===`ArrowRight`?1:-1))}}navAction(e){e&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{}},bubbles:!0,composed:!0}))}_stride(){let e=this.renderRoot.querySelectorAll(`.section`);return e.length>1?e[1].offsetLeft:this._rail?.clientWidth??0}_boundaries(){let e=this._rail;if(!e)return[];let t=e.scrollWidth-e.clientWidth,n=[...this.renderRoot.querySelectorAll(`.section`)].map(e=>Math.max(0,Math.min(e.offsetLeft,t)));return[...new Set(n)]}_snapToNearest(){let e=this._rail;if(!e)return;let t=this._boundaries();if(!t.length)return;let n=t.reduce((t,n)=>Math.abs(n-e.scrollLeft)<Math.abs(t-e.scrollLeft)?n:t);Math.abs(n-e.scrollLeft)<1||(this._snapping=!0,e.scrollTo({left:n,behavior:`smooth`}),window.setTimeout(()=>{this._snapping=!1},400))}_syncPin(){let e=this._rail,t=this._first;if(!e||!t)return;let n=this._stride(),r=Math.min(e.scrollLeft,n);t.style.transform=r?`translateX(${r}px)`:``,t.classList.toggle(`floating`,e.scrollLeft>0);let i=e.scrollWidth-e.clientWidth,a=i>32;this._less=a&&e.scrollLeft>2,this._more=a&&e.scrollLeft<i-2}_step(e){let t=this._rail;if(!t)return;let n=this._boundaries();if(!n.length)return;let r=n.reduce((e,r,i)=>Math.abs(r-t.scrollLeft)<Math.abs(n[e]-t.scrollLeft)?i:e,0),i=n[Math.max(0,Math.min(r+e,n.length-1))];this._snapping=!0,t.scrollTo({left:i,behavior:`smooth`}),window.setTimeout(()=>{this._snapping=!1},400)}_isEditingContext(){let e=document.activeElement;for(;e&&e.shadowRoot&&e.shadowRoot.activeElement;)e=e.shadowRoot.activeElement;if(!e)return!1;let t=e.tagName;return t===`INPUT`||t===`TEXTAREA`||t===`SELECT`||e.isContentEditable}_sectionFlex(e,t){if(!e.width)return v;let n=parseFloat(e.width)||1;return t===this.panels.length-1&&n<22?`flex: 22 1 var(--mateu-foldout-overview-width, 22rem);`:`flex: ${n} 1 ${e.width};`}firstUpdated(){this._fit(),this._resizeObserver=new ResizeObserver(()=>this._syncPin()),this._rail&&this._resizeObserver.observe(this._rail);for(let e of this.renderRoot.querySelectorAll(`.section`))this._resizeObserver.observe(e)}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._onKeydown),window.addEventListener(`resize`,this._fit)}disconnectedCallback(){document.removeEventListener(`keydown`,this._onKeydown),window.removeEventListener(`resize`,this._fit),this._resizeObserver?.disconnect(),this._resizeObserver=void 0,this._raf&&=(cancelAnimationFrame(this._raf),0),super.disconnectedCallback()}static{this.styles=h`
+    `},$=class extends b{constructor(...e){super(...e),this.panels=[],this.headerTitle=``,this.badges=[],this.navigation=null,this.overviewEditActionId=``,this._raf=0,this._snapping=!1,this._less=!1,this._more=!1,this._onScroll=()=>{this._raf||=requestAnimationFrame(()=>{this._raf=0,this._syncPin()})},this._onScrollEnd=()=>{this._snapping||this._snapToNearest()},this._fit=()=>{let e=this.getBoundingClientRect().top;this.style.setProperty(`--mateu-foldout-fill`,`${Math.max(240,window.innerHeight-e)}px`),this._syncPin()},this._onKeydown=e=>{if(e.key!==`ArrowRight`&&e.key!==`ArrowLeft`||e.defaultPrevented||e.ctrlKey||e.metaKey||e.altKey||this._isEditingContext())return;let t=this._rail;!t||t.scrollWidth<=t.clientWidth||(e.preventDefault(),this._step(e.key===`ArrowRight`?1:-1))}}navAction(e){e&&this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:{}},bubbles:!0,composed:!0}))}_stride(){let e=this.renderRoot.querySelectorAll(`.section`);return e.length>1?e[1].offsetLeft:this._rail?.clientWidth??0}_boundaries(){let e=this._rail;if(!e)return[];let t=e.scrollWidth-e.clientWidth,n=[...this.renderRoot.querySelectorAll(`.section`)].map(e=>Math.max(0,Math.min(e.offsetLeft,t)));return[...new Set(n)]}_snapToNearest(){let e=this._rail;if(!e)return;let t=this._boundaries();if(!t.length)return;let n=t.reduce((t,n)=>Math.abs(n-e.scrollLeft)<Math.abs(t-e.scrollLeft)?n:t);Math.abs(n-e.scrollLeft)<1||(this._snapping=!0,e.scrollTo({left:n,behavior:`smooth`}),window.setTimeout(()=>{this._snapping=!1},400))}_syncPin(){let e=this._rail,t=this._first;if(!e||!t)return;let n=this._stride(),r=Math.min(e.scrollLeft,n);t.style.transform=r?`translateX(${r}px)`:``,t.classList.toggle(`floating`,e.scrollLeft>0);let i=e.scrollWidth-e.clientWidth,a=i>32;this._less=a&&e.scrollLeft>2,this._more=a&&e.scrollLeft<i-2}_step(e){let t=this._rail;if(!t)return;let n=this._boundaries();if(!n.length)return;let r=n.reduce((e,r,i)=>Math.abs(r-t.scrollLeft)<Math.abs(n[e]-t.scrollLeft)?i:e,0),i=n[Math.max(0,Math.min(r+e,n.length-1))];this._snapping=!0,t.scrollTo({left:i,behavior:`smooth`}),window.setTimeout(()=>{this._snapping=!1},400)}_isEditingContext(){let e=document.activeElement;for(;e&&e.shadowRoot&&e.shadowRoot.activeElement;)e=e.shadowRoot.activeElement;if(!e)return!1;let t=e.tagName;return t===`INPUT`||t===`TEXTAREA`||t===`SELECT`||e.isContentEditable}_sectionFlex(e,t){if(!e.width)return v;let n=parseFloat(e.width)||1;return t===this.panels.length-1&&n<22?`flex: 22 1 var(--mateu-foldout-overview-width, 22rem);`:`flex: ${n} 1 ${e.width};`}firstUpdated(){this._fit(),this._resizeObserver=new ResizeObserver(()=>this._syncPin()),this._rail&&this._resizeObserver.observe(this._rail);for(let e of this.renderRoot.querySelectorAll(`.section`))this._resizeObserver.observe(e)}connectedCallback(){super.connectedCallback(),document.addEventListener(`keydown`,this._onKeydown),window.addEventListener(`resize`,this._fit)}disconnectedCallback(){document.removeEventListener(`keydown`,this._onKeydown),window.removeEventListener(`resize`,this._fit),this._resizeObserver?.disconnect(),this._resizeObserver=void 0,this._raf&&=(cancelAnimationFrame(this._raf),0),super.disconnectedCallback()}static{this.styles=h`
         :host {
             position: relative;
             display: flex;
@@ -10545,7 +10553,7 @@ ${i}
                     </svg>
                 </button>
             `:v}
-        `}};k([y({type:Array})],du.prototype,`panels`,void 0),k([y({type:String})],du.prototype,`headerTitle`,void 0),k([y({type:Array})],du.prototype,`badges`,void 0),k([y({attribute:!1})],du.prototype,`navigation`,void 0),k([y({type:String})],du.prototype,`overviewEditActionId`,void 0),k([x(`.rail`)],du.prototype,`_rail`,void 0),k([x(`.section--first`)],du.prototype,`_first`,void 0),k([C()],du.prototype,`_less`,void 0),k([C()],du.prototype,`_more`,void 0),du=k([g(`mateu-vaadin-foldout`)],du);var fu=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
+        `}};k([y({type:Array})],$.prototype,`panels`,void 0),k([y({type:String})],$.prototype,`headerTitle`,void 0),k([y({type:Array})],$.prototype,`badges`,void 0),k([y({attribute:!1})],$.prototype,`navigation`,void 0),k([y({type:String})],$.prototype,`overviewEditActionId`,void 0),k([x(`.rail`)],$.prototype,`_rail`,void 0),k([x(`.section--first`)],$.prototype,`_first`,void 0),k([C()],$.prototype,`_less`,void 0),k([C()],$.prototype,`_more`,void 0),$=k([g(`mateu-vaadin-foldout`)],$);var fu=(e,t,n,r,i,a,o)=>{let s=t.metadata;return T`
         <mateu-vaadin-foldout
                 .panels="${s.panels??[]}"
                 .headerTitle="${s.headerTitle??``}"
@@ -10556,7 +10564,7 @@ ${i}
                 class="${t.cssClasses}"
                 slot="${t.slot??v}"
         >
-            ${t.children?.map(t=>I(e,t,n,r,i,a,o))}
+            ${t.children?.map(t=>F(e,t,n,r,i,a,o))}
         </mateu-vaadin-foldout>
     `},pu=class extends b{constructor(...e){super(...e),this.rows=[],this.columns=[],this.navigable=!1,this.expandedItems=[],this._normalized=[],this.dataProvider=(e,t)=>{let n=e.parentItem?e.parentItem.children??[]:this.normalized;t(n,n.length)}}get normalized(){return this._src!==this.rows&&(this._src=this.rows,this._normalized=this.normalizeRows(this.rows??[])),this._normalized}normalizeRows(e){return(e??[]).map(e=>{let t=Array.isArray(e.children)&&e.children.length?this.normalizeRows(e.children):void 0;return{...e,children:t}})}collectGroups(e,t=[]){return e.forEach(e=>{e.children&&e.children.length&&(t.push(e),this.collectGroups(e.children,t))}),t}willUpdate(){this._expandedSrc!==this.rows&&(this._expandedSrc=this.rows,this.expandedItems=this.collectGroups(this.normalized))}updated(e){e.has(`rows`)&&this._grid?.clearCache?.()}dispatch(e,t){this.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e,parameters:t},bubbles:!0,composed:!0}))}render(){let e=this.columns??[],n=e[0],r=e.slice(1);return T`
             <vaadin-grid
@@ -10588,11 +10596,11 @@ ${i}
             max-height: min(60vh, 32rem);
             min-width: 22rem;
         }
-    `}};k([y({attribute:!1})],pu.prototype,`rows`,void 0),k([y({attribute:!1})],pu.prototype,`columns`,void 0),k([y()],pu.prototype,`idField`,void 0),k([y({type:Boolean})],pu.prototype,`navigable`,void 0),k([y()],pu.prototype,`selectedId`,void 0),k([C()],pu.prototype,`expandedItems`,void 0),k([x(`vaadin-grid`)],pu.prototype,`_grid`,void 0),pu=k([g(`mateu-vaadin-tree`)],pu);var mu={[j.VirtualList]:(e,t,n,r,i,a,o)=>Cc(e,t,n,r,i,a,o),[j.Notification]:(e,t)=>wc(t),[j.ProgressBar]:(e,t,n,r)=>Tc(t,r),[j.Details]:(e,t,n,r,i,a,o)=>Ec(e,t,n,r,i,a,o),[j.Avatar]:(e,t,n,r,i)=>Dc(t,r,i),[j.AvatarGroup]:(e,t)=>Oc(t),[j.Card]:(e,t,n,r,i,a,o)=>kc(e,t,n,r,i,a,o),[j.Button]:(e,t,n,r,i)=>ou(t,r,i),[j.MessageInput]:(e,t)=>su(t),[j.MessageList]:(e,t)=>cu(t),[j.ConfirmDialog]:(e,t,n,r,i,a,o)=>uu(e,t,n,r,i,a,o),[j.FormLayout]:(e,t,n,r,i,a,o)=>Mc(e,t,n,r,i,a,o),[j.HorizontalLayout]:(e,t,n,r,i,a,o)=>Ic(e,t,n,r,i,a,o),[j.VerticalLayout]:(e,t,n,r,i,a,o)=>Lc(e,t,n,r,i,a,o),[j.SplitLayout]:(e,t,n,r,i,a,o)=>Rc(e,t,n,r,i,a,o),[j.MasterDetailLayout]:(e,t,n,r,i,a,o)=>zc(e,t,n,r,i,a,o),[j.TabLayout]:(e,t,n,r,i,a,o)=>Bc(e,t,n,r,i,a,o),[j.AccordionLayout]:(e,t,n,r,i,a,o)=>Hc(e,t,n,r,i,a,o),[j.BoardLayout]:(e,t,n,r,i,a,o)=>Gc(e,t,n,r,i,a,o),[j.BoardLayoutRow]:(e,t,n,r,i,a,o)=>Kc(e,t,n,r,i,a,o),[j.BoardLayoutItem]:(e,t,n,r,i,a,o)=>qc(e,t,n,r,i,a,o),[j.Scroller]:(e,t,n,r,i,a,o)=>Wc(e,t,n,r,i,a,o),[j.MenuBar]:(e,t,n,r,i)=>Xc(e,t,n,r,i),[j.ContextMenu]:(e,t,n,r,i,a,o)=>Yc(e,t,n,r,i,a,o),[j.FormField]:(e,t,n,r,i,a,o,s)=>Zl(e,t,n,r,i,a,o,s),[j.Grid]:(e,t,n,r,i,a,o)=>Ql(e,t,n,r,i,a,o),[j.Table]:(e,t,n,r,i,a,o)=>$l(e,t,n,r,i,a,o),[j.Popover]:(e,t,n,r,i,a,o)=>tu(e,t,n,r,i,a,o),[j.FoldoutLayout]:(e,t,n,r,i,a,o)=>fu(e,t,n,r,i,a,o)},hu=class extends Sc{rendererName(){return`vaadin`}renderClientSideComponent(e,t,n,r,i,a,o,s){let c=t?.metadata?.type,l=c?mu[c]:void 0;return l&&t?l(e,t,n,r,i,a,o,s):super.renderClientSideComponent(e,t,n,r,i,a,o,s)}renderTableComponent(e,t,n,r,i,a,o){return eu(e,t,n,r,a,o)}renderTreeComponent(e,t){return T`
+    `}};k([y({attribute:!1})],pu.prototype,`rows`,void 0),k([y({attribute:!1})],pu.prototype,`columns`,void 0),k([y()],pu.prototype,`idField`,void 0),k([y({type:Boolean})],pu.prototype,`navigable`,void 0),k([y()],pu.prototype,`selectedId`,void 0),k([C()],pu.prototype,`expandedItems`,void 0),k([x(`vaadin-grid`)],pu.prototype,`_grid`,void 0),pu=k([g(`mateu-vaadin-tree`)],pu);var mu={[j.VirtualList]:(e,t,n,r,i,a,o)=>wc(e,t,n,r,i,a,o),[j.Notification]:(e,t)=>Tc(t),[j.ProgressBar]:(e,t,n,r)=>Ec(t,r),[j.Details]:(e,t,n,r,i,a,o)=>Dc(e,t,n,r,i,a,o),[j.Avatar]:(e,t,n,r,i)=>Oc(t,r,i),[j.AvatarGroup]:(e,t)=>kc(t),[j.Card]:(e,t,n,r,i,a,o)=>Ac(e,t,n,r,i,a,o),[j.Button]:(e,t,n,r,i)=>su(t,r,i),[j.MessageInput]:(e,t)=>cu(t),[j.MessageList]:(e,t)=>lu(t),[j.ConfirmDialog]:(e,t,n,r,i,a,o)=>du(e,t,n,r,i,a,o),[j.FormLayout]:(e,t,n,r,i,a,o)=>Nc(e,t,n,r,i,a,o),[j.HorizontalLayout]:(e,t,n,r,i,a,o)=>Lc(e,t,n,r,i,a,o),[j.VerticalLayout]:(e,t,n,r,i,a,o)=>Rc(e,t,n,r,i,a,o),[j.SplitLayout]:(e,t,n,r,i,a,o)=>zc(e,t,n,r,i,a,o),[j.MasterDetailLayout]:(e,t,n,r,i,a,o)=>Bc(e,t,n,r,i,a,o),[j.TabLayout]:(e,t,n,r,i,a,o)=>Vc(e,t,n,r,i,a,o),[j.AccordionLayout]:(e,t,n,r,i,a,o)=>Uc(e,t,n,r,i,a,o),[j.BoardLayout]:(e,t,n,r,i,a,o)=>Kc(e,t,n,r,i,a,o),[j.BoardLayoutRow]:(e,t,n,r,i,a,o)=>qc(e,t,n,r,i,a,o),[j.BoardLayoutItem]:(e,t,n,r,i,a,o)=>Jc(e,t,n,r,i,a,o),[j.Scroller]:(e,t,n,r,i,a,o)=>Gc(e,t,n,r,i,a,o),[j.MenuBar]:(e,t,n,r,i)=>Zc(e,t,n,r,i),[j.ContextMenu]:(e,t,n,r,i,a,o)=>Xc(e,t,n,r,i,a,o),[j.FormField]:(e,t,n,r,i,a,o,s)=>Ql(e,t,n,r,i,a,o,s),[j.Grid]:(e,t,n,r,i,a,o)=>$l(e,t,n,r,i,a,o),[j.Table]:(e,t,n,r,i,a,o)=>eu(e,t,n,r,i,a,o),[j.Popover]:(e,t,n,r,i,a,o)=>nu(e,t,n,r,i,a,o),[j.FoldoutLayout]:(e,t,n,r,i,a,o)=>fu(e,t,n,r,i,a,o)},hu=class extends Cc{rendererName(){return`vaadin`}renderClientSideComponent(e,t,n,r,i,a,o,s){let c=t?.metadata?.type,l=c?mu[c]:void 0;return l&&t?l(e,t,n,r,i,a,o,s):super.renderClientSideComponent(e,t,n,r,i,a,o,s)}renderTableComponent(e,t,n,r,i,a,o){return tu(e,t,n,r,a,o)}renderTreeComponent(e,t){return T`
             <mateu-vaadin-tree
                     .rows="${t.rows}"
                     .columns="${t.columns}"
                     .idField="${t.idField}"
                     .navigable="${t.navigable}"
                     .selectedId="${t.selectedId}"
-            ></mateu-vaadin-tree>`}renderToolbarButton(e,t,n){return nu(e,t,n)}renderPeerNav(e){return ru(e)}renderIcon(e,t,n){return au(e,t,n)}renderTopNav(e,t,n){return Jc(e,t,n)}};function gu(e){switch(e){case`topStretch`:return`top-stretch`;case`topStart`:return`top-start`;case`topCenter`:return`top-center`;case`topEnd`:return`top-end`;case`middle`:return`middle`;case`bottomStart`:return`bottom-start`;case`bottomEnd`:return`bottom-end`;case`bottomStretch`:return`bottom-stretch`;case`bottomCenter`:return`bottom-center`}return`bottom-end`}function _u(e,t){if(e.onAction)return{label:e.actionLabel??`Retry`,run:e.onAction};if(e.undoActionId)return{label:e.undoLabel??`Undo`,run:()=>t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.undoActionId,parameters:e.undoParameters??{}},bubbles:!0,composed:!0}))}}function vu(e,t){let n=new r;n.position=gu(e.position),n.duration=e.duration??1e4,e.variant&&n.setAttribute(`theme`,e.variant),n.renderer=r=>{if(r.firstElementChild)return;let i=document.createElement(`span`);i.textContent=e.text;let a=_u(e,t),o=document.createElement(`button`);o.textContent=a.label,o.style.cssText=`margin-left: 0.75rem; background: none; border: 1px solid currentColor; border-radius: var(--lumo-border-radius-s, 4px); color: inherit; cursor: pointer; padding: 0.15rem 0.6rem; font: inherit; font-weight: 600;`,o.addEventListener(`click`,()=>{a.run(),n.opened=!1}),r.append(i,o)},document.body.appendChild(n),n.opened=!0,n.addEventListener(`opened-changed`,e=>{e.detail.value||n.remove()})}F.set(new hu),Ma({show(e,t){if(gt(e.text,{politeness:e.variant===`error`?`assertive`:`polite`}),e.undoActionId||e.onAction){vu(e,t);return}r.show(e.text,{position:e.position?gu(e.position):`bottom-end`,theme:e.variant,duration:e.duration})}});
+            ></mateu-vaadin-tree>`}renderToolbarButton(e,t,n){return ru(e,t,n)}renderPeerNav(e){return iu(e)}renderIcon(e,t,n){return ou(e,t,n)}renderTopNav(e,t,n){return Yc(e,t,n)}};function gu(e){switch(e){case`topStretch`:return`top-stretch`;case`topStart`:return`top-start`;case`topCenter`:return`top-center`;case`topEnd`:return`top-end`;case`middle`:return`middle`;case`bottomStart`:return`bottom-start`;case`bottomEnd`:return`bottom-end`;case`bottomStretch`:return`bottom-stretch`;case`bottomCenter`:return`bottom-center`}return`bottom-end`}function _u(e,t){if(e.onAction)return{label:e.actionLabel??`Retry`,run:e.onAction};if(e.undoActionId)return{label:e.undoLabel??`Undo`,run:()=>t.dispatchEvent(new CustomEvent(`action-requested`,{detail:{actionId:e.undoActionId,parameters:e.undoParameters??{}},bubbles:!0,composed:!0}))}}function vu(e,t){let n=new r;n.position=gu(e.position),n.duration=e.duration??1e4,e.variant&&n.setAttribute(`theme`,e.variant),n.renderer=r=>{if(r.firstElementChild)return;let i=document.createElement(`span`);i.textContent=e.text;let a=_u(e,t),o=document.createElement(`button`);o.textContent=a.label,o.style.cssText=`margin-left: 0.75rem; background: none; border: 1px solid currentColor; border-radius: var(--lumo-border-radius-s, 4px); color: inherit; cursor: pointer; padding: 0.15rem 0.6rem; font: inherit; font-weight: 600;`,o.addEventListener(`click`,()=>{a.run(),n.opened=!1}),r.append(i,o)},document.body.appendChild(n),n.opened=!0,n.addEventListener(`opened-changed`,e=>{e.detail.value||n.remove()})}P.set(new hu),Na({show(e,t){if(gt(e.text,{politeness:e.variant===`error`?`assertive`:`polite`}),e.undoActionId||e.onAction){vu(e,t);return}r.show(e.text,{position:e.position?gu(e.position):`bottom-end`,theme:e.variant,duration:e.duration})}});

--- a/e2e/sut/modules/sample1/src/main/java/io/mateu/sample1/SimpleListingForm.java
+++ b/e2e/sut/modules/sample1/src/main/java/io/mateu/sample1/SimpleListingForm.java
@@ -9,6 +9,7 @@ import io.mateu.uidl.data.SearchRequest;
 import io.mateu.uidl.annotations.TriggerType;
 import io.mateu.uidl.interfaces.HttpRequest;
 import io.mateu.uidl.interfaces.Listing;
+import io.mateu.uidl.interfaces.Searchable;
 import java.util.List;
 import java.util.stream.IntStream;
 
@@ -23,15 +24,19 @@ import java.util.stream.IntStream;
 @UI("/simple-listing")
 @Title("Simple listing")
 @Trigger(type = TriggerType.OnLoad, actionId = "search")
-public class SimpleListingForm implements Listing<SimpleListingForm.Row> {
+public class SimpleListingForm implements Listing<SimpleListingForm.Row>, Searchable {
 
   public record Row(String code, String name, int units) {}
 
   @Override
   public ListingData<Row> search(SearchRequest request, HttpRequest httpRequest) {
+    var searchText = request.searchText() == null ? "" : request.searchText().trim().toLowerCase();
+    // Honouring the search text is what lets a test tell the two empty screens apart: a listing
+    // that found nothing says so, a listing that is still asking says nothing of the sort.
     var rows =
         IntStream.rangeClosed(1, 25)
             .mapToObj(i -> new Row("C-%03d".formatted(i), "Item " + i, i * 3))
+            .filter(row -> searchText.isEmpty() || row.name().toLowerCase().contains(searchText))
             .toList();
     return new ListingData<>(new Page<>("", rows.size(), 0, rows.size(), rows));
   }

--- a/e2e/tests/shared/listing-loading-state.spec.ts
+++ b/e2e/tests/shared/listing-loading-state.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test';
+
+// "Still loading" and "found nothing" are different facts, and a listing used to report both with
+// the same words — the empty state. It shows up on every search, too, because a re-search clears
+// the rows it is about to replace. So the reader is told there is nothing there at the exact moment
+// the answer is on its way.
+test.describe('listing loading state', () => {
+
+  const skeletonShown = (page: any) => page.evaluate(() => {
+    const deep = (root: Document | ShadowRoot): boolean => {
+      for (const el of Array.from(root.querySelectorAll('*'))) {
+        if (el.tagName.toLowerCase() === 'mateu-skeleton') return true;
+        if (el.shadowRoot && deep(el.shadowRoot)) return true;
+      }
+      return false;
+    };
+    return deep(document);
+  });
+
+  test('says it is loading rather than that there is nothing', async ({ page }) => {
+    // Hold the search back, the way a slow backend does. Without this the answer arrives too fast
+    // for the state to be observable — which is why nobody noticed it was wrong.
+    await page.route('**/mateu/v3/**', async (route) => {
+      if ((route.request().postData() || '').includes('"search"')) {
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+      }
+      await route.continue();
+    });
+
+    await page.goto('/simple-listing');
+    await page.waitForTimeout(900);
+
+    expect(await skeletonShown(page)).toBe(true);
+    await expect(page.getByText('Nothing here yet.')).toHaveCount(0);
+
+    // And it gives way to the rows once they arrive.
+    await page.waitForTimeout(2500);
+    expect(await skeletonShown(page)).toBe(false);
+  });
+
+  test('and still says there is nothing when a search really finds nothing', async ({ page }) => {
+    await page.goto('/simple-listing');
+    await expect(page.locator('vaadin-grid').first()).toBeAttached();
+    await page.waitForTimeout(800);
+
+    // The listing filters by its search text, so this one genuinely has no rows to show.
+    const search = page.locator('input[type="search"], mateu-filter-bar input').first();
+    await search.fill('zzzz');
+    await search.press('Enter');
+
+    await expect(page.getByText('Nothing here yet.')).toBeVisible({ timeout: 10000 });
+    expect(await skeletonShown(page)).toBe(false);
+  });
+
+});

--- a/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/mateu-table-crud.ts
+++ b/frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/mateu-table-crud.ts
@@ -1,5 +1,6 @@
 import {customElement, property, state} from "lit/decorators.js";
 import { emptyStateTemplate } from "@infra/ui/renderers/emptyStateRenderer.ts";
+import "@infra/ui/mateu-skeleton.ts";
 import { icon } from "@infra/ui/renderers/neutralIcon.ts";
 import {css, html, LitElement, nothing, PropertyValues, TemplateResult} from "lit";
 import './mateu-filter-bar'
@@ -297,11 +298,52 @@ export class MateuTableCrud extends LitElement {
 
     disconnectedCallback() {
         super.disconnectedCallback()
+        clearTimeout(this.loadingTimer)
         window.removeEventListener('resize', this.windowResizeListener)
         this.resizeObserver?.disconnect()
     }
 
+    /**
+     * When the rows were last asked for, while the answer has not arrived.
+     *
+     * A listing that is still fetching used to say "nothing here" — and it says it in the same
+     * words it uses for a search that genuinely found nothing, so the reader cannot tell "wait" from
+     * "there is nothing". Worse, a re-search CLEARS the rows it is about to replace, so the empty
+     * state appears every time somebody types in the filter bar.
+     *
+     * It is a timestamp rather than a flag because the answer may never come: a failed request
+     * shows its error in a toast, which the reader dismisses, and a skeleton left shimmering
+     * underneath would be a second lie on top of the first. Past the valve the listing goes back to
+     * saying what it actually knows.
+     */
+    @state()
+    private loadingSince?: number
+
+    private static readonly LOADING_VALVE_MS = 15_000
+
+    private loadingTimer?: ReturnType<typeof setTimeout>
+
+    /** The listing has asked for rows and is still waiting for them. */
+    private get awaitingRows(): boolean {
+        return this.loadingSince != undefined
+            && Date.now() - this.loadingSince < MateuTableCrud.LOADING_VALVE_MS
+    }
+
+    private beginLoading() {
+        this.loadingSince = Date.now()
+        clearTimeout(this.loadingTimer)
+        // Nothing else would re-render at the deadline, and a stale skeleton is what this exists
+        // to avoid.
+        this.loadingTimer = setTimeout(() => this.requestUpdate(), MateuTableCrud.LOADING_VALVE_MS)
+    }
+
+    private endLoading() {
+        this.loadingSince = undefined
+        clearTimeout(this.loadingTimer)
+    }
+
     search = () => {
+        this.beginLoading()
         const metadata = (this.component as ClientSideComponent).metadata as Crud
         this.state = { ...this.state, size: metadata.pageSize, page: 0, crud_selected_items: [] }
         this._syncStateToUrl(metadata)
@@ -416,6 +458,7 @@ export class MateuTableCrud extends LitElement {
         if (!metadata.infiniteScrolling && this.data?.[this.id]?.page) {
             this.data[this.id].page.content = []
         }
+        this.beginLoading()
         this.dispatchEvent(new CustomEvent('action-requested', {
             detail: {
                 actionId: 'search',
@@ -495,6 +538,12 @@ export class MateuTableCrud extends LitElement {
         if (_changedProperties.has("component")) this.pendingMeasure = true
         this.measureFill()
         this.trimOverflow()
+        // A routed listing renders before its rows exist: the search is dispatched by the trigger
+        // on the component around it, so the only thing this element sees is that nobody has
+        // answered for its id yet.
+        if (this.data?.[this.id] != undefined) this.endLoading()
+        else if (this.loadingSince == undefined && this._initializedForComponentId != undefined
+            && !this.awaitingRows) this.beginLoading()
         if (_changedProperties.has("component")) {
             const componentId = this.component?.id
             if (componentId !== this._initializedForComponentId) {
@@ -933,7 +982,18 @@ export class MateuTableCrud extends LitElement {
             return renderTree()
         }
 
-        const contentHtml = html`
+        // "Loading" and "empty" are different facts and must not share a screen. Waiting wins:
+        // the rows may still turn up, and until the server has said otherwise the listing does not
+        // know that there are none.
+        const contentHtml = rows.length === 0 && this.awaitingRows ? html`
+            <div role="status" aria-live="polite" aria-busy="true"
+                 style="padding: var(--lumo-space-m, 1rem); width: 100%; box-sizing: border-box;">
+                <span style="position: absolute; width: 1px; height: 1px; overflow: hidden;
+                             clip: rect(0 0 0 0); clip-path: inset(50%); white-space: nowrap;"
+                >Loading…</span>
+                <mateu-skeleton variant="grid" count="6"></mateu-skeleton>
+            </div>
+        ` : html`
             ${metadata.infiniteScrolling ? html`
                 <div>${this.data[this.id]?.page?.totalElements} items found.</div>
             ` : nothing}


### PR DESCRIPTION
> "en los listados, mientras se están cargando los datos, no podríamos ver un mensaje en la tabla?
> ahora dice que no hay filas y es un poco confuso"

"Still loading" and "found nothing" are different facts, and the listing reported both with the same
words. And it is not only the first render: a re-search **clears the rows it is about to replace**,
so the empty state appears every time somebody types in the filter bar or changes page — the reader
is told there is nothing there at the exact moment the answer is on its way.

## What it does now

While the rows are outstanding, the table area shows the skeleton the design system already has for
this (`mateu-skeleton variant="grid"`), marked `role="status"` + `aria-busy` with a visually hidden
"Loading…" so a screen reader is told what is happening rather than left in silence.

The waiting is a **timestamp, not a flag**: the answer may never come — a failed request shows its
error in a toast, the reader dismisses it, and a skeleton left shimmering underneath would be a
second lie on top of the first. Past 15 seconds the listing goes back to saying what it actually
knows.

Applies to every renderer that goes through `mateu-table-crud`, and to all its layouts (table, list,
cards, master-detail, tree) since it wraps the content once rather than patching each empty spot.

## Verified

Measured in a browser with the search held back 2s, the way a slow backend does:

- during the wait: skeleton present, **no** "Nothing here yet."
- after: skeleton gone, 23 rows
- a search that genuinely matches nothing (`zzzz`): "Nothing here yet." and **no** skeleton — the
  distinction that makes the change worth anything

Two e2e tests pin exactly that pair. Full shared suite: **281 green**. The fixture gained a search
filter so the second case is reachable.