### PR TITLE
test+docs: characterize CRUD record deep-link multi-load (reload flicker)

### DIFF
--- a/doc/notes/crud-record-deeplink-multiload.md
+++ b/doc/notes/crud-record-deeplink-multiload.md
@@ -1,0 +1,81 @@
+# CRUD record deep-link: multi-phase cold-load ("reload flicker")
+
+Status: **open / characterized**. Cosmetic. Engine-wide (not shell- or federation-specific).
+
+## Symptom
+
+Opening — or reloading — a deep-link to a **record inside a listing** (e.g. the EventConductor
+demo's `/workflow/processes/{uuid}`) makes the content area repaint in visible stages: a brief
+"the page is reloading" effect. It is **not** a "Not found" (no such text ever reaches the DOM or
+the wire) and **not** a failed request — every load returns 200. The content ends up correct.
+
+## Root cause (measured, 2026-09-12)
+
+A deep-link to a CRUD record loads the **same route** in **three sequential phases**, and each
+phase paints:
+
+1. the **App** shell structure,
+2. the **listing / CRUD** (a `ServerSide` component),
+3. the **record detail** (a `ServerSide` component, carries `SetWindowTitle`).
+
+### It is NOT the shell / federation
+
+Decisive test: loading the remote CRUD **directly, with no shell in front** —
+`http://localhost:8085/remote/things/t3` on the e2e federation SUT — also produced **3 loads** of
+`/mateu/v3/sync/things/t3`, with exactly the App → listing → detail response sequence above. So the
+multi-phase cold-load is **inherent to CRUD record deep-links across all of Mateu**. Behind a
+federated shell the shell's own top `<mateu-ux>` is added on top (hence "2–3" loads of the remote
+content route when measured through the shell, 3 direct).
+
+This is the same family as the "listing drawn twice/thrice on cold load" issues the renderer has
+chipped at before — see the comments in
+`frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/renderers/appRenderer.ts` (variant-flip
+remount, stable `contentUxId`) and the load trigger in
+`frontend/web/monorepo/libs/mateu/src/mateu/ui/infra/ui/mateu-ux.ts` `updated()` (a load fires when
+`id` / `baseurl` / `route` / `consumedRoute` / `instant` change).
+
+## Where the phases originate (investigation map)
+
+- **Phase 1 (App):** backend route resolution returns the `@UI` app for the route —
+  `backend/shared/core/.../runaction/RouteInstanceCreator.java` (`resolveAsApp`) /
+  `AppMenuResolver.java`. The top `<mateu-ux>` renders the app shell; its content `<mateu-ux>` is
+  created for the route (see `renderApp` / `chooseRoute` in `appRenderer.ts`).
+- **Phase 2 (listing):** the content ux loads the route; it resolves to the CRUD listing —
+  `backend/shared/core/.../infra/declarative/orchestrators/crud/routeresolvers/ListRouteResolver.java`
+  (consumes `/things`, leaves the `/t3` tail), `CapabilityCrud.java` / `Crud.java`. The listing
+  renders via `mateu-table-crud.ts`.
+- **Phase 3 (detail):** the `/t3` tail is resolved to the record — `CrudNavigationAdjuster.java`
+  (rewrites the route for `view`/`edit`) and the `mateu-table-crud.ts` detail path
+  (`rowRoute.ts` → `navigateToRoute`). This is the extra load that re-requests the route to open
+  the record.
+
+The surplus that reads as a "reload" is phases 2→3 (and, behind a shell, the extra top-ux hop):
+the listing is brought up and then the record view replaces it, each as its own authoritative
+load + paint.
+
+## Candidate fixes (for the framework owner to choose — each has real blast radius)
+
+1. **Resolve a record deep-link straight to the detail, server-side, in one load** — when the route
+   tail identifies a record of a `Navigable` CRUD, return the detail as the content load instead of
+   the listing-then-detail two-step. Risk: back-navigation to the list, master-detail (`SPLIT`)
+   layouts that show list + detail together, and listings whose detail needs list context.
+2. **Lazy the listing search when the cold route opens a record** — keep the CRUD structure but skip
+   the list data fetch until the detail is closed / the list pane is shown. Risk: `SPLIT` layouts,
+   filters/URL state restore.
+3. **Coalesce same-route authoritative loads in the client** — if a `<mateu-ux>` is about to fire an
+   authoritative load for a route whose detail load is already in flight (phase 3 superseding phase
+   2), drop the superseded one. Risk: dropping a load that carried different `consumedRoute`/state.
+
+All three touch the CRUD cold-load path that EVERY listing/CRUD/master-detail/back-nav in Mateu
+rides, so any of them needs broad e2e coverage before shipping — which is why it is characterized
+here rather than patched in passing.
+
+## Repro + guard
+
+- Repro harness: `e2e/sut/apps/fed-{remote,shell}-app` (:8085 / :8084), UI in
+  `e2e/sut/modules/federation-{remote,shell}-ui`. A record deep-link is `/remote/things/t3`
+  (`RemoteThings` is a `Navigable` listing). The remote alone reproduces it (no shell needed).
+- Guard test: `e2e/tests/federation/remote-record-deeplink-load-count.spec.ts` — a passing
+  characterization that records today's load count, plus a `test.fixme` that asserts the **target**
+  (the record route loads once). When a fix above lands, drop `.fixme` to turn it into the
+  regression guard.

