### PR TITLE
Example 1: demo-starwars (100%-DSL app on an external API) + fix Listing YAML registration

### DIFF
--- a/backend/shared/core/src/main/java/io/mateu/core/application/runaction/YamlUidlMapperFactory.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/runaction/YamlUidlMapperFactory.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.mateu.uidl.data.*;
 import io.mateu.uidl.fluent.AppShell;
 import io.mateu.uidl.fluent.Component;
+import io.mateu.uidl.fluent.Listing;
 import io.mateu.uidl.interfaces.Actionable;
 
 final class YamlUidlMapperFactory {
@@ -82,6 +83,7 @@ final class YamlUidlMapperFactory {
         new NamedType(Icon.class, "Icon"),
         new NamedType(Image.class, "Image"),
         new NamedType(KPI.class, "KPI"),
+        new NamedType(Listing.class, "Listing"),
         new NamedType(Map.class, "Map"),
         new NamedType(Markdown.class, "Markdown"),
         new NamedType(MasterDetailLayout.class, "MasterDetailLayout"),

--- a/backend/shared/core/src/test/java/io/mateu/core/application/runaction/YamlUidlLoaderTest.java
+++ b/backend/shared/core/src/test/java/io/mateu/core/application/runaction/YamlUidlLoaderTest.java
@@ -46,6 +46,22 @@ class YamlUidlLoaderTest {
   }
 
   @Test
+  void parsesAListingBoundToAnExternalSourceByRef() {
+    // A 100%-DSL app renders a listing over an existing API as `type: Listing` with a rowsSource
+    // ref. This pins that Listing is registered as a Component subtype (it was missing, so a
+    // YAML-only listing failed to deserialise even though the authoring schema advertised it).
+    Component component = layoutFor("demo/starwars-listing");
+
+    assertThat(component).isInstanceOf(io.mateu.uidl.fluent.Listing.class);
+    var listing = (io.mateu.uidl.fluent.Listing) component;
+    assertThat(listing.title()).isEqualTo("People");
+    assertThat(listing.rowsSource()).isNotNull();
+    assertThat(listing.rowsSource().ref()).isEqualTo("swapi-people");
+    assertThat(listing.columns()).hasSize(3);
+    assertThat(((GridColumn) listing.columns().get(0)).id()).isEqualTo("name");
+  }
+
+  @Test
   void parsesFormFieldsCorrectly() {
     VerticalLayout layout = (VerticalLayout) layoutFor("demo/hello");
 

--- a/backend/shared/core/src/test/resources/specs/ui/demo/starwars-listing.yaml
+++ b/backend/shared/core/src/test/resources/specs/ui/demo/starwars-listing.yaml
@@ -1,0 +1,17 @@
+# A YAML-authored Listing bound to a named external source by ref — the shape a 100%-DSL app uses to
+# render a listing over an existing API with no Java class. Pins that `type: Listing` deserialises
+# (it must be registered as a Component subtype in YamlUidlMapperFactory).
+type: Listing
+title: People
+rowsSource:
+  ref: swapi-people
+columns:
+  - type: GridColumn
+    id: name
+    label: Name
+  - type: GridColumn
+    id: gender
+    label: Gender
+  - type: GridColumn
+    id: birth_year
+    label: Birth year

--- a/demo/demo-starwars/README.md
+++ b/demo/demo-starwars/README.md
@@ -1,0 +1,57 @@
+# demo-starwars — a 100%-DSL Mateu app on an external API
+
+**Example 1** of the progressive example suite. It exists to *document* how a Mateu app is built with
+zero Java UI code, and to *validate* that the framework's "works without any Java class" principle
+holds end to end.
+
+## What it demonstrates
+
+A complete Mateu application — mount, app shell, pages and its REST source catalogue — authored
+**entirely as data** under `src/main/resources/specs/ui/`, reading live data from the public
+[Star Wars API](https://swapi.info). The only Java is `StarwarsApplication`, a Spring Boot `main`
+that boots the server; it declares nothing about the UI.
+
+```
+specs/ui/
+  starwars.ui.yaml   # the mount (type: UI) — served at "/"
+  app.yaml           # the app shell (type: AppShell) — title, subtitle, top menu
+  routes.yaml        # each URL bound to a page definition (no viewModel — no Java behind them)
+  sources.yaml       # the REST source catalogue — each SWAPI endpoint, named once
+  people.yaml        # a type: Listing whose rows come from the `swapi-people` source
+  planets.yaml       # …from `swapi-planets`
+  films.yaml         # …from `swapi-films`
+```
+
+Each page is a `type: Listing` with a `rowsSource: { ref: … }`. The browser resolves the ref against
+the catalogue, fetches the endpoint directly (swapi.info sends `Access-Control-Allow-Origin: *`, so no
+proxy is needed), and each column reads its field by id. No server search action, no view model.
+
+This is the concrete pay-off of two recent pieces: **DSL-app enumeration** (a mount announced with no
+class) and the **REST source catalogue** (`sources.yaml`).
+
+## Run it
+
+```bash
+cd demo/demo-starwars
+mvn -s ../../settings.xml spring-boot:run     # → http://localhost:8600
+```
+
+Open <http://localhost:8600> and click People / Planets / Films.
+
+> The Star Wars API is a free, community-run service and is sometimes slow or down. When it is
+> unreachable the listings render their chrome (title, search, columns) but stay empty — that is the
+> API, not Mateu.
+
+## How it is validated
+
+- **Unit (in CI):** `YamlUidlLoaderTest.parsesAListingBoundToAnExternalSourceByRef` pins that a
+  `type: Listing` with a `rowsSource` ref deserialises — the authoring surface an app like this needs.
+- **End-to-end:** `e2e/starwars-probe.mjs` drives this app in a real browser and asserts the three
+  listings render rows mapped from the source. It **intercepts** the SWAPI endpoints and answers them
+  from local fixtures, so it validates *our* pipeline (mount → shell → listing → source → fetch →
+  mapping → grid) deterministically, without depending on the live API's uptime:
+
+  ```bash
+  cd demo/demo-starwars && mvn -s ../../settings.xml spring-boot:run   # keep running
+  cd e2e && node starwars-probe.mjs
+  ```

--- a/demo/demo-starwars/pom.xml
+++ b/demo/demo-starwars/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.5</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>io.mateu.demo</groupId>
+    <artifactId>demo-starwars</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>demo-starwars</name>
+    <description>Example 1 of the progressive example suite: a 100%-DSL Mateu app with NO Java @UI
+        class, consuming an existing external API (the Star Wars API). The whole app — mount, shell,
+        pages and the REST source catalogue — is authored as data in src/main/resources/specs/ui/.
+        The only Java is the Spring Boot main that boots the server.</description>
+
+    <properties>
+        <java.version>21</java.version>
+        <mateu.version>0.0.1-MATEU</mateu.version>
+    </properties>
+
+    <dependencies>
+        <!-- Mateu MVC runtime -->
+        <dependency>
+            <groupId>io.mateu</groupId>
+            <artifactId>mvc-core</artifactId>
+            <version>${mateu.version}</version>
+        </dependency>
+
+        <!-- Frontend web components (Vaadin renderer) -->
+        <dependency>
+            <groupId>io.mateu</groupId>
+            <artifactId>vaadin-lit</artifactId>
+            <version>${mateu.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/demo/demo-starwars/src/main/java/io/mateu/demo/starwars/StarwarsApplication.java
+++ b/demo/demo-starwars/src/main/java/io/mateu/demo/starwars/StarwarsApplication.java
@@ -1,0 +1,22 @@
+package io.mateu.demo.starwars;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * A Mateu app with NO Java {@code @UI} class and NO business code at all: the whole thing — the mount
+ * ({@code starwars.ui.yaml}), the app shell ({@code app.yaml}), every page ({@code people.yaml},
+ * {@code planets.yaml}, {@code films.yaml}) and the REST source catalogue ({@code sources.yaml}) —
+ * is authored as data under {@code src/main/resources/specs/ui/}. The pages read live data from the
+ * public Star Wars API; this class is the only Java, and it does nothing but boot the server.
+ *
+ * <p>Example 1 of the progressive example suite: it validates that a Mateu app truly works without a
+ * single Java UI class, backed by an existing external API.
+ */
+@SpringBootApplication(scanBasePackages = "io.mateu")
+public class StarwarsApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(StarwarsApplication.class, args);
+  }
+}

--- a/demo/demo-starwars/src/main/resources/application.properties
+++ b/demo/demo-starwars/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+spring.application.name=demo-starwars
+server.port=8600

--- a/demo/demo-starwars/src/main/resources/specs/ui/app.yaml
+++ b/demo/demo-starwars/src/main/resources/specs/ui/app.yaml
@@ -1,0 +1,20 @@
+# The app shell — a view of its own, discriminated by `type: AppShell`. Bound to the mount root
+# ("") in routes.yaml. Title, subtitle and the top menu, all as data.
+$schema: https://raw.githubusercontent.com/miguelperezcolom/mateu/master/backend/shared/uidl/uidl-schema.json
+type: AppShell
+title: Star Wars
+subtitle: A Mateu app authored entirely in YAML, powered by the public Star Wars API
+variant: MENU_ON_TOP
+menu:
+  - type: RouteLink
+    label: People
+    route: people
+    icon: vaadin:user
+  - type: RouteLink
+    label: Planets
+    route: planets
+    icon: vaadin:globe
+  - type: RouteLink
+    label: Films
+    route: films
+    icon: vaadin:film

--- a/demo/demo-starwars/src/main/resources/specs/ui/films.yaml
+++ b/demo/demo-starwars/src/main/resources/specs/ui/films.yaml
@@ -1,0 +1,21 @@
+$schema: https://raw.githubusercontent.com/miguelperezcolom/mateu/master/backend/shared/uidl/uidl-schema.json
+type: Listing
+title: Films
+rowsSource:
+  ref: swapi-films
+columns:
+  - type: GridColumn
+    id: episode_id
+    label: Episode
+  - type: GridColumn
+    id: title
+    label: Title
+  - type: GridColumn
+    id: director
+    label: Director
+  - type: GridColumn
+    id: producer
+    label: Producer
+  - type: GridColumn
+    id: release_date
+    label: Released

--- a/demo/demo-starwars/src/main/resources/specs/ui/people.yaml
+++ b/demo/demo-starwars/src/main/resources/specs/ui/people.yaml
@@ -1,0 +1,23 @@
+# A Listing page whose rows come from a named external source. No viewModel: the browser fetches the
+# source (resolved by ref against sources.yaml) and each column reads its field by id.
+$schema: https://raw.githubusercontent.com/miguelperezcolom/mateu/master/backend/shared/uidl/uidl-schema.json
+type: Listing
+title: People
+rowsSource:
+  ref: swapi-people
+columns:
+  - type: GridColumn
+    id: name
+    label: Name
+  - type: GridColumn
+    id: gender
+    label: Gender
+  - type: GridColumn
+    id: birth_year
+    label: Birth year
+  - type: GridColumn
+    id: height
+    label: Height (cm)
+  - type: GridColumn
+    id: mass
+    label: Mass (kg)

--- a/demo/demo-starwars/src/main/resources/specs/ui/planets.yaml
+++ b/demo/demo-starwars/src/main/resources/specs/ui/planets.yaml
@@ -1,0 +1,21 @@
+$schema: https://raw.githubusercontent.com/miguelperezcolom/mateu/master/backend/shared/uidl/uidl-schema.json
+type: Listing
+title: Planets
+rowsSource:
+  ref: swapi-planets
+columns:
+  - type: GridColumn
+    id: name
+    label: Name
+  - type: GridColumn
+    id: climate
+    label: Climate
+  - type: GridColumn
+    id: terrain
+    label: Terrain
+  - type: GridColumn
+    id: population
+    label: Population
+  - type: GridColumn
+    id: diameter
+    label: Diameter (km)

--- a/demo/demo-starwars/src/main/resources/specs/ui/routes.yaml
+++ b/demo/demo-starwars/src/main/resources/specs/ui/routes.yaml
@@ -1,0 +1,14 @@
+# The route registry: each URL bound to a definition. The root is the app shell; each menu target is
+# a Listing page that reads live rows from a named REST source (see sources.yaml). No viewModel on
+# any route — there is no Java behind these screens.
+$schema: https://raw.githubusercontent.com/miguelperezcolom/mateu/master/backend/shared/uidl/routes-schema.json
+type: Routes
+routes:
+  - route: ""          # the mount root → the app shell
+    definition: app.yaml
+  - route: people
+    definition: people.yaml
+  - route: planets
+    definition: planets.yaml
+  - route: films
+    definition: films.yaml

--- a/demo/demo-starwars/src/main/resources/specs/ui/sources.yaml
+++ b/demo/demo-starwars/src/main/resources/specs/ui/sources.yaml
@@ -1,0 +1,19 @@
+# The REST source catalogue: each external endpoint named ONCE, referenced by the pages. swapi.info
+# serves each collection as a plain JSON array of full objects (no envelope), so no itemsPath is
+# needed — the response IS the row array — and it sends `Access-Control-Allow-Origin: *`, so the
+# browser fetches it directly (no backend proxy). These are somebody else's endpoints (absolute url →
+# provenance inferred as `existing`): documented and consumed, never generated.
+$schema: https://raw.githubusercontent.com/miguelperezcolom/mateu/master/backend/shared/uidl/sources-schema.json
+sources:
+  - name: swapi-people
+    description: Characters of the Star Wars saga
+    source:
+      url: https://swapi.info/api/people
+  - name: swapi-planets
+    description: Planets of the Star Wars galaxy
+    source:
+      url: https://swapi.info/api/planets
+  - name: swapi-films
+    description: The Star Wars films
+    source:
+      url: https://swapi.info/api/films

--- a/demo/demo-starwars/src/main/resources/specs/ui/starwars.ui.yaml
+++ b/demo/demo-starwars/src/main/resources/specs/ui/starwars.ui.yaml
@@ -1,0 +1,7 @@
+# The mount: a UI served at a base path (the data-driven equivalent of @UI). Discovered by scanning
+# specs/ui/** for `type: UI`. No Java class declares this app — the file does.
+$schema: https://raw.githubusercontent.com/miguelperezcolom/mateu/master/backend/shared/uidl/mount-schema.json
+type: UI
+basePath: /
+routes:
+  - routes.yaml

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -19,6 +19,7 @@
 
   <modules>
     <module>demo-app-definition</module>
+    <module>demo-starwars</module>
     <module>demo-vaadin-webflux</module>
     <module>demo-vaadin-mvc</module>
     <module>demo-vaadin-quarkus</module>

--- a/e2e/starwars-probe.mjs
+++ b/e2e/starwars-probe.mjs
@@ -1,0 +1,98 @@
+/**
+ * Star Wars DSL-app probe — validates example 1 of the progressive example suite: a 100%-DSL Mateu
+ * app (NO Java @UI class) that renders listings over an existing external API.
+ *
+ * It boots against the running demo (demo/demo-starwars on :8600) and asserts the three YAML-authored
+ * listings render rows mapped from a named REST source. The external endpoints (swapi.info) are
+ * INTERCEPTED and answered from local fixtures, so the probe validates OUR pipeline — YAML mount →
+ * app shell → `type: Listing` with a rowsSource ref → source catalogue → external fetch → row
+ * mapping → grid — deterministically, without depending on the Star Wars API's (famously flaky)
+ * uptime. Run the demo pointed at the real API for a live view; the probe pins the mechanism.
+ *
+ *   cd demo/demo-starwars && mvn -s ../../settings.xml spring-boot:run   # or java -jar target/*.jar
+ *   cd e2e && node starwars-probe.mjs
+ *
+ * Exits non-zero on any failure, so it gates changes to the DSL/listing/external-source pipeline.
+ */
+import { chromium } from 'playwright'
+
+const BASE = process.env.BASE ?? 'http://localhost:8600'
+
+const FIXTURES = {
+  people: [
+    { name: 'Luke Skywalker', gender: 'male', birth_year: '19BBY', height: '172', mass: '77' },
+    { name: 'Leia Organa', gender: 'female', birth_year: '19BBY', height: '150', mass: '49' },
+    { name: 'Darth Vader', gender: 'male', birth_year: '41.9BBY', height: '202', mass: '136' },
+  ],
+  planets: [
+    { name: 'Tatooine', climate: 'arid', terrain: 'desert', population: '200000', diameter: '10465' },
+    { name: 'Hoth', climate: 'frozen', terrain: 'tundra, ice caves', population: 'unknown', diameter: '7200' },
+  ],
+  films: [
+    { episode_id: 4, title: 'A New Hope', director: 'George Lucas', producer: 'Gary Kurtz', release_date: '1977-05-25' },
+    { episode_id: 5, title: 'The Empire Strikes Back', director: 'Irvin Kershner', producer: 'Gary Kurtz', release_date: '1980-05-17' },
+  ],
+}
+
+const results = []
+const check = (name, pass, detail = '') => {
+  results.push({ name, pass })
+  console.log(`${pass ? 'PASS' : 'FAIL'}  ${name}${detail ? ` — ${detail}` : ''}`)
+}
+
+const browser = await chromium.launch()
+try {
+  const page = await browser.newPage()
+  // Answer each SWAPI collection from a local fixture — deterministic, no live-host dependency.
+  for (const key of Object.keys(FIXTURES)) {
+    await page.route(`**/swapi.info/api/${key}**`, (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(FIXTURES[key]) }),
+    )
+  }
+
+  const deepText = () =>
+    page.evaluate(() => {
+      const out = []
+      const walk = (root) => {
+        out.push(root.textContent || '')
+        root.querySelectorAll('*').forEach((el) => el.shadowRoot && walk(el.shadowRoot))
+      }
+      walk(document)
+      return out.join(' ')
+    })
+
+  const gridLen = () =>
+    page.evaluate(() => {
+      let el = null
+      const walk = (r) => {
+        const f = r.querySelector('mateu-table-crud')
+        if (f) el = f
+        r.querySelectorAll('*').forEach((e) => e.shadowRoot && walk(e.shadowRoot))
+      }
+      walk(document)
+      return el?.data?.[el.id]?.page?.content?.length ?? 0
+    })
+
+  const cases = [
+    { route: 'people', rows: 3, needle: 'Luke Skywalker' },
+    { route: 'planets', rows: 2, needle: 'Tatooine' },
+    { route: 'films', rows: 2, needle: 'A New Hope' },
+  ]
+
+  for (const c of cases) {
+    await page.goto(`${BASE}/${c.route}`, { waitUntil: 'load' })
+    await page.waitForTimeout(3000)
+    const text = await deepText()
+    const len = await gridLen()
+    check(`/${c.route} renders "${c.needle}" from the external source`, text.includes(c.needle), `grid rows=${len}`)
+    check(`/${c.route} mapped every fixture row into the grid`, len === c.rows, `${len}/${c.rows}`)
+  }
+
+  await page.close()
+} finally {
+  await browser.close()
+}
+
+const failed = results.filter((r) => !r.pass)
+console.log(`\n${results.length - failed.length}/${results.length} checks passed`)
+process.exit(failed.length ? 1 : 0)


### PR DESCRIPTION
## What

**Example 1** of the progressive example suite — an app that both *documents* how to build with Mateu and *validates* the "works without any Java class" principle end to end.

`demo/demo-starwars` is a complete Mateu app authored **entirely as data** under `specs/ui/`:
- `starwars.ui.yaml` — the mount (`type: UI`)
- `app.yaml` — the shell (`type: AppShell`, title/menu)
- `routes.yaml` — each URL → a `type: Listing` page (no viewModel)
- `sources.yaml` — the REST source catalogue → the public Star Wars API (swapi.info)
- `people.yaml` / `planets.yaml` / `films.yaml` — listings sourced by `ref`

The only Java is a Spring Boot `main`. Each listing reads rows from a named source; the browser resolves the ref, fetches directly (swapi.info sends `ACAO: *`), and columns read fields by id. It's the concrete pay-off of DSL-app enumeration (alpha.316) + the REST source catalogue.

## Framework fix it surfaced

`Listing` was in the generated authoring schema (`uidl-schema.json`) but **missing from the Jackson subtype registration** in `YamlUidlMapperFactory` — so a YAML-only `type: Listing` failed to deserialise (`Could not resolve type id 'Listing'`). Registered it. Exactly the derived-schema-vs-hand-maintained-registration drift the example suite is meant to catch.

## Validation
- **Unit (CI):** `YamlUidlLoaderTest.parsesAListingBoundToAnExternalSourceByRef` pins that a `type: Listing` with a `rowsSource` ref deserialises. (9/9 in that suite.)
- **E2E:** `e2e/starwars-probe.mjs` drives the running app in a real browser and asserts the three listings render rows mapped from the source. It **intercepts** the SWAPI endpoints with local fixtures → deterministic, no dependency on the (famously flaky) live API. **6/6 green.**

Verified live in a browser too; the probe confirmed the only live failure mode is the external host being unreachable.

Docs: `demo/demo-starwars/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)