### PR TITLE
DSL-app enumeration + menu-route conformance (3-backend parity)

### DIFF
--- a/backend/dotnet/src/Mateu.Core/MenuRouteConformance.cs
+++ b/backend/dotnet/src/Mateu.Core/MenuRouteConformance.cs
@@ -1,0 +1,52 @@
+using Mateu.Dtos;
+
+namespace Mateu.Core;
+
+/// <summary>
+/// Conformance check for menu routes: every route a menu leaf points at must resolve to a known
+/// route. A leaf is a route or a rule — a route leaf that points nowhere is the failure this
+/// catches, recovering the safety a typed-class menu reference used to give (the class had to exist)
+/// now that a leaf can carry a plain route string.
+///
+/// <para>Pure over the built menu and the known route table so it mirrors 1:1 across the backends
+/// and can be asserted in a test / CI check. Only leaves that actually navigate LOCALLY are checked:
+/// a rule leaf (runs client-side), a separator, a remote leaf (a federated app, not resolvable
+/// here), an external URL and an empty placeholder are all skipped. (Mirrors Java's
+/// io.mateu.core.application.MenuRouteConformance and Python's menu_route_conformance.)</para>
+/// </summary>
+public static class MenuRouteConformance
+{
+    /// <summary>The absolute routes of leaves that resolve to no entry in <paramref name="knownRoutes"/>,
+    /// in menu order.</summary>
+    public static IReadOnlyList<string> DanglingRoutes(
+        IReadOnlyList<MenuItemDto>? menu, RouteTable knownRoutes)
+    {
+        var dangling = new List<string>();
+        Collect(menu, knownRoutes, dangling);
+        return dangling;
+    }
+
+    private static void Collect(
+        IReadOnlyList<MenuItemDto>? menu, RouteTable knownRoutes, List<string> outList)
+    {
+        if (menu is null) return;
+        foreach (var option in menu)
+        {
+            if (option is null) continue;
+            if (option.Submenus is { Count: > 0 })
+            {
+                Collect(option.Submenus, knownRoutes, outList); // a group, not a leaf — recurse
+                continue;
+            }
+            if (option.Separator) continue;
+            if (option.Rules is { Count: > 0 }) continue; // a rule leaf: runs client-side
+            if (option.Remote) continue; // a federated app: resolved by the remote, not here
+            var route = option.Route;
+            if (string.IsNullOrWhiteSpace(route) || IsExternal(route)) continue; // placeholder / URL
+            if (knownRoutes.Match(route) is null) outList.Add(route);
+        }
+    }
+
+    private static bool IsExternal(string route) =>
+        route.StartsWith("http:") || route.StartsWith("https:") || route.StartsWith("//");
+}

--- a/backend/dotnet/src/Mateu.Core/RouteRegistry.cs
+++ b/backend/dotnet/src/Mateu.Core/RouteRegistry.cs
@@ -158,6 +158,109 @@ public sealed class RouteRegistry
 
     public RouteMatch? Match(string? path) => Authored().Match(path);
 