--- a/e2e/tests/federation/remote-record-deeplink-load-count.spec.ts
+++ b/e2e/tests/federation/remote-record-deeplink-load-count.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * CHARACTERIZATION + TARGET GUARD for the "cold-load flicker" on a CRUD RECORD deep-link.
+ *
+ * Symptom (reported on the EventConductor demo, ec1.mateu.io): opening/reloading a process —
+ * a RECORD inside a listing, URL `/workflow/processes/{uuid}` — shows a brief "reload effect":
+ * the content area repaints in stages. It is NOT a "Not found" (no such text reaches the DOM or
+ * the wire) and NOT a failed request — every load is 200.
+ *
+ * What it actually is (proven, 2026-09-12): a deep-link to a record of a CRUD/Navigable loads the
+ * SAME route in THREE sequential phases, and each phase paints:
+ *   1) the App shell structure,
+ *   2) the listing/CRUD (ServerSide),
+ *   3) the record detail (ServerSide, carries SetWindowTitle).
+ *
+ * DECISIVE finding: this is NOT a shell/federation bug. Hitting the remote CRUD DIRECTLY, with no
+ * shell in front (`http://localhost:8085/remote/things/t3`), also produced 3 loads of the route.
+ * So the multi-phase cold-load is inherent to CRUD record deep-links across all of Mateu; the
+ * federation/shell path only adds its own top <mateu-ux> on top of that.
+ *
+ * This file pins the behaviour two ways:
+ *   - `counts the loads of a record deep-link route` — a PASSING characterization that records how
+ *     many times the record route is loaded today (no assertion on the exact number, so it never
+ *     goes stale). Run it to see the current count in the attached annotation / console.
+ *   - `a record deep-link loads its route once` — the TARGET, marked test.fixme so CI does not fail
+ *     on the known issue. When the CRUD cold-load is collapsed (see
+ *     doc/.../crud-record-deeplink-multiload.md for where and the risks), drop `.fixme` and it
+ *     becomes the regression guard.
+ *
+ * Topology: the shell (fed-shell-app :8084) aggregates the remote (:8085) via RemoteMenu; the
+ * remote declares a Navigable listing `RemoteThings` at `/remote/things`, so `/remote/things/t3`
+ * is a record deep-link — the exact shape of `/workflow/processes/{uuid}`.
+ */
+
+/** POSTs that load the remote's OWN content route (the listing/record), i.e. the flickering loads. */
+const RECORD_ROUTE = /\/mateu\/v3\/sync\/things\/t3\b/;
+
+function countRecordLoads(page: import('@playwright/test').Page): { get(): number } {
+  let n = 0;
+  page.on('request', (request) => {
+    if (request.method() === 'POST' && RECORD_ROUTE.test(request.url())) n++;
+  });
+  return { get: () => n };
+}
+
+test.describe('CRUD record deep-link cold-load (flicker characterization)', () => {
+
+  test('counts the loads of a record deep-link route', async ({ page }, testInfo) => {
+    const loads = countRecordLoads(page);
+
+    await page.goto('/remote/things/t3');
+    // The record view only appears once the remote has answered — wait on it, not on a clock.
+    await expect(page.getByRole('heading', { name: 'Remote Thing' })).toBeVisible();
+    // Let any trailing re-load settle so the count is stable.
+    await page.waitForTimeout(1500);
+
+    // No assertion on the exact number (it must not go stale as the engine improves); the value is
+    // recorded so a reader sees today's behaviour. As of 2026-09-12 this is > 1 (observed 3 direct /
+    // 2–3 behind the shell) — that surplus IS the flicker.
+    testInfo.annotations.push({ type: 'record-route-loads', description: String(loads.get()) });
+    expect(loads.get()).toBeGreaterThan(0);
+  });
+
+  // TARGET: a record deep-link should resolve its content in a single load (one paint, no flicker).
+  // Marked fixme because it fails today BY DESIGN of the current CRUD cold-load; it is the guard a
+  // future engine fix must turn green. Removing `.fixme` without the fix will (correctly) fail CI.
+  test.fixme('a record deep-link loads its route once (no staged repaint / flicker)', async ({ page }) => {
+    const loads = countRecordLoads(page);
+
+    await page.goto('/remote/things/t3');
+    await expect(page.getByRole('heading', { name: 'Remote Thing' })).toBeVisible();
+    await page.waitForTimeout(1500);
+
+    // One authoritative load for the record. (If a master-detail layout legitimately needs the
+    // listing too, relax to `toBeLessThanOrEqual(2)` — but never the 3 that reads as a reload.)
+    expect(loads.get()).toBe(1);
+  });
+
+});


