### PR TITLE
fix(core): deep-link into a remote menu nested inside a group

### DIFF
--- a/backend/shared/core/src/main/java/io/mateu/core/application/runaction/AppMenuResolver.java
+++ b/backend/shared/core/src/main/java/io/mateu/core/application/runaction/AppMenuResolver.java
@@ -194,14 +194,42 @@ public class AppMenuResolver {
 
   private Mono<?> tryRemoteMenusForRoute(
       AppShell app, RunActionCommand command, HttpRequest httpRequest) {
-    return reactor.core.publisher.Flux.fromIterable(app.menu())
-        .filter(item -> item instanceof RemoteMenu)
-        .cast(RemoteMenu.class)
+    return reactor.core.publisher.Flux.fromIterable(remoteMenusIn(app.menu()))
         .concatMap(
             remoteMenu ->
                 remoteMenuHandler.tryResolveRoute(
                     remoteMenu, command.route(), app, httpRequest, command))
         .next();
+  }
+
+  /**
+   * Every {@link RemoteMenu} in the tree, at whatever depth it sits. A shell that groups its remote
+   * sections under one entry — "Admin", holding Workflow, Forms and Worker — nests them below an
+   * ordinary {@link Menu}, so a deep link into one of them (a reloaded or bookmarked {@code
+   * /workflow/processes}) was never offered to the remote that owns it: this looked at the top
+   * level only, found nothing, and let the route fall through to the shell as "Not found". The
+   * frontend's menu completion already descends the same way (see {@code
+   * ConnectedElement.getRemoteMenus}).
+   *
+   * <p>A RemoteMenu is NOT descended into: whatever it has underneath is the remote app's to
+   * declare, and it has not answered yet.
+   */
+  private static List<RemoteMenu> remoteMenusIn(List<Actionable> menu) {
+    if (menu == null) {
+      return List.of();
+    }
+    return menu.stream()
+        .flatMap(
+            option -> {
+              if (option instanceof RemoteMenu remoteMenu) {
+                return java.util.stream.Stream.of(remoteMenu);
+              }
+              if (option instanceof Menu group) {
+                return remoteMenusIn(group.submenu()).stream();
+              }
+              return java.util.stream.Stream.empty();
+            })
+        .toList();
   }
 
   // ── Helpers ──────────────────────────────────────────────────────────────

--- a/backend/shared/core/src/test/java/io/mateu/core/application/RemoteMenuNestedInGroupDeepLinkSyncTest.java
+++ b/backend/shared/core/src/test/java/io/mateu/core/application/RemoteMenuNestedInGroupDeepLinkSyncTest.java
@@ -1,0 +1,154 @@
+package io.mateu.core.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.mateu.core.application.out.MateuHttpClient;
+import io.mateu.core.testutil.TestMateu;
+import io.mateu.dtos.AppDto;
+import io.mateu.dtos.ClientSideComponentDto;
+import io.mateu.dtos.ComponentDto;
+import io.mateu.dtos.MenuOptionDto;
+import io.mateu.dtos.RunActionRqDto;
+import io.mateu.dtos.UIFragmentDto;
+import io.mateu.dtos.UIIncrementDto;
+import io.mateu.uidl.annotations.Menu;
+import io.mateu.uidl.annotations.Title;
+import io.mateu.uidl.annotations.UI;
+import io.mateu.uidl.data.RemoteMenu;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Deep-link into a remote that sits INSIDE a menu group — the other axis of {@link
+ * RemoteMenuPrefixedDeepLinkSyncTest}, whose remote is declared at the top level.
+ *
+ * <p>Real case: the EventConductor demo console. Its shell groups the platform sections under one
+ * entry — {@code @Menu AdminMenu admin} holding Workflow, Forms and Worker — so the forms service's
+ * {@code RemoteMenu("/_forms")} is nested below the group, not on the bar. Clicking the entry
+ * always worked (the frontend's menu completion descends into groups). Reloading or bookmarking
+ * {@code /forms/tasks} did not: the deep-link resolver looked at the top-level menu only, never
+ * offered the route to the nested remote, and the page fell through to the shell as "Not found" —
+ * with {@code homeBaseUrl} left empty because the shell claimed the route as its own.
+ *
+ * <p>{@link TestMateu} runs the whole server side, so the mounted home asserted here is what the
+ * frontend receives.
+ */
+class RemoteMenuNestedInGroupDeepLinkSyncTest {
+
+  /** A menu group (field type annotated with {@code @Menu} fields) — label/path "/admin". */
+  @SuppressWarnings("unused")
+  public static class AdminMenu {
+    @Menu RemoteMenu forms = new RemoteMenu("/_forms");
+  }
+
+  @SuppressWarnings("unused")
+  @UI("")
+  @Title("Demo Console")
+  public static class ShellRoot {
+    // The remote lives UNDER this group, so its menu path becomes "/admin/forms" — while the remote
+    // still declares its own routes as "/forms/...". The top-level bar carries no remote at all.
+    @Menu AdminMenu admin = new AdminMenu();
+  }
+
+  /** A remote that declares its routes WITH the /forms prefix (like the demo's forms service). */
+  public static class FakeForms implements MateuHttpClient {
+    @Override
+    public CompletableFuture<UIIncrementDto> send(String baseUrl, RunActionRqDto request) {
+      return send(baseUrl, request, null);
+    }
+
+    @Override
+    public CompletableFuture<UIIncrementDto> send(
+        String baseUrl, RunActionRqDto request, String authorization) {
+      var appDto =
+          AppDto.builder()
+              .route("")
+              .title("Forms")
+              .homeRoute("_no_home_route")
+              .homeConsumedRoute("")
+              .homeServerSideType("io.mateu.workflow.infra.in.ui.FormsHome")
+              .menu(
+                  List.of(
+                      MenuOptionDto.builder()
+                          .label("Forms")
+                          .path("/forms")
+                          .route("/forms")
+                          .submenus(
+                              List.of(
+                                  MenuOptionDto.builder()
+                                      .label("Tasks")
+                                      .path("/forms/tasks")
+                                      .route("/forms/tasks")
+                                      .build()))
+                          .build()))
+              .build();
+      var component = new ClientSideComponentDto(appDto, "forms_app", List.of(), null, null, null);
+      var fragment = UIFragmentDto.builder().component(component).build();
+      return CompletableFuture.completedFuture(
+          UIIncrementDto.builder().fragments(List.of(fragment)).build());
+    }
+  }
+
+  static TestMateu mateu;
+
+  @BeforeEach
+  void boot() {
+    mateu = TestMateu.withUisAndBeans(List.of(new FakeForms()), ShellRoot.class);
+  }
+
+  @AfterEach
+  void shutdown() {
+    mateu.close();
+  }
+
+  private static AppDto shellApp(UIIncrementDto increment) {
+    for (var fragment : increment.fragments()) {
+      var found = findApp(fragment.component());
+      if (found != null) {
+        return found;
+      }
+    }
+    return null;
+  }
+
+  private static AppDto findApp(ComponentDto component) {
+    if (component instanceof ClientSideComponentDto cs) {
+      if (cs.metadata() instanceof AppDto app) {
+        return app;
+      }
+      for (var child : cs.children()) {
+        var found = findApp(child);
+        if (found != null) {
+          return found;
+        }
+      }
+    }
+    return null;
+  }
+
+  private UIIncrementDto viaUrl(String route) {
+    return mateu.run(
+        RunActionRqDto.builder().route(route).consumedRoute("_empty").actionId("").build());
+  }
+
+  @Test
+  void pageDeepLinkIntoAGroupedRemoteMountsTheRemoteNotTheShell() {
+    var app = shellApp(viaUrl("/forms/tasks"));
+    assertThat(app).isNotNull();
+    // The bug: a nested remote was never tried, so the shell claimed the route and mounted it with
+    // an EMPTY baseUrl (itself) — which has no such route, hence "Not found".
+    assertThat(app.homeBaseUrl()).isEqualTo("/_forms");
+    assertThat(app.homeRoute()).isEqualTo("/forms/tasks");
+  }
+
+  @Test
+  void recordDeepLinkIntoAGroupedRemoteMountsTheRouteBelowTheListing() {
+    var app = shellApp(viaUrl("/forms/tasks/t-42"));
+    assertThat(app).isNotNull();
+    assertThat(app.homeBaseUrl()).isEqualTo("/_forms");
+    assertThat(app.homeRoute()).isEqualTo("/forms/tasks/t-42");
+  }
+}


### PR DESCRIPTION
## Problem

A shell that groups its remote sections under one entry — the EventConductor demo's **"Admin"** menu holding Workflow, Forms and Worker — nests each `RemoteMenu` below an ordinary `Menu` group.

- Clicking an entry always worked (the frontend's `completeMenu` descends into groups).
- **Reloading or bookmarking** a route owned by one of those nested remotes (e.g. `/workflow/processes`, `/workflow/processes/{uuid}`) rendered **"Not found"**.

## Root cause

`AppMenuResolver.tryRemoteMenusForRoute` iterated the **top-level** menu only:

```java
Flux.fromIterable(app.menu()).filter(item -> item instanceof RemoteMenu)...
```

So a `RemoteMenu` nested inside a group was never offered the route. The deep link fell through to the shell, which claimed it as its own and mounted it with an **empty `baseUrl`** (`homeBaseUrl=""`, `homeRoute=/workflow/processes`) — a route the shell does not have.

This is the **server-side twin** of the frontend bug already fixed by `ConnectedElement.getRemoteMenus` recursing into groups ("A RemoteMenu nested under a group was never fetched"). The backend was left behind, and its deep-link resolver was only ever tested with top-level remotes (`RemoteMenuPrefixedDeepLinkSyncTest`, `RemoteMenuRootDeepLinkSyncTest`) — both excluded from the live-HTTP coverage path.

## Fix

Collect **every** `RemoteMenu` in the menu tree, at whatever depth, before resolving the route against them. Once the nested remote is tried, the existing `claimedRoute`/`ownsRoute` logic mounts it correctly (`homeBaseUrl=/_forms`, `homeRoute=/forms/tasks`). No change to prefix/URL composition — so no risk of double-prefixing.

## Test

`RemoteMenuNestedInGroupDeepLinkSyncTest` reproduces the demo exactly (a `RemoteMenu("/_forms")` nested under an `@Menu AdminMenu` group whose routes carry the `/forms` prefix):

- **Without the fix:** fails — `homeBaseUrl` is `""` instead of `/_forms`.
- **With the fix:** passes.

Full `shared/core` suite: **1032 tests, 0 failures** (coverage gate included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)