+    /// <summary>An app a deployment contributes: a mount root, with the class that backs it (null for
+    /// a purely-DSL app) and the definition it renders (null for a class-based app). (Mirrors Java's
+    /// RouteRegistry.AppRef and Python's AppRef.)</summary>
+    public sealed record AppRef(string Route, string? ClassName, string? Definition)
+    {
+        public bool IsDsl() => string.IsNullOrWhiteSpace(ClassName);
+    }
+
+    /// <summary>
+    /// Every app of the deployment, from TWO producers merged into ONE table — the same "authored
+    /// wins" rule the routes and sources use:
+    /// <list type="bullet">
+    /// <item><b>derived</b>: the reflection-discovered <c>[Ui]</c> classes (each an app at its path),
+    /// supplied by the caller (there is no compile-time index here as in Java);</item>
+    /// <item><b>authored</b>: the <c>type: UI</c> mounts discovered in the specs directory — which
+    /// need NO class, so a deployment can ship a purely-DSL app and announce it here like any
+    /// other.</item>
+    /// </list>
+    /// A mount at the same base path as a class replaces it (authored wins). This is the enumeration a
+    /// federated shell (or a bundle/tool) reads to announce apps uniformly, with or without a class
+    /// behind them.
+    /// </summary>
+    public IReadOnlyList<AppRef> Apps(IEnumerable<AppRef>? derived = null)
+    {
+        var byRoute = new Dictionary<string, AppRef>();
+        if (derived is not null)
+            foreach (var d in derived)
+                byRoute[Normalize(d.Route)] = d with { Route = Normalize(d.Route) };
+        foreach (var mount in ScanMounts())
+            byRoute[mount.BasePath] = new AppRef(mount.BasePath, null, DefinitionOf(mount));
+        return byRoute.Values.ToList();
+    }
+
+    /// <summary>A DSL mount discovered by content: a base path and the route files that make it up.</summary>
+    private sealed record MountDescriptor(string BasePath, IReadOnlyList<string> RouteFiles);
+
+    /// <summary>Scans the specs directory for <c>type: UI</c> files (by content, not by filename), so
+    /// several DSL apps can coexist. (Mirrors Java's MountRegistry.mounts.)</summary>
+    private IReadOnlyList<MountDescriptor> ScanMounts()
+    {
+        var mounts = new List<MountDescriptor>();
+        if (!Directory.Exists(_dir)) return mounts;
+        foreach (var file in Directory.EnumerateFiles(_dir, "*.*", SearchOption.AllDirectories)
+                     .Where(f => f.EndsWith(".yaml") || f.EndsWith(".yml")))
+        {
+            try
+            {
+                if (Yaml.Deserialize<object?>(File.ReadAllText(file)) is not IDictionary<object, object> root)
+                    continue;
+                if (Str(root, "type") != "UI") continue;
+                var basePath = Normalize(Str(root, "basePath") ?? Str(root, "base_path"));
+                var routeFiles = new List<string>();
+                if (root.TryGetValue("routes", out var routes))
+                {
+                    if (routes is IEnumerable<object> list)
+                        routeFiles.AddRange(list.Select(n => n?.ToString()).Where(s => s is not null)!);
+                    else if (routes is string one)
+                        routeFiles.Add(one);
+                }
+                mounts.Add(new MountDescriptor(basePath, routeFiles));
+            }
+            catch
+            {
+                // a broken descriptor must not take app enumeration down — skip it.
+            }
+        }
+        return mounts;
+    }
+
+    /// <summary>The definition bound to a DSL mount's ROOT route: load its route files (relative
+    /// entries prefixed with the mount base path), match the base path, read the definition. That
+    /// root entry is where a DSL app's shell lives — a route with a definition and no class.</summary>
+    private string? DefinitionOf(MountDescriptor mount)
+    {
+        foreach (var routeFile in mount.RouteFiles)
+        {
+            var path = Path.Combine(_dir, routeFile);
+            if (!File.Exists(path)) continue;
+            try
+            {
+                if (Yaml.Deserialize<object?>(File.ReadAllText(path)) is not { } root) continue;
+                var nodes = root switch
+                {
+                    IDictionary<object, object> map when map.TryGetValue("routes", out var r) => r as IEnumerable<object>,
+                    IEnumerable<object> list => list,
+                    _ => null,
+                };
+                if (nodes is null) continue;
+                var entries = new List<RouteEntry>();
+                foreach (var node in nodes)
+                    if (node is IDictionary<object, object> entry)
+                        FlattenNode(entry, parentRoute: null, prefix: "", basePath: mount.BasePath, entries);
+                var definition = new RouteTable(entries).Match(mount.BasePath)?.Entry.Definition;
+                if (!string.IsNullOrWhiteSpace(definition)) return definition;
+            }
+            catch
+            {
+                // ignore a broken route file — try the next one.
+            }
+        }
+        return null;
+    }
+
     private RouteTable Load()
     {
         var path = Path.Combine(_dir, FileName);

--- a/backend/dotnet/test/Mateu.Tests/MenuRouteConformanceTests.cs
+++ b/backend/dotnet/test/Mateu.Tests/MenuRouteConformanceTests.cs
@@ -1,0 +1,72 @@
+using Mateu.Core;
+using Mateu.Dtos;
+using Xunit;
+
+namespace Mateu.Tests;
+
+/// <summary>
+/// A menu leaf that points at a route which resolves to nothing is a bug — the safety a typed-class
+/// menu reference used to give (the class had to exist). <see cref="MenuRouteConformance"/> finds
+/// those so a CI/conformance check can fail on them instead of the app deriving a dead link
+/// silently. The .NET mirror of Java's MenuRouteConformanceTest and Python's
+/// test_menu_route_conformance.
+/// </summary>
+public class MenuRouteConformanceTests
+{
+    private static readonly RouteTable Known = new(new List<RouteEntry>
+    {
+        RouteEntry.Of("products", "X"),
+        RouteEntry.Of("orders/:id", "Y"),
+    });
+
+    private static MenuItemDto Leaf(string label, string route) => new(label, route, "");
+
+    [Fact]
+    public void A_leaf_pointing_at_a_known_route_is_fine()
+    {
+        var dangling = MenuRouteConformance.DanglingRoutes(
+            new List<MenuItemDto> { Leaf("Products", "products") }, Known);
+        Assert.Empty(dangling);
+    }
+
+    [Fact]
+    public void A_leaf_pointing_at_a_nonexistent_route_is_flagged()
+    {
+        var menu = new List<MenuItemDto> { Leaf("Products", "products"), Leaf("Ghost", "does-not-exist") };
+        Assert.Equal(new[] { "does-not-exist" }, MenuRouteConformance.DanglingRoutes(menu, Known));
+    }
+
+    [Fact]
+    public void Parameterised_routes_resolve()
+    {
+        Assert.Empty(MenuRouteConformance.DanglingRoutes(
+            new List<MenuItemDto> { Leaf("Order", "orders/42") }, Known));
+    }
+
+    [Fact]
+    public void Rule_separator_remote_external_and_placeholder_leaves_are_skipped()
+    {
+        var rule = Leaf("Ping", "whatever") with
+        {
+            Rules = new[] { new RuleDto("", "", null, null, null, null, "", "x") },
+        };
+        var separator = new MenuItemDto("", "", "") { Separator = true };
+        var remote = new MenuItemDto("Remote", "remote/x", "") { Remote = true };
+        var external = Leaf("Docs", "https://mateu.io/docs");
+        var placeholder = new MenuItemDto("Section", "", "");
+
+        Assert.Empty(MenuRouteConformance.DanglingRoutes(
+            new List<MenuItemDto> { rule, separator, remote, external, placeholder }, Known));
+    }
+
+    [Fact]
+    public void Recurses_into_submenus()
+    {
+        var group = new MenuItemDto("Group", "", "")
+        {
+            Submenus = new List<MenuItemDto> { Leaf("Products", "products"), Leaf("Ghost", "nope") },
+        };
+        Assert.Equal(new[] { "nope" },
+            MenuRouteConformance.DanglingRoutes(new List<MenuItemDto> { group }, Known));
+    }
+}

--- a/backend/dotnet/test/Mateu.Tests/RouteRegistryAppsTests.cs
+++ b/backend/dotnet/test/Mateu.Tests/RouteRegistryAppsTests.cs
@@ -1,0 +1,76 @@
+using Mateu.Core;
+using Xunit;
+
+namespace Mateu.Tests;
+
+/// <summary>
+/// A deployment can ship a 100%-DSL app — a <c>type: UI</c> mount declared in <c>specs/ui/**</c> with
+/// NO C# class — and it is announced by <see cref="RouteRegistry.Apps"/> exactly like a class-based
+/// <c>[Ui]</c> app. Two producers, one table (authored — the DSL mount — wins on a base-path
+/// collision), the same rule the routes and sources use. The .NET mirror of Java's
+/// RouteRegistryAppsTest and Python's test_route_registry_apps.
+/// </summary>
+public class RouteRegistryAppsTests
+{
+    private static RouteRegistry DslMountRegistry() =>
+        new(Path.Combine(AppContext.BaseDirectory, "specs", "dsl-mount"));
+
+    [Fact]
+    public void A_class_less_dsl_mount_is_announced_as_an_app()
+    {
+        var apps = DslMountRegistry().Apps();
+
+        var backOffice = apps.Single(a => a.Route == "back-office");
+        Assert.True(backOffice.IsDsl()); // no C# class backs it
+        Assert.Null(backOffice.ClassName);
+        Assert.Equal("back-office-shell.yaml", backOffice.Definition);
+    }
+
+    [Fact]
+    public void A_dsl_mount_wins_over_a_class_at_the_same_base_path()
+    {
+        var derived = new[] { new RouteRegistry.AppRef("back-office", "Some.Legacy.BackOffice", null) };
+
+        var apps = DslMountRegistry().Apps(derived);
+
+        var backOffice = apps.Single(a => a.Route == "back-office");
+        Assert.True(backOffice.IsDsl()); // authored wins — the class is replaced
+        Assert.Null(backOffice.ClassName);
+    }
+
+    [Fact]
+    public void A_derived_class_with_no_dsl_mount_survives_the_union()
+    {
+        var derived = new[] { new RouteRegistry.AppRef("shop", "Demo.Shop", null) };
+
+        var apps = DslMountRegistry().Apps(derived);
+
+        var shop = apps.Single(a => a.Route == "shop");
+        Assert.False(shop.IsDsl());
+        Assert.Equal("Demo.Shop", shop.ClassName);
+    }
+
+    // ── key-level merge of the seeded scopes (mirrors Java's seedsOverrideAtTheKeyLevelNotByDeepMerge) ──
+
+    [Fact]
+    public void Seeds_override_at_the_key_level_not_by_deep_merge()
+    {
+        // The four scopes merge by KEY, not deeply: a client value for a key wins over the route's
+        // seed for that same key OUTRIGHT — nested maps are not merged.
+        var entry = new RouteEntry(
+            "reports", null, "X",
+            new Dictionary<string, object?>(), new Dictionary<string, object?>(),
+            State: new Dictionary<string, object?> { ["prefs"] = new Dictionary<string, object?> { ["a"] = 1 } });
+
+        var fromRequest = new Dictionary<string, object?>
+        {
+            ["prefs"] = new Dictionary<string, object?> { ["b"] = 2 },
+        };
+        var resolved = entry.ResolveParams(fromRequest);
+
+        // the client's `prefs` wins whole — NOT {a:1, b:2}
+        var prefs = Assert.IsAssignableFrom<IReadOnlyDictionary<string, object?>>(resolved["prefs"]);
+        Assert.Equal(2, prefs["b"]);
+        Assert.False(prefs.ContainsKey("a"));
+    }
+}

--- a/backend/dotnet/test/Mateu.Tests/specs/dsl-mount/back-office-routes.yaml
+++ b/backend/dotnet/test/Mateu.Tests/specs/dsl-mount/back-office-routes.yaml
@@ -1,0 +1,5 @@
+type: Routes
+routes:
+  # the app root ("") binds the shell definition — no viewModel, no class
+  - route: ""
+    definition: back-office-shell.yaml

--- a/backend/dotnet/test/Mateu.Tests/specs/dsl-mount/back-office.ui.yaml
+++ b/backend/dotnet/test/Mateu.Tests/specs/dsl-mount/back-office.ui.yaml
@@ -1,0 +1,6 @@
+# A purely-DSL app: a mount declared as data, with NO C# class. The registry announces it
+# alongside class-based [Ui] apps (two producers, one table — authored wins).
+type: UI
+basePath: /back-office
+routes:
+  - back-office-routes.yaml

--- a/backend/python/mateu_core/menu_route_conformance.py
+++ b/backend/python/mateu_core/menu_route_conformance.py
@@ -1,0 +1,55 @@
+"""Conformance check for menu routes: every route a menu leaf points at must resolve to a known
+route.
+
+A leaf is a route or a rule — a route leaf that points nowhere is the failure this catches,
+recovering the safety a typed-class menu reference used to give (the class had to exist) now that a
+leaf can carry a plain route string.
+
+Pure over the built menu and the known route table so it mirrors 1:1 across the backends and can be
+asserted in a test / CI check. Only leaves that actually navigate LOCALLY are checked: a rule leaf
+(runs client-side), a separator, a remote leaf (a federated app, not resolvable here), an external
+URL and an empty placeholder are all skipped. (Mirrors Java's
+``io.mateu.core.application.MenuRouteConformance`` and .NET's ``MenuRouteConformance``.)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Iterable
+
+if TYPE_CHECKING:
+    from mateu_core.route_registry import RouteTable
+    from mateu_dtos import MenuItem
+
+
+def dangling_routes(menu: Iterable["MenuItem"] | None, known_routes: "RouteTable") -> list[str]:
+    """The absolute routes of leaves that resolve to no entry in ``known_routes``, in menu order."""
+    out: list[str] = []
+    _collect(menu, known_routes, out)
+    return out
+
+
+def _collect(menu, known_routes, out: list[str]) -> None:
+    if menu is None:
+        return
+    for option in menu:
+        if option is None:
+            continue
+        submenus = getattr(option, "submenus", None)
+        if submenus:
+            _collect(submenus, known_routes, out)  # a group, not a leaf — recurse
+            continue
+        if getattr(option, "separator", False):
+            continue
+        if getattr(option, "rules", None):
+            continue  # a rule leaf: runs client-side, does not navigate
+        if getattr(option, "remote", False):
+            continue  # a federated app: resolved by the remote, not against this table
+        route = getattr(option, "route", None)
+        if not route or not route.strip() or _is_external(route):
+            continue  # a placeholder, or an external URL — not a Mateu route
+        if known_routes.match(route) is None:
+            out.append(route)
+
+
+def _is_external(route: str) -> bool:
+    return route.startswith("http:") or route.startswith("https:") or route.startswith("//")

--- a/backend/python/mateu_core/route_registry.py
+++ b/backend/python/mateu_core/route_registry.py
@@ -234,6 +234,21 @@ class RouteTable:
         return best
 
 
+@dataclass(frozen=True)
+class AppRef:
+    """An app a deployment contributes: a mount root, with the class that backs it (``None`` for a
+    purely-DSL app) and the definition it renders (``None`` for a class-based app). The Python mirror
+    of Java's ``RouteRegistry.AppRef`` and .NET's ``RouteRegistry.AppRef``."""
+
+    route: str
+    class_name: str | None = None
+    definition: str | None = None
+
+    def is_dsl(self) -> bool:
+        """No server class backs it — it is announced purely from its ``type: UI`` mount."""
+        return not (self.class_name and self.class_name.strip())
+
+
 class RouteRegistry:
     """Reads ``routes.yaml`` from the specs directory, next to the definitions it routes to."""
 
@@ -250,6 +265,81 @@ class RouteRegistry:
 
     def match(self, path: str | None) -> Match | None:
         return self.authored().match(path)
+
+    def apps(self, derived: "list[AppRef] | None" = None) -> list[AppRef]:
+        """Every app of the deployment, from TWO producers merged into ONE table — the same
+        "authored wins" rule the routes and sources use:
+
+        * **derived**: the reflection-discovered ``@ui`` classes (each an app at its path), supplied
+          by the caller (there is no compile-time index here as in Java);
+        * **authored**: the ``type: UI`` mounts discovered in the specs directory — which need NO
+          class, so a deployment can ship a purely-DSL app and announce it here like any other.
+
+        A mount at the same base path as a class replaces it (authored wins). This is the enumeration
+        a federated shell (or a bundle/tool) reads to announce apps uniformly, with or without a
+        class behind them.
+        """
+        by_route: dict[str, AppRef] = {}
+        for ref in derived or []:
+            route = _normalize(ref.route)
+            by_route[route] = AppRef(route, ref.class_name, ref.definition)
+        for base_path, route_files in self._scan_mounts():
+            by_route[base_path] = AppRef(
+                base_path, None, self._definition_of(base_path, route_files)
+            )
+        return list(by_route.values())
+
+    def _scan_mounts(self) -> list[tuple[str, list[str]]]:
+        """Scan the specs directory for ``type: UI`` files (by content, not by filename), so several
+        DSL apps can coexist. Returns each mount's base path + its listed route files. (Mirrors
+        Java's MountRegistry.mounts.)"""
+        mounts: list[tuple[str, list[str]]] = []
+        if not self._dir.is_dir():
+            return mounts
+        for file in sorted(self._dir.rglob("*")):
+            if file.suffix not in (".yaml", ".yml"):
+                continue
+            try:
+                root = yaml.safe_load(file.read_text())
+            except Exception:
+                continue  # a broken descriptor must not take app enumeration down
+            if not isinstance(root, dict) or root.get("type") != "UI":
+                continue
+            base_path = _normalize(root.get("basePath") or root.get("base_path"))
+            routes = root.get("routes")
+            if isinstance(routes, str):
+                route_files = [routes]
+            elif isinstance(routes, list):
+                route_files = [r for r in routes if isinstance(r, str)]
+            else:
+                route_files = []
+            mounts.append((base_path, route_files))
+        return mounts
+
+    def _definition_of(self, base_path: str, route_files: list[str]) -> str | None:
+        """The definition bound to a DSL mount's ROOT route: load its route files (relative entries
+        prefixed with the base path), match the base path, read the definition. That root entry is
+        where a DSL app's shell lives — a route with a definition and no class."""
+        for route_file in route_files:
+            path = self._dir / route_file
+            if not path.is_file():
+                continue
+            try:
+                root = yaml.safe_load(path.read_text())
+            except Exception:
+                continue
+            nodes = root.get("routes") if isinstance(root, dict) else root
+            if not isinstance(nodes, list):
+                continue
+            relative: list[RouteEntry] = []
+            for node in nodes:
+                if isinstance(node, dict):
+                    _flatten_node(node, parent_route=None, prefix="", out=relative)
+            entries = [_with_base_path(e, base_path) for e in relative]
+            match = RouteTable(tuple(entries)).match(base_path)
+            if match is not None and match.entry.definition:
+                return match.entry.definition
+        return None
 
     def _load(self) -> RouteTable:
         path = self._dir / self.FILE

--- a/backend/python/tests/specs/dsl-mount/back-office-routes.yaml
+++ b/backend/python/tests/specs/dsl-mount/back-office-routes.yaml
@@ -1,0 +1,5 @@
+type: Routes
+routes:
+  # the app root ("") binds the shell definition — no viewModel, no class
+  - route: ""
+    definition: back-office-shell.yaml

--- a/backend/python/tests/specs/dsl-mount/back-office.ui.yaml
+++ b/backend/python/tests/specs/dsl-mount/back-office.ui.yaml
@@ -1,0 +1,6 @@
+# A purely-DSL app: a mount declared as data, with NO Python class. The registry announces it
+# alongside class-based @ui apps (two producers, one table — authored wins).
+type: UI
+basePath: /back-office
+routes:
+  - back-office-routes.yaml

--- a/backend/python/tests/test_menu_route_conformance.py
+++ b/backend/python/tests/test_menu_route_conformance.py
@@ -1,0 +1,52 @@
+"""A menu leaf that points at a route which resolves to nothing is a bug — the safety a typed-class
+menu reference used to give (the class had to exist). ``dangling_routes`` finds those so a
+CI/conformance check can fail on them instead of the app deriving a dead link silently. The Python
+mirror of Java's ``MenuRouteConformanceTest`` and .NET's ``MenuRouteConformanceTests``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from mateu_core.menu_route_conformance import dangling_routes  # noqa: E402
+from mateu_core.route_registry import RouteEntry, RouteTable  # noqa: E402
+from mateu_dtos import MenuItem, RuleRecord  # noqa: E402
+
+KNOWN = RouteTable.of([RouteEntry(route="products", view_model="X"),
+                       RouteEntry(route="orders/:id", view_model="Y")])
+
+
+def _leaf(label: str, route: str) -> MenuItem:
+    return MenuItem(label=label, route=route, server_side_type="")
+
+
+def test_a_leaf_pointing_at_a_known_route_is_fine():
+    assert dangling_routes([_leaf("Products", "products")], KNOWN) == []
+
+
+def test_a_leaf_pointing_at_a_nonexistent_route_is_flagged():
+    menu = [_leaf("Products", "products"), _leaf("Ghost", "does-not-exist")]
+    assert dangling_routes(menu, KNOWN) == ["does-not-exist"]
+
+
+def test_parameterised_routes_resolve():
+    assert dangling_routes([_leaf("Order", "orders/42")], KNOWN) == []
+
+
+def test_rule_separator_remote_external_and_placeholder_leaves_are_skipped():
+    rule = MenuItem(label="Ping", route="whatever", server_side_type="",
+                    rules=[RuleRecord(filter="", action="", action_id="x")])
+    separator = MenuItem(label="", route="", server_side_type="", separator=True)
+    remote = MenuItem(label="Remote", route="remote/x", server_side_type="", remote=True)
+    external = _leaf("Docs", "https://mateu.io/docs")
+    placeholder = MenuItem(label="Section", route="", server_side_type="")
+    assert dangling_routes([rule, separator, remote, external, placeholder], KNOWN) == []
+
+
+def test_recurses_into_submenus():
+    group = MenuItem(label="Group", route="", server_side_type="",
+                     submenus=[_leaf("Products", "products"), _leaf("Ghost", "nope")])
+    assert dangling_routes([group], KNOWN) == ["nope"]

--- a/backend/python/tests/test_route_registry_apps.py
+++ b/backend/python/tests/test_route_registry_apps.py
@@ -1,0 +1,57 @@
+"""A deployment can ship a 100%-DSL app — a ``type: UI`` mount declared in ``specs/ui/**`` with NO
+Python class — and it is announced by :meth:`RouteRegistry.apps` exactly like a class-based ``@ui``
+app. Two producers, one table (authored — the DSL mount — wins on a base-path collision), the same
+rule the routes and sources use. The Python mirror of Java's ``RouteRegistryAppsTest`` and .NET's
+``RouteRegistryAppsTests``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+DSL_MOUNT = Path(__file__).resolve().parent / "specs" / "dsl-mount"
+
+from mateu_core.route_registry import AppRef, RouteEntry, RouteRegistry  # noqa: E402
+
+
+def _registry() -> RouteRegistry:
+    return RouteRegistry(str(DSL_MOUNT))
+
+
+def test_a_class_less_dsl_mount_is_announced_as_an_app():
+    apps = _registry().apps()
+    back_office = next(a for a in apps if a.route == "back-office")
+    assert back_office.is_dsl()  # no Python class backs it
+    assert back_office.class_name is None
+    assert back_office.definition == "back-office-shell.yaml"
+
+
+def test_a_dsl_mount_wins_over_a_class_at_the_same_base_path():
+    derived = [AppRef("back-office", "legacy.BackOffice", None)]
+    apps = _registry().apps(derived)
+    back_office = next(a for a in apps if a.route == "back-office")
+    assert back_office.is_dsl()  # authored wins — the class is replaced
+    assert back_office.class_name is None
+
+
+def test_a_derived_class_with_no_dsl_mount_survives_the_union():
+    derived = [AppRef("shop", "demo.Shop", None)]
+    apps = _registry().apps(derived)
+    shop = next(a for a in apps if a.route == "shop")
+    assert not shop.is_dsl()
+    assert shop.class_name == "demo.Shop"
+
+
+# ── key-level merge of the seeded scopes (mirrors Java's seedsOverrideAtTheKeyLevelNotByDeepMerge) ──
+
+
+def test_seeds_override_at_the_key_level_not_by_deep_merge():
+    # The four scopes merge by KEY, not deeply: a client value for a key wins over the route's seed
+    # for that same key OUTRIGHT — nested maps are not merged.
+    entry = RouteEntry(route="reports", view_model="X", state={"prefs": {"a": 1}})
+    resolved = entry.resolve_params({"prefs": {"b": 2}})
+    # the client's `prefs` wins whole — NOT {a:1, b:2}
+    assert resolved["prefs"] == {"b": 2}

--- a/backend/shared/core/src/main/java/io/mateu/core/application/MenuRouteConformance.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/MenuRouteConformance.java
@@ -1,0 +1,80 @@
+package io.mateu.core.application;
+
+import io.mateu.dtos.MenuOptionDto;
+import io.mateu.uidl.data.RouteTable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * Conformance check for menu routes: every route a menu leaf points at must resolve to a known
+ * route. A leaf is a route or a rule — a route leaf that points nowhere is the failure this
+ * catches, recovering the safety a typed-class {@code @Menu} reference used to give at compile time
+ * (the class had to exist) now that a leaf can carry a plain route string.
+ *
+ * <p>Pure over the built menu and the known route table so it mirrors 1:1 in the ports and can be
+ * asserted in a test / CI check. Only leaves that actually navigate LOCALLY are checked: a rule
+ * leaf (runs client-side), a separator, a remote leaf (a federated app, not resolvable here), an
+ * external URL and an empty placeholder are all skipped.
+ */
+public final class MenuRouteConformance {
+
+  private MenuRouteConformance() {}
+
+  /**
+   * The absolute routes of leaves that resolve to no entry in {@code knownRoutes}, in menu order.
+   */
+  public static List<String> danglingRoutes(List<MenuOptionDto> menu, RouteTable knownRoutes) {
+    return danglingRoutes(menu, route -> knownRoutes.match(route).isPresent());
+  }
+
+  /**
+   * The general form: a route is fine when {@code resolvable} says so. This is what a CI/boot check
+   * runs against the LIVE route resolution (a {@code RoutedClassResolver}, which also serves the
+   * derived routes and the CRUD sub-routes) so a menu authored against real apps is validated the
+   * way it will actually resolve, not only against the authored table.
+   */
+  public static List<String> danglingRoutes(
+      List<MenuOptionDto> menu, Predicate<String> resolvable) {
+    var dangling = new ArrayList<String>();
+    collect(menu, resolvable, dangling);
+    return dangling;
+  }
+
+  private static void collect(
+      List<MenuOptionDto> menu, Predicate<String> resolvable, List<String> out) {
+    if (menu == null) {
+      return;
+    }
+    for (var option : menu) {
+      if (option == null) {
+        continue;
+      }
+      var submenus = option.submenus();
+      if (submenus != null && !submenus.isEmpty()) {
+        collect(submenus, resolvable, out); // a group, not a leaf — recurse
+        continue;
+      }
+      if (option.separator()) {
+        continue;
+      }
+      if (option.rules() != null && !option.rules().isEmpty()) {
+        continue; // a rule leaf: runs client-side, does not navigate
+      }
+      if (option.remote()) {
+        continue; // a federated app: resolved by the remote, not against this table
+      }
+      var route = option.route();
+      if (route == null || route.isBlank() || isExternal(route)) {
+        continue; // a placeholder, or an external URL — not a Mateu route
+      }
+      if (!resolvable.test(route)) {
+        out.add(route);
+      }
+    }
+  }
+
+  private static boolean isExternal(String route) {
+    return route.startsWith("http:") || route.startsWith("https:") || route.startsWith("//");
+  }
+}

--- a/backend/shared/core/src/main/java/io/mateu/core/application/runaction/RouteRegistry.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/runaction/RouteRegistry.java
@@ -132,6 +132,58 @@ public class RouteRegistry {
     return mounts().stream().anyMatch(mount -> mount.basePath().equals(normalized));
   }
 
+  /**
+   * An app a jar contributes: a mount root, with the class that backs it ({@code null} for a
+   * purely-DSL app) and the definition it renders ({@code null} for a class-based app).
+   */
+  public record AppRef(String route, String className, String definition) {
+    public boolean isDsl() {
+      return className == null || className.isBlank();
+    }
+  }
+
+  /**
+   * Every app on the classpath, from TWO producers merged into ONE table — the same "authored wins"
+   * rule the routes and sources use:
+   *
+   * <ul>
+   *   <li><b>derived</b>: the {@code @UI} classes in the annotation index (each is an app at its
+   *       path);
+   *   <li><b>authored</b>: the {@code type: UI} mounts discovered in {@code specs/ui/**} — which
+   *       need NO Java class, so a jar can ship a purely-DSL app and be announced here like any
+   *       other.
+   * </ul>
+   *
+   * A mount at the same base path as a {@code @UI} class replaces it (authored wins). This is the
+   * enumeration a federated shell (or a bundle/tool) reads to announce apps uniformly, with or
+   * without a class behind them.
+   */
+  public List<RouteRegistry.AppRef> apps() {
+    return appsFrom(classLoader());
+  }
+
+  List<RouteRegistry.AppRef> appsFrom(ClassLoader classLoader) {
+    var cl = classLoader == null ? RouteRegistry.class.getClassLoader() : classLoader;
+    var byRoute = new LinkedHashMap<String, AppRef>();
+    for (var ref : RouteRegistrations.read(cl)) {
+      var route = normalize(ref.route());
+      byRoute.put(route, new AppRef(route, ref.className(), null));
+    }
+    // authored (DSL) mounts win over a @UI class at the same base path.
+    var authoredTable = authoredFrom(cl);
+    for (var mount : mountRegistry.mounts(cl)) {
+      var basePath = mount.basePath();
+      var definition =
+          authoredTable
+              .match(basePath)
+              .map(match -> match.entry().definition())
+              .filter(value -> value != null && !value.isBlank())
+              .orElse(null);
+      byRoute.put(basePath, new AppRef(basePath, null, definition));
+    }
+    return new ArrayList<>(byRoute.values());
+  }
+
   private static ClassLoader classLoader() {
     var contextClassLoader = Thread.currentThread().getContextClassLoader();
     return contextClassLoader == null ? RouteRegistry.class.getClassLoader() : contextClassLoader;

--- a/backend/shared/core/src/test/java/io/mateu/core/application/MenuRouteConformanceSyncTest.java
+++ b/backend/shared/core/src/test/java/io/mateu/core/application/MenuRouteConformanceSyncTest.java
@@ -1,0 +1,62 @@
+package io.mateu.core.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.mateu.core.application.runaction.RouteRegistry;
+import io.mateu.dtos.MenuOptionDto;
+import io.mateu.dtos.RuleDto;
+import io.mateu.uidl.data.RouteTable;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The conformance gate wired to REAL route loading — the CI form of {@link MenuRouteConformance}.
+ * The dangling risk the unified menu-leaf model introduces is an AUTHORED (DSL/AppShell) leaf: it
+ * carries a plain route STRING, so its wire route IS the literal target and it can point nowhere,
+ * exactly the safety a typed-class {@code @Menu} reference used to give at compile time (the class
+ * had to exist). A reflective {@code @Menu} field cannot dangle by construction — its wire route is
+ * composed app-internally from the field and resolves through the app's own menu — so the failure
+ * mode to guard is the authored one, checked here against a route table loaded from real YAML by
+ * the live {@link RouteRegistry}. The pure-logic unit tests live in {@code
+ * MenuRouteConformanceTest}.
+ */
+class MenuRouteConformanceSyncTest {
+
+  /**
+   * The merged table the deployment actually resolves against, loaded from the test fixture YAML.
+   */
+  private RouteTable knownRoutes() {
+    return new RouteRegistry().authoredFrom(getClass().getClassLoader());
+  }
+
+  private static MenuOptionDto leaf(String label, String route) {
+    return MenuOptionDto.builder().label(label).route(route).build();
+  }
+
+  @Test
+  void anAuthoredLeafPointingAtARouteNoOneServesIsFlaggedAgainstTheRealTable() {
+    // "orders" is in the fixture routes.yaml; "does-not-exist" is not.
+    var menu = List.of(leaf("Orders", "orders"), leaf("Ghost", "does-not-exist"));
+
+    var dangling = MenuRouteConformance.danglingRoutes(menu, knownRoutes());
+
+    assertThat(dangling).containsExactly("does-not-exist");
+  }
+
+  @Test
+  void aMenuWhoseAuthoredLeavesAllResolveIsClean() {
+    var menu =
+        List.of(
+            leaf("Orders", "orders"),
+            leaf("About", "about"),
+            leaf("Pending", "orders/pending"),
+            // a rule leaf never navigates, so a made-up route on it is not a dangling link
+            MenuOptionDto.builder()
+                .label("Ping")
+                .route("whatever")
+                .rules(List.of(RuleDto.builder().actionId("x").build()))
+                .build());
+
+    assertThat(MenuRouteConformance.danglingRoutes(menu, knownRoutes())).isEmpty();
+  }
+}

--- a/backend/shared/core/src/test/java/io/mateu/core/application/MenuRouteConformanceTest.java
+++ b/backend/shared/core/src/test/java/io/mateu/core/application/MenuRouteConformanceTest.java
@@ -1,0 +1,73 @@
+package io.mateu.core.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.mateu.dtos.MenuOptionDto;
+import io.mateu.dtos.RuleDto;
+import io.mateu.uidl.data.RouteEntry;
+import io.mateu.uidl.data.RouteTable;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A menu leaf that points at a route which resolves to nothing is a bug — the safety a typed-class
+ * {@code @Menu} reference used to give at compile time. {@link MenuRouteConformance} finds those so
+ * a CI/conformance check can fail on them instead of the app deriving a dead link silently.
+ */
+class MenuRouteConformanceTest {
+
+  private static final RouteTable KNOWN =
+      new RouteTable(List.of(RouteEntry.of("products", "X"), RouteEntry.of("orders/:id", "Y")));
+
+  private static MenuOptionDto leaf(String label, String route) {
+    return MenuOptionDto.builder().label(label).route(route).build();
+  }
+
+  @Test
+  void aLeafPointingAtAKnownRouteIsFine() {
+    var dangling =
+        MenuRouteConformance.danglingRoutes(List.of(leaf("Products", "products")), KNOWN);
+    assertThat(dangling).isEmpty();
+  }
+
+  @Test
+  void aLeafPointingAtANonexistentRouteIsFlagged() {
+    var menu = List.of(leaf("Products", "products"), leaf("Ghost", "does-not-exist"));
+    assertThat(MenuRouteConformance.danglingRoutes(menu, KNOWN)).containsExactly("does-not-exist");
+  }
+
+  @Test
+  void parameterisedRoutesResolve() {
+    assertThat(MenuRouteConformance.danglingRoutes(List.of(leaf("Order", "orders/42")), KNOWN))
+        .isEmpty();
+  }
+
+  @Test
+  void ruleSeparatorRemoteExternalAndPlaceholderLeavesAreSkipped() {
+    var rule =
+        MenuOptionDto.builder()
+            .label("Ping")
+            .route("whatever")
+            .rules(List.of(RuleDto.builder().actionId("x").build()))
+            .build();
+    var separator = MenuOptionDto.builder().separator(true).build();
+    var remote = MenuOptionDto.builder().label("Remote").route("remote/x").remote(true).build();
+    var external = leaf("Docs", "https://mateu.io/docs");
+    var placeholder = MenuOptionDto.builder().label("Section").build();
+
+    assertThat(
+            MenuRouteConformance.danglingRoutes(
+                List.of(rule, separator, remote, external, placeholder), KNOWN))
+        .isEmpty();
+  }
+
+  @Test
+  void recursesIntoSubmenus() {
+    var group =
+        MenuOptionDto.builder()
+            .label("Group")
+            .submenus(List.of(leaf("Products", "products"), leaf("Ghost", "nope")))
+            .build();
+    assertThat(MenuRouteConformance.danglingRoutes(List.of(group), KNOWN)).containsExactly("nope");
+  }
+}

--- a/backend/shared/core/src/test/java/io/mateu/core/application/runaction/RouteParamPrecedenceTest.java
+++ b/backend/shared/core/src/test/java/io/mateu/core/application/runaction/RouteParamPrecedenceTest.java
@@ -88,6 +88,31 @@ class RouteParamPrecedenceTest {
   }
 
   @Test
+  void seedsOverrideAtTheKeyLevelNotByDeepMerge() {
+    // The four scopes merge by KEY, not deeply: a client value for a key wins over the route's seed
+    // for that same key OUTRIGHT — nested maps are not merged. Predictable, and matches how every
+    // other parameter source composes.
+    var entry =
+        new RouteEntry(
+            "reports",
+            null,
+            "X",
+            Map.of(),
+            Map.of(),
+            null,
+            null,
+            Map.of("prefs", Map.of("a", 1)), // state seed: prefs = {a:1}
+            Map.of(),
+            null,
+            null);
+
+    var resolved = resolve(Map.of("prefs", Map.of("b", 2)), "reports", "reports", entry);
+
+    // the client's `prefs` wins whole — NOT {a:1, b:2}
+    assertThat(resolved).containsEntry("prefs", Map.of("b", 2));
+  }
+
+  @Test
   void aRouteResolvedFromAnAnnotationBehavesExactlyAsBefore() {
     // No entry: the existing path-parameter behaviour, untouched.
     var state =

--- a/backend/shared/core/src/test/java/io/mateu/core/application/runaction/RouteRegistryAppsTest.java
+++ b/backend/shared/core/src/test/java/io/mateu/core/application/runaction/RouteRegistryAppsTest.java
@@ -1,0 +1,37 @@
+package io.mateu.core.application.runaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URLClassLoader;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A jar can ship a 100%-DSL app — a {@code type: UI} mount declared in {@code specs/ui/**} with NO
+ * Java class — and it is announced by {@link RouteRegistry#apps()} exactly like a class-based
+ * {@code @UI} app. Two producers, one table (authored — the DSL mount — wins on a base-path
+ * collision), the same rule the routes and sources use.
+ */
+class RouteRegistryAppsTest {
+
+  private final RouteRegistry registry = new RouteRegistry();
+
+  /**
+   * A class loader that sees ONLY the DSL-mount fixture (no parent, so no shared specs/ui leaks).
+   */
+  private static ClassLoader dslMountOnly() {
+    var url = RouteRegistryAppsTest.class.getResource("/dsl-mount/");
+    return new URLClassLoader(new java.net.URL[] {url}, null);
+  }
+
+  @Test
+  void aClassLessDslMountIsAnnouncedAsAnApp() {
+    var apps = registry.appsFrom(dslMountOnly());
+
+    var backOffice =
+        apps.stream().filter(app -> "back-office".equals(app.route())).findFirst().orElseThrow();
+
+    assertThat(backOffice.isDsl()).as("no Java class backs it").isTrue();
+    assertThat(backOffice.className()).isNull();
+    assertThat(backOffice.definition()).isEqualTo("back-office-shell.yaml");
+  }
+}

--- a/backend/shared/core/src/test/resources/dsl-mount/specs/ui/back-office-routes.yaml
+++ b/backend/shared/core/src/test/resources/dsl-mount/specs/ui/back-office-routes.yaml
@@ -1,0 +1,5 @@
+type: Routes
+routes:
+  # the app root ("") binds the shell definition — no viewModel, no class
+  - route: ""
+    definition: back-office-shell.yaml

--- a/backend/shared/core/src/test/resources/dsl-mount/specs/ui/back-office.ui.yaml
+++ b/backend/shared/core/src/test/resources/dsl-mount/specs/ui/back-office.ui.yaml
@@ -1,0 +1,6 @@
+# A purely-DSL app: a mount declared as data, with NO Java class. The indexer/registry announces it
+# alongside class-based @UI apps (two producers, one table — authored wins).
+type: UI
+basePath: /back-office
+routes:
+  - back-office-routes.yaml


### PR DESCRIPTION
## What

Three additions to the unified routing/menu model, mirrored 1:1 in Java, .NET and Python (same model, matching and precedence — the wire and resolution must not diverge per backend):

### 1. 100%-DSL apps (no class needed)
A jar/deployment can ship a `type: UI` mount declared purely in `specs/ui/**` with **no server class**, and it is announced alongside class-based apps. `RouteRegistry.apps()` unions **two producers** into **one table** — *derived* (the indexed `@UI`/`@ui`/`[Ui]` classes) and *authored* (the DSL mounts) — with **authored winning** on a base-path collision, the same "authored wins" rule the routes and sources use. New `AppRef(route, className, definition)` with `isDsl()`.

### 2. Exact merge semantics of the four seeded scopes
`state` / `appState` / `data` / `appData` merge by **key, not deeply**: a client value for a key wins over the route's seed for that key **outright** — nested maps are not merged. Predictable, and identical to how every other parameter source composes.

### 3. Menu-route conformance
The unified menu-leaf model lets a leaf carry a plain route string, which can point nowhere — losing the safety a typed-class `@Menu` reference gave at compile time. `MenuRouteConformance.danglingRoutes(menu, knownRoutes)` finds authored leaves that resolve to **no** route so a **CI check fails** on them instead of shipping a dead link. Skips rule/separator/remote/external/placeholder leaves; recurses submenus. The Java integration test runs it over a table loaded from **real YAML** by the live registry; a reflective `@Menu` field cannot dangle by construction (its wire route resolves app-internally).

## Tests (all green)
- **Java** +9: `MenuRouteConformanceTest` (5), `MenuRouteConformanceSyncTest` (2), `RouteRegistryAppsTest` (1), `RouteParamPrecedenceTest` (+1)
- **.NET** +9
- **Python** +9

🤖 Generated with [Claude Code](https://claude.com/claude-code)