### PR DESCRIPTION
## What

Characterizes the **"reload flicker"** seen when opening/reloading a deep-link to a **record inside a listing** (e.g. the EventConductor demo's `/workflow/processes/{uuid}`): the content area repaints in stages.

**Not a bug fix** — this lays the verified foundation for one.

## Finding (measured)

A CRUD record deep-link loads the **same route in 3 sequential phases** — App shell → listing/CRUD → record detail — and each paints. Decisive: hitting a remote CRUD **directly, no shell** (`:8085/remote/things/t3`) *also* loads the route 3×. So it is **engine-wide CRUD cold-load behaviour, not shell/federation-specific**. The functional deep-link bug (permanent "Not found") was already fixed separately (#477, released alpha.330).

## Contents

- `e2e/tests/federation/remote-record-deeplink-load-count.spec.ts`
  - a passing characterization that records today's load count (no brittle exact-count assertion);
  - `test.fixme` asserting the **target** (record route loads once) — the guard a future fix turns green.
- `doc/notes/crud-record-deeplink-multiload.md` — root cause, the direct-remote proof, where each phase originates (`RouteInstanceCreator`/`AppMenuResolver`; `ListRouteResolver`/`CapabilityCrud`/`Crud`; `CrudNavigationAdjuster`/`mateu-table-crud`/`rowRoute`), and 3 candidate fixes **with their blast radius** (they touch the cold-load path every listing/CRUD/master-detail rides).

## Why no fix here

The fix is a frontend CRUD cold-load change with engine-wide blast radius; it must be validated against the full CRUD e2e matrix (filters/pagination/edit/new/master-detail/back-nav) before shipping into EventConductor + the live demo. This PR is the characterization + guard so that fix can be done deliberately and proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)