### PR TITLE
Wire a route's data:/state: seeds on the definition-only path

### DIFF
--- a/backend/shared/core/src/main/java/io/mateu/core/application/runaction/ActionInstanceCreator.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/runaction/ActionInstanceCreator.java
@@ -124,9 +124,59 @@ public class ActionInstanceCreator {
       return Mono.empty();
     }
     if (spec.modelView() == null || spec.modelView().isBlank()) {
-      return Mono.justOrEmpty(spec.layout());
+      return Mono.justOrEmpty(seedBareLayout(spec.layout(), command));
     }
     return createInstanceAndPostHydrate(spec.modelView(), command);
+  }
+
+  /**
+   * A definition-only page has no view model to hold state, so a route that SEEDS it — a {@code
+   * data:}/{@code appData:} source, {@code state:}/{@code appState:} literals, or query/path params
+   * the page reads as {@code ${state.x}} — needs those applied here, exactly as the class path does
+   * via {@link RouteSegmentUtils#addParameterValues}. When the route seeds something we fold it
+   * into the state and wrap the layout as a {@link SeededYamlPage} so the mapping emits that state
+   * and the {@code __restdata__} OnLoad the resolver stashed on the request; otherwise the bare
+   * layout is returned unchanged (a plain static page).
+   */
+  private Object seedBareLayout(io.mateu.uidl.fluent.Component layout, RunActionCommand command) {
+    if (layout == null) {
+      return null;
+    }
+    var pathOnly = stripQuery(command.route());
+    var match = routeRegistry.match(pathOnly).orElse(null);
+    if (match == null || match.entry() == null) {
+      return layout; // no registry entry (e.g. convention-only page) → nothing to seed
+    }
+    var entry = match.entry();
+    var httpRequest = command.httpRequest();
+    var hasQueryParams =
+        httpRequest != null && httpRequest.getParameterNames().iterator().hasNext();
+    var seeds =
+        entry.data() != null
+            || entry.appData() != null
+            || !entry.appState().isEmpty()
+            || !entry.state().isEmpty()
+            || !entry.defaultParams().isEmpty()
+            || !entry.fixedParams().isEmpty()
+            || hasQueryParams;
+    if (!seeds) {
+      return layout; // a static page: keep the bare-layout shape (unchanged wire)
+    }
+    var resolved =
+        new io.mateu.core.application.ResolvedRoute(pathOnly, entry.route(), Void.class, entry);
+    var state =
+        RouteSegmentUtils.addParameterValues(
+            command.componentState(), pathOnly, resolved, httpRequest);
+    return new SeededYamlPage(layout, state);
+  }
+
+  private static String stripQuery(String route) {
+    if (route == null) {
+      return "";
+    }
+    var q = route.indexOf('?');
+    var path = q >= 0 ? route.substring(0, q) : route;
+    return path.startsWith("/") ? path.substring(1) : path;
   }
 
   private Mono<?> instantiateWithKnownType(RunActionCommand command) {

--- a/backend/shared/core/src/main/java/io/mateu/core/application/runaction/SeededYamlPage.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/runaction/SeededYamlPage.java
@@ -1,0 +1,34 @@
+package io.mateu.core.application.runaction;
+
+import io.mateu.uidl.fluent.Component;
+import io.mateu.uidl.interfaces.ComponentTreeSupplier;
+import io.mateu.uidl.interfaces.HttpRequest;
+import io.mateu.uidl.interfaces.StateSupplier;
+import java.util.Map;
+
+/**
+ * A definition-only YAML page (no view model) that the ROUTE seeds with state and/or a data source.
+ *
+ * <p>A bare {@code spec.layout()} is otherwise mapped as a static component tree with no state and
+ * no triggers, so a route that declares {@code data:} (or carries query/path params the page reads
+ * as {@code ${state.x}}) had nowhere for those to land — the data-source fetch never fired and the
+ * params never reached the state. Wrapping the layout as a {@link ComponentTreeSupplier} + {@link
+ * StateSupplier} routes it through the normal mapping, which emits the seeded state and — from the
+ * {@code _routeData} the resolver stashed — the synthetic {@code __restdata__} action + OnLoad
+ * trigger. The client then fetches the source (its url may interpolate {@code ${state.x}}) and
+ * merges the record into the same state, exactly like an {@code @RestData} view. Only used when the
+ * route actually seeds something; a plain static page keeps its bare-layout shape.
+ */
+record SeededYamlPage(Component layout, Map<String, Object> state)
+    implements ComponentTreeSupplier, StateSupplier {
+
+  @Override
+  public Component component(HttpRequest httpRequest) {
+    return layout;
+  }
+
+  @Override
+  public Object state(HttpRequest httpRequest) {
+    return state;
+  }
+}

--- a/backend/shared/core/src/test/java/io/mateu/core/application/DefinitionRouteDataSyncTest.java
+++ b/backend/shared/core/src/test/java/io/mateu/core/application/DefinitionRouteDataSyncTest.java
@@ -1,0 +1,48 @@
+package io.mateu.core.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.mateu.core.testutil.TestMateu;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A DEFINITION-ONLY route (a {@code definition:} with NO {@code viewModel}) can now be SEEDED by
+ * the route, exactly like a class-backed one: {@code state:} literals reach the page state and a
+ * {@code data:} source is fetched on load.
+ *
+ * <p>Before, only the class path applied a route's seeds — a bare {@code spec.layout()} was mapped
+ * as a static tree with no state and no triggers, so a pure-DSL detail page ({@code definition +
+ * data}) could not read {@code ${state.x}} nor fetch its record. The {@code seeded-yaml-detail}
+ * route (test {@code routes.yaml}) has no view model, seeds {@code tab: summary} and declares
+ * {@code data: reportData}; the fix wraps the layout so the increment carries that state and the
+ * synthetic {@code __restdata__} action + OnLoad the client uses to fetch and merge the record.
+ */
+class DefinitionRouteDataSyncTest {
+
+  static TestMateu mateu;
+
+  @BeforeAll
+  static void boot() {
+    mateu = TestMateu.withUis();
+  }
+
+  @AfterAll
+  static void shutdown() {
+    mateu.close();
+  }
+
+  @Test
+  void aDefinitionOnlyRouteSeedsStateAndSourcesItsData() throws Exception {
+    var increment = mateu.sync("/seeded-yaml-detail");
+    var wire = new ObjectMapper().writeValueAsString(increment);
+
+    // the data source is wired on the definition-only path: __restdata__ action + OnLoad + the ref
+    assertThat(wire).contains("__restdata__");
+    assertThat(wire).contains("reportData");
+    // the state seed reached the page state, so ${state.tab} resolves
+    assertThat(wire).contains("summary");
+  }
+}

--- a/backend/shared/core/src/test/resources/specs/ui/routes.yaml
+++ b/backend/shared/core/src/test/resources/specs/ui/routes.yaml
@@ -68,6 +68,12 @@ routes:
 
   # A route that SEEDS the app state on entry (merged under the client's persisted @AppContext),
   # and SOURCES its component data from a named source by ref (reuses the @RestData load path).
+  - route: seeded-yaml-detail   # definition-only (no viewModel) route that SEEDS state + a data source
+    definition: seeded-yaml-detail.yaml
+    data: reportData
+    state:
+      tab: summary
+
   - route: appstate-seed
     viewModel: io.mateu.core.application.AppStateSeedView
     appState:

--- a/backend/shared/core/src/test/resources/specs/ui/seeded-yaml-detail.yaml
+++ b/backend/shared/core/src/test/resources/specs/ui/seeded-yaml-detail.yaml
@@ -1,0 +1,5 @@
+# A definition-only page (no modelView) whose ROUTE seeds it: `state:` literals + a `data:` source.
+type: VerticalLayout
+content:
+  - type: Text
+    text: "Tab: ${state.tab}"


### PR DESCRIPTION
## What

Closes the **definition-only data-route gap**: a route with a `definition:` and **no `viewModel`** now applies the route's seeds exactly like a class-backed route — `state:`/`appState:` literals reach the page state, query/path params are folded in, and a `data:`/`appData:` source is fetched on load.

Before, a bare `spec.layout()` was mapped as a static tree with no state and no triggers, so a pure-DSL detail page (`definition` + `data`) could neither read `${state.x}` nor fetch its record.

## Fix

`ActionInstanceCreator.loadYamlPage`, when the route seeds anything, now:
1. calls `RouteSegmentUtils.addParameterValues` — which stashes `_routeData`/`_routeAppData`/`_routeAppState` and folds query/path params + `state`/`default`/`fixed` params into the state; and
2. wraps the layout as a new **`SeededYamlPage`** (`ComponentTreeSupplier` + `StateSupplier`), so it flows through the normal mapping.

The increment then carries the seeded state and the synthetic `__restdata__` action + OnLoad trigger the client uses to fetch the source and merge the record into that same state — the whole `@RestData` path, reachable from data alone. A route that seeds **nothing** keeps its bare-layout shape (unchanged wire), so static pages are unaffected.

## Verification
- **`DefinitionRouteDataSyncTest`** (new): a `definition`-only route seeding `state: {tab: summary}` + `data: reportData` emits `__restdata__` + OnLoad and seeds the state. Green; no regressions across the route/YAML suites (`AppStateSeedSyncTest`, `DefinitionOnlyRouteSyncTest`, `RouteRegistryTest`, `RestDataSyncTest`, `YamlUidlLoaderTest`, `FullSyncPipelineTest`).
- Verified end-to-end: the content-load response carries `__restdata__` + the folded query param in state, and in a real browser the source fetch **fires** for a definition-only route.

## Known follow-up (separate, not this gap)
A non-menu detail route **deep-linked into a data-driven app shell** is remounted by the RRA content flow, dropping the merged state before paint; and row-click→detail-route navigation for viewModel-less listings is still unwired. So demo-starwars keeps master-detail as its person detail; this PR makes the `definition + data` route itself work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)