### PR TITLE
fix(core): a component nothing can render is reported, not printed

### DIFF
--- a/backend/shared/core/src/main/java/io/mateu/core/domain/out/componentmapper/PageMetadataExtractor.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/out/componentmapper/PageMetadataExtractor.java
@@ -11,6 +11,7 @@ import io.mateu.uidl.data.BannerTheme;
 import io.mateu.uidl.data.KPI;
 import io.mateu.uidl.data.PageBanner;
 import io.mateu.uidl.data.PeerNav;
+import io.mateu.uidl.fluent.Component;
 import io.mateu.uidl.interfaces.*;
 import java.util.List;
 
@@ -39,6 +40,15 @@ final class PageMetadataExtractor {
       return TranslatorContext.translate(named.name());
     }
     if (instance != null) {
+      // A UI component's toString is never a page title. The rule below reads an overridden
+      // toString as the developer naming the record ("Booking 123"), which holds for a domain
+      // object and never for a component: every uidl component is a record, so its generated
+      // toString is a field dump — that is how a page once came back titled
+      // "Data[data={error=Process not found}, style=, cssClasses=, newState=null]", in the header
+      // AND in the browser tab.
+      if (instance instanceof Component) {
+        return getPageTitle(instance);
+      }
       try {
         if (instance.getClass().getMethod("toString").getDeclaringClass().equals(Object.class)) {
           return getPageTitle(instance);

--- a/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/ComponentToFragmentDtoMapper.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/domain/out/fragmentmapper/ComponentToFragmentDtoMapper.java
@@ -46,6 +46,9 @@ public final class ComponentToFragmentDtoMapper {
 
   private static final Set<String> warnedLongEmbeddedWizards = ConcurrentHashMap.newKeySet();
 
+  /** Component types already reported as unrenderable, so the warning is logged once each. */
+  private static final Set<String> warnedUnrenderableComponents = ConcurrentHashMap.newKeySet();
+
   private static void warnIfGuidedProcessDrawerTooLong(Object view) {
     if (!(view instanceof Wizard wizard)) {
       return;
@@ -239,8 +242,20 @@ public final class ComponentToFragmentDtoMapper {
             component, baseUrl, route, consumedRoute, initiatorComponentId, httpRequest);
     if (result != null) return result;
 
+    // Nothing knows how to render this component. That is a bug in the component or in the mapper,
+    // so it is reported to the DEVELOPER — once per type, since it would otherwise repeat on every
+    // render — instead of dumping the object's Java toString on the user's screen, which is how a
+    // "Process not found" once reached a page as
+    // "Data[data={error=Process not found}, style=, cssClasses=, newState=null]".
+    if (warnedUnrenderableComponents.add(component.getClass().getName())) {
+      log.warn(
+          "No mapper renders {} — it is emitted as an empty element. If it is meant to appear on a"
+              + " page, it needs a mapper; if it is a wire fragment (Data, State), it must be"
+              + " returned from an action, not from a view.",
+          component.getClass().getName());
+    }
     return new ClientSideComponentDto(
-        new ElementDto("div", Map.of(), Map.of(), component.toString()),
+        new ElementDto("div", Map.of(), Map.of(), ""),
         UUID.randomUUID().toString(),
         List.of(),
         component.style(),

--- a/backend/shared/core/src/test/java/io/mateu/core/application/UnrenderableComponentSyncTest.java
+++ b/backend/shared/core/src/test/java/io/mateu/core/application/UnrenderableComponentSyncTest.java
@@ -1,0 +1,139 @@
+package io.mateu.core.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.mateu.core.infra.declarative.orchestrators.crud.Crud;
+import io.mateu.core.testutil.TestMateu;
+import io.mateu.dtos.RunActionRqDto;
+import io.mateu.uidl.annotations.Title;
+import io.mateu.uidl.annotations.UI;
+import io.mateu.uidl.data.Data;
+import io.mateu.uidl.data.ListingData;
+import io.mateu.uidl.data.Page;
+import io.mateu.uidl.data.SearchRequest;
+import io.mateu.uidl.interfaces.HttpRequest;
+import io.mateu.uidl.interfaces.Identifiable;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * What reaches the screen when a view hands back something nothing can render.
+ *
+ * <p>Real case (the workflow service behind a demo console): a crud's {@code view(id)} answered an
+ * unknown id with a {@code Data} — a WIRE FRAGMENT, meant to come back from an action, not from a
+ * view. Two separate rules then turned that into Java on a user's screen: the page title falls back
+ * to the model's {@code toString()}, and a component no mapper claims is emitted as a div holding
+ * its {@code toString()}. The page came out titled — browser tab included — {@code
+ * Data[data={error=Process not found}, style=, cssClasses=, newState=null]}.
+ *
+ * <p>Returning a Data from a view is still a mistake; what this pins is that the mistake is
+ * reported to the developer in the log instead of being rendered to whoever pasted the link.
+ */
+class UnrenderableComponentSyncTest {
+
+  public static class Thing implements Identifiable {
+    String id;
+    String name;
+
+    public Thing() {}
+
+    public Thing(String id, String name) {
+      this.id = id;
+      this.name = name;
+    }
+
+    @Override
+    public String id() {
+      return id;
+    }
+  }
+
+  @SuppressWarnings("unused")
+  @UI("/things")
+  @Title("Things")
+  public static class Things extends Crud<Object, Object, Object, Object, Thing, String> {
+
+    @Override
+    public ListingData<Thing> search(SearchRequest request, HttpRequest httpRequest) {
+      var rows = List.of(new Thing("t1", "One"));
+      return new ListingData<>(new Page<>("", rows.size(), 0, rows.size(), rows));
+    }
+
+    @Override
+    public Object view(String id, HttpRequest httpRequest) {
+      return "t1".equals(id)
+          ? new Thing("t1", "One")
+          : new Data(Map.of("error", "Thing not found"));
+    }
+
+    @Override
+    public Object edit(String id, HttpRequest httpRequest) {
+      return new Thing("t1", "One");
+    }
+
+    @Override
+    public Object creationForm(HttpRequest httpRequest) {
+      return new Thing();
+    }
+
+    @Override
+    public String create(HttpRequest httpRequest) {
+      return "t1";
+    }
+
+    @Override
+    public String save(HttpRequest httpRequest) {
+      return "t1";
+    }
+
+    @Override
+    public void deleteAllById(List<String> ids, HttpRequest httpRequest) {}
+  }
+
+  static TestMateu mateu;
+
+  @BeforeEach
+  void boot() {
+    mateu = TestMateu.withUis(Things.class);
+  }
+
+  @AfterEach
+  void shutdown() {
+    mateu.close();
+  }
+
+  /** The second hop: the mediator loading the record itself, which is where the view is built. */
+  private String viewOf(String id) {
+    return mateu
+        .run(
+            RunActionRqDto.builder()
+                .route("/things/" + id)
+                .consumedRoute("/things")
+                .serverSideType(Things.class.getName())
+                .actionId("")
+                .build())
+        .toString();
+  }
+
+  @Test
+  void aComponentNothingCanRenderNeverReachesTheScreenAsJava() {
+    var increment = viewOf("nope");
+
+    // Neither in the page, nor in the window title command that names the browser tab.
+    assertThat(increment).doesNotContain("Data[data=");
+    // The title falls back to the type's own name, which says nothing private and reads as a label.
+    assertThat(increment).contains("title=Data");
+  }
+
+  @Test
+  void aViewThatRendersIsUntouched() {
+    var increment = viewOf("t1");
+
+    assertThat(increment).doesNotContain("Data[data=");
+    // The model's own toString still names the page — the rule this guards is about components.
+    assertThat(increment).contains("FormFieldDto");
+  }
+}


### PR DESCRIPTION
## What the user saw

A link to a process that no longer exists rendered this as the page heading — and as the browser tab title:

```
Data[data={error=Process not found}, style=, cssClasses=, newState=null]
```

The app had returned a `Data` from a crud's `view()`. A `Data` is a **wire fragment** (data + `newState`), meant to come back from an action, not from a view — that part is the app's mistake, and it stays a mistake. What this PR changes is that the mistake no longer reaches whoever pasted the link.

## The two rules that printed it

| where | rule | now |
|---|---|---|
| `PageMetadataExtractor.getTitle` | an overridden `toString()` is taken as the page title | a `Component` takes the same path as an object that overrides nothing: its type's own name |
| `ComponentToFragmentDtoMapper` | a component no mapper claims → a `div` holding `component.toString()` | a `log.warn` naming the type and what to do about it (once per type), and an empty element |

The title rule is right for a domain object (`Booking 123`) and never for a component: every uidl component is a record, so its generated `toString` is a field dump.

## Tests

`UnrenderableComponentSyncTest` — a crud whose `view()` answers an unknown id with a `Data`, built on the shape that produced the report: the increment carries no `toString` anywhere (page nor `SetWindowTitle`), and an ordinary view is untouched. Red before the change; the whole core suite (954) is green after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)