### PR TITLE
Ask a remote for its menu once a navigation, not once a click

### DIFF
--- a/backend/shared/core/src/main/java/io/mateu/core/application/runaction/RemoteAppDescriptorCache.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/runaction/RemoteAppDescriptorCache.java
@@ -1,0 +1,129 @@
+package io.mateu.core.application.runaction;
+
+import io.mateu.dtos.AppDto;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.LongSupplier;
+
+/**
+ * The remote app descriptors a shell has already asked for, held briefly.
+ *
+ * <p>A shell fronting remote menus asks each remote for its {@link AppDto} — title, menu, home
+ * wiring — every time it resolves a route, and that ask is an HTTP round trip that lands on the
+ * remote's HOME route, so the remote renders its home just to answer "here is my menu". Measured on
+ * the reference deployment that hop took 777 ms to return 418 bytes, and it happens on every
+ * navigation: three clicks within one remote made three of them (see {@code
+ * RemoteMenuFetchCountSyncTest}).
+ *
+ * <p>The descriptor is app-shaped, not request-shaped: it changes when the remote is redeployed and
+ * at no other time. The TTL is therefore what bounds how long a redeployed remote's new menu takes
+ * to show up in the shell — 30 s by default, and the reason it is not longer.
+ *
+ * <p><b>The key includes who is asking.</b> A remote receives the caller's {@code authorization}
+ * header and is free to answer with a menu built for that user; Mateu's core does not filter menus
+ * by role, but a remote may. Keying on the base URL alone would serve one user's menu to another,
+ * which is a privacy bug rather than a slow page — so the token is part of the key. It is stored as
+ * a SHA-256 digest: the map lives for the life of the process, and a bearer token is not something
+ * to keep in memory any longer than the request that carried it.
+ */
+@Named
+@Singleton
+public class RemoteAppDescriptorCache {
+
+  /** How long a descriptor stays usable. {@code 0} disables the cache entirely. */
+  static final String TTL_PROPERTY = "mateu.remote-menu.descriptor-ttl-ms";
+
+  static final String TTL_ENV = "MATEU_REMOTE_MENU_DESCRIPTOR_TTL_MS";
+  static final long DEFAULT_TTL_MS = 30_000;
+
+  /**
+   * Enough for every remote a shell fronts, several users deep. Past it the map is emptied rather
+   * than evicted one by one: this is a latency cache, and rebuilding it costs one round trip per
+   * remote — cheaper than carrying eviction bookkeeping for a map that should never get here.
+   */
+  private static final int MAX_ENTRIES = 512;
+
+  private final Map<String, Entry> entries = new ConcurrentHashMap<>();
+  private final LongSupplier clock;
+  private final long ttlMs;
+
+  public RemoteAppDescriptorCache() {
+    this(System::currentTimeMillis, configuredTtlMs());
+  }
+
+  RemoteAppDescriptorCache(LongSupplier clock, long ttlMs) {
+    this.clock = clock;
+    this.ttlMs = ttlMs;
+  }
+
+  private record Entry(AppDto app, long expiresAt) {}
+
+  /** The descriptor for this remote and this caller, or null if none is held or it has expired. */
+  AppDto get(String baseUrl, String route, String authorization) {
+    if (ttlMs <= 0) {
+      return null;
+    }
+    var entry = entries.get(key(baseUrl, route, authorization));
+    if (entry == null) {
+      return null;
+    }
+    if (clock.getAsLong() >= entry.expiresAt()) {
+      entries.remove(key(baseUrl, route, authorization));
+      return null;
+    }
+    return entry.app();
+  }
+
+  void put(String baseUrl, String route, String authorization, AppDto app) {
+    if (ttlMs <= 0 || app == null) {
+      return;
+    }
+    if (entries.size() >= MAX_ENTRIES) {
+      entries.clear();
+    }
+    entries.put(key(baseUrl, route, authorization), new Entry(app, clock.getAsLong() + ttlMs));
+  }
+
+  private static String key(String baseUrl, String route, String authorization) {
+    return baseUrl + "\n" + route + "\n" + fingerprint(authorization);
+  }
+
+  /**
+   * The caller's identity as far as this cache is concerned. Anonymous is its own bucket rather
+   * than a shared one, so an unauthenticated resolution never reads an authenticated answer.
+   */
+  private static String fingerprint(String authorization) {
+    if (authorization == null || authorization.isBlank()) {
+      return "anonymous";
+    }
+    try {
+      var digest = MessageDigest.getInstance("SHA-256");
+      return HexFormat.of()
+          .formatHex(digest.digest(authorization.getBytes(StandardCharsets.UTF_8)));
+    } catch (Exception e) {
+      // No SHA-256 in this JVM: share nothing rather than key on the raw token. Every lookup then
+      // misses, which costs the round trip this class exists to avoid and breaks nothing.
+      return "unhashable-" + System.identityHashCode(authorization);
+    }
+  }
+
+  private static long configuredTtlMs() {
+    var configured = System.getProperty(TTL_PROPERTY);
+    if (configured == null || configured.isBlank()) {
+      configured = System.getenv(TTL_ENV);
+    }
+    if (configured == null || configured.isBlank()) {
+      return DEFAULT_TTL_MS;
+    }
+    try {
+      return Math.max(0, Long.parseLong(configured.trim()));
+    } catch (NumberFormatException e) {
+      return DEFAULT_TTL_MS;
+    }
+  }
+}

