### PR TITLE
Star Wars person detail (master-detail) + fix 48 unregistered YAML components

### DIFF
--- a/backend/shared/core/src/main/java/io/mateu/core/application/runaction/YamlUidlMapperFactory.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/runaction/YamlUidlMapperFactory.java
@@ -8,7 +8,9 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.mateu.uidl.data.*;
 import io.mateu.uidl.fluent.AppShell;
 import io.mateu.uidl.fluent.Component;
+import io.mateu.uidl.fluent.Form;
 import io.mateu.uidl.fluent.Listing;
+import io.mateu.uidl.fluent.MenuBar;
 import io.mateu.uidl.interfaces.Actionable;
 
 final class YamlUidlMapperFactory {
@@ -103,6 +105,58 @@ final class YamlUidlMapperFactory {
         new NamedType(VerticalLayout.class, "VerticalLayout"),
         new NamedType(VirtualList.class, "VirtualList"),
         new NamedType(Workflow.class, "Workflow"),
+        // The rest of the authoring catalogue. These were authorable per the generated schema but
+        // never registered here, so a YAML page using any of them failed to deserialise — the same
+        // drift that hid Listing. YamlComponentRegistrationTest now pins this list against the
+        // schema.
+        new NamedType(AddOnPicker.class, "AddOnPicker"),
+        new NamedType(BulletedList.class, "BulletedList"),
+        new NamedType(ButtonGroup.class, "ButtonGroup"),
+        new NamedType(Calendar.class, "Calendar"),
+        new NamedType(CalloutCard.class, "CalloutCard"),
+        new NamedType(Checklist.class, "Checklist"),
+        new NamedType(CommentThread.class, "CommentThread"),
+        new NamedType(ComparisonCard.class, "ComparisonCard"),
+        new NamedType(ContentLayout.class, "ContentLayout"),
+        new NamedType(DashboardLayout.class, "DashboardLayout"),
+        new NamedType(DashboardPanel.class, "DashboardPanel"),
+        new NamedType(EmbeddedView.class, "EmbeddedView"),
+        new NamedType(EmptyState.class, "EmptyState"),
+        new NamedType(EntityHeader.class, "EntityHeader"),
+        new NamedType(Faq.class, "Faq"),
+        new NamedType(FeatureGrid.class, "FeatureGrid"),
+        new NamedType(FileList.class, "FileList"),
+        new NamedType(FoldoutLayout.class, "FoldoutLayout"),
+        new NamedType(FoldoutPanel.class, "FoldoutPanel"),
+        new NamedType(Form.class, "Form"),
+        new NamedType(Funnel.class, "Funnel"),
+        new NamedType(Gantt.class, "Gantt"),
+        new NamedType(Heatmap.class, "Heatmap"),
+        new NamedType(HeroSection.class, "HeroSection"),
+        new NamedType(Kanban.class, "Kanban"),
+        new NamedType(Ledger.class, "Ledger"),
+        new NamedType(MenuBar.class, "MenuBar"),
+        new NamedType(Meter.class, "Meter"),
+        new NamedType(MetricCard.class, "MetricCard"),
+        new NamedType(Notice.class, "Notice"),
+        new NamedType(OfferCard.class, "OfferCard"),
+        new NamedType(OrgChart.class, "OrgChart"),
+        new NamedType(PaymentPicker.class, "PaymentPicker"),
+        new NamedType(PlanningBoard.class, "PlanningBoard"),
+        new NamedType(PricingTable.class, "PricingTable"),
+        new NamedType(ProcessMonitor.class, "ProcessMonitor"),
+        new NamedType(ProgressSteps.class, "ProgressSteps"),
+        new NamedType(ResourceGrid.class, "ResourceGrid"),
+        new NamedType(Scoreboard.class, "Scoreboard"),
+        new NamedType(Separator.class, "Separator"),
+        new NamedType(Skeleton.class, "Skeleton"),
+        new NamedType(Stat.class, "Stat"),
+        new NamedType(StatusList.class, "StatusList"),
+        new NamedType(TaskProgress.class, "TaskProgress"),
+        new NamedType(TaskQueue.class, "TaskQueue"),
+        new NamedType(Testimonials.class, "Testimonials"),
+        new NamedType(Timeline.class, "Timeline"),
+        new NamedType(TrendChart.class, "TrendChart"),
         new NamedType(ContentLink.class, "ContentLink"),
         new NamedType(FieldLink.class, "FieldLink"),
         new NamedType(Menu.class, "Menu"),

--- a/backend/shared/core/src/test/java/io/mateu/core/application/runaction/YamlComponentRegistrationTest.java
+++ b/backend/shared/core/src/test/java/io/mateu/core/application/runaction/YamlComponentRegistrationTest.java
@@ -1,0 +1,85 @@
+package io.mateu.core.application.runaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Drift guard: every component the generated authoring schema advertises as authorable MUST be
+ * registered in {@link YamlUidlMapperFactory}, or a YAML page that uses it fails to deserialise
+ * even though the schema (and the editor IntelliSense pointed at it) says it is valid.
+ *
+ * <p>The two are separate lists — {@code UidlSchemaGenerator} derives the schema from the records,
+ * while the Jackson subtype registration is hand-maintained — and they had drifted badly: 48 of the
+ * 116 authorable components (Listing, Separator, every archetype layout, Gantt, Kanban…) were
+ * absent, so nearly half the catalogue was unusable from YAML. Building the first data-only demo
+ * surfaced it. This test parses the schema's {@code Component} union and asserts the factory mapper
+ * can resolve each type id, so any future component added to the schema but not registered here
+ * fails CI.
+ */
+class YamlComponentRegistrationTest {
+
+  @Test
+  void everyAuthorableComponentInTheSchemaIsRegisteredForYamlDeserialisation() throws Exception {
+    var mapper = YamlUidlMapperFactory.create();
+    var schema = new ObjectMapper().readTree(Files.readString(schemaPath()));
+
+    var componentTypes = componentTypeNames(schema);
+    // Sanity: the schema really did expose the full catalogue (not an empty/partial read).
+    assertThat(componentTypes).hasSizeGreaterThan(100).contains("Listing", "Separator", "Text");
+
+    var unresolved = new ArrayList<String>();
+    for (var type : componentTypes) {
+      try {
+        // Resolving the type id is what we assert; a record that then fails to construct from an
+        // empty body (a missing required field) has still RESOLVED, which is all this guards.
+        mapper.readValue("type: \"" + type + "\"\n", io.mateu.uidl.fluent.Component.class);
+      } catch (InvalidTypeIdException e) {
+        unresolved.add(type);
+      } catch (Exception constructionButResolved) {
+        // type id resolved fine — ignore construction failures for this guard.
+      }
+    }
+
+    assertThat(unresolved)
+        .as("authorable components missing from YamlUidlMapperFactory.registerSubtypes")
+        .isEmpty();
+  }
+
+  /** The type names of every entry in the schema's {@code Component} oneOf union. */
+  private static List<String> componentTypeNames(JsonNode schema) {
+    var defs = schema.has("$defs") ? schema.get("$defs") : schema.get("definitions");
+    var names = new ArrayList<String>();
+    for (var ref : defs.get("Component").get("oneOf")) {
+      var defName = ref.get("$ref").asText().substring("#/$defs/".length());
+      var type = defs.get(defName).path("properties").path("type");
+      var value = type.has("const") ? type.get("const") : type.path("enum").path(0);
+      if (value != null && value.isTextual()) {
+        names.add(value.asText());
+      }
+    }
+    return names;
+  }
+
+  /** The generated schema lives at the uidl module root; tests run from the core module dir. */
+  private static Path schemaPath() {
+    for (var candidate :
+        List.of(
+            Path.of("..", "uidl", "uidl-schema.json"),
+            Path.of("shared", "uidl", "uidl-schema.json"),
+            Path.of("backend", "shared", "uidl", "uidl-schema.json"))) {
+      if (Files.exists(candidate)) {
+        return candidate;
+      }
+    }
+    throw new IllegalStateException(
+        "uidl-schema.json not found from " + Path.of(".").toAbsolutePath());
+  }
+}

--- a/backend/shared/uidl/specs-schema.json
+++ b/backend/shared/uidl/specs-schema.json
@@ -133,6 +133,8 @@
         "$ref" : "#/$defs/RemoteMenu"
       }, {
         "$ref" : "#/$defs/RouteLink"
+      }, {
+        "$ref" : "#/$defs/RuleLink"
       } ]
     },
     "AddOn" : {
@@ -4870,6 +4872,86 @@
     "RouteTarget" : {
       "type" : "string",
       "enum" : [ "Top", "Parent" ]
+    },
+    "Rule" : {
+      "type" : "object",
+      "properties" : {
+        "filter" : {
+          "type" : "string"
+        },
+        "action" : {
+          "$ref" : "#/$defs/RuleAction"
+        },
+        "fieldName" : {
+          "type" : "string"
+        },
+        "fieldAttribute" : {
+          "$ref" : "#/$defs/RuleFieldAttribute"
+        },
+        "value" : { },
+        "expression" : {
+          "type" : "string"
+        },
+        "actionId" : {
+          "type" : "string"
+        },
+        "result" : {
+          "$ref" : "#/$defs/RuleResult"
+        }
+      }
+    },
+    "RuleAction" : {
+      "type" : "string",
+      "enum" : [ "SetAppDataValue", "SetAppStateValue", "SetDataValue", "RunAction", "RunJS", "SetAttributeValue", "SetStateValue", "SetCssClass", "SetStyle" ]
+    },
+    "RuleFieldAttribute" : {
+      "type" : "string",
+      "enum" : [ "required", "disabled", "hidden", "pattern", "minValue", "maxValue", "minLength", "maxLength", "css", "style", "theme", "errorMessage", "description", "none" ]
+    },
+    "RuleLink" : {
+      "type" : "object",
+      "required" : [ "type" ],
+      "properties" : {
+        "type" : {
+          "type" : "string",
+          "const" : "RuleLink"
+        },
+        "path" : {
+          "type" : "string"
+        },
+        "label" : {
+          "type" : "string"
+        },
+        "rules" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/$defs/Rule"
+          }
+        },
+        "selected" : {
+          "type" : "boolean"
+        },
+        "component" : {
+          "$ref" : "#/$defs/Component"
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "disabled" : {
+          "type" : "boolean"
+        },
+        "disabledOnClick" : {
+          "type" : "boolean"
+        },
+        "itemData" : { },
+        "description" : {
+          "type" : "string"
+        }
+      }
+    },
+    "RuleResult" : {
+      "type" : "string",
+      "enum" : [ "Continue", "Stop" ]
     },
     "Scoreboard" : {
       "type" : "object",

--- a/backend/shared/uidl/uidl-schema.json
+++ b/backend/shared/uidl/uidl-schema.json
@@ -83,6 +83,8 @@
         "$ref" : "#/$defs/RemoteMenu"
       }, {
         "$ref" : "#/$defs/RouteLink"
+      }, {
+        "$ref" : "#/$defs/RuleLink"
       } ]
     },
     "AddOn" : {
@@ -4820,6 +4822,86 @@
     "RouteTarget" : {
       "type" : "string",
       "enum" : [ "Top", "Parent" ]
+    },
+    "Rule" : {
+      "type" : "object",
+      "properties" : {
+        "filter" : {
+          "type" : "string"
+        },
+        "action" : {
+          "$ref" : "#/$defs/RuleAction"
+        },
+        "fieldName" : {
+          "type" : "string"
+        },
+        "fieldAttribute" : {
+          "$ref" : "#/$defs/RuleFieldAttribute"
+        },
+        "value" : { },
+        "expression" : {
+          "type" : "string"
+        },
+        "actionId" : {
+          "type" : "string"
+        },
+        "result" : {
+          "$ref" : "#/$defs/RuleResult"
+        }
+      }
+    },
+    "RuleAction" : {
+      "type" : "string",
+      "enum" : [ "SetAppDataValue", "SetAppStateValue", "SetDataValue", "RunAction", "RunJS", "SetAttributeValue", "SetStateValue", "SetCssClass", "SetStyle" ]
+    },
+    "RuleFieldAttribute" : {
+      "type" : "string",
+      "enum" : [ "required", "disabled", "hidden", "pattern", "minValue", "maxValue", "minLength", "maxLength", "css", "style", "theme", "errorMessage", "description", "none" ]
+    },
+    "RuleLink" : {
+      "type" : "object",
+      "required" : [ "type" ],
+      "properties" : {
+        "type" : {
+          "type" : "string",
+          "const" : "RuleLink"
+        },
+        "path" : {
+          "type" : "string"
+        },
+        "label" : {
+          "type" : "string"
+        },
+        "rules" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/$defs/Rule"
+          }
+        },
+        "selected" : {
+          "type" : "boolean"
+        },
+        "component" : {
+          "$ref" : "#/$defs/Component"
+        },
+        "className" : {
+          "type" : "string"
+        },
+        "disabled" : {
+          "type" : "boolean"
+        },
+        "disabledOnClick" : {
+          "type" : "boolean"
+        },
+        "itemData" : { },
+        "description" : {
+          "type" : "string"
+        }
+      }
+    },
+    "RuleResult" : {
+      "type" : "string",
+      "enum" : [ "Continue", "Stop" ]
     },
     "Scoreboard" : {
       "type" : "object",

--- a/demo/demo-starwars/README.md
+++ b/demo/demo-starwars/README.md
@@ -26,6 +26,16 @@ Each page is a `type: Listing` with a `rowsSource: { ref: … }`. The browser re
 the catalogue, fetches the endpoint directly (swapi.info sends `Access-Control-Allow-Origin: *`, so no
 proxy is needed), and each column reads its field by id. No server search action, no view model.
 
+**Person detail** — the People page is a `gridLayout: masterDetail` listing: clicking a person shows
+their full record in the detail pane, entirely from the already-fetched rows (no re-fetch, no id).
+This is the fully-declarative detail that swapi.info's shape allows: its list rows carry no numeric
+id — only a `url` and `name` — so a re-fetch-by-id route is not expressible in pure YAML here.
+
+> A separate URL-addressable detail route (a page bound to a `data:` source that fetches one record)
+> is the natural next step, but it currently surfaces two framework gaps on the **definition-only**
+> (no view model) path: a route's `data:` source is not wired there, and query params do not reach
+> page state. Tracked as a follow-up; master-detail is the working detail today.
+
 This is the concrete pay-off of two recent pieces: **DSL-app enumeration** (a mount announced with no
 class) and the **REST source catalogue** (`sources.yaml`).
 

--- a/demo/demo-starwars/src/main/resources/specs/ui/people.yaml
+++ b/demo/demo-starwars/src/main/resources/specs/ui/people.yaml
@@ -1,14 +1,18 @@
-# A Listing page whose rows come from a named external source. No viewModel: the browser fetches the
-# source (resolved by ref against sources.yaml) and each column reads its field by id.
+# A Listing whose rows come from a named external source. `gridLayout: masterDetail` turns it into a
+# list + detail: clicking a person shows their full record in the right pane — entirely from the
+# already-fetched rows, no re-fetch and no id needed (swapi.info rows carry no numeric id). The name
+# column is the identifier, so the selected row is tracked by name.
 $schema: https://raw.githubusercontent.com/miguelperezcolom/mateu/master/backend/shared/uidl/uidl-schema.json
 type: Listing
 title: People
+gridLayout: masterDetail
 rowsSource:
   ref: swapi-people
 columns:
   - type: GridColumn
     id: name
     label: Name
+    identifier: true
   - type: GridColumn
     id: gender
     label: Gender
@@ -21,3 +25,9 @@ columns:
   - type: GridColumn
     id: mass
     label: Mass (kg)
+  - type: GridColumn
+    id: hair_color
+    label: Hair
+  - type: GridColumn
+    id: eye_color
+    label: Eyes

--- a/e2e/starwars-probe.mjs
+++ b/e2e/starwars-probe.mjs
@@ -20,9 +20,9 @@ const BASE = process.env.BASE ?? 'http://localhost:8600'
 
 const FIXTURES = {
   people: [
-    { name: 'Luke Skywalker', gender: 'male', birth_year: '19BBY', height: '172', mass: '77' },
-    { name: 'Leia Organa', gender: 'female', birth_year: '19BBY', height: '150', mass: '49' },
-    { name: 'Darth Vader', gender: 'male', birth_year: '41.9BBY', height: '202', mass: '136' },
+    { name: 'Luke Skywalker', gender: 'male', birth_year: '19BBY', height: '172', mass: '77', hair_color: 'blond', eye_color: 'blue' },
+    { name: 'Leia Organa', gender: 'female', birth_year: '19BBY', height: '150', mass: '49', hair_color: 'brown', eye_color: 'brown' },
+    { name: 'Darth Vader', gender: 'male', birth_year: '41.9BBY', height: '202', mass: '136', hair_color: 'none', eye_color: 'yellow' },
   ],
   planets: [
     { name: 'Tatooine', climate: 'arid', terrain: 'desert', population: '200000', diameter: '10465' },
@@ -87,6 +87,33 @@ try {
     check(`/${c.route} renders "${c.needle}" from the external source`, text.includes(c.needle), `grid rows=${len}`)
     check(`/${c.route} mapped every fixture row into the grid`, len === c.rows, `${len}/${c.rows}`)
   }
+
+  // People is a master-detail listing: clicking a person shows their full record in the detail
+  // pane, entirely from the already-fetched rows (no re-fetch, no id).
+  await page.goto(`${BASE}/people`, { waitUntil: 'load' })
+  await page.waitForTimeout(3000)
+  const selected = await page.evaluate(() => {
+    let el = null
+    const walk = (r) => {
+      const f = r.querySelector('mateu-table-crud')
+      if (f) el = f
+      r.querySelectorAll('*').forEach((e) => e.shadowRoot && walk(e.shadowRoot))
+    }
+    walk(document)
+    if (!el) return { err: 'no table-crud' }
+    const root = el.shadowRoot || el
+    const cell = [...root.querySelectorAll('*')].find(
+      (n) => /Luke Skywalker/.test(n.textContent) && n.children.length === 0,
+    )
+    if (!cell) return { err: 'no row cell' }
+    cell.click()
+    return { name: el.selectedItem?.name, hair: el.selectedItem?.hair_color }
+  })
+  check(
+    'People master-detail: clicking a person selects their full record',
+    selected.name === 'Luke Skywalker' && selected.hair === 'blond',
+    JSON.stringify(selected),
+  )
 
   await page.close()
 } finally {


### PR DESCRIPTION
## What

Adds a **person detail** to the Star Wars DSL example (rung 2) and — driven by building it — fixes a **major authoring-surface bug** it exposed.

### Person detail
The People page becomes a `gridLayout: masterDetail` Listing: clicking a person shows their full record in the detail pane, entirely from the already-fetched rows (no re-fetch, no id). This is the fully-declarative detail swapi.info's shape allows — its rows carry no numeric id, only `url`/`name`.

> A separate URL-addressable detail route (a definition bound to a `data:` source) surfaced two further gaps on the **definition-only** path — route `data:` isn't wired there, and query params don't reach state. Documented as a follow-up; master-detail is the working detail today.

### Framework fix (the reason to release)
Building `person.yaml` hit `Could not resolve type id 'Separator'` — the **same drift that hid `Listing`, at scale**. **48 of the 116** components the generated schema advertises (Separator, every archetype layout, Gantt, Kanban, MetricCard, Notice, Form, MenuBar…) were **never registered** as Jackson subtypes in `YamlUidlMapperFactory`, so nearly half the catalogue was unusable from YAML. Registered all 48. Added **`YamlComponentRegistrationTest`**, which parses the schema's Component union and asserts the factory resolves every type id — so future drift **fails CI**.

Also **regenerated the checked-in schemas** (`uidl-schema.json`, `specs-schema.json`): they were **stale on master** (records had drifted), failing `UidlSchemaTest` 2/12 independently of this change → now **12/12**. Additions-only (enum/nested-record catch-up; still 116 Component types).

## Validation
- `e2e/starwars-probe.mjs` **7/7** (three listings + master-detail selecting a person's full record).
- `YamlComponentRegistrationTest`, `YamlUidlLoaderTest`, `UidlSchemaTest` green. Verified in a real browser.
- Docs: `demo-starwars/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)