### PR TITLE
chore: raise annotation-density ceiling to 5.2

### DIFF
--- a/scripts/annotation-density.json
+++ b/scripts/annotation-density.json
@@ -1,6 +1,6 @@
 {
-  "ceiling": 4.6,
-  "_baseline": "4.38 over 444 screens, measured 2026-08-12",
+  "ceiling": 5.2,
+  "_baseline": "5.13 over the corpus, measured 2026-09-12 (was 4.38 / 444 screens on 2026-08-12)",
   "_why_headroom": "A ceiling pinned to the exact current value fails on the very next annotation added anywhere, and a check that fires on ordinary work gets raised by reflex until it means nothing. ~5% of headroom means normal work passes and a TREND trips it — roughly 100 net new annotations across the corpus.",
   "_when_it_fires": "Either infer it instead (doc/.../authoring-rule.md), or raise this deliberately and say why in the commit. Raising it is allowed; raising it silently is the thing to avoid."
 }


### PR DESCRIPTION
The per-screen annotation average drifted to 5.13 (from 4.38 on 2026-08-12), above the 4.6 ceiling, from demo/e2e screens added since August. Raised deliberately (the guard sanctions this when not silent) to unblock releases; 5.2 keeps headroom over 5.13.