### PR TITLE
Resolve an SSO session silently, so a deep link does not load the SPA twice

### DIFF
--- a/backend/mvc/annotation-processor-mvc/src/main/resources/templates/index.ftl
+++ b/backend/mvc/annotation-processor-mvc/src/main/resources/templates/index.ftl
@@ -66,10 +66,20 @@ public class ${simpleClassName}Controller {
             });
         }
         keycloak.init({
-            onLoad: 'login-required',
+            onLoad: 'check-sso',
+            silentCheckSsoRedirectUri: window.location.origin + '/silent-check-sso.html',
         }).then(function(authenticated) {
             console.log(authenticated ? 'authenticated' : 'not authenticated');
-            if (authenticated) {
+            if (!authenticated) {
+                // No SSO session yet: one redirect to the login page. With check-sso this is the
+                // only full-page navigation, and only for genuinely unauthenticated users. An
+                // existing session is resolved silently in a hidden iframe (auth.* and the app are
+                // same-site under the parent domain, so no third-party cookie is needed) — no
+                // top-level redirect, no reload, no double load of the whole SPA.
+                keycloak.login();
+                return;
+            }
+            {
                 localStorage.setItem('__mateu_auth_token', keycloak.token);
                 localStorage.setItem('__mateu_auth_subject', keycloak.subject);
                 const s = document.createElement('script');

--- a/backend/shared/frontend/vaadin-lit/src/main/resources/META-INF/resources/silent-check-sso.html
+++ b/backend/shared/frontend/vaadin-lit/src/main/resources/META-INF/resources/silent-check-sso.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+<body>
+<!--
+  Keycloak silent SSO check. Loaded in a hidden iframe by keycloak-js when init is called with
+  onLoad: 'check-sso' and silentCheckSsoRedirectUri pointing here. Keycloak redirects the iframe
+  back to this page with the auth result in the URL; the script hands that URL to the parent
+  window so the token is established without a full-page redirect (no double load).
+-->
+<script>
+  parent.postMessage(location.href, location.origin);
+</script>
+</body>
+</html>

--- a/backend/shared/frontend/vaadin-lit/src/main/resources/static/silent-check-sso.html
+++ b/backend/shared/frontend/vaadin-lit/src/main/resources/static/silent-check-sso.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+<body>
+<!--
+  Keycloak silent SSO check. Loaded in a hidden iframe by keycloak-js when init is called with
+  onLoad: 'check-sso' and silentCheckSsoRedirectUri pointing here. Keycloak redirects the iframe
+  back to this page with the auth result in the URL; the script hands that URL to the parent
+  window so the token is established without a full-page redirect (no double load).
+-->
+<script>
+  parent.postMessage(location.href, location.origin);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Problem

Entering a shell-fronted app by URL (e.g. `ec1.mateu.io/workflow/definitions`) loads the whole SPA **twice**. The served index bootstrap runs `keycloak.init({ onLoad: 'login-required' })`, which — with no token in the freshly-loaded page — redirects the browser to Keycloak and straight back (the SSO session already exists), so the document and every asset load a second time; the token is only exchanged on the second load.

Browser capture on ec1 (2026-08-29): two `GET /workflow/definitions` + two full asset sets, `POST .../token` only after the second load.

This is **separate** from the menu-rebuild flicker fixed in #422 — it's the auth bootstrap, which that PR never touched.

## Fix

`onLoad: 'check-sso'` resolves an existing session in a **hidden iframe** instead of a top-level redirect — no reload. keycloak-js is pointed at a served `silent-check-sso.html` (added under vaadin-lit `static/` + `META-INF/resources/`, next to `vite.svg`, so it answers at `/silent-check-sso.html`). Only a genuinely unauthenticated visitor gets a single redirect, now explicit via `keycloak.login()`.

The auth host and the app are **same-site** under the parent domain, so the iframe's cookie is first-party and Chrome's third-party-cookie blocking doesn't break the silent check.

## Deployment note

The client's valid-redirect-URIs must allow the silent-check URI (a `https://<host>/*` entry covers it). If not, the silent check fails closed and falls back to the login redirect — the previous behaviour, no worse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)