### PR TITLE
fix(visual-editor): sort view models with localeCompare (Sonar S2871)

### DIFF
--- a/frontend/web/monorepo/apps/visual-editor/src/model/projectIndex.ts
+++ b/frontend/web/monorepo/apps/visual-editor/src/model/projectIndex.ts
@@ -64,7 +64,7 @@ export function buildIndex(files: ProjectFile[]): ProjectIndex {
         pages: dedupe(pages),
         partials: dedupe(partials),
         appShells: dedupe(appShells),
-        viewModels: [...viewModels].sort(),
+        viewModels: [...viewModels].sort((a, b) => a.localeCompare(b)),
     }
 }
 


### PR DESCRIPTION
Fixes the single SonarCloud reliability bug from #426: a bare `Array.sort()` on the view-model list sorts by UTF-16 code unit rather than alphabetically. Adds a `localeCompare` comparator.

Build + 71 vitest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)