### PR TITLE
fix(core): a link to a record inside a remote listing reaches the remote

### DIFF
--- a/backend/shared/core/src/main/java/io/mateu/core/application/runaction/RemoteMenuHandler.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/runaction/RemoteMenuHandler.java
@@ -89,10 +89,26 @@ public class RemoteMenuHandler {
   /**
    * Does the remote app claim this route? Every remote answers ANY route with its app shell (a
    * fallback home with that route stamped), so "anything but the Not-found text" is too weak a test
-   * — the route must be one of the app's own menu routes.
+   * — the route must be one of the app's own menu routes, or live UNDER one.
+   *
+   * <p>Under one, because a menu route names a SCREEN and a link often names something inside it:
+   * {@code /workflow/processes/5f7b6ac6…} is one record of the {@code /workflow/processes} listing,
+   * and {@code /new} or {@code /{id}/edit} are the crud's own sub-routes. Asking for an exact match
+   * left every one of them unclaimed, so the stripped route was mounted by default and the remote —
+   * whose routes carry the prefix — answered "Not found." The {@code /} boundary is what keeps
+   * {@code /forms-archive} from being claimed by a remote that only owns {@code /forms}.
    */
   private boolean ownsRoute(AppDto app, String route) {
-    return menuRoutes(app.menu()).anyMatch(route::equals);
+    var path = withoutQuery(route);
+    return menuRoutes(app.menu())
+        .filter(menuRoute -> menuRoute != null && !menuRoute.isBlank())
+        .anyMatch(menuRoute -> path.equals(menuRoute) || path.startsWith(menuRoute + "/"));
+  }
+
+  /** The route alone: a deep link may carry query params, and no menu route ever does. */
+  private static String withoutQuery(String route) {
+    var query = route.indexOf('?');
+    return query < 0 ? route : route.substring(0, query);
   }
 
   private java.util.stream.Stream<String> menuRoutes(

--- a/backend/shared/core/src/test/java/io/mateu/core/application/RemoteMenuPrefixedDeepLinkSyncTest.java
+++ b/backend/shared/core/src/test/java/io/mateu/core/application/RemoteMenuPrefixedDeepLinkSyncTest.java
@@ -139,6 +139,39 @@ class RemoteMenuPrefixedDeepLinkSyncTest {
   }
 
   @Test
+  void recordDeepLinkMountsTheRouteBelowTheListing() {
+    // A link to ONE record of a listing: the remote's menu names the screen ("/forms/tasks") and
+    // the link names something inside it. Asking the remote for an exact menu route left this
+    // unclaimed, so the stripped "/tasks/t-42" was mounted and the page said "Not found" — while
+    // the very same record opened fine by clicking the listing and then the row.
+    var app = shellApp(viaUrl("/forms/tasks/t-42"));
+    assertThat(app).isNotNull();
+    assertThat(app.homeBaseUrl()).isEqualTo("/_forms");
+    assertThat(app.homeRoute()).isEqualTo("/forms/tasks/t-42");
+    // The consumed route is the remote app's own — which is what the remote answers that route
+    // with, asked exactly like this.
+    assertThat(app.homeConsumedRoute()).isEqualTo("");
+  }
+
+  @Test
+  void deepLinkWithQueryParamsIsClaimedByTheScreenItBelongsTo() {
+    // Same rule with a query string attached (a listing opened on page 2): no menu route carries
+    // one, so the match has to look at the route alone.
+    var app = shellApp(viaUrl("/forms/tasks?page=2"));
+    assertThat(app).isNotNull();
+    assertThat(app.homeRoute()).startsWith("/forms/tasks");
+  }
+
+  @Test
+  void aSiblingPathIsNotClaimedByTheScreenItMerelyStartsWith() {
+    // "/forms/tasks-archive" is NOT inside "/forms/tasks": the boundary is a segment, not a prefix.
+    // It is still inside "/forms", which the remote also declares, so it is claimed verbatim there.
+    var app = shellApp(viaUrl("/forms/tasks-archive"));
+    assertThat(app).isNotNull();
+    assertThat(app.homeRoute()).isEqualTo("/forms/tasks-archive");
+  }
+
+  @Test
   void rootDeepLinkStillMountsTheMenuPathAsHomeContent() {
     var app = shellApp(viaUrl("/forms"));
     assertThat(app).isNotNull();

--- a/backend/shared/core/src/test/java/io/mateu/core/application/RemoteMenuRootDeepLinkSyncTest.java
+++ b/backend/shared/core/src/test/java/io/mateu/core/application/RemoteMenuRootDeepLinkSyncTest.java
@@ -155,4 +155,13 @@ class RemoteMenuRootDeepLinkSyncTest {
     assertThat(app).isNotNull();
     assertThat(app.homeRoute()).isEqualTo("/disponibilidad");
   }
+
+  @Test
+  void recordDeepLinkKeepsBeingStrippedWhenTheRemoteDeclaresItsRoutesUnprefixed() {
+    // The counterpart of the prefixed case: here the record lives under an UNPREFIXED menu route,
+    // so the one the remote claims is the stripped one — id included.
+    var app = shellApp(viaUrl("/distribucion/disponibilidad/2026-08-20"));
+    assertThat(app).isNotNull();
+    assertThat(app.homeRoute()).isEqualTo("/disponibilidad/2026-08-20");
+  }
 }


### PR DESCRIPTION
## What fails

Pasting `https://ec1.mateu.io/workflow/processes/<uuid>` renders nothing. Clicking through to the same record works.

Measured against the live deployment (not the bench): the request goes to the right service — the base-URL fix does its job — and the workflow service answers `Text "Not found."`, because the shell mounts `homeRoute = "/processes/<uuid>"`, with the `/workflow` prefix stripped.

## Why

`RemoteMenuHandler.claimedRoute` picks between two candidates — the route with the shell's menu path stripped, or the route verbatim — by asking the remote's own menu which one it owns. That test was an **exact** match, and a menu route names a *screen* while a link often names something *inside* it:

| link | menu route | claimed before |
|---|---|---|
| `/workflow/processes/<uuid>` | `/workflow/processes` | neither |
| `/workflow/processes/new` | `/workflow/processes` | neither |
| `/workflow/processes?page=2` | `/workflow/processes` | neither |

Unclaimed fell back to the stripped route — which a remote that prefixes its own routes does not have.

## The change

`ownsRoute` also claims what lives **under** a menu route, on a segment boundary (`menuRoute + "/"`, so `/forms-archive` is not claimed by a remote that only owns `/forms`), and matches on the route alone since no menu route carries a query string.

Asked rather than assumed: the live workflow service, given `/workflow/processes/<uuid>` with `consumedRoute ""`, answers with the record — exactly the mount this produces.

## Tests

`RemoteMenuPrefixedDeepLinkSyncTest`: the record, the query string and the sibling path. `RemoteMenuRootDeepLinkSyncTest`: the symmetric record case for a remote whose routes are unprefixed. Three of them are red before the change; the whole core suite (952) is green after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)