### PR TITLE
La URL del renderer Redwood llevaba un # sólo por estar la app securizada

### DIFF
--- a/backend/mvc/annotation-processor-mvc/src/main/resources/templates/index.ftl
+++ b/backend/mvc/annotation-processor-mvc/src/main/resources/templates/index.ftl
@@ -105,8 +105,19 @@ public class ${simpleClassName}Controller {
                 const deferred = Array.from(
                     document.querySelectorAll('script[type="text/mateu-deferred"]'));
                 if (deferred.length) {
-                    // La página trae su propio arranque y su propia raíz; solo le faltaba el
-                    // token. No se le añade un mateu-ui: ya tiene dónde pintarse.
+                    // La página trae su propio arranque y su propia raíz; sólo le faltaba el
+                    // token. Aun así se le añade el mateu-ui, oculto: no está ahí para pintar
+                    // nada, sino porque TRANSPORTA el baseUrl y es la SEÑAL de que a esta página
+                    // la sirve el backend de Mateu — que es lo que decide si la shell rutea por
+                    // path (/ruta) o por hash (#/ruta). Sin él, la misma app cambiaba de esquema
+                    // de URL por el mero hecho de estar securizada, que no tiene nada que ver.
+                    // Va ANTES de arrancar: la shell lo consulta nada más entrar.
+                    const u = document.createElement('mateu-ui');
+                    u.setAttribute('baseUrl', '${path}');
+                    u.setAttribute('pathPrefix', '${path}');
+                    u.setAttribute('style', 'display:none;');
+                    document.body.appendChild(u);
+
                     bootDeferred(deferred).catch(function (e) {
                         console.log('failed to boot the deferred scripts', e);
                     });

--- a/backend/probe-tmp.mjs
+++ b/backend/probe-tmp.mjs
@@ -1,0 +1,29 @@
+import { chromium } from 'playwright';
+const b = await chromium.launch();
+const p = await b.newPage();
+// Simulates the fix: the controller's Keycloak boot appends the hidden <mateu-ui> for a
+// deferred-boot page too, before starting it — it is not only a render root, it carries the
+// baseUrl and is the URL-mode signal the VB shell reads.
+await p.addInitScript(() => {
+  const add = () => {
+    if (document.body && !document.querySelector('mateu-ui')) {
+      const u = document.createElement('mateu-ui');
+      u.setAttribute('baseUrl', ''); u.setAttribute('pathPrefix', '');
+      document.body.appendChild(u);
+    } else if (!document.body) requestAnimationFrame(add);
+  };
+  add();
+});
+await p.goto('https://rw.ec1.mateu.io/', { waitUntil: 'domcontentloaded' });
+await p.waitForTimeout(2500);
+if (await p.locator('#username').count()) {
+  await p.fill('#username', 'demo'); await p.fill('#password', 'demo');
+  await p.click('input[type=submit], button[type=submit]');
+  await p.waitForTimeout(8000);
+}
+console.log(await p.evaluate(() => JSON.stringify({
+  hasMateuUi: !!document.querySelector('mateu-ui'),
+  pathMode: window.__mateuUrlPathMode,
+  href: location.href,
+}, null, 1)));
+await b.close();


### PR DESCRIPTION
En `rw.ec1.mateu.io` la URL sale como `https://rw.ec1.mateu.io/#/workflow/processes` —con almohadilla— y la misma app sin securizar rutea por path. El esquema de URL no tiene nada que ver con la autenticación, así que el fallo estaba en otro sitio.

## Qué pasaba

La shell VB decide el modo mirando si hay un `<mateu-ui>` en la página:

```js
const pathMode = !!document.querySelector('mateu-ui');
```

Ese elemento no está ahí para pintar nada —en la app VB va oculto—, sino porque **transporta el baseUrl y es la señal** de que a esta página la sirve el backend de Mateu, que es el único capaz de reescribir un path arbitrario al index. En serving estático (vb-serve, VB hosteado) no lo hay, y de ahí que las chains vayan por hash.

Con `@KeycloakSecured` el arranque se aplaza hasta tener token: el controller **quita** el `<mateu-ui>` del HTML y la llamada de vuelta de Keycloak lo repone… salvo cuando la página trae su propio arranque (los scripts `text/mateu-deferred` de la app VB), donde la rama decía explícitamente *"no se le añade un mateu-ui: ya tiene dónde pintarse"*. Cierto para pintar, falso para todo lo demás: sin él nadie repone la señal ni el baseUrl, y la shell cae a hash.

## El arreglo

Esa rama también lo añade ahora, oculto y **antes** de arrancar los scripts aplazados (la shell lo consulta nada más entrar). Una línea en `annotation-processor-mvc/templates/index.ftl` — es el único adaptador con arranque aplazado.

## Comprobación

Contra el despliegue real:

| | `hasMateuUi` | `pathMode` | URL |
|---|---|---|---|
| hoy | `false` | `false` | `https://rw.ec1.mateu.io/#_no_home_route` |
| inyectando el elemento por delante del arranque | `true` | `true` | `https://rw.ec1.mateu.io/` |

(en modo path el centinela `_no_home_route` que manda el server se escribe como `/`, que es lo correcto)

Y el controller generado para un `@UI` `@KeycloakSecured` lleva el elemento con su `baseUrl` sustituido y compila (verificado habilitando temporalmente el `@KeycloakSecured` de `demo-vaadin-mvc`).

No hay test automático: el arnés tendría que levantar un Keycloak y servir la app VB. Queda dicho.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014mtJZib3iJNDxb4GPy6KpE