--- a/backend/shared/core/src/main/java/io/mateu/core/application/runaction/RemoteMenuHandler.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/runaction/RemoteMenuHandler.java
@@ -22,6 +22,7 @@ import reactor.core.publisher.Mono;
 public class RemoteMenuHandler {
 
   private final MateuHttpClient mateuHttpClient;
+  private final RemoteAppDescriptorCache descriptorCache;
 
   Mono<?> handleRemoteMenuActionable(
       RemoteMenu remoteMenu, AppShell app, HttpRequest httpRequest, RunActionCommand command) {
@@ -122,9 +123,20 @@ public class RemoteMenuHandler {
                         menuRoutes(option.submenus())));
   }
 
-  /** The remote app's descriptor (title, menu, home wiring), asked at its home route. */
+  /**
+   * The remote app's descriptor (title, menu, home wiring), asked at its home route.
+   *
+   * <p>Asked once per remote per caller per TTL rather than once per navigation: this is an HTTP
+   * round trip that lands on the remote's home, so the remote renders its home just to say what its
+   * menu is. See {@link RemoteAppDescriptorCache} for what the TTL bounds.
+   */
   private Mono<AppDto> fetchRemoteAppDto(
       RemoteMenu remoteMenu, HttpRequest httpRequest, RunActionCommand command) {
+    var authorization = httpRequest.getHeaderValue("authorization");
+    var cached = descriptorCache.get(remoteMenu.baseUrl(), remoteMenu.route(), authorization);
+    if (cached != null) {
+      return Mono.just(cached);
+    }
     RunActionRqDto request =
         RunActionRqDto.builder()
             .actionId("")
@@ -139,8 +151,7 @@ public class RemoteMenuHandler {
       baseUrl = httpRequest.getHeaderValue("origin") + baseUrl;
     }
 
-    return Mono.fromFuture(
-            mateuHttpClient.send(baseUrl, request, httpRequest.getHeaderValue("authorization")))
+    return Mono.fromFuture(mateuHttpClient.send(baseUrl, request, authorization))
         .flatMap(
             uiIncrementDto ->
                 Mono.justOrEmpty(
@@ -152,7 +163,11 @@ public class RemoteMenuHandler {
                         .map(ClientSideComponentDto::metadata)
                         .filter(metadata -> metadata instanceof AppDto)
                         .map(metadata -> (AppDto) metadata)
-                        .findFirst()));
+                        .findFirst()))
+        .doOnNext(
+            appDto ->
+                descriptorCache.put(
+                    remoteMenu.baseUrl(), remoteMenu.route(), authorization, appDto));
   }
 
   private Mono<?> resolveRemoteMenu(

--- a/backend/shared/core/src/test/java/io/mateu/core/application/RemoteMenuFetchCountSyncTest.java
+++ b/backend/shared/core/src/test/java/io/mateu/core/application/RemoteMenuFetchCountSyncTest.java
@@ -1,0 +1,136 @@
+package io.mateu.core.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.mateu.core.application.out.MateuHttpClient;
+import io.mateu.core.testutil.TestMateu;
+import io.mateu.dtos.AppDto;
+import io.mateu.dtos.ClientSideComponentDto;
+import io.mateu.dtos.MenuOptionDto;
+import io.mateu.dtos.RunActionRqDto;
+import io.mateu.dtos.UIFragmentDto;
+import io.mateu.dtos.UIIncrementDto;
+import io.mateu.uidl.annotations.Menu;
+import io.mateu.uidl.annotations.Title;
+import io.mateu.uidl.annotations.UI;
+import io.mateu.uidl.data.RemoteMenu;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * How many times a shell asks its remotes for their app descriptor in order to paint one page.
+ *
+ * <p>This is a measurement, not a preference. Each of those calls is an HTTP round trip to the
+ * remote's home route, so the remote renders its home just to answer "here is my menu" — on the
+ * reference deployment that hop took 777 ms to return 418 bytes.
+ */
+class RemoteMenuFetchCountSyncTest {
+
+  static final List<String> CALLS = new ArrayList<>();
+
+  @SuppressWarnings("unused")
+  @UI("")
+  @Title("Console")
+  public static class ShellRoot {
+    @Menu
+    RemoteMenu booking = new RemoteMenu("/_booking").withLabel("Booking").withPath("/booking");
+
+    @Menu
+    RemoteMenu content = new RemoteMenu("/_content").withLabel("Content").withPath("/content");
+
+    @Menu
+    RemoteMenu workflow = new RemoteMenu("/_workflow").withLabel("Workflow").withPath("/workflow");
+  }
+
+  /** Every remote answers with its own two menu routes, unprefixed. */
+  public static class CountingRemotes implements MateuHttpClient {
+    @Override
+    public CompletableFuture<UIIncrementDto> send(String baseUrl, RunActionRqDto request) {
+      return send(baseUrl, request, null);
+    }
+
+    @Override
+    public CompletableFuture<UIIncrementDto> send(
+        String baseUrl, RunActionRqDto request, String authorization) {
+      CALLS.add(baseUrl);
+      var name = baseUrl.replace("/_", "");
+      var appDto =
+          AppDto.builder()
+              .route("")
+              .title(name)
+              .homeRoute("_no_home_route")
+              .homeConsumedRoute("")
+              .homeServerSideType(name + ".Home")
+              .menu(
+                  List.of(
+                      MenuOptionDto.builder()
+                          .label("Processes")
+                          .path("/processes")
+                          .route("/processes")
+                          .build(),
+                      MenuOptionDto.builder()
+                          .label("Definitions")
+                          .path("/definitions")
+                          .route("/definitions")
+                          .build()))
+              .build();
+      var component =
+          new ClientSideComponentDto(appDto, name + "_app", List.of(), null, null, null);
+      return CompletableFuture.completedFuture(
+          UIIncrementDto.builder()
+              .fragments(List.of(UIFragmentDto.builder().component(component).build()))
+              .build());
+    }
+  }
+
+  static TestMateu mateu;
+  final java.util.concurrent.atomic.AtomicLong clock = new java.util.concurrent.atomic.AtomicLong();
+
+  @BeforeEach
+  void boot() {
+    CALLS.clear();
+    mateu = TestMateu.withUisAndBeans(List.of(new CountingRemotes()), ShellRoot.class);
+  }
+
+  @AfterEach
+  void shutdown() {
+    mateu.close();
+  }
+
+  private void viaUrl(String route) {
+    mateu.run(RunActionRqDto.builder().route(route).consumedRoute("_empty").actionId("").build());
+  }
+
+  @Test
+  void oneNavigationAsksTheRemoteOnce() {
+    viaUrl("/workflow/processes");
+
+    assertThat(CALLS).containsExactly("null/_workflow");
+  }
+
+  /**
+   * The measurement this exists for. Every click within one remote used to be its own round trip to
+   * that remote's home; the descriptor changes when the remote is redeployed and at no other time.
+   */
+  @Test
+  void navigatingWithinOneRemoteDoesNotAskItAgain() {
+    viaUrl("/workflow/processes");
+    viaUrl("/workflow/definitions");
+    viaUrl("/workflow/processes");
+
+    assertThat(CALLS).containsExactly("null/_workflow");
+  }
+
+  /** Each remote is still its own entry — one answer must never stand in for another's. */
+  @Test
+  void eachRemoteIsAskedForItself() {
+    viaUrl("/workflow/processes");
+    viaUrl("/booking/processes");
+
+    assertThat(CALLS).containsExactly("null/_workflow", "null/_booking");
+  }
+}

--- a/backend/shared/core/src/test/java/io/mateu/core/application/runaction/RemoteAppDescriptorCacheTest.java
+++ b/backend/shared/core/src/test/java/io/mateu/core/application/runaction/RemoteAppDescriptorCacheTest.java
@@ -1,0 +1,179 @@
+package io.mateu.core.application.runaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.mateu.dtos.AppDto;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * What the descriptor cache may and may not hand back.
+ *
+ * <p>The one that matters is {@link #oneCallersDescriptorIsNotServedToAnother()}. The rest is
+ * latency; that one is the difference between a cache and a leak.
+ */
+class RemoteAppDescriptorCacheTest {
+
+  private final AtomicLong clock = new AtomicLong();
+
+  private RemoteAppDescriptorCache cache(long ttlMs) {
+    return new RemoteAppDescriptorCache(clock::get, ttlMs);
+  }
+
+  private static AppDto app(String title) {
+    return AppDto.builder().route("").title(title).build();
+  }
+
+  @Test
+  @DisplayName("a held descriptor is handed back until it expires")
+  void anExpiredDescriptorIsAskedForAgain() {
+    var cache = cache(30_000);
+    var app = app("Workflow");
+    cache.put("/_workflow", "", null, app);
+
+    clock.set(29_999);
+    assertThat(cache.get("/_workflow", "", null)).isSameAs(app);
+
+    clock.set(30_000);
+    assertThat(cache.get("/_workflow", "", null)).isNull();
+  }
+
+  /**
+   * A remote receives the caller's authorization header and is free to build its menu for that user
+   * — Mateu's core does not filter menus by role, but a remote may. Sharing one entry across
+   * callers would hand one user another user's menu, so the token is part of the key.
+   */
+  @Test
+  @DisplayName("one caller's descriptor is never served to another")
+  void oneCallersDescriptorIsNotServedToAnother() {
+    var cache = cache(30_000);
+    var forAna = app("Ana");
+    cache.put("/_workflow", "", "Bearer ana", forAna);
+
+    assertThat(cache.get("/_workflow", "", "Bearer ana")).isSameAs(forAna);
+    assertThat(cache.get("/_workflow", "", "Bearer bob")).isNull();
+    assertThat(cache.get("/_workflow", "", null)).isNull();
+  }
+
+  /** Anonymous is its own bucket, not a shared one. */
+  @Test
+  @DisplayName("an authenticated answer is never served to an anonymous caller")
+  void anonymousDoesNotReadAnAuthenticatedAnswer() {
+    var cache = cache(30_000);
+    cache.put("/_workflow", "", null, app("public"));
+
+    assertThat(cache.get("/_workflow", "", "Bearer ana")).isNull();
+  }
+
+  @Test
+  @DisplayName("remotes and routes are separate entries")
+  void oneRemoteNeverAnswersForAnother() {
+    var cache = cache(30_000);
+    var workflow = app("Workflow");
+    cache.put("/_workflow", "", null, workflow);
+
+    assertThat(cache.get("/_workflow", "", null)).isSameAs(workflow);
+    assertThat(cache.get("/_booking", "", null)).isNull();
+    assertThat(cache.get("/_workflow", "/elsewhere", null)).isNull();
+  }
+
+  @Test
+  @DisplayName("a zero TTL holds nothing, which is how it is switched off")
+  void aZeroTtlHoldsNothing() {
+    var cache = cache(0);
+    cache.put("/_workflow", "", null, app("Workflow"));
+
+    assertThat(cache.get("/_workflow", "", null)).isNull();
+  }
+
+  @Test
+  @DisplayName("nothing is held for a remote that answered with no descriptor")
+  void aNullDescriptorIsNotHeld() {
+    var cache = cache(30_000);
+    cache.put("/_workflow", "", null, null);
+
+    assertThat(cache.get("/_workflow", "", null)).isNull();
+  }
+
+  /**
+   * Past its bound the map is emptied rather than evicted entry by entry: rebuilding costs one
+   * round trip per remote, which is cheaper than carrying eviction bookkeeping for a map that
+   * should never reach this size.
+   */
+  @Test
+  @DisplayName("the map stays bounded")
+  void theMapDoesNotGrowWithoutEnd() {
+    var cache = cache(30_000);
+    for (int i = 0; i < 600; i++) {
+      cache.put("/_remote" + i, "", null, app("r" + i));
+    }
+
+    var last = app("last");
+    cache.put("/_last", "", null, last);
+    assertThat(cache.get("/_last", "", null)).isSameAs(last);
+  }
+
+  // ── the configured TTL ───────────────────────────────────────────────────
+
+  private static RemoteAppDescriptorCache configuredWith(String ttl) {
+    var previous = System.getProperty(RemoteAppDescriptorCache.TTL_PROPERTY);
+    try {
+      if (ttl == null) {
+        System.clearProperty(RemoteAppDescriptorCache.TTL_PROPERTY);
+      } else {
+        System.setProperty(RemoteAppDescriptorCache.TTL_PROPERTY, ttl);
+      }
+      return new RemoteAppDescriptorCache();
+    } finally {
+      if (previous == null) {
+        System.clearProperty(RemoteAppDescriptorCache.TTL_PROPERTY);
+      } else {
+        System.setProperty(RemoteAppDescriptorCache.TTL_PROPERTY, previous);
+      }
+    }
+  }
+
+  @Test
+  @DisplayName("with nothing configured, descriptors are held")
+  void theDefaultHoldsDescriptors() {
+    var cache = configuredWith(null);
+    var app = app("Workflow");
+    cache.put("/_workflow", "", null, app);
+
+    assertThat(cache.get("/_workflow", "", null)).isSameAs(app);
+  }
+
+  /** The documented way to switch it off, for a shell whose remotes change under it. */
+  @Test
+  @DisplayName("the property can switch it off")
+  void theTtlPropertyCanDisableIt() {
+    var cache = configuredWith("0");
+    cache.put("/_workflow", "", null, app("Workflow"));
+
+    assertThat(cache.get("/_workflow", "", null)).isNull();
+  }
+
+  /**
+   * A typo in a tuning knob must not be the reason a shell stops resolving its remotes, so an
+   * unreadable value means the default rather than zero.
+   */
+  @Test
+  @DisplayName("an unreadable value falls back to the default rather than to off")
+  void aMalformedTtlDoesNotSilentlyDisableIt() {
+    var cache = configuredWith("half a minute");
+    var app = app("Workflow");
+    cache.put("/_workflow", "", null, app);
+
+    assertThat(cache.get("/_workflow", "", null)).isSameAs(app);
+  }
+
+  @Test
+  @DisplayName("a negative value is off, not a descriptor that never expires")
+  void aNegativeTtlIsOff() {
+    var cache = configuredWith("-1");
+    cache.put("/_workflow", "", null, app("Workflow"));
+
+    assertThat(cache.get("/_workflow", "", null)).isNull();
+  }
+}


### PR DESCRIPTION
## What this is

A shell fronting `RemoteMenu`s asks each remote for its `AppDto` — title, menu, home wiring — **every time it resolves a route**. That ask is an HTTP round trip, and it lands on the remote's *home* route, so the remote renders its home just to answer "here is my menu".

## The measurement

`RemoteMenuFetchCountSyncTest` counts the calls through the whole server side (`TestMateu` + a `MateuHttpClient` double). Before this change:

| | remote fetches |
|---|---|
| one navigation | 1 |
| three navigations within the same remote | **3** |

On the reference deployment — `ec1.mateu.io`, a workflow engine behind a console shell — that hop took **777 ms to return 418 bytes**, and it is the first of the two requests the browser makes on every page change. It is the flicker.

After: three navigations within one remote make **one** fetch.

## Why it is safe to hold

The descriptor is app-shaped, not request-shaped: it changes when the remote is redeployed and at no other time. The TTL is therefore exactly what bounds how long a redeployed remote's new menu takes to show up in the shell — 30 s by default, and the reason it is not longer.

`mateu.remote-menu.descriptor-ttl-ms` (or `MATEU_REMOTE_MENU_DESCRIPTOR_TTL_MS`) tunes it; `0` switches it off. A malformed value falls back to the default rather than to off, so a typo in a tuning knob is not the reason a shell stops resolving its remotes.

## The part that is not about latency

**The cache key includes who is asking.** A remote receives the caller's `authorization` header and is free to build its menu for that user. Mateu's core does not filter menus by role — I checked — but a remote may, and keying on the base URL alone would serve one user's menu to another. That is a privacy bug, not a slow page. The token is part of the key, and it is stored as a SHA-256 digest rather than kept in process memory for as long as the map lives. Anonymous is its own bucket, so an unauthenticated resolution never reads an authenticated answer.

## Verification

- `mvn verify` on the whole `backend` reactor: **BUILD SUCCESS**, `All coverage checks have been met` on `core` (968 tests).
- 11 new tests: 3 counting fetches end-to-end, 8 on the cache itself (expiry, per-caller isolation, anonymous isolation, per-remote isolation, TTL off, null descriptor, bounded map, and the configured-TTL paths).

## What this does not fix

The *second* request still happens: the browser asks the shell to resolve the route (`action: "Replace"` on root, `component: null`) and then asks for the page. This change makes the first one cheap; it does not remove it. That is a separate question in the frontend's routing against a remote menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VjvwX8jB4DAEPKBKszSoKe